### PR TITLE
fix(user-sandbox): allow adding more apps after session completion

### DIFF
--- a/packages/mesh-plugin-user-sandbox/server/routes/connect.ts
+++ b/packages/mesh-plugin-user-sandbox/server/routes/connect.ts
@@ -208,8 +208,10 @@ export function connectRoutes(app: Hono, ctx: ServerPluginContext): void {
         return c.json({ error: "app_name is required" }, 400);
       }
 
-      // Validate session
-      const session = await validateSessionAccess(sessionId, storage);
+      // Validate session (allow completed so users can add more apps later)
+      const session = await validateSessionAccess(sessionId, storage, {
+        allowCompleted: true,
+      });
 
       // Get template to find app configuration
       const template = await templates.findById(session.template_id);
@@ -303,8 +305,10 @@ export function connectRoutes(app: Hono, ctx: ServerPluginContext): void {
         return c.json({ error: "app_name is required" }, 400);
       }
 
-      // Validate session
-      const session = await validateSessionAccess(sessionId, storage);
+      // Validate session (allow completed so users can add more apps later)
+      const session = await validateSessionAccess(sessionId, storage, {
+        allowCompleted: true,
+      });
 
       // Get template to verify app is required
       const template = await templates.findById(session.template_id);
@@ -380,8 +384,10 @@ export function connectRoutes(app: Hono, ctx: ServerPluginContext): void {
         return c.json({ error: "access_token is required" }, 400);
       }
 
-      // Validate session
-      const session = await validateSessionAccess(sessionId, storage);
+      // Validate session (allow completed so users can add more apps later)
+      const session = await validateSessionAccess(sessionId, storage, {
+        allowCompleted: true,
+      });
 
       // Verify the connection belongs to this session
       const connectionBelongsToSession = Object.values(
@@ -486,8 +492,10 @@ export function connectRoutes(app: Hono, ctx: ServerPluginContext): void {
     try {
       const sessionId = c.req.param("sessionId");
 
-      // Validate session
-      const session = await validateSessionAccess(sessionId, storage);
+      // Validate session (allow completed so users can re-complete after adding more apps)
+      const session = await validateSessionAccess(sessionId, storage, {
+        allowCompleted: true,
+      });
 
       // Get template
       const template = await templates.findById(session.template_id);


### PR DESCRIPTION
Users should be able to add more OAuth apps to their session even after clicking 'Save Permissions'. This change adds `allowCompleted: true` to the session validation in the provision, configure, oauth-token, and complete endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow users to add more OAuth apps after clicking “Save Permissions” by permitting access to completed sessions across the connect routes. This removes the block that prevented adding apps post-completion.

- **Bug Fixes**
  - Pass allowCompleted: true to validateSessionAccess in provision, configure, oauth-token, and complete endpoints.
  - Let users re-complete the session after adding additional apps.

<sup>Written for commit 3b47c15867c0becf36aa062fbd209739336d52b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

