### PR TITLE
feat: add generate passphrase button for webhook triggers

### DIFF
--- a/apps/web/src/components/triggers/webhook-trigger-form.tsx
+++ b/apps/web/src/components/triggers/webhook-trigger-form.tsx
@@ -22,14 +22,15 @@ import Ajv from "ajv";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { IntegrationIcon } from "../integrations/common.tsx";
+import { BindingSelector } from "../toolsets/binding-selector.tsx";
+import { SingleToolSelector } from "../toolsets/single-selector.tsx";
 
-// Generate a secure random passphrase
 function generateSecurePassphrase(): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
   const length = 24;
   let result = '';
   
-  // Use crypto.getRandomValues for secure random generation
   const array = new Uint8Array(length);
   crypto.getRandomValues(array);
   
@@ -39,9 +40,6 @@ function generateSecurePassphrase(): string {
   
   return result;
 }
-import { IntegrationIcon } from "../integrations/common.tsx";
-import { BindingSelector } from "../toolsets/binding-selector.tsx";
-import { SingleToolSelector } from "../toolsets/single-selector.tsx";
 
 function JsonSchemaInput({ value, onChange }: {
   value: string | undefined;
@@ -252,7 +250,6 @@ export function WebhookTriggerForm({
                 <Input
                   {...field}
                   placeholder="Send birthday message"
-                  className="rounded-md"
                   required
                 />
               </FormControl>
@@ -294,13 +291,11 @@ export function WebhookTriggerForm({
                   <Input
                     {...field}
                     placeholder="Enter passphrase or generate one"
-                    className="rounded-md"
                     type="text"
                   />
                   <Button
                     type="button"
                     variant="secondary"
-                    size="sm"
                     onClick={handleGeneratePassphrase}
                     className="whitespace-nowrap"
                   >

--- a/apps/web/src/components/triggers/webhook-trigger-form.tsx
+++ b/apps/web/src/components/triggers/webhook-trigger-form.tsx
@@ -26,21 +26,6 @@ import { IntegrationIcon } from "../integrations/common.tsx";
 import { BindingSelector } from "../toolsets/binding-selector.tsx";
 import { SingleToolSelector } from "../toolsets/single-selector.tsx";
 
-function generateSecurePassphrase(): string {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
-  const length = 24;
-  let result = '';
-  
-  const array = new Uint8Array(length);
-  crypto.getRandomValues(array);
-  
-  for (let i = 0; i < length; i++) {
-    result += chars[array[i] % chars.length];
-  }
-  
-  return result;
-}
-
 function JsonSchemaInput({ value, onChange }: {
   value: string | undefined;
   onChange: (v: string) => void;
@@ -154,6 +139,21 @@ export function WebhookTriggerForm({
       type: "webhook",
     },
   });
+
+  function generateSecurePassphrase(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
+    const length = 24;
+    let result = '';
+    
+    const array = new Uint8Array(length);
+    crypto.getRandomValues(array);
+    
+    for (let i = 0; i < length; i++) {
+      result += chars[array[i] % chars.length];
+    }
+    
+    return result;
+  }
 
   function handleOutputSchemaChange(val: string) {
     form.setValue("schema", val, { shouldValidate: true });

--- a/apps/web/src/components/triggers/webhook-trigger-form.tsx
+++ b/apps/web/src/components/triggers/webhook-trigger-form.tsx
@@ -102,7 +102,8 @@ type WebhookTriggerFormType = z.infer<typeof FormSchema>;
 type WebhookTriggerData = z.infer<typeof WebhookTriggerSchema>;
 
 function generateSecurePassphrase(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
   const length = 24;
   let result = "";
   

--- a/apps/web/src/components/triggers/webhook-trigger-form.tsx
+++ b/apps/web/src/components/triggers/webhook-trigger-form.tsx
@@ -22,6 +22,23 @@ import Ajv from "ajv";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+
+// Generate a secure random passphrase
+function generateSecurePassphrase(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
+  const length = 24;
+  let result = '';
+  
+  // Use crypto.getRandomValues for secure random generation
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  
+  for (let i = 0; i < length; i++) {
+    result += chars[array[i] % chars.length];
+  }
+  
+  return result;
+}
 import { IntegrationIcon } from "../integrations/common.tsx";
 import { BindingSelector } from "../toolsets/binding-selector.tsx";
 import { SingleToolSelector } from "../toolsets/single-selector.tsx";
@@ -142,6 +159,11 @@ export function WebhookTriggerForm({
 
   function handleOutputSchemaChange(val: string) {
     form.setValue("schema", val, { shouldValidate: true });
+  }
+
+  function handleGeneratePassphrase() {
+    const newPassphrase = generateSecurePassphrase();
+    form.setValue("passphrase", newPassphrase, { shouldValidate: true });
   }
 
   const onSubmit = (data: WebhookTriggerFormType) => {
@@ -268,12 +290,24 @@ export function WebhookTriggerForm({
                 <span className="text-xs text-muted-foreground">Optional</span>
               </div>
               <FormControl>
-                <Input
-                  {...field}
-                  placeholder="Passphrase"
-                  className="rounded-md"
-                  type="text"
-                />
+                <div className="flex gap-2">
+                  <Input
+                    {...field}
+                    placeholder="Enter passphrase or generate one"
+                    className="rounded-md"
+                    type="text"
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleGeneratePassphrase}
+                    className="whitespace-nowrap"
+                  >
+                    <Icon name="refresh" size={16} className="mr-1" />
+                    Generate
+                  </Button>
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/apps/web/src/components/triggers/webhook-trigger-form.tsx
+++ b/apps/web/src/components/triggers/webhook-trigger-form.tsx
@@ -101,6 +101,21 @@ type WebhookTriggerFormType = z.infer<typeof FormSchema>;
 
 type WebhookTriggerData = z.infer<typeof WebhookTriggerSchema>;
 
+function generateSecurePassphrase(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+  const length = 24;
+  let result = "";
+  
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  
+  for (let i = 0; i < length; i++) {
+    result += chars[array[i] % chars.length];
+  }
+  
+  return result;
+}
+
 export function WebhookTriggerForm({
   agentId,
   onSuccess,
@@ -139,21 +154,6 @@ export function WebhookTriggerForm({
       type: "webhook",
     },
   });
-
-  function generateSecurePassphrase(): string {
-    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
-    const length = 24;
-    let result = '';
-    
-    const array = new Uint8Array(length);
-    crypto.getRandomValues(array);
-    
-    for (let i = 0; i < length; i++) {
-      result += chars[array[i] % chars.length];
-    }
-    
-    return result;
-  }
 
   function handleOutputSchemaChange(val: string) {
     form.setValue("schema", val, { shouldValidate: true });


### PR DESCRIPTION
Add a "Generate" button next to the passphrase input field in webhook creation form that automatically populates the field with a secure 24-character random passphrase using crypto.getRandomValues(). This addresses user confusion when the passphrase field is empty.

Fixes #502

Generated with [Claude Code](https://claude.ai/code)