### PR TITLE
[feat]: Adds ON_MCP_CONFIGURE callback

### DIFF
--- a/apps/mesh/src/tools/connection/configure.ts
+++ b/apps/mesh/src/tools/connection/configure.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import { createMCPProxy } from "../../api/routes/proxy";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/mesh-context";
 
@@ -149,6 +150,15 @@ export const CONNECTION_CONFIGURE = defineTool({
       configuration_state: state,
       configuration_scopes: scopes,
     });
+
+    // Invoke ON_MCP_CONFIGURE callback on the connection
+    // Ignore errors but await for the response before responding
+    try {
+      const proxy = await createMCPProxy(connectionId, ctx);
+      await proxy.callTool("ON_MCP_CONFIGURE", { state, scopes });
+    } catch {
+      // Silently ignore callback errors
+    }
 
     return {
       success: true,


### PR DESCRIPTION
This allows calling back the MCP on configure (so they can do "side-effects")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP proxy now exposes a programmatic tool-calling capability alongside its existing fetch interface.
  * MCP configuration now triggers callback invocations to properly initialize connected services.

* **Refactor**
  * Consolidated tool execution logic into a shared pipeline for consistent metrics and tracing across all tool invocation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->