### PR TITLE
Search integration filter tools instead

### DIFF
--- a/apps/web/src/components/settings/integrations.tsx
+++ b/apps/web/src/components/settings/integrations.tsx
@@ -2,7 +2,7 @@ import { Form, FormItem } from "@deco/ui/components/form.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { useCallback, useState } from "react";
+import { useCallback, useDeferredValue, useState } from "react";
 import { Button } from "@deco/ui/components/button.tsx";
 import { useAgentSettingsForm } from "../agent/edit.tsx";
 import { SelectConnectionDialog } from "../integrations/select-connection-dialog.tsx";
@@ -65,7 +65,8 @@ function Connections() {
     installedIntegrations,
     disableAllTools,
   } = useAgentSettingsToolsSet();
-  const [search, setSearch] = useState("");
+  const [_search, setSearch] = useState("");
+  const search = useDeferredValue(_search.toLowerCase());
 
   const onConfigureConnection = useConfigureConnection();
 
@@ -112,7 +113,7 @@ function Connections() {
                   />
                   <Input
                     placeholder="Search tools..."
-                    value={search}
+                    value={_search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="flex-1 h-full border-none focus-visible:ring-0 placeholder:text-muted-foreground bg-transparent px-2"
                   />

--- a/apps/web/src/components/settings/integrations.tsx
+++ b/apps/web/src/components/settings/integrations.tsx
@@ -71,14 +71,7 @@ function Connections() {
 
   const connections = installedIntegrations
     .filter(connectionFilter)
-    .filter((connection) => !!toolsSet[connection.id])
-    .filter((connection) => {
-      const searchTerm = search.toLowerCase();
-      return (
-        connection?.name?.toLowerCase().includes(searchTerm) ||
-        connection?.description?.toLowerCase().includes(searchTerm)
-      );
-    });
+    .filter((connection) => !!toolsSet[connection.id]);
 
   const showAddConnectionEmptyState = connections.length === 0 && !search;
   return (
@@ -118,7 +111,7 @@ function Connections() {
                     className="text-muted-foreground"
                   />
                   <Input
-                    placeholder="Search"
+                    placeholder="Search tools..."
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     className="flex-1 h-full border-none focus-visible:ring-0 placeholder:text-muted-foreground bg-transparent px-2"
@@ -138,6 +131,7 @@ function Connections() {
                       onConfigure={onConfigureConnection}
                       onRemove={(integrationId) =>
                         disableAllTools(integrationId)}
+                      searchTerm={search}
                     />
                   ))}
                 </div>

--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -85,20 +85,22 @@ export function IntegrationListItem({
   // Helper function to check if a tool matches the search term
   const toolMatchesSearch = (tool: MCPTool, searchTerm: string) => {
     if (!searchTerm) return true;
-    
+
     const lowerSearchTerm = searchTerm.toLowerCase();
     const toolNameFormatted = beautifyToolName(tool.name).toLowerCase();
     const toolNameOriginal = tool.name.toLowerCase();
     const toolDescription = tool.description?.toLowerCase() || "";
-    
+
     return toolNameFormatted.includes(lowerSearchTerm) ||
-           toolNameOriginal.includes(lowerSearchTerm) ||
-           toolDescription.includes(lowerSearchTerm);
+      toolNameOriginal.includes(lowerSearchTerm) ||
+      toolDescription.includes(lowerSearchTerm);
   };
 
   // Filter tools based on search term
-  const filteredTools = allTools.filter((tool) => toolMatchesSearch(tool, searchTerm));
-  
+  const filteredTools = allTools.filter((tool) =>
+    toolMatchesSearch(tool, searchTerm)
+  );
+
   // Hide integration if searching and no tools match
   if (searchTerm && filteredTools.length === 0 && !isLoading) {
     return null;
@@ -197,7 +199,11 @@ export function IntegrationListItem({
                     isLoading && "animate-pulse",
                   )}
                 >
-                  {isLoading ? "Loading tools..." : searchTerm ? `${filteredTools.length} matching tools` : "All tools"}
+                  {isLoading
+                    ? "Loading tools..."
+                    : searchTerm
+                    ? `${filteredTools.length} matching tools`
+                    : "All tools"}
                 </span>
               </div>
               <div className="flex items-center gap-2">
@@ -261,12 +267,12 @@ function ToolList({
   className?: string;
 }) {
   const { data: profile } = useProfile();
-  
+
   // Apply client-side filtering for hidden tools on top of search filtering
   const displayTools = filteredTools.filter((tool) =>
     !(clientHiddenTools.includes(tool.name) && hideFor(profile?.email))
   );
-  
+
   if (isLoading) {
     return (
       <div className={cn("space-y-2", className)}>

--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -83,10 +83,9 @@ export function IntegrationListItem({
   const isEmpty = !isLoading && allTools.length === 0;
 
   // Helper function to check if a tool matches the search term
-  const toolMatchesSearch = (tool: MCPTool, searchTerm: string) => {
-    if (!searchTerm) return true;
+  const toolMatchesSearch = (tool: MCPTool, lowerSearchTerm: string) => {
+    if (!lowerSearchTerm) return true;
 
-    const lowerSearchTerm = searchTerm.toLowerCase();
     const toolNameFormatted = beautifyToolName(tool.name).toLowerCase();
     const toolNameOriginal = tool.name.toLowerCase();
     const toolDescription = tool.description?.toLowerCase() || "";

--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -60,6 +60,7 @@ export function IntegrationListItem({
   onRemove,
   onConfigure,
   hideTools,
+  searchTerm = "",
 }: {
   toolsSet: ToolsMap;
   setIntegrationTools: (integrationId: string, tools: string[]) => void;
@@ -67,6 +68,7 @@ export function IntegrationListItem({
   onConfigure: (integration: Integration) => void;
   onRemove: (integrationId: string) => void;
   hideTools?: boolean;
+  searchTerm?: string;
 }) {
   const [toolsOpen, setToolsOpen] = useState(false);
   const { data: toolsData, isLoading } = useTools(integration.connection);
@@ -79,6 +81,32 @@ export function IntegrationListItem({
       .length;
   const isAll = enabledCount === total && total > 0;
   const isEmpty = !isLoading && allTools.length === 0;
+
+  // Helper function to check if a tool matches the search term
+  const toolMatchesSearch = (tool: MCPTool, searchTerm: string) => {
+    if (!searchTerm) return true;
+    
+    const lowerSearchTerm = searchTerm.toLowerCase();
+    const toolNameFormatted = beautifyToolName(tool.name).toLowerCase();
+    const toolNameOriginal = tool.name.toLowerCase();
+    const toolDescription = tool.description?.toLowerCase() || "";
+    
+    return toolNameFormatted.includes(lowerSearchTerm) ||
+           toolNameOriginal.includes(lowerSearchTerm) ||
+           toolDescription.includes(lowerSearchTerm);
+  };
+
+  // Filter tools based on search term
+  const filteredTools = allTools.filter((tool) => toolMatchesSearch(tool, searchTerm));
+  
+  // Hide integration if searching and no tools match
+  if (searchTerm && filteredTools.length === 0 && !isLoading) {
+    return null;
+  }
+
+  // Auto-expand tools when searching
+  const shouldExpandTools = searchTerm && filteredTools.length > 0;
+  const effectiveToolsOpen = toolsOpen || shouldExpandTools;
 
   function handleAll(checked: boolean) {
     setIntegrationTools(
@@ -142,14 +170,14 @@ export function IntegrationListItem({
         <div
           className={cn(
             "flex flex-col items-start gap-1 min-w-0 border-t border-border cursor-pointer bg-primary-foreground rounded-b-xl",
-            !toolsOpen && "hover:bg-muted",
+            !effectiveToolsOpen && "hover:bg-muted",
           )}
         >
           <span
             onClick={() => setToolsOpen(!toolsOpen)}
             className={cn(
               "text-muted-foreground text-sm h-10 flex items-center w-full hover:bg-muted pl-2 pr-4",
-              !toolsOpen && "rounded-b-xl",
+              !effectiveToolsOpen && "rounded-b-xl",
             )}
           >
             <div className="w-full flex items-center justify-between">
@@ -160,7 +188,7 @@ export function IntegrationListItem({
                   size={14}
                   className={cn(
                     "inline-block mr-1 align-text-bottom text-foreground",
-                    toolsOpen && "rotate-90",
+                    effectiveToolsOpen && "rotate-90",
                   )}
                 />
                 <span
@@ -169,7 +197,7 @@ export function IntegrationListItem({
                     isLoading && "animate-pulse",
                   )}
                 >
-                  {isLoading ? "Loading tools..." : "All tools"}
+                  {isLoading ? "Loading tools..." : searchTerm ? `${filteredTools.length} matching tools` : "All tools"}
                 </span>
               </div>
               <div className="flex items-center gap-2">
@@ -189,13 +217,15 @@ export function IntegrationListItem({
               </div>
             </div>
           </span>
-          {toolsOpen && (
+          {effectiveToolsOpen && (
             <ToolList
               integration={integration}
               toolsSet={toolsSet}
               isLoading={isLoading}
               allTools={allTools}
               setIntegrationTools={setIntegrationTools}
+              searchTerm={searchTerm}
+              filteredTools={filteredTools}
             />
           )}
         </div>
@@ -224,18 +254,25 @@ function ToolList({
   isLoading,
   allTools,
   setIntegrationTools,
+  searchTerm,
+  filteredTools,
 }: {
   integration: Integration;
   toolsSet: ToolsMap;
   isLoading: boolean;
   allTools: MCPTool[];
   setIntegrationTools: (integrationId: string, tools: string[]) => void;
+  searchTerm?: string;
+  filteredTools: MCPTool[];
   className?: string;
 }) {
   const { data: profile } = useProfile();
-  const filteredTools = allTools.filter((tool) =>
+  
+  // Apply client-side filtering for hidden tools on top of search filtering
+  const displayTools = filteredTools.filter((tool) =>
     !(clientHiddenTools.includes(tool.name) && hideFor(profile?.email))
   );
+  
   if (isLoading) {
     return (
       <div className={cn("space-y-2", className)}>
@@ -248,7 +285,7 @@ function ToolList({
 
   return (
     <div className="space-y-2 rounded-b-xl max-h-[350px] w-full overflow-y-auto">
-      {filteredTools?.map((tool) => {
+      {displayTools?.map((tool) => {
         const enabled = toolsSet[integration.id]?.includes(tool.name) ??
           false;
 

--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -222,9 +222,7 @@ export function IntegrationListItem({
               integration={integration}
               toolsSet={toolsSet}
               isLoading={isLoading}
-              allTools={allTools}
               setIntegrationTools={setIntegrationTools}
-              searchTerm={searchTerm}
               filteredTools={filteredTools}
             />
           )}
@@ -252,17 +250,13 @@ function ToolList({
   integration,
   toolsSet,
   isLoading,
-  allTools,
   setIntegrationTools,
-  searchTerm,
   filteredTools,
 }: {
   integration: Integration;
   toolsSet: ToolsMap;
   isLoading: boolean;
-  allTools: MCPTool[];
   setIntegrationTools: (integrationId: string, tools: string[]) => void;
-  searchTerm?: string;
   filteredTools: MCPTool[];
   className?: string;
 }) {

--- a/packages/ai/src/agent.ts
+++ b/packages/ai/src/agent.ts
@@ -58,7 +58,7 @@ import {
 import { type StorageThreadType, Telemetry } from "@mastra/core";
 import type { ToolsetsInput, ToolsInput } from "@mastra/core/agent";
 import { Agent } from "@mastra/core/agent";
-import { type MastraMemory } from "@mastra/core/memory";
+import type { MastraMemory } from "@mastra/core/memory";
 import { TokenLimiter } from "@mastra/memory/processors";
 import { createServerClient } from "@supabase/ssr";
 import {


### PR DESCRIPTION
**Prompt:**
```
I want to change the search mechanism here

It shouldn't search based on Integration's name, but on the integration's tools. And it should filter the tool list based on the search.

The goal is, for integrations with lots of tools, I can search by tool name to better activate/deactivate it

Plan and implement this change
```

**Before**
![before-tools](https://github.com/user-attachments/assets/7db39680-d6ea-4a62-af33-1e34c88d12c4)


**After:**
![after-tools](https://github.com/user-attachments/assets/37faa084-8af8-4b04-a3f6-4a21c500c749)
