### PR TITLE
chore: add code execution as gateway mode

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -37,9 +37,11 @@
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.0",
     "@untitledui/icons": "^0.0.19",
+    "@jitl/quickjs-wasmfile-release-sync": "^0.31.0",
     "@xyflow/react": "^12.10.0",
     "kysely": "^0.28.8",
-    "kysely-bun-worker": "^0.6.0"
+    "kysely-bun-worker": "^0.6.0",
+    "quickjs-emscripten-core": "^0.31.0"
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.0",

--- a/apps/mesh/src/api/llm-provider.ts
+++ b/apps/mesh/src/api/llm-provider.ts
@@ -31,7 +31,7 @@ function responseToStream(
               const parsed = JSON.parse(line) as LanguageModelV2StreamPart;
               controller.enqueue(parsed);
             } catch (error) {
-              console.error("Failed to parse stream chunk:", error);
+              console.error("Failed to parse stream chunk:", error, chunk);
               throw error;
             }
           }

--- a/apps/mesh/src/api/routes/models.ts
+++ b/apps/mesh/src/api/routes/models.ts
@@ -172,6 +172,8 @@ app.post("/:org/models/stream", async (c) => {
       );
     }
 
+    mcpClient = client;
+
     // Prune messages to reduce context size
     const prunedMessages = pruneMessages({
       messages: modelMessages,
@@ -185,7 +187,6 @@ app.post("/:org/models/stream", async (c) => {
       client.tools({ schemas: "automatic" }),
     ]);
 
-    mcpClient = client;
     const llmBinding = LanguageModelBinding.forClient(proxy);
     const provider = createLLMProvider(llmBinding).languageModel(
       modelConfig.id,
@@ -202,10 +203,10 @@ app.post("/:org/models/stream", async (c) => {
       stopWhen: stepCountIs(30), // Stop after 30 steps with tool calls
       onError: async (error) => {
         console.error("[models:stream] Error", error);
-        await mcpClient?.close().catch(console.error);
+        await client.close().catch(console.error);
       },
       onFinish: async () => {
-        await mcpClient?.close().catch(console.error);
+        await client.close().catch(console.error);
       },
     });
 

--- a/apps/mesh/src/sandbox/builtins/console.ts
+++ b/apps/mesh/src/sandbox/builtins/console.ts
@@ -1,0 +1,49 @@
+import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten-core";
+
+export type SandboxLog = { type: "log" | "warn" | "error"; content: string };
+
+export interface ConsoleBuiltin {
+  readonly logs: SandboxLog[];
+  [Symbol.dispose]: () => void;
+}
+
+export function installConsole(ctx: QuickJSContext): ConsoleBuiltin {
+  const logs: SandboxLog[] = [];
+  const handles: QuickJSHandle[] = [];
+
+  const makeLog = (level: "log" | "warn" | "error") => {
+    const logFn = ctx.newFunction(level, (...args: QuickJSHandle[]) => {
+      try {
+        const parts = args.map((h) => ctx.dump(h));
+        logs.push({
+          type: level ?? "log",
+          content: parts.map(String).join(" "),
+        });
+      } finally {
+        args.forEach((h) => h.dispose());
+      }
+      return ctx.undefined;
+    });
+    handles.push(logFn);
+    return logFn;
+  };
+
+  const consoleObj = ctx.newObject();
+  handles.push(consoleObj);
+
+  const log = makeLog("log");
+  const warn = makeLog("warn");
+  const error = makeLog("error");
+
+  ctx.setProp(consoleObj, "log", log);
+  ctx.setProp(consoleObj, "warn", warn);
+  ctx.setProp(consoleObj, "error", error);
+  ctx.setProp(ctx.global, "console", consoleObj);
+
+  return {
+    logs,
+    [Symbol.dispose]() {
+      handles.forEach((handle) => handle.dispose());
+    },
+  };
+}

--- a/apps/mesh/src/sandbox/index.ts
+++ b/apps/mesh/src/sandbox/index.ts
@@ -1,0 +1,5 @@
+export {
+  runCode,
+  type ToolHandler,
+  type RunCodeResult,
+} from "./run-code.ts";

--- a/apps/mesh/src/sandbox/quickjs.ts
+++ b/apps/mesh/src/sandbox/quickjs.ts
@@ -1,0 +1,12 @@
+import variant from "@jitl/quickjs-wasmfile-release-sync";
+import {
+  newQuickJSWASMModuleFromVariant,
+  type QuickJSWASMModule,
+} from "quickjs-emscripten-core";
+
+let quickJSSingleton: Promise<QuickJSWASMModule> | undefined;
+
+export function getQuickJS() {
+  quickJSSingleton ??= newQuickJSWASMModuleFromVariant(variant);
+  return quickJSSingleton;
+}

--- a/apps/mesh/src/sandbox/run-code.ts
+++ b/apps/mesh/src/sandbox/run-code.ts
@@ -1,0 +1,137 @@
+import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten-core";
+import { installConsole, type SandboxLog } from "./builtins/console.ts";
+import { createSandboxRuntime } from "./runtime.ts";
+import { inspect } from "./utils/error-handling.ts";
+import { toQuickJS } from "./utils/to-quickjs.ts";
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function executePendingJobs(ctx: {
+  runtime: { executePendingJobs: Function };
+}) {
+  const res = ctx.runtime.executePendingJobs(100);
+  try {
+    if ("unwrap" in res && typeof res.unwrap === "function") {
+      res.unwrap();
+    }
+  } finally {
+    if ("dispose" in res && typeof res.dispose === "function") {
+      res.dispose();
+    }
+  }
+}
+
+async function resolvePromiseWithJobPump(
+  ctx: QuickJSContext,
+  promiseLikeHandle: QuickJSHandle,
+  timeoutMs: number,
+) {
+  const startedAt = Date.now();
+  const hostPromise = ctx.resolvePromise(promiseLikeHandle);
+
+  while (true) {
+    executePendingJobs(ctx);
+
+    const raced = await Promise.race([hostPromise, sleep(0).then(() => null)]);
+
+    if (raced !== null) {
+      return raced;
+    }
+
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(
+        `Timed out after ${timeoutMs}ms while awaiting a QuickJS promise`,
+      );
+    }
+  }
+}
+
+export interface RunCodeOptions {
+  tools: Record<string, ToolHandler>;
+  code: string;
+  timeoutMs: number;
+}
+
+export interface RunCodeResult {
+  returnValue?: unknown;
+  error?: string;
+  consoleLogs: SandboxLog[];
+}
+
+export type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+
+export async function runCode({
+  tools,
+  code,
+  timeoutMs,
+}: RunCodeOptions): Promise<RunCodeResult> {
+  const runtime = await createSandboxRuntime({
+    memoryLimitBytes: 32 * 1024 * 1024,
+    stackSizeBytes: 512 * 1024,
+  });
+
+  using ctx = runtime.newContext({ interruptAfterMs: timeoutMs });
+  using consoleBuiltin = installConsole(ctx);
+
+  try {
+    const moduleRes = ctx.evalCode(code, "index.mjs", {
+      strip: true,
+      strict: true,
+      type: "module",
+    });
+    const exportsOrPromiseHandle = ctx.unwrapResult(moduleRes);
+
+    const toolsHandle = toQuickJS(ctx, tools);
+    ctx.setProp(ctx.global, "tools", toolsHandle);
+
+    // When evaluating ES modules, QuickJS can return either:
+    // - the module exports object, or
+    // - a promise for the module exports (top-level await / async module init)
+    const exportsHandle = ctx.runtime.hasPendingJob()
+      ? ctx.unwrapResult(
+          await resolvePromiseWithJobPump(
+            ctx,
+            exportsOrPromiseHandle,
+            timeoutMs,
+          ),
+        )
+      : exportsOrPromiseHandle;
+
+    if (exportsHandle !== exportsOrPromiseHandle) {
+      exportsOrPromiseHandle.dispose();
+    }
+
+    const userFnHandle = ctx.getProp(exportsHandle, "default");
+    const userFnType = ctx.typeof(userFnHandle);
+
+    if (userFnType !== "function") {
+      return {
+        error: `Code must export default a function (tools). Got ${userFnType}. Example: export default async (tools) => { /* ... */ }`,
+        consoleLogs: consoleBuiltin.logs,
+      };
+    }
+
+    const callRes = ctx.callFunction(userFnHandle, ctx.undefined, toolsHandle);
+    const callHandle = ctx.unwrapResult(callRes);
+
+    const awaitedRes = await resolvePromiseWithJobPump(
+      ctx,
+      callHandle,
+      timeoutMs,
+    );
+    const awaited = ctx.unwrapResult(awaitedRes);
+
+    // Drain any final microtasks (best-effort)
+    if (ctx.runtime.hasPendingJob()) {
+      executePendingJobs(ctx);
+    }
+
+    const value = ctx.dump(awaited);
+
+    return { returnValue: value, consoleLogs: consoleBuiltin.logs };
+  } catch (err) {
+    console.log(err);
+    return { error: inspect(err), consoleLogs: consoleBuiltin.logs };
+  }
+}

--- a/apps/mesh/src/sandbox/runtime.ts
+++ b/apps/mesh/src/sandbox/runtime.ts
@@ -1,0 +1,75 @@
+import {
+  DefaultIntrinsics,
+  type Intrinsics,
+  type QuickJSContext,
+  type QuickJSRuntime,
+} from "quickjs-emscripten-core";
+import { getQuickJS } from "./quickjs.ts";
+
+export interface SandboxRuntimeOptions {
+  memoryLimitBytes?: number;
+  stackSizeBytes?: number;
+}
+
+export interface SandboxContextOptions extends Intrinsics {
+  interruptAfterMs?: number;
+}
+
+export interface SandboxRuntime {
+  newContext: (options?: SandboxContextOptions) => QuickJSContext;
+  dispose: () => void;
+  [Symbol.dispose]: () => void;
+}
+
+/**
+ * Creates a fresh QuickJS runtime.
+ *
+ * Note: we intentionally create a new runtime per `run_code` execution to avoid
+ * concurrency issues with a shared runtime interrupt handler.
+ */
+export async function createSandboxRuntime(
+  options: SandboxRuntimeOptions = {},
+): Promise<SandboxRuntime> {
+  const QuickJS = await getQuickJS();
+  const runtime: QuickJSRuntime = QuickJS.newRuntime({
+    maxStackSizeBytes: options.stackSizeBytes,
+    memoryLimitBytes: options.memoryLimitBytes,
+  });
+
+  const newContext = ({
+    interruptAfterMs,
+    ...intrinsics
+  }: SandboxContextOptions = {}): QuickJSContext => {
+    const ctx = runtime.newContext({
+      intrinsics: { ...DefaultIntrinsics, ...intrinsics },
+    });
+
+    let deadline = 0;
+    const setDeadline = (ms?: number) => {
+      deadline = ms ? Date.now() + ms : 0;
+    };
+
+    runtime.setInterruptHandler(() => {
+      const now = Date.now();
+      const shouldInterrupt = deadline > 0 && now > deadline;
+      if (shouldInterrupt) {
+      }
+      return shouldInterrupt;
+    });
+
+    if (interruptAfterMs) {
+      setDeadline(interruptAfterMs);
+    }
+    return ctx;
+  };
+
+  return {
+    newContext,
+    dispose: () => {
+      runtime.dispose();
+    },
+    [Symbol.dispose]() {
+      runtime.dispose();
+    },
+  };
+}

--- a/apps/mesh/src/sandbox/utils/error-handling.ts
+++ b/apps/mesh/src/sandbox/utils/error-handling.ts
@@ -1,0 +1,80 @@
+/**
+ * Inspects and serializes any value to a meaningful string representation.
+ * Similar to Node.js's util.inspect, but optimized for error handling and debugging.
+ */
+export function inspect(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+
+  if (value instanceof Error) {
+    const message = value.message || value.name || "Error";
+    if (value.stack && value.stack.length < 2000) {
+      return `${message}\n${value.stack}`;
+    }
+    return message;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const obj = value as Record<string, unknown>;
+
+    let message = "";
+    if (typeof obj.message === "string" && obj.message) message = obj.message;
+    else if (typeof obj.error === "string" && obj.error) message = obj.error;
+    else if (typeof obj.description === "string" && obj.description)
+      message = obj.description;
+    else if (typeof obj.reason === "string" && obj.reason) message = obj.reason;
+
+    if (message) {
+      if (
+        typeof obj.stack === "string" &&
+        obj.stack &&
+        obj.stack.length < 2000
+      ) {
+        return `${message}\n${obj.stack}`;
+      }
+      return message;
+    }
+
+    try {
+      const stringified = JSON.stringify(obj, null, 2);
+      if (stringified !== "{}" && stringified.length < 1000) {
+        if (
+          typeof obj.stack === "string" &&
+          obj.stack &&
+          obj.stack.length < 2000
+        ) {
+          return `${stringified}\n\nStack trace:\n${obj.stack}`;
+        }
+        return stringified;
+      }
+    } catch {
+      // ignore
+    }
+
+    if (typeof obj.toString === "function") {
+      try {
+        const stringified = obj.toString();
+        if (stringified !== "[object Object]") return stringified;
+      } catch {
+        // ignore
+      }
+    }
+
+    const keys = Object.keys(obj);
+    if (keys.length > 0) return `Object with keys: ${keys.join(", ")}`;
+    return "[object Object]";
+  }
+
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  if (typeof value === "function") return `[Function: ${value.name || "anon"}]`;
+  if (typeof value === "symbol") return value.toString();
+  if (typeof value === "bigint") return value.toString();
+
+  try {
+    return String(value);
+  } catch {
+    return "Unknown value (could not convert to string)";
+  }
+}

--- a/apps/mesh/src/sandbox/utils/to-quickjs.ts
+++ b/apps/mesh/src/sandbox/utils/to-quickjs.ts
@@ -1,0 +1,116 @@
+import type { QuickJSContext, QuickJSHandle } from "quickjs-emscripten-core";
+import { inspect } from "./error-handling.ts";
+
+export function toQuickJS(ctx: QuickJSContext, value: unknown): QuickJSHandle {
+  switch (typeof value) {
+    case "string":
+      return ctx.newString(value);
+    case "number":
+      return ctx.newNumber(value);
+    case "boolean":
+      return value ? ctx.true : ctx.false;
+    case "undefined":
+      return ctx.undefined;
+    case "object": {
+      if (value === null) return ctx.null;
+      if (Array.isArray(value)) {
+        const arr = ctx.newArray();
+        value.forEach((v, i) => {
+          const hv = toQuickJS(ctx, v);
+          try {
+            ctx.setProp(arr, String(i), hv);
+          } finally {
+            // Setting a property retains a reference inside the VM.
+            // We must dispose the temporary handle we created to avoid leaks.
+            hv.dispose?.();
+          }
+        });
+        return arr;
+      }
+
+      const obj = ctx.newObject();
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        const hv = toQuickJS(ctx, v);
+        try {
+          ctx.setProp(obj, k, hv);
+        } finally {
+          // Setting a property retains a reference inside the VM.
+          // We must dispose the temporary handle we created to avoid leaks.
+          hv.dispose?.();
+        }
+      }
+      return obj;
+    }
+    case "function": {
+      const functionId = `__hostFn_${Date.now()}_${Math.random()
+        .toString(36)
+        .substr(2, 9)}`;
+
+      const proxyFn = ctx.newFunction(
+        functionId,
+        (...args: QuickJSHandle[]) => {
+          try {
+            const jsArgs = args.map((h) => ctx.dump(h));
+            const result = value(...jsArgs);
+
+            if (
+              result &&
+              typeof (result as Promise<unknown>).then === "function"
+            ) {
+              const deferredPromise = ctx.newPromise();
+
+              (result as Promise<unknown>)
+                .then((resolvedValue: unknown) => {
+                  try {
+                    const quickJSValue = toQuickJS(ctx, resolvedValue);
+                    deferredPromise.resolve(quickJSValue);
+                    quickJSValue.dispose();
+                    ctx.runtime.executePendingJobs();
+                  } catch (e) {
+                    const errorMsg = inspect(e);
+                    const errorHandle = ctx.newString(
+                      `Promise resolution error: ${errorMsg}`,
+                    );
+                    deferredPromise.reject(errorHandle);
+                    errorHandle.dispose();
+                    ctx.runtime.executePendingJobs();
+                  }
+                })
+                .catch((error: unknown) => {
+                  const errorMsg = inspect(error);
+                  const errorHandle = ctx.newString(
+                    `Promise rejection: ${errorMsg}`,
+                  );
+                  deferredPromise.reject(errorHandle);
+                  errorHandle.dispose();
+                  ctx.runtime.executePendingJobs();
+                });
+
+              return deferredPromise.handle;
+            }
+
+            return toQuickJS(ctx, result);
+          } catch (e) {
+            const msg = inspect(e);
+            return ctx.newString(`HostFunctionError: ${msg}`);
+          } finally {
+            args.forEach((h) => h.dispose());
+          }
+        },
+      );
+
+      return proxyFn;
+    }
+    case "bigint":
+      return ctx.newString(value.toString());
+    case "symbol":
+      return ctx.newString(value.toString());
+    default: {
+      try {
+        return ctx.newString(String(value));
+      } catch {
+        return ctx.undefined;
+      }
+    }
+  }
+}

--- a/apps/mesh/src/web/components/chat/gateway-selector.tsx
+++ b/apps/mesh/src/web/components/chat/gateway-selector.tsx
@@ -49,7 +49,7 @@ function GatewayItemContent({
           )}
         </div>
         {gateway.description && (
-          <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+          <p className="text-xs text-muted-foreground line-clamp-1 leading-relaxed">
             {gateway.description}
           </p>
         )}

--- a/apps/mesh/src/web/components/chat/parts/tool-call-part.tsx
+++ b/apps/mesh/src/web/components/chat/parts/tool-call-part.tsx
@@ -2,6 +2,7 @@ import { AlertCircle, Terminal } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import { ToolOutputRenderer } from "./tool-outputs/tool-output-renderer.tsx";
+import { Spinner } from "@deco/ui/components/spinner.js";
 
 interface ToolCallPartProps {
   part: ToolUIPart | DynamicToolUIPart;
@@ -22,13 +23,15 @@ export function ToolCallPart({ part }: ToolCallPartProps) {
           <Terminal className="h-3.5 w-3.5" />
         )}
         <span className={cn(state === "output-error" && "text-destructive/90")}>
-          {state === "input-streaming" && `Streaming ${toolName} arguments...`}
-          {state === "input-available" && `Calling ${toolName}...`}
+          {state === "input-streaming" && `Streaming ${toolName} arguments`}
+          {state === "input-available" && `Calling ${toolName}`}
           {state === "output-available" && `Called ${toolName}`}
           {state === "output-error" && `Error calling ${toolName}`}
         </span>
         {(state === "input-streaming" || state === "input-available") && (
-          <span className="animate-pulse">...</span>
+          <span className="animate-spin">
+            <Spinner size="xs" />
+          </span>
         )}
       </div>
 

--- a/apps/mesh/src/web/components/integration-icon.tsx
+++ b/apps/mesh/src/web/components/integration-icon.tsx
@@ -1,14 +1,37 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { useState, type ReactNode } from "react";
 import { Container } from "@untitledui/icons";
+import { useState, type ReactNode } from "react";
 
 interface IntegrationIconProps {
   icon: string | null | undefined;
   name: string;
-  size?: "xs" | "sm" | "md" | "lg";
+  size?: Size;
   className?: string;
   fallbackIcon?: ReactNode;
 }
+
+const SIZE_CLASSES = {
+  xs: "h-6 w-6",
+  sm: "h-8 w-8",
+  md: "h-12 w-12",
+  lg: "h-16 w-16",
+};
+
+type Size = keyof typeof SIZE_CLASSES;
+
+const MIN_WIDTH_CLASSES: Record<Size, string> = {
+  xs: "min-w-6",
+  sm: "min-w-8",
+  md: "min-w-12",
+  lg: "min-w-16",
+};
+
+const ICON_SIZES: Record<Size, number> = {
+  xs: 12,
+  sm: 16,
+  md: 24,
+  lg: 32,
+};
 
 export function IntegrationIcon({
   icon,
@@ -17,62 +40,61 @@ export function IntegrationIcon({
   className,
   fallbackIcon,
 }: IntegrationIconProps) {
-  const [imageError, setImageError] = useState(icon ? false : true);
-
-  const sizeClasses = {
-    xs: "h-6 w-6",
-    sm: "h-8 w-8",
-    md: "h-12 w-12",
-    lg: "h-16 w-16",
-  };
-
-  const minWidthClasses = {
-    xs: "min-w-6",
-    sm: "min-w-8",
-    md: "min-w-12",
-    lg: "min-w-16",
-  };
-
-  const iconSizes = {
-    xs: 12,
-    sm: 16,
-    md: 24,
-    lg: 32,
-  };
-
-  const defaultFallback = (
-    <Container size={iconSizes[size]} className="text-muted-foreground" />
+  // Key the stateful subtree by `icon` so load state resets whenever the icon URL changes,
+  // without needing effects.
+  return (
+    <IntegrationIconStateful
+      key={icon ?? "no-icon"}
+      icon={icon}
+      name={name}
+      size={size}
+      className={className}
+      fallbackIcon={fallbackIcon}
+    />
   );
+}
 
-  const fallbackIconElement = (
+function IntegrationIconStateful({
+  icon,
+  name,
+  size = "md",
+  className,
+  fallbackIcon,
+}: IntegrationIconProps) {
+  const [loaded, setLoaded] = useState(false);
+  const showImage = Boolean(icon) && loaded;
+
+  return (
     <div
       className={cn(
-        "rounded-lg flex items-center justify-center bg-muted border border-border shrink-0",
-        sizeClasses[size],
-        minWidthClasses[size],
+        "rounded-lg border border-border shrink-0 overflow-hidden",
+        SIZE_CLASSES[size],
+        MIN_WIDTH_CLASSES[size],
         className,
       )}
     >
-      {fallbackIcon ?? defaultFallback}
+      <img
+        src={icon || undefined}
+        alt={name}
+        className={cn("h-full w-full object-cover", !showImage && "hidden")}
+        onError={() => setLoaded(false)}
+        onLoad={() => setLoaded(true)}
+      />
+
+      {/* Fallback: muted icon with connection symbol */}
+      <div
+        className={cn(
+          "h-full w-full flex items-center justify-center bg-muted",
+          showImage && "hidden",
+        )}
+      >
+        {fallbackIcon ?? (
+          <Container
+            size={ICON_SIZES[size]}
+            className="text-muted-foreground"
+          />
+        )}
+      </div>
     </div>
   );
-
-  if (icon && !imageError) {
-    return (
-      <img
-        src={icon}
-        alt={name}
-        onError={() => setImageError(true)}
-        className={cn(
-          "rounded-lg object-cover border border-border shrink-0",
-          sizeClasses[size],
-          minWidthClasses[size],
-          className,
-        )}
-      />
-    );
-  }
-
-  // Fallback: muted icon with connection symbol
-  return fallbackIconElement;
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add sandboxed JavaScript execution via QuickJS and enable the code_execution gateway strategy with a new GATEWAY_RUN_CODE tool for running code that calls other tools. Includes a hardened runtime with timeouts, console capture, and structured JSON results.

- **New Features**
  - QuickJS sandbox: memory/stack limits, interrupt-based timeouts, console.log/warn/error capture, error inspection, and a host-bridge to call tools. Code runs as an ES module that export default async (tools) => { … }.
  - Gateway strategy: implements code_execution exposing GATEWAY_SEARCH_TOOLS, GATEWAY_DESCRIBE_TOOLS, and GATEWAY_RUN_CODE with Zod-validated inputs and consistent JSON result/error helpers.
  - Dependencies: add quickjs-emscripten-core and @jitl/quickjs-wasmfile-release-sync. Minor UI polish for integration icons and single-line gateway descriptions.

- **Bug Fixes**
  - models:stream now assigns the MCP client before use and closes the correct client in onError/onFinish.
  - LLM provider logs now include the raw chunk on stream parse failures for easier debugging.

<sup>Written for commit f7ec0f0d30216f032bdf20313e084668f3062292. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





