### PR TITLE
change workspace to locator to save in jwt

### DIFF
--- a/packages/sdk/src/mcp/api-keys/api.ts
+++ b/packages/sdk/src/mcp/api-keys/api.ts
@@ -278,7 +278,11 @@ export const reissueApiKey = createTool({
       .from("deco_chat_api_keys")
       .select(SELECT_API_KEY_QUERY)
       .eq("id", id)
-      .or(`workspace.eq.${workspace},project_id.eq.${projectId}`)
+      .or(
+        projectId
+          ? `workspace.eq.${workspace},project_id.eq.${projectId}`
+          : `workspace.eq.${workspace}`,
+      )
       .is("deleted_at", null)
       .single();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys now require a locator when created or reissued, preventing missing-locator cases.
  * API keys are now tied to the active project context to improve scoping and access control.
  * Token audience is set to the locator value (instead of the workspace) for both create and reissue flows.
  * If you verify tokens, update your checks to expect the locator as the audience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->