### PR TITLE
fix(oauth-proxy): handle ClickHouse-style servers returning wrong metadata format

### DIFF
--- a/apps/mesh/src/api/routes/oauth-proxy.auth-detection.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.auth-detection.test.ts
@@ -71,4 +71,105 @@ describe("oauth-proxy auth detection", () => {
       global.fetch = originalFetch;
     }
   });
+
+  it("claims OAuth support when origin returns 401 without WWW-Authenticate but has OAuth metadata (ClickHouse-style)", async () => {
+    // ClickHouse returns 401 without WWW-Authenticate header but has OAuth metadata
+    // at /.well-known/oauth-authorization-server
+    const originalFetch = global.fetch;
+    try {
+      let callCount = 0;
+      global.fetch = mock((url: string) => {
+        callCount++;
+        // First call: MCP endpoint returns 401 without WWW-Authenticate
+        if (callCount === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: "Authentication required" }), {
+              status: 401,
+              headers: {
+                "Content-Type": "application/json",
+                // No WWW-Authenticate header!
+              },
+            }),
+          );
+        }
+        // Second call: OAuth metadata endpoint returns valid metadata
+        if ((url as string).includes("oauth-authorization-server")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                issuer: "https://mcp.clickhouse.cloud",
+                authorization_endpoint:
+                  "https://mcp.clickhouse.cloud/authorize",
+                token_endpoint: "https://mcp.clickhouse.cloud/token",
+                registration_endpoint: "https://mcp.clickhouse.cloud/register",
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+        }
+        return Promise.resolve(new Response("Not found", { status: 404 }));
+      }) as unknown as typeof fetch;
+
+      const res = await handleAuthError({
+        error: { status: 401, message: "401 Unauthorized" } as any,
+        reqUrl: new URL("http://localhost:3000/mcp/conn_123"),
+        connectionId: "conn_123",
+        connectionUrl: "https://mcp.clickhouse.cloud/mcp",
+        headers: {},
+      });
+
+      expect(res).toBeTruthy();
+      expect(res!.status).toBe(401);
+      // Should have WWW-Authenticate header indicating OAuth is supported
+      expect(res!.headers.get("WWW-Authenticate")).toBeTruthy();
+      expect(res!.headers.get("WWW-Authenticate") ?? "").toContain(
+        "resource_metadata=",
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it("does not claim OAuth support when origin returns 401 without WWW-Authenticate and no OAuth metadata", async () => {
+    const originalFetch = global.fetch;
+    try {
+      let callCount = 0;
+      global.fetch = mock(() => {
+        callCount++;
+        // First call: MCP endpoint returns 401 without WWW-Authenticate
+        if (callCount === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: "Unauthorized" }), {
+              status: 401,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }),
+          );
+        }
+        // Second call: No OAuth metadata
+        return Promise.resolve(new Response("Not found", { status: 404 }));
+      }) as unknown as typeof fetch;
+
+      const res = await handleAuthError({
+        error: { status: 401, message: "401 Unauthorized" } as any,
+        reqUrl: new URL("http://localhost:3000/mcp/conn_123"),
+        connectionId: "conn_123",
+        connectionUrl: "https://api.example.com/mcp",
+        headers: {},
+      });
+
+      expect(res).toBeTruthy();
+      expect(res!.status).toBe(401);
+      // Should NOT have WWW-Authenticate header
+      expect(res!.headers.get("WWW-Authenticate")).toBeNull();
+      const body = await res!.json();
+      expect(body.error).toBe("unauthorized");
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes OAuth authentication failures with ClickHouse MCP server
- Detects when origin servers return Authorization Server Metadata (RFC 8414) at the Protected Resource Metadata endpoint instead of proper Protected Resource Metadata (RFC 9728)
- Generates clean synthetic metadata when this malformed response is detected, ensuring MCP SDK clients receive the expected format

## Problem

ClickHouse's `/.well-known/oauth-protected-resource` endpoint returns:
```json
{
  "issuer": "https://mcp.clickhouse.cloud",
  "authorization_endpoint": "https://mcp.clickhouse.cloud/authorize",
  "token_endpoint": "https://mcp.clickhouse.cloud/token",
  ...
}
```

But the MCP spec (RFC 9728) expects:
```json
{
  "resource": "https://mcp.clickhouse.cloud/mcp",
  "authorization_servers": ["https://mcp.clickhouse.cloud"],
  "bearer_methods_supported": ["header"],
  "scopes_supported": ["*"]
}
```

Previously, we spread the original response which polluted it with unexpected fields (`issuer`, `authorization_endpoint`, etc.) that could confuse MCP SDK clients.

## Test plan

- [x] Added unit test for ClickHouse-style servers
- [x] All 35 oauth-proxy unit tests pass
- [x] Verified ClickHouse returns auth server metadata at protected resource endpoint via curl

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth failures with ClickHouse-style MCP servers by normalizing malformed protected resource metadata and detecting OAuth support when 401 responses lack WWW-Authenticate. We synthesize clean RFC 9728 resource metadata and a standard WWW-Authenticate header so MCP clients can authenticate reliably.

- **Bug Fixes**
  - Detect auth server metadata (issuer present, no resource) at the protected resource endpoint.
  - Generate synthetic protected resource metadata pointing to our proxy; preserve scopes or default to ["*"]; set bearer_methods_supported to ["header"].
  - When 401 lacks WWW-Authenticate, check /.well-known/oauth-authorization-server and return a synthetic WWW-Authenticate if OAuth metadata exists.
  - Added tests for ClickHouse-style metadata and fallback auth detection.

<sup>Written for commit 94f12d74733c94e5f693c16b7ecb3387ac989b34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

