### PR TITLE
fix: agent view without app instance

### DIFF
--- a/apps/web/src/components/decopilot/use-app-additional-tools.ts
+++ b/apps/web/src/components/decopilot/use-app-additional-tools.ts
@@ -9,11 +9,15 @@ export function useAppAdditionalTools() {
   const data = useGroupedApp({ appKey });
 
   // TODO: change for the selected one
-  const instance = data.instances?.[0];
+  const instance = data.instances?.[0] as
+    | (typeof data.instances)[number]
+    | undefined;
+
+  if (!instance) return {};
 
   return {
     [instance.id]:
-      (instance as unknown as { tools?: { name: string }[] }).tools?.map(
+      (instance as unknown as { tools?: { name: string }[] })?.tools?.map(
         (tool) => tool.name,
       ) ?? [],
   };


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
1. Open https://admin.deco.cx/<org-id>/<project-id>/connection/<app-connection-id> for app which isn't installed in project
2. Click to open agent/chat

before: 
<img width="425" height="423" alt="image" src="https://github.com/user-attachments/assets/487ea583-85d0-476f-8135-0b673e870c13" />

after: 
<img width="1111" height="959" alt="image" src="https://github.com/user-attachments/assets/3e9793d6-a1d1-43f1-b833-747fe9c6dd6b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors when no instance is available by handling empty selections gracefully.
  * Safely handles missing or undefined tools to avoid crashes and UI glitches.
  * Improves reliability of the additional tools panel in edge cases.

* **Refactor**
  * Hardened logic around instance and tool selection with safer access patterns and early exits, reducing undefined-state issues and improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->