### PR TITLE
fix: only select registrys

### DIFF
--- a/apps/mesh/src/web/hooks/use-binding.ts
+++ b/apps/mesh/src/web/hooks/use-binding.ts
@@ -256,3 +256,29 @@ export function useCollectionBindings(
     [connection?.tools],
   );
 }
+
+/**
+ * Check if a connection has any collections (registry capability)
+ * A registry connection is one that exposes collections via COLLECTION_{NAME}_LIST tools
+ */
+function hasCollections(connection: ConnectionEntity): boolean {
+  const collectionNames = extractCollectionNames(connection.tools);
+  return collectionNames.length > 0;
+}
+
+/**
+ * Hook to filter connections that have registry/store capabilities
+ * Returns only connections that expose collections
+ *
+ * @param connections - Array of connections to filter
+ * @returns Filtered array of connections that have collections (registries)
+ */
+export function useRegistryConnections(
+  connections: ConnectionEntity[] | undefined,
+): ConnectionEntity[] {
+  return useMemo(
+    () =>
+      !connections ? [] : connections.filter((conn) => hasCollections(conn)),
+    [connections],
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/store.tsx
+++ b/apps/mesh/src/web/routes/orgs/store.tsx
@@ -2,6 +2,7 @@ import { StoreRegistrySelect } from "@/web/components/store-registry-select";
 import { EmptyState } from "@/web/components/empty-state";
 import { StoreDiscovery } from "@/web/components/store";
 import { useConnections } from "@/web/hooks/collections/use-connection";
+import { useRegistryConnections } from "@/web/hooks/use-binding";
 import { useProjectContext } from "@/web/providers/project-context-provider";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
@@ -10,16 +11,19 @@ export default function StorePage() {
   const { org } = useProjectContext();
   const navigate = useNavigate();
   const [selectedRegistry, setSelectedRegistry] = useState<string>("");
-  const { data: connections, isLoading, isError } = useConnections();
+  const { data: allConnections, isLoading, isError } = useConnections();
+
+  // Filter to only show registry connections (those with collections)
+  const registryConnections = useRegistryConnections(allConnections);
 
   const registryOptions = useMemo(
     () =>
-      (connections ?? []).map((c) => ({
+      registryConnections.map((c) => ({
         id: c.id,
         name: c.title,
         icon: c.icon || undefined,
       })),
-    [connections],
+    [registryConnections],
   );
 
   if (isLoading) {
@@ -38,8 +42,8 @@ export default function StorePage() {
     );
   }
 
-  const safeConnections = connections ?? [];
-  const effectiveRegistry = selectedRegistry || safeConnections[0]?.id || "";
+  const effectiveRegistry =
+    selectedRegistry || registryConnections[0]?.id || "";
 
   const handleAddNewRegistry = () => {
     navigate({


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Registry connection options now display only registry-specific connections, providing a cleaner and more relevant list of available choices for registry configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->