### PR TITLE
Fix parsing of MicroDollar strings

### DIFF
--- a/packages/sdk/src/mcp/wallet/microdollar.ts
+++ b/packages/sdk/src/mcp/wallet/microdollar.ts
@@ -13,8 +13,8 @@ export class MicroDollar {
   }
 
   public static fromMicrodollarString(microdollars: string): MicroDollar {
-    // Remove the underscore and parse as BigInt
-    const cleanedStr = microdollars.replace("_", "");
+    // Remove any underscores and parse as BigInt
+    const cleanedStr = microdollars.replace(/_/g, "");
     const parsed = BigInt(cleanedStr);
     return new MicroDollar(parsed);
   }

--- a/packages/sdk/test/microdollar.test.ts
+++ b/packages/sdk/test/microdollar.test.ts
@@ -39,6 +39,13 @@ describe("MicroDollar - fromMicrodollarString and toMicrodollarString", () => {
     expect(largeValue.toMicrodollarString()).toBe("123456789_123456");
     expect(largeValue.toDollars()).toBe(123456789.123456);
   });
+
+  test("should handle multiple underscores in input", () => {
+    const value =
+      MicroDollar.fromMicrodollarString("1_234_567_890_123456");
+    expect(value.toMicrodollarString()).toBe("1234567890_123456");
+    expect(value.toDollars()).toBe(1234567890.123456);
+  });
 });
 
 describe("MicroDollar - negative values", () => {


### PR DESCRIPTION
## Summary
- handle underscores correctly when parsing microdollar values
- test parsing with multiple underscores

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ba7c0759883208b7ad7310756c70a