### PR TITLE
fix(private-registry): remove QA mode from configuration page

### DIFF
--- a/packages/mesh-plugin-private-registry/client/components/monitor-configuration.tsx
+++ b/packages/mesh-plugin-private-registry/client/components/monitor-configuration.tsx
@@ -24,11 +24,7 @@ import {
   useMonitorScheduleSet,
   useRegistryMonitorConfig,
 } from "../hooks/use-monitor";
-import type {
-  MonitorFailureAction,
-  MonitorMode,
-  RegistryMonitorConfig,
-} from "../lib/types";
+import type { MonitorFailureAction, RegistryMonitorConfig } from "../lib/types";
 import { MONITOR_AGENT_DEFAULT_SYSTEM_PROMPT, PLUGIN_ID } from "../../shared";
 import { CronScheduleSelector } from "./cron-schedule-selector";
 
@@ -37,7 +33,6 @@ function hasChanges(
   b: RegistryMonitorConfig,
 ): boolean {
   return (
-    a.monitorMode !== b.monitorMode ||
     a.onFailure !== b.onFailure ||
     a.llmConnectionId !== b.llmConnectionId ||
     a.llmModelId !== b.llmModelId ||
@@ -182,24 +177,6 @@ export function MonitorConfiguration() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div className="space-y-1">
           <FieldLabel
-            label="QA mode"
-            hint="Defines HOW each MCP is validated: connectivity only, direct tool calls, or multi-step agent execution."
-          />
-          <select
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-            value={draft.monitorMode}
-            onChange={(e) =>
-              setPartial({ monitorMode: e.target.value as MonitorMode })
-            }
-          >
-            <option value="health_check">Health check</option>
-            <option value="tool_call">Tool call</option>
-            <option value="full_agent">Agentic (LLM model)</option>
-          </select>
-        </div>
-
-        <div className="space-y-1">
-          <FieldLabel
             label="On failure"
             hint="Automatic action to apply when an MCP fails tests in a run."
           />
@@ -277,25 +254,6 @@ export function MonitorConfiguration() {
               />
               Include pending requests in tests
             </label>
-          </div>
-        </div>
-
-        <div className="space-y-1">
-          <FieldLabel
-            label="What is tested?"
-            hint="Clarifies the difference between QA mode and test execution output."
-          />
-          <div className="rounded-md border border-input bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-            <p>
-              <strong>QA mode</strong> defines the execution strategy.
-            </p>
-            <p>
-              <strong>QA run history</strong> stores past runs.
-            </p>
-            <p>
-              <strong>QA results log</strong> shows per-MCP outcomes inside one
-              run.
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
QA mode is already selectable in the dashboard when starting a run. Having it duplicated in the configuration page was confusing since the dashboard override takes precedence anyway.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed QA mode selection and related help text from the Private Registry monitor configuration page. QA mode is now set only when starting a run in the dashboard to avoid conflicts; removed monitorMode import and change tracking accordingly.

<sup>Written for commit 1b36bc8a61da4a1ab14c69ca8646c4ee310b0e50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

