### PR TITLE
make topbar whitelabel by removing the deco logo

### DIFF
--- a/apps/web/src/components/layout/org-project-switcher.tsx
+++ b/apps/web/src/components/layout/org-project-switcher.tsx
@@ -9,7 +9,7 @@ import {
 } from "@deco/ui/components/popover.tsx";
 import { Separator } from "@deco/ui/components/separator.tsx";
 import { Suspense, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 import { Avatar } from "../common/avatar";
 import { CreateOrganizationDialog } from "../sidebar/create-team-dialog";
 import { SwitcherProjects } from "./project-switcher";
@@ -49,18 +49,24 @@ export function BreadcrumbOrgSwitcher() {
   return (
     <>
       <Popover>
-        <PopoverTrigger asChild>
-          <div className="flex items-center gap-2 cursor-pointer rounded-md hover:bg-accent p-0.5">
-            <Avatar
-              url={currentOrg?.avatar_url}
-              fallback={currentOrg?.name ?? org}
-              size="xs"
-              objectFit="contain"
-            />
-            <span>{currentOrg?.name ?? org}</span>
-            <Icon name="expand_all" size={16} className="opacity-50" />
-          </div>
-        </PopoverTrigger>
+        <div className="flex items-center gap-1">
+          <Button variant="link" className="p-0.5" asChild>
+            <Link to={`/${org}`} className="flex items-center gap-2 h-auto">
+              <Avatar
+                url={currentOrg?.avatar_url}
+                fallback={currentOrg?.name ?? org}
+                size="xs"
+                objectFit="contain"
+              />
+              <span>{currentOrg?.name ?? org}</span>
+            </Link>
+          </Button>
+          <PopoverTrigger asChild>
+            <Button size="icon" variant="ghost" className="w-6 h-6 p-0">
+              <Icon name="expand_all" size={16} className="opacity-50" />
+            </Button>
+          </PopoverTrigger>
+        </div>
         <PopoverContent
           align="start"
           className="p-0 flex items-start w-[480px]"
@@ -91,7 +97,7 @@ export function BreadcrumbOrgSwitcher() {
                     url={organization.avatar_url}
                     fallback={organization.name}
                     size="xs"
-                    className="!w-[22px] !h-[22px]"
+                    className="w-[22px]! h-[22px]!"
                     objectFit="contain"
                   />
                   <span className="overflow-hidden text-ellipsis whitespace-nowrap">
@@ -112,6 +118,15 @@ export function BreadcrumbOrgSwitcher() {
             </div>
             <Separator />
             <div className="px-1 pb-1 pt-0.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start font-normal"
+                onClick={() => navigate("/")}
+              >
+                <Icon name="grid_view" size={16} />
+                <span>See all organizations</span>
+              </Button>
               <Button
                 variant="ghost"
                 size="sm"

--- a/apps/web/src/components/layout/project-switcher.tsx
+++ b/apps/web/src/components/layout/project-switcher.tsx
@@ -8,7 +8,7 @@ import {
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
 import { Suspense, useMemo, useState } from "react";
-import { useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams } from "react-router";
 import { Avatar } from "../common/avatar";
 import { useFile } from "@deco/sdk";
 
@@ -89,18 +89,27 @@ export function BreadcrumbProjectSwitcher() {
   return (
     <>
       <Popover>
-        <PopoverTrigger asChild>
-          <div className="flex items-center gap-2 cursor-pointer hover:bg-accent p-0.5 rounded-md">
-            <Avatar
-              url={resolvedAvatar ?? undefined}
-              fallback={currentProject?.title ?? projectParam}
-              size="xs"
-              objectFit="contain"
-            />
-            <span>{currentProject?.title ?? projectParam}</span>
-            <Icon name="expand_all" size={16} className="opacity-50" />
-          </div>
-        </PopoverTrigger>
+        <div className="flex items-center gap-1">
+          <Button variant="link" className="p-0.5" asChild>
+            <Link
+              to={`/${org}/${projectParam}`}
+              className="flex items-center gap-2 h-auto"
+            >
+              <Avatar
+                url={resolvedAvatar ?? undefined}
+                fallback={currentProject?.title ?? projectParam}
+                size="xs"
+                objectFit="contain"
+              />
+              <span>{currentProject?.title ?? projectParam}</span>
+            </Link>
+          </Button>
+          <PopoverTrigger asChild>
+            <Button size="icon" variant="ghost" className="w-6 h-6 p-0">
+              <Icon name="expand_all" size={16} className="opacity-50" />
+            </Button>
+          </PopoverTrigger>
+        </div>
         <PopoverContent
           align="start"
           className="rounded-xl p-0 flex items-start w-full"

--- a/apps/web/src/components/layout/topbar.tsx
+++ b/apps/web/src/components/layout/topbar.tsx
@@ -1,4 +1,3 @@
-import { BreadcrumbSeparator } from "@deco/ui/components/breadcrumb.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Icon } from "@deco/ui/components/icon.tsx";
 import {
@@ -9,7 +8,6 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import { Suspense } from "react";
-import { Link } from "react-router";
 import { ErrorBoundary } from "../../error-boundary.tsx";
 import { ReportIssueButton } from "../common/report-issue-button.tsx";
 import { LoggedUser, LoggedUserAvatarTrigger } from "../sidebar/footer";
@@ -76,16 +74,6 @@ export function Topbar({ breadcrumb }: { breadcrumb: BreadcrumbItem[] }) {
         <ErrorBoundary fallback={null}>
           <SidebarToggle />
         </ErrorBoundary>
-        <Link to="/" className="ml-2">
-          <div className="size-8 flex items-center justify-center">
-            <img
-              src="/img/logo-tiny.svg"
-              className="size-4.5"
-              alt="Deco Logo"
-            />
-          </div>
-        </Link>
-        <BreadcrumbSeparator className="text-muted-foreground" />
         <DefaultBreadcrumb items={breadcrumb} useWorkspaceLink={false} />
       </div>
       <div className="flex items-center gap-2">


### PR DESCRIPTION
Move from this: 
<img width="467" height="49" alt="Screenshot 2025-11-02 at 12 53 31" src="https://github.com/user-attachments/assets/69c1de77-36df-446c-a25b-b251c37b4c0b" />

To this:
<img width="406" height="49" alt="Screenshot 2025-11-02 at 12 53 46" src="https://github.com/user-attachments/assets/1eb19b06-0850-49e2-99ce-77ec4420ac98" />


- Updated BreadcrumbOrgSwitcher and BreadcrumbProjectSwitcher to use Link components for better navigation.
- Improved button styling and structure for a more consistent UI.
- Added a button to navigate to all organizations in BreadcrumbOrgSwitcher.
- Removed unused imports and cleaned up the Topbar component.