### PR TITLE
[Experiment] New sidebar design, removed topbar

### DIFF
--- a/apps/mesh/src/web/components/mesh-sidebar.tsx
+++ b/apps/mesh/src/web/components/mesh-sidebar.tsx
@@ -1,15 +1,109 @@
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { SidebarItemsSection } from "@/web/components/sidebar-items-section";
+import { MeshOrgSwitcher } from "@/web/components/org-switcher";
+import { MeshUserMenu } from "@/web/components/user-menu";
 import { useProjectSidebarItems } from "@/web/hooks/use-project-sidebar-items";
 import { NavigationSidebar } from "@deco/ui/components/navigation-sidebar.tsx";
-import { Suspense } from "react";
+import { useSidebar } from "@deco/ui/components/sidebar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { ChevronLeft, ChevronRight, MessageCircle02 } from "@untitledui/icons";
+import { useParams, useRouterState } from "@tanstack/react-router";
+import { authClient } from "@/web/lib/auth-client";
+import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
+import { Suspense, useState } from "react";
+
+function CollapsedOrgToggle() {
+  const [isHovered, setIsHovered] = useState(false);
+  const { toggleSidebar } = useSidebar();
+  const { org } = useParams({ strict: false });
+  const { data: organizations } = authClient.useListOrganizations();
+
+  const currentOrg = organizations?.find((o) => o.slug === org);
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="size-8"
+      onClick={toggleSidebar}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {isHovered ? (
+        <ChevronRight size={18} />
+      ) : (
+        <Avatar
+          url={currentOrg?.logo ?? ""}
+          fallback={currentOrg?.name ?? org ?? ""}
+          size="xs"
+          objectFit="cover"
+        />
+      )}
+    </Button>
+  );
+}
 
 export function MeshSidebar() {
   const sidebarItems = useProjectSidebarItems();
+  const { state, toggleSidebar } = useSidebar();
+  const isCollapsed = state === "collapsed";
+  const routerState = useRouterState();
+  const { org } = useParams({ strict: false });
+  const [chatOpen, setChatOpen] = useDecoChatOpen();
+
+  // Check if we're on the home route (/$org)
+  const isHomeRoute =
+    routerState.location.pathname === `/${org}` ||
+    routerState.location.pathname === `/${org}/`;
+
+  const toggleChat = () => {
+    setChatOpen(!chatOpen);
+  };
 
   return (
     <NavigationSidebar
       navigationItems={sidebarItems}
+      header={
+        <div
+          className={`flex items-center h-12 ${isCollapsed ? "justify-center" : "pl-2.5 pr-3.5"}`}
+        >
+          {isCollapsed ? (
+            <CollapsedOrgToggle />
+          ) : (
+            <div className="flex items-center mt-2 w-full gap-2">
+              <div className="flex items-center gap-1.5 flex-1 min-w-0 overflow-hidden">
+                <Suspense fallback={<MeshOrgSwitcher.Skeleton />}>
+                  <MeshOrgSwitcher />
+                </Suspense>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7"
+                  onClick={toggleSidebar}
+                  title="Collapse sidebar"
+                >
+                  <ChevronLeft size={16} />
+                </Button>
+                {!isHomeRoute && (
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    onClick={toggleChat}
+                    title={chatOpen ? "Close chat" : "Open chat"}
+                  >
+                    <MessageCircle02 size={16} />
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      }
+      footer={<MeshUserMenu />}
       additionalContent={
         <>
           <ErrorBoundary>

--- a/apps/mesh/src/web/components/org-switcher.tsx
+++ b/apps/mesh/src/web/components/org-switcher.tsx
@@ -3,9 +3,11 @@ import { useState } from "react";
 import { authClient } from "@/web/lib/auth-client";
 import { CreateOrganizationDialog } from "./create-organization-dialog";
 import { TopbarSwitcher } from "@deco/ui/components/topbar-switcher.tsx";
+import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import { Grid01 } from "@untitledui/icons";
 
 export function MeshOrgSwitcher() {
+  const { state } = useSidebar();
   const { org } = useParams({ strict: false });
   const { data: organizations } = authClient.useListOrganizations();
   const navigate = useNavigate();
@@ -52,56 +54,64 @@ export function MeshOrgSwitcher() {
       }
     : undefined;
 
+  const isCollapsed = state === "collapsed";
+
   return (
     <>
-      <TopbarSwitcher>
+      <TopbarSwitcher collapsed={isCollapsed}>
         <TopbarSwitcher.Trigger
           onClick={() => navigate({ to: "/$org", params: { org: org ?? "" } })}
+          collapsed={isCollapsed}
         >
-          <TopbarSwitcher.CurrentItem item={mappedCurrentOrg} />
+          <TopbarSwitcher.CurrentItem
+            item={mappedCurrentOrg}
+            collapsed={isCollapsed}
+          />
         </TopbarSwitcher.Trigger>
 
-        <TopbarSwitcher.Content>
-          <TopbarSwitcher.Panel>
-            <TopbarSwitcher.Search
-              placeholder="Search organizations..."
-              value={orgSearch}
-              onChange={setOrgSearch}
-            />
+        {!isCollapsed && (
+          <TopbarSwitcher.Content>
+            <TopbarSwitcher.Panel>
+              <TopbarSwitcher.Search
+                placeholder="Search organizations..."
+                value={orgSearch}
+                onChange={setOrgSearch}
+              />
 
-            <TopbarSwitcher.Items emptyMessage="No organizations found.">
-              {mappedOrgs.map((organization) => (
-                <TopbarSwitcher.Item
-                  key={organization.slug}
-                  item={organization}
-                  onClick={(item) =>
-                    navigate({ to: "/$org", params: { org: item.slug } })
-                  }
-                />
-              ))}
-            </TopbarSwitcher.Items>
+              <TopbarSwitcher.Items emptyMessage="No organizations found.">
+                {mappedOrgs.map((organization) => (
+                  <TopbarSwitcher.Item
+                    key={organization.slug}
+                    item={organization}
+                    onClick={(item) =>
+                      navigate({ to: "/$org", params: { org: item.slug } })
+                    }
+                  />
+                ))}
+              </TopbarSwitcher.Items>
 
-            <TopbarSwitcher.Actions>
-              <TopbarSwitcher.Action
-                onClick={() => setCreatingOrganization(true)}
-                variant="muted"
-              >
-                + Create organization
-              </TopbarSwitcher.Action>
-            </TopbarSwitcher.Actions>
+              <TopbarSwitcher.Actions>
+                <TopbarSwitcher.Action
+                  onClick={() => setCreatingOrganization(true)}
+                  variant="muted"
+                >
+                  + Create organization
+                </TopbarSwitcher.Action>
+              </TopbarSwitcher.Actions>
 
-            <TopbarSwitcher.Separator />
+              <TopbarSwitcher.Separator />
 
-            <TopbarSwitcher.Actions>
-              <TopbarSwitcher.Action
-                onClick={() => navigate({ to: "/" })}
-                icon={<Grid01 />}
-              >
-                See all organizations
-              </TopbarSwitcher.Action>
-            </TopbarSwitcher.Actions>
-          </TopbarSwitcher.Panel>
-        </TopbarSwitcher.Content>
+              <TopbarSwitcher.Actions>
+                <TopbarSwitcher.Action
+                  onClick={() => navigate({ to: "/" })}
+                  icon={<Grid01 />}
+                >
+                  See all organizations
+                </TopbarSwitcher.Action>
+              </TopbarSwitcher.Actions>
+            </TopbarSwitcher.Panel>
+          </TopbarSwitcher.Content>
+        )}
       </TopbarSwitcher>
 
       <CreateOrganizationDialog

--- a/apps/mesh/src/web/components/user-menu.tsx
+++ b/apps/mesh/src/web/components/user-menu.tsx
@@ -16,6 +16,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
+import {
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from "@deco/ui/components/sidebar.tsx";
 import { authClient } from "@/web/lib/auth-client";
 import {
   AuthUIContext,
@@ -133,79 +137,83 @@ function MeshUserMenuBase({
   // Return skeleton/placeholder if no session yet
   return (
     <>
-      <UserMenu
-        user={user}
-        trigger={() => (
-          <div className="relative">
-            <Avatar
-              url={userImage}
-              fallback={user.name || user.email || "U"}
-              shape="circle"
-              size="sm"
-              className="cursor-pointer hover:ring-2 ring-muted-foreground transition-all"
-            />
-            {hasInvites && (
-              <span className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-destructive ring-2 ring-background" />
-            )}
-          </div>
-        )}
-        align="end"
-      >
-        <UserMenu.Item onClick={() => setProfileOpen(true)}>
-          <UserCircle className="text-muted-foreground" size={18} />
-          Profile
-        </UserMenu.Item>
-
-        {showInvitesItem && (
-          <UserMenu.Item onClick={() => setInvitesOpen(true)}>
-            <Mail01 className="text-muted-foreground" size={18} />
-            Invitations
-            {hasInvites && (
-              <span className="ml-auto h-2 w-2 rounded-full bg-destructive" />
-            )}
+      <SidebarMenuItem className="w-full">
+        <UserMenu
+          user={user}
+          trigger={() => (
+            <SidebarMenuButton className="group/nav-item cursor-pointer text-foreground/90 hover:text-foreground relative">
+              <Avatar
+                url={userImage}
+                fallback={user.name || user.email || "U"}
+                shape="circle"
+                size="xs"
+              />
+              <span className="text-sm truncate flex-1">
+                {user.name || user.email}
+              </span>
+              {hasInvites && (
+                <span className="absolute top-1.5 left-7 h-2 w-2 rounded-full bg-destructive ring-2 ring-sidebar" />
+              )}
+            </SidebarMenuButton>
+          )}
+          align="end"
+        >
+          <UserMenu.Item onClick={() => setProfileOpen(true)}>
+            <UserCircle className="text-muted-foreground" size={18} />
+            Profile
           </UserMenu.Item>
-        )}
 
-        <UserMenu.Separator />
+          {showInvitesItem && (
+            <UserMenu.Item onClick={() => setInvitesOpen(true)}>
+              <Mail01 className="text-muted-foreground" size={18} />
+              Invitations
+              {hasInvites && (
+                <span className="ml-auto h-2 w-2 rounded-full bg-destructive" />
+              )}
+            </UserMenu.Item>
+          )}
 
-        <UserMenu.Item asChild>
-          <a
-            href="https://github.com/decocms/admin"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex w-full items-center gap-2 text-sm cursor-pointer"
-          >
-            <GitHubIcon className="w-4 h-4 text-muted-foreground" />
-            decocms/admin
-            <LinkExternal01
-              size={18}
-              className="text-muted-foreground ml-auto"
-            />
-          </a>
-        </UserMenu.Item>
-        <UserMenu.Item asChild>
-          <a
-            href="https://decocms.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex w-full items-center gap-2 text-sm cursor-pointer"
-          >
-            <Globe01 className="text-muted-foreground" size={18} />
-            Homepage
-            <LinkExternal01
-              size={18}
-              className="ml-auto text-muted-foreground"
-            />
-          </a>
-        </UserMenu.Item>
+          <UserMenu.Separator />
 
-        <UserMenu.Separator />
+          <UserMenu.Item asChild>
+            <a
+              href="https://github.com/decocms/admin"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex w-full items-center gap-2 text-sm cursor-pointer"
+            >
+              <GitHubIcon className="w-4 h-4 text-muted-foreground" />
+              decocms/admin
+              <LinkExternal01
+                size={18}
+                className="text-muted-foreground ml-auto"
+              />
+            </a>
+          </UserMenu.Item>
+          <UserMenu.Item asChild>
+            <a
+              href="https://decocms.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex w-full items-center gap-2 text-sm cursor-pointer"
+            >
+              <Globe01 className="text-muted-foreground" size={18} />
+              Homepage
+              <LinkExternal01
+                size={18}
+                className="ml-auto text-muted-foreground"
+              />
+            </a>
+          </UserMenu.Item>
 
-        <UserMenu.Item onClick={() => authClient.signOut()}>
-          <LogOut01 size={18} className="text-muted-foreground" />
-          Log out
-        </UserMenu.Item>
-      </UserMenu>
+          <UserMenu.Separator />
+
+          <UserMenu.Item onClick={() => authClient.signOut()}>
+            <LogOut01 size={18} className="text-muted-foreground" />
+            Log out
+          </UserMenu.Item>
+        </UserMenu>
+      </SidebarMenuItem>
 
       {profileOpen && (
         <ProfileDialog
@@ -234,14 +242,12 @@ export function MeshUserMenu() {
   // Return skeleton/placeholder if no session yet
   if (!session?.user) {
     return (
-      <Avatar
-        url={undefined}
-        fallback="U"
-        shape="circle"
-        size="sm"
-        className="cursor-pointer"
-        muted
-      />
+      <SidebarMenuItem>
+        <div className="peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-lg px-2 py-1.5 text-left text-sm outline-hidden transition-colors duration-150 ease-out hover:transition-none hover:bg-sidebar-accent text-foreground/90 hover:text-foreground active:text-sidebar-foreground h-7 font-[450]">
+          <Avatar url={undefined} fallback="U" shape="circle" size="xs" muted />
+          <span className="text-sm truncate flex-1">Loading...</span>
+        </div>
+      </SidebarMenuItem>
     );
   }
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -21,7 +21,7 @@ const rootRoute = createRootRoute({
       <Suspense fallback={<SplashScreen />}>
         <Outlet />
       </Suspense>
-      <TanStackRouterDevtools />
+      <TanStackRouterDevtools position="bottom-right" />
     </Providers>
   ),
 });

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -1,8 +1,6 @@
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { MeshSidebar } from "@/web/components/mesh-sidebar";
-import { MeshOrgSwitcher } from "@/web/components/org-switcher";
 import { SplashScreen } from "@/web/components/splash-screen";
-import { MeshUserMenu } from "@/web/components/user-menu";
 import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
 import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
@@ -13,16 +11,12 @@ import {
   ProjectContextProvider,
   ProjectContextProviderProps,
 } from "@/web/providers/project-context-provider";
-import { AppTopbar } from "@deco/ui/components/app-topbar.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
 import { DecoChatSkeleton } from "@/web/components/chat/deco-chat-skeleton";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@deco/ui/components/resizable.tsx";
-import { SidebarToggleButton } from "@deco/ui/components/sidebar-toggle-button.tsx";
 import {
   SidebarInset,
   SidebarLayout,
@@ -31,71 +25,9 @@ import {
 import { cn } from "@deco/ui/lib/utils.js";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Outlet, useParams, useRouterState } from "@tanstack/react-router";
-import { PropsWithChildren, Suspense, useTransition, useRef } from "react";
+import { PropsWithChildren, Suspense, useTransition } from "react";
 import { KEYS } from "../lib/query-keys";
 import { ChatPanel } from "@/web/components/chat/side-panel-chat";
-
-// Capybara avatar URL from decopilotAgent
-const CAPYBARA_AVATAR_URL =
-  "https://assets.decocache.com/decocms/fd07a578-6b1c-40f1-bc05-88a3b981695d/f7fc4ffa81aec04e37ae670c3cd4936643a7b269.png";
-
-function Topbar({
-  showSidebarToggle = false,
-  showOrgSwitcher = false,
-  showDecoChat = false,
-  disableDecoChat = false,
-}: {
-  showSidebarToggle?: boolean;
-  showOrgSwitcher?: boolean;
-  showDecoChat?: boolean;
-  disableDecoChat?: boolean;
-}) {
-  const [isOpen, setChatOpen] = useDecoChatOpen();
-  const prevDisableRef = useRef(disableDecoChat);
-
-  // Close chat panel if disabled (synchronous check)
-  if (disableDecoChat && isOpen && prevDisableRef.current !== disableDecoChat) {
-    setChatOpen(false);
-  }
-  prevDisableRef.current = disableDecoChat;
-
-  const toggleChat = () => {
-    if (!disableDecoChat) {
-      setChatOpen((prev) => !prev);
-    }
-  };
-
-  return (
-    <AppTopbar>
-      {showSidebarToggle && (
-        <AppTopbar.Sidebar>
-          <SidebarToggleButton />
-        </AppTopbar.Sidebar>
-      )}
-      <AppTopbar.Left>
-        {showOrgSwitcher && (
-          <Suspense fallback={<MeshOrgSwitcher.Skeleton />}>
-            <MeshOrgSwitcher />
-          </Suspense>
-        )}
-      </AppTopbar.Left>
-      <AppTopbar.Right className="gap-2">
-        {showDecoChat && !disableDecoChat && (
-          <Button size="sm" variant="default" onClick={toggleChat}>
-            <Avatar
-              url={CAPYBARA_AVATAR_URL}
-              fallback="DC"
-              size="2xs"
-              className="rounded-sm"
-            />
-            deco chat
-          </Button>
-        )}
-        <MeshUserMenu />
-      </AppTopbar.Right>
-    </AppTopbar>
-  );
-}
 
 /**
  * This component persists the width of the chat panel across reloads.
@@ -205,10 +137,7 @@ function ShellLayoutContent() {
   if (!projectContext) {
     return (
       <div className="min-h-screen bg-background">
-        <Topbar />
-        <div className="pt-12">
-          <Outlet />
-        </div>
+        <Outlet />
       </div>
     );
   }
@@ -216,28 +145,20 @@ function ShellLayoutContent() {
   return (
     <ProjectContextProvider {...projectContext}>
       <PersistentSidebarProvider>
-        <div className="flex flex-col h-screen">
-          <Topbar
-            showSidebarToggle
-            showOrgSwitcher
-            showDecoChat
-            disableDecoChat={isHomeRoute}
-          />
-          <SidebarLayout
-            className="flex-1 bg-sidebar"
-            style={
-              {
-                "--sidebar-width": "13rem",
-                "--sidebar-width-mobile": "11rem",
-              } as Record<string, string>
-            }
-          >
-            <MeshSidebar />
-            <SidebarInset className="pt-12">
-              <ChatPanels disableChat={isHomeRoute} />
-            </SidebarInset>
-          </SidebarLayout>
-        </div>
+        <SidebarLayout
+          className="h-screen"
+          style={
+            {
+              "--sidebar-width": "14rem",
+              "--sidebar-width-mobile": "11rem",
+            } as Record<string, string>
+          }
+        >
+          <MeshSidebar />
+          <SidebarInset>
+            <ChatPanels disableChat={isHomeRoute} />
+          </SidebarInset>
+        </SidebarLayout>
       </PersistentSidebarProvider>
     </ProjectContextProvider>
   );

--- a/packages/ui/src/components/navigation-sidebar.tsx
+++ b/packages/ui/src/components/navigation-sidebar.tsx
@@ -2,8 +2,10 @@ import type { ReactNode } from "react";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -20,6 +22,7 @@ export interface NavigationSidebarItem {
 
 interface NavigationSidebarProps {
   navigationItems: NavigationSidebarItem[];
+  header?: ReactNode;
   footer?: ReactNode;
   additionalContent?: ReactNode;
   variant?: "sidebar" | "floating" | "inset";
@@ -32,6 +35,7 @@ interface NavigationSidebarProps {
  */
 export function NavigationSidebar({
   navigationItems,
+  header,
   footer,
   additionalContent,
   variant = "sidebar",
@@ -39,14 +43,15 @@ export function NavigationSidebar({
 }: NavigationSidebarProps) {
   return (
     <Sidebar variant={variant} collapsible={collapsible}>
+      {header && <SidebarHeader className="p-0">{header}</SidebarHeader>}
       <SidebarContent className="flex-1 overflow-x-hidden">
-        <SidebarGroup className="font-medium">
+        <SidebarGroup className="font-medium mt-1.5 px-2">
           <SidebarGroupContent>
             <SidebarMenu className="gap-0.5">
               {navigationItems.map((item) => (
                 <SidebarMenuItem key={item.key}>
                   <SidebarMenuButton
-                    className="group/nav-item cursor-pointer text-foreground/90 hover:text-foreground"
+                    className="group/nav-item cursor-pointer text-foreground/90 hover:text-foreground h-7 px-2 gap-2"
                     onClick={item.onClick}
                     isActive={item.isActive}
                     tooltip={item.label}
@@ -54,7 +59,7 @@ export function NavigationSidebar({
                     <span className="text-muted-foreground group-hover/nav-item:text-foreground transition-colors [&>svg]:size-4">
                       {item.icon}
                     </span>
-                    <span className="truncate">{item.label}</span>
+                    <span className="truncate text-sm">{item.label}</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -63,7 +68,11 @@ export function NavigationSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      {footer}
+      {footer && (
+        <SidebarFooter className="border-t border-border py-2 px-2 mt-1.5">
+          {footer}
+        </SidebarFooter>
+      )}
     </Sidebar>
   );
 }

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -248,7 +248,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed top-12 bottom-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed top-0 bottom-0 z-10 hidden w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -263,7 +263,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border py-2 flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          className="bg-muted/50 group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
         >
           {children}
         </div>

--- a/packages/ui/src/components/topbar-switcher.tsx
+++ b/packages/ui/src/components/topbar-switcher.tsx
@@ -5,7 +5,7 @@ import { Separator } from "./separator.tsx";
 import { Avatar } from "./avatar.tsx";
 import { createContext, useContext, type ReactNode } from "react";
 import { cn } from "../lib/utils.ts";
-import { ChevronSelectorVertical } from "@untitledui/icons";
+import { ChevronDown } from "@untitledui/icons";
 
 export interface TopbarSwitcherEntity {
   slug: string;
@@ -37,11 +37,13 @@ function useTopbarSwitcherContext() {
 interface TopbarSwitcherRootProps {
   children: ReactNode;
   onItemHover?: (slug: string | null) => void;
+  collapsed?: boolean;
 }
 
 function TopbarSwitcherRoot({
   children,
   onItemHover,
+  collapsed = false,
 }: TopbarSwitcherRootProps) {
   const [hoveredItem, setHoveredItemInternal] = React.useState<string | null>(
     null,
@@ -54,7 +56,7 @@ function TopbarSwitcherRoot({
 
   return (
     <TopbarSwitcherContext.Provider value={{ hoveredItem, setHoveredItem }}>
-      <Popover>{children}</Popover>
+      {collapsed ? <>{children}</> : <Popover>{children}</Popover>}
     </TopbarSwitcherContext.Provider>
   );
 }
@@ -63,28 +65,40 @@ function TopbarSwitcherRoot({
 interface TopbarSwitcherTriggerProps {
   children: ReactNode;
   onClick?: () => void;
+  collapsed?: boolean;
 }
 
 function TopbarSwitcherTrigger({
   children,
   onClick,
+  collapsed = false,
 }: TopbarSwitcherTriggerProps) {
-  return (
-    <div className="flex items-center gap-1">
+  if (collapsed) {
+    return (
       <Button
         variant="link"
-        className="p-0.5 h-auto"
+        className="p-0 h-auto min-w-0 flex-1"
         onClick={onClick}
         type="button"
       >
         {children}
       </Button>
-      <PopoverTrigger asChild>
-        <Button size="icon" variant="ghost" className="w-6 h-6 p-0">
-          <ChevronSelectorVertical size={16} className="opacity-50" />
-        </Button>
-      </PopoverTrigger>
-    </div>
+    );
+  }
+
+  return (
+    <PopoverTrigger asChild>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="justify-start !pl-1 !pr-1.5 min-w-0 flex-1"
+        onClick={onClick}
+        type="button"
+      >
+        {children}
+        <ChevronDown size={16} className="opacity-50 shrink-0" />
+      </Button>
+    </PopoverTrigger>
   );
 }
 
@@ -92,21 +106,28 @@ function TopbarSwitcherTrigger({
 interface TopbarSwitcherCurrentItemProps<T extends TopbarSwitcherEntity> {
   item: T | undefined;
   fallback?: string;
+  collapsed?: boolean;
 }
 
 function TopbarSwitcherCurrentItem<T extends TopbarSwitcherEntity>({
   item,
   fallback = "",
+  collapsed = false,
 }: TopbarSwitcherCurrentItemProps<T>) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-1.5 min-w-0">
       <Avatar
         url={item?.avatarUrl ?? ""}
         fallback={item?.name ?? fallback}
-        size="xs"
-        objectFit="contain"
+        size="sm"
+        objectFit="cover"
+        className="shrink-0 size-5 rounded-md"
       />
-      <span>{item?.name ?? fallback}</span>
+      {!collapsed && (
+        <span className="truncate font-medium text-[14px]">
+          {item?.name ?? fallback}
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/user-menu.tsx
+++ b/packages/ui/src/components/user-menu.tsx
@@ -34,17 +34,18 @@ interface UserMenuSeparatorProps {
 function UserMenuRoot({
   user,
   trigger,
-  align = "start",
+  align: _align = "start",
   children,
 }: UserMenuProps) {
   return (
     <ResponsiveDropdown>
-      <ResponsiveDropdownTrigger asChild>
-        <div>{trigger(user)}</div>
+      <ResponsiveDropdownTrigger asChild className="w-full">
+        {trigger(user)}
       </ResponsiveDropdownTrigger>
       <ResponsiveDropdownContent
         side="top"
-        align={align}
+        align="end"
+        alignOffset={-32}
         className="md:w-[240px]"
       >
         {children}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Built a new sidebar and removed the topbar. Org switching and the user menu now live in the sidebar, with a chat toggle and better collapsed behavior.

- **New Features**
  - Org switcher in the sidebar header with a collapsed avatar toggle.
  - Chat toggle button in the sidebar header (hidden on the home route).
  - User menu moved to the sidebar footer with an invites badge.

- **Refactors**
  - NavigationSidebar now supports a header and footer; tightened spacing and sizing.
  - Removed AppTopbar and simplified the shell layout to a sidebar-only structure.
  - Updated Sidebar and TopbarSwitcher to handle collapsed mode; sidebar now anchors at top-0.
  - Moved TanStack Router Devtools to the bottom-right.

<sup>Written for commit b786a1df33cd3ed11f2d7a146e0dc603fa5986ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

