### PR TITLE
fix(auth): eliminate multi-tab org context bleed

### DIFF
--- a/apps/mesh/e2e/tests/multi-tab-org-isolation.spec.ts
+++ b/apps/mesh/e2e/tests/multi-tab-org-isolation.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from "@playwright/test";
+import { signUp } from "../fixtures/auth";
+
+// This test involves multiple navigations across two tabs — give it room.
+test.describe("Multi-tab org isolation", () => {
+  test("each tab stays scoped to its own org after navigation and cache hits", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    // 1. Sign up — auto-creates first org, lands on home
+    await signUp(page);
+    await page.waitForURL("/");
+
+    // 2. Extract org A slug from the home page card
+    const slugTextA = page.locator("text=/@[a-z0-9-]+/").first();
+    await slugTextA.waitFor({ state: "visible" });
+    const orgSlugA =
+      (await slugTextA.textContent())?.replace("@", "").trim() ?? "";
+
+    // 3. Create org B via the "New organization" button on the home page
+    const orgBName = `Org B ${Date.now()}`;
+    await page.getByRole("button", { name: "New organization" }).click();
+    await page.getByPlaceholder("Acme Inc.").fill(orgBName);
+    await page.getByRole("button", { name: "Create Organization" }).click();
+
+    // Creating an org does window.location.href = `/${slug}` redirect.
+    await page.waitForURL(
+      (url) => url.pathname !== "/" && url.pathname !== "",
+      { timeout: 15_000 },
+    );
+
+    // Extract org B slug from the URL
+    const orgSlugB = new URL(page.url()).pathname.split("/")[1];
+
+    // ── Multi-tab isolation ──────────────────────────────────────────
+
+    // 4. Open a second tab in the SAME browser context (shared session cookies)
+    const page2 = await page.context().newPage();
+
+    // 5. Tab 1 → org A, Tab 2 → org B. Wait for the sidebar "Home" link
+    //    to appear as a signal the shell has rendered.
+    await page.goto(`/${orgSlugA}/org-admin`);
+    await page.getByText("Connections").first().waitFor({ timeout: 15_000 });
+
+    await page2.goto(`/${orgSlugB}/org-admin`);
+    await page2.getByText("Connections").first().waitFor({ timeout: 15_000 });
+
+    // 6. Collect outbound organizationId from each tab's Better Auth requests.
+    const capturedOrgIds = { tab1: [] as string[], tab2: [] as string[] };
+
+    page.on("request", (req) => {
+      try {
+        const url = new URL(req.url());
+        if (url.pathname.includes("/organization/")) {
+          const id = url.searchParams.get("organizationId");
+          if (id) capturedOrgIds.tab1.push(id);
+        }
+      } catch {}
+    });
+
+    page2.on("request", (req) => {
+      try {
+        const url = new URL(req.url());
+        if (url.pathname.includes("/organization/")) {
+          const id = url.searchParams.get("organizationId");
+          if (id) capturedOrgIds.tab2.push(id);
+        }
+      } catch {}
+    });
+
+    // 7. Reload both tabs to trigger org-scoped requests with listeners active.
+    await page.reload();
+    await page.getByText("Connections").first().waitFor({ timeout: 15_000 });
+
+    await page2.reload();
+    await page2.getByText("Connections").first().waitFor({ timeout: 15_000 });
+
+    // Verify each tab is on the correct URL
+    await expect(page).toHaveURL(new RegExp(`/${orgSlugA}/`));
+    await expect(page2).toHaveURL(new RegExp(`/${orgSlugB}/`));
+
+    // 8. Verify captured org IDs never cross-contaminate
+    if (capturedOrgIds.tab1.length > 0 && capturedOrgIds.tab2.length > 0) {
+      const tab1Ids = new Set(capturedOrgIds.tab1);
+      const tab2Ids = new Set(capturedOrgIds.tab2);
+      for (const id of tab1Ids) {
+        expect(tab2Ids.has(id)).toBe(false);
+      }
+      for (const id of tab2Ids) {
+        expect(tab1Ids.has(id)).toBe(false);
+      }
+    }
+
+    // ── Cache-hit regression (org A → B → back to A) ────────────────
+
+    // 9. In tab 1: navigate to org B, then BACK to org A.
+    //    The query for org A is cached (staleTime: Infinity), so queryFn won't
+    //    re-execute. Without the fix, the org store would be stuck on org B's ID.
+    await page.goto(`/${orgSlugB}/org-admin`);
+    await page.getByText("Connections").first().waitFor({ timeout: 15_000 });
+    await expect(page).toHaveURL(new RegExp(`/${orgSlugB}/`));
+
+    // Now go back to org A — this is the cache-hit path
+    await page.goto(`/${orgSlugA}/org-admin`);
+    await page.getByText("Connections").first().waitFor({ timeout: 15_000 });
+    await expect(page).toHaveURL(new RegExp(`/${orgSlugA}/`));
+
+    // 10. After returning to org A via cache hit, intercept the next org-scoped
+    //     request to verify the auth-client injects org A's ID (not org B's).
+    //     Navigate to the Members page which triggers org-scoped API calls.
+    const membersRequestPromise = page.waitForRequest(
+      (req) => {
+        const url = req.url();
+        return (
+          url.includes("/organization/") &&
+          req.method() === "GET" &&
+          url.includes("organizationId")
+        );
+      },
+      { timeout: 10_000 },
+    );
+
+    await page.goto(`/${orgSlugA}/org-admin/members`);
+
+    const membersReq = await membersRequestPromise.catch(() => null);
+    if (membersReq) {
+      const url = new URL(membersReq.url());
+      const injectedOrgId = url.searchParams.get("organizationId");
+
+      // The critical assertion: after A → B → A with cache hit, the org ID
+      // in the request must belong to org A. We stored which IDs each org
+      // produced earlier — if org B's ID leaked here, the test fails.
+      if (injectedOrgId && capturedOrgIds.tab2.length > 0) {
+        const orgBIds = new Set(capturedOrgIds.tab2);
+        expect(orgBIds.has(injectedOrgId)).toBe(false);
+      }
+    }
+
+    // 11. Final assertion: tab 2 is still on org B, unaffected by tab 1's navigation
+    await expect(page2).toHaveURL(new RegExp(`/${orgSlugB}/`));
+
+    await page2.close();
+  });
+});

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -632,9 +632,47 @@ async function authenticateRequest(
       let organization: OrganizationContext | undefined;
       let role: string | undefined;
 
-      if (session.session.activeOrganizationId) {
-        // Get full organization data (includes members with roles)
+      // Prefer the explicit x-org-id request header over the session's activeOrganizationId.
+      // The MCP client sends this header on every request with the org from the URL, enabling
+      // multiple browser tabs to operate in different orgs simultaneously without one tab's
+      // setActive() call clobbering another tab's session state.
+      const headerOrgId = req.headers.get("x-org-id");
 
+      if (headerOrgId) {
+        // Resolve org directly from DB and verify the session user is a member.
+        // This bypasses the shared session state entirely for per-request org resolution.
+        const membership = await timings.measure(
+          "auth_query_org_membership",
+          () =>
+            db
+              .selectFrom("member")
+              .innerJoin(
+                "organization",
+                "organization.id",
+                "member.organizationId",
+              )
+              .select([
+                "member.role",
+                "organization.id as orgId",
+                "organization.slug as orgSlug",
+                "organization.name as orgName",
+              ])
+              .where("member.userId", "=", session.user.id)
+              .where("member.organizationId", "=", headerOrgId)
+              .executeTakeFirst(),
+        );
+
+        if (membership) {
+          organization = {
+            id: membership.orgId,
+            slug: membership.orgSlug,
+            name: membership.orgName,
+          };
+          role = membership.role;
+        }
+      } else if (session.session.activeOrganizationId) {
+        // Fall back to the session's active org when no explicit header is present.
+        // (Existing behavior for requests that don't send x-org-id.)
         const orgData = await timings.measure(
           "auth_get_full_organization",
           () =>

--- a/apps/mesh/src/web/components/organizations-home.tsx
+++ b/apps/mesh/src/web/components/organizations-home.tsx
@@ -1,4 +1,5 @@
 import { authClient } from "@/web/lib/auth-client";
+import { setCurrentOrgId } from "@/web/lib/org-store";
 import { useNavigate } from "@tanstack/react-router";
 import { EntityCard } from "@deco/ui/components/entity-card.tsx";
 import { EntityGrid } from "@deco/ui/components/entity-grid.tsx";
@@ -40,10 +41,15 @@ function InvitationCard({ invitation }: { invitation: Invitation }) {
         toast.error(result.error.message);
         setIsAccepting(false);
       } else {
-        // Set the new org as active to update session
+        // Set the new org as active to update session and get org data.
         const setActiveResult = await authClient.organization.setActive({
           organizationId: invitation.organizationId,
         });
+
+        // Keep the per-tab org store in sync with the explicit switch.
+        if (setActiveResult?.data?.id) {
+          setCurrentOrgId(setActiveResult.data.id);
+        }
 
         if (setActiveResult?.data?.slug) {
           toast.success("Invitation accepted!");

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -1,4 +1,5 @@
 import { authClient } from "@/web/lib/auth-client";
+import { setCurrentOrgId } from "@/web/lib/org-store";
 import { MeshUserMenu } from "@/web/components/user-menu";
 import { useSettingsModal } from "@/web/hooks/use-settings-modal";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -55,6 +56,12 @@ function InvitationItem({ invitation }: { invitation: Invitation }) {
         const setActiveResult = await authClient.organization.setActive({
           organizationId: invitation.organizationId,
         });
+
+        // Keep the per-tab org store in sync with the explicit switch.
+        if (setActiveResult?.data?.id) {
+          setCurrentOrgId(setActiveResult.data.id);
+        }
+
         toast.success("Invitation accepted!");
         const slug = setActiveResult?.data?.slug;
         window.location.href = slug ? `/${slug}` : "/";

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -195,10 +195,6 @@ function ShellLayoutContent() {
         query: { organizationSlug: org },
       });
 
-      // Populate the per-tab org store so the auth client injects organizationId
-      // on all subsequent Better Auth org-management calls from this tab.
-      setCurrentOrgId(data?.id ?? null);
-
       return {
         org: data,
         // Project slug comes from URL param, actual project data is fetched in project-layout
@@ -213,6 +209,12 @@ function ShellLayoutContent() {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });
+
+  // Sync the per-tab org store on every render so the auth client injects the
+  // correct organizationId on all outbound Better Auth calls from this tab.
+  // This must live outside queryFn because cache hits (staleTime: Infinity)
+  // skip the fetch function, which would leave the store stale after org switches.
+  setCurrentOrgId(projectContext?.org?.id ?? null);
 
   if (!projectContext) {
     return (

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -11,6 +11,7 @@ import { useLocalStorage } from "@/web/hooks/use-local-storage";
 import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
 import { authClient } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { setCurrentOrgId } from "@/web/lib/org-store";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -187,9 +188,16 @@ function ShellLayoutContent() {
         return null;
       }
 
-      const { data } = await authClient.organization.setActive({
-        organizationSlug: org,
+      // Pure read — does not mutate the shared session's activeOrganizationId.
+      // This is the key fix for multi-tab org isolation: previously setActive()
+      // would overwrite the session for every other open tab.
+      const { data } = await authClient.organization.getFullOrganization({
+        query: { organizationSlug: org },
       });
+
+      // Populate the per-tab org store so the auth client injects organizationId
+      // on all subsequent Better Auth org-management calls from this tab.
+      setCurrentOrgId(data?.id ?? null);
 
       return {
         org: data,

--- a/apps/mesh/src/web/lib/auth-client.ts
+++ b/apps/mesh/src/web/lib/auth-client.ts
@@ -5,6 +5,7 @@ import {
   magicLinkClient,
 } from "better-auth/client/plugins";
 import { ssoClient } from "@better-auth/sso/client";
+import { getCurrentOrgId } from "./org-store";
 
 export const authClient = createAuthClient({
   plugins: [
@@ -17,4 +18,38 @@ export const authClient = createAuthClient({
     ssoClient(),
     magicLinkClient(),
   ],
+  fetchOptions: {
+    onRequest: (ctx) => {
+      const orgId = getCurrentOrgId();
+      if (!orgId) return;
+
+      const urlStr = typeof ctx.url === "string" ? ctx.url : ctx.url.toString();
+
+      // Only intercept organization-management routes.
+      // Skip /set-active — those calls carry their own explicit org ID in the
+      // body (the org the user is switching TO) and must not be overridden.
+      if (!urlStr.includes("/organization/") || urlStr.includes("/set-active"))
+        return;
+
+      if (ctx.method?.toUpperCase() === "GET") {
+        // Inject as query param — Better Auth reads organizationId from query
+        // for listMembers, listRoles, getFullOrganization, etc.
+        const url = new URL(urlStr, window.location.origin);
+        url.searchParams.set("organizationId", orgId);
+        ctx.url = url.toString();
+      } else if (
+        ctx.body &&
+        typeof ctx.body === "object" &&
+        !Array.isArray(ctx.body)
+      ) {
+        // Inject into body — Better Auth reads organizationId from body for
+        // inviteMember, removeMember, createRole, updateRole, deleteRole, etc.
+        // Only inject if not already explicitly provided by the caller.
+        const body = ctx.body as Record<string, unknown>;
+        if (!body.organizationId) {
+          ctx.body = { ...body, organizationId: orgId };
+        }
+      }
+    },
+  },
 });

--- a/apps/mesh/src/web/lib/org-store.ts
+++ b/apps/mesh/src/web/lib/org-store.ts
@@ -1,0 +1,17 @@
+/**
+ * Per-tab org ID store.
+ *
+ * Browser tabs each have their own JS execution context, so module-level state
+ * is naturally isolated per tab. We use this to track the org the current tab
+ * is operating in, so the auth client can inject it on every outbound request
+ * rather than relying on the shared server-side session's activeOrganizationId.
+ */
+let currentOrgId: string | null = null;
+
+export function setCurrentOrgId(id: string | null): void {
+  currentOrgId = id;
+}
+
+export function getCurrentOrgId(): string | null {
+  return currentOrgId;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `shell-layout.tsx` called `setActive()` on every org navigation, writing `activeOrganizationId` to the shared server-side session. The last tab to navigate won, causing every other open tab to fetch data from the wrong org.
- Two separate request surfaces needed fixing: MeshContext (MCP routes) and Better Auth's own org-management routes.

## Changes

### Server — MeshContext / MCP routes
- `context-factory.ts`: when `x-org-id` header is present on a browser session request, resolve org directly from DB with membership verification instead of reading `session.activeOrganizationId`. The MCP client already sends `x-org-id` on every call, so all MCP tool operations are now per-request rather than per-session.

### Client — Better Auth org-management routes
- **`org-store.ts`** (new): module-level per-tab org ID store. Each browser tab has its own JS execution context so this is naturally isolated.
- **`auth-client.ts`**: `fetchOptions.onRequest` injects `organizationId` on every Better Auth organization route call — as a query param for `GET` requests (`listMembers`, `listRoles`, `getFullOrganization`) and in the request body for `POST` requests (`inviteMember`, `removeMember`, `createRole`, `updateRole`, `deleteRole`). Better Auth already accepts an explicit `organizationId` that overrides the session fallback on all these endpoints.
- **`shell-layout.tsx`**: replaced `setActive()` with `getFullOrganization({ query: { organizationSlug } })`. Pure read — zero session mutation. Populates the org store so all subsequent calls are scoped correctly.
- **`organizations-home.tsx`, `inbox.tsx`**: update org store on explicit intentional org switches so the store stays current.

## Testing

- `bun run check` — all workspaces pass
- `bun test apps/mesh/src/core/context-factory.test.ts` — 11/11 pass
- Manual: open two tabs on different orgs, confirm each tab shows data from its own org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-tab org context bleed by removing session mutations on nav and scoping org per request/per tab. Each tab now stays in its own org, including on cache-hit navigation.

- **Bug Fixes**
  - Server: prefer x-org-id with membership check; fall back to session if absent. MCP calls are now per-request.
  - Client: add per-tab org store; auth-client injects organizationId on Better Auth org routes (GET query, POST body), skipping set-active.
  - shell-layout: replace setActive() with getFullOrganization(); sync the org store outside queryFn to keep the correct org on cache hits (A → B → A).
  - organizations-home/inbox: update the org store on explicit org switches.
  - Tests: added Playwright e2e for multi-tab isolation and cache-hit regression; unit tests pass.

<sup>Written for commit 982374129fb6a5483df2e193688958a0003c0c1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

