### PR TITLE
fix: replace z.date() with z.string().datetime() for JSON Schema compatibility

### DIFF
--- a/apps/mesh/src/tools/apiKeys/create.ts
+++ b/apps/mesh/src/tools/apiKeys/create.ts
@@ -37,13 +37,24 @@ export const API_KEY_CREATE = defineTool({
     });
 
     // Return the created key with its value (only time it's visible)
+    // Convert dates to ISO strings for JSON Schema compatibility
+    const expiresAt = result.expiresAt
+      ? result.expiresAt instanceof Date
+        ? result.expiresAt.toISOString()
+        : result.expiresAt
+      : null;
+    const createdAt =
+      result.createdAt instanceof Date
+        ? result.createdAt.toISOString()
+        : result.createdAt;
+
     return {
       id: result.id,
       name: result.name ?? input.name, // Fallback to input name if null
       key: result.key, // This is the only time the key value is returned!
       permissions: result.permissions ?? {},
-      expiresAt: result.expiresAt ?? null,
-      createdAt: result.createdAt,
+      expiresAt,
+      createdAt,
     };
   },
 });

--- a/apps/mesh/src/tools/apiKeys/list.ts
+++ b/apps/mesh/src/tools/apiKeys/list.ts
@@ -58,8 +58,15 @@ export const API_KEY_LIST = defineTool({
         name: key.name ?? "Unnamed Key", // Fallback if name is null
         userId: key.userId,
         permissions: key.permissions ?? {},
-        expiresAt: key.expiresAt ?? null,
-        createdAt: key.createdAt,
+        expiresAt: key.expiresAt
+          ? key.expiresAt instanceof Date
+            ? key.expiresAt.toISOString()
+            : key.expiresAt
+          : null,
+        createdAt:
+          key.createdAt instanceof Date
+            ? key.createdAt.toISOString()
+            : key.createdAt,
       }));
 
     return {

--- a/apps/mesh/src/tools/apiKeys/schema.ts
+++ b/apps/mesh/src/tools/apiKeys/schema.ts
@@ -46,13 +46,15 @@ const ApiKeyEntitySchema = z.object({
     'Permissions granted to this API key. Format: { resource: [actions] } where resource is "self" for management tools or "conn_<UUID>" for connection-specific tools. Example: { "self": ["API_KEY_CREATE"], "conn_abc123": ["SEND_MESSAGE"] }',
   ),
   expiresAt: z
-    .union([z.string(), z.date()])
+    .string()
+    .datetime()
     .nullable()
     .optional()
-    .describe("Expiration date of the API key"),
+    .describe("Expiration date of the API key (ISO 8601)"),
   createdAt: z
-    .union([z.string(), z.date()])
-    .describe("When the API key was created"),
+    .string()
+    .datetime()
+    .describe("When the API key was created (ISO 8601)"),
   // Note: key value is never returned after creation
 });
 
@@ -105,13 +107,15 @@ export const ApiKeyCreateOutputSchema = z.object({
     'Permissions granted to this API key. Format: { resource: [actions] } where resource is "self" for management tools or "conn_<UUID>" for connection-specific tools',
   ),
   expiresAt: z
-    .union([z.string(), z.date()])
+    .string()
+    .datetime()
     .nullable()
     .optional()
-    .describe("Expiration date of the API key"),
+    .describe("Expiration date of the API key (ISO 8601)"),
   createdAt: z
-    .union([z.string(), z.date()])
-    .describe("When the API key was created"),
+    .string()
+    .datetime()
+    .describe("When the API key was created (ISO 8601)"),
 });
 
 export type ApiKeyCreateOutput = z.infer<typeof ApiKeyCreateOutputSchema>;

--- a/apps/mesh/src/tools/apiKeys/update.ts
+++ b/apps/mesh/src/tools/apiKeys/update.ts
@@ -74,14 +74,22 @@ export const API_KEY_UPDATE = defineTool({
     }
 
     // Return the updated key (without key value)
+    // Convert dates to ISO strings for JSON Schema compatibility
     return {
       item: {
         id: result.id,
         name: result.name ?? input.name ?? "Unnamed Key", // Fallback if name is null
         userId: result.userId,
         permissions: result.permissions ?? {},
-        expiresAt: result.expiresAt ?? null,
-        createdAt: result.createdAt,
+        expiresAt: result.expiresAt
+          ? result.expiresAt instanceof Date
+            ? result.expiresAt.toISOString()
+            : result.expiresAt
+          : null,
+        createdAt:
+          result.createdAt instanceof Date
+            ? result.createdAt.toISOString()
+            : result.createdAt,
       },
     };
   },

--- a/apps/mesh/src/tools/eventbus/list.ts
+++ b/apps/mesh/src/tools/eventbus/list.ts
@@ -38,8 +38,14 @@ export const EVENT_SUBSCRIPTION_LIST = defineTool({
         publisher: sub.publisher,
         filter: sub.filter,
         enabled: sub.enabled,
-        createdAt: sub.createdAt,
-        updatedAt: sub.updatedAt,
+        createdAt:
+          sub.createdAt instanceof Date
+            ? sub.createdAt.toISOString()
+            : sub.createdAt,
+        updatedAt:
+          sub.updatedAt instanceof Date
+            ? sub.updatedAt.toISOString()
+            : sub.updatedAt,
       })),
     };
   },

--- a/apps/mesh/src/tools/eventbus/schema.ts
+++ b/apps/mesh/src/tools/eventbus/schema.ts
@@ -86,10 +86,10 @@ const SubscriptionEntitySchema = z.object({
   enabled: z.boolean().describe("Whether subscription is enabled"),
 
   /** Created timestamp */
-  createdAt: z.union([z.string(), z.date()]).describe("Created timestamp"),
+  createdAt: z.string().datetime().describe("Created timestamp (ISO 8601)"),
 
   /** Updated timestamp */
-  updatedAt: z.union([z.string(), z.date()]).describe("Updated timestamp"),
+  updatedAt: z.string().datetime().describe("Updated timestamp (ISO 8601)"),
 });
 
 export type SubscriptionEntity = z.infer<typeof SubscriptionEntitySchema>;

--- a/apps/mesh/src/tools/eventbus/subscribe.ts
+++ b/apps/mesh/src/tools/eventbus/subscribe.ts
@@ -45,8 +45,14 @@ export const EVENT_SUBSCRIBE = defineTool({
         publisher: subscription.publisher,
         filter: subscription.filter,
         enabled: subscription.enabled,
-        createdAt: subscription.createdAt,
-        updatedAt: subscription.updatedAt,
+        createdAt:
+          subscription.createdAt instanceof Date
+            ? subscription.createdAt.toISOString()
+            : subscription.createdAt,
+        updatedAt:
+          subscription.updatedAt instanceof Date
+            ? subscription.updatedAt.toISOString()
+            : subscription.updatedAt,
       },
     };
   },

--- a/apps/mesh/src/tools/eventbus/sync-subscriptions.ts
+++ b/apps/mesh/src/tools/eventbus/sync-subscriptions.ts
@@ -52,8 +52,14 @@ export const EVENT_SYNC_SUBSCRIPTIONS = defineTool({
         publisher: sub.publisher,
         filter: sub.filter,
         enabled: sub.enabled,
-        createdAt: sub.createdAt,
-        updatedAt: sub.updatedAt,
+        createdAt:
+          sub.createdAt instanceof Date
+            ? sub.createdAt.toISOString()
+            : sub.createdAt,
+        updatedAt:
+          sub.updatedAt instanceof Date
+            ? sub.updatedAt.toISOString()
+            : sub.updatedAt,
       })),
     };
   },

--- a/apps/mesh/src/tools/organization/create.ts
+++ b/apps/mesh/src/tools/organization/create.ts
@@ -31,7 +31,7 @@ export const ORGANIZATION_CREATE = defineTool({
     slug: z.string(),
     logo: z.string().nullable().optional(),
     metadata: z.any().optional(),
-    createdAt: z.union([z.date(), z.string()]),
+    createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
     members: z.array(z.any()).optional(),
   }),
 
@@ -62,6 +62,13 @@ export const ORGANIZATION_CREATE = defineTool({
       throw new Error("Failed to create organization");
     }
 
-    return result;
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...result,
+      createdAt:
+        result.createdAt instanceof Date
+          ? result.createdAt.toISOString()
+          : result.createdAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/get.ts
+++ b/apps/mesh/src/tools/organization/get.ts
@@ -22,7 +22,7 @@ export const ORGANIZATION_GET = defineTool({
     slug: z.string(),
     logo: z.string().nullable().optional(),
     metadata: z.any().optional(),
-    createdAt: z.union([z.date(), z.string()]),
+    createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
     members: z.array(z.any()).optional(),
     invitations: z.array(z.any()).optional(),
   }),
@@ -42,6 +42,13 @@ export const ORGANIZATION_GET = defineTool({
       throw new Error("No active organization found");
     }
 
-    return organization;
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...organization,
+      createdAt:
+        organization.createdAt instanceof Date
+          ? organization.createdAt.toISOString()
+          : organization.createdAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/list.ts
+++ b/apps/mesh/src/tools/organization/list.ts
@@ -24,7 +24,7 @@ export const ORGANIZATION_LIST = defineTool({
         slug: z.string(),
         logo: z.string().nullable().optional(),
         metadata: z.any().optional(),
-        createdAt: z.union([z.date(), z.string()]),
+        createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
       }),
     ),
   }),
@@ -46,8 +46,15 @@ export const ORGANIZATION_LIST = defineTool({
 
     const organizations = await ctx.boundAuth.organization.list(userId);
 
+    // Convert dates to ISO strings for JSON Schema compatibility
     return {
-      organizations,
+      organizations: organizations.map((org) => ({
+        ...org,
+        createdAt:
+          org.createdAt instanceof Date
+            ? org.createdAt.toISOString()
+            : org.createdAt,
+      })),
     };
   },
 });

--- a/apps/mesh/src/tools/organization/member-add.ts
+++ b/apps/mesh/src/tools/organization/member-add.ts
@@ -23,7 +23,7 @@ export const ORGANIZATION_MEMBER_ADD = defineTool({
     organizationId: z.string(),
     userId: z.string(),
     role: z.union([z.string(), z.array(z.string())]), // Better Auth can return string or array
-    createdAt: z.union([z.date(), z.string()]),
+    createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
   }),
 
   handler: async (input, ctx) => {
@@ -53,6 +53,14 @@ export const ORGANIZATION_MEMBER_ADD = defineTool({
     }
 
     // Better Auth returns role as string, but we accept string or array
-    return result as typeof result & { role: string | string[] };
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...result,
+      role: result.role as string | string[],
+      createdAt:
+        result.createdAt instanceof Date
+          ? result.createdAt.toISOString()
+          : result.createdAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/member-list.ts
+++ b/apps/mesh/src/tools/organization/member-list.ts
@@ -24,7 +24,7 @@ export const ORGANIZATION_MEMBER_LIST = defineTool({
         organizationId: z.string(),
         userId: z.string(),
         role: z.string(),
-        createdAt: z.union([z.date(), z.string()]),
+        createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
         user: z
           .object({
             id: z.string(),
@@ -58,8 +58,15 @@ export const ORGANIZATION_MEMBER_LIST = defineTool({
       offset: input.offset,
     });
 
-    return {
-      members: Array.isArray(result) ? result : [],
-    };
+    // Convert dates to ISO strings for JSON Schema compatibility
+    const members = (Array.isArray(result) ? result : []).map((member) => ({
+      ...member,
+      createdAt:
+        member.createdAt instanceof Date
+          ? member.createdAt.toISOString()
+          : member.createdAt,
+    }));
+
+    return { members };
   },
 });

--- a/apps/mesh/src/tools/organization/member-update-role.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.ts
@@ -27,7 +27,7 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
       z.literal("member"),
       z.literal("owner"),
     ]),
-    createdAt: z.union([z.date(), z.string()]),
+    createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
     user: z.object({
       email: z.string(),
       name: z.string(),
@@ -61,6 +61,13 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
       throw new Error("Failed to update member role");
     }
 
-    return result;
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...result,
+      createdAt:
+        result.createdAt instanceof Date
+          ? result.createdAt.toISOString()
+          : result.createdAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/settings-get.ts
+++ b/apps/mesh/src/tools/organization/settings-get.ts
@@ -12,8 +12,8 @@ export const ORGANIZATION_SETTINGS_GET = defineTool({
   outputSchema: z.object({
     organizationId: z.string(),
     sidebar_items: z.array(SidebarItemSchema).nullable().optional(),
-    createdAt: z.union([z.date(), z.string()]).optional(),
-    updatedAt: z.union([z.date(), z.string()]).optional(),
+    createdAt: z.string().datetime().optional().describe("ISO 8601 timestamp"),
+    updatedAt: z.string().datetime().optional().describe("ISO 8601 timestamp"),
   }),
 
   handler: async (_, ctx) => {
@@ -34,6 +34,17 @@ export const ORGANIZATION_SETTINGS_GET = defineTool({
       };
     }
 
-    return settings;
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...settings,
+      createdAt:
+        settings.createdAt instanceof Date
+          ? settings.createdAt.toISOString()
+          : settings.createdAt,
+      updatedAt:
+        settings.updatedAt instanceof Date
+          ? settings.updatedAt.toISOString()
+          : settings.updatedAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/settings-update.ts
+++ b/apps/mesh/src/tools/organization/settings-update.ts
@@ -15,8 +15,8 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
   outputSchema: z.object({
     organizationId: z.string(),
     sidebar_items: z.array(SidebarItemSchema).nullable().optional(),
-    createdAt: z.union([z.date(), z.string()]),
-    updatedAt: z.union([z.date(), z.string()]),
+    createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
+    updatedAt: z.string().datetime().describe("ISO 8601 timestamp"),
   }),
 
   handler: async (input, ctx) => {
@@ -34,6 +34,17 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
       },
     );
 
-    return settings;
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...settings,
+      createdAt:
+        settings.createdAt instanceof Date
+          ? settings.createdAt.toISOString()
+          : settings.createdAt,
+      updatedAt:
+        settings.updatedAt instanceof Date
+          ? settings.updatedAt.toISOString()
+          : settings.updatedAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/update.ts
+++ b/apps/mesh/src/tools/organization/update.ts
@@ -30,7 +30,7 @@ export const ORGANIZATION_UPDATE = defineTool({
     slug: z.string(),
     logo: z.string().nullable().optional(),
     metadata: z.any().optional(),
-    createdAt: z.union([z.date(), z.string()]),
+    createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
   }),
 
   handler: async (input, ctx) => {
@@ -57,6 +57,13 @@ export const ORGANIZATION_UPDATE = defineTool({
       throw new Error("Failed to update organization");
     }
 
-    return result;
+    // Convert dates to ISO strings for JSON Schema compatibility
+    return {
+      ...result,
+      createdAt:
+        result.createdAt instanceof Date
+          ? result.createdAt.toISOString()
+          : result.createdAt,
+    };
   },
 });

--- a/packages/bindings/src/well-known/event-bus.ts
+++ b/packages/bindings/src/well-known/event-bus.ts
@@ -150,10 +150,10 @@ export const EventSubscribeOutputSchema = z.object({
     enabled: z.boolean().describe("Whether subscription is enabled"),
 
     /** Created timestamp */
-    createdAt: z.union([z.string(), z.date()]).describe("Created timestamp"),
+    createdAt: z.string().datetime().describe("Created timestamp (ISO 8601)"),
 
     /** Updated timestamp */
-    updatedAt: z.union([z.string(), z.date()]).describe("Updated timestamp"),
+    updatedAt: z.string().datetime().describe("Updated timestamp (ISO 8601)"),
   }),
 });
 
@@ -209,10 +209,10 @@ export const SubscriptionDetailSchema = z.object({
   enabled: z.boolean().describe("Whether subscription is enabled"),
 
   /** Created timestamp */
-  createdAt: z.union([z.string(), z.date()]).describe("Created timestamp"),
+  createdAt: z.string().datetime().describe("Created timestamp (ISO 8601)"),
 
   /** Updated timestamp */
-  updatedAt: z.union([z.string(), z.date()]).describe("Updated timestamp"),
+  updatedAt: z.string().datetime().describe("Updated timestamp (ISO 8601)"),
 });
 
 export type SubscriptionDetail = z.infer<typeof SubscriptionDetailSchema>;


### PR DESCRIPTION
## Summary

`z.date()` cannot be represented in JSON Schema, causing MCP `tools/list` to fail with:
```
MCP Error: Error: Failed to list tools: MCP error -32603: Date cannot be represented in JSON Schema (code: -32603)
```

## Solution

Changed all datetime fields in tool schemas to use `z.string().datetime()` which:
- ✅ Converts to JSON Schema as `{ type: 'string', format: 'date-time' }`
- ✅ Validates ISO 8601 datetime format
- ✅ Works with MCP SDK's `toJSONSchema()` conversion

## Affected Files

- `apps/mesh/src/tools/apiKeys/schema.ts` (`expiresAt`, `createdAt`)
- `apps/mesh/src/tools/eventbus/schema.ts` (`createdAt`, `updatedAt`)
- `apps/mesh/src/tools/organization/*.ts` (`createdAt`, `updatedAt`)
- `packages/bindings/src/well-known/event-bus.ts` (`createdAt`, `updatedAt`)

## Testing

- Verified the tool details page at `/mcps/:connectionId/tools/API_KEY_CREATE` now loads without errors
- The `tools/list` MCP request succeeds with 200 status

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced z.date() with z.string().datetime() and normalized tool responses to ISO strings to make JSON Schema conversion work and stop MCP tools/list from failing. This unblocks tool discovery and fixes errors on tool detail pages.

- **Bug Fixes**
  - All date/time fields now use ISO 8601 strings (z.string().datetime()), which serialize to { type: "string", format: "date-time" } and work with MCP toJSONSchema().
  - Normalized outputs to return ISO strings (convert Date -> toISOString) and updated schemas/handlers in apiKeys, eventbus, organization tools, and bindings event-bus.

<sup>Written for commit 5d29e8be0b3db3585a7214fbd99813de42ae1bac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

