### PR TITLE
fix(chat): preserve toolApprovalLevel across tool re-sends

### DIFF
--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -179,8 +179,11 @@ const createModelsTransport = (
         ? [systemMessage, ...userMessage]
         : userMessage;
 
-      // Fall back to last message metadata when requestMetadata is missing models/agent
+      // Fall back to last message metadata when requestMetadata is missing fields
+      // (e.g. during re-sends from addToolOutput / addToolApprovalResponse)
       const lastMsgMeta = (messages.at(-1)?.metadata ?? {}) as Metadata;
+      const lastUserMeta = (messages.findLast((m) => m.role === "user")
+        ?.metadata ?? {}) as Metadata;
       const mergedMetadata = {
         ...metadata,
         agent: metadata.agent ?? lastMsgMeta.agent,
@@ -188,11 +191,18 @@ const createModelsTransport = (
         thread_id: metadata.thread_id ?? lastMsgMeta.thread_id,
       };
 
+      const resolvedToolApprovalLevel =
+        toolApprovalLevel ??
+        lastMsgMeta.toolApprovalLevel ??
+        lastUserMeta.toolApprovalLevel;
+
       return {
         body: {
           messages: allMessages,
           ...mergedMetadata,
-          ...(toolApprovalLevel && { toolApprovalLevel }),
+          ...(resolvedToolApprovalLevel && {
+            toolApprovalLevel: resolvedToolApprovalLevel,
+          }),
         },
       };
     },
@@ -904,6 +914,7 @@ export function ChatProvider({ children }: PropsWithChildren) {
       tiptapDoc,
       created_at: new Date().toISOString(),
       thread_id: threadManager.activeThreadId,
+      toolApprovalLevel: preferences.toolApprovalLevel,
       agent: {
         id: selectedVirtualMcp?.id ?? decopilotId,
         mode: selectedMode,
@@ -918,7 +929,6 @@ export function ChatProvider({ children }: PropsWithChildren) {
       ...messageMetadata,
       system: contextPrompt,
       models: selectedModel,
-      toolApprovalLevel: preferences.toolApprovalLevel,
     };
 
     const userMessage: ChatMessage = {


### PR DESCRIPTION
## Summary

- Fixes `toolApprovalLevel` being lost after responding to `user_ask` or approving/denying tool calls
- When `addToolOutput` or `addToolApprovalResponse` trigger a re-send, the AI SDK passes no `requestMetadata`, so `toolApprovalLevel` defaulted to `"none"`
- Stores `toolApprovalLevel` on the user message metadata (single source of truth) and resolves it from message metadata in the transport fallback

## Test plan

- [ ] Set tool approval to "yolo", trigger a `user_ask` tool, answer it — verify subsequent tools auto-execute
- [ ] Set tool approval to "readonly", approve a write tool — verify subsequent read-only tools still auto-execute
- [ ] Verify normal message send still includes `toolApprovalLevel` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves toolApprovalLevel across tool re-sends so auto-execute settings persist. Stores the level on user message metadata and resolves it when requestMetadata is missing.

- **Bug Fixes**
  - Store toolApprovalLevel on the user message metadata as the source of truth.
  - On re-sends from addToolOutput/addToolApprovalResponse, resolve toolApprovalLevel from request, last message, or last user message metadata while keeping existing fallbacks for agent/models/thread_id.

<sup>Written for commit 5249744091a3f63162a5f75597001441be959557. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

