### PR TITLE
Refactor decopilot model provider and request validation

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/model-provider.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-provider.ts
@@ -19,15 +19,15 @@ export async function createModelProviderFromProxy(
   config: {
     modelId: string;
     connectionId: string;
-    cheapModelId?: string | null;
+    fastId?: string | null;
   },
 ): Promise<ModelProvider> {
   const llmBinding = LanguageModelBinding.forClient(toServerClient(proxy));
 
   const llmProvider = createLLMProvider(llmBinding);
   const model = llmProvider.languageModel(config.modelId);
-  const cheapModel = config.cheapModelId
-    ? llmProvider.languageModel(config.cheapModelId)
+  const cheapModel = config.fastId
+    ? llmProvider.languageModel(config.fastId)
     : undefined;
 
   return {

--- a/apps/mesh/src/api/routes/decopilot/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/schemas.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from "zod";
+import { DEFAULT_WINDOW_SIZE } from "./constants";
 
 const UIMessageSchema = z.looseObject({
   id: z.string().optional(),
@@ -14,7 +15,7 @@ const UIMessageSchema = z.looseObject({
 });
 
 const MemoryConfigSchema = z.object({
-  windowSize: z.number().optional(),
+  windowSize: z.number().default(DEFAULT_WINDOW_SIZE),
   threadId: z.string(),
 });
 
@@ -25,6 +26,11 @@ export const StreamRequestSchema = z.object({
     .object({
       id: z.string(),
       connectionId: z.string(),
+      fastId: z
+        .string()
+        .optional()
+        .nullable()
+        .describe("ID of a fast/cheap model for background operations"),
       capabilities: z
         .object({
           vision: z.boolean().optional(),
@@ -54,7 +60,7 @@ export const StreamRequestSchema = z.object({
     .loose(),
   agent: z.object({ id: z.string() }).loose(),
   stream: z.boolean().optional(),
-  temperature: z.number().optional(),
+  temperature: z.number().default(0.5),
   thread_id: z.string().optional(),
 });
 

--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -179,7 +179,7 @@ const useModelState = (
   const [modelState, setModelState] = useLocalStorage<{
     id: string;
     connectionId: string;
-    cheapModelId?: string | null;
+    fastId?: string | null;
   } | null>(LOCALSTORAGE_KEYS.chatSelectedModel(locator), null);
 
   // Determine connectionId to use (from stored selection or first available)
@@ -212,7 +212,7 @@ const useModelState = (
           limits: selectedModel.limits,
           capabilities: selectedModel.capabilities,
           connectionId: modelsConnection.id,
-          cheapModelId: cheapestModel?.id,
+          fastId: cheapestModel?.id,
         }
       : null;
 
@@ -692,7 +692,6 @@ export function ChatProvider({ children }: PropsWithChildren) {
       tiptapDoc,
       created_at: new Date().toISOString(),
       thread_id: activeThreadId,
-      cheapModelId: selectedModel.cheapModelId,
       agent: {
         id: selectedVirtualMcp?.id ?? decopilotId,
       },
@@ -715,6 +714,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
           text: selectedModel.capabilities?.includes("text") ?? undefined,
           tools: selectedModel.capabilities?.includes("tools") ?? undefined,
         },
+        fastId: selectedModel.fastId,
       },
     };
 

--- a/apps/mesh/src/web/components/chat/types.ts
+++ b/apps/mesh/src/web/components/chat/types.ts
@@ -8,6 +8,7 @@ import type { UIMessage } from "ai";
 export interface ChatModelConfig {
   id: string;
   connectionId: string;
+  fastId?: string | null;
   provider?: string | null;
   limits?: {
     contextWindow?: number;
@@ -51,7 +52,7 @@ export type TiptapNode = JSONContent;
 // ============================================================================
 
 export interface Metadata {
-  cheapModelId?: string | null;
+  fastId?: string | null;
   reasoning_start_at?: string | Date;
   reasoning_end_at?: string | Date;
   model?: ChatModelConfig;


### PR DESCRIPTION
- Renamed `cheapModelId` to `fastId` in model provider and related components for clarity.
- Updated request validation to streamline data handling by spreading parsed results.
- Set default values for `windowSize` and `temperature` in schemas to improve consistency.
- Adjusted imports and removed unused types to clean up the codebase.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored Decopilot model provider and request validation to simplify payloads and standardize defaults. Renames cheapModelId to fastId and sets schema defaults for temperature and memory window size.

- **Refactors**
  - Renamed cheapModelId to fastId across provider, schemas, and chat types/context.
  - Validation now returns the parsed schema directly (removed custom ValidatedRequest).
  - Routes derive windowSize and threadId from memory config or thread_id.
  - Model provider uses model.fastId instead of message metadata.
  - Set defaults: temperature = 0.5, memory.windowSize = DEFAULT_WINDOW_SIZE; minor import/type cleanup.

- **Migration**
  - If clients send a fast/cheap model, pass it as model.fastId; stop sending cheapModelId in message metadata.
  - Review any code relying on previous temperature/windowSize defaults.

<sup>Written for commit 83deba7a51a453541c4a3c61a95e2e2cbf743d5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

