### PR TITLE
feat: webhook output tool

### DIFF
--- a/apps/web/src/components/toolsets/single-selector.tsx
+++ b/apps/web/src/components/toolsets/single-selector.tsx
@@ -1,0 +1,284 @@
+import { useIntegrations, useTools } from "@deco/sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+} from "@deco/ui/components/dialog.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { useMemo, useState } from "react";
+import { IntegrationIcon } from "../integrations/list/common.tsx";
+import type { Integration } from "@deco/sdk";
+import type { MCPTool } from "@deco/sdk";
+
+interface SingleToolSelectorProps {
+  value: string | null;
+  onChange: (value: string) => void;
+}
+
+interface IntegrationListProps {
+  integrations: Integration[];
+  isLoading: boolean;
+  search: string;
+  onSelect: (integration: Integration) => void;
+}
+
+function IntegrationList(
+  { integrations, isLoading, search, onSelect }: IntegrationListProps,
+) {
+  const filtered = useMemo(
+    () =>
+      !search
+        ? integrations
+        : integrations.filter((integration) =>
+          integration.name.toLowerCase().includes(search.toLowerCase())
+        ),
+    [integrations, search],
+  );
+
+  if (isLoading) {
+    return <div className="p-4 text-slate-400">Loading integrations...</div>;
+  }
+  if (filtered.length === 0) {
+    return <div className="p-4 text-slate-400">No integrations found.</div>;
+  }
+  return (
+    <>
+      {filtered.map((integration) => (
+        <button
+          type="button"
+          key={integration.id}
+          className="w-full flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors text-left cursor-pointer"
+          onClick={() => onSelect(integration)}
+        >
+          <IntegrationIcon
+            icon={integration.icon}
+            name={integration.name}
+            className="h-8 w-8"
+          />
+          <div className="flex flex-col min-w-0">
+            <span className="font-medium truncate">{integration.name}</span>
+            {integration.description && (
+              <span className="text-xs text-slate-500 truncate">
+                {integration.description}
+              </span>
+            )}
+          </div>
+        </button>
+      ))}
+    </>
+  );
+}
+
+interface ToolListProps {
+  integration: Integration;
+  value: string | null;
+  search: string;
+  onSelect: (tool: MCPTool) => void;
+}
+
+function ToolList({ integration, value, search, onSelect }: ToolListProps) {
+  const { data: toolsData, isLoading } = useTools(
+    integration.connection || { type: "HTTP", url: "" },
+  );
+  const filtered = useMemo(
+    () =>
+      !toolsData
+        ? []
+        : !search
+        ? toolsData.tools
+        : toolsData.tools.filter((tool) =>
+          tool.name.toLowerCase().includes(search.toLowerCase()) ||
+          (tool.description?.toLowerCase().includes(search.toLowerCase()) ??
+            false)
+        ),
+    [toolsData, search],
+  );
+
+  return (
+    <>
+      {isLoading
+        ? <div className="p-4 text-slate-400">Loading tools...</div>
+        : filtered.length === 0
+        ? <div className="p-4 text-slate-400">No tools found.</div>
+        : (
+          filtered.map((tool) => (
+            <button
+              type="button"
+              key={tool.name}
+              className={`w-full flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors text-left ${
+                value === `${integration.id}/${tool.name}` ? "bg-slate-100" : ""
+              }`}
+              onClick={() => onSelect(tool)}
+            >
+              <IntegrationIcon
+                icon={integration.icon}
+                name={integration.name}
+                className="h-8 w-8"
+              />
+              <div className="flex flex-col min-w-0">
+                <span className="font-medium truncate">
+                  {integration.name} / {tool.name}
+                </span>
+                {tool.description && (
+                  <span className="text-xs text-slate-500 truncate">
+                    {tool.description}
+                  </span>
+                )}
+              </div>
+              {value === `${integration.id}/${tool.name}` && (
+                <Icon
+                  name="check"
+                  size={18}
+                  className="ml-auto text-slate-500"
+                />
+              )}
+            </button>
+          ))
+        )}
+    </>
+  );
+}
+
+interface SelectorDialogProps {
+  open: boolean;
+  value: string | null;
+  onClose: () => void;
+  onChange: (value: string) => void;
+}
+
+function SelectorDialog(
+  { open, value, onClose, onChange }: SelectorDialogProps,
+) {
+  const [search, setSearch] = useState("");
+  const [selectedIntegration, setSelectedIntegration] = useState<
+    Integration | null
+  >(null);
+  const { data: integrations = [], isLoading: isIntegrationsLoading } =
+    useIntegrations();
+
+  const handleDialogChange = (v: boolean) => {
+    if (!v) {
+      setSelectedIntegration(null);
+      setSearch("");
+      onClose();
+    }
+  };
+
+  function handleToolSelect(tool: MCPTool) {
+    if (!selectedIntegration) return;
+    onChange(`${selectedIntegration.id}/${tool.name}`);
+    setSelectedIntegration(null);
+    setSearch("");
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent className="max-w-md w-full p-0 gap-0">
+        <DialogHeader>
+          <div className="flex items-center justify-between p-3 border-b border-slate-200">
+            <div className="flex flex-col gap-2">
+              {selectedIntegration && (
+                <button
+                  type="button"
+                  className="flex text-xs h-6 items-center gap-2 px-2 text-slate-500 hover:text-slate-700 bg-slate-50 rounded-md hover:bg-slate-100 transition-colors"
+                  onClick={() => {
+                    setSelectedIntegration(null);
+                    setSearch("");
+                  }}
+                >
+                  <Icon name="arrow_back" size={18} />
+                  Back to integrations
+                </button>
+              )}
+              <span>Select a Tool</span>
+            </div>
+          </div>
+        </DialogHeader>
+        <div className="border-b border-slate-200">
+          <Input
+            placeholder={selectedIntegration
+              ? `Search ${selectedIntegration.name} tools...`
+              : "Search integrations..."}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full border-none focus-visible:ring-0 placeholder:text-slate-500"
+          />
+        </div>
+        <div className="max-h-96 overflow-y-auto">
+          <div className="divide-y divide-slate-100">
+            {!selectedIntegration
+              ? (
+                <IntegrationList
+                  integrations={integrations}
+                  isLoading={isIntegrationsLoading}
+                  search={search}
+                  onSelect={(integration) => {
+                    setSelectedIntegration(integration);
+                    setSearch("");
+                  }}
+                />
+              )
+              : (
+                <ToolList
+                  integration={selectedIntegration}
+                  value={value}
+                  search={search}
+                  onSelect={handleToolSelect}
+                />
+              )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function SingleToolSelector(
+  { value, onChange }: SingleToolSelectorProps,
+) {
+  const [open, setOpen] = useState(false);
+  const { data: integrations = [] } = useIntegrations();
+
+  const selected = useMemo(() => {
+    if (!value) return null;
+    const [integrationId, toolName] = value.split("/");
+    const integration = integrations.find((i) => i.id === integrationId);
+    return integration ? { integration, toolName } : null;
+  }, [value, integrations]);
+
+  return (
+    <div>
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full justify-between"
+        onClick={() => setOpen(true)}
+      >
+        {selected
+          ? (
+            <span className="flex items-center gap-2 truncate">
+              <IntegrationIcon
+                icon={selected.integration.icon}
+                name={selected.integration.name}
+                className="h-5 w-5"
+              />
+              <span className="truncate">
+                {selected.integration.name} / {selected.toolName}
+              </span>
+            </span>
+          )
+          : <span className="text-slate-400">Select a tool...</span>}
+        <Icon name="expand_more" size={18} className="ml-2 text-slate-400" />
+      </Button>
+      <SelectorDialog
+        open={open}
+        value={value}
+        onClose={() => setOpen(false)}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/toolsets/single-selector.tsx
+++ b/apps/web/src/components/toolsets/single-selector.tsx
@@ -56,7 +56,7 @@ function IntegrationList(
           <IntegrationIcon
             icon={integration.icon}
             name={integration.name}
-            className="h-8 w-8"
+            className="h-8 w-8 shrink-0"
           />
           <div className="flex flex-col min-w-0">
             <span className="font-medium truncate">{integration.name}</span>
@@ -116,9 +116,9 @@ function ToolList({ integration, value, search, onSelect }: ToolListProps) {
               <IntegrationIcon
                 icon={integration.icon}
                 name={integration.name}
-                className="h-8 w-8"
+                className="h-8 w-8 shrink-0"
               />
-              <div className="flex flex-col min-w-0">
+              <div className="flex flex-col min-w-0 flex-1">
                 <span className="font-medium truncate">
                   {integration.name} / {tool.name}
                 </span>

--- a/apps/web/src/components/toolsets/single-selector.tsx
+++ b/apps/web/src/components/toolsets/single-selector.tsx
@@ -263,7 +263,7 @@ export function SingleToolSelector(
               <IntegrationIcon
                 icon={selected.integration.icon}
                 name={selected.integration.name}
-                className="h-5 w-5"
+                className="h-8 w-8"
               />
               <span className="truncate">
                 {selected.integration.name} / {selected.toolName}

--- a/apps/web/src/components/toolsets/single-selector.tsx
+++ b/apps/web/src/components/toolsets/single-selector.tsx
@@ -11,6 +11,7 @@ import { useMemo, useState } from "react";
 import { IntegrationIcon } from "../integrations/list/common.tsx";
 import type { Integration } from "@deco/sdk";
 import type { MCPTool } from "@deco/sdk";
+import { cn } from "@deco/ui/lib/utils.ts";
 
 interface SingleToolSelectorProps {
   value: string | null;
@@ -250,16 +251,18 @@ export function SingleToolSelector(
   }, [value, integrations]);
 
   return (
-    <div>
+    <div className="max-w-[410px]">
       <Button
         type="button"
         variant="outline"
-        className="w-full justify-between truncate"
+        className={cn("w-full justify-between truncate", {
+          "px-1": selected,
+        })}
         onClick={() => setOpen(true)}
       >
         {selected
           ? (
-            <span className="flex items-center gap-2 truncate">
+            <span className="flex items-center gap-2">
               <IntegrationIcon
                 icon={selected.integration.icon}
                 name={selected.integration.name}

--- a/apps/web/src/components/toolsets/single-selector.tsx
+++ b/apps/web/src/components/toolsets/single-selector.tsx
@@ -254,7 +254,7 @@ export function SingleToolSelector(
       <Button
         type="button"
         variant="outline"
-        className="w-full justify-between"
+        className="w-full justify-between truncate"
         onClick={() => setOpen(true)}
       >
         {selected
@@ -265,7 +265,7 @@ export function SingleToolSelector(
                 name={selected.integration.name}
                 className="h-8 w-8"
               />
-              <span className="truncate">
+              <span className="truncate overflow-hidden whitespace-nowrap max-w-[350px]">
                 {selected.integration.name} / {selected.toolName}
               </span>
             </span>

--- a/apps/web/src/components/triggers/webhookTriggerForm.tsx
+++ b/apps/web/src/components/triggers/webhookTriggerForm.tsx
@@ -16,6 +16,7 @@ import {
   FormMessage,
 } from "@deco/ui/components/form.tsx";
 import { SingleToolSelector } from "../toolsets/single-selector.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
 
 function JsonSchemaInput({ value, onChange }: {
   value: string;
@@ -240,12 +241,25 @@ export function WebhookTriggerForm({
                   the selected tool
                 </span>
               </div>
-              <FormControl>
-                <SingleToolSelector
-                  value={field.value || null}
-                  onChange={field.onChange}
-                />
-              </FormControl>
+              <div className="flex gap-2 items-center">
+                <FormControl>
+                  <SingleToolSelector
+                    value={field.value || null}
+                    onChange={field.onChange}
+                  />
+                </FormControl>
+                {field.value && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="p-1"
+                    onClick={() => field.onChange("")}
+                  >
+                    <Icon name="close" size={12} className="text-slate-400" />
+                  </Button>
+                )}
+              </div>
               <FormMessage />
             </FormItem>
           )}

--- a/apps/web/src/components/triggers/webhookTriggerForm.tsx
+++ b/apps/web/src/components/triggers/webhookTriggerForm.tsx
@@ -15,6 +15,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@deco/ui/components/form.tsx";
+import { SingleToolSelector } from "../toolsets/single-selector.tsx";
 
 function JsonSchemaInput({ value, onChange }: {
   value: string;
@@ -101,6 +102,7 @@ export function WebhookTriggerForm({
       description: "",
       passphrase: "",
       schema: "",
+      outputTool: "",
       type: "webhook",
     },
   });
@@ -219,6 +221,28 @@ export function WebhookTriggerForm({
                 <JsonSchemaInput
                   value={field.value}
                   onChange={handleOutputSchemaChange}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="outputTool"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex flex-col gap-1 px-1 justify-between">
+                <FormLabel>Output Tool</FormLabel>
+                <span className="text-xs text-slate-400">
+                  When selected, this webhook trigger will always end calling
+                  the selected tool
+                </span>
+              </div>
+              <FormControl>
+                <SingleToolSelector
+                  value={field.value || null}
+                  onChange={field.onChange}
                 />
               </FormControl>
               <FormMessage />

--- a/apps/web/src/components/triggers/webhookTriggerForm.tsx
+++ b/apps/web/src/components/triggers/webhookTriggerForm.tsx
@@ -131,6 +131,7 @@ export function WebhookTriggerForm({
         passphrase: data.passphrase || undefined,
         // deno-lint-ignore no-explicit-any
         schema: schemaObj as unknown as any || undefined,
+        outputTool: data.outputTool || undefined,
       },
       {
         onSuccess: () => {

--- a/packages/ai/src/agent.ts
+++ b/packages/ai/src/agent.ts
@@ -145,11 +145,6 @@ export class AIAgent extends BaseActor<AgentMetadata> implements IIAgent {
     });
     this.agentMemoryConfig = null as unknown as AgentMemoryConfig;
     this.agentId = this.state.id.split("/").pop() ?? "";
-    console.log(
-      "creating supa storage",
-      this.env.SUPABASE_SERVER_TOKEN,
-      SUPABASE_URL,
-    );
     this.storage = createSupabaseStorage(
       createServerClient(
         SUPABASE_URL,

--- a/packages/ai/src/agent.ts
+++ b/packages/ai/src/agent.ts
@@ -145,6 +145,11 @@ export class AIAgent extends BaseActor<AgentMetadata> implements IIAgent {
     });
     this.agentMemoryConfig = null as unknown as AgentMemoryConfig;
     this.agentId = this.state.id.split("/").pop() ?? "";
+    console.log(
+      "creating supa storage",
+      this.env.SUPABASE_SERVER_TOKEN,
+      SUPABASE_URL,
+    );
     this.storage = createSupabaseStorage(
       createServerClient(
         SUPABASE_URL,

--- a/packages/ai/src/triggers/outputTool.ts
+++ b/packages/ai/src/triggers/outputTool.ts
@@ -97,8 +97,8 @@ export const handleOutputTool = async ({
     }
 
     const { tool, schema } = getToolResult;
-    // deno-lint-ignore no-explicit-any
     const toolArgs =
+      // deno-lint-ignore no-explicit-any
       (await agent.generateObject(messages, schema as any)).object;
 
     // deno-lint-ignore no-explicit-any

--- a/packages/ai/src/triggers/outputTool.ts
+++ b/packages/ai/src/triggers/outputTool.ts
@@ -7,6 +7,7 @@ import type { AIAgent } from "../agent.ts";
 import type { Message } from "../types.ts";
 import type { Trigger } from "./trigger.ts";
 import { mcpServerTools } from "../mcp.ts";
+import { slugify } from "../utils/slugify.ts";
 
 export interface RunOutputToolArgs {
   agent: ActorProxy<AIAgent>;
@@ -52,7 +53,7 @@ export async function getOutputTool(
   }
 
   const tools = await mcpServerTools(integration, agent as unknown as AIAgent);
-  const maybeTool = tools[toolId];
+  const maybeTool = tools[slugify(toolId)];
   if (!maybeTool || !maybeTool.execute) {
     return {
       error: "Tool not found",
@@ -97,10 +98,10 @@ export const handleOutputTool = async ({
 
     const { tool, schema } = getToolResult;
     // deno-lint-ignore no-explicit-any
-    const toolArgs = await agent.generateObject(messages, schema as any);
+    const toolArgs = (await agent.generateObject(messages, schema as any)).object;
 
     // deno-lint-ignore no-explicit-any
-    const result = await tool.execute!(toolArgs as any);
+    const result = await tool.execute!({ context: toolArgs } as any);
 
     return {
       args: toolArgs,

--- a/packages/ai/src/triggers/outputTool.ts
+++ b/packages/ai/src/triggers/outputTool.ts
@@ -98,7 +98,8 @@ export const handleOutputTool = async ({
 
     const { tool, schema } = getToolResult;
     // deno-lint-ignore no-explicit-any
-    const toolArgs = (await agent.generateObject(messages, schema as any)).object;
+    const toolArgs =
+      (await agent.generateObject(messages, schema as any)).object;
 
     // deno-lint-ignore no-explicit-any
     const result = await tool.execute!({ context: toolArgs } as any);

--- a/packages/ai/src/triggers/outputTool.ts
+++ b/packages/ai/src/triggers/outputTool.ts
@@ -107,9 +107,7 @@ export const handleOutputTool = async ({
       result,
     };
   } catch (err) {
-    console.log({
-      err,
-    });
+    console.error("Error calling output tool", err);
     return Response.json({
       message: "Error calling webhook with output tool",
       error: err instanceof Error ? err.message : err,

--- a/packages/ai/src/triggers/outputTool.ts
+++ b/packages/ai/src/triggers/outputTool.ts
@@ -1,0 +1,118 @@
+import { ToolAction } from "@mastra/core";
+import { DecoChatStorage } from "../storage/index.ts";
+import { ActorProxy } from "@deco/actors";
+import type { Workspace } from "@deco/sdk/path";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { AIAgent } from "../agent.ts";
+import type { Message } from "../types.ts";
+import type { Trigger } from "./trigger.ts";
+import { mcpServerTools } from "../mcp.ts";
+
+export interface RunOutputToolArgs {
+  agent: ActorProxy<AIAgent>;
+  outputTool: string;
+  storage: DecoChatStorage;
+  workspace: Workspace;
+}
+
+interface RunOutputToolError {
+  error: string;
+  status: number;
+  details?: unknown;
+}
+
+interface RunOutputToolSuccess {
+  tool: ToolAction;
+  schema: ReturnType<typeof zodToJsonSchema>;
+}
+
+export type RunOutputToolResult = RunOutputToolError | RunOutputToolSuccess;
+
+export async function getOutputTool(
+  { agent, outputTool, storage, workspace }: RunOutputToolArgs,
+): Promise<RunOutputToolResult> {
+  const [integrationId, toolId] = outputTool.split("/");
+  if (!integrationId || !toolId) {
+    return {
+      error: "Invalid outputTool format",
+      status: 400,
+      details: { outputTool },
+    };
+  }
+
+  const integration = await storage.integrations.for(workspace)
+    .get(integrationId);
+
+  if (!integration) {
+    return {
+      error: "Integration not found",
+      status: 404,
+      details: { integrationId },
+    };
+  }
+
+  const tools = await mcpServerTools(integration, agent as unknown as AIAgent);
+  const maybeTool = tools[toolId];
+  if (!maybeTool || !maybeTool.execute) {
+    return {
+      error: "Tool not found",
+      status: 404,
+      details: { toolId },
+    };
+  }
+
+  const schema = zodToJsonSchema(maybeTool.inputSchema);
+  return { tool: maybeTool, schema };
+}
+
+export const handleOutputTool = async ({
+  outputTool,
+  agent,
+  messages,
+  trigger,
+  workspace,
+}: {
+  outputTool: string;
+  agent: ActorProxy<AIAgent>;
+  messages: Message[];
+  trigger: Trigger;
+  workspace: Workspace;
+}) => {
+  try {
+    const getToolResult = await getOutputTool({
+      agent,
+      outputTool,
+      storage: trigger.storage as DecoChatStorage,
+      workspace,
+    });
+
+    if ("error" in getToolResult) {
+      return Response.json({
+        error: getToolResult.error,
+        ...(getToolResult.details && typeof getToolResult.details === "object"
+          ? getToolResult.details
+          : {}),
+      }, { status: getToolResult.status });
+    }
+
+    const { tool, schema } = getToolResult;
+    // deno-lint-ignore no-explicit-any
+    const toolArgs = await agent.generateObject(messages, schema as any);
+
+    // deno-lint-ignore no-explicit-any
+    const result = await tool.execute!(toolArgs as any);
+
+    return {
+      args: toolArgs,
+      result,
+    };
+  } catch (err) {
+    console.log({
+      err,
+    });
+    return Response.json({
+      message: "Error calling webhook with output tool",
+      error: err instanceof Error ? err.message : err,
+    }, { status: 500 });
+  }
+};

--- a/packages/ai/src/triggers/trigger.ts
+++ b/packages/ai/src/triggers/trigger.ts
@@ -43,7 +43,7 @@ export class Trigger {
   protected data: TriggerData | null = null;
   public agentId: string;
   protected hooks: TriggerHooks<TriggerData> | null = null;
-  protected storage?: DecoChatStorage;
+  public storage?: DecoChatStorage;
   protected workspace: Workspace;
 
   constructor(public state: ActorState, protected env: any) {

--- a/packages/ai/src/triggers/webhook.ts
+++ b/packages/ai/src/triggers/webhook.ts
@@ -4,7 +4,7 @@ import { threadOf } from "./tools.ts";
 import type { TriggerHooks } from "./trigger.ts";
 import type { TriggerData } from "./services.ts";
 import { handleOutputTool } from "./outputTool.ts";
-import type { Workspace } from "@deco/sdk/path";
+import { getWorkspaceFromTriggerId } from "../utils/workspace.ts";
 
 export interface WebhookArgs {
   threadId?: string;
@@ -70,9 +70,7 @@ export const hooks: TriggerHooks<TriggerData & { type: "webhook" }> = {
 
     const outputTool = url?.searchParams.get("outputTool");
     if (outputTool) {
-      const workspace = trigger.agentId.split("/").slice(0, 3).join(
-        "/",
-      ) as Workspace;
+      const workspace = getWorkspaceFromTriggerId(trigger.agentId);
       return handleOutputTool({
         outputTool,
         agent,

--- a/packages/ai/src/triggers/webhook.ts
+++ b/packages/ai/src/triggers/webhook.ts
@@ -3,6 +3,8 @@ import type { Message } from "../types.ts";
 import { threadOf } from "./tools.ts";
 import type { TriggerHooks } from "./trigger.ts";
 import type { TriggerData } from "./services.ts";
+import { handleOutputTool } from "./outputTool.ts";
+import type { Workspace } from "@deco/sdk/path";
 
 export interface WebhookArgs {
   threadId?: string;
@@ -65,6 +67,21 @@ export const hooks: TriggerHooks<TriggerData & { type: "webhook" }> = {
         ]
         : []),
     ];
+
+    const outputTool = url?.searchParams.get("outputTool");
+    if (outputTool) {
+      const workspace = trigger.agentId.split("/").slice(0, 3).join(
+        "/",
+      ) as Workspace;
+      return handleOutputTool({
+        outputTool,
+        agent,
+        messages,
+        trigger,
+        workspace,
+      });
+    }
+
     if (
       data.schema ||
       (typeof args === "object" &&

--- a/packages/ai/src/triggers/webhook.ts
+++ b/packages/ai/src/triggers/webhook.ts
@@ -4,7 +4,7 @@ import { threadOf } from "./tools.ts";
 import type { TriggerHooks } from "./trigger.ts";
 import type { TriggerData } from "./services.ts";
 import { handleOutputTool } from "./outputTool.ts";
-import { getWorkspaceFromTriggerId } from "../utils/workspace.ts";
+import { getWorkspaceFromAgentId } from "../utils/workspace.ts";
 
 export interface WebhookArgs {
   threadId?: string;
@@ -70,7 +70,7 @@ export const hooks: TriggerHooks<TriggerData & { type: "webhook" }> = {
 
     const outputTool = url?.searchParams.get("outputTool");
     if (outputTool) {
-      const workspace = getWorkspaceFromTriggerId(trigger.agentId);
+      const workspace = getWorkspaceFromAgentId(trigger.agentId);
       return handleOutputTool({
         outputTool,
         agent,

--- a/packages/ai/src/utils/workspace.ts
+++ b/packages/ai/src/utils/workspace.ts
@@ -1,0 +1,5 @@
+import type { Workspace } from "@deco/sdk/path";
+
+export const getWorkspaceFromTriggerId = (triggerId: string): Workspace => {
+  return triggerId.split("/").slice(0, 3).join("/") as Workspace;
+};

--- a/packages/ai/src/utils/workspace.ts
+++ b/packages/ai/src/utils/workspace.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "@deco/sdk/path";
 
-export const getWorkspaceFromTriggerId = (triggerId: string): Workspace => {
-  return triggerId.split("/").slice(0, 3).join("/") as Workspace;
+export const getWorkspaceFromAgentId = (agentId: string): Workspace => {
+  return agentId.split("/").slice(0, 3).join("/") as Workspace;
 };

--- a/packages/sdk/src/crud/trigger.ts
+++ b/packages/sdk/src/crud/trigger.ts
@@ -119,6 +119,7 @@ export const webhookTriggerSchema = z.object({
   description: z.string().optional(),
   passphrase: z.string().optional(),
   schema: z.any().optional(),
+  outputTool: z.string().optional(),
   type: z.literal("webhook"),
 });
 

--- a/packages/sdk/src/hooks/tools.ts
+++ b/packages/sdk/src/hooks/tools.ts
@@ -18,7 +18,7 @@ export interface MCPToolCallResult {
   error?: string;
 }
 
-type ToolsData = {
+export type ToolsData = {
   tools: MCPTool[];
   instructions: string;
   version?: {


### PR DESCRIPTION
You can now opt to have an `outputTool` on your webhook trigger.

This creates a way to deterministically call tools at the end of webhook calls, good for when you need to "reply" to an external system in some way.

<img width="707" alt="Captura de Tela 2025-05-15 às 14 33 58" src="https://github.com/user-attachments/assets/14c81768-52ba-4219-b4f1-e0ecbd8654d0" />
