### PR TITLE
fix(mcp-clients): preserve Client prototype methods in withToolCachin…

### DIFF
--- a/apps/mesh/src/mcp-clients/decorators/with-tool-caching.ts
+++ b/apps/mesh/src/mcp-clients/decorators/with-tool-caching.ts
@@ -56,8 +56,8 @@ export function withToolCaching(
     return await originalListTools();
   };
 
-  return {
-    ...client,
-    listTools: cachedListTools,
-  } as Client;
+  // Override listTools directly on the instance to preserve prototype methods
+  // (e.g. getServerCapabilities, getInstructions) which would be lost by spreading
+  client.listTools = cachedListTools;
+  return client;
 }


### PR DESCRIPTION
# Fix: Preserve Client prototype methods in withToolCaching decorator

## Issue
Event bus notifications were failing with:
```
[EventBus] Failed to notify connection conn_JyiVk7dNRxnLZr_9mV455: 
cachedClient.getServerCapabilities is not a function.
(In 'cachedClient.getServerCapabilities()', 'cachedClient.getServerCapabilities' is undefined)
```

## Root Cause
The `withToolCaching` decorator was using object spread to override the `listTools` method:

```typescript
return {
  ...client,
  listTools: cachedListTools,
} as Client;
```

JavaScript's spread operator only copies **own enumerable properties** — it does **not** copy prototype methods. The MCP SDK `Client` class defines methods like `getServerCapabilities()` and `getInstructions()` on the prototype, so spreading the client created a plain object that lost access to these essential methods.

When `proxy.ts:createMCPProxyDoNotUseDirectly` called `cachedClient.getServerCapabilities()` on line 153, it failed because the method was `undefined` on the plain object.

## Solution
Directly assign the override on the instance instead of spreading:

```typescript
client.listTools = cachedListTools;
return client;
```

This:
1. Creates an **own property** that **shadows** the prototype method (standard JS pattern)
2. Preserves access to all inherited prototype methods via the chain
3. Maintains access to internal state (`this._serverCapabilities`, etc.)

## Impact
- **Scope**: Only affects `withToolCaching` decorator, used in one place: `proxy.ts:createMCPProxyDoNotUseDirectly`
- **Safety**: Direct property assignment is idempotent; repeated calls safely re-override
- **Compatibility**: No breaking changes; decorator maintains same interface and behavior
- **Performance**: No change; same caching logic applies

## Testing
- Event bus notifications should now successfully deliver to subscriber connections
- Verify `proxy.ts` calls like `cachedClient.getServerCapabilities()` and `cachedClient.getInstructions()` work correctly
- Confirm caching still applies (indexed tools returned from DB when available)
