### PR TITLE
docs(proxy): add TODO comment for userId fallback handling in MCP proxy

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -266,6 +266,11 @@ async function createMCPProxyDoNotUseDirectly(
 
     // Issue short-lived JWT with configuration permissions
     // JWT can be decoded directly by downstream to access payload
+    // TODO: The superUser fallback to connection.created_by is a workaround for background
+    // processes (e.g., event-triggered handlers) that need a userId but aren't acting as a
+    // real user. This causes monitoring to incorrectly attribute actions to the connection
+    // creator. Better solution: create a dedicated "Decopilot" service user per organization
+    // for automated actions, so they're properly distinguished from real user activity.
     const userId =
       ctx.auth.user?.id ??
       ctx.auth.apiKey?.userId ??


### PR DESCRIPTION
- Added a TODO comment explaining the current workaround for background processes needing a userId, which incorrectly attributes actions to the connection creator. Suggested creating a dedicated "Decopilot" service user for better distinction between automated and real user activity.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a TODO in the MCP proxy to document the current userId fallback (superUser → connection.created_by) used by background tasks. Highlights the misattribution risk in monitoring and recommends creating a per‑org “Decopilot” service user to separate automated from human activity.

<sup>Written for commit b1ac1986bb0d899ffcef9cea5e1b1672a12fe0d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

