### PR TITLE
feat: add GatewaySelector to MCP configuration form for agent binding

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
@@ -18,6 +18,7 @@ import validator from "@rjsf/validator-ajv8";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { toast } from "sonner";
+import { GatewaySelector } from "@/web/components/chat/gateway-selector";
 
 interface McpConfigurationFormProps {
   formState: Record<string, unknown>;
@@ -346,6 +347,30 @@ function CustomObjectFieldTemplate(props: ObjectFieldTemplateProps) {
         .replace(/\b\w/g, (c) => c.toUpperCase());
 
     const displayTitle = title ? formatTitle(title) : formatTitle(fieldPath);
+
+    if (bindingType === "@deco/agent") {
+      return (
+        <div className="flex items-center gap-3 justify-between">
+          <div className="flex-1 min-w-0">
+            <label className="text-sm font-medium truncate block">
+              {displayTitle}
+            </label>
+            {description && (
+              <p className="text-xs text-muted-foreground truncate">
+                {description}
+              </p>
+            )}
+          </div>
+          <GatewaySelector
+            selectedGatewayId={currentValue || undefined}
+            onGatewayChange={handleBindingChange}
+            variant="bordered"
+            placeholder="Select Agent"
+            className="w-[200px] shrink-0"
+          />
+        </div>
+      );
+    }
 
     return (
       <div className="flex items-center gap-3 justify-between">


### PR DESCRIPTION
This update introduces a GatewaySelector component in the MCP configuration form, allowing users to select an agent when the binding type is set to "@deco/agent". The new UI enhances the user experience by providing a dedicated selection interface for agents.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dedicated agent selection to the MCP configuration form.
> 
> - Imports and conditionally renders `GatewaySelector` when `bindingType === "@deco/agent"`, wiring `selectedGatewayId` and `onGatewayChange`
> - Falls back to existing `BindingFieldWithDynamicSchema` for other bindings
> - UI: bordered selector with placeholder "Select Agent" and fixed width
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1158483121e57bf6948c764f47d6efa3988a274b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a GatewaySelector to the MCP configuration form to let users pick an agent when binding type is "@deco/agent". This replaces the generic field with a compact, bordered dropdown for clearer, faster agent binding.

<sup>Written for commit 1158483121e57bf6948c764f47d6efa3988a274b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

