### PR TITLE
feat(monitoring): add toggle to hide system tool calls

### DIFF
--- a/apps/mesh/src/storage/monitoring.ts
+++ b/apps/mesh/src/storage/monitoring.ts
@@ -98,6 +98,7 @@ export class SqlMonitoringStorage implements MonitoringStorage {
   async query(filters: {
     organizationId?: string;
     connectionId?: string;
+    excludeConnectionIds?: string[];
     virtualMcpId?: string;
     toolName?: string;
     isError?: boolean;
@@ -124,6 +125,21 @@ export class SqlMonitoringStorage implements MonitoringStorage {
     if (filters.connectionId) {
       query = query.where("connection_id", "=", filters.connectionId);
       countQuery = countQuery.where("connection_id", "=", filters.connectionId);
+    }
+    if (
+      filters.excludeConnectionIds &&
+      filters.excludeConnectionIds.length > 0
+    ) {
+      query = query.where(
+        "connection_id",
+        "not in",
+        filters.excludeConnectionIds,
+      );
+      countQuery = countQuery.where(
+        "connection_id",
+        "not in",
+        filters.excludeConnectionIds,
+      );
     }
     if (filters.virtualMcpId) {
       query = query.where("virtual_mcp_id", "=", filters.virtualMcpId);

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -142,6 +142,7 @@ export interface MonitoringStorage {
   query(filters: {
     organizationId?: string;
     connectionId?: string;
+    excludeConnectionIds?: string[];
     virtualMcpId?: string;
     toolName?: string;
     isError?: boolean;

--- a/apps/mesh/src/tools/monitoring/list.ts
+++ b/apps/mesh/src/tools/monitoring/list.ts
@@ -41,6 +41,12 @@ export const MONITORING_LOGS_LIST = defineTool({
   description: "List monitoring logs for tool calls in the organization",
   inputSchema: z.object({
     connectionId: z.string().optional().describe("Filter by connection ID"),
+    excludeConnectionIds: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Exclude logs from these connection IDs (e.g. system connections)",
+      ),
     virtualMcpId: z
       .string()
       .optional()
@@ -108,6 +114,7 @@ export const MONITORING_LOGS_LIST = defineTool({
     const filters = {
       organizationId: org.id,
       connectionId: input.connectionId,
+      excludeConnectionIds: input.excludeConnectionIds,
       virtualMcpId: input.virtualMcpId,
       toolName: input.toolName,
       isError: input.isError,

--- a/apps/mesh/src/web/components/monitoring/types.tsx
+++ b/apps/mesh/src/web/components/monitoring/types.tsx
@@ -106,6 +106,8 @@ export interface MonitoringSearchParams {
   // Property filters (serialized as "key:operator:value,key2:operator2:value2")
   // Operators: eq (equals), contains, exists
   propertyFilters?: string;
+  // Hide system/management tool calls (e.g. from the self MCP)
+  hideSystem?: boolean;
 }
 
 // ============================================================================

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -261,6 +261,7 @@ const monitoringRoute = createRoute({
       page: z.number().optional(),
       streaming: z.boolean().default(true),
       propertyFilters: z.string().default(""),
+      hideSystem: z.boolean().default(false),
     }),
   ),
 });


### PR DESCRIPTION
## Summary

- Adds a **"Hide system calls"** toggle to the monitoring filters popover that excludes tool calls from the built-in self/management MCP (`{orgId}_self`) at the database level
- Filtering is done server-side via a new `excludeConnectionIds` parameter through the full stack (storage, tool, frontend), so infinite-scroll pagination remains accurate
- Toggle state is persisted in the URL search params and counted in the active filters badge

## Changes

- **Storage layer**: Added `excludeConnectionIds` to `MonitoringStorage.query()` with a `WHERE connection_id NOT IN (...)` clause
- **Backend tool**: Added `excludeConnectionIds` to `MONITORING_LOGS_LIST` input schema
- **Frontend**: Added `hideSystem` URL param, `Switch` toggle in `FiltersPopover`, and wired it through to the query using `WellKnownOrgMCPId.SELF(orgId)`

## Test plan

- [ ] Open Monitoring page, toggle "Hide system calls" on -- verify management tool calls (e.g. `MONITORING_LOGS_LIST`, `CONNECTION_*`) are hidden
- [ ] Toggle off -- verify all logs reappear
- [ ] Verify the filter badge count increments when the toggle is on
- [ ] Verify pagination (infinite scroll) works correctly with the toggle enabled
- [ ] Verify the toggle state persists across page reloads via URL param (`?hideSystem=true`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Hide system calls” toggle to Monitoring that filters out logs from the self/management MCP at the database level. Pagination stays accurate, and the toggle persists via URL and counts toward active filters.

- **New Features**
  - Storage: add excludeConnectionIds to MonitoringStorage.query with NOT IN filtering.
  - Tool: extend MONITORING_LOGS_LIST input with excludeConnectionIds and pass through.
  - UI: add Switch in FiltersPopover; add hideSystem URL param (default false) and include in active filter count.
  - Behavior: excludes WellKnownOrgMCPId.SELF(orgId) when enabled.

<sup>Written for commit 696881f8a37d8de136ba76a805aac242f9633eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

