### PR TITLE
Allow apps that uses DO to share its state

### DIFF
--- a/apps/deconfig/server/package.json
+++ b/apps/deconfig/server/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "deco dev --clean-build-dir ./view-build",
-    "deploy": "wrangler build && deco deploy ./dist --public",
+    "deploy": "wrangler build && deco deploy -l -y ./dist --public",
     "deploy:ci": "wrangler build && deco deploy -y -t $DECO_DEPLOY_TOKEN ./dist --public",
     "gen": "deco gen --output=deco.gen.ts",
     "gen:self": "deco gen --self=$DECO_SELF_URL --output=deco.gen.ts"

--- a/apps/deconfig/server/package.json
+++ b/apps/deconfig/server/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "deco dev --clean-build-dir ./view-build",
-    "deploy": "wrangler build && deco deploy -l -y ./dist --public",
+    "deploy": "wrangler build && deco deploy -y ./dist --public",
     "deploy:ci": "wrangler build && deco deploy -y -t $DECO_DEPLOY_TOKEN ./dist --public",
     "gen": "deco gen --output=deco.gen.ts",
     "gen:self": "deco gen --self=$DECO_SELF_URL --output=deco.gen.ts"

--- a/packages/sdk/src/mcp/hosting/api.ts
+++ b/packages/sdk/src/mcp/hosting/api.ts
@@ -686,7 +686,10 @@ Important Notes:
     hosts: z.array(z.string()).describe("The hosts of the app"),
     id: z.string().describe("The id of the app"),
     workspace: z.string().describe("The workspace of the app"),
-    deploymentId: z.string().describe("The deployment id of the app"),
+    deploymentId: z
+      .string()
+      .describe("The deployment id of the app")
+      .optional(),
   }),
   handler: async (
     {

--- a/packages/sdk/src/mcp/hosting/api.ts
+++ b/packages/sdk/src/mcp/hosting/api.ts
@@ -1,5 +1,4 @@
 import { D1Store } from "@deco/workers-runtime/d1";
-import { default as ShortUniqueId } from "short-unique-id";
 import { parse as parseToml } from "smol-toml";
 import { z } from "zod";
 import { JwtIssuer } from "../../auth/jwt.ts";
@@ -26,10 +25,6 @@ import { assertsDomainUniqueness } from "./custom-domains.ts";
 import { type DeployResult, deployToCloudflare } from "./deployment.ts";
 import type { WranglerConfig } from "./wrangler.ts";
 import { AppName } from "../../common/index.ts";
-const uid = new ShortUniqueId({
-  dictionary: "alphanum_lower",
-  length: 10,
-});
 
 const SCRIPT_FILE_NAME = "script.mjs";
 export const HOSTING_APPS_DOMAIN = ".deco.page";
@@ -148,7 +143,7 @@ interface UpdateDatabaseArgs {
   c: AppContext;
   workspace: string;
   scriptSlug: string;
-  deploymentId: string;
+  deploymentId?: string;
   result: DeployResult;
   wranglerConfig: WranglerConfig;
   force?: boolean;
@@ -197,6 +192,13 @@ async function updateDatabase({
   }
   if (!app) {
     throw new Error("Failed to create or update app.");
+  }
+  // FIXME Current limitation: Apps that uses DOs can't have custom domains.
+  // That's because DurableObjects states are stored in the worker, meaning that new instances are created for each deployment.
+  // So the durable object state is lost.
+  // @author @mcandeia
+  if (!deploymentId) {
+    return Mappers.toApp(app);
   }
 
   // Create new deployment record with manual deployment ID
@@ -791,8 +793,6 @@ Important Notes:
         sub: `app:${appName}`,
         aud: workspace,
       });
-      // using a shorter version than uuid to get friendlier urls
-      const deploymentId = uid.rnd();
 
       const appEnvVars = {
         DECO_CHAT_WORKSPACE: workspace,
@@ -800,8 +800,6 @@ Important Notes:
         DECO_CHAT_API_JWT_PUBLIC_KEY: keyPair?.public,
         DECO_CHAT_APP_SLUG: scriptSlug,
         DECO_CHAT_APP_NAME: appName,
-        DECO_CHAT_APP_DEPLOYMENT_ID: deploymentId,
-        DECO_CHAT_APP_ENTRYPOINT: Entrypoint.build(scriptSlug, deploymentId),
       };
 
       await Promise.all(
@@ -812,11 +810,10 @@ Important Notes:
         ),
       );
 
-      const result = await deployToCloudflare({
+      const { deploymentId, ...result } = await deployToCloudflare({
         c,
         wranglerConfig,
         mainModule: bundle ? SCRIPT_FILE_NAME : entrypoint,
-        deploymentId,
         bundledCode,
         assets: assetFiles,
         _envVars: { ...envVars, ...appEnvVars },
@@ -866,7 +863,10 @@ Important Notes:
         });
       return {
         entrypoint: data.entrypoint,
-        hosts: [data.entrypoint, Entrypoint.build(data.slug!, deploymentId)],
+        hosts: [
+          data.entrypoint,
+          ...(deploymentId ? [Entrypoint.build(data.slug!, deploymentId)] : []),
+        ],
         id: data.id,
         workspace: data.workspace,
         deploymentId,

--- a/packages/sdk/src/mcp/hosting/deployment.ts
+++ b/packages/sdk/src/mcp/hosting/deployment.ts
@@ -266,10 +266,10 @@ export async function deployToCloudflare({
       class_name: binding.class_name,
     })) ?? [];
   const hasAnyDoAsideWorkflows = durableObjects.some(
-    (durableObject) => "Workflow" === durableObject.class_name,
+    (durableObject) => "DECO_CHAT_WORKFLOW_DO" !== durableObject.name,
   );
 
-  const deploymentId = hasAnyDoAsideWorkflows ? uid.rnd() : undefined;
+  const deploymentId = hasAnyDoAsideWorkflows ? undefined : uid.rnd();
   const scriptSlug = Entrypoint.id(wranglerName, deploymentId);
   await Promise.all(
     (routes ?? []).map(

--- a/packages/sdk/src/mcp/hosting/deployment.ts
+++ b/packages/sdk/src/mcp/hosting/deployment.ts
@@ -11,10 +11,16 @@ import { assertsDomainOwnership } from "./custom-domains.ts";
 import { polyfill } from "./fs-polyfill.ts";
 import { isDoBinding, migrationDiff } from "./migrations.ts";
 import type { Contract, WranglerConfig } from "./wrangler.ts";
+import ShortUniqueId from "short-unique-id";
+const uid = new ShortUniqueId({
+  dictionary: "alphanum_lower",
+  length: 10,
+});
 
 const METADATA_FILE_NAME = "metadata.json";
 // Common types and utilities
 export type DeployResult = {
+  deploymentId?: string;
   etag?: string;
   id?: string;
   contracts?: Contract[];
@@ -218,7 +224,6 @@ export async function deployToCloudflare({
   bundledCode,
   assets,
   _envVars,
-  deploymentId,
   wranglerConfig: {
     name: wranglerName,
     compatibility_flags,
@@ -243,22 +248,28 @@ export async function deployToCloudflare({
   c: AppContext;
   wranglerConfig: WranglerConfig;
   mainModule: string;
-  deploymentId: string;
   bundledCode: Record<string, File>;
   assets: Record<string, string>;
   _envVars?: Record<string, string>;
 }): Promise<DeployResult> {
   assertHasWorkspace(c);
   const env = getEnv(c);
-  const envVars = {
-    ..._envVars,
-    ...vars,
-  };
+
   const zoneId = env.CF_ZONE_ID;
   if (!zoneId) {
     throw new Error("CF_ZONE_ID is not set");
   }
+  const durableObjects =
+    durable_objects?.bindings?.map((binding) => ({
+      type: "durable_object_namespace" as const,
+      name: binding.name,
+      class_name: binding.class_name,
+    })) ?? [];
+  const hasAnyDoAsideWorkflows = durableObjects.some(
+    (durableObject) => "Workflow" === durableObject.class_name,
+  );
 
+  const deploymentId = hasAnyDoAsideWorkflows ? uid.rnd() : undefined;
   const scriptSlug = Entrypoint.id(wranglerName, deploymentId);
   await Promise.all(
     (routes ?? []).map(
@@ -285,6 +296,13 @@ export async function deployToCloudflare({
         }),
     ),
   );
+
+  const envVars: Record<string, string | undefined> = {
+    ..._envVars,
+    ...vars,
+    DECO_CHAT_APP_DEPLOYMENT_ID: deploymentId,
+    DECO_CHAT_APP_ENTRYPOINT: Entrypoint.build(scriptSlug, deploymentId),
+  };
 
   const decoBindings = deco?.bindings ?? [];
   if (decoBindings.length > 0) {
@@ -426,22 +444,24 @@ export async function deployToCloudflare({
   if (envVars) {
     const promises = [];
     for (const [key, value] of Object.entries(envVars)) {
-      promises.push(
-        c.cf.workersForPlatforms.dispatch.namespaces.scripts.secrets.update(
-          env.CF_DISPATCH_NAMESPACE,
-          scriptSlug,
-          {
-            account_id: env.CF_ACCOUNT_ID,
-            name: key,
-            text: value,
-            type: "secret_text",
-          },
-        ),
-      );
+      value &&
+        promises.push(
+          c.cf.workersForPlatforms.dispatch.namespaces.scripts.secrets.update(
+            env.CF_DISPATCH_NAMESPACE,
+            scriptSlug,
+            {
+              account_id: env.CF_ACCOUNT_ID,
+              name: key,
+              text: value,
+              type: "secret_text",
+            },
+          ),
+        );
     }
     await Promise.all(promises);
   }
   return {
+    deploymentId,
     etag: result.etag,
     id: result.id,
     contracts: decoBindings

--- a/packages/sdk/src/mcp/hosting/deployment.ts
+++ b/packages/sdk/src/mcp/hosting/deployment.ts
@@ -444,7 +444,7 @@ export async function deployToCloudflare({
   if (envVars) {
     const promises = [];
     for (const [key, value] of Object.entries(envVars)) {
-      value &&
+      value != null &&
         promises.push(
           c.cf.workersForPlatforms.dispatch.namespaces.scripts.secrets.update(
             env.CF_DISPATCH_NAMESPACE,


### PR DESCRIPTION
Currently there is a limitation around DurableObject usage. The durable object state is lost each deployment. So I'm keeping old deployments to allow that. Because of that, breaking change check is not possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved deployment reliability by using provider-issued deployment IDs.
  * Prevented broken routes by only adding secondary hosts when a deployment exists.
  * Reduced secret update errors by only pushing truthy values.

* Refactor
  * Streamlined deployment flow; no changes required for existing integrations.

* Documentation
  * Clarified current limitations around custom domains with specific backends.

* Chores
  * Removed an unused dependency to reduce bundle size and maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->