### PR TITLE
fix(sdk): project ID filtering retrieval with organization filtering

### DIFF
--- a/packages/sdk/src/mcp/projects/util.ts
+++ b/packages/sdk/src/mcp/projects/util.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { organizations, projects } from "../schema";
 import { AppContext } from "../context";
 import { assertHasWorkspace } from "../assertions";
@@ -10,9 +10,17 @@ export async function getProjectIdFromContext(
     return null;
   }
   const project = await c.drizzle
-    .select()
+    .select({
+      id: projects.id,
+    })
     .from(projects)
-    .where(eq(projects.slug, c.locator?.project))
+    .leftJoin(organizations, eq(projects.org_id, organizations.id))
+    .where(
+      and(
+        eq(projects.slug, c.locator.project),
+        eq(organizations.slug, c.locator.org),
+      ),
+    )
     .limit(1)
     .then((r) => r[0]);
   return project?.id ?? null;


### PR DESCRIPTION
- Updated the `getProjectIdFromContext` function to include organization filtering by adding a left join with the `organizations` table.
- Modified the select query to retrieve the project ID based on both project and organization slugs, improving accuracy in project identification.

This change enhances the functionality of the SDK by ensuring that project IDs are correctly fetched in the context of their associated organizations.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected project lookup to respect the organization context, preventing mismatches when identical project slugs exist across different organizations.
* **Performance**
  * Reduced data retrieved during project resolution for faster, more efficient lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->