### PR TITLE
Add recent projects and fix back button

### DIFF
--- a/apps/web/src/components/common/avatar/index.tsx
+++ b/apps/web/src/components/common/avatar/index.tsx
@@ -152,7 +152,6 @@ function UnifiedAvatar({
   muted = false,
   ...props
 }: BaseAvatarProps) {
-  const [isLoaded, setIsLoaded] = useState(false);
   const [isError, setIsError] = useState(false);
   const fallbackContent = useMemo(() => {
     if (typeof fallback === "string") {
@@ -195,7 +194,6 @@ function UnifiedAvatar({
               src={url}
               alt="Avatar"
               className={cn(avatarImageVariants({ objectFit }))}
-              onLoad={() => setIsLoaded(true)}
               onError={() => setIsError(true)}
             />
           )}

--- a/apps/web/src/components/common/avatar/index.tsx
+++ b/apps/web/src/components/common/avatar/index.tsx
@@ -6,7 +6,7 @@ import {
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { cva, type VariantProps } from "class-variance-authority";
-import { type HTMLAttributes, type ReactNode, useMemo } from "react";
+import { type HTMLAttributes, type ReactNode, useMemo, useState } from "react";
 
 // Predefined color palette for avatar backgrounds with gradients and shadows
 const AVATAR_COLORS = [
@@ -152,6 +152,8 @@ function UnifiedAvatar({
   muted = false,
   ...props
 }: BaseAvatarProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isError, setIsError] = useState(false);
   const fallbackContent = useMemo(() => {
     if (typeof fallback === "string") {
       return fallback.substring(0, 1).toUpperCase();
@@ -188,14 +190,20 @@ function UnifiedAvatar({
         </div>
       ) : (
         <>
-          <AvatarImage
-            src={url}
-            alt="Avatar"
-            className={cn(avatarImageVariants({ objectFit }))}
-          />
-          <AvatarFallback className={cn(fallbackColor, "rounded-none")}>
-            {fallbackContent}
-          </AvatarFallback>
+          {url && !isError && (
+            <AvatarImage
+              src={url}
+              alt="Avatar"
+              className={cn(avatarImageVariants({ objectFit }))}
+              onLoad={() => setIsLoaded(true)}
+              onError={() => setIsError(true)}
+            />
+          )}
+          {(!url || isError) && (
+            <AvatarFallback className={cn(fallbackColor, "rounded-none")}>
+              {fallbackContent}
+            </AvatarFallback>
+          )}
         </>
       )}
     </AvatarUI>

--- a/apps/web/src/components/common/register-activity.tsx
+++ b/apps/web/src/components/common/register-activity.tsx
@@ -2,10 +2,11 @@ import { useRegisterActivity } from "../../hooks/use-register-activity.ts";
 
 interface Props {
   orgSlug?: string;
+  projectSlug?: string;
 }
 
-export default function RegisterActivity({ orgSlug }: Props) {
-  useRegisterActivity(orgSlug);
+export default function RegisterActivity({ orgSlug, projectSlug }: Props) {
+  useRegisterActivity(orgSlug, projectSlug);
 
   return null;
 }

--- a/apps/web/src/components/home/organizations.tsx
+++ b/apps/web/src/components/home/organizations.tsx
@@ -136,7 +136,7 @@ function RecentProjectsSection() {
         {recent.map((project) => (
           <Link
             key={`${project.org.slug}/${project.slug}`}
-            to={`/${project.org.slug}/${project.slug}/agents`}
+            to={`/${project.org.slug}/${project.slug}`}
             className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg border border-border"
           >
             <div className="p-4 flex flex-col gap-4">

--- a/apps/web/src/components/home/organizations.tsx
+++ b/apps/web/src/components/home/organizations.tsx
@@ -136,7 +136,7 @@ function RecentProjectsSection() {
         {recent.map((project) => (
           <Link
             key={`${project.org.slug}/${project.slug}`}
-            to={`/${project.org.slug}/${project.slug}`}
+            to={`/${project.org.slug}/${project.slug}/agents`}
             className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg border border-border"
           >
             <div className="p-4 flex flex-col gap-4">

--- a/apps/web/src/components/home/organizations.tsx
+++ b/apps/web/src/components/home/organizations.tsx
@@ -127,50 +127,78 @@ Organizations.Empty = () => (
 function RecentProjectsSection() {
   const recent = useRecentProjects();
 
-  if (!recent?.length) return null;
-
   return (
     <div className="@container flex flex-col gap-4">
       <h2 className="text-xl font-medium">Recent projects</h2>
-      <div className="grid grid-cols-2 @min-3xl:grid-cols-3 @min-6xl:grid-cols-4 gap-4">
-        {recent.map((project) => (
-          <Link
-            key={`${project.org.slug}/${project.slug}`}
-            to={`/${project.org.slug}/${project.slug}`}
-            className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg border border-border"
-          >
-            <div className="p-4 flex flex-col gap-4">
-              <div className="flex justify-between items-start">
-                <Avatar
-                  url={project.avatar_url || project.org.avatar_url || ""}
-                  fallback={project.org.slug}
-                  size="lg"
-                  objectFit="contain"
-                />
-                <Icon
-                  name="chevron_right"
-                  size={20}
-                  className="text-muted-foreground"
-                />
+      {recent?.length ? (
+        <div className="grid grid-cols-2 @min-3xl:grid-cols-3 @min-6xl:grid-cols-4 gap-4">
+          {recent.map((project) => (
+            <Link
+              key={`${project.org.slug}/${project.slug}`}
+              to={`/${project.org.slug}/${project.slug}`}
+              className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg border border-border"
+            >
+              <div className="p-4 flex flex-col gap-4">
+                <div className="flex justify-between items-start">
+                  <Avatar
+                    url={project.avatar_url || project.org.avatar_url || ""}
+                    fallback={project.org.slug}
+                    size="lg"
+                    objectFit="contain"
+                  />
+                  <Icon
+                    name="chevron_right"
+                    size={20}
+                    className="text-muted-foreground"
+                  />
+                </div>
+                <div className="flex flex-col gap-[2px]">
+                  <h3 className="text-sm text-muted-foreground truncate">
+                    /{project.org.slug}/{project.slug}
+                  </h3>
+                  <p className="font-medium truncate">{project.title}</p>
+                  {project.last_accessed_at && (
+                    <span className="text-xs text-muted-foreground">
+                      Last accessed {timeAgo(project.last_accessed_at)}
+                    </span>
+                  )}
+                </div>
               </div>
-              <div className="flex flex-col gap-[2px]">
-                <h3 className="text-sm text-muted-foreground truncate">
-                  /{project.org.slug}/{project.slug}
-                </h3>
-                <p className="font-medium truncate">{project.title}</p>
-                {project.last_accessed_at && (
-                  <span className="text-xs text-muted-foreground">
-                    Last accessed {timeAgo(project.last_accessed_at)}
-                  </span>
-                )}
-              </div>
-            </div>
-          </Link>
-        ))}
-      </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="text-sm text-muted-foreground">
+          No recent projects. Create one now.
+        </div>
+      )}
     </div>
   );
 }
+
+RecentProjectsSection.Skeleton = () => (
+  <div className="@container flex flex-col gap-4">
+    <div className="h-6 w-40 bg-stone-100 rounded animate-pulse" />
+    <div className="grid grid-cols-2 @min-3xl:grid-cols-3 @min-6xl:grid-cols-4 gap-4">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          key={index}
+          className="bg-stone-50 flex flex-col rounded-lg border border-border"
+        >
+          <div className="p-4 flex flex-col gap-4">
+            <div className="flex justify-between items-start">
+              <div className="h-12 w-12 bg-stone-100 rounded-lg animate-pulse" />
+              <div className="h-5 w-5 bg-stone-100 rounded animate-pulse" />
+            </div>
+            <div className="h-4 w-40 bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-48 bg-stone-100 rounded animate-pulse" />
+            <div className="h-3 w-32 bg-stone-100 rounded animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
 
 function MyOrganizations() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -180,7 +208,11 @@ function MyOrganizations() {
     <div className="flex w-full h-full items-start bg-background">
       <div className="p-8 flex flex-col gap-4 w-full">
         <DecoDayBanner />
-        <RecentProjectsSection />
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={<RecentProjectsSection.Skeleton />}>
+            <RecentProjectsSection />
+          </Suspense>
+        </ErrorBoundary>
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-medium">My organizations</h2>
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/home/organizations.tsx
+++ b/apps/web/src/components/home/organizations.tsx
@@ -1,11 +1,12 @@
 // deno-lint-ignore-file ensure-tailwind-design-system-tokens/ensure-tailwind-design-system-tokens
-import { useOrganizations } from "@deco/sdk";
+import { useOrganizations, useRecentProjects } from "@deco/sdk";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Suspense, useState } from "react";
 import { Link } from "react-router";
 import { ErrorBoundary } from "../../error-boundary";
 import { Avatar } from "../common/avatar";
+import { timeAgo } from "../../utils/time-ago";
 import { DecoDayBanner } from "../common/event/deco-day";
 import { OrgAvatars, OrgMemberCount } from "./members";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -28,7 +29,7 @@ function OrganizationCard({
   return (
     <Link
       to={url}
-      className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg"
+      className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg border border-border"
     >
       <div className="p-4 flex flex-col gap-4">
         <div className="flex justify-between items-start">
@@ -45,7 +46,7 @@ function OrganizationCard({
           />
         </div>
         <div className="flex flex-col gap-[2px]">
-          <h3 className="text-sm text-muted-foreground truncate">@{slug}</h3>
+          <h3 className="text-sm text-muted-foreground truncate">/{slug}</h3>
           <p className="font-medium truncate">{name}</p>
         </div>
       </div>
@@ -123,6 +124,48 @@ Organizations.Empty = () => (
   </div>
 );
 
+function RecentProjectsSection() {
+  const recent = useRecentProjects();
+
+  if (!recent?.length) return null;
+
+  return (
+    <div className="@container flex flex-col gap-4">
+      <h2 className="text-xl font-medium">Recent projects</h2>
+      <div className="grid grid-cols-2 @min-3xl:grid-cols-3 @min-6xl:grid-cols-4 gap-4">
+        {recent.map((project) => (
+          <Link
+            key={`${project.org.slug}/${project.slug}`}
+            to={`/${project.org.slug}/${project.slug}`}
+            className="bg-stone-50 hover:bg-stone-100 transition-colors flex flex-col rounded-lg border border-border"
+          >
+            <div className="p-4 flex flex-col gap-4">
+              <div className="flex justify-between items-start">
+                <Avatar
+                  url={project.avatar_url || project.org.avatar_url || ""}
+                  fallback={project.org.slug}
+                  size="lg"
+                  objectFit="contain"
+                />
+                <Icon name="chevron_right" size={20} className="text-muted-foreground" />
+              </div>
+              <div className="flex flex-col gap-[2px]">
+                <h3 className="text-sm text-muted-foreground truncate">/{project.org.slug}/{project.slug}</h3>
+                <p className="font-medium truncate">{project.title}</p>
+                {project.last_accessed_at && (
+                  <span className="text-xs text-muted-foreground">
+                    Last accessed {timeAgo(project.last_accessed_at)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function MyOrganizations() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -131,6 +174,7 @@ function MyOrganizations() {
     <div className="flex w-full h-full items-start bg-background">
       <div className="p-8 flex flex-col gap-4 w-full">
         <DecoDayBanner />
+        <RecentProjectsSection />
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-medium">My organizations</h2>
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/home/organizations.tsx
+++ b/apps/web/src/components/home/organizations.tsx
@@ -147,10 +147,16 @@ function RecentProjectsSection() {
                   size="lg"
                   objectFit="contain"
                 />
-                <Icon name="chevron_right" size={20} className="text-muted-foreground" />
+                <Icon
+                  name="chevron_right"
+                  size={20}
+                  className="text-muted-foreground"
+                />
               </div>
               <div className="flex flex-col gap-[2px]">
-                <h3 className="text-sm text-muted-foreground truncate">/{project.org.slug}/{project.slug}</h3>
+                <h3 className="text-sm text-muted-foreground truncate">
+                  /{project.org.slug}/{project.slug}
+                </h3>
                 <p className="font-medium truncate">{project.title}</p>
                 {project.last_accessed_at && (
                   <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/home/project-home.tsx
+++ b/apps/web/src/components/home/project-home.tsx
@@ -3,5 +3,5 @@ import { useWorkspaceLink } from "../../hooks/use-navigate-workspace";
 
 export function ProjectHome() {
   const workspaceLink = useWorkspaceLink();
-  return <Navigate to={workspaceLink("/agents")} />;
+  return <Navigate to={workspaceLink("/agents")} replace />;
 }

--- a/apps/web/src/components/layout/project.tsx
+++ b/apps/web/src/components/layout/project.tsx
@@ -60,7 +60,7 @@ export function ProjectLayout() {
     defaultValue: true,
   });
   const [open, setOpen] = useState(defaultOpen);
-  const { org } = useParams();
+  const { org, project } = useParams();
 
   const {
     profileOpen,
@@ -98,7 +98,7 @@ export function ProjectLayout() {
             <SidebarInset className="h-full flex-col bg-sidebar">
               <Outlet />
             </SidebarInset>
-            <RegisterActivity orgSlug={org} />
+            <RegisterActivity orgSlug={org} projectSlug={project} />
           </SidebarProvider>
         </ProfileModalProvider>
       </WithWorkspaceTheme>

--- a/apps/web/src/hooks/use-register-activity.ts
+++ b/apps/web/src/hooks/use-register-activity.ts
@@ -1,9 +1,18 @@
-import {
-  useRegisterActivity as useSDKRegisterActivity,
-  useTeam,
-} from "@deco/sdk";
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { registerProjectActivity } from "@deco/sdk";
 
-export const useRegisterActivity = (org?: string) => {
-  const { data: team } = useTeam(org);
-  useSDKRegisterActivity(team?.id);
+export const useRegisterActivity = (org?: string, project?: string) => {
+  const client = useQueryClient();
+
+  useEffect(() => {
+    if (!org || !project) return;
+    registerProjectActivity(org, project)
+      .then(() => {
+        client.invalidateQueries({ queryKey: ["recent-projects"] });
+      })
+      .catch((err) => {
+        console.error("Failed to register project activity", err);
+      });
+  }, [org, project]);
 };

--- a/packages/sdk/src/crud/projects.ts
+++ b/packages/sdk/src/crud/projects.ts
@@ -2,3 +2,6 @@ import { MCPClient } from "../fetcher.ts";
 
 export const listProjects = (org: string, init?: RequestInit) =>
   MCPClient.PROJECTS_LIST({ org }, init).then((res) => res.items);
+
+export const listRecentProjects = (init?: RequestInit) =>
+  MCPClient.PROJECTS_RECENT({ limit: 6 }, init).then((res) => res.items);

--- a/packages/sdk/src/crud/projects.ts
+++ b/packages/sdk/src/crud/projects.ts
@@ -8,6 +8,12 @@ export const listProjects = (
   MCPClient.PROJECTS_LIST({ org }, init).then((res) => res.items as Project[]);
 
 export const listRecentProjects = (init?: RequestInit): Promise<Project[]> =>
-  MCPClient.PROJECTS_RECENT({ limit: 12 }, init).then(
+  MCPClient.PROJECTS_RECENT({ limit: 6 }, init).then(
     (res) => res.items as Project[],
   );
+
+export const registerProjectActivity = (
+  org: string,
+  project: string,
+): Promise<{ success: boolean }> =>
+  MCPClient.PROJECT_ACTIVITY_REGISTER({ org, project });

--- a/packages/sdk/src/crud/projects.ts
+++ b/packages/sdk/src/crud/projects.ts
@@ -1,7 +1,13 @@
 import { MCPClient } from "../fetcher.ts";
+import type { Project } from "../models/project.ts";
 
-export const listProjects = (org: string, init?: RequestInit) =>
-  MCPClient.PROJECTS_LIST({ org }, init).then((res) => res.items);
+export const listProjects = (
+  org: string,
+  init?: RequestInit,
+): Promise<Project[]> =>
+  MCPClient.PROJECTS_LIST({ org }, init).then((res) => res.items as Project[]);
 
-export const listRecentProjects = (init?: RequestInit) =>
-  MCPClient.PROJECTS_RECENT({ limit: 6 }, init).then((res) => res.items);
+export const listRecentProjects = (init?: RequestInit): Promise<Project[]> =>
+  MCPClient.PROJECTS_RECENT({ limit: 12 }, init).then(
+    (res) => res.items as Project[],
+  );

--- a/packages/sdk/src/hooks/api.ts
+++ b/packages/sdk/src/hooks/api.ts
@@ -66,6 +66,7 @@ export const KEYS = {
   ],
   TEAMS: () => ["teams"],
   PROJECTS: (org: string) => ["projects", org],
+  RECENT_PROJECTS: () => ["recent-projects"],
   ORGANIZATION: (slug: string) => ["team", slug],
   TEAM_THEME: (slug: string) => ["team-theme", slug],
   TEAM_VIEWS: (locator: ProjectLocator, integrationId: string) => [

--- a/packages/sdk/src/hooks/teams.ts
+++ b/packages/sdk/src/hooks/teams.ts
@@ -61,7 +61,7 @@ export interface Project {
   org: {
     id: number;
     slug: string;
-    avatar_url?: string;
+    avatar_url?: string | null;
   };
   last_accessed_at?: string;
 }

--- a/packages/sdk/src/hooks/teams.ts
+++ b/packages/sdk/src/hooks/teams.ts
@@ -54,7 +54,6 @@ export const useOrganizations = (options: { searchQuery?: string } = {}) => {
   return queryResult;
 };
 
-
 export const useProjects = (options: {
   searchQuery?: string;
   org: string;

--- a/packages/sdk/src/hooks/teams.ts
+++ b/packages/sdk/src/hooks/teams.ts
@@ -79,13 +79,6 @@ export const useRecentProjects = (): Project[] => {
   const query = useSuspenseQuery<Project[]>({
     queryKey: KEYS.RECENT_PROJECTS(),
     queryFn: () => listRecentProjects(),
-    // Reduce auth/mcp pressure: rely on cache, no automatic refetches
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    networkMode: "online",
-    staleTime: 60_000,
-    gcTime: 300_000,
-    retry: 0,
   });
   return query.data;
 };

--- a/packages/sdk/src/hooks/teams.ts
+++ b/packages/sdk/src/hooks/teams.ts
@@ -54,7 +54,6 @@ export const useOrganizations = (options: { searchQuery?: string } = {}) => {
   return queryResult;
 };
 
-// Project interface moved to ../models/project.ts to avoid drift
 
 export const useProjects = (options: {
   searchQuery?: string;

--- a/packages/sdk/src/hooks/teams.ts
+++ b/packages/sdk/src/hooks/teams.ts
@@ -25,7 +25,7 @@ import { DEFAULT_THEME } from "../theme.ts";
 import { useSDK } from "./store.tsx";
 import { MCPConnection } from "../models/index.ts";
 import { listIntegrations } from "../crud/mcp.ts";
-import { listProjects } from "../crud/projects.ts";
+import { listProjects, listRecentProjects } from "../crud/projects.ts";
 import { Locator } from "../locator.ts";
 
 /**
@@ -63,6 +63,7 @@ export interface Project {
     slug: string;
     avatar_url?: string;
   };
+  last_accessed_at?: string;
 }
 
 export const useProjects = (options: {
@@ -82,6 +83,14 @@ export const useProjects = (options: {
   );
 
   return filtered;
+};
+
+export const useRecentProjects = (): Project[] => {
+  const query = useSuspenseQuery({
+    queryKey: KEYS.RECENT_PROJECTS(),
+    queryFn: () => listRecentProjects(),
+  });
+  return query.data;
 };
 
 export const useTeam = (slug: string = "") => {

--- a/packages/sdk/src/hooks/teams.ts
+++ b/packages/sdk/src/hooks/teams.ts
@@ -26,6 +26,7 @@ import { useSDK } from "./store.tsx";
 import { MCPConnection } from "../models/index.ts";
 import { listIntegrations } from "../crud/mcp.ts";
 import { listProjects, listRecentProjects } from "../crud/projects.ts";
+import type { Project } from "../models/project.ts";
 import { Locator } from "../locator.ts";
 
 /**
@@ -53,18 +54,7 @@ export const useOrganizations = (options: { searchQuery?: string } = {}) => {
   return queryResult;
 };
 
-export interface Project {
-  id: string;
-  title: string;
-  slug: string;
-  avatar_url: string | null;
-  org: {
-    id: number;
-    slug: string;
-    avatar_url?: string | null;
-  };
-  last_accessed_at?: string;
-}
+// Project interface moved to ../models/project.ts to avoid drift
 
 export const useProjects = (options: {
   searchQuery?: string;
@@ -86,9 +76,16 @@ export const useProjects = (options: {
 };
 
 export const useRecentProjects = (): Project[] => {
-  const query = useSuspenseQuery({
+  const query = useSuspenseQuery<Project[]>({
     queryKey: KEYS.RECENT_PROJECTS(),
     queryFn: () => listRecentProjects(),
+    // Reduce auth/mcp pressure: rely on cache, no automatic refetches
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    networkMode: "online",
+    staleTime: 60_000,
+    gcTime: 300_000,
+    retry: 0,
   });
   return query.data;
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,6 +16,7 @@ export * from "./crud/user.ts";
 export * from "./crud/wallet.ts";
 export * from "./crud/workflows.ts";
 export * from "./crud/roles.ts";
+export * from "./crud/projects.ts";
 export * from "./crud/registry.ts";
 
 export * from "./hooks/agent.ts";

--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -72,6 +72,7 @@ export const GLOBAL_TOOLS = [
   teamsAPI.updateTeam,
   teamsAPI.deleteTeam,
   teamsAPI.listTeams,
+  teamsAPI.listRecentProjects,
   teamsAPI.createTeamRole,
   teamsAPI.updateTeamRole,
   teamsAPI.deleteTeamRole,

--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -83,6 +83,7 @@ export const GLOBAL_TOOLS = [
   membersAPI.updateTeamMember,
   membersAPI.removeTeamMember,
   membersAPI.registerMemberActivity,
+  membersAPI.registerProjectActivity,
   membersAPI.getMyInvites,
   membersAPI.acceptInvite,
   membersAPI.deleteInvite,

--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -1240,8 +1240,8 @@ export const listRecentProjects = createTool({
   name: "PROJECTS_RECENT",
   description: "List recent projects for the current user based on activity",
   inputSchema: z.object({
-    // Prevent abuse: UI uses 6; allow up to 12
-    limit: z.number().int().min(1).max(12).optional().default(6),
+    // Prevent abuse: UI shows 12 by default; allow up to 24
+    limit: z.number().int().min(1).max(24).optional().default(12),
   }),
   outputSchema: z.object({
     items: z.array(
@@ -1265,7 +1265,7 @@ export const listRecentProjects = createTool({
 
     const user = c.user;
     const { limit } = props;
-    const safeLimit = Math.min(12, Math.max(1, Number(limit ?? 6)));
+    const safeLimit = Math.min(24, Math.max(1, Number(limit ?? 12)));
 
     // Get latest user activity rows (most recent first) and dedupe by team id
     const { data: activityData, error: activityError } = await c.db

--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -1329,6 +1329,15 @@ export const listRecentProjects = createTool({
       projectById.set(String(p.id), p);
     }
 
+    // Build a quick lookup for last access times (first seen = most recent)
+    const lastAccessedByProjectId = new Map<string, string>();
+    for (const row of activityData ?? []) {
+      const pid = String(row.value);
+      if (!lastAccessedByProjectId.has(pid)) {
+        lastAccessedByProjectId.set(pid, row.created_at as string);
+      }
+    }
+
     // Build items preserving the activity order of projects
     const items = (
       await Promise.all(
@@ -1372,9 +1381,7 @@ export const listRecentProjects = createTool({
                 slug: String(project.teams.slug || ""),
                 avatar_url: orgAvatar,
               },
-              last_accessed_at:
-                activityData?.find((a) => a.value === String(project.id))
-                  ?.created_at || undefined,
+              last_accessed_at: lastAccessedByProjectId.get(String(project.id)) || undefined,
             };
           }),
       )

--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -1245,7 +1245,7 @@ export const listRecentProjects = createTool({
   outputSchema: z.object({
     items: z.array(
       z.object({
-        id: z.union([z.string(), z.number()]),
+        id: z.string(),
         title: z.string(),
         slug: z.string(),
         avatar_url: z.string().nullable(),
@@ -1371,7 +1371,7 @@ export const listRecentProjects = createTool({
             }
 
             return {
-              id: project.id,
+              id: String(project.id),
               title: project.title,
               slug: project.slug,
               avatar_url: projectAvatar ?? orgAvatar ?? null,

--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -1242,10 +1242,26 @@ export const listRecentProjects = createTool({
   inputSchema: z.object({
     limit: z.number().optional().default(6),
   }),
+  outputSchema: z.object({
+    items: z.array(
+      z.object({
+        id: z.union([z.string(), z.number()]),
+        title: z.string(),
+        slug: z.string(),
+        avatar_url: z.string().nullable(),
+        org: z.object({
+          id: z.number(),
+          slug: z.string(),
+          avatar_url: z.string().nullable().optional(),
+        }),
+        last_accessed_at: z.string().optional(),
+      }),
+    ),
+  }),
   handler: async (props, c) => {
+    assertPrincipalIsUser(c);
     c.resourceAccess.grant();
 
-    assertPrincipalIsUser(c);
     const user = c.user;
     const { limit } = props;
 
@@ -1361,7 +1377,7 @@ export const listRecentProjects = createTool({
               avatar_url: projectAvatar ?? orgAvatar ?? null,
               org: {
                 id: project.teams.id,
-                slug: project.teams.slug,
+                slug: String(project.teams.slug || ""),
                 avatar_url: orgAvatar,
               },
               last_accessed_at:

--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -1381,7 +1381,8 @@ export const listRecentProjects = createTool({
                 slug: String(project.teams.slug || ""),
                 avatar_url: orgAvatar,
               },
-              last_accessed_at: lastAccessedByProjectId.get(String(project.id)) || undefined,
+              last_accessed_at:
+                lastAccessedByProjectId.get(String(project.id)) || undefined,
             };
           }),
       )

--- a/packages/sdk/src/models/project.ts
+++ b/packages/sdk/src/models/project.ts
@@ -1,0 +1,14 @@
+export interface ProjectOrgMeta {
+  id: number;
+  slug: string;
+  avatar_url?: string | null;
+}
+
+export interface Project {
+  id: string;
+  title: string;
+  slug: string;
+  avatar_url: string | null;
+  org: ProjectOrgMeta;
+  last_accessed_at?: string;
+}


### PR DESCRIPTION
<img width="1305" height="1045" alt="CleanShot 2025-09-14 at 11 48 34" src="https://github.com/user-attachments/assets/cd826a8c-1e87-454e-89b1-db46f1f2e0ff" />

### Summary
This PR implements the “Recent projects” section at the top of the home page, aggregates activity across all orgs, and aligns the card/UI styles with organization cards. It also fixes avatar/icon sourcing for recent projects and adds last-accessed metadata.

Closes [#1228](https://github.com/deco-cx/chat/issues/1228)

### What’s new
- Recent projects section appears before “My organizations”, not inside the orgs scroller.
- Shows up to 6 most recently accessed projects across any org.
- Each card displays:
  - Path as /org/project
  - Title
  - “Last accessed …” relative time
  - Avatar (org icon fallback if project icon is missing)
  - Subtle border and spacing consistent with org cards

### Backend
- Added PROJECTS_RECENT tool:
  - Reads from user_activity ordered by created_at desc, deduped by team, limit 6.
  - Resolves avatars:
    - Signs relative project icons (team-avatars/...) with the org’s workspace bucket.
    - Includes signed org avatar.
  - Returns last_accessed_at for each item.
- Avoided pulling sandbox/QuickJS tooling into web bundle by excluding sandbox tools from the global exported tools set (prevents Vite dep-scan WASM errors).

### SDK
- CRUD: listRecentProjects()
- Hooks/keys: KEYS.RECENT_PROJECTS(), useRecentProjects() (includes last_accessed_at in project shape)

### Web (apps/web)
- Home/organizations:
  - New RecentProjectsSection rendered above orgs.
  - Cards use same grid, paddings, and subtle border as organization cards.
  - Avatar logic prefers org icon, falls back to project icon; signed absolute URLs.
  - Path text updated to /org and /org/project (removed @ prefix).
  - Headers for Recent projects and My organizations share the same weight/size.
- Minor: kept scroll behavior to only wrap orgs grid.

### Why
- Faster return-to-work for users (requested in #1228).
- Consistent card hierarchy improves scannability.
- Fixes icon inconsistency and relative-path avatar issues.

### Notes on navigation
- Adjusted project landing redirect handling to avoid awkward history behavior when entering a project. Users can navigate back to orgs normally.

### Testing
- Visited multiple projects across orgs, confirmed ordering and dedupe.
- Verified relative project icon paths are signed to absolute URLs.
- Confirmed org icons appear as fallback when project icon missing.
- Checked responsive grid and header sizes.
- Ensured Vite dev server runs without WASM dep-scan errors.

### Risks / Rollout
- Recent projects relies on user_activity; if an environment lacks data, section hides gracefully.
- Tool added to global API surface; scopes validated.

### Checklist
- [x] UI matches design system spacing, borders, and typography
- [x] Uses @deco/ui components
- [x] No linter/type errors
- [x] Docs and code self-explanatory for new tool and hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent Projects section on the Organizations page with responsive project cards, avatars, links and “Last accessed” timestamps (includes loading skeleton).

* **Style**
  * Organization cards now have a border.
  * Organization slugs now display as “/slug” instead of “@slug”.

* **Bug Fixes**
  * Navigating from Project Home to Agents now replaces the history entry for better back-button behavior.

* **Improvements**
  * Avatars gracefully fall back on load error.
  * Recent Projects update more reliably when projects are accessed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->