### PR TITLE
Fix all inputs required in connect app modal

### DIFF
--- a/apps/web/src/components/integrations/select-connection-dialog.tsx
+++ b/apps/web/src/components/integrations/select-connection-dialog.tsx
@@ -137,8 +137,9 @@ export const useIntegrationInstallStep = ({
       const dependencyName = maybeAppDependencyList?.[stepIndex] ?? "";
       const dependencySchema =
         integrationState.schema?.properties?.[dependencyName] ?? {};
-      const isRequired = integrationState.schema?.required?.includes(dependencyName);
-      
+      const isRequired =
+        integrationState.schema?.required?.includes(dependencyName);
+
       return {
         type: "object",
         properties: {
@@ -158,14 +159,17 @@ export const useIntegrationInstallStep = ({
           {} as Record<string, JSONSchema7Definition>,
         ) ?? {};
 
-      const requiredFields = maybeAppList?.filter(
-        (app) => integrationState.schema?.required?.includes(app)
+      const requiredFields = maybeAppList?.filter((app) =>
+        integrationState.schema?.required?.includes(app),
       );
 
       return {
         type: "object",
         properties,
-        required: requiredFields && requiredFields.length > 0 ? requiredFields : undefined,
+        required:
+          requiredFields && requiredFields.length > 0
+            ? requiredFields
+            : undefined,
       } satisfies JSONSchema7;
     }
   }, [totalSteps, stepIndex, integrationState.schema]);


### PR DESCRIPTION
- Adjusted the required fields logic to dynamically include dependencies based on the integration schema.
- Enhanced the handling of required properties for the integration installation step, ensuring accurate validation based on the schema's requirements.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
The inputs did not match what was coming from the integration API

## Screenshots/Demonstration
| Antes | Depois |
|-------|--------|
| <img width="1440" height="900" alt="Screenshot 2025-11-04 at 16 53 06" src="https://github.com/user-attachments/assets/af89f10c-c406-4405-ab83-85b6350020c8" /> | <img width="1440" height="900" alt="Screenshot 2025-11-04 at 16 52 34" src="https://github.com/user-attachments/assets/7b8bcb77-22a1-4430-8b03-599f6bb5974b" /> |

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of required fields in connection dialogs for dependency and app steps. Required fields are now more accurately determined based on the configuration schema, reducing unnecessary field requirements in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->