### PR TITLE
fix(cli): make deco login work on Windows PowerShell by skipping chmod

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/cli",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "A CLI for interacting with deco.chat.",
   "license": "MIT",
   "exports": "./cli.ts",

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -48,7 +48,15 @@ export async function saveSession(
     ),
   );
   // Set file permissions to 600 (read/write for user only)
-  await Deno.chmod(sessionPath, 0o600);
+  // Skip chmod on Windows as it doesn't support Unix-style file permissions
+  if (Deno.build.os !== "windows") {
+    try {
+      await Deno.chmod(sessionPath, 0o600);
+    } catch (error) {
+      // Silently ignore chmod errors on systems that don't support it
+      console.warn("Warning: Could not set file permissions on session file:", error.message);
+    }
+  }
 }
 
 /**

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -56,7 +56,7 @@ export async function saveSession(
       // Silently ignore chmod errors on systems that don't support it
       console.warn(
         "Warning: Could not set file permissions on session file:",
-        error.message,
+        error instanceof Error ? error.message : String(error),
       );
     }
   }

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -54,7 +54,10 @@ export async function saveSession(
       await Deno.chmod(sessionPath, 0o600);
     } catch (error) {
       // Silently ignore chmod errors on systems that don't support it
-      console.warn("Warning: Could not set file permissions on session file:", error.message);
+      console.warn(
+        "Warning: Could not set file permissions on session file:",
+        error.message,
+      );
     }
   }
 }


### PR DESCRIPTION
Fixes #816

## Summary
- Skip chmod call on Windows as it doesn't support Unix-style file permissions
- Wrap chmod in try-catch for better error handling on supported systems
- Add warning message if chmod fails
- Follows existing OS detection pattern used in other CLI files

## Test plan
- [] Test on Windows PowerShell to ensure login works without chmod errors
- [] Test on Unix-like systems to ensure chmod still works correctly
- [] Verify session file permissions are properly set on supported systems

Generated with [Claude Code](https://claude.ai/code)