### PR TITLE
chore: deny_list for purplevara

### DIFF
--- a/apps/api/src/decopilot-stream.ts
+++ b/apps/api/src/decopilot-stream.ts
@@ -198,7 +198,6 @@ type ToolLike = {
 
 const INTEGRATIONS_DENY_LIST = new Set([
   "i:contracts-management",
-  "i:thread-management",
   "i:prompt-management",
   "i:oauth-management",
   "i:model-management",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restricted the list of available integrations shown in the app by filtering out specific integrations; these denied options are no longer visible when browsing or selecting integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->