### PR TITLE
fix(chat): update billing links in ChatError and DepositDialog components

### DIFF
--- a/apps/web/src/components/chat/chat-error.tsx
+++ b/apps/web/src/components/chat/chat-error.tsx
@@ -67,7 +67,7 @@ export function ChatError() {
               className="bg-background hover:bg-background/80 shadow-none border border-input py-3 px-4 h-10"
               asChild
             >
-              <Link to={orgLink("/monitor/billing?add_credits")}>
+              <Link to={orgLink("/billing?add_credits")}>
                 <Icon name="wallet" className="mr-2" />
                 Add credits
               </Link>

--- a/apps/web/src/components/wallet/deposit-dialog.tsx
+++ b/apps/web/src/components/wallet/deposit-dialog.tsx
@@ -19,7 +19,7 @@ import {
   usePlan,
   useSDK,
 } from "@deco/sdk";
-import { useWorkspaceLink } from "../../hooks/use-navigate-workspace.ts";
+import { useOrgLink } from "../../hooks/use-navigate-workspace.ts";
 import { useSearchParams } from "react-router";
 
 const MINIMUM_AMOUNT = 200; // $2.00 in cents
@@ -68,7 +68,7 @@ function useDepositDialog() {
 
 export function DepositDialog() {
   const { locator } = useSDK();
-  const workspaceLink = useWorkspaceLink();
+  const orgLink = useOrgLink();
   const plan = usePlan();
   const { isOpen, setIsOpen } = useDepositDialog();
 
@@ -77,11 +77,11 @@ export function DepositDialog() {
       createWalletCheckoutSession({
         locator: locator,
         amountUSDCents: amountInCents,
-        successUrl: `${location.origin}${workspaceLink(
-          "/monitor/billing?deposit_success=true",
+        successUrl: `${location.origin}${orgLink(
+          "/billing?deposit_success=true",
         )}`,
-        cancelUrl: `${location.origin}${workspaceLink(
-          "/monitor/billing?deposit_success=false",
+        cancelUrl: `${location.origin}${orgLink(
+          "/billing?deposit_success=false",
         )}`,
       }),
   });


### PR DESCRIPTION


- Changed the billing link in the ChatError component to point directly to the billing page.
- Refactored the DepositDialog component to replace the workspace link with the organization link for success and cancel URLs, ensuring consistency in navigation.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation paths for billing-related actions, including Add credits and deposit confirmation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->