### PR TITLE
[release]: bump runtime to 1.2.10

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Bump `@decocms/runtime` version from `1.2.9` to `1.2.10`

## Changes
- Patch release following the runtime fix in #2492 (pass undefined outputSchema when tool has no output schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps @decocms/runtime from 1.2.9 to 1.2.10 to ship a patch that handles tools without an output schema correctly. This prevents runtime errors by passing undefined for outputSchema when none is defined.

<sup>Written for commit 709e24e9b2382da3b9f7c0f26731aab802c330fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

