### PR TITLE
Bump runtime package

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.0.0-alpha.34",
+  "version": "1.0.0-alpha.35",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit"
@@ -8,7 +8,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250617.0",
     "@deco/mcp": "npm:@jsr/deco__mcp@0.7.8",
-    "@decocms/bindings": "1.0.1-alpha.19",
+    "@decocms/bindings": "1.0.1-alpha.20",
     "@modelcontextprotocol/sdk": "1.20.2",
     "@ai-sdk/provider": "^2.0.0",
     "hono": "^4.10.7",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shifted event bus to a single EVENT_SYNC_SUBSCRIPTIONS call to sync adds/deletes in one step and simplified runtime subscription logic. Also bumped runtime and bindings versions.

- **Refactors**
  - Changed EventSubscription to a flat shape: { eventType, publisher } and updated eventsSubscriptions to return a flat list.
  - Replaced per-event EVENT_SUBSCRIBE loops with bus.EVENT_SYNC_SUBSCRIPTIONS({ subscriptions }).
  - Updated scopes to use "<bus>::EVENT_SYNC_SUBSCRIPTIONS".

- **Dependencies**
  - @decocms/runtime 1.0.0-alpha.35; @decocms/bindings 1.0.1-alpha.20.

<sup>Written for commit c56186769bf3f2b8d5efcfa53b42eeb1a0bb2c57. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

