### PR TITLE
fix: slugify name before copy

### DIFF
--- a/apps/mesh/src/web/utils/slugify.ts
+++ b/apps/mesh/src/web/utils/slugify.ts
@@ -6,7 +6,8 @@ export function slugify(input: string): string {
   return input
     .toLowerCase()
     .trim()
-    .replace(/[^a-z0-9\s_-]+/g, "")
-    .replace(/[\s_-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/\//g, "-") // Replace forward slashes with hyphens
+    .replace(/[^a-z0-9\s_-]+/g, "") // Remove special characters except word chars, spaces, underscores, and hyphens
+    .replace(/[\s_-]+/g, "-") // Replace spaces, underscores, and hyphens with single hyphen
+    .replace(/^-+|-+$/g, ""); // Remove leading and trailing hyphens
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slugify server names before generating MCP config, deeplinks, and CLI commands to prevent invalid keys and failed installs. Fixes issues with names containing slashes or special characters.

- **Bug Fixes**
  - Use slugified serverName for MCP config, Cursor/Windsurf deeplinks, and Claude CLI command.
  - Update slugify to replace "/" with "-", remove special chars, and collapse spaces/underscores/hyphens into a single "-".

<sup>Written for commit 8ca5de140f057929df34830d986a60e989daaa85. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

