### PR TITLE
fix(config): remove redundant MESH_URL env var in favor of ctx.baseUrl

### DIFF
--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -56,7 +56,7 @@ export async function buildRequestHeaders(
         user: { id: userId },
         metadata: {
           state: connection.configuration_state ?? undefined,
-          meshUrl: process.env.MESH_URL ?? ctx.baseUrl,
+          meshUrl: ctx.baseUrl,
           connectionId,
           organizationId: ctx.organization?.id,
         },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "private": true,
   "scripts": {
-    "link": "deco link -p 3000 -e MESH_URL -- bun run dev",
+    "link": "deco link -p 3000 -e BASE_URL -- bun run dev",
     "dev": "bun run --env-file=.env --cwd=apps/mesh dev",
     "fmt": "biome format --write",
     "lint": "oxlint",


### PR DESCRIPTION
## What is this contribution about?

Removes the redundant `MESH_URL` environment variable from the server-side codebase. `ctx.baseUrl` (derived from `BASE_URL`) already resolves correctly in both request and background (event bus) contexts, making `MESH_URL` unnecessary and a source of confusion during debugging.

Changes:
- `apps/mesh/src/mcp-clients/outbound/headers.ts` — Use `ctx.baseUrl` directly instead of `process.env.MESH_URL ?? ctx.baseUrl`
- `package.json` — Update `link` script from `-e MESH_URL` to `-e BASE_URL`

Note: `MESH_URL` in `packages/runtime/` (`DefaultEnv`) is a **client-side** env var for downstream MCPs — a different concept, intentionally unchanged.

## Screenshots/Demonstration

N/A — no UI changes.

## How to Test

1. Verify `ctx.baseUrl` resolution: in `apps/mesh/src/core/context-factory.ts`, confirm `getBaseUrl()` returns `BASE_URL ?? http://localhost:PORT`
2. Run `bun test` — all relevant tests pass (878 pass, 1 pre-existing Playwright failure unrelated to this change)
3. Run `bun run check:ci` — type checking passes across all workspaces
4. In production, `BASE_URL=https://studio.decocms.com` is set, so behavior is identical to before

## Migration Notes

If you previously relied on `MESH_URL` in your environment, use `BASE_URL` instead. In production this is already set.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the server-side MESH_URL env var and now always use ctx.baseUrl (from BASE_URL). This simplifies config and avoids mismatches between request and background contexts; no behavior change in prod.

- **Refactors**
  - Set metadata.meshUrl = ctx.baseUrl in outbound headers.
  - Update link script to pass BASE_URL instead of MESH_URL.

- **Migration**
  - If you set MESH_URL, switch to BASE_URL. Production already uses BASE_URL.

<sup>Written for commit da5a721afe15e27c0b567ddb166dd9b690446425. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

