### PR TITLE
fix(layout): fix project switcher avatar loading + reuse same project list for org/project switcher

### DIFF
--- a/apps/web/src/components/layout/org-project-switcher.tsx
+++ b/apps/web/src/components/layout/org-project-switcher.tsx
@@ -1,5 +1,4 @@
-// deno-lint-ignore-file ensure-tailwind-design-system-tokens/ensure-tailwind-design-system-tokens
-import { useOrganizations, useProjects } from "@deco/sdk";
+import { useOrganizations } from "@deco/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
@@ -13,46 +12,7 @@ import { Suspense, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Avatar } from "../common/avatar";
 import { CreateOrganizationDialog } from "../sidebar/create-team-dialog";
-
-function SwitcherOrgProjects({ org, search }: { org: string; search: string }) {
-  const projects = useProjects({ searchQuery: search, org });
-  const navigate = useNavigate();
-  return (
-    <div className="flex flex-col gap-0.5 p-1 max-h-44 overflow-y-auto">
-      {projects.length === 0 && (
-        <div className="text-muted-foreground text-sm px-1 py-8 text-center">
-          No projects found.
-        </div>
-      )}
-      {projects.map((project) => (
-        <Button
-          key={project.id}
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start font-normal"
-          onClick={() => navigate(`/${org}/${project.slug}`)}
-        >
-          <Avatar
-            url={project.avatar_url ?? undefined}
-            fallback={project.slug}
-            size="xs"
-            objectFit="contain"
-          />
-          <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-            {project.title}
-          </span>
-        </Button>
-      ))}
-    </div>
-  );
-}
-
-SwitcherOrgProjects.Skeleton = () => (
-  <div className="flex flex-col w-full gap-0.5 p-1 max-h-44 overflow-y-auto">
-    <div className="h-8 w-full bg-stone-100 rounded-lg animate-pulse"></div>
-    <div className="h-8 w-full bg-stone-100 rounded-lg animate-pulse"></div>
-  </div>
-);
+import { SwitcherProjects } from "./project-switcher";
 
 export function BreadcrumbOrgSwitcher() {
   const { org } = useParams();
@@ -171,8 +131,8 @@ export function BreadcrumbOrgSwitcher() {
               className="rounded-b-none rounded-l-none border-l-0 focus-visible:border-border focus-visible:ring-0 border-t-0"
             />
             {hoveredOrg && (
-              <Suspense fallback={<SwitcherOrgProjects.Skeleton />}>
-                <SwitcherOrgProjects org={hoveredOrg} search={projectSearch} />
+              <Suspense fallback={<SwitcherProjects.Skeleton />}>
+                <SwitcherProjects org={hoveredOrg} search={projectSearch} />
               </Suspense>
             )}
           </div>
@@ -187,5 +147,5 @@ export function BreadcrumbOrgSwitcher() {
 }
 
 BreadcrumbOrgSwitcher.Skeleton = () => (
-  <div className="h-4 w-16 bg-stone-100 rounded-full animate-pulse"></div>
+  <div className="h-4 w-16 bg-accent rounded-full animate-pulse"></div>
 );

--- a/apps/web/src/components/layout/project-switcher.tsx
+++ b/apps/web/src/components/layout/project-switcher.tsx
@@ -1,4 +1,4 @@
-import { useProjects } from "@deco/sdk";
+import { Project, useProjects } from "@deco/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
@@ -10,10 +10,48 @@ import {
 import { Suspense, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Avatar } from "../common/avatar";
+import { useFile } from "@deco/sdk";
 
-function SwitcherProjects({ org, search }: { org: string; search: string }) {
-  const projects = useProjects({ searchQuery: search, org });
+function SwitcherProjectItem({
+  project,
+  org,
+}: {
+  project: Project;
+  org: string;
+}) {
   const navigate = useNavigate();
+  const { data: resolvedAvatar } = useFile(project.avatar_url ?? "");
+
+  return (
+    <Button
+      key={project.id}
+      variant="ghost"
+      size="sm"
+      className="w-full justify-start font-normal"
+      onClick={() => navigate(`/${org}/${project.slug}`)}
+    >
+      <Avatar
+        url={resolvedAvatar ?? undefined}
+        fallback={project.slug}
+        size="xs"
+        objectFit="contain"
+      />
+      <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+        {project.title}
+      </span>
+    </Button>
+  );
+}
+
+export function SwitcherProjects({
+  org,
+  search,
+}: {
+  org: string;
+  search: string;
+}) {
+  const projects = useProjects({ searchQuery: search, org });
+
   return (
     <div className="flex flex-col gap-0.5 p-1 max-h-44 overflow-y-auto">
       {projects.length === 0 && (
@@ -22,23 +60,7 @@ function SwitcherProjects({ org, search }: { org: string; search: string }) {
         </div>
       )}
       {projects.map((project) => (
-        <Button
-          key={project.id}
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start font-normal"
-          onClick={() => navigate(`/${org}/${project.slug}`)}
-        >
-          <Avatar
-            url={project.avatar_url ?? undefined}
-            fallback={project.slug}
-            size="xs"
-            objectFit="contain"
-          />
-          <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-            {project.title}
-          </span>
-        </Button>
+        <SwitcherProjectItem key={project.id} org={org} project={project} />
       ))}
     </div>
   );
@@ -60,6 +82,8 @@ export function BreadcrumbProjectSwitcher() {
     [projects, projectParam],
   );
 
+  const { data: resolvedAvatar } = useFile(currentProject?.avatar_url ?? "");
+
   const [projectSearch, setProjectSearch] = useState("");
 
   return (
@@ -68,7 +92,7 @@ export function BreadcrumbProjectSwitcher() {
         <PopoverTrigger asChild>
           <div className="flex items-center gap-2 cursor-pointer hover:bg-muted-foreground/10 px-2 py-1 rounded-md">
             <Avatar
-              url={currentProject?.avatar_url ?? undefined}
+              url={resolvedAvatar ?? undefined}
               fallback={currentProject?.title ?? projectParam}
               size="xs"
               objectFit="contain"


### PR DESCRIPTION
- Removed the SwitcherOrgProjects component and integrated its functionality into the new SwitcherProjects component for better organization.
- Introduced a SwitcherProjectItem component to encapsulate project rendering logic, improving code readability and maintainability.
- Updated avatar handling in the BreadcrumbProjectSwitcher to resolve avatar URLs dynamically, enhancing user experience.
- Adjusted Skeleton components for consistent styling across the project switcher UI.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project switcher and breadcrumb now display resolved project avatars for clearer, more consistent visuals and streamlined navigation.

* **Style**
  * Updated loading skeleton to use the accent palette for improved contrast.
  * Minor UI consistency improvements in project and organization switchers.

* **Refactor**
  * Unified project rendering into a reusable item and standardized the project switcher across views to improve consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->