### PR TITLE
refactor(connection): use tools from connection

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab.tsx
@@ -11,7 +11,6 @@ import {
 import { useBindingConnections } from "@/web/hooks/use-binding";
 import { useBindingSchemaFromRegistry } from "@/web/hooks/use-binding-schema-from-registry";
 import { useInstallFromRegistry } from "@/web/hooks/use-install-from-registry";
-import { useIsMCPAuthenticated } from "@/web/hooks/use-oauth-token-validation";
 import { useToolCall } from "@/web/hooks/use-tool-call";
 import { authenticateMcp } from "@/web/lib/browser-oauth-provider";
 import { useProjectContext } from "@/web/providers/project-context-provider";
@@ -65,6 +64,7 @@ interface SettingsTabProps {
   connection: ConnectionEntity;
   onUpdate: (connection: Partial<ConnectionEntity>) => Promise<void>;
   isUpdating: boolean;
+  isMCPAuthenticated: boolean;
 }
 
 type SettingsTabWithMcpBindingProps = SettingsTabProps & {
@@ -671,23 +671,18 @@ function SettingsTabContentWithoutMcpBinding(
 }
 
 function SettingsRightPanel({
-  connection,
   hasMcpBinding,
   stateSchema,
   form,
   onAuthenticate,
+  isMCPAuthenticated,
 }: {
-  connection: ConnectionEntity;
   hasMcpBinding: boolean;
   stateSchema?: Record<string, unknown>;
   form: ReturnType<typeof useForm<ConnectionFormData>>;
   onAuthenticate: () => void | Promise<void>;
+  isMCPAuthenticated: boolean;
 }) {
-  const isMCPAuthenticated = useIsMCPAuthenticated({
-    url: connection.connection_url,
-    token: connection?.connection_token,
-  });
-
   const hasProperties =
     stateSchema &&
     stateSchema.properties &&
@@ -817,11 +812,11 @@ function SettingsTabContentImpl(props: SettingsTabContentImplProps) {
           }
         >
           <SettingsRightPanel
-            connection={connection}
             hasMcpBinding={hasMcpBinding}
             stateSchema={stateSchema}
             form={form}
             onAuthenticate={handleAuthenticate}
+            isMCPAuthenticated={props.isMCPAuthenticated}
           />
         </Suspense>
       </div>


### PR DESCRIPTION
enhance connection inspector and settings tab functionality

- Refactored ConnectionInspectorViewContent to utilize ConnectionInspectorViewWithConnection for improved structure and clarity.
- Integrated useIsMCPAuthenticated hook to manage MCP authentication state within the connection inspector.
- Updated SettingsTab to accept isMCPAuthenticated prop, streamlining the authentication handling in the settings panel.
- Simplified connection handling logic and improved tab management for better user experience.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the connection inspector to use MCP auth state and connection.tools, simplifying tab logic and improving reliability. Tools and collection tabs now appear only when authenticated, and Settings handles auth via a new isMCPAuthenticated prop.

- **Refactors**
  - Extracted ConnectionInspectorViewWithConnection to separate data wiring from rendering.
  - Replaced use-mcp/react with useIsMCPAuthenticated and connection.tools.
  - Tabs: show Tools and collections only when authenticated; Tools count from connection.tools; validate requested tab.
  - SettingsTab now accepts isMCPAuthenticated; removed internal auth hook from the right panel.
  - Simplified update handling and reduced conditional logic across the inspector.

<sup>Written for commit 0b4df4ca482be8403c2ccf428d654ce1385dec95. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

