### PR TITLE
fix public agent

### DIFF
--- a/apps/web/src/components/agent/provider.tsx
+++ b/apps/web/src/components/agent/provider.tsx
@@ -155,7 +155,9 @@ export function AgentProvider({
   const latestRulesRef = useRef<string[] | null>(null);
 
   const mergedUiOptions = { ...DEFAULT_UI_OPTIONS, ...uiOptions };
-  const { data: threads } = useThreads();
+  const { data: threads } = useThreads({
+    enabled: mergedUiOptions.showThreadMessages,
+  });
   const { data: { messages: threadMessages } = { messages: [] } } =
     !mergedUiOptions.showThreadMessages
       ? { data: { messages: [] } }

--- a/packages/sdk/src/crud/thread.ts
+++ b/packages/sdk/src/crud/thread.ts
@@ -12,6 +12,7 @@ export interface ThreadFilterOptions {
     | "updatedAt_asc";
   cursor?: string;
   limit?: number;
+  enabled?: boolean;
 }
 
 export interface ThreadList {

--- a/packages/sdk/src/hooks/thread.ts
+++ b/packages/sdk/src/hooks/thread.ts
@@ -125,7 +125,10 @@ export const useThreads = (partialOptions: ThreadFilterOptions = {}) => {
 
   return useSuspenseQuery({
     queryKey: key,
-    queryFn: ({ signal }) => listThreads(locator, options, { signal }),
+    queryFn: ({ signal }) =>
+      options.enabled
+        ? listThreads(locator, options, { signal })
+        : { threads: [], pagination: { hasMore: false, nextCursor: null } },
   });
 };
 


### PR DESCRIPTION
- Updated the useThreads hook to accept an `enabled` option, allowing conditional fetching of thread data.
- Modified AgentProvider to utilize the new `enabled` option, improving control over thread message visibility based on UI options.

This change optimizes data retrieval and enhances performance by preventing unnecessary queries when thread messages are not needed.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional “enabled” filter to thread listing, allowing clients to control when thread data is fetched.
- Performance
  - Thread and thread message data are no longer fetched when thread messages are hidden, reducing unnecessary network calls and speeding up loads.
  - When disabled, thread data presents an empty state with no pagination, avoiding redundant processing.
- Refactor
  - Improved control flow around data fetching to align with UI visibility settings for thread messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->