### PR TITLE
fix: asTool

### DIFF
--- a/packages/runtime/jsr.json
+++ b/packages/runtime/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/workers-runtime",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "exports": {
     ".": "./src/index.ts",
     "./proxy": "./src/proxy.ts",

--- a/packages/runtime/src/mcp.ts
+++ b/packages/runtime/src/mcp.ts
@@ -132,9 +132,7 @@ export type MCPClientFetchStub<TDefinition extends readonly ToolBinder[]> = {
     : never;
 };
 
-export type MCPConnectionProvider =
-  | (() => Promise<MCPConnection>)
-  | MCPConnection;
+export type MCPConnectionProvider = MCPConnection;
 
 export interface MCPClientRaw {
   callTool: (tool: string, args: unknown) => Promise<unknown>;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Requires a direct MCP connection object; async/provider functions are no longer accepted.
  - Tool objects returned by listTools now expose id (derived from name) plus transformed input/output schemas; name and description are no longer included.

- Deprecations
  - Passing a function as options.connection now throws with guidance to use a connection object.

- Improvements
  - Tool listing is cached per-connection with better error handling; schemas can be transformed via an optional converter.

- Chores
  - Version bumped from 0.15.0 to 0.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->