### PR TITLE
fix(sidebar): remove profile and security menu items, fix preferences dialog unmounting

### DIFF
--- a/apps/mesh/src/web/components/sidebar/header/account-switcher/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/account-switcher/index.tsx
@@ -13,6 +13,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { UserPanel } from "./user-panel";
 import { OrgPanel } from "./org-panel";
+import { UserSettingsDialog } from "@/web/components/user-settings-dialog";
 
 interface MeshAccountSwitcherProps {
   isCollapsed?: boolean;
@@ -31,6 +32,7 @@ export function MeshAccountSwitcher({
   );
 
   const [open, setOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const user = session?.user;
   const userImage = (user as { image?: string } | undefined)?.image;
@@ -91,7 +93,10 @@ export function MeshAccountSwitcher({
             <UserPanel
               user={user}
               userImage={userImage}
-              onSettingsOpenChange={() => setOpen(false)}
+              onOpenSettings={() => {
+                setSettingsOpen(true);
+                setOpen(false);
+              }}
             />
           )}
           <OrgPanel
@@ -102,6 +107,15 @@ export function MeshAccountSwitcher({
           />
         </PopoverContent>
       </Popover>
+
+      {user && settingsOpen && user.email && (
+        <UserSettingsDialog
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          user={{ ...user, name: user.name ?? undefined, email: user.email }}
+          userImage={userImage}
+        />
+      )}
     </>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/header/account-switcher/user-panel.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/account-switcher/user-panel.tsx
@@ -1,11 +1,7 @@
-import { useState } from "react";
 import { authClient } from "@/web/lib/auth-client";
-import { UserSettingsDialog } from "@/web/components/user-settings-dialog";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
-  UserCircle,
-  Lock01,
   Settings04,
   BookOpen01,
   LogOut02,
@@ -22,16 +18,10 @@ interface UserPanelProps {
     email?: string | null;
   };
   userImage?: string;
-  onSettingsOpenChange: (open: boolean) => void;
+  onOpenSettings: () => void;
 }
 
-export function UserPanel({
-  user,
-  userImage,
-  onSettingsOpenChange,
-}: UserPanelProps) {
-  const [settingsOpen, setSettingsOpen] = useState(false);
-
+export function UserPanel({ user, userImage, onOpenSettings }: UserPanelProps) {
   const handleCopyUserInfo = async () => {
     if (!user) return;
     const userInfo = `ID: ${user.id}\nName: ${user.name || "N/A"}\nEmail: ${user.email}`;
@@ -71,22 +61,7 @@ export function UserPanel({
 
         {/* Menu Items */}
         <div className="p-1 flex flex-col">
-          <MenuItem
-            onClick={() => {
-              onSettingsOpenChange(false);
-              setSettingsOpen(true);
-            }}
-          >
-            <UserCircle size={18} />
-            Profile
-          </MenuItem>
-
-          <MenuItem>
-            <Lock01 size={18} />
-            Security & Access
-          </MenuItem>
-
-          <MenuItem>
+          <MenuItem onClick={onOpenSettings}>
             <Settings04 size={18} />
             Preferences
           </MenuItem>
@@ -121,15 +96,6 @@ export function UserPanel({
           </MenuItem>
         </div>
       </div>
-
-      {user && settingsOpen && user.email && (
-        <UserSettingsDialog
-          open={settingsOpen}
-          onOpenChange={setSettingsOpen}
-          user={{ ...user, name: user.name ?? undefined, email: user.email }}
-          userImage={userImage}
-        />
-      )}
     </>
   );
 }


### PR DESCRIPTION
## Changes

- Remove Profile and Security & Access menu items from sidebar header per designer feedback
- Keep Preferences menu item to open settings dialog (which contains Developer Mode toggle)
- Fix dialog closing immediately after opening by lifting state out of PopoverContent

## Problem

When clicking "Preferences", the dialog would open and immediately close because:
1. The UserSettingsDialog was rendered inside UserPanel
2. UserPanel was inside PopoverContent
3. When Popover closed, React unmounted PopoverContent, destroying UserPanel and its state
4. This caused the dialog to unmount before it could properly render

## Solution

Lifted the dialog state and rendering to the parent MeshAccountSwitcher component, outside the Popover tree. Now the dialog persists independently when the popover closes.

## Testing

- ✅ Clicking Preferences opens the dialog correctly
- ✅ Dialog stays open after popover closes
- ✅ All formatting, linting, and type checks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed “Profile” and “Security & Access” from the sidebar account menu. “Preferences” remains and now opens a stable settings dialog that stays open after the popover closes.

- **Bug Fixes**
  - The settings dialog was unmounted because it lived inside PopoverContent via UserPanel. Closing the popover destroyed it.
  - Moved dialog state and rendering to MeshAccountSwitcher and updated UserPanel to use onOpenSettings.

<sup>Written for commit 3fed1d1aaf39f73b9fee0e21be91b027e5fc635a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

