### PR TITLE
Fix pg column name

### DIFF
--- a/apps/mesh/migrations/017-downstream-token-remove-userid.ts
+++ b/apps/mesh/migrations/017-downstream-token-remove-userid.ts
@@ -13,12 +13,13 @@ import { sql, type Kysely } from "kysely";
 export async function up(db: Kysely<unknown>): Promise<void> {
   // Step 1: Delete duplicate tokens, keeping only the most recently updated per connectionId
   // This handles cases where multiple users had tokens for the same connection
+  // Note: Column names must be quoted for PostgreSQL (camelCase)
   await sql`
     DELETE FROM downstream_tokens
     WHERE id NOT IN (
       SELECT id FROM (
-        SELECT id, connectionId,
-          ROW_NUMBER() OVER (PARTITION BY connectionId ORDER BY updatedAt DESC) as rn
+        SELECT id, "connectionId",
+          ROW_NUMBER() OVER (PARTITION BY "connectionId" ORDER BY "updatedAt" DESC) as rn
         FROM downstream_tokens
       ) ranked
       WHERE rn = 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Quote camelCase column names in migration 017 to make the downstream_tokens dedupe step work on PostgreSQL. This prevents errors and ensures we keep the latest token per connection by partitioning on "connectionId" and ordering by "updatedAt".

<sup>Written for commit e8039875df709f3e4c65d173f9e8ceab7e1efef9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

