### PR TITLE
feat(workflow): enhance WorkflowStepCard with execution output handling

### DIFF
--- a/apps/mesh/src/web/components/details/workflow/hooks/queries/use-workflow-collection-item.ts
+++ b/apps/mesh/src/web/components/details/workflow/hooks/queries/use-workflow-collection-item.ts
@@ -73,6 +73,7 @@ export function usePollingWorkflowExecution(executionId?: string) {
 export function useExecutionCompletedStep(
   executionId?: string,
   stepName?: string,
+  options?: { refetchInterval?: number | false; enabled?: boolean },
 ) {
   const { org } = useProjectContext();
   const connection = useWorkflowBindingConnection();
@@ -81,6 +82,8 @@ export function useExecutionCompletedStep(
     connectionId: connection.id,
     orgId: org.id,
   });
+
+  const isEnabled = (options?.enabled ?? true) && !!executionId && !!stepName;
 
   const { data, isLoading } = useMCPToolCallQuery<{
     output: unknown | null;
@@ -92,7 +95,8 @@ export function useExecutionCompletedStep(
       executionId: executionId,
       stepId: stepName,
     },
-    enabled: !!executionId && !!stepName,
+    enabled: isEnabled,
+    refetchInterval: options?.refetchInterval,
     select: (result) =>
       ((result as { structuredContent?: unknown }).structuredContent ??
         result) as { output: unknown | null; error: string | null },


### PR DESCRIPTION
- Added a new function to resolve reference paths for step outputs, improving data retrieval for nested outputs.
- Integrated logic to check for completed steps in 'forEach' scenarios, allowing dynamic display of completed items.
- Updated the `useExecutionCompletedStep` hook to support refetching based on execution status and step completion.
- Refactored imports for better organization and clarity.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhanced WorkflowStepCard to fetch and display outputs for forEach steps, including nested refs, and to show live progress counts. Updated useExecutionCompletedStep to support conditional polling and step-completion checks for reliable data.

- **New Features**
  - Resolve nested output refs via resolveRefPath for @step.foo.bar.
  - Show “completed/total” count for forEach steps based on target output length.
  - Poll target step output while execution runs; gate by step completion.

- **Refactors**
  - useExecutionCompletedStep accepts options { enabled, refetchInterval }.
  - Read output schema properties from schema.items.properties when arrays.
  - Cleaned up imports.

<sup>Written for commit 9528492532e9aced44e290d8d73e2574a06d2e55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

