### PR TITLE
feat(decopilot): enhance subtask tool UI and message extraction

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -9,7 +9,7 @@ import {
   getApprovalId,
   getEffectiveState,
 } from "./utils.tsx";
-import { getToolPartErrorText } from "../utils.ts";
+import { getToolPartErrorText, safeStringify } from "../utils.ts";
 import { ApprovalActions } from "./approval-actions.tsx";
 
 interface GenericToolCallPartProps {
@@ -22,12 +22,13 @@ interface GenericToolCallPartProps {
   latency?: number;
 }
 
-function safeStringify(value: unknown): string {
-  if (value === undefined || value === null) return "";
+function safeStringifyFormatted(value: unknown): string {
+  const str = safeStringify(value);
+  if (str === "" || str === "[Non-serializable value]") return str;
   try {
-    return JSON.stringify(value, null, 2);
+    return JSON.stringify(JSON.parse(str), null, 2);
   } catch {
-    return "[Non-serializable value]";
+    return str;
   }
 }
 
@@ -91,7 +92,7 @@ export function GenericToolCallPart({
   // Build expanded content
   let detail = "";
   if (part.input !== undefined) {
-    detail += "# Input\n" + safeStringify(part.input);
+    detail += "# Input\n" + safeStringifyFormatted(part.input);
   }
 
   if (part.state === "output-error") {
@@ -100,7 +101,7 @@ export function GenericToolCallPart({
     detail += "# Error\n" + errorText;
   } else if (part.output !== undefined) {
     if (detail) detail += "\n\n";
-    detail += "# Output\n" + safeStringify(part.output);
+    detail += "# Output\n" + safeStringifyFormatted(part.output);
   }
 
   // Build approval actions for approval-requested state


### PR DESCRIPTION
## What is this contribution about?

This PR improves the subtask tool and UI message rendering with enhanced safety and comprehensive test coverage:

1. **Permission mode for subagent tools**: Fixes the subtask tool to pass the "yolo" permission mode when loading tools for subagents, ensuring they inherit the correct approval behavior.

2. **Enhanced UI message text extraction**: Refactors `extractTextFromOutput` to handle all UIMessagePart types from the AI SDK, including:
   - Text, reasoning, and step-start parts
   - Source URLs and documents
   - File attachments
   - All tool states (input-streaming, input-available, approval-requested, approval-responded, output-available, output-error, output-denied)

3. **Safe stringification**: Guards all tool input/output stringification to prevent crashes from non-serializable values:
   - Extracts `safeStringify` from GenericToolCallPart to shared utils
   - Handles circular references, BigInt, undefined, null gracefully
   - Returns "[Non-serializable value]" fallback on errors
   - Comprehensive test coverage (49 tests total)

This improves type safety, robustness, and ensures subtask tool outputs can be properly extracted and displayed in the UI without crashes.

## Screenshots/Demonstration

N/A

## How to Test

1. Start the development environment: `bun run dev`
2. Create a subtask that uses tools requiring approval
3. Verify the subagent tools execute without re-prompting for approval
4. Check that subtask output is correctly extracted and displayed in the chat UI
5. Test with different message part types (text, reasoning, tool calls, etc.)
6. Test edge cases:
   - Create a tool call with circular references in input/output
   - Create a tool call with BigInt values
   - Verify no crashes occur and fallback text is displayed

**Automated tests:**
```bash
bun test apps/mesh/src/web/components/chat/message/parts/extract-text-from-output.test.ts
```

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes