### PR TITLE
add version in user panel

### DIFF
--- a/apps/mesh/src/web/components/sidebar/header/account-switcher/user-panel.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/account-switcher/user-panel.tsx
@@ -98,6 +98,13 @@ export function UserPanel({ user, userImage, onOpenSettings }: UserPanelProps) {
             Log out
           </MenuItem>
         </div>
+
+        {/* Version */}
+        <div className="mt-auto px-3 py-2 border-t border-border">
+          <span className="text-[11px] text-muted-foreground/75">
+            v{__MESH_VERSION__}
+          </span>
+        </div>
       </div>
     </>
   );

--- a/apps/mesh/src/web/components/user-menu.tsx
+++ b/apps/mesh/src/web/components/user-menu.tsx
@@ -122,8 +122,8 @@ function MeshUserMenuBase({
 
         <UserMenu.Separator />
 
-        <div className="px-2 py-1.5 text-[11px] text-muted-foreground/60">
-          Mesh v{__MESH_VERSION__}
+        <div className="px-2 py-1.5 text-[11px] text-muted-foreground/75">
+          v{__MESH_VERSION__}
         </div>
       </UserMenu>
 

--- a/apps/mesh/src/web/components/user-settings-dialog.tsx
+++ b/apps/mesh/src/web/components/user-settings-dialog.tsx
@@ -125,8 +125,8 @@ export function UserSettingsDialog({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            <span className="text-xs text-muted-foreground/50">
-              Mesh v{__MESH_VERSION__}
+            <span className="text-xs text-muted-foreground/75">
+              v{__MESH_VERSION__}
             </span>
           </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the app version to the user panel and standardizes version display across the user menu and settings dialog for better visibility and support.

- **New Features**
  - User panel now shows v{__MESH_VERSION__} at the bottom with a subtle divider.
  - Standardized label to "v{__MESH_VERSION__}" and increased contrast in the user menu and settings dialog.

<sup>Written for commit 7f59823867034fa39051596ebcebc3781863b2a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

