### PR TITLE
fix: Command for healthcheck

### DIFF
--- a/deploy/docker-compose.postgres.yml
+++ b/deploy/docker-compose.postgres.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mesh_user}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-mesh_user} -d ${POSTGRES_DB:-mesh_db}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fix configuration for health check for error "mesh_user not exist"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Postgres healthcheck in docker-compose by adding the configured database to pg_isready (-d ${POSTGRES_DB:-mesh_db}). This targets the correct DB and resolves "mesh_user not exist" errors.

<sup>Written for commit ac22c852b7018dd911f8d874036e5e5387d59806. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

