### PR TITLE
feat: add plan critique skills

### DIFF
--- a/.cursor/skills/plan-critique/SKILL.md
+++ b/.cursor/skills/plan-critique/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: plan-critique
+description: Spawn parallel subagents to criticize implementation plans from multiple perspectives (duplication, correctness, security, performance, testing, architecture, scope), then improve the plan based on feedback. Use when reviewing a plan before implementation or when stress-testing a plan for gaps.
+---
+
+# Plan Critique
+
+Spawn parallel subagents, each critiquing a plan from a single perspective. Synthesize results into actionable feedback, then improve the plan and document decisions.
+
+## When to Use
+
+- Before implementing a plan (stress-test for gaps)
+- After drafting a plan in superpowers:writing-plans
+- When a plan feels risky or complex
+- When you want diverse criticism without one reviewer dominating
+
+## Critique Perspectives
+
+Dispatch one subagent per perspective. Each critic is independent.
+
+| Perspective | Focus |
+|-------------|-------|
+| **Duplication** | DRY violations, repeated logic, consolidation opportunities |
+| **Correctness** | Completeness, edge cases, missing steps, unclear requirements |
+| **Security** | Auth, validation, sensitive data, injection risks |
+| **Performance** | N+1, scalability, bottlenecks, efficiency |
+| **Testing** | Coverage strategy, edge cases, integration needs |
+| **Architecture** | Fit with existing patterns, dependencies, layering |
+| **Scope** | YAGNI, scope creep, unnecessary features |
+
+## Workflow
+
+### 1. Prepare the Plan
+
+Ensure the plan is in context (read the file or paste it). Note the plan path for subagent prompts.
+
+### 2. Dispatch Critics in Parallel
+
+For each perspective, spawn a subagent with a focused prompt. Use the Task tool with the critic template below.
+
+**Template per critic:**
+
+```
+Critique the implementation plan from the [{PERSPECTIVE}] perspective.
+
+**Plan:** [path or paste plan content]
+
+**Your role:** You are a critical reviewer focused ONLY on [{PERSPECTIVE}]. Be skeptical. Find gaps, risks, and oversights.
+
+**Check:**
+[PERSPECTIVE-SPECIFIC CHECKS - see critic-prompts.md]
+
+**Output format:**
+- **Issues found:** (Blocker / Important / Minor)
+- **Missing considerations:** What the plan doesn't address
+- **Recommendations:** Specific improvements
+- **Verdict:** Ready / Needs changes / High risk
+```
+
+For full prompts per perspective, see [critic-prompts.md](critic-prompts.md).
+
+### 3. Synthesize Results
+
+When all critics return:
+
+1. **Merge by severity** – Collect Blockers from all critics first
+2. **Deduplicate** – Same issue raised by multiple critics = higher priority
+3. **Prioritize** – Blockers before Important, Important before Minor
+4. **Present** – Structured summary with actionable next steps
+
+### 4. Output Format
+
+```markdown
+# Plan Critique Summary
+
+## Blockers
+[Must address before implementation]
+
+## Important
+[Should address]
+
+## Minor
+[Nice to have]
+
+## Recommendations
+[Improvements to consider]
+
+## Overall Verdict
+[Ready / Needs changes / High risk]
+```
+
+### 5. Improve the Plan (Replan)
+
+Apply feedback selectively—treat feedback as guidance, not mandatory.
+
+**For each feedback item:**
+- **Adopt** – if you agree, update the plan.
+- **Reject** – if you disagree, document why and leave the plan unchanged.
+- **Adapt** – if partially valid, implement a middle ground.
+
+**Document decisions** – add a short "Critique Decisions" section to the plan.
+
+## Feedback as Guidance
+
+**Core principle:** Critics are advisors. You are the decision-maker.
+
+**Adopt when:**
+- You agree with the reasoning
+- The fix is low-cost and improves the plan
+- Multiple critics flag the same issue
+
+**Reject when:**
+- You have valid counter-arguments (e.g., scope justified, YAGNI not applicable here)
+- The suggestion contradicts project constraints or conventions
+- It would add unnecessary complexity
+
+**Adapt when:**
+- Feedback is partially right (e.g., address the concern differently)
+- You want a lighter version of the suggestion
+
+**Never:**
+- Blindly apply every critique
+- Treat critic verdict as final
+- Assume critics have full context (they may not)
+
+## Critique Decisions Section
+
+Add to the plan after the improvement pass:
+
+```markdown
+## Critique Decisions
+
+**Adopted:** [Brief list of changes made based on feedback]
+
+**Rejected (with reason):** [Item] – [Why you kept the original]
+
+**Adapted:** [Item] – [How you addressed it differently]
+```
+
+## Example
+
+```
+Plan: .cursor/plans/tasks_feature_implementation_a2a999e8.plan.md
+
+Dispatch 7 subagents in parallel:
+- Task("Critique from Duplication perspective...")
+- Task("Critique from Correctness perspective...")
+- Task("Critique from Security perspective...")
+- Task("Critique from Performance perspective...")
+- Task("Critique from Testing perspective...")
+- Task("Critique from Architecture perspective...")
+- Task("Critique from Scope perspective...")
+
+[Synthesize when all return] → Critique Summary
+
+[Improve plan] → Adopt/Reject/Adapt each item
+
+[Add Critique Decisions section]
+```
+
+## Integration
+
+- **superpowers:writing-plans** – Use after drafting to critique before implementation
+- **plan-with-critique** – Runs plan first, then invokes this skill
+- **superpowers:dispatching-parallel-agents** – Same pattern (independent domains)
+
+## Red Flags
+
+- **Don't** run critics sequentially (wastes time; perspectives are independent)
+- **Don't** let one critic's verdict override synthesis (merge all)
+- **Don't** spawn critics without the full plan in context (each needs the plan)
+- **Don't** adopt every critique without evaluation
+- **Don't** skip the Critique Decisions section (it clarifies your reasoning)
+- **Don't** let critics override project conventions (e.g., CLAUDE.md patterns)
+- **Don't** make the plan worse by over-incorporating feedback (e.g., scope creep from "add more")

--- a/.cursor/skills/plan-critique/critic-prompts.md
+++ b/.cursor/skills/plan-critique/critic-prompts.md
@@ -1,0 +1,177 @@
+# Plan Critic Prompts
+
+Copy the appropriate block when dispatching each critic subagent.
+
+---
+
+## Duplication Critic
+
+```
+Critique this implementation plan from the DUPLICATION perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Find potential DRY violations, repeated logic, or consolidation opportunities. Ask: will this plan produce duplicated code or patterns?
+
+**Check:**
+- Are similar operations repeated across tasks?
+- Could multiple tasks share a helper, schema, or utility?
+- Is there existing code the plan could reuse instead of reimplementing?
+- Are there copy-paste risks (e.g., similar forms, handlers, types)?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Consolidation opportunities
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```
+
+---
+
+## Correctness Critic
+
+```
+Critique this implementation plan from the CORRECTNESS perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Find gaps in requirements, missing edge cases, unclear steps, or logic flaws.
+
+**Check:**
+- Are all requirements explicit enough to implement?
+- Are edge cases (null, empty, missing) addressed?
+- Is task ordering correct (dependencies respected)?
+- Are there ambiguous or underspecified steps?
+- Could the plan produce incorrect behavior?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Missing considerations
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```
+
+---
+
+## Security Critic
+
+```
+Critique this implementation plan from the SECURITY perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Find auth, validation, and sensitive data gaps.
+
+**Check:**
+- Is authentication/authorization addressed for new endpoints/flows?
+- Is input validation planned (type, format, bounds)?
+- Are sensitive data (tokens, secrets) handled safely?
+- SQL injection, XSS, or other injection risks?
+- Permission checks at the right boundaries?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Missing considerations
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```
+
+---
+
+## Performance Critic
+
+```
+Critique this implementation plan from the PERFORMANCE perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Find N+1 risks, scalability issues, and bottlenecks.
+
+**Check:**
+- Could loops trigger N+1 queries or repeated API calls?
+- Are there anticipated hot paths or high-volume operations?
+- Is pagination/batching considered where needed?
+- Any expensive operations in loops or frequent paths?
+- Caching or indexing considerations?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Missing considerations
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```
+
+---
+
+## Testing Critic
+
+```
+Critique this implementation plan from the TESTING perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Assess whether the testing strategy is adequate.
+
+**Check:**
+- Which behaviors will be tested? Which won't?
+- Are edge cases and error paths covered?
+- Is integration testing needed (DB, APIs, auth)?
+- Are tests mentioned in the plan or assumed?
+- Could implementation proceed without tests?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Missing considerations
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```
+
+---
+
+## Architecture Critic
+
+```
+Critique this implementation plan from the ARCHITECTURE perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Assess fit with existing patterns, dependencies, and layering.
+
+**Check:**
+- Does it follow project conventions (e.g., defineTool, MeshContext)?
+- Are dependencies on the right layers (no direct DB in tools)?
+- Does it integrate with existing systems correctly?
+- New dependencies justified?
+- Could it conflict with other features or refactors?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Missing considerations
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```
+
+---
+
+## Scope Critic
+
+```
+Critique this implementation plan from the SCOPE perspective.
+
+**Plan:** {PLAN_PATH_OR_CONTENT}
+
+**Your role:** Find scope creep, YAGNI violations, or unnecessary features.
+
+**Check:**
+- Is everything in the plan actually needed now?
+- Are there "nice to have" items that could be deferred?
+- Does the plan over-engineer for hypothetical future needs?
+- Could scope be reduced for a faster, safer first iteration?
+- Are there features with no clear user or system need?
+
+**Output:**
+- Issues found: (Blocker / Important / Minor)
+- Scope reduction opportunities
+- Recommendations
+- Verdict: Ready / Needs changes / High risk
+```

--- a/.cursor/skills/plan-with-critique/SKILL.md
+++ b/.cursor/skills/plan-with-critique/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: plan-with-critique
+description: Create implementation plan from user input, then run plan-critique for feedback and improvement. Use when the user wants a plan that has been stress-tested and refined before implementation.
+---
+
+# Plan with Critique
+
+Create a plan, then run the plan-critique skill to critique and improve it.
+
+## When to Use
+
+- User asks for a plan and wants it vetted before implementation
+- User wants "plan with critique" or "plan then critique"
+- User wants a stress-tested plan with feedback incorporated
+
+## Workflow
+
+### Phase 1: Plan
+
+1. **Use superpowers:writing-plans** to create the implementation plan from user input.
+2. Follow the writing-plans skill (bite-sized tasks, exact paths, TDD, DRY, YAGNI).
+3. Save plan to `docs/plans/YYYY-MM-DD-<feature-name>.md` or `.cursor/plans/<id>.plan.md`.
+
+### Phase 2: Critique and Improve
+
+4. **Use plan-critique skill** – it will:
+   - Spawn parallel subagents, each critiquing from one perspective
+   - Synthesize critic feedback into Blockers, Important, Minor, Recommendations
+   - Apply feedback selectively (adopt/reject/adapt)
+   - Add a "Critique Decisions" section to the plan
+
+## Integration
+
+- **superpowers:writing-plans** – Phase 1
+- **plan-critique** – Phase 2 (handles critique + replan)
+- **superpowers:executing-plans** / **superpowers:subagent-driven-development** – after plan is final
+
+## Red Flags
+
+- **Don't** duplicate the improvement logic—plan-critique owns it
+- **Don't** skip running plan-critique after creating the plan


### PR DESCRIPTION
## Summary
- Add plan-critique skill for reviewing implementation plans
- Add plan-with-critique skill for integrated planning with critique
- Include comprehensive critic prompts for plan evaluation

## Changes
- New `.cursor/skills/plan-critique/` with skill definition and critic prompts
- New `.cursor/skills/plan-with-critique/` for integrated workflow

## Test plan
- [ ] Verify plan-critique skill loads correctly
- [ ] Test plan evaluation with sample plans
- [ ] Verify integrated plan-with-critique workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds plan-critique and plan-with-critique skills to stress-test and refine implementation plans before execution. Includes perspective-specific critic prompts and a clear workflow for parallel review and synthesis.

- **New Features**
  - plan-critique skill with seven critic perspectives (duplication, correctness, security, performance, testing, architecture, scope), parallel subagents, synthesis, and verdict/output format
  - critic-prompts with checks and output templates for each perspective
  - plan-with-critique skill that drafts a plan via superpowers:writing-plans, runs plan-critique, applies feedback (adopt/reject/adapt), and adds a “Critique Decisions” section

<sup>Written for commit 8c8b610ce8a86a8bd035192070686c748d2ab2f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

