### PR TITLE
Fix project plugin config get/update

### DIFF
--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -74,7 +74,11 @@ export interface ProjectStoragePort {
 
 export interface ProjectPluginConfigStoragePort {
   list(projectId: string): Promise<ProjectPluginConfig[]>;
-  get(projectId: string, pluginId: string): Promise<ProjectPluginConfig | null>;
+  get(
+    projectId: string,
+    pluginId: string,
+    organizationId: string,
+  ): Promise<ProjectPluginConfig | null>;
   upsert(
     projectId: string,
     pluginId: string,
@@ -82,6 +86,7 @@ export interface ProjectPluginConfigStoragePort {
       connectionId?: string | null;
       settings?: Record<string, unknown> | null;
     },
+    organizationId: string,
   ): Promise<ProjectPluginConfig>;
   delete(projectId: string, pluginId: string): Promise<boolean>;
 }

--- a/apps/mesh/src/storage/project-plugin-configs.ts
+++ b/apps/mesh/src/storage/project-plugin-configs.ts
@@ -66,17 +66,9 @@ export class ProjectPluginConfigsStorage
       .selectFrom("project_plugin_configs")
       .selectAll("project_plugin_configs")
       .where("project_plugin_configs.project_id", "=", projectId)
-      .where("project_plugin_configs.plugin_id", "=", pluginId);
-
-    if (organizationId) {
-      query = query
-        .innerJoin(
-          "projects",
-          "projects.id",
-          "project_plugin_configs.project_id",
-        )
-        .where("projects.organization_id", "=", organizationId);
-    }
+      .where("project_plugin_configs.plugin_id", "=", pluginId)
+      .innerJoin("projects", "projects.id", "project_plugin_configs.project_id")
+      .where("projects.organization_id", "=", organizationId);
 
     const row = await query.executeTakeFirst();
     return row ? this.parseRow(row) : null;

--- a/apps/mesh/src/storage/project-plugin-configs.ts
+++ b/apps/mesh/src/storage/project-plugin-configs.ts
@@ -60,13 +60,25 @@ export class ProjectPluginConfigsStorage
   async get(
     projectId: string,
     pluginId: string,
+    organizationId: string,
   ): Promise<ProjectPluginConfig | null> {
-    const row = await this.db
+    let query = this.db
       .selectFrom("project_plugin_configs")
-      .selectAll()
-      .where("project_id", "=", projectId)
-      .where("plugin_id", "=", pluginId)
-      .executeTakeFirst();
+      .selectAll("project_plugin_configs")
+      .where("project_plugin_configs.project_id", "=", projectId)
+      .where("project_plugin_configs.plugin_id", "=", pluginId);
+
+    if (organizationId) {
+      query = query
+        .innerJoin(
+          "projects",
+          "projects.id",
+          "project_plugin_configs.project_id",
+        )
+        .where("projects.organization_id", "=", organizationId);
+    }
+
+    const row = await query.executeTakeFirst();
     return row ? this.parseRow(row) : null;
   }
 
@@ -77,9 +89,10 @@ export class ProjectPluginConfigsStorage
       connectionId?: string | null;
       settings?: Record<string, unknown> | null;
     },
+    organizationId: string,
   ): Promise<ProjectPluginConfig> {
     const now = new Date().toISOString();
-    const existing = await this.get(projectId, pluginId);
+    const existing = await this.get(projectId, pluginId, organizationId);
 
     if (existing) {
       const updateData: Record<string, unknown> = { updated_at: now };
@@ -98,7 +111,7 @@ export class ProjectPluginConfigsStorage
         .where("plugin_id", "=", pluginId)
         .execute();
 
-      const updated = await this.get(projectId, pluginId);
+      const updated = await this.get(projectId, pluginId, organizationId);
       if (!updated) {
         throw new Error("Failed to update project plugin config");
       }
@@ -119,7 +132,7 @@ export class ProjectPluginConfigsStorage
       })
       .execute();
 
-    const created = await this.get(projectId, pluginId);
+    const created = await this.get(projectId, pluginId, organizationId);
     if (!created) {
       throw new Error("Failed to create project plugin config");
     }

--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -47,7 +47,6 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
-    
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {

--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -21,7 +21,6 @@ export const PROJECT_GET = defineTool({
   },
   inputSchema: z
     .object({
-      organizationId: z.string().describe("Organization ID"),
       projectId: z
         .string()
         .optional()
@@ -48,15 +47,12 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
-    if (input.organizationId !== ctx.organization?.id) {
-      throw new Error("Organization ID does not match authenticated organization");
-    }
-
+    
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {
       project = await ctx.storage.projects.getBySlug(
-        input.organizationId,
+        ctx.organization!.id,
         input.slug,
       );
     }

--- a/apps/mesh/src/tools/projects/get.ts
+++ b/apps/mesh/src/tools/projects/get.ts
@@ -48,6 +48,10 @@ export const PROJECT_GET = defineTool({
 
     let project = null;
 
+    if (input.organizationId !== ctx.organization?.id) {
+      throw new Error("Organization ID does not match authenticated organization");
+    }
+
     if (input.projectId) {
       project = await ctx.storage.projects.get(input.projectId);
     } else if (input.slug) {

--- a/apps/mesh/src/tools/projects/plugin-config-get.ts
+++ b/apps/mesh/src/tools/projects/plugin-config-get.ts
@@ -37,10 +37,18 @@ export const PROJECT_PLUGIN_CONFIG_GET = defineTool({
 
     const { projectId, pluginId } = input;
 
+    let organizationId = null;
+
+    if (ctx.organization?.id) {
+      organizationId = ctx.organization.id;
+    } else {
+      throw new Error("Organization context is required");
+    }
+
     const config = await ctx.storage.projectPluginConfigs.get(
       projectId,
       pluginId,
-      ctx.organization!.id,
+      organizationId,
     );
 
     if (!config) {

--- a/apps/mesh/src/tools/projects/plugin-config-get.ts
+++ b/apps/mesh/src/tools/projects/plugin-config-get.ts
@@ -40,6 +40,7 @@ export const PROJECT_PLUGIN_CONFIG_GET = defineTool({
     const config = await ctx.storage.projectPluginConfigs.get(
       projectId,
       pluginId,
+      ctx.organization!.id,
     );
 
     if (!config) {

--- a/apps/mesh/src/tools/projects/plugin-config-update.ts
+++ b/apps/mesh/src/tools/projects/plugin-config-update.ts
@@ -59,6 +59,14 @@ export const PROJECT_PLUGIN_CONFIG_UPDATE = defineTool({
       throw new Error(`Project not found: ${projectId}`);
     }
 
+    let organizationId = null;
+
+    if (ctx.organization?.id) {
+      organizationId = ctx.organization.id;
+    } else {
+      throw new Error("Organization context is required");
+    }
+
     const connectionExists = connectionId
       ? await ctx.storage.connections.findById(connectionId)
       : null;
@@ -92,7 +100,7 @@ export const PROJECT_PLUGIN_CONFIG_UPDATE = defineTool({
         connectionId,
         settings,
       },
-      ctx.organization!.id,
+      organizationId,
     );
 
     return {

--- a/apps/mesh/src/tools/projects/plugin-config-update.ts
+++ b/apps/mesh/src/tools/projects/plugin-config-update.ts
@@ -92,6 +92,7 @@ export const PROJECT_PLUGIN_CONFIG_UPDATE = defineTool({
         connectionId,
         settings,
       },
+      ctx.organization!.id,
     );
 
     return {


### PR DESCRIPTION
## What is this contribution about?

Fix a cross-organization data access vulnerability in project plugin configs.

Previously, the `get` and `upsert` methods on `ProjectPluginConfigsStorage` did not scope queries by organization. This meant a caller with a valid `projectId` and `pluginId` could read or modify plugin configs belonging to a project in a **different** organization — bypassing tenant isolation.

This fix:

- Adds a required `organizationId` parameter to `get()` and `upsert()` in both the storage port interface and the implementation.
- Joins the `projects` table and filters by `projects.organization_id` so that queries are scoped to the caller's organization.
- Updates all call sites (`plugin-config-get.ts`, `plugin-config-update.ts`) to pass `ctx.organization!.id`.
- Fixes internal `this.get()` calls within `upsert` (for existing-check, post-update, and post-create reads) that were previously missing the organization scope.

## How to Test

1. Set up two organizations (e.g., `org_A` and `org_B`) each with at least one project that has a plugin config.
2. Authenticate as a user in `org_A`.
3. Call `PROJECT_PLUGIN_CONFIG_GET` with a `projectId` belonging to `org_B`.
4. **Expected:** Returns `null` / config not found (previously would have returned `org_B`'s config).
5. Call `PROJECT_PLUGIN_CONFIG_UPDATE` targeting a project in `org_B`.
6. **Expected:** Fails to find/update the config (previously would have succeeded).
7. Repeat steps 3–6 using valid project IDs within `org_A`.
8. **Expected:** Get and update work normally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped project plugin config get/update and project slug lookups to the current organization to fix cross-tenant access. Prevents reading or editing configs or projects across orgs.

- **Bug Fixes**
  - Added required organizationId to ProjectPluginConfigStoragePort.get/upsert and scoped queries by projects.organization_id.
  - PROJECT_PLUGIN_CONFIG_GET/UPDATE now use ctx.organization.id and throw if no organization context is present.
  - Fixed upsert’s internal reads to use org scope.
  - PROJECT_GET: removed organizationId input; getBySlug uses session org to prevent IDOR.

<sup>Written for commit 460042803e2caa7d7ca2b25467117191b0b59c08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

