### PR TITLE
fix: disables form on submit to prevent multiple form submission

### DIFF
--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -501,10 +501,16 @@ function OrgMcpsContent() {
                 >
                   Cancel
                 </Button>
-                <Button type="submit">
-                  {editingConnection
-                    ? "Update Connection"
-                    : "Create Connection"}
+                <Button
+                  type="submit"
+                  disabled={form.formState.isSubmitting}
+                  className="min-w-40"
+                >
+                  {form.formState.isSubmitting
+                    ? "Saving..."
+                    : editingConnection
+                      ? "Update Connection"
+                      : "Create Connection"}
                 </Button>
               </DialogFooter>
             </form>


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the submit button during submission in the org connection form to prevent duplicate creates/updates and show a clear “Saving...” state. Keeps the button width stable to avoid layout shift.

<sup>Written for commit a71e5c615f2c7caf20e6d5b80b22ac882cac611f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

