### PR TITLE
feat(mcp-apps): add allow-popups to iframe sandbox

### DIFF
--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -109,7 +109,7 @@ export function MCPAppRenderer({
       <iframe
         ref={iframeRef}
         srcDoc={html}
-        sandbox="allow-scripts allow-same-origin allow-forms"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
         className={cn("w-full h-full border-0", isLoading && "invisible")}
         title={`MCP App: ${toolName ?? uri}`}
       />


### PR DESCRIPTION
## What is this contribution about?

Adds `allow-popups` to the MCP App iframe `sandbox` attribute so that apps rendered inside the iframe can open new browser windows/tabs (e.g., via `window.open()` or `<a target="_blank">` links).

## Screenshots/Demonstration

N/A

## How to Test

1. Load an MCP App that attempts to open a popup or navigate via `target="_blank"`.
2. Verify the popup/new tab opens successfully.
3. Confirm existing MCP App functionality (scripts, forms, same-origin access) still works.

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow MCP App iframes to open popups by adding allow-popups to the iframe sandbox. Apps can now use window.open() and target="_blank" links while existing script, same-origin, and form permissions remain unchanged.

<sup>Written for commit 3c6f61e14b2b8b8ed222579fce44b32d47e1f413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

