### PR TITLE
Show agent views

### DIFF
--- a/apps/web/src/components/agent/edit.tsx
+++ b/apps/web/src/components/agent/edit.tsx
@@ -45,6 +45,7 @@ import Threads from "./threads.tsx";
 import { WhatsAppButton } from "./whatsapp-button.tsx";
 import { lazy } from "react";
 import { wrapWithUILoadingFallback } from "../../main.tsx";
+import { useTabsForAgent } from "./preview.tsx";
 
 interface Props {
   agentId?: string;
@@ -236,6 +237,8 @@ function FormProvider(props: Props & { agentId: string; threadId: string }) {
   const updateAgentCache = useUpdateAgentCache();
   const createAgent = useCreateAgent();
 
+  const tabs = useTabsForAgent(agent, TABS);
+
   const isWellKnownAgent = Boolean(
     WELL_KNOWN_AGENTS[agentId as keyof typeof WELL_KNOWN_AGENTS],
   );
@@ -337,7 +340,7 @@ function FormProvider(props: Props & { agentId: string; threadId: string }) {
           }}
         >
           <PageLayout
-            tabs={TABS}
+            tabs={tabs}
             key={agentId}
             actionButtons={
               <ActionButtons

--- a/apps/web/src/components/agent/preview.tsx
+++ b/apps/web/src/components/agent/preview.tsx
@@ -1,6 +1,8 @@
-import { DetailedHTMLProps, IframeHTMLAttributes } from "react";
+import { DetailedHTMLProps, IframeHTMLAttributes, useMemo } from "react";
 import { ALLOWANCES } from "../../constants.ts";
 import { IMAGE_REGEXP } from "../chat/utils/preview.ts";
+import type { Agent } from "@deco/sdk";
+import type { Tab } from "../dock/index.tsx";
 
 type Props = DetailedHTMLProps<
   IframeHTMLAttributes<HTMLIFrameElement>,
@@ -29,6 +31,51 @@ function Preview(props: Props) {
       {...props}
     />
   );
+}
+
+export function useTabsForAgent(agent: Agent | undefined, baseTabs: Record<string, Tab>) {
+  // Create dynamic tabs for agent views
+  const dynamicViewTabs = useMemo(() => {
+    if (!agent?.views?.length) return {};
+    
+    const viewTabs: Record<string, Tab> = {};
+    agent.views.forEach((view, index) => {
+      const tabKey = `view-${index}`;
+      viewTabs[tabKey] = {
+        Component: () => <Preview src={view.url} title={view.name} />,
+        title: view.name,
+        initialOpen: index === 0 ? "within" : false, // Open first view by default
+      };
+    });
+    return viewTabs;
+  }, [agent?.views]);
+
+  // Combine static tabs with dynamic view tabs, placing views after chat
+  const allTabs = useMemo(() => {
+    const tabs = { ...baseTabs };
+    
+    // Insert view tabs after chat tab
+    if (Object.keys(dynamicViewTabs).length > 0) {
+      const tabEntries = Object.entries(tabs);
+      const chatIndex = tabEntries.findIndex(([key]) => key === 'chat');
+      
+      if (chatIndex !== -1) {
+        // Split tabs at chat position and insert view tabs after
+        const beforeChat = tabEntries.slice(0, chatIndex + 1);
+        const afterChat = tabEntries.slice(chatIndex + 1);
+        
+        return Object.fromEntries([
+          ...beforeChat,
+          ...Object.entries(dynamicViewTabs),
+          ...afterChat,
+        ]);
+      }
+    }
+    
+    return tabs;
+  }, [baseTabs, dynamicViewTabs]);
+
+  return allTabs;
 }
 
 export default Preview;

--- a/apps/web/src/components/agent/preview.tsx
+++ b/apps/web/src/components/agent/preview.tsx
@@ -33,11 +33,14 @@ function Preview(props: Props) {
   );
 }
 
-export function useTabsForAgent(agent: Agent | undefined, baseTabs: Record<string, Tab>) {
+export function useTabsForAgent(
+  agent: Agent | undefined,
+  baseTabs: Record<string, Tab>,
+) {
   // Create dynamic tabs for agent views
   const dynamicViewTabs = useMemo(() => {
     if (!agent?.views?.length) return {};
-    
+
     const viewTabs: Record<string, Tab> = {};
     agent.views.forEach((view, index) => {
       const tabKey = `view-${index}`;
@@ -53,17 +56,17 @@ export function useTabsForAgent(agent: Agent | undefined, baseTabs: Record<strin
   // Combine static tabs with dynamic view tabs, placing views after chat
   const allTabs = useMemo(() => {
     const tabs = { ...baseTabs };
-    
+
     // Insert view tabs after chat tab
     if (Object.keys(dynamicViewTabs).length > 0) {
       const tabEntries = Object.entries(tabs);
-      const chatIndex = tabEntries.findIndex(([key]) => key === 'chat');
-      
+      const chatIndex = tabEntries.findIndex(([key]) => key === "chat");
+
       if (chatIndex !== -1) {
         // Split tabs at chat position and insert view tabs after
         const beforeChat = tabEntries.slice(0, chatIndex + 1);
         const afterChat = tabEntries.slice(chatIndex + 1);
-        
+
         return Object.fromEntries([
           ...beforeChat,
           ...Object.entries(dynamicViewTabs),
@@ -71,7 +74,7 @@ export function useTabsForAgent(agent: Agent | undefined, baseTabs: Record<strin
         ]);
       }
     }
-    
+
     return tabs;
   }, [baseTabs, dynamicViewTabs]);
 


### PR DESCRIPTION
## Prompt
```
Some agents have views. Views is an array with name and url. 

For agens that have views, I want the view to be displayed in the agent screen in a new tab close to chat.

Study @layout.tsx @/dock and implement this.
```

## Results
**Before:**
![image](https://github.com/user-attachments/assets/db1775ff-713d-43a1-8e8e-a20118e80cae)

**After:**
![image](https://github.com/user-attachments/assets/afa750d3-4ac3-4f76-824f-10a4f250ef13)


![image](https://github.com/user-attachments/assets/56f0ede6-eac9-4dbe-8987-ccdbc5e9d520)

