### PR TITLE
Fix oauth proxy urls

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/mesh",
-  "version": "1.0.0-alpha.14",
+  "version": "1.0.0-alpha.15",
   "description": "MCP Mesh - Self-hostable MCP Gateway for managing AI connections and tools",
   "license": "MIT",
   "author": "Deco team",

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -128,6 +128,15 @@ async function ensureContext(c: {
 // Protected Resource Metadata Proxy
 // ============================================================================
 
+const forceHttps = (url: URL) => {
+  const isLocal = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  if (!isLocal) {
+    // force http if not local
+    url.protocol = "https:";
+  }
+  return url;
+};
+
 /**
  * Handler for proxying OAuth protected resource metadata
  * Rewrites resource to /mcp/:connectionId and authorization_servers to /oauth-proxy/:connectionId
@@ -163,7 +172,7 @@ const protectedResourceMetadataHandler = async (c: {
     const data = (await response.json()) as Record<string, unknown>;
 
     // Build our proxy resource URL (matches the MCP proxy endpoint)
-    const requestUrl = new URL(c.req.url);
+    const requestUrl = forceHttps(new URL(c.req.url));
     const proxyResourceUrl = `${requestUrl.origin}/mcp/${connectionId}`;
 
     // Rewrite authorization_servers to point to our proxy


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix OAuth proxy URLs by forcing https in non‑local environments to ensure correct origins and secure redirects. Bumps @decocms/mesh to 1.0.0-alpha.15.

- **Bug Fixes**
  - Force https (except localhost/127.0.0.1) when building the proxy resource origin in oauth-proxy metadata handler.

- **Dependencies**
  - Update @decocms/mesh version from 1.0.0-alpha.14 to 1.0.0-alpha.15.

<sup>Written for commit f1c8d089d0261c2136d86a91afbe3002aac3f755. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

