### PR TITLE
fix(oauth): treat .localhost subdomains as local

### DIFF
--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -334,9 +334,11 @@ export async function handleAuthError({
 }
 
 const fixProtocol = (url: URL) => {
-  const isLocal = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  const isLocal =
+    url.hostname === "localhost" ||
+    url.hostname.endsWith(".localhost") ||
+    url.hostname === "127.0.0.1";
   if (!isLocal) {
-    // force http if not local
     url.protocol = "https:";
   }
   return url;

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -20,6 +20,7 @@ function isValidRedirectUri(uri: string): boolean {
     return (
       url.protocol === "https:" ||
       url.hostname === "localhost" ||
+      url.hostname.endsWith(".localhost") ||
       url.hostname === "127.0.0.1" ||
       // Allow custom schemes for native apps (e.g., cursor://, vscode://)
       !url.protocol.startsWith("http")
@@ -71,9 +72,11 @@ interface CodePayload {
 }
 
 const forceHttps = (url: URL) => {
-  const isLocal = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  const isLocal =
+    url.hostname === "localhost" ||
+    url.hostname.endsWith(".localhost") ||
+    url.hostname === "127.0.0.1";
   if (!isLocal) {
-    // force http if not local
     url.protocol = "https:";
   }
   return url;


### PR DESCRIPTION
## Summary
- `fixProtocol` / `forceHttps` only recognized `localhost` and `127.0.0.1` as local, forcing HTTPS for everything else — including `.localhost` subdomains like `krakow.localhost`
- This caused the MCP SDK to reject OAuth with: `Protected resource https://... does not match expected http://...`
- Added `hostname.endsWith(".localhost")` checks to all three local-detection sites (`.localhost` is reserved by RFC 6761 for loopback)

## Test plan
- [ ] OAuth flow works with `*.localhost` subdomains in local dev (e.g. Caddy proxy)
- [ ] OAuth flow still forces HTTPS for non-local hostnames
- [ ] Redirect URIs on `*.localhost` are accepted as valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats *.localhost as local in OAuth flows to prevent HTTP/HTTPS mismatches in dev. Fixes OAuth failures behind local proxies while still enforcing HTTPS for non-local hosts.

- **Bug Fixes**
  - Recognize *.localhost as local in protocol checks.
  - Accept redirect URIs on *.localhost in validation.
  - Keep forcing HTTPS for all non-local hostnames.

<sup>Written for commit 4cbd6c0fbea159225dd244599304299b9c716d40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

