### PR TITLE
feat(agents): simple redesign Connect button and share modal

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
@@ -35,7 +35,6 @@ import {
   Loading01,
   Play,
   Plus,
-  ZapCircle,
   Tool01,
   Users03,
 } from "@untitledui/icons";
@@ -308,7 +307,30 @@ function VirtualMcpDetailViewWithData({
             dispatch({ type: "SET_SHARE_DIALOG_OPEN", payload: true })
           }
         >
-          <ZapCircle size={14} />
+          <div className="flex items-center -space-x-1.5 mr-0.5">
+            <div
+              className="size-4 rounded-full ring-1 ring-background flex items-center justify-center"
+              style={{ backgroundColor: "#181818" }}
+            >
+              <img
+                src="/logos/cursor.svg"
+                alt="Cursor"
+                className="size-2.5"
+                style={{ filter: "brightness(0) invert(1)" }}
+              />
+            </div>
+            <div
+              className="size-4 rounded-full ring-1 ring-background flex items-center justify-center"
+              style={{ backgroundColor: "#D97757" }}
+            >
+              <img
+                src="/logos/Claude Code.svg"
+                alt="Claude Code"
+                className="size-2.5"
+                style={{ filter: "brightness(0) invert(1)" }}
+              />
+            </div>
+          </div>
           Connect
         </Button>
       </ViewActions>

--- a/apps/mesh/src/web/components/details/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -26,12 +26,14 @@ import type { VirtualMCPEntity } from "@decocms/mesh-sdk";
 import {
   ArrowsRight,
   Check,
+  ChevronDown,
   Code01,
   Copy01,
   InfoCircle,
   Key01,
   Lightbulb02,
   Loading01,
+  Terminal,
 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Suspense, useState } from "react";
@@ -49,140 +51,81 @@ function utf8ToBase64(str: string): string {
   return btoa(binary);
 }
 
-/**
- * Shared button props interfaces
- */
-interface ShareButtonProps {
-  url: string;
-}
-
-interface ShareWithNameProps extends ShareButtonProps {
-  serverName: string;
-}
+type AgentMode = "passthrough" | "smart_tool_selection" | "code_execution";
 
 /**
- * Copy URL Button Component
+ * Client card — colored icon bg + white logo + one-click action
  */
-function CopyUrlButton({ url }: ShareButtonProps) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(url);
-    setCopied(true);
-    toast.success("Agent URL copied to clipboard");
-    setTimeout(() => setCopied(false), 2000);
-  };
-
+function ClientCard({
+  logo,
+  alt,
+  label,
+  bgColor,
+  onClick,
+  copied,
+}: {
+  logo: string;
+  alt: string;
+  label: string;
+  bgColor: string;
+  onClick: () => void;
+  copied?: boolean;
+}) {
   return (
-    <Button
+    <button
       type="button"
-      variant="outline"
-      onClick={handleCopy}
-      className="h-auto py-3 px-4 flex flex-col items-center gap-2"
+      onClick={onClick}
+      className="group flex items-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-left transition-colors hover:border-ring/50 hover:bg-accent/5"
     >
-      {copied ? (
-        <Check size={20} className="text-green-600" />
-      ) : (
-        <Copy01 size={20} />
-      )}
-      <span className="text-xs font-medium">
+      <div
+        className="shrink-0 size-8 rounded-lg flex items-center justify-center"
+        style={{ backgroundColor: bgColor }}
+      >
+        {copied ? (
+          <Check size={16} className="text-white" />
+        ) : (
+          <img
+            src={logo}
+            alt={alt}
+            className="size-4"
+            style={{ filter: "brightness(0) invert(1)" }}
+          />
+        )}
+      </div>
+      <span className="text-sm font-medium text-foreground">
+        {copied ? "Copied!" : label}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Copy URL card — uses Copy icon instead of a logo
+ */
+function CopyUrlCard({
+  onClick,
+  copied,
+}: {
+  onClick: () => void;
+  copied?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex items-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-left transition-colors hover:border-ring/50 hover:bg-accent/5"
+    >
+      <div className="shrink-0 size-8 rounded-lg bg-muted flex items-center justify-center">
+        {copied ? (
+          <Check size={16} className="text-green-600" />
+        ) : (
+          <Copy01 size={16} className="text-muted-foreground" />
+        )}
+      </div>
+      <span className="text-sm font-medium text-foreground">
         {copied ? "Copied!" : "Copy URL"}
       </span>
-    </Button>
-  );
-}
-
-/**
- * Install on Cursor Button Component
- */
-function InstallCursorButton({ url, serverName }: ShareWithNameProps) {
-  const handleInstall = () => {
-    const slugifiedServerName = slugify(serverName);
-    const connectionConfig = {
-      type: "http",
-      url: url,
-      headers: {
-        "x-mesh-client": "Cursor",
-      },
-    };
-    const base64Config = utf8ToBase64(
-      JSON.stringify(connectionConfig, null, 2),
-    );
-    const deeplink = `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(slugifiedServerName)}&config=${encodeURIComponent(base64Config)}`;
-
-    window.open(deeplink, "_blank");
-    toast.success("Opening Cursor...");
-  };
-
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      onClick={handleInstall}
-      className="h-auto py-3 px-4 flex flex-col items-center gap-2"
-    >
-      <img
-        src="/logos/cursor.svg"
-        alt="Cursor"
-        className="h-5 w-5"
-        style={{
-          filter:
-            "brightness(0) saturate(100%) invert(11%) sepia(8%) saturate(785%) hue-rotate(1deg) brightness(95%) contrast(89%)",
-        }}
-      />
-      <span className="text-xs font-medium">Install on Cursor</span>
-    </Button>
-  );
-}
-
-/**
- * Install on Claude Code Button Component
- */
-function InstallClaudeButton({ url, serverName }: ShareWithNameProps) {
-  const [copied, setCopied] = useState(false);
-
-  const handleInstall = async () => {
-    const slugifiedServerName = slugify(serverName);
-    const connectionConfig = {
-      type: "http",
-      url: url,
-      headers: {
-        "x-mesh-client": "Claude Code",
-      },
-    };
-    const configJson = JSON.stringify(connectionConfig, null, 2);
-    const command = `claude mcp add-json "${slugifiedServerName}" '${configJson.replace(/'/g, "'\\''")}'`;
-
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    toast.success("Claude Code command copied to clipboard");
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      onClick={handleInstall}
-      className="h-auto py-3 px-4 flex flex-col items-center gap-2"
-    >
-      {copied ? (
-        <Check size={20} className="text-green-600" />
-      ) : (
-        <img
-          src="/logos/Claude Code.svg"
-          alt="Claude Code"
-          className="h-5 w-5"
-          style={{
-            filter:
-              "brightness(0) saturate(100%) invert(55%) sepia(31%) saturate(1264%) hue-rotate(331deg) brightness(92%) contrast(86%)",
-          }}
-        />
-      )}
-      <span className="text-xs font-medium">
-        {copied ? "Copied!" : "Install on Claude"}
-      </span>
-    </Button>
+    </button>
   );
 }
 
@@ -197,13 +140,19 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
   });
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [copiedCmd, setCopiedCmd] = useState(false);
+  const [copiedEnv, setCopiedEnv] = useState(false);
 
   const mcpId = virtualMcp.id;
   const agentName = virtualMcp.title || `agent-${mcpId.slice(0, 8)}`;
   const command = apiKey
     ? `bunx @decocms/typegen@latest --mcp ${mcpId} --key ${apiKey} --output client.ts`
     : `bunx @decocms/typegen@latest --mcp ${mcpId} --key <api-key> --output client.ts`;
+
+  const meshUrl = window.location.origin;
+  const keyLine = apiKey ? `MESH_API_KEY=${apiKey}` : `MESH_API_KEY=<api-key>`;
+  const urlLine = `MESH_BASE_URL=${meshUrl}`;
+  const envBlock = `${keyLine}\n${urlLine}`;
 
   const handleGenerateKey = async () => {
     setGenerating(true);
@@ -225,54 +174,28 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
     }
   };
 
-  const handleCopy = async () => {
+  const handleCopyCmd = async () => {
     await navigator.clipboard.writeText(command);
-    setCopied(true);
-    toast.success("Command copied to clipboard");
-    setTimeout(() => setCopied(false), 2000);
+    setCopiedCmd(true);
+    toast.success("Command copied");
+    setTimeout(() => setCopiedCmd(false), 2000);
+  };
+
+  const handleCopyEnv = async () => {
+    await navigator.clipboard.writeText(envBlock);
+    setCopiedEnv(true);
+    toast.success("Environment variables copied");
+    setTimeout(() => setCopiedEnv(false), 2000);
   };
 
   return (
-    <div className="flex min-w-0 flex-col gap-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex flex-col gap-0.5">
-          <h4 className="text-sm font-medium text-foreground">
-            Generate typed client
-          </h4>
-          <p className="text-xs text-muted-foreground">
-            Introspects this agent and writes a typed{" "}
-            <code className="font-mono">client.ts</code> you can import
-            directly.
-          </p>
-        </div>
-        {!apiKey && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0 gap-1.5"
-            onClick={handleGenerateKey}
-            disabled={generating}
-          >
-            {generating ? (
-              <Loading01 size={14} className="animate-spin" />
-            ) : (
-              <Key01 size={14} />
-            )}
-            <span>{generating ? "Generating…" : "Generate API key"}</span>
-          </Button>
-        )}
-      </div>
-
+    <div className="flex flex-col gap-2">
       {apiKey && (
         <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
           Store this key securely — it won't be shown again.
         </p>
       )}
 
-      <p className="text-xs font-medium text-muted-foreground">
-        Generate client
-      </p>
       <div className="rounded-md border border-input bg-muted/50 px-3 py-2.5">
         <div className="flex items-start gap-2">
           <code className="min-w-0 flex-1 break-all font-mono text-xs text-muted-foreground">
@@ -283,9 +206,9 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
             variant="ghost"
             size="icon"
             className="size-6 shrink-0"
-            onClick={handleCopy}
+            onClick={handleCopyCmd}
           >
-            {copied ? (
+            {copiedCmd ? (
               <Check size={12} className="text-green-600" />
             ) : (
               <Copy01 size={12} />
@@ -294,60 +217,78 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
         </div>
       </div>
 
-      <p className="text-xs font-medium text-muted-foreground">
-        Runtime variables
-      </p>
-      <EnvVarsBlock apiKey={apiKey} />
-    </div>
-  );
-}
+      <div className="rounded-md border border-input bg-muted/50 px-3 py-2.5">
+        <div className="flex items-start gap-2">
+          <code className="min-w-0 flex-1 font-mono text-xs text-muted-foreground">
+            <span className={cn({ "opacity-50": !apiKey })}>{keyLine}</span>
+            <br />
+            <span>{urlLine}</span>
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6 shrink-0"
+            onClick={handleCopyEnv}
+          >
+            {copiedEnv ? (
+              <Check size={12} className="text-green-600" />
+            ) : (
+              <Copy01 size={12} />
+            )}
+          </Button>
+        </div>
+      </div>
 
-function EnvVarsBlock({ apiKey }: { apiKey: string | null }) {
-  const [copied, setCopied] = useState(false);
-  const meshUrl = window.location.origin;
-  const keyLine = apiKey ? `MESH_API_KEY=${apiKey}` : `MESH_API_KEY=<api-key>`;
-  const urlLine = `MESH_BASE_URL=${meshUrl}`;
-  const envBlock = `${keyLine}\n${urlLine}`;
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(envBlock);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <div className="rounded-md border border-input bg-muted/50 px-3 py-2.5">
-      <div className="flex items-start gap-2">
-        <code className="min-w-0 flex-1 font-mono text-xs text-muted-foreground">
-          <span className={cn({ "opacity-50": !apiKey })}>{keyLine}</span>
-          <br />
-          <span>{urlLine}</span>
-        </code>
+      {!apiKey && (
         <Button
           type="button"
-          variant="ghost"
-          size="icon"
-          className="size-6 shrink-0"
-          onClick={handleCopy}
+          variant="outline"
+          size="sm"
+          className="self-start gap-1.5 mt-1"
+          onClick={handleGenerateKey}
+          disabled={generating}
         >
-          {copied ? (
-            <Check size={12} className="text-green-600" />
+          {generating ? (
+            <Loading01 size={14} className="animate-spin" />
           ) : (
-            <Copy01 size={12} />
+            <Key01 size={14} />
           )}
+          <span>{generating ? "Generating…" : "Generate API key"}</span>
         </Button>
-      </div>
+      )}
     </div>
   );
 }
 
 function TypegenSection({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
+  const [open, setOpen] = useState(false);
   return (
-    <Suspense
-      fallback={<div className="h-20 animate-pulse rounded-md bg-muted" />}
-    >
-      <TypegenSectionInner virtualMcp={virtualMcp} />
-    </Suspense>
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <Terminal size={14} />
+        <span className="font-medium">Typed client</span>
+        <ChevronDown
+          size={14}
+          className={cn("transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div className="pt-1 pb-1">
+          <Suspense
+            fallback={
+              <div className="h-20 animate-pulse rounded-md bg-muted" />
+            }
+          >
+            <TypegenSectionInner virtualMcp={virtualMcp} />
+          </Suspense>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -363,9 +304,9 @@ export function VirtualMCPShareModal({
   onOpenChange: (open: boolean) => void;
   virtualMcp: VirtualMCPEntity;
 }) {
-  const [mode, setMode] = useState<
-    "passthrough" | "smart_tool_selection" | "code_execution"
-  >("code_execution");
+  const [mode, setMode] = useState<AgentMode>("code_execution");
+  const [copiedUrl, setCopiedUrl] = useState(false);
+  const [copiedClaude, setCopiedClaude] = useState(false);
 
   const handleModeChange = (value: string) => {
     if (
@@ -377,17 +318,51 @@ export function VirtualMCPShareModal({
     }
   };
 
-  // Build URL with mode query parameter
-  // Virtual MCPs (agents) are accessed via the virtual-mcp endpoint
   const virtualMcpUrl = new URL(
     `/mcp/virtual-mcp/${virtualMcp.id}`,
     window.location.origin,
   );
   virtualMcpUrl.searchParams.set("mode", mode);
 
-  // Server name for IDE integrations
   const serverName =
     virtualMcp.title || `agent-${virtualMcp.id?.slice(0, 8) ?? "default"}`;
+
+  const handleCopyUrl = async () => {
+    await navigator.clipboard.writeText(virtualMcpUrl.href);
+    setCopiedUrl(true);
+    toast.success("Agent URL copied to clipboard");
+    setTimeout(() => setCopiedUrl(false), 2000);
+  };
+
+  const handleInstallCursor = () => {
+    const slugifiedServerName = slugify(serverName);
+    const connectionConfig = {
+      type: "http",
+      url: virtualMcpUrl.href,
+      headers: { "x-mesh-client": "Cursor" },
+    };
+    const base64Config = utf8ToBase64(
+      JSON.stringify(connectionConfig, null, 2),
+    );
+    const deeplink = `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(slugifiedServerName)}&config=${encodeURIComponent(base64Config)}`;
+    window.open(deeplink, "_blank");
+    toast.success("Opening Cursor...");
+  };
+
+  const handleInstallClaude = async () => {
+    const slugifiedServerName = slugify(serverName);
+    const connectionConfig = {
+      type: "http",
+      url: virtualMcpUrl.href,
+      headers: { "x-mesh-client": "Claude Code" },
+    };
+    const configJson = JSON.stringify(connectionConfig, null, 2);
+    const command = `claude mcp add-json "${slugifiedServerName}" '${configJson.replace(/'/g, "'\\''")}'`;
+    await navigator.clipboard.writeText(command);
+    setCopiedClaude(true);
+    toast.success("Claude Code command copied to clipboard");
+    setTimeout(() => setCopiedClaude(false), 2000);
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -395,8 +370,9 @@ export function VirtualMCPShareModal({
         <DialogHeader>
           <DialogTitle>Connect</DialogTitle>
         </DialogHeader>
+
         <div className="flex flex-col gap-6">
-          {/* Mode Selection */}
+          {/* Mode Selection — original radio card layout */}
           <div className="flex flex-col gap-3">
             <div>
               <h4 className="text-sm font-medium text-foreground mt-1">
@@ -406,12 +382,17 @@ export function VirtualMCPShareModal({
             <RadioGroup
               value={mode}
               onValueChange={handleModeChange}
-              className="flex flex-col gap-4.5"
+              className="flex flex-col gap-2"
             >
               {/* Passthrough Option */}
               <label
                 htmlFor="mode-passthrough"
-                className="flex items-center gap-3 px-3 py-5 rounded-lg border border-border hover:border-ring/50 cursor-pointer transition-colors has-checked:border-ring has-checked:bg-accent/5"
+                className={cn(
+                  "flex items-center gap-3 px-3 py-3 rounded-lg border cursor-pointer transition-colors",
+                  mode === "passthrough"
+                    ? "border-ring bg-accent/30"
+                    : "border-border hover:border-ring/50",
+                )}
               >
                 <div className="p-1.5 shrink-0">
                   <ArrowsRight className="size-5 text-muted-foreground" />
@@ -445,7 +426,12 @@ export function VirtualMCPShareModal({
               {/* Smart Tool Selection Option */}
               <label
                 htmlFor="mode-smart"
-                className="flex items-center gap-3 px-3 py-5 rounded-lg border border-border hover:border-ring/50 cursor-pointer transition-colors has-checked:border-ring has-checked:bg-accent/5"
+                className={cn(
+                  "flex items-center gap-3 px-3 py-3 rounded-lg border cursor-pointer transition-colors",
+                  mode === "smart_tool_selection"
+                    ? "border-ring bg-accent/30"
+                    : "border-border hover:border-ring/50",
+                )}
               >
                 <div className="p-1.5 shrink-0">
                   <Lightbulb02 className="size-5 text-muted-foreground" />
@@ -481,7 +467,12 @@ export function VirtualMCPShareModal({
               {/* Code Execution Option */}
               <label
                 htmlFor="mode-code"
-                className="relative flex items-center gap-3 px-3 py-5 rounded-lg border border-border hover:border-ring/50 cursor-pointer transition-colors has-checked:border-ring has-checked:bg-accent/5"
+                className={cn(
+                  "relative flex items-center gap-3 px-3 py-3 rounded-lg border cursor-pointer transition-colors",
+                  mode === "code_execution"
+                    ? "border-ring bg-accent/30"
+                    : "border-border hover:border-ring/50",
+                )}
               >
                 <div className="p-1.5 shrink-0">
                   <Code01 className="size-5 text-muted-foreground" />
@@ -522,25 +513,30 @@ export function VirtualMCPShareModal({
             </RadioGroup>
           </div>
 
-          {/* Action Buttons */}
-          <div className="flex flex-col gap-3 pt-2">
-            <div className="grid grid-cols-3 gap-2">
-              <CopyUrlButton url={virtualMcpUrl.href} />
-              <InstallCursorButton
-                url={virtualMcpUrl.href}
-                serverName={serverName}
-              />
-              <InstallClaudeButton
-                url={virtualMcpUrl.href}
-                serverName={serverName}
-              />
-            </div>
+          {/* Client actions */}
+          <div className="flex flex-col gap-2">
+            <ClientCard
+              logo="/logos/cursor.svg"
+              alt="Cursor"
+              label="Install on Cursor"
+              bgColor="#181818"
+              onClick={handleInstallCursor}
+            />
+            <ClientCard
+              logo="/logos/Claude Code.svg"
+              alt="Claude Code"
+              label="Install on Claude Code"
+              bgColor="#D97757"
+              onClick={handleInstallClaude}
+              copied={copiedClaude}
+            />
+            <CopyUrlCard onClick={handleCopyUrl} copied={copiedUrl} />
           </div>
 
-          <div className="border-t border-border" />
-
-          {/* Typegen */}
-          <TypegenSection virtualMcp={virtualMcp} />
+          {/* Typegen — collapsible */}
+          <div className="border-t border-border pt-2">
+            <TypegenSection virtualMcp={virtualMcp} />
+          </div>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
- Replace lightning icon with overlapping Cursor/Claude branded icons on Connect button
- Redesign client action cards with colored backgrounds and white logos
- Replace Windsurf card with generic Copy URL action
- Make typegen section collapsible by default
- Fix mode selection highlighting with state-driven bg-accent/30
- Reduce radio card padding and gap for tighter layout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Connect button and share modal to make installs clearer and sharing faster. Adds branded client cards, a Copy URL action, and a collapsible typed client with one‑click copy for the command and env vars.

- **New Features**
  - Connect button shows overlapping Cursor + Claude icons.
  - Client actions are now vertical cards with colored backgrounds and white logos; “Install on Claude Code” copies the CLI command; added a generic “Copy URL” action.
  - Typed client section is collapsible by default, with quick copy for command and env vars and an inline “Generate API key” button.

- **Bug Fixes**
  - Mode selection uses state-driven highlighting (bg-accent/30) and tighter padding/gaps for a cleaner layout.

<sup>Written for commit 90dd9e8de2476fe691b469e062217494d5ca9ce1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

