### PR TITLE
fix: Update app name in well-known MCP connection data for consistency

### DIFF
--- a/apps/mesh/src/core/well-known-mcp.ts
+++ b/apps/mesh/src/core/well-known-mcp.ts
@@ -48,7 +48,7 @@ export function getWellKnownCommunityRegistryConnection(): ConnectionCreateData 
     connection_type: "HTTP",
     connection_url: "https://sites-registry.decocache.com/mcp",
     icon: "https://assets.decocache.com/decocms/cd7ca472-0f72-463a-b0de-6e44bdd0f9b4/mcp.png",
-    app_name: "registrys",
+    app_name: "mcp-registry",
     app_id: null,
     connection_token: null,
     connection_headers: null,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the well-known MCP connection data to use app_name "mcp-registry" for consistent naming with the Community Registry and correct app identification. Fixes the previous "registrys" typo to prevent mislabeling in clients and analytics.

<sup>Written for commit 766e14e810cc1c9dc5cb40c9bdc8a5f7f385e367. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

