### PR TITLE
[wip] Pinned sidebar

### DIFF
--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -26,6 +26,7 @@ import { ReadmeTab } from "./readme-tab";
 import { ResourcesTab } from "./resources-tab";
 import { SettingsTab } from "./settings-tab";
 import { ToolsTab } from "./tools-tab";
+import { useAutoPinConnectionCollections } from "@/web/components/sidebar-items-section";
 
 function ConnectionInspectorViewWithConnection({
   connection,
@@ -60,6 +61,14 @@ function ConnectionInspectorViewWithConnection({
     connectionId: connectionId,
   });
   const isMCPAuthenticated = authStatus.isAuthenticated;
+
+  // Auto-pin collections when they're detected
+  useAutoPinConnectionCollections(
+    connection.id,
+    connection.title,
+    connection.icon,
+    connection.tools,
+  );
 
   // Check if connection has repository info for README tab (stored in metadata)
   const repository = connection?.metadata?.repository as

--- a/apps/mesh/src/web/components/org-switcher.tsx
+++ b/apps/mesh/src/web/components/org-switcher.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { authClient } from "@/web/lib/auth-client";
 import { CreateOrganizationDialog } from "./create-organization-dialog";
 import { TopbarSwitcher } from "@deco/ui/components/topbar-switcher.tsx";
-import { Grid01 } from "@untitledui/icons";
+import { Grid01, Settings01 } from "@untitledui/icons";
 
 export function MeshOrgSwitcher() {
   const { org } = useParams({ strict: false });
@@ -98,6 +98,14 @@ export function MeshOrgSwitcher() {
                 icon={<Grid01 />}
               >
                 See all organizations
+              </TopbarSwitcher.Action>
+              <TopbarSwitcher.Action
+                onClick={() =>
+                  navigate({ to: "/$org/settings", params: { org: org ?? "" } })
+                }
+                icon={<Settings01 />}
+              >
+                Settings
               </TopbarSwitcher.Action>
             </TopbarSwitcher.Actions>
           </TopbarSwitcher.Panel>

--- a/apps/mesh/src/web/components/sidebar-items-section.tsx
+++ b/apps/mesh/src/web/components/sidebar-items-section.tsx
@@ -1,18 +1,27 @@
 import { SidebarItem } from "@/storage/types";
-import { X, File06 } from "@untitledui/icons";
+import { X, File06, ChevronRight } from "@untitledui/icons";
 import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarSeparator,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
 } from "@deco/ui/components/sidebar.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@deco/ui/components/collapsible.tsx";
 import { useNavigate } from "@tanstack/react-router";
-import { PropsWithChildren, Suspense } from "react";
+import { Suspense, useState, useEffect } from "react";
 import {
   useOrganizationSettings,
   useOrganizationSettingsActions,
 } from "../hooks/collections/use-organization-settings";
 import { useProjectContext } from "../providers/project-context-provider";
+import { type ValidatedCollection } from "../hooks/use-binding";
 
 /**
  * Individual sidebar item
@@ -26,12 +35,35 @@ function SidebarItemListItem({ item }: { item: SidebarItem }) {
   const handleDelete = async () => {
     const currentItems = settings?.sidebar_items || [];
     const updatedItems = currentItems.filter(
-      (sidebarItem) => sidebarItem.url !== item.url,
+      (sidebarItem: SidebarItem) => sidebarItem.url !== item.url,
     );
 
     await actions.update.mutateAsync({
       sidebar_items: updatedItems,
     });
+  };
+
+  const handleClick = () => {
+    // Parse the URL to navigate properly with TanStack Router
+    // URL format: /{orgSlug}/mcps/{connectionId}?tab={collectionName}
+    const url = new URL(item.url, window.location.origin);
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const searchParams = new URLSearchParams(url.search);
+
+    if (pathParts.length >= 3 && pathParts[1] === "mcps") {
+      const orgSlug = pathParts[0]; // Use the slug from the URL
+      const connectionId = pathParts[2];
+      const tab = searchParams.get("tab");
+
+      navigate({
+        to: "/$org/mcps/$connectionId",
+        params: { org: orgSlug, connectionId },
+        search: tab ? { tab } : undefined,
+      });
+    } else {
+      // Fallback for other URL formats
+      window.location.href = item.url;
+    }
   };
 
   const isIconUrl = /^https?:\/\/.+/.test(item.icon);
@@ -40,9 +72,7 @@ function SidebarItemListItem({ item }: { item: SidebarItem }) {
     <SidebarMenuItem>
       <SidebarMenuButton
         className="w-full pr-2 group/item relative cursor-pointer text-foreground/90 hover:text-foreground"
-        onClick={() => {
-          navigate({ to: item.url });
-        }}
+        onClick={handleClick}
         tooltip={item.title}
       >
         <div className="flex items-center justify-center shrink-0">
@@ -79,12 +109,123 @@ function SidebarItemListItem({ item }: { item: SidebarItem }) {
 }
 
 /**
- * Sidebar items section content - renders above Recent Threads
- * Only shows when there are pinned sidebar items
+ * Helper function to detect collections from connection tools
+ */
+export function detectCollections(
+  tools: Array<{
+    name: string;
+    inputSchema?: Record<string, unknown>;
+    outputSchema?: Record<string, unknown>;
+  }> | null,
+): ValidatedCollection[] {
+  if (!tools || tools.length === 0) return [];
+
+  // Extract collection names using regex
+  const collectionRegex = /^COLLECTION_(.+)_LIST$/;
+  const names: string[] = [];
+
+  for (const tool of tools) {
+    const match = tool.name.match(collectionRegex);
+    if (match?.[1]) {
+      names.push(match[1]);
+    }
+  }
+
+  return names.map((name) => ({
+    name,
+    displayName: name
+      .toLowerCase()
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" "),
+    hasCreateTool: tools.some((t) => t.name === `COLLECTION_${name}_CREATE`),
+    hasUpdateTool: tools.some((t) => t.name === `COLLECTION_${name}_UPDATE`),
+    hasDeleteTool: tools.some((t) => t.name === `COLLECTION_${name}_DELETE`),
+  }));
+}
+
+/**
+ * Hook to auto-pin collections for a specific connection
+ * Should be called from connection detail page where connection data is available
+ */
+export function useAutoPinConnectionCollections(
+  connectionId: string,
+  connectionTitle: string,
+  connectionIcon: string | null,
+  tools:
+    | Array<{
+        name: string;
+        inputSchema?: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
+      }>
+    | null
+    | undefined,
+) {
+  const { org } = useProjectContext();
+  const settings = useOrganizationSettings(org.id);
+  const actions = useOrganizationSettingsActions(org.id);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    // Wait for tools and settings to load
+    if (!tools || !settings) return;
+
+    const collections = detectCollections(tools);
+    if (collections.length === 0) return;
+
+    // Check localStorage to see if we've already auto-pinned this connection
+    const storageKey = `auto-pinned-${org.id}-${connectionId}`;
+    const alreadyProcessed = localStorage.getItem(storageKey);
+
+    if (alreadyProcessed) {
+      // Already processed this connection, don't pin again
+      return;
+    }
+
+    const currentItems = settings.sidebar_items || [];
+    const currentUrls = new Set(
+      currentItems.map((item: SidebarItem) => item.url),
+    );
+    const newItemsToPin: SidebarItem[] = [];
+
+    // Only add collections that aren't already pinned
+    collections.forEach((collection) => {
+      const collectionUrl = `/${org.slug}/mcps/${connectionId}?tab=${collection.name}`;
+
+      if (!currentUrls.has(collectionUrl)) {
+        newItemsToPin.push({
+          url: collectionUrl,
+          title: collection.displayName, // Just the collection name
+          icon: connectionIcon || "",
+        });
+      }
+    });
+
+    // Only pin if there are new items
+    if (newItemsToPin.length > 0) {
+      console.log(
+        "[Auto-pin] Pinning new collections:",
+        connectionTitle,
+        newItemsToPin,
+      );
+      actions.update.mutate({
+        sidebar_items: [...currentItems, ...newItemsToPin],
+      });
+    }
+
+    // Mark this connection as processed (even if no new items to prevent future checks)
+    localStorage.setItem(storageKey, "true");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionId, tools, actions, org.id, org.slug]);
+}
+
+/**
+ * Sidebar items section content - pinned items
  */
 function SidebarItemsSectionContent() {
   const { org } = useProjectContext();
   const settings = useOrganizationSettings(org.id);
+  const [isPinnedOpen, setIsPinnedOpen] = useState(true);
 
   const sidebarItems = settings?.sidebar_items;
 
@@ -93,54 +234,41 @@ function SidebarItemsSectionContent() {
   }
 
   return (
-    <SidebarItemLayout>
-      {sidebarItems.map((item) => (
-        <SidebarItemListItem key={item.url} item={item} />
-      ))}
-    </SidebarItemLayout>
-  );
-}
-
-/**
- * Skeleton for loading sidebar item entries
- */
-function SidebarItemSkeleton() {
-  return (
-    <SidebarMenuItem>
-      <div className="flex items-center gap-2 px-4 py-2">
-        <Skeleton className="h-4 flex-1" />
-      </div>
-    </SidebarMenuItem>
-  );
-}
-
-function SidebarItemLayout({ children }: PropsWithChildren) {
-  return (
     <>
       <SidebarSeparator className="my-2 -ml-1" />
-      <SidebarMenuItem>
-        <div className="group-data-[collapsible=icon]:hidden px-2 py-0 text-xs font-medium h-6 text-muted-foreground flex items-center justify-between">
-          <span className="whitespace-nowrap">Pinned Views</span>
-        </div>
-      </SidebarMenuItem>
-      {children}
+      <SidebarGroup>
+        <Collapsible open={isPinnedOpen} onOpenChange={setIsPinnedOpen}>
+          <SidebarGroupLabel asChild>
+            <CollapsibleTrigger className="w-full flex items-center gap-1 hover:bg-sidebar-accent rounded-md px-2 h-7! py-0! group-data-[collapsible=icon]:hidden">
+              <span className="text-xs font-medium text-muted-foreground">
+                Pinned Views
+              </span>
+              <ChevronRight
+                className={`size-3 transition-transform text-muted-foreground ${isPinnedOpen ? "rotate-90" : ""}`}
+              />
+            </CollapsibleTrigger>
+          </SidebarGroupLabel>
+          <CollapsibleContent>
+            <SidebarGroupContent>
+              <SidebarMenu className="gap-0.5">
+                {sidebarItems.map((item: SidebarItem) => (
+                  <SidebarItemListItem key={item.url} item={item} />
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </CollapsibleContent>
+        </Collapsible>
+      </SidebarGroup>
     </>
   );
 }
 
 /**
- * Sidebar items section - renders above Recent Threads
+ * Sidebar items section - renders pinned items (auto-pins collections from MCP servers)
  */
 export function SidebarItemsSection() {
   return (
-    <Suspense
-      fallback={
-        <SidebarItemLayout>
-          <SidebarItemSkeleton />
-          <SidebarItemSkeleton />
-        </SidebarItemLayout>
-      }
-    >
+    <Suspense fallback={null}>
       <SidebarItemsSectionContent />
     </Suspense>
   );

--- a/packages/ui/src/components/navigation-sidebar.tsx
+++ b/packages/ui/src/components/navigation-sidebar.tsx
@@ -1,14 +1,23 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarSeparator,
 } from "./sidebar.tsx";
 import { Skeleton } from "./skeleton.tsx";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./collapsible.tsx";
+import { ChevronRight } from "@untitledui/icons";
 
 export interface NavigationSidebarItem {
   key: string;
@@ -24,6 +33,7 @@ interface NavigationSidebarProps {
   additionalContent?: ReactNode;
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
+  defaultNavigationOpen?: boolean;
 }
 
 /**
@@ -36,14 +46,29 @@ export function NavigationSidebar({
   additionalContent,
   variant = "sidebar",
   collapsible = "icon",
+  defaultNavigationOpen = true,
 }: NavigationSidebarProps) {
+  const [isNavigationOpen, setIsNavigationOpen] = useState(
+    defaultNavigationOpen,
+  );
+
+  // Separate top-level items from accordion items
+  const topLevelKeys = ["home"];
+  const topLevelItems = navigationItems.filter((item) =>
+    topLevelKeys.includes(item.key),
+  );
+  const accordionItems = navigationItems.filter(
+    (item) => !topLevelKeys.includes(item.key) && item.key !== "settings",
+  );
+
   return (
     <Sidebar variant={variant} collapsible={collapsible}>
       <SidebarContent className="flex-1 overflow-x-hidden">
         <SidebarGroup className="font-medium">
           <SidebarGroupContent>
             <SidebarMenu className="gap-0.5">
-              {navigationItems.map((item) => (
+              {/* Top-level items outside accordion */}
+              {topLevelItems.map((item) => (
                 <SidebarMenuItem key={item.key}>
                   <SidebarMenuButton
                     className="group/nav-item cursor-pointer text-foreground/90 hover:text-foreground"
@@ -58,10 +83,53 @@ export function NavigationSidebar({
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
-              {additionalContent}
             </SidebarMenu>
           </SidebarGroupContent>
+
+          {/* Separator between top-level and Navigation */}
+          <SidebarSeparator className="my-2 -ml-1" />
+
+          {/* Other navigation items in accordion */}
+          {accordionItems.length > 0 && (
+            <Collapsible
+              open={isNavigationOpen}
+              onOpenChange={setIsNavigationOpen}
+            >
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger className="w-full flex items-center gap-1 hover:bg-sidebar-accent rounded-md px-2 h-7! py-0! group-data-[collapsible=icon]:hidden">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Default
+                  </span>
+                  <ChevronRight
+                    className={`size-3 transition-transform text-muted-foreground ${isNavigationOpen ? "rotate-90" : ""}`}
+                  />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu className="gap-0.5">
+                    {accordionItems.map((item) => (
+                      <SidebarMenuItem key={item.key}>
+                        <SidebarMenuButton
+                          className="group/nav-item cursor-pointer text-foreground/90 hover:text-foreground"
+                          onClick={item.onClick}
+                          isActive={item.isActive}
+                          tooltip={item.label}
+                        >
+                          <span className="text-muted-foreground group-hover/nav-item:text-foreground transition-colors [&>svg]:size-4">
+                            {item.icon}
+                          </span>
+                          <span className="truncate">{item.label}</span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    ))}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
         </SidebarGroup>
+        {additionalContent}
       </SidebarContent>
       {footer}
     </Sidebar>

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -395,7 +395,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a pinned sidebar section that auto-detects and pins MCP collections per connection, with a collapsible UI for cleaner navigation. Also adds an org Settings shortcut and restructures the navigation sidebar.

- **New Features**
  - Auto-pin collection tabs from MCP tools when viewing a connection (avoids duplicates via localStorage).
  - Collapsible “Pinned Views” group with Chevron toggle.
  - Pinned item click navigates to /$org/mcps/$connectionId with optional tab.
  - Org Switcher: “Settings” action added.

- **Refactors**
  - Navigation sidebar groups top-level items and collapses the rest under “Default” (configurable via defaultNavigationOpen).
  - Minor spacing tweaks and separator added; additionalContent rendered after navigation.

<sup>Written for commit 0197391209603cbeba2ee0784c8ee6eca891a6b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

