### PR TITLE
fix: create org modal keeps open

### DIFF
--- a/apps/mesh/src/web/components/create-organization-dialog.tsx
+++ b/apps/mesh/src/web/components/create-organization-dialog.tsx
@@ -22,7 +22,6 @@ import { Input } from "@deco/ui/components/input.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -51,8 +50,6 @@ export function CreateOrganizationDialog({
   open,
   onOpenChange,
 }: CreateOrganizationDialogProps) {
-  const navigate = useNavigate();
-
   const form = useForm<CreateOrgFormData>({
     resolver: zodResolver(createOrgSchema),
     defaultValues: { name: "" },
@@ -84,7 +81,7 @@ export function CreateOrganizationDialog({
       return { orgSlug };
     },
     onSuccess: ({ orgSlug }) => {
-      navigate({ to: "/$org", params: { org: orgSlug } });
+      window.location.href = `/${orgSlug}`;
     },
   });
 


### PR DESCRIPTION
Uses href on org creation. This is fine because org is used as key for almost everything so it's good to avoid some rogue key not being refreshed on org navigation