### PR TITLE
Adds prompts and resources tab

### DIFF
--- a/apps/mesh/src/web/components/details/connection/prompts-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/prompts-tab.tsx
@@ -1,0 +1,234 @@
+import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
+import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
+import { CollectionTableWrapper } from "@/web/components/collections/collection-table-wrapper.tsx";
+import { EmptyState } from "@/web/components/empty-state.tsx";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import { Card } from "@deco/ui/components/card.tsx";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { ViewActions } from "@/web/components/details/layout";
+import type { McpPrompt } from "@/web/hooks/use-connection-prompts";
+
+export interface PromptsListProps {
+  /** Array of prompts to display */
+  prompts: McpPrompt[] | undefined;
+  /** Connection ID for navigation */
+  connectionId?: string;
+  /** Organization slug for navigation */
+  org?: string;
+  /** Custom click handler - if provided, overrides default navigation */
+  onPromptClick?: (prompt: McpPrompt) => void;
+  /** Whether to show the ViewActions toolbar (default: true) */
+  showToolbar?: boolean;
+  /** Custom empty state message */
+  emptyMessage?: string;
+}
+
+/**
+ * Shared component for displaying a list of prompts with search, sort, and view modes.
+ */
+function PromptsList({
+  prompts,
+  connectionId,
+  org,
+  onPromptClick,
+  showToolbar = true,
+  emptyMessage = "This connection doesn't have any prompts yet.",
+}: PromptsListProps) {
+  const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useState<"table" | "cards">("table");
+  const [sortKey, setSortKey] = useState<string | undefined>("name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc" | null>(
+    "asc",
+  );
+
+  const handleSort = (key: string) => {
+    if (sortKey === key) {
+      setSortDirection((prev) =>
+        prev === "asc" ? "desc" : prev === "desc" ? null : "asc",
+      );
+      if (sortDirection === "desc") setSortKey(undefined);
+    } else {
+      setSortKey(key);
+      setSortDirection("asc");
+    }
+  };
+
+  const handlePromptClick = (prompt: McpPrompt) => {
+    if (onPromptClick) {
+      onPromptClick(prompt);
+    } else if (connectionId && org) {
+      navigate({
+        to: "/$org/mcps/$connectionId/$collectionName/$itemId",
+        params: {
+          org: org,
+          connectionId: connectionId,
+          collectionName: "prompts",
+          itemId: encodeURIComponent(prompt.name),
+        },
+      });
+    }
+  };
+
+  const filteredPrompts =
+    !prompts || prompts.length === 0
+      ? []
+      : !search.trim()
+        ? prompts
+        : (() => {
+            const searchLower = search.toLowerCase();
+            return prompts.filter(
+              (p) =>
+                p.name.toLowerCase().includes(searchLower) ||
+                (p.description &&
+                  p.description.toLowerCase().includes(searchLower)),
+            );
+          })();
+
+  const sortedPrompts =
+    !sortKey || !sortDirection
+      ? filteredPrompts
+      : [...filteredPrompts].sort((a, b) => {
+          const aVal = (a as unknown as Record<string, unknown>)[sortKey] || "";
+          const bVal = (b as unknown as Record<string, unknown>)[sortKey] || "";
+          const comparison = String(aVal).localeCompare(String(bVal));
+          return sortDirection === "asc" ? comparison : -comparison;
+        });
+
+  const columns = [
+    {
+      id: "name",
+      header: "Name",
+      render: (prompt: McpPrompt) => (
+        <span className="text-sm font-medium font-mono text-foreground">
+          {prompt.name}
+        </span>
+      ),
+      sortable: true,
+    },
+    {
+      id: "description",
+      header: "Description",
+      render: (prompt: McpPrompt) => (
+        <span className="text-sm text-foreground">
+          {prompt.description || "—"}
+        </span>
+      ),
+      cellClassName: "flex-1",
+      sortable: true,
+    },
+  ];
+
+  const sortOptions = columns
+    .filter((col) => col.sortable)
+    .map((col) => ({
+      id: col.id,
+      label: typeof col.header === "string" ? col.header : col.id,
+    }));
+
+  return (
+    <>
+      {showToolbar && (
+        <ViewActions>
+          <CollectionDisplayButton
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            sortOptions={sortOptions}
+          />
+        </ViewActions>
+      )}
+
+      <div className="flex flex-col h-full overflow-hidden">
+        {/* Search */}
+        <CollectionSearch
+          value={search}
+          onChange={setSearch}
+          placeholder="Search prompts..."
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setSearch("");
+              (event.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+
+        {/* Content: Cards or Table */}
+        {viewMode === "cards" ? (
+          <div className="flex-1 overflow-auto p-5">
+            {sortedPrompts.length === 0 ? (
+              <EmptyState
+                image={null}
+                title={search ? "No prompts found" : "No prompts available"}
+                description={
+                  search ? "Try adjusting your search terms" : emptyMessage
+                }
+              />
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                {sortedPrompts.map((prompt) => (
+                  <Card
+                    key={prompt.name}
+                    className="cursor-pointer transition-colors"
+                    onClick={() => handlePromptClick(prompt)}
+                  >
+                    <div className="flex flex-col gap-4 p-6">
+                      <IntegrationIcon
+                        icon={null}
+                        name={prompt.name}
+                        size="md"
+                        className="shrink-0 shadow-sm"
+                      />
+                      <div className="flex flex-col gap-0">
+                        <h3 className="text-base font-medium text-foreground truncate">
+                          {prompt.name}
+                        </h3>
+                        <p className="text-base text-muted-foreground line-clamp-2">
+                          {prompt.description || "No description"}
+                        </p>
+                      </div>
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <CollectionTableWrapper
+            columns={columns}
+            data={sortedPrompts}
+            isLoading={false}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            onRowClick={(prompt: McpPrompt) => handlePromptClick(prompt)}
+            emptyState={
+              <EmptyState
+                image={null}
+                title={search ? "No prompts found" : "No prompts available"}
+                description={
+                  search ? "Try adjusting your search terms" : emptyMessage
+                }
+              />
+            }
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+interface PromptsTabProps {
+  prompts: McpPrompt[] | undefined;
+  connectionId: string;
+  org: string;
+}
+
+export function PromptsTab({ prompts, connectionId, org }: PromptsTabProps) {
+  return (
+    <PromptsList prompts={prompts} connectionId={connectionId} org={org} />
+  );
+}

--- a/apps/mesh/src/web/components/details/connection/resources-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/resources-tab.tsx
@@ -1,0 +1,256 @@
+import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
+import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
+import { CollectionTableWrapper } from "@/web/components/collections/collection-table-wrapper.tsx";
+import { EmptyState } from "@/web/components/empty-state.tsx";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import { Card } from "@deco/ui/components/card.tsx";
+import { useState } from "react";
+import { ViewActions } from "@/web/components/details/layout";
+import type { McpResource } from "@/web/hooks/use-connection-resources";
+
+export interface ResourcesListProps {
+  /** Array of resources to display */
+  resources: McpResource[] | undefined;
+  /** Connection ID for context */
+  connectionId?: string;
+  /** Organization slug for context */
+  org?: string;
+  /** Custom click handler */
+  onResourceClick?: (resource: McpResource) => void;
+  /** Whether to show the ViewActions toolbar (default: true) */
+  showToolbar?: boolean;
+  /** Custom empty state message */
+  emptyMessage?: string;
+}
+
+/**
+ * Shared component for displaying a list of resources with search, sort, and view modes.
+ */
+function ResourcesList({
+  resources,
+  onResourceClick,
+  showToolbar = true,
+  emptyMessage = "This connection doesn't have any resources yet.",
+}: ResourcesListProps) {
+  const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useState<"table" | "cards">("table");
+  const [sortKey, setSortKey] = useState<string | undefined>("name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc" | null>(
+    "asc",
+  );
+
+  const handleSort = (key: string) => {
+    if (sortKey === key) {
+      setSortDirection((prev) =>
+        prev === "asc" ? "desc" : prev === "desc" ? null : "asc",
+      );
+      if (sortDirection === "desc") setSortKey(undefined);
+    } else {
+      setSortKey(key);
+      setSortDirection("asc");
+    }
+  };
+
+  const handleResourceClick = (resource: McpResource) => {
+    if (onResourceClick) {
+      onResourceClick(resource);
+    }
+  };
+
+  const filteredResources =
+    !resources || resources.length === 0
+      ? []
+      : !search.trim()
+        ? resources
+        : (() => {
+            const searchLower = search.toLowerCase();
+            return resources.filter(
+              (r) =>
+                r.uri.toLowerCase().includes(searchLower) ||
+                (r.name && r.name.toLowerCase().includes(searchLower)) ||
+                (r.description &&
+                  r.description.toLowerCase().includes(searchLower)),
+            );
+          })();
+
+  const sortedResources =
+    !sortKey || !sortDirection
+      ? filteredResources
+      : [...filteredResources].sort((a, b) => {
+          const aVal = (a as unknown as Record<string, unknown>)[sortKey] || "";
+          const bVal = (b as unknown as Record<string, unknown>)[sortKey] || "";
+          const comparison = String(aVal).localeCompare(String(bVal));
+          return sortDirection === "asc" ? comparison : -comparison;
+        });
+
+  const columns = [
+    {
+      id: "name",
+      header: "Name",
+      render: (resource: McpResource) => (
+        <span className="text-sm font-medium text-foreground">
+          {resource.name || resource.uri}
+        </span>
+      ),
+      sortable: true,
+    },
+    {
+      id: "uri",
+      header: "URI",
+      render: (resource: McpResource) => (
+        <span className="text-sm font-mono text-muted-foreground">
+          {resource.uri}
+        </span>
+      ),
+      sortable: true,
+    },
+    {
+      id: "description",
+      header: "Description",
+      render: (resource: McpResource) => (
+        <span className="text-sm text-foreground">
+          {resource.description || "—"}
+        </span>
+      ),
+      cellClassName: "flex-1",
+      sortable: true,
+    },
+    {
+      id: "mimeType",
+      header: "Type",
+      render: (resource: McpResource) => (
+        <span className="text-sm text-muted-foreground">
+          {resource.mimeType || "—"}
+        </span>
+      ),
+      sortable: true,
+    },
+  ];
+
+  const sortOptions = columns
+    .filter((col) => col.sortable)
+    .map((col) => ({
+      id: col.id,
+      label: typeof col.header === "string" ? col.header : col.id,
+    }));
+
+  return (
+    <>
+      {showToolbar && (
+        <ViewActions>
+          <CollectionDisplayButton
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            sortOptions={sortOptions}
+          />
+        </ViewActions>
+      )}
+
+      <div className="flex flex-col h-full overflow-hidden">
+        {/* Search */}
+        <CollectionSearch
+          value={search}
+          onChange={setSearch}
+          placeholder="Search resources..."
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setSearch("");
+              (event.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+
+        {/* Content: Cards or Table */}
+        {viewMode === "cards" ? (
+          <div className="flex-1 overflow-auto p-5">
+            {sortedResources.length === 0 ? (
+              <EmptyState
+                image={null}
+                title={search ? "No resources found" : "No resources available"}
+                description={
+                  search ? "Try adjusting your search terms" : emptyMessage
+                }
+              />
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                {sortedResources.map((resource) => (
+                  <Card
+                    key={resource.uri}
+                    className="cursor-pointer transition-colors"
+                    onClick={() => handleResourceClick(resource)}
+                  >
+                    <div className="flex flex-col gap-4 p-6">
+                      <IntegrationIcon
+                        icon={null}
+                        name={resource.name || resource.uri}
+                        size="md"
+                        className="shrink-0 shadow-sm"
+                      />
+                      <div className="flex flex-col gap-1">
+                        <h3 className="text-base font-medium text-foreground truncate">
+                          {resource.name || resource.uri}
+                        </h3>
+                        <p className="text-xs font-mono text-muted-foreground truncate">
+                          {resource.uri}
+                        </p>
+                        {resource.description && (
+                          <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+                            {resource.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <CollectionTableWrapper
+            columns={columns}
+            data={sortedResources}
+            isLoading={false}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            onRowClick={(resource: McpResource) =>
+              handleResourceClick(resource)
+            }
+            emptyState={
+              <EmptyState
+                image={null}
+                title={search ? "No resources found" : "No resources available"}
+                description={
+                  search ? "Try adjusting your search terms" : emptyMessage
+                }
+              />
+            }
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+interface ResourcesTabProps {
+  resources: McpResource[] | undefined;
+  connectionId: string;
+  org: string;
+}
+
+export function ResourcesTab({
+  resources,
+  connectionId,
+  org,
+}: ResourcesTabProps) {
+  return (
+    <ResourcesList
+      resources={resources}
+      connectionId={connectionId}
+      org={org}
+    />
+  );
+}


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prompts and Resources tabs to the connection inspector to display MCP-provided prompts and resources with search, sort, and table/card views. Tabs show only when authenticated and data exists, with item counts.

- **New Features**
  - Fetch prompts/resources via useConnectionsPrompts/useConnectionsResources and surface tab counts.
  - Add PromptsTab and ResourcesTab with search, sortable columns, table/card toggle, and empty states.
  - Prompt click navigates to /$org/mcps/$connectionId/prompts/$itemId; resources expose onClick but no default navigation.
  - Escape clears search input.

<sup>Written for commit 261b8c8fde050666cebac0db8c20aa9072e7d367. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

