### PR TITLE
Do not request unsupported capabilities

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -591,7 +591,12 @@ async function createMCPProxyDoNotUseDirectly(
     server.server.setRequestHandler(
       ListResourcesRequestSchema,
       async (): Promise<ListResourcesResult> => {
-        return await client.listResources();
+        if (client.getServerCapabilities()?.resources) {
+          return await client.listResources();
+        }
+        return {
+          resources: [],
+        };
       },
     );
 
@@ -605,7 +610,12 @@ async function createMCPProxyDoNotUseDirectly(
     server.server.setRequestHandler(
       ListResourceTemplatesRequestSchema,
       async (): Promise<ListResourceTemplatesResult> => {
-        return await client.listResourceTemplates();
+        if (client.getServerCapabilities()?.resourceTemplates) {
+          return await client.listResourceTemplates();
+        }
+        return {
+          resourceTemplates: [],
+        };
       },
     );
 
@@ -613,7 +623,12 @@ async function createMCPProxyDoNotUseDirectly(
     server.server.setRequestHandler(
       ListPromptsRequestSchema,
       async (): Promise<ListPromptsResult> => {
-        return await client.listPrompts();
+        if (client.getServerCapabilities()?.prompts) {
+          return await client.listPrompts();
+        }
+        return {
+          prompts: [],
+        };
       },
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip listing resources, resource templates, and prompts when the MCP server doesn’t advertise those capabilities. Return empty lists instead of making unsupported calls to prevent errors.

- **Bug Fixes**
  - Check capabilities via getServerCapabilities() before calling listResources, listResourceTemplates, and listPrompts.
  - Return empty arrays when unsupported to avoid errors and unnecessary requests.

<sup>Written for commit 8b4768a9e4d00a80b542a9321ed057f34ad58996. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

