### PR TITLE
avoid show legacy option to users that dont need

### DIFF
--- a/apps/web/src/components/documents/list-page.tsx
+++ b/apps/web/src/components/documents/list-page.tsx
@@ -1,8 +1,16 @@
+import { usePrompts } from "@deco/sdk";
 import { DocumentsResourceList } from "./documents-resource-list.tsx";
 import { DocumentsTabs } from "./tabs-nav.tsx";
 
 export default function DocumentsListPage() {
+  // it is being used to not pollute the screen for new users
+  // as soon as no one uses the old prompts anymore, we can remove it
+  // to not fetch it unnecessarily
+  const { data: legacyPrompts } = usePrompts();
+  const hideLegacy = legacyPrompts?.length <= 2;
   return (
-    <DocumentsResourceList headerSlot={<DocumentsTabs active="documents" />} />
+    <DocumentsResourceList
+      headerSlot={hideLegacy ? undefined : <DocumentsTabs active="documents" />}
+    />
   );
 }


### PR DESCRIPTION
Legacy option should be showed only to users that have at least one document in the old model.

Before:
<img width="646" height="248" alt="Screenshot 2025-10-14 at 00 37 57" src="https://github.com/user-attachments/assets/4eafb66f-6477-4aec-b148-ac04f29c741a" />

After:
<img width="643" height="224" alt="Screenshot 2025-10-14 at 00 38 47" src="https://github.com/user-attachments/assets/b8fad875-a085-4f7e-bd8a-9af591bc1e19" />

