### PR TITLE
fix(mcp-clients): restore monitoring for streamable tool calls

### DIFF
--- a/apps/mesh/src/mcp-clients/decorators/with-streaming-support.ts
+++ b/apps/mesh/src/mcp-clients/decorators/with-streaming-support.ts
@@ -9,9 +9,11 @@
 import { buildRequestHeaders } from "@/mcp-clients/outbound/headers";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { AccessControl } from "@/core/access-control";
+import { getMonitoringConfig } from "@/core/config";
 import type { MeshContext } from "@/core/mesh-context";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
+import { createProxyStreamableMonitoringMiddleware } from "@/api/routes/proxy-monitoring";
 
 /**
  * MCP Client extended with streaming support
@@ -160,122 +162,142 @@ export function withStreamingSupport(
       }
     }
 
-    // Execute streaming fetch
-    const headers = await buildRequestHeaders(
-      connection,
+    // Determine virtualMcpId: if the request is routed through a Virtual MCP,
+    // ctx.connectionId will be set to the virtual MCP's ID (different from this connection)
+    const virtualMcpId =
+      ctx.connectionId && ctx.connectionId !== connectionId
+        ? ctx.connectionId
+        : undefined;
+
+    // Monitoring middleware for database logging (wraps the streaming fetch)
+    const monitoringMiddleware = createProxyStreamableMonitoringMiddleware({
       ctx,
-      options.superUser,
-    );
+      enabled: getMonitoringConfig().enabled,
+      connectionId,
+      connectionTitle: connection.title,
+      virtualMcpId,
+    });
 
-    // Add custom headers from connection_headers
-    const httpParams = connection.connection_headers;
-    if (httpParams && "headers" in httpParams) {
-      Object.assign(headers, httpParams.headers);
-    }
+    // Execute streaming fetch wrapped in monitoring middleware
+    return monitoringMiddleware(request, async () => {
+      const headers = await buildRequestHeaders(
+        connection,
+        ctx,
+        options.superUser,
+      );
 
-    // Use fetch directly to support streaming responses
-    // Build URL with tool name appended for call-tool endpoint pattern
-    const url = new URL(connectionUrl);
-    url.pathname =
-      url.pathname.replace(/\/$/, "") + `/call-tool/${request.params.name}`;
+      // Add custom headers from connection_headers
+      const httpParams = connection.connection_headers;
+      if (httpParams && "headers" in httpParams) {
+        Object.assign(headers, httpParams.headers);
+      }
 
-    // Sanitize arguments to remove non-serializable fields
-    // This ensures JSON.stringify works correctly
-    const sanitizedArgs = JSON.parse(
-      JSON.stringify(request.params.arguments, (_key, value) => {
-        // Filter out non-serializable values
-        if (value instanceof AbortSignal) {
-          return undefined; // AbortSignal is used client-side only
-        }
-        // Filter out functions, symbols, undefined
-        if (typeof value === "function" || typeof value === "symbol") {
-          return undefined;
-        }
-        // Filter out undefined values (they can cause issues in some parsers)
-        if (value === undefined) {
-          return undefined;
-        }
-        return value;
-      }),
-    );
+      // Use fetch directly to support streaming responses
+      // Build URL with tool name appended for call-tool endpoint pattern
+      const url = new URL(connectionUrl);
+      url.pathname =
+        url.pathname.replace(/\/$/, "") + `/call-tool/${request.params.name}`;
 
-    const requestBody = JSON.stringify(sanitizedArgs);
+      // Sanitize arguments to remove non-serializable fields
+      // This ensures JSON.stringify works correctly
+      const sanitizedArgs = JSON.parse(
+        JSON.stringify(request.params.arguments, (_key, value) => {
+          // Filter out non-serializable values
+          if (value instanceof AbortSignal) {
+            return undefined; // AbortSignal is used client-side only
+          }
+          // Filter out functions, symbols, undefined
+          if (typeof value === "function" || typeof value === "symbol") {
+            return undefined;
+          }
+          // Filter out undefined values (they can cause issues in some parsers)
+          if (value === undefined) {
+            return undefined;
+          }
+          return value;
+        }),
+      );
 
-    return await ctx.tracer.startActiveSpan(
-      "mcp.proxy.callStreamableTool",
-      {
-        attributes: {
-          "connection.id": connectionId,
-          "tool.name": request.params.name,
-          "request.id": ctx.metadata.requestId,
-        },
-      },
-      async (span) => {
-        const startTime = Date.now();
+      const requestBody = JSON.stringify(sanitizedArgs);
 
-        try {
-          const response = await fetch(url.toString(), {
-            method: "POST",
-            redirect: "manual",
-            body: requestBody,
-            headers: {
-              ...headers,
-              "Content-Type": "application/json",
-            },
-          });
-          const duration = Date.now() - startTime;
-
-          // Record metrics
-          ctx.meter
-            .createHistogram("connection.proxy.streamable.duration")
-            .record(duration, {
-              "connection.id": connectionId,
-              "tool.name": request.params.name,
-              status: response.ok ? "success" : "error",
-            });
-
-          ctx.meter
-            .createCounter("connection.proxy.streamable.requests")
-            .add(1, {
-              "connection.id": connectionId,
-              "tool.name": request.params.name,
-              status: response.ok ? "success" : "error",
-            });
-
-          span.end();
-          return response;
-        } catch (error) {
-          const err = error as Error;
-          const duration = Date.now() - startTime;
-
-          console.error("[with-streaming-support] fetch error", {
-            connectionId,
-            toolName: request.params.name,
-            error: err.message,
-            errorStack: err.stack,
-            duration,
-          });
-
-          ctx.meter
-            .createHistogram("connection.proxy.streamable.duration")
-            .record(duration, {
-              "connection.id": connectionId,
-              "tool.name": request.params.name,
-              status: "error",
-            });
-
-          ctx.meter.createCounter("connection.proxy.streamable.errors").add(1, {
+      return await ctx.tracer.startActiveSpan(
+        "mcp.proxy.callStreamableTool",
+        {
+          attributes: {
             "connection.id": connectionId,
             "tool.name": request.params.name,
-            error: err.message,
-          });
+            "request.id": ctx.metadata.requestId,
+          },
+        },
+        async (span) => {
+          const startTime = Date.now();
 
-          span.recordException(err);
-          span.end();
-          throw error;
-        }
-      },
-    );
+          try {
+            const response = await fetch(url.toString(), {
+              method: "POST",
+              redirect: "manual",
+              body: requestBody,
+              headers: {
+                ...headers,
+                "Content-Type": "application/json",
+              },
+            });
+            const duration = Date.now() - startTime;
+
+            // Record metrics
+            ctx.meter
+              .createHistogram("connection.proxy.streamable.duration")
+              .record(duration, {
+                "connection.id": connectionId,
+                "tool.name": request.params.name,
+                status: response.ok ? "success" : "error",
+              });
+
+            ctx.meter
+              .createCounter("connection.proxy.streamable.requests")
+              .add(1, {
+                "connection.id": connectionId,
+                "tool.name": request.params.name,
+                status: response.ok ? "success" : "error",
+              });
+
+            span.end();
+            return response;
+          } catch (error) {
+            const err = error as Error;
+            const duration = Date.now() - startTime;
+
+            console.error("[with-streaming-support] fetch error", {
+              connectionId,
+              toolName: request.params.name,
+              error: err.message,
+              errorStack: err.stack,
+              duration,
+            });
+
+            ctx.meter
+              .createHistogram("connection.proxy.streamable.duration")
+              .record(duration, {
+                "connection.id": connectionId,
+                "tool.name": request.params.name,
+                status: "error",
+              });
+
+            ctx.meter
+              .createCounter("connection.proxy.streamable.errors")
+              .add(1, {
+                "connection.id": connectionId,
+                "tool.name": request.params.name,
+                error: err.message,
+              });
+
+            span.recordException(err);
+            span.end();
+            throw error;
+          }
+        },
+      );
+    });
   };
 
   // Create a new object with the same prototype as the client


### PR DESCRIPTION
The refactoring in 0aa923ac9 moved callStreamableTool from the proxy layer into the withStreamingSupport decorator, but forgot to carry over createProxyStreamableMonitoringMiddleware that logs to the database.

This caused LLM_DO_STREAM (streamable) calls to skip database monitoring while still recording OpenTelemetry traces and metrics.

Fix by wrapping the streaming fetch execution with createProxyStreamableMonitoringMiddleware, which:
- Clones the response to avoid blocking the stream
- Reads and logs the body in the background
- Logs tool call metadata to ctx.storage.monitoring.log()

Affected:
- Decopilot streaming LLM calls (LLM_DO_STREAM)
- OpenAI-compatible streaming routes

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores database monitoring for streamable tool calls by wrapping the streaming fetch in createProxyStreamableMonitoringMiddleware. LLM_DO_STREAM calls now log to monitoring storage again while keeping streaming behavior, traces, and metrics intact.

- **Bug Fixes**
  - Wrap with-streaming-support execution with createProxyStreamableMonitoringMiddleware.
  - Respect monitoring config (enabled flag) and include virtualMcpId when routed via a Virtual MCP.
  - Middleware clones response and logs body/metadata asynchronously to ctx.storage.monitoring.log().
  - Affects Decopilot LLM_DO_STREAM and OpenAI-compatible streaming routes.

<sup>Written for commit 15d57898e775eddb76d00fbc0c013697e50c410d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

