### PR TITLE
Use default StreamableHttpClientTransport for agents

### DIFF
--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -16,6 +16,7 @@ import {
   createTransport,
 } from "@deco/workers-runtime/mcp-client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "ai";
 import { jsonSchema } from "ai";
 import type { AIAgent, Env } from "./agent.ts";
@@ -103,9 +104,10 @@ const getMCPServerTools = async (
               },
             ),
             execute: async (input) => {
-              const innerClient = await createServerClient(mcpServer).catch(
-                console.error,
-              );
+              const innerClient = await createServerClient({
+                ...mcpServer,
+                Transport: StreamableHTTPClientTransport,
+              }).catch(console.error);
               if (!innerClient) {
                 throw new Error("Failed to create inner client");
               }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to configure a custom streamable HTTP transport for MCP connections, enabling improved streaming behavior and compatibility with alternative transport implementations.
  * Defaults to the existing transport when not configured, so no changes are required for current setups.

* **Refactor**
  * Internal client creation updated to use the configurable streamable transport while preserving existing error handling and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->