### PR TITLE
Enhance OAuth Flow: Implement Fallback for Blocked Popups

### DIFF
--- a/packages/mesh-sdk/src/lib/mcp-oauth.ts
+++ b/packages/mesh-sdk/src/lib/mcp-oauth.ts
@@ -170,9 +170,13 @@ class McpOAuthProvider implements OAuthClientProvider {
       );
 
       if (!popup) {
-        throw new Error(
-          "OAuth popup was blocked. Please allow popups for this site and try again.",
-        );
+        // Popup was blocked - fallback to new tab (uses localStorage for communication)
+        const tab = window.open(authorizationUrl.toString(), "_blank");
+        if (!tab) {
+          // Last resort: redirect current window
+          // Note: This will navigate away from the current page
+          window.location.href = authorizationUrl.toString();
+        }
       }
     }
   }


### PR DESCRIPTION
- Updated McpOAuthProvider to handle blocked popups by opening the authorization URL in a new tab or redirecting the current window as a last resort.
- Improved user experience by ensuring authentication can proceed even when popups are blocked.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the OAuth login resilient to blocked popups by falling back to a new tab, and finally a full-page redirect if needed. This ensures authentication can proceed under strict popup settings.

- **Bug Fixes**
  - If the popup is blocked, open the authorization URL in a new tab.
  - If the new tab is blocked, redirect the current window as a last resort.

<sup>Written for commit 38f1e3b23753df2cfdf02d646a5a0a7e260c16b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

