### PR TITLE
Enhance OAuth Flow: Implement Pre-Opened Popup for Authentication

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
@@ -16,7 +16,7 @@ import {
   type StdioConnectionParameters,
   type HttpConnectionParameters,
 } from "@decocms/mesh-sdk";
-import { authenticateMcp } from "@/web/lib/mcp-oauth";
+import { authenticateMcp, openOAuthPopup } from "@/web/lib/mcp-oauth";
 import { KEYS } from "@/web/lib/query-keys";
 import { PinToSidebarButton } from "@/web/components/pin-to-sidebar-button";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -507,10 +507,22 @@ function SettingsTabContentImpl(props: SettingsTabContentImplProps) {
   };
 
   const handleAuthenticate = async () => {
+    // Open popup synchronously in click handler to avoid popup blocker (Safari/iOS)
+    const popupWindow = openOAuthPopup();
+    if (!popupWindow) {
+      toast.error(
+        "Popup was blocked. Please allow popups for this site and try again.",
+      );
+      return;
+    }
+
     const { token, tokenInfo, error } = await authenticateMcp({
       connectionId: connection.id,
+      popupWindow,
     });
     if (error || !token) {
+      // Close the popup if authentication failed
+      popupWindow.close();
       toast.error(`Authentication failed: ${error}`);
       return;
     }

--- a/apps/mesh/src/web/lib/mcp-oauth.ts
+++ b/apps/mesh/src/web/lib/mcp-oauth.ts
@@ -9,6 +9,7 @@ export {
   authenticateMcp,
   handleOAuthCallback,
   isConnectionAuthenticated,
+  openOAuthPopup,
   type McpOAuthProviderOptions,
   type OAuthTokenInfo,
   type AuthenticateMcpResult,

--- a/packages/mesh-plugin-user-sandbox/client/components/connect-flow.tsx
+++ b/packages/mesh-plugin-user-sandbox/client/components/connect-flow.tsx
@@ -18,7 +18,11 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { Toaster } from "@deco/ui/components/sonner.tsx";
-import { authenticateMcp, isConnectionAuthenticated } from "@decocms/mesh-sdk";
+import {
+  authenticateMcp,
+  isConnectionAuthenticated,
+  openOAuthPopup,
+} from "@decocms/mesh-sdk";
 import { KEYS } from "../lib/query-keys";
 
 // ============================================================================
@@ -191,6 +195,19 @@ export function ConnectFlow({
   const handleConnect = async (app: RequiredApp) => {
     setConfiguringApp(app.app_name);
 
+    // Pre-open popup window synchronously in click handler to avoid popup blocker (Safari/iOS)
+    // We'll close it if OAuth isn't needed, or use it if it is
+    const isRemoteConnection =
+      app.connection_type === "HTTP" ||
+      app.connection_type === "SSE" ||
+      app.connection_type === "Websocket";
+
+    let popupWindow: Window | null = null;
+    if (isRemoteConnection) {
+      popupWindow = openOAuthPopup();
+      // Note: we don't throw if popup is blocked here - OAuth might not be needed
+    }
+
     try {
       // Step 1: Provision the connection
       const provisionRes = await fetch(
@@ -213,10 +230,6 @@ export function ConnectFlow({
       // Step 2: Check if connection needs authentication
       // For HTTP/SSE connections, probe the connection to see if it requires auth
       // OAuth discovery happens automatically - we don't need pre-configured oauth_config
-      const isRemoteConnection =
-        app.connection_type === "HTTP" ||
-        app.connection_type === "SSE" ||
-        app.connection_type === "Websocket";
 
       if (isRemoteConnection) {
         // Probe the connection to check if it requires authentication
@@ -228,12 +241,20 @@ export function ConnectFlow({
 
         // If not authenticated and supports OAuth, trigger OAuth flow
         if (!authStatus.isAuthenticated && authStatus.supportsOAuth) {
+          // Check if popup was blocked
+          if (!popupWindow) {
+            throw new Error(
+              "Popup was blocked. Please allow popups for this site and try again.",
+            );
+          }
+
           toast.info("Opening authentication window...");
 
           const authResult = await authenticateMcp({
             connectionId,
             clientName: app.title,
             timeout: 300000, // 5 minute timeout for OAuth
+            popupWindow,
           });
 
           if (authResult.error) {
@@ -267,6 +288,9 @@ export function ConnectFlow({
               );
             }
           }
+        } else {
+          // OAuth not needed, close the pre-opened popup
+          popupWindow?.close();
         }
         // If not authenticated but doesn't support OAuth, proceed anyway
         // The user may need to configure manually
@@ -280,6 +304,8 @@ export function ConnectFlow({
 
       toast.success(`${app.title} connected successfully`);
     } catch (err) {
+      // Close popup on error
+      popupWindow?.close();
       console.error("Connection error:", err);
       const error = err instanceof Error ? err : new Error("Failed to connect");
       toast.error(error.message);

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -104,6 +104,7 @@ export {
   authenticateMcp,
   handleOAuthCallback,
   isConnectionAuthenticated,
+  openOAuthPopup,
   type McpOAuthProviderOptions,
   type OAuthTokenInfo,
   type AuthenticateMcpResult,

--- a/packages/mesh-sdk/src/lib/mcp-oauth.ts
+++ b/packages/mesh-sdk/src/lib/mcp-oauth.ts
@@ -68,6 +68,12 @@ export interface McpOAuthProviderOptions {
   scope?: string | string[];
   /** Window mode: "popup" (default) or "tab" (for devices that block popups) */
   windowMode?: OAuthWindowMode;
+  /**
+   * Pre-opened popup window. Pass this to avoid popup blockers in Safari.
+   * The popup should be opened synchronously in the click handler before calling authenticateMcp.
+   * Example: const popup = window.open('about:blank', 'mcp-oauth', 'popup=yes,width=600,height=700');
+   */
+  popupWindow?: Window | null;
 }
 
 /**
@@ -79,6 +85,7 @@ class McpOAuthProvider implements OAuthClientProvider {
   private _clientMetadata: OAuthClientMetadata;
   private _redirectUrl: string;
   private _windowMode: OAuthWindowMode;
+  private _popupWindow: Window | null;
 
   // In-memory storage for OAuth flow data
   private _state: string | null = null;
@@ -91,6 +98,7 @@ class McpOAuthProvider implements OAuthClientProvider {
     this._redirectUrl =
       options.callbackUrl ?? `${window.location.origin}/oauth/callback`;
     this._windowMode = options.windowMode ?? "popup";
+    this._popupWindow = options.popupWindow ?? null;
 
     // Build scope string if provided
     const scopeStr = options.scope
@@ -157,7 +165,15 @@ class McpOAuthProvider implements OAuthClientProvider {
         window.location.href = authorizationUrl.toString();
       }
     } else {
-      // Open in popup (default)
+      // Check if we have a pre-opened popup (avoids popup blocker in Safari)
+      if (this._popupWindow && !this._popupWindow.closed) {
+        // Navigate the pre-opened popup to the auth URL
+        this._popupWindow.location.href = authorizationUrl.toString();
+        this._popupWindow.focus();
+        return;
+      }
+
+      // Open in popup (default) - may be blocked if not in direct click handler
       const width = 600;
       const height = 700;
       const left = window.screenX + (window.outerWidth - width) / 2;
@@ -205,6 +221,38 @@ class McpOAuthProvider implements OAuthClientProvider {
 }
 
 /**
+ * Default popup window dimensions and features
+ */
+const POPUP_WIDTH = 600;
+const POPUP_HEIGHT = 700;
+
+/**
+ * Open a popup window for OAuth authentication.
+ * Call this synchronously in your click handler to avoid popup blockers.
+ *
+ * @returns The popup window, or null if blocked
+ * @example
+ * const handleAuth = () => {
+ *   const popup = openOAuthPopup();
+ *   if (!popup) {
+ *     alert('Please allow popups for this site');
+ *     return;
+ *   }
+ *   await authenticateMcp({ connectionId, popupWindow: popup });
+ * };
+ */
+export function openOAuthPopup(): Window | null {
+  const left = window.screenX + (window.outerWidth - POPUP_WIDTH) / 2;
+  const top = window.screenY + (window.outerHeight - POPUP_HEIGHT) / 2;
+
+  return window.open(
+    "about:blank",
+    "mcp-oauth",
+    `width=${POPUP_WIDTH},height=${POPUP_HEIGHT},left=${left},top=${top},popup=yes`,
+  );
+}
+
+/**
  * Full OAuth token info for persistence
  */
 export interface OAuthTokenInfo {
@@ -248,6 +296,7 @@ interface FullTokenResult {
  * @param params.timeout - Timeout in ms (default 120000)
  * @param params.scope - OAuth scopes to request
  * @param params.windowMode - "popup" (default) or "tab" (for devices that block popups)
+ * @param params.popupWindow - Pre-opened popup window to avoid popup blockers (open synchronously in click handler)
  */
 export async function authenticateMcp(params: {
   connectionId: string;
@@ -261,6 +310,14 @@ export async function authenticateMcp(params: {
   scope?: string | string[];
   /** Window mode: "popup" (default) or "tab" (for devices that block popups). Tab mode uses localStorage for cross-tab communication. */
   windowMode?: OAuthWindowMode;
+  /**
+   * Pre-opened popup window to avoid popup blockers in Safari and other browsers.
+   * Open the popup synchronously in the click handler before calling authenticateMcp:
+   * @example
+   * const popup = window.open('about:blank', 'mcp-oauth', 'popup=yes,width=600,height=700');
+   * await authenticateMcp({ connectionId, popupWindow: popup });
+   */
+  popupWindow?: Window | null;
 }): Promise<AuthenticateMcpResult> {
   const baseUrl = params.meshUrl ?? window.location.origin;
   const serverUrl = new URL(`/mcp/${params.connectionId}`, baseUrl);
@@ -271,6 +328,7 @@ export async function authenticateMcp(params: {
     callbackUrl: params.callbackUrl,
     scope: params.scope,
     windowMode: params.windowMode,
+    popupWindow: params.popupWindow,
   });
 
   try {


### PR DESCRIPTION
- Added `openOAuthPopup` function to facilitate synchronous popup opening in click handlers, reducing the likelihood of popup blockers, especially in Safari/iOS.
- Updated `authenticateMcp` to accept a pre-opened popup window, allowing for smoother authentication experiences.
- Modified `SettingsTabContentImpl` and `ConnectFlow` components to utilize the new popup handling, ensuring popups are managed correctly during the authentication process.
- Included error handling for blocked popups and ensured proper closure of popups on authentication failure or when OAuth is not needed.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the OAuth flow by using a pre-opened popup to avoid browser blockers (especially Safari/iOS). Updates Settings and Connect flows for smoother auth with better error handling and cleanup.

- **New Features**
  - Added openOAuthPopup in mesh-sdk (and web) to synchronously open an auth popup; exported via index.
  - authenticateMcp now accepts popupWindow and navigates it when provided; falls back to opening a new popup/tab if needed.
  - Updated SettingsTabContentImpl and ConnectFlow to pre-open the popup in click handlers, pass it to authenticateMcp, and close it on failure or when OAuth isn’t needed; shows a clear toast if the popup was blocked.

- **Migration**
  - No breaking changes. For best Safari compatibility, pre-open a popup in the click handler and pass it as popupWindow to authenticateMcp.

<sup>Written for commit 7140bd8d2a52ea4577224190ad7a6b6d90b0ca42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

