### PR TITLE
chore(typegen): update default domain references

### DIFF
--- a/packages/typegen/README.md
+++ b/packages/typegen/README.md
@@ -16,7 +16,7 @@ bunx @decocms/typegen --mcp <virtual-mcp-id> --key <api-key> --output client.ts
 |------|---------|---------|
 | `--mcp` | — | **required** |
 | `--key` | `MESH_API_KEY` | — |
-| `--url` | `MESH_BASE_URL` | `https://mesh-admin.decocms.com` |
+| `--url` | `MESH_BASE_URL` | `https://studio.decocms.com` |
 | `--output` | — | `client.ts` |
 
 ### 2. Use the generated client
@@ -59,7 +59,7 @@ import { createMeshClient } from "@decocms/typegen";
 const client = createMeshClient<Tools>({
   mcpId: "vmc_abc123",   // Virtual MCP ID
   apiKey: "sk_...",      // Falls back to process.env.MESH_API_KEY
-  baseUrl: "https://...", // Falls back to https://mesh-admin.decocms.com
+  baseUrl: "https://...", // Falls back to https://studio.decocms.com
 });
 ```
 

--- a/packages/typegen/src/cli.ts
+++ b/packages/typegen/src/cli.ts
@@ -6,7 +6,7 @@ import { writeFile } from "node:fs/promises";
 import process from "node:process";
 import { generateClientCode } from "./codegen.js";
 
-const DEFAULT_BASE_URL = "https://mesh-admin.decocms.com";
+const DEFAULT_BASE_URL = "https://studio.decocms.com";
 
 function parseArgs(argv: string[]): {
   mcpId: string;

--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -13,7 +13,7 @@ export interface MeshClientOptions {
   mcpId: string;
   /** Falls back to process.env.MESH_API_KEY */
   apiKey?: string;
-  /** Falls back to https://mesh-admin.decocms.com */
+  /** Falls back to https://studio.decocms.com */
   baseUrl?: string;
 }
 

--- a/packages/typegen/src/runtime.test.ts
+++ b/packages/typegen/src/runtime.test.ts
@@ -139,7 +139,7 @@ describe("createMeshClient", () => {
     );
   });
 
-  test("defaults baseUrl to https://mesh-admin.decocms.com", async () => {
+  test("defaults baseUrl to https://studio.decocms.com", async () => {
     type Tools = { TOOL: { input: Record<string, never>; output: unknown } };
 
     const capturedUrls: URL[] = [];
@@ -158,7 +158,7 @@ describe("createMeshClient", () => {
     await client.TOOL({});
 
     expect(capturedUrls[0]?.toString()).toBe(
-      "https://mesh-admin.decocms.com/mcp/virtual-mcp/vmc_abc",
+      "https://studio.decocms.com/mcp/virtual-mcp/vmc_abc",
     );
   });
 });

--- a/packages/typegen/src/runtime.ts
+++ b/packages/typegen/src/runtime.ts
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { MeshClient, MeshClientOptions, ToolMap } from "./index.js";
 
-const DEFAULT_BASE_URL = "https://mesh-admin.decocms.com";
+const DEFAULT_BASE_URL = "https://studio.decocms.com";
 
 /** @internal - overrideable constructors for testing */
 export interface MeshClientDeps {


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the default Mesh base URL to https://studio.decocms.com across the typegen CLI, runtime, tests, and README so clients and docs point to the new Studio domain.

<sup>Written for commit 8cd2aa9c15af8d16b154474686676ec5cf0013ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

