### PR TITLE
feat(chat): add MainChatSkeleton component for loading state at decopilot tabs

### DIFF
--- a/apps/web/src/components/agent/chat.tsx
+++ b/apps/web/src/components/agent/chat.tsx
@@ -1,5 +1,6 @@
 import { useAgentData, useFile, WELL_KNOWN_AGENT_IDS } from "@deco/sdk";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { Suspense, useMemo } from "react";
 import { useParams } from "react-router";
@@ -25,6 +26,66 @@ interface MainChatProps {
   className?: string;
   contentClassName?: string;
 }
+
+export const MainChatSkeleton = ({
+  showInput = true,
+  className,
+}: Pick<MainChatProps, "showInput" | "className"> = {}) => {
+  return (
+    <div
+      className={`w-full flex flex-col ${className ?? "h-[calc(100vh-48px)]"}`}
+    >
+      <ScrollArea className="flex-1 min-h-0">
+        <div className="w-full min-w-0">
+          {/* Empty state skeleton - centered */}
+          <div className="h-full flex flex-col justify-between py-12">
+            <div className="flex flex-col items-center justify-center max-w-2xl mx-auto p-4">
+              <div className="flex flex-col items-center gap-4 mb-6">
+                {/* Avatar skeleton */}
+                <div className="w-12 h-12 flex items-center justify-center">
+                  <Skeleton className="h-12 w-12 rounded-md" />
+                </div>
+
+                {/* Title and description skeletons */}
+                <div className="flex flex-col items-center gap-4">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-9 w-48" />
+                  </div>
+                  <div className="flex flex-col items-center gap-2">
+                    <Skeleton className="h-5 w-96 max-w-[90vw]" />
+                    <Skeleton className="h-5 w-72 max-w-[80vw]" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </ScrollArea>
+      {showInput && (
+        <div className="w-full mx-auto p-2">
+          <div className="relative rounded-md w-full mx-auto">
+            <div className="relative flex flex-col">
+              {/* Rich text area skeleton */}
+              <div className="overflow-y-auto relative">
+                <Skeleton className="h-[88px] w-full rounded-t-2xl" />
+              </div>
+
+              {/* Input footer skeleton */}
+              <div className="flex items-center justify-between h-12 border border-t-0 rounded-b-2xl px-2 bg-background">
+                <div className="flex items-center gap-2" />
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-8 w-20 rounded-lg" />
+                  <Skeleton className="h-8 w-8 rounded-lg" />
+                  <Skeleton className="h-8 w-8 rounded-lg" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
 
 export const MainChat = ({
   showInput = true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a loading skeleton for the main chat area, including optional input placeholder.
  - Introduced per‑tab loading fallback for the chat view to improve responsiveness.
  - Automatically closes the panel when creating a new tab from the last-tab view.
- Style
  - Improved agent avatar layout with consistent minimum width for better alignment.
- Refactor
  - Wrapped chat rendering in a suspense boundary to streamline loading behavior without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->