### PR TITLE
fix(org settings): update failing due to sending logo as null everytime

### DIFF
--- a/apps/mesh/src/web/routes/orgs/settings.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings.tsx
@@ -184,9 +184,9 @@ export default function OrgSettings() {
         slug: data.slug,
       };
 
-      // Always include logo to allow clearing it with empty string
-      if (data.logo !== undefined) {
-        updateData.logo = data.logo || null;
+      // Include logo if it has a value (Better Auth expects string or undefined, not null)
+      if (data.logo) {
+        updateData.logo = data.logo;
       }
 
       const result = await authClient.organization.update({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix organization settings update by no longer sending logo as null. We now only include the logo when it has a value, matching Better Auth expectations (string or undefined) and preventing update errors.

<sup>Written for commit 2a7bec70abae6da24d0c6056af9e70215642156d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

