### PR TITLE
[Feature] Enhance deconfigResourceV2 to merge existing data before va…

### DIFF
--- a/packages/sdk/src/mcp/resources-v2/schemas.ts
+++ b/packages/sdk/src/mcp/resources-v2/schemas.ts
@@ -141,7 +141,11 @@ export function createCreateOutputSchema<T extends z.ZodTypeAny>(
 export function createUpdateInputSchema<T extends z.ZodTypeAny>(dataSchema: T) {
   return z.object({
     uri: ResourceUriSchema.describe("URI of the resource to update"),
-    data: dataSchema.describe("Updated resource data"),
+    data: (dataSchema as unknown as z.AnyZodObject)
+      .partial()
+      .describe(
+        "Partial resource data to update. Only provided fields will be updated.",
+      ),
   });
 }
 


### PR DESCRIPTION
## Fix: Update operations were overwriting fields with default values

**Problem:** When updating a resource with partial data (e.g., only changing the name), fields with default values in the schema (like `code`) were being overwritten because Zod applied defaults before merging with existing data.

**Solution:** Made the update input schema partial using `.partial()` and changed the merge order to happen before validation, ensuring defaults only apply to truly missing fields rather than fields not provided in the update payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed resource update flow to preserve existing data when applying partial updates
  * Default values no longer overwrite existing fields during updates
  * Metadata (created_at, created_by, updated_at) now correctly reflect actual state after updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->