### PR TITLE
Do not fetch prompts/resources/resourcestemplates when not available

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -415,7 +415,12 @@ async function createMCPProxyDoNotUseDirectly(
   // List resources from downstream connection
   const listResources = async (): Promise<ListResourcesResult> => {
     const client = await createClient();
-    return await client.listResources();
+    if (client.getServerCapabilities()?.resources) {
+      return await client.listResources();
+    }
+    return {
+      resources: [],
+    };
   };
 
   // Read a specific resource from downstream connection
@@ -430,13 +435,23 @@ async function createMCPProxyDoNotUseDirectly(
   const listResourceTemplates =
     async (): Promise<ListResourceTemplatesResult> => {
       const client = await createClient();
-      return await client.listResourceTemplates();
+      if (client.getServerCapabilities()?.resourceTemplates) {
+        return await client.listResourceTemplates();
+      }
+      return {
+        resourceTemplates: [],
+      };
     };
 
   // List prompts from downstream connection
   const listPrompts = async (): Promise<ListPromptsResult> => {
     const client = await createClient();
-    return await client.listPrompts();
+    if (client.getServerCapabilities()?.prompts) {
+      return await client.listPrompts();
+    }
+    return {
+      prompts: [],
+    };
   };
 
   // Get a specific prompt from downstream connection


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip fetching prompts, resources, and resource templates when the downstream server doesn’t advertise these capabilities. Return empty lists instead to prevent errors and unnecessary calls.

<sup>Written for commit 094693501583e2826440eb11ac589fbf0b3380a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

