### PR TITLE
fix(chat): strip pending approval tool calls when user sends a new message

### DIFF
--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -800,6 +800,19 @@ export function ChatProvider({ children }: PropsWithChildren) {
       return;
     }
 
+    // If the last assistant message has pending approval-requested tool calls,
+    // strip it before sending to avoid "Tool result is missing" errors.
+    const currentMessages = chat.messages;
+    const lastMessage = currentMessages.at(-1);
+    if (
+      lastMessage?.role === "assistant" &&
+      lastMessage.parts.some(
+        (part) => "state" in part && part.state === "approval-requested",
+      )
+    ) {
+      chat.setMessages(currentMessages.slice(0, -1));
+    }
+
     resetInteraction();
 
     const messageMetadata: Metadata = {


### PR DESCRIPTION
## Problem

When the assistant requests tool approval (approve/deny buttons appear) and the user sends a **new message without responding to the approval**, the chat crashes with:

> `Error occurred: Tool result is missing for tool call <id>`

This happens because the AI SDK validates the message history before each API call — if an assistant turn has tool invocations without corresponding results, it rejects the request.

## Root cause

`sendMessage` in `ChatProvider` was calling `chat.sendMessage` directly without checking whether the last assistant message had unresolved `approval-requested` tool parts. The dangling tool calls made the conversation history invalid.

## Fix

Before sending a new user message, check if the last assistant message contains any `approval-requested` parts. If it does, strip that incomplete assistant message from the history using `setMessages`. The new user message is then appended to a clean history with no dangling tool calls.

```
Before fix:
  [...messages, assistantMsg(tool: approval-requested), newUserMsg]
                                                          ↑ SDK throws here

After fix:
  [...messages, newUserMsg]   ← clean, valid history
```

The abandoned assistant message is simply discarded — which matches the user's intent of moving on to a new request.

## Affected area

- `apps/mesh/src/web/components/chat/context.tsx` — `sendMessage` function

## Testing

1. Start a chat with a tool that requires approval
2. When the approve/deny buttons appear, type a new message and send it **without approving or denying**
3. Before: error toast — `Tool result is missing for tool call ...`
4. After: new message sends cleanly, conversation continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented chat crashes when a user sends a new message while a tool approval is pending by removing the incomplete assistant turn before sending. This keeps the message history valid and the conversation continues.

- **Bug Fixes**
  - Detect the last assistant message with approval-requested tool parts and remove it before sending.
  - Avoids the "Tool result is missing" validation error in the SDK.

<sup>Written for commit f3e34b3271f41ffb6fcc496e5004748f469226f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

