### PR TITLE
Revert "Use default StreamableHttpClientTransport for agents"

### DIFF
--- a/packages/ai/src/mcp.ts
+++ b/packages/ai/src/mcp.ts
@@ -16,7 +16,6 @@ import {
   createTransport,
 } from "@deco/workers-runtime/mcp-client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "ai";
 import { jsonSchema } from "ai";
 import type { AIAgent, Env } from "./agent.ts";
@@ -104,10 +103,9 @@ const getMCPServerTools = async (
               },
             ),
             execute: async (input) => {
-              const innerClient = await createServerClient({
-                ...mcpServer,
-                Transport: StreamableHTTPClientTransport,
-              }).catch(console.error);
+              const innerClient = await createServerClient(mcpServer).catch(
+                console.error,
+              );
               if (!innerClient) {
                 throw new Error("Failed to create inner client");
               }

--- a/packages/runtime/src/mcp-client.ts
+++ b/packages/runtime/src/mcp-client.ts
@@ -6,7 +6,6 @@ import {
   SSEClientTransport,
   SSEClientTransportOptions,
 } from "@modelcontextprotocol/sdk/client/sse.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
@@ -44,20 +43,11 @@ class Client extends BaseClient {
 }
 
 export const createServerClient = async (
-  mcpServer: {
-    connection: MCPConnection;
-    name?: string;
-    Transport?: Constructor<StreamableHTTPClientTransport>;
-  },
+  mcpServer: { connection: MCPConnection; name?: string },
   signal?: AbortSignal,
   extraHeaders?: Record<string, string>,
 ): Promise<Client> => {
-  const transport = createTransport(
-    mcpServer.connection,
-    signal,
-    extraHeaders,
-    mcpServer.Transport,
-  );
+  const transport = createTransport(mcpServer.connection, signal, extraHeaders);
 
   if (!transport) {
     throw new Error("Unknown MCP connection type");
@@ -74,13 +64,10 @@ export const createServerClient = async (
   return client;
 };
 
-// deno-lint-ignore no-explicit-any
-type Constructor<T> = new (...args: any[]) => T;
 export const createTransport = (
   connection: MCPConnection,
   signal?: AbortSignal,
   extraHeaders?: Record<string, string>,
-  StreamableTransport: Constructor<StreamableHTTPClientTransport> = HTTPClientTransport,
 ) => {
   if (connection.type === "Websocket") {
     return new WebSocketClientTransport(new URL(connection.url));
@@ -122,7 +109,7 @@ export const createTransport = (
 
     return new SSEClientTransport(new URL(connection.url), config);
   }
-  return new StreamableTransport(new URL(connection.url), {
+  return new HTTPClientTransport(new URL(connection.url), {
     requestInit: {
       headers,
       signal,


### PR DESCRIPTION
Reverts deco-cx/chat#1490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Streamlined client setup: default transport is now selected automatically.
  - Removed the ability to supply a custom transport during client creation.
  - Reduced configuration parameters required for establishing connections.
  - Consistent behavior across HTTP, SSE, and WebSocket connections.

- Breaking Changes
  - Client creation no longer accepts a custom transport parameter; advanced configurations may need updates.

- Chores
  - Internal simplifications to reduce complexity and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->