### PR TITLE
feat: add prompts to agent functionality

### DIFF
--- a/apps/web/src/components/prompts/hooks/use-additional-prompts.ts
+++ b/apps/web/src/components/prompts/hooks/use-additional-prompts.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import { type Prompt, usePrompts, useCreatePrompt } from "@deco/sdk";
+
+const DATE_TIME_PROMPT_NAME = "Date/Time Now";
+const DATE_TIME_PROMPT_CONTENT = "Current date and time: {{new Date().toLocaleString()}}";
+
+export function useAdditionalPrompts() {
+  const { data: allPrompts } = usePrompts();
+  const createPrompt = useCreatePrompt();
+
+  // Check if Date/Time Now prompt exists, if not we'll show option to create it
+  const dateTimePrompt = useMemo(() => {
+    return allPrompts?.find(p => p.name === DATE_TIME_PROMPT_NAME);
+  }, [allPrompts]);
+
+  const createDateTimePrompt = async () => {
+    return await createPrompt.mutateAsync({
+      name: DATE_TIME_PROMPT_NAME,
+      description: "Adds the current date and time to your prompt",
+      content: DATE_TIME_PROMPT_CONTENT,
+    });
+  };
+
+  const ensureDateTimePromptExists = async () => {
+    if (!dateTimePrompt) {
+      return await createDateTimePrompt();
+    }
+    return dateTimePrompt;
+  };
+
+  return {
+    allPrompts: allPrompts || [],
+    dateTimePrompt,
+    createDateTimePrompt,
+    ensureDateTimePromptExists,
+    isCreatingDateTimePrompt: createPrompt.isPending,
+  };
+}
+
+export function resolvePromptContent(prompts: Prompt[], promptIds: string[]): string {
+  return promptIds
+    .map(id => {
+      const prompt = prompts.find(p => p.id === id);
+      if (!prompt) return "";
+      
+      // Handle Date/Time Now prompt specially
+      if (prompt.name === DATE_TIME_PROMPT_NAME) {
+        return `Current date and time: ${new Date().toLocaleString()}`;
+      }
+      
+      return prompt.content;
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/apps/web/src/components/prompts/select-prompts-dialog.tsx
+++ b/apps/web/src/components/prompts/select-prompts-dialog.tsx
@@ -1,0 +1,217 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useMemo, useState, useEffect } from "react";
+import { Icon } from "@deco/ui/components/icon.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { type Prompt, usePrompts, useCreatePrompt } from "@deco/sdk";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Card, CardContent } from "@deco/ui/components/card.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
+import { EmptyState } from "../common/empty-state.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
+
+function PromptCard({
+  prompt,
+  onSelect,
+  isSelected,
+}: {
+  prompt: Prompt;
+  onSelect: (prompt: Prompt) => void;
+  isSelected: boolean;
+}) {
+  return (
+    <Card
+      className={cn(
+        "group cursor-pointer hover:shadow-md transition-shadow rounded-xl relative border-border",
+        isSelected && "border-primary bg-primary/5"
+      )}
+      onClick={() => onSelect(prompt)}
+    >
+      <CardContent className="p-4">
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="text-base font-semibold truncate">
+                {prompt.name}
+              </div>
+              {prompt.name === "Date/Time Now" && (
+                <Badge variant="secondary" className="text-xs">
+                  Dynamic
+                </Badge>
+              )}
+            </div>
+            {isSelected && (
+              <Icon name="check" size={16} className="text-primary" />
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground line-clamp-3">
+            {prompt.description || prompt.content}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PromptsGrid({
+  prompts,
+  selectedPrompts,
+  onTogglePrompt,
+}: {
+  prompts: Prompt[];
+  selectedPrompts: Set<string>;
+  onTogglePrompt: (prompt: Prompt) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {prompts.map((prompt) => (
+        <PromptCard
+          key={prompt.id}
+          prompt={prompt}
+          onSelect={onTogglePrompt}
+          isSelected={selectedPrompts.has(prompt.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+const DATE_TIME_PROMPT_NAME = "Date/Time Now";
+const DATE_TIME_PROMPT_CONTENT = "Current date and time: {{new Date().toLocaleString()}}";
+
+function SelectPromptsDialogContent({
+  selectedPromptIds = [],
+  onSelect,
+}: {
+  selectedPromptIds?: string[];
+  onSelect?: (promptIds: string[]) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const { data: prompts } = usePrompts();
+  const createPrompt = useCreatePrompt();
+  const [selectedPrompts, setSelectedPrompts] = useState<Set<string>>(
+    new Set(selectedPromptIds)
+  );
+  
+  // Auto-create Date/Time Now prompt if it doesn't exist
+  useEffect(() => {
+    if (prompts && !prompts.find(p => p.name === DATE_TIME_PROMPT_NAME)) {
+      createPrompt.mutateAsync({
+        name: DATE_TIME_PROMPT_NAME,
+        description: "Adds the current date and time to your prompt",
+        content: DATE_TIME_PROMPT_CONTENT,
+      }).catch(console.error);
+    }
+  }, [prompts, createPrompt]);
+
+  const filteredPrompts = prompts?.filter(prompt => 
+    prompt.name.toLowerCase().includes(search.toLowerCase()) ||
+    (prompt.description?.toLowerCase().includes(search.toLowerCase()))
+  ) ?? [];
+
+  const handleTogglePrompt = (prompt: Prompt) => {
+    setSelectedPrompts(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(prompt.id)) {
+        newSet.delete(prompt.id);
+      } else {
+        newSet.add(prompt.id);
+      }
+      return newSet;
+    });
+  };
+
+  const handleConfirm = () => {
+    onSelect?.(Array.from(selectedPrompts));
+  };
+
+  return (
+    <DialogContent
+      className="p-0 min-w-[80vw] min-h-[80vh] gap-0"
+      closeButtonClassName="top-5 right-4"
+    >
+      <DialogHeader className="flex flex-row justify-between items-center p-2 h-14 px-5 pr-12">
+        <DialogTitle>Add Prompts</DialogTitle>
+        <Button onClick={handleConfirm} variant="special">
+          Add {selectedPrompts.size} prompt{selectedPrompts.size !== 1 ? 's' : ''}
+        </Button>
+      </DialogHeader>
+      
+      <div className="h-[calc(100vh-10rem)] p-4">
+        <Input
+          placeholder="Find prompts..."
+          value={search}
+          className="mb-4"
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        
+        {!prompts ? (
+          <div className="flex h-48 items-center justify-center">
+            <Spinner size="lg" />
+          </div>
+        ) : filteredPrompts.length === 0 ? (
+          <EmptyState
+            icon="local_library"
+            title="No prompts found"
+            description={search 
+              ? `No prompts found for "${search}"`
+              : "Create a prompt to get started."
+            }
+          />
+        ) : (
+          <div className="h-full overflow-y-auto pb-20">
+            <PromptsGrid
+              prompts={filteredPrompts}
+              selectedPrompts={selectedPrompts}
+              onTogglePrompt={handleTogglePrompt}
+            />
+          </div>
+        )}
+      </div>
+    </DialogContent>
+  );
+}
+
+interface SelectPromptsDialogProps {
+  trigger?: React.ReactNode;
+  selectedPromptIds?: string[];
+  onSelect?: (promptIds: string[]) => void;
+}
+
+export function SelectPromptsDialog(props: SelectPromptsDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  
+  const trigger = useMemo(() => {
+    if (props.trigger) {
+      return props.trigger;
+    }
+
+    return (
+      <Button variant="outline">
+        <Icon name="add" size={16} />
+        <span>Add Prompts</span>
+      </Button>
+    );
+  }, [props.trigger]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        {trigger}
+      </DialogTrigger>
+      <SelectPromptsDialogContent
+        selectedPromptIds={props.selectedPromptIds}
+        onSelect={(promptIds) => {
+          props.onSelect?.(promptIds);
+          setIsOpen(false);
+        }}
+      />
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/prompts/selected-prompts.tsx
+++ b/apps/web/src/components/prompts/selected-prompts.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
+import { type Prompt, usePrompts } from "@deco/sdk";
+import { useMemo } from "react";
+
+interface SelectedPromptsProps {
+  promptIds: string[];
+  onRemovePrompt: (promptId: string) => void;
+}
+
+export function SelectedPrompts({ promptIds, onRemovePrompt }: SelectedPromptsProps) {
+  const { data: allPrompts } = usePrompts();
+
+  const selectedPrompts = useMemo(() => {
+    if (!allPrompts || !promptIds.length) return [];
+    return promptIds.map(id => allPrompts.find(p => p.id === id)).filter(Boolean) as Prompt[];
+  }, [allPrompts, promptIds]);
+
+  if (!selectedPrompts.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-medium text-muted-foreground">
+        Additional Prompts ({selectedPrompts.length})
+      </div>
+      <div className="space-y-2">
+        {selectedPrompts.map((prompt) => (
+          <div
+            key={prompt.id}
+            className="flex items-center justify-between p-3 bg-muted/50 border border-border rounded-lg"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-sm">{prompt.name}</span>
+                {prompt.name === "Date/Time Now" && (
+                  <Badge variant="secondary" className="text-xs">
+                    Dynamic
+                  </Badge>
+                )}
+              </div>
+              {prompt.description && (
+                <div className="text-xs text-muted-foreground mt-1">
+                  {prompt.description}
+                </div>
+              )}
+            </div>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onRemovePrompt(prompt.id)}
+              className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+            >
+              <Icon name="close" size={16} />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/prompt.tsx
+++ b/apps/web/src/components/settings/prompt.tsx
@@ -6,14 +6,48 @@ import {
   FormMessage,
 } from "@deco/ui/components/form.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
 import { useAgentSettingsForm } from "../agent/edit.tsx";
 import PromptInput from "../prompts/rich-text/index.tsx";
+import { SelectPromptsDialog } from "../prompts/select-prompts-dialog.tsx";
+import { SelectedPrompts } from "../prompts/selected-prompts.tsx";
+import { useAdditionalPrompts } from "../prompts/hooks/use-additional-prompts.ts";
 
 function PromptTab() {
   const {
     form,
     handleSubmit,
   } = useAgentSettingsForm();
+  
+  const { ensureDateTimePromptExists } = useAdditionalPrompts();
+
+  const additionalPrompts = form.watch("additional_prompts") || [];
+
+  const handleAddPrompts = async (promptIds: string[]) => {
+    // Ensure Date/Time Now prompt exists if it's being added
+    const finalPromptIds = [...promptIds];
+    for (let i = 0; i < finalPromptIds.length; i++) {
+      const prompt = await ensureDateTimePromptExists();
+      if (prompt && promptIds.some(id => id === prompt.id)) {
+        // Replace any temporary ID with the actual created prompt ID
+        finalPromptIds[i] = prompt.id;
+      }
+    }
+    
+    // Merge with existing prompts, avoiding duplicates
+    const existingPrompts = new Set(additionalPrompts);
+    const newPrompts = finalPromptIds.filter(id => !existingPrompts.has(id));
+    
+    if (newPrompts.length > 0) {
+      form.setValue("additional_prompts", [...additionalPrompts, ...newPrompts]);
+    }
+  };
+
+  const handleRemovePrompt = (promptId: string) => {
+    const updated = additionalPrompts.filter((id: string) => id !== promptId);
+    form.setValue("additional_prompts", updated);
+  };
 
   return (
     <ScrollArea className="h-full w-full">
@@ -38,6 +72,27 @@ function PromptTab() {
                 </FormItem>
               )}
             />
+            
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div className="text-sm font-medium">Additional Prompts</div>
+                <SelectPromptsDialog
+                  selectedPromptIds={additionalPrompts}
+                  onSelect={handleAddPrompts}
+                  trigger={
+                    <Button variant="outline" size="sm">
+                      <Icon name="add" size={16} />
+                      <span>Add Prompts</span>
+                    </Button>
+                  }
+                />
+              </div>
+              
+              <SelectedPrompts
+                promptIds={additionalPrompts}
+                onRemovePrompt={handleRemovePrompt}
+              />
+            </div>
           </form>
         </div>
       </Form>

--- a/packages/sdk/src/models/agent.ts
+++ b/packages/sdk/src/models/agent.ts
@@ -29,6 +29,8 @@ export const AgentSchema = z.object({
   avatar: z.string().describe("URL to the agent's avatar image"),
   /** System prompt/instructions for the agent */
   instructions: z.string().describe("System prompt/instructions for the agent"),
+  /** Additional prompts to append to instructions */
+  additional_prompts: z.array(z.string()).optional().describe("Additional prompt IDs to append to instructions"),
   /** Brief description of the agent's purpose or capabilities */
   description: z.string().optional().describe(
     "Brief description of the agent's purpose or capabilities",

--- a/packages/sdk/src/utils/agent-instructions.ts
+++ b/packages/sdk/src/utils/agent-instructions.ts
@@ -1,0 +1,49 @@
+import { listPrompts } from "../crud/prompts.ts";
+import { replacePromptMentions } from "./prompt-mentions.ts";
+import type { Agent } from "../models/agent.ts";
+
+/**
+ * Processes agent instructions by replacing prompt mentions and appending additional prompts
+ */
+export async function processAgentInstructions(
+  config: Agent,
+  workspace: string,
+): Promise<string> {
+  // First process the main instructions to replace any mention-style prompts
+  const processedInstructions = await replacePromptMentions(
+    config.instructions,
+    workspace,
+  );
+
+  // If no additional prompts, return the processed instructions
+  if (!config.additional_prompts || config.additional_prompts.length === 0) {
+    return processedInstructions;
+  }
+
+  // Fetch additional prompts
+  const additionalPrompts = await listPrompts(workspace, {
+    ids: config.additional_prompts,
+  }).catch(() => []);
+
+  // Resolve prompt contents, handling Date/Time Now specially
+  const additionalContents = config.additional_prompts
+    .map(promptId => {
+      const prompt = additionalPrompts.find(p => p.id === promptId);
+      if (!prompt) return "";
+      
+      // Handle Date/Time Now prompt specially
+      if (prompt.name === "Date/Time Now") {
+        return `Current date and time: ${new Date().toLocaleString()}`;
+      }
+      
+      return prompt.content;
+    })
+    .filter(Boolean);
+
+  // Combine main instructions with additional prompts
+  if (additionalContents.length === 0) {
+    return processedInstructions;
+  }
+
+  return [processedInstructions, ...additionalContents].join("\n\n");
+}


### PR DESCRIPTION
Implements the requested feature to add prompts from a library to agent system prompts.

## Changes Made
- Extended Agent model with additional_prompts field
- Created SelectPromptsDialog component for choosing prompts from library
- Added "Add Prompts" button to agent system prompt interface
- Implemented automatic "Date/Time Now" prompt creation
- Added prompt removal functionality with delete icons
- Implemented prompt concatenation logic in agent processing

## Features
- ✅ "Add Prompts" button after System prompt field
- ✅ Modal showing existing prompts from library (similar to Add Connection)
- ✅ Default "Date/Time Now" prompt with dynamic date/time
- ✅ Delete functionality for added prompts
- ✅ Prompt concatenation appended to agent instructions

Closes #607

Generated with [Claude Code](https://claude.ai/code)