### PR TITLE
fix(api/db studio): adapt locator usage only for legacy workspaces

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -1015,7 +1015,11 @@ app.all("/:org/:project/:integrationId/studio", async (c) => {
   });
 
   const locator = Locator.from({ org, project });
-  const id = Locator.adaptToRootSlug(locator, uid);
+  const useLegacyWorkspace =
+    project === "default" || project === "personal" || org === "users";
+  const id = useLegacyWorkspace
+    ? Locator.adaptToRootSlug(locator, uid)
+    : locator;
 
   // The DO id can be overridden by the client, both on the URL
   // for GET requests and on the body "id" property for POST requests


### PR DESCRIPTION
- Introduced a conditional check to determine if the workspace is legacy (default or personal) and adjusted the locator usage accordingly.
- This change ensures that the API correctly handles workspace identifiers based on the project context, improving routing accuracy.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 