### PR TITLE
fix: refetch audit list and messages on every render to avoid cached messages

### DIFF
--- a/apps/web/src/components/agent/edit.tsx
+++ b/apps/web/src/components/agent/edit.tsx
@@ -100,14 +100,15 @@ const TABS: Record<string, Tab> = {
     title: "Setup",
     initialOpen: "within",
   },
-  chat: {
-    Component: Chat,
-    title: "Chat preview",
-    initialOpen: "right",
-  },
   audit: {
     Component: Audit,
     title: "History",
+    initialOpen: "right",
+  },
+  chat: {
+    Component: Chat,
+    title: "Chat preview",
+    initialOpen: "within",
   },
 };
 

--- a/packages/sdk/src/hooks/audit.ts
+++ b/packages/sdk/src/hooks/audit.ts
@@ -9,5 +9,7 @@ export const useAuditEvents = (options: ThreadFilterOptions = {}) => {
   return useQuery({
     queryKey: KEYS.AUDITS(workspace, options),
     queryFn: ({ signal }) => listThreads(workspace, options, { signal }),
+    staleTime: 0,
+    gcTime: 0,
   });
 };

--- a/packages/sdk/src/hooks/thread.ts
+++ b/packages/sdk/src/hooks/thread.ts
@@ -35,6 +35,8 @@ export const useThreadMessages = (threadId: string) => {
   return useSuspenseQuery({
     queryKey: KEYS.THREAD_MESSAGES(workspace, threadId),
     queryFn: ({ signal }) => getThreadMessages(workspace, threadId, { signal }),
+    staleTime: 0,
+    gcTime: 0,
   });
 };
 


### PR DESCRIPTION
Addresses the issue when the user see some messages from some time ago. Slows down the UI, but it's worth for now. 

I'll eventually come back on this in the future