### PR TITLE
fix(cli): Fix Windows login command spawning issue

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/cli",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "A CLI for interacting with deco.chat.",
   "license": "MIT",
   "exports": "./cli.ts",

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -24,7 +24,11 @@ export const loginCommand = async () => {
             aix: "open",
           }[Deno.build.os] ?? "open";
 
-        const command = new Deno.Command(browser, { args: [DECO_CHAT_LOGIN] });
+        // Windows requires using cmd.exe because 'start' is a built-in command, not an executable
+        const command = Deno.build.os === "windows" && browser === "start"
+          ? new Deno.Command("cmd", { args: ["/c", "start", DECO_CHAT_LOGIN] })
+          : new Deno.Command(browser, { args: [DECO_CHAT_LOGIN] });
+        
         command.spawn();
       },
     },

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -28,7 +28,7 @@ export const loginCommand = async () => {
         const command = Deno.build.os === "windows" && browser === "start"
           ? new Deno.Command("cmd", { args: ["/c", "start", DECO_CHAT_LOGIN] })
           : new Deno.Command(browser, { args: [DECO_CHAT_LOGIN] });
-        
+
         command.spawn();
       },
     },


### PR DESCRIPTION
## Summary

Fixed the Windows login issue where `deco login` was failing with "NotFound: Failed to spawn 'start': entity not found".

## Problem

On Windows, the `start` command is a built-in cmd.exe command, not a standalone executable. The previous code tried to spawn "start" directly which caused the error.

## Solution

- Added proper Windows command handling by using `cmd.exe /c start`
- Maintains cross-platform compatibility for Linux, macOS, etc.
- Preserves existing behavior for custom BROWSER environment variables

## Testing

The fix should resolve the issue on Windows 11 and other Windows versions.

Fixes #858

Generated with [Claude Code](https://claude.ai/code)