### PR TITLE
refactor(connection-settings): improve form state handling and clean …

### DIFF
--- a/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from "@deco/ui/components/button.tsx";
 import { Key01, File06, Loading01 } from "@untitledui/icons";
 import { Suspense } from "react";
-import type { useForm } from "react-hook-form";
+import { useWatch, type useForm } from "react-hook-form";
 import { McpConfigurationForm } from "./mcp-configuration-form";
 import type { ConnectionFormData } from "./schema";
 
@@ -147,7 +147,11 @@ function McpConfigurationContent({
 }) {
   const { stateSchema } = useMcpConfiguration(connection.id);
 
-  const formState = form.watch("configuration_state");
+  // useWatch is more reliable for triggering re-renders than form.watch()
+  const formState = useWatch({
+    control: form.control,
+    name: "configuration_state",
+  });
 
   const handleFormStateChange = (state: Record<string, unknown>) => {
     form.setValue("configuration_state", state, { shouldDirty: true });

--- a/packages/mesh-sdk/src/hooks/use-collections.ts
+++ b/packages/mesh-sdk/src/hooks/use-collections.ts
@@ -286,7 +286,7 @@ export function useCollectionList<T extends CollectionEntity>(
     staleTime: 30_000,
     retry: false,
     select: (result) => {
-      const payload = extractPayload<CollectionListOutput<T>>(result);
+      const payload = extractPayload<CollectionListOutput<T>>(result ?? {});
       return payload?.items ?? [];
     },
   });


### PR DESCRIPTION
…up unused code

- Replaced `form.watch()` with `useWatch()` for more reliable re-renders when `configuration_state` changes.
- Updated `CustomObjectFieldTemplate` to use `title` as the key for data operations, enhancing clarity.
- Removed the unused `extractFieldName` function to streamline the codebase.
- Ensured `RjsfForm` re-renders correctly by using a key based on `formState`.

These changes enhance the performance and maintainability of the connection settings component.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves connection settings form reactivity and cleans up unused code to make UI updates reliable and maintenance easier. Also prevents a crash when collection queries return undefined.

- **Refactors**
  - Switched form.watch to useWatch for configuration_state to trigger reliable re-renders.
  - Keyed RjsfForm by formState to force updates when state changes.
  - Updated CustomObjectFieldTemplate to use title as the data key and rely on formContext for source-of-truth; removed extractFieldName.

- **Bug Fixes**
  - Safely handle undefined results in useCollectionList by guarding extractPayload.

<sup>Written for commit 25ca579a4d3e1d8949af6cceed233ba3a988e225. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

