### PR TITLE
[chore]: bump bindings package to 1.3.1

### DIFF
--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/bindings",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Bump `@decocms/bindings` package version from 1.3.0 to 1.3.1

## Test plan
- [ ] Version updated correctly in package.json
- [ ] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update @decocms/bindings to 1.3.1 to pull in the latest patch release. Changes only the version in packages/bindings/package.json; no breaking changes expected.

<sup>Written for commit 55186946c36be1a81b7a4eb61bd10f9a0c0fa45d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

