### PR TITLE
fix(monitoring): implement proper infinite scroll with log accumulation

### DIFF
--- a/apps/mesh/src/web/hooks/use-infinite-scroll.ts
+++ b/apps/mesh/src/web/hooks/use-infinite-scroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 
 /**
  * Hook for infinite scroll functionality using IntersectionObserver.
@@ -41,8 +41,8 @@ export function useInfiniteScroll(
   hasMoreRef.current = hasMore;
   isLoadingRef.current = isLoading;
 
-  // Memoize the ref callback to prevent unnecessary observer recreation
-  const lastElementRef = useCallback((node: HTMLElement | null) => {
+  // Ref callback for the last element - React Compiler handles memoization
+  const lastElementRef = (node: HTMLElement | null) => {
     if (observerRef.current) {
       observerRef.current.disconnect();
     }
@@ -60,7 +60,7 @@ export function useInfiniteScroll(
     if (node) {
       observerRef.current.observe(node);
     }
-  }, []);
+  };
 
   return lastElementRef;
 }

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -121,6 +121,8 @@ export const KEYS = {
     limit?: number;
     offset?: number;
   }) => ["monitoring", "logs", filters] as const,
+  monitoringLogsInfinite: (locator: string, paramsKey: string) =>
+    ["monitoring", "logs-infinite", locator, paramsKey] as const,
 
   // Gateway prompts (for ice breakers in chat)
   gatewayPrompts: (gatewayId: string) =>

--- a/apps/mesh/src/web/routes/orgs/monitoring.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring.tsx
@@ -22,6 +22,7 @@ import { useConnections } from "@/web/hooks/collections/use-connection";
 import { useGateways } from "@/web/hooks/collections/use-gateway";
 import { useInfiniteScroll } from "@/web/hooks/use-infinite-scroll.ts";
 import { useMembers } from "@/web/hooks/use-members";
+import { KEYS } from "@/web/lib/query-keys";
 import { useProjectContext } from "@/web/providers/project-context-provider";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -517,11 +518,10 @@ function MonitoringDashboardContent({
   // Use React Query's infinite query for automatic accumulation
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery({
-      queryKey: [
-        "monitoring-logs-infinite",
+      queryKey: KEYS.monitoringLogsInfinite(
         locator,
         JSON.stringify(baseParams),
-      ],
+      ),
       queryFn: async ({ pageParam = 0 }) => {
         const result = await toolCaller("MONITORING_LOGS_LIST", {
           ...baseParams,


### PR DESCRIPTION
## Summary
Fixes the monitoring scroll issue where logs were being replaced instead of accumulated when scrolling to the bottom.

## Problem
The monitoring logs table was using URL-based pagination that replaced all logs with the next page's logs when scrolling to the bottom. Users expected infinite scroll behavior where new logs append to existing ones.

## Solution
- Replaced manual state management with `useSuspenseInfiniteQuery` from React Query
- React Query now handles all log accumulation automatically via `data.pages`
- Added `isLoading` guard to `useInfiniteScroll` hook to prevent duplicate triggers
- Memoized ref callback with `useCallback` to prevent unnecessary IntersectionObserver recreation
- Removed `page` parameter from URL (pagination now handled internally)

## Changes
- `apps/mesh/src/web/routes/orgs/monitoring.tsx` - Use `useSuspenseInfiniteQuery` for proper infinite scroll
- `apps/mesh/src/web/hooks/use-infinite-scroll.ts` - Add `isLoading` param and memoize callback

## Testing
- Navigate to monitoring page with 50+ logs
- Scroll to bottom → logs should append (not replace)
- Change a filter → logs should reset to fresh first page
- Streaming mode still works for live updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented true infinite scroll in Monitoring so logs append as you reach the bottom instead of replacing the list. This replaces URL-based pagination with React Query infinite queries and keeps streaming mode working.

- **Bug Fixes**
  - Accumulate logs via data.pages and flatten for the table and stats (using server total when available).
  - Added isLoading guard in useInfiniteScroll to prevent duplicate triggers and avoid observer churn.
  - Removed page from the URL; pagination is handled internally with fetchNextPage and hasNextPage.

<sup>Written for commit 43095b4d5843131f819e031a8f1b6d68cb6e51c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

