### PR TITLE
fix(bindings): remove early return in isImplementedBy loop

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,7 +1,7 @@
 {
-    "setup-worktree": [
-        "bun install",
-        "cp $ROOT_WORKTREE_PATH/apps/mesh/auth-config.json apps/mesh/auth-config.json",
-        "cp $ROOT_WORKTREE_PATH/apps/mesh/config.json apps/mesh/config.json"
-    ]
+  "setup-worktree": [
+    "bun install",
+    "cp $ROOT_WORKTREE_PATH/apps/mesh/auth-config.json apps/mesh/auth-config.json",
+    "cp $ROOT_WORKTREE_PATH/apps/mesh/config.json apps/mesh/config.json"
+  ]
 }

--- a/apps/docs/server/main.ts
+++ b/apps/docs/server/main.ts
@@ -20,7 +20,9 @@ const runtime = withRuntime<Env>({
         env: "development",
       });
 
-    return await assetsHandler(req) ?? new Response("Not found", { status: 404 });
+    return (
+      (await assetsHandler(req)) ?? new Response("Not found", { status: 404 })
+    );
   },
 });
 

--- a/packages/bindings/src/core/binder.ts
+++ b/packages/bindings/src/core/binder.ts
@@ -171,8 +171,6 @@ export function createBindingChecker<TDefinition extends readonly ToolBinder[]>(
         if (!matchedTool) {
           return false;
         }
-        return true;
-
         // FIXME @mcandeia Zod to JSONSchema converstion is creating inconsistent schemas
       }
       return true;


### PR DESCRIPTION
## Summary
- Fixed a bug in `createBindingChecker` where `isImplementedBy()` returned `true` after finding the **first** matching tool, instead of checking **all** required tools in the binding
- This caused false positives when only some required tools were present (e.g., binding requires `[A, B, C]` but only `A` exists → incorrectly returned `true`)

## Test plan
- [x] Existing tests pass (`bun test packages/bindings`)
- The fix is a simple one-line deletion that removes the premature `return true;` statement inside the for loop





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the early return in createBindingChecker’s isImplementedBy so it checks all required tools before returning true. This prevents false positives when a binding requires multiple tools but only some exist.

<sup>Written for commit 255ca01345af4c8fd82d5d215eb0d7a49a7436c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





