### PR TITLE
feat(chat): extract useAutoScroll hook and add detail auto-scroll

### DIFF
--- a/apps/mesh/src/web/components/chat/message/smart-auto-scroll.tsx
+++ b/apps/mesh/src/web/components/chat/message/smart-auto-scroll.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useAutoScroll } from "@deco/ui/hooks/use-auto-scroll.ts";
 
 /**
  * Smart auto-scroll sentinel component that handles auto-scrolling when visible.
@@ -12,88 +12,15 @@ export function SmartAutoScroll({
 }: {
   parts: unknown[] | null | undefined;
 }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [isVisible, setIsVisible] = useState(false);
-
-  // Extract content dependencies from parts for dependency tracking
   const partsLength = parts?.length;
   const lastPart = parts?.[parts.length - 1];
 
-  // Helper function to find and scroll the scrollable parent container
-  const scrollToBottom = () => {
-    if (!ref.current) {
-      return;
-    }
+  const { sentinelRef } = useAutoScroll({
+    enabled: true,
+    contentDeps: [partsLength, lastPart],
+    // Viewport mode: no containerRef, finds scrollable parent automatically
+    // threshold 0.1 (default for viewport mode)
+  });
 
-    // Find the scrollable parent container
-    let scrollContainer: HTMLElement | null = ref.current.parentElement;
-    while (scrollContainer) {
-      const style = window.getComputedStyle(scrollContainer);
-      if (
-        style.overflowY === "auto" ||
-        style.overflowY === "scroll" ||
-        style.overflow === "auto" ||
-        style.overflow === "scroll"
-      ) {
-        // Found the scrollable container, scroll to bottom
-        scrollContainer.scrollTop = scrollContainer.scrollHeight;
-        return;
-      }
-      scrollContainer = scrollContainer.parentElement;
-    }
-  };
-
-  // Set up IntersectionObserver to track visibility
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- Observer lifecycle management requires useEffect
-  useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // Component is visible if any part of it (10% threshold) is in viewport
-        const isIntersecting = entries[0]?.isIntersecting ?? false;
-        setIsVisible(isIntersecting);
-      },
-      {
-        threshold: 0.1, // Trigger when 10% of component is visible
-        rootMargin: "0px",
-      },
-    );
-
-    observer.observe(ref.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
-  // Periodic scrolling during streaming (only when visible)
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- Interval lifecycle management requires useEffect
-  useEffect(() => {
-    if (!isVisible) {
-      return;
-    }
-
-    const intervalId = setInterval(() => {
-      scrollToBottom();
-    }, 500);
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [isVisible]);
-
-  // Scroll when content changes (only when visible)
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- Content change tracking requires useEffect
-  useEffect(() => {
-    if (!isVisible) {
-      return;
-    }
-
-    scrollToBottom();
-  }, [isVisible, partsLength, lastPart]);
-
-  return <div ref={ref} className="h-0" />;
+  return <div ref={sentinelRef} className="h-0" />;
 }

--- a/packages/ui/src/hooks/use-auto-scroll.ts
+++ b/packages/ui/src/hooks/use-auto-scroll.ts
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+
+interface UseAutoScrollOptions {
+  /**
+   * Ref to the scrollable container element.
+   * - If provided: used as the IntersectionObserver root AND as the scroll target.
+   * - If omitted: observer uses viewport, scroll target is found by walking up from sentinel.
+   */
+  containerRef?: React.RefObject<HTMLElement | null>;
+  /** Whether auto-scrolling is enabled. When false, observer still tracks but no scrolling occurs. */
+  enabled: boolean;
+  /** Dependencies that trigger an immediate scroll when changed (e.g. content length). */
+  contentDeps?: unknown[];
+  /** IntersectionObserver threshold. Default 0.1 (viewport mode) or 0.95 (container mode). */
+  threshold?: number;
+  /** Interval in ms for periodic scrolling. Default 500. */
+  intervalMs?: number;
+}
+
+interface UseAutoScrollReturn {
+  /**
+   * Callback ref to attach to the sentinel element.
+   * Use as: `<div ref={sentinelRef} className="h-0" />`
+   * Uses setState callback ref pattern so the observer re-attaches when the sentinel mounts/unmounts.
+   */
+  sentinelRef: (node: HTMLDivElement | null) => void;
+  /** Whether the sentinel is currently visible (user hasn't scrolled away). */
+  isTracking: boolean;
+}
+
+/**
+ * Reusable auto-scroll hook.
+ *
+ * Place a sentinel `<div ref={sentinelRef} className="h-0" />` at the bottom of the
+ * scrollable content. The hook uses IntersectionObserver to detect whether the user
+ * has scrolled away. When `enabled && isTracking`, it periodically scrolls to bottom
+ * and also scrolls immediately when `contentDeps` change.
+ *
+ * Two modes:
+ * - **Viewport mode** (no `containerRef`): observer root = viewport, scrolls nearest
+ *   scrollable parent of the sentinel.
+ * - **Container mode** (`containerRef` provided): observer root = container, scrolls
+ *   the container directly.
+ */
+export function useAutoScroll({
+  containerRef,
+  enabled,
+  contentDeps = [],
+  threshold,
+  intervalMs = 500,
+}: UseAutoScrollOptions): UseAutoScrollReturn {
+  // Use setState as callback ref so effect re-runs when sentinel mounts/unmounts.
+  // This fixes the timing issue where containerRef.current or the sentinel
+  // may not be available on the initial effect run (e.g. inside CollapsibleContent).
+  const [sentinelNode, setSentinelNode] = useState<HTMLDivElement | null>(null);
+  const [isTracking, setIsTracking] = useState(false);
+
+  // Resolve default threshold based on mode
+  const resolvedThreshold = threshold ?? (containerRef ? 0.95 : 0.1);
+
+  // Helper: scroll to bottom of the target container
+  const scrollToBottom = () => {
+    // Container mode: scroll the known container
+    if (containerRef?.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      return;
+    }
+
+    // Viewport mode: walk up from sentinel to find scrollable parent
+    if (!sentinelNode) return;
+    let el: HTMLElement | null = sentinelNode.parentElement;
+    while (el) {
+      const style = window.getComputedStyle(el);
+      if (
+        style.overflowY === "auto" ||
+        style.overflowY === "scroll" ||
+        style.overflow === "auto" ||
+        style.overflow === "scroll"
+      ) {
+        el.scrollTop = el.scrollHeight;
+        return;
+      }
+      el = el.parentElement;
+    }
+  };
+
+  // 1. IntersectionObserver: track whether sentinel is visible
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- Observer lifecycle management requires useEffect
+  useEffect(() => {
+    if (!sentinelNode) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries[0]?.isIntersecting ?? false;
+        setIsTracking(visible);
+      },
+      {
+        root: containerRef?.current ?? null,
+        threshold: resolvedThreshold,
+        rootMargin: "0px",
+      },
+    );
+
+    observer.observe(sentinelNode);
+    return () => observer.disconnect();
+  }, [sentinelNode, resolvedThreshold]); // eslint-disable-line react-hooks/exhaustive-deps -- containerRef.current not in deps: refs don't trigger re-renders; sentinel mount suffices
+
+  // 2. Periodic scroll interval (only when enabled + tracking)
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- Interval lifecycle management requires useEffect
+  useEffect(() => {
+    if (!enabled || !isTracking) return;
+
+    const id = setInterval(scrollToBottom, intervalMs);
+    return () => clearInterval(id);
+  }, [enabled, isTracking, intervalMs]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 3. Immediate scroll on content changes (only when enabled + tracking)
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- Content change tracking requires useEffect
+  useEffect(() => {
+    if (!enabled || !isTracking) return;
+    scrollToBottom();
+  }, [enabled, isTracking, ...contentDeps]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { sentinelRef: setSentinelNode, isTracking };
+}


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

Extracts the auto-scroll pattern shared by `SmartAutoScroll` into a reusable `useAutoScroll` hook in `packages/ui`, then uses it to add auto-scroll behavior to the tool call detail section when expanded and loading.

**Changes:**
- **New `useAutoScroll` hook** (`packages/ui/src/hooks/use-auto-scroll.ts`): Encapsulates IntersectionObserver-based visibility tracking + interval-based scrolling. Supports two modes: viewport mode (finds scrollable parent from sentinel) and container mode (scrolls a known ref).
- **Refactored `SmartAutoScroll`**: Replaced ~100 lines with a thin ~25-line wrapper using the hook (viewport mode).
- **`ToolCallShell` auto-scroll**: When a tool call is expanded and loading, the detail area automatically scrolls to the bottom as content streams in. Stops when the user scrolls up and resumes when they scroll back to bottom.

## Screenshots/Demonstration
N/A

## How to Test
1. **Chat auto-scroll (regression):** Send a message that triggers a long streaming response. Verify the chat auto-scrolls to bottom as before.
2. **Tool call loading + expanded:** Start a task that invokes tools (e.g. subtask). While loading, expand a tool call. Verify the detail area auto-scrolls to bottom as content streams in.
3. **User scrolls up:** While auto-scrolling in the detail area, manually scroll up. Verify auto-scroll stops.
4. **User returns to bottom:** Scroll back to bottom. Verify auto-scroll resumes.
5. **Completed tool call:** Expand a completed (idle) tool call. Verify no auto-scroll.
6. **Error tool call:** Expand an errored tool call. Verify no auto-scroll.

## Migration Notes
N/A

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable useAutoScroll hook and used it to auto-scroll expanded tool call details while loading. This keeps streaming content pinned to the bottom and removes duplicate scrolling logic.

- **New Features**
  - Added useAutoScroll hook (viewport or container mode) using IntersectionObserver + periodic scrolling.
  - Tool call detail auto-scrolls when expanded and loading; pauses when user scrolls up and resumes at bottom.

- **Refactors**
  - SmartAutoScroll rewritten to use useAutoScroll, greatly reducing code.
  - Tool call detail now renders as plain text (copiable), removing markdown heuristics.

<sup>Written for commit 0dd7df6a60650f88d37030c519aa3f10d61cb666. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

