### PR TITLE
Adds gatewayId to current context

### DIFF
--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -76,7 +76,7 @@ function parseRouteContext(pathname: string): RouteContext {
 /**
  * Hook that generates a dynamic system prompt based on context
  */
-function useSystemPrompt(gatewayId: string): string {
+function useSystemPrompt(gatewayId?: string): string {
   const routerState = useRouterState();
   const { connectionId, collectionName, itemId } = parseRouteContext(
     routerState.location.pathname,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added gatewayId to the chat system prompt so the current gateway is explicitly included in the editing context. This improves gateway awareness for tool use and reduces ambiguity when multiple gateways exist.

- **New Features**
  - System prompt now lists the Gateway ID under “Current Editing Context” and clarifies gateway context for tools, resources, and prompts.
  - ChatPanel passes effectiveSelectedGatewayId into useSystemPrompt.

<sup>Written for commit 71be7f27c64ad6865c36b4b658f204abfc0a47a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

