### PR TITLE
Update localhost port in API configuration and adjust resource access…

### DIFF
--- a/apps/api/main.ts
+++ b/apps/api/main.ts
@@ -26,7 +26,7 @@ const SELF_DOMAINS: string[] = [
   // @ts-expect-error env is not typed
   ...(env.VITE_USE_LOCAL_BACKEND ? [] : [Hosts.APPS]),
   // @ts-expect-error env is not typed
-  `localhost:${env.PORT || 8000}`,
+  `localhost:${env.PORT || 3001}`,
 ];
 
 // Patch fetch globally

--- a/packages/sdk/src/mcp/integrations/api.ts
+++ b/packages/sdk/src/mcp/integrations/api.ts
@@ -166,7 +166,6 @@ export const callTool = createIntegrationManagementTool({
     "Call a tool from an integration. If you have the integration ID (from INTEGRATIONS_LIST or INTEGRATIONS_GET), prefer using 'id' over 'connection'. The ID ensures you're calling the correct configured integration. Use 'connection' only when you need to call a tool from a new or unconfigured integration.",
   inputSchema: z.lazy(() => integrationCallToolInputSchema),
   handler: async (input, c) => {
-    c.resourceAccess.grant();
     const toolCall = input.params;
 
     let connection: MCPConnection | undefined = undefined;
@@ -227,6 +226,7 @@ export const callTool = createIntegrationManagementTool({
     } finally {
       // Always dispose of the client to avoid RPC leaks
       await client.close();
+      c.resourceAccess.grant();
     }
   },
 });


### PR DESCRIPTION

- Changed the default localhost port from 8000 to 3001 in the API configuration.
- Moved the resource access grant call to the finally block in the integration tool handler to ensure it is always executed, preventing potential access issues.

These changes improve the API's default behavior and enhance resource management in integration calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource access handling timing to ensure proper cleanup in SDK operations.

* **Chores**
  * Updated default local development port configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->