### PR TITLE
Adds icebreakers based on prompts

### DIFF
--- a/apps/mesh/migrations/014-gateway-resources-prompts.ts
+++ b/apps/mesh/migrations/014-gateway-resources-prompts.ts
@@ -1,0 +1,38 @@
+/**
+ * Gateway Resources and Prompts Selection Migration
+ *
+ * Adds support for selecting resources and prompts in gateway connections,
+ * in addition to the existing tool selection.
+ *
+ * - selected_resources: JSON array of URIs/patterns (exact URIs for individual selection,
+ *   patterns with `*`/`**` for wildcard matching)
+ * - selected_prompts: JSON array of prompt names (same behavior as selected_tools)
+ */
+
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Add selected_resources column
+  await db.schema
+    .alterTable("gateway_connections")
+    .addColumn("selected_resources", "text")
+    .execute();
+
+  // Add selected_prompts column
+  await db.schema
+    .alterTable("gateway_connections")
+    .addColumn("selected_prompts", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("gateway_connections")
+    .dropColumn("selected_resources")
+    .execute();
+
+  await db.schema
+    .alterTable("gateway_connections")
+    .dropColumn("selected_prompts")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -12,6 +12,7 @@ import * as migration010gateways from "./010-gateways.ts";
 import * as migration011gatewayicon from "./011-gateway-icon.ts";
 import * as migration012gatewaytoolselectionmode from "./012-gateway-tool-selection-mode.ts";
 import * as migration013monitoringuseragentgateway from "./013-monitoring-user-agent-gateway.ts";
+import * as migration014gatewayresourcesprompts from "./014-gateway-resources-prompts.ts";
 
 const migrations = {
   "001-initial-schema": migration001initialschema,
@@ -27,6 +28,7 @@ const migrations = {
   "011-gateway-icon": migration011gatewayicon,
   "012-gateway-tool-selection-mode": migration012gatewaytoolselectionmode,
   "013-monitoring-user-agent-gateway": migration013monitoringuseragentgateway,
+  "014-gateway-resources-prompts": migration014gatewayresourcesprompts,
 } satisfies Record<string, Migration>;
 
 export default migrations;

--- a/apps/mesh/src/gateway/proxy-collection.ts
+++ b/apps/mesh/src/gateway/proxy-collection.ts
@@ -27,24 +27,39 @@ export class ProxyCollection {
     connections: Array<{
       connection: ConnectionEntity;
       selectedTools: string[] | null;
+      selectedResources: string[] | null;
+      selectedPrompts: string[] | null;
     }>,
     ctx: MeshContext,
   ): Promise<ProxyCollection> {
     const collection = new ProxyCollection();
 
     const proxyResults = await Promise.allSettled(
-      connections.map(async ({ connection, selectedTools }) => {
-        try {
-          const proxy = await ctx.createMCPProxy(connection);
-          return { connection, proxy, selectedTools };
-        } catch (error) {
-          console.error(
-            `[gateway] Failed to create proxy for connection ${connection.id}:`,
-            error,
-          );
-          return null;
-        }
-      }),
+      connections.map(
+        async ({
+          connection,
+          selectedTools,
+          selectedResources,
+          selectedPrompts,
+        }) => {
+          try {
+            const proxy = await ctx.createMCPProxy(connection);
+            return {
+              connection,
+              proxy,
+              selectedTools,
+              selectedResources,
+              selectedPrompts,
+            };
+          } catch (error) {
+            console.error(
+              `[gateway] Failed to create proxy for connection ${connection.id}:`,
+              error,
+            );
+            return null;
+          }
+        },
+      ),
     );
 
     for (const result of proxyResults) {

--- a/apps/mesh/src/gateway/types.ts
+++ b/apps/mesh/src/gateway/types.ts
@@ -32,6 +32,8 @@ export interface ProxyEntry {
   proxy: MCPProxy;
   connection: ConnectionEntity;
   selectedTools: string[] | null;
+  selectedResources: string[] | null;
+  selectedPrompts: string[] | null;
 }
 
 /** Options for creating a gateway */
@@ -39,6 +41,8 @@ export interface GatewayOptions {
   connections: Array<{
     connection: ConnectionEntity;
     selectedTools: string[] | null;
+    selectedResources: string[] | null;
+    selectedPrompts: string[] | null;
   }>;
   toolSelectionMode: ToolSelectionMode;
   toolSelectionStrategy: GatewayToolSelectionStrategy;

--- a/apps/mesh/src/storage/gateway.ts
+++ b/apps/mesh/src/storage/gateway.ts
@@ -43,6 +43,8 @@ type RawGatewayConnectionRow = {
   gateway_id: string;
   connection_id: string;
   selected_tools: string | string[] | null;
+  selected_resources: string | string[] | null;
+  selected_prompts: string | string[] | null;
   created_at: Date | string;
 };
 
@@ -101,6 +103,12 @@ export class GatewayStorage implements GatewayStoragePort {
                 selected_tools: conn.selectedTools
                   ? JSON.stringify(conn.selectedTools)
                   : null,
+                selected_resources: conn.selectedResources
+                  ? JSON.stringify(conn.selectedResources)
+                  : null,
+                selected_prompts: conn.selectedPrompts
+                  ? JSON.stringify(conn.selectedPrompts)
+                  : null,
                 created_at: now,
               })),
             )
@@ -146,6 +154,12 @@ export class GatewayStorage implements GatewayStoragePort {
             connection_id: conn.connectionId,
             selected_tools: conn.selectedTools
               ? JSON.stringify(conn.selectedTools)
+              : null,
+            selected_resources: conn.selectedResources
+              ? JSON.stringify(conn.selectedResources)
+              : null,
+            selected_prompts: conn.selectedPrompts
+              ? JSON.stringify(conn.selectedPrompts)
               : null,
             created_at: now,
           })),
@@ -360,6 +374,12 @@ export class GatewayStorage implements GatewayStoragePort {
                   selected_tools: conn.selectedTools
                     ? JSON.stringify(conn.selectedTools)
                     : null,
+                  selected_resources: conn.selectedResources
+                    ? JSON.stringify(conn.selectedResources)
+                    : null,
+                  selected_prompts: conn.selectedPrompts
+                    ? JSON.stringify(conn.selectedPrompts)
+                    : null,
                   created_at: now,
                 })),
               )
@@ -392,6 +412,12 @@ export class GatewayStorage implements GatewayStoragePort {
                 connection_id: conn.connectionId,
                 selected_tools: conn.selectedTools
                   ? JSON.stringify(conn.selectedTools)
+                  : null,
+                selected_resources: conn.selectedResources
+                  ? JSON.stringify(conn.selectedResources)
+                  : null,
+                selected_prompts: conn.selectedPrompts
+                  ? JSON.stringify(conn.selectedPrompts)
                   : null,
                 created_at: now,
               })),
@@ -510,6 +536,8 @@ export class GatewayStorage implements GatewayStoragePort {
       connections: connectionRows.map((conn) => ({
         connectionId: conn.connection_id,
         selectedTools: this.parseJson<string[]>(conn.selected_tools),
+        selectedResources: this.parseJson<string[]>(conn.selected_resources),
+        selectedPrompts: this.parseJson<string[]>(conn.selected_prompts),
       })),
     };
   }

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -90,6 +90,8 @@ export interface GatewayCreateData {
   connections: Array<{
     connectionId: string;
     selectedTools?: string[] | null;
+    selectedResources?: string[] | null;
+    selectedPrompts?: string[] | null;
   }>;
 }
 
@@ -107,6 +109,8 @@ export interface GatewayUpdateData {
   connections?: Array<{
     connectionId: string;
     selectedTools?: string[] | null;
+    selectedResources?: string[] | null;
+    selectedPrompts?: string[] | null;
   }>;
 }
 

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -587,13 +587,15 @@ export interface Gateway {
 
 /**
  * Gateway connection table definition
- * Many-to-many relationship linking gateways to connections with selected tools
+ * Many-to-many relationship linking gateways to connections with selected tools/resources/prompts
  */
 export interface GatewayConnectionTable {
   id: string;
   gateway_id: string;
   connection_id: string;
   selected_tools: JsonArray<string[]> | null; // null = all tools
+  selected_resources: JsonArray<string[]> | null; // null = all resources, supports URI patterns with * and **
+  selected_prompts: JsonArray<string[]> | null; // null = all prompts
   created_at: ColumnType<Date, Date | string, never>;
 }
 
@@ -605,6 +607,8 @@ export interface GatewayConnection {
   gatewayId: string;
   connectionId: string;
   selectedTools: string[] | null;
+  selectedResources: string[] | null; // URI patterns with * and ** wildcards
+  selectedPrompts: string[] | null;
   createdAt: Date | string;
 }
 
@@ -615,6 +619,8 @@ export interface GatewayWithConnections extends Gateway {
   connections: Array<{
     connectionId: string;
     selectedTools: string[] | null;
+    selectedResources: string[] | null;
+    selectedPrompts: string[] | null;
   }>;
 }
 

--- a/apps/mesh/src/tools/gateway/create.ts
+++ b/apps/mesh/src/tools/gateway/create.ts
@@ -60,6 +60,8 @@ export const COLLECTION_GATEWAY_CREATE = defineTool({
       connections: input.data.connections.map((conn) => ({
         connectionId: conn.connection_id,
         selectedTools: conn.selected_tools ?? null,
+        selectedResources: conn.selected_resources ?? null,
+        selectedPrompts: conn.selected_prompts ?? null,
       })),
     };
 
@@ -85,6 +87,8 @@ export const COLLECTION_GATEWAY_CREATE = defineTool({
         connections: gateway.connections.map((conn) => ({
           connection_id: conn.connectionId,
           selected_tools: conn.selectedTools,
+          selected_resources: conn.selectedResources,
+          selected_prompts: conn.selectedPrompts,
         })),
         created_at: gateway.createdAt as string,
         updated_at: gateway.updatedAt as string,

--- a/apps/mesh/src/tools/gateway/delete.ts
+++ b/apps/mesh/src/tools/gateway/delete.ts
@@ -72,6 +72,8 @@ export const COLLECTION_GATEWAY_DELETE = defineTool({
         connections: existing.connections.map((conn) => ({
           connection_id: conn.connectionId,
           selected_tools: conn.selectedTools,
+          selected_resources: conn.selectedResources,
+          selected_prompts: conn.selectedPrompts,
         })),
         created_at:
           existing.createdAt instanceof Date

--- a/apps/mesh/src/tools/gateway/get.ts
+++ b/apps/mesh/src/tools/gateway/get.ts
@@ -68,6 +68,8 @@ export const COLLECTION_GATEWAY_GET = defineTool({
         connections: gateway.connections.map((conn) => ({
           connection_id: conn.connectionId,
           selected_tools: conn.selectedTools,
+          selected_resources: conn.selectedResources,
+          selected_prompts: conn.selectedPrompts,
         })),
         created_at: gateway.createdAt as string,
         updated_at: gateway.updatedAt as string,

--- a/apps/mesh/src/tools/gateway/list.ts
+++ b/apps/mesh/src/tools/gateway/list.ts
@@ -231,6 +231,8 @@ export const COLLECTION_GATEWAY_LIST = defineTool({
       connections: gateway.connections.map((conn) => ({
         connection_id: conn.connectionId,
         selected_tools: conn.selectedTools,
+        selected_resources: conn.selectedResources,
+        selected_prompts: conn.selectedPrompts,
       })),
       created_at: gateway.createdAt as string,
       updated_at: gateway.updatedAt as string,

--- a/apps/mesh/src/tools/gateway/schema.ts
+++ b/apps/mesh/src/tools/gateway/schema.ts
@@ -37,7 +37,7 @@ export type GatewayToolSelectionStrategy = z.infer<
 >;
 
 /**
- * Gateway connection schema - defines which connection and tools are included/excluded
+ * Gateway connection schema - defines which connection and tools/resources/prompts are included/excluded
  */
 const GatewayConnectionSchema = z.object({
   connection_id: z.string().describe("Connection ID"),
@@ -46,6 +46,18 @@ const GatewayConnectionSchema = z.object({
     .nullable()
     .describe(
       "Selected tool names. With 'inclusion' mode: null = all tools included. With 'exclusion' mode: null = entire connection excluded",
+    ),
+  selected_resources: z
+    .array(z.string())
+    .nullable()
+    .describe(
+      "Selected resource URIs or patterns. Supports * and ** wildcards for pattern matching. With 'inclusion' mode: null = all resources included.",
+    ),
+  selected_prompts: z
+    .array(z.string())
+    .nullable()
+    .describe(
+      "Selected prompt names. With 'inclusion' mode: null = all prompts included. With 'exclusion' mode: null = entire connection excluded.",
     ),
 });
 
@@ -135,6 +147,20 @@ export const GatewayCreateDataSchema = z.object({
           .describe(
             "Selected tool names (null/undefined = all tools or full exclusion)",
           ),
+        selected_resources: z
+          .array(z.string())
+          .nullable()
+          .optional()
+          .describe(
+            "Selected resource URIs or patterns with * and ** wildcards (null/undefined = all resources)",
+          ),
+        selected_prompts: z
+          .array(z.string())
+          .nullable()
+          .optional()
+          .describe(
+            "Selected prompt names (null/undefined = all prompts or full exclusion)",
+          ),
       }),
     )
     .describe(
@@ -181,6 +207,20 @@ export const GatewayUpdateDataSchema = z.object({
           .optional()
           .describe(
             "Selected tool names (null/undefined = all tools or full exclusion)",
+          ),
+        selected_resources: z
+          .array(z.string())
+          .nullable()
+          .optional()
+          .describe(
+            "Selected resource URIs or patterns with * and ** wildcards (null/undefined = all resources)",
+          ),
+        selected_prompts: z
+          .array(z.string())
+          .nullable()
+          .optional()
+          .describe(
+            "Selected prompt names (null/undefined = all prompts or full exclusion)",
           ),
       }),
     )

--- a/apps/mesh/src/tools/gateway/update.ts
+++ b/apps/mesh/src/tools/gateway/update.ts
@@ -85,6 +85,8 @@ export const COLLECTION_GATEWAY_UPDATE = defineTool({
       updateData.connections = input.data.connections.map((conn) => ({
         connectionId: conn.connection_id,
         selectedTools: conn.selected_tools ?? null,
+        selectedResources: conn.selected_resources ?? null,
+        selectedPrompts: conn.selected_prompts ?? null,
       }));
     }
 
@@ -110,6 +112,8 @@ export const COLLECTION_GATEWAY_UPDATE = defineTool({
         connections: gateway.connections.map((conn) => ({
           connection_id: conn.connectionId,
           selected_tools: conn.selectedTools,
+          selected_resources: conn.selectedResources,
+          selected_prompts: conn.selectedPrompts,
         })),
         created_at: gateway.createdAt as string,
         updated_at: gateway.updatedAt as string,

--- a/apps/mesh/src/web/components/chat/ice-breakers.tsx
+++ b/apps/mesh/src/web/components/chat/ice-breakers.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@deco/ui/lib/utils.ts";
+import { MessageChatSquare } from "@untitledui/icons";
+import type { GatewayPrompt } from "@/web/hooks/use-gateway-prompts";
+
+export interface IceBreakersProps {
+  prompts: GatewayPrompt[];
+  onSelect: (prompt: GatewayPrompt) => void;
+  className?: string;
+}
+
+/**
+ * IceBreakers - Displays gateway prompts as clickable conversation starters
+ *
+ * Shows prompts as cards that, when clicked, submit the prompt as the first message
+ */
+export function IceBreakers({
+  prompts,
+  onSelect,
+  className,
+}: IceBreakersProps) {
+  if (prompts.length === 0) return null;
+
+  // Show max 4 prompts
+  const displayPrompts = prompts.slice(0, 4);
+
+  return (
+    <div className={cn("flex flex-col gap-3 w-full", className)}>
+      <p className="text-xs text-muted-foreground text-center">Try asking</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {displayPrompts.map((prompt) => (
+          <button
+            key={prompt.name}
+            type="button"
+            onClick={() => onSelect(prompt)}
+            className={cn(
+              "flex items-start gap-3 p-3 rounded-xl",
+              "bg-muted/50 hover:bg-muted transition-colors",
+              "text-left cursor-pointer group",
+              "border border-transparent hover:border-border",
+            )}
+          >
+            <div className="shrink-0 mt-0.5">
+              <MessageChatSquare
+                size={16}
+                className="text-muted-foreground group-hover:text-foreground transition-colors"
+              />
+            </div>
+            <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+              <span className="text-sm font-medium text-foreground truncate">
+                {prompt.name.replace(/_/g, " ")}
+              </span>
+              {prompt.description && (
+                <span className="text-xs text-muted-foreground line-clamp-2">
+                  {prompt.description}
+                </span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/details/connection/settings-tab/connection-gateways-section.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/connection-gateways-section.tsx
@@ -80,6 +80,8 @@ function CreateGatewayButton({
         {
           connection_id: connectionId,
           selected_tools: null,
+          selected_resources: null,
+          selected_prompts: null,
         },
       ],
     });

--- a/apps/mesh/src/web/components/details/gateway/index.tsx
+++ b/apps/mesh/src/web/components/details/gateway/index.tsx
@@ -3,11 +3,15 @@ import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { ToolSetSelector } from "@/web/components/tool-set-selector.tsx";
+import { PromptSetSelector } from "@/web/components/gateway/prompt-selector.tsx";
+import { ResourceSetSelector } from "@/web/components/gateway/resource-selector.tsx";
 import {
   useGateway,
   useGatewayActions,
 } from "@/web/hooks/collections/use-gateway";
 import { useConnections } from "@/web/hooks/collections/use-connection";
+import { useConnectionsPrompts } from "@/web/hooks/use-connection-prompts";
+import { useConnectionsResources } from "@/web/hooks/use-connection-resources";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   InfoCircle,
@@ -39,15 +43,23 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import { ResourceTabs } from "@deco/ui/components/resource-tabs.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useNavigate, useParams, useRouter } from "@tanstack/react-router";
+import {
+  useNavigate,
+  useParams,
+  useRouter,
+  useSearch,
+} from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
 import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { slugify } from "@/web/utils/slugify";
-import { ViewLayout, ViewActions } from "../layout";
+import { ViewLayout, ViewActions, ViewTabs } from "../layout";
+
+type GatewayTabId = "settings" | "tools" | "resources" | "prompts";
 
 /**
  * Unicode-safe base64 encoding for browser environments
@@ -256,14 +268,68 @@ function gatewayToToolSet(
 }
 
 /**
- * Convert ToolSetSelector format back to gateway connections format.
- * When all tools for a connection are selected, we store null (meaning "all").
+ * Convert gateway connections to ResourceSetSelector format.
  */
-function toolSetToGatewayConnections(
+function gatewayToResourceSet(
+  gateway: GatewayEntity,
+): Record<string, string[]> {
+  const resourceSet: Record<string, string[]> = {};
+
+  for (const conn of gateway.connections) {
+    if (
+      conn.selected_resources !== null &&
+      conn.selected_resources !== undefined &&
+      conn.selected_resources.length > 0
+    ) {
+      resourceSet[conn.connection_id] = conn.selected_resources;
+    }
+  }
+
+  return resourceSet;
+}
+
+/**
+ * Convert gateway connections to PromptSetSelector format.
+ */
+function gatewayToPromptSet(gateway: GatewayEntity): Record<string, string[]> {
+  const promptSet: Record<string, string[]> = {};
+
+  for (const conn of gateway.connections) {
+    if (
+      conn.selected_prompts !== null &&
+      conn.selected_prompts !== undefined &&
+      conn.selected_prompts.length > 0
+    ) {
+      promptSet[conn.connection_id] = conn.selected_prompts;
+    }
+  }
+
+  return promptSet;
+}
+
+/**
+ * Merge tool, resource, and prompt sets into gateway connections format.
+ */
+function mergeSelectionsToGatewayConnections(
   toolSet: Record<string, string[]>,
+  resourceSet: Record<string, string[]>,
+  promptSet: Record<string, string[]>,
   connectionToolsMap: Map<string, string[]>,
-): Array<{ connection_id: string; selected_tools: string[] | null }> {
-  return Object.entries(toolSet).map(([connectionId, selectedTools]) => {
+): Array<{
+  connection_id: string;
+  selected_tools: string[] | null;
+  selected_resources: string[] | null;
+  selected_prompts: string[] | null;
+}> {
+  // Collect all connection IDs from all sets
+  const allConnectionIds = new Set([
+    ...Object.keys(toolSet),
+    ...Object.keys(resourceSet),
+    ...Object.keys(promptSet),
+  ]);
+
+  return Array.from(allConnectionIds).map((connectionId) => {
+    const selectedTools = toolSet[connectionId] ?? [];
     const allTools = connectionToolsMap.get(connectionId) ?? [];
 
     // If all tools are selected, store null (meaning "all")
@@ -273,256 +339,286 @@ function toolSetToGatewayConnections(
 
     return {
       connection_id: connectionId,
-      selected_tools: hasAllTools ? null : selectedTools,
+      selected_tools:
+        selectedTools.length === 0 ? null : hasAllTools ? null : selectedTools,
+      selected_resources: resourceSet[connectionId] ?? null,
+      selected_prompts: promptSet[connectionId] ?? null,
     };
   });
 }
 
-function GatewaySettingsForm({
+/**
+ * Settings Tab - Gateway configuration (title, description, status, mode, strategy)
+ */
+function GatewaySettingsTab({
   form,
-  toolSet,
-  onToolSetChange,
+  gateway,
   icon,
 }: {
   form: ReturnType<typeof useForm<GatewayFormData>>;
-  toolSet: Record<string, string[]>;
-  onToolSetChange: (newToolSet: Record<string, string[]>) => void;
+  gateway: GatewayEntity;
   icon?: string | null;
 }) {
   return (
-    <Form {...form}>
-      <div className="flex flex-col h-full">
-        {/* Header section - Icon, Title, Description */}
-        <div className="flex flex-col gap-4 p-5 border-b border-border">
-          <div className="flex items-start justify-between">
-            <IntegrationIcon
-              icon={icon}
-              name={form.watch("title") || "Gateway"}
-              size="lg"
-              className="shrink-0 shadow-sm"
-              fallbackIcon={<CpuChip02 />}
-            />
-            <FormField
-              control={form.control}
-              name="status"
-              render={({ field }) => (
-                <FormItem>
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-muted-foreground">
-                      {field.value === "active" ? "Active" : "Inactive"}
-                    </span>
-                    <FormControl>
-                      <Switch
-                        checked={field.value === "active"}
-                        onCheckedChange={(checked) =>
-                          field.onChange(checked ? "active" : "inactive")
-                        }
-                      />
-                    </FormControl>
-                  </div>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
+    <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] h-full">
+      {/* Left panel - Settings */}
+      <div className="lg:border-r border-b lg:border-b-0 border-border overflow-auto">
+        <Form {...form}>
           <div className="flex flex-col">
-            <FormField
-              control={form.control}
-              name="title"
-              render={({ field }) => (
-                <FormItem className="w-full space-y-0">
-                  <FormControl>
-                    <Input
-                      {...field}
-                      className="h-auto text-lg! font-medium leading-7 px-0 border-transparent hover:border-input focus:border-input bg-transparent transition-all"
-                      placeholder="Gateway Name"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem className="w-full space-y-0">
-                  <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value || ""}
-                      className="h-auto text-base text-muted-foreground leading-6 px-0 border-transparent hover:border-input focus:border-input bg-transparent transition-all"
-                      placeholder="Add a description..."
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-        </div>
-
-        {/* Settings section */}
-        <div className="flex flex-col gap-4 p-5 border-b border-border">
-          {/* Tool Selection Mode */}
-          <FormField
-            control={form.control}
-            name="tool_selection_mode"
-            render={({ field }) => (
-              <FormItem>
-                <div className="flex items-center justify-between gap-3">
-                  <FormLabel className="mb-0">Tool Selection Mode</FormLabel>
-                  <div className="flex items-center gap-1.5">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            className="cursor-help flex items-center"
-                          >
-                            <InfoCircle
-                              size={14}
-                              className="text-muted-foreground"
-                            />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" className="max-w-sm">
-                          <div className="text-xs space-y-1">
-                            <div>
-                              <strong>Include:</strong> Only selected
-                              connections/tools are exposed.
-                            </div>
-                            <div>
-                              <strong>Exclude:</strong> All connections/tools
-                              except selected ones are exposed.
-                            </div>
-                          </div>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <Select value={field.value} onValueChange={field.onChange}>
+            {/* Header section - Icon, Title, Description */}
+            <div className="flex flex-col gap-4 p-5 border-b border-border">
+              <div className="flex items-start justify-between">
+                <IntegrationIcon
+                  icon={icon}
+                  name={form.watch("title") || "Gateway"}
+                  size="lg"
+                  className="shrink-0 shadow-sm"
+                  fallbackIcon={<CpuChip02 />}
+                />
+                <FormField
+                  control={form.control}
+                  name="status"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                          {field.value === "active" ? "Active" : "Inactive"}
+                        </span>
+                        <FormControl>
+                          <Switch
+                            checked={field.value === "active"}
+                            onCheckedChange={(checked) =>
+                              field.onChange(checked ? "active" : "inactive")
+                            }
+                          />
+                        </FormControl>
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className="flex flex-col">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem className="w-full space-y-0">
                       <FormControl>
-                        <SelectTrigger className="w-[180px]">
-                          <SelectValue />
-                        </SelectTrigger>
+                        <Input
+                          {...field}
+                          className="h-auto text-lg! font-medium leading-7 px-0 border-transparent hover:border-input focus:border-input bg-transparent transition-all"
+                          placeholder="Gateway Name"
+                        />
                       </FormControl>
-                      <SelectContent>
-                        <SelectItem value="inclusion">
-                          Include Selected
-                        </SelectItem>
-                        <SelectItem value="exclusion">
-                          Exclude Selected
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {/* Gateway Strategy */}
-          <FormField
-            control={form.control}
-            name="tool_selection_strategy"
-            render={({ field }) => (
-              <FormItem>
-                <div className="flex items-center justify-between gap-3">
-                  <FormLabel className="mb-0">Gateway Strategy</FormLabel>
-                  <div className="flex items-center gap-1.5">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            className="cursor-help flex items-center"
-                          >
-                            <InfoCircle
-                              size={14}
-                              className="text-muted-foreground"
-                            />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" className="max-w-sm">
-                          <div className="text-xs space-y-1">
-                            <div>
-                              <strong>Passthrough:</strong> Pass tools through
-                              as-is (default).
-                            </div>
-                            <div>
-                              <strong>Smart Tool Selection:</strong> Intelligent
-                              tool selection behavior.
-                            </div>
-                            <div>
-                              <strong>Code Execution:</strong> Code execution
-                              behavior.
-                            </div>
-                          </div>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem className="w-full space-y-0">
                       <FormControl>
-                        <SelectTrigger className="w-[180px]">
-                          <SelectValue />
-                        </SelectTrigger>
+                        <Input
+                          {...field}
+                          value={field.value || ""}
+                          className="h-auto text-base text-muted-foreground leading-6 px-0 border-transparent hover:border-input focus:border-input bg-transparent transition-all"
+                          placeholder="Add a description..."
+                        />
                       </FormControl>
-                      <SelectContent>
-                        <SelectItem value="passthrough">Passthrough</SelectItem>
-                        <SelectItem value="smart_tool_selection">
-                          Smart Tool Selection
-                        </SelectItem>
-                        <SelectItem value="code_execution">
-                          Code Execution
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
 
-        {/* Tool Selection section */}
-        <div className="flex-1 min-h-0 overflow-auto">
-          <ErrorBoundary>
-            <Suspense
-              fallback={
-                <div className="flex-1 flex items-center justify-center p-5">
-                  <Loading01
-                    size={32}
-                    className="animate-spin text-muted-foreground"
-                  />
-                </div>
-              }
-            >
-              <ToolSetSelector
-                toolSet={toolSet}
-                onToolSetChange={onToolSetChange}
+            {/* Settings section */}
+            <div className="flex flex-col gap-4 p-5">
+              {/* Selection Mode */}
+              <FormField
+                control={form.control}
+                name="tool_selection_mode"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex items-center justify-between gap-3">
+                      <FormLabel className="mb-0">Selection Mode</FormLabel>
+                      <div className="flex items-center gap-1.5">
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                className="cursor-help flex items-center"
+                              >
+                                <InfoCircle
+                                  size={14}
+                                  className="text-muted-foreground"
+                                />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="left" className="max-w-sm">
+                              <div className="text-xs space-y-1">
+                                <div>
+                                  <strong>Include:</strong> Only selected items
+                                  are exposed.
+                                </div>
+                                <div>
+                                  <strong>Exclude:</strong> All items except
+                                  selected ones are exposed.
+                                </div>
+                              </div>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <Select
+                          value={field.value}
+                          onValueChange={field.onChange}
+                        >
+                          <FormControl>
+                            <SelectTrigger className="w-[180px]">
+                              <SelectValue />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="inclusion">
+                              Include Selected
+                            </SelectItem>
+                            <SelectItem value="exclusion">
+                              Exclude Selected
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-            </Suspense>
-          </ErrorBoundary>
+
+              {/* Gateway Strategy */}
+              <FormField
+                control={form.control}
+                name="tool_selection_strategy"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex items-center justify-between gap-3">
+                      <FormLabel className="mb-0">Gateway Strategy</FormLabel>
+                      <div className="flex items-center gap-1.5">
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                className="cursor-help flex items-center"
+                              >
+                                <InfoCircle
+                                  size={14}
+                                  className="text-muted-foreground"
+                                />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="left" className="max-w-sm">
+                              <div className="text-xs space-y-1">
+                                <div>
+                                  <strong>Passthrough:</strong> Pass tools
+                                  through as-is (default).
+                                </div>
+                                <div>
+                                  <strong>Smart Tool Selection:</strong>{" "}
+                                  Intelligent tool selection behavior.
+                                </div>
+                                <div>
+                                  <strong>Code Execution:</strong> Code
+                                  execution behavior.
+                                </div>
+                              </div>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <Select
+                          value={field.value}
+                          onValueChange={field.onChange}
+                        >
+                          <FormControl>
+                            <SelectTrigger className="w-[180px]">
+                              <SelectValue />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="passthrough">
+                              Passthrough
+                            </SelectItem>
+                            <SelectItem value="smart_tool_selection">
+                              Smart Tool Selection
+                            </SelectItem>
+                            <SelectItem value="code_execution">
+                              Code Execution
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+        </Form>
+      </div>
+
+      {/* Right panel - IDE Integration */}
+      <div className="flex flex-col overflow-auto">
+        <div className="p-5">
+          <IDEIntegration
+            serverName={gateway.title || `gateway-${gateway.id.slice(0, 8)}`}
+            gatewayUrl={`${window.location.origin}/mcp/gateway/${gateway.id}`}
+          />
+        </div>
+
+        {/* Last Updated section */}
+        <div className="flex items-center gap-4 p-5 border-t border-border">
+          <span className="flex-1 text-sm text-foreground">Last Updated</span>
+          <span className="text-muted-foreground uppercase text-xs">
+            {gateway.updated_at
+              ? formatDistanceToNow(new Date(gateway.updated_at), {
+                  addSuffix: false,
+                })
+              : "Unknown"}
+          </span>
         </div>
       </div>
-    </Form>
+    </div>
   );
 }
 
 function GatewayInspectorViewWithGateway({
   gateway,
   gatewayId,
+  requestedTabId,
 }: {
   gateway: GatewayEntity;
   gatewayId: string;
+  requestedTabId: GatewayTabId;
 }) {
   const router = useRouter();
+  const navigate = useNavigate({ from: "/$org/gateways/$gatewayId" });
   const actions = useGatewayActions();
 
   // Fetch all connections to get tool names for "all tools" expansion
   const connections = useConnections({});
+
+  // Get all connection IDs
+  const connectionIds = connections.map((c) => c.id);
+
+  // Fetch prompts and resources for all connections
+  const { promptsMap: connectionPrompts } =
+    useConnectionsPrompts(connectionIds);
+  const { resourcesMap: connectionResources } =
+    useConnectionsResources(connectionIds);
 
   // Build a map of connectionId -> all tool names
   const connectionToolsMap = new Map<string, string[]>();
@@ -540,12 +636,34 @@ function GatewayInspectorViewWithGateway({
     gatewayToToolSet(gateway, connectionToolsMap),
   );
 
-  // Track if toolSet has changed
-  const [toolSetDirty, setToolSetDirty] = useState(false);
+  // Initialize resourceSet from gateway connections
+  const [resourceSet, setResourceSet] = useState<Record<string, string[]>>(() =>
+    gatewayToResourceSet(gateway),
+  );
+
+  // Initialize promptSet from gateway connections
+  const [promptSet, setPromptSet] = useState<Record<string, string[]>>(() =>
+    gatewayToPromptSet(gateway),
+  );
+
+  // Track if any selection has changed
+  const [selectionDirty, setSelectionDirty] = useState(false);
 
   const handleToolSetChange = (newToolSet: Record<string, string[]>) => {
     setToolSet(newToolSet);
-    setToolSetDirty(true);
+    setSelectionDirty(true);
+  };
+
+  const handleResourceSetChange = (
+    newResourceSet: Record<string, string[]>,
+  ) => {
+    setResourceSet(newResourceSet);
+    setSelectionDirty(true);
+  };
+
+  const handlePromptSetChange = (newPromptSet: Record<string, string[]>) => {
+    setPromptSet(newPromptSet);
+    setSelectionDirty(true);
   };
 
   // Form setup
@@ -561,14 +679,16 @@ function GatewayInspectorViewWithGateway({
   });
 
   const hasFormChanges = form.formState.isDirty;
-  const hasAnyChanges = hasFormChanges || toolSetDirty;
+  const hasAnyChanges = hasFormChanges || selectionDirty;
 
   const handleSave = async () => {
     const formData = form.getValues();
 
-    // Convert toolSet back to gateway connections format
-    const newConnections = toolSetToGatewayConnections(
+    // Merge all selections into gateway connections format
+    const newConnections = mergeSelectionsToGatewayConnections(
       toolSet,
+      resourceSet,
+      promptSet,
       connectionToolsMap,
     );
 
@@ -586,11 +706,34 @@ function GatewayInspectorViewWithGateway({
 
     // Reset dirty states
     form.reset(formData);
-    setToolSetDirty(false);
+    setSelectionDirty(false);
+  };
+
+  // Define tabs
+  const tabs = [
+    { id: "settings", label: "Settings" },
+    { id: "tools", label: "Tools" },
+    { id: "resources", label: "Resources" },
+    { id: "prompts", label: "Prompts" },
+  ];
+
+  const activeTabId = tabs.some((t) => t.id === requestedTabId)
+    ? requestedTabId
+    : "settings";
+
+  const handleTabChange = (tabId: string) => {
+    navigate({ search: (prev) => ({ ...prev, tab: tabId }), replace: true });
   };
 
   return (
     <ViewLayout onBack={() => router.history.back()}>
+      <ViewTabs>
+        <ResourceTabs
+          tabs={tabs}
+          activeTab={activeTabId}
+          onTabChange={handleTabChange}
+        />
+      </ViewTabs>
       <ViewActions>
         {hasAnyChanges && (
           <Button
@@ -607,37 +750,45 @@ function GatewayInspectorViewWithGateway({
         )}
       </ViewActions>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] h-full">
-        {/* Left sidebar - Gateway Settings with Tool Selection (2/3 on desktop, full on mobile) */}
-        <div className="lg:border-r border-b lg:border-b-0 border-border overflow-auto">
-          <GatewaySettingsForm
-            form={form}
-            toolSet={toolSet}
-            onToolSetChange={handleToolSetChange}
-            icon={gateway.icon}
-          />
-        </div>
-
-        {/* Right panel - IDE Integration (1/3 on desktop, full on mobile) */}
-        <div className="flex flex-col overflow-auto">
-          <div className="p-5">
-            <IDEIntegration
-              serverName={gateway.title || `gateway-${gateway.id.slice(0, 8)}`}
-              gatewayUrl={`${window.location.origin}/mcp/gateway/${gateway.id}`}
-            />
-          </div>
-
-          {/* Last Updated section */}
-          <div className="flex items-center gap-4 p-5 border-t border-border">
-            <span className="flex-1 text-sm text-foreground">Last Updated</span>
-            <span className="text-muted-foreground uppercase text-xs">
-              {gateway.updated_at
-                ? formatDistanceToNow(new Date(gateway.updated_at), {
-                    addSuffix: false,
-                  })
-                : "Unknown"}
-            </span>
-          </div>
+      <div className="flex h-full w-full bg-background overflow-hidden">
+        <div className="flex-1 flex flex-col min-w-0 bg-background overflow-auto">
+          <ErrorBoundary key={activeTabId}>
+            <Suspense
+              fallback={
+                <div className="flex h-full items-center justify-center">
+                  <Loading01
+                    size={32}
+                    className="animate-spin text-muted-foreground"
+                  />
+                </div>
+              }
+            >
+              {activeTabId === "settings" ? (
+                <GatewaySettingsTab
+                  form={form}
+                  gateway={gateway}
+                  icon={gateway.icon}
+                />
+              ) : activeTabId === "tools" ? (
+                <ToolSetSelector
+                  toolSet={toolSet}
+                  onToolSetChange={handleToolSetChange}
+                />
+              ) : activeTabId === "resources" ? (
+                <ResourceSetSelector
+                  resourceSet={resourceSet}
+                  onResourceSetChange={handleResourceSetChange}
+                  connectionResources={connectionResources}
+                />
+              ) : activeTabId === "prompts" ? (
+                <PromptSetSelector
+                  promptSet={promptSet}
+                  onPromptSetChange={handlePromptSetChange}
+                  connectionPrompts={connectionPrompts}
+                />
+              ) : null}
+            </Suspense>
+          </ErrorBoundary>
         </div>
       </div>
     </ViewLayout>
@@ -649,6 +800,10 @@ function GatewayInspectorViewContent() {
   const { gatewayId, org } = useParams({
     from: "/shell/$org/gateways/$gatewayId",
   });
+
+  // Get tab from search params
+  const search = useSearch({ from: "/shell/$org/gateways/$gatewayId" });
+  const requestedTabId = (search.tab as GatewayTabId) || "settings";
 
   const gateway = useGateway(gatewayId);
 
@@ -677,7 +832,11 @@ function GatewayInspectorViewContent() {
   }
 
   return (
-    <GatewayInspectorViewWithGateway gateway={gateway} gatewayId={gatewayId} />
+    <GatewayInspectorViewWithGateway
+      gateway={gateway}
+      gatewayId={gatewayId}
+      requestedTabId={requestedTabId}
+    />
   );
 }
 

--- a/apps/mesh/src/web/components/gateway/item-selector.tsx
+++ b/apps/mesh/src/web/components/gateway/item-selector.tsx
@@ -1,0 +1,454 @@
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ArrowLeft } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { memo, useDeferredValue, useRef, useState } from "react";
+import { useConnections } from "@/web/hooks/collections/use-connection";
+import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
+
+/**
+ * Generic item that can be displayed in the selector
+ */
+export interface SelectableItem {
+  id: string; // Unique identifier (e.g., tool name, resource URI, prompt name)
+  name: string; // Display name
+  description?: string; // Optional description
+}
+
+/**
+ * Connection with items that can be selected
+ */
+export interface ConnectionWithItems {
+  id: string;
+  title: string;
+  description?: string | null;
+  icon?: string | null;
+  items: SelectableItem[];
+}
+
+export interface ItemSetSelectorProps {
+  /** Current selection: connectionId -> array of selected item ids */
+  itemSet: Record<string, string[]>;
+  /** Callback when selection changes */
+  onItemSetChange: (itemSet: Record<string, string[]>) => void;
+  /** Function to get items from a connection */
+  getItems: (
+    connection: ReturnType<typeof useConnections>[number],
+  ) => SelectableItem[];
+  /** Label for items (e.g., "tools", "resources", "prompts") */
+  itemLabel: string;
+  /** Placeholder for empty state */
+  emptyItemsMessage?: string;
+  /** Extra content to render in the items panel */
+  extraContent?: React.ReactNode;
+}
+
+interface ConnectionItemProps {
+  connection: {
+    id: string;
+    title: string;
+    description?: string | null;
+    icon?: string | null;
+  };
+  isSelected: boolean;
+  hasItemsEnabled: boolean;
+  activeItemsCount: number;
+  totalItemsCount: number;
+  onSelect: () => void;
+  onToggle: () => void;
+}
+
+const ConnectionItem = memo(function ConnectionItem({
+  connection,
+  isSelected,
+  hasItemsEnabled,
+  activeItemsCount,
+  totalItemsCount,
+  onSelect,
+  onToggle,
+}: ConnectionItemProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 p-2 rounded-lg transition-colors will-change-auto",
+        isSelected ? "bg-accent/50" : "hover:bg-muted/50",
+      )}
+    >
+      <div
+        className="flex items-center gap-3 flex-1 min-w-0 cursor-pointer"
+        onClick={onSelect}
+      >
+        <IntegrationIcon
+          icon={connection.icon}
+          name={connection.title}
+          size="xs"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {connection.title}
+          </p>
+        </div>
+      </div>
+      {totalItemsCount > 0 && (
+        <>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {activeItemsCount}/{totalItemsCount}
+          </span>
+          <Checkbox
+            checked={hasItemsEnabled}
+            onCheckedChange={onToggle}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </>
+      )}
+    </div>
+  );
+});
+
+interface SelectableItemRowProps {
+  connectionId: string;
+  item: SelectableItem;
+  isSelected: boolean;
+  onToggle: () => void;
+}
+
+const SelectableItemRow = memo(function SelectableItemRow({
+  connectionId,
+  item,
+  isSelected,
+  onToggle,
+}: SelectableItemRowProps) {
+  return (
+    <label
+      className="flex items-center gap-3 p-3 rounded-lg hover:bg-muted/50 cursor-pointer group will-change-auto"
+      htmlFor={`item-${connectionId}-${item.id}`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span
+            className={cn(
+              "text-sm font-medium",
+              isSelected ? "text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {item.name}
+          </span>
+        </div>
+        {item.description && (
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {item.description}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center shrink-0">
+        <Checkbox
+          id={`item-${connectionId}-${item.id}`}
+          checked={isSelected}
+          onCheckedChange={onToggle}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </div>
+    </label>
+  );
+});
+
+type FilterMode = "all" | "selected" | "unselected";
+
+export function ItemSetSelector({
+  itemSet,
+  onItemSetChange,
+  getItems,
+  itemLabel,
+  emptyItemsMessage,
+  extraContent,
+}: ItemSetSelectorProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const [filterMode, setFilterMode] = useState<FilterMode>("all");
+  const [showMobileDetail, setShowMobileDetail] = useState(false);
+  const initialOrder = useRef<Set<string>>(new Set(Object.keys(itemSet)));
+
+  const connections = useConnections({
+    searchTerm: deferredSearchQuery.trim() || undefined,
+  });
+
+  const initialOrderSet = initialOrder.current;
+
+  // selected first
+  const selected = [...initialOrderSet.values()]
+    .map((id) => connections.find((c) => c.id === id))
+    .filter((c) => c !== undefined);
+
+  // then not selected
+  const notSelected = connections.filter((c) => !initialOrderSet.has(c.id));
+
+  const sortedConnections = [...selected, ...notSelected];
+
+  // Check if connection has any items enabled
+  const isConnectionSelected = (connectionId: string): boolean => {
+    const enabledItems = itemSet[connectionId];
+    return enabledItems !== undefined && enabledItems.length > 0;
+  };
+
+  // Apply filter
+  const filteredConnections = sortedConnections.filter((connection) => {
+    if (filterMode === "all") return true;
+    const hasItems = isConnectionSelected(connection.id);
+    if (filterMode === "selected") return hasItems;
+    if (filterMode === "unselected") return !hasItems;
+    return true;
+  });
+
+  const [selectedConnectionId, setSelectedConnectionId] = useState<
+    string | null
+  >(sortedConnections[0]?.id ?? null);
+
+  // Get selected connection
+  const selectedConnection = selectedConnectionId
+    ? (sortedConnections.find((c) => c.id === selectedConnectionId) ?? null)
+    : null;
+
+  // Get items for selected connection
+  const connectionItems = selectedConnection
+    ? getItems(selectedConnection)
+    : [];
+
+  // Check if specific item is enabled
+  const isItemSelected = (connectionId: string, itemId: string): boolean => {
+    return itemSet[connectionId]?.includes(itemId) ?? false;
+  };
+
+  // Toggle a single item
+  const toggleItem = (connectionId: string, itemId: string) => {
+    const currentItems = itemSet[connectionId] ?? [];
+    const isSelected = currentItems.includes(itemId);
+
+    const newItemSet = { ...itemSet };
+
+    if (isSelected) {
+      // Remove item
+      const updatedItems = currentItems.filter((t) => t !== itemId);
+      if (updatedItems.length === 0) {
+        // Remove connection entry if no items left
+        delete newItemSet[connectionId];
+      } else {
+        newItemSet[connectionId] = updatedItems;
+      }
+    } else {
+      // Add item
+      newItemSet[connectionId] = [...currentItems, itemId];
+    }
+
+    onItemSetChange(newItemSet);
+  };
+
+  // Toggle all items for a connection
+  const toggleConnection = (connectionId: string) => {
+    const connection = sortedConnections.find((c) => c.id === connectionId);
+    if (!connection) return;
+
+    const items = getItems(connection);
+    if (items.length === 0) return;
+
+    const currentItems = itemSet[connectionId] ?? [];
+    const allItemIds = items.map((t) => t.id);
+    const allSelected =
+      currentItems.length > 0 &&
+      allItemIds.every((id) => currentItems.includes(id));
+
+    const newItemSet = { ...itemSet };
+
+    if (allSelected) {
+      // Deselect all items
+      delete newItemSet[connectionId];
+    } else {
+      // Select all items
+      newItemSet[connectionId] = allItemIds;
+      // Set this connection as the selected connection
+      setSelectedConnectionId(connectionId);
+    }
+
+    onItemSetChange(newItemSet);
+  };
+
+  // Handle connection selection (mobile opens detail view)
+  const handleConnectionSelect = (connectionId: string) => {
+    setSelectedConnectionId(connectionId);
+    setShowMobileDetail(true);
+  };
+
+  // Handle back button (mobile only)
+  const handleMobileBack = () => {
+    setShowMobileDetail(false);
+  };
+
+  return (
+    <div className="flex h-full">
+      {/* Left Column - Connections List (hidden on mobile when detail view is shown) */}
+      <div
+        className={cn(
+          "w-full md:w-80 border-r border-border flex flex-col",
+          showMobileDetail && "hidden md:flex",
+        )}
+      >
+        {/* Search Input */}
+        <CollectionSearch
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="Search MCP Servers..."
+        />
+
+        {/* Filter Buttons */}
+        <div className="flex gap-1 p-2 border-b border-border">
+          <button
+            onClick={() => setFilterMode("all")}
+            className={cn(
+              "flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors border cursor-pointer",
+              filterMode === "all"
+                ? "bg-muted border-border"
+                : "border-border opacity-75 hover:opacity-100",
+            )}
+          >
+            All
+          </button>
+          <button
+            onClick={() => setFilterMode("selected")}
+            className={cn(
+              "flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors border cursor-pointer",
+              filterMode === "selected"
+                ? "bg-muted border-border"
+                : "border-border opacity-75 hover:opacity-100",
+            )}
+          >
+            Selected
+          </button>
+          <button
+            onClick={() => setFilterMode("unselected")}
+            className={cn(
+              "flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors border cursor-pointer",
+              filterMode === "unselected"
+                ? "bg-muted border-border"
+                : "border-border opacity-75 hover:opacity-100",
+            )}
+          >
+            Unselected
+          </button>
+        </div>
+
+        {/* Connections List */}
+        <div className="flex-1 overflow-auto">
+          {filteredConnections.length === 0 ? (
+            <div className="p-4 text-sm text-muted-foreground text-center">
+              {searchQuery
+                ? "No connections found"
+                : filterMode === "selected"
+                  ? "No servers selected"
+                  : filterMode === "unselected"
+                    ? "No unselected servers"
+                    : "No connections available"}
+            </div>
+          ) : (
+            <div className="p-2 space-y-1">
+              {filteredConnections.map((connection) => {
+                const items = getItems(connection);
+                const totalItems = items.length;
+                const activeItems = itemSet[connection.id]?.length ?? 0;
+
+                return (
+                  <ConnectionItem
+                    key={connection.id}
+                    connection={connection}
+                    isSelected={selectedConnectionId === connection.id}
+                    hasItemsEnabled={isConnectionSelected(connection.id)}
+                    activeItemsCount={activeItems}
+                    totalItemsCount={totalItems}
+                    onSelect={() => handleConnectionSelect(connection.id)}
+                    onToggle={() => toggleConnection(connection.id)}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Right Column - Items List (full width on mobile when shown) */}
+      <div
+        className={cn(
+          "flex-1 flex-col",
+          showMobileDetail ? "flex" : "hidden md:flex",
+        )}
+      >
+        {selectedConnection ? (
+          <>
+            {/* Mobile Header with Back Button */}
+            <div className="md:hidden border-b border-border p-4 flex items-center gap-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleMobileBack}
+                className="h-8 w-8 p-0 shrink-0"
+              >
+                <ArrowLeft size={20} />
+              </Button>
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                <IntegrationIcon
+                  icon={selectedConnection.icon}
+                  name={selectedConnection.title}
+                  size="sm"
+                />
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-base font-medium text-foreground truncate">
+                    {selectedConnection.title}
+                  </h3>
+                  {selectedConnection.description && (
+                    <p className="text-sm text-muted-foreground truncate">
+                      {selectedConnection.description}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Extra content (e.g., pattern input for resources) */}
+            {extraContent}
+
+            {/* Items List */}
+            <div className="flex-1 overflow-auto p-4">
+              {connectionItems.length === 0 ? (
+                <div className="text-sm text-muted-foreground text-center py-8">
+                  {emptyItemsMessage ||
+                    `This connection has no ${itemLabel} available`}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {connectionItems.map((item) => (
+                    <SelectableItemRow
+                      key={item.id}
+                      connectionId={selectedConnection.id}
+                      item={item}
+                      isSelected={isItemSelected(
+                        selectedConnection.id,
+                        item.id,
+                      )}
+                      onToggle={() =>
+                        toggleItem(selectedConnection.id, item.id)
+                      }
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-sm text-muted-foreground text-center">
+              Select a connection to view its {itemLabel}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/gateway/prompt-selector.tsx
+++ b/apps/mesh/src/web/components/gateway/prompt-selector.tsx
@@ -1,0 +1,43 @@
+import { ItemSetSelector, type SelectableItem } from "./item-selector";
+import type { useConnections } from "@/web/hooks/collections/use-connection";
+
+export interface PromptSetSelectorProps {
+  /** Current selection: connectionId -> array of selected prompt names */
+  promptSet: Record<string, string[]>;
+  /** Callback when selection changes */
+  onPromptSetChange: (promptSet: Record<string, string[]>) => void;
+  /** Prompts per connection: connectionId -> array of prompts */
+  connectionPrompts: Map<string, Array<{ name: string; description?: string }>>;
+}
+
+/**
+ * PromptSetSelector - Selector for prompts in gateway configuration
+ *
+ * Reuses the ItemSetSelector pattern for consistent UX with tools.
+ */
+export function PromptSetSelector({
+  promptSet,
+  onPromptSetChange,
+  connectionPrompts,
+}: PromptSetSelectorProps) {
+  const getPrompts = (
+    connection: ReturnType<typeof useConnections>[number],
+  ): SelectableItem[] => {
+    const prompts = connectionPrompts.get(connection.id) ?? [];
+    return prompts.map((p) => ({
+      id: p.name,
+      name: p.name,
+      description: p.description,
+    }));
+  };
+
+  return (
+    <ItemSetSelector
+      itemSet={promptSet}
+      onItemSetChange={onPromptSetChange}
+      getItems={getPrompts}
+      itemLabel="prompts"
+      emptyItemsMessage="This connection has no prompts available"
+    />
+  );
+}

--- a/apps/mesh/src/web/components/gateway/resource-selector.tsx
+++ b/apps/mesh/src/web/components/gateway/resource-selector.tsx
@@ -1,0 +1,191 @@
+import { ItemSetSelector, type SelectableItem } from "./item-selector";
+import type { useConnections } from "@/web/hooks/collections/use-connection";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Plus, X } from "@untitledui/icons";
+import { useState } from "react";
+
+export interface ResourceSetSelectorProps {
+  /** Current selection: connectionId -> array of selected resource URIs or patterns */
+  resourceSet: Record<string, string[]>;
+  /** Callback when selection changes */
+  onResourceSetChange: (resourceSet: Record<string, string[]>) => void;
+  /** Resources per connection: connectionId -> array of resources */
+  connectionResources: Map<
+    string,
+    Array<{ uri: string; name?: string; description?: string }>
+  >;
+}
+
+/**
+ * Check if a string is a pattern (contains wildcards)
+ */
+function isPattern(value: string): boolean {
+  return value.includes("*");
+}
+
+/**
+ * Pattern input component for adding resource URI patterns
+ */
+function PatternInput({
+  patterns,
+  onAddPattern,
+  onRemovePattern,
+}: {
+  patterns: string[];
+  onAddPattern: (pattern: string) => void;
+  onRemovePattern: (pattern: string) => void;
+}) {
+  const [inputValue, setInputValue] = useState("");
+
+  const handleAddPattern = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed && !patterns.includes(trimmed)) {
+      onAddPattern(trimmed);
+      setInputValue("");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddPattern();
+    }
+  };
+
+  // Filter to only show patterns (not exact URIs)
+  const displayPatterns = patterns.filter(isPattern);
+
+  return (
+    <div className="border-b border-border p-4 space-y-3">
+      <div className="text-xs text-muted-foreground">
+        Add URI patterns to match multiple resources. Use <code>*</code> for
+        single segment and <code>**</code> for multiple segments.
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="e.g., file:///**/*.ts or db://users/*"
+          className="flex-1 text-sm"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAddPattern}
+          disabled={!inputValue.trim()}
+        >
+          <Plus size={16} />
+        </Button>
+      </div>
+      {displayPatterns.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {displayPatterns.map((pattern) => (
+            <div
+              key={pattern}
+              className="flex items-center gap-1 px-2 py-1 bg-muted rounded-md text-xs"
+            >
+              <code className="text-foreground">{pattern}</code>
+              <button
+                type="button"
+                onClick={() => onRemovePattern(pattern)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * ResourceSetSelector - Selector for resources in gateway configuration
+ *
+ * Supports both individual resource selection (via checkboxes) and
+ * pattern-based selection (via URI patterns with wildcards).
+ */
+export function ResourceSetSelector({
+  resourceSet,
+  onResourceSetChange,
+  connectionResources,
+}: ResourceSetSelectorProps) {
+  const [selectedConnectionId, _setSelectedConnectionId] = useState<
+    string | null
+  >(null);
+
+  const getResources = (
+    connection: ReturnType<typeof useConnections>[number],
+  ): SelectableItem[] => {
+    const resources = connectionResources.get(connection.id) ?? [];
+    return resources.map((r) => ({
+      id: r.uri,
+      name: r.name || r.uri,
+      description: r.description || r.uri,
+    }));
+  };
+
+  const handleAddPattern = (connectionId: string, pattern: string) => {
+    const currentItems = resourceSet[connectionId] ?? [];
+    if (!currentItems.includes(pattern)) {
+      onResourceSetChange({
+        ...resourceSet,
+        [connectionId]: [...currentItems, pattern],
+      });
+    }
+  };
+
+  const handleRemovePattern = (connectionId: string, pattern: string) => {
+    const currentItems = resourceSet[connectionId] ?? [];
+    const updated = currentItems.filter((item) => item !== pattern);
+    if (updated.length === 0) {
+      const newSet = { ...resourceSet };
+      delete newSet[connectionId];
+      onResourceSetChange(newSet);
+    } else {
+      onResourceSetChange({
+        ...resourceSet,
+        [connectionId]: updated,
+      });
+    }
+  };
+
+  // Track which connection is selected to show pattern input
+  const handleItemSetChange = (newResourceSet: Record<string, string[]>) => {
+    onResourceSetChange(newResourceSet);
+  };
+
+  // Get patterns for the selected connection
+  const selectedPatterns = selectedConnectionId
+    ? (resourceSet[selectedConnectionId] ?? [])
+    : [];
+
+  const extraContent = selectedConnectionId ? (
+    <PatternInput
+      patterns={selectedPatterns}
+      onAddPattern={(pattern) =>
+        handleAddPattern(selectedConnectionId, pattern)
+      }
+      onRemovePattern={(pattern) =>
+        handleRemovePattern(selectedConnectionId, pattern)
+      }
+    />
+  ) : null;
+
+  return (
+    <div className="h-full">
+      <ItemSetSelector
+        itemSet={resourceSet}
+        onItemSetChange={handleItemSetChange}
+        getItems={getResources}
+        itemLabel="resources"
+        emptyItemsMessage="This connection has no resources available"
+        extraContent={extraContent}
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/hooks/use-connection-prompts.ts
+++ b/apps/mesh/src/web/hooks/use-connection-prompts.ts
@@ -1,0 +1,131 @@
+import { KEYS } from "@/web/lib/query-keys";
+import { useQueries } from "@tanstack/react-query";
+
+/**
+ * Prompt definition from MCP protocol
+ */
+export interface McpPrompt {
+  name: string;
+  description?: string;
+  arguments?: Array<{
+    name: string;
+    description?: string;
+    required?: boolean;
+  }>;
+}
+
+/**
+ * JSON-RPC 2.0 response
+ */
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Fetch prompts from a single connection
+ */
+async function fetchPromptsForConnection(
+  connectionId: string,
+): Promise<McpPrompt[]> {
+  const proxyUrl = `/mcp/${connectionId}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  try {
+    // Initialize MCP connection
+    const initResponse = await fetch(proxyUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: {
+            name: "mesh-prompts",
+            version: "1.0.0",
+          },
+        },
+      }),
+    });
+
+    if (!initResponse.ok) {
+      return [];
+    }
+
+    const initData: JsonRpcResponse = await initResponse.json();
+    if (initData.error) {
+      return [];
+    }
+
+    // List prompts
+    const promptsResponse = await fetch(proxyUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "prompts/list",
+        params: {},
+      }),
+    });
+
+    if (!promptsResponse.ok) {
+      return [];
+    }
+
+    const promptsData: JsonRpcResponse<{ prompts?: McpPrompt[] }> =
+      await promptsResponse.json();
+
+    if (promptsData.error) {
+      return [];
+    }
+
+    return promptsData.result?.prompts || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Hook to fetch prompts from multiple connections in parallel
+ * Returns a Map of connectionId -> prompts array
+ */
+export function useConnectionsPrompts(connectionIds: string[]) {
+  const queries = useQueries({
+    queries: connectionIds.map((connectionId) => ({
+      queryKey: KEYS.connectionPrompts(connectionId),
+      queryFn: () => fetchPromptsForConnection(connectionId),
+      staleTime: 60000,
+      retry: false,
+    })),
+  });
+
+  // Combine results into a Map
+  const promptsMap = new Map<
+    string,
+    Array<{ name: string; description?: string }>
+  >();
+  const isLoading = queries.some((q) => q.isLoading);
+
+  connectionIds.forEach((connectionId, index) => {
+    const query = queries[index];
+    if (query?.data) {
+      promptsMap.set(
+        connectionId,
+        query.data.map((p) => ({ name: p.name, description: p.description })),
+      );
+    } else {
+      promptsMap.set(connectionId, []);
+    }
+  });
+
+  return { promptsMap, isLoading };
+}

--- a/apps/mesh/src/web/hooks/use-connection-resources.ts
+++ b/apps/mesh/src/web/hooks/use-connection-resources.ts
@@ -1,0 +1,132 @@
+import { KEYS } from "@/web/lib/query-keys";
+import { useQueries } from "@tanstack/react-query";
+
+/**
+ * Resource definition from MCP protocol
+ */
+export interface McpResource {
+  uri: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+}
+
+/**
+ * JSON-RPC 2.0 response
+ */
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Fetch resources from a single connection
+ */
+async function fetchResourcesForConnection(
+  connectionId: string,
+): Promise<McpResource[]> {
+  const proxyUrl = `/mcp/${connectionId}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  try {
+    // Initialize MCP connection
+    const initResponse = await fetch(proxyUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: {
+            name: "mesh-resources",
+            version: "1.0.0",
+          },
+        },
+      }),
+    });
+
+    if (!initResponse.ok) {
+      return [];
+    }
+
+    const initData: JsonRpcResponse = await initResponse.json();
+    if (initData.error) {
+      return [];
+    }
+
+    // List resources
+    const resourcesResponse = await fetch(proxyUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/list",
+        params: {},
+      }),
+    });
+
+    if (!resourcesResponse.ok) {
+      return [];
+    }
+
+    const resourcesData: JsonRpcResponse<{ resources?: McpResource[] }> =
+      await resourcesResponse.json();
+
+    if (resourcesData.error) {
+      return [];
+    }
+
+    return resourcesData.result?.resources || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Hook to fetch resources from multiple connections in parallel
+ * Returns a Map of connectionId -> resources array
+ */
+export function useConnectionsResources(connectionIds: string[]) {
+  const queries = useQueries({
+    queries: connectionIds.map((connectionId) => ({
+      queryKey: KEYS.connectionResources(connectionId),
+      queryFn: () => fetchResourcesForConnection(connectionId),
+      staleTime: 60000,
+      retry: false,
+    })),
+  });
+
+  // Combine results into a Map
+  const resourcesMap = new Map<
+    string,
+    Array<{ uri: string; name?: string; description?: string }>
+  >();
+  const isLoading = queries.some((q) => q.isLoading);
+
+  connectionIds.forEach((connectionId, index) => {
+    const query = queries[index];
+    if (query?.data) {
+      resourcesMap.set(
+        connectionId,
+        query.data.map((r) => ({
+          uri: r.uri,
+          name: r.name,
+          description: r.description,
+        })),
+      );
+    } else {
+      resourcesMap.set(connectionId, []);
+    }
+  });
+
+  return { resourcesMap, isLoading };
+}

--- a/apps/mesh/src/web/hooks/use-gateway-prompts.ts
+++ b/apps/mesh/src/web/hooks/use-gateway-prompts.ts
@@ -1,0 +1,103 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { KEYS } from "../lib/query-keys";
+
+export interface GatewayPrompt {
+  name: string;
+  description?: string;
+  arguments?: Array<{
+    name: string;
+    description?: string;
+    required?: boolean;
+  }>;
+}
+
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  id: number;
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Fetch prompts from a gateway via MCP protocol
+ */
+async function fetchGatewayPrompts(
+  gatewayId: string,
+): Promise<GatewayPrompt[]> {
+  const gatewayUrl = `/mcp/gateway/${gatewayId}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  try {
+    // Initialize MCP connection
+    const initResponse = await fetch(gatewayUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: {
+            name: "mesh-chat",
+            version: "1.0.0",
+          },
+        },
+      }),
+    });
+
+    if (!initResponse.ok) {
+      return [];
+    }
+
+    const initData: JsonRpcResponse = await initResponse.json();
+    if (initData.error) {
+      return [];
+    }
+
+    // List prompts
+    const promptsResponse = await fetch(gatewayUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "prompts/list",
+        params: {},
+      }),
+    });
+
+    if (!promptsResponse.ok) {
+      return [];
+    }
+
+    const promptsData: JsonRpcResponse<{ prompts?: GatewayPrompt[] }> =
+      await promptsResponse.json();
+
+    if (promptsData.error) {
+      return [];
+    }
+
+    return promptsData.result?.prompts || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Suspense hook to fetch prompts from a gateway via MCP protocol.
+ * Must be used within a Suspense boundary.
+ * @param gatewayId - The gateway ID (required)
+ */
+export function useGatewayPrompts(gatewayId: string) {
+  return useSuspenseQuery({
+    queryKey: KEYS.gatewayPrompts(gatewayId),
+    queryFn: () => fetchGatewayPrompts(gatewayId),
+    staleTime: 60000, // 1 minute
+    retry: false,
+  });
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -179,6 +179,11 @@ const gatewayDetailRoute = createRoute({
   component: lazyRouteComponent(
     () => import("./routes/orgs/gateway-detail.tsx"),
   ),
+  validateSearch: z.lazy(() =>
+    z.object({
+      tab: z.string().optional(),
+    }),
+  ),
 });
 
 const oauthCallbackRoute = createRoute({

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -106,4 +106,16 @@ export const KEYS = {
     limit?: number;
     offset?: number;
   }) => ["monitoring", "logs", filters] as const,
+
+  // Gateway prompts (for ice breakers in chat)
+  gatewayPrompts: (gatewayId: string) =>
+    ["gateway", gatewayId, "prompts"] as const,
+
+  // Connection prompts (for gateway settings)
+  connectionPrompts: (connectionId: string) =>
+    ["connection", connectionId, "prompts"] as const,
+
+  // Connection resources (for gateway settings)
+  connectionResources: (connectionId: string) =>
+    ["connection", connectionId, "resources"] as const,
 } as const;


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds icebreakers to chat using gateway prompts and adds per-connection prompt/resource selection to gateways with wildcard resource patterns and inclusion/exclusion filtering.

- **New Features**
  - Icebreakers in chat: fetch gateway prompts and let users start a conversation with one click.
  - Gateway selection: choose prompts and resources per connection; resources support URI patterns with * and **.
  - Consistent filtering: inclusion requires explicit selection; exclusion removes only selected items.
  - UI: new tabs (Settings, Tools, Resources, Prompts) and selectors to manage items; pattern input for resources.
  - Storage/API: persist selected_resources and selected_prompts; tools updated to create/get/list/update with new fields.

- **Migration**
  - Run migration 014-gateway-resources-prompts to add selected_resources and selected_prompts to gateway_connections.
  - Note: in inclusion mode, unselected prompts/resources are not exposed.

<sup>Written for commit d3e8ee22187b7ea05ca11a986fe011887210aa47. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



