### PR TITLE
fix(worktree): fix stdin consumption in WorktreeCreate hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/setup-worktree.sh"
+            "command": "sh .claude/setup-worktree.sh"
           }
         ]
       }

--- a/.claude/setup-worktree.sh
+++ b/.claude/setup-worktree.sh
@@ -1,13 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # WorktreeCreate hook script
-# Reads JSON from stdin: { "name": "<worktree-name>", "cwd": "<repo-root>" }
+# Reads JSON from stdin: { "name": "...", "cwd": "..." }
 # Must print the new worktree directory path as the last line of stdout.
 # All other output must go to stderr (>&2).
 
-NAME=$(jq -r .name)
-CWD=$(jq -r .cwd)
+# Read stdin once into a variable (stdin can only be consumed once)
+INPUT=$(cat)
+
+NAME=$(echo "$INPUT" | jq -r .name)
+CWD=$(echo "$INPUT" | jq -r .cwd)
 DIR="$CWD/.claude/worktrees/$NAME"
 BRANCH="claude/$NAME"
 


### PR DESCRIPTION
## Summary
- Fix WorktreeCreate hook script that called `jq` twice on stdin — stdin can only be consumed once, so the second call (`jq -r .cwd`) received empty input, breaking worktree creation
- Buffer stdin into a variable with `INPUT=$(cat)` and pipe it to each `jq` call
- Switch from `bash` to `sh` for broader compatibility

## Test plan
- [ ] Run `claude --worktree` and verify a worktree is created successfully
- [ ] Verify `bun install` runs in the new worktree
- [ ] Verify `.env` is copied to the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the WorktreeCreate hook by reading stdin once and piping the buffered input to jq, restoring worktree creation. Also switches the script and settings to use sh for broader compatibility.

- **Bug Fixes**
  - Buffer stdin with INPUT=$(cat) and pipe to jq for name and cwd.
  - Update settings to run sh .claude/setup-worktree.sh instead of bash.

<sup>Written for commit f03258dd49f4814dd2bdbde1e31a60817a51925a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

