### PR TITLE
fix(sdk): include scopeKey in collection query keys to prevent cross-org cache leaks

### DIFF
--- a/apps/mesh/src/web/hooks/use-collection-cache-prefill.test.ts
+++ b/apps/mesh/src/web/hooks/use-collection-cache-prefill.test.ts
@@ -34,10 +34,9 @@ describe("Collection Cache Prefill Logic", () => {
 
     expect(queryKey).not.toBeNull();
     if (queryKey) {
-      expect(queryKey[0]).toBe("mcp");
-      expect(queryKey[1]).toBe("client");
-      expect(queryKey[3]).toBe("tool-call");
-      expect(queryKey[4]).toBe("COLLECTION_THREAD_MESSAGES_LIST");
+      expect(queryKey[1]).toBe("org-123");
+      expect(queryKey[3]).toBe("collection");
+      expect(queryKey[4]).toBe("THREAD_MESSAGES");
     }
   });
 
@@ -50,11 +49,12 @@ describe("Collection Cache Prefill Logic", () => {
     );
 
     expect(queryKey).toEqual([
-      "mcp",
-      "client",
       null,
-      "tool-call",
-      "COLLECTION_THREAD_MESSAGES_LIST",
+      "org-123",
+      "",
+      "collection",
+      "THREAD_MESSAGES",
+      "list",
       JSON.stringify({
         orderBy: [{ field: ["updated_at"], direction: "asc" }],
         limit: 100,
@@ -72,11 +72,12 @@ describe("Collection Cache Prefill Logic", () => {
     );
 
     expect(queryKey).toEqual([
-      "mcp",
-      "client",
       undefined,
-      "tool-call",
-      "COLLECTION_THREAD_MESSAGES_LIST",
+      "org-123",
+      "",
+      "collection",
+      "THREAD_MESSAGES",
+      "list",
       JSON.stringify({
         orderBy: [{ field: ["updated_at"], direction: "asc" }],
         limit: 100,
@@ -173,8 +174,8 @@ describe("Collection Cache Prefill Logic", () => {
     expect(messagesKey).not.toBeNull();
 
     if (threadsKey && messagesKey) {
-      expect(threadsKey[4]).toBe("COLLECTION_THREADS_LIST");
-      expect(messagesKey[4]).toBe("COLLECTION_THREAD_MESSAGES_LIST");
+      expect(threadsKey[4]).toBe("THREADS");
+      expect(messagesKey[4]).toBe("THREAD_MESSAGES");
     }
   });
 });

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -585,13 +585,11 @@ function OrgMcpsContent() {
     queryClient.invalidateQueries({
       predicate: (query) => {
         const key = query.queryKey;
-        if (key[0] !== "mcp" || key[1] !== "client" || key[3] !== "tool-call") {
-          return false;
-        }
-        const toolName = key[4];
+        // Match collectionList/collectionItem keys: [client, scopeKey, "", "collection", collectionName, ...]
         return (
-          typeof toolName === "string" &&
-          toolName.startsWith("COLLECTION_CONNECTIONS_")
+          key[1] === org.id &&
+          key[3] === "collection" &&
+          key[4] === "CONNECTIONS"
         );
       },
     });


### PR DESCRIPTION
## Summary

- **Root cause:** `scopeKey` (org ID) was passed to `useCollectionList`, `useCollectionItem`, `buildCollectionQueryKey`, and `useCollectionActions` but explicitly discarded with `void scopeKey; // Reserved for future use`. Collection query keys used `KEYS.mcpToolCall(client, toolName, argsKey)`, which relied entirely on `client.toJSON()` for org isolation — a fragile implicit mechanism.
- **Bug scenario:** If a `Client` is created without `toJSON` (e.g. bypassing `createMCPClient`), `JSON.stringify` falls back to the class instance's enumerable properties, which can be identical across orgs, causing connections from one org to appear in another.
- **Fix:** Switch all collection query keys from `KEYS.mcpToolCall` to `KEYS.collectionList` / `KEYS.collectionItem` (already defined in `KEYS` for this purpose). These include `scopeKey` explicitly at index 1, making org scoping unambiguous and robust.

## Changes

- **`packages/mesh-sdk/src/hooks/use-collections.ts`** — Remove all `void scopeKey;` lines. Use `KEYS.collectionList(client, scopeKey, "", upperName, argsKey)` and `KEYS.collectionItem(client, scopeKey, "", upperName, itemId)` instead of `KEYS.mcpToolCall`. Update `CollectionQueryKey` type to match the new shape. Update `invalidateCollection` predicate to scope by `key[1] === scopeKey` instead of matching tool name strings without scope. Remove unused `listToolName` from `buildCollectionQueryKey`.
- **`apps/mesh/src/web/routes/orgs/connections.tsx`** — Update `invalidateConnections` to match the new key shape, and scope invalidation to the current org (`key[1] === org.id`) — previously it invalidated connections across all orgs.
- **`apps/mesh/src/web/hooks/use-collection-cache-prefill.test.ts`** — Update assertions for the new key shape: `[client, scopeKey, "", "collection", collectionName, "list", argsKey]`.

## Test Plan

- [x] `bun test apps/mesh/src/web/hooks/use-collection-cache-prefill.test.ts` — 6 pass
- [x] `bun run check` — no type errors across all workspaces
- [x] `bun run fmt` — no formatting issues
- [x] `bun test` — 829 pass, 0 fail (1 flaky workflow test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-org cache leaks by adding scopeKey (org ID) to all collection query keys and switching to KEYS.collectionList/collectionItem. Invalidation is now scoped per org, making cache isolation robust even when clients lack toJSON.

- **Bug Fixes**
  - Include scopeKey in collection query keys and replace KEYS.mcpToolCall with KEYS.collectionList/collectionItem.
  - Update invalidation to match new shape and scope to the current org in useCollectionActions and orgs/connections.
  - Adjust CollectionQueryKey type and tests to the new list key shape: [client, scopeKey, "", "collection", NAME, "list", argsKey].

- **Migration**
  - If you have custom cache invalidation or prefill code relying on mcpToolCall or the old key shape, switch to KEYS.collectionList/collectionItem and include scopeKey. Check key[1] for org scoping and key[3] === "collection".

<sup>Written for commit e92aed6363c163b911299e2248ca5a2df5b9fbe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

