### PR TITLE
fix(chat): skip LLM list fetch for restricted connections and add error boundaries to model selector

### DIFF
--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -524,8 +524,12 @@ export function ChatProvider({ children }: PropsWithChildren) {
     string | null
   >(`${locator}:selected-virtual-mcp-id`, null);
 
-  // Model state
-  const modelsConnections = useModelConnections();
+  // Model state — filter out connections where the user's role allows no models
+  const allModelsConnections = useModelConnections();
+  const { hasConnectionModels } = useAllowedModels();
+  const modelsConnections = allModelsConnections.filter((conn) =>
+    hasConnectionModels(conn.id),
+  );
   const [selectedModel, setModel] = useModelState(locator, modelsConnections);
 
   // Mode state

--- a/apps/mesh/src/web/hooks/use-allowed-models.ts
+++ b/apps/mesh/src/web/hooks/use-allowed-models.ts
@@ -55,10 +55,25 @@ export function useAllowedModels() {
     return connModels.includes("*") || connModels.includes(modelId);
   };
 
+  /**
+   * Check if a connection has any allowed models at all.
+   * Used to filter out connections from the selector when the user's role
+   * doesn't grant access to any models on that connection.
+   */
+  const hasConnectionModels = (connectionId: string): boolean => {
+    if (allowAll) return true;
+    const connModels = models[connectionId];
+    if (connModels && connModels.length > 0) return true;
+    // Check wildcard connection
+    const wildcard = models["*"];
+    return wildcard ? wildcard.length > 0 : false;
+  };
+
   return {
     allowAll,
     models,
     isLoading,
     isModelAllowed,
+    hasConnectionModels,
   };
 }


### PR DESCRIPTION
## Summary

- **Filter out connections with no allowed models**: When a user's role restricts model access, connections that have zero permitted models are now excluded from the selector and from the ChatProvider's model state. This prevents fetching the LLM list from inaccessible connections — avoiding empty states and potential auth errors.
- **Error boundary around model list**: The model list inside the selector popover is wrapped in `ErrorBoundary` + `Suspense` (keyed by connection ID). If a provider fails to load, a graceful "Failed to load models" fallback with a Retry button is shown, while the connection dropdown stays accessible so the user can switch providers.
- **Resilient trigger button**: The model selector trigger button now resolves display info (name, logo) in its own `ErrorBoundary` + `Suspense`, falling back to the short model ID if resolution fails.

### Files changed

| File | Change |
|------|--------|
| `use-allowed-models.ts` | Added `hasConnectionModels(connectionId)` helper |
| `context.tsx` | Filter `modelsConnections` by allowed models before model state init |
| `select-model.tsx` | Extracted `ConnectionModelList`, added error boundaries, filtered connections |

## Test plan

- [ ] As an admin/owner, verify all model connections still appear and models load normally
- [ ] As a restricted-role user with access to only specific connections, verify:
  - Connections with no allowed models don't appear in the dropdown
  - No empty model lists or auth errors
- [ ] Simulate a provider failure (e.g. disconnect network) and verify:
  - The error fallback appears with "Failed to load models" message
  - The connection dropdown remains usable to switch providers
  - Clicking "Retry" re-attempts the fetch
- [ ] Verify the trigger button still shows the model name/logo, and degrades gracefully to the short model ID on error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents fetching LLM lists from inaccessible connections and adds error boundaries to the model selector, fixing empty states and avoiding auth errors.

- **Bug Fixes**
  - Filter out connections with zero allowed models in ChatProvider and the selector to skip restricted provider fetches.
  - Wrap the connection’s model list in ErrorBoundary + Suspense with a retry fallback so failures don’t break the selector.
  - Make the trigger button resilient by resolving name/logo in its own boundary and falling back to the short model ID on error.

<sup>Written for commit 9c029bd46985c0d85c6f418550851c1a58f3f4a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

