### PR TITLE
add support to claude worktress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ studio-demo/
 
 # Git worktrees
 .worktrees
+.claude/worktrees
 
 # Playwright
 apps/mesh/test-results/


### PR DESCRIPTION
Support claude --worktree command

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .claude/worktrees to .gitignore to support the claude --worktree command and prevent committing generated worktree files.

<sup>Written for commit 7dbdb67f0a3bebfe2ab6b873d740783704be724e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

