### PR TITLE
feat: enhance connection token handling in COLLECTION_CONNECTIONS_UPDATE

### DIFF
--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -112,12 +112,6 @@ async function fetchToolsFromHttpMCP(
           { ...tool.outputSchema, additionalProperties: true }
         : undefined,
     }));
-  } catch (error) {
-    console.error(
-      `Failed to fetch tools from HTTP connection ${connection.id}:`,
-      error,
-    );
-    return null;
   } finally {
     try {
       if (client && typeof client.close === "function") {
@@ -177,12 +171,6 @@ async function fetchToolsFromStdioMCP(
       inputSchema: tool.inputSchema ?? {},
       outputSchema: tool.outputSchema ?? undefined,
     }));
-  } catch (error) {
-    console.error(
-      `Failed to fetch tools from STDIO connection ${connection.id}:`,
-      error,
-    );
-    return null;
   } finally {
     try {
       if (client && typeof client.close === "function") {

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -10,6 +10,7 @@ import {
   parseScope,
 } from "@/auth/configuration-scopes";
 import { WellKnownMCPId } from "@/core/well-known-mcp";
+import { refreshAccessToken } from "@/oauth/token-refresh";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
@@ -25,6 +26,22 @@ import {
   ConnectionEntitySchema,
   ConnectionUpdateDataSchema,
 } from "./schema";
+
+function isUnauthorizedDownstreamMcpError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if ("code" in error && (error as { code?: unknown }).code === 401)
+    return true;
+  if (
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string" &&
+    (error as { message: string }).message
+      .toLowerCase()
+      .includes("unauthorized")
+  ) {
+    return true;
+  }
+  return false;
+}
 
 /**
  * Input schema for updating connections
@@ -167,29 +184,199 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
     // Fetch tools from the MCP server.
     // If the connection uses OAuth (token stored in downstream_tokens), use the per-user
     // access token to discover tools after authentication.
-    let tokenForToolFetch = data.connection_token ?? existing.connection_token;
-    if (!tokenForToolFetch) {
-      try {
-        const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-        const cachedToken = await tokenStorage.get(id, userId);
-        if (cachedToken?.accessToken) {
-          tokenForToolFetch = cachedToken.accessToken;
+    const hasExplicitConnectionToken = Object.prototype.hasOwnProperty.call(
+      data,
+      "connection_token",
+    );
+    const explicitConnectionToken = hasExplicitConnectionToken
+      ? (data.connection_token ?? null)
+      : null;
+
+    const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
+    let downstreamAccessToken: string | null = null;
+    let downstreamCanRefresh = false;
+    let downstreamRefreshAttempted = false;
+    let downstreamTokenWasDeleted = false;
+    let cachedDownstreamToken = await tokenStorage
+      .get(id, userId)
+      .catch(() => null);
+
+    if (cachedDownstreamToken) {
+      downstreamCanRefresh =
+        !!cachedDownstreamToken.refreshToken &&
+        !!cachedDownstreamToken.tokenEndpoint &&
+        !!cachedDownstreamToken.clientId;
+
+      const isExpired = tokenStorage.isExpired(
+        cachedDownstreamToken,
+        downstreamCanRefresh ? 5 * 60 * 1000 : 0,
+      );
+
+      if (isExpired) {
+        if (downstreamCanRefresh) {
+          downstreamRefreshAttempted = true;
+          const refreshResult = await refreshAccessToken(cachedDownstreamToken);
+
+          if (refreshResult.success && refreshResult.accessToken) {
+            await tokenStorage
+              .upsert({
+                connectionId: id,
+                userId,
+                accessToken: refreshResult.accessToken,
+                refreshToken:
+                  refreshResult.refreshToken ??
+                  cachedDownstreamToken.refreshToken,
+                scope: refreshResult.scope ?? cachedDownstreamToken.scope,
+                expiresAt: refreshResult.expiresIn
+                  ? new Date(Date.now() + refreshResult.expiresIn * 1000)
+                  : null,
+                clientId: cachedDownstreamToken.clientId,
+                clientSecret: cachedDownstreamToken.clientSecret,
+                tokenEndpoint: cachedDownstreamToken.tokenEndpoint,
+              })
+              .catch(() => null);
+            downstreamAccessToken = refreshResult.accessToken;
+          } else {
+            await tokenStorage.delete(id, userId).catch(() => null);
+            downstreamTokenWasDeleted = true;
+            cachedDownstreamToken = null;
+          }
+        } else {
+          // Expired and cannot refresh → remove so UI can prompt re-auth.
+          await tokenStorage.delete(id, userId).catch(() => null);
+          downstreamTokenWasDeleted = true;
+          cachedDownstreamToken = null;
         }
-      } catch {
-        // Ignore token lookup errors and fall back to unauthenticated discovery.
+      } else {
+        downstreamAccessToken = cachedDownstreamToken.accessToken;
       }
     }
 
-    const fetchedTools = await fetchToolsFromMCP({
+    const candidateTokens: Array<{
+      token: string | null;
+      source: "explicit" | "downstream" | "connection";
+    }> = [];
+
+    if (hasExplicitConnectionToken) {
+      candidateTokens.push({
+        token: explicitConnectionToken,
+        source: "explicit",
+      });
+    } else {
+      // Prefer downstream per-user token over connection_token (matches proxy behavior).
+      if (downstreamAccessToken) {
+        candidateTokens.push({
+          token: downstreamAccessToken,
+          source: "downstream",
+        });
+      }
+      if (existing.connection_token) {
+        candidateTokens.push({
+          token: existing.connection_token,
+          source: "connection",
+        });
+      }
+    }
+
+    // Always allow an unauthenticated attempt as a last resort (some servers expose tools publicly).
+    candidateTokens.push({ token: null, source: "explicit" });
+
+    const baseToolFetchInput = {
       id: existing.id,
       title: data.title ?? existing.title,
       connection_type: data.connection_type ?? existing.connection_type,
       connection_url: data.connection_url ?? existing.connection_url,
-      connection_token: tokenForToolFetch,
       connection_headers:
         data.connection_headers ?? existing.connection_headers,
-    }).catch(() => null);
-    const tools = fetchedTools?.length ? fetchedTools : null;
+    } as const;
+
+    let tools: Awaited<ReturnType<typeof fetchToolsFromMCP>> = null;
+    for (const candidate of candidateTokens) {
+      try {
+        const fetchedTools = await fetchToolsFromMCP({
+          ...baseToolFetchInput,
+          connection_token: candidate.token,
+        });
+        if (fetchedTools?.length) {
+          tools = fetchedTools;
+          break;
+        }
+        continue;
+      } catch (error) {
+        if (!isUnauthorizedDownstreamMcpError(error)) {
+          console.error(
+            `Failed to fetch tools from connection ${existing.id} (source=${candidate.source}):`,
+            error,
+          );
+          break;
+        }
+
+        // Unauthorized: try refresh for downstream token (if we have it), otherwise try next candidate.
+        if (
+          candidate.source === "downstream" &&
+          cachedDownstreamToken &&
+          downstreamCanRefresh &&
+          !downstreamRefreshAttempted
+        ) {
+          downstreamRefreshAttempted = true;
+          const refreshResult = await refreshAccessToken(cachedDownstreamToken);
+          if (refreshResult.success && refreshResult.accessToken) {
+            await tokenStorage
+              .upsert({
+                connectionId: id,
+                userId,
+                accessToken: refreshResult.accessToken,
+                refreshToken:
+                  refreshResult.refreshToken ??
+                  cachedDownstreamToken.refreshToken,
+                scope: refreshResult.scope ?? cachedDownstreamToken.scope,
+                expiresAt: refreshResult.expiresIn
+                  ? new Date(Date.now() + refreshResult.expiresIn * 1000)
+                  : null,
+                clientId: cachedDownstreamToken.clientId,
+                clientSecret: cachedDownstreamToken.clientSecret,
+                tokenEndpoint: cachedDownstreamToken.tokenEndpoint,
+              })
+              .catch(() => null);
+
+            // Retry once with the refreshed access token
+            try {
+              const fetchedTools = await fetchToolsFromMCP({
+                ...baseToolFetchInput,
+                connection_token: refreshResult.accessToken,
+              });
+              if (fetchedTools?.length) {
+                tools = fetchedTools;
+                break;
+              }
+            } catch (retryError) {
+              if (!isUnauthorizedDownstreamMcpError(retryError)) {
+                console.error(
+                  `Failed to fetch tools after token refresh for ${existing.id}:`,
+                  retryError,
+                );
+              }
+            }
+          }
+
+          // Refresh failed or still unauthorized → delete token so UI can re-auth.
+          await tokenStorage.delete(id, userId).catch(() => null);
+          downstreamTokenWasDeleted = true;
+          cachedDownstreamToken = null;
+        } else if (
+          candidate.source === "downstream" &&
+          cachedDownstreamToken &&
+          !downstreamTokenWasDeleted
+        ) {
+          // No refresh available but token is invalid → delete it.
+          await tokenStorage.delete(id, userId).catch(() => null);
+          downstreamTokenWasDeleted = true;
+          cachedDownstreamToken = null;
+        }
+
+        continue;
+      }
+    }
 
     // Update the connection with the refreshed tools and configuration
     const updatePayload: Partial<ConnectionEntity> = {


### PR DESCRIPTION
- Implement logic to prefer downstream OAuth token over existing connection_token when both are present.
- Add unit test to verify the new behavior for token preference.
- Refactor token fetching logic to handle explicit, downstream, and connection tokens more effectively.
- Introduce error handling for unauthorized access during token refresh attempts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer downstream OAuth tokens over connection_token during COLLECTION_CONNECTIONS_UPDATE to ensure per-user auth is used for MCP tool discovery. Adds token refresh and cleanup on unauthorized/expired tokens to improve reliability.

- **New Features**
  - Use downstream OAuth token over connection_token; an explicit token in the request still wins.
  - Refresh expired downstream tokens; on failure or unauthorized, delete to trigger re-auth.
  - Tool fetch fallback order: explicit → downstream → connection → unauthenticated.

- **Refactors**
  - Centralized token selection and error handling in COLLECTION_CONNECTIONS_UPDATE; fetch-tools no longer swallows errors.
  - Added unit test to verify downstream token preference.

<sup>Written for commit 495732e84b6d4d31c644ed2451d07d9b275669dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

