### PR TITLE
fix IDOR cross organization PROJECT_GET

### DIFF
--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -47,7 +47,6 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
-    
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {

--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -47,11 +47,19 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
+    let organizationId = null;
+
+    if (ctx.organization?.id) {
+      organizationId = ctx.organization.id;
+    } else {
+      throw new Error("Organization context is required");
+    }
+
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {
       project = await ctx.storage.projects.getBySlug(
-        ctx.organization!.id,
+        organizationId,
         input.slug,
       );
     }

--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -21,7 +21,6 @@ export const PROJECT_GET = defineTool({
   },
   inputSchema: z
     .object({
-      organizationId: z.string().describe("Organization ID"),
       projectId: z
         .string()
         .optional()
@@ -48,15 +47,12 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
-    if (input.organizationId !== ctx.organization?.id) {
-      throw new Error("Organization ID does not match authenticated organization");
-    }
-
+    
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {
       project = await ctx.storage.projects.getBySlug(
-        input.organizationId,
+        ctx.organization!.id,
         input.slug,
       );
     }

--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -48,6 +48,10 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
+    if (input.organizationId !== ctx.organization?.id) {
+      throw new Error("Organization ID does not match authenticated organization");
+    }
+
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {


### PR DESCRIPTION
## What is this contribution about?

This PR fixes a **cross-organization access control issue** in the `GET project` endpoint.

Previously, it was possible to retrieve project data across organizations by manipulating identifiers, without properly validating that the authenticated user belonged to the same organization as the requested project. This created a potential **authorization bypass / cross-tenant data exposure** risk.

### Changes made:

- Added strict organization scoping when fetching projects.
- Added proper authorization checks before returning project data.

### Why this is needed:

Mesh is a multi-tenant system. Allowing cross-organization access breaks tenant isolation and may lead to sensitive data exposure. This fix enforces proper tenant boundaries and strengthens overall security.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-organization access in the GET project tool by scoping lookups to the authenticated organization. Prevents IDOR and cross-tenant data exposure.

- **Bug Fixes**
  - Removed organizationId from input and use the current session org (ctx.organization.id) for slug lookups; fixed a formatting test.
  - Throw a clear error when organization context is missing to prevent insecure cross-org lookups.

<sup>Written for commit e5a78e1492d28afe97649af1e5e2fead7d2e7162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

