### PR TITLE
[chore](ci): add mesh-sdk to release workflow paths

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - "apps/mesh/**"
       - "packages/mesh-plugin-*/**"
+      - "packages/mesh-sdk/**"
   workflow_dispatch:
     inputs:
       deploy_to_production:


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the GitHub Actions release workflow to include packages/mesh-sdk/** in the monitored paths, so changes to the SDK trigger the release pipeline. Prevents missed releases when mesh-sdk is updated.

<sup>Written for commit 72a7e5e4b9bca2eafacaf55c833ad9e2a319af06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

