### PR TITLE
Increase connection pool keep alive

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -71,21 +71,24 @@ interface DatabaseConfig {
 // PostgreSQL Implementation
 // ============================================================================
 
+const defaultPoolOptions = {
+  // Keep connections alive to avoid reconnection latency across regions
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10000,
+  // Allow connections to stay idle longer (5 min instead of default 10s)
+  // This reduces reconnection overhead for cross-region databases
+  idleTimeoutMillis: 300000,
+  // Increase connection timeout for high-latency networks (30s)
+  connectionTimeoutMillis: 30000,
+  // Allow the process to exit even with idle connections
+  allowExitOnIdle: true,
+};
 function createPostgresDatabase(config: DatabaseConfig): PostgresDatabase {
   const pool = new Pool({
     connectionString: config.connectionString,
     max: config.options?.maxConnections || 10,
     ssl: process.env.DATABASE_PG_SSL === "true" ? true : false,
-    // Keep connections alive to avoid reconnection latency across regions
-    keepAlive: true,
-    keepAliveInitialDelayMillis: 10000,
-    // Allow connections to stay idle longer (5 min instead of default 10s)
-    // This reduces reconnection overhead for cross-region databases
-    idleTimeoutMillis: 300000,
-    // Increase connection timeout for high-latency networks (30s)
-    connectionTimeoutMillis: 30000,
-    // Allow the process to exit even with idle connections
-    allowExitOnIdle: true,
+    ...defaultPoolOptions,
   });
 
   const dialect = new PostgresDialect({ pool });
@@ -236,11 +239,7 @@ export function getDbDialect(databaseUrl?: string): Dialect {
         connectionString: config.connectionString,
         max: config.options?.maxConnections || 10,
         ssl: process.env.DATABASE_PG_SSL === "true" ? true : false,
-        keepAlive: true,
-        keepAliveInitialDelayMillis: 10000,
-        idleTimeoutMillis: 300000,
-        connectionTimeoutMillis: 30000,
-        allowExitOnIdle: true,
+        ...defaultPoolOptions,
       }),
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable TCP keep-alive and longer timeouts for the Postgres connection pool to reduce reconnections across regions and improve stability on high-latency networks. Also lets the process exit cleanly with idle connections.

- **Refactors**
  - Enable keepAlive with a 10s initial delay.
  - Increase idleTimeoutMillis to 5 minutes.
  - Increase connectionTimeoutMillis to 30 seconds.
  - Set allowExitOnIdle to true.

<sup>Written for commit 40613ca162c8cc3c3f87e408afe6af1f67eb9222. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

