### PR TITLE
Fixes registry connection id

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/mesh",
-  "version": "1.0.0-alpha.21",
+  "version": "1.0.0-alpha.22",
   "description": "MCP Mesh - Self-hostable MCP Gateway for managing AI connections and tools",
   "license": "MIT",
   "author": "Deco team",

--- a/apps/mesh/src/core/well-known-mcp.ts
+++ b/apps/mesh/src/core/well-known-mcp.ts
@@ -18,9 +18,11 @@ export const WellKnownOrgMCPId = {
  *
  * @returns ConnectionCreateData for the Deco Store registry
  */
-export function getWellKnownRegistryConnection(): ConnectionCreateData {
+export function getWellKnownRegistryConnection(
+  orgId: string,
+): ConnectionCreateData {
   return {
-    id: WellKnownMCPId.REGISTRY,
+    id: WellKnownOrgMCPId.REGISTRY(orgId),
     title: "Deco Store",
     description: "Official deco MCP registry with curated integrations",
     connection_type: "HTTP",

--- a/apps/mesh/src/web/routes/orgs/store.tsx
+++ b/apps/mesh/src/web/routes/orgs/store.tsx
@@ -55,7 +55,7 @@ export default function StorePage() {
     selectedRegistry?.id || registryConnections[0]?.id || "";
 
   // Well-known registries to show in select (hidden/less prominent)
-  const wellKnownRegistriesForSelect = [getWellKnownRegistryConnection()];
+  const wellKnownRegistriesForSelect = [getWellKnownRegistryConnection(org.id)];
 
   // Well-known registries to show in empty state (only Community Registry)
   const wellKnownRegistriesForEmptyState = [


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the registry connection ID by scoping it to the org to prevent collisions and show the correct registry in the org store page. Also bumps the mesh package to 1.0.0-alpha.22.

- **Bug Fixes**
  - Make getWellKnownRegistryConnection accept orgId and use WellKnownOrgMCPId.REGISTRY(orgId).
  - Pass org.id in StorePage so the select lists the correct well-known registry.

<sup>Written for commit 7810f14e3c9e30b0be4065f5a6a538f1dc29f48b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



