### PR TITLE
Add gateway keys

### DIFF
--- a/apps/mesh/src/web/components/details/gateway/index.tsx
+++ b/apps/mesh/src/web/components/details/gateway/index.tsx
@@ -58,6 +58,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 import { slugify } from "@/web/utils/slugify";
 import { ViewLayout, ViewActions, ViewTabs } from "../layout";
+import { GatewayKeySection } from "@/web/components/gateway/gateway-key-section";
 
 type GatewayTabId = "settings" | "tools" | "resources" | "prompts";
 
@@ -570,12 +571,20 @@ function GatewaySettingsTab({
         </Form>
       </div>
 
-      {/* Right panel - IDE Integration */}
+      {/* Right panel - IDE Integration & Gateway Keys */}
       <div className="flex flex-col overflow-auto">
         <div className="p-5">
           <IDEIntegration
             serverName={gateway.title || `gateway-${gateway.id.slice(0, 8)}`}
             gatewayUrl={`${window.location.origin}/mcp/gateway/${gateway.id}`}
+          />
+        </div>
+
+        {/* Gateway Keys section */}
+        <div className="p-5 border-t border-border">
+          <GatewayKeySection
+            gatewayId={gateway.id}
+            gatewayTitle={gateway.title || `Gateway ${gateway.id.slice(0, 8)}`}
           />
         </div>
 

--- a/apps/mesh/src/web/components/gateway/gateway-key-section.tsx
+++ b/apps/mesh/src/web/components/gateway/gateway-key-section.tsx
@@ -1,0 +1,515 @@
+/**
+ * Gateway Key Section for Gateway Detail
+ *
+ * Allows users to generate and manage gateway keys for programmatic gateway access.
+ */
+
+import { Suspense, useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
+  Key01,
+  Plus,
+  Copy01,
+  Check,
+  Trash01,
+  Loading01,
+  AlertTriangle,
+  DotsVertical,
+  Edit01,
+  Eye,
+  EyeOff,
+} from "@untitledui/icons";
+import { toast } from "sonner";
+import {
+  useGatewayKeys,
+  useGatewayKeyActions,
+  createGatewayPermissions,
+  hasGatewayPermission,
+  type GatewayKeyWithValue,
+} from "@/web/hooks/use-gateway-keys";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+
+interface GatewayKeySectionProps {
+  gatewayId: string;
+  gatewayTitle: string;
+}
+
+/**
+ * Dialog to create a new gateway key
+ */
+function CreateKeyDialog({
+  gatewayId,
+  gatewayTitle,
+  open,
+  onOpenChange,
+  onKeyCreated,
+}: {
+  gatewayId: string;
+  gatewayTitle: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onKeyCreated: (key: GatewayKeyWithValue) => void;
+}) {
+  const [name, setName] = useState(`${gatewayTitle} Gateway Key`);
+  const [createdKey, setCreatedKey] = useState<GatewayKeyWithValue | null>(
+    null,
+  );
+  const [copied, setCopied] = useState(false);
+  const [showKey, setShowKey] = useState(false);
+  const actions = useGatewayKeyActions();
+
+  // Reset state when dialog closes
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setCreatedKey(null);
+      setName(`${gatewayTitle} Gateway Key`);
+      setCopied(false);
+      setShowKey(false);
+    }
+    onOpenChange(isOpen);
+  };
+
+  const handleCreate = async () => {
+    const result = await actions.create.mutateAsync({
+      name,
+      permissions: createGatewayPermissions(gatewayId),
+    });
+    setCreatedKey(result);
+  };
+
+  const handleCopy = async () => {
+    if (createdKey) {
+      await navigator.clipboard.writeText(createdKey.key);
+      setCopied(true);
+      toast.success("Gateway key copied to clipboard");
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleDone = async () => {
+    if (createdKey && name.trim() !== createdKey.name) {
+      // Update the key name if it changed
+      try {
+        await actions.update.mutateAsync({
+          keyId: createdKey.id,
+          name: name.trim(),
+        });
+      } catch (error) {
+        // If update fails, show error but still close
+        console.error("Failed to update key name:", error);
+      }
+    }
+    if (createdKey) {
+      onKeyCreated(createdKey);
+    }
+    handleOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Key01 className="h-5 w-5" />
+            Create Gateway Key
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Gateway Key name"
+            />
+          </div>
+          {createdKey && (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <Input
+                  value={
+                    showKey
+                      ? createdKey.key
+                      : `${createdKey.key.slice(0, 12)}${"*".repeat(Math.max(0, createdKey.key.length - 12))}`
+                  }
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setShowKey(!showKey)}
+                      >
+                        {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {showKey ? "Hide key" : "Show key"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={handleCopy}
+                      >
+                        {copied ? <Check size={16} /> : <Copy01 size={16} />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy to clipboard</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <div className="flex items-start gap-2 p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg text-sm text-amber-600 dark:text-amber-400">
+                <AlertTriangle size={16} className="shrink-0 mt-0.5" />
+                <span>
+                  Store this key securely. It will not be shown again.
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            {createdKey ? "Close" : "Cancel"}
+          </Button>
+          {!createdKey ? (
+            <Button
+              onClick={handleCreate}
+              disabled={!name.trim() || actions.create.isPending}
+            >
+              {actions.create.isPending && (
+                <Loading01 size={16} className="mr-2 animate-spin" />
+              )}
+              Create Key
+            </Button>
+          ) : (
+            <Button onClick={handleDone}>Done</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Format date to short format like "1d ago", "4mo ago"
+ */
+function formatShortDate(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffMonths = Math.floor(diffDays / 30);
+  const diffYears = Math.floor(diffDays / 365);
+
+  if (diffYears > 0) return `${diffYears}y ago`;
+  if (diffMonths > 0) return `${diffMonths}mo ago`;
+  if (diffDays > 0) return `${diffDays}d ago`;
+  if (diffHours > 0) return `${diffHours}h ago`;
+  if (diffMins > 0) return `${diffMins}m ago`;
+  return "just now";
+}
+
+/**
+ * List of gateway keys for this gateway
+ */
+function GatewayKeyList({ gatewayId }: { gatewayId: string }) {
+  const { gatewayKeys } = useGatewayKeys();
+  const actions = useGatewayKeyActions();
+  const [deleteKeyId, setDeleteKeyId] = useState<string | null>(null);
+  const [renameKeyId, setRenameKeyId] = useState<string | null>(null);
+  const [renameName, setRenameName] = useState("");
+  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
+
+  // Filter to only show keys for this gateway
+  const keys = gatewayKeys.filter((key) =>
+    hasGatewayPermission(key.permissions, gatewayId),
+  );
+
+  const handleDelete = async () => {
+    if (deleteKeyId) {
+      await actions.delete.mutateAsync(deleteKeyId);
+      setDeleteKeyId(null);
+    }
+  };
+
+  const handleRename = async () => {
+    if (renameKeyId && renameName.trim()) {
+      await actions.update.mutateAsync({
+        keyId: renameKeyId,
+        name: renameName.trim(),
+      });
+      setRenameKeyId(null);
+      setRenameName("");
+    }
+  };
+
+  if (keys.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        {keys.map((key) => (
+          <div
+            key={key.id}
+            className="group flex items-center justify-between gap-3 py-2"
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <Key01 size={14} className="text-muted-foreground shrink-0" />
+              <p className="text-sm font-medium truncate">{key.name}</p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <span
+                className={`text-xs text-muted-foreground h-7 flex items-center ${openDropdownId === key.id ? "hidden" : "group-hover:hidden"}`}
+              >
+                {formatShortDate(new Date(key.createdAt))}
+              </span>
+              <DropdownMenu
+                open={openDropdownId === key.id}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    // Immediately set state to prevent repositioning flash
+                    setOpenDropdownId(null);
+                  } else {
+                    setOpenDropdownId(key.id);
+                  }
+                }}
+              >
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 ${openDropdownId === key.id ? "flex" : "hidden group-hover:flex"}`}
+                  >
+                    <DotsVertical size={14} />
+                  </Button>
+                </DropdownMenuTrigger>
+                {openDropdownId === key.id && (
+                  <DropdownMenuContent
+                    align="end"
+                    sideOffset={4}
+                    onCloseAutoFocus={(e) => e.preventDefault()}
+                    onInteractOutside={(e) => {
+                      // Prevent any repositioning during close
+                      e.preventDefault();
+                      setOpenDropdownId(null);
+                    }}
+                  >
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setRenameKeyId(key.id);
+                        setRenameName(key.name);
+                        setOpenDropdownId(null);
+                      }}
+                    >
+                      <Edit01 size={14} className="mr-2" />
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={() => {
+                        setDeleteKeyId(key.id);
+                        setOpenDropdownId(null);
+                      }}
+                    >
+                      <Trash01 size={14} className="mr-2" />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                )}
+              </DropdownMenu>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Rename dialog */}
+      <Dialog
+        open={!!renameKeyId}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameKeyId(null);
+            setRenameName("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename Gateway Key</DialogTitle>
+            <DialogDescription>
+              Enter a new name for this gateway key.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Name</label>
+              <Input
+                value={renameName}
+                onChange={(e) => setRenameName(e.target.value)}
+                placeholder="Gateway Key name"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleRename();
+                  }
+                }}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRenameKeyId(null);
+                setRenameName("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRename}
+              disabled={!renameName.trim() || actions.update.isPending}
+            >
+              {actions.update.isPending && (
+                <Loading01 size={16} className="mr-2 animate-spin" />
+              )}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={!!deleteKeyId}
+        onOpenChange={(open) => !open && setDeleteKeyId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Gateway Key</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. The gateway key will be immediately
+              revoked and any applications using it will lose access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {actions.delete.isPending ? (
+                <Loading01 size={16} className="mr-2 animate-spin" />
+              ) : null}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+/**
+ * Main Gateway Key Section Component
+ */
+function GatewayKeySectionContent({
+  gatewayId,
+  gatewayTitle,
+}: GatewayKeySectionProps) {
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-foreground">Gateway Keys</span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5"
+          onClick={() => setCreateDialogOpen(true)}
+        >
+          <Plus size={14} />
+          Create Key
+        </Button>
+      </div>
+
+      <GatewayKeyList gatewayId={gatewayId} />
+
+      <CreateKeyDialog
+        gatewayId={gatewayId}
+        gatewayTitle={gatewayTitle}
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        onKeyCreated={() => {
+          // Key was created, list will refresh automatically via query invalidation
+        }}
+      />
+    </div>
+  );
+}
+
+export function GatewayKeySection(props: GatewayKeySectionProps) {
+  return (
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-foreground">Gateway Keys</span>
+            </div>
+            <div className="flex items-center justify-center py-4">
+              <Loading01
+                size={16}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          </div>
+        }
+      >
+        <GatewayKeySectionContent {...props} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/apps/mesh/src/web/components/settings/settings-sidebar.tsx
+++ b/apps/mesh/src/web/components/settings/settings-sidebar.tsx
@@ -1,0 +1,63 @@
+/**
+ * Settings Sidebar
+ *
+ * Navigation sidebar for settings pages.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { Settings01, Key01 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useProjectContext } from "@/web/providers/project-context-provider";
+
+interface SettingsSidebarProps {
+  activeSection: "organization" | "gateway-keys";
+}
+
+const sections = [
+  {
+    id: "organization" as const,
+    label: "Organization",
+    icon: Settings01,
+    path: "/$org/settings",
+  },
+  {
+    id: "gateway-keys" as const,
+    label: "Gateway Keys",
+    icon: Key01,
+    path: "/$org/settings/gateway-keys",
+  },
+];
+
+export function SettingsSidebar({ activeSection }: SettingsSidebarProps) {
+  const { org } = useProjectContext();
+
+  return (
+    <div className="w-56 border-r border-border bg-muted/30 shrink-0">
+      <div className="p-4">
+        <nav className="flex flex-col gap-1">
+          {sections.map((section) => {
+            const Icon = section.icon;
+            const isActive = section.id === activeSection;
+
+            return (
+              <Link
+                key={section.id}
+                to={section.path}
+                params={{ org: org.slug }}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 text-sm rounded-md transition-colors",
+                  isActive
+                    ? "bg-accent text-accent-foreground font-medium"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                )}
+              >
+                <Icon size={16} />
+                {section.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/hooks/use-gateway-keys.ts
+++ b/apps/mesh/src/web/hooks/use-gateway-keys.ts
@@ -1,0 +1,162 @@
+/**
+ * Gateway Keys Hook
+ *
+ * Provides React hooks for managing gateway keys (API keys).
+ * Uses the API_KEY_* MCP tools via createToolCaller.
+ */
+
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { createToolCaller } from "../../tools/client";
+import { useProjectContext } from "../providers/project-context-provider";
+
+/**
+ * Gateway Key entity (returned from list - no key value)
+ */
+export interface GatewayKeyEntity {
+  id: string;
+  name: string;
+  userId: string;
+  permissions: Record<string, string[]>;
+  expiresAt: string | Date | null;
+  createdAt: string | Date;
+}
+
+/**
+ * Gateway Key with value (returned from create)
+ */
+export interface GatewayKeyWithValue extends GatewayKeyEntity {
+  key: string;
+}
+
+/**
+ * Input for creating a gateway key
+ */
+export interface GatewayKeyCreateInput {
+  name: string;
+  permissions?: Record<string, string[]>;
+  expiresIn?: number;
+  metadata?: Record<string, unknown>;
+}
+
+// Add query key for gateway keys to our key factory
+const gatewayKeysKey = (orgId: string) => ["gateway-keys", orgId] as const;
+
+/**
+ * Hook to list gateway keys for the current organization
+ */
+export function useGatewayKeys() {
+  const { org } = useProjectContext();
+  const toolCaller = createToolCaller();
+
+  const { data, refetch } = useSuspenseQuery({
+    queryKey: gatewayKeysKey(org.id),
+    queryFn: async () => {
+      const result = await toolCaller("API_KEY_LIST", {});
+      return (result as { items: GatewayKeyEntity[] }).items;
+    },
+    staleTime: 30_000,
+  });
+
+  return { gatewayKeys: data, refetch };
+}
+
+/**
+ * Hook for gateway key actions (create, update, delete)
+ */
+export function useGatewayKeyActions() {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const toolCaller = createToolCaller();
+
+  const create = useMutation({
+    mutationFn: async (input: GatewayKeyCreateInput) => {
+      const result = await toolCaller("API_KEY_CREATE", input);
+      return result as GatewayKeyWithValue;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gatewayKeysKey(org.id) });
+      // Don't toast here - let the caller handle it since they need to show the key
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to create gateway key: ${message}`);
+    },
+  });
+
+  const update = useMutation({
+    mutationFn: async ({ keyId, name }: { keyId: string; name: string }) => {
+      const result = await toolCaller("API_KEY_UPDATE", { keyId, name });
+      return result as { item: GatewayKeyEntity };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gatewayKeysKey(org.id) });
+      toast.success("Gateway key updated");
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to update gateway key: ${message}`);
+    },
+  });
+
+  const delete_ = useMutation({
+    mutationFn: async (keyId: string) => {
+      const result = await toolCaller("API_KEY_DELETE", { keyId });
+      return result as { success: boolean; keyId: string };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gatewayKeysKey(org.id) });
+      toast.success("Gateway key deleted");
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to delete gateway key: ${message}`);
+    },
+  });
+
+  return {
+    create,
+    update,
+    delete: delete_,
+  };
+}
+
+/**
+ * Helper to create permissions for a gateway
+ * Uses "gw_<gatewayId>" as the resource with ["*"] access
+ */
+export function createGatewayPermissions(
+  gatewayId: string,
+): Record<string, string[]> {
+  return {
+    [`gw_${gatewayId}`]: ["*"],
+  };
+}
+
+/**
+ * Check if a gateway key has permission for a specific gateway
+ */
+export function hasGatewayPermission(
+  permissions: Record<string, string[]>,
+  gatewayId: string,
+): boolean {
+  const gatewayPerms = permissions[`gw_${gatewayId}`];
+  return Boolean(
+    gatewayPerms && (gatewayPerms.includes("*") || gatewayPerms.length > 0),
+  );
+}
+
+/**
+ * Extract gateway IDs from gateway key permissions
+ */
+export function getGatewayIdsFromPermissions(
+  permissions: Record<string, string[]>,
+): string[] {
+  return Object.keys(permissions)
+    .filter((key) => key.startsWith("gw_"))
+    .map((key) => key.replace("gw_", ""));
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -96,6 +96,12 @@ const orgSettingsRoute = createRoute({
   component: lazyRouteComponent(() => import("./routes/orgs/settings.tsx")),
 });
 
+const orgGatewayKeysRoute = createRoute({
+  getParentRoute: () => shellLayout,
+  path: "/$org/settings/gateway-keys",
+  component: lazyRouteComponent(() => import("./routes/orgs/gateway-keys.tsx")),
+});
+
 const orgMonitoringRoute = createRoute({
   getParentRoute: () => shellLayout,
   path: "/$org/monitoring",
@@ -206,6 +212,7 @@ const shellRouteTree = shellLayout.addChildren([
   orgMonitoringRoute,
   orgStoreRouteWithChildren,
   orgSettingsRoute,
+  orgGatewayKeysRoute,
   connectionLayoutRoute,
   collectionDetailsRoute,
 ]);

--- a/apps/mesh/src/web/routes/orgs/gateway-keys.tsx
+++ b/apps/mesh/src/web/routes/orgs/gateway-keys.tsx
@@ -1,0 +1,742 @@
+/**
+ * Organization Gateway Keys Page
+ *
+ * Manage gateway keys for the organization.
+ */
+
+import { Suspense, useState } from "react";
+import { CollectionHeader } from "@/web/components/collections/collection-header.tsx";
+import { CollectionPage } from "@/web/components/collections/collection-page.tsx";
+import { CollectionTableWrapper } from "@/web/components/collections/collection-table-wrapper.tsx";
+import { EmptyState } from "@/web/components/empty-state.tsx";
+import { ErrorBoundary } from "@/web/components/error-boundary.tsx";
+import { SettingsSidebar } from "@/web/components/settings/settings-sidebar.tsx";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import {
+  useGatewayKeys,
+  useGatewayKeyActions,
+  getGatewayIdsFromPermissions,
+  type GatewayKeyWithValue,
+  type GatewayKeyEntity,
+} from "@/web/hooks/use-gateway-keys";
+import { useGateways } from "@/web/hooks/collections/use-gateway";
+import { useMembers } from "@/web/hooks/use-members";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { type TableColumn } from "@deco/ui/components/collection-table.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import {
+  Key01,
+  Plus,
+  Trash01,
+  Loading01,
+  CpuChip02,
+  DotsVertical,
+  Edit01,
+  Copy01,
+  Check,
+  AlertTriangle,
+  Eye,
+  EyeOff,
+} from "@untitledui/icons";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { toast } from "sonner";
+import { Link, useParams } from "@tanstack/react-router";
+
+/**
+ * Gateway selector for gateway key creation
+ */
+function GatewaySelect({
+  value,
+  onValueChange,
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+}) {
+  const gateways = useGateways();
+
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger>
+        <SelectValue placeholder="Select a gateway (optional)" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="none">No gateway (org access only)</SelectItem>
+        {gateways.map((gateway) => (
+          <SelectItem key={gateway.id} value={gateway.id}>
+            {gateway.title}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+/**
+ * Dialog to create a new gateway key
+ */
+function CreateKeyDialog({
+  open,
+  onOpenChange,
+  onKeyCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onKeyCreated: (key: GatewayKeyWithValue) => void;
+}) {
+  const [name, setName] = useState("");
+  const [selectedGateway, setSelectedGateway] = useState<string>("none");
+  const [createdKey, setCreatedKey] = useState<GatewayKeyWithValue | null>(
+    null,
+  );
+  const [copied, setCopied] = useState(false);
+  const [showKey, setShowKey] = useState(false);
+  const actions = useGatewayKeyActions();
+
+  // Reset state when dialog closes
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setCreatedKey(null);
+      setName("");
+      setSelectedGateway("none");
+      setCopied(false);
+      setShowKey(false);
+    }
+    onOpenChange(isOpen);
+  };
+
+  const handleCreate = async () => {
+    const permissions: Record<string, string[]> = {};
+
+    // If a gateway is selected, add gateway permission
+    if (selectedGateway && selectedGateway !== "none") {
+      permissions[`gw_${selectedGateway}`] = ["*"];
+    } else {
+      // Default permissions (read-only org access)
+      permissions["self"] = ["ORGANIZATION_LIST", "ORGANIZATION_GET"];
+    }
+
+    const result = await actions.create.mutateAsync({
+      name,
+      permissions,
+    });
+    setCreatedKey(result);
+  };
+
+  const handleCopy = async () => {
+    if (createdKey) {
+      await navigator.clipboard.writeText(createdKey.key);
+      setCopied(true);
+      toast.success("Gateway key copied to clipboard");
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleDone = () => {
+    if (createdKey) {
+      onKeyCreated(createdKey);
+    }
+    handleOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Key01 className="h-5 w-5" />
+            Create Gateway Key
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My Gateway Key"
+              disabled={!!createdKey}
+            />
+          </div>
+          {!createdKey && (
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Gateway Access</label>
+              <Suspense
+                fallback={
+                  <Select disabled>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Loading gateways..." />
+                    </SelectTrigger>
+                  </Select>
+                }
+              >
+                <GatewaySelect
+                  value={selectedGateway}
+                  onValueChange={setSelectedGateway}
+                />
+              </Suspense>
+              <p className="text-xs text-muted-foreground">
+                {selectedGateway && selectedGateway !== "none"
+                  ? "This key will have full access to the selected gateway."
+                  : "This key will only have read-only access to the organization."}
+              </p>
+            </div>
+          )}
+          {createdKey && (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <Input
+                  value={
+                    showKey
+                      ? createdKey.key
+                      : `${createdKey.key.slice(0, 12)}${"*".repeat(Math.max(0, createdKey.key.length - 12))}`
+                  }
+                  readOnly
+                  className="font-mono text-sm"
+                />
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setShowKey(!showKey)}
+                      >
+                        {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {showKey ? "Hide key" : "Show key"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={handleCopy}
+                      >
+                        {copied ? <Check size={16} /> : <Copy01 size={16} />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy to clipboard</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <div className="flex items-start gap-2 p-3 bg-amber-500/10 border border-amber-500/20 rounded-lg text-sm text-amber-600 dark:text-amber-400">
+                <AlertTriangle size={16} className="shrink-0 mt-0.5" />
+                <span>
+                  Store this key securely. It will not be shown again.
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            {createdKey ? "Close" : "Cancel"}
+          </Button>
+          {!createdKey ? (
+            <Button
+              onClick={handleCreate}
+              disabled={!name.trim() || actions.create.isPending}
+            >
+              {actions.create.isPending && (
+                <Loading01 size={16} className="mr-2 animate-spin" />
+              )}
+              Create Key
+            </Button>
+          ) : (
+            <Button onClick={handleDone}>Done</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Gateway display component - shows icon and name (no badge)
+ */
+function GatewayDisplay({ gatewayId }: { gatewayId: string }) {
+  const gateways = useGateways();
+  const gateway = gateways.find((g) => g.id === gatewayId);
+  const { org } = useParams({ strict: false });
+
+  if (!gateway) {
+    return (
+      <div className="flex items-center gap-2">
+        <IntegrationIcon
+          icon={null}
+          name="Unknown Gateway"
+          size="xs"
+          fallbackIcon={<CpuChip02 size={12} />}
+        />
+        <span className="text-sm text-foreground truncate">
+          Unknown Gateway
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to="/$org/gateways/$gatewayId"
+      params={{ org: org!, gatewayId: gateway.id }}
+      className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+    >
+      <IntegrationIcon
+        icon={gateway.icon}
+        name={gateway.title}
+        size="xs"
+        fallbackIcon={<CpuChip02 size={12} />}
+      />
+      <span className="text-sm text-foreground truncate">{gateway.title}</span>
+    </Link>
+  );
+}
+
+/**
+ * Format date to short format like "1d ago", "4mo ago"
+ */
+function formatShortDate(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffMonths = Math.floor(diffDays / 30);
+  const diffYears = Math.floor(diffDays / 365);
+
+  if (diffYears > 0) return `${diffYears}y ago`;
+  if (diffMonths > 0) return `${diffMonths}mo ago`;
+  if (diffDays > 0) return `${diffDays}d ago`;
+  if (diffHours > 0) return `${diffHours}h ago`;
+  if (diffMins > 0) return `${diffMins}m ago`;
+  return "just now";
+}
+
+/**
+ * Get user name from userId
+ */
+function getUserName(
+  userId: string,
+  members: Array<{
+    userId: string;
+    user: { id: string; name?: string; email: string; image?: string };
+  }>,
+): string {
+  const member = members.find((m) => m.userId === userId);
+  return member?.user?.name || member?.user?.email || "Unknown";
+}
+
+/**
+ * Get user initials for avatar
+ */
+function getInitials(name?: string, email?: string): string {
+  if (name) {
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2);
+  }
+  if (email && email.length > 0) {
+    return email[0]!.toUpperCase();
+  }
+  return "?";
+}
+
+/**
+ * Gateway Keys table
+ */
+function GatewayKeysTable({
+  onRename,
+  onDelete,
+}: {
+  onRename: (key: GatewayKeyEntity) => void;
+  onDelete: (keyId: string) => void;
+}) {
+  const { gatewayKeys } = useGatewayKeys();
+  const { data: membersData } = useMembers();
+  const members = membersData?.data?.members ?? [];
+  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
+
+  if (!membersData) {
+    return null;
+  }
+
+  const columns: TableColumn<GatewayKeyEntity>[] = [
+    {
+      id: "name",
+      header: "Name",
+      render: (key) => (
+        <div className="flex items-center gap-2">
+          <Key01 size={16} className="text-muted-foreground shrink-0" />
+          <span className="text-sm font-medium text-foreground truncate">
+            {key.name}
+          </span>
+        </div>
+      ),
+      cellClassName: "flex-1 min-w-0",
+      sortable: true,
+    },
+    {
+      id: "createdBy",
+      header: "Created By",
+      render: (key) => {
+        const member = members.find((m) => m.userId === key.userId);
+        const userName = getUserName(key.userId, members);
+        return (
+          <div className="flex items-center gap-2">
+            <Avatar
+              url={member?.user?.image}
+              fallback={getInitials(member?.user?.name, member?.user?.email)}
+              shape="circle"
+              size="xs"
+            />
+            <span className="text-sm text-foreground truncate">{userName}</span>
+          </div>
+        );
+      },
+      cellClassName: "w-40 min-w-0 shrink-0",
+    },
+    {
+      id: "createdAt",
+      header: "Created",
+      render: (key) => (
+        <span className="text-sm text-muted-foreground">
+          {formatShortDate(new Date(key.createdAt))}
+        </span>
+      ),
+      cellClassName: "w-24 shrink-0",
+      sortable: true,
+    },
+    {
+      id: "gateway",
+      header: "Gateway",
+      render: (key) => {
+        const gatewayIds = getGatewayIdsFromPermissions(key.permissions);
+        if (gatewayIds.length === 0) {
+          return <span className="text-sm text-muted-foreground">—</span>;
+        }
+        // Show first gateway (most common case)
+        const firstGatewayId = gatewayIds[0];
+        return (
+          <Suspense
+            fallback={
+              <div className="flex items-center gap-2">
+                <Loading01
+                  size={12}
+                  className="animate-spin text-muted-foreground shrink-0"
+                />
+                <span className="text-sm text-muted-foreground">
+                  Loading...
+                </span>
+              </div>
+            }
+          >
+            <GatewayDisplay gatewayId={firstGatewayId!} />
+          </Suspense>
+        );
+      },
+      cellClassName: "w-48 min-w-0 shrink-0",
+    },
+    {
+      id: "actions",
+      header: "",
+      render: (key) => (
+        <div className="flex items-center justify-end">
+          <DropdownMenu
+            open={openDropdownId === key.id}
+            onOpenChange={(open) => setOpenDropdownId(open ? key.id : null)}
+          >
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-7 w-7">
+                <DotsVertical size={14} />
+              </Button>
+            </DropdownMenuTrigger>
+            {openDropdownId === key.id && (
+              <DropdownMenuContent
+                align="end"
+                sideOffset={4}
+                onCloseAutoFocus={(e) => e.preventDefault()}
+                onInteractOutside={(e) => {
+                  e.preventDefault();
+                  setOpenDropdownId(null);
+                }}
+              >
+                <DropdownMenuItem onClick={() => onRename(key)}>
+                  <Edit01 size={14} className="mr-2" />
+                  Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={() => {
+                    onDelete(key.id);
+                    setOpenDropdownId(null);
+                  }}
+                >
+                  <Trash01 size={14} className="mr-2" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            )}
+          </DropdownMenu>
+        </div>
+      ),
+      cellClassName: "w-12 shrink-0",
+    },
+  ];
+
+  return (
+    <div className="border-t border-border">
+      <CollectionTableWrapper
+        columns={columns}
+        data={gatewayKeys}
+        isLoading={false}
+        emptyState={
+          <EmptyState
+            image={<Key01 size={48} className="text-muted-foreground/50" />}
+            title="No gateway keys yet"
+            description="Create a gateway key to access gateways and resources programmatically."
+          />
+        }
+      />
+    </div>
+  );
+}
+
+function GatewayKeysContent() {
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [renameKeyId, setRenameKeyId] = useState<string | null>(null);
+  const [renameName, setRenameName] = useState("");
+  const [deleteKeyId, setDeleteKeyId] = useState<string | null>(null);
+  const actions = useGatewayKeyActions();
+
+  const handleRename = (key: GatewayKeyEntity) => {
+    setRenameKeyId(key.id);
+    setRenameName(key.name);
+  };
+
+  const handleSaveRename = async () => {
+    if (renameKeyId && renameName.trim()) {
+      await actions.update.mutateAsync({
+        keyId: renameKeyId,
+        name: renameName.trim(),
+      });
+      setRenameKeyId(null);
+      setRenameName("");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (deleteKeyId) {
+      await actions.delete.mutateAsync(deleteKeyId);
+      setDeleteKeyId(null);
+    }
+  };
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="flex h-full">
+        {/* Sidebar */}
+        <SettingsSidebar activeSection="gateway-keys" />
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto">
+          <div className="p-5">
+            <div className="space-y-6">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-foreground">
+                    Gateway Keys
+                  </h2>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Manage gateway keys for programmatic access to your gateways
+                    and organization resources.
+                  </p>
+                </div>
+                <Button
+                  onClick={() => setCreateDialogOpen(true)}
+                  size="sm"
+                  className="h-7 px-3 rounded-lg text-sm font-medium gap-1.5"
+                >
+                  <Plus size={16} />
+                  Create Key
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <ErrorBoundary>
+            <Suspense
+              fallback={
+                <div className="flex items-center justify-center py-12">
+                  <Loading01
+                    size={24}
+                    className="animate-spin text-muted-foreground"
+                  />
+                </div>
+              }
+            >
+              <GatewayKeysTable
+                onRename={handleRename}
+                onDelete={setDeleteKeyId}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        </div>
+      </div>
+
+      <CreateKeyDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        onKeyCreated={() => {
+          // Key was created, list will refresh automatically via query invalidation
+        }}
+      />
+
+      {/* Rename dialog */}
+      <Dialog
+        open={!!renameKeyId}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameKeyId(null);
+            setRenameName("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename Gateway Key</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Name</label>
+              <Input
+                value={renameName}
+                onChange={(e) => setRenameName(e.target.value)}
+                placeholder="Gateway Key name"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleSaveRename();
+                  }
+                }}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRenameKeyId(null);
+                setRenameName("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSaveRename}
+              disabled={!renameName.trim() || actions.update.isPending}
+            >
+              {actions.update.isPending && (
+                <Loading01 size={16} className="mr-2 animate-spin" />
+              )}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={!!deleteKeyId}
+        onOpenChange={(open) => !open && setDeleteKeyId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Gateway Key</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. The gateway key will be immediately
+              revoked and any applications using it will lose access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {actions.delete.isPending ? (
+                <Loading01 size={16} className="mr-2 animate-spin" />
+              ) : null}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export default function GatewayKeysPage() {
+  return (
+    <CollectionPage>
+      <CollectionHeader title="Settings" />
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center flex-1">
+              <Loading01
+                size={24}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          }
+        >
+          <GatewayKeysContent />
+        </Suspense>
+      </ErrorBoundary>
+    </CollectionPage>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/settings.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings.tsx
@@ -1,5 +1,6 @@
 import { CollectionHeader } from "@/web/components/collections/collection-header.tsx";
 import { CollectionPage } from "@/web/components/collections/collection-page.tsx";
+import { SettingsSidebar } from "@/web/components/settings/settings-sidebar.tsx";
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { useProjectContext } from "@/web/providers/project-context-provider";
@@ -242,6 +243,9 @@ export default function OrgSettings() {
 
       <div className="flex-1 overflow-auto">
         <div className="flex h-full">
+          {/* Sidebar */}
+          <SettingsSidebar activeSection="organization" />
+
           {/* Content */}
           <div className="flex-1 overflow-auto">
             <div className="p-5 max-w-2xl">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add gateway API keys and UI to create, manage, and revoke them, with backend enforcement of gateway-scoped permissions. This enables secure programmatic access to specific gateways and improves org settings navigation.

- **New Features**
  - Backend: Require gw_<gatewayId> permission for API keys on /gateway, and restrict browser sessions to the gateway’s organization (404 on cross-org).
  - Gateway detail: New “Gateway Keys” section to create, view, rename, and delete keys; copy and show/hide key value.
  - Org settings: New sidebar and “Gateway Keys” page (/settings/gateway-keys) to manage keys across the org, with optional gateway selection during creation.
  - Hooks: useGatewayKeys and useGatewayKeyActions using API_KEY_LIST/CREATE/UPDATE/DELETE tools with React Query.

- **Migration**
  - API keys must include gw_<gatewayId>: ["*"] permission to access gateway endpoints; keys without it will be denied (403).
  - Create new keys via Org Settings > Gateway Keys or from a gateway’s Settings tab; store the key securely as it’s shown once.

<sup>Written for commit f5168f09bc47ac3b3d331832e0510ea4db49654c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

