### PR TITLE
feat(api): add media proxy endpoint to handle CORS issues

### DIFF
--- a/apps/web/src/components/agent/preview.tsx
+++ b/apps/web/src/components/agent/preview.tsx
@@ -154,7 +154,7 @@ export const PreviewIframe = forwardRef<HTMLIFrameElement, Props>(
           id={id}
           allow={ALLOWANCES}
           allowFullScreen
-          sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-downloads"
+          sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms allow-downloads allow-top-navigation-by-user-activation"
           className="w-full h-full"
           {...props}
         />

--- a/apps/web/src/components/views/view-detail.tsx
+++ b/apps/web/src/components/views/view-detail.tsx
@@ -593,6 +593,7 @@ export function ViewDetail({ resourceUri, data }: ViewDetailProps) {
                   srcDoc={htmlValue}
                   title="View Preview"
                   className="w-full h-full border-0"
+                  referrerPolicy="no-referrer"
                 />
               ) : (
                 <div className="flex items-center justify-center h-full p-8">


### PR DESCRIPTION
- Implemented a new `/proxy/media` endpoint to fetch and return media files while addressing CORS issues in iframes.
- Added URL validation and security checks to ensure only valid HTTP/HTTPS media types are processed.
- Enhanced error handling for various failure scenarios, including invalid URLs and unsupported content types.
- Updated view-template to include a media proxy interceptor for seamless media handling in the frontend.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media (images, videos, and audio) now loads correctly in preview frames
  * Enhanced iframe sandbox permissions for improved user interactions
  * Improved privacy handling with referrer policies in previews

<!-- end of auto-generated comment: release notes by coderabbit.ai -->