### PR TITLE
feat(decopilot): add header with agent info and close button to Decopilot

### DIFF
--- a/apps/web/src/components/decopilot/index.tsx
+++ b/apps/web/src/components/decopilot/index.tsx
@@ -1,7 +1,9 @@
 import { WELL_KNOWN_AGENTS } from "@deco/sdk";
+import { Icon } from "@deco/ui/components/icon.tsx";
 import { useState } from "react";
 import { MainChat } from "../agent/chat.tsx";
 import { AgentProvider } from "../agent/provider.tsx";
+import { useDecopilotOpen } from "../layout/decopilot-layout.tsx";
 import { useDecopilotContext } from "./context.tsx";
 import { useDecopilotThread } from "./thread-context.tsx";
 import { useAppAdditionalTools } from "./use-app-additional-tools.ts";
@@ -12,6 +14,7 @@ export function DecopilotChat() {
   const [threadId, _setThreadId] = useState(() => crypto.randomUUID());
   const { threadState, clearThreadState } = useDecopilotThread();
   const appAdditionalTools = useAppAdditionalTools();
+  const { setOpen } = useDecopilotOpen();
   const {
     additionalTools: contextTools,
     rules,
@@ -26,6 +29,29 @@ export function DecopilotChat() {
 
   return (
     <div className="flex h-full w-full flex-col">
+      {/* Header */}
+      <div className="flex h-10 items-center gap-2 border-b border-border px-2">
+        <div className="flex items-center gap-2">
+          <img
+            src={WELL_KNOWN_AGENTS.decopilotAgent.avatar}
+            alt={WELL_KNOWN_AGENTS.decopilotAgent.name}
+            className="size-5 rounded-md border border-border"
+          />
+          <span className="text-sm font-normal text-foreground">
+            {WELL_KNOWN_AGENTS.decopilotAgent.name}
+          </span>
+        </div>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="flex size-6 items-center justify-center rounded-md hover:bg-accent"
+        >
+          <Icon name="close" size={16} className="text-muted-foreground" />
+        </button>
+      </div>
+
+      {/* Chat Content */}
       <AgentProvider
         key={threadState.threadId}
         agentId={WELL_KNOWN_AGENTS.decopilotAgent.id}


### PR DESCRIPTION
- Integrated a header section in the DecopilotChat component displaying the agent's avatar and name.
- Added a close button to allow users to easily dismiss the Decopilot chat interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a header to the Decopilot panel showing the agent’s avatar and name.
  * Introduced a close button to quickly collapse/exit the Decopilot panel.
  * Preserved existing chat behavior and functionality.

* **Style**
  * Applied subtle, muted styling to header actions for better visual hierarchy.
  * Standardized the close icon size for consistent UI appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->