### PR TITLE
chore: create default project on team creation

### DIFF
--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -603,7 +603,7 @@ export const createTeam = createTool({
     if (roleError) throw roleError;
 
     // Insert default project
-    const { data: project, error: projectError } = await c.db
+    const { error: projectError } = await c.db
       .from("deco_chat_projects")
       .insert([
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically creates a default project for every new team (named after the team), available immediately after team creation.

- Chores
  - Streamlined team creation and update inputs by removing the subscription ID field; only name and optional slug are accepted.
  - Inserts the default project right after team creation; errors during this insertion are surfaced to the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->