### PR TITLE
feat: project templates

### DIFF
--- a/apps/mesh/src/web/components/create-project-template-dialog.tsx
+++ b/apps/mesh/src/web/components/create-project-template-dialog.tsx
@@ -1,0 +1,483 @@
+/**
+ * Create Project Template Dialog
+ *
+ * A full-width dialog for creating a new project. Displays:
+ * - Left sidebar: category navigation (All templates, My templates, Featured by Deco categories)
+ * - Right content: action cards (Start from scratch, Import file, Import from GitHub)
+ *   and a searchable template grid fetched from a bound template registry connection.
+ */
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  useConnections,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import {
+  PROJECT_TEMPLATE_REGISTRY_BINDING,
+  type ProjectTemplate,
+} from "@decocms/bindings";
+import { connectionImplementsBinding } from "@/web/hooks/use-binding";
+import { Dialog, DialogContent } from "@deco/ui/components/dialog.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Plus, SearchMd, Download01, Grid01, User01 } from "@untitledui/icons";
+import { KEYS } from "@/web/lib/query-keys";
+import { CreateProjectDialog } from "./create-project-dialog";
+import { TemplateOnboardingWizard } from "./template-onboarding-wizard";
+import type { CollectionListOutput } from "@decocms/bindings/collections";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CreateProjectTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type DialogView = "template-selection" | "onboarding";
+
+// ============================================================================
+// Hooks
+// ============================================================================
+
+/**
+ * Find the first connection that implements PROJECT_TEMPLATE_REGISTRY_BINDING
+ */
+function useTemplateRegistryConnection() {
+  const connections = useConnections();
+  if (!connections) return null;
+  return (
+    connections.find((conn) =>
+      connectionImplementsBinding(
+        conn,
+        PROJECT_TEMPLATE_REGISTRY_BINDING as never,
+      ),
+    ) ?? null
+  );
+}
+
+/**
+ * Fetch templates from the registry connection
+ */
+function useTemplates(registryConnectionId: string | null, search: string) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: registryConnectionId,
+    orgId: org.id,
+  });
+
+  return useQuery({
+    queryKey: KEYS.toolCall(
+      registryConnectionId ?? "no-registry",
+      "COLLECTION_PROJECT_TEMPLATE_LIST",
+      JSON.stringify({ search }),
+    ),
+    queryFn: async () => {
+      const searchWhere = search.trim()
+        ? {
+            operator: "or" as const,
+            conditions: [
+              {
+                field: ["title"],
+                operator: "contains" as const,
+                value: search,
+              },
+              {
+                field: ["description"],
+                operator: "contains" as const,
+                value: search,
+              },
+            ],
+          }
+        : undefined;
+
+      const result = (await client.callTool({
+        name: "COLLECTION_PROJECT_TEMPLATE_LIST",
+        arguments: {
+          limit: 100,
+          ...(searchWhere && { where: searchWhere }),
+        },
+      })) as { structuredContent?: unknown };
+
+      const payload = (result.structuredContent ??
+        result) as CollectionListOutput<ProjectTemplate>;
+      return payload.items ?? [];
+    },
+    enabled: !!registryConnectionId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+/** GitHub icon (inline SVG since @untitledui/icons may not have it) */
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10 0C4.477 0 0 4.477 0 10c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.341-3.369-1.341-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0110 4.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C17.138 18.163 20 14.418 20 10c0-5.523-4.477-10-10-10z"
+      />
+    </svg>
+  );
+}
+
+/** Sidebar category item */
+function CategoryItem({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-left",
+        active
+          ? "bg-accent text-foreground"
+          : "text-foreground/80 hover:bg-accent/50",
+      )}
+    >
+      <span className="flex-1 truncate">{label}</span>
+    </button>
+  );
+}
+
+/** Action card for Start from scratch / Import file / Import from github */
+function ActionCard({
+  icon,
+  label,
+  onClick,
+  disabled,
+  disabledReason,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  disabledReason?: string;
+}) {
+  const card = (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={cn(
+        "flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-border bg-background h-[200px] min-w-0 transition-colors",
+        disabled
+          ? "opacity-50 cursor-not-allowed"
+          : "hover:bg-accent/30 cursor-pointer",
+      )}
+    >
+      <div className="text-foreground">{icon}</div>
+      <span className="text-sm font-medium text-foreground">{label}</span>
+    </button>
+  );
+
+  if (disabled && disabledReason) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{card}</TooltipTrigger>
+        <TooltipContent>{disabledReason}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return card;
+}
+
+/** Template card in the grid */
+function TemplateCard({
+  template,
+  onClick,
+}: {
+  template: ProjectTemplate;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col gap-2.5 items-start text-left w-full group cursor-pointer"
+    >
+      <div
+        className="w-full rounded-lg aspect-[384/236]"
+        style={{
+          backgroundColor: template.iconColor ?? "var(--muted)",
+        }}
+      />
+      <div className="flex items-center gap-4 w-full">
+        <div
+          className="size-6 rounded-md shrink-0"
+          style={{
+            backgroundColor: template.iconColor ?? "var(--muted)",
+          }}
+        />
+        <div className="flex flex-col flex-1 min-w-0">
+          <span className="text-sm font-medium text-foreground truncate">
+            {template.title}
+          </span>
+          {template.description && (
+            <span className="text-xs text-muted-foreground truncate">
+              {template.description}
+            </span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function CreateProjectTemplateDialog({
+  open,
+  onOpenChange,
+}: CreateProjectTemplateDialogProps) {
+  const [view, setView] = useState<DialogView>("template-selection");
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<ProjectTemplate | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showScratchDialog, setShowScratchDialog] = useState(false);
+
+  // Find template registry connection
+  const registryConnection = useTemplateRegistryConnection();
+  const { data: templates = [], isLoading } = useTemplates(
+    registryConnection?.id ?? null,
+    searchQuery,
+  );
+
+  // Extract unique categories from templates
+  const categories = Array.from(
+    new Set(templates.map((t) => t.category).filter(Boolean)),
+  ).sort();
+
+  // Filter templates by selected category
+  const filteredTemplates = selectedCategory
+    ? templates.filter((t) => t.category === selectedCategory)
+    : templates;
+
+  const handleSelectTemplate = (template: ProjectTemplate) => {
+    setSelectedTemplate(template);
+    setView("onboarding");
+  };
+
+  const handleStartFromScratch = () => {
+    onOpenChange(false);
+    setShowScratchDialog(true);
+  };
+
+  const handleBackToSelection = () => {
+    setView("template-selection");
+    setSelectedTemplate(null);
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+    // Reset state after animation
+    setTimeout(() => {
+      setView("template-selection");
+      setSelectedTemplate(null);
+      setSelectedCategory(null);
+      setSearchQuery("");
+    }, 200);
+  };
+
+  const handleScratchDialogClose = (isOpen: boolean) => {
+    setShowScratchDialog(isOpen);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-5xl h-[80vh] max-h-[80vh] flex flex-col p-0 gap-0 overflow-hidden w-[95vw] rounded-2xl">
+          {view === "template-selection" ? (
+            <div className="flex flex-1 overflow-hidden min-h-0">
+              {/* Left Sidebar */}
+              <div className="w-[224px] shrink-0 border-r border-border flex flex-col gap-4 p-4 overflow-y-auto">
+                {/* Top menu items */}
+                <div className="flex flex-col gap-0.5">
+                  <CategoryItem
+                    label="All templates"
+                    active={selectedCategory === null}
+                    onClick={() => setSelectedCategory(null)}
+                  />
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-left text-foreground/80 hover:bg-accent/50"
+                    disabled
+                  >
+                    <User01 size={16} className="shrink-0 opacity-60" />
+                    <span className="flex-1 truncate opacity-60">
+                      My templates
+                    </span>
+                  </button>
+                </div>
+
+                {/* Category list */}
+                {categories.length > 0 && (
+                  <div className="flex flex-col gap-0.5">
+                    <div className="px-2 py-1.5">
+                      <span className="text-xs font-mono text-muted-foreground">
+                        FEATURED BY DECO
+                      </span>
+                    </div>
+                    {categories.map((category) => (
+                      <CategoryItem
+                        key={category}
+                        label={category}
+                        active={selectedCategory === category}
+                        onClick={() => setSelectedCategory(category)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Right Content */}
+              <div className="flex-1 flex flex-col overflow-y-auto min-w-0">
+                {/* Top Section: Action Cards */}
+                <div className="flex flex-col gap-4 p-5 shrink-0">
+                  <h2 className="text-base font-medium text-foreground">
+                    Create a new project
+                  </h2>
+                  <div className="flex gap-4">
+                    <ActionCard
+                      icon={<Plus size={24} />}
+                      label="Start from scratch"
+                      onClick={handleStartFromScratch}
+                    />
+                    <ActionCard
+                      icon={<Download01 size={24} />}
+                      label="Import file"
+                      disabled
+                      disabledReason="Coming soon"
+                    />
+                    <ActionCard
+                      icon={<GitHubIcon className="size-5" />}
+                      label="Import from github"
+                      disabled
+                      disabledReason="Coming soon"
+                    />
+                  </div>
+                </div>
+
+                {/* Templates Section */}
+                <div className="flex flex-col flex-1 min-h-0">
+                  {/* Templates Header */}
+                  <div className="flex items-center gap-2.5 h-12 px-5 border-y border-border shrink-0">
+                    <h3 className="flex-1 text-base font-medium text-foreground">
+                      Templates
+                    </h3>
+                    <SearchMd size={16} className="text-muted-foreground" />
+                    <Input
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      placeholder="Search for a template..."
+                      className="w-[300px] h-8 border-0 shadow-none focus-visible:ring-0 text-sm"
+                    />
+                  </div>
+
+                  {/* Templates Grid */}
+                  <div className="p-5 overflow-y-auto flex-1">
+                    {!registryConnection ? (
+                      <div className="flex flex-col items-center justify-center py-12 text-center">
+                        <Grid01
+                          size={32}
+                          className="text-muted-foreground/40 mb-3"
+                        />
+                        <p className="text-sm text-muted-foreground">
+                          No template registry connected
+                        </p>
+                        <p className="text-xs text-muted-foreground/60 mt-1">
+                          Connect a template registry to browse project
+                          templates
+                        </p>
+                      </div>
+                    ) : isLoading ? (
+                      <div className="grid grid-cols-3 gap-x-4 gap-y-8">
+                        {Array.from({ length: 6 }).map((_, i) => (
+                          <div
+                            key={`skeleton-${i}`}
+                            className="flex flex-col gap-2.5"
+                          >
+                            <div className="w-full rounded-lg aspect-[384/236] bg-muted animate-pulse" />
+                            <div className="flex items-center gap-4">
+                              <div className="size-6 rounded-md bg-muted animate-pulse" />
+                              <div className="flex flex-col gap-1 flex-1">
+                                <div className="h-4 w-24 bg-muted animate-pulse rounded" />
+                                <div className="h-3 w-40 bg-muted animate-pulse rounded" />
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : filteredTemplates.length === 0 ? (
+                      <div className="flex flex-col items-center justify-center py-12 text-center">
+                        <SearchMd
+                          size={32}
+                          className="text-muted-foreground/40 mb-3"
+                        />
+                        <p className="text-sm text-muted-foreground">
+                          {searchQuery
+                            ? "No templates match your search"
+                            : "No templates available"}
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-3 gap-x-4 gap-y-8">
+                        {filteredTemplates.map((template) => (
+                          <TemplateCard
+                            key={template.id}
+                            template={template}
+                            onClick={() => handleSelectTemplate(template)}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <TemplateOnboardingWizard
+              template={selectedTemplate!}
+              onBack={handleBackToSelection}
+              onClose={handleClose}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Existing Create Project Dialog (for Start from scratch) */}
+      <CreateProjectDialog
+        open={showScratchDialog}
+        onOpenChange={handleScratchDialogClose}
+      />
+    </>
+  );
+}

--- a/apps/mesh/src/web/components/sidebar/projects-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/projects-section.tsx
@@ -17,7 +17,7 @@ import {
 import { ChevronDown, ChevronRight, Plus } from "@untitledui/icons";
 import { ORG_ADMIN_PROJECT_SLUG, useProjectContext } from "@decocms/mesh-sdk";
 import { useProjects, type ProjectWithBindings } from "@/web/hooks/use-project";
-import { CreateProjectDialog } from "@/web/components/create-project-dialog";
+import { CreateProjectTemplateDialog } from "@/web/components/create-project-template-dialog";
 import { cn } from "@deco/ui/lib/utils.ts";
 
 function ProjectIcon({
@@ -168,7 +168,7 @@ function ProjectsSectionContent() {
         </SidebarGroup>
       </Collapsible>
 
-      <CreateProjectDialog
+      <CreateProjectTemplateDialog
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
       />

--- a/apps/mesh/src/web/components/template-onboarding-wizard.tsx
+++ b/apps/mesh/src/web/components/template-onboarding-wizard.tsx
@@ -1,0 +1,678 @@
+/**
+ * Template Onboarding Wizard
+ *
+ * Multi-step wizard shown after selecting a project template.
+ * Steps:
+ * 1. Template overview with plugin list
+ * 2..N. Plugin connection setup for each plugin requiring an MCP binding
+ * N+1. Project details (name, slug, description)
+ * Submit: Creates project with enabledPlugins + plugin configs
+ */
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { toast } from "sonner";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  ORG_ADMIN_PROJECT_SLUG,
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import type { ProjectTemplate, TemplatePlugin } from "@decocms/bindings";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@deco/ui/components/form.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ArrowLeft, Check, ChevronRight, Container } from "@untitledui/icons";
+import { KEYS } from "@/web/lib/query-keys";
+import { generateSlug, isValidSlug } from "@/web/lib/slug";
+import { BindingSelector } from "./binding-selector";
+import { sourcePlugins } from "@/web/plugins";
+import { pluginRootSidebarItems } from "@/web/index";
+import type { Project } from "@/web/hooks/use-project";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface TemplateOnboardingWizardProps {
+  template: ProjectTemplate;
+  onBack: () => void;
+  onClose: () => void;
+}
+
+type WizardStep = "overview" | "connections" | "details";
+
+type ProjectCreateOutput = { project: Project };
+
+const projectFormSchema = z.object({
+  name: z.string().min(1, "Name is required").max(200),
+  slug: z.string().min(1, "Slug is required").max(100),
+  description: z.string().max(1000).optional(),
+});
+
+type ProjectFormData = z.infer<typeof projectFormSchema>;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Get plugin metadata from sidebar items */
+function getPluginMeta(pluginId: string) {
+  return pluginRootSidebarItems.find((item) => item.pluginId === pluginId);
+}
+
+/** Get source plugin definition */
+function getSourcePlugin(pluginId: string) {
+  return sourcePlugins.find((p) => p.id === pluginId);
+}
+
+/** Check if a plugin requires an MCP binding */
+function pluginRequiresBinding(pluginId: string): boolean {
+  const plugin = getSourcePlugin(pluginId);
+  if (!plugin) return false;
+  if (
+    (plugin as { requiresMcpBinding?: boolean }).requiresMcpBinding === true
+  ) {
+    return true;
+  }
+  return plugin.binding !== undefined;
+}
+
+/** Get plugins that require connection setup */
+function getPluginsRequiringConnections(
+  templatePlugins: TemplatePlugin[],
+): TemplatePlugin[] {
+  return templatePlugins.filter((tp) => pluginRequiresBinding(tp.pluginId));
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+/** Step indicator in the wizard header */
+function StepIndicator({
+  steps,
+  currentIndex,
+}: {
+  steps: { key: string; label: string }[];
+  currentIndex: number;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      {steps.map((step, i) => (
+        <div key={step.key} className="flex items-center gap-2">
+          <div
+            className={cn(
+              "flex items-center justify-center size-6 rounded-full text-xs font-medium",
+              i < currentIndex
+                ? "bg-primary text-primary-foreground"
+                : i === currentIndex
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-muted-foreground",
+            )}
+          >
+            {i < currentIndex ? <Check size={14} /> : i + 1}
+          </div>
+          <span
+            className={cn(
+              "text-sm",
+              i === currentIndex
+                ? "text-foreground font-medium"
+                : "text-muted-foreground",
+            )}
+          >
+            {step.label}
+          </span>
+          {i < steps.length - 1 && (
+            <ChevronRight size={14} className="text-muted-foreground" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Overview step showing template info and plugins */
+function OverviewStep({ template }: { template: ProjectTemplate }) {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Template header */}
+      <div className="flex items-start gap-4">
+        <div
+          className="size-12 rounded-lg shrink-0"
+          style={{
+            backgroundColor: template.iconColor ?? "var(--muted)",
+          }}
+        />
+        <div className="flex flex-col gap-1 min-w-0">
+          <h3 className="text-lg font-medium text-foreground">
+            {template.title}
+          </h3>
+          {template.description && (
+            <p className="text-sm text-muted-foreground">
+              {template.description}
+            </p>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {template.category}
+          </span>
+        </div>
+      </div>
+
+      {/* Plugin list */}
+      <div className="flex flex-col gap-3">
+        <h4 className="text-sm font-medium text-foreground">
+          Included plugins
+        </h4>
+        <div className="divide-y divide-border border-y border-border">
+          {template.plugins.map((tp) => {
+            const meta = getPluginMeta(tp.pluginId);
+            const plugin = getSourcePlugin(tp.pluginId);
+            const needsConnection = pluginRequiresBinding(tp.pluginId);
+
+            return (
+              <div key={tp.pluginId} className="flex items-center gap-3 py-3">
+                <div className="flex-shrink-0 text-muted-foreground [&>svg]:size-4">
+                  {meta?.icon ?? <Container size={16} />}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-foreground">
+                    {meta?.label ?? tp.pluginId}
+                  </div>
+                  {plugin?.description && (
+                    <p className="text-xs text-muted-foreground">
+                      {plugin.description}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  {needsConnection && (
+                    <span className="px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                      Requires connection
+                    </span>
+                  )}
+                  {tp.required !== false && (
+                    <span className="px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+                      Required
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Connection setup step for plugins requiring MCP bindings */
+function ConnectionsStep({
+  template,
+  connectionBindings,
+  onConnectionChange,
+}: {
+  template: ProjectTemplate;
+  connectionBindings: Record<string, string | null>;
+  onConnectionChange: (pluginId: string, connectionId: string | null) => void;
+}) {
+  const pluginsNeedingConnections = getPluginsRequiringConnections(
+    template.plugins,
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-lg font-medium text-foreground">
+          Connect your services
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          Select or create connections for the plugins in this template.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {pluginsNeedingConnections.map((tp) => {
+          const meta = getPluginMeta(tp.pluginId);
+          const plugin = getSourcePlugin(tp.pluginId);
+
+          return (
+            <div
+              key={tp.pluginId}
+              className="flex flex-col gap-3 p-4 rounded-lg border border-border"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex-shrink-0 text-muted-foreground [&>svg]:size-4">
+                  {meta?.icon ?? <Container size={16} />}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-foreground">
+                    {meta?.label ?? tp.pluginId}
+                  </div>
+                  {plugin?.description && (
+                    <p className="text-xs text-muted-foreground">
+                      {plugin.description}
+                    </p>
+                  )}
+                </div>
+                {tp.required === false && (
+                  <span className="text-xs text-muted-foreground">
+                    Optional
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-3 pl-7">
+                <Label className="text-xs text-muted-foreground w-24">
+                  Connection
+                </Label>
+                <BindingSelector
+                  value={connectionBindings[tp.pluginId] ?? null}
+                  onValueChange={(value) =>
+                    onConnectionChange(tp.pluginId, value)
+                  }
+                  binding={plugin?.binding}
+                  bindingType={tp.defaultConnectionAppId ?? undefined}
+                  placeholder="Select connection..."
+                  className="w-64"
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Project details form step */
+function DetailsStep({
+  form,
+  slugManuallyEdited,
+  onSlugManuallyEdited,
+  orgSlug,
+  isPending,
+  bannerColor,
+}: {
+  form: ReturnType<typeof useForm<ProjectFormData>>;
+  slugManuallyEdited: boolean;
+  onSlugManuallyEdited: (v: boolean) => void;
+  orgSlug: string;
+  isPending: boolean;
+  bannerColor: string;
+}) {
+  const name = form.watch("name");
+  const slug = form.watch("slug");
+  const isSlugReserved = slug === ORG_ADMIN_PROJECT_SLUG;
+  const isSlugInvalid = slug.length > 0 && !isValidSlug(slug);
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newName = e.target.value;
+    form.setValue("name", newName);
+    if (!slugManuallyEdited) {
+      form.setValue("slug", generateSlug(newName));
+    }
+  };
+
+  const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onSlugManuallyEdited(true);
+    form.setValue(
+      "slug",
+      e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""),
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-lg font-medium text-foreground">Project details</h3>
+        <p className="text-sm text-muted-foreground">
+          Give your new project a name and description.
+        </p>
+      </div>
+
+      {/* Banner Preview */}
+      <div
+        className="h-20 rounded-lg relative"
+        style={{ backgroundColor: bannerColor }}
+      >
+        <div className="absolute -bottom-4 left-4">
+          <div
+            className="size-12 rounded-lg border-2 border-background flex items-center justify-center text-lg font-semibold text-white"
+            style={{ backgroundColor: bannerColor }}
+          >
+            {name?.charAt(0)?.toUpperCase() || "P"}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4 pt-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={() => (
+            <FormItem>
+              <FormLabel>Project Name *</FormLabel>
+              <FormControl>
+                <Input
+                  value={name}
+                  onChange={handleNameChange}
+                  placeholder="My Awesome Project"
+                  autoFocus
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="slug"
+          render={() => (
+            <FormItem>
+              <FormLabel>Slug *</FormLabel>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  /{orgSlug}/
+                </span>
+                <FormControl>
+                  <Input
+                    value={slug}
+                    onChange={handleSlugChange}
+                    placeholder="my-awesome-project"
+                    className="flex-1"
+                    disabled={isPending}
+                  />
+                </FormControl>
+              </div>
+              {isSlugReserved && (
+                <p className="text-xs text-destructive">
+                  &quot;{ORG_ADMIN_PROJECT_SLUG}&quot; is a reserved slug
+                </p>
+              )}
+              {isSlugInvalid && !isSlugReserved && (
+                <p className="text-xs text-destructive">
+                  Slug must be lowercase alphanumeric with hyphens only
+                </p>
+              )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  placeholder="What is this project for?"
+                  rows={2}
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function TemplateOnboardingWizard({
+  template,
+  onBack,
+  onClose,
+}: TemplateOnboardingWizardProps) {
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  // Wizard state
+  const pluginsNeedingConnections = getPluginsRequiringConnections(
+    template.plugins,
+  );
+  const hasConnectionStep = pluginsNeedingConnections.length > 0;
+
+  const [currentStep, setCurrentStep] = useState<WizardStep>("overview");
+  const [connectionBindings, setConnectionBindings] = useState<
+    Record<string, string | null>
+  >({});
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+
+  const form = useForm<ProjectFormData>({
+    mode: "onChange",
+    defaultValues: {
+      name: "",
+      slug: "",
+      description: "",
+    },
+  });
+
+  const bannerColor =
+    template.ui?.bannerColor ?? template.iconColor ?? "#3B82F6";
+
+  // Build step list
+  const steps: { key: WizardStep; label: string }[] = [
+    { key: "overview", label: "Overview" },
+    ...(hasConnectionStep
+      ? [{ key: "connections" as WizardStep, label: "Connections" }]
+      : []),
+    { key: "details", label: "Project Details" },
+  ];
+
+  const currentStepIndex = steps.findIndex((s) => s.key === currentStep);
+
+  // Navigation
+  const goNext = () => {
+    const nextIndex = currentStepIndex + 1;
+    const nextStep = steps[nextIndex];
+    if (nextStep) {
+      setCurrentStep(nextStep.key);
+    }
+  };
+
+  const goPrev = () => {
+    const prevIndex = currentStepIndex - 1;
+    const prevStep = steps[prevIndex];
+    if (prevStep) {
+      setCurrentStep(prevStep.key);
+    } else {
+      onBack();
+    }
+  };
+
+  // Create project mutation
+  const mutation = useMutation({
+    mutationFn: async (data: ProjectFormData) => {
+      // 1. Create project with enabled plugins from template
+      const enabledPluginIds = template.plugins.map((tp) => tp.pluginId);
+      const createResult = (await client.callTool({
+        name: "PROJECT_CREATE",
+        arguments: {
+          organizationId: org.id,
+          slug: data.slug,
+          name: data.name,
+          description: data.description || null,
+          enabledPlugins: enabledPluginIds,
+          ui: {
+            banner: null,
+            bannerColor: bannerColor,
+            icon: null,
+            themeColor: bannerColor,
+          },
+        },
+      })) as { structuredContent?: unknown };
+
+      const payload = (createResult.structuredContent ??
+        createResult) as ProjectCreateOutput;
+      const project = payload.project;
+
+      // 2. Set plugin connection bindings
+      const bindingUpdates = Object.entries(connectionBindings).filter(
+        ([, connectionId]) => connectionId !== null,
+      );
+
+      if (bindingUpdates.length > 0) {
+        await Promise.all(
+          bindingUpdates.map(async ([pluginId, connectionId]) => {
+            await client.callTool({
+              name: "PROJECT_PLUGIN_CONFIG_UPDATE",
+              arguments: {
+                projectId: project.id,
+                pluginId,
+                connectionId,
+              },
+            });
+          }),
+        );
+      }
+
+      return payload;
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: KEYS.projects(org.id) });
+      toast.success("Project created from template");
+      onClose();
+      navigate({
+        to: "/$org/$project",
+        params: { org: org.slug, project: result.project.slug },
+      });
+    },
+    onError: (error) => {
+      toast.error(
+        "Failed to create project: " +
+          (error instanceof Error ? error.message : "Unknown error"),
+      );
+    },
+  });
+
+  const handleSubmit = async () => {
+    const data = form.getValues();
+
+    // Validate
+    if (!data.name || !data.slug) {
+      toast.error("Please fill in the project name and slug");
+      return;
+    }
+    if (!isValidSlug(data.slug)) {
+      form.setError("slug", {
+        message: "Slug must be lowercase alphanumeric with hyphens only",
+      });
+      return;
+    }
+    if (data.slug === ORG_ADMIN_PROJECT_SLUG) {
+      form.setError("slug", {
+        message: `"${ORG_ADMIN_PROJECT_SLUG}" is a reserved slug`,
+      });
+      return;
+    }
+
+    await mutation.mutateAsync(data);
+  };
+
+  const handleConnectionChange = (
+    pluginId: string,
+    connectionId: string | null,
+  ) => {
+    setConnectionBindings((prev) => ({ ...prev, [pluginId]: connectionId }));
+  };
+
+  const name = form.watch("name");
+  const slug = form.watch("slug");
+  const isSlugValid = slug.length > 0 && isValidSlug(slug);
+  const canSubmit = name.length > 0 && isSlugValid && !mutation.isPending;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center gap-4 px-5 py-4 border-b border-border shrink-0">
+        <button
+          type="button"
+          onClick={goPrev}
+          className="p-1 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft size={16} />
+        </button>
+        <StepIndicator steps={steps} currentIndex={currentStepIndex} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-6 max-w-2xl mx-auto w-full">
+        <Form {...form}>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (currentStep === "details") {
+                handleSubmit();
+              }
+            }}
+          >
+            {currentStep === "overview" && <OverviewStep template={template} />}
+            {currentStep === "connections" && (
+              <ConnectionsStep
+                template={template}
+                connectionBindings={connectionBindings}
+                onConnectionChange={handleConnectionChange}
+              />
+            )}
+            {currentStep === "details" && (
+              <DetailsStep
+                form={form}
+                slugManuallyEdited={slugManuallyEdited}
+                onSlugManuallyEdited={setSlugManuallyEdited}
+                orgSlug={org.slug}
+                isPending={mutation.isPending}
+                bannerColor={bannerColor}
+              />
+            )}
+          </form>
+        </Form>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-6 py-4 border-t border-border shrink-0">
+        <Button type="button" variant="outline" onClick={goPrev}>
+          {currentStepIndex === 0 ? "Back to templates" : "Previous"}
+        </Button>
+
+        {currentStep === "details" ? (
+          <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
+            {mutation.isPending ? "Creating..." : "Create Project"}
+          </Button>
+        ) : (
+          <Button type="button" onClick={goNext}>
+            Continue
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Chat } from "@/web/components/chat/index";
 import { ChatPanel } from "@/web/components/chat/side-panel-chat";
-import { CreateProjectDialog } from "@/web/components/create-project-dialog";
+import { CreateProjectTemplateDialog } from "@/web/components/create-project-template-dialog";
 import { MeshSidebar } from "@/web/components/sidebar";
 import { MeshOrgSwitcher } from "@/web/components/org-switcher";
 import { SplashScreen } from "@/web/components/splash-screen";
@@ -284,7 +284,7 @@ function ShellLayoutContent() {
       </PersistentSidebarProvider>
 
       {/* Create Project Dialog */}
-      <CreateProjectDialog
+      <CreateProjectTemplateDialog
         open={createProjectDialogOpen}
         onOpenChange={setCreateProjectDialogOpen}
       />

--- a/apps/mesh/src/web/lib/feature-flags.ts
+++ b/apps/mesh/src/web/lib/feature-flags.ts
@@ -5,4 +5,4 @@
  */
 
 /** When true, projects are visible in the org sidebar and account switcher. */
-export const ENABLE_PROJECTS = false;
+export const ENABLE_PROJECTS = true;

--- a/apps/mesh/src/web/routes/projects-list.tsx
+++ b/apps/mesh/src/web/routes/projects-list.tsx
@@ -6,7 +6,7 @@ import { Page } from "@/web/components/page";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { ProjectCard } from "@/web/components/project-card";
 import { EmptyState } from "@/web/components/empty-state.tsx";
-import { CreateProjectDialog } from "@/web/components/create-project-dialog";
+import { CreateProjectTemplateDialog } from "@/web/components/create-project-template-dialog";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -138,7 +138,7 @@ export default function ProjectsListPage() {
       </Page.Content>
 
       {/* Create Project Dialog */}
-      <CreateProjectDialog
+      <CreateProjectTemplateDialog
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
       />

--- a/packages/bindings/src/index.ts
+++ b/packages/bindings/src/index.ts
@@ -84,6 +84,15 @@ export {
   type EventBusBindingClient,
 } from "./well-known/event-bus";
 
+// Re-export project template registry binding types
+export {
+  ProjectTemplateSchema,
+  TemplatePluginSchema,
+  type ProjectTemplate,
+  type TemplatePlugin,
+  PROJECT_TEMPLATE_REGISTRY_BINDING,
+} from "./well-known/project-template-registry";
+
 // Re-export object storage binding types
 export {
   OBJECT_STORAGE_BINDING,

--- a/packages/bindings/src/well-known/project-template-registry.ts
+++ b/packages/bindings/src/well-known/project-template-registry.ts
@@ -1,0 +1,88 @@
+/**
+ * Project Template Registry Well-Known Binding
+ *
+ * Defines the interface for accessing project templates from an external registry.
+ * Any MCP that implements this binding can provide a list of project templates
+ * with their plugin configurations and onboarding requirements.
+ *
+ * This binding includes:
+ * - Collection bindings for LIST and GET operations (read-only)
+ * - Templates define which plugins to enable and what connections they need
+ */
+
+import { z } from "zod";
+import {
+  BaseCollectionEntitySchema,
+  createCollectionBindings,
+} from "./collections";
+
+/**
+ * Plugin entry within a project template.
+ * Describes which plugins the template enables and their connection requirements.
+ */
+export const TemplatePluginSchema = z.object({
+  pluginId: z.string().describe("Plugin identifier to enable"),
+  required: z
+    .boolean()
+    .optional()
+    .describe("Whether this plugin is required for the template to function"),
+  defaultConnectionAppId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      "Suggested app ID from registry to create the connection for this plugin",
+    ),
+});
+
+export type TemplatePlugin = z.infer<typeof TemplatePluginSchema>;
+
+/**
+ * Project Template schema extending Collection Entity base.
+ * A template defines a predefined set of plugins and their configurations
+ * that can be used to bootstrap a new project.
+ */
+export const ProjectTemplateSchema = BaseCollectionEntitySchema.extend({
+  category: z
+    .string()
+    .describe("Template category (e.g., Marketing, Development)"),
+  iconColor: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Color for the template icon dot"),
+  image: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Preview image URL for the template"),
+  plugins: z
+    .array(TemplatePluginSchema)
+    .describe("Plugins included in this template"),
+  ui: z
+    .object({
+      bannerColor: z.string().nullable().optional(),
+      themeColor: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional()
+    .describe("Default UI settings for projects created from this template"),
+});
+
+export type ProjectTemplate = z.infer<typeof ProjectTemplateSchema>;
+
+/**
+ * Project Template Registry Binding (read-only)
+ *
+ * Collection bindings for project templates (read-only).
+ * Provides LIST and GET operations for available templates.
+ *
+ * Required tools:
+ * - COLLECTION_PROJECT_TEMPLATE_LIST: List available templates with filtering and pagination
+ * - COLLECTION_PROJECT_TEMPLATE_GET: Get a single template by ID
+ */
+export const PROJECT_TEMPLATE_REGISTRY_BINDING = createCollectionBindings(
+  "project_template",
+  ProjectTemplateSchema,
+  { readOnly: true },
+);


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project templates with a new create flow and onboarding wizard. Replaces the old Create Project dialog across the app and enables Projects in the sidebar.

- New Features
  - New Create Project dialog with categories, search, and actions (start from scratch, import placeholders).
  - Fetches templates from a bound registry (PROJECT_TEMPLATE_REGISTRY_BINDING) and renders a grid.
  - Onboarding wizard: overview, connections (binding selector for plugins), and project details. Creates the project and applies plugin connection configs.
  - New well-known binding and schemas for project templates; re-exported in bindings.
  - Replaces CreateProjectDialog usages in sidebar, shell layout, and projects list. ENABLE_PROJECTS is now true.

- Migration
  - Add an MCP connection that implements PROJECT_TEMPLATE_REGISTRY_BINDING with LIST/GET tools to surface templates.
  - If no registry is connected, the dialog shows an empty state; “Start from scratch” still works.
  - No database changes required.

<sup>Written for commit 0440ba1689678a98afa496c85c146e0a6643c621. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

