### PR TITLE
fix(chat): propagate toolApprovalLevel through agentic auto-sends

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -321,6 +321,8 @@ app.post("/:org/decopilot/stream", async (c) => {
                   created_at: new Date(),
                   thread_id: mem.thread.id,
                   toolApprovalLevel,
+                  temperature,
+                  windowSize,
                 };
               }
               if (part.type === "reasoning-start") {

--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -165,7 +165,7 @@ const createModelsTransport = (
         ? [systemMessage, ...userMessage]
         : userMessage;
 
-      // Fall back to last message metadata when requestMetadata is missing models/agent/toolApprovalLevel
+      // Fall back to last message metadata when requestMetadata is missing models/agent/toolApprovalLevel/temperature/windowSize
       const lastMsgMeta = (messages.at(-1)?.metadata ?? {}) as Metadata;
       const mergedMetadata = {
         ...metadata,
@@ -181,6 +181,16 @@ const createModelsTransport = (
           ...(lastMsgMeta.toolApprovalLevel && {
             toolApprovalLevel: lastMsgMeta.toolApprovalLevel,
           }),
+          ...(lastMsgMeta.temperature !== undefined && {
+            temperature: lastMsgMeta.temperature,
+          }),
+          ...(lastMsgMeta.windowSize !== undefined &&
+            mergedMetadata.thread_id && {
+              memory: {
+                windowSize: lastMsgMeta.windowSize,
+                thread_id: mergedMetadata.thread_id,
+              },
+            }),
         },
       };
     },

--- a/apps/mesh/src/web/components/chat/types.ts
+++ b/apps/mesh/src/web/components/chat/types.ts
@@ -67,6 +67,10 @@ export interface Metadata {
   tiptapDoc?: TiptapDoc;
   /** Tool approval level preference */
   toolApprovalLevel?: "none" | "readonly" | "yolo";
+  /** LLM sampling temperature (0–1). Persisted so auto-sends use the same value. */
+  temperature?: number;
+  /** Conversation context window size (number of messages). Persisted so auto-sends use the same value. */
+  windowSize?: number;
   usage?: {
     inputTokens?: number;
     outputTokens?: number;


### PR DESCRIPTION
## What is this contribution about?

When a user sets tool approval to **"yolo"** (disabled) in settings, `GATEWAY_SEARCH_TOOLS` and `GATEWAY_DESCRIBE_TOOLS` still prompted for approval on subsequent agentic steps.

**Root cause:** `toolApprovalLevel` was only sent in the initial `requestMetadata`, which is populated on user-initiated sends. The AI SDK's `sendAutomaticallyWhen` auto-sends fire with empty `requestMetadata`, so the field was absent from the request. The server then defaulted it to `"none"`, causing `toolNeedsApproval("none", true)` to return `true` even for read-only gateway tools.

**Fix — follow the existing `agent`/`models`/`thread_id` fallback pattern:**
1. Store `toolApprovalLevel` in the **user-message metadata** (`messageMetadata`) so it rides along in `messages.at(-1)?.metadata` for all subsequent auto-sends.
2. Echo `toolApprovalLevel` from the server in the **assistant-message metadata** (`messageMetadata` callback on `part.type === "start"`), completing the fallback chain for multi-turn flows.
3. In `prepareSendMessagesRequest`, read `toolApprovalLevel` from `lastMsgMeta` (last message metadata) instead of `requestMetadata`, and remove the now-unnecessary intersection type cast.

## Screenshots/Demonstration

N/A — no UI changes.

## How to Test

1. Open the app and go to **Settings → Tool Approval** → set to **"yolo"** (disabled).
2. Select an agent in `smart_tool_selection` or `code_execution` mode.
3. Send a message that triggers tool discovery — verify **no approval dialog** appears for `GATEWAY_SEARCH_TOOLS` or `GATEWAY_DESCRIBE_TOOLS`.
4. Let the agent run through multiple agentic steps (auto-sends) — verify approval is still not requested on subsequent steps.
5. Change approval to **"readonly"** and send a new message — verify gateway tools (readOnlyHint: true) are auto-approved but non-readonly tools still prompt.
6. Change approval to **"none"** and send a new message — verify all tools prompt for approval.

## Migration Notes

No database migrations or configuration changes required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure agent auto-sends inherit toolApprovalLevel, temperature, and windowSize from the last message metadata, preventing unwanted approval prompts and resets to server defaults.

- **Bug Fixes**
  - Persist toolApprovalLevel, temperature, and windowSize in message metadata; read them from lastMsgMeta for auto-sends instead of requestMetadata.
  - Echo these values in assistant start metadata; send windowSize under memory with thread_id when available.

<sup>Written for commit c7486935659ad5ca7bf95b3057348d6e8437f026. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

