### PR TITLE
revert(event-bus): remove diagnostic logging from auth flow

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -527,13 +527,6 @@ async function authenticateRequest(
       );
 
       if (meshJwtPayload) {
-        console.log("[EventBus:Debug] mesh JWT verified", {
-          sub: meshJwtPayload.sub?.slice(0, 8) ?? "NONE",
-          organizationId: meshJwtPayload.metadata?.organizationId ?? "NONE",
-          connectionId: meshJwtPayload.metadata?.connectionId ?? "NONE",
-          permissionKeys: Object.keys(meshJwtPayload.permissions ?? {}),
-        });
-
         // Look up user's organization role for admin/owner bypass
         let role: string | undefined;
         const organizationId = meshJwtPayload.metadata?.organizationId;
@@ -549,16 +542,6 @@ async function authenticateRequest(
                 .executeTakeFirst(),
           );
           role = membership?.role;
-
-          console.log("[EventBus:Debug] JWT membership result", {
-            organizationId,
-            role: role ?? "NO_ROLE",
-          });
-        } else {
-          console.log("[EventBus:Debug] JWT membership SKIPPED", {
-            hasSub: !!meshJwtPayload.sub,
-            hasOrgId: !!organizationId,
-          });
         }
 
         return {

--- a/apps/mesh/src/event-bus/notify.ts
+++ b/apps/mesh/src/event-bus/notify.ts
@@ -112,23 +112,8 @@ export function createNotifySubscriber(): NotifySubscriberFn {
       // Standard path: deliver via MCP proxy ON_EVENTS
       const ctx = await ContextFactory.create();
 
-      console.log("[EventBus:Debug] notify context created", {
-        hasUser: !!ctx.auth.user,
-        userId: ctx.auth.user?.id ?? "NONE",
-        hasOrg: !!ctx.organization,
-        orgId: ctx.organization?.id ?? "NONE",
-        connectionId,
-        eventCount: events.length,
-        eventTypes: events.map((e) => e.type),
-      });
-
       // Create MCP proxy for the subscriber connection
       const proxy = await dangerouslyCreateSuperUserMCPProxy(connectionId, ctx);
-
-      console.log("[EventBus:Debug] proxy created for subscriber", {
-        connectionId,
-        orgIdAfterProxy: ctx.organization?.id ?? "NONE",
-      });
 
       // Use the Event Subscriber binding - pass the whole proxy object
       // Same pattern as LanguageModelBinding.forClient(proxy) in models.ts

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -38,18 +38,6 @@ export async function buildRequestHeaders(
     connection.configuration_scopes,
   );
 
-  console.log("[EventBus:Debug] buildRequestHeaders", {
-    connectionId,
-    superUser,
-    ctxUserId: ctx.auth.user?.id?.slice(0, 8) ?? "NONE",
-    orgId: ctx.organization?.id ?? "NONE",
-    createdBy: connection.created_by?.slice(0, 8) ?? "NONE",
-    permissionKeys: Object.keys(permissions),
-    permissionDetail: Object.entries(permissions).map(
-      ([k, v]) => `${k}:[${v.join(",")}]`,
-    ),
-  });
-
   const userId =
     ctx.auth.user?.id ??
     ctx.auth.apiKey?.userId ??
@@ -78,14 +66,6 @@ export async function buildRequestHeaders(
         .catch((error) => [null, error] as const)
     : [null, new Error("User ID required to issue configuration token")];
 
-  console.log("[EventBus:Debug] token issued", {
-    connectionId,
-    hasToken: !!configurationToken,
-    error: error instanceof Error ? error.message : undefined,
-    userId: userId?.slice(0, 8) ?? "NONE",
-    orgInMetadata: ctx.organization?.id ?? "NONE",
-  });
-
   if (error) {
     console.error("Failed to issue configuration token:", configurationToken);
   }
@@ -103,14 +83,6 @@ export async function buildRequestHeaders(
 
   const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
   const cachedToken = await tokenStorage.get(connectionId);
-
-  console.log("[EventBus:Debug] downstream token", {
-    connectionId,
-    hasCachedToken: !!cachedToken,
-    hasRefresh: !!cachedToken?.refreshToken,
-    expiresAt: cachedToken?.expiresAt ?? "NONE",
-    hasConnectionToken: !!connection.connection_token,
-  });
 
   if (cachedToken) {
     const canRefresh =

--- a/apps/mesh/src/mcp-clients/outbound/index.ts
+++ b/apps/mesh/src/mcp-clients/outbound/index.ts
@@ -102,13 +102,6 @@ export async function createOutboundClient(
 
       const headers = await buildRequestHeaders(connection, ctx, superUser);
 
-      console.log("[EventBus:Debug] outbound HTTP client", {
-        connectionId,
-        url: connection.connection_url,
-        superUser,
-        headerKeys: Object.keys(headers),
-      });
-
       const httpParams = connection.connection_headers;
       if (httpParams && "headers" in httpParams) {
         Object.assign(headers, httpParams.headers);

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -114,14 +114,6 @@ export const proxyConnectionForId = (
     headers["x-mesh-token"] = ctx.token;
   }
 
-  console.log("[EventBus:Debug] proxyConnectionForId", {
-    connectionId,
-    meshUrl: ctx.meshUrl,
-    hasToken: !!ctx.token,
-    tokenPreview: ctx.token?.slice(0, 20) ?? "NONE",
-    targetUrl: new URL(`/mcp/${connectionId}`, ctx.meshUrl).href,
-  });
-
   return {
     type: "HTTP",
     url: new URL(`/mcp/${connectionId}`, ctx.meshUrl).href,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -203,14 +203,6 @@ export const withBindings = <TEnv>({
         (decoded.organizationId as string) ?? metadata.organizationId,
       ensureAuthenticated: AUTHENTICATED(decoded.user ?? decoded.sub),
     } as RequestContext<any>;
-
-    console.log("[EventBus:Debug] withBindings decoded", {
-      meshUrl: context.meshUrl ?? "NONE",
-      connectionId: context.connectionId ?? "NONE",
-      organizationId: context.organizationId ?? "NONE",
-      stateKeys: context.state ? Object.keys(context.state as object) : [],
-      hasAuth: !!context.authorization,
-    });
   } else if (typeof tokenOrContext === "object") {
     context = tokenOrContext;
     const decoded = decodeJwt(tokenOrContext.token);


### PR DESCRIPTION
## Summary

Reverts the temporary diagnostic logs added in #2523 (`[EventBus:Debug]` prefix).

Root cause was identified: the BigQuery connection (`conn_rG6PPE7g4a3ki-CnG_PPo`) has no stored downstream credential (`hasCachedToken: false`, `hasConnectionToken: false`), so the outbound call goes out without an `Authorization` header and gets a 401. The org context and JWT permissions were fine all along.

These logs served their purpose and should not remain in production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert the temporary [EventBus:Debug] logs added to the event bus auth and delivery paths. The 401s were due to a downstream connection without a stored token; cleanup only with no behavior change.

<sup>Written for commit 75e43bda3580654d5487f47eaab9b655bb9d3dde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

