### PR TITLE
fix(token-issuing): persist configuration_scopes from MCP_CONFIGURATION on connect

### DIFF
--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -130,16 +130,19 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
           connectionToken = key?.key;
         }
         // Get tools either from the lazy getter or by fetching from MCP
+        const fetchResult = await fetchToolsFromMCP({
+          id: "pending",
+          title: mcpConfig.data.title,
+          connection_type: mcpConfig.data.connection_type,
+          connection_url: mcpConfig.data.connection_url,
+          connection_token: mcpConfig.data.connection_token,
+          connection_headers: mcpConfig.data.connection_headers,
+        }).catch(() => null);
         const tools =
-          (await mcpConfig.getTools?.()) ??
-          (await fetchToolsFromMCP({
-            id: "pending",
-            title: mcpConfig.data.title,
-            connection_type: mcpConfig.data.connection_type,
-            connection_url: mcpConfig.data.connection_url,
-            connection_token: mcpConfig.data.connection_token,
-            connection_headers: mcpConfig.data.connection_headers,
-          }).catch(() => null));
+          (await mcpConfig.getTools?.()) ?? fetchResult?.tools ?? null;
+        const configuration_scopes = fetchResult?.scopes?.length
+          ? fetchResult.scopes
+          : null;
 
         // Add org prefix only if ID doesn't already have it
         // (e.g., Deco Store already includes org prefix via WellKnownOrgMCPId)
@@ -153,6 +156,7 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
           ...mcpConfig.data,
           id: connectionId,
           tools,
+          configuration_scopes,
           organization_id: organizationId,
           created_by: createdBy,
           connection_token: mcpConfig.data.connection_token ?? connectionToken,

--- a/apps/mesh/src/tools/connection/connection-tools.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.test.ts
@@ -186,13 +186,16 @@ describe("Connection Tools", () => {
         .spyOn(fetchToolsModule, "fetchToolsFromMCP")
         .mockImplementation(async (input) => {
           expect(input.connection_token).toBe("oauth-access-token");
-          return [
-            {
-              name: "COLLECTION_LLM_LIST",
-              description: "List models",
-              inputSchema: {},
-            },
-          ];
+          return {
+            tools: [
+              {
+                name: "COLLECTION_LLM_LIST",
+                description: "List models",
+                inputSchema: {},
+              },
+            ],
+            scopes: null,
+          };
         });
 
       const result = await COLLECTION_CONNECTIONS_UPDATE.execute(

--- a/apps/mesh/src/tools/connection/create.ts
+++ b/apps/mesh/src/tools/connection/create.ts
@@ -93,9 +93,9 @@ export const COLLECTION_CONNECTIONS_CREATE = defineTool({
       connectionData.connection_url = buildVirtualUrl(virtualMcpId);
     }
 
-    // Fetch tools from the MCP server before creating the connection
+    // Fetch tools and configuration scopes from the MCP server before creating the connection
     // VIRTUAL connections return null since tools are fetched dynamically
-    const fetchedTools = await fetchToolsFromMCP({
+    const fetchResult = await fetchToolsFromMCP({
       id: `pending-${Date.now()}`,
       title: connectionData.title,
       connection_type: connectionData.connection_type,
@@ -103,12 +103,16 @@ export const COLLECTION_CONNECTIONS_CREATE = defineTool({
       connection_token: connectionData.connection_token,
       connection_headers: connectionData.connection_headers,
     }).catch(() => null);
-    const tools = fetchedTools?.length ? fetchedTools : null;
+    const tools = fetchResult?.tools?.length ? fetchResult.tools : null;
+    const configuration_scopes = fetchResult?.scopes?.length
+      ? fetchResult.scopes
+      : null;
 
-    // Create the connection with the fetched tools
+    // Create the connection with the fetched tools and scopes
     const connection = await ctx.storage.connections.create({
       ...connectionData,
       tools,
+      configuration_scopes,
     });
 
     await ctx.eventBus.publish(

--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -29,16 +29,24 @@ export interface ConnectionForToolFetch {
 }
 
 /**
- * Fetches tools from an MCP connection server.
+ * Result of fetching data from an MCP connection
+ */
+export interface FetchedMCPData {
+  tools: ToolDefinition[] | null;
+  scopes: string[] | null;
+}
+
+/**
+ * Fetches tools and configuration scopes from an MCP connection server.
  * Supports HTTP, SSE, and STDIO transports based on connection_type.
  * VIRTUAL connections return null since tools are fetched dynamically at runtime.
  *
  * @param connection - Connection details for connecting to MCP
- * @returns Array of tool definitions, or null if fetch failed or not applicable
+ * @returns Fetched tools and scopes, or null if fetch failed or not applicable
  */
 export async function fetchToolsFromMCP(
   connection: ConnectionForToolFetch,
-): Promise<ToolDefinition[] | null> {
+): Promise<FetchedMCPData | null> {
   switch (connection.connection_type) {
     case "STDIO":
       return fetchToolsFromStdioMCP(connection);
@@ -57,11 +65,41 @@ export async function fetchToolsFromMCP(
 }
 
 /**
+ * Try to fetch configuration scopes from the MCP_CONFIGURATION tool.
+ * Returns null if the tool is not implemented or the call fails.
+ */
+async function fetchScopesFromMCP(client: Client): Promise<string[] | null> {
+  try {
+    const configTimeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("MCP_CONFIGURATION timeout")), 5_000),
+    );
+    const configResult = await Promise.race([
+      client.callTool({ name: "MCP_CONFIGURATION", arguments: {} }),
+      configTimeout,
+    ]);
+    if (!configResult.isError && Array.isArray(configResult.content)) {
+      const textContent = configResult.content.find(
+        (c: { type: string }) => c.type === "text",
+      );
+      if (textContent && "text" in textContent) {
+        const config = JSON.parse(String(textContent.text));
+        if (Array.isArray(config.scopes) && config.scopes.length > 0) {
+          return config.scopes as string[];
+        }
+      }
+    }
+  } catch {
+    // MCP_CONFIGURATION not implemented or failed — not all MCPs support it
+  }
+  return null;
+}
+
+/**
  * Fetch tools from an HTTP-based MCP connection
  */
 async function fetchToolsFromHttpMCP(
   connection: ConnectionForToolFetch,
-): Promise<ToolDefinition[] | null> {
+): Promise<FetchedMCPData | null> {
   if (!connection.connection_url) {
     console.error(`HTTP connection ${connection.id} missing URL`);
     return null;
@@ -103,21 +141,24 @@ async function fetchToolsFromHttpMCP(
     await Promise.race([client.connect(transport), timeoutPromise]);
     const result = await Promise.race([client.listTools(), timeoutPromise]);
 
-    if (!result.tools || result.tools.length === 0) {
-      return null;
-    }
+    const tools =
+      result.tools && result.tools.length > 0
+        ? result.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description ?? undefined,
+            inputSchema: tool.inputSchema ?? {},
+            outputSchema: tool.outputSchema
+              ? // We strive to have lenient output schemas, so allow additional properties
+                { ...tool.outputSchema, additionalProperties: true }
+              : undefined,
+            annotations: tool.annotations ?? undefined,
+            _meta: tool._meta ?? undefined,
+          }))
+        : null;
 
-    return result.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description ?? undefined,
-      inputSchema: tool.inputSchema ?? {},
-      outputSchema: tool.outputSchema
-        ? // We strive to have lenient output schemas, so allow additional properties
-          { ...tool.outputSchema, additionalProperties: true }
-        : undefined,
-      annotations: tool.annotations ?? undefined,
-      _meta: tool._meta ?? undefined,
-    }));
+    const scopes = await fetchScopesFromMCP(client);
+
+    return { tools, scopes };
   } catch (error) {
     console.error(
       `Failed to fetch tools from HTTP connection ${connection.id}:`,
@@ -140,7 +181,7 @@ async function fetchToolsFromHttpMCP(
  */
 async function fetchToolsFromSSEMCP(
   connection: ConnectionForToolFetch,
-): Promise<ToolDefinition[] | null> {
+): Promise<FetchedMCPData | null> {
   if (!connection.connection_url) {
     console.error(`SSE connection ${connection.id} missing URL`);
     return null;
@@ -177,18 +218,23 @@ async function fetchToolsFromSSEMCP(
     await Promise.race([client.connect(transport), timeoutPromise]);
     const result = await Promise.race([client.listTools(), timeoutPromise]);
 
-    if (!result.tools || result.tools.length === 0) return null;
+    const tools =
+      result.tools && result.tools.length > 0
+        ? result.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description ?? undefined,
+            inputSchema: tool.inputSchema ?? {},
+            outputSchema: tool.outputSchema
+              ? { ...tool.outputSchema, additionalProperties: true }
+              : undefined,
+            annotations: tool.annotations ?? undefined,
+            _meta: tool._meta ?? undefined,
+          }))
+        : null;
 
-    return result.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description ?? undefined,
-      inputSchema: tool.inputSchema ?? {},
-      outputSchema: tool.outputSchema
-        ? { ...tool.outputSchema, additionalProperties: true }
-        : undefined,
-      annotations: tool.annotations ?? undefined,
-      _meta: tool._meta ?? undefined,
-    }));
+    const scopes = await fetchScopesFromMCP(client);
+
+    return { tools, scopes };
   } catch (error) {
     console.error(
       `Failed to fetch tools from SSE connection ${connection.id}:`,
@@ -209,7 +255,7 @@ async function fetchToolsFromSSEMCP(
  */
 async function fetchToolsFromStdioMCP(
   connection: ConnectionForToolFetch,
-): Promise<ToolDefinition[] | null> {
+): Promise<FetchedMCPData | null> {
   const stdioParams = isStdioParameters(connection.connection_headers)
     ? connection.connection_headers
     : null;
@@ -242,18 +288,21 @@ async function fetchToolsFromStdioMCP(
     await Promise.race([client.connect(transport), timeoutPromise]);
     const result = await Promise.race([client.listTools(), timeoutPromise]);
 
-    if (!result.tools || result.tools.length === 0) {
-      return null;
-    }
+    const tools =
+      result.tools && result.tools.length > 0
+        ? result.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description ?? undefined,
+            inputSchema: tool.inputSchema ?? {},
+            outputSchema: tool.outputSchema ?? undefined,
+            annotations: tool.annotations ?? undefined,
+            _meta: tool._meta ?? undefined,
+          }))
+        : null;
 
-    return result.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description ?? undefined,
-      inputSchema: tool.inputSchema ?? {},
-      outputSchema: tool.outputSchema ?? undefined,
-      annotations: tool.annotations ?? undefined,
-      _meta: tool._meta ?? undefined,
-    }));
+    const scopes = await fetchScopesFromMCP(client);
+
+    return { tools, scopes };
   } catch (error) {
     console.error(
       `Failed to fetch tools from STDIO connection ${connection.id}:`,

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -220,7 +220,7 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       }
     }
 
-    const fetchedTools = await fetchToolsFromMCP({
+    const fetchResult = await fetchToolsFromMCP({
       id: existing.id,
       title: data.title ?? existing.title,
       connection_type: finalConnectionType,
@@ -229,7 +229,15 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       connection_headers:
         data.connection_headers ?? existing.connection_headers,
     }).catch(() => null);
-    const tools = fetchedTools?.length ? fetchedTools : null;
+    const tools = fetchResult?.tools?.length ? fetchResult.tools : null;
+
+    // Auto-populate scopes from MCP_CONFIGURATION when not explicitly provided by the caller
+    if (
+      data.configuration_scopes === undefined &&
+      fetchResult?.scopes?.length
+    ) {
+      finalScopes = fetchResult.scopes;
+    }
 
     // Update the connection with the refreshed tools and configuration
     const updatePayload: Partial<ConnectionEntity> = {


### PR DESCRIPTION
## What is this contribution about?

When mesh connects to a downstream MCP it discovers tools via `listTools()` but never called `MCP_CONFIGURATION` to retrieve the scopes the app declares (e.g. `"VTEX::*"`, `"BIGQUERY::*"`, `"EVENT_BUS::EVENT_PUBLISH"`). As a result `configuration_scopes` was always `null` in the database.

`buildRequestHeaders()` calls `extractConnectionPermissions(state, scopes)` to build JWT permissions — with `scopes = null` it returns `{}`, so every JWT issued for an `ON_EVENTS` handler had empty permissions. Mesh's `AuthTransport` then denied all binding calls from inside the event handler with `"Streamable HTTP error: Error POSTing to endpoint:"`.

**Changes:**
- `fetchToolsFromMCP()` now returns `FetchedMCPData { tools, scopes }` instead of `ToolDefinition[]`, and calls `MCP_CONFIGURATION` on the downstream (5 s timeout, silently ignored for MCPs that don't implement it)
- `create.ts` saves fetched scopes to `configuration_scopes` at connection creation time
- `update.ts` auto-populates `configuration_scopes` from `MCP_CONFIGURATION` when the caller didn't explicitly provide scopes — this also backfills existing connections on their next update/tool-refresh
- `org.ts` default-connection creation path gets the same fix
- Test mock updated to match the new return shape

## Screenshots/Demonstration

N/A — no UI changes.

## How to Test

1. Create a new connection to an MCP app that uses `withRuntime({ configuration: { scopes: [...] } })` (e.g. `ai-farmrio`)
2. After creation, inspect the connection record — `configuration_scopes` should now be populated with the app's declared scopes
3. Set `configuration_state` to map each scope key to the real connection IDs
4. Trigger an event that dispatches to this connection via `ON_EVENTS`
5. Verify the `x-mesh-token` JWT now contains non-empty `permissions` (e.g. `{ "conn_vtex_id": ["*"] }`)
6. Verify binding calls from inside the event handler succeed instead of returning 401/403

For existing connections (created before this fix): trigger a no-op update (`COLLECTION_CONNECTIONS_UPDATE` with `data: {}`). The tool re-fetches tools and now also fetches scopes, writing them to the DB.

## Migration Notes

No database migrations required — `configuration_scopes` column already exists. Existing connections with `null` scopes will be backfilled automatically on their next update call.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist configuration_scopes from MCP_CONFIGURATION on connect/update so issued JWTs include correct permissions and ON_EVENTS bindings stop failing. Existing connections backfill scopes on their next update.

- **Bug Fixes**
  - Call MCP_CONFIGURATION and store scopes during create, update, and org default-connection paths.
  - fetchToolsFromMCP now returns { tools, scopes } and attempts MCP_CONFIGURATION with a 5s timeout (skipped if unsupported).
  - Updated tests to match the new return shape.

- **Migration**
  - No database changes.
  - Existing connections populate scopes on the next update/tool refresh.

<sup>Written for commit 283d49c6e08799d9737fd1bf618a78b62c501f68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

