### PR TITLE
fix(auth): await reset password email send

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -165,7 +165,7 @@ if (
     resetPasswordEnabled = true;
 
     sendResetPassword = async ({ user, url }) => {
-      void sendEmail({
+      await sendEmail({
         to: user.email,
         subject: "Reset your password",
         html: `


### PR DESCRIPTION
## Summary
- The `sendResetPassword` callback was using `void sendEmail(...)` instead of `await sendEmail(...)`, causing the detached promise to be dropped before the Resend API call completed
- Reset password emails were never delivered despite the UI reporting success
- One-word fix: `void` → `await`, matching the working invite email pattern

## Test plan
- [ ] Trigger a password reset on staging/prod and confirm the email arrives in Resend dashboard
- [ ] Confirm the reset link in the email works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reset password emails not being sent by awaiting the email send so the Resend request completes before returning.

- **Bug Fixes**
  - In sendResetPassword, changed void sendEmail(...) to await sendEmail(...).
  - Errors now surface and delivery matches the invite email flow.

<sup>Written for commit 019695ae4f4eb44218f942b11e48946ea33c6980. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

