### PR TITLE
Tavano/fix integrations list

### DIFF
--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -457,6 +457,14 @@ function WorkspaceViews() {
     for (const view of views) {
       const integrationId = view.integrationId as string | undefined;
       if (integrationId) {
+        const isInstalled = integrations?.some(
+          (integration) => integration.id === integrationId,
+        );
+
+        if (!isInstalled) {
+          continue;
+        }
+
         if (!result.fromIntegration[integrationId]) {
           result.fromIntegration[integrationId] = [];
         }

--- a/packages/sdk/src/mcp/agents/api.ts
+++ b/packages/sdk/src/mcp/agents/api.ts
@@ -80,7 +80,7 @@ export const matchByWorkspaceOrProjectLocatorForAgents = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return locator
+  return locator && locator?.project !== "default"
     ? and(
         eq(projects.slug, locator.project),
         eq(organizations.slug, locator.org),

--- a/packages/sdk/src/mcp/agents/api.ts
+++ b/packages/sdk/src/mcp/agents/api.ts
@@ -80,15 +80,12 @@ export const matchByWorkspaceOrProjectLocatorForAgents = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return or(
-    eq(agents.workspace, workspace),
-    locator
-      ? and(
-          eq(projects.slug, locator.project),
-          eq(organizations.slug, locator.org),
-        )
-      : undefined,
-  );
+  return locator
+    ? and(
+        eq(projects.slug, locator.project),
+        eq(organizations.slug, locator.org),
+      )
+    : eq(agents.workspace, workspace);
 };
 
 const AGENT_FIELDS_SELECT = {

--- a/packages/sdk/src/mcp/agents/api.ts
+++ b/packages/sdk/src/mcp/agents/api.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import {
   AgentSchema,

--- a/packages/sdk/src/mcp/api-keys/api.ts
+++ b/packages/sdk/src/mcp/api-keys/api.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { StatementSchema } from "../../auth/policy.ts";
 import { userFromJWT } from "../../auth/user.ts";

--- a/packages/sdk/src/mcp/api-keys/api.ts
+++ b/packages/sdk/src/mcp/api-keys/api.ts
@@ -60,15 +60,12 @@ export const matchByWorkspaceOrProjectLocatorForApiKeys = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return or(
-    eq(apiKeys.workspace, workspace),
-    locator
-      ? and(
-          eq(projects.slug, locator.project),
-          eq(organizations.slug, locator.org),
-        )
-      : undefined,
-  );
+  return locator
+    ? and(
+        eq(projects.slug, locator.project),
+        eq(organizations.slug, locator.org),
+      )
+    : eq(apiKeys.workspace, workspace);
 };
 
 export const listApiKeys = createTool({

--- a/packages/sdk/src/mcp/api-keys/api.ts
+++ b/packages/sdk/src/mcp/api-keys/api.ts
@@ -60,7 +60,7 @@ export const matchByWorkspaceOrProjectLocatorForApiKeys = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return locator
+  return locator && locator?.project !== "default"
     ? and(
         eq(projects.slug, locator.project),
         eq(organizations.slug, locator.org),

--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -87,7 +87,7 @@ export const matchByWorkspaceOrProjectLocatorForIntegrations = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return locator
+  return locator && locator?.project !== "default"
     ? and(
         eq(projects.slug, locator.project),
         eq(organizations.slug, locator.org),

--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -87,15 +87,12 @@ export const matchByWorkspaceOrProjectLocatorForIntegrations = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return or(
-    eq(integrations.workspace, workspace),
-    locator
-      ? and(
-          eq(projects.slug, locator.project),
-          eq(organizations.slug, locator.org),
-        )
-      : undefined,
-  );
+  return locator
+    ? and(
+        eq(projects.slug, locator.project),
+        eq(organizations.slug, locator.org),
+      )
+    : eq(integrations.workspace, workspace);
 };
 
 // Tool factories for each group


### PR DESCRIPTION
Integrations list was listing both from workspace and project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sidebar now hides views tied to uninstalled integrations, preventing broken or irrelevant items from appearing.
  - Improved filtering for agents, API keys, and integrations so workspace/project/org locators are honored correctly, reducing incorrect cross-workspace results and unintended matches.
  - Eliminated edge cases where absent locators could produce unintended matches, making resource lookup more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->