### PR TITLE
feat(login): highlight last used login method and show message

### DIFF
--- a/apps/web/src/components/login/index.tsx
+++ b/apps/web/src/components/login/index.tsx
@@ -3,13 +3,22 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { providers } from "./providers.tsx";
 import { Link, useSearchParams } from "react-router";
 import { trackEvent } from "../../hooks/analytics.ts";
+import { useEffect, useState } from "react";
 
 function Login() {
   const [searchParams] = useSearchParams();
   const next = searchParams.get("next");
   const cli = searchParams.has("cli");
 
+  // State for last used login method
+  const [lastLoginMethod, setLastLoginMethod] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLastLoginMethod(localStorage.getItem("lastLoginMethod"));
+  }, []);
+
   const handleProviderClick = (providerName: string) => {
+    localStorage.setItem("lastLoginMethod", providerName);
     trackEvent("deco_chat_login_provider_click", {
       provider: providerName,
     });
@@ -32,34 +41,48 @@ function Login() {
         </div>
         <div className="flex flex-col items-center gap-2.5">
           {providers.map((provider) => {
+            const isLastUsed = provider.name === lastLoginMethod;
             return (
-              <Button
+              <div
                 key={provider.name}
-                variant="outline"
-                className="p-5 min-w-80 hover:text-foreground"
-                asChild
+                className={
+                  isLastUsed
+                    ? "relative w-full min-w-80 border-2 border-primary rounded-lg bg-primary/5"
+                    : "w-full min-w-80"
+                }
               >
-                <Link
-                  to={provider.authURL({
-                    next: next || globalThis.location.origin,
-                    cli,
-                  })}
-                  className="flex items-center gap-2.5 h-6"
-                  onClick={() => handleProviderClick(provider.name)}
+                <Button
+                  variant="outline"
+                  className="p-5 min-w-80 hover:text-foreground w-full"
+                  asChild
                 >
-                  <img
-                    className={provider.iconClassName}
-                    loading="lazy"
-                    src={provider.iconURL}
-                    alt={provider.name}
-                    width={20}
-                    height={20}
-                  />
-                  <span className="text-sm font-semibold">
-                    Continue with {provider.name}
-                  </span>
-                </Link>
-              </Button>
+                  <Link
+                    to={provider.authURL({
+                      next: next || globalThis.location.origin,
+                      cli,
+                    })}
+                    className="flex items-center gap-2.5 h-6"
+                    onClick={() => handleProviderClick(provider.name)}
+                  >
+                    <img
+                      className={provider.iconClassName}
+                      loading="lazy"
+                      src={provider.iconURL}
+                      alt={provider.name}
+                      width={20}
+                      height={20}
+                    />
+                    <span className="text-sm font-semibold">
+                      Continue with {provider.name}
+                    </span>
+                    {isLastUsed && (
+                      <span className="ml-3 text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">
+                        Last used
+                      </span>
+                    )}
+                  </Link>
+                </Button>
+              </div>
             );
           })}
         </div>


### PR DESCRIPTION
## Highlight Last Used Login Method on Login Page

### Summary
This PR introduces a visual highlight for the last used login method on the login page. When a user selects a login provider, that choice is saved in localStorage. On subsequent visits to the login page, the previously used method is visually distinguished with a prominent border and a “Last used” message, improving the user experience by making it easier to identify their preferred login option.

### Details
- Stores the last used login method in localStorage when a provider is clicked.
- Reads the last used method on page load and highlights the corresponding provider with a 2px primary border and subtle background.
- Displays a “Last used” badge next to the highlighted provider.
- No changes to authentication logic or provider list.

### Motivation
This feature helps users quickly identify and reuse their preferred login method, streamlining the authentication process and reducing friction.

---

Let me know if you want to tweak or translate any part of this description!