### PR TITLE
Add open Agent name to page Title

### DIFF
--- a/apps/web/src/components/agent/chat.tsx
+++ b/apps/web/src/components/agent/chat.tsx
@@ -257,17 +257,15 @@ function Page(props: Props) {
           showThreadMessages: props.showThreadMessages ?? true,
         }}
       >
-        <>
-          <AgentMetadataUpdater agentId={agentId} />
-          <PageLayout
-            tabs={TABS}
-            key={agentId}
-            actionButtons={<ActionsButtons />}
-            breadcrumb={agentId !== WELL_KNOWN_AGENT_IDS.teamAgent && (
-              <Breadcrumb agentId={agentId} />
-            )}
-          />
-        </>
+        <AgentMetadataUpdater agentId={agentId} />
+        <PageLayout
+          tabs={TABS}
+          key={agentId}
+          actionButtons={<ActionsButtons />}
+          breadcrumb={agentId !== WELL_KNOWN_AGENT_IDS.teamAgent && (
+            <Breadcrumb agentId={agentId} />
+          )}
+        />
       </ChatProvider>
     </Suspense>
   );

--- a/apps/web/src/components/agent/edit.tsx
+++ b/apps/web/src/components/agent/edit.tsx
@@ -55,9 +55,6 @@ interface Props {
 const Chat = () => {
   const { agentId, chat } = useChatContext();
   const { data: agent } = useAgent(agentId);
-  const { data: resolvedAvatar } = useFile(
-    agent?.avatar && isFilePath(agent.avatar) ? agent.avatar : "",
-  );
   const { chat: { messages } } = useChatContext();
   const { hasChanges } = useAgentSettingsForm();
   const focusChat = useFocusChat();

--- a/apps/web/src/components/sidebar/team-selector.tsx
+++ b/apps/web/src/components/sidebar/team-selector.tsx
@@ -11,7 +11,7 @@ import {
 } from "@deco/ui/components/responsive-dropdown.tsx";
 import { SidebarMenuButton } from "@deco/ui/components/sidebar.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { Link, useParams } from "react-router";
 import { useUser } from "../../hooks/use-user.ts";
 import { useWorkspaceLink } from "../../hooks/use-navigate-workspace.ts";
@@ -277,7 +277,47 @@ function SwitchTeam(
 export function TeamSelector() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
-  const { id: teamId } = useCurrentTeam();
+  const { id: teamId, label, avatarUrl } = useCurrentTeam();
+
+  /**
+   * Sync the browser tab metadata (title and favicon) with the currently selected workspace.
+   *
+   * This effect purposely only depends on the workspace identifying props so it
+   * runs strictly when the workspace actually changes, avoiding unnecessary
+   * updates that could override agent-specific overrides that take precedence
+   * while the user is inside an agent page.
+   */
+  useEffect(() => {
+    if (!label) return;
+
+    // Store previous values so that, if the whole TeamSelector ever unmounts,
+    // we can restore them. In practice this rarely happens but it makes the
+    // effect self-contained and safe.
+    const previousTitle = document.title;
+
+    const faviconSelector = 'link[rel="icon"]';
+    let faviconEl = document.querySelector<HTMLLinkElement>(faviconSelector);
+    if (!faviconEl) {
+      faviconEl = document.createElement("link");
+      faviconEl.setAttribute("rel", "icon");
+      document.head.appendChild(faviconEl);
+    }
+    const prevFaviconHref = faviconEl.getAttribute("href");
+
+    // Apply workspace title & favicon
+    document.title = `${label} | deco.chat`;
+    if (avatarUrl) {
+      faviconEl.setAttribute("href", avatarUrl);
+    }
+
+    // Cleanup – restore previous metadata when workspace changes or component unmounts.
+    return () => {
+      document.title = previousTitle;
+      if (avatarUrl && prevFaviconHref) {
+        faviconEl.setAttribute("href", prevFaviconHref);
+      }
+    };
+  }, [label, avatarUrl]);
 
   return (
     <>

--- a/apps/web/src/hooks/use-document-metadata.ts
+++ b/apps/web/src/hooks/use-document-metadata.ts
@@ -1,0 +1,105 @@
+import { useEffect } from "react";
+
+/**
+ * Shared hook to synchronise browser document metadata (title, favicon and
+ * common social meta-tags) with the current UI context.
+ *
+ * All updates are reversible – when the calling component unmounts, the
+ * previous values are restored exactly as they were before the hook ran.
+ */
+export interface DocumentMetadataOptions {
+  /** Full document title (e.g. "Foo | deco.chat"). */
+  title?: string;
+  /** Plain description, used for SEO + social previews. */
+  description?: string;
+  /** Absolute or relative URL to the favicon. */
+  favicon?: string;
+  /** Image URL used for Open Graph / Twitter cards. */
+  socialImage?: string;
+}
+
+export function useDocumentMetadata(
+  { title, description, favicon, socialImage }: DocumentMetadataOptions,
+): void {
+  useEffect(() => {
+    // Early-exit if nothing to update – avoids touching DOM unnecessarily.
+    if (!title && !description && !favicon && !socialImage) return;
+
+    /* ----------------- Title ----------------- */
+    const previousTitle = document.title;
+    if (title) {
+      document.title = title;
+    }
+
+    /* ----------------- FavIcon ---------------- */
+    const faviconSelector = 'link[rel="icon"]';
+    let faviconEl = document.querySelector<HTMLLinkElement>(faviconSelector);
+    if (!faviconEl) {
+      faviconEl = document.createElement("link");
+      faviconEl.setAttribute("rel", "icon");
+      document.head.appendChild(faviconEl);
+    }
+    const prevFaviconHref = faviconEl.getAttribute("href");
+    if (favicon) {
+      faviconEl.setAttribute("href", favicon);
+    }
+
+    /* ----------------- Meta tags -------------- */
+    const trackedMeta: Array<{ el: HTMLMetaElement; prev: string | null }> = [];
+
+    function setMeta(
+      attr: "name" | "property",
+      value: string,
+      content: string | undefined,
+    ) {
+      if (!content) return;
+      const selector = `meta[${attr}="${value}"]`;
+      let el = document.querySelector<HTMLMetaElement>(selector);
+      if (!el) {
+        el = document.createElement("meta");
+        el.setAttribute(attr, value);
+        document.head.appendChild(el);
+      }
+      // Track original value once per element.
+      if (!trackedMeta.find((m) => m.el === el)) {
+        trackedMeta.push({ el, prev: el.getAttribute("content") });
+      }
+      el.setAttribute("content", content);
+    }
+
+    if (title) {
+      setMeta("property", "og:title", title);
+      setMeta("name", "twitter:title", title);
+    }
+    if (description) {
+      setMeta("name", "description", description);
+      setMeta("property", "og:description", description);
+      setMeta("name", "twitter:description", description);
+    }
+    if (socialImage) {
+      setMeta("property", "og:image", socialImage);
+      setMeta("name", "twitter:image", socialImage);
+    }
+
+    /* ------------- Cleanup on unmount --------- */
+    return () => {
+      // Title
+      document.title = previousTitle;
+      // Favicon
+      if (prevFaviconHref) {
+        faviconEl.setAttribute("href", prevFaviconHref);
+      } else {
+        // If there was no favicon before, remove the tag to leave DOM clean.
+        faviconEl.remove();
+      }
+      // Meta tags
+      trackedMeta.forEach(({ el, prev }) => {
+        if (prev === null) {
+          el.remove();
+        } else {
+          el.setAttribute("content", prev);
+        }
+      });
+    };
+  }, [title, description, favicon, socialImage]);
+}


### PR DESCRIPTION
## What is this contribution about?

Adds the open agent's properties to the page's meta, like title, description, and favicon. this helps create the correct icon when users "Add to Home Screen"