### PR TITLE
fix(assets): catch main bundle load failures in index.html

### DIFF
--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -3,6 +3,28 @@
   <head>
     <title>MCP Mesh</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script>
+      // Catch module/script load failures (e.g. stale assets after deploy).
+      // Runs before React so it covers the main bundle, not just lazy chunks.
+      (function () {
+        var KEY = "__mesh_chunk_reload_ts";
+        window.addEventListener(
+          "error",
+          function (e) {
+            var t = e.target;
+            if (t && (t.tagName === "SCRIPT" || t.tagName === "LINK")) {
+              var last = sessionStorage.getItem(KEY);
+              var now = Date.now();
+              if (!last || now - Number(last) > 10000) {
+                sessionStorage.setItem(KEY, String(now));
+                window.location.reload();
+              }
+            }
+          },
+          true,
+        );
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Follow-up to #2561 — after deploying the cache fix, users who had stale `index.html` cached (from before `no-cache` was added) hit blank screens because the main JS bundle returned 404 from disk cache
- The `ChunkErrorBoundary` only works for lazy route chunks — if the main bundle itself fails to load, React never initializes and the page stays blank
- Adds an inline `<script>` in `index.html` that catches script/link load errors in capture phase and auto-reloads once (same sessionStorage guard as ChunkErrorBoundary)

## Test plan
- [ ] Deploy and verify blank screen scenario auto-reloads to working state
- [ ] Verify the reload guard prevents infinite loops (only reloads once per 10s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent blank screens caused by stale cached assets by catching main bundle/stylesheet load failures in index.html and auto-reloading once. This runs before React, so it recovers when the main JS fails to load.

- **Bug Fixes**
  - Add inline script that listens for SCRIPT/LINK load errors in capture phase.
  - On first failure, reload the page with a 10s sessionStorage guard to prevent loops.

<sup>Written for commit e5f11e942dd913ee7a3dee13c0f68f6cad851460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

