### PR TITLE
Change "Create Connection" to "Custom Connection

### DIFF
--- a/apps/mesh/src/web/components/binding-collection-empty-state.tsx
+++ b/apps/mesh/src/web/components/binding-collection-empty-state.tsx
@@ -86,7 +86,7 @@ export function BindingCollectionEmptyState({
               : `Install ${wellKnownMcp?.title || "MCP"}`}
           </Button>
           <Button variant="outline" onClick={handleInstallMcpServer}>
-            Create Connection
+            Custom Connection
           </Button>
         </>
       }

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -292,7 +292,7 @@ function ChatPanelContent() {
                       })
                     }
                   >
-                    Create Connection
+                    Custom Connection
                   </Button>
                 }
               />

--- a/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
@@ -302,8 +302,8 @@ function BindingSelector({
                   <Plus size={16} />
                   <span>
                     {canInstallInline
-                      ? "Create Connection"
-                      : "Create Connection"}
+                      ? "Custom Connection"
+                      : "Custom Connection"}
                   </span>
                 </>
               )}

--- a/apps/mesh/src/web/components/store/store-registry-empty-state.tsx
+++ b/apps/mesh/src/web/components/store/store-registry-empty-state.tsx
@@ -72,7 +72,7 @@ export function StoreRegistryEmptyState({
             {isInstalling ? "Installing..." : "Install Registry"}
           </Button>
           <Button variant="outline" onClick={handleInstallMcpServer}>
-            Create Connection
+            Custom Connection
           </Button>
         </>
       }

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -629,7 +629,7 @@ function OrgMcpsContent() {
         size="sm"
         className="h-7 px-3 rounded-lg text-sm font-medium"
       >
-        Create Connection
+        Custom Connection
       </Button>
     </div>
   );
@@ -643,12 +643,12 @@ function OrgMcpsContent() {
         <DialogContent className="sm:max-w-[525px]">
           <DialogHeader>
             <DialogTitle>
-              {editingConnection ? "Edit Connection" : "Create New Connection"}
+              {editingConnection ? "Edit Connection" : "Create Connection"}
             </DialogTitle>
             <DialogDescription>
               {editingConnection
                 ? "Update the connection details below."
-                : "Create a new connection in your organization. Fill in the details below."}
+                : "Create a custom connection in your organization. Fill in the details below."}
             </DialogDescription>
           </DialogHeader>
           <Form {...form}>

--- a/apps/mesh/src/web/routes/orgs/home/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/page.tsx
@@ -110,7 +110,7 @@ function WelcomeOverlay() {
           </Button>
           <Button variant="outline" onClick={handleAddMcp} size="default">
             <Plus size={16} />
-            Create Connection
+            Custom Connection
           </Button>
         </div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized UI copy by renaming “Create Connection” to “Custom Connection” across buttons and dialogs to make the manual setup path clearer and reduce confusion with install flows. Also aligned the connections dialog title/description for consistency.

<sup>Written for commit 8d4ac1d5e61c71e17a7de549b06ff0cc11d7d653. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

