### PR TITLE
Add Binding menu item and Files menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ deploy/test*
 
 # Data Test files
 apps/benchmark/data
+# Local storage
+apps/mesh/storage

--- a/apps/mesh/FILE_STORAGE_BINDING_PLAN.md
+++ b/apps/mesh/FILE_STORAGE_BINDING_PLAN.md
@@ -1,0 +1,1343 @@
+# File Storage Binding Plan
+
+> A comprehensive plan for implementing file storage capabilities in Deco Mesh, including the `FILE_STORAGE_BINDING`, `mcp-local-fs` default MCP, and drag-and-drop file upload UI.
+
+## ✅ Implementation Status
+
+| Phase | Component | Status |
+|-------|-----------|--------|
+| 1.1 | FILE_STORAGE_BINDING | ✅ Implemented |
+| 1.2 | FileEntity & FolderEntity schemas | ✅ Implemented |
+| 1.3 | Collection bindings (FILES, FOLDERS) | ✅ Implemented |
+| 2.1 | LocalFileStorage class | ✅ Implemented |
+| 2.2 | File tools (READ, WRITE, DELETE, MOVE, COPY, MKDIR) | ✅ Implemented |
+| 2.3 | Collection tools (LIST, GET for files/folders) | ✅ Implemented |
+| 3.1 | MeshContext.fileStorage | ✅ Implemented |
+| 3.2 | /mcp/local-fs route | ✅ Implemented |
+| 3.3 | /api/files route for file serving | ✅ Implemented |
+| 3.4 | Well-known MCP definition (LOCAL_FS) | ✅ Implemented |
+| 4.1 | useFileStorageConnections hook | ✅ Implemented |
+| 4.2 | FileDropZone component | ✅ Implemented |
+| 4.3 | FileBrowser component | ✅ Implemented |
+| 4.4 | FilePreview component | ✅ Implemented |
+| 4.5 | FileDetailsView / FolderDetailsView | ✅ Implemented |
+| 4.6 | Well-known views registration | ✅ Implemented |
+| 5 | Monaco editor integration | 🔜 Phase 2 |
+| 5 | File editing via tools | 🔜 Phase 2 |
+
+### Files Created/Modified
+
+**New Files:**
+- `packages/bindings/src/well-known/file-storage.ts` - FILE_STORAGE_BINDING definition
+- `apps/mesh/src/file-storage/types.ts` - File storage types
+- `apps/mesh/src/file-storage/local-fs.ts` - LocalFileStorage implementation
+- `apps/mesh/src/file-storage/index.ts` - Module exports
+- `apps/mesh/src/tools/files/*.ts` - File tools (read, write, delete, move, copy, mkdir, list)
+- `apps/mesh/src/api/routes/local-fs.ts` - MCP route for local-fs
+- `apps/mesh/src/api/routes/files.ts` - File serving route
+- `apps/mesh/src/web/hooks/use-file-storage.ts` - React hooks
+- `apps/mesh/src/web/components/file-drop-zone.tsx` - Drop zone component
+- `apps/mesh/src/web/components/files/*.tsx` - File browser/preview
+- `apps/mesh/src/web/components/details/file/index.tsx` - Detail views
+
+**Modified Files:**
+- `packages/bindings/package.json` - Added file-storage export
+- `apps/mesh/src/core/mesh-context.ts` - Added fileStorage property
+- `apps/mesh/src/core/context-factory.ts` - File storage initialization
+- `apps/mesh/src/core/well-known-mcp.ts` - Added LOCAL_FS definition
+- `apps/mesh/src/api/app.ts` - Mounted new routes
+- `apps/mesh/src/web/hooks/use-binding.ts` - Added FILE_STORAGE to bindings
+- `apps/mesh/src/web/routes/orgs/collection-detail.tsx` - Registered file/folder views
+
+---
+
+## Overview
+
+This plan introduces a first-class file storage system for Deco Mesh that allows:
+
+1. **Drag-and-drop file uploads** - Drop files anywhere in the Mesh UI when a storage provider is available
+2. **File/Folder collections** - Browse files and folders as standard collections with custom UI
+3. **mcp-local-fs** - A default MCP that stores files in a local `storage/` directory
+4. **Extensibility** - Any MCP can implement the `FILE_STORAGE_BINDING` to provide storage (S3, GCS, R2, etc.)
+
+---
+
+## Architecture
+
+### Binding-First Design
+
+Following the existing patterns in `@decocms/bindings`, we define:
+
+```
+packages/bindings/src/well-known/
+├── file-storage.ts      # FILE_STORAGE_BINDING definition
+└── index.ts             # Export file-storage binding
+
+apps/mesh/src/
+├── file-storage/        # Core file storage logic
+│   ├── index.ts         # Storage manager
+│   ├── local-fs.ts      # Local filesystem implementation
+│   └── types.ts         # Shared types
+├── tools/
+│   └── files/           # MCP tools for file operations
+│       ├── index.ts
+│       ├── schema.ts
+│       ├── read.ts
+│       ├── write.ts
+│       ├── delete.ts
+│       └── list.ts
+└── web/
+    ├── components/
+    │   ├── file-drop-zone.tsx     # Global drop zone overlay
+    │   ├── files/
+    │   │   ├── file-browser.tsx   # Folder view component
+    │   │   ├── file-editor.tsx    # Monaco editor for files
+    │   │   └── file-preview.tsx   # Preview component
+    │   └── details/
+    │       └── file/
+    │           └── index.tsx      # Well-known file detail view
+    └── hooks/
+        └── use-file-storage.ts    # React hook for file operations
+```
+
+---
+
+## Phase 1: FILE_STORAGE_BINDING
+
+### 1.1 Define the Binding (`packages/bindings/src/well-known/file-storage.ts`)
+
+```typescript
+import { z } from "zod";
+import type { ToolBinder } from "../core/binder";
+import { bindingClient } from "../core/binder";
+
+// ============================================================================
+// Entity Schemas
+// ============================================================================
+
+/**
+ * File metadata schema
+ */
+export const FileEntitySchema = z.object({
+  /** Unique file path (serves as ID) */
+  id: z.string().describe("Unique file path/identifier"),
+  
+  /** Display name */
+  title: z.string().describe("File name"),
+  
+  /** Optional description */
+  description: z.string().nullish(),
+  
+  /** File path relative to storage root */
+  path: z.string().describe("File path relative to storage root"),
+  
+  /** Parent folder path (empty string for root) */
+  parent: z.string().describe("Parent folder path"),
+  
+  /** MIME type */
+  mimeType: z.string().describe("MIME type of the file"),
+  
+  /** File size in bytes */
+  size: z.number().describe("File size in bytes"),
+  
+  /** Whether this is a directory */
+  isDirectory: z.boolean().describe("Whether this is a directory"),
+  
+  /** Created timestamp */
+  created_at: z.string().datetime(),
+  
+  /** Updated timestamp */
+  updated_at: z.string().datetime(),
+  
+  /** Optional URL for direct access (pre-signed URL or public URL) */
+  url: z.string().url().optional().describe("Direct access URL"),
+  
+  /** Optional thumbnail URL for images */
+  thumbnailUrl: z.string().url().optional(),
+});
+
+export type FileEntity = z.infer<typeof FileEntitySchema>;
+
+/**
+ * Folder entity schema (alias for directory)
+ */
+export const FolderEntitySchema = FileEntitySchema.extend({
+  isDirectory: z.literal(true),
+  /** Number of items in folder */
+  itemCount: z.number().optional().describe("Number of items in folder"),
+});
+
+export type FolderEntity = z.infer<typeof FolderEntitySchema>;
+
+// ============================================================================
+// Tool Schemas
+// ============================================================================
+
+/**
+ * FILE_READ Input - Read file content
+ */
+export const FileReadInputSchema = z.object({
+  /** File path to read */
+  path: z.string().describe("File path to read"),
+  
+  /** Encoding for text files (default: utf-8) */
+  encoding: z.enum(["utf-8", "base64", "binary"]).optional().default("utf-8"),
+});
+
+export type FileReadInput = z.infer<typeof FileReadInputSchema>;
+
+export const FileReadOutputSchema = z.object({
+  /** File content (text or base64 encoded) */
+  content: z.string().describe("File content"),
+  
+  /** File metadata */
+  metadata: FileEntitySchema,
+});
+
+export type FileReadOutput = z.infer<typeof FileReadOutputSchema>;
+
+/**
+ * FILE_WRITE Input - Write/upload file
+ */
+export const FileWriteInputSchema = z.object({
+  /** File path to write */
+  path: z.string().describe("File path to write"),
+  
+  /** File content (text or base64 encoded) */
+  content: z.string().describe("File content (text or base64)"),
+  
+  /** Content encoding */
+  encoding: z.enum(["utf-8", "base64"]).optional().default("utf-8"),
+  
+  /** MIME type (auto-detected if not provided) */
+  mimeType: z.string().optional(),
+  
+  /** Whether to create parent directories if they don't exist */
+  createParents: z.boolean().optional().default(true),
+  
+  /** Whether to overwrite if file exists */
+  overwrite: z.boolean().optional().default(true),
+});
+
+export type FileWriteInput = z.infer<typeof FileWriteInputSchema>;
+
+export const FileWriteOutputSchema = z.object({
+  /** Written file metadata */
+  file: FileEntitySchema,
+});
+
+export type FileWriteOutput = z.infer<typeof FileWriteOutputSchema>;
+
+/**
+ * FILE_DELETE Input
+ */
+export const FileDeleteInputSchema = z.object({
+  /** Path to delete */
+  path: z.string().describe("Path to delete"),
+  
+  /** Whether to recursively delete directories */
+  recursive: z.boolean().optional().default(false),
+});
+
+export type FileDeleteInput = z.infer<typeof FileDeleteInputSchema>;
+
+export const FileDeleteOutputSchema = z.object({
+  success: z.boolean(),
+  path: z.string(),
+  deletedCount: z.number().optional(),
+});
+
+export type FileDeleteOutput = z.infer<typeof FileDeleteOutputSchema>;
+
+/**
+ * FILE_MOVE Input - Move/rename file or folder
+ */
+export const FileMoveInputSchema = z.object({
+  /** Source path */
+  from: z.string().describe("Source path"),
+  
+  /** Destination path */
+  to: z.string().describe("Destination path"),
+  
+  /** Whether to overwrite if destination exists */
+  overwrite: z.boolean().optional().default(false),
+});
+
+export type FileMoveInput = z.infer<typeof FileMoveInputSchema>;
+
+export const FileMoveOutputSchema = z.object({
+  /** Moved file metadata */
+  file: FileEntitySchema,
+});
+
+export type FileMoveOutput = z.infer<typeof FileMoveOutputSchema>;
+
+/**
+ * FILE_COPY Input
+ */
+export const FileCopyInputSchema = z.object({
+  /** Source path */
+  from: z.string().describe("Source path"),
+  
+  /** Destination path */
+  to: z.string().describe("Destination path"),
+  
+  /** Whether to overwrite if destination exists */
+  overwrite: z.boolean().optional().default(false),
+});
+
+export type FileCopyInput = z.infer<typeof FileCopyInputSchema>;
+
+export const FileCopyOutputSchema = z.object({
+  /** Copied file metadata */
+  file: FileEntitySchema,
+});
+
+export type FileCopyOutput = z.infer<typeof FileCopyOutputSchema>;
+
+/**
+ * FILE_MKDIR Input - Create directory
+ */
+export const FileMkdirInputSchema = z.object({
+  /** Directory path to create */
+  path: z.string().describe("Directory path to create"),
+  
+  /** Whether to create parent directories */
+  recursive: z.boolean().optional().default(true),
+});
+
+export type FileMkdirInput = z.infer<typeof FileMkdirInputSchema>;
+
+export const FileMkdirOutputSchema = z.object({
+  /** Created directory metadata */
+  folder: FolderEntitySchema,
+});
+
+export type FileMkdirOutput = z.infer<typeof FileMkdirOutputSchema>;
+
+/**
+ * FILE_UPLOAD_URL Input - Get a pre-signed URL for direct upload
+ * (Optional - for backends that support direct upload)
+ */
+export const FileUploadUrlInputSchema = z.object({
+  /** Target path for the upload */
+  path: z.string().describe("Target path for upload"),
+  
+  /** MIME type of file to upload */
+  mimeType: z.string().describe("MIME type"),
+  
+  /** File size in bytes (for validation) */
+  size: z.number().optional(),
+  
+  /** URL expiration in seconds (default: 3600) */
+  expiresIn: z.number().optional().default(3600),
+});
+
+export type FileUploadUrlInput = z.infer<typeof FileUploadUrlInputSchema>;
+
+export const FileUploadUrlOutputSchema = z.object({
+  /** Pre-signed upload URL */
+  uploadUrl: z.string().url(),
+  
+  /** HTTP method to use (PUT or POST) */
+  method: z.enum(["PUT", "POST"]),
+  
+  /** Headers to include with the upload request */
+  headers: z.record(z.string()).optional(),
+  
+  /** Form fields for multipart uploads */
+  fields: z.record(z.string()).optional(),
+  
+  /** URL expiration timestamp */
+  expiresAt: z.string().datetime(),
+  
+  /** Final path where file will be stored */
+  path: z.string(),
+});
+
+export type FileUploadUrlOutput = z.infer<typeof FileUploadUrlOutputSchema>;
+
+// ============================================================================
+// FILE_STORAGE_BINDING Definition
+// ============================================================================
+
+/**
+ * File Storage Binding
+ * 
+ * Core tools for file operations. All storage providers must implement these.
+ * 
+ * Required:
+ * - FILE_READ: Read file content
+ * - FILE_WRITE: Write/upload file content
+ * - FILE_DELETE: Delete file or directory
+ * 
+ * Optional:
+ * - FILE_MOVE: Move/rename files
+ * - FILE_COPY: Copy files
+ * - FILE_MKDIR: Create directories
+ * - FILE_UPLOAD_URL: Get pre-signed upload URL (for direct uploads)
+ */
+export const FILE_STORAGE_BINDING = [
+  {
+    name: "FILE_READ" as const,
+    inputSchema: FileReadInputSchema,
+    outputSchema: FileReadOutputSchema,
+  },
+  {
+    name: "FILE_WRITE" as const,
+    inputSchema: FileWriteInputSchema,
+    outputSchema: FileWriteOutputSchema,
+  },
+  {
+    name: "FILE_DELETE" as const,
+    inputSchema: FileDeleteInputSchema,
+    outputSchema: FileDeleteOutputSchema,
+  },
+  {
+    name: "FILE_MOVE" as const,
+    inputSchema: FileMoveInputSchema,
+    outputSchema: FileMoveOutputSchema,
+    opt: true,
+  },
+  {
+    name: "FILE_COPY" as const,
+    inputSchema: FileCopyInputSchema,
+    outputSchema: FileCopyOutputSchema,
+    opt: true,
+  },
+  {
+    name: "FILE_MKDIR" as const,
+    inputSchema: FileMkdirInputSchema,
+    outputSchema: FileMkdirOutputSchema,
+    opt: true,
+  },
+  {
+    name: "FILE_UPLOAD_URL" as const,
+    inputSchema: FileUploadUrlInputSchema,
+    outputSchema: FileUploadUrlOutputSchema,
+    opt: true,
+  },
+] satisfies ToolBinder[];
+
+/**
+ * File Storage Binding Client
+ */
+export const FileStorageBinding = bindingClient(FILE_STORAGE_BINDING);
+
+export type FileStorageBindingClient = ReturnType<
+  typeof FileStorageBinding.forConnection
+>;
+```
+
+### 1.2 Files Collection Binding
+
+Since files should also be browseable as a collection, we create collection bindings:
+
+```typescript
+import { createCollectionBindings } from "./collections";
+
+/**
+ * Files collection binding - for browsing files
+ * Uses the standard collection pattern for LIST and GET
+ */
+export const FILES_COLLECTION_BINDING = createCollectionBindings(
+  "files",
+  FileEntitySchema,
+  { readOnly: true } // Mutations go through FILE_WRITE, FILE_DELETE
+);
+
+/**
+ * Folders collection binding - for browsing folders
+ */
+export const FOLDERS_COLLECTION_BINDING = createCollectionBindings(
+  "folders",
+  FolderEntitySchema,
+  { readOnly: true }
+);
+```
+
+---
+
+## Phase 2: mcp-local-fs (Default MCP)
+
+### 2.1 Add as Well-Known MCP
+
+Update `apps/mesh/src/core/well-known-mcp.ts`:
+
+```typescript
+export const WellKnownMCPId = {
+  SELF: "self",
+  REGISTRY: "registry",
+  COMMUNITY_REGISTRY: "community-registry",
+  LOCAL_FS: "local-fs", // NEW
+};
+
+export const WellKnownOrgMCPId = {
+  // ... existing
+  LOCAL_FS: (org: string) => `${org}_${WellKnownMCPId.LOCAL_FS}`,
+};
+
+/**
+ * Get well-known connection definition for local file storage.
+ * Stores files in a local storage/ directory where mesh is running.
+ */
+export function getWellKnownLocalFsConnection(
+  baseUrl: string,
+  orgId: string,
+): ConnectionCreateData {
+  return {
+    id: WellKnownOrgMCPId.LOCAL_FS(orgId),
+    title: "Local Files",
+    description: "File storage in the local storage/ directory",
+    connection_type: "HTTP",
+    connection_url: `${baseUrl}/mcp/local-fs`,
+    icon: "folder-open", // Use icon name for built-in icons
+    app_name: "@deco/local-fs",
+    connection_token: null,
+    connection_headers: null,
+    oauth_config: null,
+    configuration_state: null,
+    configuration_scopes: null,
+    metadata: {
+      isDefault: true,
+      type: "file-storage",
+    },
+  };
+}
+```
+
+### 2.2 Local FS Implementation
+
+Create `apps/mesh/src/file-storage/local-fs.ts`:
+
+```typescript
+import { mkdir, readFile, writeFile, unlink, stat, readdir, rename, copyFile } from "node:fs/promises";
+import { join, dirname, basename, extname } from "node:path";
+import { existsSync } from "node:fs";
+import type { FileEntity, FolderEntity } from "@decocms/bindings/file-storage";
+import mime from "mime-types";
+
+export interface LocalFsConfig {
+  /** Root directory for storage (default: ./storage) */
+  rootDir: string;
+  
+  /** Base URL for generating file URLs */
+  baseUrl: string;
+}
+
+export class LocalFileStorage {
+  private rootDir: string;
+  private baseUrl: string;
+
+  constructor(config: LocalFsConfig) {
+    this.rootDir = config.rootDir;
+    this.baseUrl = config.baseUrl;
+  }
+
+  private resolvePath(path: string): string {
+    // Sanitize path to prevent directory traversal
+    const normalized = path.replace(/\.\./g, "").replace(/^\/+/, "");
+    return join(this.rootDir, normalized);
+  }
+
+  private async ensureDir(dir: string): Promise<void> {
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+  }
+
+  private async getMetadata(path: string): Promise<FileEntity> {
+    const fullPath = this.resolvePath(path);
+    const stats = await stat(fullPath);
+    const name = basename(path);
+    const parent = dirname(path) === "." ? "" : dirname(path);
+    const mimeType = stats.isDirectory()
+      ? "inode/directory"
+      : mime.lookup(name) || "application/octet-stream";
+
+    return {
+      id: path,
+      title: name,
+      description: null,
+      path,
+      parent,
+      mimeType,
+      size: stats.size,
+      isDirectory: stats.isDirectory(),
+      created_at: stats.birthtime.toISOString(),
+      updated_at: stats.mtime.toISOString(),
+      url: stats.isDirectory() ? undefined : `${this.baseUrl}/files/${encodeURIComponent(path)}`,
+    };
+  }
+
+  async read(path: string, encoding: "utf-8" | "base64" | "binary" = "utf-8") {
+    const fullPath = this.resolvePath(path);
+    const content = await readFile(fullPath);
+    
+    return {
+      content: encoding === "base64" 
+        ? content.toString("base64")
+        : content.toString("utf-8"),
+      metadata: await this.getMetadata(path),
+    };
+  }
+
+  async write(
+    path: string,
+    content: string,
+    options: {
+      encoding?: "utf-8" | "base64";
+      createParents?: boolean;
+      overwrite?: boolean;
+      mimeType?: string;
+    } = {}
+  ) {
+    const fullPath = this.resolvePath(path);
+    
+    if (options.createParents !== false) {
+      await this.ensureDir(dirname(fullPath));
+    }
+    
+    if (!options.overwrite && existsSync(fullPath)) {
+      throw new Error(`File already exists: ${path}`);
+    }
+
+    const buffer = options.encoding === "base64"
+      ? Buffer.from(content, "base64")
+      : Buffer.from(content, "utf-8");
+    
+    await writeFile(fullPath, buffer);
+    
+    return {
+      file: await this.getMetadata(path),
+    };
+  }
+
+  async delete(path: string, recursive = false) {
+    const fullPath = this.resolvePath(path);
+    const stats = await stat(fullPath);
+    
+    if (stats.isDirectory()) {
+      if (!recursive) {
+        throw new Error("Cannot delete directory without recursive flag");
+      }
+      // Use fs.rm with recursive option
+      const { rm } = await import("node:fs/promises");
+      await rm(fullPath, { recursive: true, force: true });
+    } else {
+      await unlink(fullPath);
+    }
+    
+    return { success: true, path };
+  }
+
+  async list(
+    folder: string = "",
+    options: { limit?: number; offset?: number } = {}
+  ): Promise<FileEntity[]> {
+    const fullPath = this.resolvePath(folder);
+    
+    if (!existsSync(fullPath)) {
+      return [];
+    }
+    
+    const entries = await readdir(fullPath, { withFileTypes: true });
+    const files: FileEntity[] = [];
+    
+    for (const entry of entries) {
+      const entryPath = folder ? `${folder}/${entry.name}` : entry.name;
+      files.push(await this.getMetadata(entryPath));
+    }
+    
+    // Apply pagination
+    const start = options.offset ?? 0;
+    const end = options.limit ? start + options.limit : undefined;
+    
+    return files.slice(start, end);
+  }
+
+  async mkdir(path: string, recursive = true) {
+    const fullPath = this.resolvePath(path);
+    await mkdir(fullPath, { recursive });
+    return { folder: await this.getMetadata(path) as FolderEntity };
+  }
+
+  async move(from: string, to: string, overwrite = false) {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+    
+    if (!overwrite && existsSync(toPath)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+    
+    await this.ensureDir(dirname(toPath));
+    await rename(fromPath, toPath);
+    
+    return { file: await this.getMetadata(to) };
+  }
+
+  async copy(from: string, to: string, overwrite = false) {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+    
+    if (!overwrite && existsSync(toPath)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+    
+    await this.ensureDir(dirname(toPath));
+    await copyFile(fromPath, toPath);
+    
+    return { file: await this.getMetadata(to) };
+  }
+}
+```
+
+### 2.3 MCP Tools
+
+Create tools in `apps/mesh/src/tools/files/`:
+
+```typescript
+// apps/mesh/src/tools/files/index.ts
+import { defineTool } from "@/core/define-tool";
+import {
+  FileReadInputSchema,
+  FileReadOutputSchema,
+  FileWriteInputSchema,
+  FileWriteOutputSchema,
+  FileDeleteInputSchema,
+  FileDeleteOutputSchema,
+  FileMoveInputSchema,
+  FileMoveOutputSchema,
+  FileCopyInputSchema,
+  FileCopyOutputSchema,
+  FileMkdirInputSchema,
+  FileMkdirOutputSchema,
+} from "@decocms/bindings/file-storage";
+import type { MeshContext } from "@/core/mesh-context";
+
+export function createFileTools(ctx: MeshContext) {
+  const storage = ctx.fileStorage; // Local FS instance
+
+  return [
+    defineTool({
+      name: "FILE_READ",
+      description: "Read a file's content from storage",
+      inputSchema: FileReadInputSchema,
+      outputSchema: FileReadOutputSchema,
+      handler: async (input) => storage.read(input.path, input.encoding),
+    }),
+
+    defineTool({
+      name: "FILE_WRITE",
+      description: "Write content to a file in storage",
+      inputSchema: FileWriteInputSchema,
+      outputSchema: FileWriteOutputSchema,
+      handler: async (input) => storage.write(input.path, input.content, {
+        encoding: input.encoding,
+        createParents: input.createParents,
+        overwrite: input.overwrite,
+        mimeType: input.mimeType,
+      }),
+    }),
+
+    defineTool({
+      name: "FILE_DELETE",
+      description: "Delete a file or directory from storage",
+      inputSchema: FileDeleteInputSchema,
+      outputSchema: FileDeleteOutputSchema,
+      handler: async (input) => storage.delete(input.path, input.recursive),
+    }),
+
+    defineTool({
+      name: "FILE_MOVE",
+      description: "Move or rename a file",
+      inputSchema: FileMoveInputSchema,
+      outputSchema: FileMoveOutputSchema,
+      handler: async (input) => storage.move(input.from, input.to, input.overwrite),
+    }),
+
+    defineTool({
+      name: "FILE_COPY",
+      description: "Copy a file",
+      inputSchema: FileCopyInputSchema,
+      outputSchema: FileCopyOutputSchema,
+      handler: async (input) => storage.copy(input.from, input.to, input.overwrite),
+    }),
+
+    defineTool({
+      name: "FILE_MKDIR",
+      description: "Create a directory",
+      inputSchema: FileMkdirInputSchema,
+      outputSchema: FileMkdirOutputSchema,
+      handler: async (input) => storage.mkdir(input.path, input.recursive),
+    }),
+
+    // Collection tools for browsing
+    defineTool({
+      name: "COLLECTION_FILES_LIST",
+      description: "List files in a folder",
+      inputSchema: z.object({
+        where: z.object({
+          parent: z.string().optional(),
+        }).optional(),
+        limit: z.number().optional(),
+        offset: z.number().optional(),
+      }),
+      outputSchema: z.object({
+        items: z.array(FileEntitySchema),
+        totalCount: z.number().optional(),
+      }),
+      handler: async (input) => {
+        const parent = input.where?.parent ?? "";
+        const items = await storage.list(parent, {
+          limit: input.limit,
+          offset: input.offset,
+        });
+        return { items };
+      },
+    }),
+
+    defineTool({
+      name: "COLLECTION_FILES_GET",
+      description: "Get a file by path",
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ item: FileEntitySchema.nullable() }),
+      handler: async (input) => {
+        try {
+          const metadata = await storage.getMetadata(input.id);
+          return { item: metadata };
+        } catch {
+          return { item: null };
+        }
+      },
+    }),
+
+    defineTool({
+      name: "COLLECTION_FOLDERS_LIST",
+      description: "List folders",
+      inputSchema: z.object({
+        where: z.object({
+          parent: z.string().optional(),
+        }).optional(),
+        limit: z.number().optional(),
+        offset: z.number().optional(),
+      }),
+      outputSchema: z.object({
+        items: z.array(FolderEntitySchema),
+        totalCount: z.number().optional(),
+      }),
+      handler: async (input) => {
+        const parent = input.where?.parent ?? "";
+        const all = await storage.list(parent, {
+          limit: input.limit,
+          offset: input.offset,
+        });
+        const items = all.filter((f) => f.isDirectory);
+        return { items };
+      },
+    }),
+
+    defineTool({
+      name: "COLLECTION_FOLDERS_GET",
+      description: "Get a folder by path",
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ item: FolderEntitySchema.nullable() }),
+      handler: async (input) => {
+        try {
+          const metadata = await storage.getMetadata(input.id);
+          if (!metadata.isDirectory) return { item: null };
+          return { item: metadata as FolderEntity };
+        } catch {
+          return { item: null };
+        }
+      },
+    }),
+  ];
+}
+```
+
+---
+
+## Phase 3: UI Components
+
+### 3.1 File Drop Zone (Global Overlay)
+
+Create `apps/mesh/src/web/components/file-drop-zone.tsx`:
+
+```tsx
+import { useFileStorageConnections } from "@/web/hooks/use-file-storage";
+import { useDropzone } from "react-dropzone";
+import { Upload01 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface FileDropZoneProps {
+  children: React.ReactNode;
+}
+
+export function FileDropZone({ children }: FileDropZoneProps) {
+  const { storageConnections, uploadFile, isUploading } = useFileStorageConnections();
+  const [isDragOver, setIsDragOver] = useState(false);
+  
+  // Only show drop zone if we have at least one storage connection
+  const hasStorage = storageConnections.length > 0;
+  
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    noClick: true, // Don't open file picker on click
+    noKeyboard: true,
+    onDragEnter: () => setIsDragOver(true),
+    onDragLeave: () => setIsDragOver(false),
+    onDrop: async (acceptedFiles) => {
+      setIsDragOver(false);
+      
+      if (!hasStorage) {
+        toast.error("No file storage configured");
+        return;
+      }
+      
+      // Upload each file
+      for (const file of acceptedFiles) {
+        try {
+          await uploadFile(file);
+          toast.success(`Uploaded ${file.name}`);
+        } catch (error) {
+          toast.error(`Failed to upload ${file.name}`);
+        }
+      }
+    },
+  });
+  
+  // Only render drop zone if storage is available
+  if (!hasStorage) {
+    return <>{children}</>;
+  }
+  
+  return (
+    <div {...getRootProps()} className="relative h-full">
+      <input {...getInputProps()} />
+      
+      {/* Drop overlay */}
+      {isDragOver && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/90 backdrop-blur-sm border-2 border-dashed border-primary rounded-lg">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="p-4 rounded-full bg-primary/10">
+              <Upload01 className="h-8 w-8 text-primary" />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium">Drop files to upload</h3>
+              <p className="text-sm text-muted-foreground">
+                Files will be stored in {storageConnections[0]?.title ?? "storage"}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+      
+      {children}
+    </div>
+  );
+}
+```
+
+### 3.2 File Storage Hook
+
+Create `apps/mesh/src/web/hooks/use-file-storage.ts`:
+
+```typescript
+import { useConnections } from "@/web/hooks/collections/use-connection";
+import { createToolCaller } from "@/tools/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FILE_STORAGE_BINDING } from "@decocms/bindings/file-storage";
+import { createBindingChecker } from "@decocms/bindings";
+
+const fileStorageChecker = createBindingChecker(FILE_STORAGE_BINDING);
+
+/**
+ * Hook to find connections that implement FILE_STORAGE_BINDING
+ */
+export function useFileStorageConnections() {
+  const { data: connections } = useConnections();
+  const queryClient = useQueryClient();
+  
+  // Filter connections that implement file storage binding
+  const storageConnections = (connections ?? []).filter((conn) => {
+    const tools = conn.tools?.map((t) => ({ name: t.name })) ?? [];
+    return fileStorageChecker.isImplementedBy(tools);
+  });
+  
+  // Use the first available storage connection
+  const primaryStorage = storageConnections[0];
+  
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      if (!primaryStorage) throw new Error("No storage configured");
+      
+      const caller = createToolCaller(primaryStorage.id);
+      
+      // Read file as base64
+      const content = await fileToBase64(file);
+      
+      // Upload via FILE_WRITE
+      const result = await caller("FILE_WRITE", {
+        path: file.name,
+        content,
+        encoding: "base64",
+        mimeType: file.type,
+      });
+      
+      return result;
+    },
+    onSuccess: () => {
+      // Invalidate file collections
+      queryClient.invalidateQueries({ queryKey: ["collection", "files"] });
+      queryClient.invalidateQueries({ queryKey: ["collection", "folders"] });
+    },
+  });
+  
+  return {
+    storageConnections,
+    primaryStorage,
+    uploadFile: uploadMutation.mutateAsync,
+    isUploading: uploadMutation.isPending,
+  };
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const base64 = (reader.result as string).split(",")[1];
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+```
+
+### 3.3 File Browser Component (for Folders Collection)
+
+Create `apps/mesh/src/web/components/files/file-browser.tsx`:
+
+```tsx
+import { useCollectionData, useCollectionActions } from "@/web/hooks/use-collections";
+import { createToolCaller } from "@/tools/client";
+import { Button } from "@deco/ui/components/button";
+import { Folder01, File06, ArrowLeft } from "@untitledui/icons";
+import { useState } from "react";
+import { formatBytes } from "@/web/utils/format";
+
+interface FileBrowserProps {
+  connectionId: string;
+  initialPath?: string;
+}
+
+export function FileBrowser({ connectionId, initialPath = "" }: FileBrowserProps) {
+  const [currentPath, setCurrentPath] = useState(initialPath);
+  const toolCaller = createToolCaller(connectionId);
+  
+  const { data: files } = useCollectionData(
+    connectionId,
+    "files",
+    toolCaller,
+    { where: { parent: currentPath } }
+  );
+  
+  const navigateUp = () => {
+    const parts = currentPath.split("/").filter(Boolean);
+    parts.pop();
+    setCurrentPath(parts.join("/"));
+  };
+  
+  return (
+    <div className="flex flex-col h-full">
+      {/* Breadcrumb / navigation */}
+      <div className="flex items-center gap-2 p-3 border-b">
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={!currentPath}
+          onClick={navigateUp}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <span className="text-sm font-medium">
+          /{currentPath || ""}
+        </span>
+      </div>
+      
+      {/* File list */}
+      <div className="flex-1 overflow-auto p-2">
+        {files?.items?.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+            <Folder01 className="h-12 w-12 mb-2 opacity-30" />
+            <span>Empty folder</span>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {files?.items?.map((file) => (
+              <div
+                key={file.id}
+                className="flex items-center gap-3 p-2 rounded hover:bg-muted/50 cursor-pointer"
+                onClick={() => {
+                  if (file.isDirectory) {
+                    setCurrentPath(file.path);
+                  }
+                }}
+              >
+                {file.isDirectory ? (
+                  <Folder01 className="h-5 w-5 text-amber-500" />
+                ) : (
+                  <File06 className="h-5 w-5 text-muted-foreground" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="truncate font-medium">{file.title}</div>
+                  {!file.isDirectory && (
+                    <div className="text-xs text-muted-foreground">
+                      {formatBytes(file.size)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+### 3.4 File Editor Component (Monaco)
+
+Create `apps/mesh/src/web/components/files/file-editor.tsx`:
+
+```tsx
+import Editor from "@monaco-editor/react";
+import { useFileContent, useFileMutations } from "@/web/hooks/use-file-storage";
+import { useState } from "react";
+import { Button } from "@deco/ui/components/button";
+import { Save01 } from "@untitledui/icons";
+
+interface FileEditorProps {
+  connectionId: string;
+  path: string;
+  readOnly?: boolean;
+}
+
+export function FileEditor({ connectionId, path, readOnly = false }: FileEditorProps) {
+  const { data: file, isLoading } = useFileContent(connectionId, path);
+  const { save, isSaving } = useFileMutations(connectionId);
+  
+  const [localContent, setLocalContent] = useState<string | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+  
+  // Determine language from file extension
+  const getLanguage = (path: string) => {
+    const ext = path.split(".").pop()?.toLowerCase();
+    const languageMap: Record<string, string> = {
+      js: "javascript",
+      jsx: "javascript",
+      ts: "typescript",
+      tsx: "typescript",
+      json: "json",
+      md: "markdown",
+      html: "html",
+      css: "css",
+      py: "python",
+      yaml: "yaml",
+      yml: "yaml",
+    };
+    return languageMap[ext ?? ""] ?? "plaintext";
+  };
+  
+  const handleSave = async () => {
+    if (localContent === null) return;
+    await save({ path, content: localContent });
+    setHasChanges(false);
+  };
+  
+  if (isLoading) {
+    return <div className="flex items-center justify-center h-full">Loading...</div>;
+  }
+  
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      {!readOnly && (
+        <div className="flex items-center justify-end gap-2 p-2 border-b">
+          <Button
+            size="sm"
+            disabled={!hasChanges || isSaving}
+            onClick={handleSave}
+          >
+            <Save01 className="h-4 w-4 mr-2" />
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      )}
+      
+      {/* Editor */}
+      <div className="flex-1">
+        <Editor
+          defaultValue={file?.content ?? ""}
+          language={getLanguage(path)}
+          theme="vs-dark"
+          options={{
+            readOnly,
+            minimap: { enabled: false },
+            fontSize: 14,
+            wordWrap: "on",
+            automaticLayout: true,
+          }}
+          onChange={(value) => {
+            setLocalContent(value ?? "");
+            setHasChanges(value !== file?.content);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+### 3.5 Register Well-Known Views
+
+Update `apps/mesh/src/web/routes/orgs/collection-detail.tsx`:
+
+```typescript
+import { AssistantDetailsView } from "@/web/components/details/assistant/index.tsx";
+import { FileDetailsView } from "@/web/components/details/file/index.tsx";
+import { FolderDetailsView } from "@/web/components/details/folder/index.tsx";
+
+const WELL_KNOWN_VIEW_DETAILS: Record<
+  string,
+  ComponentType<CollectionDetailsProps>
+> = {
+  assistant: AssistantDetailsView,
+  files: FileDetailsView,      // NEW
+  folders: FolderDetailsView,  // NEW
+};
+```
+
+---
+
+## Phase 4: Integration
+
+### 4.1 Mount Drop Zone in Shell Layout
+
+Update `apps/mesh/src/web/layouts/shell.tsx`:
+
+```tsx
+import { FileDropZone } from "@/web/components/file-drop-zone";
+
+export function ShellLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <FileDropZone>
+      <div className="flex h-screen">
+        <Sidebar />
+        <main className="flex-1 overflow-hidden">
+          {children}
+        </main>
+      </div>
+    </FileDropZone>
+  );
+}
+```
+
+### 4.2 Add MCP Route for Local FS
+
+Update `apps/mesh/src/api/routes/` to add the local-fs MCP endpoint.
+
+### 4.3 Initialize Local FS on Startup
+
+Update mesh startup to:
+1. Create `storage/` directory if it doesn't exist
+2. Register the `local-fs` connection for each organization
+
+---
+
+## Implementation Order
+
+### Phase 1 (Foundation) - Week 1
+1. [ ] Create `FILE_STORAGE_BINDING` in `packages/bindings/src/well-known/file-storage.ts`
+2. [ ] Add exports to `packages/bindings/package.json`
+3. [ ] Create `LocalFileStorage` class in `apps/mesh/src/file-storage/local-fs.ts`
+4. [ ] Create file tools in `apps/mesh/src/tools/files/`
+
+### Phase 2 (MCP) - Week 1-2
+5. [ ] Add `LOCAL_FS` to `well-known-mcp.ts`
+6. [ ] Create MCP route at `/mcp/local-fs`
+7. [ ] Auto-register local-fs connection on org creation
+8. [ ] Add file serving route for downloads
+
+### Phase 3 (UI - Basic) - Week 2
+9. [ ] Create `useFileStorageConnections` hook
+10. [ ] Create `FileDropZone` component
+11. [ ] Mount drop zone in shell layout
+12. [ ] Test file uploads
+
+### Phase 4 (UI - Enhanced) - Week 3
+13. [ ] Create `FileBrowser` component
+14. [ ] Create `FileEditor` component (Monaco)
+15. [ ] Create `FilePreview` component (images, PDFs)
+16. [ ] Register `FileDetailsView` and `FolderDetailsView` in well-known views
+
+### Phase 5 (Polish) - Week 3-4
+17. [ ] Add upload progress indicators
+18. [ ] Add file type icons
+19. [ ] Add context menu (download, rename, delete)
+20. [ ] Add keyboard shortcuts
+21. [ ] Add search/filter for files
+
+---
+
+## Future Extensions
+
+### Cloud Storage Adapters
+
+The `FILE_STORAGE_BINDING` can be implemented by other MCPs:
+
+- **mcp-s3** - Amazon S3 storage
+- **mcp-gcs** - Google Cloud Storage
+- **mcp-r2** - Cloudflare R2
+- **mcp-azure-blob** - Azure Blob Storage
+
+### Advanced Features
+
+- **Versioning** - Track file versions with history
+- **Thumbnails** - Auto-generate image thumbnails
+- **Search** - Full-text search in files
+- **Sharing** - Public links with expiration
+- **Sync** - Two-way sync with local filesystem
+
+---
+
+## Testing
+
+### Unit Tests
+- `LocalFileStorage` class methods
+- Path sanitization and security
+- MIME type detection
+
+### Integration Tests
+- File upload via MCP tools
+- Collection binding responses
+- Drop zone functionality
+
+### E2E Tests
+- Drag and drop file upload
+- File browser navigation
+- Monaco editor save
+
+---
+
+## Security Considerations
+
+1. **Path Traversal** - Sanitize all paths to prevent `../` attacks
+2. **File Size Limits** - Configure max upload size
+3. **MIME Type Validation** - Validate content matches declared type
+4. **Access Control** - Respect organization boundaries
+5. **Rate Limiting** - Prevent upload abuse
+

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -628,6 +628,8 @@ export function createMeshContextFactory(
     // Note: Token revocation handled by Better Auth (deleteApiKey)
   };
 
+  // File storage is created per-request with the correct base URL
+
   // Return factory function
   return async (req?: Request): Promise<MeshContext> => {
     const connectionId = req?.headers.get("x-caller-id") ?? undefined;

--- a/apps/mesh/src/core/well-known-mcp.ts
+++ b/apps/mesh/src/core/well-known-mcp.ts
@@ -4,12 +4,14 @@ export const WellKnownMCPId = {
   SELF: "self",
   REGISTRY: "registry",
   COMMUNITY_REGISTRY: "community-registry",
+  LOCAL_FS: "local-fs",
 };
 export const WellKnownOrgMCPId = {
   SELF: (org: string) => `${org}_${WellKnownMCPId.SELF}`,
   REGISTRY: (org: string) => `${org}_${WellKnownMCPId.REGISTRY}`,
   COMMUNITY_REGISTRY: (org: string) =>
     `${org}_${WellKnownMCPId.COMMUNITY_REGISTRY}`,
+  LOCAL_FS: (org: string) => `${org}_${WellKnownMCPId.LOCAL_FS}`,
 };
 
 /**
@@ -96,6 +98,36 @@ export function getWellKnownSelfConnection(
     metadata: {
       isDefault: true,
       type: WellKnownOrgMCPId.SELF,
+    },
+  };
+}
+
+/**
+ * Get well-known connection definition for Local File Storage.
+ * Stores files in a local storage/ directory where mesh is running.
+ *
+ * @param baseUrl - The base URL for the MCP server
+ * @returns ConnectionCreateData for Local File Storage
+ */
+export function getWellKnownLocalFsConnection(
+  baseUrl: string,
+): ConnectionCreateData {
+  return {
+    id: WellKnownMCPId.LOCAL_FS,
+    title: "Local Files",
+    description: "File storage in the local storage/ directory",
+    connection_type: "HTTP",
+    connection_url: `${baseUrl}/mcp/local-fs`,
+    icon: "https://assets.decocache.com/mcp/folder-open.png",
+    app_name: "@deco/local-fs",
+    connection_token: null,
+    connection_headers: null,
+    oauth_config: null,
+    configuration_state: null,
+    configuration_scopes: null,
+    metadata: {
+      isDefault: true,
+      type: "file-storage",
     },
   };
 }

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -3,6 +3,10 @@
  *
  * Central export for all MCP Mesh management tools
  * Types are inferred from ALL_TOOLS - this is the source of truth.
+ *
+ * Note: File Storage tools are NOT included here - they are provided by
+ * external MCPs like mcp-local-fs. The Mesh only provides the binding
+ * definitions and UI for file storage.
  */
 
 import { mcpServer } from "@/api/utils/mcp";
@@ -51,6 +55,7 @@ export const ALL_TOOLS = [
   // Monitoring tools
   MonitoringTools.MONITORING_LOGS_LIST,
   MonitoringTools.MONITORING_STATS,
+
   // API Key tools
   ApiKeyTools.API_KEY_CREATE,
   ApiKeyTools.API_KEY_LIST,

--- a/apps/mesh/src/web/components/add-binding/add-binding-modal.tsx
+++ b/apps/mesh/src/web/components/add-binding/add-binding-modal.tsx
@@ -1,0 +1,559 @@
+/**
+ * Add Binding Modal
+ *
+ * A modal that allows users to add common binding implementations to their MCP Mesh.
+ * Bindings are common patterns/interfaces that MCPs can implement.
+ */
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { ArrowLeft, Check, Clock, Folder } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useProjectContext } from "@/web/providers/project-context-provider";
+import { useConnectionActions } from "@/web/hooks/collections/use-connection";
+import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { authClient } from "@/web/lib/auth-client";
+import type { StdioConnectionParameters } from "@/tools/connection/schema";
+import {
+  type BindingDefinition,
+  type BindingImplementation,
+  getAvailableBindings,
+  getComingSoonBindings,
+} from "./binding-definitions";
+
+interface AddBindingModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type ModalStep = "select-binding" | "select-implementation" | "configure";
+
+export function AddBindingModal({ open, onOpenChange }: AddBindingModalProps) {
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const { data: session } = authClient.useSession();
+  const actions = useConnectionActions();
+
+  const [step, setStep] = useState<ModalStep>("select-binding");
+  const [selectedBinding, setSelectedBinding] =
+    useState<BindingDefinition | null>(null);
+  const [selectedImplementation, setSelectedImplementation] =
+    useState<BindingImplementation | null>(null);
+  const [configValues, setConfigValues] = useState<Record<string, string>>({});
+  const [isCreating, setIsCreating] = useState(false);
+
+  const availableBindings = getAvailableBindings();
+  const comingSoonBindings = getComingSoonBindings();
+
+  const handleSelectBinding = (binding: BindingDefinition) => {
+    if (binding.status === "coming_soon") {
+      return;
+    }
+    setSelectedBinding(binding);
+
+    // If only one implementation, skip to configure
+    if (binding.implementations.length === 1 && binding.implementations[0]) {
+      setSelectedImplementation(binding.implementations[0]);
+      setStep("configure");
+    } else {
+      setStep("select-implementation");
+    }
+  };
+
+  const handleSelectImplementation = (impl: BindingImplementation) => {
+    setSelectedImplementation(impl);
+    // Apply default config if available
+    if (impl.defaultConfig) {
+      setConfigValues(impl.defaultConfig);
+    }
+    setStep("configure");
+  };
+
+  const handleBack = () => {
+    if (step === "configure") {
+      if (selectedBinding && selectedBinding.implementations.length > 1) {
+        setStep("select-implementation");
+      } else {
+        setStep("select-binding");
+        setSelectedBinding(null);
+        setSelectedImplementation(null);
+      }
+    } else if (step === "select-implementation") {
+      setStep("select-binding");
+      setSelectedBinding(null);
+      setSelectedImplementation(null);
+    }
+  };
+
+  const handleConfigChange = (field: string, value: string) => {
+    setConfigValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleCreate = async () => {
+    if (!selectedImplementation || !org || !session?.user?.id) {
+      return;
+    }
+
+    // Validate required fields
+    const requiredFields =
+      selectedImplementation.configFields?.filter((f) => f.required) ?? [];
+    const missingFields = requiredFields.filter((f) => !configValues[f.name]);
+    if (missingFields.length > 0) {
+      toast.error(
+        `Please fill in: ${missingFields.map((f) => f.label).join(", ")}`,
+      );
+      return;
+    }
+
+    setIsCreating(true);
+
+    try {
+      const connectionId = generatePrefixedId("conn");
+      const now = new Date().toISOString();
+
+      if (selectedImplementation.connectionType === "STDIO") {
+        // Build STDIO connection
+        const pathArg = configValues["path"] ?? "";
+
+        let connectionHeaders: StdioConnectionParameters;
+
+        // Use localCommand if available (for development), otherwise npx
+        if (selectedImplementation.localCommand) {
+          connectionHeaders = {
+            command: selectedImplementation.localCommand.command,
+            args: [...selectedImplementation.localCommand.args, pathArg].filter(
+              Boolean,
+            ),
+          };
+        } else {
+          connectionHeaders = {
+            command: "npx",
+            args: ["-y", selectedImplementation.npxPackage!, pathArg].filter(
+              Boolean,
+            ),
+          };
+        }
+
+        // Add env vars if there are API keys etc
+        const envVars: Record<string, string> = {};
+        for (const field of selectedImplementation.configFields ?? []) {
+          const fieldValue = configValues[field.name];
+          if (field.name !== "path" && fieldValue) {
+            // Convert to env var format (e.g., apiKey -> API_KEY)
+            const envKey = field.name
+              .replace(/([A-Z])/g, "_$1")
+              .toUpperCase()
+              .replace(/^_/, "");
+            envVars[envKey] = fieldValue;
+          }
+        }
+        if (Object.keys(envVars).length > 0) {
+          connectionHeaders.envVars = envVars;
+        }
+
+        await actions.create.mutateAsync({
+          id: connectionId,
+          title: `${selectedBinding?.name ?? "Binding"} (${selectedImplementation.name})`,
+          description:
+            selectedImplementation.description ||
+            `${selectedBinding?.name} via ${selectedImplementation.name}`,
+          connection_type: "STDIO",
+          connection_url: "",
+          connection_headers: connectionHeaders,
+          connection_token: null,
+          organization_id: org.id,
+          created_at: now,
+          updated_at: now,
+          created_by: session.user.id,
+          icon: null,
+          app_name: selectedImplementation.npxPackage ?? null,
+          app_id: null,
+          oauth_config: null,
+          configuration_state: null,
+          metadata: null,
+          tools: null,
+          bindings: selectedBinding?.bindingType
+            ? [selectedBinding.bindingType]
+            : null,
+          status: "inactive",
+        });
+      } else {
+        // HTTP/SSE connection
+        await actions.create.mutateAsync({
+          id: connectionId,
+          title: `${selectedBinding?.name ?? "Binding"} (${selectedImplementation.name})`,
+          description:
+            selectedImplementation.description ||
+            `${selectedBinding?.name} via ${selectedImplementation.name}`,
+          connection_type: selectedImplementation.connectionType,
+          connection_url: selectedImplementation.httpEndpoint ?? "",
+          connection_headers: null,
+          connection_token: configValues["apiKey"] ?? null,
+          organization_id: org.id,
+          created_at: now,
+          updated_at: now,
+          created_by: session.user.id,
+          icon: null,
+          app_name: null,
+          app_id: null,
+          oauth_config: null,
+          configuration_state: null,
+          metadata: null,
+          tools: null,
+          bindings: selectedBinding?.bindingType
+            ? [selectedBinding.bindingType]
+            : null,
+          status: "inactive",
+        });
+      }
+
+      toast.success(`${selectedImplementation.name} connected successfully!`);
+      onOpenChange(false);
+      resetState();
+
+      // Navigate to the new connection
+      navigate({
+        to: "/$org/mcps/$connectionId",
+        params: { org: org.slug, connectionId },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to create connection: ${message}`);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const resetState = () => {
+    setStep("select-binding");
+    setSelectedBinding(null);
+    setSelectedImplementation(null);
+    setConfigValues({});
+  };
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      resetState();
+    }
+    onOpenChange(newOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            {step !== "select-binding" && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                onClick={handleBack}
+              >
+                <ArrowLeft className="size-4" />
+              </Button>
+            )}
+            <div>
+              <DialogTitle>
+                {step === "select-binding" && "Add Binding to MCP Mesh"}
+                {step === "select-implementation" &&
+                  `${selectedBinding?.name} Providers`}
+                {step === "configure" &&
+                  `Configure ${selectedImplementation?.name}`}
+              </DialogTitle>
+              <DialogDescription>
+                {step === "select-binding" &&
+                  "Bindings are common patterns that MCPs implement. Select one to add capabilities to your mesh."}
+                {step === "select-implementation" &&
+                  `Choose how you want to implement ${selectedBinding?.name}`}
+                {step === "configure" &&
+                  `Set up ${selectedImplementation?.name} to add ${selectedBinding?.name} to your mesh`}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto py-4">
+          {step === "select-binding" && (
+            <div className="space-y-6">
+              {/* Available Bindings */}
+              {availableBindings.length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-medium text-muted-foreground px-1">
+                    Available
+                  </h3>
+                  <div className="grid grid-cols-2 gap-3">
+                    {availableBindings.map((binding) => (
+                      <BindingCard
+                        key={binding.id}
+                        binding={binding}
+                        onClick={() => handleSelectBinding(binding)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Coming Soon Bindings */}
+              {comingSoonBindings.length > 0 && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-medium text-muted-foreground px-1">
+                    Coming Soon
+                  </h3>
+                  <div className="grid grid-cols-2 gap-3">
+                    {comingSoonBindings.map((binding) => (
+                      <BindingCard
+                        key={binding.id}
+                        binding={binding}
+                        disabled
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === "select-implementation" && selectedBinding && (
+            <div className="grid grid-cols-1 gap-3">
+              {selectedBinding.implementations.map((impl) => (
+                <ImplementationCard
+                  key={impl.id}
+                  implementation={impl}
+                  onClick={() => handleSelectImplementation(impl)}
+                />
+              ))}
+            </div>
+          )}
+
+          {step === "configure" && selectedImplementation && (
+            <div className="space-y-6">
+              {/* Implementation Header */}
+              <div className="flex items-center gap-4 p-4 rounded-lg bg-muted/50 border">
+                <div className="text-3xl">{selectedImplementation.icon}</div>
+                <div>
+                  <h3 className="font-semibold">
+                    {selectedImplementation.name}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {selectedImplementation.description}
+                  </p>
+                </div>
+              </div>
+
+              {/* Configuration Fields */}
+              {selectedImplementation.configFields &&
+                selectedImplementation.configFields.length > 0 && (
+                  <div className="space-y-4">
+                    {selectedImplementation.configFields.map((field) => (
+                      <div key={field.name} className="space-y-2">
+                        <Label htmlFor={field.name}>
+                          {field.label}
+                          {field.required && (
+                            <span className="text-destructive ml-1">*</span>
+                          )}
+                        </Label>
+
+                        {field.type === "path" ? (
+                          <div className="flex gap-2">
+                            <Input
+                              id={field.name}
+                              placeholder={field.placeholder}
+                              value={configValues[field.name] ?? ""}
+                              onChange={(e) =>
+                                handleConfigChange(field.name, e.target.value)
+                              }
+                              className="flex-1"
+                            />
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              title="Browse folder (coming soon)"
+                              disabled
+                            >
+                              <Folder className="size-4" />
+                            </Button>
+                          </div>
+                        ) : field.type === "select" && field.options ? (
+                          <Select
+                            value={configValues[field.name]}
+                            onValueChange={(val) =>
+                              handleConfigChange(field.name, val)
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder={field.placeholder} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {field.options.map((opt) => (
+                                <SelectItem key={opt.value} value={opt.value}>
+                                  {opt.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Input
+                            id={field.name}
+                            type={
+                              field.name.toLowerCase().includes("key") ||
+                              field.name.toLowerCase().includes("secret") ||
+                              field.name.toLowerCase().includes("token")
+                                ? "password"
+                                : "text"
+                            }
+                            placeholder={field.placeholder}
+                            value={configValues[field.name] ?? ""}
+                            onChange={(e) =>
+                              handleConfigChange(field.name, e.target.value)
+                            }
+                          />
+                        )}
+
+                        {field.description && (
+                          <p className="text-xs text-muted-foreground">
+                            {field.description}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+              {/* Create Button */}
+              <div className="flex justify-end gap-3 pt-4 border-t">
+                <Button variant="outline" onClick={handleBack}>
+                  Back
+                </Button>
+                <Button onClick={handleCreate} disabled={isCreating}>
+                  {isCreating ? (
+                    <>
+                      <Spinner size="xs" />
+                      <span className="ml-2">Connecting...</span>
+                    </>
+                  ) : (
+                    <>
+                      <Check className="size-4 mr-2" />
+                      Connect {selectedImplementation.name}
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Binding Card Component
+ */
+function BindingCard({
+  binding,
+  onClick,
+  disabled,
+}: {
+  binding: BindingDefinition;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  const isComingSoon = binding.status === "coming_soon" || disabled;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isComingSoon}
+      className={cn(
+        "relative flex flex-col items-start gap-2 p-4 rounded-xl border text-left transition-all",
+        "bg-linear-to-br",
+        binding.gradient,
+        isComingSoon
+          ? "opacity-60 cursor-not-allowed"
+          : "hover:border-primary/50 hover:shadow-md cursor-pointer",
+      )}
+    >
+      {isComingSoon && (
+        <div className="absolute top-2 right-2 flex items-center gap-1 text-xs text-muted-foreground bg-background/80 px-2 py-0.5 rounded-full">
+          <Clock className="size-3" />
+          Soon
+        </div>
+      )}
+      <div className="text-2xl">{binding.icon}</div>
+      <div>
+        <h4 className="font-semibold">{binding.name}</h4>
+        <p className="text-xs text-muted-foreground line-clamp-2">
+          {binding.description}
+        </p>
+      </div>
+      {binding.implementations.length > 0 && !isComingSoon && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+          <span>{binding.implementations.length} provider</span>
+          {binding.implementations.length > 1 && "s"}
+        </div>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Implementation Card Component
+ */
+function ImplementationCard({
+  implementation,
+  onClick,
+}: {
+  implementation: BindingImplementation;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-4 p-4 rounded-xl border text-left transition-all",
+        "hover:border-primary/50 hover:bg-muted/50 hover:shadow-md cursor-pointer",
+      )}
+    >
+      <div className="text-3xl">{implementation.icon}</div>
+      <div className="flex-1">
+        <h4 className="font-semibold">{implementation.name}</h4>
+        <p className="text-sm text-muted-foreground">
+          {implementation.description}
+        </p>
+        <div className="flex items-center gap-2 mt-1">
+          <span className="text-xs bg-muted px-2 py-0.5 rounded-full">
+            {implementation.connectionType === "STDIO" ? "Local" : "Remote"}
+          </span>
+          {implementation.npxPackage && (
+            <span className="text-xs text-muted-foreground font-mono">
+              {implementation.npxPackage}
+            </span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/mesh/src/web/components/add-binding/binding-definitions.ts
+++ b/apps/mesh/src/web/components/add-binding/binding-definitions.ts
@@ -83,14 +83,6 @@ const fileStorageBinding: BindingDefinition = {
       description: "Access files on your local machine",
       icon: "💻",
       npxPackage: "@decocms/mcp-local-fs",
-      // Use local dev path until package is published with structuredContent fix
-      localCommand: {
-        command: "bun",
-        args: [
-          "run",
-          "/Users/guilherme/Projects/mcps/local-fs/server/stdio.ts",
-        ],
-      },
       connectionType: "STDIO",
       requiresConfig: true,
       configFields: [

--- a/apps/mesh/src/web/components/add-binding/binding-definitions.ts
+++ b/apps/mesh/src/web/components/add-binding/binding-definitions.ts
@@ -87,7 +87,7 @@ const fileStorageBinding: BindingDefinition = {
       requiresConfig: true,
       configFields: [
         {
-          name: "path",
+          name: "mcpLocalFsPath",
           label: "Root Path",
           type: "path",
           placeholder: "/Users/you/Documents",

--- a/apps/mesh/src/web/components/add-binding/binding-definitions.ts
+++ b/apps/mesh/src/web/components/add-binding/binding-definitions.ts
@@ -1,0 +1,425 @@
+/**
+ * Binding Definitions
+ *
+ * Defines the available bindings and their MCP implementations.
+ * Each binding represents a common pattern/interface that MCPs can implement.
+ */
+
+export type BindingStatus = "available" | "coming_soon";
+
+export interface BindingImplementation {
+  /** Unique identifier for this implementation */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Description of this implementation */
+  description: string;
+  /** Icon URL or emoji */
+  icon: string;
+  /** NPX package name (for stdio connections) */
+  npxPackage?: string;
+  /** Local command for development (overrides npxPackage if set) */
+  localCommand?: {
+    command: string;
+    args: string[];
+  };
+  /** HTTP endpoint (for remote connections) */
+  httpEndpoint?: string;
+  /** Connection type */
+  connectionType: "STDIO" | "HTTP" | "SSE";
+  /** Whether this implementation requires configuration */
+  requiresConfig?: boolean;
+  /** Configuration schema field names */
+  configFields?: BindingConfigField[];
+  /** Default configuration values */
+  defaultConfig?: Record<string, string>;
+}
+
+export interface BindingConfigField {
+  name: string;
+  label: string;
+  type: "text" | "path" | "select";
+  placeholder?: string;
+  description?: string;
+  required?: boolean;
+  options?: { value: string; label: string }[];
+}
+
+export interface BindingDefinition {
+  /** Unique identifier for the binding */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Short description */
+  description: string;
+  /** Icon for the binding category */
+  icon: string;
+  /** CSS gradient for the card */
+  gradient: string;
+  /** Available implementations */
+  implementations: BindingImplementation[];
+  /** Status: available or coming soon */
+  status: BindingStatus;
+  /** Well-known binding type from @decocms/bindings */
+  bindingType?: string;
+}
+
+/**
+ * File Storage Binding
+ * Implementations: Local File System, S3, etc.
+ */
+const fileStorageBinding: BindingDefinition = {
+  id: "file-storage",
+  name: "File Storage",
+  description: "Read, write, and manage files on local or cloud storage",
+  icon: "📁",
+  gradient: "from-blue-500/20 to-cyan-500/20",
+  bindingType: "FILE_STORAGE",
+  status: "available",
+  implementations: [
+    {
+      id: "local-fs",
+      name: "Local File System",
+      description: "Access files on your local machine",
+      icon: "💻",
+      npxPackage: "@decocms/mcp-local-fs",
+      // Use local dev path until package is published with structuredContent fix
+      localCommand: {
+        command: "bun",
+        args: [
+          "run",
+          "/Users/guilherme/Projects/mcps/local-fs/server/stdio.ts",
+        ],
+      },
+      connectionType: "STDIO",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "path",
+          label: "Root Path",
+          type: "path",
+          placeholder: "/Users/you/Documents",
+          description: "The folder to mount as the storage root",
+          required: true,
+        },
+      ],
+    },
+    // {
+    //   id: "s3",
+    //   name: "Amazon S3",
+    //   description: "Access files on Amazon S3 buckets",
+    //   icon: "☁️",
+    //   npxPackage: "@decocms/mcp-s3",
+    //   connectionType: "STDIO",
+    //   requiresConfig: true,
+    //   configFields: [
+    //     {
+    //       name: "bucket",
+    //       label: "Bucket Name",
+    //       type: "text",
+    //       placeholder: "my-bucket",
+    //       required: true,
+    //     },
+    //     {
+    //       name: "region",
+    //       label: "AWS Region",
+    //       type: "text",
+    //       placeholder: "us-east-1",
+    //       required: true,
+    //     },
+    //   ],
+    // },
+  ],
+};
+
+/**
+ * Database Binding
+ * Implementations: Readonly SQL, etc.
+ */
+const databaseBinding: BindingDefinition = {
+  id: "database",
+  name: "Database",
+  description: "Query databases with read-only SQL access",
+  icon: "🗄️",
+  gradient: "from-purple-500/20 to-pink-500/20",
+  bindingType: "DATABASE",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "readonly-sql",
+      name: "Readonly SQL",
+      description: "Safe read-only access to PostgreSQL, MySQL, SQLite",
+      icon: "📊",
+      npxPackage: "@decocms/mcp-readonly-sql",
+      connectionType: "STDIO",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "connectionString",
+          label: "Connection String",
+          type: "text",
+          placeholder: "postgresql://user:pass@localhost:5432/db",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * AI/LLM Binding
+ * Implementations: OpenRouter, etc.
+ */
+const llmBinding: BindingDefinition = {
+  id: "llm",
+  name: "AI / Language Models",
+  description: "Access language models for text generation and chat",
+  icon: "🤖",
+  gradient: "from-emerald-500/20 to-teal-500/20",
+  bindingType: "LANGUAGE_MODEL",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "openrouter",
+      name: "OpenRouter",
+      description: "Access 100+ AI models through one API",
+      icon: "🌐",
+      npxPackage: "@decocms/mcp-openrouter",
+      connectionType: "STDIO",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "apiKey",
+          label: "OpenRouter API Key",
+          type: "text",
+          placeholder: "sk-or-...",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Search Binding
+ * Implementations: Perplexity, etc.
+ */
+const searchBinding: BindingDefinition = {
+  id: "search",
+  name: "Web Search",
+  description: "Search the web for real-time information",
+  icon: "🔍",
+  gradient: "from-orange-500/20 to-amber-500/20",
+  bindingType: "SEARCH",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "perplexity",
+      name: "Perplexity",
+      description: "AI-powered search with citations",
+      icon: "🔮",
+      npxPackage: "@decocms/mcp-perplexity",
+      connectionType: "STDIO",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "apiKey",
+          label: "Perplexity API Key",
+          type: "text",
+          placeholder: "pplx-...",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Vector Database Binding
+ * Implementations: Pinecone, etc.
+ */
+const vectorDbBinding: BindingDefinition = {
+  id: "vector-db",
+  name: "Vector Database",
+  description: "Store and search embeddings for semantic search",
+  icon: "🧮",
+  gradient: "from-rose-500/20 to-red-500/20",
+  bindingType: "VECTOR_DB",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "pinecone",
+      name: "Pinecone",
+      description: "Managed vector database for embeddings",
+      icon: "🌲",
+      npxPackage: "@decocms/mcp-pinecone",
+      connectionType: "STDIO",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "apiKey",
+          label: "Pinecone API Key",
+          type: "text",
+          required: true,
+        },
+        {
+          name: "indexName",
+          label: "Index Name",
+          type: "text",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Documents Binding
+ * Implementations: Notion, Google Docs, etc.
+ */
+const documentsBinding: BindingDefinition = {
+  id: "documents",
+  name: "Documents",
+  description: "Access and manage documents from various sources",
+  icon: "📄",
+  gradient: "from-indigo-500/20 to-violet-500/20",
+  bindingType: "DOCUMENTS",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "notion",
+      name: "Notion",
+      description: "Access your Notion workspace",
+      icon: "📝",
+      httpEndpoint: "https://notion.deco.cx",
+      connectionType: "HTTP",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "apiKey",
+          label: "Notion Integration Token",
+          type: "text",
+          placeholder: "secret_...",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Email Binding
+ * Implementations: Gmail, SMTP, etc.
+ */
+const emailBinding: BindingDefinition = {
+  id: "email",
+  name: "Email",
+  description: "Send and receive emails programmatically",
+  icon: "📧",
+  gradient: "from-sky-500/20 to-blue-500/20",
+  bindingType: "EMAIL",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "gmail",
+      name: "Gmail",
+      description: "Access Gmail via OAuth",
+      icon: "📬",
+      httpEndpoint: "https://gmail.deco.cx",
+      connectionType: "HTTP",
+    },
+  ],
+};
+
+/**
+ * Calendar Binding
+ * Implementations: Google Calendar, etc.
+ */
+const calendarBinding: BindingDefinition = {
+  id: "calendar",
+  name: "Calendar",
+  description: "Manage calendar events and schedules",
+  icon: "📅",
+  gradient: "from-yellow-500/20 to-orange-500/20",
+  bindingType: "CALENDAR",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "google-calendar",
+      name: "Google Calendar",
+      description: "Access Google Calendar via OAuth",
+      icon: "🗓️",
+      httpEndpoint: "https://calendar.deco.cx",
+      connectionType: "HTTP",
+    },
+  ],
+};
+
+/**
+ * Media/Transcription Binding
+ * Implementations: Whisper, etc.
+ */
+const mediaBinding: BindingDefinition = {
+  id: "media",
+  name: "Media & Transcription",
+  description: "Transcribe audio and process media files",
+  icon: "🎙️",
+  gradient: "from-fuchsia-500/20 to-purple-500/20",
+  bindingType: "MEDIA",
+  status: "coming_soon",
+  implementations: [
+    {
+      id: "whisper",
+      name: "Whisper",
+      description: "OpenAI Whisper for audio transcription",
+      icon: "🎤",
+      npxPackage: "@decocms/mcp-whisper",
+      connectionType: "STDIO",
+      requiresConfig: true,
+      configFields: [
+        {
+          name: "apiKey",
+          label: "OpenAI API Key",
+          type: "text",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * All available binding definitions
+ */
+export const BINDING_DEFINITIONS: BindingDefinition[] = [
+  fileStorageBinding,
+  databaseBinding,
+  llmBinding,
+  searchBinding,
+  vectorDbBinding,
+  documentsBinding,
+  emailBinding,
+  calendarBinding,
+  mediaBinding,
+];
+
+/**
+ * Get binding definition by ID
+ */
+export function getBindingById(id: string): BindingDefinition | undefined {
+  return BINDING_DEFINITIONS.find((b) => b.id === id);
+}
+
+/**
+ * Get available bindings (not coming soon)
+ */
+export function getAvailableBindings(): BindingDefinition[] {
+  return BINDING_DEFINITIONS.filter((b) => b.status === "available");
+}
+
+/**
+ * Get coming soon bindings
+ */
+export function getComingSoonBindings(): BindingDefinition[] {
+  return BINDING_DEFINITIONS.filter((b) => b.status === "coming_soon");
+}

--- a/apps/mesh/src/web/components/add-binding/index.ts
+++ b/apps/mesh/src/web/components/add-binding/index.ts
@@ -1,0 +1,10 @@
+export { AddBindingModal } from "./add-binding-modal";
+export {
+  type BindingDefinition,
+  type BindingImplementation,
+  type BindingStatus,
+  BINDING_DEFINITIONS,
+  getBindingById,
+  getAvailableBindings,
+  getComingSoonBindings,
+} from "./binding-definitions";

--- a/apps/mesh/src/web/components/collections/collection-card.tsx
+++ b/apps/mesh/src/web/components/collections/collection-card.tsx
@@ -10,12 +10,15 @@ import {
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { DotsVertical, Eye, Edit01, Copy01, Trash01 } from "@untitledui/icons";
+import type { ReactNode } from "react";
 
 interface CollectionCardProps<T extends BaseCollectionEntity> {
   item: T;
   schema: JsonSchema;
   readOnly?: boolean;
   actions?: Record<string, (item: T) => void | Promise<void>>;
+  /** Custom icon renderer for the item */
+  renderIcon?: (item: T) => ReactNode;
 }
 
 function findImageField(schema: JsonSchema, item: unknown): string | undefined {
@@ -65,6 +68,7 @@ export function CollectionCard<T extends BaseCollectionEntity>({
   item,
   schema,
   actions,
+  renderIcon,
 }: CollectionCardProps<T>) {
   const iconUrl = findImageField(schema, item);
   const description =
@@ -80,12 +84,16 @@ export function CollectionCard<T extends BaseCollectionEntity>({
   return (
     <Card className="cursor-pointer transition-colors h-full flex flex-col group relative">
       <div className="flex flex-col gap-4 p-6 flex-1">
-        <IntegrationIcon
-          icon={iconUrl}
-          name={item.title}
-          size="md"
-          className="shrink-0 shadow-sm"
-        />
+        {renderIcon ? (
+          renderIcon(item)
+        ) : (
+          <IntegrationIcon
+            icon={iconUrl}
+            name={item.title}
+            size="md"
+            className="shrink-0 shadow-sm"
+          />
+        )}
         <div className="flex flex-col gap-0 flex-1">
           <h3 className="text-base font-medium text-foreground truncate">
             {item.title}

--- a/apps/mesh/src/web/components/collections/types.ts
+++ b/apps/mesh/src/web/components/collections/types.ts
@@ -123,4 +123,11 @@ export interface CollectionsListProps<T extends BaseCollectionEntity> {
    * instead of the dropdown menu. Useful for FILES collection.
    */
   simpleDeleteOnly?: boolean;
+
+  /**
+   * Custom icon renderer for collection items.
+   * If provided, renders custom icons instead of the default IntegrationIcon.
+   * Useful for file-specific icons, custom badges, etc.
+   */
+  renderIcon?: (item: T) => ReactNode;
 }

--- a/apps/mesh/src/web/components/collections/types.ts
+++ b/apps/mesh/src/web/components/collections/types.ts
@@ -117,4 +117,10 @@ export interface CollectionsListProps<T extends BaseCollectionEntity> {
    * @default [12, 24, 48, 96]
    */
   itemsPerPageOptions?: number[];
+
+  /**
+   * If true, shows only a simple trash icon for delete action
+   * instead of the dropdown menu. Useful for FILES collection.
+   */
+  simpleDeleteOnly?: boolean;
 }

--- a/apps/mesh/src/web/components/details/connection/collection-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/collection-tab.tsx
@@ -14,6 +14,7 @@ import {
   useCollectionActions,
   useCollectionList,
 } from "@/web/hooks/use-collections";
+import { useFileMutations, useFileUpload } from "@/web/hooks/use-file-storage";
 import { useListState } from "@/web/hooks/use-list-state";
 import { authClient } from "@/web/lib/auth-client";
 import { BaseCollectionJsonSchema } from "@/web/utils/constants";
@@ -30,10 +31,16 @@ import {
 import { Button } from "@deco/ui/components/button.tsx";
 import type { BaseCollectionEntity } from "@decocms/bindings/collections";
 import { useNavigate } from "@tanstack/react-router";
-import { Plus } from "@untitledui/icons";
+import { Plus, Upload01, Loading01 } from "@untitledui/icons";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ViewActions } from "../layout";
+import { cn } from "@deco/ui/lib/utils.ts";
+
+interface UploadingFile {
+  name: string;
+  status: "uploading" | "done" | "error";
+}
 
 interface CollectionTabProps {
   connectionId: string;
@@ -92,6 +99,9 @@ export function CollectionTab({
   // Collection is read-only if ALL mutation tools are missing
   const isReadOnly = !hasCreateTool && !hasUpdateTool && !hasDeleteTool;
 
+  // Check if this is the FILES collection for special handling
+  const isFilesCollection = collectionName.toUpperCase() === "FILES";
+
   // Create action handlers
   const handleEdit = (item: BaseCollectionEntity) => {
     navigate({
@@ -126,17 +136,32 @@ export function CollectionTab({
     setItemToDelete(item);
   };
 
+  // File mutations for FILES collection
+  const fileMutations = useFileMutations(connectionId);
+
   // Build actions object with only available actions
+  // For FILES collection, always show delete (uses file deletion)
   const listItemActions: Record<string, (item: BaseCollectionEntity) => void> =
-    {
-      ...(hasUpdateTool && { edit: handleEdit }),
-      ...(hasCreateTool && { duplicate: handleDuplicate }),
-      ...(hasDeleteTool && { delete: handleDelete }),
-    };
+    isFilesCollection
+      ? {
+          edit: handleEdit,
+          delete: handleDelete,
+        }
+      : {
+          ...(hasUpdateTool && { edit: handleEdit }),
+          ...(hasCreateTool && { duplicate: handleDuplicate }),
+          ...(hasDeleteTool && { delete: handleDelete }),
+        };
 
   const confirmDelete = async () => {
     if (!itemToDelete) return;
-    await actions.delete.mutateAsync(itemToDelete.id);
+
+    if (isFilesCollection) {
+      // Use file deletion mutation - item.id is the file path
+      await fileMutations.delete.mutateAsync({ path: itemToDelete.id });
+    } else {
+      await actions.delete.mutateAsync(itemToDelete.id);
+    }
     setItemToDelete(null);
   };
 
@@ -183,6 +208,70 @@ export function CollectionTab({
   const showCreateInToolbar = hasCreateTool && hasItems;
   const showCreateInEmptyState = hasCreateTool && !hasItems && !search;
 
+  // File upload mutation for FILES collection
+  const uploadMutation = useFileUpload(connectionId);
+
+  // File drop zone state
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  // Track uploading files for progress display
+  const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer?.types.includes("Files")) {
+      setIsDragOver(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+  };
+
+  const handleFileDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+
+    const files = Array.from(e.dataTransfer?.files ?? []);
+    if (files.length === 0) return;
+
+    // Add files to uploading state
+    const newUploads = files.map((f) => ({
+      name: f.name,
+      status: "uploading" as const,
+    }));
+    setUploadingFiles((prev) => [...prev, ...newUploads]);
+
+    for (const file of files) {
+      try {
+        await uploadMutation.mutateAsync({ file });
+        setUploadingFiles((prev) =>
+          prev.map((f) =>
+            f.name === file.name ? { ...f, status: "done" as const } : f,
+          ),
+        );
+        toast.success(`Uploaded ${file.name}`);
+      } catch (error) {
+        console.error("Upload failed:", error);
+        setUploadingFiles((prev) =>
+          prev.map((f) =>
+            f.name === file.name ? { ...f, status: "error" as const } : f,
+          ),
+        );
+        toast.error(`Failed to upload ${file.name}`);
+      }
+    }
+
+    // Clear completed uploads after a delay
+    setTimeout(() => {
+      setUploadingFiles((prev) => prev.filter((f) => f.status === "uploading"));
+    }, 2000);
+  };
+
   const createButton = hasCreateTool ? (
     <Button
       onClick={handleCreate}
@@ -193,6 +282,78 @@ export function CollectionTab({
       <Plus className="mr-2 h-4 w-4" />
       {actions.create.isPending ? "Creating..." : "Create"}
     </Button>
+  ) : null;
+
+  // Handle file uploads from button click
+  const handleFileInputChange = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+
+    const fileArray = Array.from(files);
+    const newUploads = fileArray.map((f) => ({
+      name: f.name,
+      status: "uploading" as const,
+    }));
+    setUploadingFiles((prev) => [...prev, ...newUploads]);
+
+    for (const file of fileArray) {
+      try {
+        await uploadMutation.mutateAsync({ file });
+        setUploadingFiles((prev) =>
+          prev.map((f) =>
+            f.name === file.name ? { ...f, status: "done" as const } : f,
+          ),
+        );
+        toast.success(`Uploaded ${file.name}`);
+      } catch (error) {
+        console.error("Upload failed:", error);
+        setUploadingFiles((prev) =>
+          prev.map((f) =>
+            f.name === file.name ? { ...f, status: "error" as const } : f,
+          ),
+        );
+        toast.error(`Failed to upload ${file.name}`);
+      }
+    }
+
+    // Clear completed uploads after a delay
+    setTimeout(() => {
+      setUploadingFiles((prev) => prev.filter((f) => f.status === "uploading"));
+    }, 2000);
+  };
+
+  const isUploading = uploadingFiles.some((f) => f.status === "uploading");
+
+  // File upload button for FILES collection
+  const uploadButton = isFilesCollection ? (
+    <label className="cursor-pointer">
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-7"
+        disabled={isUploading}
+        asChild
+      >
+        <span>
+          {isUploading ? (
+            <Loading01 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Upload01 className="mr-2 h-4 w-4" />
+          )}
+          {isUploading
+            ? `Uploading (${uploadingFiles.filter((f) => f.status === "uploading").length})...`
+            : "Upload"}
+        </span>
+      </Button>
+      <input
+        type="file"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          handleFileInputChange(e.target.files);
+          e.target.value = ""; // Reset input
+        }}
+      />
+    </label>
   ) : null;
 
   return (
@@ -211,10 +372,33 @@ export function CollectionTab({
           title={`${collectionName}s`}
           icon={connection?.icon ?? "grid_view"}
         />
+        {uploadButton}
         {showCreateInToolbar && createButton}
       </ViewActions>
 
-      <div className="flex flex-col h-full overflow-hidden">
+      <div
+        className="flex flex-col h-full overflow-hidden relative"
+        onDragOver={isFilesCollection ? handleDragOver : undefined}
+        onDragLeave={isFilesCollection ? handleDragLeave : undefined}
+        onDrop={isFilesCollection ? handleFileDrop : undefined}
+      >
+        {/* Drop zone overlay for FILES collection */}
+        {isFilesCollection && isDragOver && (
+          <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/95 backdrop-blur-sm border-2 border-dashed border-primary rounded-lg pointer-events-none">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <div className="p-4 rounded-full bg-primary/10">
+                <Upload01 className="h-8 w-8 text-primary" />
+              </div>
+              <div>
+                <h3 className="text-lg font-medium">Drop files to upload</h3>
+                <p className="text-sm text-muted-foreground">
+                  Files will be stored in local storage
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Search */}
         <CollectionSearch
           value={search}
@@ -244,20 +428,74 @@ export function CollectionTab({
             actions={listItemActions}
             onItemClick={(item) => handleEdit(item)}
             readOnly={isReadOnly}
+            simpleDeleteOnly={isFilesCollection}
             emptyState={
-              <EmptyState
-                image={null}
-                title={search ? "No items found" : "No items found"}
-                description={
-                  search
-                    ? "Try adjusting your search terms"
-                    : "This collection doesn't have any items yet."
-                }
-                actions={showCreateInEmptyState ? createButton : undefined}
-              />
+              isFilesCollection ? (
+                <div className="flex flex-col items-center justify-center py-12 text-center">
+                  <div className="p-4 rounded-full bg-muted mb-4">
+                    <Upload01 className="h-8 w-8 text-muted-foreground" />
+                  </div>
+                  <h3 className="text-lg font-medium mb-2">No files yet</h3>
+                  <p className="text-sm text-muted-foreground mb-4">
+                    Drag and drop files here or click to upload
+                  </p>
+                  {uploadButton}
+                </div>
+              ) : (
+                <EmptyState
+                  image={null}
+                  title={search ? "No items found" : "No items found"}
+                  description={
+                    search
+                      ? "Try adjusting your search terms"
+                      : "This collection doesn't have any items yet."
+                  }
+                  actions={showCreateInEmptyState ? createButton : undefined}
+                />
+              )
             }
           />
         </div>
+
+        {/* Upload progress indicator */}
+        {uploadingFiles.length > 0 && (
+          <div className="shrink-0 border-t border-border bg-muted/50 px-4 py-2">
+            <div className="flex items-center gap-3">
+              <Loading01 className="h-4 w-4 animate-spin text-muted-foreground shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium">
+                  Uploading{" "}
+                  {
+                    uploadingFiles.filter((f) => f.status === "uploading")
+                      .length
+                  }{" "}
+                  file(s)
+                </div>
+                <div className="flex items-center gap-2 overflow-x-auto text-xs text-muted-foreground">
+                  {uploadingFiles.map((f) => (
+                    <span
+                      key={f.name}
+                      className={cn(
+                        "inline-flex items-center gap-1 shrink-0 px-2 py-0.5 rounded-full",
+                        f.status === "uploading" &&
+                          "bg-primary/10 text-primary",
+                        f.status === "done" && "bg-green-100 text-green-700",
+                        f.status === "error" && "bg-red-100 text-red-700",
+                      )}
+                    >
+                      {f.status === "uploading" && (
+                        <Loading01 className="h-3 w-3 animate-spin" />
+                      )}
+                      {f.status === "done" && "✓"}
+                      {f.status === "error" && "✗"}
+                      {f.name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Delete Confirmation Dialog */}
@@ -271,22 +509,40 @@ export function CollectionTab({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete item?</AlertDialogTitle>
+            <AlertDialogTitle>
+              {isFilesCollection ? "Delete file?" : "Delete item?"}
+            </AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{itemToDelete?.title}"? This
               action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={actions.delete.isPending}>
+            <AlertDialogCancel
+              disabled={
+                isFilesCollection
+                  ? fileMutations.isDeleting
+                  : actions.delete.isPending
+              }
+            >
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={actions.delete.isPending}
+              disabled={
+                isFilesCollection
+                  ? fileMutations.isDeleting
+                  : actions.delete.isPending
+              }
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              {actions.delete.isPending ? "Deleting..." : "Delete"}
+              {(
+                isFilesCollection
+                  ? fileMutations.isDeleting
+                  : actions.delete.isPending
+              )
+                ? "Deleting..."
+                : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/mesh/src/web/components/details/connection/collection-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/collection-tab.tsx
@@ -7,6 +7,7 @@ import {
   generateSortOptionsFromSchema,
 } from "@/web/components/collections/collections-list.tsx";
 import { EmptyState } from "@/web/components/empty-state.tsx";
+import { FileIcon } from "@/web/components/files/file-icon";
 import type { ValidatedCollection } from "@/web/hooks/use-binding";
 import { PinToSidebarButton } from "@/web/components/pin-to-sidebar-button";
 import { useConnection } from "@/web/hooks/collections/use-connection";
@@ -429,6 +430,25 @@ export function CollectionTab({
             onItemClick={(item) => handleEdit(item)}
             readOnly={isReadOnly}
             simpleDeleteOnly={isFilesCollection}
+            renderIcon={
+              isFilesCollection
+                ? (item) => {
+                    const fileItem = item as unknown as {
+                      path?: string;
+                      mimeType?: string;
+                      isDirectory?: boolean;
+                    };
+                    return (
+                      <FileIcon
+                        path={fileItem.path}
+                        mimeType={fileItem.mimeType}
+                        isDirectory={fileItem.isDirectory}
+                        size="sm"
+                      />
+                    );
+                  }
+                : undefined
+            }
             emptyState={
               isFilesCollection ? (
                 <div className="flex flex-col items-center justify-center py-12 text-center">

--- a/apps/mesh/src/web/components/details/file/index.tsx
+++ b/apps/mesh/src/web/components/details/file/index.tsx
@@ -1,0 +1,155 @@
+/**
+ * File/Folder Details View
+ *
+ * Custom view components for files and folders collections.
+ */
+
+import { useParams } from "@tanstack/react-router";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Download01,
+  Trash01,
+  File06,
+  Folder,
+  Loading01,
+} from "@untitledui/icons";
+import { FileBrowser } from "@/web/components/files/file-browser";
+import { FilePreview } from "@/web/components/files/file-preview";
+import { useFileContent, useFileMutations } from "@/web/hooks/use-file-storage";
+import { ViewLayout, ViewActions, ViewTabs } from "../layout";
+import { toast } from "sonner";
+import type { FileEntity } from "@decocms/bindings/file-storage";
+
+interface FileDetailsProps {
+  itemId: string;
+  onBack: () => void;
+  onUpdate: (updates: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * File Details View
+ *
+ * Shows file preview and allows basic operations.
+ * For text files, could integrate Monaco editor in the future.
+ */
+export function FileDetailsView({ itemId, onBack }: FileDetailsProps) {
+  const { connectionId } = useParams({
+    from: "/shell/$org/mcps/$connectionId/$collectionName/$itemId",
+  });
+
+  const path = decodeURIComponent(itemId);
+  const { data, isLoading } = useFileContent(connectionId, path);
+  const { delete: deleteMutation } = useFileMutations(connectionId);
+
+  const file = data?.metadata;
+
+  const handleDelete = async () => {
+    if (!file) return;
+
+    if (!confirm(`Delete ${file.title}?`)) return;
+
+    try {
+      await deleteMutation.mutateAsync({ path: file.path });
+      toast.success(`Deleted ${file.title}`);
+      onBack();
+    } catch (error) {
+      toast.error("Failed to delete file");
+    }
+  };
+
+  const handleDownload = () => {
+    if (file?.url) {
+      window.open(file.url, "_blank");
+    }
+  };
+
+  if (isLoading || !file) {
+    return (
+      <ViewLayout onBack={onBack}>
+        <div className="flex items-center justify-center h-full">
+          <Loading01 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      </ViewLayout>
+    );
+  }
+
+  return (
+    <ViewLayout onBack={onBack}>
+      <ViewTabs>
+        <div className="flex items-center gap-2">
+          <File06 className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium">{file.title}</span>
+          <span className="text-xs text-muted-foreground">({file.path})</span>
+        </div>
+      </ViewTabs>
+
+      <ViewActions>
+        {file.url && (
+          <Button variant="outline" size="sm" onClick={handleDownload}>
+            <Download01 className="h-4 w-4 mr-2" />
+            Download
+          </Button>
+        )}
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={handleDelete}
+          disabled={deleteMutation.isPending}
+        >
+          <Trash01 className="h-4 w-4 mr-2" />
+          Delete
+        </Button>
+      </ViewActions>
+
+      <div className="h-full overflow-hidden">
+        <FilePreview
+          connectionId={connectionId}
+          file={file}
+          className="h-full"
+        />
+      </div>
+    </ViewLayout>
+  );
+}
+
+/**
+ * Folder Details View
+ *
+ * Shows folder contents with file browser.
+ */
+export function FolderDetailsView({ itemId, onBack }: FileDetailsProps) {
+  const { connectionId } = useParams({
+    from: "/shell/$org/mcps/$connectionId/$collectionName/$itemId",
+  });
+
+  const path = decodeURIComponent(itemId);
+  const folderName = path.split("/").pop() || "Root";
+
+  const handleFileSelect = (file: FileEntity) => {
+    // Navigate to file detail view
+    // For now, just show a toast
+    if (!file.isDirectory) {
+      toast.info(`Selected: ${file.title}`);
+    }
+  };
+
+  return (
+    <ViewLayout onBack={onBack}>
+      <ViewTabs>
+        <div className="flex items-center gap-2">
+          <Folder className="h-4 w-4 text-amber-500" />
+          <span className="font-medium">{folderName}</span>
+          <span className="text-xs text-muted-foreground">(/{path})</span>
+        </div>
+      </ViewTabs>
+
+      <div className="h-full overflow-hidden">
+        <FileBrowser
+          connectionId={connectionId}
+          initialPath={path}
+          onFileSelect={handleFileSelect}
+        />
+      </div>
+    </ViewLayout>
+  );
+}

--- a/apps/mesh/src/web/components/env-vars-editor.tsx
+++ b/apps/mesh/src/web/components/env-vars-editor.tsx
@@ -2,6 +2,144 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Plus, Trash01 } from "@untitledui/icons";
 
+/**
+ * Check if an env var key looks like it contains sensitive data
+ *
+ * Covers patterns from major platforms:
+ * - AWS (ACCESS_KEY, SECRET_ACCESS_KEY, SESSION_TOKEN)
+ * - Stripe (sk_, STRIPE_SECRET, WEBHOOK_SECRET)
+ * - OpenAI/Anthropic/Cohere/Perplexity (API_KEY)
+ * - Supabase (SERVICE_ROLE_KEY, JWT_SECRET, ANON_KEY)
+ * - Vercel/Netlify/Heroku (AUTH_TOKEN)
+ * - GitHub/GitLab (PAT, GH_TOKEN)
+ * - Cloudflare (CF_API_TOKEN)
+ * - Twilio (AUTH_TOKEN, API_SECRET)
+ * - SendGrid/Resend (API_KEY)
+ * - Firebase/GCP (PRIVATE_KEY, SERVICE_ACCOUNT)
+ * - Sentry/Datadog/New Relic (DSN, LICENSE_KEY)
+ * - Database URLs often contain embedded passwords
+ * - OAuth (CLIENT_SECRET, REFRESH_TOKEN)
+ */
+function isSensitiveKey(key: string): boolean {
+  const lowerKey = key.toLowerCase();
+
+  // Generic patterns that indicate secrets
+  const sensitivePatterns = [
+    // Core secret indicators
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "private",
+
+    // Token patterns
+    "token",
+    "bearer",
+    "jwt",
+    "refresh",
+    "session",
+
+    // Key patterns (but not keyboard/keycode etc)
+    "api_key",
+    "apikey",
+    "auth_key",
+    "access_key",
+    "secret_key",
+    "private_key",
+    "service_key",
+    "encryption_key",
+    "signing_key",
+    "license_key",
+
+    // Auth patterns
+    "auth",
+    "oauth",
+    "client_secret",
+    "app_secret",
+
+    // Webhook/signing
+    "webhook",
+    "signing",
+    "signature",
+
+    // Database/connection strings (often contain embedded passwords)
+    "database_url",
+    "db_url",
+    "mongo_uri",
+    "redis_url",
+    "postgres_url",
+    "mysql_url",
+    "connection_string",
+    "dsn",
+
+    // Platform-specific patterns
+    "service_role", // Supabase
+    "anon_key", // Supabase
+    "supabase_key",
+    "openai",
+    "anthropic",
+    "stripe",
+    "twilio",
+    "sendgrid",
+    "resend",
+    "firebase",
+    "sentry",
+    "datadog",
+    "newrelic",
+    "new_relic",
+    "pplx", // Perplexity
+    "replicate",
+    "pinecone",
+    "cohere",
+    "hugging", // HuggingFace
+    "hf_token",
+    "gh_token", // GitHub
+    "npm_token",
+
+    // Certificate/encryption
+    "certificate",
+    "cert",
+    "ssl",
+    "tls",
+    "encryption",
+    "salt",
+    "hash",
+    "hmac",
+
+    // Personal access tokens
+    "personal_access",
+    "github_pat",
+    "gitlab_pat",
+    "bitbucket_pat",
+  ];
+
+  // Check if key contains any sensitive pattern
+  if (sensitivePatterns.some((pattern) => lowerKey.includes(pattern))) {
+    return true;
+  }
+
+  // Check for common prefixes that indicate secrets (Stripe, etc)
+  const secretPrefixes = ["sk_", "rk_", "whsec_", "pk_live", "sk_live"];
+  if (secretPrefixes.some((prefix) => lowerKey.startsWith(prefix))) {
+    return true;
+  }
+
+  // Check if it ends with common secret suffixes
+  const secretSuffixes = [
+    "_key",
+    "_secret",
+    "_token",
+    "_password",
+    "_auth",
+    "_pat", // Personal Access Token (but not _path)
+  ];
+  if (secretSuffixes.some((suffix) => lowerKey.endsWith(suffix))) {
+    return true;
+  }
+
+  return false;
+}
+
 export interface EnvVar {
   key: string;
   value: string;
@@ -60,7 +198,7 @@ export function EnvVarsEditor({
               className="h-10 rounded-lg flex-1 font-mono text-sm"
             />
             <Input
-              type="password"
+              type={isSensitiveKey(envVar.key) ? "password" : "text"}
               placeholder={valuePlaceholder}
               value={envVar.value}
               onChange={(e) => handleValueChange(index, e.target.value)}

--- a/apps/mesh/src/web/components/file-drop-zone.tsx
+++ b/apps/mesh/src/web/components/file-drop-zone.tsx
@@ -1,0 +1,157 @@
+/**
+ * FileDropZone Component
+ *
+ * A global drop zone overlay that appears when files are dragged over the app.
+ * Only active when at least one MCP implements FILE_STORAGE_BINDING.
+ */
+
+import { useState, type ReactNode } from "react";
+import { Upload01 } from "@untitledui/icons";
+import { toast } from "sonner";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  useFileStorageConnections,
+  useFileUpload,
+} from "@/web/hooks/use-file-storage";
+
+interface FileDropZoneProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Global file drop zone that wraps the app content.
+ * Shows a drop overlay when files are dragged and a storage provider is available.
+ */
+export function FileDropZone({ children, className }: FileDropZoneProps) {
+  const storageConnections = useFileStorageConnections();
+  const hasStorage = storageConnections.length > 0;
+  const primaryStorage = storageConnections[0];
+
+  const [isDragOver, setIsDragOver] = useState(false);
+  // Track enter/leave count to handle nested elements
+  const [, setDragCounter] = useState(0);
+
+  const uploadMutation = useFileUpload(primaryStorage?.id ?? "");
+
+  // Handle drag events
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragCounter((prev) => prev + 1);
+    if (e.dataTransfer?.types.includes("Files")) {
+      setIsDragOver(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragCounter((prev) => {
+      const newCount = prev - 1;
+      if (newCount === 0) {
+        setIsDragOver(false);
+      }
+      return newCount;
+    });
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+    setDragCounter(0);
+
+    if (!hasStorage) {
+      toast.error("No file storage configured");
+      return;
+    }
+
+    const files = Array.from(e.dataTransfer?.files ?? []);
+
+    if (files.length === 0) {
+      return;
+    }
+
+    // Upload each file
+    for (const file of files) {
+      try {
+        await uploadMutation.mutateAsync({ file });
+        toast.success(`Uploaded ${file.name}`);
+      } catch (error) {
+        console.error("Upload failed:", error);
+        toast.error(`Failed to upload ${file.name}`);
+      }
+    }
+  };
+
+  // Don't render drag overlay if no storage is available
+  if (!hasStorage) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      className={cn("relative h-full", className)}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {/* Drop overlay */}
+      {isDragOver && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/95 backdrop-blur-sm border-2 border-dashed border-primary rounded-lg pointer-events-none">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="p-4 rounded-full bg-primary/10">
+              <Upload01 className="h-8 w-8 text-primary" />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium">Drop files to upload</h3>
+              <p className="text-sm text-muted-foreground">
+                Files will be stored in{" "}
+                {primaryStorage?.title ?? "local storage"}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Hook to manually trigger file upload
+ * Useful for buttons or programmatic uploads
+ */
+export function useFileDropUpload() {
+  const storageConnections = useFileStorageConnections();
+  const primaryStorage = storageConnections[0];
+  const uploadMutation = useFileUpload(primaryStorage?.id ?? "");
+
+  const uploadFiles = async (files: File[]) => {
+    if (!primaryStorage) {
+      throw new Error("No file storage configured");
+    }
+
+    const results = [];
+    for (const file of files) {
+      const result = await uploadMutation.mutateAsync({ file });
+      results.push(result);
+    }
+    return results;
+  };
+
+  return {
+    uploadFiles,
+    isUploading: uploadMutation.isPending,
+    hasStorage: !!primaryStorage,
+    storageConnection: primaryStorage,
+  };
+}

--- a/apps/mesh/src/web/components/file-storage-connection-select.tsx
+++ b/apps/mesh/src/web/components/file-storage-connection-select.tsx
@@ -1,0 +1,65 @@
+/**
+ * File Storage Connection Select
+ *
+ * Dropdown to select which file storage connection to use.
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+
+interface Connection {
+  id: string;
+  name: string;
+  icon?: string;
+}
+
+interface FileStorageConnectionSelectProps {
+  connections: Connection[];
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function FileStorageConnectionSelect({
+  connections,
+  value,
+  onValueChange,
+  placeholder = "Select storage...",
+}: FileStorageConnectionSelectProps) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger className="w-[200px] h-8!">
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {connections.map((connection) => (
+          <SelectItem
+            className="cursor-pointer"
+            key={connection.id}
+            value={connection.id}
+          >
+            <div className="flex items-center gap-2">
+              {connection.icon ? (
+                <img
+                  src={connection.icon}
+                  alt={connection.name}
+                  className="w-4 h-4 rounded"
+                />
+              ) : (
+                <div className="w-4 h-4 rounded bg-blue-500/20 flex items-center justify-center text-xs font-semibold text-blue-600">
+                  📁
+                </div>
+              )}
+              <span>{connection.name}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/mesh/src/web/components/files/file-browser.tsx
+++ b/apps/mesh/src/web/components/files/file-browser.tsx
@@ -7,18 +7,11 @@
 import { useState } from "react";
 import { Button } from "@deco/ui/components/button.tsx";
 import { EmptyState } from "@/web/components/empty-state";
-import {
-  ArrowLeft,
-  Folder,
-  File06,
-  FileCode01,
-  Image01,
-  FileCheck02,
-  Loading01,
-} from "@untitledui/icons";
+import { ArrowLeft, Folder, Loading01 } from "@untitledui/icons";
 import { useFileList } from "@/web/hooks/use-file-storage";
 import type { FileEntity } from "@decocms/bindings/file-storage";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { FileIconInline } from "./file-icon";
 
 interface FileBrowserProps {
   connectionId: string;
@@ -35,49 +28,6 @@ function formatBytes(bytes: number): string {
   const sizes = ["B", "KB", "MB", "GB", "TB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
-}
-
-/**
- * Get icon based on file type
- */
-function getFileIcon(file: FileEntity) {
-  if (file.isDirectory) {
-    return <Folder className="h-5 w-5 text-amber-500" />;
-  }
-
-  const ext = file.path.split(".").pop()?.toLowerCase();
-  const mimeType = file.mimeType;
-
-  // Images
-  if (mimeType?.startsWith("image/")) {
-    return <Image01 className="h-5 w-5 text-pink-500" />;
-  }
-
-  // Code files
-  if (
-    [
-      "js",
-      "jsx",
-      "ts",
-      "tsx",
-      "json",
-      "html",
-      "css",
-      "py",
-      "go",
-      "rs",
-    ].includes(ext ?? "")
-  ) {
-    return <FileCode01 className="h-5 w-5 text-blue-500" />;
-  }
-
-  // Markdown
-  if (["md", "mdx", "markdown"].includes(ext ?? "")) {
-    return <FileCheck02 className="h-5 w-5 text-purple-500" />;
-  }
-
-  // Default file icon
-  return <File06 className="h-5 w-5 text-muted-foreground" />;
 }
 
 /**
@@ -194,7 +144,11 @@ export function FileBrowser({
                 className="w-full flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors text-left"
                 onClick={() => handleItemClick(file)}
               >
-                {getFileIcon(file)}
+                <FileIconInline
+                  path={file.path}
+                  mimeType={file.mimeType}
+                  isDirectory={file.isDirectory}
+                />
 
                 <div className="flex-1 min-w-0">
                   <div className="truncate font-medium text-sm">

--- a/apps/mesh/src/web/components/files/file-browser.tsx
+++ b/apps/mesh/src/web/components/files/file-browser.tsx
@@ -1,0 +1,220 @@
+/**
+ * FileBrowser Component
+ *
+ * A file browser component for navigating folders and files.
+ */
+
+import { useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import { EmptyState } from "@/web/components/empty-state";
+import {
+  ArrowLeft,
+  Folder,
+  File06,
+  FileCode01,
+  Image01,
+  FileCheck02,
+  Loading01,
+} from "@untitledui/icons";
+import { useFileList } from "@/web/hooks/use-file-storage";
+import type { FileEntity } from "@decocms/bindings/file-storage";
+import { cn } from "@deco/ui/lib/utils.ts";
+
+interface FileBrowserProps {
+  connectionId: string;
+  initialPath?: string;
+  onFileSelect?: (file: FileEntity) => void;
+}
+
+/**
+ * Format bytes to human-readable size
+ */
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+/**
+ * Get icon based on file type
+ */
+function getFileIcon(file: FileEntity) {
+  if (file.isDirectory) {
+    return <Folder className="h-5 w-5 text-amber-500" />;
+  }
+
+  const ext = file.path.split(".").pop()?.toLowerCase();
+  const mimeType = file.mimeType;
+
+  // Images
+  if (mimeType?.startsWith("image/")) {
+    return <Image01 className="h-5 w-5 text-pink-500" />;
+  }
+
+  // Code files
+  if (
+    [
+      "js",
+      "jsx",
+      "ts",
+      "tsx",
+      "json",
+      "html",
+      "css",
+      "py",
+      "go",
+      "rs",
+    ].includes(ext ?? "")
+  ) {
+    return <FileCode01 className="h-5 w-5 text-blue-500" />;
+  }
+
+  // Markdown
+  if (["md", "mdx", "markdown"].includes(ext ?? "")) {
+    return <FileCheck02 className="h-5 w-5 text-purple-500" />;
+  }
+
+  // Default file icon
+  return <File06 className="h-5 w-5 text-muted-foreground" />;
+}
+
+/**
+ * File browser for navigating files and folders
+ */
+export function FileBrowser({
+  connectionId,
+  initialPath = "",
+  onFileSelect,
+}: FileBrowserProps) {
+  const [currentPath, setCurrentPath] = useState(initialPath);
+  const { data, isLoading, error } = useFileList(connectionId, currentPath);
+
+  const files = data?.items ?? [];
+
+  // Navigate to parent folder
+  const navigateUp = () => {
+    const parts = currentPath.split("/").filter(Boolean);
+    parts.pop();
+    setCurrentPath(parts.join("/"));
+  };
+
+  // Handle item click
+  const handleItemClick = (file: FileEntity) => {
+    if (file.isDirectory) {
+      setCurrentPath(file.path);
+    } else if (onFileSelect) {
+      onFileSelect(file);
+    }
+  };
+
+  // Build breadcrumb parts
+  const breadcrumbParts = currentPath.split("/").filter(Boolean);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full p-8">
+        <Loading01 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-full p-8">
+        <EmptyState
+          title="Error loading files"
+          description={error instanceof Error ? error.message : "Unknown error"}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Breadcrumb / navigation */}
+      <div className="flex items-center gap-2 p-3 border-b bg-muted/30">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          disabled={!currentPath}
+          onClick={navigateUp}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+
+        <div className="flex items-center gap-1 text-sm">
+          <button
+            type="button"
+            onClick={() => setCurrentPath("")}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            /
+          </button>
+          {breadcrumbParts.map((part, index) => (
+            <span key={part} className="flex items-center gap-1">
+              <span className="text-muted-foreground">/</span>
+              <button
+                type="button"
+                onClick={() =>
+                  setCurrentPath(breadcrumbParts.slice(0, index + 1).join("/"))
+                }
+                className={cn(
+                  "hover:text-foreground transition-colors",
+                  index === breadcrumbParts.length - 1
+                    ? "text-foreground font-medium"
+                    : "text-muted-foreground",
+                )}
+              >
+                {part}
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* File list */}
+      <div className="flex-1 overflow-auto">
+        {files.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-8">
+            <Folder className="h-12 w-12 mb-4 opacity-30" />
+            <span className="text-sm">Empty folder</span>
+            <p className="text-xs text-muted-foreground mt-1">
+              Drop files here to upload
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {files.map((file) => (
+              <button
+                key={file.id}
+                type="button"
+                className="w-full flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors text-left"
+                onClick={() => handleItemClick(file)}
+              >
+                {getFileIcon(file)}
+
+                <div className="flex-1 min-w-0">
+                  <div className="truncate font-medium text-sm">
+                    {file.title}
+                  </div>
+                  {!file.isDirectory && (
+                    <div className="text-xs text-muted-foreground">
+                      {formatBytes(file.size)}
+                    </div>
+                  )}
+                </div>
+
+                <div className="text-xs text-muted-foreground">
+                  {new Date(file.updated_at).toLocaleDateString()}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/files/file-icon.tsx
+++ b/apps/mesh/src/web/components/files/file-icon.tsx
@@ -1,0 +1,285 @@
+/**
+ * FileIcon Component
+ *
+ * Renders an icon based on file type, extension, or mime type.
+ * Used in both FileBrowser and CollectionsList for consistent file display.
+ */
+
+import {
+  Folder,
+  File06,
+  FileCode01,
+  Image01,
+  FileCheck02,
+  File04,
+  PlayCircle,
+  Archive,
+  Database01,
+  FileMinus02,
+} from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+
+interface FileIconProps {
+  /** File path or filename to detect extension */
+  path?: string;
+  /** MIME type for more accurate detection */
+  mimeType?: string;
+  /** Whether this is a directory */
+  isDirectory?: boolean;
+  /** Size class - affects both icon and container size */
+  size?: "sm" | "md" | "lg";
+  /** Additional className */
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: "h-4 w-4",
+  md: "h-5 w-5",
+  lg: "h-6 w-6",
+};
+
+const CONTAINER_CLASSES = {
+  sm: "h-8 w-8",
+  md: "h-10 w-10",
+  lg: "h-12 w-12",
+};
+
+/**
+ * Get icon component and color based on file type
+ */
+function getFileIconConfig(
+  path?: string,
+  mimeType?: string,
+  isDirectory?: boolean,
+): { Icon: typeof File06; colorClass: string; bgClass: string } {
+  // Directories
+  if (isDirectory) {
+    return {
+      Icon: Folder,
+      colorClass: "text-amber-600",
+      bgClass: "bg-amber-100 dark:bg-amber-900/30",
+    };
+  }
+
+  const ext = path?.split(".").pop()?.toLowerCase();
+
+  // Check by MIME type first
+  if (mimeType) {
+    if (mimeType.startsWith("image/")) {
+      return {
+        Icon: Image01,
+        colorClass: "text-pink-600",
+        bgClass: "bg-pink-100 dark:bg-pink-900/30",
+      };
+    }
+    if (mimeType.startsWith("audio/")) {
+      return {
+        Icon: PlayCircle,
+        colorClass: "text-green-600",
+        bgClass: "bg-green-100 dark:bg-green-900/30",
+      };
+    }
+    if (mimeType.startsWith("video/")) {
+      return {
+        Icon: PlayCircle,
+        colorClass: "text-red-600",
+        bgClass: "bg-red-100 dark:bg-red-900/30",
+      };
+    }
+    if (mimeType === "application/pdf") {
+      return {
+        Icon: File04,
+        colorClass: "text-red-600",
+        bgClass: "bg-red-100 dark:bg-red-900/30",
+      };
+    }
+    if (
+      mimeType === "application/zip" ||
+      mimeType === "application/x-tar" ||
+      mimeType === "application/gzip"
+    ) {
+      return {
+        Icon: Archive,
+        colorClass: "text-yellow-600",
+        bgClass: "bg-yellow-100 dark:bg-yellow-900/30",
+      };
+    }
+  }
+
+  // Check by extension
+  // Code files
+  if (
+    [
+      "js",
+      "jsx",
+      "ts",
+      "tsx",
+      "json",
+      "html",
+      "css",
+      "scss",
+      "py",
+      "go",
+      "rs",
+      "java",
+      "c",
+      "cpp",
+      "h",
+      "hpp",
+      "swift",
+      "kt",
+      "rb",
+      "php",
+      "sh",
+      "bash",
+      "zsh",
+      "yaml",
+      "yml",
+      "toml",
+      "xml",
+      "vue",
+      "svelte",
+    ].includes(ext ?? "")
+  ) {
+    return {
+      Icon: FileCode01,
+      colorClass: "text-blue-600",
+      bgClass: "bg-blue-100 dark:bg-blue-900/30",
+    };
+  }
+
+  // Markdown / Documentation
+  if (["md", "mdx", "markdown", "rst", "txt"].includes(ext ?? "")) {
+    return {
+      Icon: FileCheck02,
+      colorClass: "text-purple-600",
+      bgClass: "bg-purple-100 dark:bg-purple-900/30",
+    };
+  }
+
+  // Images
+  if (
+    ["jpg", "jpeg", "png", "gif", "webp", "svg", "ico", "bmp", "tiff"].includes(
+      ext ?? "",
+    )
+  ) {
+    return {
+      Icon: Image01,
+      colorClass: "text-pink-600",
+      bgClass: "bg-pink-100 dark:bg-pink-900/30",
+    };
+  }
+
+  // Audio
+  if (["mp3", "wav", "ogg", "flac", "aac", "m4a"].includes(ext ?? "")) {
+    return {
+      Icon: PlayCircle,
+      colorClass: "text-green-600",
+      bgClass: "bg-green-100 dark:bg-green-900/30",
+    };
+  }
+
+  // Video
+  if (["mp4", "webm", "mov", "avi", "mkv", "m4v"].includes(ext ?? "")) {
+    return {
+      Icon: PlayCircle,
+      colorClass: "text-red-600",
+      bgClass: "bg-red-100 dark:bg-red-900/30",
+    };
+  }
+
+  // Archives
+  if (["zip", "tar", "gz", "rar", "7z", "bz2"].includes(ext ?? "")) {
+    return {
+      Icon: Archive,
+      colorClass: "text-yellow-600",
+      bgClass: "bg-yellow-100 dark:bg-yellow-900/30",
+    };
+  }
+
+  // Database / Data
+  if (["db", "sqlite", "sql", "csv"].includes(ext ?? "")) {
+    return {
+      Icon: Database01,
+      colorClass: "text-emerald-600",
+      bgClass: "bg-emerald-100 dark:bg-emerald-900/30",
+    };
+  }
+
+  // PDF
+  if (ext === "pdf") {
+    return {
+      Icon: File04,
+      colorClass: "text-red-600",
+      bgClass: "bg-red-100 dark:bg-red-900/30",
+    };
+  }
+
+  // Lock files / config
+  if (["lock", "lockb"].includes(ext ?? "")) {
+    return {
+      Icon: FileMinus02,
+      colorClass: "text-gray-500",
+      bgClass: "bg-gray-100 dark:bg-gray-800",
+    };
+  }
+
+  // Default
+  return {
+    Icon: File06,
+    colorClass: "text-muted-foreground",
+    bgClass: "bg-muted",
+  };
+}
+
+/**
+ * FileIcon - displays a colorful icon based on file type
+ *
+ * @example
+ * <FileIcon path="document.pdf" size="md" />
+ * <FileIcon path="folder" isDirectory size="lg" />
+ * <FileIcon path="image.png" mimeType="image/png" />
+ */
+export function FileIcon({
+  path,
+  mimeType,
+  isDirectory,
+  size = "md",
+  className,
+}: FileIconProps) {
+  const { Icon, colorClass, bgClass } = getFileIconConfig(
+    path,
+    mimeType,
+    isDirectory,
+  );
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg flex items-center justify-center shrink-0",
+        bgClass,
+        CONTAINER_CLASSES[size],
+        className,
+      )}
+    >
+      <Icon className={cn(SIZE_CLASSES[size], colorClass)} />
+    </div>
+  );
+}
+
+/**
+ * FileIconInline - just the icon without container, for inline use
+ */
+export function FileIconInline({
+  path,
+  mimeType,
+  isDirectory,
+  size = "md",
+  className,
+}: FileIconProps) {
+  const { Icon, colorClass } = getFileIconConfig(path, mimeType, isDirectory);
+
+  return <Icon className={cn(SIZE_CLASSES[size], colorClass, className)} />;
+}
+
+export { getFileIconConfig };

--- a/apps/mesh/src/web/components/files/file-preview.tsx
+++ b/apps/mesh/src/web/components/files/file-preview.tsx
@@ -1,0 +1,307 @@
+/**
+ * FilePreview Component
+ *
+ * Preview different file types (images, text, code, etc.)
+ */
+
+import { Suspense, lazy, useState } from "react";
+import { Loading01 } from "@untitledui/icons";
+import { useFileContent } from "@/web/hooks/use-file-storage";
+import type { FileEntity } from "@decocms/bindings/file-storage";
+import { cn } from "@deco/ui/lib/utils.ts";
+
+// Lazy load the TextEditor to avoid loading Monaco on initial page load
+const TextEditor = lazy(() =>
+  import("./text-editor").then((mod) => ({ default: mod.TextEditor })),
+);
+
+interface FilePreviewProps {
+  connectionId: string;
+  file: FileEntity;
+  className?: string;
+}
+
+/**
+ * Check if a MIME type is previewable as text
+ */
+function isTextFile(mimeType: string): boolean {
+  return (
+    mimeType.startsWith("text/") ||
+    mimeType === "application/json" ||
+    mimeType === "application/javascript" ||
+    mimeType === "application/xml"
+  );
+}
+
+/**
+ * Check if a MIME type is an image
+ */
+function isImageFile(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+/**
+ * Check if a MIME type is a PDF
+ */
+function isPdfFile(mimeType: string): boolean {
+  return mimeType === "application/pdf";
+}
+
+/**
+ * Check if a MIME type is a video
+ */
+function isVideoFile(mimeType: string): boolean {
+  return mimeType.startsWith("video/");
+}
+
+/**
+ * Check if a MIME type is audio
+ */
+function isAudioFile(mimeType: string): boolean {
+  return mimeType.startsWith("audio/");
+}
+
+/**
+ * Image with loading state
+ */
+function ImageWithLoading({
+  src,
+  alt,
+  className,
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+}) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <div className="relative flex items-center justify-center w-full h-full">
+      {/* Loading spinner - shown while image loads */}
+      {!isLoaded && !hasError && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Loading01 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {/* Error state */}
+      {hasError && (
+        <div className="text-sm text-muted-foreground">
+          Failed to load image
+        </div>
+      )}
+
+      {/* Image - hidden until loaded */}
+      <img
+        src={src}
+        alt={alt}
+        className={cn(
+          "max-w-full max-h-full object-contain rounded transition-opacity duration-200",
+          isLoaded ? "opacity-100" : "opacity-0",
+          className,
+        )}
+        onLoad={() => setIsLoaded(true)}
+        onError={() => setHasError(true)}
+      />
+    </div>
+  );
+}
+
+/**
+ * PDF viewer using browser's native viewer
+ */
+function PdfViewer({ url, className }: { url: string; className?: string }) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <div className={cn("relative w-full h-full", className)}>
+      {isLoading && !hasError && (
+        <div className="absolute inset-0 flex items-center justify-center bg-muted/30">
+          <Loading01 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      {hasError ? (
+        <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+          <p className="text-sm">Unable to preview PDF in browser</p>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-primary hover:underline"
+          >
+            Open in new tab
+          </a>
+        </div>
+      ) : (
+        <iframe
+          src={url}
+          className="w-full h-full border-0"
+          title="PDF Preview"
+          onLoad={() => setIsLoading(false)}
+          onError={() => {
+            setIsLoading(false);
+            setHasError(true);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Preview component for different file types
+ */
+export function FilePreview({
+  connectionId,
+  file,
+  className,
+}: FilePreviewProps) {
+  const isImage = isImageFile(file.mimeType);
+  const isText = isTextFile(file.mimeType);
+  const isPdf = isPdfFile(file.mimeType);
+  const isVideo = isVideoFile(file.mimeType);
+  const isAudio = isAudioFile(file.mimeType);
+
+  // For media files that can use the URL directly, skip content fetch
+  const needsContentFetch =
+    !isPdf && !isVideo && !isAudio && (isImage || isText);
+
+  // Only fetch content for text files and images
+  const { data, isLoading, error } = useFileContent(
+    connectionId,
+    file.path,
+    isImage ? "base64" : "utf-8",
+    needsContentFetch,
+  );
+
+  // PDF preview using browser's native viewer
+  if (isPdf && file.url) {
+    return (
+      <div className={cn("h-full", className)}>
+        <PdfViewer url={file.url} />
+      </div>
+    );
+  }
+
+  // Video preview using HTML5 video element
+  if (isVideo && file.url) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center h-full bg-black p-4",
+          className,
+        )}
+      >
+        <video src={file.url} controls className="max-w-full max-h-full">
+          Your browser does not support the video tag.
+        </video>
+      </div>
+    );
+  }
+
+  // Audio preview using HTML5 audio element
+  if (isAudio && file.url) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center h-full bg-muted/30 p-8",
+          className,
+        )}
+      >
+        <audio src={file.url} controls className="w-full max-w-md">
+          Your browser does not support the audio tag.
+        </audio>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className={cn("flex items-center justify-center h-full", className)}>
+        <Loading01 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center h-full text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        Failed to load file
+      </div>
+    );
+  }
+
+  // Image preview with loading state
+  if (isImage && data?.content) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center h-full bg-muted/30 p-4",
+          className,
+        )}
+      >
+        <ImageWithLoading
+          src={`data:${file.mimeType};base64,${data.content}`}
+          alt={file.title}
+        />
+      </div>
+    );
+  }
+
+  // Text/code editor with Monaco
+  if (isText && data?.content !== undefined) {
+    return (
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center h-full bg-muted/20">
+            <div className="flex flex-col items-center gap-3">
+              <Loading01 className="h-8 w-8 animate-spin text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">
+                Loading editor...
+              </span>
+            </div>
+          </div>
+        }
+      >
+        <TextEditor
+          connectionId={connectionId}
+          file={file}
+          initialContent={data.content}
+          className={className}
+        />
+      </Suspense>
+    );
+  }
+
+  // Unsupported file type
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center h-full gap-4 text-muted-foreground",
+        className,
+      )}
+    >
+      <div className="text-center">
+        <p className="font-medium">{file.title}</p>
+        <p className="text-sm">{file.mimeType}</p>
+        {file.url && (
+          <a
+            href={file.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-primary hover:underline mt-2 inline-block"
+          >
+            Download file
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/files/index.ts
+++ b/apps/mesh/src/web/components/files/index.ts
@@ -7,3 +7,4 @@
 export { FileBrowser } from "./file-browser";
 export { FilePreview } from "./file-preview";
 export { TextEditor } from "./text-editor";
+export { FileIcon, FileIconInline, getFileIconConfig } from "./file-icon";

--- a/apps/mesh/src/web/components/files/index.ts
+++ b/apps/mesh/src/web/components/files/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Files Components
+ *
+ * Exports for file-related UI components.
+ */
+
+export { FileBrowser } from "./file-browser";
+export { FilePreview } from "./file-preview";
+export { TextEditor } from "./text-editor";

--- a/apps/mesh/src/web/components/files/text-editor.tsx
+++ b/apps/mesh/src/web/components/files/text-editor.tsx
@@ -1,0 +1,196 @@
+/**
+ * TextEditor Component
+ *
+ * Monaco-based text editor with save functionality.
+ * Lazy-loaded to avoid loading Monaco on initial page load.
+ */
+
+import { Suspense, lazy, useState } from "react";
+import { Loading01, Save01 } from "@untitledui/icons";
+import { useFileMutations } from "@/web/hooks/use-file-storage";
+import type { FileEntity } from "@decocms/bindings/file-storage";
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { toast } from "sonner";
+
+// Lazy load Monaco editor
+const Editor = lazy(() => import("@monaco-editor/react"));
+
+interface TextEditorProps {
+  connectionId: string;
+  file: FileEntity;
+  initialContent: string;
+  className?: string;
+}
+
+/**
+ * Get Monaco language from MIME type or file extension
+ */
+function getLanguage(mimeType: string, fileName: string): string {
+  // Check MIME type first
+  if (mimeType === "application/json") return "json";
+  if (mimeType === "application/javascript") return "javascript";
+  if (mimeType === "application/xml") return "xml";
+  if (mimeType === "text/html") return "html";
+  if (mimeType === "text/css") return "css";
+  if (mimeType === "text/markdown") return "markdown";
+  if (mimeType === "text/yaml" || mimeType === "application/x-yaml")
+    return "yaml";
+
+  // Fall back to file extension
+  const ext = fileName.split(".").pop()?.toLowerCase();
+  const extMap: Record<string, string> = {
+    js: "javascript",
+    jsx: "javascript",
+    ts: "typescript",
+    tsx: "typescript",
+    json: "json",
+    md: "markdown",
+    html: "html",
+    htm: "html",
+    css: "css",
+    scss: "scss",
+    less: "less",
+    xml: "xml",
+    yaml: "yaml",
+    yml: "yaml",
+    py: "python",
+    rb: "ruby",
+    go: "go",
+    rs: "rust",
+    java: "java",
+    c: "c",
+    cpp: "cpp",
+    h: "c",
+    hpp: "cpp",
+    sh: "shell",
+    bash: "shell",
+    zsh: "shell",
+    sql: "sql",
+    graphql: "graphql",
+    gql: "graphql",
+  };
+
+  return extMap[ext ?? ""] ?? "plaintext";
+}
+
+/**
+ * Loading fallback for Monaco
+ */
+function EditorLoading() {
+  return (
+    <div className="flex items-center justify-center h-full bg-muted/20">
+      <div className="flex flex-col items-center gap-3">
+        <Loading01 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">Loading editor...</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Text editor with Monaco and save functionality
+ */
+export function TextEditor({
+  connectionId,
+  file,
+  initialContent,
+  className,
+}: TextEditorProps) {
+  const [content, setContent] = useState(initialContent);
+  const [hasChanges, setHasChanges] = useState(false);
+  const fileMutations = useFileMutations(connectionId);
+
+  const language = getLanguage(file.mimeType, file.title);
+
+  const handleEditorChange = (value: string | undefined) => {
+    const newContent = value ?? "";
+    setContent(newContent);
+    setHasChanges(newContent !== initialContent);
+  };
+
+  const handleSave = async () => {
+    try {
+      await fileMutations.write.mutateAsync({
+        path: file.path,
+        content,
+        encoding: "utf-8",
+      });
+      setHasChanges(false);
+      toast.success("File saved");
+    } catch (error) {
+      console.error("Failed to save file:", error);
+      toast.error("Failed to save file");
+    }
+  };
+
+  // Handle Ctrl/Cmd+S
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+      e.preventDefault();
+      if (hasChanges) {
+        handleSave();
+      }
+    }
+  };
+
+  return (
+    <div
+      className={cn("flex flex-col h-full", className)}
+      onKeyDown={handleKeyDown}
+    >
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-mono text-muted-foreground uppercase">
+            {language}
+          </span>
+          {hasChanges && (
+            <span className="text-xs text-amber-600 dark:text-amber-400">
+              • Unsaved changes
+            </span>
+          )}
+        </div>
+        <Button
+          size="sm"
+          variant={hasChanges ? "default" : "ghost"}
+          onClick={handleSave}
+          disabled={!hasChanges || fileMutations.isSaving}
+          className="h-7"
+        >
+          {fileMutations.isSaving ? (
+            <Loading01 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Save01 className="mr-2 h-4 w-4" />
+          )}
+          {fileMutations.isSaving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+
+      {/* Editor */}
+      <div className="flex-1 overflow-hidden">
+        <Suspense fallback={<EditorLoading />}>
+          <Editor
+            height="100%"
+            language={language}
+            value={content}
+            onChange={handleEditorChange}
+            theme="vs-dark"
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              lineNumbers: "on",
+              wordWrap: "on",
+              automaticLayout: true,
+              scrollBeyondLastLine: false,
+              padding: { top: 12, bottom: 12 },
+              renderLineHighlight: "gutter",
+              folding: true,
+              bracketPairColorization: { enabled: true },
+            }}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/mesh-sidebar.tsx
+++ b/apps/mesh/src/web/components/mesh-sidebar.tsx
@@ -1,24 +1,54 @@
+import { useState, Suspense } from "react";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { SidebarItemsSection } from "@/web/components/sidebar-items-section";
 import { useProjectSidebarItems } from "@/web/hooks/use-project-sidebar-items";
 import { NavigationSidebar } from "@deco/ui/components/navigation-sidebar.tsx";
-import { Suspense } from "react";
+import {
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarSeparator,
+} from "@deco/ui/components/sidebar.tsx";
+import { Plus } from "@untitledui/icons";
+import { AddBindingModal } from "@/web/components/add-binding";
 
 export function MeshSidebar() {
   const sidebarItems = useProjectSidebarItems();
+  const [isAddBindingOpen, setIsAddBindingOpen] = useState(false);
 
   return (
-    <NavigationSidebar
-      navigationItems={sidebarItems}
-      additionalContent={
-        <>
-          <ErrorBoundary>
-            <Suspense fallback={null}>
-              <SidebarItemsSection />
-            </Suspense>
-          </ErrorBoundary>
-        </>
-      }
-    />
+    <>
+      <NavigationSidebar
+        navigationItems={sidebarItems}
+        additionalContent={
+          <>
+            <ErrorBoundary>
+              <Suspense fallback={null}>
+                <SidebarItemsSection />
+              </Suspense>
+            </ErrorBoundary>
+
+            {/* Add Binding Button */}
+            <SidebarSeparator className="my-2" />
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                className="group/nav-item cursor-pointer text-muted-foreground hover:text-foreground hover:bg-accent"
+                onClick={() => setIsAddBindingOpen(true)}
+                tooltip="Add Binding"
+              >
+                <span className="text-muted-foreground group-hover/nav-item:text-foreground transition-colors [&>svg]:size-4">
+                  <Plus />
+                </span>
+                <span className="truncate">Add Binding</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </>
+        }
+      />
+
+      <AddBindingModal
+        open={isAddBindingOpen}
+        onOpenChange={setIsAddBindingOpen}
+      />
+    </>
   );
 }

--- a/apps/mesh/src/web/hooks/use-binding.ts
+++ b/apps/mesh/src/web/hooks/use-binding.ts
@@ -413,3 +413,20 @@ export function useRegistryConnections(
         ),
       );
 }
+
+/**
+ * Hook to filter connections that implement file storage
+ * Returns only connections that have FILES collection
+ *
+ * @param connections - Array of connections to filter
+ * @returns Filtered array of connections with file storage capabilities
+ */
+export function useFileStorageConnections(
+  connections: ConnectionEntity[] | undefined,
+): ConnectionEntity[] {
+  return !connections
+    ? []
+    : connections.filter((conn) =>
+        extractCollectionNames(conn.tools).find((name) => name === "FILES"),
+      );
+}

--- a/apps/mesh/src/web/hooks/use-binding.ts
+++ b/apps/mesh/src/web/hooks/use-binding.ts
@@ -5,6 +5,7 @@ import {
   createCollectionBindings,
 } from "@decocms/bindings/collections";
 import { ASSISTANTS_BINDING } from "@decocms/bindings/assistant";
+import { FILE_STORAGE_BINDING } from "@decocms/bindings/file-storage";
 import { LANGUAGE_MODEL_BINDING } from "@decocms/bindings/llm";
 import { MCP_BINDING } from "@decocms/bindings/mcp";
 import { convertJsonSchemaToZod } from "zod-from-json-schema";
@@ -23,6 +24,7 @@ const BUILTIN_BINDINGS: Record<string, Binder> = {
   WORKFLOW_EXECUTION: WORKFLOW_EXECUTION_BINDING,
   ASSISTANTS: ASSISTANTS_BINDING,
   MCP: MCP_BINDING,
+  FILE_STORAGE: FILE_STORAGE_BINDING,
 };
 
 /**

--- a/apps/mesh/src/web/hooks/use-file-storage.ts
+++ b/apps/mesh/src/web/hooks/use-file-storage.ts
@@ -1,0 +1,287 @@
+/**
+ * File Storage Hooks
+ *
+ * Hooks for interacting with file storage connections.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useConnections } from "./collections/use-connection";
+import { useBindingConnections } from "./use-binding";
+import type { ConnectionEntity } from "@/tools/connection/schema";
+import type { FileEntity } from "@decocms/bindings/file-storage";
+import { createToolCaller } from "@/tools/client";
+import { KEYS } from "@/web/lib/query-keys";
+
+/**
+ * Query keys for file storage
+ */
+export const fileStorageKeys = {
+  all: ["file-storage"] as const,
+  connections: () => [...fileStorageKeys.all, "connections"] as const,
+  files: (connectionId: string, path: string) =>
+    [...fileStorageKeys.all, "files", connectionId, path] as const,
+  file: (connectionId: string, path: string) =>
+    [...fileStorageKeys.all, "file", connectionId, path] as const,
+};
+
+/**
+ * Hook to get connections that implement FILE_STORAGE_BINDING
+ *
+ * @returns Array of connections that can store files
+ */
+export function useFileStorageConnections(): ConnectionEntity[] {
+  // useConnections returns items directly (an array)
+  const connections = useConnections();
+
+  return useBindingConnections({
+    connections,
+    binding: "FILE_STORAGE",
+  });
+}
+
+/**
+ * Hook to check if file storage is available
+ *
+ * @returns true if at least one file storage connection is available
+ */
+export function useHasFileStorage(): boolean {
+  const storageConnections = useFileStorageConnections();
+  return storageConnections.length > 0;
+}
+
+/**
+ * Hook to get the primary file storage connection
+ * Returns the first available storage connection
+ *
+ * @returns The primary storage connection or undefined
+ */
+export function usePrimaryFileStorage(): ConnectionEntity | undefined {
+  const storageConnections = useFileStorageConnections();
+  return storageConnections[0];
+}
+
+/**
+ * Hook to list files in a folder
+ *
+ * @param connectionId - Connection ID of the storage provider
+ * @param parentPath - Parent folder path (empty string for root)
+ * @returns Query result with files
+ */
+export function useFileList(connectionId: string, parentPath = "") {
+  const toolCaller = createToolCaller(connectionId);
+
+  return useQuery({
+    queryKey: fileStorageKeys.files(connectionId, parentPath),
+    queryFn: async () => {
+      const result = await toolCaller("COLLECTION_FILES_LIST", {
+        where: parentPath
+          ? { field: ["parent"], operator: "eq", value: parentPath }
+          : undefined,
+      });
+      return result as { items: FileEntity[]; totalCount?: number };
+    },
+    enabled: !!connectionId,
+  });
+}
+
+/**
+ * Hook to read a file's content
+ *
+ * @param connectionId - Connection ID of the storage provider
+ * @param path - File path to read
+ * @param encoding - Encoding (default: utf-8)
+ * @param enabled - Whether the query should run (default: true)
+ * @returns Query result with file content
+ */
+export function useFileContent(
+  connectionId: string,
+  path: string,
+  encoding: "utf-8" | "base64" = "utf-8",
+  enabled = true,
+) {
+  const toolCaller = createToolCaller(connectionId);
+
+  return useQuery({
+    queryKey: fileStorageKeys.file(connectionId, path),
+    queryFn: async () => {
+      const result = await toolCaller("FILE_READ", { path, encoding });
+      return result as { content: string; metadata: FileEntity };
+    },
+    enabled: enabled && !!connectionId && !!path,
+  });
+}
+
+/**
+ * Convert File to base64 string
+ */
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      // Remove the data URL prefix (e.g., "data:image/png;base64,")
+      const base64 = dataUrl.split(",")[1] ?? "";
+      resolve(base64);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Hook to upload files
+ *
+ * @param connectionId - Connection ID of the storage provider
+ * @returns Mutation for uploading files
+ */
+export function useFileUpload(connectionId: string) {
+  const queryClient = useQueryClient();
+  const toolCaller = createToolCaller(connectionId);
+
+  return useMutation({
+    mutationFn: async ({ file, path }: { file: File; path?: string }) => {
+      const content = await fileToBase64(file);
+      const targetPath = path || file.name;
+
+      const result = await toolCaller("FILE_WRITE", {
+        path: targetPath,
+        content,
+        encoding: "base64",
+        mimeType: file.type,
+        createParents: true,
+        overwrite: true,
+      });
+
+      return result as { file: FileEntity };
+    },
+    onSuccess: () => {
+      // Invalidate file lists to refresh
+      queryClient.invalidateQueries({
+        queryKey: fileStorageKeys.all,
+      });
+      // Also invalidate the collection list queries for FILES and FOLDERS
+      queryClient.invalidateQueries({
+        queryKey: KEYS.collectionListPrefix(connectionId, "FILES"),
+      });
+      queryClient.invalidateQueries({
+        queryKey: KEYS.collectionListPrefix(connectionId, "FOLDERS"),
+      });
+    },
+  });
+}
+
+/**
+ * Helper to invalidate all file-related queries
+ */
+function invalidateFileQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  connectionId: string,
+) {
+  // Invalidate file storage queries
+  queryClient.invalidateQueries({
+    queryKey: fileStorageKeys.all,
+  });
+  // Invalidate collection list queries for FILES and FOLDERS
+  queryClient.invalidateQueries({
+    queryKey: KEYS.collectionListPrefix(connectionId, "FILES"),
+  });
+  queryClient.invalidateQueries({
+    queryKey: KEYS.collectionListPrefix(connectionId, "FOLDERS"),
+  });
+}
+
+/**
+ * Hook for file mutations (write, delete, move, etc.)
+ *
+ * @param connectionId - Connection ID of the storage provider
+ * @returns Object with mutation functions
+ */
+export function useFileMutations(connectionId: string) {
+  const queryClient = useQueryClient();
+  const toolCaller = createToolCaller(connectionId);
+
+  const writeMutation = useMutation({
+    mutationFn: async ({
+      path,
+      content,
+      encoding = "utf-8",
+    }: {
+      path: string;
+      content: string;
+      encoding?: "utf-8" | "base64";
+    }) => {
+      const result = await toolCaller("FILE_WRITE", {
+        path,
+        content,
+        encoding,
+        createParents: true,
+        overwrite: true,
+      });
+      return result as { file: FileEntity };
+    },
+    onSuccess: () => {
+      invalidateFileQueries(queryClient, connectionId);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async ({
+      path,
+      recursive = false,
+    }: {
+      path: string;
+      recursive?: boolean;
+    }) => {
+      const result = await toolCaller("FILE_DELETE", { path, recursive });
+      return result as { success: boolean; path: string };
+    },
+    onSuccess: () => {
+      invalidateFileQueries(queryClient, connectionId);
+    },
+  });
+
+  const moveMutation = useMutation({
+    mutationFn: async ({
+      from,
+      to,
+      overwrite = false,
+    }: {
+      from: string;
+      to: string;
+      overwrite?: boolean;
+    }) => {
+      const result = await toolCaller("FILE_MOVE", { from, to, overwrite });
+      return result as { file: FileEntity };
+    },
+    onSuccess: () => {
+      invalidateFileQueries(queryClient, connectionId);
+    },
+  });
+
+  const mkdirMutation = useMutation({
+    mutationFn: async ({
+      path,
+      recursive = true,
+    }: {
+      path: string;
+      recursive?: boolean;
+    }) => {
+      const result = await toolCaller("FILE_MKDIR", { path, recursive });
+      return result as { folder: FileEntity };
+    },
+    onSuccess: () => {
+      invalidateFileQueries(queryClient, connectionId);
+    },
+  });
+
+  return {
+    write: writeMutation,
+    save: writeMutation, // Alias for save
+    delete: deleteMutation,
+    move: moveMutation,
+    mkdir: mkdirMutation,
+    isSaving: writeMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    isMoving: moveMutation.isPending,
+  };
+}

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -2,6 +2,8 @@ import { useProjectContext } from "@/web/providers/project-context-provider";
 import { NavigationSidebarItem } from "@deco/ui/components/navigation-sidebar.js";
 import { Locator } from "@/web/lib/locator";
 import { useNavigate } from "@tanstack/react-router";
+import { useConnections } from "@/web/hooks/collections/use-connection";
+import { useFileStorageConnections } from "@/web/hooks/use-binding";
 import {
   Home02,
   Building02,
@@ -10,6 +12,7 @@ import {
   Users01,
   Settings01,
   BarChart10,
+  Folder,
 } from "@untitledui/icons";
 
 export function useProjectSidebarItems() {
@@ -17,6 +20,11 @@ export function useProjectSidebarItems() {
   const navigate = useNavigate();
   const { org } = Locator.parse(locator);
   const isOrgAdminProject = Locator.isOrgAdminProject(locator);
+
+  // Get file storage connections to conditionally show Files menu
+  const allConnections = useConnections();
+  const fileStorageConnections = useFileStorageConnections(allConnections);
+  const hasFileStorage = fileStorageConnections.length > 0;
 
   const KNOWN_ORG_ADMIN_SIDEBAR_ITEMS: NavigationSidebarItem[] = [
     {
@@ -31,6 +39,17 @@ export function useProjectSidebarItems() {
       icon: <Building02 />,
       onClick: () => navigate({ to: "/$org/store", params: { org } }),
     },
+    // Only show Files menu when there are file storage connections
+    ...(hasFileStorage
+      ? [
+          {
+            key: "files",
+            label: "Files",
+            icon: <Folder />,
+            onClick: () => navigate({ to: "/$org/files", params: { org } }),
+          },
+        ]
+      : []),
     {
       key: "mcps",
       label: "MCP Servers",

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -121,6 +121,12 @@ const orgStoreRoute = createRoute({
   component: lazyRouteComponent(() => import("./routes/orgs/store.tsx")),
 });
 
+const orgFilesRoute = createRoute({
+  getParentRoute: () => shellLayout,
+  path: "/$org/files",
+  component: lazyRouteComponent(() => import("./routes/orgs/files.tsx")),
+});
+
 const storeAppDetailRoute = createRoute({
   getParentRoute: () => orgStoreRoute,
   path: "/$appName",
@@ -205,6 +211,7 @@ const shellRouteTree = shellLayout.addChildren([
   gatewayDetailRoute,
   orgMonitoringRoute,
   orgStoreRouteWithChildren,
+  orgFilesRoute,
   orgSettingsRoute,
   connectionLayoutRoute,
   collectionDetailsRoute,

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -16,5 +16,6 @@ export const LOCALSTORAGE_KEYS = {
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,
   sidebarOpen: () => `mesh:sidebar-open`,
   selectedRegistry: (org: string) => `mesh:store:selected-registry:${org}`,
+  selectedFileStorage: (org: string) => `mesh:files:selected-storage:${org}`,
   orgHomeQuickstart: (org: string) => `mesh:org-home:quickstart:${org}`,
 } as const;

--- a/apps/mesh/src/web/routes/orgs/collection-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/collection-detail.tsx
@@ -1,5 +1,9 @@
 import { UNKNOWN_CONNECTION_ID, createToolCaller } from "@/tools/client";
 import { AssistantDetailsView } from "@/web/components/details/assistant/index.tsx";
+import {
+  FileDetailsView,
+  FolderDetailsView,
+} from "@/web/components/details/file/index.tsx";
 import { PromptDetailsView } from "@/web/components/details/prompt/index.tsx";
 import { ToolDetailsView } from "@/web/components/details/tool.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
@@ -23,6 +27,8 @@ const WELL_KNOWN_VIEW_DETAILS: Record<
 > = {
   workflow: WorkflowDetailsView,
   assistant: AssistantDetailsView,
+  files: FileDetailsView,
+  folders: FolderDetailsView,
   prompt: PromptDetailsView,
 };
 

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -511,11 +511,14 @@ function OrgMcpsContent() {
       id: "title",
       header: "Name",
       render: (connection) => (
-        <span className="text-sm font-medium text-foreground truncate">
+        <span
+          className="text-sm font-medium text-foreground truncate block"
+          title={connection.title}
+        >
           {connection.title}
         </span>
       ),
-      cellClassName: "w-48 min-w-0 shrink-0",
+      cellClassName: "w-48 max-w-48 min-w-0 shrink-0",
       sortable: true,
     },
     {

--- a/apps/mesh/src/web/routes/orgs/files.tsx
+++ b/apps/mesh/src/web/routes/orgs/files.tsx
@@ -1,0 +1,139 @@
+/**
+ * Files Page
+ *
+ * A dedicated page for browsing files from any File Storage binding connection.
+ * Reuses the same CollectionTab component used in connection detail pages.
+ */
+
+import { Suspense } from "react";
+import { CollectionHeader } from "@/web/components/collections/collection-header";
+import { CollectionTab } from "@/web/components/details/connection/collection-tab";
+import { EmptyState } from "@/web/components/empty-state";
+import {
+  useConnections,
+  useConnection,
+} from "@/web/hooks/collections/use-connection";
+import {
+  useFileStorageConnections,
+  useCollectionBindings,
+} from "@/web/hooks/use-binding";
+import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { useProjectContext } from "@/web/providers/project-context-provider";
+import { FileStorageConnectionSelect } from "@/web/components/file-storage-connection-select";
+import { Loading01, Folder } from "@untitledui/icons";
+
+export default function FilesPage() {
+  const { org } = useProjectContext();
+  const allConnections = useConnections();
+
+  // Filter to only show file storage connections
+  const fileStorageConnections = useFileStorageConnections(allConnections);
+
+  const connectionOptions = fileStorageConnections.map((c) => ({
+    id: c.id,
+    name: c.title,
+    icon: c.icon || undefined,
+  }));
+
+  // Persist selected file storage in localStorage (scoped by org)
+  const [selectedConnectionId, setSelectedConnectionId] =
+    useLocalStorage<string>(
+      LOCALSTORAGE_KEYS.selectedFileStorage(org.slug),
+      () => "",
+    );
+
+  const selectedConnection = fileStorageConnections.find(
+    (c) => c.id === selectedConnectionId,
+  );
+
+  // If there's only one connection, use it; otherwise use the selected one if it still exists.
+  const effectiveConnectionId =
+    selectedConnection?.id || fileStorageConnections[0]?.id || "";
+
+  const hasFileStorageConnections = fileStorageConnections.length > 0;
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <CollectionHeader
+        title="Files"
+        ctaButton={
+          hasFileStorageConnections ? (
+            <FileStorageConnectionSelect
+              connections={connectionOptions}
+              value={effectiveConnectionId}
+              onValueChange={setSelectedConnectionId}
+              placeholder="Select storage..."
+            />
+          ) : null
+        }
+      />
+
+      {/* Content Section */}
+      <div className="h-full flex flex-col overflow-hidden">
+        <Suspense
+          fallback={
+            <div className="flex flex-col items-center justify-center h-full">
+              <Loading01
+                size={32}
+                className="animate-spin text-muted-foreground mb-4"
+              />
+              <p className="text-sm text-muted-foreground">Loading files...</p>
+            </div>
+          }
+        >
+          {effectiveConnectionId ? (
+            <FilesContent connectionId={effectiveConnectionId} org={org.slug} />
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full">
+              <EmptyState
+                image={<Folder size={48} className="text-muted-foreground" />}
+                title="No File Storage Connected"
+                description="Add a File Storage binding to browse and manage files"
+              />
+            </div>
+          )}
+        </Suspense>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inner component that loads the connection and renders the FILES collection
+ */
+function FilesContent({
+  connectionId,
+  org,
+}: {
+  connectionId: string;
+  org: string;
+}) {
+  const connection = useConnection(connectionId);
+  const collections = useCollectionBindings(connection ?? undefined);
+
+  // Find the FILES collection
+  const filesCollection = collections.find(
+    (c) => c.name.toUpperCase() === "FILES",
+  );
+
+  if (!filesCollection) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <EmptyState
+          image={<Folder size={48} className="text-muted-foreground" />}
+          title="No Files Collection"
+          description="This connection doesn't expose a Files collection"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <CollectionTab
+      connectionId={connectionId}
+      org={org}
+      activeCollection={filesCollection}
+    />
+  );
+}

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=24.0.0"
+  },
+  "dependencies": {
+    "@monaco-editor/react": "^4.7.0"
   }
 }

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -20,7 +20,8 @@
     "./mcp": "./src/well-known/mcp.ts",
     "./assistant": "./src/well-known/assistant.ts",
     "./prompt": "./src/well-known/prompt.ts",
-    "./workflow": "./src/well-known/workflow.ts"
+    "./workflow": "./src/well-known/workflow.ts",
+    "./file-storage": "./src/well-known/file-storage.ts"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/bindings/src/well-known/file-storage.ts
+++ b/packages/bindings/src/well-known/file-storage.ts
@@ -1,0 +1,484 @@
+/**
+ * File Storage Well-Known Binding
+ *
+ * Defines the interface for file storage operations via MCP.
+ * Any MCP that implements this binding can store, retrieve, and manage files.
+ *
+ * This binding includes:
+ * - FILE_READ: Read file content
+ * - FILE_WRITE: Write/upload file content
+ * - FILE_DELETE: Delete file or directory
+ * - FILE_MOVE: Move/rename files (optional)
+ * - FILE_COPY: Copy files (optional)
+ * - FILE_MKDIR: Create directories (optional)
+ * - FILE_UPLOAD_URL: Get pre-signed upload URL (optional)
+ */
+
+import { z } from "zod";
+import { bindingClient, type ToolBinder } from "../core/binder";
+import {
+  createCollectionBindings,
+  type CollectionListInput,
+} from "./collections";
+
+// ============================================================================
+// Entity Schemas
+// ============================================================================
+
+/**
+ * File entity schema - metadata for a file or folder
+ */
+export const FileEntitySchema = z.object({
+  /** Unique file path (serves as ID) */
+  id: z.string().describe("Unique file path/identifier"),
+
+  /** Display name */
+  title: z.string().describe("File name"),
+
+  /** Optional description */
+  description: z.string().nullish(),
+
+  /** File path relative to storage root */
+  path: z.string().describe("File path relative to storage root"),
+
+  /** Parent folder path (empty string for root) */
+  parent: z.string().describe("Parent folder path"),
+
+  /** MIME type */
+  mimeType: z.string().describe("MIME type of the file"),
+
+  /** File size in bytes */
+  size: z.number().describe("File size in bytes"),
+
+  /** Whether this is a directory */
+  isDirectory: z.boolean().describe("Whether this is a directory"),
+
+  /** Created timestamp */
+  created_at: z.string().datetime(),
+
+  /** Updated timestamp */
+  updated_at: z.string().datetime(),
+
+  /** Optional URL for direct access (pre-signed URL or public URL) */
+  url: z.string().url().optional().describe("Direct access URL"),
+
+  /** Optional thumbnail URL for images */
+  thumbnailUrl: z.string().url().optional(),
+});
+
+export type FileEntity = z.infer<typeof FileEntitySchema>;
+
+/**
+ * Folder entity schema (directory with item count)
+ */
+export const FolderEntitySchema = FileEntitySchema.extend({
+  isDirectory: z.literal(true),
+  /** Number of items in folder */
+  itemCount: z.number().optional().describe("Number of items in folder"),
+});
+
+export type FolderEntity = z.infer<typeof FolderEntitySchema>;
+
+// ============================================================================
+// FILE_READ Schemas
+// ============================================================================
+
+/**
+ * FILE_READ Input - Read file content
+ */
+export const FileReadInputSchema = z.object({
+  /** File path to read */
+  path: z.string().describe("File path to read"),
+
+  /** Encoding for text files (default: utf-8) */
+  encoding: z
+    .enum(["utf-8", "base64", "binary"])
+    .optional()
+    .default("utf-8")
+    .describe("Content encoding"),
+});
+
+export type FileReadInput = z.infer<typeof FileReadInputSchema>;
+
+export const FileReadOutputSchema = z.object({
+  /** File content (text or base64 encoded) */
+  content: z.string().describe("File content"),
+
+  /** File metadata */
+  metadata: FileEntitySchema,
+});
+
+export type FileReadOutput = z.infer<typeof FileReadOutputSchema>;
+
+// ============================================================================
+// FILE_WRITE Schemas
+// ============================================================================
+
+/**
+ * FILE_WRITE Input - Write/upload file
+ */
+export const FileWriteInputSchema = z.object({
+  /** File path to write */
+  path: z.string().describe("File path to write"),
+
+  /** File content (text or base64 encoded) */
+  content: z.string().describe("File content (text or base64)"),
+
+  /** Content encoding */
+  encoding: z
+    .enum(["utf-8", "base64"])
+    .optional()
+    .default("utf-8")
+    .describe("Content encoding"),
+
+  /** MIME type (auto-detected if not provided) */
+  mimeType: z
+    .string()
+    .optional()
+    .describe("MIME type (auto-detected if omitted)"),
+
+  /** Whether to create parent directories if they don't exist */
+  createParents: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Create parent directories if needed"),
+
+  /** Whether to overwrite if file exists */
+  overwrite: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Overwrite existing file"),
+});
+
+export type FileWriteInput = z.infer<typeof FileWriteInputSchema>;
+
+export const FileWriteOutputSchema = z.object({
+  /** Written file metadata */
+  file: FileEntitySchema,
+});
+
+export type FileWriteOutput = z.infer<typeof FileWriteOutputSchema>;
+
+// ============================================================================
+// FILE_DELETE Schemas
+// ============================================================================
+
+/**
+ * FILE_DELETE Input
+ */
+export const FileDeleteInputSchema = z.object({
+  /** Path to delete */
+  path: z.string().describe("Path to delete"),
+
+  /** Whether to recursively delete directories */
+  recursive: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Recursively delete directories"),
+});
+
+export type FileDeleteInput = z.infer<typeof FileDeleteInputSchema>;
+
+export const FileDeleteOutputSchema = z.object({
+  success: z.boolean(),
+  path: z.string(),
+  deletedCount: z.number().optional(),
+});
+
+export type FileDeleteOutput = z.infer<typeof FileDeleteOutputSchema>;
+
+// ============================================================================
+// FILE_MOVE Schemas
+// ============================================================================
+
+/**
+ * FILE_MOVE Input - Move/rename file or folder
+ */
+export const FileMoveInputSchema = z.object({
+  /** Source path */
+  from: z.string().describe("Source path"),
+
+  /** Destination path */
+  to: z.string().describe("Destination path"),
+
+  /** Whether to overwrite if destination exists */
+  overwrite: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Overwrite if destination exists"),
+});
+
+export type FileMoveInput = z.infer<typeof FileMoveInputSchema>;
+
+export const FileMoveOutputSchema = z.object({
+  /** Moved file metadata */
+  file: FileEntitySchema,
+});
+
+export type FileMoveOutput = z.infer<typeof FileMoveOutputSchema>;
+
+// ============================================================================
+// FILE_COPY Schemas
+// ============================================================================
+
+/**
+ * FILE_COPY Input
+ */
+export const FileCopyInputSchema = z.object({
+  /** Source path */
+  from: z.string().describe("Source path"),
+
+  /** Destination path */
+  to: z.string().describe("Destination path"),
+
+  /** Whether to overwrite if destination exists */
+  overwrite: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Overwrite if destination exists"),
+});
+
+export type FileCopyInput = z.infer<typeof FileCopyInputSchema>;
+
+export const FileCopyOutputSchema = z.object({
+  /** Copied file metadata */
+  file: FileEntitySchema,
+});
+
+export type FileCopyOutput = z.infer<typeof FileCopyOutputSchema>;
+
+// ============================================================================
+// FILE_MKDIR Schemas
+// ============================================================================
+
+/**
+ * FILE_MKDIR Input - Create directory
+ */
+export const FileMkdirInputSchema = z.object({
+  /** Directory path to create */
+  path: z.string().describe("Directory path to create"),
+
+  /** Whether to create parent directories */
+  recursive: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Create parent directories"),
+});
+
+export type FileMkdirInput = z.infer<typeof FileMkdirInputSchema>;
+
+export const FileMkdirOutputSchema = z.object({
+  /** Created directory metadata */
+  folder: FolderEntitySchema,
+});
+
+export type FileMkdirOutput = z.infer<typeof FileMkdirOutputSchema>;
+
+// ============================================================================
+// FILE_UPLOAD_URL Schemas (for direct uploads)
+// ============================================================================
+
+/**
+ * FILE_UPLOAD_URL Input - Get a pre-signed URL for direct upload
+ */
+export const FileUploadUrlInputSchema = z.object({
+  /** Target path for the upload */
+  path: z.string().describe("Target path for upload"),
+
+  /** MIME type of file to upload */
+  mimeType: z.string().describe("MIME type"),
+
+  /** File size in bytes (for validation) */
+  size: z.number().optional().describe("File size in bytes"),
+
+  /** URL expiration in seconds (default: 3600) */
+  expiresIn: z
+    .number()
+    .optional()
+    .default(3600)
+    .describe("URL expiration in seconds"),
+});
+
+export type FileUploadUrlInput = z.infer<typeof FileUploadUrlInputSchema>;
+
+export const FileUploadUrlOutputSchema = z.object({
+  /** Pre-signed upload URL */
+  uploadUrl: z.string().url(),
+
+  /** HTTP method to use (PUT or POST) */
+  method: z.enum(["PUT", "POST"]),
+
+  /** Headers to include with the upload request */
+  headers: z.record(z.string()).optional(),
+
+  /** Form fields for multipart uploads */
+  fields: z.record(z.string()).optional(),
+
+  /** URL expiration timestamp */
+  expiresAt: z.string().datetime(),
+
+  /** Final path where file will be stored */
+  path: z.string(),
+});
+
+export type FileUploadUrlOutput = z.infer<typeof FileUploadUrlOutputSchema>;
+
+// ============================================================================
+// FILE_STORAGE_BINDING Definition
+// ============================================================================
+
+/**
+ * File Storage Binding
+ *
+ * Defines the interface for file storage operations.
+ * Implementations must provide core file operations.
+ *
+ * Required tools:
+ * - FILE_READ: Read file content
+ * - FILE_WRITE: Write/upload file content
+ * - FILE_DELETE: Delete file or directory
+ *
+ * Optional tools:
+ * - FILE_MOVE: Move/rename files
+ * - FILE_COPY: Copy files
+ * - FILE_MKDIR: Create directories
+ * - FILE_UPLOAD_URL: Get pre-signed upload URL (for direct uploads)
+ */
+export const FILE_STORAGE_BINDING = [
+  {
+    name: "FILE_READ" as const,
+    inputSchema: FileReadInputSchema,
+    outputSchema: FileReadOutputSchema,
+  },
+  {
+    name: "FILE_WRITE" as const,
+    inputSchema: FileWriteInputSchema,
+    outputSchema: FileWriteOutputSchema,
+  },
+  {
+    name: "FILE_DELETE" as const,
+    inputSchema: FileDeleteInputSchema,
+    outputSchema: FileDeleteOutputSchema,
+  },
+  {
+    name: "FILE_MOVE" as const,
+    inputSchema: FileMoveInputSchema,
+    outputSchema: FileMoveOutputSchema,
+    opt: true,
+  },
+  {
+    name: "FILE_COPY" as const,
+    inputSchema: FileCopyInputSchema,
+    outputSchema: FileCopyOutputSchema,
+    opt: true,
+  },
+  {
+    name: "FILE_MKDIR" as const,
+    inputSchema: FileMkdirInputSchema,
+    outputSchema: FileMkdirOutputSchema,
+    opt: true,
+  },
+  {
+    name: "FILE_UPLOAD_URL" as const,
+    inputSchema: FileUploadUrlInputSchema,
+    outputSchema: FileUploadUrlOutputSchema,
+    opt: true,
+  },
+] satisfies ToolBinder[];
+
+/**
+ * File Storage Binding Client
+ *
+ * Use this to create a client for interacting with a file storage provider.
+ *
+ * @example
+ * ```typescript
+ * import { FileStorageBinding } from "@decocms/bindings/file-storage";
+ *
+ * // For a connection
+ * const client = FileStorageBinding.forConnection(connection);
+ *
+ * // Read a file
+ * const file = await client.FILE_READ({ path: "docs/readme.md" });
+ *
+ * // Write a file
+ * await client.FILE_WRITE({
+ *   path: "uploads/image.png",
+ *   content: base64Content,
+ *   encoding: "base64",
+ *   mimeType: "image/png"
+ * });
+ *
+ * // Delete a file
+ * await client.FILE_DELETE({ path: "temp/old-file.txt" });
+ * ```
+ */
+export const FileStorageBinding = bindingClient(FILE_STORAGE_BINDING);
+
+/**
+ * Type helper for the File Storage binding client
+ */
+export type FileStorageBindingClient = ReturnType<
+  typeof FileStorageBinding.forConnection
+>;
+
+// ============================================================================
+// Collection Bindings for Files and Folders
+// ============================================================================
+
+/**
+ * Files collection binding - for browsing files
+ * Uses the standard collection pattern for LIST and GET
+ */
+export const FILES_COLLECTION_BINDING = createCollectionBindings(
+  "files",
+  FileEntitySchema,
+  { readOnly: true },
+);
+
+/**
+ * Folders collection binding - for browsing folders
+ */
+export const FOLDERS_COLLECTION_BINDING = createCollectionBindings(
+  "folders",
+  FolderEntitySchema,
+  { readOnly: true },
+);
+
+// ============================================================================
+// List Input Extension for Files (with parent filter)
+// ============================================================================
+
+/**
+ * Extended list input for files collection with parent filter
+ */
+export const FilesListInputSchema = z.object({
+  /** Filter by parent folder (empty string for root) */
+  parent: z.string().optional().describe("Parent folder path"),
+  limit: z.number().int().min(1).max(1000).optional(),
+  offset: z.number().int().min(0).optional(),
+});
+
+export type FilesListInput = z.infer<typeof FilesListInputSchema>;
+
+/**
+ * Convert FilesListInput to standard CollectionListInput
+ */
+export function filesToCollectionInput(
+  input: FilesListInput,
+): CollectionListInput {
+  return {
+    where:
+      input.parent !== undefined
+        ? { field: ["parent"], operator: "eq", value: input.parent }
+        : undefined,
+    limit: input.limit,
+    offset: input.offset,
+  };
+}


### PR DESCRIPTION
<img width="732" height="959" alt="CleanShot 2025-12-29 at 23 31 21" src="https://github.com/user-attachments/assets/170a26b8-c7f2-4874-824d-57d58c015a71" />

<img width="762" height="497" alt="CleanShot 2025-12-29 at 23 31 58" src="https://github.com/user-attachments/assets/4586715b-2297-4f2b-b9e5-b67e090870f6" />

this adds a local mcp server - after we publish it will default to npx @decocms/mcp-local-fs

<img width="669" height="882" alt="CleanShot 2025-12-29 at 23 32 15" src="https://github.com/user-attachments/assets/c9a718b8-ec57-41b0-a7d0-3af29ce546cd" />

<img width="1189" height="868" alt="CleanShot 2025-12-29 at 23 32 52" src="https://github.com/user-attachments/assets/cc54d3b4-549c-424a-bc1d-22dd00070c14" />

<img width="339" height="226" alt="CleanShot 2025-12-29 at 23 33 05" src="https://github.com/user-attachments/assets/7e63b0aa-8add-44bd-9ec8-c40a910ce8ec" />

in the future: S3, R2, etc etc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Add Binding modal and a Files menu, and implements the File Storage binding with a local MCP (STDIO) option plus a full file browser/editor UI.

- **New Features**
  - File Storage binding: FILES/FOLDERS collections, schemas, and tools definitions.
  - Local FS MCP: well-known connection, stable STDIO transport, /mcp/local-fs and /api/files routes; defaults to npx @decocms/mcp-local-fs after publish.
  - Files experience: new /$org/files page, drag-and-drop uploads, previews, and Monaco-based text editor; per-connection storage selector.
  - Add Binding modal: quick setup for common bindings, including file storage.
  - STDIO connections: new type with encrypted env vars; fetch-tools and proxy support; settings UI for NPX/STDIO/HTTP; disabled in production unless UNSAFE_ALLOW_STDIO_TRANSPORT=true.
  - Sidebar: shows a Files menu when a storage connection exists.
  - Dev quality: optional rate limit toggle (DISABLE_RATE_LIMIT), lefthook pre-commit, and local storage gitignore.

- **Migration**
  - Install dependencies (includes @monaco-editor/react) and lefthook: npx lefthook install.
  - To use STDIO in production, set UNSAFE_ALLOW_STDIO_TRANSPORT=true.
  - For local storage, create a Local FS connection via Add Binding and use NPX once the package is published.

<sup>Written for commit 7da18afc6bf468cfda34eaa4217e9409a7aeb2b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

