### PR TITLE
[chore]: Change aggregator error to warn

### DIFF
--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -56,7 +56,7 @@ async function createProxyMap(
         const proxy = await ctx.createMCPProxy(connection);
         return [connection.id, proxy] as const;
       } catch (error) {
-        console.error(
+        console.warn(
           `[aggregator] Failed to create proxy for connection ${connection.id}:`,
           error,
         );

--- a/apps/mesh/src/tools/code-execution/utils.ts
+++ b/apps/mesh/src/tools/code-execution/utils.ts
@@ -141,7 +141,7 @@ async function loadToolsFromConnections(
           proxy,
         };
       } catch (error) {
-        console.error(
+        console.warn(
           `[code-execution] Failed to create proxy for connection ${connection.id}:`,
           error,
         );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Downgraded logging from error to warn when proxy creation fails in aggregator and code-execution paths. This reduces noisy error logs and better reflects that the failure is non-critical.

<sup>Written for commit d6dcd51a19e9abb40eb4c549cee5437ad7bc9d3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

