### PR TITLE
Binding collection error boundary

### DIFF
--- a/apps/mesh/src/web/components/binding-collection-view.tsx
+++ b/apps/mesh/src/web/components/binding-collection-view.tsx
@@ -20,7 +20,12 @@ import {
   type ConnectionCreateData,
 } from "@decocms/mesh-sdk";
 import { Link } from "@tanstack/react-router";
-import { AlertTriangle, Loading01, RefreshCcw01, Settings02 } from "@untitledui/icons";
+import {
+  AlertTriangle,
+  Loading01,
+  RefreshCcw01,
+  Settings02,
+} from "@untitledui/icons";
 import { Suspense, useState } from "react";
 
 interface BindingCollectionViewProps {
@@ -146,17 +151,17 @@ export function BindingCollectionView({
                 activeCollection={activeCollection}
               />
             ) : (
-            <div className="flex flex-col items-center justify-center h-full">
-              <BindingCollectionEmptyState
-                title={emptyState.title}
-                description={emptyState.description}
-                wellKnownMcp={wellKnownMcp}
-                imageSrc={emptyState.imageSrc}
-                onConnected={(connectionId) => {
-                  setInstalledConnectionId(connectionId);
-                }}
-              />
-            </div>
+              <div className="flex flex-col items-center justify-center h-full">
+                <BindingCollectionEmptyState
+                  title={emptyState.title}
+                  description={emptyState.description}
+                  wellKnownMcp={wellKnownMcp}
+                  imageSrc={emptyState.imageSrc}
+                  onConnected={(connectionId) => {
+                    setInstalledConnectionId(connectionId);
+                  }}
+                />
+              </div>
             )}
           </Suspense>
         </ErrorBoundary>


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an error boundary to BindingCollectionView to catch load failures and show a clear recovery path. Users can retry or open the connection’s settings from the error state.

- **New Features**
  - Custom error UI with message and “Try again” that calls resetError.
  - Conditional “Connection Settings” link to /$org/$project/mcps/$connectionId using ORG_ADMIN_PROJECT_SLUG.
  - Suspense spinner kept for normal loading inside the boundary.

<sup>Written for commit 3e8fd610245590d0d7c42fdbcb91ac722df91cab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

