### PR TITLE
feat(ui): display Mesh version in user menu and profile settings

### DIFF
--- a/apps/mesh/src/web/components/user-menu.tsx
+++ b/apps/mesh/src/web/components/user-menu.tsx
@@ -119,6 +119,12 @@ function MeshUserMenuBase({
           <LogOut01 size={18} className="text-muted-foreground" />
           Log out
         </UserMenu.Item>
+
+        <UserMenu.Separator />
+
+        <div className="px-2 py-1.5 text-[11px] text-muted-foreground/60">
+          Mesh v{__MESH_VERSION__}
+        </div>
       </UserMenu>
 
       {settingsOpen && (

--- a/apps/mesh/src/web/components/user-settings-dialog.tsx
+++ b/apps/mesh/src/web/components/user-settings-dialog.tsx
@@ -100,7 +100,7 @@ export function UserSettingsDialog({
           </div>
 
           {/* Footer */}
-          <div className="border-t border-border px-5 py-4 flex items-center shrink-0">
+          <div className="border-t border-border px-5 py-4 flex items-center justify-between shrink-0">
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -125,6 +125,9 @@ export function UserSettingsDialog({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
+            <span className="text-xs text-muted-foreground/50">
+              Mesh v{__MESH_VERSION__}
+            </span>
           </div>
         </div>
       </DialogContent>

--- a/apps/mesh/src/web/globals.d.ts
+++ b/apps/mesh/src/web/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __MESH_VERSION__: string;

--- a/apps/mesh/vite.config.ts
+++ b/apps/mesh/vite.config.ts
@@ -3,8 +3,12 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import deco from "@decocms/vite-plugin";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
+  define: {
+    __MESH_VERSION__: JSON.stringify(pkg.version),
+  },
   server: {
     port: 4000,
     hmr: {


### PR DESCRIPTION
## Summary
- Injects the package.json version at build time via Vite's `define` config (`__MESH_VERSION__`)
- Displays "Mesh v{version}" at the bottom of the user dropdown menu
- Displays "Mesh v{version}" in the footer of the Profile Settings dialog

## Test plan
- [ ] Open the user avatar dropdown in the top-right — version should appear at the bottom
- [ ] Open Profile Settings from the dropdown — version should appear in the footer, right-aligned opposite the user ID
- [ ] Verify the version matches `package.json`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Displays the Mesh version in the UI so users can quickly see the deployed build. Injects the package.json version at build time using Vite’s define as __MESH_VERSION__.

- **New Features**
  - Shows “Mesh v{version}” at the bottom of the user menu.
  - Shows “Mesh v{version}” in the Profile Settings footer.

<sup>Written for commit d7313d88c7da4a01998c349ad52710510fa520cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

