### PR TITLE
chore(menu): remove workflows from org-admin sidebar

### DIFF
--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -128,17 +128,6 @@ export function useProjectSidebarItems(): SidebarSection[] {
       }),
   };
 
-  const workflowsItem: NavigationSidebarItem = {
-    key: "workflows",
-    label: "Workflows",
-    icon: <Dataflow03 />,
-    onClick: () =>
-      navigate({
-        to: "/$org/$project/workflows",
-        params: { org, project: ORG_ADMIN_PROJECT_SLUG },
-      }),
-  };
-
   const membersItem: NavigationSidebarItem = {
     key: "members",
     label: "Members",
@@ -155,7 +144,6 @@ export function useProjectSidebarItems(): SidebarSection[] {
   const orgAdminItems: NavigationSidebarItem[] = [
     ...(preferences.experimental_tasks ? [tasksItem] : []),
     connectionsItem,
-    workflowsItem,
     ...(preferences.experimental_projects ? [projectsItem] : []),
     storeItem,
     agentsItem,


### PR DESCRIPTION
## What is this contribution about?
Removes the Workflows item from the org-admin project sidebar menu. The `workflowsItem` definition and its inclusion in `orgAdminItems` have been deleted from `use-project-sidebar-items.tsx`.

## Screenshots/Demonstration
N/A — sidebar item removed; Workflows no longer appears in the org-admin navigation.

## How to Test
1. Start the dev environment: `bun run dev`
2. Log in and navigate to the org-admin project
3. Verify the "Workflows" entry is no longer visible in the left sidebar
4. Confirm all other sidebar items (Connections, Store, Agents, Monitor, Members) are still present

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Workflows item from the org-admin project sidebar. It no longer appears in navigation; other sidebar items remain unchanged.

<sup>Written for commit 76a71cd592b06f3c9bcfa3af0ca38591b5c4b0e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

