### PR TITLE
fix(billing): use centralized constant for AI Gateway URL detection

### DIFF
--- a/apps/mesh/src/core/deco-constants.ts
+++ b/apps/mesh/src/core/deco-constants.ts
@@ -13,6 +13,10 @@ export const DECO_STORE_URL = "https://api.decocms.com/mcp/registry";
 /** OpenRouter MCP URL (deco-hosted) */
 export const OPENROUTER_MCP_URL = "https://sites-openrouter.decocache.com/mcp";
 
+/** Deco AI Gateway MCP URL (deco-hosted) */
+export const DECO_AI_GATEWAY_MCP_URL =
+  "https://sites-deco-ai-gateway.decocache.com/mcp";
+
 /** OpenRouter icon URL */
 export const OPENROUTER_ICON_URL =
   "https://assets.decocache.com/decocms/b2e2f64f-6025-45f7-9e8c-3b3ebdd073d8/openrouter_logojpg.jpg";

--- a/apps/mesh/src/web/components/settings-modal/pages/org-billing.tsx
+++ b/apps/mesh/src/web/components/settings-modal/pages/org-billing.tsx
@@ -27,10 +27,7 @@ import {
   useMCPToolCallQuery,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-
-// -- Constants --
-
-const DECO_AI_GATEWAY_HOSTS = ["sites-deco-ai-gateway.decocache.com"];
+import { DECO_AI_GATEWAY_MCP_URL } from "@/core/deco-constants";
 
 // -- Types --
 
@@ -596,16 +593,9 @@ class BillingErrorBoundary extends Component<
 function BillingContent() {
   const connections = useConnections();
 
-  const gatewayConnection = connections.find((c) => {
-    try {
-      return (
-        !!c.connection_url &&
-        DECO_AI_GATEWAY_HOSTS.includes(new URL(c.connection_url).host)
-      );
-    } catch {
-      return false;
-    }
-  });
+  const gatewayConnection = connections.find(
+    (c) => c.connection_url === DECO_AI_GATEWAY_MCP_URL,
+  );
 
   if (!gatewayConnection?.id) {
     return <BillingEmpty />;

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -24,6 +24,7 @@ import {
   useMCPToolCallQuery,
   useProjectContext,
 } from "@decocms/mesh-sdk";
+import { DECO_AI_GATEWAY_MCP_URL } from "@/core/deco-constants";
 
 interface Invitation {
   id: string;
@@ -150,8 +151,6 @@ class SilentErrorBoundary extends Component<
   }
 }
 
-const DECO_AI_GATEWAY_HOSTS = ["sites-deco-ai-gateway.decocache.com"];
-
 interface GatewayUsageResult {
   limit: { remaining: number | null; total: number | null };
 }
@@ -193,16 +192,9 @@ function CreditChip({ connectionId }: { connectionId: string }) {
 function CreditChipConditional() {
   const connections = useConnections();
 
-  const gatewayConnection = connections.find((c) => {
-    try {
-      return (
-        !!c.connection_url &&
-        DECO_AI_GATEWAY_HOSTS.includes(new URL(c.connection_url).host)
-      );
-    } catch {
-      return false;
-    }
-  });
+  const gatewayConnection = connections.find(
+    (c) => c.connection_url === DECO_AI_GATEWAY_MCP_URL,
+  );
 
   if (!gatewayConnection?.id) {
     return null;


### PR DESCRIPTION
Replace per-file DECO_AI_GATEWAY_HOSTS arrays with a shared DECO_AI_GATEWAY_MCP_URL constant for consistent connection matching.

Made-with: Cursor

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the AI Gateway MCP URL into a single constant and updated billing views to use it for connection detection. Fixes inconsistent gateway detection in Org Billing and the Inbox credit chip.

- **Bug Fixes**
  - Use DECO_AI_GATEWAY_MCP_URL for connection_url matching in org-billing.tsx and inbox.tsx.
  - Removed per-file host arrays and URL parsing; added the constant in deco-constants.ts.

<sup>Written for commit 6bcf2b1ec6ae0d564cf8d91bf047c33e3f7a08bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

