### PR TITLE
add x-debug-trace-id to the interface

### DIFF
--- a/apps/web/src/components/common/EmptyState.tsx
+++ b/apps/web/src/components/common/EmptyState.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 export function EmptyState({
   icon,
@@ -11,7 +11,7 @@ export function EmptyState({
 }: {
   icon: string;
   title: string;
-  description: string;
+  description: string | ReactNode;
   buttonProps: ComponentProps<typeof Button>;
 }) {
   return (
@@ -34,9 +34,9 @@ export function EmptyState({
         <h3 className="text-2xl font-semibold text-foreground text-center">
           {title}
         </h3>
-        <p className="text-sm text-muted-foreground text-center">
+        <div className="text-sm text-muted-foreground text-center flex flex-col gap-1">
           {description}
-        </p>
+        </div>
       </div>
       <Button
         variant="outline"

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,11 @@
 import "./polyfills.ts";
 
-import { ForbiddenError, NotFoundError, UnauthorizedError } from "@deco/sdk";
+import {
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+  UnauthorizedError,
+} from "@deco/sdk";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { JSX, lazy, StrictMode, Suspense, useEffect } from "react";
 import { createRoot } from "react-dom/client";
@@ -158,8 +163,17 @@ function ErrorFallback() {
       <EmptyState
         icon="report"
         title="Access Denied"
-        description={error?.message ??
-          "User does not have access to this resource"}
+        description={
+          <>
+            <div>
+              {error?.message ??
+                "User does not have access to this resource"}
+            </div>
+            <div className="text-xs">
+              {error?.errorId}
+            </div>
+          </>
+        }
         buttonProps={{
           onClick: () => globalThis.location.href = "/",
           children: "Go back to home",
@@ -173,8 +187,17 @@ function ErrorFallback() {
       <EmptyState
         icon="report"
         title="Not Found"
-        description={error?.message ??
-          "The resource you are looking for does not exist"}
+        description={
+          <>
+            <div>
+              {error?.message ??
+                "The resource you are looking for does not exist"}
+            </div>
+            <div className="text-xs">
+              {error?.errorId}
+            </div>
+          </>
+        }
         buttonProps={{
           onClick: () => globalThis.location.href = "/",
           children: "Go back to home",
@@ -187,8 +210,17 @@ function ErrorFallback() {
     <EmptyState
       icon="report"
       title="Something went wrong"
-      description={error?.message ??
-        "Looks like we are facing some technical issues. Please try again."}
+      description={
+        <>
+          <div>
+            {error?.message ??
+              "Looks like we are facing some technical issues. Please try again."}
+          </div>
+          <div className="text-xs">
+            {(error as InternalServerError)?.errorId}
+          </div>
+        </>
+      }
       buttonProps={{
         onClick: () => globalThis.location.reload(),
         children: "Retry",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -170,7 +170,7 @@ function ErrorFallback() {
                 "User does not have access to this resource"}
             </div>
             <div className="text-xs">
-              {error?.errorId}
+              {error?.traceId}
             </div>
           </>
         }
@@ -194,7 +194,7 @@ function ErrorFallback() {
                 "The resource you are looking for does not exist"}
             </div>
             <div className="text-xs">
-              {error?.errorId}
+              {error?.traceId}
             </div>
           </>
         }
@@ -217,7 +217,7 @@ function ErrorFallback() {
               "Looks like we are facing some technical issues. Please try again."}
           </div>
           <div className="text-xs">
-            {(error as InternalServerError)?.errorId}
+            {(error as InternalServerError)?.traceId}
           </div>
         </>
       }

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,24 +1,24 @@
 export class HttpError extends Error {
   readonly code?: number;
-  readonly errorId?: string;
+  readonly traceId?: string;
 
-  constructor(message: string, errorId?: string) {
+  constructor(message: string, traceId?: string) {
     super(message);
-    this.errorId = errorId;
+    this.traceId = traceId;
   }
 }
 
 export class UserInputError extends HttpError {
   override code = 400;
-  constructor(message: string = "User input error", errorId?: string) {
-    super(message, errorId);
+  constructor(message: string = "User input error", traceId?: string) {
+    super(message, traceId);
   }
 }
 
 export class UnauthorizedError extends HttpError {
   override code = 401;
-  constructor(message: string = "User is not logged in", errorId?: string) {
-    super(message, errorId);
+  constructor(message: string = "User is not logged in", traceId?: string) {
+    super(message, traceId);
   }
 }
 
@@ -26,46 +26,46 @@ export class ForbiddenError extends HttpError {
   override code = 403;
   constructor(
     message: string = "User does not have access to this resource",
-    errorId?: string,
+    traceId?: string,
   ) {
-    super(message, errorId);
+    super(message, traceId);
   }
 }
 
 export class NotFoundError extends HttpError {
   override code = 404;
-  constructor(message: string = "Resource not found", errorId?: string) {
-    super(message, errorId);
+  constructor(message: string = "Resource not found", traceId?: string) {
+    super(message, traceId);
   }
 }
 
 export class InternalServerError extends HttpError {
   override code = 500;
-  constructor(message: string = "Internal server error", errorId?: string) {
-    super(message, errorId);
+  constructor(message: string = "Internal server error", traceId?: string) {
+    super(message, traceId);
   }
 }
 
 export const getErrorByStatusCode = (
   statusCode: number,
   message?: string,
-  errorId?: string,
+  traceId?: string,
 ) => {
   if (statusCode === 400) {
-    return new UserInputError(message, errorId);
+    return new UserInputError(message, traceId);
   }
 
   if (statusCode === 401) {
-    return new UnauthorizedError(message, errorId);
+    return new UnauthorizedError(message, traceId);
   }
 
   if (statusCode === 403) {
-    return new ForbiddenError(message, errorId);
+    return new ForbiddenError(message, traceId);
   }
 
   if (statusCode === 404) {
-    return new NotFoundError(message, errorId);
+    return new NotFoundError(message, traceId);
   }
 
-  return new InternalServerError(message, errorId);
+  return new InternalServerError(message, traceId);
 };

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,61 +1,71 @@
 export class HttpError extends Error {
   readonly code?: number;
-  constructor(message: string) {
+  readonly errorId?: string;
+
+  constructor(message: string, errorId?: string) {
     super(message);
+    this.errorId = errorId;
   }
 }
 
 export class UserInputError extends HttpError {
   override code = 400;
-  constructor(message: string = "User input error") {
-    super(message);
+  constructor(message: string = "User input error", errorId?: string) {
+    super(message, errorId);
   }
 }
 
 export class UnauthorizedError extends HttpError {
   override code = 401;
-  constructor(message: string = "User is not logged in") {
-    super(message);
+  constructor(message: string = "User is not logged in", errorId?: string) {
+    super(message, errorId);
   }
 }
 
 export class ForbiddenError extends HttpError {
   override code = 403;
-  constructor(message: string = "User does not have access to this resource") {
-    super(message);
+  constructor(
+    message: string = "User does not have access to this resource",
+    errorId?: string,
+  ) {
+    super(message, errorId);
   }
 }
 
 export class NotFoundError extends HttpError {
   override code = 404;
-  constructor(message: string = "Resource not found") {
-    super(message);
+  constructor(message: string = "Resource not found", errorId?: string) {
+    super(message, errorId);
   }
 }
 
 export class InternalServerError extends HttpError {
   override code = 500;
-  constructor(message: string = "Internal server error") {
-    super(message);
+  constructor(message: string = "Internal server error", errorId?: string) {
+    super(message, errorId);
   }
 }
 
-export const getErrorByStatusCode = (statusCode: number, message?: string) => {
+export const getErrorByStatusCode = (
+  statusCode: number,
+  message?: string,
+  errorId?: string,
+) => {
   if (statusCode === 400) {
-    return new UserInputError(message);
+    return new UserInputError(message, errorId);
   }
 
   if (statusCode === 401) {
-    return new UnauthorizedError(message);
+    return new UnauthorizedError(message, errorId);
   }
 
   if (statusCode === 403) {
-    return new ForbiddenError(message);
+    return new ForbiddenError(message, errorId);
   }
 
   if (statusCode === 404) {
-    return new NotFoundError(message);
+    return new NotFoundError(message, errorId);
   }
 
-  return new InternalServerError(message);
+  return new InternalServerError(message, errorId);
 };

--- a/packages/sdk/src/mcp/stub.ts
+++ b/packages/sdk/src/mcp/stub.ts
@@ -61,6 +61,7 @@ export function createMCPFetchStub<TDefinition extends readonly ApiHandler[]>(
         }
 
         return async (args: unknown, init?: RequestInit) => {
+          const traceDebugId = getTraceDebugId();
           const workspace = options?.workspace ?? "";
           const response = await fetch(
             new URL(
@@ -76,7 +77,7 @@ export function createMCPFetchStub<TDefinition extends readonly ApiHandler[]>(
               ...init,
               headers: {
                 ...init?.headers,
-                "x-trace-debug-id": getTraceDebugId(),
+                "x-trace-debug-id": traceDebugId,
               },
             },
           );
@@ -87,6 +88,7 @@ export function createMCPFetchStub<TDefinition extends readonly ApiHandler[]>(
             throw getErrorByStatusCode(
               response.status,
               data.error || "Internal Server Error",
+              traceDebugId,
             );
           }
 


### PR DESCRIPTION
Adds x-debug-trace-id to the frontend so we can look at errors on hyperdx

<img width="351" alt="Screenshot 2025-05-19 at 19 31 00" src="https://github.com/user-attachments/assets/a8d9659a-da0c-4f7b-a572-f9359143bded" />
