### PR TITLE
fix: show proper error message on connections delete error

### DIFF
--- a/apps/mesh/src/tools/connection/delete.ts
+++ b/apps/mesh/src/tools/connection/delete.ts
@@ -48,6 +48,21 @@ export const COLLECTION_CONNECTIONS_DELETE = defineTool({
       );
     }
 
+    // Check if connection is used by any Virtual MCPs (FK RESTRICT would block deletion)
+    const referencingVirtualMcps =
+      await ctx.storage.virtualMcps.listByConnectionId(
+        organization.id,
+        input.id,
+      );
+    if (referencingVirtualMcps.length > 0) {
+      const names = referencingVirtualMcps
+        .map((v) => `"${v.title}"`)
+        .join(", ");
+      throw new Error(
+        `Cannot delete this connection because it is used by the following agent(s): ${names}. Remove it from those agents first.`,
+      );
+    }
+
     // Delete connection
     await ctx.storage.connections.delete(input.id);
 


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear error when trying to delete a connection that is still used by Virtual MCP agents. The delete flow now checks for references and blocks deletion with a message listing the affected agents and instructing you to remove the connection from them first.

<sup>Written for commit 15fa1e9f15cb24965e6083a7ca0013ea19849713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

