### PR TITLE
fix(ui): constrain homepage user menu width in topbar

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -210,7 +210,9 @@ function ShellLayoutContent() {
     return (
       <div className="min-h-screen bg-background">
         <header className="h-12 flex items-center justify-end px-4 border-b border-border">
-          <MeshUserMenu />
+          <div className="w-fit">
+            <MeshUserMenu />
+          </div>
         </header>
         <Outlet />
       </div>


### PR DESCRIPTION
## Summary

- The `MeshUserMenu` trigger button uses `w-full` for the sidebar context (fills the bottom rail in org/project views)
- On the homepage topbar, this caused the menu to span the entire header width
- Fix: wrap `<MeshUserMenu />` in a `<div className="w-fit">` in `shell-layout.tsx` so it only takes its natural content size

## Affected areas

- Homepage topbar user menu (fixed - now properly sized)
- Sidebar user menu in org/project views (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrained the homepage topbar user menu to its content width so it no longer spans the full header. Wrapped MeshUserMenu in a w-fit container; sidebar layout in org/project views is unchanged.

<sup>Written for commit 1ef57210d86d0d1183fcbdfc5c168ad3fd0d6a49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

