### PR TITLE
Update layout to move sidebar collapse into sidebar and chat to the right side

### DIFF
--- a/apps/mesh/src/web/components/page/index.tsx
+++ b/apps/mesh/src/web/components/page/index.tsx
@@ -1,5 +1,13 @@
-import { SidebarTrigger } from "@deco/ui/components/sidebar.tsx";
+import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { MessageTextCircle02 } from "@untitledui/icons";
+import { useParams, useRouterState } from "@tanstack/react-router";
 import type { PropsWithChildren, ReactElement, ReactNode } from "react";
 import { Children, isValidElement } from "react";
 
@@ -15,6 +23,37 @@ function findChild<T>(
     }
   }
   return null;
+}
+
+function ChatToggleButton() {
+  const [isChatOpen, setChatOpen] = useDecoChatOpen();
+  const { org, project } = useParams({ strict: false });
+  const { location } = useRouterState();
+  const isHomeRoute =
+    location.pathname === `/${org}/${project}` ||
+    location.pathname === `/${org}/${project}/`;
+
+  if (isHomeRoute) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          className={cn(
+            "h-7 px-2 gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground",
+            isChatOpen && "bg-accent text-foreground",
+          )}
+          onClick={() => setChatOpen((prev) => !prev)}
+          aria-label="Toggle Decopilot"
+        >
+          <MessageTextCircle02 size={14} className="text-inherit" />
+          Chat
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Toggle Decopilot</TooltipContent>
+    </Tooltip>
+  );
 }
 
 // Root page container
@@ -47,18 +86,19 @@ function PageHeader({
     <div
       className={cn(
         "shrink-0 w-full border-b border-border/50 h-11 overflow-x-auto",
-        "flex items-center justify-between gap-3 pr-4 min-w-max",
-        hideSidebarTrigger ? "pl-4" : "pl-2",
+        "flex items-center justify-between gap-3 pr-2 pl-4 min-w-max",
         className,
       )}
     >
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1">{left}</div>
+      <div className="flex items-center">
+        {right}
         {!hideSidebarTrigger && (
-          <SidebarTrigger className="text-muted-foreground" />
+          <div className="flex items-center border-l border-border/50 pl-2 ml-1">
+            <ChatToggleButton />
+          </div>
         )}
-        {left}
       </div>
-      {right}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/header/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/index.tsx
@@ -1,20 +1,12 @@
-import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
-import { Button } from "@deco/ui/components/button.tsx";
 import {
   SidebarHeader as SidebarHeaderUI,
   SidebarMenu,
+  SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
 } from "@deco/ui/components/sidebar.tsx";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { MessageTextCircle02 } from "@untitledui/icons";
-import { useParams, useRouterState } from "@tanstack/react-router";
+import { LayoutLeft } from "@untitledui/icons";
 import { MeshAccountSwitcher } from "./account-switcher";
 
 interface MeshSidebarHeaderProps {
@@ -22,58 +14,43 @@ interface MeshSidebarHeaderProps {
 }
 
 export function MeshSidebarHeader({ onCreateProject }: MeshSidebarHeaderProps) {
-  const { state } = useSidebar();
+  const { state, toggleSidebar } = useSidebar();
   const isCollapsed = state === "collapsed";
-  const [isChatOpen, setChatOpen] = useDecoChatOpen();
-  const { org, project } = useParams({ strict: false });
-  const { location } = useRouterState();
-  const isHomeRoute =
-    location.pathname === `/${org}/${project}` ||
-    location.pathname === `/${org}/${project}/`;
-
-  const toggleChat = () => {
-    setChatOpen((prev) => !prev);
-  };
 
   return (
     <SidebarHeaderUI className="px-3 group-data-[collapsible=icon]:px-2 animate-in fade-in-0 duration-200">
       <SidebarMenu>
         <SidebarMenuItem>
-          <div className="flex items-center justify-between w-full gap-1">
-            <div className="min-w-0 flex-1">
+          {isCollapsed ? (
+            <div className="flex flex-col w-full gap-0.5">
               <MeshAccountSwitcher
-                isCollapsed={isCollapsed}
+                isCollapsed={true}
                 onCreateProject={onCreateProject}
               />
+              <SidebarMenuButton
+                onClick={toggleSidebar}
+                tooltip="Expand sidebar"
+              >
+                <LayoutLeft />
+              </SidebarMenuButton>
             </div>
-
-            <div
-              className={cn(
-                "flex items-center gap-0.5 shrink-0 overflow-hidden transition-[max-width,opacity] duration-300 ease-[var(--ease-out-quart)]",
-                isCollapsed || isHomeRoute
-                  ? "max-w-0 opacity-0 pointer-events-none"
-                  : "max-w-[2rem] opacity-100",
-              )}
-            >
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className={cn(
-                      "size-7 hover:bg-sidebar-accent text-sidebar-foreground/50 hover:text-sidebar-foreground",
-                      isChatOpen && "bg-sidebar-accent text-sidebar-foreground",
-                    )}
-                    onClick={toggleChat}
-                    aria-label="Toggle Decopilot"
-                  >
-                    <MessageTextCircle02 size={14} className="text-inherit" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Toggle Decopilot</TooltipContent>
-              </Tooltip>
+          ) : (
+            <div className="flex items-center justify-between w-full gap-1">
+              <div className="min-w-0 flex-1">
+                <MeshAccountSwitcher
+                  isCollapsed={false}
+                  onCreateProject={onCreateProject}
+                />
+              </div>
+              <SidebarMenuButton
+                onClick={toggleSidebar}
+                tooltip="Collapse sidebar"
+                className="size-7 shrink-0"
+              >
+                <LayoutLeft />
+              </SidebarMenuButton>
             </div>
-          </div>
+          )}
         </SidebarMenuItem>
       </SidebarMenu>
     </SidebarHeaderUI>
@@ -91,7 +68,6 @@ MeshSidebarHeader.Skeleton = function MeshSidebarHeaderSkeleton() {
               <Skeleton className="h-3.5 w-16 bg-sidebar-accent" />
             </div>
             <div className="flex items-center gap-0.5">
-              <Skeleton className="size-7 rounded-lg bg-sidebar-accent" />
               <Skeleton className="size-7 rounded-lg bg-sidebar-accent" />
             </div>
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the sidebar collapse/expand control into the sidebar header and moved the Decopilot chat toggle to the right side of the page header for clearer navigation. The chat toggle is hidden on the project home page.

- **Refactors**
  - Added a sidebar collapse/expand button (SidebarMenuButton with LayoutLeft) in the sidebar header for both collapsed and expanded states.
  - Removed the chat toggle from the sidebar; added a ChatToggleButton to the page header with tooltip and active state, hidden on the home route.
  - Simplified PageHeader layout (left/right slots, spacing, and border) and removed SidebarTrigger usage.

<sup>Written for commit cdd55725f699e941332036bb3fda87ce1f6ec6f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

