### PR TITLE
Set outbound worker for *.deco.page workers

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import { timing } from "hono/timing";
 import api from "./api.ts";
 import apps, { withAppsJWTToken } from "./apps.ts";
 import { AppEnv } from "./utils/context.ts";
+import outbound from "./outbound.ts";
 
 export const APPS_DOMAIN_QS = "app_host";
 
@@ -42,5 +43,5 @@ app.use(timing({ crossOrigin: true, total: true }));
 app.use(`/${Hosts.API}/*`, withAppsJWTToken);
 app.route(`/${Hosts.API}`, api);
 app.route(`/${Hosts.APPS}`, apps);
-app.route(`/${Hosts.APPS_OUTBOUND}`, apps);
+app.route(`/${Hosts.APPS_OUTBOUND}`, outbound);
 export default app;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,9 +1,9 @@
+import { Hosts } from "@deco/sdk/hosts";
 import { Hono } from "hono";
 import { timing } from "hono/timing";
 import api from "./api.ts";
-import apps from "./apps.ts";
+import apps, { withAppsJWTToken } from "./apps.ts";
 import { AppEnv } from "./utils/context.ts";
-import { Hosts } from "@deco/sdk/hosts";
 
 export const APPS_DOMAIN_QS = "app_host";
 
@@ -15,30 +15,32 @@ export const appsDomainOf = (req: Request, url?: URL) => {
     (referer && new URL(referer).searchParams.get(APPS_DOMAIN_QS));
 };
 
-const normalizeHost = (req: Request) => {
+const normalizeHost = (req: Request, env?: AppEnv["Bindings"]) => {
   const host = req.headers.get("host") ?? "localhost";
   const appsHost = appsDomainOf(req);
   if (appsHost) {
     return Hosts.APPS;
   }
+  const catchall = env?.DECO_CHAT_APP_ORIGIN ? Hosts.APPS_OUTBOUND : Hosts.APPS;
   return {
     [Hosts.API]: Hosts.API,
     localhost: Hosts.API,
     "localhost:3001": Hosts.API,
     "localhost:8000": Hosts.API,
-  }[host] ?? Hosts.APPS;
+  }[host] ?? catchall;
 };
 
 export const app = new Hono<AppEnv>({
-  getPath: (req) =>
+  getPath: (req, env) =>
     "/" +
-    normalizeHost(req) +
+    normalizeHost(req, env?.env) +
     req.url.replace(/^https?:\/\/[^/]+(\/[^?]*)(?:\?.*)?$/, "$1"),
 });
 
 app.use(timing({ crossOrigin: true, total: true }));
 
+app.use(`/${Hosts.API}/*`, withAppsJWTToken);
 app.route(`/${Hosts.API}`, api);
 app.route(`/${Hosts.APPS}`, apps);
-
+app.route(`/${Hosts.APPS_OUTBOUND}`, apps);
 export default app;

--- a/apps/api/src/apps.ts
+++ b/apps/api/src/apps.ts
@@ -1,6 +1,7 @@
-import { Hono } from "hono";
-import { getRuntimeKey } from "hono/adapter";
+import { createSessionTokenCookie, JwtIssuer } from "@deco/sdk/auth";
 import { Entrypoint } from "@deco/sdk/mcp";
+import { Context, Hono, Next } from "hono";
+import { getRuntimeKey } from "hono/adapter";
 import { APPS_DOMAIN_QS, appsDomainOf } from "./app.ts";
 import { AppEnv } from "./utils/context.ts";
 export type DispatcherFetch = typeof fetch;
@@ -30,7 +31,13 @@ app.all("/*", async (c) => {
     url.port = `443`;
     url.searchParams.delete(APPS_DOMAIN_QS);
   }
-  const scriptFetcher = dispatcher.get(script);
+  const scriptFetcher = dispatcher.get(script, {}, {
+    outbound: {
+      params_object: {
+        DECO_CHAT_APP_ORIGIN: script,
+      },
+    },
+  });
   const req = new Request(url, c.req.raw);
   const response = await scriptFetcher.fetch(req).catch((err) => {
     if ("message" in err && err.message.startsWith("Worker not found")) {
@@ -46,3 +53,47 @@ app.all("/*", async (c) => {
   return response;
 });
 export default app;
+
+/**
+ * Issues a token for the given app origin.
+ *
+ * This is used to allow apps to make outbound requests to the API.
+ *
+ * @param c
+ * @param next
+ * @returns
+ */
+export const withAppsJWTToken = async (c: Context<AppEnv>, next: Next) => {
+  const dispatchScript = c.env.DECO_CHAT_APP_ORIGIN;
+  const jwtSecret = c.env.ISSUER_JWT_SECRET;
+  if (!dispatchScript || typeof jwtSecret !== "string") {
+    await next();
+    return c.res;
+  }
+  console.log("invoking with dispatcher", dispatchScript);
+
+  const { data, error } = await c.var.db
+    .from("deco_chat_hosting_apps")
+    .select("*")
+    .eq("slug", dispatchScript).maybeSingle();
+  if (error) {
+    console.error("error querying script", error);
+    return new Response(null, { status: 500 });
+  }
+  if (!data) {
+    return new Response(null, { status: 404 });
+  }
+  const jwt = JwtIssuer.forSecret(jwtSecret);
+  const token = await jwt.create({
+    sub: `app:${dispatchScript}`,
+    aud: data.workspace,
+  });
+
+  const cookie = createSessionTokenCookie(
+    token,
+    new URL(c.req.raw.url).hostname,
+  );
+
+  c.req.raw.headers.append("Cookie", cookie);
+  return next();
+};

--- a/apps/api/src/outbound.ts
+++ b/apps/api/src/outbound.ts
@@ -1,0 +1,14 @@
+import { Hono } from "hono";
+import { getRuntimeKey } from "hono/adapter";
+import { AppEnv } from "./utils/context.ts";
+export const app = new Hono<AppEnv>();
+
+app.all("/*", async (c) => {
+  console.log("proxying outbound request", c.req.url);
+  const response = await fetch(c.req.raw);
+  if (getRuntimeKey() === "workerd") { // needs to be copied when resp is from an a external dispatcher.
+    return new Response(response.body, response);
+  }
+  return response;
+});
+export default app;

--- a/apps/api/src/utils/context.ts
+++ b/apps/api/src/utils/context.ts
@@ -7,7 +7,14 @@ export * from "@deco/sdk/mcp";
 export type AppEnv = {
   Variables: Vars & TimingVariables;
   Bindings: EnvVars & {
-    PROD_DISPATCHER: { get: (script: string) => { fetch: typeof fetch } };
+    DECO_CHAT_APP_ORIGIN?: string;
+    PROD_DISPATCHER: {
+      get: (
+        script: string,
+        ctx?: Record<string, unknown>,
+        metadata?: { outbound?: { params_object?: Record<string, unknown> } },
+      ) => { fetch: typeof fetch };
+    };
   };
 };
 

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -17,6 +17,7 @@ enabled = true
 [[dispatch_namespaces]]
 binding = "PROD_DISPATCHER"
 namespace = "deco-chat-prod"
+outbound = { service = "deco-chat-api", parameters = ["params_object"] }
 
 services = [{ binding = "WALLET", service = "wallet" }]
 

--- a/packages/sdk/src/hosts.ts
+++ b/packages/sdk/src/hosts.ts
@@ -3,6 +3,7 @@ export const Hosts = {
   APPS: "deco.page",
   FS: "fs.deco.chat",
   Chat: "deco.chat",
+  APPS_OUTBOUND: "used-for-apps-outbound-requests.deco.chat",
   LOCALHOST: "localhost:3000",
 } as const;
 


### PR DESCRIPTION
# Add Outbound Worker Support for Workspace API Access

## Overview
This PR implements an outbound worker solution to enable secure access to tenant APIs (api.deco.chat) from dispatched workers running on *.deco.page domains. The implementation leverages Cloudflare's Outbound Workers feature to intercept and authenticate requests to our API endpoints.

## Problem
Currently, dispatched workers running on *.deco.page domains cannot securely access tenant-specific APIs exposed through api.deco.chat. This creates a limitation where tenant-specific functionality cannot be accessed from the dispatched workers.

## Solution
We've implemented an outbound worker pattern that:
1. Intercepts all outbound requests from dispatched workers
2. Identifies requests targeting api.deco.chat
3. Issues JWT tokens for authenticated API access
4. Proxies requests to their intended destinations

## Implementation Details

### Flow Diagram
```mermaid
sequenceDiagram
    participant Client
    participant DispatchedWorker as *.deco.page Worker
    participant OutboundWorker
    participant APIMiddleware
    participant TenantAPI as api.deco.chat

    Client->>DispatchedWorker: Request
    DispatchedWorker->>OutboundWorker: Outbound Request
    alt Request to api.deco.chat
        OutboundWorker->>APIMiddleware: Request with Binding
        APIMiddleware->>APIMiddleware: Validate & Issue JWT
        APIMiddleware->>TenantAPI: Authenticated Request
        TenantAPI-->>Client: Response
    else Other Request
        OutboundWorker->>OutboundWorker: Proxy Request
        OutboundWorker-->>Client: Response
    end
```

### Key Changes
1. Added outbound worker configuration in `apps.ts` to intercept all outbound requests
2. Implemented JWT token issuance middleware in `app.ts` and `apps.ts`
3. Created proxy logic in `outbound.ts` for non-API requests
4. Added tenant workspace validation through database queries

### Security Considerations
- JWT tokens are issued only for valid tenant workspaces
- Tokens are scoped to specific app origins
- All API requests are authenticated before reaching tenant endpoints

## Related Links
- [Cloudflare Outbound Workers Documentation](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/outbound-workers/)