### PR TITLE
fix(tool-detail, view-detail): update path construction for resource …

### DIFF
--- a/apps/web/src/components/tools/tool-detail.tsx
+++ b/apps/web/src/components/tools/tool-detail.tsx
@@ -154,7 +154,7 @@ export function ToolDetail({ resourceUri }: ToolDisplayCanvasProps) {
           name: effectiveTool.name,
           type: "tool",
           icon: "build",
-          path: `/${projectKey}/rsc/i:${integrationId}/${resourceName}/${encodeURIComponent(resourceUri)}`,
+          path: `/${projectKey}/rsc/${integrationId.startsWith("i:") ? integrationId : `i:${integrationId}`}/${resourceName}/${encodeURIComponent(resourceUri)}`,
         });
       }, 0);
     }

--- a/apps/web/src/components/views/view-detail.tsx
+++ b/apps/web/src/components/views/view-detail.tsx
@@ -56,7 +56,7 @@ export function ViewDetail({ resourceUri }: ViewDetailProps) {
           name: effectiveView.name,
           type: "view",
           icon: "dashboard",
-          path: `/${projectKey}/rsc/i:${integrationId}/${resourceName}/${encodeURIComponent(resourceUri)}`,
+          path: `/${projectKey}/rsc/${integrationId.startsWith("i:") ? integrationId : `i:${integrationId}`}/${resourceName}/${encodeURIComponent(resourceUri)}`,
         });
       }, 0);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recent items for tools and views now correctly handle integration identifiers that already include the “i:” prefix, avoiding duplicate prefixes in paths.
  - Prevents malformed links and duplicate or missing entries in the recents list.
  - Improves reliability of navigation from recent items and ensures consistent display of tool and view history across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->