### PR TITLE
fix: form submission when change schema

### DIFF
--- a/apps/web/src/components/integrations/detail/inspector.tsx
+++ b/apps/web/src/components/integrations/detail/inspector.tsx
@@ -409,6 +409,7 @@ Inspector.UI = ({ connection }: InspectorProps) => {
                         <Separator />
                       </div>
                       <ToolCallForm
+                        key={selectedToolObject.name}
                         tool={selectedToolObject}
                         onSubmit={handleToolCall}
                         onCancel={handleCancelToolCall}

--- a/apps/web/src/components/integrations/detail/toolCallForm.tsx
+++ b/apps/web/src/components/integrations/detail/toolCallForm.tsx
@@ -41,7 +41,6 @@ export function ToolCallForm(
   useEffect(() => {
     if (rawMode) {
       try {
-        console.log(form.getValues());
         // Convert form data to JSON string when switching to raw mode
         setPayload(JSON.stringify(form.getValues(), null, 2));
       } catch (_err) {
@@ -61,10 +60,6 @@ export function ToolCallForm(
       }
     }
   }, [rawMode]);
-
-  useEffect(function handleResetForm() {
-    form.reset(generateDefaultValues(tool.inputSchema as JSONSchema7));
-  }, [tool.name]);
 
   const handleRawSubmit = async () => {
     try {


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
fix form submit button, where handleSubmit doesn't call callback after schema changes, remounting the component.

steps to reproduce the error:
1. open integration `i:workspace-management`
2. click to test integrations
3. choose tool `INTEGRATIONS_GET` (can be other)
4. then fill the form and submit
5. choose tool `HOSTING_APPS_LIST` or other without schema
6. press submit

expected: submit the tool call form
current behavior: does nothing