### PR TITLE
feat(chat): implement version history tracking for resource updates a…

### DIFF
--- a/apps/web/src/components/chat/provider.tsx
+++ b/apps/web/src/components/chat/provider.tsx
@@ -47,9 +47,7 @@ import { useTriggerToolCallListeners } from "../../hooks/use-tool-call-listener.
 import { notifyResourceUpdate } from "../../lib/broadcast-channels.ts";
 import { IMAGE_REGEXP, openPreviewPanel } from "../chat/utils/preview.ts";
 import { useThreadContext } from "../decopilot/thread-context-provider.tsx";
-import {
-  useAddVersion,
-} from "../../stores/resource-version-history/index.ts";
+import { useAddVersion } from "../../stores/resource-version-history/index.ts";
 import {
   extractResourceUriFromInput,
   extractUpdateDataFromInput,
@@ -607,9 +605,10 @@ export function AgenticChatProvider({
                 readCheckpointRef.current.set(finalUri, serialized);
 
                 // Persist a baseline version the first time we see this resource in this browser
-                const existing = createResourceVersionHistoryStore
-                  .getState()
-                  .history[finalUri];
+                const existing =
+                  createResourceVersionHistoryStore.getState().history[
+                    finalUri
+                  ];
                 if (!existing || existing.length === 0) {
                   const assumedUpdateTool = deriveUpdateToolFromRead(
                     (part as { toolName?: string }).toolName,
@@ -644,7 +643,8 @@ export function AgenticChatProvider({
             typeof (part as { input?: unknown }).input === "object"
           ) {
             const input = (part as { input: Record<string, unknown> }).input;
-            const resourceUri = (input.uri as string) || (input.resource as string);
+            const resourceUri =
+              (input.uri as string) || (input.resource as string);
 
             if (typeof resourceUri === "string") {
               notifyResourceUpdate(resourceUri);
@@ -717,9 +717,8 @@ export function AgenticChatProvider({
               const checkpoint = readCheckpointRef.current.get(uri);
               if (checkpoint) {
                 // Persist a checkpoint if baseline does not already exist
-                const existing = createResourceVersionHistoryStore
-                  .getState()
-                  .history[uri];
+                const existing =
+                  createResourceVersionHistoryStore.getState().history[uri];
                 if (!existing || existing.length === 0) {
                   // Persist a checkpoint version using the current update tool as the replay vehicle
                   void addVersion(

--- a/apps/web/src/components/chat/tool-message.tsx
+++ b/apps/web/src/components/chat/tool-message.tsx
@@ -161,8 +161,11 @@ const ToolStatus = memo(function ToolStatus({
     return null;
   }, [input]);
 
-  const { canRevert, revertLabel, onConfirmRevert } =
-    useVersionRevertControls(toolName, part, uri);
+  const { canRevert, revertLabel, onConfirmRevert } = useVersionRevertControls(
+    toolName,
+    part,
+    uri,
+  );
 
   const statusText = useMemo(() => {
     switch (state) {

--- a/apps/web/src/stores/resource-version-history/index.ts
+++ b/apps/web/src/stores/resource-version-history/index.ts
@@ -36,5 +36,3 @@ export function useRevertToVersion() {
 
 export * from "./types.ts";
 export * from "./utils.ts";
-
-

--- a/apps/web/src/stores/resource-version-history/store.ts
+++ b/apps/web/src/stores/resource-version-history/store.ts
@@ -1,4 +1,8 @@
-import { MCPClient, notifyResourceUpdate, type ProjectLocator } from "@deco/sdk";
+import {
+  MCPClient,
+  notifyResourceUpdate,
+  type ProjectLocator,
+} from "@deco/sdk";
 import { toast } from "sonner";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -42,9 +46,10 @@ export const createResourceVersionHistoryStore = create<VersionHistoryStore>()(
 
           set((state) => {
             const current = state.history[uri] ?? [];
-            const next = current.length >= MAX_VERSIONS_PER_RESOURCE
-              ? [...current.slice(1), version]
-              : [...current, version];
+            const next =
+              current.length >= MAX_VERSIONS_PER_RESOURCE
+                ? [...current.slice(1), version]
+                : [...current, version];
             return { history: { ...state.history, [uri]: next } };
           });
 
@@ -79,7 +84,8 @@ export const createResourceVersionHistoryStore = create<VersionHistoryStore>()(
           }
 
           // Prefer the original toolName if present; fallback to generic UPDATE pattern
-          const toolName = version.toolCall?.toolName ?? inferUpdateToolNameFromUri(uri);
+          const toolName =
+            version.toolCall?.toolName ?? inferUpdateToolNameFromUri(uri);
 
           if (!toolName) {
             toast.error("Unable to infer update tool");
@@ -88,9 +94,11 @@ export const createResourceVersionHistoryStore = create<VersionHistoryStore>()(
 
           try {
             // Re-execute the stored tool call exactly as it was, but ensure data is the stored content
-            const inputBase = (version.toolCall?.input && typeof version.toolCall.input === "object")
-              ? { ...(version.toolCall.input as Record<string, unknown>) }
-              : { uri };
+            const inputBase =
+              version.toolCall?.input &&
+              typeof version.toolCall.input === "object"
+                ? { ...(version.toolCall.input as Record<string, unknown>) }
+                : { uri };
 
             // Ensure required shape { uri, data }
             const payload = {
@@ -101,7 +109,7 @@ export const createResourceVersionHistoryStore = create<VersionHistoryStore>()(
 
             // oxlint-disable-next-line no-explicit-any
             const client = MCPClient.forLocator<any>(locator, "/mcp");
-            
+
             // Handle namespaced tool names (e.g., "i:workspace-management__DECO_RESOURCE_XXX_UPDATE")
             const parsedToolName = parseToolName(toolName);
             let result;
@@ -178,5 +186,3 @@ export function useVersions(uri: string) {
     (s) => s.history[uri] ?? EMPTY_VERSIONS,
   );
 }
-
-

--- a/apps/web/src/stores/resource-version-history/types.ts
+++ b/apps/web/src/stores/resource-version-history/types.ts
@@ -39,5 +39,3 @@ export interface VersionHistoryActions {
 export interface VersionHistoryStore extends VersionHistoryState {
   actions: VersionHistoryActions;
 }
-
-

--- a/apps/web/src/stores/resource-version-history/utils.ts
+++ b/apps/web/src/stores/resource-version-history/utils.ts
@@ -35,7 +35,9 @@ export function isResourceReadTool(toolName: string | undefined | null) {
   return /^DECO_RESOURCE_.*_READ$/.test(actualToolName);
 }
 
-export function isResourceUpdateOrCreateTool(toolName: string | undefined | null) {
+export function isResourceUpdateOrCreateTool(
+  toolName: string | undefined | null,
+) {
   const actualToolName = extractActualToolName(toolName);
   return /^DECO_RESOURCE_.*_(UPDATE|CREATE)$/.test(actualToolName);
 }
@@ -62,15 +64,13 @@ export function deriveUpdateToolFromRead(readToolName?: string | null) {
   if (!readToolName) return null;
   const actualToolName = extractActualToolName(readToolName);
   if (!/^DECO_RESOURCE_.*_READ$/.test(actualToolName)) return null;
-  
+
   // If it was namespaced, preserve the namespace
   const separatorIndex = readToolName.lastIndexOf("__");
   if (separatorIndex !== -1) {
     const namespace = readToolName.substring(0, separatorIndex);
     return `${namespace}__${actualToolName.replace(/_READ$/, "_UPDATE")}`;
   }
-  
+
   return readToolName.replace(/_READ$/, "_UPDATE");
 }
-
-


### PR DESCRIPTION
…nd add revert functionality

- Introduced version history tracking in the AgenticChatProvider to manage READ checkpoints and persist baseline versions for resources.
- Enhanced ToolStatus component with a confirmation dialog for reverting to previous resource versions, integrating tooltip support for user feedback.
- Added utility functions for extracting resource URIs and update data, improving the handling of tool outputs and updates.
- Implemented error handling for serialization and version tracking processes to ensure robustness.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Resource version history** – automatically track all changes made to resources through tool operations with complete change history
* **Version revert capability** – revert any resource to a previous version instantly with a single undo action
* **Undo UI controls** – new undo button with confirmation dialog to safely reverse recent changes
* **Local persistence** – version history is automatically saved and preserved locally for future reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->