### PR TITLE
Decrease slow query treshold

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -31,14 +31,14 @@ const queryDurationHistogram = meter.createHistogram("db.query.duration", {
   unit: "ms",
 });
 
-const SECOND_IN_MS = 1000;
+const SLOW_QUERY_TRESHOLD_MS = 400;
 const log = (event: LogEvent) => {
   const attributes = {
     "db.statement": event.query.sql,
     "db.status": event.level === "error" ? "error" : "success",
   };
 
-  if (event.queryDurationMillis > SECOND_IN_MS) {
+  if (event.queryDurationMillis > SLOW_QUERY_TRESHOLD_MS) {
     console.error("Slow query detected:", {
       durationMs: event.queryDurationMillis,
       sql: event.query.sql,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lowered the slow query detection threshold from 1s to 400ms to catch slow database queries sooner. Queries exceeding 400ms now log as slow.

<sup>Written for commit b819f636e00210769022729e665b996534087496. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

