### PR TITLE
feat: standardize fetch and instrument with trace debug id

### DIFF
--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -124,3 +124,12 @@ export const setModel = (model: string) => {
 export const getModel = () => {
   return localStorage.getItem("model") ?? DEFAULT_REASONING_MODEL;
 };
+
+/**
+ * Gets the trace debug ID from the URL or generates a new one
+ * @returns The trace debug ID
+ */
+export function getTraceDebugId(): string {
+  return new URL(globalThis.location.href).searchParams.get("__d") ||
+    crypto.randomUUID();
+}

--- a/packages/sdk/src/crud/agent.ts
+++ b/packages/sdk/src/crud/agent.ts
@@ -1,16 +1,6 @@
-import { API_HEADERS, API_SERVER_URL } from "../constants.ts";
+import { fetchAPI } from "../fetcher.ts";
 import { type Agent, AgentSchema } from "../models/agent.ts";
 import { stub } from "../stub.ts";
-
-const toPath = (segments: string[]) => segments.join("/");
-
-const fetchAPI = (segments: string[], init?: RequestInit) =>
-  fetch(new URL(toPath(segments), API_SERVER_URL), {
-    ...init,
-    credentials: "include",
-    headers: { ...API_HEADERS, ...init?.headers },
-  });
-
 export class AgentNotFoundError extends Error {
   agentId: string;
 
@@ -25,7 +15,8 @@ export class AgentNotFoundError extends Error {
  * @param agent - The agent to save
  */
 export const saveAgent = async (context: string, agent: Partial<Agent>) => {
-  const response = await fetchAPI([context, "agent"], {
+  const response = await fetchAPI({
+    segments: [context, "agent"],
     method: "POST",
     body: JSON.stringify(agent),
   });
@@ -74,7 +65,8 @@ export const loadAgent = async (
   agentId: string,
   signal?: AbortSignal,
 ) => {
-  const response = await fetchAPI([context, "agent", agentId], {
+  const response = await fetchAPI({
+    segments: [context, "agent", agentId],
     signal,
   });
 
@@ -90,7 +82,8 @@ export const loadAgent = async (
 };
 
 export const listAgents = async (context: string, signal?: AbortSignal) => {
-  const response = await fetchAPI([context, "agents"], {
+  const response = await fetchAPI({
+    segments: [context, "agents"],
     signal,
   });
 
@@ -106,7 +99,8 @@ export const listAgents = async (context: string, signal?: AbortSignal) => {
  * @param agentId - The id of the agent to delete
  */
 export const deleteAgent = async (context: string, agentId: string) => {
-  const response = await fetchAPI([context, "agent", agentId], {
+  const response = await fetchAPI({
+    segments: [context, "agent", agentId],
     method: "DELETE",
   });
 

--- a/packages/sdk/src/crud/fs.tsx
+++ b/packages/sdk/src/crud/fs.tsx
@@ -1,4 +1,4 @@
-import { API_HEADERS, API_SERVER_URL } from "../constants.ts";
+import { fetchAPI } from "../fetcher.ts";
 
 // File system module interfaces
 export interface FileSystemOptions {
@@ -10,25 +10,13 @@ export interface FileSystemOptions {
   flag?: string;
 }
 
-const fetchAPI = <T extends object>(
-  path: string,
-  target: "file" | "directory",
-  opts?: T,
-  init?: RequestInit,
-) => {
-  const url = new URL(`/fs/${target}`, API_SERVER_URL);
-  url.searchParams.set("path", path);
-  url.searchParams.set("opts", JSON.stringify(opts));
-
-  return fetch(url, {
-    ...init,
-    credentials: "include",
-    headers: { ...API_HEADERS, ...init?.headers },
-  });
-};
-
 export const readFile = async (path: string, options?: FileSystemOptions) => {
-  const response = await fetchAPI(path, "file", options, { method: "GET" });
+  const response = await fetchAPI({
+    path: `/fs/file?path=${encodeURIComponent(path)}&opts=${
+      JSON.stringify(options)
+    }`,
+    method: "GET",
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to read file: ${response.statusText}`);
@@ -41,7 +29,10 @@ export const readDirectory = async (
   path: string,
   options?: FileSystemOptions,
 ) => {
-  const response = await fetchAPI(path, "directory", options, {
+  const response = await fetchAPI({
+    path: `/fs/directory?path=${encodeURIComponent(path)}&opts=${
+      JSON.stringify(options)
+    }`,
     method: "GET",
   });
 
@@ -57,7 +48,10 @@ export const writeFile = async (
   content: string | Uint8Array,
   options?: FileSystemOptions,
 ) => {
-  const response = await fetchAPI(path, "file", options, {
+  const response = await fetchAPI({
+    path: `/fs/file?path=${encodeURIComponent(path)}&opts=${
+      JSON.stringify(options)
+    }`,
     method: "POST",
     body: typeof content === "string" ? JSON.stringify({ content }) : content,
     headers: {
@@ -75,7 +69,12 @@ export const writeFile = async (
 };
 
 export const deleteFile = async (path: string, options?: FileSystemOptions) => {
-  const response = await fetchAPI(path, "file", options, { method: "DELETE" });
+  const response = await fetchAPI({
+    path: `/fs/file?path=${encodeURIComponent(path)}&opts=${
+      JSON.stringify(options)
+    }`,
+    method: "DELETE",
+  });
 
   if (!response.ok) {
     throw new Error(`Failed to delete file: ${response.statusText}`);

--- a/packages/sdk/src/crud/mcp.ts
+++ b/packages/sdk/src/crud/mcp.ts
@@ -1,14 +1,5 @@
-import { API_HEADERS, API_SERVER_URL } from "../constants.ts";
+import { fetchAPI } from "../fetcher.ts";
 import { type Integration, IntegrationSchema } from "../models/mcp.ts";
-
-const toPath = (segments: string[]) => segments.join("/");
-
-const fetchAPI = (segments: string[], init?: RequestInit) =>
-  fetch(new URL(toPath(segments), API_SERVER_URL), {
-    ...init,
-    credentials: "include",
-    headers: { ...API_HEADERS, ...init?.headers },
-  });
 
 export class IntegrationNotFoundError extends Error {
   integrationId: string;
@@ -24,7 +15,8 @@ export class IntegrationNotFoundError extends Error {
  * @param mcp - The MCP to save
  */
 export const saveIntegration = async (context: string, mcp: Integration) => {
-  const response = await fetchAPI([context, "integration"], {
+  const response = await fetchAPI({
+    segments: [context, "integration"],
     method: "POST",
     body: JSON.stringify(mcp),
   });
@@ -66,7 +58,8 @@ export const loadIntegration = async (
   mcpId: string,
   signal?: AbortSignal,
 ): Promise<Integration> => {
-  const response = await fetchAPI([context, "integration", mcpId], {
+  const response = await fetchAPI({
+    segments: [context, "integration", mcpId],
     signal,
   });
 
@@ -85,7 +78,8 @@ export const listIntegrations = async (
   context: string,
   signal?: AbortSignal,
 ) => {
-  const response = await fetchAPI([context, "integrations"], {
+  const response = await fetchAPI({
+    segments: [context, "integrations"],
     signal,
   });
 
@@ -101,7 +95,8 @@ export const listIntegrations = async (
  * @param mcpId - The id of the MCP to delete
  */
 export const deleteIntegration = async (context: string, mcpId: string) => {
-  const response = await fetchAPI([context, "integration", mcpId], {
+  const response = await fetchAPI({
+    segments: [context, "integration", mcpId],
     method: "DELETE",
   });
 

--- a/packages/sdk/src/crud/thread.ts
+++ b/packages/sdk/src/crud/thread.ts
@@ -1,16 +1,10 @@
-import { API_HEADERS, API_SERVER_URL } from "../constants.ts";
-
-const toPath = (segments: string[]) => segments.join("/");
-
-const fetchAPI = (segments: string[], init?: RequestInit) =>
-  fetch(new URL(toPath(segments), API_SERVER_URL), {
-    ...init,
-    credentials: "include",
-    headers: { ...API_HEADERS, ...init?.headers },
-  });
+import { fetchAPI } from "../fetcher.ts";
 
 export const listThreads = async (context: string, signal?: AbortSignal) => {
-  const response = await fetchAPI([context, "threads"], { signal });
+  const response = await fetchAPI({
+    segments: [context, "threads"],
+    signal,
+  });
 
   if (response.ok) {
     return response.json();

--- a/packages/sdk/src/crud/user.ts
+++ b/packages/sdk/src/crud/user.ts
@@ -1,4 +1,8 @@
 import { AUTH_URL } from "../constants.ts";
+import { createFetcher } from "../fetcher.ts";
+
+// Create a custom fetcher for auth endpoints
+const authFetcher = createFetcher(AUTH_URL);
 
 export interface User {
   id: string;
@@ -11,8 +15,8 @@ export interface User {
 }
 
 export const fetchUser = async () => {
-  const response = await fetch(`${AUTH_URL}/api/user`, {
-    credentials: "include",
+  const response = await authFetcher({
+    path: "/api/user",
   });
 
   if (response.status === 401) {

--- a/packages/sdk/src/crud/wallet.ts
+++ b/packages/sdk/src/crud/wallet.ts
@@ -1,16 +1,9 @@
-import { API_HEADERS, API_SERVER_URL } from "../constants.ts";
-
-const toPath = (segments: string[]) => segments.join("/");
-
-const fetchAPI = (segments: string[], init?: RequestInit) =>
-  fetch(new URL(toPath(segments), API_SERVER_URL), {
-    ...init,
-    credentials: "include",
-    headers: { ...API_HEADERS, ...init?.headers },
-  });
+import { fetchAPI } from "../fetcher.ts";
 
 export const getWalletAccount = async () => {
-  const response = await fetchAPI(["wallet", "account"]);
+  const response = await fetchAPI({
+    segments: ["wallet", "account"],
+  });
   return response.json();
 };
 
@@ -27,10 +20,9 @@ interface WalletStatement {
 }
 
 export const getWalletStatements = async (cursor?: string) => {
-  const response = await fetchAPI([
-    "wallet",
-    `statements${cursor ? `?cursor=${cursor}` : ""}`,
-  ]);
+  const response = await fetchAPI({
+    path: `/wallet/statements${cursor ? `?cursor=${cursor}` : ""}`,
+  });
   return response.json() as Promise<{
     items: WalletStatement[];
     nextCursor: string;
@@ -38,7 +30,8 @@ export const getWalletStatements = async (cursor?: string) => {
 };
 
 export const createWalletCheckoutSession = async (amountInCents: number) => {
-  const response = await fetchAPI(["wallet", "checkout"], {
+  const response = await fetchAPI({
+    segments: ["wallet", "checkout"],
     method: "POST",
     body: JSON.stringify({ amountInCents }),
   });

--- a/packages/sdk/src/fetcher.ts
+++ b/packages/sdk/src/fetcher.ts
@@ -1,0 +1,44 @@
+import { API_HEADERS, API_SERVER_URL } from "./constants.ts";
+import { getTraceDebugId } from "./constants.ts";
+
+export interface FetchOptions extends RequestInit {
+  path?: string;
+  segments?: string[];
+}
+
+/**
+ * Creates a fetch function with pre-configured headers and base URL
+ * @param baseUrl - The base URL for the API
+ * @param defaultHeaders - Default headers to include in every request
+ * @returns A configured fetch function
+ */
+export function createFetcher(
+  baseUrl: string = API_SERVER_URL,
+  defaultHeaders: HeadersInit = API_HEADERS,
+) {
+  return function fetchAPI(options: FetchOptions = {}) {
+    const { path, segments, ...init } = options;
+
+    // Construct the URL
+    const url = new URL(
+      path || (segments ? segments.join("/") : ""),
+      baseUrl,
+    );
+
+    // Merge headers
+    const headers = {
+      ...defaultHeaders,
+      ...init.headers,
+      "x-trace-debug-id": getTraceDebugId(),
+    };
+
+    return fetch(url, {
+      ...init,
+      credentials: "include",
+      headers,
+    });
+  };
+}
+
+// Default fetcher instance with API_SERVER_URL and API_HEADERS
+export const fetchAPI = createFetcher();

--- a/packages/sdk/src/stub.ts
+++ b/packages/sdk/src/stub.ts
@@ -1,6 +1,7 @@
 import type { Actor } from "@deco/actors";
 import { actors } from "@deco/actors/stub";
 import { API_SERVER_URL } from "./constants.ts";
+import { getTraceDebugId } from "./constants.ts";
 
 /**
  * A utility to create a stub for an actor.
@@ -22,6 +23,25 @@ export const stub = <T extends Actor>(name: string) => {
         // TODO: do we  need this?
         // "ErrnoError": ErrnoError,
         // [ErrnoError.name]: ErrnoError,
+      },
+      fetcher: {
+        fetch: (url, options) => {
+          if (url instanceof Request) {
+            url.headers.set("x-trace-debug-id", getTraceDebugId());
+            return fetch(url, options);
+          }
+
+          return fetch(url, {
+            ...options,
+            headers: {
+              ...options?.headers,
+              "x-trace-debug-id": getTraceDebugId(),
+            },
+          });
+        },
+        createWebSocket: (url) => {
+          return new WebSocket(url);
+        },
       },
     },
   );

--- a/packages/sdk/src/stub.ts
+++ b/packages/sdk/src/stub.ts
@@ -34,7 +34,7 @@ export const stub = <T extends Actor>(name: string) => {
           return fetch(url, {
             ...options,
             headers: {
-              ...(options?.headers || {}),
+              ...(options?.headers as HeadersInit || {}),
               "x-trace-debug-id": getTraceDebugId(),
             },
           });

--- a/packages/sdk/src/stub.ts
+++ b/packages/sdk/src/stub.ts
@@ -25,18 +25,20 @@ export const stub = <T extends Actor>(name: string) => {
         // [ErrnoError.name]: ErrnoError,
       },
       fetcher: {
-        fetch: (url, options) => {
+        fetch: (url, options = {}) => {
           if (url instanceof Request) {
             url.headers.set("x-trace-debug-id", getTraceDebugId());
             return fetch(url, options);
           }
 
+          const headers: HeadersInit = {
+            ...(options.headers ?? {}),
+            "x-trace-debug-id": getTraceDebugId(),
+          };
+
           return fetch(url, {
             ...options,
-            headers: {
-              ...(options?.headers as HeadersInit || {}),
-              "x-trace-debug-id": getTraceDebugId(),
-            },
+            headers,
           });
         },
         createWebSocket: (url) => {

--- a/packages/sdk/src/stub.ts
+++ b/packages/sdk/src/stub.ts
@@ -31,10 +31,8 @@ export const stub = <T extends Actor>(name: string) => {
             return fetch(url, options);
           }
 
-          const headers: HeadersInit = {
-            ...(options.headers ?? {}),
-            "x-trace-debug-id": getTraceDebugId(),
-          };
+          const headers = new Headers(options.headers);
+          headers.set("x-trace-debug-id", getTraceDebugId());
 
           return fetch(url, {
             ...options,

--- a/packages/sdk/src/stub.ts
+++ b/packages/sdk/src/stub.ts
@@ -34,7 +34,7 @@ export const stub = <T extends Actor>(name: string) => {
           return fetch(url, {
             ...options,
             headers: {
-              ...options?.headers,
+              ...(options?.headers || {}),
               "x-trace-debug-id": getTraceDebugId(),
             },
           });

--- a/packages/sdk/src/stub.ts
+++ b/packages/sdk/src/stub.ts
@@ -25,7 +25,7 @@ export const stub = <T extends Actor>(name: string) => {
         // [ErrnoError.name]: ErrnoError,
       },
       fetcher: {
-        fetch: (url, options = {}) => {
+        fetch: (url, options: RequestInit = {}) => {
           if (url instanceof Request) {
             url.headers.set("x-trace-debug-id", getTraceDebugId());
             return fetch(url, options);


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
- Centralize fetch logic in a reusable fetcher utility
- Add trace debug ID to all API requests for better debugging
- Unify header management across the codebase
- Remove duplicate fetch implementations
