### PR TITLE
refactor(mentions): enhance mention handling and resource icon mapping

### DIFF
--- a/apps/web/src/components/chat/rich-text.tsx
+++ b/apps/web/src/components/chat/rich-text.tsx
@@ -78,6 +78,8 @@ export function RichTextArea({
     return (integrations as IntegrationWithTools[])
       .filter(
         (integration) =>
+          // Filter out workspace-management to avoid duplicate tools
+          integration.id !== "i:workspace-management" &&
           integration.tools &&
           Array.isArray(integration.tools) &&
           integration.tools.length > 0,

--- a/apps/web/src/components/documents/document-editor.tsx
+++ b/apps/web/src/components/documents/document-editor.tsx
@@ -106,6 +106,8 @@ export function DocumentEditor({
     return (integrations as IntegrationWithTools[])
       .filter(
         (integration) =>
+          // Filter out workspace-management to avoid duplicate tools
+          integration.id !== "i:workspace-management" &&
           integration.tools &&
           Array.isArray(integration.tools) &&
           integration.tools.length > 0,
@@ -131,11 +133,9 @@ export function DocumentEditor({
     const SEARCH_TOOL_RE = /^DECO_RESOURCE_[A-Z_]+_SEARCH$/;
     return (integrations as IntegrationWithTools[])
       .filter((integration) => {
-        // Only include Documents Management integration to avoid duplicates
-        // (Workspace Management also provides document resources but we want to use the dedicated integration)
-        if (integration.id !== DOCUMENTS_INTEGRATION_ID) {
-          return false;
-        }
+        // Filter out workspace-management to avoid duplicate document results
+        if (integration.id === "i:workspace-management") return false;
+
         const toolsList = integration.tools ?? [];
         return toolsList.some((t) => SEARCH_TOOL_RE.test(t.name));
       })

--- a/apps/web/src/components/prompts/rich-text/index.tsx
+++ b/apps/web/src/components/prompts/rich-text/index.tsx
@@ -76,6 +76,8 @@ export default function RichTextArea({
     return (integrations as IntegrationWithTools[])
       .filter(
         (integration) =>
+          // Filter out workspace-management to avoid duplicate tools
+          integration.id !== "i:workspace-management" &&
           integration.tools &&
           Array.isArray(integration.tools) &&
           integration.tools.length > 0,

--- a/apps/web/src/components/rich-text-editor/extensions/mention-node.tsx
+++ b/apps/web/src/components/rich-text-editor/extensions/mention-node.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@deco/ui/components/badge.js";
+import { Icon } from "@deco/ui/components/icon.js";
 import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
 import { cn } from "@deco/ui/lib/utils.js";
 
@@ -9,6 +10,16 @@ interface MentionNodeProps extends ReactNodeViewProps<HTMLSpanElement> {
   ResourceIcon?: React.ComponentType<any>;
 }
 
+// Map resource types to their corresponding icons
+const RESOURCE_TYPE_ICONS: Record<string, string> = {
+  view: "dashboard",
+  VIEW: "dashboard",
+  document: "description",
+  DOCUMENT: "description",
+  workflow: "flowchart",
+  WORKFLOW: "flowchart",
+};
+
 export function MentionNode({
   node,
   IntegrationAvatar,
@@ -18,6 +29,12 @@ export function MentionNode({
   const label = node.attrs.label;
   const integrationIcon = node.attrs.integrationIcon;
   const integrationName = node.attrs.integrationName;
+  const resourceType = node.attrs.resourceType;
+
+  // Determine which icon to use for resources
+  const resourceIconName = resourceType
+    ? RESOURCE_TYPE_ICONS[resourceType] || "description"
+    : "description";
 
   return (
     <NodeViewWrapper
@@ -29,6 +46,7 @@ export function MentionNode({
       data-integration-id={node.attrs.integrationId}
       data-resource-name={node.attrs.resourceName}
       data-resource-uri={node.attrs.resourceUri}
+      data-resource-type={node.attrs.resourceType}
     >
       <Badge
         variant="secondary"
@@ -45,8 +63,8 @@ export function MentionNode({
             className="w-3 h-3"
           />
         )}
-        {mentionType === "resource" && ResourceIcon && (
-          <ResourceIcon className="w-3 h-3" />
+        {mentionType === "resource" && (
+          <Icon name={resourceIconName} className="w-3 h-3" />
         )}
         <span className="leading-none">@{label}</span>
       </Badge>


### PR DESCRIPTION
- Updated mention dropdown to handle double space for closing the mention box.
- Improved resource icon mapping in MentionNode to dynamically assign icons based on resource type.
- Filtered out workspace-management integration to avoid duplicate tools in RichTextArea and DocumentEditor components.
- Cleaned up loading state management in unified mentions to prevent UI shifts during resource searches.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mentions now support multi-word searches (spaces allowed).
  * Resource mentions display context-specific icons based on resource type.

* **Bug Fixes**
  * Prevents duplicate tools and duplicate entries in document search.

* **Style**
  * Mention dropdown UI refinements: clearer selection/highlighting, wider “no results” state, and taller scroll area for easier browsing.

* **Refactor**
  * Streamlined mention loading: shows initial results quickly, then updates once all searches complete for smoother, more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->