### PR TITLE
Improve runtime behavior when integrationId is not available

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -301,7 +301,7 @@ const createMcpServerProxyForIntegration = async (
 const createMcpServerProxyForAppName = (c: Context) => {
   const ctx = honoCtxToAppCtx(c);
 
-  const appName = c.req.param("appName");
+  const appName = c.req.query("appName");
   const fetchIntegration = async () => {
     using _ = ctx.resourceAccess.grant();
     const integration = await State.run(ctx, () =>

--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -21,6 +21,9 @@ import {
   withMCPErrorHandling,
   WORKSPACE_TOOLS,
   wrapToolFn,
+  getIntegration,
+  type IntegrationWithTools,
+  getRegistryApp,
 } from "@deco/sdk/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type Context, Hono } from "hono";
@@ -45,7 +48,6 @@ import {
   ListToolsRequestSchema,
   ListToolsResult,
 } from "@modelcontextprotocol/sdk/types.js";
-import { getIntegration } from "packages/sdk/src/mcp/integrations/api.ts";
 import { createPosthogServerClient } from "packages/sdk/src/posthog.ts";
 import { studio } from "@outerbase/browsable-durable-object";
 
@@ -274,7 +276,47 @@ const proxy = (
   };
 };
 
-const createMcpServerProxy = async (c: Context) => {
+const createMcpServerProxyForIntegration = async (
+  c: Context,
+  fetchIntegration: () => Promise<
+    Pick<IntegrationWithTools, "connection" | "tools" | "id">
+  >,
+) => {
+  const ctx = honoCtxToAppCtx(c);
+
+  const integration = await fetchIntegration();
+
+  const mcpServerProxy = proxy(integration.connection, {
+    tools: integration.tools
+      ? { tools: integration.tools as ListToolsResult["tools"] }
+      : undefined,
+    middlewares: {
+      callTool: [withMCPAuthorization(ctx, { integrationId: integration.id })],
+    },
+  });
+
+  return mcpServerProxy;
+};
+
+const createMcpServerProxyForAppName = (c: Context) => {
+  const ctx = honoCtxToAppCtx(c);
+
+  const appName = c.req.param("appName");
+  const fetchIntegration = async () => {
+    using _ = ctx.resourceAccess.grant();
+    const integration = await State.run(ctx, () =>
+      getRegistryApp.handler({ name: appName }),
+    );
+
+    return {
+      ...integration,
+      tools: integration.tools ?? [],
+    };
+  };
+
+  return createMcpServerProxyForIntegration(c, fetchIntegration);
+};
+const createMcpServerProxy = (c: Context) => {
   const ctx = honoCtxToAppCtx(c);
 
   const integrationId = c.req.param("integrationId");
@@ -285,18 +327,7 @@ const createMcpServerProxy = async (c: Context) => {
     );
   };
 
-  const integration = await fetchIntegration();
-
-  const mcpServerProxy = proxy(integration.connection, {
-    tools: integration.tools
-      ? { tools: integration.tools as ListToolsResult["tools"] }
-      : undefined,
-    middlewares: {
-      callTool: [withMCPAuthorization(ctx, { integrationId })],
-    },
-  });
-
-  return mcpServerProxy;
+  return createMcpServerProxyForIntegration(c, fetchIntegration);
 };
 
 // Add logger middleware
@@ -365,6 +396,12 @@ app.post(
 
 app.post("/:root/:slug/:integrationId/mcp", async (c) => {
   const mcpServerProxy = await createMcpServerProxy(c);
+
+  return mcpServerProxy.fetch(c.req.raw);
+});
+
+app.post("/apps/mcp", async (c) => {
+  const mcpServerProxy = await createMcpServerProxyForAppName(c);
 
   return mcpServerProxy.fetch(c.req.raw);
 });

--- a/packages/runtime/jsr.json
+++ b/packages/runtime/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/workers-runtime",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "exports": {
     ".": "./src/index.ts",
     "./proxy": "./src/proxy.ts",

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -1,7 +1,7 @@
 import type { MCPConnection } from "./connection.ts";
 import type { DefaultEnv, RequestContext } from "./index.ts";
 import { MCPClient } from "./mcp.ts";
-import type { BindingBase, ContractBinding, MCPBinding } from "./wrangler.ts";
+import type { BindingBase, ContractBinding, MCPBinding, MCPIntegrationNameBinding } from "./wrangler.ts";
 
 interface IntegrationContext {
   integrationId: string;
@@ -87,7 +87,7 @@ const mcpClientForIntegrationId = (
   return MCPClient.forConnection(mcpConnection);
 };
 
-function mcpClientFromState(binding: BindingBase, env: DefaultEnv) {
+function mcpClientFromState(binding: BindingBase | MCPIntegrationNameBinding, env: DefaultEnv) {
   const ctx = env.DECO_CHAT_REQUEST_CONTEXT;
   const bindingFromState = ctx?.state?.[binding.name];
   const integrationId =
@@ -96,9 +96,9 @@ function mcpClientFromState(binding: BindingBase, env: DefaultEnv) {
     "value" in bindingFromState
       ? bindingFromState.value
       : undefined;
-  if (typeof integrationId !== "string") {
+  if (typeof integrationId !== "string" && "integration_name" in binding) {
     // in case of a binding to an app name, we need to use the new apps/mcp endpoint which will proxy the request to the app but without any token
-    return mcpClientForAppName(binding.name, env.DECO_CHAT_API_URL);
+    return mcpClientForAppName(binding.integration_name, env.DECO_CHAT_API_URL);
   }
   return mcpClientForIntegrationId(integrationId, ctx, env.DECO_CHAT_API_URL);
 }

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -1,7 +1,12 @@
 import type { MCPConnection } from "./connection.ts";
 import type { DefaultEnv, RequestContext } from "./index.ts";
 import { MCPClient } from "./mcp.ts";
-import type { BindingBase, ContractBinding, MCPBinding, MCPIntegrationNameBinding } from "./wrangler.ts";
+import type {
+  BindingBase,
+  ContractBinding,
+  MCPBinding,
+  MCPIntegrationNameBinding,
+} from "./wrangler.ts";
 
 interface IntegrationContext {
   integrationId: string;
@@ -87,7 +92,10 @@ const mcpClientForIntegrationId = (
   return MCPClient.forConnection(mcpConnection);
 };
 
-function mcpClientFromState(binding: BindingBase | MCPIntegrationNameBinding, env: DefaultEnv) {
+function mcpClientFromState(
+  binding: BindingBase | MCPIntegrationNameBinding,
+  env: DefaultEnv,
+) {
   const ctx = env.DECO_CHAT_REQUEST_CONTEXT;
   const bindingFromState = ctx?.state?.[binding.name];
   const integrationId =

--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -42,6 +42,11 @@ import * as teamsAPI from "./teams/api.ts";
 import * as threadsAPI from "./threads/api.ts";
 import * as triggersAPI from "./triggers/api.ts";
 import * as walletAPI from "./wallet/api.ts";
+export {
+  getIntegration,
+  type IntegrationWithTools,
+} from "./integrations/api.ts";
+export { getRegistryApp } from "./registry/api.ts";
 
 export type { ContractState } from "./contracts/api.ts";
 

--- a/packages/sdk/src/mcp/registry/api.ts
+++ b/packages/sdk/src/mcp/registry/api.ts
@@ -81,7 +81,7 @@ const RegistryToolSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string().optional(),
-  inputSchema: z.record(z.unknown()).optional(),
+  inputSchema: z.record(z.unknown()),
   outputSchema: z.record(z.unknown()).optional(),
   metadata: z.record(z.unknown()).optional(),
 });
@@ -291,7 +291,7 @@ export const getRegistryApp = createTool({
       if (result.error) throw result.error;
       data = result.data;
     } else if ("name" in ctx && ctx.name) {
-      const [scopeName, appName] = ctx.name.slice(1).split("/");
+      const { scopeName, name: appName } = AppName.parse(ctx.name);
       const result = await c.db
         .from(DECO_CHAT_APPS_REGISTRY_TABLE)
         .select(SELECT_REGISTRY_APP_WITH_SCOPE_QUERY)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added app-name based MCP proxy endpoint to route requests by app name.
  - Bindings that reference an app name now work without requiring an integration token.
  - SDK now exposes helpers to fetch integrations and registry apps.

- Improvements
  - Standardized tool mapping and typing for more consistent schemas.
  - Tools default to an empty list when not provided.

- Changes
  - Registry tools must now include an input schema (previously optional).

- Chores
  - Bumped runtime version to 0.16.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->