### PR TITLE
Revert "Remove non-indexed tools to integrations_list"

### DIFF
--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -1,5 +1,6 @@
 import {
   createServerClient as createMcpServerClient,
+  listToolsByConnectionType,
   patchApiDecoChatTokenHTTPConnection,
   isApiDecoChatMCPConnection as shouldPatchDecoChatMCPConnection,
 } from "@deco/ai/mcp";
@@ -238,15 +239,15 @@ export const callTool = createIntegrationManagementTool({
 
 async function listToolsAndSortByName(
   {
-    connection: _,
-    ignoreCache: __,
+    connection,
+    ignoreCache,
     appName,
   }: {
     connection: MCPConnection;
     appName?: string | null;
     ignoreCache?: boolean;
   },
-  _c: AppContext,
+  c: AppContext,
 ) {
   let result;
   if (appName) {
@@ -264,9 +265,7 @@ async function listToolsAndSortByName(
       ),
     };
   } else {
-    // FIXME: @mcandeia removing this since we are considering as an issue
-    // result = await listToolsByConnectionType(connection, c, ignoreCache);
-    result = { tools: [] };
+    result = await listToolsByConnectionType(connection, c, ignoreCache);
   }
 
   // Sort tools by name for consistent UI


### PR DESCRIPTION
Reverts deco-cx/chat#1498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tool discovery now works without specifying an app name, returning available tools and sorting them by name.
  - Added support to bypass cached results when listing tools.

- Bug Fixes
  - Resolved an issue where tool listing returned empty results if no app name was provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->