### PR TITLE
Fix JSONSchema form transform

### DIFF
--- a/apps/mesh/src/api/llm-provider.ts
+++ b/apps/mesh/src/api/llm-provider.ts
@@ -134,20 +134,28 @@ export const createLLMProvider = (binding: LLMBindingClient): LLMProvider => {
         modelId,
         supportedUrls,
         doGenerate: async (options: LanguageModelV2CallOptions) => {
-          const response = await binding.LLM_DO_GENERATE({
+          const result = await binding.LLM_DO_GENERATE({
             callOptions: options as Parameters<
               LLMBindingClient["LLM_DO_GENERATE"]
             >[0]["callOptions"],
             modelId,
           });
           return {
-            ...response,
+            ...result,
             usage: {
-              inputTokens: response.usage.inputTokens ?? undefined,
-              outputTokens: response.usage.outputTokens ?? undefined,
-              totalTokens: response.usage.totalTokens ?? undefined,
-              reasoningTokens: response.usage.reasoningTokens ?? undefined,
+              inputTokens: result.usage.inputTokens ?? undefined,
+              outputTokens: result.usage.outputTokens ?? undefined,
+              totalTokens: result.usage.totalTokens ?? undefined,
+              reasoningTokens: result.usage.reasoningTokens ?? undefined,
             },
+            response: result.response
+              ? {
+                  ...result.response,
+                  timestamp: result.response.timestamp
+                    ? new Date(result.response.timestamp)
+                    : undefined,
+                }
+              : undefined,
           };
         },
         doStream: async (options: LanguageModelV2CallOptions) => {

--- a/apps/mesh/src/api/utils/mcp.ts
+++ b/apps/mesh/src/api/utils/mcp.ts
@@ -270,9 +270,11 @@ class McpServerBuilder {
             tools: this.tools.map((t) => ({
               name: t.name,
               description: t.description ?? "",
-              inputSchema: z.toJSONSchema(t.inputSchema),
+              inputSchema: z.toJSONSchema(t.inputSchema, {
+                unrepresentable: "any",
+              }),
               outputSchema: t.outputSchema
-                ? z.toJSONSchema(t.outputSchema)
+                ? z.toJSONSchema(t.outputSchema, { unrepresentable: "any" })
                 : undefined,
             })),
           } as ListToolsResult;

--- a/apps/mesh/src/gateway/strategy.ts
+++ b/apps/mesh/src/gateway/strategy.ts
@@ -153,7 +153,9 @@ function createSearchTool(ctx: StrategyContext): ToolWithHandler {
     tool: {
       name: "GATEWAY_SEARCH_TOOLS",
       description: `Search for available tools by name or description. Returns tool names and brief descriptions without full schemas.${categoryList} Total tools: ${ctx.tools.length}.`,
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: z.toJSONSchema(inputSchema, {
+        unrepresentable: "any",
+      }) as Tool["inputSchema"],
     },
     handler: async (args) => {
       const parsed = inputSchema.safeParse(args);
@@ -192,7 +194,9 @@ function createDescribeTool(ctx: StrategyContext): ToolWithHandler {
       name: "GATEWAY_DESCRIBE_TOOLS",
       description:
         "Get detailed schemas for specific tools. Call after searching to get full input/output schemas.",
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: z.toJSONSchema(inputSchema, {
+        unrepresentable: "any",
+      }) as Tool["inputSchema"],
     },
     handler: async (args) => {
       const parsed = inputSchema.safeParse(args);
@@ -238,7 +242,9 @@ function createCallTool(ctx: StrategyContext): ToolWithHandler {
       name: "GATEWAY_CALL_TOOL",
       description:
         "Execute a tool by name. Use GATEWAY_DESCRIBE_TOOLS first to understand the input schema.",
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: z.toJSONSchema(inputSchema, {
+        unrepresentable: "any",
+      }) as Tool["inputSchema"],
     },
     handler: async (args) => {
       const parsed = inputSchema.safeParse(args);
@@ -284,7 +290,9 @@ function createRunCodeTool(ctx: StrategyContext): ToolWithHandler {
       name: "GATEWAY_RUN_CODE",
       description:
         'Run JavaScript code in a sandbox. Code must be an ES module that `export default`s an async function that receives (tools) as its first parameter. Use GATEWAY_DESCRIBE_TOOLS to understand the input/output schemas for a tool before calling it. Use `await tools.toolName(args)` or `await tools["tool-name"](args)` to call tools.',
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: z.toJSONSchema(inputSchema, {
+        unrepresentable: "any",
+      }) as Tool["inputSchema"],
     },
     handler: async (args) => {
       const parsed = inputSchema.safeParse(args);

--- a/apps/mesh/src/web/utils/constants.ts
+++ b/apps/mesh/src/web/utils/constants.ts
@@ -24,5 +24,5 @@ export type JsonSchema = {
  */
 export const BaseCollectionJsonSchema: JsonSchema = z.toJSONSchema(
   BaseCollectionEntitySchema,
-  { target: "draft-07" },
+  { target: "draft-07", unrepresentable: "any" },
 ) as JsonSchema;

--- a/packages/bindings/src/well-known/language-model.ts
+++ b/packages/bindings/src/well-known/language-model.ts
@@ -58,7 +58,7 @@ const TextPartSchema = z.object({
  * File data can be Uint8Array (as base64 string), base64 encoded string, or URL string
  */
 const DataContentSchema = z
-  .union([z.string(), z.instanceof(Uint8Array)])
+  .string()
   .describe("File data as base64 encoded string, URL string, or Uint8Array");
 
 /**
@@ -336,7 +336,7 @@ export const LanguageModelCallOptionsSchema = z.object({
 
   // Additional options
   headers: z
-    .record(z.string(), z.union([z.string(), z.undefined()]))
+    .record(z.string(), z.string().optional())
     .optional()
     .describe("Additional HTTP headers to be sent with the request"),
   providerOptions: z
@@ -378,14 +378,7 @@ export const LanguageModelGenerateOutputSchema = z.object({
       totalTokens: z.number().optional(),
       reasoningTokens: z.number().optional(),
     })
-    .passthrough()
-    .transform((val) => ({
-      inputTokens: val.inputTokens,
-      outputTokens: val.outputTokens,
-      totalTokens: val.totalTokens,
-      reasoningTokens: val.reasoningTokens,
-      ...val,
-    }))
+    .loose()
     .describe("Usage information for the language model call"),
 
   // Provider metadata
@@ -410,7 +403,7 @@ export const LanguageModelGenerateOutputSchema = z.object({
     .object({
       id: z.string().optional().describe("ID for the generated response"),
       timestamp: z
-        .date()
+        .string()
         .optional()
         .describe("Timestamp for the start of the generated response"),
       modelId: z

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -389,7 +389,7 @@ const toolsFor = <TSchema extends ZodTypeAny = never>({
   configuration: { state: schema, scopes, onChange } = {},
 }: CreateMCPServerOptions<any, TSchema> = {}): CreatedTool[] => {
   const jsonSchema = schema
-    ? z.toJSONSchema(schema)
+    ? z.toJSONSchema(schema, { unrepresentable: "any" })
     : { type: "object", properties: {} };
   const busProp = String(events?.bus ?? "EVENT_BUS");
   return [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix JSON Schema generation for forms and tools by handling unrepresentable Zod types and aligning schemas across MCP and Gateway. This restores valid tool schemas and prevents form rendering issues.

- **Bug Fixes**
  - Use z.toJSONSchema(..., { unrepresentable: "any" }) for MCP server, Gateway tools, runtime tools, and BaseCollection schema.
  - Simplify non-representable Zod types: DataContentSchema is now string-only; headers use string.optional to avoid unions with undefined.
  - Replace usage object transform with loose to allow provider-specific fields without breaking schema conversion.
  - Normalize response.timestamp to string in bindings; convert to Date in the provider for consumers.
  - Bump @decocms/runtime to 1.1.1.

<sup>Written for commit 3b6b4362c5c4e0923c80da13d5454f3f8d949086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

