### PR TITLE
Remove userId from downstream tokens

### DIFF
--- a/apps/mesh/migrations/017-downstream-token-remove-userid.ts
+++ b/apps/mesh/migrations/017-downstream-token-remove-userid.ts
@@ -1,0 +1,62 @@
+/**
+ * Migration 017: Remove userId from downstream_tokens
+ *
+ * Makes OAuth tokens connection-scoped instead of user-scoped.
+ * Tokens belong to connections, not individual users.
+ *
+ * Data migration: For connections with multiple tokens (from different users),
+ * keeps only the most recently updated token.
+ */
+
+import { sql, type Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Step 1: Delete duplicate tokens, keeping only the most recently updated per connectionId
+  // This handles cases where multiple users had tokens for the same connection
+  await sql`
+    DELETE FROM downstream_tokens
+    WHERE id NOT IN (
+      SELECT id FROM (
+        SELECT id, connectionId,
+          ROW_NUMBER() OVER (PARTITION BY connectionId ORDER BY updatedAt DESC) as rn
+        FROM downstream_tokens
+      ) ranked
+      WHERE rn = 1
+    )
+  `.execute(db);
+
+  // Step 2: Drop the old composite index
+  await db.schema.dropIndex("idx_downstream_tokens_connection_user").execute();
+
+  // Step 3: Drop the userId column
+  await db.schema
+    .alterTable("downstream_tokens")
+    .dropColumn("userId")
+    .execute();
+
+  // Step 4: Create unique index on connectionId (one token per connection)
+  await db.schema
+    .createIndex("idx_downstream_tokens_connection")
+    .on("downstream_tokens")
+    .column("connectionId")
+    .unique()
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Drop the unique index
+  await db.schema.dropIndex("idx_downstream_tokens_connection").execute();
+
+  // Re-add userId column as nullable (data cannot be restored)
+  await db.schema
+    .alterTable("downstream_tokens")
+    .addColumn("userId", "text")
+    .execute();
+
+  // Recreate the original composite index
+  await db.schema
+    .createIndex("idx_downstream_tokens_connection_user")
+    .on("downstream_tokens")
+    .columns(["connectionId", "userId"])
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -15,6 +15,7 @@ import * as migration013monitoringuseragentgateway from "./013-monitoring-user-a
 import * as migration014gatewayresourcesprompts from "./014-gateway-resources-prompts.ts";
 import * as migration015monitoringproperties from "./015-monitoring-properties.ts";
 import * as migration016downstreamtokenclientinfo from "./016-downstream-token-client-info.ts";
+import * as migration017downstreamtokenremoveuserid from "./017-downstream-token-remove-userid.ts";
 
 const migrations = {
   "001-initial-schema": migration001initialschema,
@@ -33,6 +34,7 @@ const migrations = {
   "014-gateway-resources-prompts": migration014gatewayresourcesprompts,
   "015-monitoring-properties": migration015monitoringproperties,
   "016-downstream-token-client-info": migration016downstreamtokenclientinfo,
+  "017-downstream-token-remove-userid": migration017downstreamtokenremoveuserid,
 } satisfies Record<string, Migration>;
 
 export default migrations;

--- a/apps/mesh/src/api/routes/downstream-token.ts
+++ b/apps/mesh/src/api/routes/downstream-token.ts
@@ -86,7 +86,6 @@ app.post("/connections/:connectionId/oauth-token", async (c) => {
   // Save token
   const tokenData: DownstreamTokenData = {
     connectionId,
-    userId,
     accessToken: body.accessToken,
     refreshToken: body.refreshToken ?? null,
     scope: body.scope ?? null,
@@ -119,7 +118,7 @@ app.delete("/connections/:connectionId/oauth-token", async (c) => {
   }
 
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-  await tokenStorage.delete(connectionId, userId);
+  await tokenStorage.delete(connectionId);
 
   return c.json({ success: true });
 });
@@ -127,7 +126,7 @@ app.delete("/connections/:connectionId/oauth-token", async (c) => {
 /**
  * GET /api/connections/:connectionId/oauth-token/status
  *
- * Check if user has a valid cached token for a connection.
+ * Check if there's a valid cached token for a connection.
  */
 app.get("/connections/:connectionId/oauth-token/status", async (c) => {
   const ctx = c.get("meshContext");
@@ -139,7 +138,7 @@ app.get("/connections/:connectionId/oauth-token/status", async (c) => {
   }
 
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-  const token = await tokenStorage.get(connectionId, userId);
+  const token = await tokenStorage.get(connectionId);
 
   if (!token) {
     return c.json({

--- a/apps/mesh/src/storage/downstream-token.test.ts
+++ b/apps/mesh/src/storage/downstream-token.test.ts
@@ -27,7 +27,6 @@ describe("DownstreamTokenStorage", () => {
     const token = {
       id: "test",
       connectionId: "c1",
-      userId: "u1",
       accessToken: "at",
       refreshToken: null,
       scope: null,
@@ -48,7 +47,6 @@ describe("DownstreamTokenStorage", () => {
     const token = {
       id: "test",
       connectionId: "c1",
-      userId: "u1",
       accessToken: "at",
       refreshToken: null,
       scope: null,
@@ -69,7 +67,6 @@ describe("DownstreamTokenStorage", () => {
   it("should upsert token atomically", async () => {
     const data: DownstreamTokenData = {
       connectionId: "conn_atomic",
-      userId: "user_atomic",
       accessToken: "access_1",
       refreshToken: "refresh_1",
       scope: "scope_1",

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -263,8 +263,7 @@ export interface OAuthRefreshTokenTable {
  */
 export interface DownstreamTokenTable {
   id: string; // Primary key
-  connectionId: string; // Foreign key
-  userId: string | null; // Null for client_credentials tokens
+  connectionId: string; // Foreign key (unique - one token per connection)
   accessToken: string; // Encrypted
   refreshToken: string | null; // Encrypted
   scope: string | null;
@@ -330,7 +329,6 @@ export interface OAuthRefreshToken {
 export interface DownstreamToken {
   id: string;
   connectionId: string;
-  userId: string | null;
   accessToken: string;
   refreshToken: string | null;
   scope: string | null;

--- a/apps/mesh/src/tools/connection/connection-tools.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.test.ts
@@ -164,7 +164,6 @@ describe("Connection Tools", () => {
       const tokenStorage = new DownstreamTokenStorage(database.db, vault);
       await tokenStorage.upsert({
         connectionId: connection.id,
-        userId: "user_1",
         accessToken: "oauth-access-token",
         refreshToken: null,
         scope: null,

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -165,13 +165,13 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
     }
 
     // Fetch tools from the MCP server.
-    // If the connection uses OAuth (token stored in downstream_tokens), use the per-user
+    // If the connection uses OAuth (token stored in downstream_tokens), use the
     // access token to discover tools after authentication.
     let tokenForToolFetch = data.connection_token ?? existing.connection_token;
     if (!tokenForToolFetch) {
       try {
         const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-        const cachedToken = await tokenStorage.get(id, userId);
+        const cachedToken = await tokenStorage.get(id);
         if (cachedToken?.accessToken) {
           tokenForToolFetch = cachedToken.accessToken;
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes downstream OAuth tokens connection-scoped by removing userId, so there’s only one token per connection. Updates storage, APIs, and proxy to use connection-only tokens and adds a migration to dedupe existing data.

- **Migration**
  - Deletes duplicate tokens per connection, keeping the most recently updated.
  - Drops userId column and the composite index; adds a unique index on connectionId.
  - Down migration re-adds userId as nullable (data can’t be restored).

- **Refactors**
  - DownstreamTokenStorage: get/delete now take connectionId only; deleteByConnection removed.
  - Updated routes: POST/DELETE/GET token endpoints no longer pass userId; status now checks connection-level token.
  - Proxy uses connection-scoped token for retrieval/refresh; deletion on failure uses connectionId only.
  - Types and tests updated to remove userId field.
  - Added migration 017 to migrations index.

<sup>Written for commit 7847f0ba635688f82c2e5a023582703abf0c804c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

