### PR TITLE
Adds api-keys outputschema and allow runtool receive authorization token

### DIFF
--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -79,13 +79,13 @@ const mcpClientForAppName = (appName: string, decoChatApiUrl?: string) => {
   return MCPClient.forConnection(mcpConnection);
 };
 
-const mcpClientForIntegrationId = (
+export const proxyConnectionForId = (
   integrationId: string,
   ctx: WorkspaceClientContext,
   decoChatApiUrl?: string,
   appName?: string,
-) => {
-  const mcpConnection: MCPConnection = {
+): MCPConnection => {
+  return {
     type: "HTTP",
     url: createIntegrationsUrl({
       integrationId,
@@ -96,6 +96,19 @@ const mcpClientForIntegrationId = (
     token: ctx.token,
     headers: appName ? { "x-caller-app": appName } : undefined,
   };
+};
+const mcpClientForIntegrationId = (
+  integrationId: string,
+  ctx: WorkspaceClientContext,
+  decoChatApiUrl?: string,
+  appName?: string,
+) => {
+  const mcpConnection = proxyConnectionForId(
+    integrationId,
+    ctx,
+    decoChatApiUrl,
+    appName,
+  );
 
   // TODO(@igorbrasileiro): Switch this proxy to be a proxy that call MCP Client.toolCall from @modelcontextprotocol
   return MCPClient.forConnection(mcpConnection);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,7 @@ import {
   workspaceClient,
 } from "./bindings.ts";
 import { DECO_MCP_CLIENT_HEADER } from "./client.ts";
+import { DeprecatedEnv } from "./deprecated.ts";
 import {
   createMCPServer,
   type CreateMCPServerOptions,
@@ -24,13 +25,12 @@ import { State } from "./state.ts";
 import type { WorkflowDO } from "./workflow.ts";
 import { Workflow } from "./workflow.ts";
 import type { Binding, ContractBinding, MCPBinding } from "./wrangler.ts";
-import { DeprecatedEnv } from "./deprecated.ts";
+export { proxyConnectionForId } from "./bindings.ts";
 export {
   createMCPFetchStub,
   type CreateStubAPIOptions,
   type ToolBinder,
 } from "./mcp.ts";
-
 export interface WorkspaceDB {
   query: (params: {
     sql: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional authorization token support when running tools; pass authorization to execute authorized tool calls.
  - Proxied connections by integration ID available via a new public helper.

- Changes
  - API Key operations now return structured outputs:
    - Create/Reissue include the key value.
    - List returns a typed list of keys.
    - Get/Update/Enable/Disable return consistent key data.
    - Validate includes a validity flag.
    - Delete confirms deletion with id and status.

- Refactor
  - Internal connection creation consolidated without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->