### PR TITLE
fix: preserve tool output schemas for CLI type generation

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,6 +23,7 @@
     "@modelcontextprotocol/sdk": "1.11.4",
     "ai": "^4.1.61",
     "json-schema-to-zod": "^2.6.1",
+    "zod-to-json-schema": "^3.24.4",
     "zod": "^3.24.3",
     "@deco/actors": "npm:@jsr/deco__actors@0.33.1",
     "@ai-sdk/provider-utils": "^2.0.5",


### PR DESCRIPTION
Tool output schemas were being lost during the conversion from JSON Schema to Zod schemas for INNATE integrations, causing empty TypeScript interfaces to be generated by the CLI (e.g., `FS_WRITEOutput {}`).

This fix uses zod-to-json-schema to convert Zod schemas back to JSON Schema format when tools are returned through the API for type generation, ensuring that output schemas like FS_WRITE's `url` property are properly included in the generated TypeScript interfaces.

Changes:
- Add zod-to-json-schema dependency for schema conversion
- Convert Zod schemas back to JSON Schema in listToolsByConnectionType
- Preserve original JSON schemas for CLI consumption while maintaining Zod schemas for internal tool execution

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 