### PR TITLE
fix(runtime): remove unused OAuthTokenRequestBody interface

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",


### PR DESCRIPTION
- Remove unused interface that was causing TS6196 errors in MCPs
- Bump version to 1.2.8 to trigger npm publish

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unused OAuthTokenRequestBody interface in the runtime to fix TS6196 errors in MCPs. Bumped the package version to 1.2.8 to publish the fix.

<sup>Written for commit 00b1335c8e6641ea64aadf5c061772bddec5ac65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

