### PR TITLE
we should also pin the view tagged to be opened

### DIFF
--- a/apps/web/src/components/integrations/app-detail.tsx
+++ b/apps/web/src/components/integrations/app-detail.tsx
@@ -317,7 +317,9 @@ function ConfigureConnectionInstanceForm({
         const views = viewsResult.views || [];
 
         const viewsToPin = views.filter(
-          (view) => view.installBehavior === "autoPin" || view.installBehavior === "open",
+          (view) =>
+            view.installBehavior === "autoPin" ||
+            view.installBehavior === "open",
         );
         const viewToOpen = views.find(
           (view) => view.installBehavior === "open",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During integration installation, views configured to open are now also auto-pinned, so they remain accessible after setup.
  * Opening behavior is preserved: a view set to open will still open after installation while being pinned.
  * Improves discoverability and quick access to newly installed integration views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->