### PR TITLE
[block saas] Feature/store search via mcp

### DIFF
--- a/apps/mesh/src/web/hooks/use-collections.ts
+++ b/apps/mesh/src/web/hooks/use-collections.ts
@@ -66,8 +66,9 @@ export interface UseCollectionListOptions<T extends CollectionEntity> {
 
 /**
  * Build a where expression from search term and filters
+ * @public Exported for use in other components (e.g., store discovery)
  */
-function buildWhereExpression<T extends CollectionEntity>(
+export function buildWhereExpression<T extends CollectionEntity>(
   searchTerm: string | undefined,
   filters: CollectionFilter[] | undefined,
   searchFields: (keyof T)[],


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side search to Store Discovery via MCP with debounced input, replacing client-side filtering. Searches the full registry and shows a clear “Searching...” state while typing.

- **New Features**
  - Server-side search using a standard where expression on name, title, and description.
  - Debounced input with a “Searching...” indicator.
  - Query caching keyed by the debounced term.
  - Infinite scroll disabled during search; enabled otherwise.

- **Refactors**
  - Removed client-side filtering; results now come directly from MCP.
  - Exported buildWhereExpression for reuse.
  - Improved empty states for “no items” vs “no search results.”

<sup>Written for commit 292b84e77043d7c24c9dff2803fcb118e1b9992b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









