### PR TITLE
Updated button component and consistency

### DIFF
--- a/apps/mesh/src/web/components/chat/gateway-selector.tsx
+++ b/apps/mesh/src/web/components/chat/gateway-selector.tsx
@@ -42,7 +42,7 @@ function GatewayItemContent({
   return (
     <div
       className={cn(
-        "flex items-start gap-3 py-3 px-3 hover:bg-accent cursor-pointer rounded-xl",
+        "flex items-start gap-3 py-3 px-3 hover:bg-accent cursor-pointer rounded-lg",
         isSelected && "bg-accent",
       )}
     >
@@ -141,8 +141,9 @@ export function GatewaySelector({
       onValueChange={handleGatewayChange}
     >
       <ResponsiveSelectTrigger
+        size="sm"
         className={cn(
-          "h-7! text-sm hover:bg-accent rounded-lg py-0.5 px-1 gap-1 shadow-none cursor-pointer group focus-visible:ring-0 focus-visible:ring-offset-0 min-w-0 max-w-full",
+          "text-sm hover:bg-accent rounded-lg py-0.5 px-1 gap-1 shadow-none cursor-pointer group focus-visible:ring-0 focus-visible:ring-offset-0 min-w-0 max-w-full",
           variant === "borderless" && "border-0 md:border-none",
           className,
         )}

--- a/apps/mesh/src/web/components/chat/model-selector.tsx
+++ b/apps/mesh/src/web/components/chat/model-selector.tsx
@@ -187,7 +187,7 @@ const ModelDetailsPanel = memo(function ModelDetailsPanel({
   // Compact mobile version - just the details without header
   if (compact) {
     return (
-      <div className="flex flex-col gap-2.5 pt-3 pb-3 px-3 rounded-b-xl text-xs">
+      <div className="flex flex-col gap-2.5 pt-3 pb-3 px-3 rounded-b-lg text-xs">
         {model.contextWindow && (
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">Context</span>
@@ -311,7 +311,7 @@ const ModelItemContent = memo(function ModelItemContent({
     <div
       className={cn(
         "flex items-center gap-2 h-10 py-4 px-3 hover:bg-accent cursor-pointer",
-        hasExpandedInfo ? "rounded-t-xl" : "rounded-xl",
+        hasExpandedInfo ? "rounded-t-lg" : "rounded-lg",
       )}
       onMouseEnter={() => onHover(model)}
     >
@@ -436,8 +436,9 @@ export function ModelSelector({
       onValueChange={handleModelChange}
     >
       <ResponsiveSelectTrigger
+        size="sm"
         className={cn(
-          "h-7! text-sm hover:bg-accent rounded-lg py-0.5 px-1 gap-1 shadow-none cursor-pointer border-0 group focus-visible:ring-0 focus-visible:ring-offset-0 min-w-0 max-w-full",
+          "text-sm hover:bg-accent rounded-lg py-0.5 px-1 gap-1 shadow-none cursor-pointer border-0 group focus-visible:ring-0 focus-visible:ring-offset-0 min-w-0 max-w-full",
           variant === "borderless" && "md:border-none",
           className,
         )}
@@ -476,7 +477,7 @@ export function ModelSelector({
                 key={m.id}
                 onClick={() => handleModelChange(m.id)}
                 className={cn(
-                  "rounded-xl mb-1",
+                  "rounded-lg mb-1",
                   m.id === selectedModelId && "bg-accent",
                 )}
               >

--- a/apps/mesh/src/web/components/collections/collection-display-button.tsx
+++ b/apps/mesh/src/web/components/collections/collection-display-button.tsx
@@ -73,7 +73,7 @@ export function CollectionDisplayButton({
 
         {/* Sort Options */}
         {sortOptions.length > 0 && onSort && (
-          <div className="p-2">
+          <div className="p-1 flex flex-col gap-0.5">
             <div className="px-2 py-1.5 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
               Sort by
             </div>

--- a/apps/mesh/src/web/components/details/connection/settings-tab/connection-settings-form-ui.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/connection-settings-form-ui.tsx
@@ -55,7 +55,7 @@ function ConnectionFields({
             <FormLabel className="text-sm font-medium">Type</FormLabel>
             <Select value={field.value} onValueChange={field.onChange}>
               <FormControl>
-                <SelectTrigger className="h-10 rounded-lg">
+                <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
               </FormControl>

--- a/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
@@ -251,7 +251,7 @@ function BindingSelector({
 
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger className={className ?? "w-[200px] h-8!"}>
+      <SelectTrigger size="sm" className={className ?? "w-[200px]"}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>

--- a/apps/mesh/src/web/components/store-registry-select.tsx
+++ b/apps/mesh/src/web/components/store-registry-select.tsx
@@ -33,7 +33,7 @@ export function StoreRegistrySelect({
 }: StoreRegistrySelectProps) {
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger className="w-[200px] h-8!">
+      <SelectTrigger size="sm" className="w-auto min-w-[160px]">
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
@@ -72,7 +72,7 @@ export function StoreRegistrySelect({
                   onAddWellKnown(registry);
                 }}
                 key={registry.id ?? registry.title}
-                className="relative flex w-full cursor-pointer items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
+                className="relative flex w-full cursor-pointer items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
               >
                 <div className="flex items-center gap-2">
                   {registry.icon ? (

--- a/apps/mesh/src/web/routes/orgs/home/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/page.tsx
@@ -104,16 +104,11 @@ function WelcomeOverlay() {
         </div>
 
         <div className="border-t border-border px-4 py-4 flex items-center justify-center gap-2">
-          <Button onClick={handleBrowseStore} size="sm" className="h-9">
+          <Button onClick={handleBrowseStore} size="default">
             <ShoppingBag01 size={16} />
             Browse Store
           </Button>
-          <Button
-            variant="outline"
-            onClick={handleAddMcp}
-            size="sm"
-            className="h-9"
-          >
+          <Button variant="outline" onClick={handleAddMcp} size="default">
             <Plus size={16} />
             Connect MCP Server
           </Button>
@@ -285,12 +280,7 @@ export default function OrgHomePage() {
                 ]}
               />
             )}
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 px-3"
-              onClick={handleAddMcp}
-            >
+            <Button variant="outline" size="sm" onClick={handleAddMcp}>
               <Plus size={16} />
               Connect MCP Server
             </Button>

--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -768,13 +768,7 @@ function OrgMembersContent() {
           </Button>
         }
       />
-      <InviteMemberDialog
-        trigger={
-          <Button size="sm" className="h-7 px-3 rounded-lg text-sm font-medium">
-            Invite Member
-          </Button>
-        }
-      />
+      <InviteMemberDialog trigger={<Button size="sm">Invite Member</Button>} />
     </div>
   );
 

--- a/apps/mesh/src/web/routes/orgs/monitoring.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring.tsx
@@ -125,7 +125,7 @@ function FiltersPopover({
   return (
     <Popover open={filterPopoverOpen} onOpenChange={setFilterPopoverOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="h-7 px-3 gap-1.5">
+        <Button variant="outline" size="sm">
           <FilterLines size={16} />
           Filters
           {activeFiltersCount > 0 && (

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -24,7 +24,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        sm: "h-7 gap-1.5 px-3 has-[>svg]:px-2.5",
         xs: "h-6 gap-1 px-2 text-xs has-[>svg]:px-1.5",
         lg: "h-10 px-6 has-[>svg]:px-4",
         icon: "size-10",

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md",
           className,
         )}
         {...props}
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xl py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xl py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-xl px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-lg px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/responsive-dropdown.tsx
+++ b/packages/ui/src/components/responsive-dropdown.tsx
@@ -77,7 +77,7 @@ const ResponsiveDropdownItem = ({
         onClick?.(e);
       }}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
     >

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 hover:bg-accent hover:text-accent-foreground dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-xl border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=sm]:h-8 data-[size=xs]:h-7 data-[size=xs]:px-2.5 data-[size=xs]:py-1.5 data-[size=xs]:rounded-lg *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 hover:bg-accent hover:text-accent-foreground dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-lg border bg-transparent px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-10 data-[size=sm]:h-7 data-[size=xs]:h-7 data-[size=xs]:px-2.5 data-[size=xs]:py-1.5 data-[size=xs]:rounded-lg *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -61,7 +61,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -110,7 +110,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/toggle.tsx
+++ b/packages/ui/src/components/toggle.tsx
@@ -17,7 +17,7 @@ const toggleVariants = cva(
       },
       size: {
         default: "h-10 px-2 min-w-9",
-        sm: "h-8 px-1.5 min-w-8",
+        sm: "h-7 px-1.5 min-w-8",
         lg: "h-10 px-2.5 min-w-10",
       },
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized control sizes and rounded corners across the UI for a cleaner, consistent look. Small controls are now 28px tall and use rounded-lg by default; components now rely on size props instead of ad‑hoc height classes.

- **Refactors**
  - Button: sm is now h-7; cleaned up usages to use size="default"/"sm" (removed h-9/h-7 overrides).
  - Toggle: sm is now h-7.
  - Select/Dropdown/ResponsiveDropdown: switched rounded-xl to rounded-lg; updated content/items; SelectTrigger sm = h-7; removed hardcoded h-8 classes; added size="sm" where needed.
  - Model/Gateway selectors: triggers set to size="sm"; items/panels use rounded-lg.
  - Lists/menus: tighter padding and consistent rounded-lg in registry and collection controls.

- **Migration**
  - If you relied on sm = 32px heights, update layouts to the new 28px height.
  - Prefer size props over custom height classes for buttons, selects, and toggles.

<sup>Written for commit 817651e597798bba648c00d08030e93fe552e978. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

