### PR TITLE
feat(audit): Add Costs do Activity Tab

### DIFF
--- a/apps/web/src/components/audit/audit-table.tsx
+++ b/apps/web/src/components/audit/audit-table.tsx
@@ -25,6 +25,7 @@ interface AuditTableProps {
   onSortChange: (sort: string) => void;
   onRowClick?: (threadId: string) => void;
   columnsDenyList?: Set<string>;
+  costByThreadId?: Record<string, string>;
 }
 
 function getSortKeyAndDirection(
@@ -37,7 +38,7 @@ function getSortKeyAndDirection(
 }
 
 export function AuditTable(
-  { threads, sort, onSortChange, onRowClick, columnsDenyList }: AuditTableProps,
+  { threads, sort, onSortChange, onRowClick, columnsDenyList, costByThreadId }: AuditTableProps,
 ) {
   const { key: sortKey, direction: sortDirection } = getSortKeyAndDirection(
     sort,
@@ -64,6 +65,11 @@ export function AuditTable(
           agentId={cell.metadata?.agentId}
         />
       ),
+    },
+    {
+      id: "cost",
+      header: "Cost",
+      accessor: (cell: Thread) => costByThreadId?.[cell.id] ?? "-",
     },
     {
       id: "user",


### PR DESCRIPTION
This PR introduces a new "Cost" column to the audit/activity table, providing clear visibility into the cost of each agent run (thread) for every workspace and customer.

**Key Features:**

Cost Column:
Displays the cost (in dollars) for each agent run, fetched dynamically for the current workspace.
The cost is shown for all threads where usage data is available; otherwise, a dash ("-") is displayed.
The column is positioned before the "Used by" column for better visibility and quick scanning.

**User Experience:**
No impact on performance or existing filters/sorting.
The cost column helps users and admins track and optimize their agent usage and spending.

**Why?**
Improves transparency and accountability for AI/agent usage costs.
Enables customers to monitor and manage their spend directly from the activity/audit view.