### PR TITLE
chore: improve route matching

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -174,13 +174,13 @@ function Router() {
 
       <Route path="about" element={<About />} />
 
-      <Route path="/:teamSlug?" element={<WorkspaceSettingsLayout />}>
-        <Route path="settings" element={<GeneralSettings />} />
-        <Route path="settings/members" element={<MembersSettings />} />
-        <Route path="settings/billing" element={<BillingSettings />} />
-        <Route path="settings/usage" element={<UsageSettings />} />
-        <Route path="settings/audit" element={<AuditList />} />
-        <Route path="settings/audit/:id" element={<AuditDetail />} />
+      <Route path="/:teamSlug?/settings" element={<WorkspaceSettingsLayout />}>
+        <Route index element={<GeneralSettings />} />
+        <Route path="members" element={<MembersSettings />} />
+        <Route path="billing" element={<BillingSettings />} />
+        <Route path="usage" element={<UsageSettings />} />
+        <Route path="audit" element={<AuditList />} />
+        <Route path="audit/:id" element={<AuditDetail />} />
       </Route>
 
       <Route path="/:teamSlug?" element={<WorkspaceLayout />}>


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
Instead of rendering two react-router routes that matches `/:teamSlug?` for app workspace and settings, split into two: `/:teamSlug?` for workspace and `/:teamSlug?/settings` for settings