### PR TITLE
feat: add --gen-watch option to CLI dev command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deco-cli",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "CLI for managing deco.chat apps & projects",
   "license": "MIT",
   "author": "Deco team",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deco-cli",
-  "version": "0.16.3",
+  "version": "0.17.0",
   "description": "CLI for managing deco.chat apps & projects",
   "license": "MIT",
   "author": "Deco team",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -323,9 +323,14 @@ const dev = new Command("dev")
       };
     },
   )
+  .option(
+    "--gen-watch [path]",
+    "Watch for TypeScript file changes and regenerate deco.gen.ts (defaults to current directory)",
+  )
   .action((options) => {
     devCommand({
       cleanBuildDirectory: options.cleanBuildDir,
+      genWatch: options.genWatch === true ? "." : options.genWatch,
     });
   });
 

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -1,6 +1,10 @@
 import { spawn } from "child_process";
-import { getConfig, readWranglerConfig } from "../../lib/config.js";
+import { watch } from "fs";
+import { join, resolve } from "path";
+import { writeFile } from "fs/promises";
+import { getConfig, readWranglerConfig, getAppDomain } from "../../lib/config.js";
 import { ensureDevEnvironment } from "../../lib/wrangler.js";
+import { genEnv } from "../gen/gen.js";
 import { link } from "./link.js";
 import process from "node:process";
 
@@ -9,6 +13,7 @@ export interface StartDevServerOptions {
     enabled: boolean;
     directory: string;
   };
+  genWatch?: string;
 }
 
 export async function devCommand(opts: StartDevServerOptions): Promise<void> {
@@ -31,7 +36,72 @@ export async function devCommand(opts: StartDevServerOptions): Promise<void> {
 
     console.log(`📦 Starting development server for '${app}'...`);
 
-    // 3. TODO: Check/setup MCP configuration when we port those utilities
+    // 3. Setup gen-watch if requested
+    if (opts.genWatch) {
+      const watchPath = resolve(opts.genWatch);
+      console.log(`👀 Setting up file watcher for TypeScript files in: ${watchPath}`);
+      
+      let isGenerating = false;
+      const debounceMs = 500;
+      let debounceTimer: NodeJS.Timeout | null = null;
+      
+      const generateTypes = async () => {
+        if (isGenerating) return;
+        isGenerating = true;
+        
+        try {
+          console.log("🔄 TypeScript file changed, regenerating deco.gen.ts...");
+          
+          const config = await getConfig();
+          const wranglerConfig = await readWranglerConfig();
+          const env = await genEnv({
+            workspace: config.workspace,
+            local: config.local,
+            bindings: config.bindings,
+            selfUrl: `https://${getAppDomain(
+              config.workspace,
+              wranglerConfig.name ?? "my-app",
+            )}/mcp`,
+          });
+          
+          const outputPath = join(process.cwd(), "deco.gen.ts");
+          await writeFile(outputPath, env);
+          console.log(`✅ Generated types written to: ${outputPath}`);
+        } catch (error) {
+          console.error(
+            "❌ Failed to generate types:",
+            error instanceof Error ? error.message : String(error)
+          );
+        } finally {
+          isGenerating = false;
+        }
+      };
+      
+      // Generate initial types
+      await generateTypes();
+      
+      // Watch for changes
+      const watcher = watch(watchPath, { recursive: true }, (eventType, filename) => {
+        if (filename && filename.endsWith(".ts") && !filename.endsWith(".gen.ts")) {
+          // Debounce to avoid excessive regeneration
+          if (debounceTimer) {
+            clearTimeout(debounceTimer);
+          }
+          debounceTimer = setTimeout(generateTypes, debounceMs);
+        }
+      });
+      
+      // Clean up on exit
+      const cleanupWatcher = () => {
+        console.log("\n📁 Stopping file watcher...");
+        watcher.close();
+      };
+      
+      process.on("SIGINT", cleanupWatcher);
+      process.on("SIGTERM", cleanupWatcher);
+    }
+
+    // 4. TODO: Check/setup MCP configuration when we port those utilities
     // const latest = await hasMCPPreferences(config.workspace, app);
     // if (!latest) {
     //   const mcpConfig = await promptIDESetup({
@@ -43,7 +113,7 @@ export async function devCommand(opts: StartDevServerOptions): Promise<void> {
     //   }
     // }
 
-    // 4. Start development server with tunnel integration
+    // 5. Start development server with tunnel integration
     console.log("🚀 Starting development server with tunnel...");
 
     // Use link command with wrangler dev as subprocess


### PR DESCRIPTION
## Summary
• Add `--gen-watch` option to the CLI dev command for automatic TypeScript file watching
• Automatically regenerates `deco.gen.ts` when TypeScript files change in the watched directory  
• Includes debounced regeneration (500ms) to prevent excessive file generation

## Features
- Optional path parameter (defaults to current directory if omitted)
- Recursive file watching for `.ts` files (excludes `.gen.ts` to avoid infinite loops)
- Initial generation when dev server starts with the option enabled
- Proper cleanup of file watchers on process termination
- Error handling and user feedback for generation process

## Usage
```bash
# Watch current directory
deco dev --gen-watch

# Watch specific directory
deco dev --gen-watch ./src
```

## Test plan
- [ ] Test `deco dev --gen-watch` in a project with TypeScript files
- [ ] Verify `deco.gen.ts` is generated initially and on file changes
- [ ] Test with custom path: `deco dev --gen-watch ./src`
- [ ] Verify debouncing works with rapid file changes
- [ ] Test cleanup on process termination (Ctrl+C)

🤖 Generated with [Claude Code](https://claude.ai/code)