### PR TITLE
feat(runtime): simple "before" middleware for tool calls

### DIFF
--- a/packages/runtime/jsr.json
+++ b/packages/runtime/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/workers-runtime",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "exports": {
     ".": "./src/index.ts",
     "./proxy": "./src/proxy.ts",

--- a/packages/runtime/src/mastra.ts
+++ b/packages/runtime/src/mastra.ts
@@ -245,6 +245,7 @@ export interface CreateMCPServerOptions<
   Env = any,
   TSchema extends z.ZodTypeAny = never,
 > {
+  before?: (env: Env & DefaultEnv<TSchema>) => Promise<void> | void;
   oauth?: {
     state?: TSchema;
     scopes?: string[];
@@ -448,6 +449,8 @@ export const createMCPServer = <
   options: CreateMCPServerOptions<TEnv, TSchema>,
 ): MCPServer<TEnv, TSchema> => {
   const createServer = async (bindings: TEnv & DefaultEnv<TSchema>) => {
+    await options.before?.(bindings);
+
     const server = new McpServer(
       { name: "@deco/mcp-api", version: "1.0.0" },
       { capabilities: { tools: {} } },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional pre-initialization hook when starting the MCP server, enabling setup tasks to run before the server is constructed. Existing setups continue to work without changes.

- Chores
  - Updated workers runtime package version to 0.20.0 to align with the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->