### PR TITLE
feat(sdk): add optional views property to WorkflowStepDefinitionSchema

### DIFF
--- a/packages/sdk/src/mcp/workflows/schemas.ts
+++ b/packages/sdk/src/mcp/workflows/schemas.ts
@@ -64,6 +64,10 @@ export const WorkflowStepDefinitionSchema = z.object({
     .record(z.unknown())
     .optional()
     .describe("Execution output of the step (if it has been run)"),
+  views: z
+    .array(z.string())
+    .optional()
+    .describe("List of URIs of View Resources that this step can render."),
 });
 
 export const WorkflowDefinitionSchema = z.object({


### PR DESCRIPTION
- Introduced a new optional `views` property in the `WorkflowStepDefinitionSchema` to hold an array of URIs for View Resources that the step can render. This enhancement allows for better integration of view resources within workflow steps.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow steps can now specify renderable views from View Resources, enabling enhanced visualization capabilities. This allows workflows to display dynamic, customized visual content during step execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->