### PR TITLE
chore: remove i:workspace-management refs

### DIFF
--- a/apps/web/src/components/chat/rich-text.tsx
+++ b/apps/web/src/components/chat/rich-text.tsx
@@ -101,8 +101,6 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
       return (integrations as IntegrationWithTools[])
         .filter(
           (integration) =>
-            // Filter out workspace-management to avoid duplicate tools
-            integration.id !== "i:workspace-management" &&
             integration.tools &&
             Array.isArray(integration.tools) &&
             integration.tools.length > 0,
@@ -135,9 +133,6 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
       const SEARCH_TOOL_RE = /^DECO_RESOURCE_[A-Z_]+_SEARCH$/;
       return (integrations as IntegrationWithTools[])
         .filter((integration) => {
-          // Filter out workspace-management to avoid duplicate document results
-          if (integration.id === "i:workspace-management") return false;
-
           const toolsList = integration.tools ?? [];
           return toolsList.some((t) => SEARCH_TOOL_RE.test(t.name));
         })

--- a/apps/web/src/components/integrations/installed-connections.tsx
+++ b/apps/web/src/components/integrations/installed-connections.tsx
@@ -2,7 +2,6 @@ import { type Integration, useIntegrations } from "@deco/sdk";
 import { Card, CardContent } from "@deco/ui/components/card.tsx";
 import { useMemo } from "react";
 import { IntegrationIcon } from "./common.tsx";
-import { LEGACY_INTEGRATIONS } from "../../constants.ts";
 
 function CardsView({
   integrations,
@@ -13,33 +12,31 @@ function CardsView({
 }) {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
-      {integrations.map((integration) =>
-        LEGACY_INTEGRATIONS.includes(integration.id) ? null : (
-          <Card
-            key={integration.id}
-            className="group hover:shadow-md transition-shadow rounded-2xl cursor-pointer h-[116px]"
-            onClick={() => onRowClick(integration)}
-          >
-            <CardContent className="p-4">
-              <div className="grid grid-cols-[min-content_1fr] gap-4">
-                <IntegrationIcon
-                  icon={integration.icon}
-                  name={integration.name}
-                  className="h-10 w-10"
-                />
-                <div className="grid grid-cols-1 gap-1">
-                  <div className="text-sm font-semibold truncate">
-                    {integration.name}
-                  </div>
-                  <div className="text-sm text-muted-foreground line-clamp-3">
-                    {integration.description}
-                  </div>
+      {integrations.map((integration) => (
+        <Card
+          key={integration.id}
+          className="group hover:shadow-md transition-shadow rounded-2xl cursor-pointer h-[116px]"
+          onClick={() => onRowClick(integration)}
+        >
+          <CardContent className="p-4">
+            <div className="grid grid-cols-[min-content_1fr] gap-4">
+              <IntegrationIcon
+                icon={integration.icon}
+                name={integration.name}
+                className="h-10 w-10"
+              />
+              <div className="grid grid-cols-1 gap-1">
+                <div className="text-sm font-semibold truncate">
+                  {integration.name}
+                </div>
+                <div className="text-sm text-muted-foreground line-clamp-3">
+                  {integration.description}
                 </div>
               </div>
-            </CardContent>
-          </Card>
-        ),
-      )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -130,8 +130,3 @@ export const POSTHOG_ORIGIN = import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
 // Uncomment this if you want to test event tracking in development
 // export const POSTHOG_SHOULD_TRACK = true;
 export const POSTHOG_SHOULD_TRACK = import.meta.env.MODE !== "development";
-
-export const LEGACY_INTEGRATIONS = [
-  "i:user-management",
-  "i:workspace-management",
-];


### PR DESCRIPTION
- Removed the `LEGACY_INTEGRATIONS` constant from constants.ts and updated the integration filtering logic in the RichTextArea and CardsView components to eliminate references to workspace-management, simplifying the codebase.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed integrations missing from search results and tool listings
  * Re-enabled access to previously unavailable integrations, including workspace-management capabilities
  * Restored visibility of all available integrations in the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->