### PR TITLE
feat: auto-copy .env to new claude worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'set -e; NAME=$(jq -r .name); CWD=$(jq -r .cwd); DIR=\"$CWD/.claude/worktrees/$NAME\"; BRANCH=\"claude/$NAME\"; git -C \"$CWD\" worktree add -b \"$BRANCH\" \"$DIR\" HEAD >&2; cp \"$CWD/.env\" \"$DIR/.env\" 2>/dev/null >&2 || true; echo \"$DIR\"'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `WorktreeCreate` hook in `.claude/settings.json` that automatically copies `.env` from the main repo into newly created worktrees, so dev servers work immediately without manual setup.

## Test plan
- [ ] Create a new worktree with Claude Code and verify `.env` is copied
- [ ] Verify worktree creation still works when no `.env` exists in the main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically copies the root .env into new Claude Code worktrees so dev servers run without manual setup. Implemented via a WorktreeCreate hook in .claude/settings.json.

- **New Features**
  - Adds a WorktreeCreate hook that creates a claude/<name> worktree and copies .env into the new dir.
  - No-op if .env is missing, so worktree creation never fails.

<sup>Written for commit c9f74a627409d3bc210861b91c27bdd138aab999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

