### PR TITLE
feat: redirect /connect route to hackathon deployment

### DIFF
--- a/apps/mesh/src/web/routes/connect.tsx
+++ b/apps/mesh/src/web/routes/connect.tsx
@@ -1,23 +1,17 @@
 /**
  * User Sandbox Connect Page
  *
- * This route renders the user-sandbox plugin's ConnectFlow component.
- * It's a public page for end users to configure integrations.
- *
- *
- * TODO: Currently, plugins cannot register their own root-level client-side routes.
- * This route exists here because the React Router tree lives in the main app.
- * In the future, the plugin system should support root-level client-side route registration
- * so this file can be removed and the route defined in the plugin itself.
- *
- * @see packages/mesh-plugin-user-sandbox/client/components/connect-flow.tsx
+ * This route redirects to the hackathon deployment for the connect flow.
  */
 
 import { useParams } from "@tanstack/react-router";
-import { ConnectFlow } from "mesh-plugin-user-sandbox/client";
 
 export default function ConnectPage() {
   const { sessionId } = useParams({ from: "/connect/$sessionId" });
 
-  return <ConnectFlow sessionId={sessionId} />;
+  if (typeof window !== "undefined") {
+    window.location.href = `https://hackathonantigravity.vercel.app/connect/${sessionId}`;
+  }
+
+  return null;
 }


### PR DESCRIPTION
Redirects the /connect/<id> route to https://hackathonantigravity.vercel.app/connect/<id> for the hackathon.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect /connect/:sessionId to https://hackathonantigravity.vercel.app/connect/:sessionId so the connect flow runs on the hackathon deployment.
Replaces the in-app ConnectFlow with a client-side redirect and returns null on SSR.

<sup>Written for commit 7b86b1528264b3ff55558451790e1732001a153b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

