### PR TITLE
feat: add auto-join team functionality for @deco.cx users

### DIFF
--- a/apps/web/src/components/common/AccessDeniedWithJoinOption.tsx
+++ b/apps/web/src/components/common/AccessDeniedWithJoinOption.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { useLocation, useParams } from "react-router";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
+import { toast } from "@deco/ui/components/sonner.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import type { ComponentProps, ReactNode } from "react";
+import { useUser } from "../../hooks/data/useUser.ts";
+import { useAutoJoinTeam } from "@deco/sdk";
+
+export function AccessDeniedWithJoinOption({
+  icon,
+  title,
+  description,
+  buttonProps,
+}: {
+  icon: string;
+  title: string;
+  description: string | ReactNode;
+  buttonProps: ComponentProps<typeof Button>;
+}) {
+  const { teamSlug } = useParams<{ teamSlug?: string }>();
+  const location = useLocation();
+  const user = useUser();
+  const autoJoinMutation = useAutoJoinTeam();
+  const [isJoining, setIsJoining] = useState(false);
+
+  // Check if user has @deco.cx email and we're in a team context
+  const isDecoUser = user?.email?.endsWith("@deco.cx");
+  const isTeamContext = teamSlug && location.pathname.includes(`/${teamSlug}/`);
+  const showJoinButton = isDecoUser && isTeamContext;
+
+  const handleJoinTeam = async () => {
+    if (!teamSlug) return;
+    
+    setIsJoining(true);
+    try {
+      await autoJoinMutation.mutateAsync(teamSlug);
+      toast.success("Successfully joined team! Refreshing page...");
+      
+      // Refresh the page to grant access
+      setTimeout(() => {
+        globalThis.location.reload();
+      }, 1000);
+    } catch (error) {
+      console.error("Failed to join team:", error);
+      toast.error("Failed to join team. Please try again or contact support.");
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-6 relative">
+      <div className="absolute flex items-center justify-center mb-80">
+        <div className="p-6 rounded-full border border-slate-50">
+          <div className="p-4 rounded-full border border-slate-100">
+            <div className="p-3.5 rounded-full border border-slate-100">
+              <div className="p-3 rounded-full border border-slate-100">
+                <div className="w-20 h-20 rounded-full bg-slate-50 flex items-center justify-center p-4">
+                  <Icon name={icon} className="text-slate-300" size={36} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-2 max-w-md z-10">
+        <h3 className="text-2xl font-semibold text-foreground text-center">
+          {title}
+        </h3>
+        <div className="text-sm text-muted-foreground text-center flex flex-col gap-1">
+          {description}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 z-10">
+        {showJoinButton && (
+          <Button
+            onClick={handleJoinTeam}
+            disabled={isJoining}
+            variant="default"
+            size="default"
+            className="gap-2"
+          >
+            {isJoining ? (
+              <>
+                <Icon name="loader-2" className="animate-spin" size={16} />
+                Joining Team...
+              </>
+            ) : (
+              <>
+                <Icon name="users" size={16} />
+                Join Team
+              </>
+            )}
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="default"
+          className={cn("gap-2", buttonProps?.className)}
+          {...buttonProps}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -16,6 +16,7 @@ import {
   useRouteError,
 } from "react-router";
 import { EmptyState } from "./components/common/EmptyState.tsx";
+import { AccessDeniedWithJoinOption } from "./components/common/AccessDeniedWithJoinOption.tsx";
 
 type LazyComp<P> = Promise<{
   default: React.ComponentType<P>;
@@ -156,7 +157,7 @@ function ErrorFallback() {
 
   if (error instanceof ForbiddenError) {
     return (
-      <EmptyState
+      <AccessDeniedWithJoinOption
         icon="report"
         title="Access Denied"
         description={

--- a/packages/sdk/src/crud/members.ts
+++ b/packages/sdk/src/crud/members.ts
@@ -112,3 +112,17 @@ export const removeTeamMember = (
 export const registerActivity = (teamId: number) => {
   MCPClient.TEAM_MEMBER_ACTIVITY_REGISTER({ teamId });
 };
+
+/**
+ * Auto-join team for @deco.cx users
+ * @param teamSlug - The slug of the team to join
+ * @returns Success status and team info
+ */
+export const autoJoinTeamForDecoUsers = (
+  teamSlug: string,
+): Promise<{
+  success: boolean;
+  message: string;
+  teamId: number;
+  teamSlug: string;
+}> => MCPClient.TEAM_AUTO_JOIN_DECO({ teamSlug });

--- a/packages/sdk/src/hooks/members.ts
+++ b/packages/sdk/src/hooks/members.ts
@@ -6,6 +6,7 @@ import {
 import { useEffect } from "react";
 import {
   acceptInvite,
+  autoJoinTeamForDecoUsers,
   getMyInvites,
   getTeamMembers,
   getTeamRoles,
@@ -127,4 +128,21 @@ export const useRegisterActivity = (teamId?: number) => {
 
     registerActivity(teamId);
   }, [teamId]);
+};
+
+/**
+ * Hook to auto-join team for @deco.cx users
+ * @returns Mutation function for auto-joining a team
+ */
+export const useAutoJoinTeam = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (teamSlug: string) => autoJoinTeamForDecoUsers(teamSlug),
+    onSuccess: () => {
+      // Invalidate teams and member queries to refresh the data
+      queryClient.invalidateQueries({ queryKey: KEYS.TEAMS() });
+      queryClient.invalidateQueries({ queryKey: ["team_members"] });
+    },
+  });
 };

--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -29,6 +29,7 @@ export const GLOBAL_TOOLS = [
   membersAPI.acceptInvite,
   membersAPI.inviteTeamMembers,
   membersAPI.teamRolesList,
+  membersAPI.autoJoinTeamForDecoUsers,
   profilesAPI.getProfile,
   profilesAPI.updateProfile,
   integrationsAPI.callTool,


### PR DESCRIPTION
Add Join Team functionality for @deco.cx users on Access Denied pages

This PR implements the requested feature from issue #407:

- Adds TEAM_AUTO_JOIN_DECO API tool that validates @deco.cx email and adds users to teams
- Creates AccessDeniedWithJoinOption component with conditional Join Team button
- Adds useAutoJoinTeam hook for frontend team joining
- Modifies ErrorFallback to show Join Team option for @deco.cx users on access denied errors
- Auto-refreshes page after successful team join to grant immediate access

Resolves #407

Generated with [Claude Code](https://claude.ai/code)