### PR TITLE
feat: add page size selector for Activity tab chat logs

### DIFF
--- a/apps/web/src/components/audit/audit-filters.tsx
+++ b/apps/web/src/components/audit/audit-filters.tsx
@@ -13,8 +13,10 @@ interface AuditFiltersProps {
   members: Member[];
   selectedAgent?: string;
   selectedUser?: string;
+  pageSize: number;
   onAgentChange: (value: string) => void;
   onUserChange: (value: string) => void;
+  onPageSizeChange: (value: number) => void;
 }
 
 export function AuditFilters({
@@ -22,8 +24,10 @@ export function AuditFilters({
   members,
   selectedAgent,
   selectedUser,
+  pageSize,
   onAgentChange,
   onUserChange,
+  onPageSizeChange,
 }: AuditFiltersProps) {
   // Ordenar membros por nome
   const sortedMembers = [...(members ?? [])].sort((a, b) => {
@@ -80,6 +84,21 @@ export function AuditFilters({
           </Select>
         </div>
       )}
+      <div className="flex flex-col gap-2 min-w-[120px]">
+        <Select
+          value={pageSize.toString()}
+          onValueChange={(value) => onPageSizeChange(Number(value))}
+        >
+          <SelectTrigger id="page-size-select" className="w-full">
+            <SelectValue placeholder="Page size" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="20">20 per page</SelectItem>
+            <SelectItem value="50">50 per page</SelectItem>
+            <SelectItem value="100">100 per page</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/hooks/use-user-preferences.ts
+++ b/apps/web/src/hooks/use-user-preferences.ts
@@ -7,6 +7,7 @@ export interface UserPreferences {
   sendReasoning: boolean;
   defaultModel: string;
   lastMessages: number;
+  activityPageSize: number;
 }
 
 const USER_PREFERENCES_KEY = "user-preferences";
@@ -23,6 +24,7 @@ export function useUserPreferences() {
       useOpenRouter: true,
       smoothStream: true,
       sendReasoning: true,
+      activityPageSize: 20,
     },
   });
 


### PR DESCRIPTION
This PR implements the requested feature to allow users to select the number of chat logs displayed per page in the Activity tab.

## Changes
- Added `activityPageSize` preference to UserPreferences with default value of 20
- Added page size dropdown in Activity tab filters (20/50/100 options)
- Replaced hardcoded limit of 11 with user-configurable page size
- Reset pagination cursor when page size changes
- Persist user preference in localStorage

## Testing
The feature maintains existing cursor-based pagination behavior and integrates seamlessly with the current filtering system.

Closes #614

Generated with [Claude Code](https://claude.ai/code)