### PR TITLE
fix(tests): move Postman to OAuth-supporting servers list

### DIFF
--- a/apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts
@@ -46,12 +46,11 @@ const MCP_SERVERS = [
   { url: "https://mcp.supabase.com/mcp", name: "Supabase" },
   { url: "https://api.grain.com/_/mcp", name: "Grain" },
   { url: "https://mcp.apify.com/", name: "Apify" },
+  { url: "https://mcp.postman.com/mcp", name: "Postman" },
 ];
 
 /** MCP servers that DON'T support OAuth - should return 401 without WWW-Authenticate */
-const NO_OAUTH_SERVERS = [
-  { url: "https://mcp.postman.com/mcp", name: "Postman" },
-];
+const NO_OAUTH_SERVERS: { url: string; name: string }[] = [];
 
 interface ProtectedResourceMetadata {
   resource?: string;


### PR DESCRIPTION
## What is this contribution about?

Fixes the CI test failure introduced after #2390. Postman's MCP server (`https://mcp.postman.com/mcp`) now supports OAuth authentication, returning a `WWW-Authenticate` header with MCP OAuth metadata.

The test expected Postman to return 401 without a `WWW-Authenticate` header, but it now returns:
```
"mcp",resource_metadata="http://localhost/mcp/conn_postman/.well-known/oauth-protected-resource"
```

This PR moves Postman from `NO_OAUTH_SERVERS` to `MCP_SERVERS` so the OAuth proxy tests correctly validate its OAuth discovery endpoints.

## Screenshots/Demonstration

N/A

## How to Test

1. Run `bun test apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts`
2. Verify all Postman OAuth tests pass (Protected Resource Metadata, Auth Server Metadata, Authorize Endpoint)

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing OAuth proxy e2e tests by treating Postman’s MCP server as OAuth-supporting. Postman now returns a WWW-Authenticate header with MCP OAuth metadata, so we validate its OAuth discovery endpoints and unblock CI.

<sup>Written for commit 7cb2bc9f3c2f4bae4ccbfa45058dd56f741d718d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

