### PR TITLE
feat(user-sandbox): add tool to clear user session data

### DIFF
--- a/packages/mesh-plugin-user-sandbox/server/storage/user-sandbox-session.ts
+++ b/packages/mesh-plugin-user-sandbox/server/storage/user-sandbox-session.ts
@@ -203,6 +203,22 @@ export class UserSandboxSessionStorage {
   }
 
   /**
+   * Delete all sessions for an external user in an organization
+   */
+  async deleteByExternalUserId(
+    organizationId: string,
+    externalUserId: string,
+  ): Promise<number> {
+    const result = await this.db
+      .deleteFrom("user_sandbox_sessions")
+      .where("organization_id", "=", organizationId)
+      .where("external_user_id", "=", externalUserId)
+      .executeTakeFirst();
+
+    return Number(result.numDeletedRows ?? 0);
+  }
+
+  /**
    * Deserialize a database row to entity
    */
   private deserialize(row: RawSessionRow): UserSandboxSessionEntity {

--- a/packages/mesh-plugin-user-sandbox/server/tools/clear-user-session.ts
+++ b/packages/mesh-plugin-user-sandbox/server/tools/clear-user-session.ts
@@ -1,0 +1,161 @@
+/**
+ * User Sandbox Plugin - Clear User Session Tool
+ *
+ * Clears all data for an external user, including:
+ * - Virtual MCPs (agents) created for this user
+ * - Child connections added to those agents
+ * - OAuth tokens for those connections
+ * - Sessions for this user
+ * - User agent linking records
+ *
+ * This is for users who want to revoke all access they've given.
+ */
+
+import { z } from "zod";
+import type { Kysely } from "kysely";
+import type { ServerPluginToolDefinition } from "@decocms/bindings/server-plugin";
+import {
+  UserSandboxClearUserSessionInputSchema,
+  UserSandboxClearUserSessionOutputSchema,
+} from "./schema";
+import { getPluginStorage } from "./utils";
+
+// Metadata fields used to tag user sandbox agents
+const EXTERNAL_USER_ID_KEY = "user_sandbox_external_user_id";
+
+/** Database types for queries */
+interface ClearSessionDatabase {
+  connections: {
+    id: string;
+    organization_id: string;
+    connection_type: string;
+    metadata: string | null;
+  };
+  connection_aggregations: {
+    id: string;
+    parent_connection_id: string;
+    child_connection_id: string;
+  };
+  user_sandbox_agents: {
+    id: string;
+    user_sandbox_id: string;
+    external_user_id: string;
+    connection_id: string;
+  };
+  downstream_tokens: {
+    connectionId: string;
+  };
+}
+
+export const USER_SANDBOX_CLEAR_USER_SESSION: ServerPluginToolDefinition = {
+  name: "USER_SANDBOX_CLEAR_USER_SESSION",
+  description:
+    "Clear all session data for an external user, revoking all access they've granted. " +
+    "This deletes their agents (Virtual MCPs), child connections, OAuth tokens, and sessions. " +
+    "Use this when a user wants to disconnect all their integrations.",
+  inputSchema: UserSandboxClearUserSessionInputSchema,
+  outputSchema: UserSandboxClearUserSessionOutputSchema,
+
+  handler: async (input, ctx) => {
+    const typedInput = input as z.infer<
+      typeof UserSandboxClearUserSessionInputSchema
+    >;
+    const meshCtx = ctx as {
+      organization: { id: string } | null;
+      access: { check: () => Promise<void> };
+      db: Kysely<unknown>;
+    };
+
+    // Require organization context
+    if (!meshCtx.organization) {
+      throw new Error("Organization context required");
+    }
+
+    // Check access
+    await meshCtx.access.check();
+
+    const db = meshCtx.db as Kysely<ClearSessionDatabase>;
+    const storage = getPluginStorage();
+
+    // Step 1: Find all Virtual MCPs (agents) for this external user
+    const virtualMcps = await db
+      .selectFrom("connections")
+      .select(["id", "metadata"])
+      .where("organization_id", "=", meshCtx.organization.id)
+      .where("connection_type", "=", "VIRTUAL")
+      .execute();
+
+    // Filter to agents that belong to this external user
+    const userAgentIds = virtualMcps
+      .filter((conn) => {
+        if (!conn.metadata) return false;
+        try {
+          const metadata = JSON.parse(conn.metadata);
+          return metadata[EXTERNAL_USER_ID_KEY] === typedInput.externalUserId;
+        } catch {
+          return false;
+        }
+      })
+      .map((conn) => conn.id);
+
+    let deletedConnections = 0;
+
+    if (userAgentIds.length > 0) {
+      // Step 2: Get all child connections for these agents
+      const aggregations = await db
+        .selectFrom("connection_aggregations")
+        .select("child_connection_id")
+        .where("parent_connection_id", "in", userAgentIds)
+        .execute();
+
+      const childConnectionIds = aggregations.map((a) => a.child_connection_id);
+
+      if (childConnectionIds.length > 0) {
+        // Step 3: Delete OAuth tokens for child connections
+        await db
+          .deleteFrom("downstream_tokens")
+          .where("connectionId", "in", childConnectionIds)
+          .execute();
+
+        // Step 4: Delete the child connections
+        await db
+          .deleteFrom("connections")
+          .where("id", "in", childConnectionIds)
+          .execute();
+
+        deletedConnections = childConnectionIds.length;
+      }
+
+      // Step 5: Delete connection aggregations for these agents
+      await db
+        .deleteFrom("connection_aggregations")
+        .where("parent_connection_id", "in", userAgentIds)
+        .execute();
+
+      // Step 6: Delete the Virtual MCPs (agents) themselves
+      await db
+        .deleteFrom("connections")
+        .where("id", "in", userAgentIds)
+        .execute();
+
+      // Step 7: Delete the user_sandbox_agents linking records
+      await db
+        .deleteFrom("user_sandbox_agents")
+        .where("external_user_id", "=", typedInput.externalUserId)
+        .execute();
+    }
+
+    // Step 8: Delete all sessions for this user
+    const deletedSessions = await storage.sessions.deleteByExternalUserId(
+      meshCtx.organization.id,
+      typedInput.externalUserId,
+    );
+
+    return {
+      success: true,
+      deletedAgents: userAgentIds.length,
+      deletedConnections,
+      deletedSessions,
+    };
+  },
+};

--- a/packages/mesh-plugin-user-sandbox/server/tools/index.ts
+++ b/packages/mesh-plugin-user-sandbox/server/tools/index.ts
@@ -13,6 +13,7 @@ import { USER_SANDBOX_GET } from "./get";
 import { USER_SANDBOX_CREATE_SESSION } from "./create-session";
 import { USER_SANDBOX_LIST_SESSIONS } from "./list-sessions";
 import { USER_SANDBOX_LIST_USER_AGENTS } from "./list-user-agents";
+import { USER_SANDBOX_CLEAR_USER_SESSION } from "./clear-user-session";
 
 export const tools = [
   USER_SANDBOX_CREATE,
@@ -23,6 +24,7 @@ export const tools = [
   USER_SANDBOX_CREATE_SESSION,
   USER_SANDBOX_LIST_SESSIONS,
   USER_SANDBOX_LIST_USER_AGENTS,
+  USER_SANDBOX_CLEAR_USER_SESSION,
 ];
 
 // Re-export utility for storage initialization

--- a/packages/mesh-plugin-user-sandbox/server/tools/schema.ts
+++ b/packages/mesh-plugin-user-sandbox/server/tools/schema.ts
@@ -269,3 +269,19 @@ const AgentSummarySchema = z.object({
 export const UserSandboxListUserAgentsOutputSchema = z.object({
   agents: z.array(AgentSummarySchema),
 });
+
+// CLEAR USER SESSION
+export const UserSandboxClearUserSessionInputSchema = z.object({
+  externalUserId: z
+    .string()
+    .describe("External user ID whose session data should be cleared"),
+});
+
+export const UserSandboxClearUserSessionOutputSchema = z.object({
+  success: z.boolean(),
+  deletedAgents: z.number().describe("Number of agents (Virtual MCPs) deleted"),
+  deletedConnections: z
+    .number()
+    .describe("Number of child connections deleted"),
+  deletedSessions: z.number().describe("Number of sessions deleted"),
+});


### PR DESCRIPTION
## Summary

Adds a new `USER_SANDBOX_CLEAR_USER_SESSION` tool that allows platform end-users to revoke all access they've granted through the connect flow.

## What's New

### New Tool: `USER_SANDBOX_CLEAR_USER_SESSION`

**Input:**
- `externalUserId` - The external user ID whose data should be cleared

**Output:**
- `success` - Whether the operation succeeded
- `deletedAgents` - Number of Virtual MCPs deleted
- `deletedConnections` - Number of child connections deleted
- `deletedSessions` - Number of sessions deleted

### What It Clears

When called, this tool removes:
1. ✨ All Virtual MCPs (agents) created for the user
2. 🔗 All child connections added to those agents
3. 🔐 OAuth tokens for those connections
4. 📋 Connection aggregations and linking records
5. 📦 All sessions for the user

## Use Case

This is useful when platform end-users want to:
- Revoke all OAuth access they've granted
- "Disconnect" all their integrations at once
- Start fresh with a clean slate

## Files Changed

- `server/storage/user-sandbox-session.ts` - Added `deleteByExternalUserId()` method
- `server/tools/schema.ts` - Added input/output schemas
- `server/tools/clear-user-session.ts` - New tool implementation
- `server/tools/index.ts` - Exported the new tool

## Testing

- [x] Type check passes (`bun run check`)
- [x] Linting passes (`bun run lint`)
- [x] Formatting applied (`bun run fmt`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a USER_SANDBOX_CLEAR_USER_SESSION tool to let users revoke all access granted via the connect flow with one action. It deletes their agents, connections, tokens, and sessions, and returns deletion counts.

- **New Features**
  - Tool: USER_SANDBOX_CLEAR_USER_SESSION
  - Input: externalUserId
  - Output: success, deletedAgents, deletedConnections, deletedSessions
  - Clears agents (Virtual MCPs), child connections, OAuth tokens, connection aggregations/linking records, and all sessions
  - Storage/schemas: added deleteByExternalUserId() to session storage, updated schemas, and exported the tool

<sup>Written for commit d48c6a91673a44b00826eca30f108a921b915c6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

