### PR TITLE
feat(registry): filter public apps by MCP Deco Site connection URLs

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -79,6 +79,7 @@ import { z } from "zod";
 import { convertJsonSchemaToZod } from "zod-from-json-schema";
 import { ROUTES as loginRoutes } from "./auth/index.ts";
 import {
+  MCP_CONFIGURATION_TOOL_NAME,
   MCP_REGISTRY_DECOCMS_KEY,
   MCP_REGISTRY_DEFAULT_VERSION,
   MCP_REGISTRY_ICON_MIME_TYPE,
@@ -830,7 +831,7 @@ const hasMCPConfigurationTool = (
   tools: Array<Record<string, unknown>> | null | undefined,
 ): boolean => {
   if (!Array.isArray(tools)) return false;
-  return tools.some((tool) => tool.name === "MCP_CONFIGURATION");
+  return tools.some((tool) => tool.name === MCP_CONFIGURATION_TOOL_NAME);
 };
 
 const listPublicRegistryApps = createPublicRegistryTools({

--- a/apps/api/src/constants.ts
+++ b/apps/api/src/constants.ts
@@ -40,3 +40,5 @@ export const MCP_REGISTRY_ICON_MIME_TYPE = "image/png";
 
 /** MCP Registry default version */
 export const MCP_REGISTRY_DEFAULT_VERSION = "1.0.0";
+
+export const MCP_CONFIGURATION_TOOL_NAME = "MCP_CONFIGURATION";


### PR DESCRIPTION
# Filter Public Registry by MCP Configuration Tool

## What is this contribution about?

This PR refines the public MCP registry endpoint to display only applications that include the `MCP_CONFIGURATION` tool. This ensures that only properly configured MCPs appear in the public registry, preventing incomplete or external MCP connections from being listed.

### Problem
Previously, the public registry (`COLLECTION_REGISTRY_APP_LIST`) was returning all unlisted apps without considering whether they had the required `MCP_CONFIGURATION` tool. This resulted in incomplete or incompatible MCPs appearing in the public registry.

### Solution
Implemented a filter that validates each app contains the `MCP_CONFIGURATION` tool before including it in the results. Only MCPs that are fully configured and ready for public consumption will now appear in the registry.

## Technical Changes

### New Helper Function
```typescript
const hasMCPConfigurationTool = (
  tools: Array<Record<string, unknown>> | null | undefined,
): boolean => {
  if (!Array.isArray(tools)) return false;
  return tools.some((tool) => tool.name === "MCP_CONFIGURATION");
};
```

### Updated Filtering Logic
- Added filtering in `COLLECTION_REGISTRY_APP_LIST` handler to exclude apps without `MCP_CONFIGURATION`
- Adjusted `totalCount`, pagination, and `hasMore` indicators to reflect the filtered dataset
- Maintains backward compatibility with existing query parameters

## Impact

### What Changed
- ✅ Public registry now filters apps by `MCP_CONFIGURATION` tool availability
- ✅ Pagination counts and "has more" indicators are accurate for filtered results
- ✅ External or incomplete MCP connections are automatically excluded

### What Stays the Same
- ✅ API endpoint remains unchanged (`COLLECTION_REGISTRY_APP_LIST`)
- ✅ Existing query parameters (`limit`, `offset`, `where`, `orderBy`) continue to work
- ✅ No breaking changes to client code

## Testing Notes

Test the following scenarios:
1. **Verify Filtering**: Call `COLLECTION_REGISTRY_APP_LIST` and confirm only apps with `MCP_CONFIGURATION` tool appear
2. **Pagination**: Test with `limit` and `offset` parameters to ensure accurate counts
3. **Empty Results**: Verify `hasMore` is `false` when no apps with the tool exist
4. **Backward Compatibility**: Ensure existing clients continue to work without changes

## Files Modified

- `apps/api/src/api.ts`: Added filtering logic to public registry endpoint

## Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`npm run lint`, `npm run fmt`, `npm run check`, `npm run knip`)
- [x] No breaking changes to API contracts
- [x] Code follows project conventions and formatting standards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public app registry now filters to display only applications with MCP configuration support. The registry listing applies this additional filtering criterion to refine the selection of available applications shown to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->