### PR TITLE
fix(user-sandboxes-plugin): ensure agent id exists on all sessions

### DIFF
--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -113,7 +113,7 @@ export {
 // Constants and well-known MCP definitions
 export {
   // Frontend self MCP ID
-  SELF_MCP_ALIAS_ID as SELF_MCP_ALIAS_ID,
+  SELF_MCP_ALIAS_ID,
   // Org-scoped MCP ID generators
   WellKnownOrgMCPId,
   // Connection factory functions


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures every user sandbox session has an agentId by creating/finding the Virtual MCP first and backfilling missing IDs on existing sessions. Prevents null agentId issues and returns consistent created status.

- **Bug Fixes**
  - Create/find Virtual MCP before checking or creating sessions.
  - Backfill created_agent_id on existing sessions when missing.
  - Return agentId consistently and use agentCreated for both existing and new sessions.

<sup>Written for commit 1a6125a2227ba06aefcb536bfab842f40dd7428b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

