### PR TITLE
Quick chat ui cleanup

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-panel.tsx
+++ b/apps/mesh/src/web/components/chat/chat-panel.tsx
@@ -241,20 +241,17 @@ function ThreadHistoryPopover() {
         </button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-80 p-0">
-        <div className="p-2 border-b">
-          <div className="relative">
-            <SearchMd
-              size={14}
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
-            />
+        <div className="border-b">
+          <label className="flex items-center gap-2.5 h-12 px-4 cursor-text">
+            <SearchMd size={16} className="text-muted-foreground shrink-0" />
             <input
               type="text"
               placeholder="Search chats..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-8 pr-3 py-1.5 text-sm bg-muted/50 border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground"
+              className="flex-1 border-0 shadow-none focus:outline-none px-0 h-full text-sm placeholder:text-muted-foreground/50 bg-transparent"
             />
-          </div>
+          </label>
         </div>
         <div className="max-h-[300px] overflow-y-auto">
           {filteredThreads.length === 0 ? (

--- a/apps/mesh/src/web/components/chat/message-assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message-assistant.tsx
@@ -74,6 +74,7 @@ function renderPart(
   part: MessageProps<Metadata>["message"]["parts"][number],
   id: string,
   index: number,
+  usageStats?: ReactNode,
 ) {
   const isToolCall =
     part.type.startsWith("tool-") || part.type === "dynamic-tool";
@@ -102,6 +103,7 @@ function renderPart(
           id={id}
           text={part.text}
           copyable={true}
+          extraActions={usageStats}
         />
       );
     case "reasoning":
@@ -156,6 +158,9 @@ export function MessageAssistant<T extends Metadata>({
   const hasContent = parts.length > 0;
   const showThought = hasContent && !isLoading && duration !== null;
 
+  // Create usage stats component to pass to the last text part
+  const usageStats = <UsageStats messages={[message]} />;
+
   return (
     <div
       className={cn(
@@ -164,17 +169,23 @@ export function MessageAssistant<T extends Metadata>({
       )}
     >
       <div className="flex flex-col gap-2 min-w-0 w-full items-start">
-        <div className="w-full min-w-0 not-only:rounded-2xl text-[0.9375rem] wrap-break-word overflow-wrap-anywhere bg-transparent">
+        <div className="w-full min-w-0 not-only:rounded-2xl text-sm wrap-break-word overflow-wrap-anywhere bg-transparent">
           {hasContent ? (
             <>
               {showThought && <ThoughtSummary duration={duration} />}
-              {parts.map((part, index) => renderPart(part, id, index))}
+              {parts.map((part, index) =>
+                renderPart(
+                  part,
+                  id,
+                  index,
+                  index === parts.length - 1 ? usageStats : undefined,
+                ),
+              )}
             </>
           ) : isLoading ? (
             <TypingIndicator />
           ) : null}
         </div>
-        <UsageStats messages={[message]} />
       </div>
     </div>
   );

--- a/apps/mesh/src/web/components/chat/message-list.tsx
+++ b/apps/mesh/src/web/components/chat/message-list.tsx
@@ -111,7 +111,7 @@ export function MessageList({
                 ref={(el) => {
                   pairRefs.current[index] = el;
                 }}
-                className="flex flex-col gap-2 py-2"
+                className="flex flex-col gap-2 pb-2"
                 style={
                   isLastPair && minHeightOffset
                     ? { minHeight: `calc(100vh - ${minHeightOffset}px)` }
@@ -119,8 +119,8 @@ export function MessageList({
                 }
               >
                 {/* Sticky overlay to prevent scrolling content from appearing above the user message */}
-                <div className="sticky top-0 z-50 bg-background w-full h-2" />
-                <div className="sticky top-2 z-50">
+                <div className="sticky top-0 z-50 bg-background w-full h-4" />
+                <div className="sticky top-4 z-50">
                   {pair.user && isValidElement(pair.user)
                     ? cloneElement(pair.user, { pairIndex: index } as any)
                     : pair.user}

--- a/apps/mesh/src/web/components/chat/parts/text-part.tsx
+++ b/apps/mesh/src/web/components/chat/parts/text-part.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useCopy } from "@deco/ui/hooks/use-copy.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { MemoizedMarkdown } from "@deco/ui/components/chat/chat-markdown.tsx";
@@ -8,12 +8,14 @@ interface MessageTextPartProps {
   id: string;
   text: string;
   copyable?: boolean;
+  extraActions?: ReactNode;
 }
 
 export function MessageTextPart({
   id,
   text,
   copyable = false,
+  extraActions,
 }: MessageTextPartProps) {
   const { handleCopy } = useCopy();
   const [isCopied, setIsCopied] = useState(false);
@@ -24,24 +26,25 @@ export function MessageTextPart({
     setTimeout(() => setIsCopied(false), 2000);
   };
 
+  const showActions = copyable || extraActions;
+
   return (
     <div className="group/part relative">
       <MemoizedMarkdown id={id} text={text} />
-      {copyable && (
-        <div className="flex w-full items-center justify-end gap-2 text-xs text-muted-foreground opacity-0 pointer-events-none transition-all duration-200 group-hover/part:opacity-100 group-hover/part:pointer-events-auto">
-          <div className="flex gap-1">
-            <Button
-              onClick={handleCopyMessage}
-              variant="ghost"
-              size="sm"
-              className="text-muted-foreground hover:text-foreground px-2 py-1 h-auto whitespace-nowrap"
-            >
-              {isCopied ? (
-                <Check className="mr-1 text-sm" />
-              ) : (
-                <Copy01 className="mr-1 text-sm" />
-              )}
-            </Button>
+      {showActions && (
+        <div className="flex w-full items-center text-xs text-muted-foreground opacity-0 pointer-events-none transition-all duration-200 group-hover/part:opacity-100 group-hover/part:pointer-events-auto mt-2">
+          <div className="flex items-center gap-1">
+            {copyable && (
+              <Button
+                onClick={handleCopyMessage}
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground hover:text-foreground size-6 whitespace-nowrap"
+              >
+                {isCopied ? <Check size={12} /> : <Copy01 size={12} />}
+              </Button>
+            )}
+            {extraActions}
           </div>
         </div>
       )}

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -3,6 +3,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@deco/ui/components/tooltip.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
 import { Coins01 } from "@untitledui/icons";
 import { Metadata } from "@deco/ui/types/chat-metadata.ts";
 import { calculateUsageStats } from "@/web/lib/usage-utils.ts";
@@ -19,15 +20,16 @@ export function UsageStats({ messages }: UsageStatsProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          type="button"
-          className="ml-auto shrink-0 flex items-center gap-1 text-[11px] text-muted-foreground/60 font-mono tabular-nums hover:text-muted-foreground transition-colors"
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground pl-1! h-6 gap-1 whitespace-nowrap"
         >
-          <Coins01 size={12} className="opacity-60" />
-          <span className="hidden md:inline">
+          <Coins01 size={12} />
+          <span className="text-[10px] font-mono tabular-nums">
             {totalTokens.toLocaleString()}
           </span>
-        </button>
+        </Button>
       </TooltipTrigger>
       <TooltipContent side="top" className="font-mono text-[11px]">
         <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">

--- a/apps/mesh/src/web/components/collections/collection-search.tsx
+++ b/apps/mesh/src/web/components/collections/collection-search.tsx
@@ -31,7 +31,7 @@ export function CollectionSearch({
     <div
       className={cn("shrink-0 w-full border-b border-border h-12", className)}
     >
-      <div className="flex items-center gap-2.5 h-12 px-4">
+      <label className="flex items-center gap-2.5 h-12 px-4 cursor-text">
         <SearchMd size={16} className="text-muted-foreground shrink-0" />
         <Input
           value={value}
@@ -40,7 +40,7 @@ export function CollectionSearch({
           placeholder={placeholder}
           className="flex-1 border-0 shadow-none focus-visible:ring-0 px-0 h-full text-sm placeholder:text-muted-foreground/50 bg-transparent"
         />
-      </div>
+      </label>
     </div>
   );
 }

--- a/packages/ui/src/components/chat/chat-markdown.tsx
+++ b/packages/ui/src/components/chat/chat-markdown.tsx
@@ -164,7 +164,7 @@ const rehypePluginsMemo = [rehypeRaw];
 // Memoize the components object to prevent re-creating it on every render
 const markdownComponents = {
   p: (props: React.HTMLAttributes<HTMLParagraphElement>) => (
-    <p {...props} className="leading-relaxed text-[0.9375rem]" />
+    <p {...props} className="leading-relaxed text-sm" />
   ),
   strong: (props: React.HTMLAttributes<HTMLElement>) => (
     <strong {...props} className="font-bold" />
@@ -187,7 +187,7 @@ const markdownComponents = {
     <ol {...props} className="list-decimal ml-6 my-4 space-y-2" />
   ),
   li: (props: React.HTMLAttributes<HTMLLIElement>) => (
-    <li {...props} className="leading-relaxed text-[0.9375rem]" />
+    <li {...props} className="leading-relaxed text-sm" />
   ),
   code: (props: React.HTMLAttributes<HTMLElement>) => (
     <code


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the chat UI for clarity and consistency. Unified text size, improved search fields, moved token usage into the message action bar, and fixed sticky overlaps.

- **UI Improvements**
  - Unified assistant and markdown text to text-sm.
  - Reworked search inputs in thread history and collections: label wrapper, larger icon, full-row click to focus, simpler input styles.
  - Moved token usage (UsageStats) into the last text part’s action row; now a small ghost button with tooltip.
  - Streamlined copy to a compact icon button; actions appear on hover.

- **Bug Fixes**
  - Increased sticky spacers/offsets in the message list to prevent content from overlapping the user message.

<sup>Written for commit ecea1bf724a6d525c2e647b7e84ddb656c1c29f9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

