### PR TITLE
Allow abort signal on MCP Client Proxy

### DIFF
--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/bindings",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/bindings/src/core/client/mcp-client.ts
+++ b/packages/bindings/src/core/client/mcp-client.ts
@@ -9,7 +9,6 @@ import {
 import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
-  CallToolRequest,
   Implementation,
   ListToolsRequest,
   ListToolsResult,
@@ -43,15 +42,15 @@ class Client extends BaseClient {
     return result;
   }
 }
-type CallToolResponse = Awaited<ReturnType<Client["callTool"]>>;
 export interface ServerClient {
   client: {
-    callTool: (params: CallToolRequest["params"]) => Promise<CallToolResponse>;
+    callTool: Client["callTool"];
     listTools: () => Promise<ListToolsResult>;
   };
   callStreamableTool: (
     tool: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ) => Promise<Response>;
 }
 export const createServerClient = async (
@@ -74,7 +73,7 @@ export const createServerClient = async (
 
   return {
     client,
-    callStreamableTool: (tool, args) => {
+    callStreamableTool: (tool, args, signal) => {
       if (mcpServer.connection.type !== "HTTP") {
         throw new Error("HTTP connection required");
       }
@@ -101,6 +100,7 @@ export const createServerClient = async (
         redirect: "manual",
         body: JSON.stringify(args),
         headers,
+        signal,
       });
     },
   };


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added AbortSignal support to MCP client and proxy so tool calls (including streamable) and HTTP requests can be canceled. Bumped @decocms/bindings to 1.1.0.

- **New Features**
  - Support AbortSignal for both streamable and non-streamable tool calls; signals propagate to fetch and SDK calls.
  - Proxy now accepts RequestInit as the second argument to pass a signal.

- **Migration**
  - When calling proxied tools, pass { signal } as the second arg: tool(args, { signal }).

<sup>Written for commit e326b7b53e0c57dc83b55e78773ddb7a01cd5c1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

