### PR TITLE
feat(mesh-sdk): Enable external apps with meshUrl param, windowMode, and npm publishing

### DIFF
--- a/.github/workflows/publish-mesh-sdk-npm.yaml
+++ b/.github/workflows/publish-mesh-sdk-npm.yaml
@@ -1,0 +1,86 @@
+name: Publish @decocms/mesh-sdk
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/mesh-sdk/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check if version changed
+        id: version-check
+        run: |
+          # Get the current version from package.json
+          CURRENT_VERSION=$(bun -e "console.log(require('./package.json').version)")
+
+          # Try to get the published version from npm (will fail if package doesn't exist)
+          PUBLISHED_VERSION=$(bun info @decocms/mesh-sdk version 2>/dev/null || echo "0.0.0")
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Published version: $PUBLISHED_VERSION"
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          if [ "$CURRENT_VERSION" != "$PUBLISHED_VERSION" ]; then
+            echo "version-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Version changed ($PUBLISHED_VERSION → $CURRENT_VERSION), will publish"
+          else
+            echo "version-changed=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Version unchanged ($CURRENT_VERSION), skipping publish"
+          fi
+
+          # Check if this is a prerelease version (contains a hyphen)
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            echo "npm-tag=next" >> $GITHUB_OUTPUT
+            echo "📦 Prerelease version detected, will publish with tag 'next'"
+          else
+            echo "npm-tag=latest" >> $GITHUB_OUTPUT
+            echo "📦 Stable version detected, will publish with tag 'latest'"
+          fi
+        working-directory: packages/mesh-sdk
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: bun publish --access public --tag ${{ steps.version-check.outputs.npm-tag }}
+        working-directory: packages/mesh-sdk
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "mesh-sdk-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/mesh-sdk v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/mesh-sdk package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/mesh-sdk
+          \`\`\`
+          
+          ### Features
+          - React hooks for MCP connections
+          - OAuth authentication utilities
+          - Support for external apps via \`meshUrl\` parameter
+          - TypeScript types for connections and virtual MCPs"

--- a/packages/mesh-sdk/package.json
+++ b/packages/mesh-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/mesh-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SDK for building external apps that integrate with Mesh MCP servers",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

This PR enables external apps (running on different domains) to integrate with Mesh by adding configuration parameters to SDK functions and setting up npm publishing.

## Changes

### mesh-sdk

- **Add `meshUrl` parameter** to `createMCPClient`, `useMCPClient`, `authenticateMcp`, and `isConnectionAuthenticated`
  - Defaults to `window.location.origin` for backwards compatibility
  - External apps can now specify their Mesh server URL

- **Add `windowMode` parameter** to `authenticateMcp`
  - `"popup"` (default): Opens OAuth in popup window
  - `"tab"`: Opens OAuth in new tab (for devices that block popups)
  - Both modes use dual-channel communication (postMessage + localStorage fallback)

- **Add npm publish workflow** (`.github/workflows/publish-mesh-sdk-npm.yaml`)
  - Auto-publishes on changes to `packages/mesh-sdk/`
  - Supports prerelease versions with `next` tag
  - Creates GitHub releases

- **Bump version to 1.1.0**

- **Update package.json for npm publishing**
  - Change `@decocms/bindings` from `workspace:*` to `^1.1.1`
  - Add peer dependencies for React, React Query, sonner
  - Add repository metadata

- **Add comprehensive README** with:
  - Server-side vs client-side usage examples
  - User Sandbox integration example
  - Direct MCP tool call examples
  - API reference with all options documented

### user-sandbox plugin

- **Add comprehensive README** with:
  - Full API reference for all MCP tools
  - REST API documentation (public endpoints)
  - Complete connect flow explanation
  - Next.js implementation guide for custom connect UI
  - Data models and TypeScript types

## Usage Example

```typescript
// External app connecting to Mesh
const client = await createMCPClient({
  meshUrl: "https://mesh.your-company.com",
  connectionId: "self",
  orgId: "org_xxx",
  token: process.env.MESH_API_KEY,
});

// OAuth with tab mode for mobile
await authenticateMcp({
  meshUrl: "https://mesh.your-company.com",
  connectionId: "conn_xxx",
  windowMode: "tab",
});
```

## Testing

- [x] `bun run check` passes
- [x] `bun run fmt` passes
- [x] Backwards compatible (defaults to `window.location.origin`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables external apps on different domains to use the Mesh SDK via a new meshUrl option and a tab-friendly OAuth windowMode. Also prepares the package for npm publishing and updates docs. Version bumped to 1.1.0.

- **New Features**
  - Add meshUrl to createMCPClient, useMCPClient, authenticateMcp, and isConnectionAuthenticated (defaults to window.location.origin).
  - Add OAuth windowMode: popup (default) or tab for devices that block popups.
  - Cross-origin auth checks now support meshUrl in token status requests.
  - Add comprehensive READMEs for mesh-sdk and user-sandbox with examples and API docs.
  - Add npm publish workflow with prerelease tag support and GitHub releases.

- **Migration**
  - External apps must pass meshUrl to SDK functions.
  - Use windowMode: "tab" for mobile or environments that block popups.
  - Ensure React and React Query are installed as peer deps; sonner is optional.
  - Node engine requirement is now >=18.

<sup>Written for commit a15630f7630a2fdff1e5a86150b59468e124e957. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

