### PR TITLE
Grant the user role so works on cloudsql

### DIFF
--- a/apps/mesh/src/tools/database/index.ts
+++ b/apps/mesh/src/tools/database/index.ts
@@ -142,6 +142,10 @@ async function createSchemaAndRole(
     await sql`CREATE ROLE ${sql.id(roleName)} NOLOGIN`.execute(db);
   }
 
+  // Grant the role to the current user so SET ROLE works
+  // Required for Cloud SQL where the connecting user isn't a true superuser
+  await sql`GRANT ${sql.id(roleName)} TO CURRENT_USER`.execute(db);
+
   // Grant access to the connection's schema only
   await sql`GRANT USAGE, CREATE ON SCHEMA ${sql.id(schemaName)} TO ${sql.id(roleName)}`.execute(
     db,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant the created database role to the current user so SET ROLE works on Cloud SQL. This prevents permission errors during schema and role setup.

<sup>Written for commit 140cc0818d4cbbd76a285320d6cd5a184d0988a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

