### PR TITLE
feat(workflow): fix "pending" status to only appear in running workflows, and show run button from workflows that don't require input

### DIFF
--- a/apps/web/src/components/workflows/workflow-run-detail.tsx
+++ b/apps/web/src/components/workflows/workflow-run-detail.tsx
@@ -329,7 +329,7 @@ export function WorkflowRunDetail({ resourceUri }: WorkflowRunDetailProps) {
                         </div>
                       )}
                       <Suspense fallback={<Spinner />}>
-                        <WorkflowStepCard step={step} index={idx} />
+                        <WorkflowStepCard step={step} index={idx} showStatus />
                       </Suspense>
                     </div>
                   ))}

--- a/apps/web/src/components/workflows/workflow-step-card.tsx
+++ b/apps/web/src/components/workflows/workflow-step-card.tsx
@@ -31,6 +31,7 @@ interface WorkflowStepCardProps {
     };
   };
   index: number;
+  showStatus?: boolean;
 }
 
 function JsonViewer({
@@ -131,7 +132,11 @@ function StepError({ error }: { error: unknown }) {
   );
 }
 
-export function WorkflowStepCard({ step, index }: WorkflowStepCardProps) {
+export function WorkflowStepCard({
+  step,
+  index,
+  showStatus = true,
+}: WorkflowStepCardProps) {
   const { data: integrations } = useIntegrations();
 
   const stepStatus =
@@ -230,12 +235,14 @@ export function WorkflowStepCard({ step, index }: WorkflowStepCardProps) {
               )}
             </div>
           </div>
-          <Badge
-            variant={getStatusBadgeVariant(stepStatus)}
-            className="capitalize text-xs shrink-0"
-          >
-            {stepStatus}
-          </Badge>
+          {showStatus && (
+            <Badge
+              variant={getStatusBadgeVariant(stepStatus)}
+              className="capitalize text-xs shrink-0"
+            >
+              {stepStatus}
+            </Badge>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
- Added `showStatus` prop to `WorkflowStepCard` for controlling the visibility of step status badges.
- Updated `WorkflowDisplayCanvas` and `WorkflowRunDetail` components to utilize the new prop, improving clarity in workflow execution states.
- Refactored related components to streamline the rendering of workflow steps and enhance user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the chat action with a “Run Workflow” button that submits with empty input when no parameters are required.
  * Button now shows a spinner and “Running…” while executing.
  * Steps and outputs reflect live run data when available.
  * Step cards can display run status via a new toggleable indicator.

* **Refactor**
  * Introduced runtime-aware logic to merge steps with run data only when a run exists.
  * Removed automatic chat toggle on startup.
  * Adjusted input/output rendering to align with run presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->