### PR TITLE
fix(docs): remove conflicting redirects and i18n config causing build failure

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -43,18 +43,9 @@ export default defineConfig({
   },
   redirects: {
     "/": "/latest/en/introduction",
-    "/en/[...slug]": "/latest/en/[...slug]",
-    "/pt-br/[...slug]": "/latest/pt-br/[...slug]",
   },
   outDir: "dist/client/",
   srcDir: "client/src",
-  i18n: {
-    locales: ["en", "pt-br"],
-    defaultLocale: "en",
-    routing: {
-      prefixDefaultLocale: true,
-    },
-  },
   integrations: [mdx(), react(), patchCsrRedirect()],
   vite: {
     plugins: [


### PR DESCRIPTION
## What is this contribution about?

The docs deploy CI was failing with a `[GetStaticPathsRequired]` error on the `/en/[...slug]` route after commit c06e7f5d3 added a new `[locale]/[...slug].astro` page.

**Root cause:** Two conflicting mechanisms were handling the same routes simultaneously:

1. **Config redirects** (`/en/[...slug]` → `/latest/en/[...slug]`) — In Astro 5 static build mode, config-level redirects with dynamic patterns create redirect routes that Astro tries to statically generate, but the redirect route handler has no `getStaticPaths()`, which triggers `[GetStaticPathsRequired]`.

2. **i18n routing** (`prefixDefaultLocale: true`) — This was creating injected fallback routes that clashed with the manual locale routing already implemented in `[locale]/[...slug].astro`.

The `[locale]/[...slug].astro` page already handles both cases programmatically via `Astro.redirect()`, making the config-level redirects redundant.

**Fix:** Remove the `/en/[...slug]` and `/pt-br/[...slug]` entries from `redirects`, and remove the `i18n` config block. The custom i18n utilities in `client/src/i18n/` are unaffected.

## Screenshots/Demonstration

N/A

## How to Test

1. Run `bun run --cwd=apps/docs build:client` from the repo root
2. Expected: `171 page(s) built` with no errors
3. Verify legacy URL redirects still work by checking that `/en/...` and `/pt-br/...` pages are generated (they redirect via the `[locale]/[...slug].astro` page)

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs build failure by removing conflicting Astro redirects and i18n routing. Build now passes, and legacy /en and /pt-br URLs still redirect via page-level logic.

- **Bug Fixes**
  - Deleted dynamic config redirects for /en/[...slug] and /pt-br/[...slug].
  - Removed i18n routing config that clashed with manual locale routing.
  - Redirects now handled in [locale]/[...slug].astro via Astro.redirect(); build succeeds in Astro 5 static mode.

<sup>Written for commit 2e8ed602734e423c265fd4768dbd24ff5fc847fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

