### PR TITLE
[release]: bump to 2.133.1

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/mesh",
-  "version": "2.133.0",
+  "version": "2.133.1",
   "description": "MCP Mesh - Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "license": "MIT",


### PR DESCRIPTION
## What is this contribution about?

Patch release bumping version from 2.133.0 to 2.133.1. The release CI (npm publish, Docker build, and GitHub release) has been triggered and is in progress.

## How to Test

Verify the release is published to npm:
```bash
npm view @decocms/mesh@2.133.1
```

Check the Docker image:
```bash
docker pull ghcr.io/decocms/mesh:2.133.1
```

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release bump for @decocms/mesh from 2.133.0 to 2.133.1. No functional changes; triggers npm publish, Docker build, and GitHub release.

<sup>Written for commit bce4d2774b89e63c467360b979fab0700282f225. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

