### PR TITLE
feat(connection-settings): add re-authenticate and remove OAuth actions

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab/connection-settings-form-ui.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/connection-settings-form-ui.tsx
@@ -6,6 +6,12 @@ import { useAuthConfig } from "@/web/providers/auth-config-provider";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
   Form,
   FormControl,
   FormDescription,
@@ -24,10 +30,13 @@ import {
 } from "@deco/ui/components/select.tsx";
 import {
   CheckCircle,
+  ChevronDown,
   Container,
   CpuChip02,
   Globe02,
+  RefreshCcw01,
   Terminal,
+  Trash01,
 } from "@untitledui/icons";
 import { formatDistanceToNow } from "date-fns";
 import { useForm, useWatch } from "react-hook-form";
@@ -41,10 +50,14 @@ function ConnectionFields({
   form,
   connection,
   hasOAuthToken,
+  onReauthenticate,
+  onRemoveOAuth,
 }: {
   form: ReturnType<typeof useForm<ConnectionFormData>>;
   connection: ConnectionEntity;
   hasOAuthToken?: boolean;
+  onReauthenticate?: () => void | Promise<void>;
+  onRemoveOAuth?: () => void | Promise<void>;
 }) {
   const uiType = useWatch({ control: form.control, name: "ui_type" });
   const connectionUrl = useWatch({
@@ -310,11 +323,34 @@ function ConnectionFields({
 
           {/* Authentication status badge */}
           {hasOAuthToken ? (
-            <div className="flex items-center">
-              <Badge variant="success" className="gap-1.5">
-                <CheckCircle size={12} />
-                Authenticated via OAuth
-              </Badge>
+            <div className="flex items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 cursor-pointer"
+                  >
+                    <Badge variant="success" className="gap-1.5">
+                      <CheckCircle size={12} />
+                      Authenticated via OAuth
+                      <ChevronDown size={12} />
+                    </Badge>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={onReauthenticate}>
+                    <RefreshCcw01 size={16} />
+                    Re-authenticate
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onClick={onRemoveOAuth}
+                  >
+                    <Trash01 size={16} />
+                    Remove OAuth
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           ) : connection.connection_token ? (
             <div className="flex items-center">
@@ -391,10 +427,14 @@ export function ConnectionSettingsFormUI({
   form,
   connection,
   hasOAuthToken,
+  onReauthenticate,
+  onRemoveOAuth,
 }: {
   form: ReturnType<typeof useForm<ConnectionFormData>>;
   connection: ConnectionEntity;
   hasOAuthToken?: boolean;
+  onReauthenticate?: () => void | Promise<void>;
+  onRemoveOAuth?: () => void | Promise<void>;
 }) {
   const { org } = useProjectContext();
 
@@ -453,6 +493,8 @@ export function ConnectionSettingsFormUI({
           form={form}
           connection={connection}
           hasOAuthToken={hasOAuthToken}
+          onReauthenticate={onReauthenticate}
+          onRemoveOAuth={onRemoveOAuth}
         />
 
         {/* Last Updated section */}

--- a/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
@@ -586,6 +586,40 @@ function SettingsTabContentImpl(props: SettingsTabContentImplProps) {
     toast.success("Authentication successful");
   };
 
+  const handleRemoveOAuth = async () => {
+    try {
+      const response = await fetch(
+        `/api/connections/${connection.id}/oauth-token`,
+        {
+          method: "DELETE",
+          credentials: "include",
+        },
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        toast.error(`Failed to remove OAuth: ${errorText}`);
+        return;
+      }
+
+      // Invalidate auth status query to trigger UI refresh
+      const mcpProxyUrl = new URL(
+        `/mcp/${connection.id}`,
+        window.location.origin,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
+      });
+
+      toast.success(
+        "OAuth removed. You can now re-authenticate with a different account.",
+      );
+    } catch (err) {
+      console.error("Error removing OAuth token:", err);
+      toast.error("Failed to remove OAuth");
+    }
+  };
+
   return (
     <>
       <ViewActions>
@@ -616,6 +650,8 @@ function SettingsTabContentImpl(props: SettingsTabContentImplProps) {
             form={form}
             connection={connection}
             hasOAuthToken={props.hasOAuthToken}
+            onReauthenticate={handleAuthenticate}
+            onRemoveOAuth={handleRemoveOAuth}
           />
         </div>
 


### PR DESCRIPTION
## Summary

- Add a dropdown menu to OAuth-authenticated integrations badge that allows users to:
  - **Re-authenticate**: Trigger the OAuth flow again to switch to a different account
  - **Remove OAuth**: Delete stored OAuth tokens so users can authorize with a different account without creating a new integration

This improves UX by allowing users to change the linked OAuth account without needing to delete and recreate the integration.

## Test plan

- [ ] Navigate to a connection with OAuth authentication
- [ ] Verify the "Authenticated via OAuth" badge now has a dropdown arrow
- [ ] Click the badge to reveal the dropdown menu
- [ ] Test "Re-authenticate" opens the OAuth flow
- [ ] Test "Remove OAuth" deletes the token and shows unauthenticated state
- [ ] After removing OAuth, verify user can re-authenticate with a different account

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dropdown to the “Authenticated via OAuth” badge with Re-authenticate and Remove OAuth actions, so users can switch accounts without recreating the integration.

- **New Features**
  - Re-authenticate triggers the OAuth flow to link a different account.
  - Remove OAuth deletes stored tokens via DELETE /api/connections/:id/oauth-token and refreshes auth status.
  - Dropdown UI with icons and toast feedback for success/error.

<sup>Written for commit d4bd759a196aaea3c4a37eaf43c6a9fb0e3d3166. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

