### PR TITLE
fix(shell): prevent crash when accessing non-existent organization

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -207,6 +207,15 @@ function ShellLayoutContent() {
     );
   }
 
+  // If org parameter exists but organization is invalid/doesn't exist, redirect to home
+  if (!projectContext.org) {
+    // Prevent infinite redirect loop - only redirect if not already at home
+    if (window.location.pathname !== "/") {
+      window.location.href = "/";
+    }
+    return null;
+  }
+
   return (
     <ProjectContextProvider {...projectContext}>
       <PersistentSidebarProvider>


### PR DESCRIPTION
## What is this contribution about?

Fixes a crash that occurs when users try to access a non-existent organization URL (e.g., `/fake-org-123`).

**Root Cause:**
When `authClient.organization.setActive()` is called with a non-existent organization slug, it returns `{ data: null }`, which creates a `projectContext` object with `org: null`. The previous null check only validated that `projectContext` exists, not that `projectContext.org` is valid. This caused `ProjectContextProvider` to receive `org: null` and crash when trying to access `org.slug`.

**Solution:**
Added an additional null check for `projectContext.org` with a redirect to the home page (`/`) when the organization doesn't exist. The redirect includes a safeguard to prevent infinite loops by checking if the current pathname is already `/`.

## Screenshots/Demonstration

N/A - Bug fix with no UI changes

## How to Test

1. Start the development server and log in
2. Navigate to a non-existent organization URL (e.g., `http://localhost:3000/fake-org-12345`)
3. **Expected:** You should be redirected to `/` (home page) without seeing any error
4. **Previous behavior:** App crashed with `TypeError: Cannot read properties of null (reading 'slug')`
5. Verify that accessing a valid organization still works normally
6. Verify that navigating directly to `/` works without any redirect loops

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a crash in ShellLayout when visiting a non-existent organization (e.g., /fake-org-123) by redirecting to the home page instead of rendering with a null org.

- **Bug Fixes**
  - Redirect to "/" when projectContext.org is null.
  - Add a safeguard to avoid redirect loops by checking the current pathname.
  - No UI changes; valid organization routes continue to work.

<sup>Written for commit a771380055a907aa386fc8298d8d94f9431941fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

