### PR TITLE
Refactor useProjectSidebarItems hook to simplify sidebar item retrieval

### DIFF
--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.ts
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.ts
@@ -1,21 +1,21 @@
 import { useProjectContext } from "@/web/providers/project-context-provider";
 import { NavigationSidebarItem } from "@deco/ui/components/navigation-sidebar.js";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { Locator, ProjectLocator } from "@/web/lib/locator";
+import { Locator } from "@/web/lib/locator";
 import { useNavigate } from "@tanstack/react-router";
-import { KEYS } from "@/web/lib/query-keys";
 
-async function getProjectSidebarItems({
-  locator,
-  navigate,
-}: {
-  locator: ProjectLocator;
-  navigate: ReturnType<typeof useNavigate>;
-}) {
+export function useProjectSidebarItems() {
+  const { locator } = useProjectContext();
+  const navigate = useNavigate();
   const { org } = Locator.parse(locator);
   const isOrgAdminProject = Locator.isOrgAdminProject(locator);
 
   const KNOWN_ORG_ADMIN_SIDEBAR_ITEMS: NavigationSidebarItem[] = [
+    {
+      key: "home",
+      label: "Home",
+      icon: "home",
+      onClick: () => navigate({ to: "/$org", params: { org } }),
+    },
     {
       key: "store",
       label: "Store",
@@ -24,7 +24,7 @@ async function getProjectSidebarItems({
     },
     {
       key: "mcps",
-      label: "MCPs",
+      label: "MCP Servers",
       icon: "grid_view",
       onClick: () => navigate({ to: "/$org/mcps", params: { org } }),
     },
@@ -48,21 +48,5 @@ async function getProjectSidebarItems({
     },
   ];
 
-  const navigationItems: NavigationSidebarItem[] = isOrgAdminProject
-    ? KNOWN_ORG_ADMIN_SIDEBAR_ITEMS
-    : [];
-
-  return Promise.resolve(navigationItems);
-}
-
-export function useProjectSidebarItems() {
-  const { locator } = useProjectContext();
-  const navigate = useNavigate();
-
-  const { data: sidebarItems } = useSuspenseQuery({
-    queryKey: KEYS.sidebarItems(locator),
-    queryFn: () => getProjectSidebarItems({ locator, navigate }),
-  });
-
-  return sidebarItems;
+  return isOrgAdminProject ? KNOWN_ORG_ADMIN_SIDEBAR_ITEMS : [];
 }


### PR DESCRIPTION
- Removed unused async function and integrated sidebar item logic directly into the useProjectSidebarItems hook.
- Updated sidebar item label for "MCPs" to "MCP Servers" for clarity.
- Streamlined the return of sidebar items based on organization admin status.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored useProjectSidebarItems to build sidebar items directly without React Query. Added a Home item and renamed “MCPs” to “MCP Servers” for clarity.

- **Refactors**
  - Removed the async helper and useSuspenseQuery; the hook now returns items synchronously.
  - Sidebar items are derived solely from org admin status.

- **New Features**
  - Added a Home shortcut for org admins.
  - Renamed “MCPs” to “MCP Servers”.

<sup>Written for commit 4ac19bb906b097216ce985a1e78cc29ea7575e0e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

