### PR TITLE
Feat/chat ctx window display

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -46,7 +46,7 @@ import {
   type TiptapInputHandle,
 } from "./tiptap/input";
 import { isTiptapDocEmpty } from "./tiptap/utils";
-import { UsageStats } from "./usage-stats";
+import { ThreadUsageStats } from "./usage-stats";
 
 // ============================================================================
 // DecopilotIconButton - Icon button for Decopilot (similar to FileUploadButton)
@@ -384,7 +384,7 @@ export function ChatInput() {
                       disabled={isStreaming}
                     />
                   )}
-                  <UsageStats usage={usage} />
+                  <ThreadUsageStats usage={usage} />
                   {contextWindow && lastTotalTokens > 0 && (
                     <ContextWindow
                       totalTokens={lastTotalTokens}

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -14,7 +14,7 @@ import type { ToolUIPart } from "ai";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { MemoizedMarkdown } from "../markdown.tsx";
 import type { ChatMessage } from "../types.ts";
-import { UsageStats } from "../usage-stats.tsx";
+import { MessageUsageStats } from "../usage-stats.tsx";
 import { MessageTextPart } from "./parts/text-part.tsx";
 import {
   GenericToolCallPart,
@@ -407,7 +407,7 @@ export function MessageAssistant({
                 key={`${message.id}-${index}`}
                 part={part}
                 id={message.id}
-                usageStats={isLastPart && <UsageStats usage={usage} />}
+                usageStats={isLastPart && <MessageUsageStats usage={usage} />}
                 dataParts={dataParts}
               />
             );

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
@@ -11,7 +11,7 @@ import {
 } from "@deco/ui/components/collapsible.tsx";
 import { useAutoScroll } from "@deco/ui/hooks/use-auto-scroll.ts";
 import { useCopy } from "@deco/ui/hooks/use-copy.ts";
-import { UsageStats } from "../../../usage-stats.tsx";
+import { MessageUsageStats } from "../../../usage-stats.tsx";
 import type { UsageStats as UsageStatsType } from "@/web/lib/usage-utils.ts";
 import { ToolAnnotationBadges } from "@/web/components/tools";
 import type { ToolDefinition } from "@decocms/mesh-sdk";
@@ -98,7 +98,7 @@ export function ToolCallShell({
                   {latency.toFixed(2)}s
                 </span>
               )}
-              <UsageStats usage={usage} />
+              <MessageUsageStats usage={usage} />
               {annotations && (
                 <ToolAnnotationBadges annotations={annotations} />
               )}

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -4,14 +4,14 @@ import {
   TooltipContent,
 } from "@deco/ui/components/tooltip.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
-import { Coins01 } from "@untitledui/icons";
+import { Activity, Coins01 } from "@untitledui/icons";
 import type { UsageStats as UsageStatsType } from "@/web/lib/usage-utils.ts";
 
 interface UsageStatsProps {
   usage: UsageStatsType | null | undefined;
 }
 
-export function UsageStats({ usage }: UsageStatsProps) {
+export function MessageUsageStats({ usage }: UsageStatsProps) {
   if (!usage) return null;
   const { totalTokens, inputTokens, outputTokens, cost } = usage;
   if (!totalTokens && !inputTokens && !outputTokens) return null;
@@ -24,26 +24,67 @@ export function UsageStats({ usage }: UsageStatsProps) {
           size="sm"
           className="text-muted-foreground hover:text-foreground pl-1! h-6 gap-1 whitespace-nowrap shrink-0"
         >
-          <Coins01 size={12} />
+          <Activity size={12} />
           <span className="text-[10px] font-mono tabular-nums">
             {totalTokens.toLocaleString()}
           </span>
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top" className="font-mono text-[11px]">
+        <p className="text-muted text-[10px] mb-1">tokens</p>
         <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
           <span className="text-muted">in</span>
-          <span>{inputTokens.toLocaleString()}</span>
+          <span className="text-right tabular-nums">
+            {inputTokens.toLocaleString()}
+          </span>
           <span className="text-muted">out</span>
-          <span>
+          <span className="text-right tabular-nums">
             {(outputTokens - (usage.reasoningTokens ?? 0)).toLocaleString()}
           </span>
           {cost > 0 && (
             <>
               <span className="text-muted">cost</span>
-              <span>${cost.toFixed(4)}</span>
+              <span className="text-right tabular-nums">
+                ${cost.toFixed(4)}
+              </span>
             </>
           )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+export function ThreadUsageStats({ usage }: UsageStatsProps) {
+  if (!usage) return null;
+  const { totalTokens, inputTokens, outputTokens, cost } = usage;
+  if (!totalTokens && !inputTokens && !outputTokens) return null;
+  if (cost <= 0) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground pl-1! h-6 gap-1 whitespace-nowrap shrink-0"
+        >
+          <Coins01 size={12} />
+          <span className="text-[10px] font-mono tabular-nums">
+            ${cost.toFixed(4)}
+          </span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="font-mono text-[11px]">
+        <p className="text-muted text-[10px] mb-1">tokens</p>
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
+          <span className="text-muted">in</span>
+          <span className="text-right tabular-nums">
+            {inputTokens.toLocaleString()}
+          </span>
+          <span className="text-muted">out</span>
+          <span className="text-right tabular-nums">
+            {outputTokens.toLocaleString()}
+          </span>
         </div>
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a context window usage indicator in the chat input and splits usage stats between per‑message tokens and thread‑level cost. Also updates the assistant “Thought” summary with a clearer header and visible reasoning token count.

- **New Features**
  - Context window ring + tooltip in ChatInput showing tokens used vs model limit (excludes reasoning tokens).
  - MessageUsageStats shows per-message tokens with accurate output; ThreadUsageStats shows per-thread cost with token breakdown in tooltip.
  - Thought summary header displays reasoning token count and handles streaming/redacted states.

<sup>Written for commit d2309213ce29ccb48ed56ac84d0b270317b82796. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

