### PR TITLE
Fix message at onError handler

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -417,7 +417,7 @@ export function createApp(options: CreateAppOptions = {}) {
   // ============================================================================
 
   app.onError((err, c) => {
-    console.error("Server error: ", err);
+    console.error("Server error :", err);
 
     // If error is Error, provide message
     const message = err instanceof Error ? err.message : "Unknown error";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed spacing in the server error log label in app.onError to improve readability and keep logs consistent.

<sup>Written for commit b5149ee8790bcd7527449ce36490f9fae321f9b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

