### PR TITLE
fix(private-registry): remove .transform() from monitor config schema

### DIFF
--- a/packages/mesh-plugin-private-registry/server/index.ts
+++ b/packages/mesh-plugin-private-registry/server/index.ts
@@ -4,7 +4,7 @@ import { migrations } from "./migrations";
 import { publicMCPServerRoutes, publicPublishRequestRoutes } from "./routes";
 import { createStorage } from "./storage";
 import { tools } from "./tools";
-import { RegistryMonitorConfigSchema } from "./tools/monitor-schemas";
+import { parseMonitorConfig } from "./tools/monitor-schemas";
 
 export const serverPlugin: ServerPlugin = {
   id: PLUGIN_ID,
@@ -32,7 +32,7 @@ export const serverPlugin: ServerPlugin = {
             eventData.config && typeof eventData.config === "object"
               ? eventData.config
               : {};
-          const config = RegistryMonitorConfigSchema.parse(rawConfig);
+          const config = parseMonitorConfig(rawConfig);
           await proxy.callTool({
             name: "REGISTRY_MONITOR_RUN_START",
             arguments: { config },

--- a/packages/mesh-plugin-private-registry/server/tools/monitor-run-start.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/monitor-run-start.ts
@@ -26,7 +26,7 @@ import type {
   PrivateRegistryItemEntity,
 } from "../storage";
 import {
-  RegistryMonitorConfigSchema,
+  parseMonitorConfig,
   RegistryMonitorRunStartInputSchema,
   RegistryMonitorRunStartOutputSchema,
   type RegistryMonitorConfig,
@@ -1334,9 +1334,7 @@ export const REGISTRY_MONITOR_RUN_START: ServerPluginToolDefinition = {
     const typedInput = input as z.infer<
       typeof RegistryMonitorRunStartInputSchema
     >;
-    const monitorConfig = RegistryMonitorConfigSchema.parse(
-      typedInput.config ?? {},
-    );
+    const monitorConfig = parseMonitorConfig(typedInput.config ?? {});
     const { run } = await startMonitorRun(ctx, monitorConfig);
     const storage = getPluginStorage();
     const fullRun = await storage.monitorRuns.findById(

--- a/packages/mesh-plugin-private-registry/server/tools/monitor-schemas.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/monitor-schemas.ts
@@ -29,32 +29,40 @@ const MonitorConnectionAuthStatusSchema = z.enum([
   "authenticated",
 ]);
 
-export const RegistryMonitorConfigSchema = z
-  .object({
-    monitorMode: MonitorModeSchema.optional(),
-    // Backward compatibility for previously persisted settings/runs.
-    testMode: MonitorModeSchema.optional(),
-    onFailure: MonitorFailureActionSchema.default("none"),
-    schedule: z.enum(["manual", "cron"]).default("manual"),
-    cronExpression: z.string().optional(),
-    scheduleEventId: z.string().optional(),
-    perMcpTimeoutMs: z.number().int().min(1000).max(600_000).default(30_000),
-    perToolTimeoutMs: z.number().int().min(500).max(120_000).default(10_000),
-    maxAgentSteps: z.number().int().min(1).max(30).default(15),
-    testPublicOnly: z.boolean().default(false),
-    testPrivateOnly: z.boolean().default(false),
-    includePendingRequests: z.boolean().default(false),
-    agentContext: z.string().max(2000).optional(),
-    llmConnectionId: z.string().optional(),
-    llmModelId: z.string().optional(),
-  })
-  .transform((value) => {
-    const { testMode, ...rest } = value;
-    return {
-      ...rest,
-      monitorMode: value.monitorMode ?? testMode ?? "health_check",
-    };
-  });
+export const RegistryMonitorConfigSchema = z.object({
+  monitorMode: MonitorModeSchema.default("health_check"),
+  // Backward compat: persisted data may still use "testMode".
+  testMode: MonitorModeSchema.optional(),
+  onFailure: MonitorFailureActionSchema.default("none"),
+  schedule: z.enum(["manual", "cron"]).default("manual"),
+  cronExpression: z.string().optional(),
+  scheduleEventId: z.string().optional(),
+  perMcpTimeoutMs: z.number().int().min(1000).max(600_000).default(30_000),
+  perToolTimeoutMs: z.number().int().min(500).max(120_000).default(10_000),
+  maxAgentSteps: z.number().int().min(1).max(30).default(15),
+  testPublicOnly: z.boolean().default(false),
+  testPrivateOnly: z.boolean().default(false),
+  includePendingRequests: z.boolean().default(false),
+  agentContext: z.string().max(2000).optional(),
+  llmConnectionId: z.string().optional(),
+  llmModelId: z.string().optional(),
+});
+
+/**
+ * Parse config with backward compat: migrate legacy "testMode" → "monitorMode".
+ */
+export function parseMonitorConfig(
+  raw: unknown,
+): z.infer<typeof RegistryMonitorConfigSchema> {
+  const input =
+    typeof raw === "object" && raw
+      ? ({ ...raw } as Record<string, unknown>)
+      : {};
+  if (!input.monitorMode && input.testMode) {
+    input.monitorMode = input.testMode;
+  }
+  return RegistryMonitorConfigSchema.parse(input);
+}
 
 const MonitorToolResultSchema = z.object({
   toolName: z.string(),


### PR DESCRIPTION
Zod transforms cannot be represented in JSON Schema. When the MCP SDK serializes tool schemas for tools/list, it fails with: 'Transforms cannot be represented in JSON Schema'.

Replace .transform() with parseMonitorConfig() helper that migrates legacy testMode → monitorMode at parse time, keeping backward compat.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Zod .transform() in the monitor config schema with a parseMonitorConfig helper so MCP SDK can serialize tool schemas to JSON Schema without failing. Keeps backward compatibility by migrating legacy testMode to monitorMode at parse time.

- **Bug Fixes**
  - Added parseMonitorConfig to migrate testMode → monitorMode and validate config.
  - Updated server and REGISTRY_MONITOR_RUN_START to use parseMonitorConfig.
  - Removed schema transform; tools/list JSON Schema serialization no longer errors.

<sup>Written for commit fe2f353e6bd42cd1bfa3892cd7dc936b9c7d6e2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

