### PR TITLE
feat(api): enhance LLM provider and message conversion

### DIFF
--- a/packages/ai/src/agent/llm-provider.ts
+++ b/packages/ai/src/agent/llm-provider.ts
@@ -54,6 +54,7 @@ type Provider = {
   creator: NativeLLMCreator;
   envVarName: string;
   supportsOpenRouter?: boolean;
+  /** Maps openrouter model name to native model name so we can use the api directly, bypassing openrouter. */
   mapOpenRouterModel?: Record<string, string>;
   tokenLimit?: Record<string | "default", number>;
 };
@@ -62,11 +63,13 @@ type Provider = {
  */
 const providers: Record<string, Provider> = {
   anthropic: {
+    supportsOpenRouter: false, // generateObject fails when using openrouter.
     creator: anthropic,
     envVarName: "ANTHROPIC_API_KEY",
     mapOpenRouterModel: {
       "claude-3.7-sonnet:thinking": "claude-3-7-sonnet-latest",
       "claude-sonnet-4": "claude-sonnet-4-20250514",
+      "claude-sonnet-4.5": "claude-sonnet-4-5-20250929",
     } satisfies Partial<Record<string, ModelsOf<AnthropicProvider>>>,
     tokenLimit: {
       default: 200_000,
@@ -145,9 +148,10 @@ export const createLLMProvider: ProviderFactory = (opts) => {
         : undefined,
     });
     return (model: string) => {
-      model = opts.bypassOpenRouter
-        ? (provider.mapOpenRouterModel?.[model] ?? model)
-        : model;
+      model =
+        opts.bypassOpenRouter || provider.supportsOpenRouter === false
+          ? (provider.mapOpenRouterModel?.[model] ?? model)
+          : model;
       return { llm: creator(model), tokenLimit: modelLimit(provider, model) };
     };
   }


### PR DESCRIPTION
- Added support for mapping OpenRouter model names to native model names in the LLM provider.
- Updated the LLM provider to handle cases where OpenRouter is not supported.
- Replaced the deprecated message preparation function with a new conversion method from the Mastra core library for improved message handling in the API.
- Enhanced the `aiGenerate` and `aiGenerateObject` functions to utilize the new message conversion logic.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic model name mapping ensures correct models are used when routing is bypassed or not supported by a provider.
  - Enhanced JSON object generation with a dedicated mode and system guidance for more consistent, schema-compliant outputs.

- Bug Fixes
  - Fixed scenarios where unsupported routing could select incompatible models, improving reliability across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->