### PR TITLE
fix(runtime): detect if its fetch only based on DECO_MCP_CLIENT_HEADER

### DIFF
--- a/packages/runtime/jsr.json
+++ b/packages/runtime/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/workers-runtime",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "exports": {
     ".": "./src/index.ts",
     "./proxy": "./src/proxy.ts",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -353,9 +353,7 @@ export const withRuntime = <TEnv, TSchema extends z.ZodTypeAny = never>(
       ctx: ExecutionContext,
     ) => {
       const referer = req.headers.get("referer");
-      const isFetchRequest =
-        req.headers.has(DECO_MCP_CLIENT_HEADER) ||
-        req.headers.get("sec-fetch-mode") === "cors";
+      const isFetchRequest = req.headers.has(DECO_MCP_CLIENT_HEADER);
 
       try {
         const bindings = withBindings({


### PR DESCRIPTION
This is for reliability on local development mainly. The vite dev server for cloudflare workers is sending sec-fetch-mode cors instead of navigate even for browser requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected request detection to ensure consistent authentication handling.
  - Unauthenticated API calls now return 401 responses instead of unexpected redirects in certain cases.
  - Improves reliability for API consumers and third-party integrations.

- Chores
  - Bumped runtime package version to 0.20.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->