### PR TITLE
fix: update Vite build targets to support top-level await

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "ai": "^4.3.13",
     "cloudflare": "^4.2.0",
     "hono": "^4.7.7",
-    "zod": "3.24.3"
+    "zod": "3.25.6"
   },
   "devDependencies": {
     "supabase": "^2.22.12",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "@deco/sdk": "^0.1.1",
     "@deco/ui": "^1.0.0",
     "@gsap/react": "^2.1.2",
-    "@hookform/resolvers": "^5.0.1",
+    "@hookform/resolvers": "^3.3.4",
     "@tanstack/react-query": "^5.72.0",
     "@tiptap/extension-placeholder": "^2.11.7",
     "@tiptap/react": "^2.11.7",
@@ -41,7 +41,7 @@
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.3",
     "tiptap-markdown": "^0.8.10",
-    "zod": "3.24.3"
+    "zod": "3.25.6"
   },
   "devDependencies": {
     "@std/assert": "npm:@jsr/std__assert@1.0.13",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,4 +6,15 @@ import { defineConfig, type PluginOption } from "vite";
 export default defineConfig({
   plugins: [react() as PluginOption[], tailwindcss() as PluginOption[]],
   server: { port: 3000, allowedHosts: [".deco.host"] },
+  build: {
+    target: ["es2022", "chrome89", "firefox89", "safari15"],
+  },
+  esbuild: {
+    target: "es2022",
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "es2022",
+    },
+  },
 });

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,7 +23,7 @@
     "@mastra/memory": "0.3.0",
     "@modelcontextprotocol/sdk": "1.11.4",
     "ai": "^4.1.61",
-    "zod": "3.24.3",
+    "zod": "3.25.6",
     "zod-to-json-schema": "^3.24.4",
     "@deco/actors": "npm:@jsr/deco__actors@0.33.1",
     "@ai-sdk/provider-utils": "^2.0.5",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,7 +23,7 @@
     "lru-cache": "^11.1.0",
     "react": "^19.1.0",
     "stripe": "18.0.0",
-    "zod": "3.24.3",
+    "zod": "3.25.6",
     "@aws-sdk/client-s3": "^3.808.0",
     "uuid": "^11.1.0",
     "@tursodatabase/api": "^1.9.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,7 +57,7 @@
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
-    "zod": "3.24.3"
+    "zod": "3.25.56"
   },
   "packageManager": "npm@10.5.0",
   "devDependencies": {


### PR DESCRIPTION
Resolves build error with @jsr/deco__actors package - Updated targets to ES2022 and modern browsers (Chrome 89+, Firefox 89+, Safari 15+) 

![image](https://github.com/user-attachments/assets/5af15387-e798-47c6-806f-375fc1fab764)
