### PR TITLE
fix: error boundary reset on select other

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/dependency-selection-dialog.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/dependency-selection-dialog.tsx
@@ -454,7 +454,11 @@ function ConnectionDetailsContent({
   activeTab: "tools" | "resources" | "prompts";
   selectedId: string;
   formData: FormData;
-  toggleTool: (connId: string, toolName: string, allToolNames: string[]) => void;
+  toggleTool: (
+    connId: string,
+    toolName: string,
+    allToolNames: string[],
+  ) => void;
   toggleResource: (
     connId: string,
     name: string,
@@ -505,11 +509,7 @@ function ConnectionDetailsContent({
           className="flex-1 flex flex-col overflow-hidden"
         >
           <TabsList variant="underline" className="shrink-0 px-6">
-            <TabsTrigger
-              value="tools"
-              variant="underline"
-              className="gap-2"
-            >
+            <TabsTrigger value="tools" variant="underline" className="gap-2">
               <Tool01 size={16} />
               Tools
             </TabsTrigger>
@@ -521,20 +521,13 @@ function ConnectionDetailsContent({
               <CubeOutline size={16} />
               Resources
             </TabsTrigger>
-            <TabsTrigger
-              value="prompts"
-              variant="underline"
-              className="gap-2"
-            >
+            <TabsTrigger value="prompts" variant="underline" className="gap-2">
               <File02 size={16} />
               Prompts
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent
-            value="tools"
-            className="flex-1 overflow-hidden mt-0"
-          >
+          <TabsContent value="tools" className="flex-1 overflow-hidden mt-0">
             <ErrorBoundary
               fallback={createMethodNotFoundFallback(
                 "Tools not supported by this server",
@@ -589,10 +582,7 @@ function ConnectionDetailsContent({
             </ErrorBoundary>
           </TabsContent>
 
-          <TabsContent
-            value="prompts"
-            className="flex-1 overflow-hidden mt-0"
-          >
+          <TabsContent value="prompts" className="flex-1 overflow-hidden mt-0">
             <ErrorBoundary
               fallback={createMethodNotFoundFallback(
                 "Prompts not supported by this server",


### PR DESCRIPTION
<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the error boundary so it resets when switching to another connection in the dependency selection dialog. This prevents stale errors and ensures the tools/resources/prompts tabs render correctly after switching.

- **Bug Fixes**
  - Force remount on connection change using key=selectedId to reset the ErrorBoundary and Suspense.
  - Truncate long error messages to 200 characters to avoid overflow.

- **Refactors**
  - Extracted the right-side content into ConnectionDetailsContent to reduce duplication and simplify state.
  - Preserved selection semantics (null = all, undefined = not configured, [] = none) by avoiding nullish coalescing.

<sup>Written for commit 13dca0052b7d84f25842af835d26b923f34bf2ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

