### PR TITLE
fix(agent): prevent setting finish reason for cancelled results

### DIFF
--- a/apps/web/src/components/agent/provider.tsx
+++ b/apps/web/src/components/agent/provider.tsx
@@ -334,8 +334,14 @@ export function AgentProvider({
       // Read finish reason from metadata attached by the backend
       const finishReason = metadata?.finishReason;
 
+      const isCancelled =
+        result.isAbort || result.isDisconnect || result.isError;
+
       // Only set finish reason if it's one we care about displaying
-      if (finishReason === "length" || finishReason === "tool-calls") {
+      if (
+        !isCancelled &&
+        (finishReason === "length" || finishReason === "tool-calls")
+      ) {
         setFinishReason(finishReason);
       } else {
         setFinishReason(null);


### PR DESCRIPTION
- Introduced a check to ensure that the finish reason is only set if the result is not cancelled (abort, disconnect, or error).
- Updated the conditional logic to improve clarity and maintainability.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session cancellation detection to more accurately reflect when an agent stops due to aborts, disconnects, or errors.
  - Adjusted finish reason display to show only when appropriate (e.g., output length limits or tool usage); otherwise, the finish reason is hidden.
  - Reduces misleading status messages by suppressing finish reasons on cancelled runs, providing clearer feedback in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->