### PR TITLE
fix(cli): skip GoTrue call when access token is still valid

### DIFF
--- a/packages/cli/src/lib/session.ts
+++ b/packages/cli/src/lib/session.ts
@@ -114,14 +114,26 @@ export async function getRequestAuthHeaders(): Promise<Record<string, string>> {
     throw new Error("Session not found. Please login again.");
   }
 
-  // Extract tokens from session
   const { access_token, refresh_token } = session;
 
   if (!access_token || !refresh_token) {
     throw new Error("Session expired. Please login again.");
   }
 
-  // Create Supabase client (no cookies needed for this local op)
+  const REFRESH_BUFFER_SECONDS = 60;
+  let needsRefresh = true;
+  try {
+    const { exp } = decodeJwt(access_token);
+    needsRefresh = !exp ||
+      exp <= Math.floor(Date.now() / 1000) + REFRESH_BUFFER_SECONDS;
+  } catch {
+    needsRefresh = true;
+  }
+
+  if (!needsRefresh) {
+    return { Authorization: `Bearer ${access_token}` };
+  }
+
   const { client: supabase, responseHeaders } = createClient();
 
   const { data, error } = await supabase.auth.setSession({


### PR DESCRIPTION
## Context

This is the companion fix to [deco-sites/admin#2904](https://github.com/deco-sites/admin/pull/2904), which addresses a Supabase GoTrue CPU spike that has been recurring since Feb 22.

### Problem

`getRequestAuthHeaders()` in the CLI calls `supabase.auth.setSession()` on **every CLI request**, which sends a POST to Supabase GoTrue to validate/exchange the refresh token. This happens even when the local access token JWT is still valid and has minutes or hours until expiry.

With the 24-hour JWT expiry configured on the `decocms` Supabase project (`jwt_exp: 86400`), the vast majority of CLI calls within a session have a perfectly valid access token. Yet every call still hits GoTrue, adding unnecessary load to the auth service.

### Fix

Before calling `setSession()`, decode the JWT locally and check its `exp` claim. If the token has more than 60 seconds until expiry, return it directly as a Bearer token without hitting GoTrue.

The 60-second buffer ensures tokens are refreshed well before they expire, avoiding edge cases where a token expires mid-request.

**Before:**
```
every CLI request
  -> readSession()
  -> supabase.auth.setSession()  // always hits GoTrue
  -> return cookies
```

**After:**
```
every CLI request
  -> readSession()
  -> decodeJwt(access_token)
  -> if exp > now + 60s:
       return Bearer token directly   // no GoTrue call
  -> else:
       supabase.auth.setSession()    // refresh only when needed
       return cookies
```

### Impact

- Eliminates ~95%+ of GoTrue calls from CLI usage (tokens are valid for 24h, typical sessions are minutes)
- `jose.decodeJwt` is already imported and used in `readSession()`, so no new dependencies
- Fallback to `setSession()` is preserved for expired/expiring tokens and decode failures

## Test plan
- [ ] Verify `deco auth login` still works and stores tokens
- [ ] Verify CLI commands work with a fresh session (token just issued)
- [ ] Verify CLI commands work with a nearly-expired token (triggers refresh)
- [ ] Verify CLI commands fail gracefully with an invalid/corrupted token
- [ ] Verify `deco auth whoami` works without extra network calls

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip GoTrue calls in CLI when the access token is still valid, returning the JWT directly as a Bearer token. This cuts most unnecessary auth requests and reduces load on Supabase GoTrue.

- **Bug Fixes**
  - Decode JWT locally and only refresh if exp ≤ now + 60s or decode fails.
  - Fallback to supabase.auth.setSession() for expired/expiring tokens.
  - Uses existing jose.decodeJwt; no new dependencies.

<sup>Written for commit fd7fb9dac98ea1d68e3c76ca3910c740ae665dc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

