### PR TITLE
[fixes]: Adds transport close

### DIFF
--- a/apps/mesh/src/api/routes/gateway.ts
+++ b/apps/mesh/src/api/routes/gateway.ts
@@ -378,7 +378,16 @@ async function handleVirtualMcpRequest(
     );
 
     // Handle the incoming MCP message
-    return await transport.handleRequest(c.req.raw);
+    // CRITICAL: Use try/finally to ensure transport is closed
+    try {
+      return await transport.handleRequest(c.req.raw);
+    } finally {
+      try {
+        await transport.close?.();
+      } catch {
+        // Ignore close errors
+      }
+    }
   } catch (error) {
     const err = error as Error;
     console.error("[virtual-mcp] Error handling virtual MCP request:", err);

--- a/apps/mesh/src/api/utils/mcp.ts
+++ b/apps/mesh/src/api/utils/mcp.ts
@@ -324,7 +324,16 @@ class McpServerBuilder {
             req.headers.get("Accept")?.includes("application/json") ?? false,
         });
         await createServer().connect(transport);
-        return await transport.handleRequest(req);
+        // CRITICAL: Use try/finally to ensure transport is closed
+        try {
+          return await transport.handleRequest(req);
+        } finally {
+          try {
+            await transport.close?.();
+          } catch {
+            // Ignore close errors
+          }
+        }
       },
     };
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure MCP transports and clients are always closed after requests to prevent memory leaks and lingering connections. Improves stability under load by adding try/finally cleanup and early client shutdowns.

- **Bug Fixes**
  - gateway.ts: Wrap transport.handleRequest in try/finally; call transport.close(), ignore close errors.
  - mcp.ts: Apply the same try/finally close pattern in McpServerBuilder handler.
  - models.ts: Assign mcpClient immediately and close client on early return when no connection is found.

<sup>Written for commit 034dcf167f8d43331afc1225ecb7711ac7d2e845. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

