### PR TITLE
Update version to 0.16.2 and replace JSONSchemaToZod with zod-from-js…

### DIFF
--- a/packages/runtime/jsr.json
+++ b/packages/runtime/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/workers-runtime",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "exports": {
     ".": "./src/index.ts",
     "./proxy": "./src/proxy.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250617.0",
     "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5",
-    "@dmitryrechkin/json-schema-to-zod": "1.0.1",
     "@mastra/cloudflare-d1": "0.12.4",
     "@mastra/core": "0.12.1",
     "@modelcontextprotocol/sdk": "1.17.1",
@@ -14,7 +13,8 @@
     "jose": "^6.0.11",
     "mime-types": "^3.0.1",
     "zod": "^3.25.67",
-    "zod-to-json-schema": "^3.24.4"
+    "zod-to-json-schema": "^3.24.4",
+    "zod-from-json-schema": "^0.0.5"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/runtime/src/mcp.ts
+++ b/packages/runtime/src/mcp.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import type { MCPConnection } from "./connection.ts";
 import type { DefaultEnv } from "./index.ts";
 import { createMCPClientProxy } from "./proxy.ts";
-import { JSONSchemaToZod } from "@dmitryrechkin/json-schema-to-zod";
 
 export interface FetchOptions extends RequestInit {
   path?: string;
@@ -152,7 +151,6 @@ export interface CreateStubAPIOptions {
   token?: string;
   connection?: MCPConnectionProvider;
   debugId?: () => string;
-  jsonSchemaToZod?: JSONSchemaToZodConverter;
   getErrorByStatusCode?: (
     statusCode: number,
     message?: string,
@@ -165,6 +163,5 @@ export function createMCPFetchStub<TDefinition extends readonly ToolBinder[]>(
 ): MCPClientFetchStub<TDefinition> {
   return createMCPClientProxy<MCPClientFetchStub<TDefinition>>({
     ...(options ?? {}),
-    jsonSchemaToZod: (schema) => JSONSchemaToZod.convert(schema),
   });
 }

--- a/packages/runtime/src/proxy.ts
+++ b/packages/runtime/src/proxy.ts
@@ -1,5 +1,6 @@
 // deno-lint-ignore-file no-explicit-any
 import type { ToolExecutionContext } from "@mastra/core";
+import { convertJsonSchemaToZod } from "zod-from-json-schema";
 import { MCPConnection } from "./connection.ts";
 import { createServerClient } from "./mcp-client.ts";
 import type { CreateStubAPIOptions } from "./mcp.ts";
@@ -138,9 +139,13 @@ export function createMCPClientProxy<T extends Record<string, unknown>>(
 
         return {
           ...tool,
-          inputSchema: options?.jsonSchemaToZod?.(tool.inputSchema),
-          outputSchema: options?.jsonSchemaToZod?.(tool.outputSchema),
           id: tool.name,
+          inputSchema: tool.inputSchema
+            ? convertJsonSchemaToZod(tool.inputSchema)
+            : undefined,
+          outputSchema: tool.outputSchema
+            ? convertJsonSchemaToZod(tool.outputSchema)
+            : undefined,
           execute: ({ context }: ToolExecutionContext<any>) => {
             return callToolFn(context);
           },


### PR DESCRIPTION
…on-schema for schema conversion

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Bumped @deco/workers-runtime to 0.16.2.
  * Replaced a JSON Schema→Zod conversion dependency with a new one; retained zod-to-json-schema.

* Refactor
  * Standardized tool schema conversion to use a built-in JSON Schema→Zod converter by default.

* Bug Fixes
  * Improved consistency of generated tool input/output schemas via unified conversion.

* Note
  * Removed the option to provide a custom JSON Schema→Zod converter in runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->