### PR TITLE
Caches zod toJSONSchema conversion to avoid zod global registry

### DIFF
--- a/apps/mesh/src/aggregator/strategy.ts
+++ b/apps/mesh/src/aggregator/strategy.ts
@@ -65,22 +65,84 @@ export interface StrategyResult {
 export type ToolSelectionStrategyFn = (ctx: StrategyContext) => StrategyResult;
 
 // ============================================================================
+// Cached JSON Schemas (avoid repeated z.toJSONSchema calls)
+// Zod 4's toJSONSchema accumulates in __zod_globalRegistry causing memory leaks
+// ============================================================================
+
+const SEARCH_INPUT_SCHEMA = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe("Search query to find tools by name or description"),
+  limit: z.number().default(10).describe("Maximum number of results to return"),
+});
+const SEARCH_INPUT_JSON_SCHEMA = z.toJSONSchema(
+  SEARCH_INPUT_SCHEMA,
+) as Tool["inputSchema"];
+
+const DESCRIBE_INPUT_SCHEMA = z.object({
+  tools: z
+    .array(z.string())
+    .min(1)
+    .describe("Array of tool names to get detailed schemas for"),
+});
+const DESCRIBE_INPUT_JSON_SCHEMA = z.toJSONSchema(
+  DESCRIBE_INPUT_SCHEMA,
+) as Tool["inputSchema"];
+
+const RUN_CODE_INPUT_SCHEMA = z.object({
+  code: z
+    .string()
+    .min(1)
+    .describe(
+      "JavaScript code to execute. It runs as an async function body; you can use top-level `return` and `await`.",
+    ),
+  timeoutMs: z
+    .number()
+    .default(3000)
+    .describe("Max execution time in milliseconds (default: 3000)."),
+});
+const RUN_CODE_INPUT_JSON_SCHEMA = z.toJSONSchema(
+  RUN_CODE_INPUT_SCHEMA,
+) as Tool["inputSchema"];
+
+// Cache for dynamic CALL_TOOL schemas (keyed by sorted tool names)
+const callToolSchemaCache = new Map<
+  string,
+  { schema: z.ZodTypeAny; jsonSchema: Tool["inputSchema"] }
+>();
+
+function getCallToolSchema(toolNames: string[]): {
+  schema: z.ZodTypeAny;
+  jsonSchema: Tool["inputSchema"];
+} {
+  const cacheKey = toolNames.slice().sort().join(",");
+  let cached = callToolSchemaCache.get(cacheKey);
+  if (!cached) {
+    const schema = z.object({
+      name: (toolNames.length > 0
+        ? z.enum(toolNames as [string, ...string[]])
+        : z.string()
+      ).describe("The name of the tool to execute"),
+      arguments: z
+        .record(z.string(), z.unknown())
+        .default({})
+        .describe("Arguments to pass to the tool"),
+    });
+    cached = {
+      schema,
+      jsonSchema: z.toJSONSchema(schema) as Tool["inputSchema"],
+    };
+    callToolSchemaCache.set(cacheKey, cached);
+  }
+  return cached;
+}
+
+// ============================================================================
 // Tool Factories (Aggregator-specific)
 // ============================================================================
 
 function createSearchTool(ctx: StrategyContext): ToolWithHandler {
-  const inputSchema = z.object({
-    query: z
-      .string()
-      .describe(
-        "Natural language search query (e.g., 'send email', 'create order')",
-      ),
-    limit: z
-      .number()
-      .default(10)
-      .describe("Maximum results to return (default: 10)"),
-  });
-
   // Filter out CODE_EXECUTION_* tools to avoid duplication
   const filteredTools = filterCodeExecutionTools(ctx.tools);
 
@@ -93,10 +155,10 @@ function createSearchTool(ctx: StrategyContext): ToolWithHandler {
     tool: {
       name: "GATEWAY_SEARCH_TOOLS",
       description: `Search for available tools by name or description. Returns tool names and brief descriptions without full schemas. Use this to discover tools before calling GATEWAY_DESCRIBE_TOOLS for detailed schemas.${categoryList} Total tools: ${filteredTools.length}.`,
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: SEARCH_INPUT_JSON_SCHEMA,
     },
     handler: async (args) => {
-      const parsed = inputSchema.safeParse(args);
+      const parsed = SEARCH_INPUT_SCHEMA.safeParse(args);
       if (!parsed.success) {
         return jsonError({ error: parsed.error.flatten() });
       }
@@ -121,13 +183,6 @@ function createSearchTool(ctx: StrategyContext): ToolWithHandler {
 }
 
 function createDescribeTool(ctx: StrategyContext): ToolWithHandler {
-  const inputSchema = z.object({
-    tools: z
-      .array(z.string())
-      .min(1)
-      .describe("Array of tool names to get detailed schemas for"),
-  });
-
   // Filter out CODE_EXECUTION_* tools to avoid duplication
   const filteredTools = filterCodeExecutionTools(ctx.tools);
 
@@ -136,10 +191,10 @@ function createDescribeTool(ctx: StrategyContext): ToolWithHandler {
       name: "GATEWAY_DESCRIBE_TOOLS",
       description:
         "Get detailed schemas for specific tools. Call after GATEWAY_SEARCH_TOOLS to get full input/output schemas.",
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: DESCRIBE_INPUT_JSON_SCHEMA,
     },
     handler: async (args) => {
-      const parsed = inputSchema.safeParse(args);
+      const parsed = DESCRIBE_INPUT_SCHEMA.safeParse(args);
       if (!parsed.success) {
         return jsonError({ error: parsed.error.flatten() });
       }
@@ -160,23 +215,15 @@ function createCallTool(ctx: StrategyContext): ToolWithHandler {
   const toolNames = filteredTools.map((t) => t.name);
   const toolMap = new Map(filteredTools.map((t) => [t.name, t]));
 
-  const inputSchema = z.object({
-    name: (toolNames.length > 0
-      ? z.enum(toolNames as [string, ...string[]])
-      : z.string()
-    ).describe("The name of the tool to execute"),
-    arguments: z
-      .record(z.string(), z.unknown())
-      .default({})
-      .describe("Arguments to pass to the tool"),
-  });
+  // Use cached schema to avoid repeated z.toJSONSchema calls
+  const { schema: inputSchema, jsonSchema } = getCallToolSchema(toolNames);
 
   return {
     tool: {
       name: "GATEWAY_CALL_TOOL",
       description:
         "Execute a tool by name. Use GATEWAY_DESCRIBE_TOOLS first to understand the input schema.",
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: jsonSchema,
     },
     handler: async (args) => {
       const parsed = inputSchema.safeParse(args);
@@ -204,19 +251,6 @@ function createCallTool(ctx: StrategyContext): ToolWithHandler {
 }
 
 function createRunCodeTool(ctx: StrategyContext): ToolWithHandler {
-  const inputSchema = z.object({
-    code: z
-      .string()
-      .min(1)
-      .describe(
-        "JavaScript code to execute. It runs as an async function body; you can use top-level `return` and `await`.",
-      ),
-    timeoutMs: z
-      .number()
-      .default(3000)
-      .describe("Max execution time in milliseconds (default: 3000)."),
-  });
-
   // Filter out CODE_EXECUTION_* tools to avoid duplication
   const filteredTools = filterCodeExecutionTools(ctx.tools);
 
@@ -225,10 +259,10 @@ function createRunCodeTool(ctx: StrategyContext): ToolWithHandler {
       name: "GATEWAY_RUN_CODE",
       description:
         'Run JavaScript code in a sandbox. Code must be an ES module that `export default`s an async function that receives (tools) as its first parameter. Use GATEWAY_DESCRIBE_TOOLS to understand the input/output schemas for a tool before calling it. Use `await tools.toolName(args)` or `await tools["tool-name"](args)` to call tools.',
-      inputSchema: z.toJSONSchema(inputSchema) as Tool["inputSchema"],
+      inputSchema: RUN_CODE_INPUT_JSON_SCHEMA,
     },
     handler: async (args) => {
-      const parsed = inputSchema.safeParse(args);
+      const parsed = RUN_CODE_INPUT_SCHEMA.safeParse(args);
       if (!parsed.success) {
         return jsonError({ error: parsed.error.flatten() });
       }

--- a/apps/mesh/src/api/utils/mcp.ts
+++ b/apps/mesh/src/api/utils/mcp.ts
@@ -123,12 +123,33 @@ class McpServerBuilder {
   private config: McpServerConfig;
   private tools: ToolDefinition[] = [];
   private callToolMiddlewares: CallToolMiddleware[] = [];
+  // Cache JSON Schema conversions to avoid repeated z.toJSONSchema calls
+  // which accumulate in Zod 4's __zod_globalRegistry and cause memory leaks
+  private jsonSchemaCache: Map<
+    z.ZodTypeAny,
+    ReturnType<typeof z.toJSONSchema>
+  > = new Map();
 
   constructor(config: McpServerConfig) {
     this.config = {
       ...config,
       capabilities: config.capabilities ?? { tools: {} },
     };
+  }
+
+  /**
+   * Get cached JSON Schema for a Zod schema.
+   * Avoids repeated z.toJSONSchema calls which accumulate in Zod 4's global registry.
+   */
+  private getCachedJsonSchema(
+    schema: z.ZodTypeAny,
+  ): ReturnType<typeof z.toJSONSchema> {
+    let cached = this.jsonSchemaCache.get(schema);
+    if (!cached) {
+      cached = z.toJSONSchema(schema);
+      this.jsonSchemaCache.set(schema, cached);
+    }
+    return cached;
   }
 
   /**
@@ -270,9 +291,9 @@ class McpServerBuilder {
             tools: this.tools.map((t) => ({
               name: t.name,
               description: t.description ?? "",
-              inputSchema: z.toJSONSchema(t.inputSchema),
+              inputSchema: this.getCachedJsonSchema(t.inputSchema),
               outputSchema: t.outputSchema
-                ? z.toJSONSchema(t.outputSchema)
+                ? this.getCachedJsonSchema(t.outputSchema)
                 : undefined,
             })),
           } as ListToolsResult;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Caches Zod toJSONSchema conversions in the aggregator and MCP server to stop leaks from Zod’s global registry and reduce repeated schema work.

- **Bug Fixes**
  - Cached JSON schemas for search, describe, and run-code tool inputs.
  - Added a callTool schema cache keyed by sorted tool names (stores both Zod and JSON Schema).
  - Introduced a JSON Schema cache in McpServerBuilder and used it when listing tools.
  - Result: prevents memory growth from repeated conversions and improves tool listing/usage performance.

<sup>Written for commit e2729979120700160945a64e41fd48ebaa061c35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

