### PR TITLE
fix(virtual-mcp): use correct claude mcp add-json command syntax

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
@@ -318,7 +318,7 @@ function InstallClaudeButton({ url, serverName }: ShareWithNameProps) {
       },
     };
     const configJson = JSON.stringify(connectionConfig, null, 2);
-    const command = `claude mcp add-json "${slugifiedServerName}" ${configJson}`;
+    const command = `claude mcp add-json "${slugifiedServerName}" '${configJson.replace(/'/g, "'\\''")}'`;
 
     await navigator.clipboard.writeText(command);
     setCopied(true);


### PR DESCRIPTION
The previous command used 'claude mcp add --config' which doesn't exist. The correct syntax is 'claude mcp add-json <name> <json-config>'.

This regression was introduced in commit 756abfdb4 during the gateway to virtual-mcp refactoring.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Virtual MCP “Install in Claude” button to copy a valid command. Uses `claude mcp add-json <name> <json-config>` so pasted commands run without errors.

- **Bug Fixes**
  - Resolves regression from the gateway→virtual-mcp refactor that used the nonexistent `claude mcp add --config` command.

<sup>Written for commit 18cae063c64bb41e1357df792239cd4dce5f1674. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

