### PR TITLE
Change Menu Order

### DIFF
--- a/apps/web/src/components/integrations/breadcrumb.tsx
+++ b/apps/web/src/components/integrations/breadcrumb.tsx
@@ -26,7 +26,7 @@ export function IntegrationPageLayout({ tabs }: { tabs: Record<string, Tab> }) {
         displayViewsTrigger={false}
         breadcrumb={
           <DefaultBreadcrumb
-            items={[{ label: "Connections", link: "/connections" }]}
+            items={[{ label: "Integrations", link: "/connections" }]}
           />
         }
         actionButtons={<SelectConnectionDialog forceTab="new-connection" />}

--- a/apps/web/src/components/integrations/connections-list.tsx
+++ b/apps/web/src/components/integrations/connections-list.tsx
@@ -6,7 +6,7 @@ export default function Page() {
     <IntegrationPageLayout
       tabs={{
         connections: {
-          title: "Connections",
+          title: "Integrations",
           Component: ConnectedAppsList,
           initialOpen: true,
         },

--- a/apps/web/src/components/integrations/select-connection-dialog.tsx
+++ b/apps/web/src/components/integrations/select-connection-dialog.tsx
@@ -154,7 +154,7 @@ export function ConfirmMarketplaceInstallDialog({
 }
 
 function AddConnectionDialogContent({
-  title = "Add connection",
+  title = "Add integration",
   filter,
   onSelect,
   forceTab,
@@ -207,7 +207,7 @@ function AddConnectionDialogContent({
                 size={16}
                 className="text-muted-foreground"
               />
-              <span>My connections</span>
+              <span>My integrations</span>
             </Button>
             <Button
               variant="ghost"
@@ -218,7 +218,7 @@ function AddConnectionDialogContent({
               onClick={() => setTab("new-connection")}
             >
               <Icon name="add" size={16} className="text-muted-foreground" />
-              <span>New connection</span>
+              <span>New integration</span>
             </Button>
             <Button
               variant="ghost"
@@ -228,7 +228,7 @@ function AddConnectionDialogContent({
               onClick={() => navigateWorkspace("/connections")}
             >
               <Icon name="arrow_outward" size={16} />
-              <span className="group-hover:underline">Manage connections</span>
+              <span className="group-hover:underline">Manage integrations</span>
             </Button>
             {/* Filters will go here */}
           </aside>
@@ -236,7 +236,7 @@ function AddConnectionDialogContent({
 
         <div className="h-full overflow-y-hidden p-4 pb-20 w-full">
           <Input
-            placeholder="Find connection..."
+            placeholder="Find integration..."
             value={search}
             className="mb-4"
             onChange={(e) => setSearch(e.target.value)}
@@ -248,7 +248,7 @@ function AddConnectionDialogContent({
                 <div className="flex flex-col h-full min-h-[200px] gap-4">
                   <div className="flex flex-col gap-2 py-8 w-full items-center">
                     <h3 className="text-2xl font-medium">
-                      No connections found for the search "{search}"
+                      No integrations found for the search "{search}"
                     </h3>
                     <p className="text-sm text-muted-foreground w-full text-center">
                       You can{" "}
@@ -257,7 +257,7 @@ function AddConnectionDialogContent({
                         className="px-0"
                         onClick={() => setTab("my-connections")}
                       >
-                        create a new custom connection
+                        create a new custom integration
                       </Button>{" "}
                       instead.
                     </p>
@@ -281,10 +281,10 @@ function AddConnectionDialogContent({
                   <div className="flex flex-col h-full min-h-[200px] gap-4 pb-16">
                     <div className="w-full flex items-center flex-col gap-2 py-8">
                       <h3 className="text-2xl font-medium">
-                        No connections found
+                        No integrations found
                       </h3>
                       <p className="text-sm text-muted-foreground">
-                        Create a new connection to get started
+                        Create a new integration to get started
                       </p>
                     </div>
                     <Marketplace
@@ -292,7 +292,7 @@ function AddConnectionDialogContent({
                       emptyState={
                         <div className="flex flex-col gap-2 py-8 w-full items-center">
                           <p className="text-sm text-muted-foreground">
-                            No connections found for the search "{search}"
+                            No integrations found for the search "{search}"
                           </p>
                         </div>
                       }
@@ -363,7 +363,7 @@ export function SelectConnectionDialog(props: SelectConnectionDialogProps) {
 
     return (
       <Button variant="special">
-        <span className="hidden md:inline">Add connection</span>
+        <span className="hidden md:inline">Add integration</span>
       </Button>
     );
   }, [props.trigger]);

--- a/apps/web/src/components/settings/integrations.tsx
+++ b/apps/web/src/components/settings/integrations.tsx
@@ -43,7 +43,7 @@ function AddConnectionButton() {
       filter={connectionFilter}
       trigger={
         <Button variant="outline">
-          <Icon name="add" /> Add connection
+          <Icon name="add" /> Add integration
         </Button>
       }
     />
@@ -77,7 +77,7 @@ function Connections() {
   const showAddConnectionEmptyState = connections.length === 0 && !search;
   return (
     <div className="flex flex-col gap-2">
-      <h6 className="text-sm font-medium">Connections</h6>
+      <h6 className="text-sm font-medium">Integrations</h6>
       <div className="flex justify-between items-center">
         <span className="block text-sm text-muted-foreground pb-2">
           Connect and configure integrations to extend your agent's capabilities

--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -63,7 +63,7 @@ const STATIC_ITEMS = [
   },
   {
     url: "/connections",
-    title: "Connections",
+    title: "Integrations",
     icon: "linked_services",
   },
   {
@@ -73,13 +73,18 @@ const STATIC_ITEMS = [
   },
   {
     url: "/prompts",
-    title: "Prompt Library",
+    title: "Prompts",
     icon: "local_library",
   },
   {
     url: "/audits",
     title: "Activity",
     icon: "forum",
+  },
+  {
+    url: "/settings",
+    title: "Monitor",
+    icon: "monitoring",
   },
 ];
 


### PR DESCRIPTION
Updates the menu structure as requested in issue #598:

- Renamed "Connections" to "Integrations"
- Renamed "Prompt Library" to "Prompts"
- Added new "Monitor" menu item that opens settings Usage tab

Generated with [Claude Code](https://claude.ai/code)