### PR TITLE
feat(tools): improve DECO_TOOL_RUN_TOOL description

### DIFF
--- a/packages/sdk/src/mcp/tools/api.ts
+++ b/packages/sdk/src/mcp/tools/api.ts
@@ -120,10 +120,13 @@ const createToolManagementTool = createToolGroup("Tools", {
 /**
  * Creates tool binding implementation that accepts a resource reader
  * Returns only the core tool execution functionality
+ *
+ * This tool is equivalent to calling DECO_RESOURCE_TOOL_CREATE + calling the tool with the input.
+ * It creates and executes a tool in a single operation.
  */
 export const runTool = createToolManagementTool({
   name: "DECO_TOOL_RUN_TOOL",
-  description: "Invoke the tool passed as input",
+  description: TOOL_CREATE_PROMPT,
   inputSchema: z.object({
     tool: ToolDefinitionSchema,
     input: z.object({}).passthrough().describe("The input of the code"),


### PR DESCRIPTION
Update DECO_TOOL_RUN_TOOL description to use TOOL_CREATE_PROMPT instead of generic 'Invoke the tool passed as input'. This provides better context about the tool's purpose and capabilities.

Also add clarifying comment explaining that this tool creates and executes a tool in a single operation.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved tool descriptions and added documentation comments clarifying that tool creation and execution occur as a unified operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->