### PR TITLE
fix(ui): pin/unpin button consistent, truncate item text only on hover

### DIFF
--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -545,7 +545,7 @@ function WorkspaceViews() {
                   >
                     <Link
                       to={href}
-                      className="group/item"
+                      className="group/item relative"
                       onClick={() => {
                         trackEvent("sidebar_navigation_click", {
                           item: view.title,
@@ -604,14 +604,20 @@ function WorkspaceViews() {
                           </SidebarMenuAction>
                         )}
                       </div>
-                      <span className="truncate">
+                      <span
+                        className={
+                          view.type === "custom"
+                            ? "truncate group-hover/item:pr-8"
+                            : "truncate"
+                        }
+                      >
                         {view.title ?? integration?.name ?? "Custom"}
                       </span>
                       {view.type === "custom" && (
                         <Icon
                           name="unpin"
                           size={18}
-                          className="text-muted-foreground opacity-0 group-hover/item:opacity-50 hover:opacity-100 transition-opacity cursor-pointer ml-auto"
+                          className="text-muted-foreground opacity-0 group-hover/item:opacity-50 hover:opacity-100 cursor-pointer absolute right-1 top-1/2 -translate-y-1/2"
                           onClick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();


### PR DESCRIPTION
- Updated class names in WorkspaceViews for improved styling consistency and responsiveness.
- Added relative positioning to sidebar items for better alignment of icons and text.
- Simplified the structure of resource title spans to conditionally apply padding based on view type.
- Enhanced icon visibility and interaction by adjusting opacity and positioning for better user experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Action icons (remove, unpin) now appear only on hover, reducing visual clutter.
  - Hover interactions improved across top-level items, collapsible sections, and pinned/recent areas.
  - Titles adjust truncation and spacing for a cleaner layout when hover controls are present.

- Bug Fixes
  - Clicking action controls no longer triggers navigation, preventing unintended page changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->