### PR TITLE
fix: use correct background token in toolsets accordion

### DIFF
--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -170,7 +170,7 @@ export function IntegrationListItem({
       {(!isEmpty && !hideTools) && (
         <div
           className={cn(
-            "flex flex-col items-start gap-1 min-w-0 border-t border-border cursor-pointer bg-primary-foreground rounded-b-xl",
+            "flex flex-col items-start gap-1 min-w-0 border-t border-border cursor-pointer bg-background rounded-b-xl",
             !effectiveToolsOpen && "hover:bg-muted",
           )}
         >


### PR DESCRIPTION
Fixed token styling issue in connections accordion where `bg-primary-foreground` was incorrectly used as background, causing poor text contrast.

Changes:
- Updated expandable tools section styling from `bg-primary-foreground` to `bg-background`
- Improves text readability in accordion sections

Fixes #600

Generated with [Claude Code](https://claude.ai/code)