### PR TITLE
feat(runtime): add MCP resources support

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -22,6 +22,12 @@ export {
   type PromptExecutionContext,
   type CreatedPrompt,
   type GetPromptResult,
+  createResource,
+  createPublicResource,
+  type Resource,
+  type ResourceExecutionContext,
+  type ResourceContents,
+  type CreatedResource,
 } from "./tools.ts";
 import type { Binding } from "./wrangler.ts";
 export { proxyConnectionForId, BindingOf } from "./bindings.ts";


### PR DESCRIPTION
## Summary

Add MCP resources support to the `@decocms/runtime` package following the same pattern as tools and prompts.

## Changes

- **Resource Types**: Added `Resource`, `ResourceExecutionContext`, `ResourceContents`, and `CreatedResource` types
- **Factory Functions**: Added `createResource` (auth required) and `createPublicResource` helper functions  
- **Server Options**: Updated `CreateMCPServerOptions` to accept `resources` array or function
- **MCP Registration**: Resources are registered with the MCP server via `server.resource()`
- **Exports**: All resource APIs exported from `index.ts`

## API Overview

Resources are read-only, addressable entities that expose data like config, docs, or context via `resources/list` and `resources/read` endpoints.

### Usage Example

```typescript
export default withRuntime({
  resources: [
    (env) => createResource({
      uri: "config://app",
      name: "App Configuration",
      description: "Current application configuration",
      mimeType: "application/json",
      read: ({ runtimeContext }) => ({
        uri: "config://app",
        mimeType: "application/json",
        text: JSON.stringify(runtimeContext.env.CONFIG),
      }),
    }),
  ],
  tools: [...],
});
```

## Testing

- [x] TypeScript check passes (`bun run check`)
- [x] Formatting applied (`bun run fmt`)
- [x] All existing tests pass (`bun test`)

## Version Bump

Package version bumped from `1.1.3` to `1.2.0` (minor version for new feature).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP resource support to @decocms/runtime so apps can expose read-only resources via resources/list and resources/read. Resources register like tools and prompts, with auth enforced by default.

- **New Features**
  - Types: Resource, ResourceExecutionContext, ResourceContents, CreatedResource
  - Helpers: createResource (auth) and createPublicResource
  - Server: options.resources, resources capability, and server.resource registration with text/blob responses
  - Exports added in index.ts
  - Version bump to 1.2.0

<sup>Written for commit 14fa5bb3ef8a9a94b7b36c592a80a239635175c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

