### PR TITLE
feat(api): implement pagination for tool and workflow searches

### DIFF
--- a/packages/sdk/src/mcp/index.ts
+++ b/packages/sdk/src/mcp/index.ts
@@ -406,8 +406,9 @@ export {
 
 // Export Resources 2.0 bindings function
 export { createResourceV2Bindings } from "./resources-v2/bindings.ts";
-export type {
-  ReadOutput,
-  ResourceItem,
-  SearchOutput,
+export {
+  createItemSchema,
+  type ReadOutput,
+  type ResourceItem,
+  type SearchOutput,
 } from "./resources-v2/schemas.ts";


### PR DESCRIPTION
- Added a new `fetchAllSearchItems` function to handle pagination for fetching all items from tool and workflow searches.
- Updated the `createSelfTools` function to utilize the new pagination logic for retrieving custom tools and workflows, enhancing data retrieval efficiency.
- Improved error handling during the reading of tool and workflow definitions to ensure robustness in the API response process.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support for retrieving tools and workflows, enabling access to all available items across multiple pages.

* **Bug Fixes**
  * Improved error handling when loading tools and workflows; individual items that fail to load are now gracefully skipped instead of breaking the entire process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->