### PR TITLE
Refactor Agents List Component: Simplify agent display and add 'See All' functionality

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -14,7 +14,7 @@ import {
   AlertTriangle,
   ArrowUp,
   ChevronDown,
-  CpuChip02,
+  Users03,
   Edit01,
   Stop,
   XCircle,
@@ -115,7 +115,8 @@ function VirtualMCPBadge({
               icon={virtualMcp.icon}
               name={virtualMcp.title}
               size="2xs"
-              fallbackIcon={virtualMcp.fallbackIcon ?? <CpuChip02 size={10} />}
+              className="bg-background rounded-sm"
+              fallbackIcon={virtualMcp.fallbackIcon ?? <Users03 size={10} />}
             />
             <span className="text-xs text-white font-normal">
               {virtualMcp.title}

--- a/apps/mesh/src/web/components/chat/select-virtual-mcp.tsx
+++ b/apps/mesh/src/web/components/chat/select-virtual-mcp.tsx
@@ -19,7 +19,7 @@ import {
   useVirtualMCPs,
   type VirtualMCPEntity,
 } from "@decocms/mesh-sdk";
-import { Check, ChevronDown, CpuChip02, SearchMd } from "@untitledui/icons";
+import { Check, ChevronDown, SearchMd, Users03 } from "@untitledui/icons";
 import {
   useEffect,
   useRef,
@@ -53,8 +53,8 @@ function VirtualMCPItemContent({
         icon={virtualMcp.icon}
         name={virtualMcp.title}
         size="sm"
-        fallbackIcon={virtualMcp.fallbackIcon ?? <CpuChip02 />}
-        className="rounded-xl border border-stone-200/60 shadow-sm shrink-0 aspect-square"
+        fallbackIcon={virtualMcp.fallbackIcon ?? <Users03 />}
+        className="rounded-xl border border-border shadow-sm shrink-0 aspect-square"
       />
 
       {/* Text Content */}
@@ -276,7 +276,7 @@ export function VirtualMCPSelector({
                   icon={selected.icon}
                   name={selected.title}
                   size="xs"
-                  fallbackIcon={<CpuChip02 size={12} />}
+                  fallbackIcon={<Users03 size={12} />}
                   className="rounded-md shrink-0 aspect-square"
                 />
                 <span className="text-sm text-muted-foreground group-hover:text-foreground transition-colors truncate min-w-0 hidden sm:inline-block">

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -5,7 +5,7 @@ import {
   getWellKnownDecopilotAgent,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { ClockRewind, CpuChip02, Plus, X } from "@untitledui/icons";
+import { ClockRewind, Users03, Plus, X } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { ErrorBoundary } from "../error-boundary";
 import { Chat, useChat } from "./index";
@@ -151,7 +151,7 @@ function ChatPanelContent() {
                     icon={displayAgent.icon}
                     name={displayAgent.title}
                     size="lg"
-                    fallbackIcon={<CpuChip02 size={32} />}
+                    fallbackIcon={<Users03 size={32} />}
                     className="size-[60px]! rounded-[18px]!"
                   />
                   <h3 className="text-xl font-medium text-foreground">

--- a/apps/mesh/src/web/components/details/connection/settings-tab/connection-settings-form-ui.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/connection-settings-form-ui.tsx
@@ -32,7 +32,7 @@ import {
   CheckCircle,
   ChevronDown,
   Container,
-  CpuChip02,
+  Users03,
   Globe02,
   RefreshCcw01,
   Terminal,
@@ -98,7 +98,7 @@ function ConnectionFields({
         <div className="flex flex-col gap-2">
           <span className="text-sm font-medium">Type</span>
           <div className="flex items-center gap-2 h-10 px-3 border border-border rounded-lg bg-muted/50">
-            <CpuChip02 className="w-4 h-4 text-muted-foreground" />
+            <Users03 className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm">Virtual MCP</span>
           </div>
           <p className="text-xs text-muted-foreground">

--- a/apps/mesh/src/web/components/details/connection/settings-tab/connection-virtual-mcps-section.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/connection-virtual-mcps-section.tsx
@@ -4,7 +4,7 @@ import {
   type VirtualMCPEntity,
 } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
-import { CpuChip02, ChevronRight, Plus, Loading01 } from "@untitledui/icons";
+import { Users03, ChevronRight, Plus, Loading01 } from "@untitledui/icons";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 interface ConnectionVirtualMCPsSectionProps {
@@ -36,7 +36,7 @@ function VirtualMCPListItem({
         />
       ) : (
         <div className="w-8 h-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
-          <CpuChip02 size={16} className="text-primary" />
+          <Users03 size={16} className="text-primary" />
         </div>
       )}
       <span className="flex-1 text-sm font-medium text-foreground truncate">
@@ -120,7 +120,7 @@ function CreateVirtualMCPButton({
       {actions.create.isPending ? (
         <Loading01 size={20} className="animate-spin" />
       ) : (
-        <CpuChip02 size={20} />
+        <Users03 size={20} />
       )}
       Create an agent
     </Button>

--- a/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
@@ -69,7 +69,7 @@ import {
   Check,
   Code01,
   Copy01,
-  CpuChip02,
+  Users03,
   FlipBackward,
   InfoCircle,
   Lightbulb02,
@@ -567,7 +567,7 @@ function VirtualMCPSettingsTab({
                 name={form.watch("title") || "Agent"}
                 size="lg"
                 className="shrink-0 shadow-sm"
-                fallbackIcon={<CpuChip02 />}
+                fallbackIcon={<Users03 />}
               />
               <FormField
                 control={form.control}

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -19,7 +19,7 @@ import {
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { useVirtualMCPs } from "@decocms/mesh-sdk";
-import { ChevronRight, CpuChip02 } from "@untitledui/icons";
+import { ChevronRight, Users03 } from "@untitledui/icons";
 import { Suspense, useEffect, useRef, useState } from "react";
 
 /**
@@ -47,7 +47,7 @@ function AgentPreview({
       onClick={handleClick}
       className={cn(
         "flex flex-col items-center gap-3 p-2 rounded-lg",
-        "transition-colors hover:bg-accent/50",
+        "transition-colors hover:bg-accent/30",
         "cursor-pointer",
         "self-stretch",
       )}
@@ -56,7 +56,7 @@ function AgentPreview({
       <IntegrationIcon
         icon={agent.icon}
         name={agent.title}
-        fallbackIcon={<CpuChip02 size={20} />}
+        fallbackIcon={<Users03 size={20} />}
       />
       <p className="text-sm text-foreground text-center leading-tight line-clamp-2">
         {agent.title}
@@ -102,7 +102,7 @@ function SeeAllButton({
           type="button"
           className={cn(
             "flex flex-col items-center gap-3 p-2 rounded-lg",
-            "transition-colors hover:bg-accent/70",
+            "transition-colors hover:bg-accent/30",
             "cursor-pointer",
             "self-stretch",
           )}

--- a/apps/mesh/src/web/components/monitoring/analytics-top-agents.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-agents.tsx
@@ -6,7 +6,7 @@
 
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { CpuChip02 } from "@untitledui/icons";
+import { Users03 } from "@untitledui/icons";
 import {
   useMCPClient,
   useMCPToolCall,
@@ -233,7 +233,7 @@ function TopAgentsContent({ metricsMode }: TopAgentsContentProps) {
                   icon={virtualMcp.icon}
                   name={virtualMcp.title}
                   size="xs"
-                  fallbackIcon={<CpuChip02 />}
+                  fallbackIcon={<Users03 />}
                   className="shrink-0"
                 />
                 <span className="text-xs font-medium text-foreground truncate min-w-0 w-32">

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -6,10 +6,10 @@ import {
   BarChart10,
   Building02,
   Container,
-  CpuChip02,
   Home02,
   Settings01,
-  Users01,
+  Users03,
+  UserSquare,
   Zap,
 } from "@untitledui/icons";
 import { pluginRootSidebarItems } from "../index.tsx";
@@ -74,7 +74,7 @@ export function useProjectSidebarItems() {
     {
       key: "agents",
       label: "Agents",
-      icon: <CpuChip02 />,
+      icon: <Users03 />,
       onClick: () => navigate({ to: "/$org/agents", params: { org } }),
     },
     {
@@ -92,7 +92,7 @@ export function useProjectSidebarItems() {
     {
       key: "members",
       label: "Members",
-      icon: <Users01 />,
+      icon: <UserSquare />,
       onClick: () => navigate({ to: "/$org/members", params: { org } }),
     },
     {

--- a/apps/mesh/src/web/routes/orgs/agents.tsx
+++ b/apps/mesh/src/web/routes/orgs/agents.tsx
@@ -38,7 +38,7 @@ import {
   Eye,
   Trash01,
   Loading01,
-  CpuChip02,
+  Users03,
 } from "@untitledui/icons";
 import { useNavigate } from "@tanstack/react-router";
 import { Suspense, useReducer } from "react";
@@ -101,7 +101,7 @@ function OrgAgentsContent() {
           name={virtualMcp.title}
           size="sm"
           className="shrink-0 shadow-sm"
-          fallbackIcon={<CpuChip02 size={16} />}
+          fallbackIcon={<Users03 size={16} />}
         />
       ),
       cellClassName: "w-16 shrink-0",
@@ -284,7 +284,7 @@ function OrgAgentsContent() {
         <div className="flex-1 overflow-auto p-5">
           {virtualMcps.length === 0 ? (
             <EmptyState
-              image={<CpuChip02 size={36} className="text-muted-foreground" />}
+              image={<Users03 size={36} className="text-muted-foreground" />}
               title={listState.search ? "No agents found" : "No agents yet"}
               description={
                 listState.search
@@ -304,7 +304,7 @@ function OrgAgentsContent() {
                     icon: virtualMcp.icon,
                     status: virtualMcp.status,
                   }}
-                  fallbackIcon={<CpuChip02 />}
+                  fallbackIcon={<Users03 />}
                   onClick={() =>
                     navigate({
                       to: "/$org/agents/$agentId",
@@ -391,17 +391,13 @@ function OrgAgentsContent() {
           emptyState={
             listState.search ? (
               <EmptyState
-                image={
-                  <CpuChip02 size={36} className="text-muted-foreground" />
-                }
+                image={<Users03 size={36} className="text-muted-foreground" />}
                 title="No agents found"
                 description={`No agents match "${listState.search}"`}
               />
             ) : (
               <EmptyState
-                image={
-                  <CpuChip02 size={36} className="text-muted-foreground" />
-                }
+                image={<Users03 size={36} className="text-muted-foreground" />}
                 title="No agents yet"
                 description="Create an agent to aggregate tools from multiple Connections."
               />

--- a/apps/mesh/src/web/routes/orgs/home/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/page.tsx
@@ -24,11 +24,11 @@ import {
 } from "@decocms/mesh-sdk";
 import {
   ClockRewind,
-  CpuChip02,
   MessageChatSquare,
   Pin01,
   Plus,
   Share07,
+  Users03,
 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
@@ -180,7 +180,7 @@ function HomeContent() {
                 icon={displayAgent.icon}
                 name={displayAgent.title}
                 size="md"
-                fallbackIcon={<CpuChip02 size={20} />}
+                fallbackIcon={<Users03 size={20} />}
                 className="size-12 rounded-xl border border-stone-200/60 shadow-sm aspect-square transition-opacity duration-200"
               />
             </div>


### PR DESCRIPTION

<img width="1011" height="727" alt="Screenshot 2026-01-26 at 19 11 42" src="https://github.com/user-attachments/assets/d63b1209-d31a-4ae4-9e47-fb7ad8d1a584" />


- Updated the Agents List to display a compact view of agents with only icons and names.
- Introduced a new 'See All' button that opens a popover for selecting agents.
- Replaced the AgentCard component with AgentPreview for a cleaner UI.
- Enhanced the layout to accommodate more agents while maintaining clarity.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the Agents List into a compact grid and adds a “See All” popover to quickly browse and select agents. Shows more agents with a cleaner UI and faster selection.

- **New Features**
  - Compact grid with icon + name; shows up to 6 recently used agents.
  - “See All” button opens a searchable popover; search auto-focuses.
  - Clicking an agent updates the chat context (selectedVirtualMcp) immediately.

- **Refactors**
  - Replaced AgentCard with AgentPreview and removed connection badges.
  - Simplified grid and skeleton; dropped useConnections and connection mapping.
  - Updated default fallback icon to Users03 when an agent icon is missing.

<sup>Written for commit 35d7bc461e398bfd0bcaa746f100b88cf59b8388. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

