### PR TITLE
fix: delete agent from same workspace only

### DIFF
--- a/packages/sdk/src/mcp/agents/api.ts
+++ b/packages/sdk/src/mcp/agents/api.ts
@@ -232,7 +232,10 @@ export const deleteAgent = createTool({
 
     await assertWorkspaceResourceAccess(c);
 
-    const { error } = await c.db.from("deco_chat_agents").delete().eq("id", id);
+    const { error } = await c.db.from("deco_chat_agents")
+      .delete()
+      .eq("id", id)
+      .eq("workspace", c.workspace.value);
 
     const triggers = await listTriggers.handler({ agentId: id });
 

--- a/packages/sdk/src/mcp/agents/api.ts
+++ b/packages/sdk/src/mcp/agents/api.ts
@@ -232,7 +232,8 @@ export const deleteAgent = createTool({
 
     await assertWorkspaceResourceAccess(c);
 
-    const { error } = await c.db.from("deco_chat_agents")
+    const { error } = await c.db
+      .from("deco_chat_agents")
       .delete()
       .eq("id", id)
       .eq("workspace", c.workspace.value);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent deletion now correctly respects the active workspace, preventing removal of agents outside the current workspace.
  * Improves data isolation and reduces the risk of unintended cross-workspace deletions.
  * No changes to the public API or input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->