### PR TITLE
fix: improve organization slug validation in ensureOrganization function

### DIFF
--- a/apps/mesh/src/api/routes/models.ts
+++ b/apps/mesh/src/api/routes/models.ts
@@ -70,8 +70,8 @@ function ensureOrganization(ctx: MeshContext, orgSlug: string) {
     throw new Error("Organization context is required");
   }
 
-  if (ctx.organization.slug !== orgSlug) {
-    throw new Error("Organization slug mismatch");
+  if ((ctx.organization.slug ?? ctx.organization.id) !== orgSlug) {
+    throw new Error("Organization mismatch");
   }
 
   return ctx.organization;


### PR DESCRIPTION
Updated the organization validation logic to allow for a fallback to the organization ID if the slug is not available. This change enhances error handling by providing a more general error message for organization mismatches.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows org validation to succeed when `slug` is absent by falling back to `id`, and standardizes the error text.
> 
> - In `models.ts` `ensureOrganization`, comparison updated to `(ctx.organization.slug ?? ctx.organization.id) !== orgSlug`
> - Error message changed from "Organization slug mismatch" to "Organization mismatch"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72d406de5b003bc34d5241bd0ef2d5c393cf4525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve ensureOrganization validation by matching the provided org value against the slug, falling back to the organization ID when the slug is missing. This prevents false mismatches and standardizes the error to "Organization mismatch".

<sup>Written for commit 72d406de5b003bc34d5241bd0ef2d5c393cf4525. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

