### PR TITLE
chore: rm hardcoded hackathon redirect

### DIFF
--- a/apps/mesh/src/web/routes/connect.tsx
+++ b/apps/mesh/src/web/routes/connect.tsx
@@ -1,17 +1,23 @@
 /**
  * User Sandbox Connect Page
  *
- * This route redirects to the hackathon deployment for the connect flow.
+ * This route renders the user-sandbox plugin's ConnectFlow component.
+ * It's a public page for end users to configure integrations.
+ *
+ *
+ * TODO: Currently, plugins cannot register their own root-level client-side routes.
+ * This route exists here because the React Router tree lives in the main app.
+ * In the future, the plugin system should support root-level client-side route registration
+ * so this file can be removed and the route defined in the plugin itself.
+ *
+ * @see packages/mesh-plugin-user-sandbox/client/components/connect-flow.tsx
  */
 
 import { useParams } from "@tanstack/react-router";
+import { ConnectFlow } from "mesh-plugin-user-sandbox/client";
 
 export default function ConnectPage() {
   const { sessionId } = useParams({ from: "/connect/$sessionId" });
 
-  if (typeof window !== "undefined") {
-    window.location.href = `https://hackathonantigravity.vercel.app/connect/${sessionId}`;
-  }
-
-  return null;
+  return <ConnectFlow sessionId={sessionId} />;
 }


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hardcoded redirect in /connect/$sessionId with the in-app ConnectFlow from the user-sandbox plugin, so the connect flow runs inside the app. This removes the external hackathon dependency and stabilizes the experience.

- **Refactors**
  - Render ConnectFlow from mesh-plugin-user-sandbox, passing the route’s sessionId.
  - Remove window.location hackathon redirect; page is now a public, plugin-powered configuration screen.

<sup>Written for commit cd8188bc6fa371d121c1f71709f1521cec70d393. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

