### PR TITLE
docs update: deco

### DIFF
--- a/docs/view/src/content/en/cli-reference.mdx
+++ b/docs/view/src/content/en/cli-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Complete reference for the deco.chat CLI commands
+description: Complete reference for the deco CLI commands
 icon: Terminal
 ---
 
@@ -8,7 +8,7 @@ The **deco CLI** is your friend for managing projects and deployment. Here are s
 
 ## Authentication Commands
 
-Authenticate with deco.chat (prompts for your credentials). Do this once to allow the CLI to act on behalf of your account:
+Authenticate with deco (prompts for your credentials). Do this once to allow the CLI to act on behalf of your account:
 
 ```bash
 deco login
@@ -23,13 +23,13 @@ deco whoami
 
 ## Project Management
 
-Initialize a new deco.chat app. This sets up boilerplate code in the current directory (or a new directory) using a chosen template. It's the easiest way to start a project without manual configuration:
+Initialize a new deco app. This sets up boilerplate code in the current directory (or a new directory) using a chosen template. It's the easiest way to start a project without manual configuration:
 
 ```bash
 deco create
 ```
 
-Set or update the workspace/app configuration for the current project. If you didn't configure during init, run this to link your local code with a deco.chat workspace and application name:
+Set or update the workspace/app configuration for the current project. If you didn't configure during init, run this to link your local code with a deco workspace and application name:
 
 ```bash
 deco configure

--- a/docs/view/src/content/en/getting-started.mdx
+++ b/docs/view/src/content/en/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Set up your development environment and create your first deco.chat project
+description: Set up your development environment and create your first deco project
 icon: Play
 ---
 
@@ -13,7 +13,7 @@ Before you begin, make sure you have the following:
 
 - **Node.js** (v18+ recommended) – required for running the frontend development server and bundling assets.
 
-- **deco.chat CLI** – the command-line interface for deco.chat, which you can install via NPM.
+- **deco CLI** – the command-line interface for deco, which you can install via NPM.
 
 - **Cloudflare Account** – needed to deploy your app (Cloudflare Workers is the runtime).
 
@@ -21,7 +21,7 @@ Before you begin, make sure you have the following:
 
 ## Project Setup with the CLI
 
-Once your environment is ready, follow these steps to create a new deco.chat project:
+Once your environment is ready, follow these steps to create a new deco project:
 
 <StepGroup>
   <Step number={1} title="Create a project">
@@ -52,10 +52,10 @@ Once your environment is ready, follow these steps to create a new deco.chat pro
     npm run dev
     ```
     
-    This will spin up the development environment – usually it runs the Cloudflare Worker (MCP server) on a local port (8787 by default) and a Vite dev server for the frontend, with hot-reload for both. Check the terminal output for the local URL (often something like `https://localhost-<hash>.deco.host`), and open it in your browser. You should see the default deco.chat app interface loading.
+    This will spin up the development environment – usually it runs the Cloudflare Worker (MCP server) on a local port (8787 by default) and a Vite dev server for the frontend, with hot-reload for both. Check the terminal output for the local URL (often something like `https://localhost-<hash>.deco.host`), and open it in your browser. You should see the default deco app interface loading.
     
     <Callout type="success">
-      At this point, you have a running deco.chat application on your machine! 🎉
+      At this point, you have a running deco application on your machine! 🎉
     </Callout>
   </Step>
 </StepGroup>

--- a/docs/view/src/content/en/guides/building-views.mdx
+++ b/docs/view/src/content/en/guides/building-views.mdx
@@ -1,10 +1,10 @@
 ---
 title: Building Views
-description: Learn how to build custom React frontends in deco.chat
+description: Learn how to build custom React frontends in deco
 icon: Globe
 ---
 
-If you want to provide a custom user interface for your agents (for example, a web dashboard or chat UI), deco.chat's project structure supports a full **React + Tailwind** frontend that lives alongside the backend. Here's how the view layer works:
+If you want to provide a custom user interface for your agents (for example, a web dashboard or chat UI), deco's project structure supports a full **React + Tailwind** frontend that lives alongside the backend. Here's how the view layer works:
 
 ## Frontend Stack
 
@@ -61,7 +61,7 @@ The template uses **TanStack Router**, which is a type-safe router similar in sp
 
 ## UI Components
 
-Tailwind makes styling easier by using classes directly in JSX. You might have pre-made components (buttons, forms, etc.) in `src/components`. Feel free to build your own or integrate a design system. The key is that the frontend can be any React app; deco.chat doesn't impose much beyond the RPC setup. So you can use React libraries (charts, modals, etc.) as you normally would.
+Tailwind makes styling easier by using classes directly in JSX. You might have pre-made components (buttons, forms, etc.) in `src/components`. Feel free to build your own or integrate a design system. The key is that the frontend can be any React app; deco doesn't impose much beyond the RPC setup. So you can use React libraries (charts, modals, etc.) as you normally would.
 
 ## Connecting to Tools/Workflows
 
@@ -73,4 +73,4 @@ During `npm run dev`, if you edit a React component, HMR (Hot Module Reloading) 
 
 In summary, building the view is just like building any React web app, but with the advantage that your backend is just a function call away via the client. This means you don't have to set up separate REST or GraphQL endpoints for your AI logic – it's all unified.
 
-_(If you prefer not to have a custom view, you can ignore/remove the `/view` folder. Agents can also be used purely via API or the deco.chat web interface. But for custom applications, the view is where you create tailored experiences for end-users.)_
+_(If you prefer not to have a custom view, you can ignore/remove the `/view` folder. Agents can also be used purely via API or the deco web interface. But for custom applications, the view is where you create tailored experiences for end-users.)_

--- a/docs/view/src/content/en/guides/building-workflows.mdx
+++ b/docs/view/src/content/en/guides/building-workflows.mdx
@@ -1,10 +1,10 @@
 ---
 title: Building Workflows
-description: Learn how to create workflows in deco.chat using Mastra
+description: Learn how to create workflows in deco using Mastra
 icon: GitBranch
 ---
 
-While a single tool can do a simple task, **Workflows** let you combine multiple tools and logic to accomplish more complex objectives. Workflows in deco.chat use the Mastra framework under the hood, giving you a set of composable patterns for control flow.
+While a single tool can do a simple task, **Workflows** let you combine multiple tools and logic to accomplish more complex objectives. Workflows in deco use the Mastra framework under the hood, giving you a set of composable patterns for control flow.
 
 ## Workflow Basics
 

--- a/docs/view/src/content/en/guides/creating-tools.mdx
+++ b/docs/view/src/content/en/guides/creating-tools.mdx
@@ -1,10 +1,10 @@
 ---
 title: Creating Tools
-description: Learn how to create tools in deco.chat
+description: Learn how to create tools in deco
 icon: Wrench
 ---
 
-Tools are the basic actions that an agent can perform. In deco.chat, you'll create tools to interface with outside services or perform computations. Each tool is essentially a function with a defined input and output.
+Tools are the basic actions that an agent can perform. In deco, you'll create tools to interface with outside services or perform computations. Each tool is essentially a function with a defined input and output.
 
 ## Defining a Tool
 

--- a/docs/view/src/content/en/guides/debugging.mdx
+++ b/docs/view/src/content/en/guides/debugging.mdx
@@ -1,6 +1,6 @@
 ---
 title: Debugging and Tips
-description: Common issues and debugging strategies for deco.chat development
+description: Common issues and debugging strategies for deco development
 icon: Bug
 ---
 
@@ -18,7 +18,7 @@ If TypeScript is complaining, check your schemas and types. A common mistake is 
 
 If a tool that calls an external integration fails, verify the integration setup:
 
-- Did you connect the service in the deco.chat UI and grant permissions?
+- Did you connect the service in the deco UI and grant permissions?
 - Are your API keys or credentials correct and not expired?
 - Check the `env` usage: e.g., `env.GMAIL.sendEmail` will only exist if the Gmail integration is configured in that workspace. If it's undefined, the integration may not be added or the `deco.gen.ts` is outdated.
 - Look at the error message or status code from the external API (you can catch errors in your tool and log `e.response` etc.). It might be a 401 (auth issue), 400 (bad request payload), etc. Adjust your code or config accordingly.
@@ -64,7 +64,7 @@ Build your agent piece by piece. Test each tool individually (you can call tools
 
 ## Community and Support
 
-If you're stuck, the deco.chat community (Discord or forums) can be helpful. Also, Cloudflare Workers documentation is relevant since many issues might actually be generic Workers issues (like how do I store a secret, etc.). Don't hesitate to consult Cloudflare's docs for Workers specifics.
+If you're stuck, the deco community (Discord or forums) can be helpful. Also, Cloudflare Workers documentation is relevant since many issues might actually be generic Workers issues (like how do I store a secret, etc.). Don't hesitate to consult Cloudflare's docs for Workers specifics.
 
 ## Key Tips Recap
 

--- a/docs/view/src/content/en/guides/deployment.mdx
+++ b/docs/view/src/content/en/guides/deployment.mdx
@@ -1,10 +1,10 @@
 ---
 title: Deployment
-description: Learn how to deploy your deco.chat applications to production
+description: Learn how to deploy your deco applications to production
 icon: Rocket
 ---
 
-When you're ready to share your agent with the world (or your team), you'll deploy it to Cloudflare Workers via the deco.chat CLI. Deployment in deco.chat is remarkably simple compared to traditional apps – since your entire stack (front and back) is serverless and lives at Cloudflare's edge, going to production is often just one command.
+When you're ready to share your agent with the world (or your team), you'll deploy it to Cloudflare Workers via the deco CLI. Deployment in deco is remarkably simple compared to traditional apps – since your entire stack (front and back) is serverless and lives at Cloudflare's edge, going to production is often just one command.
 
 ## Build and Deploy Process
 
@@ -26,7 +26,7 @@ When `deco deploy` finishes, your app will be live at a URL, likely something li
 
 - **Durable Objects**: If you need longer-running or stateful interactions (like maintaining a conversation state beyond the context provided by deco by default), you might use Durable Objects. These are like single-instance workers that can hold state. Deco's advanced libs (like the actors library) can help if needed. But for many use cases, storing state in the agent's conversation history or a database is sufficient.
 
-- **Cron Triggers**: deco.chat's platform supports agent triggers (as seen in the intro video) – e.g., running an agent daily at 9am. Under the hood, this may use Workers Cron Triggers. If you set up triggers via the UI, ensure you deploy after scheduling them so the Worker has the trigger configured in `wrangler.toml`.
+- **Cron Triggers**: deco's platform supports agent triggers (as seen in the intro video) – e.g., running an agent daily at 9am. Under the hood, this may use Workers Cron Triggers. If you set up triggers via the UI, ensure you deploy after scheduling them so the Worker has the trigger configured in `wrangler.toml`.
 
 - **Limits**: Keep an eye on your usage. Cloudflare's free tier is generous but has limits on request count, etc. If your agent is going to be heavily used, consider enabling billing or at least monitoring usage in the Cloudflare dashboard.
 

--- a/docs/view/src/content/en/guides/getting-started.mdx
+++ b/docs/view/src/content/en/guides/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Get up and running with deco.chat in minutes
+description: Get up and running with deco in minutes
 icon: Rocket
 ---
 
@@ -9,7 +9,7 @@ import { Step } from "../../../components/ui/Step";
 
 # Getting Started
 
-Welcome to deco.chat! This guide will help you create your first MCP server with a beautiful documentation site.
+Welcome to deco! This guide will help you create your first MCP server with a beautiful documentation site.
 
 <StepGroup>
   <Step number={1} title="Create a project">

--- a/docs/view/src/content/en/guides/integrations.mdx
+++ b/docs/view/src/content/en/guides/integrations.mdx
@@ -1,14 +1,14 @@
 ---
 title: Integrations
-description: Learn how to connect external services and APIs in deco.chat
+description: Learn how to connect external services and APIs in deco
 icon: Link
 ---
 
-One of the most powerful aspects of deco.chat is how easily you can connect to external services – this could be anything from a SaaS API to a database or file storage. Integrations allow your agent to do things like: send emails, query your company database, fetch documents from Google Drive, or incorporate knowledge from PDFs and websites.
+One of the most powerful aspects of deco is how easily you can connect to external services – this could be anything from a SaaS API to a database or file storage. Integrations allow your agent to do things like: send emails, query your company database, fetch documents from Google Drive, or incorporate knowledge from PDFs and websites.
 
 ## Connecting External APIs
 
-Many common integrations are available out-of-the-box in deco.chat's integration library (for example, Slack, Gmail, Notion, Stripe, etc.). These can be added via the deco.chat UI (under the "Tools" or "Integrations" section). When you "Add Integration" and configure it (often OAuth or API keys), those integration's tools become available in your environment object `Env`. For instance, after adding Gmail and granting access, your Cloudflare Worker can call `env.GMAIL.sendEmail` as we saw earlier. The `deco.gen.ts` will have the types for `GMAIL.sendEmail` (and any other Gmail tools provided).
+Many common integrations are available out-of-the-box in deco's integration library (for example, Slack, Gmail, Notion, Stripe, etc.). These can be added via the deco UI (under the "Tools" or "Integrations" section). When you "Add Integration" and configure it (often OAuth or API keys), those integration's tools become available in your environment object `Env`. For instance, after adding Gmail and granting access, your Cloudflare Worker can call `env.GMAIL.sendEmail` as we saw earlier. The `deco.gen.ts` will have the types for `GMAIL.sendEmail` (and any other Gmail tools provided).
 
 If there isn't a built-in integration for what you need, you have two options:
 
@@ -28,7 +28,7 @@ If your agent needs to read/write data, you can integrate with databases:
 
 ## Knowledge Base Integration
 
-The Knowledge Base is a special integration for unstructured data. In the deco.chat UI, you can upload documents (PDFs, text, etc.) to your workspace's knowledge base. The platform will index these (e.g., split into chunks, vectorize them) so that agents can retrieve information from them when responding. From a developer perspective, once a document is uploaded:
+The Knowledge Base is a special integration for unstructured data. In the deco UI, you can upload documents (PDFs, text, etc.) to your workspace's knowledge base. The platform will index these (e.g., split into chunks, vectorize them) so that agents can retrieve information from them when responding. From a developer perspective, once a document is uploaded:
 
 - The agent's context will automatically include relevant snippets from these docs when the agent is asked about something related. (You might not need to write code for this – it's handled by the platform's retrieval-augmented generation system.)
 

--- a/docs/view/src/content/en/introduction.mdx
+++ b/docs/view/src/content/en/introduction.mdx
@@ -1,12 +1,12 @@
 ---
 title: Introduction
-description: Learn about deco.chat - the open-source foundation for building AI-native software
+description: Learn about deco - the open-source foundation for building AI-native software
 icon: Rocket
 ---
 
-![deco.chat](https://assets.decocache.com/decochatweb/d547b59f-c80b-4a76-8fa8-524d829baed1/capyreadme.png)
+![deco](https://assets.decocache.com/decochatweb/d547b59f-c80b-4a76-8fa8-524d829baed1/capyreadme.png)
 
-**deco.chat is an open-source foundation for building AI-native software.**
+**deco is an open-source foundation for building AI-native software.**
 
 We equip developers, engineers, and AI enthusiasts with robust tools to rapidly
 prototype, develop, and deploy AI-powered applications.
@@ -17,7 +17,7 @@ prototype, develop, and deploy AI-powered applications.
 - **Agentic engineers** deploying scalable, secure, and sustainable production
   systems
 
-## Why deco.chat?
+## Why deco?
 
 Our goal is simple: empower teams with Generative AI by giving builders
 the tools to create AI applications that scale beyond the initial demo and
@@ -50,7 +50,7 @@ Multi-step sequences that orchestrate Tools and logic. Workflows let you chain t
 
 ### MCP (Model Context Protocol)
 
-The protocol underpinning deco.chat that connects AI models (like Claude or GPT) with your Tools/Workflows. An MCP "server" is essentially your Cloudflare Worker that exposes Tools and Workflows to the agent. This allows an agent to invoke functions in a structured way.
+The protocol underpinning deco that connects AI models (like Claude or GPT) with your Tools/Workflows. An MCP "server" is essentially your Cloudflare Worker that exposes Tools and Workflows to the agent. This allows an agent to invoke functions in a structured way.
 
 ### Agents
 

--- a/docs/view/src/content/en/project-structure.mdx
+++ b/docs/view/src/content/en/project-structure.mdx
@@ -1,10 +1,10 @@
 ---
 title: Project Structure
-description: Understanding the deco.chat project layout and file organization
+description: Understanding the deco project layout and file organization
 icon: Folder
 ---
 
-Understanding the project layout will help you locate where to write code for tools, workflows, and the UI. A typical deco.chat project (especially one created with the React+Tailwind template) is organized as follows:
+Understanding the project layout will help you locate where to write code for tools, workflows, and the UI. A typical deco project (especially one created with the React+Tailwind template) is organized as follows:
 
 ```
 my-deco-app/

--- a/docs/view/src/content/en/reference/faq.mdx
+++ b/docs/view/src/content/en/reference/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-description: Frequently asked questions about deco.chat
+description: Frequently asked questions about deco
 icon: HelpCircle
 ---
 
@@ -36,7 +36,7 @@ import { Accordion } from "../../../components/ui/Accordion";
   </Accordion>
 
   <Accordion title="How do I connect to an external API?" icon="Globe" client:load>
-    1. Add the integration via the deco.chat dashboard
+    1. Add the integration via the deco dashboard
     2. Run `npm run gen` to get typed interfaces
     3. Use `env.INTEGRATION_NAME.method()` in your tools
   </Accordion>
@@ -74,7 +74,7 @@ import { Accordion } from "../../../components/ui/Accordion";
 
 <AccordionGroup>
   <Accordion title="Which integrations are available?" icon="Link" client:load>
-    Many common services like Slack, Gmail, Notion, Stripe, and more. Check the deco.chat dashboard for the full list.
+    Many common services like Slack, Gmail, Notion, Stripe, and more. Check the deco dashboard for the full list.
   </Accordion>
 
   <Accordion title="Can I create custom integrations?" icon="Code" client:load>
@@ -82,7 +82,7 @@ import { Accordion } from "../../../components/ui/Accordion";
   </Accordion>
 
   <Accordion title="How do I use the Knowledge Base?" icon="BookOpen" client:load>
-    Upload documents via the deco.chat UI. The platform will index them and make them available to your agents automatically.
+    Upload documents via the deco UI. The platform will index them and make them available to your agents automatically.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/view/src/content/en/reference/info.mdx
+++ b/docs/view/src/content/en/reference/info.mdx
@@ -1,16 +1,16 @@
 ---
 title: Information
-description: Reference information about deco.chat
+description: Reference information about deco
 icon: Info
 ---
 
-This page contains reference information about deco.chat.
+This page contains reference information about deco.
 
 ## Quick Reference
 
 ### CLI Commands
 
-- `deco login` - Authenticate with deco.chat
+- `deco login` - Authenticate with deco
 - `deco init` - Create a new project
 - `deco deploy` - Deploy to Cloudflare Workers
 - `deco gen` - Generate types for integrations

--- a/docs/view/src/content/en/reference/resources.mdx
+++ b/docs/view/src/content/en/reference/resources.mdx
@@ -1,26 +1,26 @@
 ---
 title: Reference and Resources
-description: Useful links and resources for deco.chat development
+description: Useful links and resources for deco development
 icon: Library
 ---
 
-Here is a collection of useful links and resources related to deco.chat and its ecosystem:
+Here is a collection of useful links and resources decoeco.chat and its ecosystem:
 
 ## Core Documentation
 
-- **deco.chat Source (GitHub):** The platform's code is open-source. Check out the [deco.cx/chat repository on GitHub](https://github.com/deco-cx/chat) for the core codebase. It's a great reference to understand how things work under the hood, and you can even contribute or browse issues for insight.
+- **deco Source (GitHub):** The platform's code is open-source. Check out the [deco.cx/chat repository on GitHub](https://github.com/deco-cx/chat) for the core codebase. It's a great reference to understand how things work under the hood, and you can even contribute or browse issues for insight.
 
 - **Deco CLI Documentation:** For details on CLI commands and options, see the **Deco CLI Reference** on the JSR package registry (which includes all commands and usage examples). This is essentially the README for `@deco/cli` and is kept up-to-date with the latest CLI version.
 
 ## Framework Documentation
 
-- **Mastra Framework Docs:** deco.chat builds on the Mastra agent framework. To dive deeper into workflow patterns, agent design, and advanced features, visit the [Mastra Documentation](https://mastra.ai/en/docs/workflows/control-flow). Key sections include the Workflows guide and API reference, which explain the `.then()`/`.parallel()`/`.branch()`/... syntax in detail.
+- **Mastra Framework Docs:** deco builds on the Mastra agent framework. To dive deeper into workflow patterns, agent design, and advanced features, visit the [Mastra Documentation](https://mastra.ai/en/docs/workflows/control-flow). Key sections include the Workflows guide and API reference, which explain the `.then()`/`.parallel()`/`.branch()`/... syntax in detail.
 
 - **Zod Documentation:** All input/output schemas in deco are defined with Zod. The [Zod official documentation](https://zod.dev/) is an excellent resource to learn about schema definitions, parsing, and error handling.
 
 ## Examples and Templates
 
-- **Example Projects (deco Apps):** The deco.cx organization has an **apps** repository containing open-source MCP apps that power deco.chat. These can serve as real-world examples. You may find sample tools, workflows, and usage of various integrations there. It's a helpful way to see how a larger project is structured beyond the templates.
+- **Example Projects (deco Apps):** The deco.cx organization has an **apps** repository containing open-source MCP apps that power deco. These can serve as real-world examples. You may find sample tools, workflows, and usage of various integrations there. It's a helpful way to see how a larger project is structured beyond the templates.
 
 ## Infrastructure
 
@@ -30,7 +30,7 @@ Here is a collection of useful links and resources related to deco.chat and its 
 
 ## Community
 
-- **deco.chat Community & Support:** Engage with other developers building on deco.chat. Often, others have solved similar problems or can provide guidance on tricky integrations.
+- **deco Community & Support:** Engage with other developers building on deco. Often, others have solved similar problems or can provide guidance on tricky integrations.
 
 - **GitHub Repos for Integrations:** Some integrations might have their own repos or reference docs (e.g., deco-cx/actors library for Durable Object actors, or deco-cx/vibeflare for a CMS integration). Explore the deco-cx GitHub organization for these ancillary projects.
 
@@ -38,4 +38,4 @@ Here is a collection of useful links and resources related to deco.chat and its 
 
 - **deco.camp:** Become an Agentic Engineer: [https://deco.camp/](https://deco.camp/)
 
-- **deco.chat Platform:** For enterprise features like SOC 2, SSO, FinOps console, or SLA: [https://deco.chat](https://deco.chat/)
+- **deco Platform:** For enterprise features like SOC 2, SSO, FinOps console, or SLA: [https://decocms.com](https://decocms.com/)

--- a/docs/view/src/content/pt-br/cli-reference.mdx
+++ b/docs/view/src/content/pt-br/cli-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Referência CLI
-description: Referência completa para os comandos CLI do deco.chat
+description: Referência completa para os comandos CLI do deco
 icon: Terminal
 ---
 
@@ -8,15 +8,15 @@ O **CLI deco** é seu amigo para gerenciar projetos e implantação. Aqui estão
 
 ## Comandos de Autenticação
 
-- **`deco login`:** Autenticar com deco.chat (solicita suas credenciais). Faça isso uma vez para permitir que o CLI aja em nome da sua conta.
+- **`deco login`:** Autenticar com deco (solicita suas credenciais). Faça isso uma vez para permitir que o CLI aja em nome da sua conta.
 
 - **`deco logout` / `deco whoami`:** Sair do CLI, ou verificar qual conta está atualmente logada.
 
 ## Gerenciamento de Projetos
 
-- **`deco init`:** Inicializar um novo aplicativo deco.chat. Isso configura código boilerplate no diretório atual (ou um novo diretório) usando um template escolhido. É a maneira mais fácil de começar um projeto sem configuração manual.
+- **`deco init`:** Inicializar um novo aplicativo deco. Isso configura código boilerplate no diretório atual (ou um novo diretório) usando um template escolhido. É a maneira mais fácil de começar um projeto sem configuração manual.
 
-- **`deco configure`:** Definir ou atualizar a configuração workspace/app para o projeto atual. Se você não configurou durante o init, execute isso para vincular seu código local com um workspace deco.chat e nome de aplicativo.
+- **`deco configure`:** Definir ou atualizar a configuração workspace/app para o projeto atual. Se você não configurou durante o init, execute isso para vincular seu código local com um workspace deco e nome de aplicativo.
 
 ## Comandos de Desenvolvimento
 

--- a/docs/view/src/content/pt-br/getting-started.mdx
+++ b/docs/view/src/content/pt-br/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Começando
-description: Configure seu ambiente de desenvolvimento e crie seu primeiro projeto deco.chat
+description: Configure seu ambiente de desenvolvimento e crie seu primeiro projeto deco
 icon: Play
 ---
 
@@ -12,7 +12,7 @@ Antes de começar, certifique-se de ter o seguinte:
 
 - **Conhecimento básico de TypeScript** – O projeto é pesado em TypeScript, então familiaridade com TS é importante (se você é novo, veja a documentação oficial do TypeScript para uma introdução).
 
-Uma vez que seu ambiente esteja pronto, siga estes passos para criar um novo projeto deco.chat:
+Uma vez que seu ambiente esteja pronto, siga estes passos para criar um novo projeto deco:
 
 ### 1. Inicialize um novo projeto
 
@@ -40,9 +40,9 @@ Inicie seu aplicativo localmente com:
 npm run dev
 ```
 
-Isso irá iniciar o ambiente de desenvolvimento – geralmente executa o Cloudflare Worker (servidor MCP) em uma porta local (8787 por padrão) e um servidor de desenvolvimento Vite para o frontend, com hot-reload para ambos. Verifique a saída do terminal para a URL local (frequentemente algo como `https://localhost-<hash>.deco.host`), e abra no seu navegador. Você deve ver a interface padrão do aplicativo deco.chat carregando.
+Isso irá iniciar o ambiente de desenvolvimento – geralmente executa o Cloudflare Worker (servidor MCP) em uma porta local (8787 por padrão) e um servidor de desenvolvimento Vite para o frontend, com hot-reload para ambos. Verifique a saída do terminal para a URL local (frequentemente algo como `https://localhost-<hash>.deco.host`), e abra no seu navegador. Você deve ver a interface padrão do aplicativo deco carregando.
 
-Neste ponto, você tem um aplicativo deco.chat rodando na sua máquina! 🎉
+Neste ponto, você tem um aplicativo deco rodando na sua máquina! 🎉
 
 ## Exemplo "Hello World"
 

--- a/docs/view/src/content/pt-br/guides/building-workflows.mdx
+++ b/docs/view/src/content/pt-br/guides/building-workflows.mdx
@@ -1,10 +1,10 @@
 ---
 title: Construindo Fluxos de Trabalho
-description: Aprenda como criar fluxos de trabalho no deco.chat usando Mastra
+description: Aprenda como criar fluxos de trabalho no deco usando Mastra
 icon: GitBranch
 ---
 
-Enquanto uma única ferramenta pode fazer uma tarefa simples, **Fluxos de Trabalho** permitem combinar múltiplas ferramentas e lógica para realizar objetivos mais complexos. Fluxos de trabalho no deco.chat usam o framework Mastra sob o capô, dando a você um conjunto de padrões composáveis para controle de fluxo.
+Enquanto uma única ferramenta pode fazer uma tarefa simples, **Fluxos de Trabalho** permitem combinar múltiplas ferramentas e lógica para realizar objetivos mais complexos. Fluxos de trabalho no deco usam o framework Mastra sob o capô, dando a você um conjunto de padrões composáveis para controle de fluxo.
 
 ## Básicos de Fluxo de Trabalho
 

--- a/docs/view/src/content/pt-br/guides/creating-tools.mdx
+++ b/docs/view/src/content/pt-br/guides/creating-tools.mdx
@@ -1,10 +1,10 @@
 ---
 title: Criando Ferramentas
-description: Aprenda como criar ferramentas no deco.chat
+description: Aprenda como criar ferramentas no deco
 icon: Wrench
 ---
 
-Ferramentas são as ações básicas que um agente pode executar. No deco.chat, você criará ferramentas para interfacear com serviços externos ou executar computações. Cada ferramenta é essencialmente uma função com uma entrada e saída definidas.
+Ferramentas são as ações básicas que um agente pode executar. No deco, você criará ferramentas para interfacear com serviços externos ou executar computações. Cada ferramenta é essencialmente uma função com uma entrada e saída definidas.
 
 ## Definindo uma Ferramenta
 

--- a/docs/view/src/content/pt-br/introduction.mdx
+++ b/docs/view/src/content/pt-br/introduction.mdx
@@ -1,10 +1,10 @@
 ---
 title: Introdução
-description: Aprenda sobre deco.chat - a fundação open-source para construir software nativo de IA
+description: Aprenda sobre deco - a fundação open-source para construir software nativo de IA
 icon: Rocket
 ---
 
-**deco.chat é uma fundação open-source para construir software nativo de IA.**
+**deco é uma fundação open-source para construir software nativo de IA.**
 
 Fornecemos os componentes principais para criar ferramentas, fluxos de trabalho, visualizações personalizadas e sistemas completos alimentados por IA.
 
@@ -22,7 +22,7 @@ Nosso objetivo é ajudar equipes a adotar GenAI dando aos construtores as ferram
 
 ## Conceitos Principais
 
-Antes de mergulhar, vamos definir rapidamente algumas ideias principais no deco.chat:
+Antes de mergulhar, vamos definir rapidamente algumas ideias principais no deco:
 
 ### Ferramentas
 
@@ -34,7 +34,7 @@ Sequências de múltiplas etapas que orquestram Ferramentas e lógica. Os fluxos
 
 ### MCP (Model Context Protocol)
 
-O protocolo que sustenta o deco.chat que conecta modelos de IA (como Claude ou GPT) com suas Ferramentas/Fluxos de Trabalho. Um "servidor" MCP é essencialmente seu Cloudflare Worker que expõe Ferramentas e Fluxos de Trabalho para o agente. Isso permite que um agente invoque funções de forma estruturada.
+O protocolo que sustenta o deco que conecta modelos de IA (como Claude ou GPT) com suas Ferramentas/Fluxos de Trabalho. Um "servidor" MCP é essencialmente seu Cloudflare Worker que expõe Ferramentas e Fluxos de Trabalho para o agente. Isso permite que um agente invoque funções de forma estruturada.
 
 ### Agentes
 

--- a/docs/view/src/content/pt-br/project-structure.mdx
+++ b/docs/view/src/content/pt-br/project-structure.mdx
@@ -1,10 +1,10 @@
 ---
 title: Estrutura do Projeto
-description: Entendendo o layout do projeto deco.chat e organização de arquivos
+description: Entendendo o layout do projeto deco e organização de arquivos
 icon: Folder
 ---
 
-Entender o layout do projeto ajudará você a localizar onde escrever código para ferramentas, fluxos de trabalho e a UI. Um projeto deco.chat típico (especialmente um criado com o template React+Tailwind) é organizado da seguinte forma:
+Entender o layout do projeto ajudará você a localizar onde escrever código para ferramentas, fluxos de trabalho e a UI. Um projeto deco típico (especialmente um criado com o template React+Tailwind) é organizado da seguinte forma:
 
 ```
 my-deco-app/


### PR DESCRIPTION
remove decochat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Rebranded documentation from “deco.chat” to “deco” across EN and PT-BR guides, references, and introductions.
  - Added a new “Hello World” example to PT-BR Getting Started, showcasing tool creation and testing.
  - Updated CLI references, including documenting a new command: deco gen:self.
  - Refined Integrations guide wording and removed an Env-specific tooling reference.
  - Updated Resources page links and terminology, including URL change to https://decocms.com.
  - Minor heading and phrasing adjustments for consistency (e.g., “Why deco”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->