### PR TITLE
fix(database): fix studio iframe height cutting off footer

### DIFF
--- a/apps/web/src/components/database/studio.tsx
+++ b/apps/web/src/components/database/studio.tsx
@@ -31,7 +31,7 @@ export default function DatabaseStudio() {
   const studioUrl = `${DECO_CMS_API_URL}/${org}/${project}/${integrationId}/studio`;
 
   return (
-    <div className="h-[calc(100vh-48px)] w-full">
+    <div className="h-full w-full">
       <PreviewIframe
         key={refreshKey}
         src={studioUrl}


### PR DESCRIPTION
Changed from fixed calc(100vh-48px) to h-full to properly fill the available space in the Canvas container, respecting the parent layout structure (topbar + canvas tabs + other elements).

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated vertical sizing behavior in the database studio interface for improved layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->