### PR TITLE
fix: slash mcp route missing id

### DIFF
--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -14,7 +14,7 @@
  * - Supports exclusion strategy for inverse tool selection
  */
 
-import { createServerFromClient } from "@decocms/mesh-sdk";
+import { createServerFromClient, getDecopilotId } from "@decocms/mesh-sdk";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
@@ -62,12 +62,18 @@ export async function handleVirtualMcpRequest(
             .then((org) => org?.id)
         : null;
 
-    if (!virtualMcpId) {
+    const virtualId = virtualMcpId
+      ? virtualMcpId
+      : organizationId
+        ? getDecopilotId(organizationId)
+        : null;
+
+    if (!virtualId) {
       return c.json({ error: "Agent ID or organization ID is required" }, 400);
     }
 
     const virtualMcp = await ctx.storage.virtualMcps.findById(
-      virtualMcpId,
+      virtualId,
       organizationId ?? undefined,
     );
 


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /mcp route to correctly resolve the virtual MCP ID. If no agent ID is provided, it now derives a Decopilot ID from the organization ID to avoid 400 errors.

- **Bug Fixes**
  - Added getDecopilotId fallback to compute the virtual ID when only organization ID is provided.
  - Error now triggers only when both agent ID and organization ID are missing.

<sup>Written for commit 826e2511df0b64c98aca45adbffe4800917e5351. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

