### PR TITLE
fix: resolve lint and knip errors in publish-requests

### DIFF
--- a/packages/mesh-plugin-private-registry/client/components/registry-requests-page.tsx
+++ b/packages/mesh-plugin-private-registry/client/components/registry-requests-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,6 +10,7 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import { Badge } from "@deco/ui/components/badge.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card } from "@deco/ui/components/card.tsx";
 import {
@@ -99,14 +100,10 @@ export default function RegistryRequestsPage() {
   const requests = listQuery.data?.items ?? [];
   const totalCount = listQuery.data?.totalCount ?? 0;
 
-  const pendingById = useMemo(
-    () =>
-      new Set(
-        requests
-          .filter((request) => request.status === "pending")
-          .map((request) => request.id),
-      ),
-    [requests],
+  const pendingById = new Set(
+    requests
+      .filter((request) => request.status === "pending")
+      .map((request) => request.id),
   );
 
   const handleApproveConfirmed = async () => {
@@ -191,11 +188,12 @@ export default function RegistryRequestsPage() {
               <button
                 key={option.value}
                 type="button"
-                className={`px-2.5 py-1 text-xs rounded-md transition-colors ${
+                className={cn(
+                  "px-2.5 py-1 text-xs rounded-md transition-colors",
                   status === option.value
                     ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
+                    : "text-muted-foreground hover:text-foreground",
+                )}
                 onClick={() => setStatus(option.value)}
               >
                 {option.label}

--- a/packages/mesh-plugin-private-registry/server/storage/publish-api-key.ts
+++ b/packages/mesh-plugin-private-registry/server/storage/publish-api-key.ts
@@ -5,7 +5,7 @@ import type { PrivateRegistryDatabase, PublishApiKeyEntity } from "./types";
 /**
  * Hash a plaintext API key using SHA-256.
  */
-export async function hashApiKey(key: string): Promise<string> {
+async function hashApiKey(key: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(key);
   const hashBuffer = await crypto.subtle.digest("SHA-256", data);

--- a/packages/mesh-plugin-private-registry/server/tools/schema.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/schema.ts
@@ -255,13 +255,9 @@ export const RegistryAIGenerateOutputSchema = z.object({
 
 // ─── Publish Requests ───
 
-export const PublishRequestStatusSchema = z.enum([
-  "pending",
-  "approved",
-  "rejected",
-]);
+const PublishRequestStatusSchema = z.enum(["pending", "approved", "rejected"]);
 
-export const PublishRequestSchema = z.object({
+const PublishRequestSchema = z.object({
   id: z.string(),
   organization_id: z.string(),
   requested_id: z.string().nullable().optional(),
@@ -322,7 +318,7 @@ export const PublicPublishRequestInputSchema = z.object({
 
 // ─── Publish API Keys ───
 
-export const PublishApiKeySchema = z.object({
+const PublishApiKeySchema = z.object({
   id: z.string(),
   name: z.string(),
   prefix: z.string(),


### PR DESCRIPTION
- Remove useMemo (banned by React Compiler rules), use direct derivation
- Use cn() instead of template literal for className interpolation
- Remove unused exports: hashApiKey, PublishRequestStatusSchema, PublishRequestSchema, PublishApiKeySchema

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lint and knip errors in publish-requests by removing banned useMemo, switching to cn() for className, and unexporting unused helpers/schemas. This aligns with React Compiler rules and reduces the public API surface.

- **Bug Fixes**
  - Removed useMemo in RegistryRequestsPage; derive pendingById directly.
  - Replaced className template literals with cn().
  - Unexported unused items: hashApiKey, PublishRequestStatusSchema, PublishRequestSchema, PublishApiKeySchema.

<sup>Written for commit 7bca26d62cc7c0b333f3b87a865792b960002911. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

