### PR TITLE
fix: fix team member fetching logic in UserInfo component

### DIFF
--- a/apps/web/src/components/common/TableCells.tsx
+++ b/apps/web/src/components/common/TableCells.tsx
@@ -74,12 +74,10 @@ function UserInfo({
   // If userId matches current user, use user data directly
   const isCurrentUser = userId && user && userId === user.id;
 
-  // Only fetch team members if not current user and teamId is not null
-  const members = (!isCurrentUser && teamId !== null)
-    ? useTeamMembers(teamId).data
-    : undefined;
+  const { data: teamMembers = [] } = useTeamMembers(teamId ?? null);
+  const members = (!isCurrentUser && teamId !== null) ? teamMembers : [];
   const member = useMemo(
-    () => members?.find((m) => m.user_id === userId),
+    () => members.find((m) => m.user_id === userId),
     [members, userId],
   );
 


### PR DESCRIPTION
- Simplified the logic for fetching team members by directly using the data from useTeamMembers.
- Ensured that members are set to an empty array if the current user is being displayed or if teamId is null.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 