### PR TITLE
fix(connections): simplify finalScopes validation

### DIFF
--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -241,7 +241,7 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       (data.configuration_state !== undefined ||
         data.configuration_scopes !== undefined) &&
       finalState &&
-      finalScopes.length > 0
+      finalScopes
     ) {
       try {
         await using proxy = await ctx.createMCPProxy(id);


### PR DESCRIPTION
Updated the validation logic for finalScopes to directly check its truthiness instead of relying on its length. This change enhances code clarity and maintains the intended functionality without altering the overall behavior of the connection update process.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified finalScopes validation in the connections update flow by checking its truthiness instead of its length. This preserves current behavior and avoids errors when finalScopes is undefined.

<sup>Written for commit 923c14719ba24328de9b746d943b96089fd58bb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

