### PR TITLE
refactor(settings): remove team and personal system prompt fields from GeneralSettingsForm

### DIFF
--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -46,8 +46,6 @@ interface GeneralSettingsFormValues {
   teamName: string;
   teamSlug: string;
   workspaceEmailDomain: boolean;
-  teamSystemPrompt: string;
-  personalSystemPrompt: string;
   avatar: string;
   themeVariables: Record<string, string | undefined>;
 }
@@ -59,8 +57,6 @@ const generalSettingsSchema = z.object({
       "Team slug can only contain letters, numbers, dashes, underscores, and dots.",
   }),
   workspaceEmailDomain: z.boolean(),
-  teamSystemPrompt: z.string(),
-  personalSystemPrompt: z.string(),
   avatar: z.string(),
   themeVariables: z.record(z.string(), z.string().optional()),
 });
@@ -310,8 +306,6 @@ export function GeneralSettings() {
       teamName: currentTeamName,
       teamSlug: currentTeamSlug,
       workspaceEmailDomain: true,
-      teamSystemPrompt: "",
-      personalSystemPrompt: "",
       avatar: currentTeamTheme?.picture || "",
       themeVariables: currentTeamTheme?.variables ?? {},
     },
@@ -516,53 +510,6 @@ export function GeneralSettings() {
                           />
                         </FormControl>
                         <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="teamSystemPrompt"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Team System Prompt</FormLabel>
-                        <FormControl>
-                          <Textarea
-                            {...field}
-                            placeholder="This prompt is added at the start of all agent messages for your team. Use it to set tone, context, or rules."
-                            rows={6}
-                            disabled
-                            readOnly={isReadOnly}
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          This prompt is added at the start of all agent
-                          messages for your team. Use it to set tone, context,
-                          or rules.
-                        </FormDescription>
-                      </FormItem>
-                    )}
-                  />
-                  <Separator />
-                  <FormField
-                    control={form.control}
-                    name="personalSystemPrompt"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Personal System Prompt</FormLabel>
-                        <FormControl>
-                          <Textarea
-                            {...field}
-                            placeholder="This prompt is added at the end of agent messages just for you. Use it to personalize style or add your own context."
-                            rows={6}
-                            disabled
-                            readOnly={isReadOnly}
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          This prompt is added at the end of agent messages just
-                          for you. Use it to personalize style or add your own
-                          context.
-                        </FormDescription>
                       </FormItem>
                     )}
                   />


### PR DESCRIPTION

- Eliminated `teamSystemPrompt` and `personalSystemPrompt` fields from the General Settings form and schema.
- Updated the initial form values and removed associated UI components to streamline the settings interface.

This refactor simplifies the settings management by removing unnecessary fields, enhancing user experience.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed Team System Prompt and Personal System Prompt configuration options from general settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->