### PR TITLE
Reapply "[feat]: Virtual tools (#2351)" (#2372)

### DIFF
--- a/apps/mesh/migrations/031-add-dependency-mode.ts
+++ b/apps/mesh/migrations/031-add-dependency-mode.ts
@@ -1,0 +1,112 @@
+/**
+ * Add dependency_mode column to connection_aggregations
+ *
+ * This column tracks how a connection is related to a Virtual MCP:
+ * - 'direct': User explicitly added this connection to the Virtual MCP
+ * - 'indirect': Connection is referenced by virtual tool code (FK prevents deletion)
+ *
+ * Direct dependencies have their tools exposed in the Virtual MCP's tool list.
+ * Indirect dependencies exist only to enforce FK constraints - their tools are
+ * NOT exposed, but are called internally by virtual tool code.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Add dependency_mode column with default 'direct' for existing rows
+  // SQLite and PostgreSQL both support this syntax
+  await sql`
+    ALTER TABLE connection_aggregations 
+    ADD COLUMN dependency_mode TEXT NOT NULL DEFAULT 'direct'
+  `.execute(db);
+
+  // Create index for efficient filtering by dependency_mode
+  await db.schema
+    .createIndex("idx_conn_agg_dependency_mode")
+    .on("connection_aggregations")
+    .columns(["parent_connection_id", "dependency_mode"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Drop the index first
+  await db.schema.dropIndex("idx_conn_agg_dependency_mode").execute();
+
+  // Check if we're on PostgreSQL
+  const isPostgres = await sql`SELECT current_database()`
+    .execute(db)
+    .then(() => true)
+    .catch(() => false);
+
+  if (isPostgres) {
+    // PostgreSQL supports DROP COLUMN
+    await sql`ALTER TABLE connection_aggregations DROP COLUMN dependency_mode`.execute(
+      db,
+    );
+  } else {
+    // SQLite doesn't support DROP COLUMN before 3.35.0
+    // Need to recreate the table without the column
+
+    // Drop existing indexes
+    await db.schema.dropIndex("idx_conn_agg_unique").execute();
+    await db.schema.dropIndex("idx_conn_agg_child").execute();
+    await db.schema.dropIndex("idx_conn_agg_parent").execute();
+
+    // Create new table without dependency_mode
+    await db.schema
+      .createTable("connection_aggregations_new")
+      .addColumn("id", "text", (col) => col.primaryKey())
+      .addColumn("parent_connection_id", "text", (col) =>
+        col.notNull().references("connections.id").onDelete("cascade"),
+      )
+      .addColumn("child_connection_id", "text", (col) =>
+        col.notNull().references("connections.id").onDelete("restrict"),
+      )
+      .addColumn("selected_tools", "text")
+      .addColumn("selected_resources", "text")
+      .addColumn("selected_prompts", "text")
+      .addColumn("created_at", "text", (col) =>
+        col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+      )
+      .execute();
+
+    // Copy data (excluding dependency_mode)
+    await sql`
+      INSERT INTO connection_aggregations_new (
+        id, parent_connection_id, child_connection_id,
+        selected_tools, selected_resources, selected_prompts, created_at
+      )
+      SELECT
+        id, parent_connection_id, child_connection_id,
+        selected_tools, selected_resources, selected_prompts, created_at
+      FROM connection_aggregations
+    `.execute(db);
+
+    // Drop old table and rename new table
+    await db.schema.dropTable("connection_aggregations").execute();
+    await db.schema
+      .alterTable("connection_aggregations_new")
+      .renameTo("connection_aggregations")
+      .execute();
+
+    // Recreate indexes
+    await db.schema
+      .createIndex("idx_conn_agg_parent")
+      .on("connection_aggregations")
+      .columns(["parent_connection_id"])
+      .execute();
+
+    await db.schema
+      .createIndex("idx_conn_agg_child")
+      .on("connection_aggregations")
+      .columns(["child_connection_id"])
+      .execute();
+
+    await db.schema
+      .createIndex("idx_conn_agg_unique")
+      .on("connection_aggregations")
+      .columns(["parent_connection_id", "child_connection_id"])
+      .unique()
+      .execute();
+  }
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -29,6 +29,7 @@ import * as migration027updatemanagementmcpurl from "./027-update-management-mcp
 import * as migration028updatemanagementmcptoself from "./028-update-management-mcp-to-self.ts";
 import * as migration029addupdatedbytoconnections from "./029-add-updated-by-to-connections.ts";
 import * as migration030membertags from "./030-member-tags.ts";
+import * as migration031adddependencymode from "./031-add-dependency-mode.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -70,6 +71,7 @@ const migrations: Record<string, Migration> = {
   "028-update-management-mcp-to-self": migration028updatemanagementmcptoself,
   "029-add-updated-by-to-connections": migration029addupdatedbytoconnections,
   "030-member-tags": migration030membertags,
+  "031-add-dependency-mode": migration031adddependencymode,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -261,8 +261,17 @@ async function createMCPProxyDoNotUseDirectly(
   // Uses indexed tools if available, falls back to client for connections without cached tools
   // NOTE: Defined early so it can be passed to authorization middlewares for public tool check
   const listTools = async (): Promise<ListToolsResult> => {
-    // Use indexed tools if available
-    if (connection.tools && connection.tools.length > 0) {
+    // VIRTUAL connections always use client.listTools() because:
+    // 1. Their tools column contains virtual tool definitions (code), not cached downstream tools
+    // 2. The aggregator (via client.listTools()) returns virtual + aggregated downstream tools
+    const isVirtualConnection = connection.connection_type === "VIRTUAL";
+
+    // Use indexed tools if available (except for VIRTUAL connections)
+    if (
+      !isVirtualConnection &&
+      connection.tools &&
+      connection.tools.length > 0
+    ) {
       return {
         tools: connection.tools.map((tool) => ({
           name: tool.name,
@@ -275,7 +284,7 @@ async function createMCPProxyDoNotUseDirectly(
       };
     }
 
-    // Fall back to client for connections without indexed tools
+    // Fall back to client for connections without indexed tools (or VIRTUAL connections)
     return await client.listTools();
   };
 

--- a/apps/mesh/src/api/utils/mcp.ts
+++ b/apps/mesh/src/api/utils/mcp.ts
@@ -340,6 +340,9 @@ class McpServerBuilder {
       },
       /**
        * Handle fetch requests (MCP protocol over HTTP)
+       *
+       * GET requests use SSE streaming - the transport must stay open for the duration
+       * of the SSE connection. We only close for non-GET requests (POST for JSON-RPC).
        */
       fetch: async (req: Request): Promise<Response> => {
         const transport = new WebStandardStreamableHTTPServerTransport({
@@ -349,6 +352,13 @@ class McpServerBuilder {
 
         await createServer().connect(transport);
 
+        // For GET requests (SSE), don't close transport - it's a long-lived streaming connection
+        // The transport will close itself when the client disconnects
+        if (req.method === "GET") {
+          return await transport.handleRequest(req);
+        }
+
+        // For POST/other requests, close transport after handling
         return await transport.handleRequest(req);
       },
     };

--- a/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
@@ -6,6 +6,7 @@
 
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { VirtualMCPEntity } from "../../tools/virtual/schema";
+import type { VirtualToolDefinition } from "../../tools/virtual-tool/schema";
 import type { MCPProxyClient } from "../../api/routes/proxy";
 
 /** Entry in the proxy map (connection ID -> proxy entry) */
@@ -29,6 +30,8 @@ export type ToolSelectionStrategy =
 export interface VirtualClientOptions {
   connections: ConnectionEntity[];
   virtualMcp: VirtualMCPEntity;
+  /** Virtual tools defined on this Virtual MCP (tools with code in _meta["mcp.mesh"]["tool.fn"]) */
+  virtualTools?: VirtualToolDefinition[];
 }
 
 /**

--- a/apps/mesh/src/storage/connection.ts
+++ b/apps/mesh/src/storage/connection.ts
@@ -122,12 +122,21 @@ export class ConnectionStorage implements ConnectionStoragePort {
     return row ? this.deserializeConnection(row as RawConnectionRow) : null;
   }
 
-  async list(organizationId: string): Promise<ConnectionEntity[]> {
-    const rows = await this.db
+  async list(
+    organizationId: string,
+    options?: { includeVirtual?: boolean },
+  ): Promise<ConnectionEntity[]> {
+    let query = this.db
       .selectFrom("connections")
       .selectAll()
-      .where("organization_id", "=", organizationId)
-      .execute();
+      .where("organization_id", "=", organizationId);
+
+    // By default, exclude VIRTUAL connections unless explicitly requested
+    if (!options?.includeVirtual) {
+      query = query.where("connection_type", "!=", "VIRTUAL");
+    }
+
+    const rows = await query.execute();
 
     return Promise.all(
       rows.map((row) => this.deserializeConnection(row as RawConnectionRow)),

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -44,7 +44,10 @@ export interface ThreadStoragePort {
 export interface ConnectionStoragePort {
   create(data: Partial<ConnectionEntity>): Promise<ConnectionEntity>;
   findById(id: string): Promise<ConnectionEntity | null>;
-  list(organizationId: string): Promise<ConnectionEntity[]>;
+  list(
+    organizationId: string,
+    options?: { includeVirtual?: boolean },
+  ): Promise<ConnectionEntity[]>;
   update(
     id: string,
     data: Partial<ConnectionEntity>,
@@ -125,6 +128,15 @@ export type {
   VirtualMCPUpdateData,
 } from "../tools/virtual/schema";
 
+import type {
+  VirtualToolEntity,
+  VirtualToolCreateData,
+  VirtualToolUpdateData,
+} from "../tools/virtual-tool/schema";
+
+// Re-export virtual tool types
+export type { VirtualToolEntity, VirtualToolCreateData, VirtualToolUpdateData };
+
 export interface VirtualMCPStoragePort {
   create(
     organizationId: string,
@@ -146,6 +158,31 @@ export interface VirtualMCPStoragePort {
     data: VirtualMCPUpdateData,
   ): Promise<VirtualMCPEntity>;
   delete(id: string): Promise<void>;
+
+  // Virtual Tool CRUD methods
+  listVirtualTools(virtualMcpId: string): Promise<VirtualToolEntity[]>;
+  getVirtualTool(
+    virtualMcpId: string,
+    toolName: string,
+  ): Promise<VirtualToolEntity | null>;
+  createVirtualTool(
+    virtualMcpId: string,
+    data: VirtualToolCreateData,
+    connectionDependencies: string[],
+  ): Promise<VirtualToolEntity>;
+  updateVirtualTool(
+    virtualMcpId: string,
+    toolName: string,
+    data: VirtualToolUpdateData,
+    connectionDependencies?: string[],
+  ): Promise<VirtualToolEntity>;
+  deleteVirtualTool(virtualMcpId: string, toolName: string): Promise<void>;
+
+  // Indirect dependency management
+  syncIndirectDependencies(
+    virtualMcpId: string,
+    connectionIds: string[],
+  ): Promise<void>;
 }
 
 // ============================================================================

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -572,6 +572,13 @@ export interface EventDelivery {
 export type ToolSelectionMode = "inclusion" | "exclusion";
 
 /**
+ * Dependency mode for connection aggregations
+ * - 'direct': User explicitly added this connection to the Virtual MCP (tools exposed)
+ * - 'indirect': Connection is referenced by virtual tool code (FK only, tools hidden)
+ */
+export type DependencyMode = "direct" | "indirect";
+
+/**
  * Connection aggregation table definition
  * Many-to-many relationship linking VIRTUAL connections (agents) to their child connections
  * with selected tools/resources/prompts
@@ -586,6 +593,7 @@ export interface ConnectionAggregationTable {
   selected_tools: JsonArray<string[]> | null; // null = all tools
   selected_resources: JsonArray<string[]> | null; // null = all resources, supports URI patterns with * and **
   selected_prompts: JsonArray<string[]> | null; // null = all prompts
+  dependency_mode: DependencyMode; // 'direct' = tools exposed, 'indirect' = FK only
   created_at: ColumnType<Date, Date | string, never>;
 }
 

--- a/apps/mesh/src/storage/virtual.ts
+++ b/apps/mesh/src/storage/virtual.ts
@@ -5,6 +5,9 @@
  * Virtual MCPs are stored as connections with connection_type = 'VIRTUAL'.
  * The aggregations (which child connections are included) are stored in
  * the connection_aggregations table.
+ *
+ * Virtual tools are stored in the connections.tools JSON column and are
+ * identified by having _meta["mcp.mesh"]["tool.fn"] containing their code.
  */
 
 import type { Kysely } from "kysely";
@@ -18,8 +21,17 @@ import type {
   VirtualMCPEntity,
   VirtualMCPStoragePort,
   VirtualMCPUpdateData,
+  VirtualToolEntity,
+  VirtualToolCreateData,
+  VirtualToolUpdateData,
 } from "./ports";
-import type { Database } from "./types";
+import type { ToolDefinition } from "../tools/connection/schema";
+import {
+  type VirtualToolDefinition,
+  isVirtualTool,
+  fromVirtualToolDefinition,
+} from "../tools/virtual-tool/schema";
+import type { Database, DependencyMode } from "./types";
 
 /** Raw database row type for connections (VIRTUAL type) */
 type RawConnectionRow = {
@@ -44,6 +56,7 @@ type RawAggregationRow = {
   selected_tools: string | string[] | null;
   selected_resources: string | string[] | null;
   selected_prompts: string | string[] | null;
+  dependency_mode: DependencyMode;
   created_at: Date | string;
 };
 
@@ -86,7 +99,7 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
       })
       .execute();
 
-    // Insert connection aggregations
+    // Insert connection aggregations (all explicit connections are 'direct' dependencies)
     if (data.connections.length > 0) {
       await this.db
         .insertInto("connection_aggregations")
@@ -104,6 +117,7 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
             selected_prompts: conn.selected_prompts
               ? JSON.stringify(conn.selected_prompts)
               : null,
+            dependency_mode: "direct" as DependencyMode,
             created_at: now,
           })),
         )
@@ -167,10 +181,12 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
       return null;
     }
 
+    // Only fetch 'direct' dependencies - indirect deps are not exposed in the entity
     const aggregationRows = await db
       .selectFrom("connection_aggregations")
       .selectAll()
       .where("parent_connection_id", "=", id)
+      .where("dependency_mode", "=", "direct")
       .execute();
 
     return this.deserializeVirtualMCPEntity(
@@ -193,11 +209,12 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
       return [];
     }
 
-    // Fetch all aggregations for all virtual MCPs in one query
+    // Fetch only 'direct' aggregations for all virtual MCPs in one query
     const aggregationRows = await this.db
       .selectFrom("connection_aggregations")
       .selectAll()
       .where("parent_connection_id", "in", virtualMcpIds)
+      .where("dependency_mode", "=", "direct")
       .execute();
 
     // Group aggregations by parent_connection_id
@@ -220,7 +237,7 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
     organizationId: string,
     connectionId: string,
   ): Promise<VirtualMCPEntity[]> {
-    // Find virtual MCP IDs that include this connection as a child
+    // Find virtual MCP IDs that include this connection as a child (any dependency mode)
     const aggregationRows = await this.db
       .selectFrom("connection_aggregations")
       .select("parent_connection_id")
@@ -248,11 +265,12 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
 
     const resultVirtualMcpIds = rows.map((r) => r.id);
 
-    // Fetch all aggregations for these virtual MCPs
+    // Fetch only 'direct' aggregations for these virtual MCPs
     const allAggregationRows = await this.db
       .selectFrom("connection_aggregations")
       .selectAll()
       .where("parent_connection_id", "in", resultVirtualMcpIds)
+      .where("dependency_mode", "=", "direct")
       .execute();
 
     // Group aggregations by parent_connection_id
@@ -312,9 +330,11 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
 
     // Update aggregations if provided
     if (data.connections !== undefined) {
+      // Only delete 'direct' dependencies - preserve 'indirect' ones from virtual tools
       await this.db
         .deleteFrom("connection_aggregations")
         .where("parent_connection_id", "=", id)
+        .where("dependency_mode", "=", "direct")
         .execute();
 
       if (data.connections.length > 0) {
@@ -334,6 +354,7 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
               selected_prompts: conn.selected_prompts
                 ? JSON.stringify(conn.selected_prompts)
                 : null,
+              dependency_mode: "direct" as DependencyMode,
               created_at: now,
             })),
           )
@@ -424,5 +445,456 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
       }
     }
     return value as T;
+  }
+
+  // ============================================================================
+  // Virtual Tool CRUD Methods
+  // ============================================================================
+
+  /**
+   * List all virtual tools for a Virtual MCP
+   * Virtual tools are stored in the tools column and identified by _meta["mcp.mesh"]["tool.fn"]
+   */
+  async listVirtualTools(virtualMcpId: string): Promise<VirtualToolEntity[]> {
+    const row = await this.db
+      .selectFrom("connections")
+      .select(["tools", "created_at", "updated_at"])
+      .where("id", "=", virtualMcpId)
+      .where("connection_type", "=", "VIRTUAL")
+      .executeTakeFirst();
+
+    if (!row) {
+      return [];
+    }
+
+    const tools = this.parseJson<ToolDefinition[]>(
+      row.tools as string | ToolDefinition[] | null,
+    );
+    if (!tools) {
+      return [];
+    }
+
+    const createdAt =
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : (row.created_at as string);
+    const updatedAt =
+      row.updated_at instanceof Date
+        ? row.updated_at.toISOString()
+        : (row.updated_at as string);
+
+    // Filter for virtual tools and convert to entity format
+    // Preserve the original array index for consistent IDs with getVirtualTool
+    return tools
+      .map((tool, originalIndex) => ({ tool, originalIndex }))
+      .filter(({ tool }) => isVirtualTool(tool))
+      .map(({ tool, originalIndex }) =>
+        fromVirtualToolDefinition(
+          `${virtualMcpId}:${tool.name}:${originalIndex}`,
+          tool as VirtualToolDefinition,
+          createdAt,
+          updatedAt,
+        ),
+      );
+  }
+
+  /**
+   * Get a specific virtual tool by name
+   */
+  async getVirtualTool(
+    virtualMcpId: string,
+    toolName: string,
+  ): Promise<VirtualToolEntity | null> {
+    const row = await this.db
+      .selectFrom("connections")
+      .select(["tools", "created_at", "updated_at"])
+      .where("id", "=", virtualMcpId)
+      .where("connection_type", "=", "VIRTUAL")
+      .executeTakeFirst();
+
+    if (!row) {
+      return null;
+    }
+
+    const tools = this.parseJson<ToolDefinition[]>(
+      row.tools as string | ToolDefinition[] | null,
+    );
+    if (!tools) {
+      return null;
+    }
+
+    const toolIndex = tools.findIndex(
+      (t) => t.name === toolName && isVirtualTool(t),
+    );
+    if (toolIndex === -1) {
+      return null;
+    }
+
+    const tool = tools[toolIndex] as VirtualToolDefinition;
+    const createdAt =
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : (row.created_at as string);
+    const updatedAt =
+      row.updated_at instanceof Date
+        ? row.updated_at.toISOString()
+        : (row.updated_at as string);
+
+    return fromVirtualToolDefinition(
+      `${virtualMcpId}:${tool.name}:${toolIndex}`,
+      tool,
+      createdAt,
+      updatedAt,
+    );
+  }
+
+  /**
+   * Create a new virtual tool in a Virtual MCP
+   */
+  async createVirtualTool(
+    virtualMcpId: string,
+    data: VirtualToolCreateData,
+    connectionDependencies: string[],
+  ): Promise<VirtualToolEntity> {
+    const now = new Date().toISOString();
+
+    // Get current tools
+    const row = await this.db
+      .selectFrom("connections")
+      .select(["tools"])
+      .where("id", "=", virtualMcpId)
+      .where("connection_type", "=", "VIRTUAL")
+      .executeTakeFirst();
+
+    if (!row) {
+      throw new Error(`Virtual MCP not found: ${virtualMcpId}`);
+    }
+
+    const tools =
+      this.parseJson<ToolDefinition[]>(
+        row.tools as string | ToolDefinition[] | null,
+      ) ?? [];
+
+    // Check for duplicate name
+    if (tools.some((t) => t.name === data.name)) {
+      throw new Error(`Tool with name "${data.name}" already exists`);
+    }
+
+    // Create virtual tool definition
+    const virtualToolDef: VirtualToolDefinition = {
+      name: data.name,
+      description: data.description,
+      inputSchema: data.inputSchema,
+      outputSchema: data.outputSchema,
+      annotations: data.annotations,
+      _meta: {
+        "mcp.mesh": {
+          "tool.fn": data.code,
+        },
+        connectionDependencies,
+      },
+    };
+
+    // Add to tools array
+    tools.push(virtualToolDef);
+
+    // Update the connection
+    await this.db
+      .updateTable("connections")
+      .set({
+        tools: JSON.stringify(tools),
+        updated_at: now,
+      })
+      .where("id", "=", virtualMcpId)
+      .execute();
+
+    // Sync indirect dependencies
+    await this.syncIndirectDependencies(virtualMcpId, connectionDependencies);
+
+    return fromVirtualToolDefinition(
+      `${virtualMcpId}:${data.name}:${tools.length - 1}`,
+      virtualToolDef,
+      now,
+      now,
+    );
+  }
+
+  /**
+   * Update an existing virtual tool
+   */
+  async updateVirtualTool(
+    virtualMcpId: string,
+    toolName: string,
+    data: VirtualToolUpdateData,
+    connectionDependencies?: string[],
+  ): Promise<VirtualToolEntity> {
+    const now = new Date().toISOString();
+
+    // Get current tools
+    const row = await this.db
+      .selectFrom("connections")
+      .select(["tools", "created_at"])
+      .where("id", "=", virtualMcpId)
+      .where("connection_type", "=", "VIRTUAL")
+      .executeTakeFirst();
+
+    if (!row) {
+      throw new Error(`Virtual MCP not found: ${virtualMcpId}`);
+    }
+
+    const tools =
+      this.parseJson<ToolDefinition[]>(
+        row.tools as string | ToolDefinition[] | null,
+      ) ?? [];
+
+    // Find the tool
+    const toolIndex = tools.findIndex(
+      (t) => t.name === toolName && isVirtualTool(t),
+    );
+    if (toolIndex === -1) {
+      throw new Error(`Virtual tool not found: ${toolName}`);
+    }
+
+    const existingTool = tools[toolIndex] as VirtualToolDefinition;
+
+    // Check for name conflict if renaming
+    if (data.name && data.name !== toolName) {
+      if (tools.some((t) => t.name === data.name)) {
+        throw new Error(`Tool with name "${data.name}" already exists`);
+      }
+    }
+
+    // Get dependencies - use new ones if provided, otherwise keep existing
+    const newDependencies =
+      connectionDependencies ?? existingTool._meta.connectionDependencies ?? [];
+
+    // Update the tool
+    const updatedTool: VirtualToolDefinition = {
+      name: data.name ?? existingTool.name,
+      description:
+        data.description !== undefined
+          ? (data.description ?? undefined)
+          : existingTool.description,
+      inputSchema: data.inputSchema ?? existingTool.inputSchema,
+      outputSchema:
+        data.outputSchema !== undefined
+          ? (data.outputSchema ?? undefined)
+          : existingTool.outputSchema,
+      annotations:
+        data.annotations !== undefined
+          ? (data.annotations ?? undefined)
+          : existingTool.annotations,
+      _meta: {
+        "mcp.mesh": {
+          "tool.fn": data.code ?? existingTool._meta["mcp.mesh"]["tool.fn"],
+        },
+        connectionDependencies: newDependencies,
+      },
+    };
+
+    tools[toolIndex] = updatedTool;
+
+    // Update the connection
+    await this.db
+      .updateTable("connections")
+      .set({
+        tools: JSON.stringify(tools),
+        updated_at: now,
+      })
+      .where("id", "=", virtualMcpId)
+      .execute();
+
+    // Sync indirect dependencies if they were provided
+    if (connectionDependencies !== undefined) {
+      // Recalculate all indirect dependencies from all virtual tools
+      await this.recalculateIndirectDependencies(virtualMcpId, tools);
+    }
+
+    const createdAt =
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : (row.created_at as string);
+
+    return fromVirtualToolDefinition(
+      `${virtualMcpId}:${updatedTool.name}:${toolIndex}`,
+      updatedTool,
+      createdAt,
+      now,
+    );
+  }
+
+  /**
+   * Delete a virtual tool from a Virtual MCP
+   */
+  async deleteVirtualTool(
+    virtualMcpId: string,
+    toolName: string,
+  ): Promise<void> {
+    const now = new Date().toISOString();
+
+    // Get current tools
+    const row = await this.db
+      .selectFrom("connections")
+      .select(["tools"])
+      .where("id", "=", virtualMcpId)
+      .where("connection_type", "=", "VIRTUAL")
+      .executeTakeFirst();
+
+    if (!row) {
+      throw new Error(`Virtual MCP not found: ${virtualMcpId}`);
+    }
+
+    const tools =
+      this.parseJson<ToolDefinition[]>(
+        row.tools as string | ToolDefinition[] | null,
+      ) ?? [];
+
+    // Find and remove the tool
+    const toolIndex = tools.findIndex(
+      (t) => t.name === toolName && isVirtualTool(t),
+    );
+    if (toolIndex === -1) {
+      throw new Error(`Virtual tool not found: ${toolName}`);
+    }
+
+    tools.splice(toolIndex, 1);
+
+    // Update the connection
+    await this.db
+      .updateTable("connections")
+      .set({
+        tools: tools.length > 0 ? JSON.stringify(tools) : null,
+        updated_at: now,
+      })
+      .where("id", "=", virtualMcpId)
+      .execute();
+
+    // Recalculate indirect dependencies
+    await this.recalculateIndirectDependencies(virtualMcpId, tools);
+  }
+
+  // ============================================================================
+  // Indirect Dependency Management
+  // ============================================================================
+
+  /**
+   * Sync indirect dependencies for a Virtual MCP
+   * Adds any new connection dependencies as 'indirect' aggregations
+   */
+  async syncIndirectDependencies(
+    virtualMcpId: string,
+    connectionIds: string[],
+  ): Promise<void> {
+    if (connectionIds.length === 0) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+
+    // Get existing aggregations
+    const existingAggregations = await this.db
+      .selectFrom("connection_aggregations")
+      .select(["child_connection_id", "dependency_mode"])
+      .where("parent_connection_id", "=", virtualMcpId)
+      .execute();
+
+    const existingConnectionIds = new Set(
+      existingAggregations.map((a) => a.child_connection_id),
+    );
+
+    // Find new indirect dependencies (not already in aggregations)
+    const newIndirectDeps = connectionIds.filter(
+      (id) => !existingConnectionIds.has(id),
+    );
+
+    if (newIndirectDeps.length > 0) {
+      await this.db
+        .insertInto("connection_aggregations")
+        .values(
+          newIndirectDeps.map((connectionId) => ({
+            id: generatePrefixedId("agg"),
+            parent_connection_id: virtualMcpId,
+            child_connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+            dependency_mode: "indirect" as DependencyMode,
+            created_at: now,
+          })),
+        )
+        .execute();
+    }
+  }
+
+  /**
+   * Recalculate all indirect dependencies from virtual tools
+   * Called after updating or deleting virtual tools
+   */
+  private async recalculateIndirectDependencies(
+    virtualMcpId: string,
+    tools: ToolDefinition[],
+  ): Promise<void> {
+    // Collect all connection dependencies from virtual tools
+    const allDependencies = new Set<string>();
+    for (const tool of tools) {
+      if (isVirtualTool(tool)) {
+        const deps =
+          (tool as VirtualToolDefinition)._meta.connectionDependencies ?? [];
+        for (const dep of deps) {
+          allDependencies.add(dep);
+        }
+      }
+    }
+
+    // Get existing aggregations
+    const existingAggregations = await this.db
+      .selectFrom("connection_aggregations")
+      .select(["id", "child_connection_id", "dependency_mode"])
+      .where("parent_connection_id", "=", virtualMcpId)
+      .execute();
+
+    // Find indirect deps that are no longer needed
+    const indirectToRemove = existingAggregations
+      .filter(
+        (a) =>
+          a.dependency_mode === "indirect" &&
+          !allDependencies.has(a.child_connection_id),
+      )
+      .map((a) => a.id);
+
+    // Remove orphaned indirect dependencies
+    if (indirectToRemove.length > 0) {
+      await this.db
+        .deleteFrom("connection_aggregations")
+        .where("id", "in", indirectToRemove)
+        .execute();
+    }
+
+    // Add any new indirect dependencies
+    const existingDirectAndIndirect = new Set(
+      existingAggregations.map((a) => a.child_connection_id),
+    );
+    const newIndirect = Array.from(allDependencies).filter(
+      (id) => !existingDirectAndIndirect.has(id),
+    );
+
+    if (newIndirect.length > 0) {
+      const now = new Date().toISOString();
+      await this.db
+        .insertInto("connection_aggregations")
+        .values(
+          newIndirect.map((connectionId) => ({
+            id: generatePrefixedId("agg"),
+            parent_connection_id: virtualMcpId,
+            child_connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+            dependency_mode: "indirect" as DependencyMode,
+            created_at: now,
+          })),
+        )
+        .execute();
+    }
   }
 }

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -189,10 +189,16 @@ function applyOrderBy(
 }
 
 /**
- * Extended input schema with optional binding parameter
+ * Extended input schema with optional binding and include_virtual parameters
  */
 const ConnectionListInputSchema = CollectionListInputSchema.extend({
   binding: z.union([z.object({}).passthrough(), z.string()]).optional(),
+  include_virtual: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to include VIRTUAL connections in the results. Defaults to false.",
+    ),
 });
 
 /**
@@ -234,7 +240,10 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
       ? createBindingChecker(bindingDefinition)
       : undefined;
 
-    const connections = await ctx.storage.connections.list(organization.id);
+    // By default, exclude VIRTUAL connections unless explicitly requested
+    const connections = await ctx.storage.connections.list(organization.id, {
+      includeVirtual: input.include_virtual ?? false,
+    });
 
     // In dev mode, inject the dev-assets connection for local file storage
     // This provides object storage functionality without requiring an external S3 bucket
@@ -252,16 +261,10 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
       }
     }
 
-    // Filter out VIRTUAL connections (they are agents, not regular connections)
-    // VIRTUAL connections are managed through the Virtual MCP / Agents UI
-    const nonVirtualConnections = connections.filter(
-      (c) => c.connection_type !== "VIRTUAL",
-    );
-
     // Filter connections by binding if specified (tools are pre-populated at create/update time)
     let filteredConnections = bindingChecker
       ? await Promise.all(
-          nonVirtualConnections.map(async (connection) => {
+          connections.map(async (connection) => {
             if (!connection.tools || connection.tools.length === 0) {
               return null;
             }
@@ -281,7 +284,7 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
         ).then((results) =>
           results.filter((c): c is ConnectionEntity => c !== null),
         )
-      : nonVirtualConnections;
+      : connections;
 
     // Apply where filter if specified
     if (input.where) {

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -19,6 +19,7 @@ import * as ConnectionTools from "./connection";
 import * as DatabaseTools from "./database";
 import * as EventBusTools from "./eventbus";
 import * as VirtualMCPTools from "./virtual";
+import * as VirtualToolTools from "./virtual-tool";
 import * as MonitoringTools from "./monitoring";
 import * as OrganizationTools from "./organization";
 import * as TagTools from "./tags";
@@ -54,6 +55,13 @@ const CORE_TOOLS = [
   VirtualMCPTools.COLLECTION_VIRTUAL_MCP_GET,
   VirtualMCPTools.COLLECTION_VIRTUAL_MCP_UPDATE,
   VirtualMCPTools.COLLECTION_VIRTUAL_MCP_DELETE,
+
+  // Virtual Tool collection tools
+  VirtualToolTools.COLLECTION_VIRTUAL_TOOLS_CREATE,
+  VirtualToolTools.COLLECTION_VIRTUAL_TOOLS_LIST,
+  VirtualToolTools.COLLECTION_VIRTUAL_TOOLS_GET,
+  VirtualToolTools.COLLECTION_VIRTUAL_TOOLS_UPDATE,
+  VirtualToolTools.COLLECTION_VIRTUAL_TOOLS_DELETE,
 
   // Database tools
   DatabaseTools.DATABASES_RUN_SQL,

--- a/apps/mesh/src/tools/registry.ts
+++ b/apps/mesh/src/tools/registry.ts
@@ -22,6 +22,7 @@ export type ToolCategory =
   | "Organizations"
   | "Connections"
   | "Virtual MCPs"
+  | "Virtual Tools"
   | "Threads"
   | "Monitoring"
   | "Users"
@@ -59,6 +60,12 @@ const ALL_TOOL_NAMES = [
   "COLLECTION_VIRTUAL_MCP_GET",
   "COLLECTION_VIRTUAL_MCP_UPDATE",
   "COLLECTION_VIRTUAL_MCP_DELETE",
+  // Virtual Tool tools
+  "COLLECTION_VIRTUAL_TOOLS_CREATE",
+  "COLLECTION_VIRTUAL_TOOLS_LIST",
+  "COLLECTION_VIRTUAL_TOOLS_GET",
+  "COLLECTION_VIRTUAL_TOOLS_UPDATE",
+  "COLLECTION_VIRTUAL_TOOLS_DELETE",
   // Database tools
   "DATABASES_RUN_SQL",
   // Monitoring tools
@@ -260,6 +267,33 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     category: "Virtual MCPs",
     dangerous: true,
   },
+  // Virtual Tool tools
+  {
+    name: "COLLECTION_VIRTUAL_TOOLS_CREATE",
+    description: "Create virtual tools on Virtual MCPs",
+    category: "Virtual Tools",
+  },
+  {
+    name: "COLLECTION_VIRTUAL_TOOLS_LIST",
+    description: "List virtual tools",
+    category: "Virtual Tools",
+  },
+  {
+    name: "COLLECTION_VIRTUAL_TOOLS_GET",
+    description: "View virtual tool details",
+    category: "Virtual Tools",
+  },
+  {
+    name: "COLLECTION_VIRTUAL_TOOLS_UPDATE",
+    description: "Update virtual tools",
+    category: "Virtual Tools",
+  },
+  {
+    name: "COLLECTION_VIRTUAL_TOOLS_DELETE",
+    description: "Delete virtual tools",
+    category: "Virtual Tools",
+    dangerous: true,
+  },
   // Monitoring tools
   {
     name: "MONITORING_LOGS_LIST",
@@ -439,6 +473,11 @@ const TOOL_LABELS: Record<ToolName, string> = {
   COLLECTION_VIRTUAL_MCP_GET: "View virtual MCP details",
   COLLECTION_VIRTUAL_MCP_UPDATE: "Update virtual MCPs",
   COLLECTION_VIRTUAL_MCP_DELETE: "Delete virtual MCPs",
+  COLLECTION_VIRTUAL_TOOLS_CREATE: "Create virtual tools",
+  COLLECTION_VIRTUAL_TOOLS_LIST: "List virtual tools",
+  COLLECTION_VIRTUAL_TOOLS_GET: "View virtual tool details",
+  COLLECTION_VIRTUAL_TOOLS_UPDATE: "Update virtual tools",
+  COLLECTION_VIRTUAL_TOOLS_DELETE: "Delete virtual tools",
   MONITORING_LOGS_LIST: "List monitoring logs",
   MONITORING_STATS: "View monitoring statistics",
   API_KEY_CREATE: "Create API key",
@@ -482,6 +521,7 @@ export function getToolsByCategory() {
     Organizations: [],
     Connections: [],
     "Virtual MCPs": [],
+    "Virtual Tools": [],
     Threads: [],
     Monitoring: [],
     Users: [],

--- a/apps/mesh/src/tools/virtual-tool/create.ts
+++ b/apps/mesh/src/tools/virtual-tool/create.ts
@@ -1,0 +1,67 @@
+/**
+ * COLLECTION_VIRTUAL_TOOLS_CREATE Tool
+ *
+ * Create a new virtual tool on a Virtual MCP.
+ * The creator specifies which connections the tool depends on.
+ * Indirect aggregations are created to prevent deletion of referenced connections.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { VirtualToolEntitySchema, VirtualToolCreateDataSchema } from "./schema";
+
+/**
+ * Input schema for creating a virtual tool
+ */
+const CreateInputSchema = z.object({
+  virtual_mcp_id: z
+    .string()
+    .describe("ID of the Virtual MCP to add the tool to"),
+  data: VirtualToolCreateDataSchema.describe("Virtual tool data"),
+});
+
+export type CreateVirtualToolInput = z.infer<typeof CreateInputSchema>;
+
+/**
+ * Output schema for virtual tool create
+ */
+const CreateOutputSchema = z.object({
+  item: VirtualToolEntitySchema.describe("The created virtual tool"),
+});
+
+export const COLLECTION_VIRTUAL_TOOLS_CREATE = defineTool({
+  name: "COLLECTION_VIRTUAL_TOOLS_CREATE",
+  description:
+    "Create a new virtual tool on a Virtual MCP. The tool code should be a JavaScript ES module that exports a default async function: export default async (tools, args) => { ... }. Specify connection_dependencies to indicate which connections this tool uses.",
+
+  inputSchema: CreateInputSchema,
+  outputSchema: CreateOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+
+    await ctx.access.check();
+
+    // Verify the Virtual MCP exists and belongs to the organization
+    const virtualMcp = await ctx.storage.virtualMcps.findById(
+      input.virtual_mcp_id,
+    );
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      throw new Error(`Virtual MCP not found: ${input.virtual_mcp_id}`);
+    }
+
+    // Use the dependencies specified by the creator
+    const connectionDependencies = input.data.connection_dependencies ?? [];
+
+    // Create the virtual tool
+    const tool = await ctx.storage.virtualMcps.createVirtualTool(
+      input.virtual_mcp_id,
+      input.data,
+      connectionDependencies,
+    );
+
+    return { item: tool };
+  },
+});

--- a/apps/mesh/src/tools/virtual-tool/delete.ts
+++ b/apps/mesh/src/tools/virtual-tool/delete.ts
@@ -1,0 +1,68 @@
+/**
+ * COLLECTION_VIRTUAL_TOOLS_DELETE Tool
+ *
+ * Delete a virtual tool from a Virtual MCP.
+ * Automatically recalculates indirect dependencies after deletion.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { VirtualToolEntitySchema } from "./schema";
+
+/**
+ * Input schema for deleting a virtual tool
+ */
+const DeleteInputSchema = z.object({
+  virtual_mcp_id: z.string().describe("ID of the Virtual MCP"),
+  name: z.string().describe("Name of the virtual tool to delete"),
+});
+
+export type DeleteVirtualToolInput = z.infer<typeof DeleteInputSchema>;
+
+/**
+ * Output schema for virtual tool delete
+ */
+const DeleteOutputSchema = z.object({
+  item: VirtualToolEntitySchema.describe("The deleted virtual tool"),
+});
+
+export const COLLECTION_VIRTUAL_TOOLS_DELETE = defineTool({
+  name: "COLLECTION_VIRTUAL_TOOLS_DELETE",
+  description: "Delete a virtual tool from a Virtual MCP",
+
+  inputSchema: DeleteInputSchema,
+  outputSchema: DeleteOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+
+    await ctx.access.check();
+
+    // Verify the Virtual MCP exists and belongs to the organization
+    const virtualMcp = await ctx.storage.virtualMcps.findById(
+      input.virtual_mcp_id,
+    );
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      throw new Error(`Virtual MCP not found: ${input.virtual_mcp_id}`);
+    }
+
+    // Get the tool before deleting (to return it)
+    const tool = await ctx.storage.virtualMcps.getVirtualTool(
+      input.virtual_mcp_id,
+      input.name,
+    );
+    if (!tool) {
+      throw new Error(`Virtual tool not found: ${input.name}`);
+    }
+
+    // Delete the virtual tool
+    await ctx.storage.virtualMcps.deleteVirtualTool(
+      input.virtual_mcp_id,
+      input.name,
+    );
+
+    return { item: tool };
+  },
+});

--- a/apps/mesh/src/tools/virtual-tool/get.ts
+++ b/apps/mesh/src/tools/virtual-tool/get.ts
@@ -1,0 +1,60 @@
+/**
+ * COLLECTION_VIRTUAL_TOOLS_GET Tool
+ *
+ * Get a single virtual tool by name from a Virtual MCP.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { VirtualToolEntitySchema } from "./schema";
+
+/**
+ * Input schema for getting a virtual tool
+ */
+const GetInputSchema = z.object({
+  virtual_mcp_id: z.string().describe("ID of the Virtual MCP"),
+  name: z.string().describe("Name of the virtual tool to retrieve"),
+});
+
+export type GetVirtualToolInput = z.infer<typeof GetInputSchema>;
+
+/**
+ * Output schema for virtual tool get
+ */
+const GetOutputSchema = z.object({
+  item: VirtualToolEntitySchema.nullable().describe(
+    "The retrieved virtual tool, or null if not found",
+  ),
+});
+
+export const COLLECTION_VIRTUAL_TOOLS_GET = defineTool({
+  name: "COLLECTION_VIRTUAL_TOOLS_GET",
+  description: "Get a virtual tool by name from a Virtual MCP",
+
+  inputSchema: GetInputSchema,
+  outputSchema: GetOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+
+    await ctx.access.check();
+
+    // Verify the Virtual MCP exists and belongs to the organization
+    const virtualMcp = await ctx.storage.virtualMcps.findById(
+      input.virtual_mcp_id,
+    );
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      return { item: null };
+    }
+
+    // Get the virtual tool
+    const tool = await ctx.storage.virtualMcps.getVirtualTool(
+      input.virtual_mcp_id,
+      input.name,
+    );
+
+    return { item: tool };
+  },
+});

--- a/apps/mesh/src/tools/virtual-tool/index.ts
+++ b/apps/mesh/src/tools/virtual-tool/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Virtual Tool Management Tools
+ *
+ * Export all virtual tool-related tools with collection binding compliance.
+ * Virtual tools are custom JavaScript tools defined on Virtual MCPs.
+ */
+
+// Collection-compliant CRUD tools
+export { COLLECTION_VIRTUAL_TOOLS_CREATE } from "./create";
+export { COLLECTION_VIRTUAL_TOOLS_LIST } from "./list";
+export { COLLECTION_VIRTUAL_TOOLS_GET } from "./get";
+export { COLLECTION_VIRTUAL_TOOLS_UPDATE } from "./update";
+export { COLLECTION_VIRTUAL_TOOLS_DELETE } from "./delete";
+
+// Re-export schema types
+export type {
+  VirtualToolEntity,
+  VirtualToolCreateData,
+  VirtualToolUpdateData,
+  VirtualToolDefinition,
+} from "./schema";

--- a/apps/mesh/src/tools/virtual-tool/list.ts
+++ b/apps/mesh/src/tools/virtual-tool/list.ts
@@ -1,0 +1,98 @@
+/**
+ * COLLECTION_VIRTUAL_TOOLS_LIST Tool
+ *
+ * List all virtual tools for a Virtual MCP with collection binding compliance.
+ * Supports pagination via limit/offset.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { VirtualToolEntitySchema } from "./schema";
+
+/**
+ * Input schema for listing virtual tools
+ * Extends standard collection list with required virtual_mcp_id
+ */
+const ListInputSchema = z.object({
+  virtual_mcp_id: z
+    .string()
+    .describe("ID of the Virtual MCP to list tools for"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .optional()
+    .describe("Maximum number of items to return"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of items to skip"),
+});
+
+export type ListVirtualToolsInput = z.infer<typeof ListInputSchema>;
+
+/**
+ * Output schema for virtual tools list
+ */
+const ListOutputSchema = z.object({
+  items: z.array(VirtualToolEntitySchema).describe("Array of virtual tools"),
+  totalCount: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Total number of virtual tools"),
+  hasMore: z
+    .boolean()
+    .optional()
+    .describe("Whether there are more items available"),
+});
+
+export const COLLECTION_VIRTUAL_TOOLS_LIST = defineTool({
+  name: "COLLECTION_VIRTUAL_TOOLS_LIST",
+  description: "List all virtual tools for a Virtual MCP",
+
+  inputSchema: ListInputSchema,
+  outputSchema: ListOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+
+    await ctx.access.check();
+
+    // Verify the Virtual MCP exists and belongs to the organization
+    const virtualMcp = await ctx.storage.virtualMcps.findById(
+      input.virtual_mcp_id,
+    );
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      return {
+        items: [],
+        totalCount: 0,
+        hasMore: false,
+      };
+    }
+
+    // Get all virtual tools
+    const allTools = await ctx.storage.virtualMcps.listVirtualTools(
+      input.virtual_mcp_id,
+    );
+
+    // Apply pagination
+    const totalCount = allTools.length;
+    const offset = input.offset ?? 0;
+    const limit = input.limit ?? 100;
+    const paginatedTools = allTools.slice(offset, offset + limit);
+    const hasMore = offset + limit < totalCount;
+
+    return {
+      items: paginatedTools,
+      totalCount,
+      hasMore,
+    };
+  },
+});

--- a/apps/mesh/src/tools/virtual-tool/schema.ts
+++ b/apps/mesh/src/tools/virtual-tool/schema.ts
@@ -1,0 +1,218 @@
+/**
+ * Virtual Tool Entity Schema
+ *
+ * Virtual tools are custom tools defined on Virtual MCPs with JavaScript code
+ * that executes in a QuickJS sandbox. They can reference tools from other
+ * connections using the flat namespace pattern (tools.TOOL_NAME(args)).
+ *
+ * Virtual tools are stored in the `tools` JSON column of the connections table
+ * (for VIRTUAL connections). They are distinguished by the presence of
+ * `_meta["mcp.mesh"]["tool.fn"]` containing the executable JavaScript code.
+ */
+
+import { z } from "zod";
+
+/**
+ * Tool annotations schema from MCP spec (internal use)
+ */
+const ToolAnnotationsSchema = z.object({
+  title: z.string().optional(),
+  readOnlyHint: z.boolean().optional(),
+  destructiveHint: z.boolean().optional(),
+  idempotentHint: z.boolean().optional(),
+  openWorldHint: z.boolean().optional(),
+});
+
+type ToolAnnotations = z.infer<typeof ToolAnnotationsSchema>;
+
+/**
+ * MCP Mesh virtual tool metadata (internal use)
+ * Contains the JavaScript code that implements the tool
+ */
+const VirtualToolMetaSchema = z.object({
+  "tool.fn": z
+    .string()
+    .describe(
+      "JavaScript ES module code that exports a default async function",
+    ),
+});
+
+type VirtualToolMeta = z.infer<typeof VirtualToolMetaSchema>;
+
+/**
+ * Virtual tool entity schema
+ * Represents a tool defined with JavaScript code on a Virtual MCP
+ */
+export const VirtualToolEntitySchema = z.object({
+  // Tool identity
+  id: z
+    .string()
+    .describe("Unique identifier for the virtual tool (auto-generated)"),
+  name: z
+    .string()
+    .min(1)
+    .max(255)
+    .describe("Tool name (must be unique within the Virtual MCP)"),
+  description: z
+    .string()
+    .optional()
+    .describe("Human-readable description of what the tool does"),
+
+  // Tool interface
+  inputSchema: z
+    .record(z.string(), z.unknown())
+    .describe("JSON Schema defining the tool's input parameters"),
+  outputSchema: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("JSON Schema defining the tool's output (optional)"),
+  annotations: ToolAnnotationsSchema.optional().describe(
+    "MCP tool annotations",
+  ),
+
+  // Virtual tool code
+  code: z
+    .string()
+    .describe(
+      "JavaScript ES module code. Must export default an async function: export default async (tools, args) => { ... }",
+    ),
+
+  // Dependency tracking
+  connection_dependencies: z
+    .array(z.string())
+    .describe(
+      "Connection IDs that this tool depends on (specified by the creator)",
+    ),
+
+  // Audit fields
+  created_at: z.string().describe("When the virtual tool was created"),
+  updated_at: z.string().describe("When the virtual tool was last updated"),
+});
+
+export type VirtualToolEntity = z.infer<typeof VirtualToolEntitySchema>;
+
+/**
+ * Input schema for creating a virtual tool
+ */
+export const VirtualToolCreateDataSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(255)
+    .describe("Tool name (must be unique within the Virtual MCP)"),
+  description: z.string().optional().describe("Human-readable description"),
+  inputSchema: z
+    .record(z.string(), z.unknown())
+    .describe("JSON Schema defining the tool's input parameters"),
+  outputSchema: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("JSON Schema for output"),
+  annotations: ToolAnnotationsSchema.optional().describe(
+    "MCP tool annotations",
+  ),
+  code: z
+    .string()
+    .describe(
+      "JavaScript ES module code. Must export default an async function: export default async (tools, args) => { ... }",
+    ),
+  connection_dependencies: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Connection IDs that this tool depends on. Creates indirect aggregations to prevent deletion of referenced connections.",
+    ),
+});
+
+export type VirtualToolCreateData = z.infer<typeof VirtualToolCreateDataSchema>;
+
+/**
+ * Input schema for updating a virtual tool
+ */
+export const VirtualToolUpdateDataSchema = z.object({
+  name: z.string().min(1).max(255).optional().describe("New tool name"),
+  description: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("New description (null to clear)"),
+  inputSchema: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("New input schema"),
+  outputSchema: z
+    .record(z.string(), z.unknown())
+    .nullable()
+    .optional()
+    .describe("New output schema (null to clear)"),
+  annotations: ToolAnnotationsSchema.nullable()
+    .optional()
+    .describe("New annotations (null to clear)"),
+  code: z.string().optional().describe("New JavaScript code"),
+  connection_dependencies: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Connection IDs that this tool depends on. Replaces existing dependencies if provided.",
+    ),
+});
+
+export type VirtualToolUpdateData = z.infer<typeof VirtualToolUpdateDataSchema>;
+
+/**
+ * Internal representation of a virtual tool as stored in the tools JSON column
+ * This matches the ToolDefinition format with the special _meta["mcp.mesh"] marker
+ */
+export interface VirtualToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: ToolAnnotations;
+  _meta: {
+    "mcp.mesh": VirtualToolMeta;
+    /** Connection IDs that this virtual tool depends on */
+    connectionDependencies?: string[];
+  };
+}
+
+/**
+ * Type guard to check if a tool definition is a virtual tool
+ */
+export function isVirtualTool(
+  tool: { _meta?: Record<string, unknown> } | null | undefined,
+): tool is VirtualToolDefinition {
+  if (!tool?._meta) return false;
+  const mcpMesh = tool._meta["mcp.mesh"] as Record<string, unknown> | undefined;
+  return typeof mcpMesh?.["tool.fn"] === "string";
+}
+
+/**
+ * Extract the code from a virtual tool definition
+ */
+export function getVirtualToolCode(tool: VirtualToolDefinition): string {
+  return tool._meta["mcp.mesh"]["tool.fn"];
+}
+
+/**
+ * Convert a VirtualToolDefinition (storage format) to VirtualToolEntity
+ */
+export function fromVirtualToolDefinition(
+  id: string,
+  def: VirtualToolDefinition,
+  createdAt: string,
+  updatedAt: string,
+): VirtualToolEntity {
+  return {
+    id,
+    name: def.name,
+    description: def.description,
+    inputSchema: def.inputSchema,
+    outputSchema: def.outputSchema,
+    annotations: def.annotations,
+    code: def._meta["mcp.mesh"]["tool.fn"],
+    connection_dependencies: def._meta.connectionDependencies ?? [],
+    created_at: createdAt,
+    updated_at: updatedAt,
+  };
+}

--- a/apps/mesh/src/tools/virtual-tool/update.ts
+++ b/apps/mesh/src/tools/virtual-tool/update.ts
@@ -1,0 +1,77 @@
+/**
+ * COLLECTION_VIRTUAL_TOOLS_UPDATE Tool
+ *
+ * Update an existing virtual tool on a Virtual MCP.
+ * The creator can specify new connection dependencies when updating.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { VirtualToolEntitySchema, VirtualToolUpdateDataSchema } from "./schema";
+
+/**
+ * Input schema for updating a virtual tool
+ */
+const UpdateInputSchema = z.object({
+  virtual_mcp_id: z.string().describe("ID of the Virtual MCP"),
+  name: z.string().describe("Current name of the virtual tool to update"),
+  data: VirtualToolUpdateDataSchema.describe(
+    "Partial virtual tool data to update",
+  ),
+});
+
+export type UpdateVirtualToolInput = z.infer<typeof UpdateInputSchema>;
+
+/**
+ * Output schema for virtual tool update
+ */
+const UpdateOutputSchema = z.object({
+  item: VirtualToolEntitySchema.describe("The updated virtual tool"),
+});
+
+export const COLLECTION_VIRTUAL_TOOLS_UPDATE = defineTool({
+  name: "COLLECTION_VIRTUAL_TOOLS_UPDATE",
+  description:
+    "Update an existing virtual tool on a Virtual MCP. Specify connection_dependencies to update which connections this tool uses.",
+
+  inputSchema: UpdateInputSchema,
+  outputSchema: UpdateOutputSchema,
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const organization = requireOrganization(ctx);
+
+    await ctx.access.check();
+
+    // Verify the Virtual MCP exists and belongs to the organization
+    const virtualMcp = await ctx.storage.virtualMcps.findById(
+      input.virtual_mcp_id,
+    );
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      throw new Error(`Virtual MCP not found: ${input.virtual_mcp_id}`);
+    }
+
+    // Verify the tool exists
+    const existingTool = await ctx.storage.virtualMcps.getVirtualTool(
+      input.virtual_mcp_id,
+      input.name,
+    );
+    if (!existingTool) {
+      throw new Error(`Virtual tool not found: ${input.name}`);
+    }
+
+    // Use the dependencies specified by the creator (if provided)
+    const connectionDependencies = input.data.connection_dependencies;
+
+    // Update the virtual tool
+    const tool = await ctx.storage.virtualMcps.updateVirtualTool(
+      input.virtual_mcp_id,
+      input.name,
+      input.data,
+      connectionDependencies,
+    );
+
+    return { item: tool };
+  },
+});


### PR DESCRIPTION
This reverts commit 761682fdf5e38a2c3b530accbdf72dd90ba45d14.

<!-- deno-fmt-ignore-file -->

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reapplies Virtual Tools for Virtual MCPs. Users can define JS tools that run in a sandbox, call downstream tools, and manage connection dependencies with clear direct vs. indirect behavior.

- **New Features**
  - Virtual tools on Virtual MCPs
    - Create/list/get/update/delete via new collection tools.
    - Code stored in connections.tools (_meta["mcp.mesh"]["tool.fn"]); optional output schema and annotations.
    - Track connection_dependencies; only “direct” deps expose tools, “indirect” enforce FK only.
  - Execution and aggregation
    - Passthrough client merges virtual tools with downstream tools and executes virtual tool code in the sandbox (tools.TOOL_NAME(args)).
    - Virtual tools do not call other virtual tools; downstream tools only.
  - Proxy/UI behavior
    - VIRTUAL connections always list tools via client (not cached); UI treats VIRTUAL as always authenticated and fetches tools dynamically.
    - Connection list tool now excludes VIRTUAL by default; add include_virtual to include them.
  - Reliability
    - Keeps SSE transport open for GET requests in MCP server builder.

- **Migration**
  - Adds dependency_mode to connection_aggregations with index; values: direct | indirect.
  - Existing rows default to direct; SQLite/Postgres compatible up/down.
  - Run database migrations.

<sup>Written for commit 093cef1c4c64b1d3aa3f479b530f394fc36c754a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

