### PR TITLE
Add native tool calls for AI

### DIFF
--- a/apps/web/src/components/settings/integrations.tsx
+++ b/apps/web/src/components/settings/integrations.tsx
@@ -26,6 +26,7 @@ import {
 const ADVANCED_INTEGRATIONS = [
   "i:user-management",
   "i:workspace-management",
+  "i:ai-integration",
   getKnowledgeBaseIntegrationId("standard"),
   "DECO_INTEGRATIONS",
   "DECO_UTILS",

--- a/packages/sdk/src/mcp/ai/README.md
+++ b/packages/sdk/src/mcp/ai/README.md
@@ -1,0 +1,95 @@
+# AI Integration Tools
+
+The AI Integration provides native tool calls for AI text and object generation with automatic wallet credit debiting.
+
+## Available Tools
+
+### AI_GENERATE_TEXT
+Generate text responses using AI models.
+
+**Input Schema:**
+- `messages`: Array of conversation messages with `role` and `content`
+- `model` (optional): AI model to use (defaults to `claude-3-5-sonnet-latest`)
+- `maxTokens` (optional): Maximum tokens to generate
+- `temperature` (optional): Temperature for generation (default 0.7)
+- `maxSteps` (optional): Maximum steps for tool use
+
+**Output:**
+- `text`: Generated text
+- `usage`: Token usage information
+- `finishReason`: Reason for completion
+
+### AI_GENERATE_OBJECT
+Generate structured JSON objects using AI models.
+
+**Input Schema:**
+- `messages`: Array of conversation messages
+- `schema`: JSON Schema for the expected output
+- `model` (optional): AI model to use
+- `maxTokens` (optional): Maximum tokens to generate
+- `temperature` (optional): Temperature for generation
+
+**Output:**
+- `object`: Generated object matching the schema
+- `usage`: Token usage information
+- `finishReason`: Reason for completion
+
+## Usage Examples
+
+### From an Agent
+```typescript
+// Extract structured data from a PDF
+const result = await callTool("i:ai-integration.AI_GENERATE_OBJECT", {
+  messages: [
+    { role: "system", content: "Extract invoice details from the following text" },
+    { role: "user", content: pdfContent }
+  ],
+  schema: {
+    type: "object",
+    properties: {
+      invoiceNumber: { type: "string" },
+      date: { type: "string" },
+      totalAmount: { type: "number" },
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            description: { type: "string" },
+            quantity: { type: "number" },
+            price: { type: "number" }
+          }
+        }
+      }
+    }
+  }
+});
+```
+
+### From a Custom UI
+```typescript
+// Using the SDK
+const response = await MCPClient.forWorkspace(workspace)
+  .AI_GENERATE_TEXT({
+    messages: [
+      { role: "user", content: "Summarize this document in 3 bullet points" }
+    ],
+    maxTokens: 500
+  });
+```
+
+## Credit System
+
+- All AI tool calls consume credits from the workspace wallet
+- Credits are debited based on token usage (input + output tokens)
+- If insufficient funds, the tool call will fail with an error
+- Same pricing model as agent executions
+
+## Model Support
+
+Currently supports all models available through OpenRouter:
+- Claude models (3.5 Sonnet, etc.)
+- GPT models
+- Other models available on OpenRouter
+
+Future updates will allow configuring default models per workspace/user.

--- a/packages/sdk/src/mcp/ai/api.ts
+++ b/packages/sdk/src/mcp/ai/api.ts
@@ -1,0 +1,248 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModelUsage } from "ai";
+import { generateObject, generateText } from "ai";
+import type { JSONSchema7 } from "@ai-sdk/provider";
+import { z } from "zod";
+import {
+  DEFAULT_MAX_STEPS,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_MODEL,
+  MAX_MAX_STEPS,
+  MAX_MAX_TOKENS,
+  MIN_MAX_TOKENS,
+} from "../../constants.ts";
+import { MicroDollar, type Transaction, WellKnownWallets } from "../wallet/index.ts";
+import {
+  assertHasWorkspace,
+  assertWorkspaceResourceAccess,
+} from "../assertions.ts";
+import { createTool } from "../context.ts";
+import { createWalletClient } from "../wallet/client.ts";
+import { getPlan } from "../wallet/api.ts";
+import { InternalServerError } from "../index.ts";
+
+export const AI_INTEGRATION_GROUP = "AI_INTEGRATION";
+
+const DEFAULT_AI_MODEL = "claude-3-5-sonnet-latest"; // Default model for AI integration
+
+interface AIUsageTransaction {
+  usage: LanguageModelUsage;
+  model: string;
+  workspace: string;
+  threadId?: string;
+  userId?: string;
+}
+
+async function createAIUsageTransaction({
+  usage,
+  model,
+  workspace,
+  threadId,
+  userId,
+  plan,
+}: AIUsageTransaction & { plan: string }): Promise<Transaction> {
+  const vendor = {
+    type: "vendor" as const,
+    id: workspace,
+  };
+  const generatedBy = {
+    type: "user" as const,
+    id: userId || "unknown",
+  };
+
+  return {
+    type: "AgentGeneration" as const,
+    usage: {
+      usage,
+      model,
+      agentId: "ai-integration",
+      threadId: threadId || crypto.randomUUID(),
+      workspace,
+      agentPath: `${workspace}/ai-integration`,
+    },
+    generatedBy,
+    vendor,
+    payer: plan === "trial"
+      ? {
+        type: "wallet" as const,
+        id: WellKnownWallets.build(
+          ...WellKnownWallets.workspace.trialCredits(workspace),
+        ),
+      }
+      : undefined,
+    metadata: {
+      model,
+      workspace,
+      threadId: threadId || crypto.randomUUID(),
+      ...usage,
+    },
+    timestamp: new Date(),
+  };
+}
+
+async function checkAndDebitWallet(c: any, usage: LanguageModelUsage, model: string) {
+  const wallet = createWalletClient(c.envVars.WALLET_API_KEY, c.walletBinding);
+  const workspace = c.workspace.value;
+  const userId = c.user?.id;
+  
+  // Check wallet balance
+  const walletId = WellKnownWallets.build(
+    ...WellKnownWallets.workspace.genCredits(workspace),
+  );
+  
+  const response = await wallet["GET /accounts/:id"]({
+    id: encodeURIComponent(walletId),
+  });
+
+  if (response.status === 404) {
+    throw new Error("Insufficient funds");
+  }
+
+  if (!response.ok) {
+    console.error("Failed to check balance", response);
+    throw new Error("Failed to check wallet balance");
+  }
+
+  const data = await response.json();
+  const balance = MicroDollar.fromMicrodollarString(data.balance);
+
+  if (balance.isNegative() || balance.isZero()) {
+    throw new Error("Insufficient funds");
+  }
+
+  // Get plan and create transaction
+  const plan = await getPlan(c);
+  const transaction = await createAIUsageTransaction({
+    usage,
+    model,
+    workspace,
+    threadId: c.metadata?.threadId,
+    userId,
+    plan: plan.id,
+  });
+
+  // Debit the wallet
+  const transactionResponse = await wallet["POST /transactions"]({}, {
+    body: transaction,
+  });
+
+  if (!transactionResponse.ok) {
+    console.error("Failed to debit wallet", transactionResponse);
+  }
+}
+
+export const generateAIText = createTool({
+  name: "AI_GENERATE_TEXT",
+  description: "Generate text using AI models. The response will be a JSON object with the generated text.",
+  group: AI_INTEGRATION_GROUP,
+  inputSchema: z.object({
+    messages: z.array(z.object({
+      role: z.enum(["user", "assistant", "system"]),
+      content: z.string(),
+    })).describe("The conversation messages"),
+    model: z.string().optional().default(DEFAULT_AI_MODEL).describe("The model to use for generation"),
+    maxTokens: z.number().optional().default(DEFAULT_MAX_TOKENS).describe("Maximum tokens to generate"),
+    temperature: z.number().optional().default(0.7).describe("Temperature for generation"),
+    maxSteps: z.number().optional().default(DEFAULT_MAX_STEPS).describe("Maximum steps for tool use"),
+  }),
+  handler: async ({ messages, model, maxTokens, temperature, maxSteps }, c) => {
+    assertHasWorkspace(c);
+    await assertWorkspaceResourceAccess(c.tool.name, c);
+
+    const openai = createOpenAI({
+      apiKey: c.envVars.OPENROUTER_API_KEY,
+      baseURL: "https://openrouter.ai/api/v1",
+    });
+
+    const llm = openai(model || DEFAULT_AI_MODEL);
+
+    try {
+      // Adjust token limits
+      const adjustedMaxTokens = Math.min(
+        Math.max(MIN_MAX_TOKENS, maxTokens || DEFAULT_MAX_TOKENS),
+        MAX_MAX_TOKENS
+      );
+      const adjustedMaxSteps = Math.min(
+        Math.max(1, maxSteps || DEFAULT_MAX_STEPS),
+        MAX_MAX_STEPS
+      );
+
+      const result = await generateText({
+        model: llm,
+        messages,
+        maxTokens: adjustedMaxTokens,
+        temperature,
+        maxSteps: adjustedMaxSteps,
+      });
+
+      // Debit wallet after successful generation
+      await checkAndDebitWallet(c, result.usage, model || DEFAULT_AI_MODEL);
+
+      return {
+        text: result.text,
+        usage: result.usage,
+        finishReason: result.finishReason,
+      };
+    } catch (error) {
+      throw new InternalServerError(
+        error instanceof Error ? error.message : "Failed to generate text"
+      );
+    }
+  },
+});
+
+export const generateAIObject = createTool({
+  name: "AI_GENERATE_OBJECT",
+  description: "Generate structured JSON objects using AI models",
+  group: AI_INTEGRATION_GROUP,
+  inputSchema: z.object({
+    messages: z.array(z.object({
+      role: z.enum(["user", "assistant", "system"]),
+      content: z.string(),
+    })).describe("The conversation messages"),
+    schema: z.any().describe("JSON Schema for the expected output"),
+    model: z.string().optional().default(DEFAULT_AI_MODEL).describe("The model to use for generation"),
+    maxTokens: z.number().optional().default(DEFAULT_MAX_TOKENS).describe("Maximum tokens to generate"),
+    temperature: z.number().optional().default(0.7).describe("Temperature for generation"),
+  }),
+  handler: async ({ messages, schema, model, maxTokens, temperature }, c) => {
+    assertHasWorkspace(c);
+    await assertWorkspaceResourceAccess(c.tool.name, c);
+
+    const openai = createOpenAI({
+      apiKey: c.envVars.OPENROUTER_API_KEY,
+      baseURL: "https://openrouter.ai/api/v1",
+    });
+
+    const llm = openai(model || DEFAULT_AI_MODEL);
+
+    try {
+      // Adjust token limits
+      const adjustedMaxTokens = Math.min(
+        Math.max(MIN_MAX_TOKENS, maxTokens || DEFAULT_MAX_TOKENS),
+        MAX_MAX_TOKENS
+      );
+
+      const result = await generateObject({
+        model: llm,
+        messages,
+        schema: schema as JSONSchema7,
+        maxTokens: adjustedMaxTokens,
+        temperature,
+      });
+
+      // Debit wallet after successful generation
+      await checkAndDebitWallet(c, result.usage, model || DEFAULT_AI_MODEL);
+
+      return {
+        object: result.object,
+        usage: result.usage,
+        finishReason: result.finishReason,
+      };
+    } catch (error) {
+      throw new InternalServerError(
+        error instanceof Error ? error.message : "Failed to generate object"
+      );
+    }
+  },
+});

--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -26,8 +26,10 @@ import * as threadsAPI from "./threads/api.ts";
 import * as triggersAPI from "./triggers/api.ts";
 import * as walletAPI from "./wallet/api.ts";
 import * as whatsappAPI from "./whatsapp/api.ts";
+import * as aiAPI from "./ai/api.ts";
 
 export * from "./bindings/binder.ts";
+export { AI_INTEGRATION_GROUP } from "./ai/api.ts";
 
 // Register tools for each API handler
 export const GLOBAL_TOOLS = [
@@ -131,6 +133,8 @@ export const WORKSPACE_TOOLS = [
   promptsAPI.listPrompts,
   promptsAPI.getPrompt,
   promptsAPI.searchPrompts,
+  aiAPI.generateAIText,
+  aiAPI.generateAIObject,
 ] as const;
 
 export type GlobalTools = typeof GLOBAL_TOOLS;

--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -166,9 +166,26 @@ const virtualIntegrationsFor = (
     created_at: new Date().toISOString(),
   };
 
+  // Create a virtual AI Integration
+  const aiIntegrationUrl = new URL(workspaceMcp);
+  aiIntegrationUrl.searchParams.set("group", "AI_INTEGRATION");
+  const aiIntegration = {
+    id: formatId("i", "ai-integration"),
+    name: "AI Integration",
+    description: "Call AI models directly for text and structured object generation",
+    connection: {
+      type: "HTTP",
+      url: aiIntegrationUrl.href,
+    },
+    icon: "https://cdn-icons-png.flaticon.com/512/11865/11865223.png",
+    workspace,
+    created_at: new Date().toISOString(),
+  };
+
   return [
     userManagementIntegration,
     workspaceManagementIntegration,
+    aiIntegration,
     ...knowledgeBases.map((kb) => {
       const url = new URL(workspaceMcp);
       url.searchParams.set("group", KNOWLEDGE_BASE_GROUP);


### PR DESCRIPTION
Native tool calls for AI integration were added to enhance worker capabilities.

*   Two new tools, `AI_GENERATE_TEXT` and `AI_GENERATE_OBJECT`, were implemented in `packages/sdk/src/mcp/ai/api.ts`.
    *   These tools enable text and structured JSON object generation using AI models.
    *   They adhere to an OpenAI SDK-like signature, returning JSON responses.
    *   An optional `model` parameter defaults to `claude-3-5-sonnet-latest` via OpenRouter.
    *   Token limits (`maxTokens`, `maxSteps`) are configurable and clamped within defined bounds.
*   A new special group, `AI_INTEGRATION_GROUP`, was created to categorize these tools.
*   Wallet integration was implemented in `checkAndDebitWallet` to debit workspace generation credits based on token usage, mirroring agent execution costs.
    *   Checks for insufficient funds and uses trial credits if applicable.
*   The new tools were registered in `WORKSPACE_TOOLS` within `packages/sdk/src/mcp/index.ts`.
*   A virtual "AI Integration" was added to the list of advanced integrations in `apps/web/src/components/settings/integrations.tsx` and `packages/sdk/src/mcp/integrations/api.ts`, allowing it to be enabled for agents.
*   Comprehensive documentation for the new tools, including usage examples and credit system details, was added in `packages/sdk/src/mcp/ai/README.md`.