### PR TITLE
Enhance BindingSelector to filter connections by tools and add useToo…

### DIFF
--- a/apps/mesh/src/web/hooks/use-tools-from-binding.ts
+++ b/apps/mesh/src/web/hooks/use-tools-from-binding.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { createToolCaller } from "@/tools/client";
+import type { RegistryItem } from "@/web/components/store/registry-items-section";
+import { useConnections } from "@/web/hooks/collections/use-connection";
+import { useRegistryConnections } from "@/web/hooks/use-binding";
+import { useToolCall } from "@/web/hooks/use-tool-call";
+import { getToolsFromBindingType } from "@/web/utils/extract-connection-data";
+import {
+  findListToolName,
+  extractItemsFromResponse,
+} from "@/web/utils/registry-utils";
+
+/**
+ * Hook to get tools from a binding type in the registry
+ * @param bindingType - Binding type string (e.g., "@deco/database")
+ * @returns Object with tools array, loading state, and error
+ */
+export function useToolsFromBinding(bindingType: string | undefined) {
+  const allConnections = useConnections();
+  const registryConnections = useRegistryConnections(allConnections);
+
+  const registryId = registryConnections[0]?.id || "";
+  const registryConnection = registryConnections[0];
+
+  const listToolName = findListToolName(registryConnection?.tools);
+  const toolCaller = createToolCaller(registryId);
+
+  const { data: listResults, isLoading, error } = useToolCall({
+    toolCaller,
+    toolName: listToolName,
+    toolInputParams: {},
+    connectionId: registryId,
+    enabled: !!listToolName && !!registryId && !!bindingType,
+  });
+
+  const registryItems = extractItemsFromResponse<RegistryItem>(listResults);
+
+  const tools = useMemo(() => {
+    if (!bindingType) return [];
+    return getToolsFromBindingType(registryItems, bindingType);
+  }, [registryItems, bindingType]);
+
+  return { tools, isLoading, error };
+}
+


### PR DESCRIPTION
…lsFromBinding hook

- Introduced a new `tools` prop in `BindingSelector` to filter connections based on specific tool names.
- Refactored connection filtering logic to prioritize tool-based filtering.
- Added `useToolsFromBinding` hook to retrieve tools associated with a given binding type.
- Updated `McpConfigurationForm` to utilize the new tools functionality for binding selection.

This improves the flexibility of connection selection in the UI.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tool-based filtering to BindingSelector and a hook to fetch tools from a binding type via the registry. Updates the MCP configuration form to use tool-based filtering for more precise connection selection.

- **New Features**
  - BindingSelector accepts a tools prop and shows connections that expose those tools.
  - Added useToolsFromBinding to resolve tool names from a bindingType, using the registry and a known-tools fallback.
  - Added getToolsFromBindingType utility to extract tools from registry items or fall back to KNOWN_BINDING_TOOLS.

- **Refactors**
  - BindingSelector now prioritizes tool-based filtering, then falls back to binding filtering.
  - Removed inline MCP install UI and onAddNew handling from BindingSelector.
  - MCP configuration stores the selected connection ID as a string and derives tools from bindingType.

<sup>Written for commit 99a5003b16fedea15e058098be268d1d256580a2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

