### PR TITLE
Revert "Decrease total log limit on query"

### DIFF
--- a/apps/mesh/src/tools/monitoring/list.ts
+++ b/apps/mesh/src/tools/monitoring/list.ts
@@ -57,7 +57,7 @@ export const MONITORING_LOGS_LIST = defineTool({
       .datetime()
       .optional()
       .describe("Filter by end date (ISO 8601 datetime string)"),
-    limit: z.number().default(10).describe("Maximum number of results"),
+    limit: z.number().default(100).describe("Maximum number of results"),
     offset: z.number().default(0).describe("Offset for pagination"),
     // Property filters
     properties: z

--- a/apps/mesh/src/web/components/monitoring/analytics-top-agents.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-agents.tsx
@@ -142,7 +142,7 @@ function TopAgentsContent({ metricsMode }: TopAgentsContentProps) {
     useMCPToolCall<MonitoringLogsWithVirtualMCPResponse>({
       client,
       toolName: "MONITORING_LOGS_LIST",
-      toolArguments: { ...dateRange, limit: 10, offset: 0 },
+      toolArguments: { ...dateRange, limit: 1000, offset: 0 },
       staleTime: 30_000,
       select: (result) =>
         ((result as { structuredContent?: unknown }).structuredContent ??

--- a/apps/mesh/src/web/components/monitoring/analytics-top-servers.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-servers.tsx
@@ -147,7 +147,7 @@ function TopServersContent({
     useMCPToolCall<MonitoringLogsWithVirtualMCPResponse>({
       client,
       toolName: "MONITORING_LOGS_LIST",
-      toolArguments: { ...dateRange, limit: 10, offset: 0 },
+      toolArguments: { ...dateRange, limit: 1000, offset: 0 },
       staleTime: 30_000,
       select: (result) =>
         ((result as { structuredContent?: unknown }).structuredContent ??

--- a/apps/mesh/src/web/components/monitoring/analytics-top-tools.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-tools.tsx
@@ -139,7 +139,7 @@ function TopToolsContent(_props: TopToolsContentProps) {
   const { data: logsData } = useMCPToolCall<BaseMonitoringLogsResponse>({
     client,
     toolName: "MONITORING_LOGS_LIST",
-    toolArguments: { ...dateRange, limit: 20, offset: 0 },
+    toolArguments: { ...dateRange, limit: 2000, offset: 0 },
     staleTime: 30_000,
     select: (result) =>
       ((result as { structuredContent?: unknown }).structuredContent ??

--- a/apps/mesh/src/web/routes/orgs/home/mesh-graph.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/mesh-graph.tsx
@@ -255,7 +255,7 @@ function useNodeMetrics(): NodeMetricsMap {
     useMCPToolCall<MonitoringLogsWithVirtualMCPResponse>({
       client,
       toolName: "MONITORING_LOGS_LIST",
-      toolArguments: { ...dateRange, limit: 10, offset: 0 },
+      toolArguments: { ...dateRange, limit: 1000, offset: 0 },
       staleTime: 30_000,
       select: (result) =>
         ((result as { structuredContent?: unknown }).structuredContent ??


### PR DESCRIPTION
Reverts decocms/mesh#2289

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore higher log fetch limits so analytics dashboards and the mesh graph show complete data. MONITORING_LOGS_LIST default limit is back to 100; UI calls now request 1000 logs for agents, servers, and node metrics, and 2000 for tools.

<sup>Written for commit 3c1e588b1a518567d4075ba954798c2f68d1c10f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

