### PR TITLE
fix(reports-plugin): guard against missing sections/unknown status, add Tailwind source

### DIFF
--- a/packages/mesh-plugin-reports/components/report-detail.tsx
+++ b/packages/mesh-plugin-reports/components/report-detail.tsx
@@ -264,7 +264,7 @@ export default function ReportDetail({
 
       {/* Sections */}
       <div className="flex-1 px-6 py-6 space-y-8">
-        {report.sections.map((section, idx) => (
+        {(report.sections ?? []).map((section, idx) => (
           <ReportSectionRenderer key={idx} section={section} />
         ))}
       </div>

--- a/packages/mesh-plugin-reports/components/status-badge.tsx
+++ b/packages/mesh-plugin-reports/components/status-badge.tsx
@@ -47,7 +47,7 @@ export function StatusBadge({
   status: ReportStatus;
   size?: "sm" | "default";
 }) {
-  const cfg = STATUS_CONFIG[status];
+  const cfg = STATUS_CONFIG[status] ?? STATUS_CONFIG["info"];
   const Icon = cfg.icon;
   const isSmall = size === "sm";
   return (

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -20,6 +20,7 @@
 /* Scan mesh-plugin components for Tailwind classes */
 @source "../../../mesh-plugin-object-storage/**/*.tsx";
 @source "../../../mesh-plugin-private-registry/**/*.tsx";
+@source "../../../mesh-plugin-reports/**/*.tsx";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary

- **report-detail**: `report.sections ?? []` prevents crash when the MCP response omits the `sections` field
- **status-badge**: fall back to `"info"` config for status values outside the known enum, preventing a crash on `.icon` access
- **global.css**: add `@source` for `mesh-plugin-reports` so Tailwind v4 scans and includes its utility classes

## Notes

The `sections` and `status` guards are defensive — the MCP should follow the binding schema. A separate fix on the MCP side is needed to return `REPORTS_GET` output as a flat `Report` (not wrapped in `{ "report": {...} }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent render crashes in the reports plugin by guarding missing sections and unknown status values. Also ensure Tailwind picks up plugin styles by adding the mesh-plugin-reports @source path.

- **Bug Fixes**
  - report-detail: render with (report.sections ?? []) when MCP omits sections.
  - status-badge: default to "info" config for unknown statuses to avoid icon lookup errors.
  - global.css: add @source for mesh-plugin-reports so Tailwind includes its utility classes.

<sup>Written for commit 3370748dac8bc3e65ad396e00dbf7f6e85549260. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

