### PR TITLE
update tools_set at navigation

### DIFF
--- a/apps/web/src/components/agent/provider.tsx
+++ b/apps/web/src/components/agent/provider.tsx
@@ -201,6 +201,10 @@ export function AgentProvider({
     };
   }, [serverAgent.tools_set, additionalTools]);
 
+  useEffect(() => {
+    form.setValue("tools_set", mergedToolsSet);
+  }, [mergedToolsSet]);
+
   // Form state - for editing agent settings
   const form = useForm({
     defaultValues: { ...serverAgent, tools_set: mergedToolsSet },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Tools Set field in the agent form now stays in sync with changes to available tools, automatically updating when tool configurations merge or change. This prevents stale selections, reduces confusion during setup, and ensures the displayed selection accurately reflects the current options when switching providers or modifying tool availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->