### PR TITLE
fix(auth): add 127.0.0.1 as trusted origin for Better Auth

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -312,9 +312,25 @@ const database = getDbDialect(databaseUrl);
 /**
  * Better Auth instance with MCP, API Key, and Admin plugins
  */
+const baseUrl = getBaseUrl();
+
+// Build trusted origins: include both localhost and 127.0.0.1 variants
+function getTrustedOrigins(): string[] {
+  const origins = [baseUrl];
+  const url = new URL(baseUrl);
+  if (url.hostname === "localhost") {
+    origins.push(baseUrl.replace("localhost", "127.0.0.1"));
+  } else if (url.hostname === "127.0.0.1") {
+    origins.push(baseUrl.replace("127.0.0.1", "localhost"));
+  }
+  return origins;
+}
+
 export const auth = betterAuth({
   // Base URL for OAuth - will be overridden by request context
-  baseURL: getBaseUrl(),
+  baseURL: baseUrl,
+
+  trustedOrigins: getTrustedOrigins(),
 
   // Better Auth can use the dialect directly
   database,


### PR DESCRIPTION
## Summary
- Adds `trustedOrigins` to Better Auth config so both `localhost` and `127.0.0.1` are accepted
- Automatically mirrors whichever hostname is in `baseURL` to include the other variant
- Fixes "invalid origin" error when accessing the app via `http://127.0.0.1:3000`

## Test plan
- [ ] Access the app via `http://127.0.0.1:3000` and verify auth works without "invalid origin" errors
- [ ] Access via `http://localhost:3000` and confirm it still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trustedOrigins to Better Auth and mirrors baseURL so both localhost and 127.0.0.1 are accepted. Fixes "invalid origin" errors when opening the app via 127.0.0.1.

- **Bug Fixes**
  - Compute trustedOrigins from baseURL to include both localhost and 127.0.0.1.
  - Prevent errors on http://127.0.0.1:3000 while keeping http://localhost:3000 working.

<sup>Written for commit bd25ad66e76d7e66a6a7e8db998d4678858614c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

