### PR TITLE
chore: community registry by default

### DIFF
--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -1,4 +1,7 @@
-import { getWellKnownSelfConnection } from "@/core/well-known-mcp";
+import {
+  getWellKnownCommunityRegistryConnection,
+  getWellKnownSelfConnection,
+} from "@/core/well-known-mcp";
 import { getDb } from "@/database";
 import { CredentialVault } from "@/encryption/credential-vault";
 import { ConnectionStorage } from "@/storage/connection";
@@ -61,6 +64,10 @@ function getDefaultOrgMcps(): MCPCreationSpec[] {
       data: getWellKnownSelfConnection(
         process.env.BASE_URL || "http://localhost:3000",
       ),
+    },
+    // MCP Registry (Community Registry) - public registry, no permissions required
+    {
+      data: getWellKnownCommunityRegistryConnection(),
     },
   ];
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add the Community MCP Registry to the default org MCP connections. New orgs now have the public registry enabled by default, with no permissions required.

<sup>Written for commit 6448530c93dd3ef473f3803e161d0e8c1b936b83. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

