### PR TITLE
default to new domain for MCPs now that 522 is fixed

### DIFF
--- a/packages/runtime/jsr.json
+++ b/packages/runtime/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/workers-runtime",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "exports": {
     ".": "./src/index.ts",
     "./proxy": "./src/proxy.ts",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -225,7 +225,7 @@ export const withBindings = <TEnv>({
 }): TEnv => {
   const env = _env as DefaultEnv<any>;
 
-  const apiUrl = env.DECO_API_URL ?? "https://api.deco.chat";
+  const apiUrl = env.DECO_API_URL ?? "https://api.decocms.com";
   let context;
   if (typeof tokenOrContext === "string") {
     const decoded = decodeJwt(tokenOrContext);

--- a/packages/sdk/src/auth/jwt.ts
+++ b/packages/sdk/src/auth/jwt.ts
@@ -95,7 +95,7 @@ export async function verifyJWT<
   return payload as JwtPayloadWithClaims<TClaims>;
 }
 
-const DECO_CHAT_ISSUER = "https://api.deco.chat";
+const DECO_CHAT_ISSUER = "https://api.decocms.com";
 
 export type JwtPayloadWithClaims<
   TClaims extends Record<string, unknown> = Record<string, unknown>,

--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -192,10 +192,7 @@ const virtualIntegrationsFor = (
   token?: string,
 ) => {
   // Create a virtual User Management integration
-  const legacyApiUrl = "https://api.deco.chat";
-  // const decoChatMcp = new URL("/mcp", DECO_CMS_API_URL);
-  // Point to legacy API for now
-  const decoChatMcp = new URL("/mcp", legacyApiUrl);
+  const decoChatMcp = new URL("/mcp", DECO_CMS_API_URL);
   const userManagementIntegration = {
     id: formatId("i", "user-management"),
     name: "User Management",
@@ -209,7 +206,7 @@ const virtualIntegrationsFor = (
     workspace,
     created_at: new Date().toISOString(),
   };
-  const workspaceMcp = new URL(`${workspace}/mcp`, legacyApiUrl);
+  const workspaceMcp = new URL(`${workspace}/mcp`, DECO_CMS_API_URL);
 
   // Create a virtual Workspace Management integration
   const workspaceManagementIntegration = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Switched default API base from api.deco.chat to api.decocms.com, affecting OAuth redirects when no custom URL is set.
  - Updated authentication issuer to decocms.com for JWT validation.
  - Redirected User Management and Workspace Management virtual integrations to the DECO CMS API.

- **Chores**
  - Bumped @deco/workers-runtime version from 0.17.1 to 0.17.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->