### PR TITLE
Oauth fallback

### DIFF
--- a/apps/web/src/components/integrations/connection-detail.tsx
+++ b/apps/web/src/components/integrations/connection-detail.tsx
@@ -70,6 +70,7 @@ import {
   ConfirmMarketplaceInstallDialog,
 } from "./select-connection-dialog.tsx";
 import { MarketplaceIntegration } from "./marketplace.tsx";
+import { OAuthCompletionDialog } from "./oauth-completion-dialog.tsx";
 
 function ConnectionInstanceActions({
   onConfigure,
@@ -606,6 +607,11 @@ function Overview({ data, appKey }: {
   const [installingIntegration, setInstallingIntegration] = useState<
     MarketplaceIntegration | null
   >(null);
+  const [oauthCompletionDialog, setOauthCompletionDialog] = useState<{
+    open: boolean;
+    url: string;
+    integrationName: string;
+  }>({ open: false, url: "", integrationName: "" });
 
   const handleAddConnection = () => {
     setInstallingIntegration({
@@ -655,20 +661,25 @@ function Overview({ data, appKey }: {
               authorizeOauthUrl,
               "_blank",
             );
-            if (!popup || popup.closed || typeof popup.closed === "undefined") {
-              alert(
-                "Please allow popups for this site to complete the OAuth flow.",
-              );
-              const link = document.createElement("a");
-              link.href = authorizeOauthUrl;
-              link.target = "_blank";
-              link.textContent = "Click here to continue OAuth flow";
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
+            if (
+              !popup || popup.closed || typeof popup.closed === "undefined"
+            ) {
+              setOauthCompletionDialog({
+                open: true,
+                url: authorizeOauthUrl,
+                integrationName: installingIntegration?.name || "the service",
+              });
             }
           }
         }}
+      />
+
+      <OAuthCompletionDialog
+        open={oauthCompletionDialog.open}
+        onOpenChange={(open) =>
+          setOauthCompletionDialog((prev) => ({ ...prev, open }))}
+        authorizeOauthUrl={oauthCompletionDialog.url}
+        integrationName={oauthCompletionDialog.integrationName}
       />
     </div>
   );

--- a/apps/web/src/components/integrations/oauth-completion-dialog.tsx
+++ b/apps/web/src/components/integrations/oauth-completion-dialog.tsx
@@ -1,0 +1,70 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
+
+interface OAuthCompletionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  authorizeOauthUrl: string;
+  integrationName?: string;
+}
+
+export function OAuthCompletionDialog({
+  open,
+  onOpenChange,
+  authorizeOauthUrl,
+  integrationName = "the service",
+}: OAuthCompletionDialogProps) {
+  const handleContinueOAuth = () => {
+    globalThis.open(authorizeOauthUrl, "_blank");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+              <Icon name="security" size={20} className="text-primary" />
+            </div>
+            <div>
+              <DialogTitle>Finish Authentication</DialogTitle>
+            </div>
+          </div>
+          <DialogDescription className="text-left">
+            Complete the authentication flow with {integrationName}{" "}
+            by clicking the link below. This will open in a new tab.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="p-4 bg-accent/50 rounded-lg border border-border">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
+              <Icon name="info" size={16} />
+              <span>Authentication Required</span>
+            </div>
+            <p className="text-sm">
+              Your browser blocked the popup window. Click the button below to
+              continue the authentication process.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleContinueOAuth} className="gap-2">
+              <Icon name="open_in_new" size={16} />
+              Continue Authentication
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/integrations/select-connection-dialog.tsx
+++ b/apps/web/src/components/integrations/select-connection-dialog.tsx
@@ -26,6 +26,7 @@ import {
   useNavigateWorkspace,
   useWorkspaceLink,
 } from "../../hooks/use-navigate-workspace.ts";
+import { OAuthCompletionDialog } from "./oauth-completion-dialog.tsx";
 
 export function ConfirmMarketplaceInstallDialog({
   integration,
@@ -174,6 +175,11 @@ function AddConnectionDialogContent({
   const [installingIntegration, setInstallingIntegration] = useState<
     MarketplaceIntegration | null
   >(null);
+  const [oauthCompletionDialog, setOauthCompletionDialog] = useState<{
+    open: boolean;
+    url: string;
+    integrationName: string;
+  }>({ open: false, url: "", integrationName: "" });
   const navigateWorkspace = useNavigateWorkspace();
   const showEmptyState = search.length > 0;
 
@@ -318,19 +324,22 @@ function AddConnectionDialogContent({
               "_blank",
             );
             if (!popup || popup.closed || typeof popup.closed === "undefined") {
-              alert(
-                "Please allow popups for this site to complete the OAuth flow.",
-              );
-              const link = document.createElement("a");
-              link.href = authorizeOauthUrl;
-              link.target = "_blank";
-              link.textContent = "Click here to continue OAuth flow";
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
+              setOauthCompletionDialog({
+                open: true,
+                url: authorizeOauthUrl,
+                integrationName: installingIntegration?.name || "the service",
+              });
             }
           }
         }}
+      />
+
+      <OAuthCompletionDialog
+        open={oauthCompletionDialog.open}
+        onOpenChange={(open) =>
+          setOauthCompletionDialog((prev) => ({ ...prev, open }))}
+        authorizeOauthUrl={oauthCompletionDialog.url}
+        integrationName={oauthCompletionDialog.integrationName}
       />
     </DialogContent>
   );


### PR DESCRIPTION
Prompt:
```md
There's a problem with this logic that sometimes it will work and sometimes it will show this alert. But the link creation is not working

I want to do something different. Remove the alert and the <a href creation as fallback and, instead, crea te a <Dialog with Finish Authentication Flow and inside the Dialog there's a link for the user to click.

After finish, do the same for @select-connection-dialog.tsx that has a similar flow
```

![image](https://github.com/user-attachments/assets/754628b7-6bd1-4ea2-b674-24a0644618d2)
