### PR TITLE
Implements deconfig head configuration and default value for path

### DIFF
--- a/packages/cli/src/commands/deconfig/clone.ts
+++ b/packages/cli/src/commands/deconfig/clone.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import process from "node:process";
 import { fetchFileContent } from "./base.js";
+import { writeDeconfigHead } from "../../lib/deconfig-head.js";
 
 interface CloneOptions {
   branchName: string;
@@ -99,6 +100,16 @@ export async function cloneCommand(options: CloneOptions): Promise<void> {
     console.log(
       `🎉 Clone completed! Downloaded ${result.count} files to ${localPath}`,
     );
+
+    // Write HEAD file with current configuration
+    await writeDeconfigHead({
+      workspace: workspace || "",
+      branch: branchName,
+      path: localPath,
+      pathFilter,
+      local,
+    });
+    console.log(`📝 Saved deconfig HEAD to .deconfig/head`);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/packages/cli/src/commands/deconfig/pull.ts
+++ b/packages/cli/src/commands/deconfig/pull.ts
@@ -11,6 +11,7 @@ import { fetchFileContent } from "./base.js";
 import { walk } from "../../lib/fs.js";
 import { createHash } from "crypto";
 import { createIgnoreChecker } from "../../lib/ignore.js";
+import { writeDeconfigHead } from "../../lib/deconfig-head.js";
 
 interface PullOptions {
   branchName: string;
@@ -260,6 +261,15 @@ export async function pullCommand(options: PullOptions): Promise<void> {
         `\n🎉 Pull completed successfully! Applied ${successCount} changes from ${branchName}`,
       );
     }
+
+    // Write/update HEAD file with current configuration
+    await writeDeconfigHead({
+      workspace: workspace || "",
+      branch: branchName,
+      path: localPath,
+      pathFilter,
+      local,
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/packages/cli/src/lib/deconfig-head.ts
+++ b/packages/cli/src/lib/deconfig-head.ts
@@ -1,0 +1,109 @@
+import { existsSync, promises as fs, mkdirSync } from "fs";
+import process from "node:process";
+import { join } from "path";
+
+export interface DeconfigHead {
+  workspace: string;
+  branch: string;
+  path?: string;
+  pathFilter?: string;
+  local?: boolean;
+}
+
+const DECONFIG_DIR = ".deconfig";
+const HEAD_FILE = "head";
+
+/**
+ * Get the path to the .deconfig/head file
+ * @param cwd - The current working directory (defaults to process.cwd())
+ * @returns The full path to the .deconfig/head file
+ */
+export function getDeconfigHeadPath(cwd?: string): string {
+  const targetCwd = cwd || process.cwd();
+  return join(targetCwd, DECONFIG_DIR, HEAD_FILE);
+}
+
+/**
+ * Get the path to the .deconfig directory
+ * @param cwd - The current working directory (defaults to process.cwd())
+ * @returns The full path to the .deconfig directory
+ */
+export function getDeconfigDir(cwd?: string): string {
+  const targetCwd = cwd || process.cwd();
+  return join(targetCwd, DECONFIG_DIR);
+}
+
+/**
+ * Ensure the .deconfig directory exists
+ * @param cwd - The current working directory (defaults to process.cwd())
+ */
+function ensureDeconfigDir(cwd?: string): void {
+  const deconfigDir = getDeconfigDir(cwd);
+  if (!existsSync(deconfigDir)) {
+    mkdirSync(deconfigDir, { recursive: true });
+  }
+}
+
+/**
+ * Read the deconfig HEAD file
+ * @param cwd - The current working directory (defaults to process.cwd())
+ * @returns The deconfig HEAD configuration or null if the file doesn't exist
+ */
+export async function readDeconfigHead(
+  cwd?: string,
+): Promise<DeconfigHead | null> {
+  const headPath = getDeconfigHeadPath(cwd);
+
+  try {
+    const content = await fs.readFile(headPath, "utf-8");
+    const config = JSON.parse(content) as DeconfigHead;
+    return config;
+  } catch (error) {
+    // File doesn't exist or is invalid JSON
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    console.warn(
+      `Warning: Could not read .deconfig/head file: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Write the deconfig HEAD file
+ * @param config - The deconfig HEAD configuration to write
+ * @param cwd - The current working directory (defaults to process.cwd())
+ */
+export async function writeDeconfigHead(
+  config: DeconfigHead,
+  cwd?: string,
+): Promise<void> {
+  ensureDeconfigDir(cwd);
+  const headPath = getDeconfigHeadPath(cwd);
+
+  try {
+    // Write config as formatted JSON
+    const content = JSON.stringify(config, null, 2);
+    await fs.writeFile(headPath, content, "utf-8");
+  } catch (error) {
+    console.error(
+      `❌ Failed to write .deconfig/head file: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    throw error;
+  }
+}
+
+/**
+ * Check if a deconfig HEAD file exists
+ * @param cwd - The current working directory (defaults to process.cwd())
+ * @returns True if the HEAD file exists, false otherwise
+ */
+export function hasDeconfigHead(cwd?: string): boolean {
+  const headPath = getDeconfigHeadPath(cwd);
+  return existsSync(headPath);
+}

--- a/packages/cli/src/lib/ignore.ts
+++ b/packages/cli/src/lib/ignore.ts
@@ -38,6 +38,7 @@ export class DeconfigIgnore {
     const defaultPatterns = [
       "node_modules/",
       ".git/",
+      ".deconfig/",
       ".DS_Store",
       "*.tmp",
       "*.temp",


### PR DESCRIPTION
# Add Git-like HEAD System for Deconfig Commands

## Summary

This PR implements a Git-like HEAD system for deconfig commands, allowing users to work without repeatedly specifying `-w` (workspace) and `-b` (branch) flags. After cloning or pulling a deconfig branch, a `.deconfig/head` file stores the current workspace, branch, and path configuration, which subsequent commands automatically use.

## Motivation

Currently, every deconfig command requires explicit workspace and branch flags:
```bash
deco deconfig push --path ./src -w my-workspace -b main
deco deconfig pull --path ./src -w my-workspace -b main
deco deconfig list -w my-workspace -b main
```

This is repetitive and error-prone. This PR introduces a `.deconfig/head` file (similar to `.git/HEAD`) that stores the current configuration, enabling simpler workflows:
```bash
# Initial setup
deco deconfig clone -b main --path ./src -w my-workspace

# Subsequent commands just work
deco deconfig push
deco deconfig pull
deco deconfig list
```

## Changes

### 1. New File: `packages/cli/src/lib/deconfig-head.ts`
- Created utilities to read/write `.deconfig/head` file in JSON format
- Stores: `workspace`, `branch`, `path`, `pathFilter`, and `local` flag
- Key functions:
  - `readDeconfigHead()` - Read current HEAD configuration
  - `writeDeconfigHead()` - Write/update HEAD configuration
  - `getDeconfigHeadPath()` - Get path to HEAD file
  - `hasDeconfigHead()` - Check if HEAD file exists

### 2. Updated: `packages/cli/src/lib/ignore.ts`
- Added `.deconfig/` to default ignore patterns
- Ensures the `.deconfig/head` file is never pushed to remote branches
- Updated alongside existing patterns: `node_modules/`, `.git/`, `.DS_Store`, etc.

### 3. Updated: `packages/cli/src/commands/deconfig/clone.ts`
- Writes `.deconfig/head` file after successful clone
- Displays confirmation message: `📝 Saved deconfig HEAD to .deconfig/head`

### 4. Updated: `packages/cli/src/commands/deconfig/pull.ts`
- Writes/updates `.deconfig/head` file after successful pull
- Keeps HEAD in sync with latest pull configuration

### 5. Updated: `packages/cli/src/cli.ts`
- Modified all deconfig command handlers to support HEAD system:
  - `push`, `pull`, `clone`, `list`, `delete`, `get`, `put`, `watch`
- Each command now:
  1. Reads from `.deconfig/head` if it exists
  2. Merges HEAD values with CLI flags (flags always override HEAD)
  3. Updates HEAD file with final values used

## How It Works

### Initial Setup (Clone or Pull)
```bash
# Clone creates the .deconfig/head file
deco deconfig clone -b main --path ./my-project -w my-workspace

# .deconfig/head contents:
# {
#   "workspace": "my-workspace",
#   "branch": "main",
#   "path": "./my-project",
#   "local": false
# }
```

### Subsequent Commands (No Flags Required)
```bash
# All values read from .deconfig/head
deco deconfig push
deco deconfig pull
deco deconfig list
deco deconfig delete /some-file
```

### Override HEAD Values
```bash
# CLI flags override HEAD values and update HEAD
deco deconfig push -b develop  # Switches to develop branch

# .deconfig/head is updated with new branch
```

### Priority Order
1. CLI flags (highest priority)
2. `.deconfig/head` values
3. Default values (e.g., `main` for branch, `.` for path)

## Testing Checklist

- [x] Clone command creates `.deconfig/head` file
- [x] Pull command updates `.deconfig/head` file
- [x] Push command reads from HEAD when no flags provided
- [x] All commands work without HEAD file (backward compatible)
- [x] CLI flags override HEAD values
- [x] HEAD file is updated when flags are provided
- [x] `.deconfig/` directory is ignored during push
- [x] No linter errors introduced
- [x] TypeScript compilation passes

## Breaking Changes

None. This is fully backward compatible:
- Commands work exactly as before when flags are provided
- HEAD file is optional - commands fall back to defaults if it doesn't exist
- Existing workflows are unaffected

## Benefits

✅ **Better DX**: Fewer flags to type after initial setup  
✅ **Git-like workflow**: Familiar pattern for developers  
✅ **Less error-prone**: Reduces chance of using wrong workspace/branch  
✅ **Flexible**: CLI flags can still override HEAD values  
✅ **Backward compatible**: Existing scripts continue to work  

## Examples

### Before (repetitive)
```bash
deco deconfig push --path ./src -w my-workspace -b main
deco deconfig list -w my-workspace -b main
deco deconfig delete /old-file -w my-workspace -b main
deco deconfig get /config.json -w my-workspace -b main
```

### After (streamlined)
```bash
deco deconfig clone -b main --path ./src -w my-workspace
deco deconfig push
deco deconfig list
deco deconfig delete /old-file
deco deconfig get /config.json
```

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Persistent workspace/branch/path settings across deconfig commands via saved HEAD; CLI flags merge with saved values and are auto-saved after successful runs.
  - Default path is now “.” for clone, pull, push, watch, and related commands, reducing required flags.
  - Clone and pull record the latest settings to enable seamless follow-up operations.
  - The .deconfig directory is ignored by default.
- Documentation
  - Help text updated to reflect new defaults, ignore patterns, and state synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->