### PR TITLE
fix(event-bus): add diagnostic logging for auth flow in event delivery

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -527,6 +527,13 @@ async function authenticateRequest(
       );
 
       if (meshJwtPayload) {
+        console.log("[EventBus:Debug] mesh JWT verified", {
+          sub: meshJwtPayload.sub?.slice(0, 8) ?? "NONE",
+          organizationId: meshJwtPayload.metadata?.organizationId ?? "NONE",
+          connectionId: meshJwtPayload.metadata?.connectionId ?? "NONE",
+          permissionKeys: Object.keys(meshJwtPayload.permissions ?? {}),
+        });
+
         // Look up user's organization role for admin/owner bypass
         let role: string | undefined;
         const organizationId = meshJwtPayload.metadata?.organizationId;
@@ -542,6 +549,16 @@ async function authenticateRequest(
                 .executeTakeFirst(),
           );
           role = membership?.role;
+
+          console.log("[EventBus:Debug] JWT membership result", {
+            organizationId,
+            role: role ?? "NO_ROLE",
+          });
+        } else {
+          console.log("[EventBus:Debug] JWT membership SKIPPED", {
+            hasSub: !!meshJwtPayload.sub,
+            hasOrgId: !!organizationId,
+          });
         }
 
         return {

--- a/apps/mesh/src/event-bus/notify.ts
+++ b/apps/mesh/src/event-bus/notify.ts
@@ -112,8 +112,23 @@ export function createNotifySubscriber(): NotifySubscriberFn {
       // Standard path: deliver via MCP proxy ON_EVENTS
       const ctx = await ContextFactory.create();
 
+      console.log("[EventBus:Debug] notify context created", {
+        hasUser: !!ctx.auth.user,
+        userId: ctx.auth.user?.id ?? "NONE",
+        hasOrg: !!ctx.organization,
+        orgId: ctx.organization?.id ?? "NONE",
+        connectionId,
+        eventCount: events.length,
+        eventTypes: events.map((e) => e.type),
+      });
+
       // Create MCP proxy for the subscriber connection
       const proxy = await dangerouslyCreateSuperUserMCPProxy(connectionId, ctx);
+
+      console.log("[EventBus:Debug] proxy created for subscriber", {
+        connectionId,
+        orgIdAfterProxy: ctx.organization?.id ?? "NONE",
+      });
 
       // Use the Event Subscriber binding - pass the whole proxy object
       // Same pattern as LanguageModelBinding.forClient(proxy) in models.ts

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -38,6 +38,18 @@ export async function buildRequestHeaders(
     connection.configuration_scopes,
   );
 
+  console.log("[EventBus:Debug] buildRequestHeaders", {
+    connectionId,
+    superUser,
+    ctxUserId: ctx.auth.user?.id?.slice(0, 8) ?? "NONE",
+    orgId: ctx.organization?.id ?? "NONE",
+    createdBy: connection.created_by?.slice(0, 8) ?? "NONE",
+    permissionKeys: Object.keys(permissions),
+    permissionDetail: Object.entries(permissions).map(
+      ([k, v]) => `${k}:[${v.join(",")}]`,
+    ),
+  });
+
   const userId =
     ctx.auth.user?.id ??
     ctx.auth.apiKey?.userId ??
@@ -66,6 +78,14 @@ export async function buildRequestHeaders(
         .catch((error) => [null, error] as const)
     : [null, new Error("User ID required to issue configuration token")];
 
+  console.log("[EventBus:Debug] token issued", {
+    connectionId,
+    hasToken: !!configurationToken,
+    error: error instanceof Error ? error.message : undefined,
+    userId: userId?.slice(0, 8) ?? "NONE",
+    orgInMetadata: ctx.organization?.id ?? "NONE",
+  });
+
   if (error) {
     console.error("Failed to issue configuration token:", configurationToken);
   }
@@ -83,6 +103,14 @@ export async function buildRequestHeaders(
 
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
   const cachedToken = await tokenStorage.get(connectionId);
+
+  console.log("[EventBus:Debug] downstream token", {
+    connectionId,
+    hasCachedToken: !!cachedToken,
+    hasRefresh: !!cachedToken?.refreshToken,
+    expiresAt: cachedToken?.expiresAt ?? "NONE",
+    hasConnectionToken: !!connection.connection_token,
+  });
 
   if (cachedToken) {
     const canRefresh =

--- a/apps/mesh/src/mcp-clients/outbound/index.ts
+++ b/apps/mesh/src/mcp-clients/outbound/index.ts
@@ -102,6 +102,13 @@ export async function createOutboundClient(
 
       const headers = await buildRequestHeaders(connection, ctx, superUser);
 
+      console.log("[EventBus:Debug] outbound HTTP client", {
+        connectionId,
+        url: connection.connection_url,
+        superUser,
+        headerKeys: Object.keys(headers),
+      });
+
       const httpParams = connection.connection_headers;
       if (httpParams && "headers" in httpParams) {
         Object.assign(headers, httpParams.headers);

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -114,6 +114,14 @@ export const proxyConnectionForId = (
     headers["x-mesh-token"] = ctx.token;
   }
 
+  console.log("[EventBus:Debug] proxyConnectionForId", {
+    connectionId,
+    meshUrl: ctx.meshUrl,
+    hasToken: !!ctx.token,
+    tokenPreview: ctx.token?.slice(0, 20) ?? "NONE",
+    targetUrl: new URL(`/mcp/${connectionId}`, ctx.meshUrl).href,
+  });
+
   return {
     type: "HTTP",
     url: new URL(`/mcp/${connectionId}`, ctx.meshUrl).href,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -203,6 +203,14 @@ export const withBindings = <TEnv>({
         (decoded.organizationId as string) ?? metadata.organizationId,
       ensureAuthenticated: AUTHENTICATED(decoded.user ?? decoded.sub),
     } as RequestContext<any>;
+
+    console.log("[EventBus:Debug] withBindings decoded", {
+      meshUrl: context.meshUrl ?? "NONE",
+      connectionId: context.connectionId ?? "NONE",
+      organizationId: context.organizationId ?? "NONE",
+      stateKeys: context.state ? Object.keys(context.state as object) : [],
+      hasAuth: !!context.authorization,
+    });
   } else if (typeof tokenOrContext === "object") {
     context = tokenOrContext;
     const decoded = decodeJwt(tokenOrContext.token);


### PR DESCRIPTION
## Summary

- Adds 11 targeted `[EventBus:Debug]` diagnostic logs across the event bus → binding auth chain to diagnose "Streamable HTTP error" failures during async event delivery
- Logs trace org context, JWT permissions, membership lookups, and downstream token state at each hop — no full secrets are exposed (tokens truncated to 8-20 chars)
- Covers 6 files: `notify.ts`, `headers.ts`, `outbound/index.ts`, `runtime/index.ts`, `runtime/bindings.ts`, `context-factory.ts`

### What to look for in logs
- `orgId: "NONE"` anywhere → org context is lost in the chain
- `permissionKeys` missing the BigQuery connection ID → JWT permissions don't grant access
- `downstream token` expired with no refresh → OAuth token is dead
- `JWT membership SKIPPED` → second-hop auth has no role, which may block access

## Test plan

- [ ] Deploy and trigger the event bus flow (publish event → subscriber handles → subscriber calls BigQuery binding)
- [ ] Filter logs with `grep "EventBus:Debug"` and verify the expected log sequence appears
- [ ] Confirm the logs reveal which of the three suspects (orgId, permissions, or OAuth token) causes the failure
- [ ] Remove diagnostic logs after root cause is identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds focused [EventBus:Debug] logs to the event-bus → bindings auth chain to diagnose "Streamable HTTP error" during async event delivery. Traces org context, permission keys, membership results, token issuance/refresh state, and outbound header keys (tokens truncated; no secrets).

<sup>Written for commit 0f1645a1f4d71e1e5b3fe5d2a65e697e535f8616. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

