### PR TITLE
feat(user-sandbox): add 'created' boolean to create session output

### DIFF
--- a/packages/mesh-plugin-user-sandbox/server/tools/schema.ts
+++ b/packages/mesh-plugin-user-sandbox/server/tools/schema.ts
@@ -237,6 +237,11 @@ export const UserSandboxCreateSessionOutputSchema = z.object({
     .nullable()
     .optional()
     .describe("Virtual MCP ID for this user (unique per template + user)"),
+  created: z
+    .boolean()
+    .describe(
+      "Whether the agent was newly created (true) or already existed (false)",
+    ),
 });
 
 // LIST SESSIONS


### PR DESCRIPTION
## Summary

The `USER_SANDBOX_CREATE_SESSION` tool now returns a `created` property:
- `true` when a new agent was created for the user  
- `false` when an existing agent was found and reused

This helps consumers distinguish between new and existing users during the session creation flow.

## Changes

- Modified `findOrCreateVirtualMCP` to return `{ connectionId, created }` object
- Updated `UserSandboxCreateSessionOutputSchema` to include the new `created` boolean field
- Updated handler to propagate the `created` flag in all return paths

## Testing

This is a straightforward change to the return type. The logic was already tracking whether the agent existed - we're now exposing that information to callers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a created flag to USER_SANDBOX_CREATE_SESSION to indicate if a new agent was created or an existing one was reused. This helps clients distinguish new vs existing users during session creation.

- **New Features**
  - Output includes created: boolean.
  - findOrCreateVirtualMCP returns { connectionId, created }.
  - Handler propagates created for both existing and new sessions.

<sup>Written for commit 5a022210cf95e2d4817f3c9f90ce54b2ff52ef51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

