### PR TITLE
fix(tool-detail): update UI for no input tools

### DIFF
--- a/apps/web/src/components/tools/tool-detail.tsx
+++ b/apps/web/src/components/tools/tool-detail.tsx
@@ -27,7 +27,6 @@ import {
 import { useParams } from "react-router";
 import { z } from "zod";
 import { EmptyState } from "../common/empty-state.tsx";
-import { useDecopilotOpen } from "../layout/decopilot-layout.tsx";
 import { ToolCallResultV2 } from "@deco/sdk/hooks";
 
 const LazyHighlighter = lazy(() => import("../chat/lazy-highlighter.tsx"));
@@ -129,7 +128,6 @@ export function ToolDetail({ resourceUri }: ToolDisplayCanvasProps) {
   const { addRecent } = useRecentResources(projectKey);
   const params = useParams<{ org: string; project: string }>();
   const hasTrackedRecentRef = useRef(false);
-  const { toggle: toggleChat } = useDecopilotOpen();
 
   // Track as recently opened when tool is loaded (only once)
   useEffect(() => {
@@ -391,26 +389,27 @@ export function ToolDetail({ resourceUri }: ToolDisplayCanvasProps) {
                   </div>
                 </Form>
               ) : (
-                <div className="flex flex-col items-center justify-center py-12 text-center">
-                  <div className="bg-background rounded-full p-4 mb-4">
-                    <Icon
-                      name="chat"
-                      size={32}
-                      className="text-muted-foreground"
-                    />
-                  </div>
-                  <h3 className="text-lg font-medium mb-2">No Input Form</h3>
-                  <p className="text-sm text-muted-foreground max-w-md">
-                    Create and configure tools in chat.
+                <div className="flex flex-col items-center justify-center py-8 text-center gap-4">
+                  <p className="text-sm text-muted-foreground">
+                    This tool does not require any input parameters.
                   </p>
                   <Button
-                    variant="outline"
-                    size="sm"
-                    className="mt-4"
-                    onClick={toggleChat}
+                    disabled={isExecuting}
+                    size="lg"
+                    onClick={() => handleFormSubmit({})}
+                    className="min-w-[200px] flex items-center gap-2"
                   >
-                    <Icon name="chat" size={16} className="mr-2" />
-                    Open Chat
+                    {isExecuting ? (
+                      <>
+                        <Spinner size="xs" />
+                        Executing...
+                      </>
+                    ) : (
+                      <>
+                        <Icon name="play_arrow" size={18} />
+                        Execute Tool
+                      </>
+                    )}
                   </Button>
                 </div>
               )}


### PR DESCRIPTION
- Removed unused `useDecopilotOpen` hook and related chat toggle functionality.
- Updated the UI to clearly indicate when a tool does not require input parameters, enhancing user clarity.
- Adjusted button styles and functionality to improve the execution experience for tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools with no input now display a clear “No parameters required” message.
  * Added a one-click “Execute Tool” action that runs the tool directly without opening chat.
  * Introduced an execution loading state with spinner and “Executing...” label; button is disabled during processing.

* **Style**
  * Updated layout and text for the Input section when no schema is present.
  * Adjusted button sizing and spacing to fit the new execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->