### PR TITLE
chore: revert back rolldown-vite with patch update

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,6 @@
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react-swc": "^3.8.0",
     "tailwindcss": "^4.1.1",
-    "vite": "npm:rolldown-vite@^6.3.9"
+    "vite": "npm:rolldown-vite@^6.3.11"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,6 @@
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react-swc": "^3.8.0",
     "tailwindcss": "^4.1.1",
-    "vite": "^6.2.5"
+    "vite": "npm:rolldown-vite@^6.3.9"
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,9 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react() as PluginOption[], tailwindcss() as PluginOption[]],
   server: { port: 3000, allowedHosts: [".deco.host"] },
 });


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
Revert back this PR https://github.com/deco-cx/chat/pull/254 with the [rolldown-vite issue](https://github.com/vitejs/rolldown-vite/issues/175#issuecomment-2890196302) fixed.