### PR TITLE
chore: bring back separate agent edit route

### DIFF
--- a/apps/web/src/components/agent/ChatHeader.tsx
+++ b/apps/web/src/components/agent/ChatHeader.tsx
@@ -1,9 +1,11 @@
-import { AgentNotFoundError, WELL_KNOWN_AGENT_IDS } from "@deco/sdk";
+import { AgentNotFoundError, useAgent, WELL_KNOWN_AGENT_IDS } from "@deco/sdk";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { Suspense } from "react";
 import { ErrorBoundary } from "../../ErrorBoundary.tsx";
 import { useChatContext } from "../chat/context.tsx";
-import { AgentHeader } from "./DetailHeader.tsx";
+import { useEditAgent, useFocusChat } from "../agents/hooks.ts";
+import { AgentAvatar } from "../common/Avatar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
 
 interface Props {
   agentId: string;
@@ -50,7 +52,50 @@ ChatHeader.Skeleton = () => {
   return <div className="h-10 w-full" />;
 };
 
-ChatHeader.UI = AgentHeader.UI;
+ChatHeader.UI = ({ agentId }: Props) => {
+  const { data: agent } = useAgent(agentId);
+  const focusChat = useFocusChat();
+  const focusEditAgent = useEditAgent();
+
+  return (
+    <>
+      <Container>
+        <div className="w-8 h-8 rounded-[10px] overflow-hidden flex items-center justify-center">
+          <AgentAvatar
+            name={agent.name}
+            avatar={agent.avatar}
+            className="rounded-lg text-xs"
+          />
+        </div>
+        <h1 className="text-sm font-medium tracking-tight">
+          {agent.name}
+        </h1>
+      </Container>
+
+      <div className="flex items-center gap-2 py-1">
+        <Button
+          variant="outline"
+          title="New Chat"
+          onClick={() => focusChat(agentId, crypto.randomUUID())}
+        >
+          <Icon name="chat_add_on" />
+          New chat
+        </Button>
+        <Button
+          id="settings"
+          title="Settings"
+          variant="outline"
+          size="icon"
+          onClick={() => {
+            focusEditAgent(agentId, crypto.randomUUID());
+          }}
+        >
+          <Icon name="tune" />
+        </Button>
+      </div>
+    </>
+  );
+};
 
 const Container = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/apps/web/src/components/agent/DetailHeader.tsx
+++ b/apps/web/src/components/agent/DetailHeader.tsx
@@ -7,7 +7,6 @@ import { AgentAvatar } from "../common/Avatar.tsx";
 import { DockedToggleButton } from "../pageLayout.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { useFocusChat } from "../agents/hooks.ts";
-import { useOpenSettingsIfQueryParam } from "./chat.tsx";
 
 interface Props {
   agentId: string;
@@ -55,7 +54,6 @@ AgentHeader.Skeleton = () => {
 };
 
 AgentHeader.UI = ({ agentId }: Props) => {
-  useOpenSettingsIfQueryParam();
   const { data: agent } = useAgent(agentId);
   const focusChat = useFocusChat();
 

--- a/apps/web/src/components/agent/edit.tsx
+++ b/apps/web/src/components/agent/edit.tsx
@@ -18,7 +18,7 @@ import {
 } from "@deco/ui/components/tabs.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { useSidebar } from "@deco/ui/components/sidebar.tsx";
-import { useIsMobile } from "../../../../../packages/ui/src/hooks/use-mobile.ts";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { useAgentHasChanges } from "../../hooks/useAgentOverrides.ts";
 import { useFocusChat } from "../agents/hooks.ts";

--- a/apps/web/src/components/agent/edit.tsx
+++ b/apps/web/src/components/agent/edit.tsx
@@ -1,5 +1,5 @@
-import { Suspense, useEffect, useMemo, useState } from "react";
-import { useParams, useSearchParams } from "react-router";
+import { Suspense, useMemo, useState } from "react";
+import { useParams } from "react-router";
 import { ChatInput } from "../chat/ChatInput.tsx";
 import { ChatMessages } from "../chat/ChatMessages.tsx";
 import { ChatProvider } from "../chat/context.tsx";
@@ -8,7 +8,6 @@ import AgentSettings from "../settings/agent.tsx";
 import { AgentHeader } from "./DetailHeader.tsx";
 import AgentPreview from "./preview.tsx";
 import ThreadView from "./thread.tsx";
-import ThreadSettingsTab from "../settings/chat.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -22,7 +21,6 @@ import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import { useIsMobile } from "../../../../../packages/ui/src/hooks/use-mobile.ts";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { useAgentHasChanges } from "../../hooks/useAgentOverrides.ts";
-import { togglePanel, useDock } from "../dock/index.tsx";
 import { useFocusChat } from "../agents/hooks.ts";
 
 // Custom CSS to override shadow styles

--- a/apps/web/src/components/agents/hooks.ts
+++ b/apps/web/src/components/agents/hooks.ts
@@ -2,21 +2,22 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router";
 import { useBasePath } from "../../hooks/useBasePath.ts";
 
+interface AgentNavigationOptions {
+  message?: string;
+}
+
+const getEditAgentPath = (agentId: string, threadId?: string): string =>
+  `/agent/${agentId}/${threadId}`;
 const getChatPath = (agentId: string, threadId: string): string =>
   `/chat/${agentId}/${threadId}`;
 
-interface ChatNavigationOptions {
-  message?: string;
-  openSettings?: boolean;
-}
-
-export const useFocusChat = () => {
+export const useEditAgent = () => {
   const navigate = useNavigate();
   const withBasePath = useBasePath();
 
-  const navigateToAgent = useCallback(
-    (agentId: string, threadId: string, options?: ChatNavigationOptions) => {
-      const pathname = withBasePath(getChatPath(agentId, threadId));
+  return useCallback(
+    (agentId: string, threadId?: string, options?: AgentNavigationOptions) => {
+      const pathname = withBasePath(getEditAgentPath(agentId, threadId));
       // Add query parameters if options are provided
       let url = pathname;
       const searchParams = new URLSearchParams();
@@ -25,8 +26,31 @@ export const useFocusChat = () => {
         searchParams.append("message", options.message);
       }
 
-      if (options?.openSettings) {
-        searchParams.append("openSettings", "true");
+      // Only append search params if we have any
+      if (searchParams.toString()) {
+        url = `${pathname}?${searchParams.toString()}`;
+      }
+
+      // Navigate to the agent page
+      navigate(url);
+    },
+    [navigate, withBasePath],
+  );
+};
+
+export const useFocusChat = () => {
+  const navigate = useNavigate();
+  const withBasePath = useBasePath();
+
+  const navigateToAgent = useCallback(
+    (agentId: string, threadId: string, options?: AgentNavigationOptions) => {
+      const pathname = withBasePath(getChatPath(agentId, threadId));
+      // Add query parameters if options are provided
+      let url = pathname;
+      const searchParams = new URLSearchParams();
+
+      if (options?.message) {
+        searchParams.append("message", options.message);
       }
 
       // Only append search params if we have any

--- a/apps/web/src/components/agents/list.tsx
+++ b/apps/web/src/components/agents/list.tsx
@@ -342,7 +342,6 @@ function listReducer(state: ListState, action: ListAction): ListState {
 export default function List() {
   const [state, dispatch] = useReducer(listReducer, initialState);
   const { filter } = state;
-  const focusChat = useFocusChat();
   const focusEditAgent = useEditAgent();
   const [creating, setCreating] = useState(false);
   const createAgent = useCreateAgent();

--- a/apps/web/src/components/agents/list.tsx
+++ b/apps/web/src/components/agents/list.tsx
@@ -41,7 +41,7 @@ import { Avatar } from "../common/Avatar.tsx";
 import { EmptyState } from "../common/EmptyState.tsx";
 import { PageLayout } from "../pageLayout.tsx";
 import { useAgentHasChanges } from "../../hooks/useAgentOverrides.ts";
-import { useFocusChat } from "./hooks.ts";
+import { useEditAgent, useFocusChat } from "./hooks.ts";
 
 export const useDuplicateAgent = (agent: Agent | null) => {
   const [duplicating, setDuplicating] = useState(false);
@@ -64,9 +64,7 @@ export const useDuplicateAgent = (agent: Agent | null) => {
         model: agent.model,
         views: agent.views,
       });
-      focusChat(duplicatedAgent.id, crypto.randomUUID(), {
-        openSettings: true,
-      });
+      focusChat(duplicatedAgent.id, crypto.randomUUID());
 
       trackEvent("agent_duplicate", {
         success: true,
@@ -345,6 +343,7 @@ export default function List() {
   const [state, dispatch] = useReducer(listReducer, initialState);
   const { filter } = state;
   const focusChat = useFocusChat();
+  const focusEditAgent = useEditAgent();
   const [creating, setCreating] = useState(false);
   const createAgent = useCreateAgent();
   const updateThreadMessages = useUpdateThreadMessages();
@@ -361,9 +360,7 @@ export default function List() {
       setCreating(true);
       const agent = await createAgent.mutateAsync({});
       updateThreadMessages(agent.id, agent.id);
-      focusChat(agent.id, crypto.randomUUID(), {
-        openSettings: true,
-      });
+      focusEditAgent(agent.id, crypto.randomUUID());
 
       trackEvent("agent_create", {
         success: true,

--- a/apps/web/src/components/chat/tools/AgentCard.tsx
+++ b/apps/web/src/components/chat/tools/AgentCard.tsx
@@ -69,9 +69,7 @@ export function AgentCard(
         {displayLink && (
           <Button
             onClick={() => {
-              focusChat(id, crypto.randomUUID(), {
-                openSettings: true,
-              });
+              focusChat(id, crypto.randomUUID());
             }}
             size="sm"
             className="text-sm"

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -68,6 +68,10 @@ const Chat = lazy(
   () => wrapWithUILoadingFallback(import("./components/agent/chat.tsx")),
 );
 
+const EditAgent = lazy(
+  () => wrapWithUILoadingFallback(import("./components/agent/edit.tsx")),
+);
+
 const Wallet = lazy(
   () => wrapWithUILoadingFallback(import("./components/wallet/index.tsx")),
 );
@@ -156,6 +160,10 @@ function Router() {
         <Route
           path="agents"
           element={<AgentsList />}
+        />
+        <Route
+          path="agent/:id/:threadId"
+          element={<EditAgent />}
         />
         <Route
           path="chat/:id/:threadId"


### PR DESCRIPTION
Refactor: Separate Agent Chat and Edit Views

Re-Introduce a dedicated /agent/:id/:threadId route and edit.tsx component for agent configuration, including settings and a chat preview.
Update the main chat view (/chat/:id/:threadId) to focus solely on conversation.
Modify ChatHeader to include buttons for creating new chats and navigating to the new agent edit view.
Create useEditAgent hook for navigating to the edit route.
Remove the openSettings option from useFocusChat and related logic.
Update agent list actions (create, duplicate) to navigate to the appropriate view (edit or chat).
Remove the docked settings panel from the main chat layout.

