### PR TITLE
fix: requires text for submission

### DIFF
--- a/apps/web/src/components/chat/ChatInput.tsx
+++ b/apps/web/src/components/chat/ChatInput.tsx
@@ -370,8 +370,7 @@ ChatInput.UI = (
                   <Button
                     type={isLoading ? "button" : "submit"}
                     size="icon"
-                    disabled={isUploading || (!isLoading &&
-                      (!input.trim() && uploadedFiles.length === 0))}
+                    disabled={isUploading || (!isLoading && !input.trim())}
                     onClick={isLoading ? stop : undefined}
                     className="h-8 w-8 transition-all hover:opacity-70"
                     title={isLoading


### PR DESCRIPTION
Somehow, we can't upload files only. vercel ai sdk has some quirks that prevent this from happening. 

A temporary fix is to disable the submit button before any text is written.

Bug evidence:

![May-21-2025 11-11-55](https://github.com/user-attachments/assets/9d70033c-66fc-4303-a4d3-ccdebd9b07d6)
