### PR TITLE
Cancel unused bodies

### DIFF
--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -142,6 +142,7 @@ const getMCPServerTools = async (
 export const fetchMeta = async (baseUrl: string) => {
   const response = await fetch(new URL("/live/_meta", baseUrl));
   if (!response.ok) {
+    await response.body?.cancel().catch(() => {});
     return null;
   }
   const meta: { schema: any } = await response.json();

--- a/packages/ai/src/tools.ts
+++ b/packages/ai/src/tools.ts
@@ -206,6 +206,8 @@ export const POLL_FOR_CONTENT = createInnateTool({
                   contentLength || "unknown"
                 }, Content-Type: ${contentType || "unknown"})`;
               }
+            } else {
+              await headRes.body?.cancel().catch(() => {});
             }
           } catch (headError) {
             console.debug(

--- a/packages/sdk/src/posthog.ts
+++ b/packages/sdk/src/posthog.ts
@@ -71,6 +71,7 @@ export async function trackServerEvent(
       },
     });
 
+    await response.body?.cancel().catch(() => {});
     if (!response.ok) {
       throw new Error(
         `Failed to track event: ${response.statusText} ${response.status}`,


### PR DESCRIPTION
Tentatively fixes the following error:

`A stalled HTTP response was canceled to prevent deadlock. This can happen when a Worker calls fetch() or cache.match() several times without reading the bodies of the returned Response objects. There is a limit on the number of concurrent HTTP requests that can be in-flight at one time. Normally, additional requests made beyond that limit are delayed until previous responses complete. However, because the Worker did not read the responses, they would never complete. Therefore, to prevent deadlock, the oldest response was canceled. To avoid this warning, make sure to either read the body of every HTTP Response or call response.body.cancel() to cancel a response that you don't plan to read from.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of network responses on error, preventing potential resource leaks.
  * Ensured response streams are properly cancelled after requests, increasing stability during failed or partial requests.
  * Enhanced reliability when falling back from HEAD to GET requests by cleaning up resources first.

* **Performance and Reliability**
  * Reduced memory footprint under error conditions through proactive stream cancellation.
  * Minor robustness improvements during telemetry/event tracking network calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->