### PR TITLE
fix(runtime): resolve CI failure in JSON schema generation

### DIFF
--- a/packages/runtime/scripts/generate-json-schema.ts
+++ b/packages/runtime/scripts/generate-json-schema.ts
@@ -1,11 +1,16 @@
 // heavily inspired by https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/scripts/generate-json-schema.ts
 import { writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createGenerator } from "ts-json-schema-generator";
 import type { Config, Schema } from "ts-json-schema-generator";
 
+// Use standard ESM __dirname pattern for cross-runtime compatibility
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const config: Config = {
-  path: join(import.meta.dirname!, "../src/wrangler.ts"),
+  path: join(__dirname, "../src/wrangler.ts"),
+  tsconfig: join(__dirname, "../tsconfig.json"),
   type: "WranglerConfig",
   skipTypeCheck: true,
 };
@@ -19,6 +24,6 @@ const schema = applyFormattingRules(
 );
 
 writeFileSync(
-  join(import.meta.dirname!, "../config-schema.json"),
+  join(__dirname, "../config-schema.json"),
   JSON.stringify(schema, null, 2),
 );


### PR DESCRIPTION
## What is this contribution about?

Fixes CI failure in the "Publish @decocms/runtime" workflow where the "Generate JSON schema" step was failing with "No input files" error.

**Root cause:** The script used Bun-specific `import.meta.dirname` which may behave inconsistently across different runtime environments and Bun versions. Additionally, `ts-json-schema-generator` wasn't explicitly given the tsconfig path, causing it to potentially use the wrong TypeScript configuration.

**Changes:**
- Use standard ESM `__dirname` pattern (`fileURLToPath` + `dirname`) for cross-runtime compatibility
- Explicitly specify `tsconfig` path to ensure consistent TypeScript program resolution

**Failed run:** https://github.com/decocms/mesh/actions/runs/21712974584/job/62621116147

## Screenshots/Demonstration

N/A

## How to Test

1. Run locally: `cd packages/runtime && bun run scripts/generate-json-schema.ts`
2. Verify it completes without error and generates `config-schema.json`
3. CI should now pass the "Generate JSON schema" step

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing "Generate JSON schema" step in the Publish @decocms/runtime workflow. Uses a cross-runtime ESM __dirname and sets the tsconfig path so schema generation runs reliably in CI and locally.

- **Bug Fixes**
  - Replace Bun-specific import.meta.dirname with fileURLToPath + dirname.
  - Pass tsconfig path to ts-json-schema-generator.

<sup>Written for commit 637bc23882815d9b7e2919942b0a13847d2e6f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

