### PR TITLE
[chore]: Mesh public tool

### DIFF
--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -179,6 +179,7 @@ export class AccessControl implements Disposable {
    * Check if the current tool is marked as public via _meta["mcp.mesh"].public_tool
    */
   private async isToolPublic(): Promise<boolean> {
+    if (this.toolName?.startsWith("MESH_PUBLIC_")) return true;
     if (!this.getToolMeta) return false;
     try {
       const meta = await this.getToolMeta();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
AccessControl now treats tools prefixed with MESH_PUBLIC_ as public. This adds a naming convention fallback when tool metadata is unavailable, making it easier to expose tools without extra config.

<sup>Written for commit d5b51927dbac673f88babd378c9baf8b6bebd103. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

