### PR TITLE
Fix/mcp detail oauth prevention

### DIFF
--- a/apps/mesh/src/web/routes/orgs/store-app-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/store-app-detail.tsx
@@ -321,8 +321,7 @@ export default function StoreAppDetail() {
 
   const isLoadingRemoteTools =
     shouldFetchRemote &&
-    (remoteMcp.state === "connecting" ||
-      remoteMcp.state === "authenticating");
+    (remoteMcp.state === "connecting" || remoteMcp.state === "authenticating");
 
   const remoteTools =
     shouldFetchRemote && remoteMcp.state === "ready"


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent automatic OAuth on the Store App Detail page and simplify the remote tools loading state to avoid unintended auth prompts.

- **Bug Fixes**
  - Initialize the MCP client with preventAutoAuth: true to block auto-auth flows.
  - Remove pending_auth from the loading condition; loading now only shows during connecting or authenticating.

<sup>Written for commit 44348e673bba9dbcb62d8568e894348377266367. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



