### PR TITLE
Chore(mcp auth)/handle blocked redirect

### DIFF
--- a/packages/mesh-sdk/src/lib/mcp-oauth.ts
+++ b/packages/mesh-sdk/src/lib/mcp-oauth.ts
@@ -274,6 +274,10 @@ export async function authenticateMcp(params: {
     windowMode: params.windowMode,
   });
 
+  // Object to hold the abort function - using an object wrapper so TypeScript
+  // properly tracks mutations inside closures
+  const oauthAbort: { fn: ((error: Error) => void) | null } = { fn: null };
+
   try {
     // Wait for OAuth callback message from popup and handle token exchange
     // Uses both postMessage (primary) and localStorage (fallback for when opener is lost)
@@ -299,6 +303,14 @@ export async function authenticateMcp(params: {
           } catch {
             // Ignore storage errors
           }
+        };
+
+        // Expose abort function so we can clean up if auth() throws
+        oauthAbort.fn = (error: Error) => {
+          if (resolved) return;
+          resolved = true;
+          cleanup();
+          reject(error);
         };
 
         const processCallback = async (data: {
@@ -409,6 +421,10 @@ export async function authenticateMcp(params: {
       },
     );
 
+    // Attach a no-op catch to prevent unhandled rejection if auth() throws
+    // (we'll abort the promise properly in the catch block, but this is a safety net)
+    oauthCompletePromise.catch(() => {});
+
     // Start the auth flow
     const result: AuthResult = await auth(provider, { serverUrl });
 
@@ -451,6 +467,11 @@ export async function authenticateMcp(params: {
       error: null,
     };
   } catch (error) {
+    // Abort the OAuth promise to trigger cleanup (clear timeout, remove event listeners)
+    // This prevents unhandled promise rejections and lingering listeners
+    if (oauthAbort.fn) {
+      oauthAbort.fn(error instanceof Error ? error : new Error(String(error)));
+    }
     return {
       token: null,
       tokenInfo: null,


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved MCP OAuth by throwing explicit errors when popups or tabs are blocked, and added cleanup to prevent unhandled rejections. This avoids state loss and lets the app handle the flow safely.

- **Refactors**
  - Throw explicit errors when tab or popup opening is blocked.
  - Removed fallback redirect to the current window.
  - Added an abort function to clean up timeouts/listeners and prevent unhandled promise rejections.

- **Migration**
  - Catch these errors in the OAuth flow and show a message asking users to allow popups or try again.

<sup>Written for commit 4c6ac041bacb9e1ef60c063aaa7ea510836b0741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

