### PR TITLE
Fallback MESH_JWT_SECRET to better auth secret

### DIFF
--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -24,7 +24,10 @@ function getSecret(): Uint8Array {
     return jwtSecret;
   }
 
-  const envSecret = process.env.MESH_JWT_SECRET ?? authConfig.jwt?.secret;
+  const envSecret =
+    process.env.MESH_JWT_SECRET ??
+    authConfig.jwt?.secret ??
+    process.env.BETTER_AUTH_SECRET;
   if (envSecret) {
     jwtSecret = new TextEncoder().encode(envSecret);
   } else {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add BETTER_AUTH_SECRET as a fallback for the Mesh JWT secret. Prevents startup errors when MESH_JWT_SECRET or authConfig.jwt.secret aren’t set and keeps auth consistent across services.

<sup>Written for commit 150931e798cc770a5dad75808c8c9b41befeef46. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

