### PR TITLE
chore: use custom transport to reduce number of calls

### DIFF
--- a/apps/mesh/src/web/hooks/use-virtual-mcp-client.ts
+++ b/apps/mesh/src/web/hooks/use-virtual-mcp-client.ts
@@ -1,5 +1,4 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type {
   GetPromptRequest,
   GetPromptResult,
@@ -10,6 +9,7 @@ import type {
   ReadResourceResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { StreamableHTTPClientTransport } from "../lib/streamable-http-client-transport";
 import { KEYS } from "../lib/query-keys";
 import { useProjectContext } from "../providers/project-context-provider";
 
@@ -38,20 +38,17 @@ function createVirtualMCPTransport(
     : `/mcp/virtual-mcp`;
   const virtualMcpUrl = new URL(path, window.location.origin);
 
-  const webStandardStreamableHttpTransport = new StreamableHTTPClientTransport(
-    virtualMcpUrl,
-    {
-      requestInit: {
-        headers: {
-          Accept: "application/json, text/event-stream",
-          "Content-Type": "application/json",
-          "x-org-slug": orgSlug,
-        },
+  const transport = new StreamableHTTPClientTransport(virtualMcpUrl, {
+    requestInit: {
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "x-org-slug": orgSlug,
       },
     },
-  );
+  });
 
-  return webStandardStreamableHttpTransport;
+  return transport;
 }
 
 async function withVirtualMCPClient<T>(

--- a/apps/mesh/src/web/lib/streamable-http-client-transport.ts
+++ b/apps/mesh/src/web/lib/streamable-http-client-transport.ts
@@ -1,0 +1,70 @@
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import {
+  StreamableHTTPClientTransport as BaseStreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+/**
+ * Client-side HTTP transport for MCP connections.
+ * Extends StreamableHTTPClientTransport with support for mocking certain MCP protocol messages.
+ */
+export class StreamableHTTPClientTransport extends BaseStreamableHTTPClientTransport {
+  constructor(url: URL, opts?: StreamableHTTPClientTransportOptions) {
+    super(url, opts);
+  }
+
+  override send(
+    message: JSONRPCMessage,
+    options?: {
+      resumptionToken?: string;
+      onresumptiontoken?: (token: string) => void;
+    },
+  ): Promise<void> {
+    const mockAction = getMockActionFor(message);
+    if (mockAction?.type === "emit") {
+      this.onmessage?.(mockAction.message);
+      return Promise.resolve();
+    }
+    if (mockAction?.type === "suppress") {
+      return Promise.resolve();
+    }
+    return super.send(message, options);
+  }
+}
+
+type MockAction =
+  | { type: "emit"; message: JSONRPCMessage }
+  | { type: "suppress" };
+
+function getMockActionFor(message: JSONRPCMessage): MockAction | null {
+  const m = message;
+  if (!m || typeof m !== "object" || !("method" in m)) return null;
+
+  switch (m.method) {
+    case "initialize": {
+      const protocolVersion = m?.params?.protocolVersion;
+      if (!protocolVersion) return null;
+      return {
+        type: "emit",
+        message: {
+          result: {
+            protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: "mesh-virtual-mcp", version: "1.0.0" },
+          },
+          jsonrpc: m.jsonrpc ?? "2.0",
+          // @ts-expect-error - id is not typed
+          id: m.id,
+        } as JSONRPCMessage,
+      };
+    }
+    case "notifications/roots/list_changed":
+    case "notifications/initialized":
+    case "notifications/cancelled":
+    case "notifications/progress": {
+      return { type: "suppress" };
+    }
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
The standard transport does some handshaking. This PR removes this handshaking, bringing the standard 4 request into 1 single.

Before
<img width="639" height="166" alt="Screenshot 2026-01-21 at 16 35 52" src="https://github.com/user-attachments/assets/b49d80b1-ed88-4f1b-b03c-32900d108f33" />

After 
<img width="642" height="151" alt="Screenshot 2026-01-21 at 16 36 07" src="https://github.com/user-attachments/assets/631ecf92-93a5-4357-8e8d-cd201998cf00" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the MCP client transport with a custom streamable HTTP transport that removes handshake overhead. Cuts startup calls from 4 to 1 to reduce latency.

- **Refactors**
  - Added a custom StreamableHTTPClientTransport that mocks the initialize response and suppresses non-essential notifications.
  - Updated use-virtual-mcp-client.ts to use the custom transport with the same headers.

<sup>Written for commit 0271a1ca486d19a5d6d26c7c749555c00654fc81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

