### PR TITLE
feat: add MCP tool call timeout configuration

### DIFF
--- a/apps/mesh/src/api/routes/models.ts
+++ b/apps/mesh/src/api/routes/models.ts
@@ -24,6 +24,7 @@ import type { MeshContext } from "../../core/mesh-context";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import { createLLMProvider } from "../llm-provider";
 import { fixProtocol } from "./oauth-proxy";
+import { MCP_TOOL_CALL_TIMEOUT_MS } from "./proxy";
 
 // Default values
 const DEFAULT_MAX_TOKENS = 32768;
@@ -176,7 +177,7 @@ const toolsFromMCP = async (
               arguments: argsWithMeta as Record<string, unknown>,
             },
             CallToolResultSchema,
-            { signal: options.abortSignal },
+            { signal: options.abortSignal, timeout: MCP_TOOL_CALL_TIMEOUT_MS },
           ) as Promise<CallToolResult>;
         },
         toModelOutput: ({ output }) => {

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -67,6 +67,17 @@ type Variables = {
 const app = new Hono<{ Variables: Variables }>();
 
 // ============================================================================
+// MCP Tool Call Configuration
+// ============================================================================
+
+/**
+ * Default timeout for MCP tool calls in milliseconds.
+ * The MCP SDK default is 60 seconds (60000ms).
+ * Increase this value for tools that take longer to execute.
+ */
+export const MCP_TOOL_CALL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// ============================================================================
 // Middleware Types
 // ============================================================================
 
@@ -488,7 +499,9 @@ async function createMCPProxyDoNotUseDirectly(
         },
         async (span) => {
           try {
-            const result = await client.callTool(forwardParams);
+            const result = await client.callTool(forwardParams, undefined, {
+              timeout: MCP_TOOL_CALL_TIMEOUT_MS,
+            });
             const duration = Date.now() - startTime;
 
             // Record duration histogram


### PR DESCRIPTION
- Introduced a new constant `MCP_TOOL_CALL_TIMEOUT_MS` to set a default timeout of 5 minutes for MCP tool calls, enhancing control over long-running operations.
- Updated the `callTool` method in both `models.ts` and `proxy.ts` to utilize the new timeout setting, ensuring consistent timeout behavior across tool calls.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a 5-minute default timeout for MCP tool calls to prevent premature failures on long-running tools. Introduced MCP_TOOL_CALL_TIMEOUT_MS and applied it to callTool in models.ts and proxy.ts for consistent behavior.

<sup>Written for commit bc725f764489ba5dafaf920481bc7227bb2ca29c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

