### PR TITLE
Tavano/remove view

### DIFF
--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -57,7 +57,7 @@ import { Link, useMatch } from "react-router";
 import { z } from "zod";
 import { trackEvent } from "../../hooks/analytics.ts";
 import { useUser } from "../../hooks/use-user.ts";
-import { useWorkspaceLink } from "../../hooks/use-navigate-workspace.ts";
+import { useNavigateWorkspace, useWorkspaceLink } from "../../hooks/use-navigate-workspace.ts";
 import { useFocusChat } from "../agents/hooks.ts";
 import { AgentAvatar } from "../common/avatar/agent.tsx";
 import { groupThreadsByDate } from "../threads/index.tsx";
@@ -420,7 +420,17 @@ function WorkspaceViews() {
   const { data: integrations } = useIntegrations();
   const team = useCurrentTeam();
   const removeViewMutation = useRemoveView();
+  const navigateWorkspace = useNavigateWorkspace();
+  
   const handleRemoveView = async (view: View) => {
+    const isUserInView = globalThis.location.pathname.includes(`/views/${view.id}`);
+    if(isUserInView){
+      navigateWorkspace("/");
+      await removeViewMutation.mutateAsync({
+        viewId: view.id,
+      });
+      return;
+    }
     await removeViewMutation.mutateAsync({
       viewId: view.id,
     });

--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -57,7 +57,10 @@ import { Link, useMatch } from "react-router";
 import { z } from "zod";
 import { trackEvent } from "../../hooks/analytics.ts";
 import { useUser } from "../../hooks/use-user.ts";
-import { useNavigateWorkspace, useWorkspaceLink } from "../../hooks/use-navigate-workspace.ts";
+import {
+  useNavigateWorkspace,
+  useWorkspaceLink,
+} from "../../hooks/use-navigate-workspace.ts";
 import { useFocusChat } from "../agents/hooks.ts";
 import { AgentAvatar } from "../common/avatar/agent.tsx";
 import { groupThreadsByDate } from "../threads/index.tsx";
@@ -421,10 +424,12 @@ function WorkspaceViews() {
   const team = useCurrentTeam();
   const removeViewMutation = useRemoveView();
   const navigateWorkspace = useNavigateWorkspace();
-  
+
   const handleRemoveView = async (view: View) => {
-    const isUserInView = globalThis.location.pathname.includes(`/views/${view.id}`);
-    if(isUserInView){
+    const isUserInView = globalThis.location.pathname.includes(
+      `/views/${view.id}`,
+    );
+    if (isUserInView) {
       navigateWorkspace("/");
       await removeViewMutation.mutateAsync({
         viewId: view.id,


### PR DESCRIPTION
The code was removing view and keeping user there, now it redirects before remove.

<img width="395" height="448" alt="Screenshot 2025-09-04 at 15 19 02" src="https://github.com/user-attachments/assets/a63ee798-0fce-441d-9260-7c8d005d87bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Deleting a view you’re currently viewing now safely redirects to the workspace home before removal, preventing errors, broken links, or blank screens.
  - Improved navigation flow after removing views to ensure a smooth transition and consistent sidebar state.
  - Reduces chances of ending up on an invalid or unavailable page when a view is removed, enhancing reliability and continuity during workspace navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->