### PR TITLE
Refactoring: Replace useNavigate with useNavigateWorkspace.

### DIFF
--- a/apps/web/src/components/agents/list.tsx
+++ b/apps/web/src/components/agents/list.tsx
@@ -42,10 +42,10 @@ import {
   useReducer,
   useState,
 } from "react";
-import { useNavigate } from "react-router";
 import { ErrorBoundary } from "../../ErrorBoundary.tsx";
 import { trackEvent } from "../../hooks/analytics.ts";
 import { useLocalStorage } from "../../hooks/useLocalStorage.ts";
+import { useNavigateWorkspace } from "../../hooks/useNavigateWorkspace.ts";
 import { getPublicChatLink } from "../agent/chats.tsx";
 import { AgentVisibility } from "../common/AgentVisibility.tsx";
 import { AgentAvatar, Avatar } from "../common/Avatar.tsx";
@@ -102,7 +102,7 @@ export const useDuplicateAgent = (agent: Agent | null) => {
 
 function IntegrationMiniature({ toolSetId }: { toolSetId: string }) {
   const { data: integration } = useIntegration(toolSetId);
-  const navigate = useNavigate();
+  const navigateWorkspace = useNavigateWorkspace();
 
   if (!integration) {
     return null;
@@ -116,7 +116,7 @@ function IntegrationMiniature({ toolSetId }: { toolSetId: string }) {
         <TooltipTrigger
           onClick={(e) => {
             e.stopPropagation();
-            navigate(`/integration/${integration.id}`);
+            navigateWorkspace(`/integration/${integration.id}`);
           }}
           asChild
         >


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
When clicking on integration badges in the agent list, users were being redirected to their personal workspace instead of staying within their current team context.

**Solution**
- Replaced useNavigate with useNavigateWorkspace hook in the IntegrationMiniature component
- Removed unused useNavigate import
- The useNavigateWorkspace hook automatically preserves the team slug from the current URL and constructs the correct path

**Changes**
- Updated apps/web/src/components/agents/list.tsx:
- Added import for useNavigateWorkspace hook
- Replaced navigate() with navigateWorkspace() in integration click handler
- Removed unused useNavigate import

**Impact**

Users will now remain in their team workspace when navigating to integration details from the agent list, providing a consistent team-scoped experience.

## Screenshots/Demonstration

**In Prod:**
![ezgif-54767dfbb4cd91](https://github.com/user-attachments/assets/d90c7f35-6e16-4d3a-bf38-69fdd685dbd7)

**The refactor:**
![ezgif-3c1cae243fc634 (1)](https://github.com/user-attachments/assets/069d24c7-8cb0-4233-b07d-770d9a3f5a68)




## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes 