### PR TITLE
feat(ci): add Pinecone docs ingestion to deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -27,16 +27,17 @@ jobs:
           bun install
 
       - name: Install rag-docs script dependencies
-        run: bun install @pinecone-database/pinecone fast-glob @langchain/textsplitters tsx
+        run: bun install @pinecone-database/pinecone fast-glob tsx
 
       - name: Ingest docs to Pinecone
         run: bunx tsx scripts/ingest-docs-pinecone.ts
         env:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-          PINECONE_INDEX_NAME: ${{ secrets.PINECONE_INDEX_NAME }}
-          NAMESPACE: docs
+          PINECONE_ASSISTANT_NAME: ${{ secrets.PINECONE_ASSISTANT_NAME }}
           DOCS_DIR: docs/view/src/content/pt-br
           DELETE_ALL: "true"
+          UPLOAD_DELAY_MS: "2000"
+          CONVERT_MDX: "true"
 
       - name: Deploy
         run: |

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -26,6 +26,18 @@ jobs:
           cd docs
           bun install
 
+      - name: Install rag-docs script dependencies
+        run: bun install @pinecone-database/pinecone fast-glob @langchain/textsplitters tsx
+
+      - name: Ingest docs to Pinecone
+        run: bunx tsx scripts/ingest-docs-pinecone.ts
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          PINECONE_INDEX_NAME: ${{ secrets.PINECONE_INDEX_NAME }}
+          NAMESPACE: docs
+          DOCS_DIR: docs/view/src/content/pt-br
+          DELETE_ALL: "true"
+
       - name: Deploy
         run: |
           cd docs

--- a/scripts/ingest-docs-pinecone.ts
+++ b/scripts/ingest-docs-pinecone.ts
@@ -1,0 +1,130 @@
+// ingest-docs-pinecone.ts
+// Reindex EVERYTHING from the DOCS_DIR directory into a Pinecone index with integrated embedding.
+// - Chunking: LangChain RecursiveCharacterTextSplitter
+// - Embedding: Pinecone automatically generates via integrated embedding
+// - Upsert: uses upsertRecords() sending text + metadata
+//
+// ENV obrigatórios:
+//   PINECONE_API_KEY
+//   PINECONE_INDEX_NAME 
+// Optional ENV:
+//   NAMESPACE=docs
+//   DOCS_DIR=docs
+//   EXTENSIONS=.md,.mdx,.txt
+//   MAX_FILE_MB=2
+//   CHUNK_SIZE=2800
+//   CHUNK_OVERLAP=300
+//   BATCH_SIZE=500
+//   DELETE_ALL=false    
+//
+// Execution:
+//   npx tsx scripts/ingest-docs-pinecone.ts
+
+import { Pinecone } from "@pinecone-database/pinecone";
+import fg from "fast-glob";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+
+// Tipo para upsertRecords com integrated embedding
+type TextRecord = {
+  _id: string;
+  text: string;
+  path: string;
+  [key: string]: unknown;
+};
+
+const PINECONE_API_KEY = process.env.PINECONE_API_KEY!;
+const PINECONE_INDEX_NAME = process.env.PINECONE_INDEX_NAME!;
+
+if (!PINECONE_API_KEY) throw new Error("Define PINECONE_API_KEY");
+if (!PINECONE_INDEX_NAME) throw new Error("Define PINECONE_INDEX_NAME (index name)");
+
+const NAMESPACE = process.env.NAMESPACE || "docs";
+const DOCS_DIR = process.env.DOCS_DIR || "docs";
+const EXTENSIONS = (process.env.EXTENSIONS || ".md,.mdx,.txt")
+  .split(",")
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+const MAX_FILE_MB = Number(process.env.MAX_FILE_MB || "2");
+const CHUNK_SIZE = Number(process.env.CHUNK_SIZE || "2800");
+const CHUNK_OVERLAP = Number(process.env.CHUNK_OVERLAP || "300");
+const BATCH_SIZE = Number(process.env.BATCH_SIZE || "500");
+const DELETE_ALL = String(process.env.DELETE_ALL || "true").toLowerCase() === "true";
+
+const bytesLimit = MAX_FILE_MB * 1024 * 1024;
+
+function shouldKeep(file: string): boolean {
+  const ext = path.extname(file).toLowerCase();
+  return EXTENSIONS.includes(ext);
+}
+
+async function readIfSmall(file: string): Promise<string | null> {
+  try {
+    const stat = await fs.stat(file);
+    if (stat.size > bytesLimit) {
+      console.warn(`Skip por tamanho (${(stat.size / 1024 / 1024).toFixed(2)}MB): ${file}`);
+      return null;
+    }
+    const raw = await fs.readFile(file, "utf8");
+    if (!raw.trim()) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+const splitter = new RecursiveCharacterTextSplitter({
+  chunkSize: CHUNK_SIZE,
+  chunkOverlap: CHUNK_OVERLAP,
+});
+
+async function main() {
+  const pc = new Pinecone({ apiKey: PINECONE_API_KEY });
+  const index = pc.Index(PINECONE_INDEX_NAME);
+
+  if (DELETE_ALL) {
+    console.log(`Cleaning namespace "${NAMESPACE}"...`);
+    await index.namespace(NAMESPACE).deleteAll();
+  }
+
+  const pattern = [`${DOCS_DIR.replaceAll(path.sep, "/")}/**/*`];
+  const files = await fg(pattern, { onlyFiles: true, dot: false });
+
+  const picked = files.filter(shouldKeep);
+  console.log(`Files candidates: ${picked.length} (exts: ${EXTENSIONS.join(", ")})`);
+
+  const records: TextRecord[] = [];
+
+  for (const file of picked) {
+    const text = await readIfSmall(file);
+    if (!text) continue;
+
+    const normalizedPath = file.replaceAll(path.sep, "/");
+    const docs = await splitter.createDocuments([text], [{ path: normalizedPath }]);
+
+    docs.forEach((d, i) => {
+      records.push({
+        _id: `${normalizedPath}#chunk=${i}`,
+        text: d.pageContent,
+        path: normalizedPath,
+      });
+    });
+  }
+
+  console.log(`Total chunks: ${records.length}`);
+
+  for (let i = 0; i < records.length; i += BATCH_SIZE) {
+    const batch = records.slice(i, i + BATCH_SIZE);
+    await index.namespace(NAMESPACE).upsertRecords(batch);
+    console.log(`Upserted ${Math.min(i + BATCH_SIZE, records.length)}/${records.length}`);
+  }
+
+  console.log(`Completed. Namespace: ${NAMESPACE}. Files: ${picked.length}. Chunks: ${records.length}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
  ## What is this contribution about?

  This PR adds automated Pinecone documentation ingestion to the CI/CD pipeline. The
  changes include:

  - New step in the deploy-docs workflow for ingesting Deco Chat documentation into Pinecone.
  - TypeScript script (`scripts/ingest-docs-pinecone.ts`) that handles the ingestion
  process into Pinecone vector database

  This enables automatic synchronization of documentation into Pinecone whenever changes
   are deployed.

  ## Screenshots/Demonstration

  N/A - Backend/CI changes only

  ## Review Checklist
  - [x] PR title is clear and descriptive
  - [x] Changes are tested and working
  - [x] Documentation is updated (if needed)
  - [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment workflow to automate indexing/ingestion into the docs assistant and improved deployment authentication.
  * Added robust document ingestion with MDX conversion support, file validation, retry handling, optional replacement of existing indexed docs, and upload progress logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->