### PR TITLE
feat(oauth): add force_new parameter to deco store OAuth URLs

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -89,6 +89,8 @@ function buildDecoOAuthParams(projectLocator: string | null): URLSearchParams {
     params.set("auto_personal", "true");
   }
 
+  params.set("force_new", "true");
+
   return params;
 }
 


### PR DESCRIPTION
## Summary
Adds `force_new=true` query parameter to all deco store OAuth authorization URLs to ensure users always get a fresh authentication flow.

## Changes
- Updated `buildDecoOAuthParams()` function to always include `force_new=true` parameter
- This parameter is added alongside existing `workspace_hint`/`project_hint` or `auto_personal` parameters

## Test plan
- [ ] Test OAuth flow with deco store connections
- [ ] Verify `force_new=true` appears in authorization URL
- [ ] Confirm fresh authentication is forced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces fresh OAuth sessions for deco-hosted MCPs by always appending `force_new=true` to authorization URLs.
> 
> - Updates `buildDecoOAuthParams()` in `apps/mesh/src/api/app.ts` to always add `force_new="true"` alongside existing `workspace_hint`/`project_hint` or `auto_personal` params
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65a6ee074aefa5c3f40d2b845048fa291cdb39a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added force_new=true to deco store OAuth authorization URLs so users always start a fresh auth flow and don’t reuse existing sessions.

<sup>Written for commit 65a6ee074aefa5c3f40d2b845048fa291cdb39a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

