### PR TITLE
feat(model-selector): tier categories, shortlist management, and rich cost details

### DIFF
--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -536,7 +536,13 @@ function ModelAutoSelector({
       ? models
       : models.filter((m) => isModelAllowed(firstConnection.id, m.id));
 
-    const first = allowedModels[0];
+    // Prefer Claude Opus 4.6 as default, fall back to Sonnet 4.6, then any
+    const preferred =
+      allowedModels.find((m) => m.id.includes("claude-4.6-opus")) ??
+      allowedModels.find((m) => m.id.includes("claude-opus-4.6")) ??
+      allowedModels.find((m) => m.id.includes("claude-sonnet-4.6")) ??
+      allowedModels.find((m) => m.id.includes("claude-sonnet"));
+    const first = preferred ?? allowedModels[0];
     if (!first) return;
     onAutoSelect({
       id: first.id,

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -1,10 +1,12 @@
 import { Button } from "@deco/ui/components/button.tsx";
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@deco/ui/components/dialog.tsx";
 import {
   Select,
   SelectContent,
@@ -16,6 +18,7 @@ import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   AlertTriangle,
+  ArrowLeft,
   ChevronDown,
   ChevronSelectorVertical,
   CurrencyDollar,
@@ -40,66 +43,258 @@ import {
 import { useAllowedModels } from "../../hooks/use-allowed-models";
 import { ErrorBoundary } from "../error-boundary";
 
-// Prioritized models in order
-const prioritizedModelIds = [
-  "x-ai/grok-code-fast-1",
-  "anthropic/claude-sonnet-4.5",
-  "google/gemini-2.5-flash",
-  "xiaomi/mimo-v2-flash:free",
-  "google/gemini-3-flash-preview",
-  "deepseek/deepseek-v3.2",
-  "anthropic/claude-opus-4.5",
-  "x-ai/grok-4.1-fast",
-  "google/gemini-2.5-flash-lite",
-  "google/gemini-2.0-flash-001",
+// ============================================================================
+// Tier Classification System
+// ============================================================================
+
+const TIER_IDS = ["smarter", "faster", "cheaper"] as const;
+type TierId = (typeof TIER_IDS)[number];
+
+const TIER_LABELS: Record<TierId, string> = {
+  smarter: "Smarter",
+  faster: "Faster",
+  cheaper: "Cheaper",
+};
+
+const TIER_PATTERNS: Array<{ tier: TierId; prefixes: string[] }> = [
+  {
+    tier: "smarter",
+    prefixes: [
+      "anthropic/claude-4.6-opus",
+      "anthropic/claude-opus-4.6",
+      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-4.6-sonnet",
+      "openai/gpt-5.3-codex",
+      "google/gemini-3-pro",
+      "google/gemini-2.5-pro",
+      "cohere/command-r-plus",
+      "cohere/command-a",
+    ],
+  },
+  {
+    tier: "faster",
+    prefixes: [
+      "anthropic/claude-haiku-4.5",
+      "anthropic/claude-4.5-haiku",
+      "google/gemini-3-flash",
+      "openai/gpt-5.1-codex-mini",
+      "x-ai/grok-code-fast",
+      "x-ai/grok-3",
+      "mistralai/mistral-large",
+      "mistralai/codestral",
+      "mistralai/mistral-medium",
+      "qwen/qwen-plus",
+      "qwen/qwen-turbo",
+      "qwen/qwen3-235b",
+      "minimax/minimax-m1",
+    ],
+  },
+  {
+    tier: "cheaper",
+    prefixes: [
+      "google/gemini-2.5-flash-lite",
+      "google/gemini-2.5-flash",
+      "google/gemini-2.0-flash",
+      "deepseek/deepseek-v3",
+      "openai/gpt-oss-120b",
+      "mistralai/mistral-small",
+      "mistralai/pixtral",
+      "qwen/qwen-long",
+      "cohere/command-r",
+    ],
+  },
 ];
 
-// Create a map for quick priority lookup
-const priorityMap = new Map<string, number>();
-prioritizedModelIds.forEach((modelId, index) => {
-  priorityMap.set(modelId, index);
-});
+const FREE_SUFFIX = ":free";
 
-/**
- * Hook to fetch LLM models from a specific connection.
- * Returns filtered and sorted models.
- */
+const SORTED_TIER_RULES = TIER_PATTERNS.flatMap(({ tier, prefixes }) =>
+  prefixes.map((prefix) => ({ tier, prefix })),
+).sort((a, b) => b.prefix.length - a.prefix.length);
+
+// Some prefixes should only match exactly (no sub-variants)
+// e.g. "google/gemini-2.5-pro" should NOT match "google/gemini-2.5-pro-preview-05-06"
+const EXACT_ONLY_PREFIXES = new Set(["google/gemini-2.5-pro"]);
+
+function classifyModel(modelId: string): TierId | null {
+  if (modelId.endsWith(FREE_SUFFIX)) return "cheaper";
+  for (const { tier, prefix } of SORTED_TIER_RULES) {
+    if (modelId.startsWith(prefix)) {
+      // For exact-only prefixes, the rest must be empty or start with a non-alpha char (date suffixes ok)
+      if (EXACT_ONLY_PREFIXES.has(prefix) && modelId.length > prefix.length) {
+        const nextChar = modelId[prefix.length];
+        if (nextChar === "-") continue; // skip sub-variants like -preview
+      }
+      return tier;
+    }
+  }
+  return null;
+}
+
+const DEFAULT_SHORTLIST = [
+  // Smarter
+  "anthropic/claude-4.6-opus-20260205",
+  "anthropic/claude-opus-4.6",
+  "anthropic/claude-sonnet-4.6",
+  "anthropic/claude-4.6-sonnet",
+  "anthropic/claude-sonnet-4.6:extended",
+  "openai/gpt-5.3-codex",
+  "google/gemini-3-pro-preview",
+  "google/gemini-2.5-pro",
+  // Faster
+  "anthropic/claude-haiku-4.5",
+  "anthropic/claude-haiku-4.5-20251001",
+  "anthropic/claude-4.5-haiku",
+  "google/gemini-3-flash-preview",
+  "openai/gpt-5.1-codex-mini",
+  "x-ai/grok-code-fast-1",
+  // Cheaper
+  "google/gemini-2.5-flash",
+  "deepseek/deepseek-v3.2",
+  "google/gemini-2.5-flash-lite",
+  "openai/gpt-oss-120b:free",
+];
+const defaultShortlistSet = new Set(DEFAULT_SHORTLIST);
+
+const priorityMap = new Map<string, number>();
+DEFAULT_SHORTLIST.forEach((id, i) => priorityMap.set(id, i));
+
+// ============================================================================
+// localStorage Shortlist Helpers
+// ============================================================================
+
+const SHORTLIST_KEY_PREFIX = "mesh:model-shortlist:";
+
+function getShortlist(connectionId: string): string[] | null {
+  try {
+    const raw = localStorage.getItem(SHORTLIST_KEY_PREFIX + connectionId);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setShortlist(connectionId: string, ids: string[]) {
+  localStorage.setItem(
+    SHORTLIST_KEY_PREFIX + connectionId,
+    JSON.stringify(ids),
+  );
+}
+
+// ============================================================================
+// Model Stats (percentile computation)
+// ============================================================================
+
+interface ModelStats {
+  inputCosts: number[];
+  outputCosts: number[];
+  contextWindows: number[];
+}
+
+function computeModelStats(models: LLM[]): ModelStats {
+  const inputCosts = models
+    .map((m) => m.costs?.input)
+    .filter((c): c is number => c != null && c > 0)
+    .map((c) => c * 1_000_000)
+    .sort((a, b) => a - b);
+
+  const outputCosts = models
+    .map((m) => m.costs?.output)
+    .filter((c): c is number => c != null && c > 0)
+    .map((c) => c * 1_000_000)
+    .sort((a, b) => a - b);
+
+  const contextWindows = models
+    .map((m) => m.limits?.contextWindow)
+    .filter((c): c is number => c != null && c > 0)
+    .sort((a, b) => a - b);
+
+  return { inputCosts, outputCosts, contextWindows };
+}
+
+function getPercentile(sortedValues: number[], value: number): number {
+  if (sortedValues.length === 0) return 50;
+  let count = 0;
+  for (const v of sortedValues) {
+    if (v < value) count++;
+    else break;
+  }
+  return Math.round((count / sortedValues.length) * 100);
+}
+
+function getCostColor(percentile: number): string {
+  if (percentile <= 15) return "var(--color-green-600)";
+  if (percentile <= 35) return "var(--color-green-500)";
+  if (percentile <= 65) return "var(--color-amber-500)";
+  if (percentile <= 85) return "var(--color-orange-500)";
+  return "var(--color-red-500)";
+}
+
+function getCostTag(
+  percentile: number,
+): { label: string; color: string } | null {
+  if (percentile <= 10)
+    return { label: "Bottom 10%", color: "var(--color-green-600)" };
+  if (percentile <= 25)
+    return { label: "Budget", color: "var(--color-green-500)" };
+  if (percentile >= 95)
+    return { label: "Top 5%", color: "var(--color-red-500)" };
+  if (percentile >= 90)
+    return { label: "Top 10%", color: "var(--color-red-500)" };
+  if (percentile >= 75)
+    return { label: "Premium", color: "var(--color-orange-500)" };
+  return null;
+}
+
+function getContextSizeLabel(tokens: number): { label: string; color: string } {
+  if (tokens < 32_000)
+    return { label: "Small", color: "var(--color-amber-500)" };
+  if (tokens < 200_000)
+    return { label: "Medium", color: "var(--color-blue-500)" };
+  if (tokens < 1_000_000)
+    return { label: "Large", color: "var(--color-green-500)" };
+  return { label: "XL", color: "var(--color-green-600)" };
+}
+
+function getOutputSizeLabel(tokens: number): { label: string; color: string } {
+  if (tokens < 8_000)
+    return { label: "Small", color: "var(--color-amber-500)" };
+  if (tokens < 32_000)
+    return { label: "Medium", color: "var(--color-blue-500)" };
+  if (tokens < 128_000)
+    return { label: "Large", color: "var(--color-green-500)" };
+  return { label: "XL", color: "var(--color-green-600)" };
+}
+
+// ============================================================================
+// useModels Hook
+// ============================================================================
+
 export function useModels(connectionId: string | undefined): LLM[] {
-  // Fetch models from the connection using the collection hook
   const models = useLLMsFromConnection(connectionId ?? undefined, {
     pageSize: 999,
   });
 
-  // Filter models that have required limits
   const filteredModels = models.filter(
     (m) => m.limits?.contextWindow && m.limits?.maxOutputTokens,
   );
 
-  // Sort models
   return filteredModels.sort((a, b) => {
-    // First, check if either model is prioritized
     const aPriority = priorityMap.get(a.id);
     const bPriority = priorityMap.get(b.id);
-
-    // If both are prioritized, sort by priority order
-    if (aPriority !== undefined && bPriority !== undefined) {
+    if (aPriority !== undefined && bPriority !== undefined)
       return aPriority - bPriority;
-    }
-
-    // If only one is prioritized, it comes first
     if (aPriority !== undefined) return -1;
     if (bPriority !== undefined) return 1;
-
-    // If neither is prioritized, sort alphabetically
     return a.title.localeCompare(b.title);
   });
 }
 
+// ============================================================================
+// UI Components
+// ============================================================================
+
 const CAPABILITY_CONFIGS: Record<string, { icon: ReactNode; label: string }> = {
-  reasoning: {
-    icon: <Stars01 className="size-4" />,
-    label: "Reasoning",
-  },
+  reasoning: { icon: <Stars01 className="size-4" />, label: "Reasoning" },
   "image-upload": {
     icon: <Image01 className="size-4" />,
     label: "Can analyze images",
@@ -117,12 +312,7 @@ const CAPABILITY_CONFIGS: Record<string, { icon: ReactNode; label: string }> = {
 function CapabilityBadge({ capability }: { capability: string }) {
   const config = (() => {
     const knownConfig = CAPABILITY_CONFIGS[capability];
-    return (
-      knownConfig || {
-        icon: null,
-        label: capability,
-      }
-    );
+    return knownConfig || { icon: null, label: capability };
   })();
 
   const displayLabel = config.label
@@ -146,11 +336,27 @@ function CapabilityBadge({ capability }: { capability: string }) {
   );
 }
 
+function CostBadge({ label, color }: { label: string; color: string }) {
+  return (
+    <span
+      className="text-[10px] font-medium px-1.5 py-0.5 rounded-full ml-1.5 whitespace-nowrap"
+      style={{
+        backgroundColor: `color-mix(in oklch, ${color} 12%, transparent)`,
+        color,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
 function ModelDetailsPanel({
   model,
+  stats,
   compact = false,
 }: {
   model: LLM | null;
+  stats?: ModelStats | null;
   compact?: boolean;
 }) {
   if (!model) {
@@ -161,7 +367,6 @@ function ModelDetailsPanel({
     );
   }
 
-  // Check if model has extended info (contextWindow, costs, etc)
   const hasDetails =
     model.limits?.contextWindow ||
     model.costs?.input ||
@@ -184,11 +389,38 @@ function ModelDetailsPanel({
     );
   }
 
-  if (!hasDetails && compact) {
-    return null;
-  }
+  if (!hasDetails && compact) return null;
 
-  // Compact mobile version - just the details without header
+  const inputCostPerM =
+    model.costs?.input != null ? model.costs.input * 1_000_000 : null;
+  const outputCostPerM =
+    model.costs?.output != null ? model.costs.output * 1_000_000 : null;
+  const inputPercentile =
+    inputCostPerM != null && stats
+      ? getPercentile(stats.inputCosts, inputCostPerM)
+      : null;
+  const outputPercentile =
+    outputCostPerM != null && stats
+      ? getPercentile(stats.outputCosts, outputCostPerM)
+      : null;
+  const inputTag = inputPercentile != null ? getCostTag(inputPercentile) : null;
+  const outputTag =
+    outputPercentile != null ? getCostTag(outputPercentile) : null;
+  const inputColor =
+    inputPercentile != null
+      ? getCostColor(inputPercentile)
+      : "var(--muted-foreground)";
+  const outputColor =
+    outputPercentile != null
+      ? getCostColor(outputPercentile)
+      : "var(--muted-foreground)";
+  const contextSize = model.limits?.contextWindow
+    ? getContextSizeLabel(model.limits.contextWindow)
+    : null;
+  const outputSize = model.limits?.maxOutputTokens
+    ? getOutputSizeLabel(model.limits.maxOutputTokens)
+    : null;
+
   if (compact) {
     return (
       <div className="flex flex-col gap-2.5 pt-3 pb-3 px-3 rounded-b-lg text-xs">
@@ -197,33 +429,45 @@ function ModelDetailsPanel({
             <span className="text-muted-foreground">Context</span>
             <span className="text-foreground font-medium">
               {model.limits.contextWindow.toLocaleString()} tokens
+              {contextSize && (
+                <CostBadge
+                  label={contextSize.label}
+                  color={contextSize.color}
+                />
+              )}
             </span>
           </div>
         )}
-
-        {model.costs?.input && (
+        {inputCostPerM != null && (
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">Input cost</span>
-            <span className="text-foreground font-medium">
-              ${(model.costs.input * 1_000_000).toFixed(2)} / 1M
+            <span className="font-medium" style={{ color: inputColor }}>
+              ${inputCostPerM.toFixed(2)} / 1M
+              {inputTag && (
+                <CostBadge label={inputTag.label} color={inputTag.color} />
+              )}
             </span>
           </div>
         )}
-
-        {model.costs?.output && (
+        {outputCostPerM != null && (
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">Output cost</span>
-            <span className="text-foreground font-medium">
-              ${(model.costs.output * 1_000_000).toFixed(2)} / 1M
+            <span className="font-medium" style={{ color: outputColor }}>
+              ${outputCostPerM.toFixed(2)} / 1M
+              {outputTag && (
+                <CostBadge label={outputTag.label} color={outputTag.color} />
+              )}
             </span>
           </div>
         )}
-
         {model.limits?.maxOutputTokens && (
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground">Output limit</span>
             <span className="text-foreground font-medium">
               {model.limits.maxOutputTokens.toLocaleString()} tokens
+              {outputSize && (
+                <CostBadge label={outputSize.label} color={outputSize.color} />
+              )}
             </span>
           </div>
         )}
@@ -231,22 +475,31 @@ function ModelDetailsPanel({
     );
   }
 
-  // Full desktop version with header
   return (
     <div className="flex flex-col gap-3 py-1 px-1.5">
       <div className="flex flex-col gap-3 py-2 px-0">
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex items-center gap-3 min-w-0 pr-6">
           {model.logo && (
             <img
               src={model.logo}
-              className="w-6 h-6 shrink-0"
+              className="w-7 h-7 shrink-0"
               alt={model.title}
             />
           )}
-          <p className="text-lg font-medium leading-7 wrap-break-word min-w-0">
-            {model.title}
-          </p>
+          <div className="flex flex-col min-w-0">
+            <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wide">
+              {model.title.includes(": ")
+                ? model.title.split(": ")[0]
+                : (model.provider ?? model.id.split("/")[0])}
+            </span>
+            <p className="text-base font-semibold leading-snug truncate">
+              {model.title.includes(": ")
+                ? model.title.split(": ").slice(1).join(": ")
+                : model.title}
+            </p>
+          </div>
         </div>
+        <p className="text-xs text-muted-foreground/60 font-mono">{model.id}</p>
         {model.capabilities && model.capabilities.length > 0 && (
           <div className="flex items-center gap-2">
             {model.capabilities.map((capability) => (
@@ -262,6 +515,12 @@ function ModelDetailsPanel({
             <div className="flex items-center gap-1.5">
               <Grid01 className="w-3.5 h-3.5 text-muted-foreground" />
               <p className="text-sm text-foreground">Context window</p>
+              {contextSize && (
+                <CostBadge
+                  label={contextSize.label}
+                  color={contextSize.color}
+                />
+              )}
             </div>
             <p className="text-sm text-muted-foreground">
               {model.limits.contextWindow.toLocaleString()} tokens
@@ -269,27 +528,36 @@ function ModelDetailsPanel({
           </div>
         )}
 
-        {(model.costs?.input || model.costs?.output) && (
+        {(inputCostPerM != null || outputCostPerM != null) && (
           <div className="flex flex-col gap-1.5">
             <div className="flex items-center gap-1.5">
               <CurrencyDollar className="w-3.5 h-3.5 text-muted-foreground" />
               <p className="text-sm text-foreground">Costs</p>
             </div>
-            <div className="flex flex-col gap-0.5">
-              {model.costs?.input !== null &&
-                model.costs?.input !== undefined && (
-                  <p className="text-sm text-muted-foreground">
-                    ${(model.costs.input * 1_000_000).toFixed(2)} / 1M tokens
-                    (input)
-                  </p>
-                )}
-              {model.costs?.output !== null &&
-                model.costs?.output !== undefined && (
-                  <p className="text-sm text-muted-foreground">
-                    ${(model.costs.output * 1_000_000).toFixed(2)} / 1M tokens
-                    (output)
-                  </p>
-                )}
+            <div className="flex flex-col gap-1">
+              {inputCostPerM != null && (
+                <div className="flex items-center">
+                  <span className="text-sm" style={{ color: inputColor }}>
+                    ${inputCostPerM.toFixed(2)} / 1M tokens (input)
+                  </span>
+                  {inputTag && (
+                    <CostBadge label={inputTag.label} color={inputTag.color} />
+                  )}
+                </div>
+              )}
+              {outputCostPerM != null && (
+                <div className="flex items-center">
+                  <span className="text-sm" style={{ color: outputColor }}>
+                    ${outputCostPerM.toFixed(2)} / 1M tokens (output)
+                  </span>
+                  {outputTag && (
+                    <CostBadge
+                      label={outputTag.label}
+                      color={outputTag.color}
+                    />
+                  )}
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -299,6 +567,9 @@ function ModelDetailsPanel({
             <div className="flex items-center gap-1.5">
               <LogOut04 className="w-4.5 h-4.5 text-muted-foreground/70" />
               <p className="text-sm text-foreground">Output limit</p>
+              {outputSize && (
+                <CostBadge label={outputSize.label} color={outputSize.color} />
+              )}
             </div>
             <p className="text-sm text-muted-foreground">
               {model.limits.maxOutputTokens.toLocaleString()} token limit
@@ -339,10 +610,6 @@ function ModelItemContent({
   );
 }
 
-/**
- * Error fallback shown when fetching models from a connection fails.
- * Allows the user to retry or navigate to connection configuration.
- */
 function ModelListErrorFallback({
   error,
   onRetry,
@@ -355,7 +622,6 @@ function ModelListErrorFallback({
   orgSlug?: string;
 }) {
   const navigate = useNavigate();
-
   const handleConfigure = () => {
     if (!connectionId || !orgSlug) return;
     navigate({
@@ -408,9 +674,6 @@ function ModelListErrorFallback({
   );
 }
 
-/**
- * Skeleton loader for the model list area while models are being fetched.
- */
 function ModelListSkeleton() {
   return (
     <div className="flex-1 overflow-y-auto px-0.5 pt-2 space-y-1">
@@ -428,12 +691,10 @@ function ModelListSkeleton() {
   );
 }
 
-/**
- * Fetches and renders the model list for a specific connection.
- * Isolated so it can be wrapped with ErrorBoundary + Suspense — when the
- * fetch fails (e.g. no auth), the error boundary catches it and the user
- * can switch to another provider.
- */
+// ============================================================================
+// ConnectionModelList — browse + manage modes
+// ============================================================================
+
 function ConnectionModelList({
   connectionId,
   allowAll,
@@ -442,6 +703,10 @@ function ConnectionModelList({
   selectedModel,
   onModelSelect,
   onHover,
+  managing,
+  onToggleManage,
+  allModelsRef,
+  onSelectedModelResolved,
 }: {
   connectionId: string | null;
   allowAll: boolean;
@@ -450,20 +715,140 @@ function ConnectionModelList({
   selectedModel?: SelectedModelState;
   onModelSelect: (model: LLM) => void;
   onHover: (model: LLM) => void;
+  managing: boolean;
+  onToggleManage: () => void;
+  allModelsRef: React.RefObject<LLM[]>;
+  onSelectedModelResolved: (model: LLM | null) => void;
 }) {
-  // This suspense-enabled call can throw if the connection is inaccessible
   const allModels = useModels(connectionId ?? undefined);
+  allModelsRef.current = allModels;
 
-  // Filter models based on permissions
+  // Resolve the selected model for the details panel default
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    if (selectedModel && allModels.length > 0) {
+      const found =
+        allModels.find((m) => m.id === selectedModel.thinking.id) ?? null;
+      if (found) {
+        onSelectedModelResolved(found);
+      }
+    }
+  }, [selectedModel, allModels, onSelectedModelResolved]);
+
   const models = allowAll
     ? allModels
     : allModels.filter(
         (m) => connectionId && isModelAllowed(connectionId, m.id),
       );
 
-  // Filter models based on search term
+  const [shortlistVersion, setShortlistVersion] = useState(0);
+  void shortlistVersion;
+
+  const shortlist = connectionId ? getShortlist(connectionId) : null;
+  const shortlistSet = shortlist ? new Set(shortlist) : defaultShortlistSet;
+
+  const groupByTier = (list: LLM[]) => {
+    const groups: Record<TierId | "other", LLM[]> = {
+      smarter: [],
+      faster: [],
+      cheaper: [],
+      other: [],
+    };
+    for (const m of list) {
+      const tier = classifyModel(m.id);
+      groups[tier ?? "other"].push(m);
+    }
+    // Sort each group alphabetically by title
+    for (const key of Object.keys(groups)) {
+      groups[key as TierId | "other"].sort((a, b) =>
+        a.title.localeCompare(b.title),
+      );
+    }
+    return groups;
+  };
+
+  if (managing) {
+    const displayModels = searchTerm.trim()
+      ? models.filter((model) => {
+          const search = searchTerm.toLowerCase();
+          return (
+            model.title.toLowerCase().includes(search) ||
+            model.provider?.toLowerCase().includes(search)
+          );
+        })
+      : models;
+
+    const grouped = groupByTier(displayModels);
+
+    const handleToggle = (modelId: string) => {
+      if (!connectionId) return;
+      const current = shortlist ?? [...defaultShortlistSet];
+      const next = current.includes(modelId)
+        ? current.filter((id) => id !== modelId)
+        : [...current, modelId];
+      setShortlist(connectionId, next);
+      setShortlistVersion((v) => v + 1);
+    };
+
+    const renderManageSection = (label: string, items: LLM[]) => {
+      if (items.length === 0) return null;
+      return (
+        <div key={label}>
+          <div className="text-xs font-medium text-muted-foreground px-3 pt-3 pb-1">
+            {label}
+          </div>
+          {items.map((m) => (
+            <label
+              key={m.id}
+              className="flex items-center gap-3 min-h-8 py-2.5 px-3 hover:bg-accent cursor-pointer rounded-lg"
+              onMouseEnter={() => onHover(m)}
+            >
+              <Checkbox
+                checked={shortlistSet.has(m.id)}
+                onCheckedChange={() => handleToggle(m.id)}
+              />
+              {m.logo && (
+                <img src={m.logo} className="w-5 h-5 shrink-0" alt={m.title} />
+              )}
+              <span className="text-sm text-foreground flex-1 min-w-0 line-clamp-1">
+                {m.title}
+              </span>
+            </label>
+          ))}
+        </div>
+      );
+    };
+
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+          <button
+            type="button"
+            onClick={onToggleManage}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground cursor-pointer"
+          >
+            <ArrowLeft size={14} />
+            Back
+          </button>
+          <span className="text-xs text-muted-foreground">
+            {models.filter((m) => shortlistSet.has(m.id)).length} selected
+          </span>
+        </div>
+        <div className="flex-1 overflow-y-auto px-0.5 pt-1">
+          {TIER_IDS.map((tierId) =>
+            renderManageSection(TIER_LABELS[tierId], grouped[tierId]),
+          )}
+          {renderManageSection("Other", grouped.other)}
+        </div>
+      </div>
+    );
+  }
+
+  // --- Browse mode ---
+  const shortlistedModels = models.filter((m) => shortlistSet.has(m.id));
+
   const filteredModels = searchTerm.trim()
-    ? models.filter((model) => {
+    ? shortlistedModels.filter((model) => {
         const search = searchTerm.toLowerCase();
         return (
           model.title.toLowerCase().includes(search) ||
@@ -471,33 +856,87 @@ function ConnectionModelList({
           model.description?.toLowerCase().includes(search)
         );
       })
-    : models;
+    : shortlistedModels;
 
   if (filteredModels.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center py-8 text-sm text-muted-foreground">
-        No models found
+      <div className="flex-1 flex flex-col items-center justify-center py-8 gap-3">
+        <p className="text-sm text-muted-foreground">No models found</p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onToggleManage}
+          className="gap-1.5"
+        >
+          <Settings01 className="size-3.5" />
+          Manage models
+        </Button>
       </div>
     );
   }
 
+  if (searchTerm.trim().length > 0) {
+    return (
+      <div className="flex-1 overflow-y-auto px-0.5 pt-2">
+        {filteredModels.map((m) => {
+          const isSelected = m.id === selectedModel?.thinking.id;
+          return (
+            <div
+              key={m.id}
+              onClick={() => onModelSelect(m)}
+              className={cn("rounded-lg mb-1", isSelected && "bg-accent")}
+            >
+              <ModelItemContent model={m} onHover={onHover} />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  const grouped = groupByTier(filteredModels);
+
+  const renderBrowseSection = (label: string, items: LLM[]) => {
+    if (items.length === 0) return null;
+    return (
+      <div key={label}>
+        <div className="text-xs font-medium text-muted-foreground px-3 pt-3 pb-1">
+          {label}
+        </div>
+        {items.map((m) => {
+          const isSelected = m.id === selectedModel?.thinking.id;
+          return (
+            <div
+              key={m.id}
+              onClick={() => onModelSelect(m)}
+              className={cn("rounded-lg mb-1", isSelected && "bg-accent")}
+            >
+              <ModelItemContent model={m} onHover={onHover} />
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   return (
     <div className="flex-1 overflow-y-auto px-0.5 pt-2">
-      {filteredModels.map((m) => {
-        const isSelected = m.id === selectedModel?.thinking.id;
-        return (
-          <div
-            key={m.id}
-            onClick={() => onModelSelect(m)}
-            className={cn("rounded-lg mb-1", isSelected && "bg-accent")}
-          >
-            <ModelItemContent model={m} onHover={onHover} />
-          </div>
-        );
-      })}
+      {TIER_IDS.map((tierId) =>
+        renderBrowseSection(TIER_LABELS[tierId], grouped[tierId]),
+      )}
+      {grouped.other.length > 0 && (
+        <>
+          <div className="mx-3 my-2 border-t border-border" />
+          {renderBrowseSection("Other", grouped.other)}
+        </>
+      )}
     </div>
   );
 }
+
+// ============================================================================
+// Display Components
+// ============================================================================
 
 function SelectedModelDisplay({
   model,
@@ -518,8 +957,12 @@ function SelectedModelDisplay({
     );
   }
 
+  const displayName = model.title.includes(": ")
+    ? model.title.split(": ").slice(1).join(": ")
+    : model.title;
+
   return (
-    <div className="flex items-center gap-0 group-hover:gap-2 group-data-[state=open]:gap-2 min-w-0 overflow-hidden transition-all duration-200">
+    <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
       {model.logo && (
         <img
           src={model.logo}
@@ -527,35 +970,25 @@ function SelectedModelDisplay({
           alt={model.title}
         />
       )}
-      <span className="text-sm text-muted-foreground group-hover:text-foreground group-data-[state=open]:text-foreground truncate whitespace-nowrap max-w-0 opacity-0 group-hover:max-w-[150px] group-hover:opacity-100 group-data-[state=open]:max-w-[150px] group-data-[state=open]:opacity-100 transition-all duration-200 ease-in-out overflow-hidden">
-        {model.title}
+      <span className="text-sm text-muted-foreground truncate whitespace-nowrap hidden md:inline">
+        {displayName}
       </span>
       <ChevronDown
         size={14}
-        className="text-muted-foreground opacity-0 max-w-0 group-hover:opacity-50 group-hover:max-w-[14px] group-data-[state=open]:opacity-50 group-data-[state=open]:max-w-[14px] shrink-0 transition-all duration-200 ease-in-out overflow-hidden"
+        className="text-muted-foreground opacity-50 shrink-0 hidden md:inline"
       />
     </div>
   );
 }
 
-/**
- * Selected model state shape for controlled components
- * Alias for ChatModelsConfig for backwards compatibility.
- */
 export type SelectedModelState = ChatModelsConfig;
 
-/**
- * Check if a model supports file uploads (vision capability)
- */
 export function modelSupportsFiles(
   selectedModel: SelectedModelState | null | undefined,
 ): boolean {
   return selectedModel?.thinking?.capabilities?.vision === true;
 }
 
-/**
- * Model change callback payload
- */
 export interface ModelChangePayload {
   id: string;
   connectionId: string;
@@ -564,15 +997,14 @@ export interface ModelChangePayload {
   limits?: { contextWindow?: number; maxOutputTokens?: number };
 }
 
-/**
- * Loading state for ModelSelectorContent
- */
+// ============================================================================
+// ModelSelectorContent — fixed size popover, no resize on manage toggle
+// ============================================================================
+
 function ModelSelectorContentFallback() {
   return (
-    <div className="flex flex-col md:flex-row h-[350px]">
-      {/* Left column - model list with search */}
-      <div className="flex-1 flex flex-col md:border-r md:w-[400px] md:min-w-[400px]">
-        {/* Search input skeleton */}
+    <div className="flex flex-col md:flex-row h-[460px]">
+      <div className="flex-1 flex flex-col md:border-r md:w-[420px] md:min-w-[420px]">
         <div className="border-b border-border h-12 bg-background/95 backdrop-blur sticky top-0 z-10">
           <div className="flex items-center gap-2.5 h-12 px-4">
             <Skeleton className="size-4 shrink-0" />
@@ -580,10 +1012,8 @@ function ModelSelectorContentFallback() {
             <Skeleton className="w-[140px] h-8 shrink-0" />
           </div>
         </div>
-
-        {/* Model list skeleton */}
         <div className="flex-1 overflow-y-auto px-0.5 pt-2 space-y-1">
-          {Array.from({ length: 6 }).map((_, i) => (
+          {Array.from({ length: 8 }).map((_, i) => (
             <div
               key={i}
               className="flex items-center gap-2 min-h-8 py-3 px-3 rounded-lg"
@@ -595,8 +1025,6 @@ function ModelSelectorContentFallback() {
           ))}
         </div>
       </div>
-
-      {/* Right column - details panel skeleton (desktop only) */}
       <div className="hidden md:block md:w-[320px] md:shrink-0 p-3">
         <div className="flex flex-col gap-3 py-1 px-1.5">
           <div className="flex flex-col gap-3 py-2 px-0">
@@ -625,12 +1053,6 @@ function ModelSelectorContentFallback() {
   );
 }
 
-/**
- * Modal content component for model selection.
- * The model-fetching logic lives in `ConnectionModelList` which is wrapped
- * with ErrorBoundary + Suspense so a failed provider doesn't break the whole
- * selector — the user can switch connections and retry.
- */
 function ModelSelectorContent({
   selectedModel,
   onModelChange,
@@ -644,35 +1066,32 @@ function ModelSelectorContent({
 }) {
   const [hoveredModel, setHoveredModel] = useState<LLM | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
+  const [managing, setManaging] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const allModelsRef = useRef<LLM[]>([]);
+
+  // The resolved selected model — set by ConnectionModelList once models load
+  const [resolvedSelectedModel, setResolvedSelectedModel] =
+    useState<LLM | null>(null);
 
   const { org } = useProjectContext();
 
-  // Use provided modelsConnections or fetch from hook
   const modelsConnectionsFromHook = useModelConnections();
   const allModelsConnections =
     modelsConnectionsProp ?? modelsConnectionsFromHook;
 
-  // Fetch allowed models for current user
   const { isModelAllowed, allowAll, hasConnectionModels } = useAllowedModels();
 
-  // Filter connections to only those with at least one allowed model.
-  // This prevents fetching the LLM list from connections the user has no access to,
-  // which would show empty states and potentially cause auth errors.
   const modelsConnections = allowAll
     ? allModelsConnections
     : allModelsConnections.filter((conn) => hasConnectionModels(conn.id));
 
-  // Default to the stored connection, or the first available connection so the
-  // list (and any error fallback) renders immediately without a manual selection.
   const [selectedConnectionId, setSelectedConnectionId] = useState<
     string | null
   >(selectedModel?.connectionId ?? modelsConnections[0]?.id ?? null);
 
-  // Focus search input when mounted
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
-    // Small delay to ensure the dialog is fully rendered
     setTimeout(() => {
       searchInputRef.current?.focus();
     }, 0);
@@ -685,7 +1104,6 @@ function ModelSelectorContent({
 
   const handleModelSelect = (model: LLM) => {
     if (!selectedConnectionId) return;
-
     onModelChange({
       id: model.id,
       connectionId: selectedConnectionId,
@@ -697,18 +1115,23 @@ function ModelSelectorContent({
     onClose();
   };
 
+  const stats =
+    allModelsRef.current.length > 0
+      ? computeModelStats(allModelsRef.current)
+      : null;
+
   return (
-    <div className="flex flex-col md:flex-row h-[350px]">
-      {/* Left column - model list with search */}
-      <div className="flex-1 flex flex-col md:border-r md:w-[400px] md:min-w-[400px]">
-        {/* Search input + connection selector — always visible even on error */}
+    <div className="flex flex-col md:flex-row h-[460px]">
+      <div className="flex-1 flex flex-col md:border-r md:w-[420px] md:min-w-[420px]">
         <div className="border-b border-border h-12 bg-background/95 backdrop-blur sticky top-0 z-10">
           <label className="flex items-center gap-2.5 h-12 px-4 cursor-text">
             <SearchMd size={16} className="text-muted-foreground shrink-0" />
             <Input
               ref={searchInputRef}
               type="text"
-              placeholder="Search for a model..."
+              placeholder={
+                managing ? "Search all models..." : "Search for a model..."
+              }
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="flex-1 border-0 shadow-none focus-visible:ring-0 px-0 h-full text-sm placeholder:text-muted-foreground/50 bg-transparent"
@@ -751,9 +1174,6 @@ function ModelSelectorContent({
           </label>
         </div>
 
-        {/* Model list — wrapped in ErrorBoundary so a failed provider
-            doesn't break the selector. key={connectionId} resets the
-            boundary when the user switches connections. */}
         <ErrorBoundary
           key={selectedConnectionId}
           fallback={({ error, resetError }) => (
@@ -774,18 +1194,42 @@ function ModelSelectorContent({
               selectedModel={selectedModel}
               onModelSelect={handleModelSelect}
               onHover={setHoveredModel}
+              managing={managing}
+              onToggleManage={() => setManaging((v) => !v)}
+              allModelsRef={allModelsRef}
+              onSelectedModelResolved={setResolvedSelectedModel}
             />
           </Suspense>
         </ErrorBoundary>
       </div>
 
-      {/* Right column - details panel (desktop only) */}
-      <div className="hidden md:block md:w-[320px] md:shrink-0 p-3">
-        <ModelDetailsPanel model={hoveredModel} />
+      <div className="hidden md:flex md:flex-col md:w-[320px] md:shrink-0 p-3">
+        <div className="flex-1">
+          <ModelDetailsPanel
+            model={hoveredModel ?? resolvedSelectedModel}
+            stats={stats}
+          />
+        </div>
+        {!managing && (
+          <div className="flex justify-end pt-2">
+            <button
+              type="button"
+              onClick={() => setManaging(true)}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+            >
+              <Settings01 className="size-3.5" />
+              Manage models
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );
 }
+
+// ============================================================================
+// Public Components
+// ============================================================================
 
 export interface ModelSelectorProps {
   selectedModel?: SelectedModelState;
@@ -796,11 +1240,6 @@ export interface ModelSelectorProps {
   placeholder?: string;
 }
 
-/**
- * Resolves the selected model's display info (name, logo) by fetching the
- * model list. Extracted so it can be wrapped with Suspense/ErrorBoundary
- * independently of the trigger button.
- */
 function ResolvedModelDisplay({
   selectedModel,
   placeholder,
@@ -818,10 +1257,6 @@ function ResolvedModelDisplay({
   );
 }
 
-/**
- * Fallback trigger display when the model list can't be resolved.
- * Shows the short model name extracted from the ID.
- */
 function FallbackModelDisplay({
   selectedModel,
   placeholder,
@@ -832,27 +1267,21 @@ function FallbackModelDisplay({
   if (!selectedModel) {
     return <SelectedModelDisplay model={undefined} placeholder={placeholder} />;
   }
-
-  // Show short model name from the ID (e.g. "claude-sonnet-4.5" from "anthropic/claude-sonnet-4.5")
   const id = selectedModel.thinking.id;
   const shortName = id.split("/").pop() ?? id;
   return (
-    <div className="flex items-center gap-0 group-hover:gap-2 group-data-[state=open]:gap-2 min-w-0 overflow-hidden transition-all duration-200">
-      <span className="text-sm text-muted-foreground group-hover:text-foreground group-data-[state=open]:text-foreground truncate whitespace-nowrap max-w-0 opacity-0 group-hover:max-w-[150px] group-hover:opacity-100 group-data-[state=open]:max-w-[150px] group-data-[state=open]:opacity-100 transition-all duration-200 ease-in-out overflow-hidden">
+    <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
+      <span className="text-sm text-muted-foreground truncate whitespace-nowrap hidden md:inline">
         {shortName}
       </span>
       <ChevronDown
         size={14}
-        className="text-muted-foreground opacity-0 max-w-0 group-hover:opacity-50 group-hover:max-w-[14px] group-data-[state=open]:opacity-50 group-data-[state=open]:max-w-[14px] shrink-0 transition-all duration-200 ease-in-out overflow-hidden"
+        className="text-muted-foreground opacity-50 shrink-0 hidden md:inline"
       />
     </div>
   );
 }
 
-/**
- * Rich model selector with detailed info panel, capabilities badges, and responsive UI.
- * Fetches models internally from the connected LLM provider.
- */
 export function ModelSelector({
   selectedModel,
   onModelChange,
@@ -862,18 +1291,14 @@ export function ModelSelector({
   placeholder = "Select model",
 }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
-
-  // Use provided modelsConnections or fetch from hook
   const modelsConnectionsFromHook = useModelConnections();
   const modelsConnections = modelsConnectionsProp ?? modelsConnectionsFromHook;
 
-  if (modelsConnections.length === 0) {
-    return null;
-  }
+  if (modelsConnections.length === 0) return null;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
         <Button
           variant={variant === "borderless" ? "ghost" : "outline"}
           size="sm"
@@ -883,7 +1308,6 @@ export function ModelSelector({
             className,
           )}
         >
-          {/* Resolve model display info — falls back gracefully on error */}
           <ErrorBoundary
             fallback={
               <FallbackModelDisplay
@@ -907,13 +1331,12 @@ export function ModelSelector({
             </Suspense>
           </ErrorBoundary>
         </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-full md:w-auto p-0"
-        align="start"
-        side="bottom"
-        sideOffset={8}
+      </DialogTrigger>
+      <DialogContent
+        className="p-0 gap-0 sm:max-w-fit overflow-hidden"
+        closeButtonClassName="top-3.5 right-3.5 z-20"
       >
+        <DialogTitle className="sr-only">Select model</DialogTitle>
         <Suspense fallback={<ModelSelectorContentFallback />}>
           <ModelSelectorContent
             selectedModel={selectedModel}
@@ -922,7 +1345,7 @@ export function ModelSelector({
             modelsConnections={modelsConnections}
           />
         </Suspense>
-      </PopoverContent>
-    </Popover>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/mesh/src/web/hooks/use-binding.ts
+++ b/apps/mesh/src/web/hooks/use-binding.ts
@@ -203,6 +203,7 @@ export interface ValidatedCollection {
  * e.g., "LLM" -> "Llm", "USER_PROFILES" -> "User Profiles"
  */
 function formatCollectionName(name: string): string {
+  if (name === "LLM") return "Models";
   return name
     .toLowerCase()
     .split("_")


### PR DESCRIPTION
## Summary

- **Tier system**: models grouped into Smarter / Faster / Cheaper based on provider prefix patterns; browse mode renders grouped sections
- **Shortlist management**: per-connection model shortlist persisted in `localStorage`; manage mode lets users toggle models on/off; defaults to a curated shortlist when none saved
- **Rich details panel**: cost percentile badges (Budget / Premium / Top 5% etc.), context/output size labels (Small / Medium / Large / XL), costs color-coded relative to the full model catalog
- **Dialog instead of Popover**: fixed-size layout that doesn't reflow when switching to manage mode
- **Auto-selector**: `ModelAutoSelector` now prefers Claude Opus → Sonnet over picking the first available model
- `formatCollectionName`: special-cases `"LLM"` → `"Models"` for display

## Test plan

- [ ] Open model selector — models appear grouped by tier
- [ ] Search filters within the shortlist only
- [ ] "Manage models" toggles individual models; shortlist persists on reload
- [ ] Details panel shows cost badges and size labels
- [ ] No model connection → selector hidden (unchanged)
- [ ] Mobile layout (single column, no details panel)

> Split from #2528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a tiered model selector with per-connection shortlists and richer cost details to make choosing models faster and clearer. Moves the selector to a fixed-size dialog and improves the default auto-selection.

- **New Features**
  - Tier grouping: models classified into Smarter / Faster / Cheaper; browse mode shows grouped sections.
  - Shortlist management: per-connection shortlist saved in localStorage; manage mode with checkboxes and a curated default; search filters within shortlist in browse mode.
  - Details panel: input/output costs per 1M with percentile badges (Budget/Premium/Top 5%), context/output size labels (Small–XL), and color-coded costs.

- **Refactors**
  - Switched from Popover to Dialog for a stable, fixed-size layout.
  - Auto-selector now prefers Claude Opus 4.6 → Sonnet 4.6 → Sonnet before falling back.
  - formatCollectionName special-case: “LLM” → “Models”.

<sup>Written for commit 4a06b4cc5097d249265e5f287e2904a4c0ac9d23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

