### PR TITLE
refactor(integrations): remove special handling for self integration tools

### DIFF
--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -838,19 +838,6 @@ export const getIntegration = createIntegrationManagementTool({
 
     const virtualIntegrations = virtualIntegrationsFor(c, [], c.token);
 
-    // Handle self integration - don't return tools
-    if (id === formatId("i", WellKnownMcpGroups.Self)) {
-      const selfIntegration = virtualIntegrations.find(
-        (i) => i.id === formatId("i", WellKnownMcpGroups.Self),
-      );
-      if (selfIntegration) {
-        return {
-          ...IntegrationSchema.parse(selfIntegration),
-          tools: null, // Don't return tools for self integration
-        };
-      }
-    }
-
     if (virtualIntegrations.some((i) => i.id === id)) {
       const baseIntegration = IntegrationSchema.parse({
         ...virtualIntegrations.find((i) => i.id === id),


### PR DESCRIPTION
## Context

Previously, the self integration (`i:self`) had special handling that returned `tools: null` to prevent fetching tools via the standard MCP connection path. This was because self tools are dynamically generated via `createSelfTools()` rather than being stored in a traditional MCP server.

## Problem

The `READ_MCP` tool (used in decopilot) now depends on being able to access self tools to generate safe code. `READ_MCP` uses `INTEGRATIONS_GET` and expects tools to be available in the response. With the special handling in place, self tools were not accessible, preventing `READ_MCP` from discovering and using them.

## Solution

By removing this special case, the self integration will now be handled like other virtual integrations and will fetch tools through the normal flow via `listToolsAndSortByName()`, which connects to the `/self/mcp` endpoint that provides the dynamically generated tools.

## Changes

- Removed the special handling block that returned `tools: null` for self integration
- Self integration now goes through the standard virtual integration flow
- Tools are fetched via `listToolsAndSortByName()` which connects to `/self/mcp`

## Impact

This change enables `READ_MCP` to properly discover and use self tools for code generation, which is essential for the decopilot functionality.

## Testing

- [ ] Verify that `READ_MCP` can now access self tools
- [ ] Verify that self integration tools are properly listed when fetching the integration
- [ ] Verify that tools are still dynamically generated correctly via `/self/mcp` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated self-integration behavior to process through standard virtual integration flow, which may now return tools consistent with other virtual integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->