### PR TITLE
fix(cors): expose WWW-Authenticate header for cross-origin OAuth discovery

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -196,6 +196,8 @@ export function createApp(options: CreateAppOptions = {}) {
       credentials: true,
       allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
       allowHeaders: ["Content-Type", "Authorization", "mcp-protocol-version"],
+      // Expose WWW-Authenticate so OAuth discovery works from cross-origin clients
+      exposeHeaders: ["WWW-Authenticate"],
     }),
   );
 


### PR DESCRIPTION
## Summary

This PR adds `WWW-Authenticate` to the CORS `exposeHeaders` configuration, allowing cross-origin JavaScript clients to read this header on 401 responses.

## Problem

When a client app (e.g., running on localhost:3000) makes cross-origin requests to the Mesh server (e.g., mesh-admin.decocms.com), the browser's CORS policy blocks JavaScript from reading the `WWW-Authenticate` header even though the server sends it.

This breaks OAuth discovery in the `@decocms/mesh-sdk`'s `isConnectionAuthenticated` function, which checks for this header to determine if the server supports OAuth:

```javascript
const wwwAuth = response.headers.get('WWW-Authenticate');
const supportsOAuth = !!wwwAuth;
```

## Solution

Add `exposeHeaders: ['WWW-Authenticate']` to the Hono CORS middleware configuration. This tells the browser to allow JavaScript to read this header on cross-origin responses.

## Testing

- Tested with the hackathonantigravity app making cross-origin requests to mesh-admin.decocms.com
- OAuth discovery now correctly detects `supportsOAuth: true` when the server returns 401 with WWW-Authenticate header

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the WWW-Authenticate header in CORS so cross-origin clients can read it on 401 responses. This fixes OAuth discovery in @decocms/mesh-sdk (isConnectionAuthenticated) when calling mesh-admin.decocms.com.

<sup>Written for commit 4f9c715e363f20374db7a1a8bf2c2e9fbcdd67fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

