### PR TITLE
perf(event-bus): parallelize subscriber batch delivery

### DIFF
--- a/apps/mesh/src/event-bus/worker.ts
+++ b/apps/mesh/src/event-bus/worker.ts
@@ -189,66 +189,69 @@ export class EventBusWorker {
     // Group by subscription (connection)
     const grouped = groupByConnection(pendingDeliveries);
 
-    // Process each subscription's batch
+    // Process each subscriber's batch in parallel -- deliveries to different
+    // connections are independent, so a slow/dead connection doesn't block others.
     const eventIdsToUpdate = new Set<string>();
 
-    for (const [subscriptionId, batch] of grouped) {
-      try {
-        // Call ON_EVENTS on the subscriber connection
-        const result = await this.notifySubscriber(
-          batch.connectionId,
-          batch.events,
-        );
-
-        // Check if per-event results were provided
-        if (result.results && Object.keys(result.results).length > 0) {
-          // Per-event mode: process each event individually
-          await this.processPerEventResults(batch, result);
-        } else if (result.success) {
-          // Batch mode: mark all deliveries as delivered
-          await this.storage.markDeliveriesDelivered(batch.deliveryIds);
-        } else if (result.retryAfter && result.retryAfter > 0) {
-          // Batch mode: subscriber wants re-delivery after a delay
-          await this.storage.scheduleRetryWithoutAttemptIncrement(
-            batch.deliveryIds,
-            result.retryAfter,
+    await Promise.allSettled(
+      Array.from(grouped.entries()).map(async ([subscriptionId, batch]) => {
+        try {
+          // Call ON_EVENTS on the subscriber connection
+          const result = await this.notifySubscriber(
+            batch.connectionId,
+            batch.events,
           );
-        } else {
-          // Batch mode: mark as failed with error and apply exponential backoff
+
+          // Check if per-event results were provided
+          if (result.results && Object.keys(result.results).length > 0) {
+            // Per-event mode: process each event individually
+            await this.processPerEventResults(batch, result);
+          } else if (result.success) {
+            // Batch mode: mark all deliveries as delivered
+            await this.storage.markDeliveriesDelivered(batch.deliveryIds);
+          } else if (result.retryAfter && result.retryAfter > 0) {
+            // Batch mode: subscriber wants re-delivery after a delay
+            await this.storage.scheduleRetryWithoutAttemptIncrement(
+              batch.deliveryIds,
+              result.retryAfter,
+            );
+          } else {
+            // Batch mode: mark as failed with error and apply exponential backoff
+            await this.storage.markDeliveriesFailed(
+              batch.deliveryIds,
+              result.error || "Subscriber returned success=false",
+              this.config.maxAttempts,
+              this.config.retryDelayMs,
+              this.config.maxDelayMs,
+            );
+          }
+        } catch (error) {
+          // Network error or other failure
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          console.error(
+            `[EventBus] Failed to notify subscription ${subscriptionId}:`,
+            errorMessage,
+          );
+
+          // Apply exponential backoff with config settings
           await this.storage.markDeliveriesFailed(
             batch.deliveryIds,
-            result.error || "Subscriber returned success=false",
+            errorMessage,
             this.config.maxAttempts,
             this.config.retryDelayMs,
             this.config.maxDelayMs,
           );
         }
-      } catch (error) {
-        // Network error or other failure
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        console.error(
-          `[EventBus] Failed to notify subscription ${subscriptionId}:`,
-          errorMessage,
-        );
 
-        // Apply exponential backoff with config settings
-        await this.storage.markDeliveriesFailed(
-          batch.deliveryIds,
-          errorMessage,
-          this.config.maxAttempts,
-          this.config.retryDelayMs,
-          this.config.maxDelayMs,
-        );
-      }
-
-      // Collect event IDs for status update
-      for (const pending of pendingDeliveries) {
-        if (batch.deliveryIds.includes(pending.delivery.id)) {
-          eventIdsToUpdate.add(pending.event.id);
+        // Collect event IDs for status update
+        for (const pending of pendingDeliveries) {
+          if (batch.deliveryIds.includes(pending.delivery.id)) {
+            eventIdsToUpdate.add(pending.event.id);
+          }
         }
-      }
-    }
+      }),
+    );
 
     // Update event statuses and handle cron scheduling
     for (const eventId of eventIdsToUpdate) {


### PR DESCRIPTION
Convert event bus worker from sequential to parallel batch processing. Deliveries to different connections are now independent, preventing slow or unresponsive subscribers from blocking others. Uses Promise.allSettled() to handle individual connection failures gracefully.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized subscriber batch delivery in the event bus so slow or failed connections no longer block others. This improves throughput and isolates failures using Promise.allSettled.

- **Refactors**
  - Switched from sequential processing to Promise.allSettled over grouped subscriber batches.
  - Kept per-event and batch handling: mark delivered, schedule retryAfter, or fail with exponential backoff.
  - Maintains event status updates for affected deliveries.

<sup>Written for commit 10ac193fe0982f9b0fddef0f136916485964402c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

