### PR TITLE
feat(shell-layout): implement local storage for chat panel width

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -1,32 +1,33 @@
-import { Outlet, useParams } from "@tanstack/react-router";
+import { DecoChatPanel } from "@/web/components/deco-chat-panel";
+import { MeshSidebar } from "@/web/components/mesh-sidebar";
+import { MeshOrgSwitcher } from "@/web/components/org-switcher";
+import { SplashScreen } from "@/web/components/splash-screen";
+import { MeshUserMenu } from "@/web/components/user-menu";
+import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
+import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
+import { authClient } from "@/web/lib/auth-client";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { Locator } from "@/web/lib/locator";
+import { LocalStorageChatThreadsProvider } from "@/web/providers/localstorage-chat-threads-provider";
+import { ProjectContextProvider } from "@/web/providers/project-context-provider";
 import { AppTopbar } from "@deco/ui/components/app-topbar.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
-import {
-  SidebarInset,
-  SidebarLayout,
-  SidebarProvider,
-} from "@deco/ui/components/sidebar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@deco/ui/components/resizable.tsx";
 import { SidebarToggleButton } from "@deco/ui/components/sidebar-toggle-button.tsx";
-import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
-import { MeshUserMenu } from "@/web/components/user-menu";
-import { authClient } from "@/web/lib/auth-client";
+import {
+  SidebarInset,
+  SidebarLayout,
+  SidebarProvider,
+} from "@deco/ui/components/sidebar.tsx";
 import { useMutation } from "@tanstack/react-query";
-import { useEffect, useState, Suspense, useCallback } from "react";
-import { SplashScreen } from "@/web/components/splash-screen";
-import { MeshSidebar } from "@/web/components/mesh-sidebar";
-import { MeshOrgSwitcher } from "@/web/components/org-switcher";
-import { ProjectContextProvider } from "@/web/providers/project-context-provider";
-import { Locator } from "@/web/lib/locator";
-import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
-import { DecoChatPanel } from "@/web/components/deco-chat-panel";
-import { LocalStorageChatThreadsProvider } from "@/web/providers/localstorage-chat-threads-provider";
-import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { Outlet, useParams } from "@tanstack/react-router";
+import { Suspense, useCallback, useEffect, useState } from "react";
 
 // Capybara avatar URL from decopilotAgent
 const CAPYBARA_AVATAR_URL =
@@ -116,6 +117,10 @@ export default function ShellLayout() {
     () => setChatOpen((prev) => !prev),
     [setChatOpen],
   );
+  const [chatPanelWidth, setChatPanelWidth] = useLocalStorage(
+    LOCALSTORAGE_KEYS.decoChatPanelWidth(),
+    30,
+  );
   const hasOrg = !!org;
 
   return (
@@ -152,9 +157,10 @@ export default function ShellLayout() {
                           <>
                             <ResizableHandle withHandle />
                             <ResizablePanel
-                              defaultSize={30}
+                              defaultSize={chatPanelWidth}
                               minSize={20}
                               className="min-w-0"
+                              onResize={setChatPanelWidth}
                             >
                               <Suspense fallback={<div>Loading chat...</div>}>
                                 <DecoChatPanel />

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -11,4 +11,5 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:thread-manager-state:${locator}`,
   chatSelectedModel: (locator: ProjectLocator) =>
     `mesh:chat:selectedModel:${locator}`,
+  decoChatPanelWidth: () => `mesh:decochat:panel-width`,
 } as const;


### PR DESCRIPTION
- Added functionality to store and retrieve the width of the DecoChatPanel using local storage.
- Introduced a new key in local storage for the chat panel width.
- Updated the ShellLayout component to use the stored width for the resizable chat panel, enhancing user experience by preserving layout preferences.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The DecoChat panel is now resizable—adjust its width to suit your workflow, and your preference will be automatically saved and restored on each visit for a personalized experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->