### PR TITLE
fix: remove og:url to fix linkedin links

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,7 +14,6 @@
       content="Build AI that cares about your brand and strategy, with autonomy and governance"
     />
     <meta property="og:image" content="https://deco.chat/img/seo.jpg" />
-    <meta property="og:url" content="https://deco.chat" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="https://deco.chat/img/seo.jpg" />


### PR DESCRIPTION
When Open graph renders the image preview, it renders the url alongside it. Since we don't have ssr, it was rendering always deco.chat, taking users to the wrong link.

Removing this property ensures the user will be redirected to the right url