### PR TITLE
fix(decopilot): allow direct tool calls in gateway modes with activeT…

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -180,10 +180,16 @@ app.post("/:org/decopilot/stream", async (c) => {
       status: "in_progress",
     });
 
-    // Create model client and virtual MCP client in parallel (they are independent)
-    const [modelClient, mcpClient] = await Promise.all([
+    // Always create a passthrough client (all real tools) + model client.
+    // If mode is smart_tool_selection or code_execution, also create the strategy
+    // client so we get the gateway meta-tools (SEARCH/DESCRIBE/CALL_TOOL/RUN_CODE).
+    const isGatewayMode = agent.mode !== "passthrough";
+    const [modelClient, passthroughClient, strategyClient] = await Promise.all([
       clientFromConnection(modelConnection, ctx, false),
-      createVirtualClientFrom(virtualMcp, ctx, agent.mode),
+      createVirtualClientFrom(virtualMcp, ctx, "passthrough"),
+      isGatewayMode
+        ? createVirtualClientFrom(virtualMcp, ctx, agent.mode)
+        : Promise.resolve(null),
     ]);
 
     // Add streaming support since agents may use streaming models
@@ -207,7 +213,8 @@ app.post("/:org/decopilot/stream", async (c) => {
     const abortSignal = c.req.raw.signal;
     abortSignal.addEventListener("abort", () => {
       modelClient.close().catch(() => {});
-      // Mark thread as failed on client disconnect
+      passthroughClient.close().catch(() => {});
+      strategyClient?.close().catch(() => {});
       if (mem.thread.id) {
         ctx.storage.threads
           .update(mem.thread.id, { status: "failed" })
@@ -216,7 +223,7 @@ app.post("/:org/decopilot/stream", async (c) => {
     });
 
     // Get server instructions if available (for virtual MCP agents)
-    const serverInstructions = mcpClient.getInstructions();
+    const serverInstructions = passthroughClient.getInstructions();
 
     // Merge platform instructions with request system messages
     const systemPrompt = DECOPILOT_BASE_PROMPT(serverInstructions);
@@ -245,12 +252,24 @@ app.post("/:org/decopilot/stream", async (c) => {
     const uiStream = createUIMessageStream({
       execute: async ({ writer }) => {
         // Create tools inside execute so they have access to writer
-        const mcpTools = await toolsFromMCP(
-          mcpClient,
+        // Always get the full passthrough tools (all real tools from connections)
+        const passthroughTools = await toolsFromMCP(
+          passthroughClient,
           toolOutputMap,
           writer,
           toolApprovalLevel,
         );
+
+        // If using a gateway mode, also get the strategy meta-tools
+        // (GATEWAY_SEARCH_TOOLS, GATEWAY_DESCRIBE_TOOLS, GATEWAY_CALL_TOOL / GATEWAY_RUN_CODE)
+        const strategyTools = strategyClient
+          ? await toolsFromMCP(
+              strategyClient,
+              toolOutputMap,
+              writer,
+              toolApprovalLevel,
+            )
+          : {};
 
         const builtInTools = await getBuiltInTools(
           writer,
@@ -264,7 +283,23 @@ app.post("/:org/decopilot/stream", async (c) => {
           ctx,
         );
 
-        const tools = { ...mcpTools, ...builtInTools };
+        // Merge all tools: strategy meta-tools override passthrough tools with the same name,
+        // and built-in tools take final precedence.
+        const tools = {
+          ...passthroughTools,
+          ...strategyTools,
+          ...builtInTools,
+        };
+
+        // In gateway modes, only expose the strategy meta-tools + built-ins to the LLM.
+        // The passthrough tools are still registered (so the AI SDK won't throw if the
+        // model calls a discovered tool directly), but the LLM won't see their schemas.
+        const activeToolNames = strategyClient
+          ? ([
+              ...Object.keys(strategyTools),
+              ...Object.keys(builtInTools),
+            ] as (keyof typeof tools)[])
+          : undefined;
 
         // Process conversation with tools for validation
         const {
@@ -314,6 +349,7 @@ app.post("/:org/decopilot/stream", async (c) => {
           system: processedSystemMessages,
           messages: processedMessages,
           tools,
+          activeTools: activeToolNames,
           temperature,
           maxOutputTokens,
           abortSignal,


### PR DESCRIPTION
## Summary

- Always create a passthrough client (all real tools) in decopilot mode
- In `smart_tool_selection` and `code_execution` modes, also create a strategy client for gateway meta-tools
- Register both tool sets with `streamText` but filter visibility via `activeTools`
- Prevents AI SDK errors when the model discovers a tool and tries to call it directly

## Motivation

Previously, when the model used smart tool selection or code execution mode and discovered a tool (e.g., XPTO) via GATEWAY_SEARCH_TOOLS, it would sometimes attempt to call XPTO directly instead of routing through GATEWAY_CALL_TOOL. Since XPTO was not registered as a tool in streamText, the AI SDK would throw an error.

## Implementation

The approach uses AI SDK's `activeTools` field: tools exist and are callable, but their schemas are not shown to the LLM, allowing direct calls without errors while maintaining the intended gateway routing pattern.

## Testing

- Test smart_tool_selection mode: verify model uses GATEWAY_CALL_TOOL, not direct calls
- Test code_execution mode: verify model uses GATEWAY_RUN_CODE, not direct calls  
- Test passthrough mode: verify behavior unchanged (all tools visible)
- Verify tool execution still works end-to-end when model bypasses gateway (fallback path)

## Notes

- Two lazy client instances created per request in gateway modes (minimal overhead due to lazy connection pattern)
- Could be optimized to share underlying connection pool in future if needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tool discovery errors in decopilot gateway modes. Registers all real tools and hides them with activeTools so direct tool calls work without SDK errors, while keeping gateway routing.

- **Bug Fixes**
  - Always create a passthrough client with all real tools and use it for server instructions.
  - In smart_tool_selection and code_execution, also create a strategy client for gateway meta-tools.
  - Register passthrough + strategy + built-in tools; expose only strategy + built-ins via activeTools (strategy overrides passthrough, built-ins override both).
  - Close model, passthrough, and strategy clients on abort.
  - Passthrough mode behavior unchanged.

<sup>Written for commit 96b21f877274b792ff8573bba753b69b89874e00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

