### PR TITLE
fix(mesh-sdk): handle relative URLs in isConnectionAuthenticated

### DIFF
--- a/apps/mesh/src/web/routes/connect.tsx
+++ b/apps/mesh/src/web/routes/connect.tsx
@@ -4,6 +4,7 @@
  * This route renders the user-sandbox plugin's ConnectFlow component.
  * It's a public page for end users to configure integrations.
  *
+ *
  * TODO: Currently, plugins cannot register their own root-level client-side routes.
  * This route exists here because the React Router tree lives in the main app.
  * In the future, the plugin system should support root-level client-side route registration


### PR DESCRIPTION
## Problem

The `isConnectionAuthenticated` function in `@decocms/mesh-sdk` failed when passed relative URLs like `/mcp/conn_...`. This caused OAuth discovery to fail silently:

- `new URL(url)` throws when given a relative URL without a base
- The error was caught and returned `supportsOAuth: false`
- OAuth flow was skipped entirely, causing integrations to "auto-connect" without authentication

This affected the User Sandbox plugin's `/connect` flow where users configure OAuth-protected integrations.

## Solution

Use `window.location.origin` as the base URL when parsing URLs:

```typescript
// Before
new URL(url)

// After  
new URL(url, window.location.origin)
```

This works correctly for both:
- **Relative URLs** (`/mcp/conn_...`) - resolves against current origin
- **Absolute URLs** (`https://mesh.example.com/mcp/conn_...`) - base is ignored

## Testing

Verified with debug instrumentation:

| Before | After |
|--------|-------|
| `error: "Failed to construct 'URL': Invalid URL"` | `error: "HTTP 401"` |
| `supportsOAuth: false` | `supportsOAuth: true` |
| `willTriggerOAuth: false` | `willTriggerOAuth: true` |

OAuth popup now opens correctly for OAuth-protected integrations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed isConnectionAuthenticated to handle relative URLs so OAuth discovery works and integrations don’t auto-connect without authentication.

- **Bug Fixes**
  - Parse relative URLs using new URL(url, window.location.origin).
  - Apply the same base when deriving apiBaseUrl.
  - Restores OAuth detection and popup for /mcp connections in the User Sandbox /connect flow.

<sup>Written for commit 746aea345fd2a3098858d65a6fe47f9754ef2f18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

