### PR TITLE
remove messages that got limit in the history

### DIFF
--- a/apps/web/src/components/chat/context.tsx
+++ b/apps/web/src/components/chat/context.tsx
@@ -20,6 +20,7 @@ import { useUserPreferences } from "../../hooks/useUserPreferences.ts";
 import { IMAGE_REGEXP, openPreviewPanel } from "./utils/preview.ts";
 
 const LAST_MESSAGES_COUNT = 10;
+const MAX_TOKENS = 200000;
 interface FileData {
   name: string;
   contentType: string;
@@ -110,7 +111,7 @@ export function ChatProvider({
       const files = fileDataRef.current;
       const allMessages = (messages as CreateMessage[]).slice(
         -LAST_MESSAGES_COUNT,
-      );
+      ).filter((msg) => JSON.stringify({parts: msg.parts, content: msg.content}).length < MAX_TOKENS);
       const last = allMessages.at(-1);
       const annotations = files && files.length > 0
         ? [

--- a/apps/web/src/components/chat/context.tsx
+++ b/apps/web/src/components/chat/context.tsx
@@ -111,10 +111,13 @@ export function ChatProvider({
       const files = fileDataRef.current;
       const allMessages = (messages as CreateMessage[]).slice(
         -LAST_MESSAGES_COUNT,
-      ).filter((msg) =>
-        JSON.stringify({ parts: msg.parts, content: msg.content }).length <
-          MAX_TOKENS
-      );
+      ).filter((msg, i, arr) => {
+        const isLast = i === arr.length - 1;
+        const isTooLong =
+          JSON.stringify({ parts: msg.parts, content: msg.content }).length >
+            MAX_TOKENS;
+        return isLast || !isTooLong;
+      });
       const last = allMessages.at(-1);
       const annotations = files && files.length > 0
         ? [

--- a/apps/web/src/components/chat/context.tsx
+++ b/apps/web/src/components/chat/context.tsx
@@ -111,7 +111,10 @@ export function ChatProvider({
       const files = fileDataRef.current;
       const allMessages = (messages as CreateMessage[]).slice(
         -LAST_MESSAGES_COUNT,
-      ).filter((msg) => JSON.stringify({parts: msg.parts, content: msg.content}).length < MAX_TOKENS);
+      ).filter((msg) =>
+        JSON.stringify({ parts: msg.parts, content: msg.content }).length <
+          MAX_TOKENS
+      );
       const last = allMessages.at(-1);
       const annotations = files && files.length > 0
         ? [


### PR DESCRIPTION
Currently, when a message with too many tokens is sent or received, the chat fails because it always tries to include the full thread history.

not sure about use the number 200.000

https://www.loom.com/share/ccb8f8f1b7374e1bad7177d6ccffe27a