### PR TITLE
fix(cli - windows): spawning npm for self-upgrade. + rename `update` to `upgrade` command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deco-cli",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "A Node.js CLI for interacting with deco.chat.",
   "license": "MIT",
   "author": "Deco team",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -56,7 +56,7 @@ import { createCommand, listTemplates } from "./commands/create/create.js";
 import { devCommand } from "./commands/dev/dev.js";
 import { link } from "./commands/dev/link.js";
 import { genEnv } from "./commands/gen/gen.js";
-import { updateCommand } from "./commands/update/update.js";
+import { upgradeCommand } from "./commands/update/upgrade.js";
 import { addCommand } from "./commands/add/add.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -287,10 +287,9 @@ const linkCmd = new Command("link")
     }
   });
 
-// Update command implementation
-const update = new Command("update")
-  .description("Update the deco CLI to the latest version.")
-  .action(updateCommand);
+const upgrade = new Command("upgrade")
+  .description("Upgrade the deco CLI to the latest version.")
+  .action(upgradeCommand);
 
 // Dev command implementation
 const dev = new Command("dev")
@@ -401,7 +400,7 @@ const program = new Command()
   .addCommand(dev)
   .addCommand(configure)
   .addCommand(add)
-  .addCommand(update)
+  .addCommand(upgrade)
   .addCommand(linkCmd)
   .addCommand(gen)
   .addCommand(create)

--- a/packages/cli/src/commands/update/upgrade.ts
+++ b/packages/cli/src/commands/update/upgrade.ts
@@ -52,6 +52,7 @@ export const upgrade = (packageName: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     const child = spawn("npm", ["install", "-g", packageName], {
       stdio: "inherit",
+      shell: true,
     });
 
     child.on("close", (code) => {
@@ -122,7 +123,7 @@ export async function checkForUpdates(): Promise<void> {
   }
 }
 
-export async function updateCommand(): Promise<void> {
+export async function upgradeCommand(): Promise<void> {
   try {
     const packageJson = await getPackageJson();
     const currentVersion = packageJson.version;


### PR DESCRIPTION
Spawning npm for self upgrade needs `shell: true` on windows