### PR TITLE
fix(runtime): pass undefined outputSchema when tool has no output schema

### DIFF
--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -732,7 +732,7 @@ export const createMCPServer = <
                 typeof tool.outputSchema === "object" &&
                 "shape" in tool.outputSchema
               ? (tool.outputSchema.shape as ZodRawShape)
-              : z.object({}).shape,
+              : undefined,
         },
         async (args) => {
           const result = await tool.execute({


### PR DESCRIPTION
## What is this contribution about?

Tools without an `outputSchema` were being registered with an empty `z.object({}).shape` fallback in `packages/runtime/src/tools.ts`. This caused the MCP SDK to advertise a structured output contract for every tool — even tools that return arbitrary data — which is incorrect.

**Root cause:** the ternary expression fell through to `z.object({}).shape` as a catch-all. The fix changes that fallback to `undefined`, so `server.registerTool()` only receives an `outputSchema` when the tool explicitly defines one (or is streamable, which retains its explicit `bytes` schema).

**Change (one line):**
```diff
-              : z.object({}).shape,
+              : undefined,
```

## Screenshots/Demonstration

N/A — no UI changes.

## How to Test

1. Register a tool that does **not** define an `outputSchema` through the runtime.
2. Inspect the registered tool's MCP schema (e.g. via `tools/list`).
3. Confirm the tool no longer advertises a structured output contract.
4. Register a tool **with** an `outputSchema` and confirm it still appears in the schema.
5. Register a streamable tool and confirm it still advertises `{ bytes: Record<string, number> }`.

`bun test packages/runtime/` passes (34/34).

## Migration Notes

No database migrations or configuration changes required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass undefined for outputSchema when a tool does not define one. This prevents the MCP SDK from advertising a structured output contract for arbitrary-output tools while keeping explicit and streamable schemas intact.

<sup>Written for commit 70f9f2482fc9f8f3a40b022337b5083fab0cd7a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

