### PR TITLE
fix(home): add z-index and background to header for proper stacking

### DIFF
--- a/apps/mesh/src/web/routes/orgs/home/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/page.tsx
@@ -80,7 +80,7 @@ function HomeContent() {
 
   return (
     <Chat className="bg-background">
-      <Page.Header className="flex-none">
+      <Page.Header className="flex-none z-10 bg-background">
         <Page.Header.Left className="gap-2">
           {activeThread?.title && (
             <TypewriterTitle


### PR DESCRIPTION
## What is this contribution about?

Adds `z-10` and `bg-background` classes to the Page.Header in the home page to ensure the header stays visually above scrolling chat content. This prevents elements with their own stacking contexts (shadows, transforms, etc.) from rendering above the header when content scrolls.

## Screenshots/Demonstration

N/A - Visual fix for header stacking order.

## How to Test

1. Navigate to the organization home page
2. Start a chat conversation with enough messages to require scrolling
3. Scroll through the messages
4. Verify the header stays visually on top of the scrolling content

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix header stacking on the org home page so it always renders above chat content. Adds z-10 and bg-background to Page.Header to prevent items with their own stacking contexts (shadows, transforms) from overlapping.

<sup>Written for commit d64f94e455e8c636f8d4da68ca54ad99feaac085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

