### PR TITLE
fix: resolve contact us email encoding and address issues

### DIFF
--- a/apps/web/src/hooks/use-contact-us.ts
+++ b/apps/web/src/hooks/use-contact-us.ts
@@ -4,16 +4,14 @@
 import { useSDK } from "@deco/sdk";
 
 const getContactUsUrl = (workspace: string) => {
-  const url = new URL("mailto:sales@deco.chat");
+  const url = new URL("mailto:sales_decochat@deco.cx");
   url.searchParams.set(
     "subject",
-    encodeURIComponent(`Workspace ${workspace} Plan Upgrade`),
+    `Workspace ${workspace} Plan Upgrade`,
   );
   url.searchParams.set(
     "body",
-    encodeURIComponent(
-      `Hi, I'm a member of workspace ${workspace} on deco chat and I'd like to upgrade my plan so I can invite other member to join my workspace`,
-    ),
+    `Hi, I'm a member of workspace ${workspace} on deco chat and I'd like to upgrade my plan so I can invite other member to join my workspace`,
   );
   return url.toString();
 };


### PR DESCRIPTION
Fixes the contact us email functionality by:

- Removing double URL encoding that caused %020 to appear in spaces
- Updating email address from sales@deco.chat to sales_decochat@deco.cx

Fixes #486

Generated with [Claude Code](https://claude.ai/code)