### PR TITLE
chore: Bring back the self contained mcp route for the mesh MCP

### DIFF
--- a/apps/mesh/migrations/028-update-management-mcp-to-self.ts
+++ b/apps/mesh/migrations/028-update-management-mcp-to-self.ts
@@ -1,0 +1,54 @@
+/**
+ * Update Management MCP Connection URLs from /mcp/management to /mcp/self
+ *
+ * This migration:
+ * 1. Updates existing management MCP connections from `/mcp/management` to `/mcp/self`
+ *    to match the new route structure.
+ * 2. Resets the `tools` column to NULL so tools are fetched fresh from the
+ *    management MCP endpoint.
+ *
+ * The management MCP endpoint has been moved from `/mcp/management` to `/mcp/self`
+ * to better reflect its purpose as the self-management endpoint.
+ *
+ * Setting tools to NULL causes the proxy to fall back to fetching tools
+ * directly from the MCP endpoint, which returns the current ALL_TOOLS.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Update connection_url for management MCP connections
+  // Replace '/management' with '/self' in URLs that end with '/mcp/management'
+  // This handles both http://localhost:3000/mcp/management and https://mesh.example.com/mcp/management
+  await sql`
+    UPDATE connections
+    SET connection_url = REPLACE(connection_url, '/mcp/management', '/mcp/self'),
+        tools = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE connection_url LIKE '%/mcp/management'
+      AND app_name = '@deco/management-mcp'
+  `.execute(db);
+
+  // Also reset tools for management MCP connections that already have the correct URL
+  // (in case URL was manually updated but tools weren't)
+  await sql`
+    UPDATE connections
+    SET tools = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE connection_url LIKE '%/mcp/self'
+      AND app_name = '@deco/management-mcp'
+      AND tools IS NOT NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Revert by replacing '/self' with '/management' in URLs that end with '/mcp/self'
+  // Note: tools will remain NULL (they'll be fetched fresh on next request)
+  await sql`
+    UPDATE connections
+    SET connection_url = REPLACE(connection_url, '/mcp/self', '/mcp/management'),
+        updated_at = CURRENT_TIMESTAMP
+    WHERE connection_url LIKE '%/mcp/self'
+      AND app_name = '@deco/management-mcp'
+  `.execute(db);
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -26,6 +26,7 @@ import * as migration024consolidatevirtualmcp from "./024-consolidate-virtual-mc
 import * as migration025addmonitoringvirtualmcpid from "./025-add-monitoring-virtual-mcp-id.ts";
 import * as migration026restrictchildconnectiondelete from "./026-restrict-child-connection-delete.ts";
 import * as migration027updatemanagementmcpurl from "./027-update-management-mcp-url.ts";
+import * as migration028updatemanagementmcptoself from "./028-update-management-mcp-to-self.ts";
 
 const migrations = {
   "001-initial-schema": migration001initialschema,
@@ -57,6 +58,7 @@ const migrations = {
   "026-restrict-child-connection-delete":
     migration026restrictchildconnectiondelete,
   "027-update-management-mcp-url": migration027updatemanagementmcpurl,
+  "028-update-management-mcp-to-self": migration028updatemanagementmcptoself,
 } satisfies Record<string, Migration>;
 
 export default migrations;

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -1058,19 +1058,12 @@ app.all("/", async (c) => {
  *
  * Route: POST /mcp/:connectionId
  * Connection IDs are globally unique UUIDs (no project prefix needed)
- * Special case: connectionIds ending with "_self" are routed to the management MCP
  */
 app.all("/:connectionId", async (c) => {
   const connectionId = c.req.param("connectionId");
   const ctx = c.get("meshContext");
 
   try {
-    // Check if this is the SELF/management MCP (org-scoped pattern: {org}_self)
-    if (connectionId.endsWith("_self")) {
-      const { managementMCP } = await import("../../tools");
-      return managementMCP(ctx).fetch(c.req.raw);
-    }
-
     // Otherwise proxy to downstream
     const proxy = await ctx.createMCPProxy(connectionId);
     return await proxy.fetch(c.req.raw);

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -1,0 +1,28 @@
+/**
+ * Self MCP Server
+ *
+ * Exposes MCP Mesh management tools via MCP protocol at /mcp/self endpoint
+ * Tools: PROJECT_CREATE, PROJECT_LIST, CONNECTION_CREATE, etc.
+ */
+import { Hono } from "hono";
+import type { MeshContext } from "../../core/mesh-context";
+import { managementMCP } from "../../tools";
+
+// Define Hono variables type
+type Variables = {
+  meshContext: MeshContext;
+};
+
+const app = new Hono<{ Variables: Variables }>();
+
+/**
+ * MCP Server endpoint for self-management tools
+ *
+ * Route: POST /mcp/self
+ * Exposes all PROJECT_* and CONNECTION_* tools via MCP protocol
+ */
+app.all("/", async (c) => {
+  return managementMCP(c.get("meshContext")).fetch(c.req.raw);
+});
+
+export default app;

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -97,8 +97,8 @@ export function getWellKnownSelfConnection(
     title: "Mesh MCP",
     description: "The MCP for the mesh API",
     connection_type: "HTTP",
-    // URL is routed through the proxy which detects _self suffix
-    connection_url: `${baseUrl}/mcp/${WellKnownOrgMCPId.SELF(orgId)}`,
+    // Custom url for targeting this mcp. It's a standalone endpoint that exposes all management tools.
+    connection_url: `${baseUrl}/mcp/self`,
     icon: "https://assets.decocache.com/mcp/09e44283-f47d-4046-955f-816d227c626f/app.png",
     app_name: "@deco/management-mcp",
     connection_token: null,


### PR DESCRIPTION
Apparently, we do need the self contained mesh MCP for things to work properly

Implement migration to update Management MCP connection URLs to new self-management endpoint

- Added migration script to update existing connection URLs from `/mcp/management` to `/mcp/self`.
- Reset `tools` column to NULL for fresh fetching from the new endpoint.
- Updated routing in the application to expose management tools at the new `/mcp/self` endpoint.
- Refactored proxy handling to accommodate the new self-management structure.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored a dedicated /mcp/self endpoint for the Management MCP and updated existing connections to use it. This fixes self-management tooling and removes the fragile _self proxy behavior.

- **New Features**
  - Added /mcp/self route that exposes all management tools.
  - Secured with mcpAuth and registered in app routing.
  - Updated SDK to use /mcp/self for the well-known self connection.

- **Migration**
  - Migration 028 updates connection_url from /mcp/management to /mcp/self for @deco/management-mcp and clears tools to refetch.
  - Removed the proxy special-case for connectionIds ending in _self; use /mcp/self instead.

<sup>Written for commit 47867fea65b19e70a88f3235b5548ca454fef53b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

