### PR TITLE
fix(event-bus): use connection creator as userId fallback for super u…

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -266,7 +266,10 @@ async function createMCPProxyDoNotUseDirectly(
 
     // Issue short-lived JWT with configuration permissions
     // JWT can be decoded directly by downstream to access payload
-    const userId = ctx.auth.user?.id ?? ctx.auth.apiKey?.userId;
+    const userId =
+      ctx.auth.user?.id ??
+      ctx.auth.apiKey?.userId ??
+      (superUser ? connection.created_by : undefined);
     if (!userId) {
       console.error("User ID required to issue configuration token");
       return;

--- a/apps/mesh/src/event-bus/notify.ts
+++ b/apps/mesh/src/event-bus/notify.ts
@@ -26,10 +26,7 @@ export function createNotifySubscriber(): NotifySubscriberFn {
       const ctx = await ContextFactory.create();
 
       // Create MCP proxy for the subscriber connection
-      const proxy = await dangerouslyCreateSuperUserMCPProxy(connectionId, {
-        ...ctx,
-        auth: { ...ctx.auth, user: { id: "notify-worker" } },
-      });
+      const proxy = await dangerouslyCreateSuperUserMCPProxy(connectionId, ctx);
 
       // Use the Event Subscriber binding - pass the whole proxy object
       // Same pattern as LanguageModelBinding.forClient(proxy) in models.ts


### PR DESCRIPTION
…ser proxies

Remove manual auth override in notify worker by falling back to connection.created_by when issuing configuration tokens for super user proxies. This ensures proper userId resolution without fake user IDs.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use connection.created_by as the userId fallback when issuing configuration tokens for super-user MCP proxies. Removes the manual "notify-worker" auth override so tokens resolve to real users.

- **Bug Fixes**
  - Proxy route now falls back to connection.created_by when superUser and no user/api key ID is present.
  - Notify subscriber no longer injects a fake user; passes the existing context through.

<sup>Written for commit 1b63c10ee230ffb451bfa6a26fb90733b77d820e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

