### PR TITLE
fix(user-sandbox): allow partial app configuration on complete

### DIFF
--- a/packages/mesh-plugin-user-sandbox/server/routes/connect.ts
+++ b/packages/mesh-plugin-user-sandbox/server/routes/connect.ts
@@ -495,17 +495,16 @@ export function connectRoutes(app: Hono, ctx: ServerPluginContext): void {
         return c.json({ error: "Template not found" }, 404);
       }
 
-      // Check all required apps are configured
-      const unconfiguredApps = template.required_apps.filter((app) => {
+      // Check at least one app is configured (allow partial configuration)
+      const configuredApps = template.required_apps.filter((app) => {
         const status = session.app_statuses[app.app_name];
-        return !status?.configured;
+        return status?.configured;
       });
 
-      if (unconfiguredApps.length > 0) {
+      if (configuredApps.length === 0) {
         return c.json(
           {
-            error: "Not all required apps are configured",
-            unconfigured: unconfiguredApps.map((a) => a.app_name),
+            error: "At least one app must be configured",
           },
           400,
         );


### PR DESCRIPTION
## Summary

Allow users to complete a User Sandbox session even if not all required apps are configured.

## Problem

The complete endpoint was rejecting sessions where not all apps were configured, returning:
```json
{
  "error": "Not all required apps are configured",
  "unconfigured": ["@deco/google-gmail"]
}
```

## Solution

Changed validation from requiring ALL apps to requiring at least ONE app:
- ❌ Before: Required all apps to be configured
- ✅ After: Requires at least one app to be configured

This allows users to complete setup with partial configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow completing User Sandbox sessions with partial app configuration. The complete endpoint now requires at least one required app to be configured instead of all, so users can finish setup without configuring every app.

<sup>Written for commit fc11d44ffbc8f71c37f1fd9c34574e51b4d09137. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

