### PR TITLE
fix: keep path on magiclink

### DIFF
--- a/apps/web/src/components/login/hooks/use-send-magic-link.ts
+++ b/apps/web/src/components/login/hooks/use-send-magic-link.ts
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 
 export function useSendMagicLink() {
   return useMutation({
-    mutationFn: (prop: { email: string; cli: boolean }) =>
+    mutationFn: (prop: { email: string; cli: boolean; next?: string }) =>
       fetch(new URL("/login/magiclink", DECO_CMS_API_URL), {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/apps/web/src/components/login/index.tsx
+++ b/apps/web/src/components/login/index.tsx
@@ -55,6 +55,7 @@ function Login() {
     const ok = await sendMagicLink.mutateAsync({
       email,
       cli,
+      next: next || undefined,
     });
 
     if (ok) {


### PR DESCRIPTION
This PR makes the params stick to magiclink links, so we keep the onboarding after sending the link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional redirect URL parameter in magic link authentication, enabling users to be redirected to a specified destination after completing sign-in via magic link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->