### PR TITLE
Tavano/add more props at publish

### DIFF
--- a/packages/runtime/src/wrangler.ts
+++ b/packages/runtime/src/wrangler.ts
@@ -81,6 +81,9 @@ export interface Route {
 
 export interface WranglerConfig {
   name: string;
+  icon?: string;
+  friendly_name?: string;
+  description?: string;
   main?: string;
   scope?: string;
   main_module?: string;

--- a/packages/sdk/src/mcp/hosting/api.ts
+++ b/packages/sdk/src/mcp/hosting/api.ts
@@ -852,8 +852,15 @@ Important Notes:
         .REGISTRY_PUBLISH_APP({
           name: scriptSlug,
           scopeName: wranglerConfig?.scope ?? c.workspace.slug,
-          description: `App ${scriptSlug} by deco workers for workspace ${workspace}`,
-          icon: "https://assets.decocache.com/mcp/09e44283-f47d-4046-955f-816d227c626f/app.png",
+          description:
+            wranglerConfig?.description ??
+            `App ${scriptSlug} by deco workers for workspace ${workspace}`,
+          friendlyName:
+            wranglerConfig?.friendly_name ??
+            `App ${scriptSlug} by deco workers for workspace ${workspace}`,
+          icon:
+            wranglerConfig?.icon ??
+            "https://assets.decocache.com/mcp/09e44283-f47d-4046-955f-816d227c626f/app.png",
           ...wranglerConfig.deco?.integration,
           unlisted: isUnlisted,
           connection: Entrypoint.mcp(data.entrypoint),


### PR DESCRIPTION
Add more config options to deploy:

- description
- icon
-friendly_name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now set an app icon, friendly name, and description in your configuration.
  * These metadata fields are automatically included when publishing to the MCP registry.
  * If not provided, sensible defaults are used, ensuring consistent publish behavior without additional setup.
  * No other behavior changes; existing configurations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->