### PR TITLE
feat: improve open agent thread responsiveness

### DIFF
--- a/apps/web/src/components/agent/chat.tsx
+++ b/apps/web/src/components/agent/chat.tsx
@@ -54,6 +54,8 @@ function Conversation(props: Props) {
     return <div>Agent not found</div>;
   }
 
+  const chatKey = agentId + threadId;
+
   return (
     <Suspense
       fallback={
@@ -61,6 +63,7 @@ function Conversation(props: Props) {
           <Spinner />
         </div>
       }
+      key={chatKey}
     >
       <ChatProvider
         agentId={agentId}
@@ -70,7 +73,7 @@ function Conversation(props: Props) {
         <DockedPageLayout
           main={MAIN}
           tabs={COMPONENTS}
-          key={agentId + threadId}
+          key={chatKey}
         />
       </ChatProvider>
     </Suspense>

--- a/apps/web/src/components/agent/chat.tsx
+++ b/apps/web/src/components/agent/chat.tsx
@@ -63,6 +63,7 @@ function Conversation(props: Props) {
           <Spinner />
         </div>
       }
+      // This make the react render fallback when changin agent+threadid, instead of hang the whole navigation while the subtree isn't changed
       key={chatKey}
     >
       <ChatProvider


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
Before:
- When clicking on sidebar thread chat, at second time, it take some time to "navigate" (i mean select the new route). The explanation https://react.dev/reference/react/Suspense#resetting-suspense-boundaries-on-navigation

After: 
- When clicking on sidebar chat, at second time, it navigates and show load spinner

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 