### PR TITLE
feat(runtime): add MCP prompts support

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,6 +14,15 @@ import {
   type CreateMCPServerOptions,
   MCPServer,
 } from "./tools.ts";
+export {
+  createPrompt,
+  createPublicPrompt,
+  type Prompt,
+  type PromptArgsRawShape,
+  type PromptExecutionContext,
+  type CreatedPrompt,
+  type GetPromptResult,
+} from "./tools.ts";
 import type { Binding } from "./wrangler.ts";
 export { proxyConnectionForId, BindingOf } from "./bindings.ts";
 export { type CORSOptions, type CORSOrigin } from "./cors.ts";


### PR DESCRIPTION
## Summary

Add support for MCP prompts in the runtime server, following the same patterns established for tools.

## Changes

- Add `Prompt`, `PromptExecutionContext`, `CreatedPrompt` types
- Add `createPrompt` (requires auth by default) and `createPublicPrompt` factory functions
- Extend `CreateMCPServerOptions` with `prompts` option
- Register prompts with McpServer SDK (handles `prompts/list`, `prompts/get` protocol methods)
- Export prompt types from runtime package
- Bump version to 1.0.0-alpha.42

## Usage Example

```typescript
import { withRuntime, createPrompt } from "@deco/runtime";
import { z } from "zod";

export default withRuntime({
  prompts: [
    () => createPrompt({
      name: "code_review",
      title: "Code Review",
      description: "Asks the LLM to review code",
      argsSchema: {
        code: z.string().describe("The code to review"),
        language: z.string().optional().describe("Programming language"),
      },
      execute: async ({ args }) => ({
        messages: [
          {
            role: "user",
            content: {
              type: "text",
              text: \`Please review this \${args.language ?? ""} code:\n\${args.code}\`,
            },
          },
        ],
      }),
    }),
  ],
  tools: [...],
});
```

## Testing

- [x] TypeScript check passes
- [x] Linting passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added MCP prompts support to the runtime server so apps can declare and serve typed prompts like tools. Prompts are registered with the MCP server and support prompts/list and prompts/get.

- **New Features**
  - Added Prompt, PromptExecutionContext, CreatedPrompt, PromptArgsRawShape, and re-exported GetPromptResult.
  - Added createPrompt (auth enforced) and createPublicPrompt factories.
  - CreateMCPServerOptions now accepts prompts; server advertises prompts capability and registers provided prompts.
  - Exported prompt APIs from the runtime package and bumped version to 1.0.0-alpha.42.

<sup>Written for commit d276df453b8dcf4db92f399658310054c2f3f9d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

