### PR TITLE
feat(event-bus): enhance event processing with pending notifications

### DIFF
--- a/apps/mesh/src/event-bus/worker.ts
+++ b/apps/mesh/src/event-bus/worker.ts
@@ -193,16 +193,6 @@ export class EventBusWorker {
     );
     if (pendingDeliveries.length === 0) return;
 
-    const wfEvents = pendingDeliveries.filter((p) =>
-      p.event.type.startsWith("workflow."),
-    );
-    if (wfEvents.length > 0) {
-      console.log(
-        `[WF:bus] processEvents — claimed ${pendingDeliveries.length} deliveries (${wfEvents.length} workflow)`,
-        wfEvents.map((p) => `${p.event.type}:${p.event.subject?.slice(0, 8)}`),
-      );
-    }
-
     // Group by subscription (connection)
     const grouped = groupByConnection(pendingDeliveries);
 


### PR DESCRIPTION
Added a mechanism to handle concurrent processing in the EventBusWorker. When processing is already in progress, subsequent notifications are queued until the current processing completes. This change improves the reliability of event handling. Additionally, added logging for workflow events to provide better visibility into event deliveries.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents concurrent EventBusWorker runs and defers notifications that arrive mid-run into an immediate follow-up pass.

- **New Features**
  - Use a pendingNotify flag and a do/while loop to re-run processing when notify() fires during processing.

<sup>Written for commit fe806db408fdb0d075e3645e08d8e463a54358e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

