### PR TITLE
feat: add ModelSelector to MCP configuration form for language model …

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
@@ -19,6 +19,11 @@ import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { toast } from "sonner";
 import { GatewaySelector } from "@/web/components/chat/gateway-selector";
+import {
+  ModelChangePayload,
+  ModelSelector,
+  SelectedModelState,
+} from "@/web/components/chat";
 
 interface McpConfigurationFormProps {
   formState: Record<string, unknown>;
@@ -340,6 +345,16 @@ function CustomObjectFieldTemplate(props: ObjectFieldTemplateProps) {
       formContext?.onFieldChange(fieldPath, newFieldData);
     };
 
+    const handleModelChange = (model: ModelChangePayload) => {
+      formContext?.onFieldChange(fieldPath, {
+        __type: bindingType,
+        value: {
+          id: model.id,
+          connectionId: model.connectionId,
+        },
+      });
+    };
+
     const formatTitle = (str: string) =>
       str
         .toLowerCase()
@@ -366,6 +381,32 @@ function CustomObjectFieldTemplate(props: ObjectFieldTemplateProps) {
             onGatewayChange={handleBindingChange}
             variant="bordered"
             placeholder="Select Agent"
+            className="w-[200px] shrink-0"
+          />
+        </div>
+      );
+    }
+
+    if (bindingType === "@deco/language-model") {
+      return (
+        <div className="flex items-center gap-3 justify-between">
+          <div className="flex-1 min-w-0">
+            <label className="text-sm font-medium truncate block">
+              {displayTitle}
+            </label>
+            {description && (
+              <p className="text-xs text-muted-foreground truncate">
+                {description}
+              </p>
+            )}
+          </div>
+          <ModelSelector
+            selectedModel={
+              currentValue as unknown as SelectedModelState | undefined
+            }
+            onModelChange={handleModelChange}
+            variant="bordered"
+            placeholder="Select Language Model"
             className="w-[200px] shrink-0"
           />
         </div>


### PR DESCRIPTION
…binding

This update introduces a ModelSelector component in the MCP configuration form, enabling users to select a language model when the binding type is set to "@deco/language-model". The new functionality enhances the user experience by providing a dedicated interface for model selection.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated UI for selecting language models in the MCP configuration form.
> 
> - Integrates `ModelSelector` when binding type is `"@deco/language-model"`, with `onModelChange` persisting `{ id, connectionId }` into the field's `value`
> - Imports `ModelSelector`, `ModelChangePayload`, and `SelectedModelState`; maps existing `currentValue` to `selectedModel`
> - Keeps existing `GatewaySelector` flow for `"@deco/agent"`; other binding paths unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d019c594abc9cfb03591bb1de245f893892da658. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ModelSelector to the MCP configuration form for @deco/language-model bindings, letting users pick a model directly in the form. The selection updates form state with the model id and connectionId.

<sup>Written for commit d019c594abc9cfb03591bb1de245f893892da658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

