### PR TITLE
Fix message of invite

### DIFF
--- a/apps/mesh/src/web/components/inbox-button.tsx
+++ b/apps/mesh/src/web/components/inbox-button.tsx
@@ -97,11 +97,6 @@ function InvitationItem({
 
   // Use what data we have from the invitation
   const orgName = invitation.organizationName || invitation.organizationId;
-  const inviterDisplay =
-    invitation.inviter?.name ||
-    invitation.inviter?.email ||
-    invitation.email ||
-    "Someone";
 
   const isPending = invitation.status === "pending";
   const isAccepted = invitation.status === "accepted";
@@ -115,10 +110,7 @@ function InvitationItem({
         <Mail01 size={16} className="text-muted-foreground" />
       </div>
       <p className="flex-1 text-sm text-foreground min-w-0 whitespace-nowrap overflow-hidden">
-        <span className="font-semibold inline-block max-w-[120px] truncate align-bottom">
-          {inviterDisplay}
-        </span>
-        {" invited you to join "}
+        {"You have been invited to "}
         <span className="font-semibold inline-block max-w-[200px] truncate align-bottom">
           {orgName}
         </span>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the inbox invitation message to remove the inviter name/email and show “You have been invited to <org>”. This avoids misleading placeholders, prevents truncation issues, and makes the copy consistent across invitations.

<sup>Written for commit 8f928ab17b33191e88ad21e4cee3f6ec4606af7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

