### PR TITLE
fix prev esc vulnerability

### DIFF
--- a/packages/sdk/src/mcp/teams/api.ts
+++ b/packages/sdk/src/mcp/teams/api.ts
@@ -2035,6 +2035,13 @@ export const autoJoinTeam = createTool({
       );
     }
 
+    // validate if user email domain got the same domain supplied input
+    if (user.email.split('@')[1].toLowerCase() !== domain.toLowerCase()) {
+  throw new UserInputError(
+    "Cannot auto-join team, user email is different from domain"
+  );
+}
+
     // Find team with matching domain
     const { data: team, error: teamError } = await c.db
       .from("teams")


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?

This will fix the Privilege escalation attack, which anyone can join a workspace just by knowing their domain.  

## Screenshots/Demonstration
PoC vid:

https://github.com/user-attachments/assets/95a65031-c660-4d08-a21b-85a1c52720bd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added domain validation to the team auto-join process to ensure the authenticated user's email domain matches the intended team domain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->