### PR TITLE
fix(outerbase studio proxy): block durable id override on body

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,7 @@
     "@deco/sdk": "^0.1.1",
     "@libsql/client": "^0.15.4",
     "@modelcontextprotocol/sdk": "1.17.1",
-    "@outerbase/browsable-durable-object": "^0.1.1",
+    "outerbase-browsable-do-enforced": "0.2.0",
     "@supabase/ssr": "0.6.1",
     "@supabase/supabase-js": "2.49.4",
     "ai": "^4.3.13",

--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -433,7 +433,7 @@ app.all("/:root/:slug/i:databases-management/studio", async (c) => {
     resource: "DATABASES_RUN_SQL",
   });
 
-  // The DO id can be overridden by the client, both on the URL 
+  // The DO id can be overridden by the client, both on the URL
   // for GET requests and on the body "id" property for POST requests
   // i've forked the library to add the ability to enforce the id
   return studio(c.req.raw, ctx.workspaceDO, {

--- a/apps/api/src/durable-objects/workspace-database.ts
+++ b/apps/api/src/durable-objects/workspace-database.ts
@@ -5,7 +5,7 @@ import {
   IWorkspaceDB,
   IWorkspaceDBMeta,
 } from "@deco/sdk/mcp";
-import { Browsable } from "@outerbase/browsable-durable-object";
+import { Browsable } from "outerbase-browsable-do-enforced";
 
 @Browsable()
 export class WorkspaceDatabase extends DurableObject implements IWorkspaceDB {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures the studio endpoint consistently enforces the workspace/tenant identifier for both GET and POST requests, reducing cross-tenant mix-ups, authorization errors, and “not found” issues.
  - Allows clients to explicitly override the workspace identifier via request parameters or body when needed, improving routing predictability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->