### PR TITLE
Remove item counts and 'All' section title when no verified items

### DIFF
--- a/apps/mesh/src/web/components/store/registry-items-section.tsx
+++ b/apps/mesh/src/web/components/store/registry-items-section.tsx
@@ -97,21 +97,16 @@ export function RegistryItemsSection({
   items,
   title,
   onItemClick,
-  totalCount,
 }: RegistryItemsSectionProps) {
   if (items.length === 0) return null;
 
-  const itemsText =
-    totalCount != null
-      ? `${items.length} of ${totalCount}`
-      : `${items.length} items`;
-
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between w-max gap-2">
-        <h2 className="text-lg font-medium">{title}</h2>
-        <span className="block text-xs text-muted-foreground">{itemsText}</span>
-      </div>
+      {title && (
+        <div className="flex items-center justify-between w-max gap-2">
+          <h2 className="text-lg font-medium">{title}</h2>
+        </div>
+      )}
       <div className="grid grid-cols-4 gap-4">
         {items.map((item) => {
           const displayData = extractCardDisplayData(item);

--- a/apps/mesh/src/web/components/store/store-discovery-ui.tsx
+++ b/apps/mesh/src/web/components/store/store-discovery-ui.tsx
@@ -61,7 +61,6 @@ export function StoreDiscoveryUI({
   registryId,
   hasMore = false,
   onLoadMore,
-  totalCount,
 }: StoreDiscoveryUIProps) {
   const [search, setSearch] = useState("");
   const navigate = useNavigate();
@@ -168,9 +167,8 @@ export function StoreDiscoveryUI({
                 {allItems.length > 0 && (
                   <RegistryItemsSection
                     items={allItems}
-                    title="All"
+                    title={verifiedItems.length > 0 ? "All" : ""}
                     onItemClick={handleItemClick}
-                    totalCount={totalCount}
                   />
                 )}
 


### PR DESCRIPTION
- Remove numbers (item counts) from section headers
- Hide 'All' title when verified items are not present
- Keep all items displayed even without verified section
- Clean up unused totalCount parameter
- 
## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.
<img width="1706" height="1035" alt="Captura de Tela 2025-12-19 às 11 54 27" src="https://github.com/user-attachments/assets/f27d1ad0-41fc-496f-bed3-10c705ed75b3" />
<img width="1720" height="1040" alt="Captura de Tela 2025-12-19 às 11 55 31" src="https://github.com/user-attachments/assets/00694360-af43-4450-b4ef-4069c6b4ef47" />


## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the store discovery headers: removed item counts and hide the “All” title when there are no verified items. This cleans up the UI while keeping all items visible.

- **Refactors**
  - Removed totalCount prop and itemsText logic from RegistryItemsSection.
  - Only render a section title when provided; omit “All” if no verified items.
  - Keep all items displayed even when the Verified section is absent.

<sup>Written for commit 27ecf615dfe7e734f08cb30ffcd7dc08137e6646. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

