### PR TITLE
Enhance PassthroughClient and runCodeWithTools to prefer structuredCo…

### DIFF
--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -410,7 +410,16 @@ export class PassthroughClient extends Client {
           name,
           arguments: innerArgs,
         });
-        // Extract the actual content from the result
+
+        // Prefer structuredContent when available (MCP spec: present when tool defines outputSchema)
+        if (
+          result.structuredContent &&
+          typeof result.structuredContent === "object"
+        ) {
+          return result.structuredContent;
+        }
+
+        // Fall back to extracting from content array
         const content = result.content as
           | Array<{ type: string; text?: string }>
           | undefined;


### PR DESCRIPTION
…ntent in CallToolResult. This change ensures that when available, structuredContent is returned directly, improving data handling and consistency with MCP specifications. Fallback logic for content extraction remains intact.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer structuredContent from CallToolResult in PassthroughClient and runCodeWithTools. This aligns with MCP spec and returns structured data directly to sandbox code, with safe fallbacks.

- **Bug Fixes**
  - PassthroughClient: return structuredContent when present; otherwise extract from content array.
  - runCodeWithTools: tool wrappers return structured data to the sandbox; prefer structuredContent, else JSON-parse text content, else return the original result.

<sup>Written for commit cbbe1b8abc0dc4caa60a65d92ee79bae2288d3aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

