### PR TITLE
Fix agent link generation for workspace slugs

### DIFF
--- a/packages/sdk/src/mcp/channels/api.ts
+++ b/packages/sdk/src/mcp/channels/api.ts
@@ -182,10 +182,7 @@ export const createChannel = createTool({
   },
 });
 
-const generateAgentLink = (
-  locator: { value: string },
-  agentId: string,
-) => {
+const generateAgentLink = (locator: { value: string }, agentId: string) => {
   return `https://${Hosts.WEB_APP}/${locator.value}/agent/${agentId}/${crypto.randomUUID()}`;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent access links now use the locator value in the URL, improving link consistency and reliability.
  * Channel creation and join flows now require and validate a locator before proceeding, reducing broken or invalid links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->