### PR TITLE
fix(view iframes): always keep the agent custom view rendered

### DIFF
--- a/apps/web/src/components/agent/preview.tsx
+++ b/apps/web/src/components/agent/preview.tsx
@@ -52,6 +52,7 @@ export function useTabsForAgent(
         Component: () => <Preview src={view.url} title={view.name} />,
         title: view.name,
         initialOpen: index === 0 ? "within" : false, // Open first view by default
+        renderer: "always",
       };
     });
     return viewTabs;

--- a/apps/web/src/components/dock/index.tsx
+++ b/apps/web/src/components/dock/index.tsx
@@ -165,6 +165,7 @@ export interface Tab {
   maximumHeight?: number;
   maximumWidth?: number;
   hideFromViews?: boolean;
+  renderer?: "always" | "onlyWhenVisible";
 }
 
 type Props =
@@ -257,6 +258,7 @@ function Docked(
           id: key,
           component: key,
           title: value.title,
+          renderer: value.renderer,
           initialHeight: !isMobile ? value.initialHeight : undefined,
           initialWidth: !isMobile ? value.initialWidth : undefined,
           maximumHeight: !isMobile ? value.maximumHeight : undefined,


### PR DESCRIPTION
Very annoying to lose input states, etc. when switching, moving or resizing tabs for agent views!