### PR TITLE
fix(ui): use server-side search in agent connection dialog

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/dependency-selection-dialog.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/dependency-selection-dialog.tsx
@@ -732,6 +732,7 @@ export function DependencySelectionDialog({
   const formData = connectionsToRecord(connections ?? []);
 
   const currentConnection = findOrFirst(allConnections, dialogState.selectedId);
+  const effectiveSelectedId = currentConnection?.id ?? null;
 
   // Use shared helper functions from selection-utils
   const hasSelections = (connId: string): boolean =>
@@ -910,7 +911,7 @@ export function DependencySelectionDialog({
               <ConnectionsList
                 allConnections={allConnections}
                 searchTerm={dialogState.searchTerm}
-                selectedId={dialogState.selectedId}
+                selectedId={effectiveSelectedId}
                 hasSelections={hasSelections}
                 getSelectionSummary={getSelectionSummary}
                 onConnectionClick={handleConnectionClick}
@@ -921,12 +922,12 @@ export function DependencySelectionDialog({
 
           {/* Right Content - Tools/Resources/Prompts */}
           <div className="flex-1 flex flex-col overflow-hidden">
-            {currentConnection && dialogState.selectedId ? (
+            {currentConnection && effectiveSelectedId ? (
               <ConnectionDetailsContent
-                key={dialogState.selectedId}
+                key={effectiveSelectedId}
                 currentConnection={currentConnection}
                 activeTab={dialogState.activeTab}
-                selectedId={dialogState.selectedId}
+                selectedId={effectiveSelectedId}
                 formData={formData}
                 toggleTool={toggleTool}
                 toggleResource={toggleResource}


### PR DESCRIPTION
## Summary
- The agent dependency selection dialog fetched only 100 connections sorted by `updated_at ASC` (oldest first) and searched client-side — newly added MCPs were excluded when orgs had 100+ connections
- Pass the dialog search term to `useConnections()` for server-side filtering (before pagination), and use `useDeferredValue` to batch rapid keystrokes

## Test plan
- [ ] Add a new MCP connection, then open an agent's "Add connection" dialog and search for it — it should appear
- [ ] Verify search still works responsively (deferred value batches keystrokes without lag)
- [ ] Verify the connection list loads correctly when the dialog opens with no search term

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the agent “Add connection” dialog to server-side search so new MCP connections appear even in orgs with 100+ connections.

- **Bug Fixes**
  - Pass searchTerm to useConnections for server-side filtering before pagination, and derive effectiveSelectedId from currentConnection to auto-select the first match on open.
  - Use useDeferredValue to batch keystrokes and keep the UI responsive.

<sup>Written for commit 9feea9ae241daf0ad7ed54d95828ba8002b6e284. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

