### PR TITLE
perf: improve entry point asset size

### DIFF
--- a/apps/web/src/components/about/index.tsx
+++ b/apps/web/src/components/about/index.tsx
@@ -5,7 +5,7 @@ import { Hero } from "./Hero.tsx";
 import Integrations from "./Integrations.tsx";
 import { DECO_CHAT_PAGE_CONTENT } from "./content.ts";
 
-export function About() {
+export default function About() {
   const {
     hero,
     features,

--- a/apps/web/src/components/agent/chat.tsx
+++ b/apps/web/src/components/agent/chat.tsx
@@ -26,8 +26,11 @@ import { AgentBreadcrumbSegment } from "./BreadcrumbSegment.tsx";
 import AgentPreview from "./preview.tsx";
 import ThreadView from "./thread.tsx";
 
+export type WellKnownAgents =
+  typeof WELL_KNOWN_AGENT_IDS[keyof typeof WELL_KNOWN_AGENT_IDS];
+
 interface Props {
-  agentId?: string;
+  agentId?: WellKnownAgents;
   threadId?: string;
   disableThreadMessages?: boolean;
   includeThreadTools?: boolean;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,11 +12,8 @@ import {
   useLocation,
   useNavigate,
 } from "react-router";
-import { About } from "./components/about/index.tsx";
 import { PageviewTracker } from "./components/analytics/PageviewTracker.tsx";
 import { EmptyState } from "./components/common/EmptyState.tsx";
-import { RouteLayout } from "./components/layout.tsx";
-import Login from "./components/login/index.tsx";
 
 import { ErrorBoundary, useError } from "./ErrorBoundary.tsx";
 import { trackException } from "./hooks/analytics.ts";
@@ -40,6 +37,15 @@ const wrapWithUILoadingFallback = <P,>(
       </Suspense>
     ),
   }));
+
+const RouteLayout = lazy(() =>
+  import("./components/layout.tsx").then((mod) => ({
+    default: mod.RouteLayout,
+  }))
+);
+
+const Login = lazy(() => import("./components/login/index.tsx"));
+const About = lazy(() => import("./components/about/index.tsx"));
 
 /**
  * Route component with Suspense + Spinner. Remove the wrapWithUILoadingFallback if

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,5 @@
 import "./polyfills.ts";
 
-import { WELL_KNOWN_AGENT_IDS } from "@deco/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { JSX, lazy, StrictMode, Suspense, useEffect } from "react";
@@ -12,11 +11,9 @@ import {
   useLocation,
   useNavigate,
 } from "react-router";
-import { PageviewTracker } from "./components/analytics/PageviewTracker.tsx";
-import { EmptyState } from "./components/common/EmptyState.tsx";
 
+import { EmptyState } from "./components/common/EmptyState.tsx";
 import { ErrorBoundary, useError } from "./ErrorBoundary.tsx";
-import { trackException } from "./hooks/analytics.ts";
 
 type LazyComp<P> = Promise<{
   default: React.ComponentType<P>;
@@ -43,9 +40,13 @@ const RouteLayout = lazy(() =>
     default: mod.RouteLayout,
   }))
 );
-
 const Login = lazy(() => import("./components/login/index.tsx"));
 const About = lazy(() => import("./components/about/index.tsx"));
+const PageviewTracker = lazy(() =>
+  import("./components/analytics/PageviewTracker.tsx").then((mod) => ({
+    default: mod.PageviewTracker,
+  }))
+);
 
 /**
  * Route component with Suspense + Spinner. Remove the wrapWithUILoadingFallback if
@@ -187,12 +188,13 @@ function Router() {
             <Chat
               includeThreadTools
               disableThreadMessages
-              agentId={WELL_KNOWN_AGENT_IDS.teamAgent}
+              agentId="teamAgent"
               threadId={crypto.randomUUID()}
               key="disabled-messages"
             />
           }
         />
+
         <Route
           path="wallet"
           element={<Wallet />}
@@ -254,11 +256,16 @@ createRoot(document.getElementById("root")!).render(
       <ErrorBoundary
         fallback={<ErrorFallback />}
         shouldCatch={(error) => {
-          trackException(error);
+          import("./hooks/analytics.ts").then((mod) =>
+            mod.trackException(error)
+          );
+
           return true;
         }}
       >
-        <PageviewTracker />
+        <Suspense fallback={null}>
+          <PageviewTracker />
+        </Suspense>
         <Suspense
           fallback={
             <div className="h-full w-full flex items-center justify-center">

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -39,7 +39,7 @@ export const API_HEADERS = {
 export const WELL_KNOWN_AGENT_IDS = {
   teamAgent: "teamAgent",
   setupAgent: "setupAgent",
-};
+} as const;
 
 export interface Model {
   id: string;

--- a/packages/sdk/src/hooks/agent.ts
+++ b/packages/sdk/src/hooks/agent.ts
@@ -155,7 +155,7 @@ export const useAgentRoot = (agentId: string) => {
 
 // TODO: I guess we can improve this and have proper typings
 export const useAgentStub = (
-  agentId = WELL_KNOWN_AGENT_IDS.teamAgent,
+  agentId: string = WELL_KNOWN_AGENT_IDS.teamAgent,
   threadId?: string,
 ) => {
   const agentRoot = useAgentRoot(agentId);


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
Improve index ertrypoint bundle size

main (production): ~1.200kb
![image](https://github.com/user-attachments/assets/0f69b0e7-0b15-48e5-8878-f116cefcff38)

branch (with changes): ~266kb only react, react-router and tailwind-merge
![image](https://github.com/user-attachments/assets/e8f5fc17-43c5-4542-9f94-f42386807130)

also could check running ` npx vite-bundle-visualizer -c vite.config.ts`
