### PR TITLE
fix(dev): set BASE_URL in worktree dev script

### DIFF
--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -46,6 +46,7 @@ startWorktree(slug, async (ctx) => {
       ...dotEnv,
       PORT: String(port),
       VITE_PORT: String(vitePort),
+      BASE_URL: `http://${ctx.slug}.localhost`,
     },
     stdio: ["inherit", "inherit", "inherit"],
   });


### PR DESCRIPTION
## Summary
- Injects `BASE_URL=http://{slug}.localhost` into the worktree dev server environment so that `getBaseUrl()`, Better Auth trusted origins, and context-factory all resolve to the correct origin when accessed via Caddy reverse proxy.

## Test plan
- [ ] Run `WORKTREE_SLUG=test bun run dev:worktree` and verify the app is accessible at `http://test.localhost`
- [ ] Verify auth flows work correctly (login, OAuth callbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set BASE_URL to http://{slug}.localhost in the worktree dev script so requests resolve to the correct origin behind Caddy. Fixes getBaseUrl(), Better Auth trusted origins, and auth flows (login and OAuth callbacks) when accessing via {slug}.localhost.

<sup>Written for commit c74465feb9fa969a0a856e05816282aff32245c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

