### PR TITLE
feat(browser-rendering): add Cloudflare Browser Rendering integration

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -22,6 +22,7 @@ DATABASE_URL=
 # Cloudflare
 CF_ACCOUNT_ID=
 CF_API_TOKEN=
+CF_API_BROWSER_RENDERING=  # Optional: Dedicated token with Browser Rendering permissions
 CF_ZONE_ID=
 CF_DISPATCH_NAMESPACE=
 CF_R2_ACCESS_KEY_ID=

--- a/apps/web/src/components/browser-rendering/browser-rendering-resource-list.tsx
+++ b/apps/web/src/components/browser-rendering/browser-rendering-resource-list.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { useTrackNativeViewVisit, useSDK, type View } from "@deco/sdk";
+import { useCurrentTeam } from "../sidebar/team-selector.tsx";
+import { BrowserRenderingView } from "./browser-rendering-view.tsx";
+
+export function BrowserRenderingResourceList() {
+  const { locator } = useSDK();
+  const team = useCurrentTeam();
+
+  const projectKey = typeof locator === "string" ? locator : undefined;
+  const browserRenderingViewId = useMemo(() => {
+    const views = (team?.views ?? []) as View[];
+    const view = views.find((v) => v.title === "Browser");
+    return view?.id;
+  }, [team?.views]);
+
+  // Track visit for recents/pinning
+  useTrackNativeViewVisit({
+    viewId: browserRenderingViewId || "browser-rendering-fallback",
+    viewTitle: "Browser",
+    viewIcon: "camera",
+    viewPath: `/${projectKey}/browser-rendering`,
+    projectKey,
+  });
+
+  return <BrowserRenderingView />;
+}

--- a/apps/web/src/components/browser-rendering/browser-rendering-view.tsx
+++ b/apps/web/src/components/browser-rendering/browser-rendering-view.tsx
@@ -1,0 +1,414 @@
+import { useDeferredValue, useMemo, useState } from "react";
+import {
+  useCaptureScreenshot,
+  useDeleteScreenshot,
+  useScreenshots,
+} from "@deco/sdk/hooks/browser-rendering";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Card, CardContent } from "@deco/ui/components/card.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { useSetThreadContextEffect } from "../decopilot/thread-context-provider.tsx";
+import { toast } from "sonner";
+import { Badge } from "@deco/ui/components/badge.tsx";
+import { Icon } from "@deco/ui/components/icon.tsx";
+
+type DateFilter = "all" | "today" | "week" | "month";
+
+export function BrowserRenderingView() {
+  const [searchTerm, setSearchTerm] = useState("");
+  // Use useDeferredValue to keep search input responsive during filtering
+  const deferredSearchTerm = useDeferredValue(searchTerm);
+  const [dateFilter, setDateFilter] = useState<DateFilter>("all");
+  const [selectedScreenshot, setSelectedScreenshot] = useState<string | null>(
+    null,
+  );
+  const [captureUrl, setCaptureUrl] = useState("");
+
+  // Load screenshots
+  const {
+    data: screenshots = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useScreenshots({
+    prefix: getDatePrefix(dateFilter),
+    limit: 100,
+  });
+
+  const deleteMutation = useDeleteScreenshot();
+  const captureMutation = useCaptureScreenshot();
+
+  // AI Chat Context Integration
+  const threadContextItems = useMemo<
+    Array<
+      | { id: string; type: "rule"; text: string }
+      | {
+          id: string;
+          type: "toolset";
+          integrationId: string;
+          enabledTools: string[];
+        }
+    >
+  >(() => {
+    const rules = [
+      `You are helping the user capture screenshots, generate PDFs, and scrape websites using Cloudflare Browser Rendering.`,
+      `Use BROWSER_SCREENSHOT to capture screenshots of websites. You can provide a URL or custom HTML.`,
+      `Use BROWSER_PDF to generate PDFs from web pages.`,
+      `Use BROWSER_HTML to fetch the fully rendered HTML content after JavaScript execution.`,
+      `Use BROWSER_SCRAPE to extract specific elements from a page using CSS selectors.`,
+      `All captured screenshots are automatically saved to the workspace's file storage in browser-rendering/screenshots/ organized by date.`,
+      `Examples:`,
+      `- Screenshot: { "url": "https://example.com" }`,
+      `- Full page: { "url": "https://example.com", "screenshotOptions": { "fullPage": true } }`,
+      `- Element: { "url": "https://example.com", "selector": "#main-content" }`,
+      `- Custom HTML: { "html": "<h1>Hello World</h1>" }`,
+    ];
+
+    const contextItems: Array<
+      | { id: string; type: "rule"; text: string }
+      | {
+          id: string;
+          type: "toolset";
+          integrationId: string;
+          enabledTools: string[];
+        }
+    > = rules.map((text) => ({
+      id: crypto.randomUUID(),
+      type: "rule" as const,
+      text,
+    }));
+
+    // Add browser rendering toolset
+    contextItems.push({
+      id: crypto.randomUUID(),
+      type: "toolset" as const,
+      integrationId: "i:browser-rendering",
+      enabledTools: [
+        "BROWSER_SCREENSHOT",
+        "BROWSER_PDF",
+        "BROWSER_HTML",
+        "BROWSER_SCRAPE",
+        "BROWSER_SCREENSHOTS_LIST",
+      ],
+    });
+
+    // Add HTTP fetch for external data
+    contextItems.push({
+      id: crypto.randomUUID(),
+      type: "toolset" as const,
+      integrationId: "i:http",
+      enabledTools: ["HTTP_FETCH"],
+    });
+
+    return contextItems;
+  }, []);
+
+  // Inject context into AI thread
+  useSetThreadContextEffect(threadContextItems);
+
+  // Filter screenshots by search term (use deferred value for performance)
+  const filteredScreenshots = useMemo(() => {
+    if (!deferredSearchTerm) return screenshots;
+
+    const lowerSearch = deferredSearchTerm.toLowerCase();
+    return screenshots.filter(
+      (screenshot) =>
+        screenshot.metadata?.sourceUrl?.toLowerCase().includes(lowerSearch) ||
+        screenshot.path.toLowerCase().includes(lowerSearch),
+    );
+  }, [screenshots, deferredSearchTerm]);
+
+  const handleDelete = async (path: string) => {
+    if (!confirm("Are you sure you want to delete this screenshot?")) return;
+
+    try {
+      await deleteMutation.mutateAsync({ path });
+      toast.success("Screenshot deleted successfully");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete screenshot",
+      );
+    }
+  };
+
+  const handleCapture = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!captureUrl.trim()) {
+      toast.error("Please enter a URL");
+      return;
+    }
+
+    // Basic URL validation
+    try {
+      new URL(captureUrl);
+    } catch {
+      toast.error("Please enter a valid URL (including https://)");
+      return;
+    }
+
+    try {
+      await captureMutation.mutateAsync({ url: captureUrl });
+      toast.success("Screenshot captured successfully!");
+      setCaptureUrl("");
+    } catch (error) {
+      console.error("Screenshot capture error:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Failed to capture screenshot",
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="border-b p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Browser</h1>
+            <p className="text-muted-foreground text-sm">
+              Capture screenshots, generate PDFs, and scrape websites
+            </p>
+          </div>
+          <Button onClick={() => refetch()} variant="outline" size="sm">
+            <Icon name="refresh" className="w-4 h-4 mr-2" />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Quick Capture Form */}
+        <Card className="mb-4">
+          <CardContent className="pt-6">
+            <form onSubmit={handleCapture} className="flex gap-2">
+              <Input
+                placeholder="https://example.com"
+                value={captureUrl}
+                onChange={(e) => setCaptureUrl(e.target.value)}
+                className="flex-1"
+                disabled={captureMutation.isPending}
+              />
+              <Button type="submit" disabled={captureMutation.isPending}>
+                {captureMutation.isPending ? (
+                  <>
+                    <Icon
+                      name="hourglass_empty"
+                      className="w-4 h-4 mr-2 animate-spin"
+                    />
+                    Capturing...
+                  </>
+                ) : (
+                  <>
+                    <Icon name="camera" className="w-4 h-4 mr-2" />
+                    Capture Screenshot
+                  </>
+                )}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        {/* Filters */}
+        <div className="flex gap-3 flex-wrap">
+          <Input
+            placeholder="Search by URL..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="max-w-xs"
+          />
+          <Select
+            value={dateFilter}
+            onValueChange={(value) => setDateFilter(value as DateFilter)}
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Time</SelectItem>
+              <SelectItem value="today">Today</SelectItem>
+              <SelectItem value="week">This Week</SelectItem>
+              <SelectItem value="month">This Month</SelectItem>
+            </SelectContent>
+          </Select>
+          {screenshots && (
+            <Badge variant="secondary" className="ml-auto">
+              {filteredScreenshots.length} screenshot
+              {filteredScreenshots.length !== 1 ? "s" : ""}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Gallery */}
+      <div className="flex-1 overflow-auto p-6">
+        {isLoading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Card key={i}>
+                <Skeleton className="h-48 w-full" />
+              </Card>
+            ))}
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-center justify-center h-full text-center p-8">
+            <Icon name="error" className="w-16 h-16 text-destructive mb-4" />
+            <h3 className="text-lg font-semibold mb-2">
+              Failed to load screenshots
+            </h3>
+            <p className="text-muted-foreground text-sm max-w-md mb-4">
+              There was an error loading your screenshots. Please try again.
+            </p>
+            <Button variant="outline" onClick={() => refetch()}>
+              <Icon name="refresh" className="w-4 h-4 mr-2" />
+              Retry
+            </Button>
+          </div>
+        ) : filteredScreenshots.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center p-8">
+            <Icon
+              name="camera"
+              className="w-16 h-16 text-muted-foreground mb-4"
+            />
+            <h3 className="text-lg font-semibold mb-2">
+              {screenshots.length === 0
+                ? "No screenshots yet"
+                : "No matches found"}
+            </h3>
+            <p className="text-muted-foreground text-sm max-w-md mb-4">
+              {screenshots.length === 0
+                ? "Use AI chat to capture screenshots, or use the MCP tools directly"
+                : "Try adjusting your search or date filter"}
+            </p>
+            <Button variant="outline" onClick={() => refetch()}>
+              <Icon name="refresh" className="w-4 h-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {filteredScreenshots.map((screenshot) => (
+              <Card
+                key={screenshot.path}
+                className="group hover:shadow-lg transition-shadow cursor-pointer overflow-hidden"
+              >
+                <div
+                  onClick={() => setSelectedScreenshot(screenshot.url)}
+                  className="relative aspect-video bg-muted"
+                >
+                  <img
+                    src={screenshot.url}
+                    alt={screenshot.metadata?.sourceUrl || "Screenshot"}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
+                </div>
+                <CardContent className="p-3">
+                  <div className="space-y-2">
+                    {screenshot.metadata?.sourceUrl && (
+                      <p
+                        className="text-xs text-muted-foreground truncate"
+                        title={screenshot.metadata.sourceUrl}
+                      >
+                        {screenshot.metadata.sourceUrl}
+                      </p>
+                    )}
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-muted-foreground">
+                        {new Date(screenshot.lastModified).toLocaleDateString()}
+                      </span>
+                      {screenshot.metadata?.dimensions && (
+                        <span className="text-muted-foreground">
+                          {screenshot.metadata.dimensions.width}×
+                          {screenshot.metadata.dimensions.height}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          window.open(screenshot.url, "_blank");
+                        }}
+                      >
+                        <Icon name="open_in_new" className="w-3 h-3 mr-1" />
+                        Open
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(screenshot.path);
+                        }}
+                        disabled={deleteMutation.isPending}
+                      >
+                        <Icon name="delete" className="w-3 h-3" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Lightbox Dialog */}
+      <Dialog
+        open={!!selectedScreenshot}
+        onOpenChange={() => setSelectedScreenshot(null)}
+      >
+        <DialogContent className="max-w-6xl max-h-[90vh]">
+          <DialogHeader>
+            <DialogTitle>Screenshot</DialogTitle>
+          </DialogHeader>
+          <div className="relative w-full h-full overflow-auto">
+            {selectedScreenshot && (
+              <img src={selectedScreenshot} alt="" className="w-full h-auto" />
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function getDatePrefix(filter: DateFilter): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+
+  switch (filter) {
+    case "today":
+      return `browser-rendering/screenshots/${year}/${month}/${day}`;
+    case "week": {
+      // Get the start of the week (last Monday)
+      const weekStart = new Date(now);
+      weekStart.setDate(now.getDate() - now.getDay() + 1);
+      return `browser-rendering/screenshots/${year}/${month}`;
+    }
+    case "month":
+      return `browser-rendering/screenshots/${year}/${month}`;
+    case "all":
+    default:
+      return "browser-rendering/screenshots/";
+  }
+}

--- a/apps/web/src/components/chat/provider.tsx
+++ b/apps/web/src/components/chat/provider.tsx
@@ -548,6 +548,19 @@ export function AgenticChatProvider({
         }
       }
 
+      // Handle browser screenshot captures - refresh gallery
+      if (toolCall.toolName === "BROWSER_SCREENSHOT") {
+        // Invalidate all screenshot queries to refresh the gallery
+        queryClient.invalidateQueries({
+          queryKey: ["browser-rendering", "screenshots", locator],
+        });
+
+        // Force immediate refetch
+        queryClient.refetchQueries({
+          queryKey: ["browser-rendering", "screenshots", locator],
+        });
+      }
+
       // Broadcast resource updates for auto-refresh
       if (
         /^DECO_RESOURCE_.*_(UPDATE|CREATE)$/.test(toolCall.toolName ?? "") &&

--- a/apps/web/src/components/integrations/apps.ts
+++ b/apps/web/src/components/integrations/apps.ts
@@ -159,6 +159,16 @@ export const NATIVE_APPS: GroupedApp[] = [
     usedBy: [],
     isNative: true,
   },
+  {
+    id: "native:::browser-rendering",
+    name: "Browser",
+    icon: "icon://camera",
+    description: "Capture screenshots, generate PDFs, and scrape websites",
+    instances: 1,
+    provider: "native",
+    usedBy: [],
+    isNative: true,
+  },
 ];
 
 // Map native app names to their canonical titles for view matching
@@ -169,6 +179,7 @@ export const NATIVE_APP_NAME_MAP: Record<string, string> = {
   "native:::tools": "Tools",
   "native:::views": "Views",
   "native:::files": "Files",
+  "native:::browser-rendering": "Browser",
 };
 
 export function getConnectionAppKey(connection: Integration): AppKey {

--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -462,6 +462,7 @@ function WorkspaceViews() {
     "Workflows",
     "Documents",
     "Agents",
+    "Browser",
   ];
   const legacyTitleMap: Record<string, string> = {
     Prompts: "Documents",
@@ -497,6 +498,7 @@ function WorkspaceViews() {
     "Views",
     "Database",
     "Files",
+    "Browser",
   ];
   const resourceItems = resourceTypeOrder
     .map((title) => {
@@ -507,6 +509,16 @@ function WorkspaceViews() {
           icon: "folder",
           onClick: () => setFilesModalOpen(true),
           comingSoon: true,
+        };
+      }
+      if (title === "Browser") {
+        // Always use the explicit route for Browser
+        return {
+          id: "native:::browser-rendering",
+          title: "Browser",
+          icon: "camera",
+          metadata: { path: "/browser-rendering" },
+          comingSoon: false,
         };
       }
       const item = mcpItems.find(

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -439,6 +439,13 @@ const router = createBrowserRouter([
             path: "settings",
             Component: OrgSettings,
           },
+          {
+            path: "browser-rendering",
+            lazy: () =>
+              import(
+                "./components/browser-rendering/browser-rendering-resource-list.tsx"
+              ).then((m) => ({ Component: m.BrowserRenderingResourceList })),
+          },
         ],
       },
       {
@@ -506,6 +513,13 @@ const router = createBrowserRouter([
           { path: "documents", Component: DocumentsListPage },
           { path: "documents/prompts", Component: PromptsLegacyPage },
           { path: "documents/:id", Component: DocumentEdit },
+          {
+            path: "browser-rendering",
+            lazy: () =>
+              import(
+                "./components/browser-rendering/browser-rendering-resource-list.tsx"
+              ).then((m) => ({ Component: m.BrowserRenderingResourceList })),
+          },
           {
             path: "workflow-runs",
             Component: () => <Navigate to="../workflows/runs-legacy" replace />,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -76,6 +76,7 @@
     "./fetch": "./src/fetch.ts",
     "./hooks": "./src/hooks/index.ts",
     "./hooks/profile": "./src/hooks/profile.ts",
+    "./hooks/browser-rendering": "./src/hooks/browser-rendering.ts",
     "./utils": "./src/utils/index.ts",
     "./mcp/bindings": "./src/mcp/bindings/index.ts",
     "./mcp/binder": "./src/mcp/bindings/binder.ts",

--- a/packages/sdk/src/crud/browser-rendering.ts
+++ b/packages/sdk/src/crud/browser-rendering.ts
@@ -1,0 +1,189 @@
+import { MCPClient } from "../fetcher.ts";
+import type { ProjectLocator } from "../locator.ts";
+
+export interface CaptureScreenshotInput {
+  locator: ProjectLocator;
+  url?: string;
+  html?: string;
+  selector?: string;
+  viewport?: {
+    width: number;
+    height: number;
+  };
+  screenshotOptions?: {
+    fullPage?: boolean;
+    omitBackground?: boolean;
+    quality?: number;
+    type?: "png" | "jpeg";
+    clip?: {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    };
+  };
+  gotoOptions?: {
+    waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+    timeout?: number;
+  };
+}
+
+export interface Screenshot {
+  url: string;
+  path: string;
+  metadata: {
+    sourceUrl?: string;
+    dimensions?: {
+      width: number;
+      height: number;
+    };
+    capturedAt: string;
+    format: string;
+  };
+}
+
+export interface ScreenshotListItem {
+  path: string;
+  url: string;
+  metadata?: {
+    sourceUrl?: string;
+    dimensions?: {
+      width: number;
+      height: number;
+    };
+    capturedAt: string;
+    format: string;
+  };
+  lastModified: string;
+  size: number;
+}
+
+export const captureScreenshot = async (
+  input: CaptureScreenshotInput,
+  init?: RequestInit,
+): Promise<Screenshot> => {
+  const { locator, ...props } = input;
+  const result = await MCPClient.forLocator(locator).BROWSER_SCREENSHOT(
+    props,
+    init,
+  );
+  return result.screenshot;
+};
+
+export interface GeneratePdfInput {
+  locator: ProjectLocator;
+  url?: string;
+  html?: string;
+  viewport?: {
+    width: number;
+    height: number;
+  };
+  gotoOptions?: {
+    waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+    timeout?: number;
+  };
+}
+
+export interface Pdf {
+  url: string;
+  path: string;
+  metadata: {
+    sourceUrl?: string;
+    generatedAt: string;
+  };
+}
+
+export const generatePdf = async (
+  input: GeneratePdfInput,
+  init?: RequestInit,
+): Promise<Pdf> => {
+  const { locator, ...props } = input;
+  const result = await MCPClient.forLocator(locator).BROWSER_PDF(props, init);
+  return result.pdf;
+};
+
+export interface FetchHtmlInput {
+  locator: ProjectLocator;
+  url: string;
+  gotoOptions?: {
+    waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+    timeout?: number;
+  };
+}
+
+export interface HtmlContent {
+  html: string;
+  metadata: {
+    url: string;
+    fetchedAt: string;
+  };
+}
+
+export const fetchHtml = async (
+  input: FetchHtmlInput,
+  init?: RequestInit,
+): Promise<HtmlContent> => {
+  const { locator, ...props } = input;
+  return await MCPClient.forLocator(locator).BROWSER_HTML(props, init);
+};
+
+export interface ScrapeWebsiteInput {
+  locator: ProjectLocator;
+  url: string;
+  selectors: Record<string, string>;
+  gotoOptions?: {
+    waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+    timeout?: number;
+  };
+}
+
+export interface ScrapedContent {
+  elements: Record<string, string[]>;
+  metadata: {
+    url: string;
+    scrapedAt: string;
+  };
+}
+
+export const scrapeWebsite = async (
+  input: ScrapeWebsiteInput,
+  init?: RequestInit,
+): Promise<ScrapedContent> => {
+  const { locator, ...props } = input;
+  return await MCPClient.forLocator(locator).BROWSER_SCRAPE(props, init);
+};
+
+export interface ListScreenshotsInput {
+  locator: ProjectLocator;
+  prefix?: string;
+  limit?: number;
+}
+
+export const listScreenshots = async (
+  input: ListScreenshotsInput,
+  init?: RequestInit,
+): Promise<ScreenshotListItem[]> => {
+  const { locator, ...props } = input;
+  const result = await MCPClient.forLocator(locator).BROWSER_SCREENSHOTS_LIST(
+    props,
+    init,
+  );
+  return result.screenshots;
+};
+
+export interface DeleteScreenshotInput {
+  locator: ProjectLocator;
+  path: string;
+}
+
+export const deleteScreenshot = async (
+  input: DeleteScreenshotInput,
+  init?: RequestInit,
+): Promise<boolean> => {
+  const { locator, path } = input;
+  const result = await MCPClient.forLocator(locator).BROWSER_SCREENSHOT_DELETE(
+    { path },
+    init,
+  );
+  return result.success;
+};

--- a/packages/sdk/src/hooks/browser-rendering.ts
+++ b/packages/sdk/src/hooks/browser-rendering.ts
@@ -1,0 +1,122 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  captureScreenshot,
+  deleteScreenshot,
+  fetchHtml,
+  generatePdf,
+  listScreenshots,
+  scrapeWebsite,
+  type CaptureScreenshotInput,
+  type DeleteScreenshotInput,
+  type FetchHtmlInput,
+  type GeneratePdfInput,
+  type ScrapeWebsiteInput,
+} from "../crud/browser-rendering.ts";
+import { useSDK } from "./store.tsx";
+
+// Query Keys - centralized for consistent cache management
+export const BROWSER_RENDERING_KEYS = {
+  screenshotsRoot: (locator?: string) =>
+    ["browser-rendering", "screenshots", locator] as const,
+  screenshots: (locator?: string, opts?: { prefix?: string; limit?: number }) =>
+    [
+      ...BROWSER_RENDERING_KEYS.screenshotsRoot(locator),
+      opts?.prefix,
+      opts?.limit,
+    ] as const,
+};
+
+// Hooks
+export function useScreenshots(options?: { prefix?: string; limit?: number }) {
+  const { locator } = useSDK();
+
+  return useQuery({
+    queryKey: BROWSER_RENDERING_KEYS.screenshots(locator, options),
+    queryFn: async () => {
+      if (!locator) throw new Error("No locator available");
+      try {
+        return await listScreenshots({
+          locator,
+          prefix: options?.prefix,
+          limit: options?.limit,
+        });
+      } catch (error) {
+        console.error("Failed to list screenshots:", error);
+        // Return empty array on error instead of throwing
+        return [];
+      }
+    },
+    enabled: !!locator,
+    retry: false,
+    staleTime: 30000, // 30 seconds
+  });
+}
+
+export function useCaptureScreenshot() {
+  const client = useQueryClient();
+  const { locator } = useSDK();
+
+  return useMutation({
+    mutationFn: (input: Omit<CaptureScreenshotInput, "locator">) => {
+      if (!locator) throw new Error("No locator available");
+      return captureScreenshot({ ...input, locator });
+    },
+    onSuccess: () => {
+      // Invalidate all screenshot queries for this locator
+      client.invalidateQueries({
+        queryKey: BROWSER_RENDERING_KEYS.screenshotsRoot(locator),
+      });
+    },
+  });
+}
+
+export function useGeneratePdf() {
+  const { locator } = useSDK();
+
+  return useMutation({
+    mutationFn: (input: Omit<GeneratePdfInput, "locator">) => {
+      if (!locator) throw new Error("No locator available");
+      return generatePdf({ ...input, locator });
+    },
+  });
+}
+
+export function useFetchHtml() {
+  const { locator } = useSDK();
+
+  return useMutation({
+    mutationFn: (input: Omit<FetchHtmlInput, "locator">) => {
+      if (!locator) throw new Error("No locator available");
+      return fetchHtml({ ...input, locator });
+    },
+  });
+}
+
+export function useScrapeWebsite() {
+  const { locator } = useSDK();
+
+  return useMutation({
+    mutationFn: (input: Omit<ScrapeWebsiteInput, "locator">) => {
+      if (!locator) throw new Error("No locator available");
+      return scrapeWebsite({ ...input, locator });
+    },
+  });
+}
+
+export function useDeleteScreenshot() {
+  const client = useQueryClient();
+  const { locator } = useSDK();
+
+  return useMutation({
+    mutationFn: (input: Omit<DeleteScreenshotInput, "locator">) => {
+      if (!locator) throw new Error("No locator available");
+      return deleteScreenshot({ ...input, locator });
+    },
+    onSuccess: () => {
+      // Invalidate all screenshot queries for this locator
+      client.invalidateQueries({
+        queryKey: BROWSER_RENDERING_KEYS.screenshotsRoot(locator),
+      });
+    },
+  });
+}

--- a/packages/sdk/src/mcp/browser-rendering/api.ts
+++ b/packages/sdk/src/mcp/browser-rendering/api.ts
@@ -1,0 +1,712 @@
+import { z } from "zod";
+import { createToolGroup, getEnv } from "../context.ts";
+import type { AppContext } from "../context.ts";
+import { assertHasUser } from "../assertions.ts";
+import { getWorkspaceBucketName, listFiles, deleteFile } from "../fs/api.ts";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { assertHasWorkspace } from "../assertions.ts";
+
+export const createTool = createToolGroup("BrowserRendering", {
+  name: "Browser Rendering",
+  description:
+    "Capture screenshots, generate PDFs, fetch HTML content, and scrape websites using Cloudflare's Browser Rendering API.",
+  icon: "https://assets.decocache.com/mcp/cloudflare-browser-rendering/icon.png",
+});
+
+// Schema definitions
+const ViewportSchema = z.object({
+  width: z.number().default(1920),
+  height: z.number().default(1080),
+});
+
+const ScreenshotOptionsSchema = z.object({
+  fullPage: z.boolean().optional().describe("Capture the full scrollable page"),
+  omitBackground: z
+    .boolean()
+    .optional()
+    .describe("Hide the default white background"),
+  quality: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Image quality (only for JPEG)"),
+  type: z.enum(["png", "jpeg"]).optional().default("png"),
+  clip: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number(),
+      height: z.number(),
+    })
+    .optional()
+    .describe("Capture a specific region"),
+});
+
+const GotoOptionsSchema = z.object({
+  waitUntil: z
+    .enum(["load", "domcontentloaded", "networkidle0", "networkidle2"])
+    .optional(),
+  timeout: z.number().optional().describe("Maximum time in milliseconds"),
+});
+
+// Helper to generate date-based path
+function getDateBasedPath(type: "screenshots" | "pdfs"): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `browser-rendering/${type}/${year}/${month}/${day}`;
+}
+
+// Helper to build Cloudflare auth headers
+function buildCloudflareAuthHeaders(
+  env: ReturnType<typeof getEnv>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  // Prefer dedicated browser rendering token if available
+  if (env.CF_API_BROWSER_RENDERING) {
+    headers["Authorization"] = `Bearer ${env.CF_API_BROWSER_RENDERING}`;
+  } else if (env.CF_API_TOKEN) {
+    // Fall back to general CF_API_TOKEN
+    headers["Authorization"] = `Bearer ${env.CF_API_TOKEN}`;
+  }
+  return headers;
+}
+
+// BROWSER_SCREENSHOT tool
+export const browserScreenshot = createTool({
+  name: "BROWSER_SCREENSHOT",
+  description: `Capture a screenshot of a webpage using Cloudflare Browser Rendering.
+
+You can provide either a URL to navigate to, or custom HTML content to render.
+
+Examples:
+- Screenshot a URL: { "url": "https://example.com" }
+- Screenshot with full page: { "url": "https://example.com", "screenshotOptions": { "fullPage": true } }
+- Screenshot from HTML: { "html": "<h1>Hello World</h1>" }
+- Screenshot specific element: { "url": "https://example.com", "selector": "#main-content" }
+- Custom viewport: { "url": "https://example.com", "viewport": { "width": 1280, "height": 720 } }`,
+  inputSchema: z
+    .object({
+      url: z.string().url().optional().describe("URL to navigate to"),
+      html: z.string().optional().describe("Custom HTML content to render"),
+      selector: z
+        .string()
+        .optional()
+        .describe("CSS selector to screenshot a specific element"),
+      viewport: ViewportSchema.optional(),
+      screenshotOptions: ScreenshotOptionsSchema.optional(),
+      gotoOptions: GotoOptionsSchema.optional(),
+    })
+    .refine((data) => data.url || data.html, {
+      message: "Either url or html must be provided",
+    })
+    .refine((data) => !(data.url && data.html), {
+      message: "Cannot provide both url and html - choose one",
+    }),
+  outputSchema: z.object({
+    screenshot: z.object({
+      url: z.string().describe("Public URL to access the screenshot"),
+      path: z.string().describe("Storage path"),
+      metadata: z.object({
+        sourceUrl: z.string().optional(),
+        dimensions: z
+          .object({
+            width: z.number(),
+            height: z.number(),
+          })
+          .optional(),
+        capturedAt: z.string(),
+        format: z.string(),
+      }),
+    }),
+  }),
+  // @ts-expect-error - Return type mismatch with dimensions being optional
+  handler: async (props, c: AppContext) => {
+    // TODO: Uncomment after migration is applied
+    // await assertWorkspaceResourceAccess(c);
+    c.resourceAccess.grant();
+
+    const env = getEnv(c);
+    const { url, html, selector, viewport, screenshotOptions, gotoOptions } =
+      props;
+
+    // Manual validation since MCP layer might not enforce Zod refine rules
+    if (!url && !html) {
+      throw new Error("Either 'url' or 'html' must be provided");
+    }
+    if (url && html) {
+      throw new Error("Cannot provide both 'url' and 'html' - choose one");
+    }
+
+    // Validate required credentials
+    if (!env.CF_ACCOUNT_ID) {
+      throw new Error(
+        "CF_ACCOUNT_ID environment variable is not set. Please add your Cloudflare Account ID to .dev.vars",
+      );
+    }
+    if (!env.CF_API_TOKEN) {
+      throw new Error(
+        "CF_API_TOKEN environment variable is not set. Please add your Cloudflare API Token to .dev.vars",
+      );
+    }
+
+    // Build request body for Cloudflare Browser Rendering API
+    // Only include the field that was actually provided (not both)
+    const requestBody: Record<string, unknown> = {};
+
+    // Add url OR html (mutually exclusive per Cloudflare API requirements)
+    if (url) {
+      requestBody.url = url;
+    } else if (html) {
+      requestBody.html = html;
+    }
+
+    // Add optional fields
+    if (selector) requestBody.selector = selector;
+    if (viewport) requestBody.viewport = viewport;
+    if (screenshotOptions) requestBody.screenshotOptions = screenshotOptions;
+    if (gotoOptions) requestBody.gotoOptions = gotoOptions;
+
+    // Debug log to see what's being sent
+    console.log(
+      "[BROWSER_SCREENSHOT] Request body:",
+      JSON.stringify(requestBody, null, 2),
+    );
+
+    // Call Cloudflare Browser Rendering API with timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000); // 30s timeout
+
+    try {
+      console.log("[BROWSER_SCREENSHOT] Calling Cloudflare API...");
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/browser-rendering/screenshot`,
+        {
+          method: "POST",
+          headers: buildCloudflareAuthHeaders(env),
+          body: JSON.stringify(requestBody),
+          signal: controller.signal,
+        },
+      );
+
+      console.log("[BROWSER_SCREENSHOT] Got response:", response.status);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        if (response.status === 401) {
+          // Try to verify token to give actionable diagnostics
+          try {
+            const verify = await fetch(
+              "https://api.cloudflare.com/client/v4/user/tokens/verify",
+              { method: "GET", headers: buildCloudflareAuthHeaders(env) },
+            );
+            const verifyJson = await verify.json().catch(() => undefined);
+            // @ts-expect-error - verifyJson shape not strictly typed
+            const scopes = verifyJson?.result?.policies
+              ?.flatMap((p: { permission_groups?: Array<{ name?: string }> }) =>
+                p?.permission_groups?.map((g) => g?.name),
+              )
+              ?.filter(Boolean);
+            throw new Error(
+              `Cloudflare authentication failed. Please verify:\n` +
+                `1. CF_ACCOUNT_ID matches the token's account\n` +
+                `2. Browser Rendering is enabled on your account\n` +
+                `3. Token must include permissions for Browser Rendering (Workers Browser Rendering)\n` +
+                `4. Alternatively set CF_API_KEY and CF_API_EMAIL (global key)\n` +
+                // @ts-expect-error - verifyJson shape not strictly typed
+                `Token verify: ${JSON.stringify({ success: verifyJson?.success, scopes }, null, 2)}\n` +
+                `Original error: ${errorText}`,
+            );
+          } catch {
+            throw new Error(
+              `Cloudflare authentication failed. Please verify:\n` +
+                `1. CF_ACCOUNT_ID and CF_API_TOKEN are set in .dev.vars\n` +
+                `2. Browser Rendering is enabled on your Cloudflare account\n` +
+                `3. Your API token has the correct permissions\n` +
+                `Original error: ${errorText}`,
+            );
+          }
+        }
+        throw new Error(
+          `Cloudflare Browser Rendering API error: ${response.status} - ${errorText}`,
+        );
+      }
+
+      const imageBuffer = await response.arrayBuffer();
+      console.log(
+        "[BROWSER_SCREENSHOT] Got image buffer, size:",
+        imageBuffer.byteLength,
+        "bytes",
+      );
+      const imageType = screenshotOptions?.type || "png";
+
+      const dimensions = viewport
+        ? { width: viewport.width, height: viewport.height }
+        : undefined;
+
+      // Upload directly to R2 using S3 client (same as FS tools internally)
+      assertHasWorkspace(c);
+      const bucketName = getWorkspaceBucketName(c.workspace.value);
+
+      const datePath = getDateBasedPath("screenshots");
+      const timestamp = Date.now();
+      const uuid = crypto.randomUUID();
+      const filename = `${timestamp}-${uuid}.${imageType}`;
+      const storagePath = `${datePath}/${filename}`;
+
+      console.log(
+        "[BROWSER_SCREENSHOT] Saving to bucket:",
+        bucketName,
+        "path:",
+        storagePath,
+      );
+
+      // Create S3 client for R2 (same as FS tools)
+      const s3Client = new S3Client({
+        region: "auto",
+        endpoint: `https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+        credentials: {
+          accessKeyId: env.CF_R2_ACCESS_KEY_ID!,
+          secretAccessKey: env.CF_R2_SECRET_ACCESS_KEY!,
+        },
+      });
+
+      // Upload directly to R2 (convert ArrayBuffer to Uint8Array)
+      const putCommand = new PutObjectCommand({
+        Bucket: bucketName,
+        Key: storagePath,
+        Body: new Uint8Array(imageBuffer),
+        ContentType: `image/${imageType}`,
+      });
+
+      await s3Client.send(putCommand);
+
+      // Construct public URL (same pattern as chat file uploads)
+      const Hosts = await import("../../hosts.ts").then((m) => m.Hosts);
+      const locator = c.workspace?.value;
+      const publicUrl = `https://${Hosts.API_LEGACY}/files/${locator}/${storagePath}`;
+
+      console.log("[BROWSER_SCREENSHOT] Saved! URL:", publicUrl);
+
+      // Return with structuredContent.image for inline display (same as GENERATE_IMAGE)
+      return {
+        structuredContent: {
+          image: publicUrl, // URL string for inline display in chat
+        },
+        screenshot: {
+          url: publicUrl,
+          path: storagePath,
+          size: imageBuffer.byteLength,
+          metadata: {
+            sourceUrl: url,
+            dimensions,
+            capturedAt: new Date().toISOString(),
+            format: imageType,
+          },
+        },
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  },
+});
+
+// BROWSER_PDF tool
+export const browserPdf = createTool({
+  name: "BROWSER_PDF",
+  description: `Generate a PDF from a webpage using Cloudflare Browser Rendering.
+
+Examples:
+- PDF from URL: { "url": "https://example.com" }
+- PDF from HTML: { "html": "<h1>Invoice</h1><p>Total: $100</p>" }`,
+  inputSchema: z
+    .object({
+      url: z.string().url().optional(),
+      html: z.string().optional(),
+      viewport: ViewportSchema.optional(),
+      gotoOptions: GotoOptionsSchema.optional(),
+    })
+    .refine((data) => data.url || data.html, {
+      message: "Either url or html must be provided",
+    })
+    .refine((data) => !(data.url && data.html), {
+      message: "Cannot provide both url and html - choose one",
+    }),
+  outputSchema: z.object({
+    pdf: z.object({
+      url: z.string(),
+      path: z.string(),
+      metadata: z.object({
+        sourceUrl: z.string().optional(),
+        generatedAt: z.string(),
+      }),
+    }),
+  }),
+  handler: async (props, c: AppContext) => {
+    // TODO: Uncomment after migration is applied
+    // await assertWorkspaceResourceAccess(c);
+    c.resourceAccess.grant();
+
+    const env = getEnv(c);
+    const { url, html, viewport, gotoOptions } = props;
+
+    // Manual validation
+    if (!url && !html) {
+      throw new Error("Either 'url' or 'html' must be provided");
+    }
+    if (url && html) {
+      throw new Error("Cannot provide both 'url' and 'html' - choose one");
+    }
+
+    // Build request body - url OR html (mutually exclusive)
+    const requestBody: Record<string, unknown> = {};
+    if (url) {
+      requestBody.url = url;
+    } else if (html) {
+      requestBody.html = html;
+    }
+    if (viewport) requestBody.viewport = viewport;
+    if (gotoOptions) requestBody.gotoOptions = gotoOptions;
+
+    // Call Cloudflare Browser Rendering API with timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000); // 30s timeout
+
+    try {
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/browser-rendering/pdf`,
+        {
+          method: "POST",
+          headers: buildCloudflareAuthHeaders(env),
+          body: JSON.stringify(requestBody),
+          signal: controller.signal,
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Cloudflare Browser Rendering API error: ${response.status} - ${errorText}`,
+        );
+      }
+
+      const pdfBuffer = await response.arrayBuffer();
+
+      // Upload directly to R2 using S3 client (same as screenshots)
+      assertHasWorkspace(c);
+      const bucketName = getWorkspaceBucketName(c.workspace.value);
+
+      const datePath = getDateBasedPath("pdfs");
+      const timestamp = Date.now();
+      const uuid = crypto.randomUUID();
+      const filename = `${timestamp}-${uuid}.pdf`;
+      const storagePath = `${datePath}/${filename}`;
+
+      console.log(
+        "[BROWSER_PDF] Saving to bucket:",
+        bucketName,
+        "path:",
+        storagePath,
+      );
+
+      // Create S3 client for R2 (same as FS tools)
+      const s3Client = new S3Client({
+        region: "auto",
+        endpoint: `https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+        credentials: {
+          accessKeyId: env.CF_R2_ACCESS_KEY_ID!,
+          secretAccessKey: env.CF_R2_SECRET_ACCESS_KEY!,
+        },
+      });
+
+      // Upload directly to R2 (convert ArrayBuffer to Uint8Array)
+      const putCommand = new PutObjectCommand({
+        Bucket: bucketName,
+        Key: storagePath,
+        Body: new Uint8Array(pdfBuffer),
+        ContentType: "application/pdf",
+      });
+
+      await s3Client.send(putCommand);
+
+      // Construct public URL (same pattern as chat file uploads)
+      const Hosts = await import("../../hosts.ts").then((m) => m.Hosts);
+      const locator = c.workspace?.value;
+      const publicUrl = `https://${Hosts.API_LEGACY}/files/${locator}/${storagePath}`;
+
+      console.log("[BROWSER_PDF] Saved! URL:", publicUrl);
+
+      return {
+        pdf: {
+          url: publicUrl,
+          path: storagePath,
+          metadata: {
+            sourceUrl: url,
+            generatedAt: new Date().toISOString(),
+          },
+        },
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  },
+});
+
+// BROWSER_HTML tool
+export const browserHtml = createTool({
+  name: "BROWSER_HTML",
+  description: `Fetch the fully rendered HTML content of a webpage after JavaScript execution.
+
+Example: { "url": "https://example.com" }`,
+  inputSchema: z.object({
+    url: z.string().url(),
+    gotoOptions: GotoOptionsSchema.optional(),
+  }),
+  outputSchema: z.object({
+    html: z.string(),
+    metadata: z.object({
+      url: z.string(),
+      fetchedAt: z.string(),
+    }),
+  }),
+  handler: async (props, c: AppContext) => {
+    // TODO: Uncomment after migration is applied
+    // await assertWorkspaceResourceAccess(c);
+    c.resourceAccess.grant();
+
+    const env = getEnv(c);
+    const { url, gotoOptions } = props;
+
+    const requestBody: Record<string, unknown> = { url };
+    if (gotoOptions) requestBody.gotoOptions = gotoOptions;
+
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/browser-rendering/content`,
+      {
+        method: "POST",
+        headers: buildCloudflareAuthHeaders(env),
+        body: JSON.stringify(requestBody),
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Cloudflare Browser Rendering API error: ${response.status} - ${errorText}`,
+      );
+    }
+
+    const html = await response.text();
+
+    return {
+      html,
+      metadata: {
+        url,
+        fetchedAt: new Date().toISOString(),
+      },
+    };
+  },
+});
+
+// BROWSER_SCRAPE tool
+export const browserScrape = createTool({
+  name: "BROWSER_SCRAPE",
+  description: `Scrape specific elements from a webpage using CSS selectors.
+
+Example: { "url": "https://example.com", "selectors": { "title": "h1", "price": ".price" } }`,
+  inputSchema: z.object({
+    url: z.string().url(),
+    selectors: z.record(z.string()).describe("Map of name to CSS selector"),
+    gotoOptions: GotoOptionsSchema.optional(),
+  }),
+  outputSchema: z.object({
+    elements: z.record(z.array(z.string())),
+    metadata: z.object({
+      url: z.string(),
+      scrapedAt: z.string(),
+    }),
+  }),
+  handler: async (props, c: AppContext) => {
+    // TODO: Uncomment after migration is applied
+    // await assertWorkspaceResourceAccess(c);
+    c.resourceAccess.grant();
+
+    const env = getEnv(c);
+    const { url, selectors, gotoOptions } = props;
+
+    const requestBody: Record<string, unknown> = { url, selectors };
+    if (gotoOptions) requestBody.gotoOptions = gotoOptions;
+
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/browser-rendering/scrape`,
+      {
+        method: "POST",
+        headers: buildCloudflareAuthHeaders(env),
+        body: JSON.stringify(requestBody),
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Cloudflare Browser Rendering API error: ${response.status} - ${errorText}`,
+      );
+    }
+
+    const result = (await response.json()) as {
+      elements: Record<string, string[]>;
+    };
+
+    return {
+      elements: result.elements,
+      metadata: {
+        url,
+        scrapedAt: new Date().toISOString(),
+      },
+    };
+  },
+});
+
+// LIST_SCREENSHOTS tool for gallery
+export const listScreenshots = createTool({
+  name: "BROWSER_SCREENSHOTS_LIST",
+  description:
+    "List all screenshots captured in the current workspace, organized by date",
+  inputSchema: z.object({
+    prefix: z
+      .string()
+      .optional()
+      .describe(
+        "Optional path prefix to filter (e.g., 'browser-rendering/screenshots/2024/10')",
+      ),
+    limit: z.number().optional().default(100),
+  }),
+  outputSchema: z.object({
+    screenshots: z.array(
+      z.object({
+        path: z.string(),
+        url: z.string(),
+        metadata: z
+          .object({
+            sourceUrl: z.string().optional(),
+            dimensions: z
+              .object({
+                width: z.number(),
+                height: z.number(),
+              })
+              .optional(),
+            capturedAt: z.string(),
+            format: z.string(),
+          })
+          .optional(),
+        lastModified: z.string(),
+        size: z.number(),
+      }),
+    ),
+  }),
+  handler: async (props, c: AppContext) => {
+    // TODO: Uncomment after migration is applied
+    // await assertWorkspaceResourceAccess(c);
+    c.resourceAccess.grant();
+
+    const { prefix, limit = 100 } = props;
+    const searchPrefix = prefix || "browser-rendering/screenshots/";
+
+    console.log(
+      "[BROWSER_SCREENSHOTS_LIST] Starting with prefix:",
+      searchPrefix,
+    );
+
+    try {
+      // Use native FS_LIST tool
+      const listResult = await listFiles.handler({ prefix: searchPrefix });
+
+      console.log("[BROWSER_SCREENSHOTS_LIST] FS_LIST returned:", listResult);
+
+      // Filter for image files only
+      const imageFiles = (listResult.items || []).filter((item) => {
+        const key = item.key;
+        return key.match(/\.(png|jpeg|jpg)$/i) && !key.endsWith(".meta.json");
+      });
+
+      console.log(
+        "[BROWSER_SCREENSHOTS_LIST] Filtered image files:",
+        imageFiles.length,
+      );
+
+      // Convert to screenshot objects
+      const Hosts = await import("../../hosts.ts").then((m) => m.Hosts);
+      const locator = c.workspace?.value;
+
+      const screenshots = imageFiles.slice(0, limit).map((item) => ({
+        path: item.key,
+        url: `https://${Hosts.API_LEGACY}/files/${locator}/${item.key}`,
+        lastModified: item.lastModified || new Date().toISOString(),
+        size: item.size || 0,
+      }));
+
+      console.log(
+        "[BROWSER_SCREENSHOTS_LIST] Returning screenshots:",
+        screenshots.length,
+      );
+
+      return { screenshots };
+    } catch (error) {
+      console.warn(
+        "[BROWSER_SCREENSHOTS_LIST] Failed to list screenshots (R2 credentials issue):",
+        error,
+      );
+      // Return empty array gracefully when R2 is not configured
+      return { screenshots: [] };
+    }
+  },
+});
+
+// DELETE_SCREENSHOT tool
+export const deleteScreenshot = createTool({
+  name: "BROWSER_SCREENSHOT_DELETE",
+  description: "Delete a screenshot and its metadata from storage",
+  inputSchema: z.object({
+    path: z.string().describe("Screenshot file path to delete"),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+  }),
+  handler: async (props, c: AppContext) => {
+    const { path } = props;
+
+    // 1. Validate path is in browser-rendering directory
+    if (!path.startsWith("browser-rendering/")) {
+      throw new Error("Invalid path: must be in browser-rendering directory");
+    }
+
+    // 2. Ensure user is authenticated
+    assertHasUser(c);
+
+    // 3. For now, rely on workspace resource access for authorization
+    // TODO: In the future, read metadata to check ownership
+    // TODO: Uncomment after migration is applied
+    // await assertWorkspaceResourceAccess(c);
+
+    // 4. Authorization successful - grant resource access
+    c.resourceAccess.grant();
+
+    // 5. Delete the screenshot file using native FS tool
+    await deleteFile.handler({ path });
+
+    // 6. Delete metadata file if it exists
+    const metadataPath = path.replace(/\.(png|jpeg|pdf)$/, ".meta.json");
+    try {
+      await deleteFile.handler({ path: metadataPath });
+    } catch {
+      // Metadata file might not exist or already deleted, that's okay
+    }
+
+    return { success: true };
+  },
+});

--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -3,6 +3,7 @@ import * as agentAPI from "./agent/api.ts";
 import * as agentsAPI from "./agents/api.ts";
 import * as aiAPI from "./ai/api.ts";
 import * as apiKeysAPI from "./api-keys/api.ts";
+import * as browserRenderingAPI from "./browser-rendering/api.ts";
 import * as channelsAPI from "./channels/api.ts";
 import { type AppContext, State, type Tool } from "./context.ts";
 import {
@@ -185,6 +186,13 @@ export const PROJECT_TOOLS = [
   fsAPI.readFileMetadata,
   fsAPI.writeFile,
   fsAPI.deleteFile,
+  // Browser Rendering tools
+  browserRenderingAPI.browserScreenshot,
+  browserRenderingAPI.browserPdf,
+  browserRenderingAPI.browserHtml,
+  browserRenderingAPI.browserScrape,
+  browserRenderingAPI.listScreenshots,
+  browserRenderingAPI.deleteScreenshot,
   modelsAPI.createModel,
   modelsAPI.deleteModel,
   modelsAPI.listModels,

--- a/supabase/migrations/20251026110000_browser_rendering_and_fs_policies.sql
+++ b/supabase/migrations/20251026110000_browser_rendering_and_fs_policies.sql
@@ -1,0 +1,52 @@
+-- BROWSER RENDERING and FILE SYSTEM policies for screenshots, PDFs, and file management
+INSERT INTO "public"."policies" ("id", "created_at", "name", "statements", "description", "team_id") VALUES 
+('76', '2025-10-26 11:00:00.000000+00', 'use_browser_rendering', ARRAY[
+    '{"effect":"allow","resource":"BROWSER_SCREENSHOT"}'::jsonb,
+    '{"effect":"allow","resource":"BROWSER_PDF"}'::jsonb,
+    '{"effect":"allow","resource":"BROWSER_HTML"}'::jsonb,
+    '{"effect":"allow","resource":"BROWSER_SCRAPE"}'::jsonb,
+    '{"effect":"allow","resource":"BROWSER_SCREENSHOTS_LIST"}'::jsonb
+], 'Allow users to capture screenshots, generate PDFs, fetch HTML, and scrape websites using Cloudflare Browser Rendering API', null),
+('77', '2025-10-26 11:00:00.000000+00', 'manage_browser_screenshots', ARRAY[
+    '{"effect":"allow","resource":"BROWSER_SCREENSHOT_DELETE"}'::jsonb
+], 'Allow users to delete screenshots', null),
+('78', '2025-10-26 11:00:00.000000+00', 'use_file_system', ARRAY[
+    '{"effect":"allow","resource":"FS_LIST"}'::jsonb,
+    '{"effect":"allow","resource":"FS_READ"}'::jsonb,
+    '{"effect":"allow","resource":"FS_WRITE"}'::jsonb,
+    '{"effect":"allow","resource":"FS_READ_METADATA"}'::jsonb
+], 'Allow users to list, read, write, and read metadata from file system (R2 storage)', null),
+('79', '2025-10-26 11:00:00.000000+00', 'delete_files', ARRAY[
+    '{"effect":"allow","resource":"FS_DELETE"}'::jsonb
+], 'Allow users to delete files from file system', null)
+ON CONFLICT (id) DO NOTHING;
+
+-- Associate browser rendering usage policy with all roles (1=owner, 3=member, 4=admin)
+INSERT INTO "public"."role_policies" ("id", "created_at", "role_id", "policy_id") VALUES 
+('397', '2025-10-26 11:00:00.000000+00', '1', '76'),
+('398', '2025-10-26 11:00:00.000000+00', '3', '76'),
+('399', '2025-10-26 11:00:00.000000+00', '4', '76')
+ON CONFLICT (id) DO NOTHING;
+
+-- Associate screenshot deletion policy with owner (1) and admin (4)
+-- Screenshot deletion should be restricted to prevent accidental data loss
+INSERT INTO "public"."role_policies" ("id", "created_at", "role_id", "policy_id") VALUES 
+('400', '2025-10-26 11:00:00.000000+00', '1', '77'),
+('401', '2025-10-26 11:00:00.000000+00', '4', '77')
+ON CONFLICT (id) DO NOTHING;
+
+-- Associate file system usage policy with all roles (1=owner, 3=member, 4=admin)
+-- File system operations are required for storing screenshots and other assets
+INSERT INTO "public"."role_policies" ("id", "created_at", "role_id", "policy_id") VALUES 
+('402', '2025-10-26 11:00:00.000000+00', '1', '78'),
+('403', '2025-10-26 11:00:00.000000+00', '3', '78'),
+('404', '2025-10-26 11:00:00.000000+00', '4', '78')
+ON CONFLICT (id) DO NOTHING;
+
+-- Associate file deletion policy with owner (1) and admin (4)
+-- File deletion should be restricted to prevent accidental data loss
+INSERT INTO "public"."role_policies" ("id", "created_at", "role_id", "policy_id") VALUES 
+('405', '2025-10-26 11:00:00.000000+00', '1', '79'),
+('406', '2025-10-26 11:00:00.000000+00', '4', '79')
+ON CONFLICT (id) DO NOTHING;
+


### PR DESCRIPTION
split from https://github.com/decocms/admin/pull/1641

- Add BROWSER_SCREENSHOT, BROWSER_PDF, BROWSER_HTML, BROWSER_SCRAPE tools
- Create browser-rendering UI with screenshot gallery, date filters, and quick capture
- Add SDK hooks (useCaptureScreenshot, useScreenshots, useDeleteScreenshot, etc.)
- Integrate with chat: auto-refresh gallery on screenshot capture
- Add browser-rendering routes to org and project layouts
- Register Browser as native app in marketplace
- Add migration for browser-rendering and filesystem policies
- Update .dev.vars.example with CF_API_BROWSER_RENDERING token placeholder

Screenshots are automatically saved to R2 in browser-rendering/screenshots/ organized by date. AI chat can capture screenshots with inline preview and gallery auto-refresh.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Browser feature enabling screenshot capture, PDF generation, HTML fetching, and website scraping.
  * Added screenshot gallery with search filtering, date-range filtering, and management capabilities (view, delete).
  * Integrated browser rendering tools into AI assistant context for enhanced automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->