### PR TITLE
fix(ci): preserve deploy checkbox state across release comment updates

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -77,6 +77,18 @@ jobs:
           echo "major_version=$NEW_MAJOR_VERSION" >> $GITHUB_OUTPUT
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Preserve deploy checkbox state
+        id: checkbox_state
+        env:
+          COMMENT_BODY: ${{ steps.find_comment.outputs.comment-body }}
+        run: |
+          # If an existing comment has the checkbox checked, preserve it
+          if echo "$COMMENT_BODY" | grep -q '\[x\] Deploy to production'; then
+            echo "deploy_checked=- [x] Deploy to production (triggers ArgoCD sync after Docker image is published)" >> $GITHUB_OUTPUT
+          else
+            echo "deploy_checked=- [ ] Deploy to production (triggers ArgoCD sync after Docker image is published)" >> $GITHUB_OUTPUT
+          fi
+
       - name: Post Release Options Comment
         uses: peter-evans/create-or-update-comment@v4
         id: comment
@@ -102,7 +114,7 @@ jobs:
             Current version: `${{ steps.calculate_versions.outputs.current_version }}`
 
             ### Deployment
-            - [ ] Deploy to production (triggers ArgoCD sync after Docker image is published)
+            ${{ steps.checkbox_state.outputs.deploy_checked }}
 
   determine-tag:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- **Fix**: The release-tagging workflow resets the "Deploy to production" checkbox to unchecked on every commit push
- **Root cause**: The `tag-discussion` job runs on `synchronize` events and uses `edit-mode: replace` to rewrite the entire Release Options comment with a hardcoded `- [ ]` unchecked checkbox
- **Fix**: Added a step that reads the existing comment body via `peter-evans/find-comment`'s `comment-body` output, checks if the checkbox was `[x]`, and preserves that state when rebuilding the comment

## Test plan

- [ ] Push a commit to a PR that touches `apps/mesh/` — verify the Release Options comment is created with an unchecked checkbox
- [ ] Manually check the deploy checkbox, then push another commit — verify the checkbox remains checked after the comment is updated
- [ ] Verify the `determine-tag` job still correctly reads `[x]` on merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the "Deploy to production" checkbox state in the Release Options comment when the release-tagging workflow updates it on synchronize events. Prevents the checkbox from resetting so the tag job can still read the selected state.

- **Bug Fixes**
  - Read the existing comment body with peter-evans/find-comment and detect if the checkbox is checked.
  - Build the checkbox line dynamically and pass it to create-or-update-comment.

<sup>Written for commit 47ae3087bebc069b271a2cac2304a8a82e5e7923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

