### PR TITLE
fix(invitations): filter out expired invitations from UI

### DIFF
--- a/apps/mesh/src/tools/organization/get.ts
+++ b/apps/mesh/src/tools/organization/get.ts
@@ -42,9 +42,17 @@ export const ORGANIZATION_GET = defineTool({
       throw new Error("No active organization found");
     }
 
+    // Filter out expired invitations - Better Auth returns all invitations
+    // but acceptInvitation/rejectInvitation will fail for expired ones
+    const now = new Date();
+    const validInvitations = organization.invitations?.filter(
+      (inv: { expiresAt: string | Date }) => new Date(inv.expiresAt) > now,
+    );
+
     // Convert dates to ISO strings for JSON Schema compatibility
     return {
       ...organization,
+      invitations: validInvitations,
       createdAt:
         organization.createdAt instanceof Date
           ? organization.createdAt.toISOString()

--- a/apps/mesh/src/web/components/inbox-button.tsx
+++ b/apps/mesh/src/web/components/inbox-button.tsx
@@ -168,8 +168,14 @@ export function InboxButton() {
 
   const rawInvitations = (_invitations ?? []) as Invitation[];
 
+  // Filter out expired invitations - Better Auth returns all invitations
+  // but acceptInvitation/rejectInvitation will fail for expired ones
+  const validInvitations = rawInvitations.filter(
+    (inv) => new Date(inv.expiresAt) > new Date(),
+  );
+
   // Enrich invitations with organization slugs
-  const enrichedInvitations = rawInvitations.map((inv) => {
+  const enrichedInvitations = validInvitations.map((inv) => {
     const org = (organizations ?? []).find((o) => o.id === inv.organizationId);
     return {
       ...inv,

--- a/apps/mesh/src/web/components/organizations-home.tsx
+++ b/apps/mesh/src/web/components/organizations-home.tsx
@@ -144,9 +144,10 @@ function InvitationsGrid({ query }: { query?: string }) {
 
   const invitations = (_invitations ?? []) as Invitation[];
 
-  // Filter to only show pending invitations
+  // Filter to only show pending invitations that haven't expired
+  // Better Auth returns all invitations but accept/reject will fail for expired ones
   const pendingInvitations = invitations.filter(
-    (inv) => inv.status === "pending",
+    (inv) => inv.status === "pending" && new Date(inv.expiresAt) > new Date(),
   );
 
   // Filter invitations based on search query


### PR DESCRIPTION
## Summary

Fixes an issue where organization invitations would appear in the UI but return "not found" errors when users tried to accept or reject them.

## Root Cause

Better Auth's organization plugin has an inconsistency:
- `listUserInvitations` and `getFullOrganization` return **all** invitations (including expired ones)
- `acceptInvitation` and `rejectInvitation` check expiration and return `INVITATION_NOT_FOUND` for expired invitations

The default invitation expiration is **48 hours**.

## Changes

Added expiration filtering in three places:

| File | Type | Description |
|------|------|-------------|
| `apps/mesh/src/tools/organization/get.ts` | Server-side | Filter expired invitations in `ORGANIZATION_GET` tool (used by members page) |
| `apps/mesh/src/web/components/inbox-button.tsx` | Client-side | Filter expired invitations in inbox dropdown |
| `apps/mesh/src/web/components/organizations-home.tsx` | Client-side | Filter expired invitations in home page grid |

All filters check `new Date(inv.expiresAt) > new Date()` to exclude expired invitations.

## Testing

- Invitations older than 48 hours should no longer appear in the UI
- Valid (non-expired) invitations continue to work normally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures only valid (unexpired) invitations are shown and processed, aligning UI with backend acceptance rules.
> 
> - **Server**: In `ORGANIZATION_GET`, filters `organization.invitations` by `expiresAt > now` and returns only valid invites; preserves ISO conversion for dates.
> - **UI (Inbox)**: Filters expired invites before enriching with org data and rendering.
> - **UI (Home)**: `InvitationsGrid` now shows only pending, unexpired invitations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c88bda77354a8fbbf716f97febd1bfc396a587b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out expired organization invitations so users only see valid invites and avoid “not found” errors on accept/reject. Applied on server and UI for consistent behavior.

- **Bug Fixes**
  - Server: Filter expired invitations in ORGANIZATION_GET.
  - UI (Inbox): Filter expired invitations before enriching and displaying.
  - UI (Home): Show only pending, unexpired invitations in InvitationsGrid.

<sup>Written for commit c88bda77354a8fbbf716f97febd1bfc396a587b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

