### PR TITLE
fix(auth): lookup user role from membership for mesh JWT and API keys

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -495,6 +495,7 @@ async function authenticateRequest(
             connectionId: meshJwtPayload.metadata?.connectionId,
             role,
           },
+          role,
           permissions: meshJwtPayload.permissions,
           organization: meshJwtPayload.metadata?.organizationId
             ? {
@@ -537,6 +538,7 @@ async function authenticateRequest(
         return {
           apiKeyId: result.key.id,
           user: { id: result.key.userId, role }, // Include userId and role from membership
+          role,
           permissions, // Store the API key's permissions
           organization: orgMetadata
             ? {


### PR DESCRIPTION
Previously, mesh JWT tokens and API keys didn't include the user's organization role, preventing admin/owner bypass in access control. This adds role lookup from the member table for both auth methods.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing organization role in auth for mesh JWTs and API keys. We now look up member.role by userId and attach it to user in the request context, so admin/owner bypass works.

<sup>Written for commit b1a752e3d5283c4ce1bd44fd442450e8783bcf21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds role resolution to Bearer-token auth paths.
> 
> - For verified Mesh JWTs and API keys, query `member.role` (by `userId` + organization) and set `user.role` in the returned auth context
> - Keeps existing permission handling; organization still sourced from token/metadata
> - Enables built-in role bypass in `AccessControl` via populated `role`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de852d57ff246bee602103e357b68d17606d735e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->