### PR TITLE
feat(ui): restore version display in user panel and settings

### DIFF
--- a/apps/mesh/src/web/components/settings-modal/pages/account-profile.tsx
+++ b/apps/mesh/src/web/components/settings-modal/pages/account-profile.tsx
@@ -52,7 +52,7 @@ export function AccountProfilePage() {
         <p className="py-4 text-base font-semibold text-foreground border-b border-border">
           User ID
         </p>
-        <div className="flex items-center justify-between gap-6 py-4 border-b border-border">
+        <div className="flex items-center justify-between gap-6 py-4">
           <p className="text-sm text-muted-foreground">User ID</p>
           <TooltipProvider>
             <Tooltip>
@@ -78,12 +78,6 @@ export function AccountProfilePage() {
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-        </div>
-        <div className="flex items-center justify-between gap-6 py-4">
-          <p className="text-sm text-muted-foreground">Mesh version</p>
-          <span className="font-mono text-sm text-muted-foreground">
-            v{__MESH_VERSION__}
-          </span>
         </div>
       </div>
     </div>

--- a/apps/mesh/src/web/components/settings-modal/sidebar.tsx
+++ b/apps/mesh/src/web/components/settings-modal/sidebar.tsx
@@ -233,6 +233,12 @@ export function SettingsSidebar({
           </Suspense>
         </div>
       )}
+      {/* Version */}
+      <div className="mt-auto px-4 pb-1">
+        <span className="text-xs text-muted-foreground/50">
+          v{__MESH_VERSION__}
+        </span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What is this contribution about?
Restores the Mesh version indicator that was lost after recent layout updates. The version is now displayed in two locations:
- **User panel dropdown**: Shows `v{version}` as subtle footer text below the sign out button
- **Settings profile page**: Displays the version alongside the User ID in the info section

## How to Test
1. Open the user menu (click user avatar in sidebar footer)
2. Scroll to the bottom of the dropdown menu — the version appears below the sign out button
3. Open Settings → Profile (via user menu)
4. Scroll to the "User ID" section — the version is displayed below as "Mesh version"

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Mesh version display removed by recent layout changes. Shows v{version} in the user menu footer and at the bottom of the Settings sidebar.

<sup>Written for commit 7a78ee985694e5b53e3d2bd7ecea9139ba458795. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

