### PR TITLE
feat(apps-auth): auto login when opening app inside iframe and project has only 1 install of that app

### DIFF
--- a/apps/web/src/components/agent/preview.tsx
+++ b/apps/web/src/components/agent/preview.tsx
@@ -1,4 +1,10 @@
-import { callTool, useIntegration, useUpdateIntegration, useSDK, Locator } from "@deco/sdk";
+import {
+  callTool,
+  useIntegration,
+  useUpdateIntegration,
+  useSDK,
+  Locator,
+} from "@deco/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import {
@@ -81,16 +87,18 @@ export function IFrameMessageHandler({ id }: { id: string }) {
 
       if (org && project) {
         // Send context to iframe - it will use it if needed
-        channel.send({
-          type: "parent_context",
-          payload: {
-            org,
-            project,
-          },
-        }).catch((err) => {
-          // Silently fail if iframe can't receive message
-          console.debug("Could not send parent context to iframe:", err);
-        });
+        channel
+          .send({
+            type: "parent_context",
+            payload: {
+              org,
+              project,
+            },
+          })
+          .catch((err) => {
+            // Silently fail if iframe can't receive message
+            console.debug("Could not send parent context to iframe:", err);
+          });
       }
     };
 

--- a/apps/web/src/components/apps/auth.tsx
+++ b/apps/web/src/components/apps/auth.tsx
@@ -617,7 +617,10 @@ const SelectProjectAppInstance = ({
       !autoConfirmRef.current
     ) {
       autoConfirmRef.current = true;
-      console.log("Auto-confirming with single integration:", installedIntegrations[0].id);
+      console.log(
+        "Auto-confirming with single integration:",
+        installedIntegrations[0].id,
+      );
       createOAuthCodeAndRedirectBackToApp({
         integrationId: installedIntegrations[0].id,
       });
@@ -846,7 +849,7 @@ function AppsOAuth({
   useEffect(() => {
     const inIframe = globalThis.self !== globalThis.top;
     setIsInIframe(inIframe);
-    
+
     if (!inIframe) {
       // Not in iframe, don't wait for parent context
       setWaitingForParentContext(false);

--- a/apps/web/src/lib/bidc.ts
+++ b/apps/web/src/lib/bidc.ts
@@ -82,4 +82,4 @@ export const useBidcForTopWindow = <T extends z.ZodTypeAny>({
   });
 
   return channel;
-}
+};


### PR DESCRIPTION
- Added functionality to send parent context information to iframes upon load, improving integration with parent applications.
- Implemented auto-confirmation of integration when a single integration is detected, streamlining user experience.
- Refactored bidc channel handling to support both iframe and top window communication, enhancing message handling capabilities.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic integration confirmation when only one integration is available to speed authorization.
  * Improved iframe-based OAuth flow: waits for parent context, shows loading state, and pre-fills organization and project.
  * Enhanced cross-window communication to reliably deliver parent context to embedded app, reducing manual input and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->