### PR TITLE
fix(auth): strip Authorization header before session retrieval to pre…

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -613,8 +613,16 @@ async function authenticateRequest(
   }
 
   try {
+    // Strip the Authorization header before calling getSession.
+    // We've already tried all Bearer-based auth (Mesh JWT, API key) above.
+    // If we pass the Bearer token to getSession, Better Auth's API key plugin
+    // will attempt to validate it as an API key and throw INVALID_API_KEY,
+    // flooding logs with false-positive errors.
+    const sessionHeaders = new Headers(req.headers);
+    sessionHeaders.delete("Authorization");
+
     const session = await timings.measure("auth_get_session", () =>
-      auth.api.getSession({ headers: req.headers }),
+      auth.api.getSession({ headers: sessionHeaders }),
     );
 
     if (session) {
@@ -628,7 +636,7 @@ async function authenticateRequest(
           "auth_get_full_organization",
           () =>
             auth.api
-              .getFullOrganization({ headers: req.headers })
+              .getFullOrganization({ headers: sessionHeaders })
               .catch(() => null),
         );
 

--- a/apps/mesh/src/tools/database/index.ts
+++ b/apps/mesh/src/tools/database/index.ts
@@ -107,10 +107,12 @@ function isRoleOrSchemaNotFoundError(error: unknown): boolean {
     // PostgreSQL error codes:
     // 3F000 - invalid_schema_name (schema doesn't exist)
     // 42704 - undefined_object (role doesn't exist)
+    // 22023 - invalid_parameter_value (SET LOCAL ROLE with non-existent role)
     const code = (error as { code?: string }).code;
     return (
       code === "3F000" ||
       code === "42704" ||
+      code === "22023" ||
       (msg.includes("schema") && msg.includes("does not exist")) ||
       (msg.includes("role") && msg.includes("does not exist"))
     );

--- a/packages/bindings/src/core/client/proxy.ts
+++ b/packages/bindings/src/core/client/proxy.ts
@@ -111,7 +111,17 @@ export function createMCPClientProxy<T extends Record<string, unknown>>(
             )}`,
           );
         }
-        return structuredContent;
+
+        // Prefer structuredContent, but fall back to parsing content[0].text
+        // structuredContent may be undefined if the response doesn't include it
+        // (e.g., SDK version mismatch, schema parsing stripping unknown fields)
+        if (structuredContent !== undefined) {
+          return structuredContent;
+        }
+        const textContent = (content as { text: string }[])?.[0]?.text;
+        return typeof textContent === "string"
+          ? safeParse(textContent)
+          : undefined;
       }
 
       async function listToolsFn() {


### PR DESCRIPTION
…vent false-positive errors

Modifies the authenticateRequest function to remove the Authorization header from the request before calling getSession. This change prevents Better Auth's API key plugin from incorrectly validating Bearer tokens, which could flood logs with invalid API key errors.

Additionally, updates error handling in isRoleOrSchemaNotFoundError to include a new PostgreSQL error code for invalid parameter values.

Also, enhances the createMCPClientProxy function to prefer structuredContent while providing a fallback to text content parsing, improving response handling.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Better Auth from misclassifying Bearer tokens as API keys by stripping the Authorization header before session retrieval. Also improves Postgres error handling and MCP client response parsing.

- **Bug Fixes**
  - Remove Authorization header before auth.api.getSession/getFullOrganization to prevent invalid API key errors.
  - Handle PostgreSQL error code 22023 in isRoleOrSchemaNotFoundError.
  - Prefer structuredContent in createMCPClientProxy, with a fallback to safe parsing of text content.

<sup>Written for commit 3385fab4f358424ea5e4679ae740e8da4a326d88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

