### PR TITLE
fix: use workspace-aware navigation for "New Agent" button in triggers

### DIFF
--- a/apps/web/src/components/triggers/triggerModal.tsx
+++ b/apps/web/src/components/triggers/triggerModal.tsx
@@ -28,6 +28,7 @@ import { CronTriggerForm } from "./cronTriggerForm.tsx";
 import { WebhookTriggerForm } from "./webhookTriggerForm.tsx";
 import { TriggerOutputSchema } from "@deco/sdk";
 import { z } from "zod";
+import { useNavigateWorkspace } from "../../hooks/useNavigateWorkspace.ts";
 
 function AgentSelect({
   agents,
@@ -94,6 +95,7 @@ export function TriggerModal(
   },
 ) {
   const { data: agents = [] } = useAgents();
+  const navigateWorkspace = useNavigateWorkspace();
   const [selectedAgentId, setSelectedAgentId] = useState<string>(
     trigger?.agent?.id || agentId || agents[0]?.id || "",
   );
@@ -122,7 +124,7 @@ export function TriggerModal(
               buttonProps={{
                 onClick: () => {
                   onOpenChange?.(false);
-                  globalThis.location.href = "/agents";
+                  navigateWorkspace("/agents");
                 },
                 variant: "special",
                 className: "mt-2",


### PR DESCRIPTION
The "New Agent" button in the triggers modal was hardcoded to navigate to "/agents" instead of using the current workspace context. This caused users in team workspaces to be redirected to their personal workspace.

Fixed by replacing the hardcoded navigation with the `useNavigateWorkspace()` hook that properly handles workspace-specific routing.

Fixes #414

Generated with [Claude Code](https://claude.ai/code)