### PR TITLE
fix(agent): improve hook condition to list threads 

### DIFF
--- a/apps/web/src/components/agent/edit.tsx
+++ b/apps/web/src/components/agent/edit.tsx
@@ -54,6 +54,7 @@ import ToolsAndKnowledgeTab from "../settings/integrations.tsx";
 import { AgentTriggers } from "../triggers/agent-triggers.tsx";
 import { AgentProvider, useAgent } from "./provider.tsx";
 import Threads from "./threads.tsx";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface Props {
   agentId?: string;
@@ -107,6 +108,8 @@ function ThreadsButton() {
 // Unified chat interface that works for both agent and decopilot modes
 function UnifiedChat() {
   const { agentId, chat, agent, hasUnsavedChanges: hasChanges } = useAgent();
+  const client = useQueryClient();
+  const { locator } = useSDK();
   const { messages } = chat;
   const focusChat = useFocusChat();
   const { chatMode } = usePreviewContext();
@@ -136,11 +139,14 @@ function UnifiedChat() {
                 variant="outline"
                 size="sm"
                 className="text-xs"
-                onClick={() =>
+                onClick={() => {
+                  client.invalidateQueries({
+                    queryKey: ["threads", locator, agentId],
+                  });
                   focusChat(agentId, crypto.randomUUID(), {
                     history: false,
-                  })
-                }
+                  });
+                }}
               >
                 New Thread
               </Button>

--- a/apps/web/src/components/threads/index.tsx
+++ b/apps/web/src/components/threads/index.tsx
@@ -165,7 +165,7 @@ function ThreadsList({ agentId }: { agentId: string }) {
   return (
     <div
       className={cn(
-        "p-4 text-foreground w-full max-w-3xl mx-auto space-y-6 inline-block",
+        "text-foreground w-full max-w-3xl mx-auto space-y-6 inline-block",
       )}
     >
       {nothing ? (

--- a/packages/sdk/src/hooks/thread.ts
+++ b/packages/sdk/src/hooks/thread.ts
@@ -127,7 +127,7 @@ export const useThreads = (partialOptions: ThreadFilterOptions = {}) => {
   return useSuspenseQuery({
     queryKey: key,
     queryFn: ({ signal }) =>
-      options.enabled
+      options.enabled || options.enabled === undefined
         ? listThreads(locator, options, { signal })
         : {
             threads: [],


### PR DESCRIPTION
Before (always): 
<img width="316" height="308" alt="Screenshot 2025-10-15 at 12 21 52" src="https://github.com/user-attachments/assets/346fd476-863f-4e32-8320-3d6bc13673fe" />

Now:
<img width="496" height="341" alt="Screenshot 2025-10-15 at 12 21 28" src="https://github.com/user-attachments/assets/82fb3f99-2a1a-4fde-b360-abce9874a519" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Threads list now refreshes automatically after starting a new thread.
  * Thread data fetch is enabled by default when not explicitly disabled, reducing cases of empty or missing threads.

* **Style**
  * Reduced outer padding in the Threads list for a tighter layout while retaining existing spacing between items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->