### PR TITLE
[chore]: Adds public check before userId check

### DIFF
--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -109,6 +109,11 @@ export class AccessControl implements Disposable {
     if (this._granted) {
       return;
     }
+    // tool is public with zero IO operations, so we can grant access immediately
+    if (this.toolName?.startsWith("MESH_PUBLIC_")) {
+      this.grant();
+      return;
+    }
 
     // Check if authenticated first (401)
     if (!this.userId && !this.boundAuth) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Grant access immediately for public tools (names starting with MESH_PUBLIC_) in AccessControl, before any userId/auth checks. This prevents unnecessary 401s and avoids extra IO for public tools.

<sup>Written for commit 145866b45e5bf1645019463e214baff5a1a4e555. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

