### PR TITLE
Refactor channel handling to use Integration binding

### DIFF
--- a/apps/web/src/components/settings/channels.tsx
+++ b/apps/web/src/components/settings/channels.tsx
@@ -28,8 +28,7 @@ import { Link } from "react-router";
 import { useWorkspaceLink } from "../../hooks/use-navigate-workspace.ts";
 import { useAgentSettingsForm } from "../agent/edit.tsx";
 import { IntegrationIcon } from "../integrations/list/common.tsx";
-import { MCPConnection } from "@deco/sdk";
-import { Channel } from "@deco/sdk/models";
+import { Channel, Integration } from "@deco/sdk/models";
 
 interface ChannelsProps {
   className?: string;
@@ -359,7 +358,7 @@ export function Channels({ className }: ChannelsProps) {
                 (
                   <ConnectionChannels
                     key={selectedBindingId}
-                    connection={selectedBinding?.connection}
+                    binding={selectedBinding}
                     discriminator={discriminator}
                     setDiscriminator={setDiscriminator}
                     setName={setName}
@@ -409,44 +408,54 @@ export function Channels({ className }: ChannelsProps) {
 }
 
 function ConnectionChannels(
-  { connection, discriminator, setDiscriminator, setName }: {
-    connection: MCPConnection;
+  { binding, discriminator, setDiscriminator, setName }: {
+    binding: Integration;
     discriminator: string;
     setDiscriminator: (discriminator: string) => void;
     setName: (name: string | undefined) => void;
   },
 ) {
   const { data: availableChannels, isLoading: isLoadingAvailableChannels } =
-    useConnectionChannels(connection);
+    useConnectionChannels(binding);
+  if (isLoadingAvailableChannels) {
+    return (
+      <div className="w-full flex items-center gap-2">
+        <Spinner size="sm" />
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
   return (
     <div className="w-full">
       <Label htmlFor="discriminator">
         Channel
       </Label>
       <div className="mt-2 w-full">
-        <Select
-          onValueChange={(value) => {
-            const nameForChannel = availableChannels?.channels?.find((
-              channel,
-            ) => channel.value === value)?.label;
-            setDiscriminator(value);
-            setName(nameForChannel);
-          }}
-          disabled={isLoadingAvailableChannels}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select a channel" />
-          </SelectTrigger>
-          <SelectContent className="w-full">
-            {availableChannels?.channels?.map((channel) => {
-              return (
-                <SelectItem key={channel.value} value={channel.value}>
-                  {channel.label}
-                </SelectItem>
-              );
-            })}
-          </SelectContent>
-        </Select>
+        {availableChannels?.channels?.length && (
+          <Select
+            onValueChange={(value) => {
+              const nameForChannel = availableChannels?.channels?.find((
+                channel,
+              ) => channel.value === value)?.label;
+              setDiscriminator(value);
+              setName(nameForChannel);
+            }}
+            disabled={isLoadingAvailableChannels}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select a channel" />
+            </SelectTrigger>
+            <SelectContent className="w-full">
+              {availableChannels?.channels?.map((channel) => {
+                return (
+                  <SelectItem key={channel.value} value={channel.value}>
+                    {channel.label}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        )}
         {(!availableChannels?.channels && !isLoadingAvailableChannels) && (
           <Input
             id="discriminator"

--- a/packages/sdk/src/hooks/channels.ts
+++ b/packages/sdk/src/hooks/channels.ts
@@ -12,7 +12,7 @@ import {
 import { InternalServerError } from "../errors.ts";
 import { KEYS } from "./api.ts";
 import { useSDK } from "./store.tsx";
-import { MCPConnection } from "../index.ts";
+import { Integration } from "../index.ts";
 
 export const useCreateChannel = () => {
   const client = useQueryClient();
@@ -165,15 +165,15 @@ export const useChannels = () => {
   return data;
 };
 
-export const useConnectionChannels = (connection: MCPConnection) => {
+export const useConnectionChannels = (binding: Integration) => {
   const { workspace } = useSDK();
 
   const data = useQuery({
-    queryKey: KEYS.CHANNELS(workspace, connection.type), // TODO: use the connection id ?
+    queryKey: KEYS.CHANNELS(workspace, binding.id),
     queryFn: async () => {
       const result = await listAvailableChannelsForConnection(
         workspace,
-        connection,
+        binding.connection,
       ).catch((error) => {
         console.error(error);
         return { channels: [] };


### PR DESCRIPTION
- Updated the `Channels` component to utilize `Integration` instead of `MCPConnection`.
- Modified the `ConnectionChannels` component to accept `binding` as a prop.
- Enhanced the channel selection logic to conditionally render the `Select` component based on available channels.
- Adjusted hooks to align with the new binding structure for fetching channels.

This refactor improves code clarity and aligns the channel management with the updated SDK models.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 