### PR TITLE
feat: change Monitor default view to Usage and Wallet tabs

### DIFF
--- a/apps/web/src/components/settings/page.tsx
+++ b/apps/web/src/components/settings/page.tsx
@@ -11,7 +11,6 @@ const TABS: Record<string, Tab> = {
     title: "General",
     Component: GeneralSettings,
     initialOpen: true,
-    active: true,
   },
   members: {
     title: "Members",
@@ -27,11 +26,13 @@ const TABS: Record<string, Tab> = {
     title: "Usage",
     Component: UsageSettings,
     initialOpen: true,
+    active: true,
   },
   wallet: {
     title: "Wallet",
     Component: WalletSettings,
     initialOpen: true,
+    active: true,
   },
 };
 


### PR DESCRIPTION
This PR changes the Monitor menu default view from showing the General tab to displaying Usage and Wallet tabs side by side.

## Changes
- Remove default active state from General tab
- Set Usage and Wallet tabs as active by default
- This displays both tabs side by side when Monitor opens

Fixes #636

Generated with [Claude Code](https://claude.ai/code)