### PR TITLE
fix(event bus cron): cron event being marked as `delivered` after one successful run

### DIFF
--- a/apps/mesh/src/event-bus/worker.ts
+++ b/apps/mesh/src/event-bus/worker.ts
@@ -406,6 +406,8 @@ export class EventBusWorker {
         console.log(
           `[EventBus] Cron expression for event ${event.id} has no more runs`,
         );
+        // Cron is exhausted — mark the event as delivered (terminal state)
+        await this.storage.markEventCompleted(event.id);
         return;
       }
 

--- a/apps/mesh/src/storage/event-bus.ts
+++ b/apps/mesh/src/storage/event-bus.ts
@@ -266,6 +266,14 @@ export interface EventBusStorage {
   ): Promise<{ success: boolean }>;
 
   /**
+   * Mark a cron event as completed (delivered) when there are no more runs.
+   * Called by the worker when a cron expression produces no next run time.
+   *
+   * @param eventId - The event ID to mark as completed
+   */
+  markEventCompleted(eventId: string): Promise<void>;
+
+  /**
    * Sync subscriptions to a desired state.
    * Creates new subscriptions, deletes removed ones, and updates filters.
    * Subscriptions are identified by (eventType, publisher) - only one per combination.
@@ -784,6 +792,19 @@ class KyselyEventBusStorage implements EventBusStorage {
     );
 
     if (allDelivered) {
+      // For cron events, don't mark as "delivered" — the event represents an
+      // ongoing schedule. The worker's scheduleNextCronDelivery() owns the
+      // lifecycle and will mark it delivered when the cron has no more runs.
+      const event = await this.db
+        .selectFrom("events")
+        .select(["cron"])
+        .where("id", "=", eventId)
+        .executeTakeFirst();
+
+      if (event?.cron) {
+        return; // Cron events stay "pending" between delivery cycles
+      }
+
       await this.db
         .updateTable("events")
         .set({
@@ -1000,6 +1021,17 @@ class KyselyEventBusStorage implements EventBusStorage {
     }
 
     return { success: updated };
+  }
+
+  async markEventCompleted(eventId: string): Promise<void> {
+    await this.db
+      .updateTable("events")
+      .set({
+        status: "delivered",
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", eventId)
+      .execute();
   }
 
   async syncSubscriptions(


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cron events being marked as delivered after the first run. Cron events now stay pending between deliveries and are only marked delivered when the schedule is exhausted.

- **Bug Fixes**
  - Worker marks cron events as delivered only when there is no next run.
  - Storage skips auto-marking cron events as delivered and adds markEventCompleted to set the final state.

<sup>Written for commit 8f5cf8ad0cfc0ef14d1708b6e1b4ea4cd14dec39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

