### PR TITLE
Feat/signup screen firsts

### DIFF
--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -20,7 +20,7 @@ export function UnifiedAuthForm({ redirectUrl }: UnifiedAuthFormProps) {
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [isSignUp, setIsSignUp] = useState(() => {
-    const hasLoggedIn = localStorage.getItem("hasLoggedIn");
+    const hasLoggedIn = globalThis.localStorage?.getItem("hasLoggedIn");
     return hasLoggedIn !== "true";
   });
   const [emailError, setEmailError] = useState("");
@@ -59,7 +59,7 @@ export function UnifiedAuthForm({ redirectUrl }: UnifiedAuthFormProps) {
       }
     },
     onSuccess: () => {
-      localStorage.setItem("hasLoggedIn", "true");
+      globalThis.localStorage?.setItem("hasLoggedIn", "true");
       // If OAuth flow, redirect to authorize endpoint to complete the flow
       if (redirectUrl) {
         window.location.href = redirectUrl;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the unified auth form to open Sign Up for first-time users and Log In for returning users. Preserve email/password when toggling to prevent losing typed input.

- **New Features**
  - Initial mode is based on prior login (localStorage hasLoggedIn); flag is set on successful auth.
  - Email and password are no longer cleared on toggle; name and errors still reset.

<sup>Written for commit 5dae0310dc0894f7fbacdf5fe67ffee2154fbfbe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





