### PR TITLE
feat: change integration name best effort at sdk/hooks/mcp

### DIFF
--- a/apps/web/src/components/integrations/connection-detail.tsx
+++ b/apps/web/src/components/integrations/connection-detail.tsx
@@ -32,7 +32,7 @@ import {
   useTools,
 } from "@deco/sdk";
 import { useEffect, useRef, useState } from "react";
-import { useIntegrationDisplayName } from "../../hooks/use-integration-display-name.ts";
+
 import {
   RemoveConnectionAlert,
   useRemoveConnection,
@@ -491,8 +491,6 @@ function ConnectionInstanceItem(
   const { deletingId, performDelete, setDeletingId, isDeletionPending } =
     useRemoveConnection();
   const instanceRef = useRef<HTMLDivElement>(null);
-  const displayName = useIntegrationDisplayName(instance);
-
   // Smooth scroll to this instance when connectionId matches
   useEffect(() => {
     setTimeout(() => {
@@ -540,7 +538,7 @@ function ConnectionInstanceItem(
         className="h-10 w-10"
       />
       <div className="h-12 flex flex-col gap-1 flex-1 min-w-0">
-        <h5 className="text-sm font-medium truncate">{displayName}</h5>
+        <h5 className="text-sm font-medium truncate">{instance.name}</h5>
         <p className="text-sm text-muted-foreground truncate">
           {instance.description}
         </p>
@@ -895,14 +893,13 @@ function ToolsInspector({ data, selectedConnectionId }: {
 
   // Create a helper component for displaying instance names
   const InstanceSelectItem = ({ instance }: { instance: Integration }) => {
-    const displayName = useIntegrationDisplayName(instance);
     return (
       <SelectItem key={instance.id} value={instance.id}>
         <IntegrationIcon
           icon={instance.icon}
           className="w-8 h-8 flex-shrink-0"
         />
-        {displayName}
+        {instance.name}
       </SelectItem>
     );
   };

--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
-import { useIntegrationDisplayName } from "../../hooks/use-integration-display-name.ts";
 
 interface ToolsMap {
   [integrationId: string]: string[];
@@ -73,7 +72,6 @@ export function IntegrationListItem({
 }) {
   const [toolsOpen, setToolsOpen] = useState(false);
   const { data: toolsData, isLoading } = useTools(integration.connection);
-  const displayName = useIntegrationDisplayName(integration);
 
   const total = toolsData?.tools?.length ?? 0;
 
@@ -136,7 +134,7 @@ export function IntegrationListItem({
           </div>
           <div className="flex flex-col gap-1 w-full">
             <span className="text-sm font-semibold text-left truncate">
-              {displayName}
+              {integration.name}
             </span>
           </div>
         </div>


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
This PR replaces the old hook `useIntegrationDisplayName` that replace integration name in UI and move to mcp/useIntegrations.

The benefits of this change is to prevent call useIntegrationDisplayName everywhere when use integration.name and make the UI consistent and less error prone.