### PR TITLE
refactor: enhance MCP configuration handling in connection settings

### DIFF
--- a/apps/mesh/src/web/components/details/connection.tsx
+++ b/apps/mesh/src/web/components/details/connection.tsx
@@ -442,13 +442,16 @@ function SettingsTab({
     Record<string, unknown>
   >(connection.configuration_state ?? {});
 
-  // Fetch MCP configuration (stateSchema and scopes) directly
   const {
     stateSchema: mcpStateSchema,
-    scopes: mcpScopes,
+    scopes: fetchedScopes,
     isLoading: isMcpConfigLoading,
     error: mcpConfigError,
   } = useMcpConfiguration(connection.id);
+
+  const mcpScopes = isMcpConfigLoading
+    ? (connection.configuration_scopes ?? [])
+    : fetchedScopes;
 
   // Reset MCP state when connection changes
   // oxlint-disable-next-line ban-use-effect/ban-use-effect

--- a/apps/mesh/src/web/components/details/mcp-configuration-form.tsx
+++ b/apps/mesh/src/web/components/details/mcp-configuration-form.tsx
@@ -13,17 +13,14 @@ interface McpConfigurationResult {
   scopes?: string[];
 }
 
-/**
- * Hook to fetch MCP configuration (stateSchema and scopes) for a connection.
- * Use this in the parent component to get scopes directly without callbacks.
- */
 export function useMcpConfiguration(connectionId: string) {
   const toolCaller = createToolCaller(connectionId);
 
-  const { data: configResult, isLoading, error } = useToolCall<
-    Record<string, never>,
-    McpConfigurationResult
-  >({
+  const {
+    data: configResult,
+    isLoading,
+    error,
+  } = useToolCall<Record<string, never>, McpConfigurationResult>({
     toolCaller,
     toolName: "MCP_CONFIGURATION",
     toolInputParams: {},


### PR DESCRIPTION
- Introduced `useMcpConfiguration` hook to fetch MCP configuration directly, simplifying data management.
- Updated `McpConfigurationForm` to accept `stateSchema`, `isLoading`, and `error` props for improved state handling.
- Removed local state management for MCP scopes in `SettingsTab`, streamlining the component structure.
- Enhanced the `ConnectionInspectorViewContent` to utilize the new hook for better integration of MCP settings.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored MCP configuration handling in connection settings to fetch config via a new hook and pass state/loading into the form. This simplifies data flow, removes redundant local state, and improves reliability.

- **Refactors**
  - Added useMcpConfiguration to load stateSchema and scopes for a connection.
  - Updated McpConfigurationForm to accept stateSchema, isLoading, and error; removed internal fetching and the connection prop.
  - Removed local MCP scopes state in SettingsTab and switched to hook-provided data.
  - Updated ConnectionInspectorViewContent to use the new hook for consistent MCP settings integration.

<sup>Written for commit a7f569a3347b61e6d89410fab634c853b60d9895. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated MCP configuration data fetching into a reusable hook and simplified the configuration form to receive data via props, improving maintainability.

* **Bug Fixes / UX**
  * Configuration form now surfaces loading and error states consistently and falls back gracefully, yielding clearer feedback when MCP data is slow or fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->