### PR TITLE
fix IDOR in /org/:organizationId/watch endpoint

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -658,6 +658,11 @@ export async function createApp(options: CreateAppOptions = {}) {
 
     const orgId = c.req.param("organizationId");
 
+    // check that the authenticated user has access to the requested organization
+    if (orgId !== meshContext.organization?.id) {
+      return c.json({ error: "Forbidden access to organization" }, 403);
+    }
+
     // Optional type filter: ?types=workflow.*,public.* (comma-separated patterns)
     const typesParam = c.req.query("types");
     const typePatterns = typesParam


### PR DESCRIPTION
## What is this contribution about?

This PR fixes an **Insecure Direct Object Reference (IDOR)** vulnerability that allowed unauthorized access to resources by manipulating identifiers in requests.

### Changes made

- Added proper authorization checks before accessing protected resources.
- Ensured that resource ownership is validated against the authenticated user/session.
- Removed direct trust of client-supplied identifiers without server-side verification.
- Improved error handling to prevent information leakage (returning proper `403 Forbidden` instead of unintended responses).

### Why this is needed

The previous implementation allowed users to access or manipulate resources that did not belong to them by altering request parameters (e.g., IDs in query/path). This fix enforces strict access control and prevents horizontal privilege escalation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an IDOR in /org/:organizationId/watch by verifying the path orgId matches the authenticated organization. Prevents cross-organization access and returns 403 on mismatch.

- **Bug Fixes**
  - Added server-side org check before handling the watch request.
  - Return 403 Forbidden on org mismatch to avoid information leakage.

<sup>Written for commit 3f84f8919f146e70156d2d3bc2c1dc563f2f28f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

