### PR TITLE
fix(store): fix registry ID duplication and localStorage persistence

### DIFF
--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -72,7 +72,7 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
     {
       data: getWellKnownCommunityRegistryConnection(),
     },
-    // Deco Store Registry - official deco MCP registry with curated integrations
+    // Deco Store Registry - official deco MCP registry with curated integrations (installed last)
     {
       data: getWellKnownRegistryConnection(organizationId),
     },
@@ -125,8 +125,12 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
             connection_headers: mcpConfig.data.connection_headers,
           }).catch(() => null));
 
+        // Add org prefix only if ID doesn't already have it
+        // (e.g., Deco Store already includes org prefix via WellKnownOrgMCPId)
         const connectionId = mcpConfig.data.id
-          ? `${organizationId}_${mcpConfig.data.id}`
+          ? mcpConfig.data.id.startsWith(`${organizationId}_`)
+            ? mcpConfig.data.id
+            : `${organizationId}_${mcpConfig.data.id}`
           : undefined;
 
         const connection = await connectionStorage.create({

--- a/apps/mesh/src/web/routes/orgs/store/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/store/page.tsx
@@ -42,7 +42,7 @@ export default function StorePage() {
   // Persist selected registry in localStorage (scoped by org)
   const [selectedRegistryId, setSelectedRegistryId] = useLocalStorage<string>(
     LOCALSTORAGE_KEYS.selectedRegistry(org.slug),
-    () => "",
+    (existing) => existing ?? "",
   );
 
   const selectedRegistry = registryConnections.find(


### PR DESCRIPTION
- Fix connection ID generation to avoid double org prefix (e.g., orgId_orgId_registry -> orgId_registry)
- Fix localStorage initializer to preserve selected registry on refresh
- Update comment for Deco Store registry installation order

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
before:
<img width="192" height="201" alt="Captura de Tela 2026-01-08 às 11 21 21" src="https://github.com/user-attachments/assets/006a1d77-c3fc-45da-92f4-31572db05627" />
After:
<img width="193" height="141" alt="Captura de Tela 2026-01-08 às 11 20 43" src="https://github.com/user-attachments/assets/d491b1a1-f4b3-4603-a84e-1c6552a479ad" />


## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate org prefixes in registry connection IDs and preserves the selected registry across refresh on the Store page. Prevents broken IDs and keeps user selection stable per org.

- **Bug Fixes**
  - Add org prefix only when missing in connection IDs (avoid orgId_orgId_registry).
  - Initialize localStorage with existing value to keep selected registry per org after refresh.

- **Refactors**
  - Clarified comment: Deco Store registry is installed last.

<sup>Written for commit 84e06253d92ed0e82d1c684ef58eaa1e2d54ddfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

