### PR TITLE
fix: validate agent model property with union of well-known models and UUIDs

### DIFF
--- a/packages/sdk/src/models/agent.ts
+++ b/packages/sdk/src/models/agent.ts
@@ -9,7 +9,7 @@ const ModelSchema = z.union([
   // Well-known model IDs
   z.enum(WELL_KNOWN_MODELS.map(m => m.id) as [string, ...string[]]),
   // UUID format for BYOK models
-  z.string().uuid()
+  z.string().uuid().describe("UUID for BYOK models"),
 ]);
 
 /**
@@ -45,7 +45,7 @@ export const AgentSchema = z.object({
   ),
   /** Model to use for the agent */
   model: ModelSchema.default(DEFAULT_MODEL.id)
-    .describe("Model to use for the agent - either a well-known model ID or UUID for BYOK"),
+    .describe("Model to use for the agent - either a well-known model ID or UUID for BYOK models"),
   /** Memory to use for the agent */
   memory: z.object({
     discriminator: z.string().optional().describe(

--- a/packages/sdk/src/models/agent.ts
+++ b/packages/sdk/src/models/agent.ts
@@ -1,5 +1,16 @@
 import { z } from "zod";
-import { DEFAULT_MODEL } from "../constants.ts";
+import { DEFAULT_MODEL, WELL_KNOWN_MODELS } from "../constants.ts";
+
+/**
+ * Schema for agent model validation
+ * Accepts either well-known model IDs or UUIDs for BYOK models
+ */
+const ModelSchema = z.union([
+  // Well-known model IDs
+  z.enum(WELL_KNOWN_MODELS.map(m => m.id) as [string, ...string[]]),
+  // UUID format for BYOK models
+  z.string().uuid()
+]);
 
 /**
  * Zod schema for an AI Agent
@@ -33,8 +44,8 @@ export const AgentSchema = z.object({
     "Maximum number of tokens the agent can use, defaults to 8192",
   ),
   /** Model to use for the agent */
-  model: z.string().default(DEFAULT_MODEL.id)
-    .describe("Model to use for the agent"),
+  model: ModelSchema.default(DEFAULT_MODEL.id)
+    .describe("Model to use for the agent - either a well-known model ID or UUID for BYOK"),
   /** Memory to use for the agent */
   memory: z.object({
     discriminator: z.string().optional().describe(

--- a/packages/sdk/src/models/agent.ts
+++ b/packages/sdk/src/models/agent.ts
@@ -7,7 +7,7 @@ import { DEFAULT_MODEL, WELL_KNOWN_MODELS } from "../constants.ts";
  */
 const ModelSchema = z.union([
   // Well-known model IDs
-  z.enum(WELL_KNOWN_MODELS.map(m => m.id) as [string, ...string[]]),
+  z.enum(WELL_KNOWN_MODELS.map((m) => m.id) as [string, ...string[]]),
   // UUID format for BYOK models
   z.string().uuid().describe("UUID for BYOK models"),
 ]);
@@ -45,7 +45,9 @@ export const AgentSchema = z.object({
   ),
   /** Model to use for the agent */
   model: ModelSchema.default(DEFAULT_MODEL.id)
-    .describe("Model to use for the agent - either a well-known model ID or UUID for BYOK models"),
+    .describe(
+      "Model to use for the agent - either a well-known model ID or UUID for BYOK models",
+    ),
   /** Memory to use for the agent */
   memory: z.object({
     discriminator: z.string().optional().describe(


### PR DESCRIPTION
Fixes #561

## Summary
- Add ModelSchema as union of well-known model IDs enum and UUID validation
- Update agent model property to use ModelSchema instead of plain string
- Prevents creation of agents with invalid model IDs

## Test plan
-  [ ] Verify agent creation with well-known models works
-  [ ] Verify agent creation with BYOK UUID models works
-  [ ] Verify agent creation with invalid models fails with proper error

Generated with [Claude Code](https://claude.ai/code)