### PR TITLE
fix(ui): remove broken uploaded img

### DIFF
--- a/apps/web/src/components/chat/chat-message.tsx
+++ b/apps/web/src/components/chat/chat-message.tsx
@@ -1,5 +1,4 @@
 import type { UIMessage } from "@ai-sdk/react";
-import { useFile } from "@deco/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -57,6 +56,7 @@ export const ChatMessage = memo(function ChatMessage({
     () =>
       message.parts
         ?.filter((part) => part.type === "file")
+        .filter((part) => !part.mediaType?.startsWith("image/"))
         .map((part) => ({
           contentType: part.mediaType,
           url: part.url,
@@ -194,16 +194,21 @@ export const ChatMessage = memo(function ChatMessage({
 });
 
 function ImagePart({ part }: { part: FileUIPart }) {
-  const { data: fileUrl } = useFile(part.url);
-
-  if (!fileUrl) return null;
-
   return (
-    <img
-      src={fileUrl}
-      alt={part.filename || "Uploaded image"}
-      className="rounded-lg max-h-[300px] object-cover"
-    />
+    <a
+      href={part.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="relative group flex items-center gap-2 rounded-xl"
+    >
+      <div className="relative">
+        <img
+          src={part.url}
+          alt={part.filename || "Uploaded image"}
+          className="rounded-lg max-h-[300px] object-cover"
+        />
+      </div>
+    </a>
   );
 }
 


### PR DESCRIPTION
Fix this:
<img width="353" height="416" alt="Screenshot 2025-10-30 at 19 24 35" src="https://github.com/user-attachments/assets/885ed12f-56c3-4189-8146-a2f15ce8e502" />

To this:
<img width="352" height="383" alt="Screenshot 2025-10-30 at 19 25 00" src="https://github.com/user-attachments/assets/afa41586-345c-4145-b945-1d0cff9b7fd1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images in chat messages are now clickable and open in a new tab for better viewing.

* **Bug Fixes**
  * Improved handling of file attachments by separating images from downloadable files for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->