### PR TITLE
Fix execute integration tools error

### DIFF
--- a/packages/sdk/src/hooks/resources-tools.ts
+++ b/packages/sdk/src/hooks/resources-tools.ts
@@ -302,28 +302,33 @@ export async function callToolV2(
       const toolName = decodeURIComponent(parts[parts.length - 1]);
 
       // Call INTEGRATIONS_CALL_TOOL with the integration ID
-      const result = await client.INTEGRATIONS_CALL_TOOL({
-        id: integrationId,
-        params: {
-          name: toolName,
-          arguments: params.input,
+      const result = await client.INTEGRATIONS_CALL_TOOL(
+        {
+          id: integrationId,
+          params: {
+            name: toolName,
+            arguments: params.input,
+          },
         },
-      }, { signal });
+        { signal },
+      );
 
       // Transform the MCP result to match ToolCallResultV2 format
       if (result.isError) {
         let errorMessage = "Tool execution failed";
         let errorStack = undefined;
-        
+
         if (result.structuredContent) {
           errorMessage = result.structuredContent.message || errorMessage;
           errorStack = result.structuredContent.stack;
         } else if (result.content && result.content[0]?.text) {
           errorMessage = result.content[0].text;
         }
-        
+
         return {
-          error: errorStack ? `${errorMessage}\n\nStack trace:\n${errorStack}` : errorMessage,
+          error: errorStack
+            ? `${errorMessage}\n\nStack trace:\n${errorStack}`
+            : errorMessage,
           logs: [],
         };
       }
@@ -334,7 +339,10 @@ export async function callToolV2(
       };
     } catch (error) {
       return {
-        error: error instanceof Error ? `${error.message}\n\n${error.stack}` : String(error),
+        error:
+          error instanceof Error
+            ? `${error.message}\n\n${error.stack}`
+            : String(error),
         logs: [],
       };
     }


### PR DESCRIPTION
## What is this contribution about?
This Pull Request fixes a bug in the integration tools.

The issue was that when the tool was called from the chat, it worked correctly, but when it was called using “execute tool” for testing, it would throw an error.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved routing for tool executions to automatically invoke external integrations when referenced
  * Returns structured content for successful integration tool calls and preserves cancellable operations via abort signals

* **Bug Fixes**
  * Consolidated and clearer error messages for failed tool calls, with enhanced stack-trace details for diagnostics
  * More robust error handling to prevent uncaught failures during integration calls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->