### PR TITLE
fix error after select first tool

### DIFF
--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -81,7 +81,7 @@ export function IntegrationListItem({
   const enabledCount = allTools.filter((tool) =>
     toolsSet[integration.id]?.includes(tool.name),
   ).length;
-  const isAll = total > 0;
+  const isAll = enabledCount === total && total > 0;
   const isEmpty = !isLoading && allTools.length === 0;
 
   // Helper function to check if a tool matches the search term
@@ -220,6 +220,7 @@ export function IntegrationListItem({
                   checked={isAll}
                   onClick={(e) => {
                     e.stopPropagation();
+                    e.preventDefault();
                     handleAll(!isAll);
                   }}
                   disabled={isLoading}

--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -81,7 +81,7 @@ export function IntegrationListItem({
   const enabledCount = allTools.filter((tool) =>
     toolsSet[integration.id]?.includes(tool.name),
   ).length;
-  const isAll = enabledCount === total && total > 0;
+  const isAll = total > 0;
   const isEmpty = !isLoading && allTools.length === 0;
 
   // Helper function to check if a tool matches the search term


### PR DESCRIPTION
the bug was:

https://github.com/user-attachments/assets/7e1e6951-b5f6-4c65-a2e4-2b4fd42e2693



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated the toolset selector’s “Select all” checkbox behavior. It now appears checked whenever at least one tool is available, while the toggle still selects or deselects all tools as before. You may see the checkbox checked even if not all tools are enabled; selections only change when you interact with the control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->