### PR TITLE
STDIO connection support improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,34 @@ Bun is the test runner throughout. Co-locate test files next to source as `*.tes
 ## Authentication & Authorization
 Uses Better Auth for authentication (OAuth 2.1 + SSO + API keys). Authorization uses custom AccessControl layer with organization/project-level RBAC. Auth configuration is in `apps/mesh/auth-config.json` (example: `auth-config.example.json`).
 
+## Documentation Requirements
+
+**IMPORTANT**: Documentation must be updated alongside code changes. Before committing:
+
+1. **Check for relevant docs** in `apps/docs/client/src/content/` (EN + PT-BR)
+2. **Update affected docs** when changing:
+   - API behavior or endpoints
+   - Configuration options
+   - Authentication/authorization flows
+   - Connection types or proxy behavior
+   - New features or removed functionality
+3. **Update README.md** for significant features
+4. **Review docs diff** before committing to ensure accuracy
+
+Documentation locations:
+- `apps/docs/client/src/content/en/` - English docs
+- `apps/docs/client/src/content/pt-br/` - Portuguese docs
+- `README.md` - Project overview and quick start
+- `packages/*/README.md` - Package-specific docs
+
+Run `bun run docs:dev` to preview documentation changes locally.
+
 ## Commit & Pull Request Guidelines
 Follow Conventional Commit-style history: `type(scope): message`, optionally wrapping the type in brackets for chores (e.g., `[chore]: update deps`). Reference issues with `(#1234)` when applicable. PRs should include:
 - Succinct summary of changes
 - Testing notes and affected areas
 - Screenshots for UI changes
+- **Documentation updates** for any behavior changes
 - Confirm formatting (`bun run fmt`) and linting (`bun run lint`) pass
 - Run tests (`bun test`) before requesting review
 - Flag follow-up work with TODOs linked to issues

--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ Virtual MCPs are configurable and extensible. You can add new strategies and als
 
 ---
 
+## STDIO Connections (Local MCPs)
+
+Run npx packages or custom scripts as MCP servers. Mesh passes credentials via environment variables:
+
+```bash
+# Mesh spawns your MCP with these env vars:
+MESH_TOKEN=<jwt>        # Infinite-expiry JWT for mesh API calls
+MESH_URL=<url>          # Mesh instance URL
+MESH_STATE=<json>       # Binding values as JSON
+```
+
+Your MCP just reads `process.env.MESH_TOKEN` — no special configuration tools needed. This mirrors how HTTP connections receive `x-mesh-token` headers.
+
+→ See [Building STDIO MCPs](https://docs.deco.page/en/mcp-mesh/mcp-servers) for examples in [decocms/mcps](https://github.com/decocms/mcps).
+
+---
+
 ## Define Tools
 
 Tools are first-class citizens. Type-safe, audited, observable, and callable via MCP.

--- a/apps/docs/client/src/content/en/introduction.mdx
+++ b/apps/docs/client/src/content/en/introduction.mdx
@@ -20,7 +20,7 @@ If MCP is the standard interface for tool access, deco CMS is the **production l
 - **The MCP Mesh**: [decocms.com/mesh](https://www.decocms.com/mesh)
 - **MCP Studio**: [decocms.com/mcp-studio](https://www.decocms.com/mcp-studio)
 
-If you know us from before (as **deco.cx**) and you’re looking for **headless CMS + storefront** capabilities, visit [deco.cx](https://www.decocms.com/use-case/deco-cx). See the deco.cx docs at [docs.deco.cx](https://docs.deco.cx/en/getting-started/overview).
+If you know us from before (as **deco.cx**) and you're looking for **headless CMS + storefront** capabilities, visit [deco.cx](https://www.decocms.com/use-case/deco-cx). See the deco.cx docs at [docs.deco.cx](https://docs.deco.cx/en/getting-started/overview).
 
 ## Start with the MCP Mesh
 
@@ -92,7 +92,7 @@ The application will be available at `http://localhost:8080`.
 - **[MCP Mesh Overview](/en/mcp-mesh/overview)**
 - **[Quickstart](/en/mcp-mesh/quickstart)**
 - **[Concepts](/en/mcp-mesh/concepts)**
-- **[MCP Servers (Connections)](/en/mcp-mesh/mcp-servers)**
+- **[Connections](/en/mcp-mesh/mcp-servers)**
 - **[MCP Agents](/en/mcp-mesh/mcp-gateways)**
 - **[API Keys](/en/mcp-mesh/api-keys)**
 - **[Monitoring](/en/mcp-mesh/monitoring)**
@@ -101,9 +101,9 @@ The application will be available at `http://localhost:8080`.
   **Docs split (quick guide):**
 
   - **The MCP Mesh** → Self-hosting, deploying, and operating the Mesh (recommended).
-  - **Legacy Admin** → If you’re using `admin.decocms.com` (still supported, **deprecated soon**).
+  - **Legacy Admin** → If you're using `admin.decocms.com` (still supported, **deprecated soon**).
 
-  We’re launching **MCP Studio** (on top of the Mesh), which will bring the current SaaS admin capabilities to the Mesh (including a hosted option by us) and replace the legacy SaaS over time.
+  We're launching **MCP Studio** (on top of the Mesh), which will bring the current SaaS admin capabilities to the Mesh (including a hosted option by us) and replace the legacy SaaS over time.
 </Callout>
 
 ## Problem: the production gap
@@ -139,7 +139,7 @@ A path to distribute reusable MCP-native capabilities across teams (and eventual
 
 ## Why MCP?
 
-We’re built on MCP because enterprises need interoperability at the tool layer — and a way to operate that tool access with the rigor of any production surface.
+We're built on MCP because enterprises need interoperability at the tool layer — and a way to operate that tool access with the rigor of any production surface.
 
 MCP gives you a standard interface. deco CMS provides the **control plane** around it:
 
@@ -150,7 +150,7 @@ MCP gives you a standard interface. deco CMS provides the **control plane** arou
 
 ## Legacy Admin quick start (admin.decocms.com)
 
-If you’re using the current SaaS admin at `admin.decocms.com` (still supported, deprecated soon), start here:
+If you're using the current SaaS admin at `admin.decocms.com` (still supported, deprecated soon), start here:
 
 - **[For AI Builders](/en/getting-started/ai-builders)**
 - **[For Developers](/en/getting-started/developers)**

--- a/apps/docs/client/src/content/en/mcp-mesh/mcp-servers.mdx
+++ b/apps/docs/client/src/content/en/mcp-mesh/mcp-servers.mdx
@@ -8,7 +8,72 @@ import Callout from "../../../components/ui/Callout.astro";
 
 ## What is a connection?
 
-A **Connection** in the Mesh is a configured upstream MCP endpoint (typically HTTP). The Mesh stores its configuration and (optionally) credentials, and can then proxy MCP requests to it.
+A **Connection** in the Mesh is a configured upstream MCP endpoint. The Mesh stores its configuration and (optionally) credentials, and can then proxy MCP requests to it.
+
+## Connection Types
+
+The Mesh supports two types of connections:
+
+### HTTP Connections
+
+HTTP connections are the most common type. They connect to remote MCP servers via HTTP/SSE endpoints.
+
+- **Use cases**: Cloud-hosted MCP servers, SaaS integrations, production deployments
+- **Token handling**: Short-lived tokens (5 minutes) issued per request
+
+### STDIO Connections (Local Commands)
+
+STDIO connections spawn a local process (like `npx` or custom scripts) and communicate via stdin/stdout.
+
+- **Use cases**: Local tools, npx packages, development, private MCPs
+- **Token handling**: Infinite-expiry tokens persisted locally by the MCP server
+
+<Callout type="tip">
+  STDIO connections are perfect for running npm packages as MCP servers. Example: `npx @decocms/local-fs` runs a file system MCP locally.
+</Callout>
+
+## STDIO Credentials via Environment Variables
+
+When mesh spawns an STDIO MCP process, it passes credentials as environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `MESH_TOKEN` | JWT token for authenticating with Mesh API (infinite expiry) |
+| `MESH_URL` | Base URL of the Mesh instance |
+| `MESH_STATE` | JSON-encoded state with binding values |
+
+This is analogous to how HTTP connections receive `x-mesh-token` headers.
+
+<Callout type="tip">
+  **No special tools needed!** Just read `process.env.MESH_TOKEN` on startup. No need to implement `ON_MCP_CONFIGURATION` or any configuration protocol.
+</Callout>
+
+### Example (Node.js/Bun)
+
+```typescript
+// Read mesh credentials from env
+const meshToken = process.env.MESH_TOKEN;
+const meshUrl = process.env.MESH_URL;
+const state = process.env.MESH_STATE ? JSON.parse(process.env.MESH_STATE) : {};
+
+// Connection ID (get it in the UI under Connections, or via the API)
+const connectionId = "<connection-id>";
+
+// Use token for mesh API calls
+const response = await fetch(`${meshUrl}/mcp/${connectionId}`, {
+  headers: { Authorization: `Bearer ${meshToken}` },
+  // ...
+});
+```
+
+## Building STDIO-Compatible MCPs
+
+See examples in the [decocms/mcps](https://github.com/decocms/mcps) repository:
+
+- `template-minimal/` - Minimal MCP without view
+- `template-with-view/` - MCP with web interface
+- `local-fs/` - File system MCP (runs via npx)
+- `perplexity/`, `openrouter/` - Production MCPs
 
 ## In the UI
 

--- a/apps/docs/client/src/content/pt-br/introduction.mdx
+++ b/apps/docs/client/src/content/pt-br/introduction.mdx
@@ -92,7 +92,7 @@ A aplicação ficará disponível em `http://localhost:8080`.
 - **[Visão geral](/pt-br/mcp-mesh/overview)**
 - **[Quickstart](/pt-br/mcp-mesh/quickstart)**
 - **[Conceitos](/pt-br/mcp-mesh/concepts)**
-- **[MCP Servers](/pt-br/mcp-mesh/mcp-servers)**
+- **[Conexões](/pt-br/mcp-mesh/mcp-servers)**
 - **[MCP Agents](/pt-br/mcp-mesh/mcp-gateways)**
 - **[API Keys](/pt-br/mcp-mesh/api-keys)**
 - **[Monitoring](/pt-br/mcp-mesh/monitoring)**

--- a/apps/docs/client/src/content/pt-br/mcp-mesh/mcp-servers.mdx
+++ b/apps/docs/client/src/content/pt-br/mcp-mesh/mcp-servers.mdx
@@ -1,27 +1,90 @@
 ---
 title: Conexões
-description: Conexões com MCP servers upstream (HTTP) que o Mesh faz proxy e observa
+description: Conexões com MCPs upstream que o Mesh faz proxy e observa
 icon: Server
 ---
 
-## O que é uma Conexão (no Mesh)?
+import Callout from "../../../components/ui/Callout.astro";
 
-No Mesh, uma **Conexão** é uma **connection** para um MCP upstream (normalmente um endpoint MCP via HTTP).
+## O que é uma conexão?
 
-Cada connection guarda:
+No Mesh, uma **Conexão** é a configuração de um MCP upstream.
 
-- **URL do MCP**
+Cada conexão guarda:
+
+- **URL do MCP** (para HTTP) ou **comando** (para STDIO)
 - **credenciais/config** (quando necessário, armazenadas no vault)
 - metadados para operação (nome, status, etc.)
 
-## Quando usar vs Agent
+## Tipos de Conexão
 
-- Use **connection** para isolar e depurar um upstream específico.
+### Conexões HTTP
+
+Conexões HTTP conectam a servidores MCP remotos via endpoints HTTP/SSE.
+
+- **Casos de uso**: MCPs em nuvem, integrações SaaS, produção
+- **Tokens**: JWT com expiração curta (5 minutos)
+
+### Conexões STDIO (Comandos Locais)
+
+Conexões STDIO iniciam um processo local (como `npx` ou scripts) e comunicam via stdin/stdout.
+
+- **Casos de uso**: Ferramentas locais, pacotes npx, desenvolvimento
+- **Tokens**: JWT sem expiração, persistido localmente
+
+<Callout type="tip">
+  Conexões STDIO são perfeitas para rodar pacotes npm como MCPs. Exemplo: `npx @decocms/local-fs` roda um MCP de sistema de arquivos localmente.
+</Callout>
+
+## Credenciais STDIO via Variáveis de Ambiente
+
+Quando o mesh inicia um processo MCP STDIO, ele passa credenciais como variáveis de ambiente:
+
+| Variável | Descrição |
+|----------|-----------|
+| `MESH_TOKEN` | Token JWT para autenticação com a API do Mesh (sem expiração) |
+| `MESH_URL` | URL base da instância Mesh |
+| `MESH_STATE` | Estado com valores de bindings em JSON |
+
+Isso é análogo a como conexões HTTP recebem headers `x-mesh-token`.
+
+<Callout type="tip">
+  **Nenhuma ferramenta especial necessária!** Apenas leia `process.env.MESH_TOKEN` na inicialização. Não precisa implementar `ON_MCP_CONFIGURATION` ou qualquer protocolo de configuração.
+</Callout>
+
+### Exemplo (Node.js/Bun)
+
+```typescript
+// Ler credenciais mesh das env vars
+const meshToken = process.env.MESH_TOKEN;
+const meshUrl = process.env.MESH_URL;
+const state = process.env.MESH_STATE ? JSON.parse(process.env.MESH_STATE) : {};
+
+// ID da Conexão (você pega na UI em Connections, ou via API)
+const connectionId = "<connection-id>";
+
+// Usar token para chamadas à API mesh
+const response = await fetch(`${meshUrl}/mcp/${connectionId}`, {
+  headers: { Authorization: `Bearer ${meshToken}` },
+  // ...
+});
+```
+
+## Quando usar vs Agents
+
+- Use **Conexão** para isolar e depurar um upstream específico.
 - Use **Agent** para expor um surface agregado/curado para os clients.
+
+## Construindo MCPs STDIO
+
+Veja exemplos no repositório [decocms/mcps](https://github.com/decocms/mcps):
+
+- `template-minimal/` - MCP mínimo sem view
+- `template-with-view/` - MCP com interface web
+- `local-fs/` - MCP de sistema de arquivos (roda via npx)
+- `perplexity/`, `openrouter/` - MCPs em produção
 
 ## Boas práticas
 
 - Mantenha URLs e credenciais por ambiente (dev/staging/prod).
-- Evite expor uma connection diretamente em produção; prefira um Agent para governança.
-
-
+- Evite expor uma Conexão diretamente em produção; prefira um Agent para governança.

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -21,7 +21,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "dev": "bun run migrate && concurrently \"bun run dev:client\" \"bun run dev:server\"",
+    "dev": "bun run migrate && concurrently --kill-others --kill-signal SIGTERM \"bun run dev:client\" \"bun run dev:server\"",
     "dev:client": "bun --bun vite dev",
     "dev:server": "NODE_ENV=development bun --hot run src/index.ts",
     "build:client": "bun --bun vite build",

--- a/apps/mesh/src/aggregator/prompt-aggregator.ts
+++ b/apps/mesh/src/aggregator/prompt-aggregator.ts
@@ -76,10 +76,21 @@ export class PromptAggregator {
 
           return { connectionId, prompts };
         } catch (error) {
-          console.error(
-            `[PromptAggregator] Failed to list prompts for connection ${connectionId}:`,
-            error,
-          );
+          // Error code -32601 is "Method not found" - expected for MCPs without prompts
+          const isMethodNotFound =
+            error &&
+            typeof error === "object" &&
+            "code" in error &&
+            error.code === -32601;
+          // Spawn failures are already logged by StableStdio
+          const isSpawnFailure =
+            error instanceof Error && error.message.includes("Spawn failed");
+          if (!isMethodNotFound && !isSpawnFailure) {
+            console.error(
+              `[PromptAggregator] Failed to list prompts for connection ${connectionId}:`,
+              error,
+            );
+          }
           return { connectionId, prompts: [] as Prompt[] };
         }
       },

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -107,7 +107,9 @@ import {
 import { MiddlewareHandler } from "hono/types";
 import { getToolsByCategory, MANAGEMENT_TOOLS } from "../tools/registry";
 import { Env } from "./env";
+import { resetStdioConnectionPool } from "../stdio/stable-transport";
 import { devLogger } from "./utils/dev-logger";
+
 const getHandleOAuthProtectedResourceMetadata = () =>
   oAuthProtectedResourceMetadata(auth);
 const getHandleOAuthDiscoveryMetadata = () => oAuthDiscoveryMetadata(auth);
@@ -138,6 +140,12 @@ export interface CreateAppOptions {
  */
 export function createApp(options: CreateAppOptions = {}) {
   const database = options.database ?? getDb();
+
+  // Kill and respawn STDIO connections on restart/HMR
+  // Old processes have stale credentials, need fresh spawn with new tokens
+  resetStdioConnectionPool().catch((err) => {
+    console.error("[StableStdio] Error resetting pool:", err);
+  });
 
   // Stop any existing event bus worker (cleanup during HMR)
   if (currentEventBus && currentEventBus.isRunning()) {

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -418,6 +418,10 @@ async function createMCPProxyDoNotUseDirectly(
       env.MESH_URL = meshUrl;
     }
 
+    // Pass the connection ID so STDIO servers can identify themselves
+    // (needed for event bus subscriptions via gateway)
+    env.MESH_CONNECTION_ID = connectionId;
+
     // Pass state as JSON for bindings
     const state = connection.configuration_state;
     if (state && Object.keys(state).length > 0) {
@@ -792,6 +796,13 @@ async function createMCPProxyDoNotUseDirectly(
         error.code === ErrorCode.MethodNotFound
       ) {
         return { prompts: [] };
+      }
+
+      // Also don't log spawn failures - those are already logged by StableStdio
+      const isSpawnFailure =
+        error instanceof Error && error.message.includes("Spawn failed");
+      if (!isSpawnFailure) {
+        console.error("[proxy:listPrompts] Error listing prompts:", error);
       }
 
       throw error;

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -264,8 +264,9 @@ async function createMCPProxyDoNotUseDirectly(
       connection.configuration_scopes,
     );
 
-    // Issue short-lived JWT with configuration permissions
-    // JWT can be decoded directly by downstream to access payload
+    // Issue JWT with configuration permissions
+    // HTTP connections get 5-min tokens, STDIO connections get infinite tokens
+    // STDIO servers persist tokens locally to .env for restart survival
     const userId = ctx.auth.user?.id ?? ctx.auth.apiKey?.userId;
     if (!userId) {
       console.error("User ID required to issue configuration token");
@@ -273,17 +274,24 @@ async function createMCPProxyDoNotUseDirectly(
     }
 
     try {
-      configurationToken = await issueMeshToken({
-        sub: userId,
-        user: { id: userId },
-        metadata: {
-          state: connection.configuration_state ?? undefined,
-          meshUrl: process.env.MESH_URL ?? ctx.baseUrl,
-          connectionId,
-          organizationId: ctx.organization?.id,
+      // STDIO connections get infinite tokens - they persist them locally to .env
+      // This avoids the need to re-send ON_MCP_CONFIGURATION on every request
+      const isStdioConnection = connection.connection_type === "STDIO";
+
+      configurationToken = await issueMeshToken(
+        {
+          sub: userId,
+          user: { id: userId },
+          metadata: {
+            state: connection.configuration_state ?? undefined,
+            meshUrl: process.env.MESH_URL ?? ctx.baseUrl,
+            connectionId,
+            organizationId: ctx.organization?.id,
+          },
+          permissions,
         },
-        permissions,
-      });
+        { noExpiration: isStdioConnection },
+      );
     } catch (error) {
       console.error("Failed to issue configuration token:", error);
       // Continue without configuration token - downstream will fail if it requires it
@@ -395,6 +403,30 @@ async function createMCPProxyDoNotUseDirectly(
     ? (connection.connection_headers as HttpConnectionParameters | null)
     : null;
 
+  // Build env vars for STDIO connections (token + state passed via env)
+  const buildStdioEnv = async (): Promise<Record<string, string>> => {
+    await ensureConfigurationToken();
+    const meshUrl = process.env.MESH_URL ?? ctx.baseUrl;
+
+    const env: Record<string, string> = {};
+
+    // Pass mesh credentials via env vars - STDIO servers just read these
+    if (configurationToken) {
+      env.MESH_TOKEN = configurationToken;
+    }
+    if (meshUrl) {
+      env.MESH_URL = meshUrl;
+    }
+
+    // Pass state as JSON for bindings
+    const state = connection.configuration_state;
+    if (state && Object.keys(state).length > 0) {
+      env.MESH_STATE = JSON.stringify(state);
+    }
+
+    return env;
+  };
+
   // Create client factory for downstream MCP based on connection_type
   const createClient = async () => {
     const client = new Client(
@@ -426,6 +458,10 @@ async function createMCPProxyDoNotUseDirectly(
           throw new Error("STDIO connection missing parameters");
         }
 
+        // Build env with mesh credentials - STDIO servers read MESH_TOKEN/MESH_URL/MESH_STATE
+        const meshEnv = await buildStdioEnv();
+        const env = { ...stdioParams.envVars, ...meshEnv };
+
         // Get or create stable connection - respawns automatically if closed
         // We want stable local MCP connection - don't spawn new process per request
         return getStableStdioClient(
@@ -434,7 +470,7 @@ async function createMCPProxyDoNotUseDirectly(
             name: connection.title,
             command: stdioParams.command,
             args: stdioParams.args,
-            env: stdioParams.envVars,
+            env,
             cwd: stdioParams.cwd,
           },
           client,
@@ -1011,6 +1047,21 @@ async function createMCPProxyDoNotUseDirectly(
       getPrompt,
     },
     callStreamableTool,
+    /**
+     * Get the configuration token for this proxy.
+     * This is the JWT that downstream MCPs can use to call back to Mesh.
+     * Useful for STDIO connections that can't receive headers per-request.
+     */
+    getConfigurationToken: async (): Promise<string | undefined> => {
+      await ensureConfigurationToken();
+      return configurationToken;
+    },
+    /**
+     * Get the Mesh URL that downstream MCPs should call back to.
+     */
+    getMeshUrl: (): string => {
+      return process.env.MESH_URL ?? ctx.baseUrl;
+    },
   };
 }
 

--- a/apps/mesh/src/auth/jwt.test.ts
+++ b/apps/mesh/src/auth/jwt.test.ts
@@ -78,7 +78,7 @@ describe("JWT Utility Functions", () => {
         },
       };
 
-      const token = await issueMeshToken(payload, "1h");
+      const token = await issueMeshToken(payload, { expiresIn: "1h" });
       const decoded = decodeMeshToken(token);
 
       // Expiration should be ~1 hour from now
@@ -343,7 +343,7 @@ describe("Token Expiration", () => {
     };
 
     // Issue token with very short expiration
-    const token = await issueMeshToken(payload, "1s");
+    const token = await issueMeshToken(payload, { expiresIn: "1s" });
 
     // Token should be valid immediately
     const validResult = await verifyMeshToken(token);
@@ -369,7 +369,7 @@ describe("Token Expiration", () => {
       },
     };
 
-    const token = await issueMeshToken(payload, "1s");
+    const token = await issueMeshToken(payload, { expiresIn: "1s" });
 
     // Wait for expiration
     await new Promise((resolve) => setTimeout(resolve, 1500));

--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -6,39 +6,51 @@
  * - Verified by downstream services using the shared secret
  *
  * The secret is loaded from MESH_JWT_SECRET environment variable.
- * If not set, a random secret is generated (not persistent across restarts).
+ * If not set, a random secret is generated (persisted via globalThis for HMR).
  */
 
 import { decodeJwt, type JWTPayload, jwtVerify, SignJWT } from "jose";
 import { randomBytes } from "crypto";
 import { authConfig } from "./index";
 
-// JWT signing secret - loaded from env or generated
-let jwtSecret: Uint8Array | null = null;
+// Use globalThis to persist JWT secret across HMR (hot module reload)
+// This prevents tokens from becoming invalid during development
+const JWT_SECRET_KEY = "__mesh_jwt_secret__";
+
+declare global {
+  var __mesh_jwt_secret__: Uint8Array | undefined;
+}
 
 /**
  * Get or generate the JWT signing secret
+ * Uses globalThis to survive HMR reloads in development
  */
 function getSecret(): Uint8Array {
-  if (jwtSecret) {
-    return jwtSecret;
+  // Check globalThis first (survives HMR)
+  if (globalThis[JWT_SECRET_KEY]) {
+    return globalThis[JWT_SECRET_KEY];
   }
 
   const envSecret =
     process.env.MESH_JWT_SECRET ??
     authConfig.jwt?.secret ??
     process.env.BETTER_AUTH_SECRET;
+
+  let secret: Uint8Array;
   if (envSecret) {
-    jwtSecret = new TextEncoder().encode(envSecret);
+    secret = new TextEncoder().encode(envSecret);
   } else {
-    // Generate a random secret - note: not persistent across restarts
+    // Generate a random secret - note: not persistent across full restarts
+    // but will survive HMR reloads via globalThis
     console.warn(
-      "MESH_JWT_SECRET not set - generating random secret (not persistent)",
+      "MESH_JWT_SECRET not set - generating random secret (survives HMR, not full restart)",
     );
-    jwtSecret = new Uint8Array(randomBytes(32));
+    secret = new Uint8Array(randomBytes(32));
   }
 
-  return jwtSecret;
+  // Store in globalThis to survive HMR
+  globalThis[JWT_SECRET_KEY] = secret;
+  return secret;
 }
 
 /**
@@ -66,24 +78,37 @@ export interface MeshTokenPayload {
 
 export type MeshJwtPayload = JWTPayload & MeshTokenPayload;
 
+export interface IssueMeshTokenOptions {
+  /** Expiration time (default: "5m"). Ignored if noExpiration is true. */
+  expiresIn?: string;
+  /** If true, issues a token with no expiration. Use for STDIO connections. */
+  noExpiration?: boolean;
+}
+
 /**
  * Issue a signed JWT with mesh token payload
  *
  * @param payload - The token payload
- * @param expiresIn - Expiration time (default: 5 minutes)
+ * @param options - Token options (expiresIn, noExpiration)
  * @returns Signed JWT string
  */
 export async function issueMeshToken(
   payload: MeshTokenPayload,
-  expiresIn: string = "5m",
+  options: IssueMeshTokenOptions = {},
 ): Promise<string> {
+  const { expiresIn = "5m", noExpiration = false } = options;
   const secret = getSecret();
 
-  return await new SignJWT(payload as unknown as JWTPayload)
+  const jwt = new SignJWT(payload as unknown as JWTPayload)
     .setProtectedHeader({ alg: "HS256", typ: "JWT" })
-    .setIssuedAt()
-    .setExpirationTime(expiresIn)
-    .sign(secret);
+    .setIssuedAt();
+
+  // STDIO connections get infinite tokens - they persist them locally
+  if (!noExpiration) {
+    jwt.setExpirationTime(expiresIn);
+  }
+
+  return await jwt.sign(secret);
 }
 
 /**

--- a/apps/mesh/src/stdio/stable-transport.ts
+++ b/apps/mesh/src/stdio/stable-transport.ts
@@ -40,6 +40,8 @@ interface StableConnection {
   config: StableStdioConfig;
   status: "connecting" | "connected" | "reconnecting" | "failed";
   connectPromise: Promise<StableClient> | null;
+  /** Process ID for killing the process tree on cleanup */
+  pid?: number;
 }
 
 /**
@@ -95,9 +97,18 @@ export async function getStableStdioClient(
 ): Promise<Client> {
   const existing = connectionPool.get(config.id);
 
-  // If we have an existing connection that's connected, return the stable wrapper
+  // If we have an existing connection that's connected, verify it's still alive
   if (existing?.status === "connected" && existing.stableClient) {
-    return existing.stableClient;
+    try {
+      // Quick ping to verify connection is alive (listTools has low overhead)
+      await existing.stableClient.listTools();
+      return existing.stableClient;
+    } catch {
+      // Connection is dead, mark for respawn
+      console.log(`[StableStdio] Stale connection detected: ${config.id}`);
+      existing.status = "failed";
+      existing.connectPromise = null;
+    }
   }
 
   // If we're already connecting/reconnecting, wait for that
@@ -198,7 +209,17 @@ export async function getStableStdioClient(
       }
 
       connection.status = "connected";
-      console.log(`[StableStdio] Connected: ${config.id}`);
+
+      // Capture PID for process tree cleanup during shutdown
+      // The MCP SDK stores the spawned process in _process (private but accessible)
+      const transportProcess = (
+        transport as unknown as { _process?: { pid?: number } }
+      )._process;
+      connection.pid = transportProcess?.pid;
+
+      console.log(
+        `[StableStdio] Connected: ${config.id} (PID: ${connection.pid ?? "unknown"})`,
+      );
 
       // Return the stable wrapper (close() is disabled)
       return connection.stableClient;
@@ -222,6 +243,53 @@ export async function getStableStdioClient(
 }
 
 /**
+ * Kill a process tree (parent and all children)
+ * This is needed because `bun --watch` spawns child processes
+ * that don't get killed when the parent receives SIGTERM
+ */
+async function killProcessTree(pid: number): Promise<void> {
+  try {
+    // First, find all child processes
+    const { spawn } = await import("child_process");
+
+    // Use pgrep to find children (works on macOS and Linux)
+    const pgrep = spawn("pgrep", ["-P", String(pid)]);
+    const childPids: number[] = [];
+
+    pgrep.stdout?.on("data", (data: Buffer) => {
+      const pids = data
+        .toString()
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(Number);
+      childPids.push(...pids);
+    });
+
+    await new Promise<void>((resolve) => pgrep.on("close", resolve));
+
+    // Recursively kill children first
+    for (const childPid of childPids) {
+      await killProcessTree(childPid);
+    }
+
+    // Kill the process itself with SIGKILL
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Process might already be dead
+    }
+  } catch {
+    // Fallback: just try to kill the PID directly
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Process might already be dead
+    }
+  }
+}
+
+/**
  * Force close a stable stdio connection
  * Used for explicit shutdown (e.g., server shutdown)
  */
@@ -236,9 +304,25 @@ async function forceCloseStdioConnection(id: string): Promise<void> {
     if (connection.client) {
       connection.client.onclose = undefined;
     }
-    await connection.client?.close();
-  } catch {
-    // Ignore close errors
+
+    // Use the PID we captured when the connection was created
+    const pid = connection.pid;
+
+    // First, try graceful close
+    try {
+      await connection.client?.close();
+    } catch {
+      // Ignore close errors
+    }
+
+    // Then, kill the entire process tree to ensure children are dead
+    // This is important for `bun --watch` which spawns child processes
+    if (pid) {
+      console.log(`[StableStdio] Killing process tree for PID ${pid}`);
+      await killProcessTree(pid);
+    }
+  } catch (error) {
+    console.error(`[StableStdio] Error closing connection ${id}:`, error);
   }
 
   connectionPool.delete(id);
@@ -257,6 +341,31 @@ async function forceCloseAllStdioConnections(): Promise<void> {
 
   await Promise.allSettled(closePromises);
   connectionPool.clear();
+
+  // Small delay to ensure OS releases ports after processes are killed
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+/**
+ * Force close all connections and clear the pool
+ * Used on app startup/HMR to ensure fresh processes with new credentials
+ */
+export async function resetStdioConnectionPool(): Promise<void> {
+  console.log(
+    `[StableStdio] Reset requested. Pool size: ${connectionPool.size}, keys: [${Array.from(connectionPool.keys()).join(", ")}]`,
+  );
+
+  if (connectionPool.size > 0) {
+    console.log(
+      `[StableStdio] Resetting ${connectionPool.size} connections (killing processes)`,
+    );
+    await forceCloseAllStdioConnections();
+    console.log(
+      `[StableStdio] Reset complete. Pool size: ${connectionPool.size}`,
+    );
+  } else {
+    console.log(`[StableStdio] Pool was empty, nothing to reset`);
+  }
 }
 
 // Register shutdown handlers - clean up connections before exit

--- a/apps/mesh/src/tools/connection/connection-tools.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.test.ts
@@ -19,6 +19,11 @@ import { DownstreamTokenStorage } from "../../storage/downstream-token";
 import type { EventBus } from "../../event-bus/interface";
 import * as fetchToolsModule from "./fetch-tools";
 
+// Mock fetchToolsFromMCP to avoid network calls and error logs during tests
+vi.mock("./fetch-tools", () => ({
+  fetchToolsFromMCP: vi.fn().mockResolvedValue([]),
+}));
+
 // Create a mock BoundAuthClient for tests
 const createMockBoundAuth = (): BoundAuthClient =>
   ({

--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -239,8 +239,18 @@ async function fetchToolsFromStdioMCP(
       setTimeout(() => reject(new Error("Tool fetch timeout")), 10_000);
     });
 
+    console.log(
+      `[STDIO tool fetch] Connecting to ${connection.id}: ${stdioParams.command} ${stdioParams.args?.join(" ")}`,
+    );
+
     await Promise.race([client.connect(transport), timeoutPromise]);
+    console.log(`[STDIO tool fetch] Connected, listing tools...`);
+
     const result = await Promise.race([client.listTools(), timeoutPromise]);
+    console.log(
+      `[STDIO tool fetch] Got ${result.tools?.length ?? 0} tools:`,
+      result.tools?.map((t) => t.name),
+    );
 
     if (!result.tools || result.tools.length === 0) {
       return null;
@@ -255,10 +265,7 @@ async function fetchToolsFromStdioMCP(
       _meta: tool._meta ?? undefined,
     }));
   } catch (error) {
-    console.error(
-      `Failed to fetch tools from STDIO connection ${connection.id}:`,
-      error,
-    );
+    console.error(`[STDIO tool fetch] Failed for ${connection.id}:`, error);
     return null;
   } finally {
     try {

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -241,11 +241,19 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
     ) {
       try {
         const proxy = await ctx.createMCPProxy(id);
+        // Get configuration token and mesh URL for STDIO connections
+        // HTTP connections receive these via headers, but STDIO needs them in arguments
+        const meshToken = await proxy.getConfigurationToken();
+        const meshUrl = proxy.getMeshUrl();
+
         await proxy.client.callTool({
           name: "ON_MCP_CONFIGURATION",
           arguments: {
             state: finalState,
             scopes: finalScopes,
+            // Include mesh context for STDIO connections that can't receive headers
+            meshToken,
+            meshUrl,
           },
         });
       } catch (error) {

--- a/apps/mesh/src/tools/eventbus/subscribe.ts
+++ b/apps/mesh/src/tools/eventbus/subscribe.ts
@@ -22,11 +22,12 @@ export const EVENT_SUBSCRIBE = defineTool({
     const organization = requireOrganization(ctx);
     await ctx.access.check();
 
-    // Get the subscriber connection ID from the caller's token
-    const connectionId = ctx.connectionId;
+    // Get the subscriber connection ID
+    // Use explicit subscriberId if provided (for calls via gateway), otherwise use caller's connection
+    const connectionId = input.subscriberId || ctx.connectionId;
     if (!connectionId) {
       throw new Error(
-        "Connection ID required to subscribe. Use a connection-scoped token.",
+        "Connection ID required to subscribe. Use a connection-scoped token or provide subscriberId.",
       );
     }
     // Create the subscription

--- a/apps/mesh/src/tools/eventbus/subscribe.ts
+++ b/apps/mesh/src/tools/eventbus/subscribe.ts
@@ -30,6 +30,22 @@ export const EVENT_SUBSCRIBE = defineTool({
         "Connection ID required to subscribe. Use a connection-scoped token or provide subscriberId.",
       );
     }
+
+    // If subscriberId was provided and differs from the caller's connection,
+    // verify the target connection exists and belongs to the same organization
+    if (input.subscriberId && input.subscriberId !== ctx.connectionId) {
+      const targetConnection = await ctx.storage.connections.findById(
+        input.subscriberId,
+      );
+      if (
+        !targetConnection ||
+        targetConnection.organization_id !== organization.id
+      ) {
+        throw new Error(
+          "Cannot subscribe on behalf of a connection outside your organization",
+        );
+      }
+    }
     // Create the subscription
     const subscription = await ctx.eventBus.subscribe(organization.id, {
       connectionId,

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.25.2",
-    "@tanstack/react-router": "1.139.7",
+    "@tanstack/react-router": "^1.150.0",
     "react": "^19.2.0",
     "zod": "^4.0.0",
     "zod-from-json-schema": "^0.5.2"

--- a/packages/bindings/src/well-known/event-bus.ts
+++ b/packages/bindings/src/well-known/event-bus.ts
@@ -121,6 +121,18 @@ export const EventSubscribeInputSchema = z.object({
     .max(1000)
     .optional()
     .describe("JSONPath filter expression on event data"),
+
+  /**
+   * Optional: Override the subscriber connection ID.
+   * When calling through a gateway, use this to specify which connection
+   * should receive the events (defaults to the caller's connection ID).
+   */
+  subscriberId: z
+    .string()
+    .optional()
+    .describe(
+      "Override subscriber connection ID (for subscriptions via gateway)",
+    ),
 });
 
 export type EventSubscribeInput = z.infer<typeof EventSubscribeInputSchema>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds robust STDIO MCP connection support with environment-based credentials and stable process management. Improves hot-reload stability.

- **New Features**
  - Issue infinite JWTs for STDIO and pass credentials via MESH_TOKEN, MESH_URL, MESH_STATE, and MESH_CONNECTION_ID; HTTP tokens remain 5 minutes.
  - Proxy exposes getConfigurationToken/getMeshUrl and includes mesh context in ON_MCP_CONFIGURATION for STDIO.
  - Stable STDIO transport: PID capture, process-tree kill, pool reset; app resets pool on startup/HMR; spawn_failed state with 5-minute cooldown to stop retry loops.
  - UI: “Refresh Tools” button in connection settings.
  - Docs: STDIO connection guide (EN/PT-BR), README updates, and AGENTS.md documentation requirements.

- **Bug Fixes**
  - Persist JWT secret and ContextFactory via globalThis to survive HMR.
  - STDIO stability: detect dead clients on reuse, add spawn cooldown, and suppress noisy “Method not found” prompt errors with cleaner spawn failure logs.
  - Event bus reliability: process pending events published during a batch and support gateway subscriptions via subscriberId; validate subscriberId belongs to the same organization. 
  - Tests updated to new issueMeshToken options API.

<sup>Written for commit 97e37b117491a4f33df32d6754e53b92185ee339. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

