### PR TITLE
refactor(prompts): clarify return value requirements in outputSchema …

### DIFF
--- a/packages/sdk/src/mcp/workflows/prompts.ts
+++ b/packages/sdk/src/mcp/workflows/prompts.ts
@@ -58,6 +58,7 @@ export default async function(input, ctx) {
     
     // CRITICAL: Return ALL properties from outputSchema
     // Check actual tool response structure - don't assume property names!
+    // You don't need to access .structuredContent here, it's already in the result
     return { 
       poem: result.object?.poem || '', 
     };
@@ -230,7 +231,7 @@ export default async function(input, ctx) {
 
 **Important Rules:**
 1. **Function signature is \`(input, ctx)\`** - Input is first parameter
-2. **Return value MUST match outputSchema** - Include ALL properties
+2. **Return value MUST match outputSchema** - Include ALL properties, you don't need to access .structuredContent in the return, it's already in the result
 3. **Always use try/catch** - Return safe defaults on error
 4. **Use optional chaining** - Don't assume tool response structure
 


### PR DESCRIPTION
It was generating: 
```typescript
    const response = await ctx.env['i:123].LIST_ORDERS({
      f_creationDate: creationDateFilter,
      per_page: 100
    });
    const name = response?.structuredContent?.name
 ```
 
 but should be:
 ```typescript
    const response = await ctx.env['i:123].LIST_ORDERS({
      f_creationDate: creationDateFilter,
      per_page: 100
    });
    const name = response?.name
 ```
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced inline documentation with clarifications regarding API return value handling in workflow prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->