### PR TITLE
feat(mcp-apps): implement app.downloadFile support

### DIFF
--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -25,6 +25,7 @@ const HOST_CAPABILITIES: McpUiHostCapabilities = {
   serverResources: {},
   logging: {},
   message: {},
+  downloadFile: {},
 };
 
 const INIT_TIMEOUT_MS = 15_000;
@@ -246,6 +247,30 @@ class BridgeStore {
     bridge.onloggingmessage = ({ level, data }) => {
       const method = level === "error" ? "error" : "debug";
       console[method](`[MCP App ${this.config.toolName ?? "unknown"}]`, data);
+    };
+
+    bridge.ondownloadfile = async ({ contents }) => {
+      for (const item of contents) {
+        if (item.type === "resource") {
+          const res = item.resource;
+          const blob =
+            "blob" in res
+              ? new Blob(
+                  [Uint8Array.from(atob(res.blob), (c) => c.charCodeAt(0))],
+                  { type: res.mimeType },
+                )
+              : new Blob([res.text ?? ""], { type: res.mimeType });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.download = res.uri.split("/").pop() ?? "download";
+          link.click();
+          URL.revokeObjectURL(url);
+        } else if (item.type === "resource_link") {
+          window.open(item.uri, "_blank");
+        }
+      }
+      return {};
     };
   }
 


### PR DESCRIPTION
## What is this contribution about?

Implements the `app.downloadFile` capability from the MCP ext-apps specification. MCP apps running in sandboxed iframes can now request file downloads through the host. The implementation adds the downloadFile capability to HOST_CAPABILITIES and registers the ondownloadfile handler to process both EmbeddedResource (text and base64 blob data) and ResourceLink (URI-based) content types.

## How to Test

1. Create or use an MCP app that calls `app.downloadFile()` with test content
2. Verify embedded text resources download correctly
3. Verify embedded blob resources (base64-encoded) decode and download correctly
4. Verify resource links open in a new tab
5. Confirm downloads work in the host UI without errors

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements app.downloadFile so sandboxed MCP apps can download files via the host. Supports embedded text/base64 content downloads and opens resource links in a new tab.

- **New Features**
  - Added downloadFile to HOST_CAPABILITIES and registered the ondownloadfile handler in the app bridge.
  - For EmbeddedResource: create a Blob from text or base64, generate an object URL, trigger a download with an inferred filename.
  - For ResourceLink: open the URI in a new tab.

<sup>Written for commit 01e1c943cd2a7a6fdca24020732949a100c1b390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

