### PR TITLE
Remove dark mode from Studio's sidebar and adjust spacing

### DIFF
--- a/apps/mesh/src/web/components/sidebar/header/account-switcher/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/account-switcher/index.tsx
@@ -206,7 +206,7 @@ export function MeshAccountSwitcher({
                 </div>
                 <ChevronSelectorVertical
                   size={16}
-                  className="shrink-0 text-sidebar-foreground/40 group-data-[studio]/sidebar-wrapper:text-sidebar-foreground/85"
+                  className="shrink-0 text-sidebar-foreground/40"
                 />
               </>
             )}

--- a/apps/mesh/src/web/components/sidebar/header/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/index.tsx
@@ -61,7 +61,7 @@ export function MeshSidebarHeader({ onCreateProject }: MeshSidebarHeaderProps) {
                     variant="ghost"
                     size="icon"
                     className={cn(
-                      "size-7 hover:bg-sidebar-accent text-sidebar-foreground/50 hover:text-sidebar-foreground group-data-[studio]/sidebar-wrapper:text-sidebar-foreground/85",
+                      "size-7 hover:bg-sidebar-accent text-sidebar-foreground/50 hover:text-sidebar-foreground",
                       isChatOpen && "bg-sidebar-accent text-sidebar-foreground",
                     )}
                     onClick={toggleChat}

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -15,7 +15,7 @@ import {
   FaceSmile,
   Folder,
   Home02,
-  Target04,
+  Settings01,
   Users03,
 } from "@untitledui/icons";
 import { pluginRootSidebarItems, pluginSidebarGroups } from "../index.tsx";
@@ -204,16 +204,28 @@ export function useProjectSidebarItems(): SidebarSection[] {
 
   if (isOrgAdminProject) {
     // Org-admin sidebar layout:
-    // - Home, Projects (top-level)
-    // - Build group: Agents, Connections, Monitor, Tasks (if enabled)
-    // - Manage group: Members, Store
+    // - Home, Tasks (if enabled), Projects (if enabled) (top-level)
+    // - Build group: Agents, Connections, Store
+    // - Manage group: Monitor, Members, Settings
     // - Plugin items / groups
-    // (Settings is in the footer)
+    const settingsItem: NavigationSidebarItem = {
+      key: "settings",
+      label: "Settings",
+      icon: <Settings01 />,
+      isActive: isActiveRoute("settings"),
+      onClick: () =>
+        navigate({
+          to: "/$org/$project/settings",
+          params: { org, project: ORG_ADMIN_PROJECT_SLUG },
+        }),
+    };
+
     const sections: SidebarSection[] = [
       {
         type: "items",
         items: [
           homeItem,
+          ...(preferences.experimental_tasks ? [tasksItem] : []),
           ...(preferences.experimental_projects ? [projectsItem] : []),
         ],
       },
@@ -222,12 +234,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
         group: {
           id: "build",
           label: "Build",
-          items: [
-            agentsItem,
-            connectionsItem,
-            monitorItem,
-            ...(preferences.experimental_tasks ? [tasksItem] : []),
-          ],
+          items: [agentsItem, connectionsItem, storeItem],
           defaultExpanded: true,
         },
       },
@@ -236,7 +243,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
         group: {
           id: "manage",
           label: "Manage",
-          items: [membersItem, storeItem],
+          items: [monitorItem, membersItem, settingsItem],
           defaultExpanded: true,
         },
       },
@@ -244,15 +251,11 @@ export function useProjectSidebarItems(): SidebarSection[] {
 
     // Add flat plugin items if any
     if (pluginItems.length > 0) {
-      sections.push({ type: "divider" });
       sections.push({ type: "items", items: pluginItems });
     }
 
     // Add plugin groups
     if (pluginGroupSections.length > 0) {
-      if (pluginItems.length === 0) {
-        sections.push({ type: "divider" });
-      }
       sections.push(...pluginGroupSections);
     }
 
@@ -263,7 +266,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
   const projectTasksItem: NavigationSidebarItem = {
     key: "tasks",
     label: "Tasks",
-    icon: <Target04 />,
+    icon: <CheckDone01 />,
     isActive: isActiveRoute("tasks"),
     onClick: () =>
       navigate({

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -107,43 +107,6 @@
     oklch(0 0 0 / 0.08) 0px 8px 32px, oklch(0 0 0 / 0.06) 0px 4px 12px;
 }
 
-/* Studio (org-admin) — dark sidebar */
-[data-studio] {
-  --sidebar: oklch(0.18 0.008 60);
-  --sidebar-foreground: oklch(0.82 0.006 60);
-  --sidebar-accent: oklch(0.235 0.01 60);
-  --sidebar-accent-foreground: oklch(0.96 0.005 60);
-  --sidebar-border: oklch(0.255 0.008 60);
-  --sidebar-primary: oklch(0.96 0.005 60);
-  --sidebar-primary-foreground: oklch(0.18 0.008 60);
-  --sidebar-ring: oklch(0.5 0.008 60);
-}
-
-/* Inside the dark sidebar, override generic tokens so text-foreground,
-   text-muted-foreground, bg-accent etc. all resolve to dark-mode values
-   without needing per-component overrides. */
-[data-studio] [data-sidebar="sidebar"] {
-  --foreground: oklch(0.96 0.005 60);
-  --muted-foreground: oklch(0.62 0.008 60);
-  --muted: oklch(0.235 0.01 60);
-  --accent: oklch(0.235 0.01 60);
-  --accent-foreground: oklch(0.96 0.005 60);
-  --border: oklch(0.255 0.008 60);
-  --background: oklch(0.18 0.008 60);
-}
-
-.dark [data-studio],
-[data-studio].dark {
-  --sidebar: oklch(0.12 0.006 60);
-  --sidebar-foreground: oklch(0.82 0.005 60);
-  --sidebar-accent: oklch(0.17 0.008 60);
-  --sidebar-accent-foreground: oklch(0.96 0.005 60);
-  --sidebar-border: oklch(0.19 0.006 60);
-  --sidebar-primary: oklch(0.96 0.005 60);
-  --sidebar-primary-foreground: oklch(0.14 0.006 60);
-  --sidebar-ring: oklch(0.5 0.006 60);
-}
-
 .dark {
   --background: oklch(0.155 0.005 60);
   --foreground: oklch(0.96 0.005 60);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Studio-specific dark sidebar and simplified the org-admin sidebar layout. This unifies styling, reduces spacing clutter, and updates a few icons.

- **Refactors**
  - Removed all [data-studio] dark sidebar CSS tokens and related class variants.
  - Reworked org-admin sidebar:
    - Top-level: Home, Tasks (if enabled), Projects (if enabled).
    - Build: Agents, Connections, Store.
    - Manage: Monitor, Members, Settings (moved from footer).
  - Updated icons: Tasks → CheckDone01, Settings → Settings01.
  - Dropped plugin dividers to tighten spacing.

<sup>Written for commit a52b05a60eba7d0858e83daabc2191d1833d8bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

