### PR TITLE
fix(gateway): use correct claude mcp add-json command syntax

### DIFF
--- a/apps/mesh/src/web/components/details/gateway/index.tsx
+++ b/apps/mesh/src/web/components/details/gateway/index.tsx
@@ -322,8 +322,8 @@ function InstallClaudeButton({
         "x-mesh-client": "Claude Code",
       },
     };
-    const configJson = JSON.stringify(connectionConfig, null, 2);
-    const command = `claude mcp add "${slugifiedServerName}" --config '${configJson.replace(/'/g, "'\\''")}'`;
+    const configJson = JSON.stringify(connectionConfig);
+    const command = `claude mcp add-json ${slugifiedServerName} '${configJson.replace(/'/g, "'\\''")}'`;
 
     await navigator.clipboard.writeText(command);
     setCopied(true);


### PR DESCRIPTION
The previous command used 'claude mcp add --config' which doesn't exist. The correct syntax is 'claude mcp add-json <name> <json-config>'.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Gateway “Install Claude” copy-to-clipboard command to use the correct Claude MCP syntax: claude mcp add-json <name> '<json-config>', replacing the invalid claude mcp add --config. This prevents setup errors when adding a gateway in Claude Code.

<sup>Written for commit 8bbb89f89765106886209ab3769a02afe646542a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

