### PR TITLE
add unpin one view option

### DIFF
--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -361,7 +361,7 @@ function WorkspaceViews() {
                   <SidebarMenuButton
                     asChild
                     isActive={isActive}
-                    className="w-full pr-8"
+                    className="w-full pr-2!"
                   >
                     <Link
                       to={href}
@@ -425,6 +425,18 @@ function WorkspaceViews() {
                       <span className="truncate">
                         {view.title ?? integration?.name ?? "Custom"}
                       </span>
+                      {view.type === "custom" && (
+                        <Icon
+                          name="unpin"
+                          size={18}
+                          className="text-muted-foreground/75 opacity-0 group-hover/item:opacity-50 hover:opacity-100 transition-opacity cursor-pointer ml-auto"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            handleRemoveView(view);
+                          }}
+                        />
+                      )}
                     </Link>
                   </SidebarMenuButton>
                 )}
@@ -438,7 +450,7 @@ function WorkspaceViews() {
             <Collapsible asChild defaultOpen className="group/collapsible">
               <div className="group/integration-header relative">
                 <CollapsibleTrigger asChild>
-                  <SidebarMenuButton className="w-full">
+                  <SidebarMenuButton className="w-full pr-2!">
                     <div className="relative">
                       <IntegrationAvatar
                         size="xs"


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/789253b2-a1f0-4467-86d5-98b8e466c1b3

After:

https://github.com/user-attachments/assets/22072c8e-64fc-4a66-a54a-abff6729d5cc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unpin icon to custom views in the sidebar, allowing users to remove/unpin a view directly without navigating away.

* **Style**
  * Reduced right padding on sidebar items and collapsible headers for a tighter, more consistent layout.
  * Introduced hover-revealed unpin icon with smooth opacity transitions to keep the UI clean while maintaining quick access to actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->