### PR TITLE
fix background by moving highlights outside

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -193,12 +193,14 @@ export function ChatHighlight() {
 
   if (!isStreaming && error) {
     return (
-      <StatusHighlight
-        variant="error"
-        error={error}
-        onDismiss={clearError}
-        onFixInChat={handleFixInChat}
-      />
+      <div className="absolute bottom-full left-0 right-0 bg-background">
+        <StatusHighlight
+          variant="error"
+          error={error}
+          onDismiss={clearError}
+          onFixInChat={handleFixInChat}
+        />
+      </div>
     );
   }
 
@@ -209,12 +211,14 @@ export function ChatHighlight() {
     !isWaitingForApprovals
   ) {
     return (
-      <StatusHighlight
-        variant="warning"
-        finishReason={finishReason}
-        onDismiss={clearFinishReason}
-        onContinue={handleContinue}
-      />
+      <div className="absolute bottom-full left-0 right-0 bg-background">
+        <StatusHighlight
+          variant="warning"
+          finishReason={finishReason}
+          onDismiss={clearFinishReason}
+          onContinue={handleContinue}
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat highlight background by rendering error/warning banners in an absolute wrapper above the chat, ensuring full-width alignment and consistent theme background.

- **Bug Fixes**
  - Moved error and warning StatusHighlight into an absolute container (bottom-full, left-0, right-0) outside the chat content to prevent clipping.
  - Applied bg-background on the wrapper to remove background bleed and match the app theme.

<sup>Written for commit cab7f69d886f82755ac484e90d1052545d890be6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

