### PR TITLE
Revert "Tavano/fix integrations list"

### DIFF
--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -457,14 +457,6 @@ function WorkspaceViews() {
     for (const view of views) {
       const integrationId = view.integrationId as string | undefined;
       if (integrationId) {
-        const isInstalled = integrations?.some(
-          (integration) => integration.id === integrationId,
-        );
-
-        if (!isInstalled) {
-          continue;
-        }
-
         if (!result.fromIntegration[integrationId]) {
           result.fromIntegration[integrationId] = [];
         }

--- a/packages/sdk/src/mcp/agents/api.ts
+++ b/packages/sdk/src/mcp/agents/api.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, or } from "drizzle-orm";
 import { z } from "zod";
 import {
   AgentSchema,
@@ -80,12 +80,15 @@ export const matchByWorkspaceOrProjectLocatorForAgents = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return locator && locator?.project !== "default"
-    ? and(
-        eq(projects.slug, locator.project),
-        eq(organizations.slug, locator.org),
-      )
-    : eq(agents.workspace, workspace);
+  return or(
+    eq(agents.workspace, workspace),
+    locator
+      ? and(
+          eq(projects.slug, locator.project),
+          eq(organizations.slug, locator.org),
+        )
+      : undefined,
+  );
 };
 
 const AGENT_FIELDS_SELECT = {

--- a/packages/sdk/src/mcp/api-keys/api.ts
+++ b/packages/sdk/src/mcp/api-keys/api.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import { z } from "zod";
 import { StatementSchema } from "../../auth/policy.ts";
 import { userFromJWT } from "../../auth/user.ts";
@@ -60,12 +60,15 @@ export const matchByWorkspaceOrProjectLocatorForApiKeys = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return locator && locator?.project !== "default"
-    ? and(
-        eq(projects.slug, locator.project),
-        eq(organizations.slug, locator.org),
-      )
-    : eq(apiKeys.workspace, workspace);
+  return or(
+    eq(apiKeys.workspace, workspace),
+    locator
+      ? and(
+          eq(projects.slug, locator.project),
+          eq(organizations.slug, locator.org),
+        )
+      : undefined,
+  );
 };
 
 export const listApiKeys = createTool({

--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -87,12 +87,15 @@ export const matchByWorkspaceOrProjectLocatorForIntegrations = (
   workspace: string,
   locator?: LocatorStructured,
 ) => {
-  return locator && locator?.project !== "default"
-    ? and(
-        eq(projects.slug, locator.project),
-        eq(organizations.slug, locator.org),
-      )
-    : eq(integrations.workspace, workspace);
+  return or(
+    eq(integrations.workspace, workspace),
+    locator
+      ? and(
+          eq(projects.slug, locator.project),
+          eq(organizations.slug, locator.org),
+        )
+      : undefined,
+  );
 };
 
 // Tool factories for each group


### PR DESCRIPTION
Reverts deco-cx/chat#1309

this PR might have introduced a bug:
<img width="1066" height="500" alt="image" src="https://github.com/user-attachments/assets/27b6a529-7e20-443f-9786-42924a588109" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced filtering for agents, API keys, and integrations: results can match by workspace or by project/organization for more complete listings.

* **Bug Fixes**
  * Sidebar now consistently shows views tied to integrations, preventing views from being hidden when the related integration isn’t installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->