### PR TITLE
add gateway id

### DIFF
--- a/apps/mesh/src/web/components/details/workflow/stores/workflow.tsx
+++ b/apps/mesh/src/web/components/details/workflow/stores/workflow.tsx
@@ -390,6 +390,10 @@ const createWorkflowStore = (initialState: State) => {
             set((state) => ({
               ...state,
               selectedGatewayId: gatewayId,
+              workflow: {
+                ...state.workflow,
+                gateway_id: gatewayId,
+              },
             })),
         },
       }),
@@ -431,7 +435,7 @@ export function WorkflowStoreProvider({
       currentStepName: undefined,
       trackingExecutionId,
       currentStepTab: "input",
-      selectedGatewayId: undefined,
+      selectedGatewayId: workflow.gateway_id,
     }),
   );
 

--- a/packages/bindings/src/well-known/workflow.ts
+++ b/packages/bindings/src/well-known/workflow.ts
@@ -279,6 +279,11 @@ export const WorkflowSchema = BaseCollectionEntitySchema.extend({
     .describe(
       "Ordered list of steps. Execution order is auto-determined by @ref dependencies: steps with no @ref dependencies run in parallel; steps referencing @stepName wait for that step to complete.",
     ),
+
+  gateway_id: z
+    .string()
+    .optional()
+    .describe("Default gateway ID to use when executing this workflow"),
 });
 
 export type Workflow = z.infer<typeof WorkflowSchema>;


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a default gateway ID to the Workflow model and sync it in the workflow store so the selected gateway is persisted and used by default during execution.

- **New Features**
  - Added optional gateway_id to WorkflowSchema.
  - Workflow store initializes selectedGatewayId from workflow.gateway_id and keeps both in sync when a gateway is selected.

<sup>Written for commit 455dea07d7c5dc4d5c4664348a97b0937fee1185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

