### PR TITLE
fix(ci): add Node.js setup to runtime publish workflow

### DIFF
--- a/.github/workflows/publish-runtime-npm.yaml
+++ b/.github/workflows/publish-runtime-npm.yaml
@@ -7,12 +7,12 @@ on:
       - "packages/runtime/**"
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,6 +21,12 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## What is this contribution about?

Fixes the failing "Generate JSON schema" step in the `@decocms/runtime` publish workflow.

The `ts-json-schema-generator` package uses TypeScript's compiler API internally, which requires a proper Node.js/TypeScript environment in CI. This PR adds:

1. **`actions/setup-node@v4`** - Ensures TypeScript and the npm registry are properly configured
2. **`id-token: write` permission** - Required for OIDC authentication (aligning with PR #2387's migration goal)
3. **Moved permissions to job level** - Cleaner structure matching other publish workflows

## Screenshots/Demonstration

N/A - CI workflow changes only.

## How to Test

1. Trigger the "Publish @decocms/runtime" workflow via workflow_dispatch
2. Verify the "Generate JSON schema" step completes successfully
3. Verify the rest of the workflow runs as expected

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the failing “Generate JSON schema” step in the @decocms/runtime publish workflow by adding Node.js setup and job-level permissions. This ensures TypeScript tooling runs correctly and OIDC auth works during publish.

- **Bug Fixes**
  - Added actions/setup-node@v4 (Node 22) with npm registry configuration.
  - Granted id-token: write for OIDC in the publish job.
  - Moved permissions to the job level for consistency with other workflows.

<sup>Written for commit a7d6b0d39304c19312b22a180b1b754ff4c33fd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

