### PR TITLE
fix(sidebar): prevent organization button and chevron from appearing simultaneously

### DIFF
--- a/apps/mesh/src/web/components/sidebar/header/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/index.tsx
@@ -39,9 +39,9 @@ export function MeshSidebarHeader() {
               {/* Account switcher - hidden when collapsed and hovering */}
               <div
                 className={cn(
-                  "w-full min-w-0",
+                  "w-full min-w-0 transition-opacity",
                   isCollapsed &&
-                    "group-hover/account-switcher:opacity-0 group-hover/account-switcher:pointer-events-none transition-opacity",
+                    "group-hover/account-switcher:opacity-0 group-hover/account-switcher:pointer-events-none group-hover/account-switcher:invisible",
                 )}
               >
                 <MeshAccountSwitcher isCollapsed={isCollapsed} />
@@ -53,8 +53,8 @@ export function MeshSidebarHeader() {
                 className={cn(
                   "absolute inset-0 m-auto size-7 hover:bg-sidebar-accent transition-opacity",
                   isCollapsed
-                    ? "opacity-0 group-hover/account-switcher:opacity-100 pointer-events-none group-hover/account-switcher:pointer-events-auto"
-                    : "opacity-0 pointer-events-none",
+                    ? "opacity-0 invisible pointer-events-none group-hover/account-switcher:opacity-100 group-hover/account-switcher:visible group-hover/account-switcher:pointer-events-auto"
+                    : "opacity-0 invisible pointer-events-none",
                 )}
                 onClick={toggleSidebar}
                 aria-label="Expand sidebar"


### PR DESCRIPTION
## Summary
Fixed an issue where both the organization button and the expand chevron were visible at the same time when hovering over the sidebar header in collapsed state.

## Changes
- Added `invisible` class to account switcher when collapsed and hovering
- Added `visible`/`invisible` classes to expand chevron button for proper visibility control
- Ensures only one element is visible at a time with smooth transitions

## Testing
- Verified that when sidebar is collapsed and hovering, only the expand chevron is visible
- Verified that when sidebar is collapsed but not hovering, only the account switcher is visible
- Verified that when sidebar is expanded, only the account switcher is visible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the collapsed sidebar header so the account switcher and the expand chevron never show at the same time. Adds invisible/visible and pointer-events class toggles to swap them on hover with smooth transitions.

<sup>Written for commit 1775e4a1fcf6e6967a188f5e8f6b40f8bc9f78a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

