### PR TITLE
feat(runtime): pass _meta.ui.csp through resource registration

### DIFF
--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -157,6 +157,22 @@ export interface ResourceExecutionContext {
 }
 
 /**
+ * CSP policy for MCP UI resources.
+ * Allows an MCP app to declare which external origins it needs to load scripts,
+ * styles, images, fonts, and establish network connections.
+ */
+export interface McpUiResourceCsp {
+  /** Origins allowed in script-src, style-src, img-src, font-src (e.g. ["http://localhost:3000"]) */
+  resourceDomains?: string[];
+  /** Origins allowed in connect-src (fetch/XHR/WebSocket) */
+  connectDomains?: string[];
+  /** Origins allowed in frame-src */
+  frameDomains?: string[];
+  /** Origins allowed in base-uri */
+  baseUriDomains?: string[];
+}
+
+/**
  * Resource contents returned from read operations.
  * Per MCP spec, resources return either text or blob content.
  */
@@ -169,6 +185,29 @@ export interface ResourceContents {
   text?: string;
   /** Base64-encoded binary content (for binary resources) */
   blob?: string;
+  /**
+   * Optional metadata for MCP UI resources.
+   * Use `_meta.ui.csp` to declare which external origins the HTML content needs
+   * (e.g. a Vite dev server URL). MCP Mesh uses this to build a permissive
+   * Content Security Policy for the sandboxed iframe that renders the app.
+   *
+   * @example
+   * ```ts
+   * _meta: {
+   *   ui: {
+   *     csp: {
+   *       resourceDomains: ["http://localhost:3000"],
+   *       connectDomains: ["http://localhost:3000"],
+   *     },
+   *   },
+   * }
+   * ```
+   */
+  _meta?: {
+    ui?: {
+      csp?: McpUiResourceCsp;
+    };
+  };
 }
 
 /**
@@ -865,6 +904,7 @@ export const createMCPServer = <
                   uri: result.uri,
                   mimeType: result.mimeType,
                   text: result.text,
+                  ...(result._meta ? { _meta: result._meta } : {}),
                 },
               ],
             };
@@ -875,6 +915,7 @@ export const createMCPServer = <
                   uri: result.uri,
                   mimeType: result.mimeType,
                   blob: result.blob,
+                  ...(result._meta ? { _meta: result._meta } : {}),
                 },
               ],
             };
@@ -883,7 +924,12 @@ export const createMCPServer = <
           // Fallback to empty text if neither provided
           return {
             contents: [
-              { uri: result.uri, mimeType: result.mimeType, text: "" },
+              {
+                uri: result.uri,
+                mimeType: result.mimeType,
+                text: "",
+                ...(result._meta ? { _meta: result._meta } : {}),
+              },
             ],
           };
         },


### PR DESCRIPTION
## What is this contribution about?

MCP UI apps that use a Vite dev server (or any external script host) were hitting CSP violations like:

> Loading the script 'http://localhost:3000/@vite/client' violates the following Content Security Policy directive: "script-src 'unsafe-inline'"

The CSP injected into sandboxed iframes already supports `McpUiResourceCsp.resourceDomains` to whitelist external origins in `script-src`/`style-src`/etc. — but the `ResourceContents` type in `@decocms/runtime` had no `_meta` field, so any CSP declaration returned by an MCP app's `read` function was silently dropped before reaching the MCP SDK.

This PR:
1. Adds `McpUiResourceCsp` interface and a `_meta?: { ui?: { csp?: McpUiResourceCsp } }` field to `ResourceContents`, giving MCP apps a typed API to declare their CSP needs.
2. Forwards `_meta` in all three content return paths inside `createMCPServer` (text, blob, and the empty-text fallback) so the MCP SDK delivers it to MCP Mesh's CSP injector.

## Screenshots/Demonstration

N/A

## How to Test

1. In an MCP app that renders a Vite dev UI, return `_meta.ui.csp` from the resource `read` function:
   ```ts
   return {
     uri: "ui://my-app",
     mimeType: "text/html",
     text: html,
     _meta: {
       ui: {
         csp: {
           resourceDomains: ["http://localhost:3000"],
           connectDomains: ["http://localhost:3000"],
         },
       },
     },
   };
   ```
2. Load the app through MCP Mesh — the iframe should render without CSP violations and Vite HMR should work.
3. Without the `_meta` field the CSP violation reappears, confirming the fix is effective.

## Migration Notes

No migrations required. `_meta` is optional and fully backwards-compatible.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable MCP UI resources to declare CSP needs and forward them through the runtime so sandboxed iframes allow required external origins (e.g., Vite dev server), fixing CSP violations.

- **New Features**
  - Added McpUiResourceCsp and optional _meta.ui.csp on ResourceContents.
  - createMCPServer now forwards _meta in text, blob, and empty-text paths.
  - Supports whitelisting script/style/img/font/connect/frame/base-uri domains to avoid CSP errors.

- **Migration**
  - No changes required; _meta is optional and backward-compatible.

<sup>Written for commit 40f04c546337c1c8600199a98a2fb950b1a6e798. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

