### PR TITLE
feat(private-registry): add bulk selection and floating actions for r…

### DIFF
--- a/packages/mesh-plugin-private-registry/client/components/registry-requests-page.tsx
+++ b/packages/mesh-plugin-private-registry/client/components/registry-requests-page.tsx
@@ -581,13 +581,18 @@ export default function RegistryRequestsPage() {
               size="sm"
               variant="outline"
               className="h-7 text-xs px-2"
-              onClick={
-                allVisiblePendingSelected
-                  ? clearSelection
-                  : selectVisiblePending
-              }
+              onClick={selectVisiblePending}
+              disabled={allVisiblePendingSelected}
             >
-              {allVisiblePendingSelected ? "Clear selection" : "Select all"}
+              Select all
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 text-xs px-2"
+              onClick={clearSelection}
+            >
+              Clear selection
             </Button>
             <Button
               size="sm"


### PR DESCRIPTION
…equests

Enable multi-select on pending request cards with a floating bulk action bar and batch approval flow. This improves moderation throughput while keeping the list layout stable and reducing accidental UI shifts.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-select and a floating bulk action bar to approve private registry requests in batches, speeding up moderation and preventing layout shifts.

- New Features
  - Multi-select pending requests via checkbox or card click; selected cards are highlighted.
  - Floating bulk bar shows count with Select all, Clear selection (always available), and Approve selected.
  - Bulk approve modal applies a single visibility (public/private), disables actions when no visible items are selected, and shows success/warning/error toasts; failed items stay selected for retry.
  - UX polish: button clicks don’t toggle selection, selection clears on tab change, empty states match each status, and per-item Approve is disabled when selected (shows “Selected”).

<sup>Written for commit ee9fa1997d8b5f76b33b3e98580b2729d74ebb4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

