### PR TITLE
feat(chat): add inline editing for thread titles

### DIFF
--- a/apps/mesh/src/web/components/chat/editable-thread-title.tsx
+++ b/apps/mesh/src/web/components/chat/editable-thread-title.tsx
@@ -1,0 +1,79 @@
+import { cn } from "@deco/ui/lib/utils.js";
+import { useState } from "react";
+import { useChatStable } from "./context";
+import { TypewriterTitle } from "./typewriter-title";
+
+/**
+ * Editable thread title for chat headers.
+ *
+ * Display mode: renders TypewriterTitle animation.
+ * Click: switches to an input for renaming (text auto-selected for easy copy).
+ * Enter/blur: saves if changed. Escape: discards.
+ */
+export function EditableThreadTitle({
+  threadId,
+  text,
+  className,
+}: {
+  threadId: string;
+  text: string;
+  className?: string;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingTitle, setEditingTitle] = useState("");
+  const { renameThread } = useChatStable();
+
+  const startEditing = () => {
+    setEditingTitle(text);
+    setIsEditing(true);
+  };
+
+  const commitEdit = async () => {
+    const trimmed = editingTitle.trim();
+    if (trimmed && trimmed !== text) {
+      await renameThread(threadId, trimmed);
+    }
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitEdit();
+    } else if (e.key === "Escape") {
+      setIsEditing(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <input
+        ref={(el) => {
+          if (el) {
+            el.focus();
+            el.select();
+          }
+        }}
+        value={editingTitle}
+        onChange={(e) => setEditingTitle(e.target.value)}
+        onBlur={() => commitEdit()}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          className,
+          "bg-transparent border-b border-foreground/30 focus:border-foreground outline-none pb-0.5 min-w-0",
+        )}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      className={cn(className, "cursor-pointer truncate text-left")}
+      title="Click to rename"
+    >
+      <TypewriterTitle text={text} />
+    </button>
+  );
+}

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -11,7 +11,7 @@ import { Suspense, useState, useTransition } from "react";
 import { ErrorBoundary } from "../error-boundary";
 import { Chat, useChat } from "./index";
 import { ThreadsView } from "./threads-sidebar";
-import { TypewriterTitle } from "./typewriter-title";
+import { EditableThreadTitle } from "./editable-thread-title";
 
 function ChatPanelContent() {
   const { org } = useProjectContext();
@@ -92,7 +92,8 @@ function ChatPanelContent() {
         <Page.Header className="flex-none" hideSidebarTrigger>
           <Page.Header.Left className="gap-2">
             {!isChatEmpty && activeThread?.title && (
-              <TypewriterTitle
+              <EditableThreadTitle
+                threadId={activeThread.id}
                 text={activeThread.title}
                 className="text-sm font-medium text-foreground"
               />

--- a/apps/mesh/src/web/routes/orgs/home/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/home/page.tsx
@@ -7,7 +7,7 @@
 
 import { Chat, useChat } from "@/web/components/chat/index";
 import { ThreadsSidebar } from "@/web/components/chat/threads-sidebar.tsx";
-import { TypewriterTitle } from "@/web/components/chat/typewriter-title";
+import { EditableThreadTitle } from "@/web/components/chat/editable-thread-title";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { AgentsList } from "@/web/components/home/agents-list.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
@@ -83,7 +83,8 @@ function HomeContent() {
       <Page.Header className="flex-none z-10 bg-background">
         <Page.Header.Left className="gap-2">
           {activeThread?.title && (
-            <TypewriterTitle
+            <EditableThreadTitle
+              threadId={activeThread.id}
               text={activeThread.title}
               className="text-sm font-medium text-foreground"
             />


### PR DESCRIPTION
## What is this contribution about?

Adds inline editing capability for thread titles in the chat interface. Users can now click on a thread title to rename it directly in the header without needing a separate modal or settings panel.

**Changes:**
- New `EditableThreadTitle` component that wraps the existing `TypewriterTitle` animation
- Supports inline editing with click-to-edit interaction
- Input auto-selects text for quick copy/rename workflows
- Saves on Enter or blur; discards on Escape
- Only commits changes if title is non-empty and different from current value
- Replaces `TypewriterTitle` usage in `side-panel-chat` and `orgs/home` page headers

## How to Test

1. Start the dev server: `bun run dev`
2. Open the chat interface and create or select a thread
3. Click on the thread title in the header
4. Type a new name and press Enter (or click outside to save)
5. Verify the title updates in the header and sidebar
6. Try pressing Escape to discard changes
7. Test with special characters and whitespace trimming

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes
- [x] Follows project patterns (React 19, no useEffect/useMemo, Tailwind tokens)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline editing for chat thread titles so users can rename titles directly in the header without a modal. Replaces TypewriterTitle with EditableThreadTitle in side-panel-chat and orgs/home while keeping the animation.

- **New Features**
  - Click title to edit; text auto-selected.
  - Save on Enter or blur; Esc cancels.
  - Trims input; only saves non-empty changes.
  - Uses threadId to call renameThread.

<sup>Written for commit 5551ded9cf02c8e02da9c35bf6152fe0dfc11fbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

