### PR TITLE
bump create document button to the new version and add agent

### DIFF
--- a/apps/web/src/components/agents/list.tsx
+++ b/apps/web/src/components/agents/list.tsx
@@ -389,7 +389,7 @@ const VISIBILITY_LABELS = {
 type Visibility = (typeof VISIBILITIES)[number];
 type TabId = "active" | Visibility;
 
-const useFocusTeamAgent = () => {
+export const useFocusTeamAgent = () => {
   const focusChat = useFocusChat();
   const handleCreate = () => {
     focusChat(WELL_KNOWN_AGENT_IDS.teamAgent, crypto.randomUUID(), {


### PR DESCRIPTION
At **generate** button:

Add agent
<img width="435" height="372" alt="Screenshot 2025-10-13 at 19 47 38" src="https://github.com/user-attachments/assets/576af952-35b0-4a70-aaec-4e298f5e9faf" />

Update create document button to use the new version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Agent creation option in the Generate modal, enabling quick setup of a new agent.
  * Replaced prompt creation with a document creation flow that auto-generates an “Untitled” document (with timestamp) and navigates to it immediately.

* **Improvements**
  * Streamlined navigation after creating content, taking you directly to the new document.

* **Style**
  * Minor UI adjustments for icon and text alignment in the sidebar and modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->