### PR TITLE
Tavano/add personal slug

### DIFF
--- a/packages/sdk/src/mcp/registry/api.ts
+++ b/packages/sdk/src/mcp/registry/api.ts
@@ -333,7 +333,9 @@ export const listRegistryApps = createTool({
       .from(DECO_CHAT_APPS_REGISTRY_TABLE)
       .select(SELECT_REGISTRY_APP_WITH_SCOPE_QUERY)
       .or(
-        `unlisted.eq.false,and(workspace.eq.${workspace},unlisted.eq.true),and(workspace.eq.${personalSlug},unlisted.eq.true)`,
+        `unlisted.eq.false,` +
+          `and(workspace.eq."${workspace}",unlisted.eq.true),` +
+          `and(workspace.eq."${personalSlug}",unlisted.eq.true)`,
       );
 
     if (scopeName) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Registry browsing now surfaces personal apps when viewing unlisted apps, displaying results from both your current workspace and your personal workspace.
  - Listed apps continue to behave as before; only unlisted visibility is expanded.
  - No changes required to your setup or workflows; the enhanced visibility applies automatically when using the unlisted filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->