### PR TITLE
add org invites to user menu

### DIFF
--- a/apps/mesh/src/web/components/user-menu.tsx
+++ b/apps/mesh/src/web/components/user-menu.tsx
@@ -220,6 +220,10 @@ function MeshUserMenuBase({
 export function MeshUserMenu() {
   const { data: session } = authClient.useSession();
   const authUi = useContext(AuthUIContext);
+  const { data: _invitations } = authUi.hooks.useListUserInvitations();
+
+  const invitations = _invitations ?? [];
+  const hasInvites = invitations.length > 0;
 
   // Return skeleton/placeholder if no session yet
   if (!session?.user) {
@@ -241,10 +245,6 @@ export function MeshUserMenu() {
     name: user.name ?? undefined,
   } as typeof user;
   const userImage = (user as { image?: string }).image;
-
-  const invitationsQuery = authUi?.hooks?.useListUserInvitations?.();
-  const invitations = (invitationsQuery as any)?.data ?? [];
-  const hasInvites = Array.isArray(invitations) && invitations.length > 0;
 
   return (
     <MeshUserMenuBase


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add organization invitations to the user menu with a modal that lists pending invites and shows a small red badge when invites are available. Invites are pulled from better-auth-ui hooks; signed-out behavior is unchanged.

- **New Features**
  - Added Invitations menu item that opens a dialog with UserInvitationsCard.
  - Show a red badge on the avatar and menu item when there are pending invites.
  - Fetch invites via AuthUIContext.hooks.useListUserInvitations.

- **Refactors**
  - Extracted MeshUserMenuBase and InvitationsDialog for cleaner structure.
  - Kept placeholder avatar for unauthenticated users.

<sup>Written for commit 0f837976b9006e23c818de542fafd33406aaa3f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



