### PR TITLE
Revert "Enhance OAuth Flow: Implement Pre-Opened Popup for Authentication"

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
@@ -16,7 +16,7 @@ import {
   type StdioConnectionParameters,
   type HttpConnectionParameters,
 } from "@decocms/mesh-sdk";
-import { authenticateMcp, openOAuthPopup } from "@/web/lib/mcp-oauth";
+import { authenticateMcp } from "@/web/lib/mcp-oauth";
 import { KEYS } from "@/web/lib/query-keys";
 import { PinToSidebarButton } from "@/web/components/pin-to-sidebar-button";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -507,22 +507,10 @@ function SettingsTabContentImpl(props: SettingsTabContentImplProps) {
   };
 
   const handleAuthenticate = async () => {
-    // Open popup synchronously in click handler to avoid popup blocker (Safari/iOS)
-    const popupWindow = openOAuthPopup();
-    if (!popupWindow) {
-      toast.error(
-        "Popup was blocked. Please allow popups for this site and try again.",
-      );
-      return;
-    }
-
     const { token, tokenInfo, error } = await authenticateMcp({
       connectionId: connection.id,
-      popupWindow,
     });
     if (error || !token) {
-      // Close the popup if authentication failed
-      popupWindow.close();
       toast.error(`Authentication failed: ${error}`);
       return;
     }

--- a/apps/mesh/src/web/lib/mcp-oauth.ts
+++ b/apps/mesh/src/web/lib/mcp-oauth.ts
@@ -9,7 +9,6 @@ export {
   authenticateMcp,
   handleOAuthCallback,
   isConnectionAuthenticated,
-  openOAuthPopup,
   type McpOAuthProviderOptions,
   type OAuthTokenInfo,
   type AuthenticateMcpResult,

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -104,7 +104,6 @@ export {
   authenticateMcp,
   handleOAuthCallback,
   isConnectionAuthenticated,
-  openOAuthPopup,
   type McpOAuthProviderOptions,
   type OAuthTokenInfo,
   type AuthenticateMcpResult,


### PR DESCRIPTION
Reverts decocms/mesh#2336

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the pre-opened OAuth popup change and restores the standard OAuth flow. The SDK no longer supports pre-opening windows; standard popup/tab behavior is used again.

- **Refactors**
  - Removed openOAuthPopup and popupWindow support from mesh-sdk OAuth.
  - Updated SettingsTab and ConnectFlow to call authenticateMcp without pre-opening a window.
  - Kept windowMode: "popup" | "tab" for auth window behavior.

- **Migration**
  - Stop using openOAuthPopup and do not pass popupWindow to authenticateMcp.
  - If popups are blocked, call authenticateMcp with windowMode: "tab".

<sup>Written for commit 7aa26d0feac054da1b9525c67aaf6d32f2dd83f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

