### PR TITLE
fix: render tool call button for tools without input schema

### DIFF
--- a/apps/web/src/components/JSONSchemaForm/index.ts
+++ b/apps/web/src/components/JSONSchemaForm/index.ts
@@ -1,2 +1,0 @@
-export * from "./Form.tsx";
-export * from "./utils/index.ts";

--- a/apps/web/src/components/integrations/detail/toolCallForm.tsx
+++ b/apps/web/src/components/integrations/detail/toolCallForm.tsx
@@ -9,11 +9,8 @@ import { Form } from "@deco/ui/components/form.tsx";
 import { useForm } from "react-hook-form";
 import { ajvResolver } from "@hookform/resolvers/ajv";
 import type { JSONSchema7 } from "json-schema";
-import {
-  Form as JSONSchemaForm,
-  generateDefaultValues,
-  type SchemaType,
-} from "../../JSONSchemaForm/index.ts";
+import { generateDefaultValues } from "../../JSONSchemaForm/utils/generateDefaultValues.ts";
+import JSONSchemaForm, { type SchemaType } from "../../JSONSchemaForm/Form.tsx";
 
 interface ToolCallFormProps {
   tool: MCPTool;

--- a/apps/web/src/components/integrations/detail/toolCallForm.tsx
+++ b/apps/web/src/components/integrations/detail/toolCallForm.tsx
@@ -4,7 +4,6 @@ import { Icon } from "@deco/ui/components/icon.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { useEffect, useState } from "react";
-import { Switch } from "@deco/ui/components/switch.tsx";
 import { Form } from "@deco/ui/components/form.tsx";
 import { useForm } from "react-hook-form";
 import { ajvResolver } from "@hookform/resolvers/ajv";
@@ -104,16 +103,16 @@ export function ToolCallForm(
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center space-x-2">
-        <div className="text-sm font-medium">Form Mode</div>
-        <Switch
-          checked={!rawMode}
-          onCheckedChange={() => toggleEditMode()}
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={toggleEditMode}
           disabled={isLoading}
-        />
-        <div className="text-sm text-muted-foreground">
-          {rawMode ? "Switch to form mode" : "Switch to raw JSON mode"}
-        </div>
+          className="flex items-center gap-2"
+        >
+          <Icon name={rawMode ? "text_ad" : "data_object"} />
+        </Button>
       </div>
 
       {rawMode
@@ -122,7 +121,7 @@ export function ToolCallForm(
             <div>
               <div className="text-sm font-medium mb-2">Input Schema</div>
               <pre className="p-4 rounded-lg bg-muted text-sm overflow-auto">
-          {JSON.stringify(tool.inputSchema, null, 2)}
+                {JSON.stringify(tool.inputSchema, null, 2)}
               </pre>
             </div>
 
@@ -168,34 +167,31 @@ export function ToolCallForm(
           </div>
         )
         : (
-          <div>
-            <div className="text-sm font-medium mb-2">Form Input</div>
-            <Form {...form}>
-              <JSONSchemaForm
-                schema={tool.inputSchema as JSONSchema7}
-                form={form}
-                disabled={isLoading}
-                onSubmit={handleFormSubmit}
-                error={error}
-                submitButton={
-                  <Button
-                    type="submit"
-                    className="flex-1 gap-2"
-                    disabled={isLoading}
-                  >
-                    {isLoading
-                      ? (
-                        <>
-                          <Spinner size="xs" />
-                          Processing...
-                        </>
-                      )
-                      : "Execute Tool Call"}
-                  </Button>
-                }
-              />
-            </Form>
-          </div>
+          <Form {...form}>
+            <JSONSchemaForm
+              schema={tool.inputSchema as JSONSchema7}
+              form={form}
+              disabled={isLoading}
+              onSubmit={handleFormSubmit}
+              error={error}
+              submitButton={
+                <Button
+                  type="submit"
+                  className="flex-1 gap-2"
+                  disabled={isLoading}
+                >
+                  {isLoading
+                    ? (
+                      <>
+                        <Spinner size="xs" />
+                        Processing...
+                      </>
+                    )
+                    : "Execute Tool Call"}
+                </Button>
+              }
+            />
+          </Form>
         )}
     </div>
   );


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
Render tool call button even if tool inputSchema is empty. Also change the form header

before: 
![image](https://github.com/user-attachments/assets/bd5098ff-8c74-41b7-8477-b4855d95648c)

after:
![image](https://github.com/user-attachments/assets/51e9bda7-7c0d-47a5-91c7-49813791f9c0)