### PR TITLE
Change 'Apps' to 'Context'

### DIFF
--- a/apps/web/src/components/integrations/breadcrumb.tsx
+++ b/apps/web/src/components/integrations/breadcrumb.tsx
@@ -17,7 +17,7 @@ export const Header = ({
   return (
     <ListPageHeader
       input={{
-        placeholder: "Search apps",
+        placeholder: "Search context",
         value: query,
         onChange: (e) => setQuery(e.target.value),
       }}

--- a/apps/web/src/components/sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/index.tsx
@@ -1518,7 +1518,7 @@ function WorkspaceViews() {
           onClick={() => {
             navigateWorkspace("/apps");
             trackEvent("sidebar_navigation_click", {
-              item: "Apps",
+              item: "Context",
             });
             isMobile && toggleSidebar();
           }}
@@ -1528,7 +1528,7 @@ function WorkspaceViews() {
             size={20}
             className="text-muted-foreground/75"
           />
-          <span className="truncate">Apps</span>
+          <span className="truncate">Context</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -521,7 +521,7 @@ const router = createBrowserRouter([
           {
             path: "apps",
             Component: InstalledAppsList,
-            handle: { title: "Apps" },
+            handle: { title: "Context" },
           },
           {
             path: "apps/:appKey",

--- a/packages/sdk/src/views.ts
+++ b/packages/sdk/src/views.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const DEFAULT_VIEWS: View[] = [
   {
     id: "apps",
-    title: "Apps",
+    title: "Context",
     icon: "linked_services",
     type: "default",
     metadata: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed "Apps" terminology to "Context" throughout the application UI, including navigation labels, search placeholders, and page titles for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->