### PR TITLE
Change "Add connection" to "Add Instance" in Connection Detail Page

### DIFF
--- a/apps/web/src/components/integrations/connection-detail.tsx
+++ b/apps/web/src/components/integrations/connection-detail.tsx
@@ -641,7 +641,7 @@ function Overview({ data, appKey }: {
       {(!isWellKnown && data.info?.provider !== "custom")
         ? (
           <Button variant="special" onClick={handleAddConnection}>
-            <span className="hidden md:inline">Add connection</span>
+            <span className="hidden md:inline">Add Instance</span>
           </Button>
         )
         : null}


### PR DESCRIPTION
**Summary**

This PR updates the label on the connection detail page (/connection/) so that the button now displays "Add Instance" instead of "Add connection".

This change is scoped only to the connection detail route, ensuring that the terminology is more accurate and consistent with the intended user experience.

**Motivation**
Improves clarity for users by distinguishing between adding a new integration and adding a new instance to an existing integration.
Aligns the UI language with the product's conceptual model.