### PR TITLE
[chore]: Allow SELF subscriptions for event-bus

### DIFF
--- a/apps/mesh/src/event-bus/event-bus.ts
+++ b/apps/mesh/src/event-bus/event-bus.ts
@@ -86,6 +86,19 @@ export class EventBus implements IEventBus {
           `Invalid cron expression: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+
+      // Idempotent cron publishing: check if an active cron event already exists
+      const existingCron = await this.storage.findActiveCronEvent(
+        organizationId,
+        input.type,
+        sourceConnectionId,
+        input.cron,
+      );
+
+      if (existingCron) {
+        // Return existing cron event - idempotent
+        return existingCron;
+      }
     }
 
     const eventId = crypto.randomUUID();

--- a/apps/mesh/src/tools/eventbus/sync-subscriptions.ts
+++ b/apps/mesh/src/tools/eventbus/sync-subscriptions.ts
@@ -6,7 +6,6 @@
  * Subscriptions are identified by (eventType, publisher).
  */
 
-import { WellKnownOrgMCPId } from "@/core/well-known-mcp";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/mesh-context";
 import {
@@ -40,27 +39,6 @@ export const EVENT_SYNC_SUBSCRIPTIONS = defineTool({
       connectionId,
       subscriptions: input.subscriptions,
     });
-    const cronSubscriptions = result.subscriptions.filter(
-      (sub) =>
-        sub.eventType?.startsWith("cron/") &&
-        sub.publisher === WellKnownOrgMCPId.SELF(organization.id),
-    );
-
-    await Promise.all(
-      cronSubscriptions.map(async (sub) => {
-        const cron = sub.eventType.split("/")[1];
-        cron &&
-          (await ctx.eventBus.publish(
-            organization.id,
-            WellKnownOrgMCPId.SELF(organization.id),
-            {
-              type: sub.eventType,
-              cron,
-              data: {},
-            },
-          ));
-      }),
-    );
 
     return {
       created: result.created,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add SELF subscriptions to let a connection subscribe to its own events and schedule cron triggers in an idempotent way. Also updates the runtime API to use prefixed event names for global handlers and moves cron publishing into the runtime.

- New Features
  - SELF binding for subscriptions and handlers (import SELF from runtime tools).
  - Global handlers now use prefixed events: "BINDING::event.type" (e.g., "SELF::order.created").
  - Runtime publishes cron events for SELF subscriptions by parsing "cron/name/expr" event types.
  - Event bus enforces idempotent cron scheduling via findActiveCronEvent and a pre-publish check.
  - Execution filters events to only those matching declared subscriptions.

- Migration
  - Global handlers: update events to be prefixed (e.g., "SELF::foo.bar" instead of "foo.bar").
  - Use SELF in handlers: { SELF: { "event.type": handler } } or events: ["SELF::event.type"].
  - Cron: express schedules as "cron/name/CRON_EXPR" and handle them as normal event handlers; runtime will publish and dedupe.
  - The old special cron handler signature and tool-level cron publishing are removed.
  - Bump @decocms/runtime to 1.1.0.

<sup>Written for commit 8e26997ac8451336cbafd0a5ef44c12ae5708b4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

