### PR TITLE
add deco store by default

### DIFF
--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -1,5 +1,6 @@
 import {
   getWellKnownCommunityRegistryConnection,
+  getWellKnownRegistryConnection,
   getWellKnownSelfConnection,
 } from "@/core/well-known-mcp";
 import { getDb } from "@/database";
@@ -27,7 +28,7 @@ interface MCPCreationSpec {
  * This is a function (not a constant) to defer evaluation of ALL_TOOLS
  * until after all modules have finished initializing.
  */
-function getDefaultOrgMcps(): MCPCreationSpec[] {
+function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
   return [
     {
       permissions: {
@@ -71,6 +72,10 @@ function getDefaultOrgMcps(): MCPCreationSpec[] {
     {
       data: getWellKnownCommunityRegistryConnection(),
     },
+    // Deco Store Registry - official deco MCP registry with curated integrations
+    {
+      data: getWellKnownRegistryConnection(organizationId),
+    },
   ];
 }
 
@@ -85,7 +90,7 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
     const vault = new CredentialVault(process.env.ENCRYPTION_KEY || "");
     const connectionStorage = new ConnectionStorage(database.db, vault);
     const gatewayStorage = new GatewayStorage(database.db);
-    const defaultOrgMcps = getDefaultOrgMcps();
+    const defaultOrgMcps = getDefaultOrgMcps(organizationId);
 
     // Create default connections and collect their IDs
     const createdConnectionIds: string[] = [];


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Deco Store Registry as a default MCP connection when a new org is seeded, so curated integrations are available out of the box.

- **New Features**
  - Seeds Deco Store via getWellKnownRegistryConnection(organizationId).
  - getDefaultOrgMcps now accepts organizationId and is used in seedOrgDb.

<sup>Written for commit d91eb0abf7727e9c5194ea0349e8e9098936518d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

