### PR TITLE
feat: add initialOpen right to ensure Usage and Wallet tabs stay side by side

### DIFF
--- a/apps/web/src/components/settings/page.tsx
+++ b/apps/web/src/components/settings/page.tsx
@@ -11,7 +11,6 @@ const TABS: Record<string, Tab> = {
     title: "General",
     Component: GeneralSettings,
     initialOpen: true,
-    active: true,
   },
   members: {
     title: "Members",
@@ -26,12 +25,14 @@ const TABS: Record<string, Tab> = {
   usage: {
     title: "Usage",
     Component: UsageSettings,
-    initialOpen: true,
+    initialOpen: "left",
+    active: true,
   },
   wallet: {
     title: "Wallet",
     Component: WalletSettings,
-    initialOpen: true,
+    initialOpen: "right",
+    active: true,
   },
 };
 


### PR DESCRIPTION
This PR ensures Usage and Wallet tabs are displayed side by side when Monitor is opened, using the initialOpen property.

## Changes
- Remove active state from General tab
- Set Usage tab with initialOpen: "left" and active: true
- Set Wallet tab with initialOpen: "right" and active: true
- This ensures both tabs are displayed side by side when Monitor is opened

Fixes #636

Generated with [Claude Code](https://claude.ai/code)