### PR TITLE
feat: mesh

### DIFF
--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -13,7 +13,7 @@ import {
   useMCPClient,
   useProjectContext,
   useVirtualMCPs,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type {
@@ -532,7 +532,7 @@ export function ChatProvider({
 
   // MCP client for thread operations
   const mcpClient = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/components/monitoring/analytics-top-agents.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-agents.tsx
@@ -12,7 +12,7 @@ import {
   useMCPToolCall,
   useProjectContext,
   useVirtualMCPs,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { HomeGridCell } from "@/web/routes/orgs/home/home-grid-cell.tsx";
@@ -134,7 +134,7 @@ function TopAgentsContent({ metricsMode }: TopAgentsContentProps) {
   const virtualMcps = useVirtualMCPs({ pageSize: 100 }) ?? [];
 
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/components/monitoring/analytics-top-servers.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-servers.tsx
@@ -12,7 +12,7 @@ import {
   useMCPClient,
   useMCPToolCall,
   useProjectContext,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import {
   ToggleGroup,
@@ -139,7 +139,7 @@ function TopServersContent({
   const connections = useConnections({ pageSize: 100 }) ?? [];
 
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/components/monitoring/analytics-top-tools.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-tools.tsx
@@ -11,7 +11,7 @@ import {
   useMCPClient,
   useMCPToolCall,
   useProjectContext,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import { ChartContainer, ChartTooltip } from "@deco/ui/components/chart.tsx";
 import { useNavigate } from "@tanstack/react-router";
@@ -132,7 +132,7 @@ function TopToolsContent(_props: TopToolsContentProps) {
   const connections = useConnections() ?? [];
 
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/hooks/collections/use-organization-settings.ts
+++ b/apps/mesh/src/web/hooks/collections/use-organization-settings.ts
@@ -15,7 +15,7 @@ import { KEYS } from "../../lib/query-keys";
 import {
   useMCPClient,
   useProjectContext,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 
 /**
@@ -27,7 +27,7 @@ import {
 export function useOrganizationSettings(organizationId: string) {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 
@@ -70,7 +70,7 @@ export function useOrganizationSettingsActions(organizationId: string) {
   const queryClient = useQueryClient();
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/hooks/use-chat-store.ts
+++ b/apps/mesh/src/web/hooks/use-chat-store.ts
@@ -13,7 +13,7 @@ import { KEYS } from "../lib/query-keys";
 import {
   useMCPClient,
   useProjectContext,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import type { Message, Thread } from "../components/chat/types.ts";
 import type {
@@ -31,7 +31,7 @@ const THREADS_PAGE_SIZE = 50;
 export function useThreads() {
   const { locator, org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
   const listToolName = "COLLECTION_THREADS_LIST";
@@ -92,7 +92,7 @@ export function useThreads() {
 export function useThreadMessages(threadId: string | null) {
   const { locator, org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
   const listToolName = "COLLECTION_THREAD_MESSAGES_LIST";

--- a/apps/mesh/src/web/hooks/use-invitations.ts
+++ b/apps/mesh/src/web/hooks/use-invitations.ts
@@ -9,7 +9,7 @@ import { KEYS } from "@/web/lib/query-keys";
 import {
   useMCPClient,
   useProjectContext,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import {
   useMutation,
@@ -44,7 +44,7 @@ interface OrganizationData {
 export function useInvitations() {
   const { org, locator } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/hooks/use-user-by-id.ts
+++ b/apps/mesh/src/web/hooks/use-user-by-id.ts
@@ -10,7 +10,7 @@ import { KEYS } from "../lib/query-keys";
 import {
   useMCPClient,
   useProjectContext,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 
 /**
@@ -34,7 +34,7 @@ type UserGetOutput = { user: UserData | null };
 export function useUserById(userId: string) {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/routes/orgs/home/mesh-graph.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/mesh-graph.tsx
@@ -13,7 +13,7 @@ import {
   useMCPToolCall,
   useProjectContext,
   useVirtualMCPs,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
   type ConnectionEntity,
   type VirtualMCPEntity,
 } from "@decocms/mesh-sdk";
@@ -247,7 +247,7 @@ function useNodeMetrics(): NodeMetricsMap {
   const dateRange = getLast24HoursDateRange();
 
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/apps/mesh/src/web/routes/orgs/monitoring.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring.tsx
@@ -25,7 +25,7 @@ import {
   useMCPClient,
   useProjectContext,
   useVirtualMCPs,
-  WellKnownOrgMCPId,
+  SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -799,7 +799,7 @@ function MonitoringDashboardContent({
   const { pageSize, streamingRefetchInterval } = MONITORING_CONFIG;
   const { org, locator } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/packages/mesh-sdk/src/hooks/use-connection.ts
+++ b/packages/mesh-sdk/src/hooks/use-connection.ts
@@ -15,7 +15,7 @@ import {
   type UseCollectionListOptions,
 } from "./use-collections";
 import { useMCPClient } from "./use-mcp-client";
-import { WellKnownOrgMCPId } from "../lib/constants";
+import { SELF_MCP_ALIAS_ID } from "../lib/constants";
 
 /**
  * Filter definition for connections (matches @deco/ui Filter shape)
@@ -36,7 +36,7 @@ export type UseConnectionsOptions = UseCollectionListOptions<ConnectionEntity>;
 export function useConnections(options: UseConnectionsOptions = {}) {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
   return useCollectionList<ConnectionEntity>(
@@ -56,7 +56,7 @@ export function useConnections(options: UseConnectionsOptions = {}) {
 export function useConnection(connectionId: string | undefined) {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
   return useCollectionItem<ConnectionEntity>(
@@ -75,7 +75,7 @@ export function useConnection(connectionId: string | undefined) {
 export function useConnectionActions() {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
   return useCollectionActions<ConnectionEntity>(org.id, "CONNECTIONS", client);

--- a/packages/mesh-sdk/src/hooks/use-mcp-client.ts
+++ b/packages/mesh-sdk/src/hooks/use-mcp-client.ts
@@ -9,7 +9,7 @@ const DEFAULT_CLIENT_INFO = {
 };
 
 export interface CreateMcpClientOptions {
-  /** Connection ID - use WellKnownOrgMCPId.SELF(org.id) for the self/management MCP, or any connectionId for other MCPs */
+  /** Connection ID - use SELF_MCP_ALIAS_ID for the self/management MCP (ALL_TOOLS), or any connectionId for other MCPs */
   connectionId: string | null;
   /** Organization ID - required, transforms to x-org-id header */
   orgId: string;

--- a/packages/mesh-sdk/src/hooks/use-virtual-mcp.ts
+++ b/packages/mesh-sdk/src/hooks/use-virtual-mcp.ts
@@ -15,7 +15,7 @@ import {
   type UseCollectionListOptions,
 } from "./use-collections";
 import { useMCPClient } from "./use-mcp-client";
-import { WellKnownOrgMCPId } from "../lib/constants";
+import { SELF_MCP_ALIAS_ID } from "../lib/constants";
 
 /**
  * Filter definition for virtual MCPs (matches @deco/ui Filter shape)
@@ -36,7 +36,7 @@ export type UseVirtualMCPsOptions = UseCollectionListOptions<VirtualMCPEntity>;
 export function useVirtualMCPs(options: UseVirtualMCPsOptions = {}) {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 
@@ -59,7 +59,7 @@ export function useVirtualMCP(
 ): VirtualMCPEntity | null {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 
@@ -83,7 +83,7 @@ export function useVirtualMCP(
 export function useVirtualMCPActions() {
   const { org } = useProjectContext();
   const client = useMCPClient({
-    connectionId: WellKnownOrgMCPId.SELF(org.id),
+    connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
 

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -101,6 +101,8 @@ export { KEYS } from "./lib/query-keys";
 
 // Constants and well-known MCP definitions
 export {
+  // Frontend self MCP ID
+  SELF_MCP_ALIAS_ID as SELF_MCP_ALIAS_ID,
   // Org-scoped MCP ID generators
   WellKnownOrgMCPId,
   // Connection factory functions

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -24,6 +24,13 @@ export const WellKnownOrgMCPId = {
 };
 
 /**
+ * Frontend connection ID for the self/management MCP endpoint.
+ * Use this constant when calling management tools (ALL_TOOLS) from the frontend.
+ * The endpoint is exposed at /mcp/self.
+ */
+export const SELF_MCP_ALIAS_ID = "self";
+
+/**
  * Get well-known connection definition for the Deco Store registry.
  * This can be used by both frontend and backend to create registry connections.
  *
@@ -98,7 +105,7 @@ export function getWellKnownSelfConnection(
     description: "The MCP for the mesh API",
     connection_type: "HTTP",
     // Custom url for targeting this mcp. It's a standalone endpoint that exposes all management tools.
-    connection_url: `${baseUrl}/mcp/self`,
+    connection_url: `${baseUrl}/mcp/${SELF_MCP_ALIAS_ID}`,
     icon: "https://assets.decocache.com/mcp/09e44283-f47d-4046-955f-816d227c626f/app.png",
     app_name: "@deco/management-mcp",
     connection_token: null,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the self/management MCP connection by introducing a frontend alias (SELF_MCP_ALIAS_ID) and replacing org-scoped IDs, ensuring consistent calls to the management tools endpoint.

- **Refactors**
  - Added and exported SELF_MCP_ALIAS_ID ("self") in mesh-sdk constants.
  - Updated useMCPClient docs to reference SELF_MCP_ALIAS_ID for ALL_TOOLS.
  - Replaced WellKnownOrgMCPId.SELF(org.id) with SELF_MCP_ALIAS_ID across chat, monitoring, hooks, and routes.
  - Updated getWellKnownSelfConnection to use /mcp/{SELF_MCP_ALIAS_ID} instead of /mcp/self.

<sup>Written for commit 24b205121a9f3311945a22b1a33454012937ba3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

