### PR TITLE
feat: enhance onboarding dialog with theme selection

### DIFF
--- a/apps/web/src/components/theme-editor/theme-presets.ts
+++ b/apps/web/src/components/theme-editor/theme-presets.ts
@@ -1321,3 +1321,16 @@ export const THEME_PRESETS = [
     },
   },
 ] as const satisfies ReadonlyArray<ThemePreset>;
+
+/**
+ * Find a theme preset by name (case-insensitive)
+ * @param name - The name of the theme (e.g., "Cyberpunk", "cyberpunk")
+ * @returns The theme object if found, undefined otherwise
+ */
+export function findThemeByName(name: string): Theme | undefined {
+  const normalizedName = name.toLowerCase().trim();
+  const preset = THEME_PRESETS.find(
+    (p) => p.name.toLowerCase() === normalizedName || p.id === normalizedName,
+  );
+  return preset?.theme;
+}

--- a/packages/sdk/src/crud/teams.ts
+++ b/packages/sdk/src/crud/teams.ts
@@ -50,6 +50,7 @@ export interface CreateTeamInput {
   stripe_subscription_id?: string;
   avatar_url?: string;
   domain?: string;
+  theme?: Theme;
   [key: string]: unknown;
 }
 

--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -425,6 +425,7 @@ export const createTeam = createTool({
       slug: z.string(),
       avatar_url: z.string().optional(),
       domain: z.string().optional(),
+      theme: enhancedThemeSchema.optional(),
     }),
   ),
 
@@ -439,7 +440,7 @@ export const createTeam = createTool({
     c.resourceAccess.grant();
 
     assertPrincipalIsUser(c);
-    const { name, slug, avatar_url, domain } = props;
+    const { name, slug, avatar_url, domain, theme } = props;
     const user = c.user;
 
     // Enforce unique slug if provided
@@ -475,6 +476,7 @@ export const createTeam = createTool({
           slug,
           avatar_url,
           domain: domain?.toLowerCase(),
+          theme: theme || null,
         },
       ])
       .select()


### PR DESCRIPTION
- Added functionality to select a theme during team creation in the onboarding dialog.
- Implemented a new utility function to find theme presets by name.
- Updated the CreateTeamInput interface to include an optional theme parameter.
- Adjusted API handling to accommodate the new theme parameter in team creation requests.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teams can be created or joined with a predefined visual theme: a theme passed via URL query will prefill onboarding, apply across personal and company flows (including retries and auto-join), and is persisted with the team so new teams retain the selected appearance.
  * Added name/id-based theme lookup (case-insensitive) so URL-supplied theme values resolve reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->