### PR TITLE
fix(tools): use ignoreCache to avoid displaying cached tools to the user on agent edit

### DIFF
--- a/apps/web/src/components/toolsets/selector.tsx
+++ b/apps/web/src/components/toolsets/selector.tsx
@@ -73,7 +73,7 @@ export function IntegrationListItem({
   searchTerm?: string;
 }) {
   const [toolsOpen, setToolsOpen] = useState(false);
-  const { data: toolsData, isLoading } = useTools(integration.connection);
+  const { data: toolsData, isLoading } = useTools(integration.connection, true);
 
   const total = toolsData?.tools?.length ?? 0;
 

--- a/apps/web/src/hooks/use-agent-settings-tools-set.ts
+++ b/apps/web/src/hooks/use-agent-settings-tools-set.ts
@@ -43,7 +43,7 @@ export function useAgentSettingsToolsSet() {
           return;
         }
 
-        listTools(connection)
+        listTools(connection, {}, true)
           .then((result) => {
             // If fetching goes well, update the form again
             newToolsSet[integrationId] = result.tools.map((tool) => tool.name);

--- a/packages/sdk/src/hooks/react-query-keys.ts
+++ b/packages/sdk/src/hooks/react-query-keys.ts
@@ -338,7 +338,7 @@ export const KEYS = {
             ? connection.name
             : "";
 
-    return ["tools", connection.type, identifier, ignoreCache];
+    return ["tools", connection.type, identifier, `${!!ignoreCache}`];
   },
   OPTIONS_LOADER: (type: string) => ["optionsLoader", type],
   WALLET_SIMPLE: () => ["wallet"],

--- a/packages/sdk/src/hooks/tools.ts
+++ b/packages/sdk/src/hooks/tools.ts
@@ -59,11 +59,16 @@ export const callTool = (
   });
 };
 
-export function useTools(connection: MCPConnection, ignoreCache?: boolean) {
+export function useTools(connection: MCPConnection, ignoreCache = false) {
   const response = useQuery({
     retry: false,
     queryKey: KEYS.MCP_TOOLS(connection, ignoreCache),
     queryFn: ({ signal }) => listTools(connection, { signal }, ignoreCache),
+    refetchOnMount: ignoreCache,
+    refetchOnWindowFocus: ignoreCache,
+    refetchOnReconnect: ignoreCache,
+    staleTime: ignoreCache ? 0 : undefined,
+    gcTime: ignoreCache ? 0 : undefined,
   });
 
   return {


### PR DESCRIPTION

- Updated the `useTools` hook to include default parameters for `ignoreCache`, enhancing its flexibility.
- Modified the `listTools` function call to support an additional parameter for cache control.
- Adjusted the query key generation in `react-query-keys` to ensure proper string representation of the `ignoreCache` flag.
- Improved the `IntegrationListItem` component to utilize the updated `useTools` hook with cache management.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tool data fetching and caching behavior across the application. The system now supports configurable cache control options, allowing selective data refresh when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->