### PR TITLE
feat(chat): integrate dynamic system prompt and refactor chat hook

### DIFF
--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -18,6 +18,7 @@ import type { Metadata } from "@deco/ui/types/chat-metadata.ts";
 import { usePersistedChat } from "../../hooks/use-persisted-chat";
 import { useConnections } from "../../hooks/collections/use-connection";
 import { useBindingConnections } from "../../hooks/use-binding";
+import { useSystemPrompt } from "../../hooks/use-system-prompt";
 
 // Capybara avatar URL from decopilotAgent
 const CAPYBARA_AVATAR_URL =
@@ -52,13 +53,6 @@ export function ChatPanel() {
   const hasGateways = gateways.length > 0;
   const hasRequiredSetup = hasModelsBinding && hasGateways;
 
-  // Use shared persisted chat hook - must be called unconditionally (Rules of Hooks)
-  const chat = usePersistedChat({
-    threadId: activeThreadId,
-    onCreateThread: (thread) =>
-      createThread({ id: thread.id, title: thread.title }),
-  });
-
   const [selectedModelState, setSelectedModelState] = useLocalStorage<{
     id: string;
     connectionId: string;
@@ -90,6 +84,17 @@ export function ChatPanel() {
       m.id === effectiveSelectedModelState?.id &&
       m.connectionId === effectiveSelectedModelState?.connectionId,
   );
+
+  // Generate dynamic system prompt based on context
+  const systemPrompt = useSystemPrompt();
+
+  // Use shared persisted chat hook - must be called unconditionally (Rules of Hooks)
+  const chat = usePersistedChat({
+    threadId: activeThreadId,
+    systemPrompt,
+    onCreateThread: (thread) =>
+      createThread({ id: thread.id, title: thread.title }),
+  });
 
   const handleSendMessage = async (text: string) => {
     if (!selectedModel) {

--- a/apps/mesh/src/web/components/details/assistant/index.tsx
+++ b/apps/mesh/src/web/components/details/assistant/index.tsx
@@ -378,7 +378,7 @@ function AssistantDetailContent({
                       <span className="text-xs text-muted-foreground font-normal">
                         •
                       </span>
-                      <span className="text-xs text-muted-foreground font-normal truncate min-w-0">
+                      <span className="text-xs text-muted-foreground font-normal truncate min-w-0 max-w-[20ch]">
                         {assistant.description}
                       </span>
                     </>

--- a/apps/mesh/src/web/hooks/use-system-prompt.ts
+++ b/apps/mesh/src/web/hooks/use-system-prompt.ts
@@ -1,0 +1,65 @@
+/**
+ * Dynamic System Prompt Hook
+ *
+ * Generates a context-aware system prompt for the chat based on:
+ * - The MCP Mesh environment
+ * - Current route context (e.g., resource editing)
+ */
+
+import { useRouterState } from "@tanstack/react-router";
+
+/**
+ * Route context extracted from collection detail routes
+ */
+interface RouteContext {
+  connectionId: string | null;
+  collectionName: string | null;
+  itemId: string | null;
+}
+
+/**
+ * Parse route context from the current URL pathname
+ * Looks for pattern: /:org/mcps/:connectionId/:collectionName/:itemId
+ */
+function parseRouteContext(pathname: string): RouteContext {
+  const mcpsPattern = /\/[^/]+\/mcps\/([^/]+)\/([^/]+)\/([^/]+)/;
+  const match = pathname.match(mcpsPattern);
+
+  if (match && match[1] && match[2] && match[3]) {
+    return {
+      connectionId: decodeURIComponent(match[1]),
+      collectionName: decodeURIComponent(match[2]),
+      itemId: decodeURIComponent(match[3]),
+    };
+  }
+
+  return { connectionId: null, collectionName: null, itemId: null };
+}
+
+/**
+ * Hook that generates a dynamic system prompt based on context
+ */
+export function useSystemPrompt(): string {
+  const routerState = useRouterState();
+  const { connectionId, collectionName, itemId } = parseRouteContext(
+    routerState.location.pathname,
+  );
+
+  return `You are an AI assistant running in an MCP Mesh environment.
+
+## About MCP Mesh
+The Model Context Protocol (MCP) Mesh allows users to connect external MCP servers and expose their capabilities through gateways. Each gateway provides access to a curated set of tools from connected MCP servers.
+
+## Important Notes
+- All tool calls are logged and audited for security and compliance
+- You have access to the tools exposed through the selected gateway
+- MCPs may expose resources that users can browse and edit
+
+## Current Editing Context
+${connectionId ? `- Connection ID: ${connectionId}` : ""}
+${collectionName ? `- Collection Name: ${collectionName}` : ""}
+${itemId ? `- Item ID: ${itemId}` : ""}
+
+Help the user understand and work with this resource.
+`;
+}


### PR DESCRIPTION
- Added a new `useSystemPrompt` hook to generate context-aware system prompts for the chat.
- Refactored the `ChatPanel` component to utilize the new system prompt in the persisted chat hook.
- Updated the assistant description display to limit its maximum width for better UI consistency.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates a dynamic, context-aware system prompt into chat for more relevant replies, and tightens assistant description width for a cleaner UI. ChatPanel now passes the prompt to the persisted chat hook.

- **New Features**
  - Added useSystemPrompt hook that builds an MCP Mesh-aware prompt from route context (connectionId, collectionName, itemId).
  - Capped assistant description width to keep the details header tidy.

- **Refactors**
  - Updated ChatPanel to pass systemPrompt into usePersistedChat while keeping hook calls unconditional.

<sup>Written for commit a2b5ef537151688ce44f688b1d32033553cd48f7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

