### PR TITLE
Add store app share route and improve login redirection

### DIFF
--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -72,6 +72,21 @@ const connectRoute = createRoute({
   component: lazyRouteComponent(() => import("./routes/connect.tsx")),
 });
 
+/**
+ * Store invite route - deep links to store apps without knowing the org slug
+ * After login, redirects to the user's first org and first registry
+ */
+const storeInviteRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/store/$appName",
+  component: lazyRouteComponent(() => import("./routes/store-invite.tsx")),
+  validateSearch: z.lazy(() =>
+    z.object({
+      serverName: z.string().optional(),
+    }),
+  ),
+});
+
 const shellLayout = createRoute({
   getParentRoute: () => rootRoute,
   id: "shell",
@@ -296,6 +311,7 @@ const routeTree = rootRoute.addChildren([
   betterAuthRoutes,
   oauthCallbackRoute,
   connectRoute,
+  storeInviteRoute,
 ]);
 
 const router = createRouter({

--- a/apps/mesh/src/web/layouts/required-auth-layout.tsx
+++ b/apps/mesh/src/web/layouts/required-auth-layout.tsx
@@ -1,6 +1,13 @@
-import { Navigate } from "@tanstack/react-router";
+import { Navigate, useRouterState } from "@tanstack/react-router";
 import { AuthLoading, SignedIn, SignedOut } from "@daveyplate/better-auth-ui";
 import { SplashScreen } from "@/web/components/splash-screen";
+
+function RedirectToLogin() {
+  const routerState = useRouterState();
+  const currentUrl = routerState.location.href;
+
+  return <Navigate to="/login" search={{ next: currentUrl }} replace />;
+}
 
 export default function RequiredAuthLayout({
   children,
@@ -16,7 +23,7 @@ export default function RequiredAuthLayout({
       <SignedIn>{children}</SignedIn>
 
       <SignedOut>
-        <Navigate to="/login" replace />
+        <RedirectToLogin />
       </SignedOut>
     </>
   );

--- a/apps/mesh/src/web/routes/store-invite.tsx
+++ b/apps/mesh/src/web/routes/store-invite.tsx
@@ -1,0 +1,64 @@
+import { Navigate, useParams, useSearch } from "@tanstack/react-router";
+import { AuthLoading, SignedIn, SignedOut } from "@daveyplate/better-auth-ui";
+import { SplashScreen } from "@/web/components/splash-screen";
+import { authClient } from "@/web/lib/auth-client";
+
+function RedirectToLogin({ appName }: { appName: string }) {
+  const search = useSearch({ strict: false });
+
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(search)) {
+    if (value !== undefined && value !== null) {
+      searchParams.set(key, String(value));
+    }
+  }
+  const searchString = searchParams.toString();
+  const encodedAppName = encodeURIComponent(appName);
+  const nextUrl = `/store/${encodedAppName}${searchString ? `?${searchString}` : ""}`;
+
+  return <Navigate to="/login" search={{ next: nextUrl }} replace />;
+}
+
+function StoreInviteRedirect() {
+  const { appName } = useParams({ strict: false }) as { appName: string };
+  const search = useSearch({ strict: false }) as Record<string, string>;
+  const { data: organizations, isPending } = authClient.useListOrganizations();
+
+  if (isPending) {
+    return <SplashScreen />;
+  }
+
+  const org = organizations?.[0];
+  if (!org) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <Navigate
+      to="/$org/store/$appName"
+      params={{ org: org.slug, appName }}
+      search={search}
+      replace
+    />
+  );
+}
+
+export default function StoreInviteRoute() {
+  const { appName } = useParams({ strict: false }) as { appName: string };
+
+  return (
+    <>
+      <AuthLoading>
+        <SplashScreen />
+      </AuthLoading>
+
+      <SignedIn>
+        <StoreInviteRedirect />
+      </SignedIn>
+
+      <SignedOut>
+        <RedirectToLogin appName={appName} />
+      </SignedOut>
+    </>
+  );
+}


### PR DESCRIPTION
- Introduced a new route for store invites that allows deep linking to store apps without needing the organization slug. After login, users are redirected to their first organization and registry.
- Enhanced the RequiredAuthLayout component to use a dedicated RedirectToLogin function, which captures the current URL and redirects users to the login page with a 'next' parameter for seamless navigation after authentication.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shareable /store/:appName route that deep-links to a store app without an org slug. Improves login redirects by preserving the target URL via a next param.

- **New Features**
  - New /store/$appName route that preserves search params and, after sign-in, redirects to the user’s first organization at /$org/store/$appName.
  - Signed-out users hitting store links are sent to /login with next pointing back to the store deep link.
  - RequiredAuthLayout now uses RedirectToLogin to send users to /login?next=currentUrl across protected pages.

<sup>Written for commit 995ac740a1dc602b5ae173558f5c2383a5682b4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

