### PR TITLE
Add default Open command for deco CLI login command

### DIFF
--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -18,7 +18,7 @@ export const loginCommand = async () => {
             illumos: "xdg-open",
             android: "xdg-open",
             freebsd: "xdg-open",
-            netbsd: "xdg-open", 
+            netbsd: "xdg-open",
             windows: "start",
             darwin: "open",
             aix: "open",


### PR DESCRIPTION
### When running deco login on Linux I got this error 

<img width="807" height="203" alt="image" src="https://github.com/user-attachments/assets/56e71ef7-387d-4234-b946-88d086dfab15" />

To fix it, I just added a default value to use if no env is declared.

I also formatted with the deno, and it made it look like I changed the entire file. I think I'm missing something. If you know what I did wrong, I can try to run again and format correctly

I was able to work on Linux, and will work on Mac (default command is open), but I don't have windows to test the default value