### PR TITLE
chore: simplify history popover

### DIFF
--- a/apps/mesh/src/web/components/chat/thread-history-popover.tsx
+++ b/apps/mesh/src/web/components/chat/thread-history-popover.tsx
@@ -135,13 +135,13 @@ export function ThreadHistoryPopover({
     }
   };
 
-  if (variant === "outline") {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <Popover onOpenChange={handleOpenChange}>
-            <TooltipTrigger asChild>
-              <PopoverTrigger asChild>
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <Popover onOpenChange={handleOpenChange}>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              {variant === "outline" ? (
                 <Button
                   type="button"
                   variant="outline"
@@ -151,179 +151,100 @@ export function ThreadHistoryPopover({
                 >
                   <Clock size={16} />
                 </Button>
-              </PopoverTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Chat history</TooltipContent>
-            <PopoverContent align="end" className="w-80 p-0">
-              <div className="border-b">
-                <label className="flex items-center gap-2.5 h-12 px-4 cursor-text">
-                  <SearchMd
+              ) : (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-6 p-1 hover:bg-transparent"
+                  aria-label="Chat history"
+                >
+                  <Clock
                     size={16}
-                    className="text-muted-foreground shrink-0"
+                    className="text-muted-foreground hover:text-foreground transition-colors"
                   />
-                  <input
-                    type="text"
-                    placeholder="Search chats..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="flex-1 border-0 shadow-none focus:outline-none px-0 h-full text-sm placeholder:text-muted-foreground/50 bg-transparent"
-                  />
-                </label>
-              </div>
-
-              <div className="max-h-[300px] overflow-y-auto">
-                {filteredThreads.length === 0 ? (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
-                    {searchQuery.trim() ? "No chats found" : "No chats yet"}
-                  </div>
-                ) : (
-                  sections.map((section, sectionIndex) => (
-                    <div key={section.label}>
-                      {sectionIndex > 0 && <div className="border-t mx-3" />}
-                      <div className="px-3 py-1">
-                        <span className="text-xs font-medium text-muted-foreground tracking-wide">
-                          {section.label}
-                        </span>
-                      </div>
-                      {section.threads.map((thread) => {
-                        const isActive = thread.id === activeThreadId;
-                        return (
-                          <div
-                            key={thread.id}
-                            className={`flex items-center gap-2 px-3 py-2 hover:bg-accent cursor-pointer group ${
-                              isActive ? "bg-accent/50" : ""
-                            }`}
-                            onClick={() => onSelectThread(thread.id)}
-                          >
-                            <div className="flex-1 min-w-0 flex items-center gap-2">
-                              <span className="text-sm truncate">
-                                {thread.title || "New chat"}
-                              </span>
-                              <span className="text-xs text-muted-foreground shrink-0">
-                                {isActive
-                                  ? "current"
-                                  : section.showRelativeTime
-                                    ? formatRelativeTime(thread.updated_at)
-                                    : null}
-                              </span>
-                            </div>
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onRemoveThread(thread.id);
-                              }}
-                              className="opacity-0 cursor-pointer group/trash group-hover:opacity-100 p-1 hover:bg-destructive/10 rounded transition-opacity"
-                              title="Remove chat"
-                            >
-                              <Trash01
-                                size={14}
-                                className="text-muted-foreground group-hover/trash:text-destructive"
-                              />
-                            </button>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  ))
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-
-  return (
-    <Popover onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-6 p-1 hover:bg-transparent"
-          aria-label="Chat history"
-        >
-          <Clock
-            size={16}
-            className="text-muted-foreground hover:text-foreground transition-colors"
-          />
-        </Button>
-      </PopoverTrigger>
-
-      <PopoverContent align="end" className="w-80 p-0">
-        <div className="border-b">
-          <label className="flex items-center gap-2.5 h-12 px-4 cursor-text">
-            <SearchMd size={16} className="text-muted-foreground shrink-0" />
-            <input
-              type="text"
-              placeholder="Search chats..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="flex-1 border-0 shadow-none focus:outline-none px-0 h-full text-sm placeholder:text-muted-foreground/50 bg-transparent"
-            />
-          </label>
-        </div>
-
-        <div className="max-h-[300px] overflow-y-auto">
-          {filteredThreads.length === 0 ? (
-            <div className="p-4 text-center text-sm text-muted-foreground">
-              {searchQuery.trim() ? "No chats found" : "No chats yet"}
+                </Button>
+              )}
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Chat history</TooltipContent>
+          <PopoverContent align="end" className="w-80 p-0">
+            <div className="border-b">
+              <label className="flex items-center gap-2.5 h-12 px-4 cursor-text">
+                <SearchMd
+                  size={16}
+                  className="text-muted-foreground shrink-0"
+                />
+                <input
+                  type="text"
+                  placeholder="Search chats..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="flex-1 border-0 shadow-none focus:outline-none px-0 h-full text-sm placeholder:text-muted-foreground/50 bg-transparent"
+                />
+              </label>
             </div>
-          ) : (
-            sections.map((section, sectionIndex) => (
-              <div key={section.label}>
-                {sectionIndex > 0 && <div className="border-t mx-3" />}
-                <div className="px-3 py-1">
-                  <span className="text-xs font-medium text-muted-foreground tracking-wide">
-                    {section.label}
-                  </span>
+
+            <div className="max-h-[300px] overflow-y-auto">
+              {filteredThreads.length === 0 ? (
+                <div className="p-4 text-center text-sm text-muted-foreground">
+                  {searchQuery.trim() ? "No chats found" : "No chats yet"}
                 </div>
-                {section.threads.map((thread) => {
-                  const isActive = thread.id === activeThreadId;
-                  return (
-                    <div
-                      key={thread.id}
-                      className={`flex items-center gap-2 px-3 py-2 hover:bg-accent cursor-pointer group ${
-                        isActive ? "bg-accent/50" : ""
-                      }`}
-                      onClick={() => onSelectThread(thread.id)}
-                    >
-                      <div className="flex-1 min-w-0 flex items-center gap-2">
-                        <span className="text-sm truncate">
-                          {thread.title || "New chat"}
-                        </span>
-                        <span className="text-xs text-muted-foreground shrink-0">
-                          {isActive
-                            ? "current"
-                            : section.showRelativeTime
-                              ? formatRelativeTime(thread.updated_at)
-                              : null}
-                        </span>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onRemoveThread(thread.id);
-                        }}
-                        className="opacity-0 cursor-pointer group/trash group-hover:opacity-100 p-1 hover:bg-destructive/10 rounded transition-opacity"
-                        title="Remove chat"
-                      >
-                        <Trash01
-                          size={14}
-                          className="text-muted-foreground group-hover/trash:text-destructive"
-                        />
-                      </button>
+              ) : (
+                sections.map((section, sectionIndex) => (
+                  <div key={section.label}>
+                    {sectionIndex > 0 && <div className="border-t mx-3" />}
+                    <div className="px-3 py-1">
+                      <span className="text-xs font-medium text-muted-foreground tracking-wide">
+                        {section.label}
+                      </span>
                     </div>
-                  );
-                })}
-              </div>
-            ))
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+                    {section.threads.map((thread) => {
+                      const isActive = thread.id === activeThreadId;
+                      return (
+                        <div
+                          key={thread.id}
+                          className={`flex items-center gap-2 px-3 py-2 hover:bg-accent cursor-pointer group ${
+                            isActive ? "bg-accent/50" : ""
+                          }`}
+                          onClick={() => onSelectThread(thread.id)}
+                        >
+                          <div className="flex-1 min-w-0 flex items-center gap-2">
+                            <span className="text-sm truncate">
+                              {thread.title || "New chat"}
+                            </span>
+                            <span className="text-xs text-muted-foreground shrink-0">
+                              {isActive
+                                ? "current"
+                                : section.showRelativeTime
+                                  ? formatRelativeTime(thread.updated_at)
+                                  : null}
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onRemoveThread(thread.id);
+                            }}
+                            className="opacity-0 cursor-pointer group/trash group-hover:opacity-100 p-1 hover:bg-destructive/10 rounded transition-opacity"
+                            title="Remove chat"
+                          >
+                            <Trash01
+                              size={14}
+                              className="text-muted-foreground group-hover/trash:text-destructive"
+                            />
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Streamlined the chat history popover and added gateway-scoped threads so history shows the right items per gateway. New threads store gatewayId, and you can hide threads.

- **New Features**
  - Simplified popover UI using Button + Tooltip, with "icon" and "outline" variants.
  - Gateway views show only threads for that gateway via ThreadHistoryPopover; refetch on open.
  - New threads include gatewayId in chat-context, side-panel-chat, and gateway chat panel.
  - Added useThreads({ gatewayId }) and KEYS.gatewayThreads; insert/update now invalidate scoped queries.
  - Support hiding threads (sets hidden = true) from the gateway inspector.

<sup>Written for commit 61147a95de845f1ebcad74f67218a0db27f84bbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

