### PR TITLE
feat(tool-details): add boolean selection input using Select component

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -5,6 +5,13 @@ import {
 } from "@deco/ui/components/alert.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import {
   Tooltip,
@@ -269,7 +276,7 @@ function ToolDetailsAuthenticated({
     }
   };
 
-  const handleInputChange = (key: string, value: string) => {
+  const handleInputChange = (key: string, value: unknown) => {
     setEditedParams((prev) => ({ ...prev, [key]: value }));
   };
 
@@ -383,6 +390,25 @@ function ToolDetailsAuthenticated({
                             placeholder={`Enter ${key} as JSON...`}
                             rows={3}
                           />
+                        ) : prop.type === "boolean" ? (
+                          <Select
+                            value={
+                              hasEditedKey(key)
+                                ? String(editedParams[key] ?? "")
+                                : ""
+                            }
+                            onValueChange={(v) =>
+                              handleInputChange(key, v === "true")
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select true or false..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="true">true</SelectItem>
+                              <SelectItem value="false">false</SelectItem>
+                            </SelectContent>
+                          </Select>
                         ) : (
                           <Input
                             value={


### PR DESCRIPTION
- Introduced a new Select component for boolean properties in ToolDetailsAuthenticated.
- Updated handleInputChange to accept unknown type for improved type safety.
- Enhanced user experience by allowing selection of true/false values instead of text input.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a boolean Select input to ToolDetailsAuthenticated so users choose true/false instead of typing. Updates handleInputChange to accept unknown, improving type safety and correctly storing boolean values.

<sup>Written for commit c38537b8bdd08bf47e909f778a6d3f8d8a21b4d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

