### PR TITLE
feat: change default Max Steps from 3 to 10 in agent settings

### DIFF
--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -197,7 +197,7 @@ export const INNATE_INTEGRATIONS = {
 } satisfies Record<string, Integration>;
 
 export const MAX_MAX_STEPS = 100;
-export const DEFAULT_MAX_STEPS = 3;
+export const DEFAULT_MAX_STEPS = 10;
 export const DEFAULT_MAX_TOKENS = 8192;
 export const DEFAULT_MAX_THINKING_TOKENS = 12000;
 export const DEFAULT_MIN_THINKING_TOKENS = 1024;


### PR DESCRIPTION
This PR implements the feature request from issue #655 to change the default value of Max Steps from 3 to 10 in the agent settings screen.

## Changes
- Updated `DEFAULT_MAX_STEPS` constant from 3 to 10 in `packages/sdk/src/constants.ts`

## Impact
- Agent settings forms will now default to 10 instead of 3
- New agents will be created with Max Steps = 10 by default
- Applies to both Profile and Advanced settings tabs

Closes #655

Generated with [Claude Code](https://claude.ai/code)