### PR TITLE
Bump CLI version to 0.8.4

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "A CLI for interacting with deco.chat.",
   "license": "MIT",
   "exports": "./cli.ts",


### PR DESCRIPTION
Forgot to bump the version in my last PR https://github.com/deco-cx/chat/pull/811

Changelog:

Add a fallback based on the OS for the command to open the browser.

