### PR TITLE
fix(database): migrate plugin records before Kysely migrator runs

### DIFF
--- a/apps/mesh/src/database/migrate.ts
+++ b/apps/mesh/src/database/migrate.ts
@@ -160,10 +160,7 @@ async function migrateExistingPluginRecords(
  * Each plugin's migrations are tracked independently in the plugin_migrations table.
  * Migrations are run in order within each plugin (sorted by name).
  */
-async function runPluginMigrations(
-  db: Kysely<Database>,
-  dbType: "sqlite" | "postgres",
-): Promise<void> {
+async function runPluginMigrations(db: Kysely<Database>): Promise<void> {
   const pluginMigrations = collectPluginMigrations();
 
   if (pluginMigrations.length === 0) {
@@ -356,7 +353,7 @@ export async function migrateToLatest<T = unknown>(
     console.log("🎉 Core migrations completed successfully");
 
     // Phase 2: Run plugin migrations (separate tracking)
-    await runPluginMigrations(database.db, database.type);
+    await runPluginMigrations(database.db);
 
     // Run seed if specified
     let seedResult: T | undefined;

--- a/apps/mesh/src/web/hooks/use-tags.ts
+++ b/apps/mesh/src/web/hooks/use-tags.ts
@@ -12,6 +12,7 @@ import {
   SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
+import { KEYS } from "../lib/query-keys";
 
 /**
  * Tag data structure
@@ -22,21 +23,6 @@ export interface Tag {
   name: string;
   createdAt: string;
 }
-
-// ============================================================================
-// Query Keys
-// ============================================================================
-
-// Extend KEYS with tag-specific keys (local extension)
-const TAG_KEYS = {
-  tags: (locator: string) => [locator, "tags"] as const,
-  memberTags: (locator: string, memberId: string) =>
-    [locator, "member-tags", memberId] as const,
-};
-
-// ============================================================================
-// Organization Tags Hooks
-// ============================================================================
 
 type TagsListOutput = { tags: Tag[] };
 type TagCreateOutput = { tag: Tag };
@@ -52,7 +38,7 @@ export function useTags() {
   });
 
   return useQuery({
-    queryKey: TAG_KEYS.tags(locator),
+    queryKey: KEYS.tags(locator),
     queryFn: async () => {
       const result = (await client.callTool({
         name: "TAGS_LIST",
@@ -86,7 +72,7 @@ export function useCreateTag() {
       return payload.tag;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: TAG_KEYS.tags(locator) });
+      queryClient.invalidateQueries({ queryKey: KEYS.tags(locator) });
     },
     onError: (error) => {
       toast.error(
@@ -114,7 +100,7 @@ export function useMemberTags(memberId: string) {
   });
 
   return useQuery({
-    queryKey: TAG_KEYS.memberTags(locator, memberId),
+    queryKey: KEYS.memberTags(locator, memberId),
     queryFn: async () => {
       const result = (await client.callTool({
         name: "MEMBER_TAGS_GET",
@@ -159,7 +145,7 @@ export function useSetMemberTags() {
     onSuccess: (_data, variables) => {
       // Invalidate the specific member's tags
       queryClient.invalidateQueries({
-        queryKey: TAG_KEYS.memberTags(locator, variables.memberId),
+        queryKey: KEYS.memberTags(locator, variables.memberId),
       });
     },
     onError: (error) => {

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -175,4 +175,9 @@ export const KEYS = {
   // Remote MCP tools (for store server detail page)
   remoteMcpTools: (remoteUrl: string | null) =>
     ["remote-mcp-tools", remoteUrl] as const,
+
+  // Tags (scoped by locator)
+  tags: (locator: string) => [locator, "tags"] as const,
+  memberTags: (locator: string, memberId: string) =>
+    [locator, "member-tags", memberId] as const,
 } as const;


### PR DESCRIPTION
## Summary

Fixes the "corrupted migrations" error when deploying to prod:
```
error: corrupted migrations: previously executed migration user-sandbox/001-user-sandbox is missing
```

**Root cause**: Kysely's migrator checks for missing migrations at startup *before* running any new migrations. The previous fix (#2377) moved plugin records to a separate table, but this happened *after* the Kysely migrator tried to validate the migration state - so it was too late.

**Fix**: Move the plugin record cleanup (`migrateExistingPluginRecords`) to run *before* creating the Kysely Migrator, so old plugin records are moved to `plugin_migrations` table before Kysely validates migration state.

## Test plan

- [ ] Deploy to prod environment with existing plugin migrations in `kysely_migration` table
- [ ] Verify migrations complete without "corrupted migrations" error
- [ ] Confirm plugin migrations are correctly moved to `plugin_migrations` table

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates plugin migrations from core Kysely migrations and moves plugin record cleanup to run before the migrator, fixing the "corrupted migrations" startup error in production.

- **Bug Fixes**
  - Migrate existing plugin records from kysely_migration into plugin_migrations before Kysely validates state.
  - Track plugin migrations in plugin_migrations and run them after core migrations.
  - Verify INSERT before deleting old records to prevent data loss; coerce COUNT(*) to Number for cross-db consistency.

<sup>Written for commit 6878d416a935d82cec2ac7c4a0c9eb1fe7a20e70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

