### PR TITLE
fix: preserve existing SELF types when gen command fails

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -391,17 +391,20 @@ const gen = new Command("gen")
     try {
       const wranglerConfig = await readWranglerConfig();
       const config = await getConfig({});
-      const env = await genEnv({
-        workspace: config.workspace,
-        local: config.local,
-        bindings: config.bindings,
-        selfUrl:
-          options.self ??
-          `https://${getAppDomain(
-            config.workspace,
-            wranglerConfig.name ?? "my-app",
-          )}/mcp`,
-      });
+      const env = await genEnv(
+        {
+          workspace: config.workspace,
+          local: config.local,
+          bindings: config.bindings,
+          selfUrl:
+            options.self ??
+            `https://${getAppDomain(
+              config.workspace,
+              wranglerConfig.name ?? "my-app",
+            )}/mcp`,
+        },
+        options.output,
+      );
       if (options.output) {
         await writeFile(options.output, env);
       } else {

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -191,13 +191,15 @@ async function customizeTemplate({
       await writeWranglerConfig(newConfig, wranglerRoot || targetDir);
 
       // Generate environment variables file
-      const envContent = await genEnv({
-        workspace: workspace,
-        local: false,
-        bindings: newConfig.deco.bindings || [],
-      });
-
       const outputPath = join(wranglerRoot || targetDir, "deco.gen.ts");
+      const envContent = await genEnv(
+        {
+          workspace: workspace,
+          local: false,
+          bindings: newConfig.deco.bindings || [],
+        },
+        outputPath,
+      );
       await fs.writeFile(outputPath, envContent);
       console.log(`✅ Environment types written to: ${outputPath}`);
     } catch (error) {

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -62,17 +62,19 @@ export async function devCommand(opts: StartDevServerOptions): Promise<void> {
 
           const config = await getConfig();
           const wranglerConfig = await readWranglerConfig();
-          const env = await genEnv({
-            workspace: config.workspace,
-            local: config.local,
-            bindings: config.bindings,
-            selfUrl: `https://${getAppDomain(
-              config.workspace,
-              wranglerConfig.name ?? "my-app",
-            )}/mcp`,
-          });
-
           const outputPath = join(process.cwd(), "deco.gen.ts");
+          const env = await genEnv(
+            {
+              workspace: config.workspace,
+              local: config.local,
+              bindings: config.bindings,
+              selfUrl: `https://${getAppDomain(
+                config.workspace,
+                wranglerConfig.name ?? "my-app",
+              )}/mcp`,
+            },
+            outputPath,
+          );
           await writeFile(outputPath, env);
           console.log(`✅ Generated types written to: ${outputPath}`);
         } catch (error) {


### PR DESCRIPTION
## Summary
Fixes the issue where the `deco gen` command would remove existing SELF types when the SELF integration could not be reached during generation.

Previously, when the SELF integration failed, the entire deco.gen.ts file would be regenerated without the SELF types, leaving users with non-functional code until the integration became available again.

## Changes
- Added preservation functions to read existing SELF types from generated files
- Enhanced the `genEnv` function to preserve existing SELF types when generation fails
- Modified the generation logic to include preserved types with clear comments
- Updated all callers to pass output path for proper preservation

## Test plan
- [x] Lint and format checks pass
- [x] TypeScript compilation succeeds
- [x] Code handles both successful SELF generation and fallback to preserved types
- [x] Preserved types are clearly marked with comments in generated files

🤖 Generated with [Claude Code](https://claude.ai/code)