### PR TITLE
feat(ui): add icon picker for agents and custom MCP connections

### DIFF
--- a/apps/mesh/src/constants/capybara-icons.ts
+++ b/apps/mesh/src/constants/capybara-icons.ts
@@ -21,3 +21,14 @@ export function pickRandomCapybaraIcon(): string {
     CAPYBARA_ICON_MIN;
   return `/icons/capy-${index}.png`;
 }
+
+/**
+ * Returns all available capybara icon paths.
+ */
+export function getAllCapybaraIcons(): string[] {
+  const icons: string[] = [];
+  for (let i = CAPYBARA_ICON_MIN; i <= CAPYBARA_ICON_MAX; i++) {
+    icons.push(`/icons/capy-${i}.png`);
+  }
+  return icons;
+}

--- a/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
@@ -1,6 +1,7 @@
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { parseVirtualUrl } from "@/tools/connection/schema";
 import { EnvVarsEditor } from "@/web/components/env-vars-editor";
+import { IconPicker } from "@/web/components/icon-picker.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
 import { useProjectContext } from "@decocms/mesh-sdk";
@@ -40,7 +41,7 @@ import {
   XClose,
 } from "@untitledui/icons";
 import { formatDistanceToNow } from "date-fns";
-import { useForm, useWatch } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { User } from "@/web/components/user/user.tsx";
 import { ConnectionVirtualMCPsSection } from "./settings-tab/connection-virtual-mcps-section";
 import type { ConnectionFormData } from "./settings-tab/schema";
@@ -456,12 +457,28 @@ export function ConnectionSidebar({
       <div className="flex flex-col h-full overflow-auto">
         {/* Header section - Icon, Title, Description */}
         <div className="flex flex-col gap-4 p-5 border-b border-border">
-          <IntegrationIcon
-            icon={connection.icon}
-            name={connection.title}
-            size="lg"
-            className="shadow-sm"
-          />
+          {connection.app_name && connection.icon ? (
+            <IntegrationIcon
+              icon={connection.icon}
+              name={connection.title}
+              size="lg"
+              className="shadow-sm"
+            />
+          ) : (
+            <Controller
+              control={form.control}
+              name="icon"
+              render={({ field }) => (
+                <IconPicker
+                  value={field.value}
+                  onChange={field.onChange}
+                  name={connection.title}
+                  size="lg"
+                  className="shadow-sm"
+                />
+              )}
+            />
+          )}
           <div className="flex flex-col">
             <FormField
               control={form.control}

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -151,6 +151,7 @@ function connectionToFormValues(
   const baseFields = {
     title: connection.title,
     description: connection.description ?? "",
+    icon: connection.icon ?? null,
     configuration_state: connection.configuration_state ?? {},
     configuration_scopes: scopes || connection.configuration_scopes || [],
   };
@@ -243,6 +244,7 @@ function formValuesToConnectionUpdate(
   return {
     title: data.title,
     description: data.description || null,
+    icon: data.icon ?? null,
     connection_type: connectionType,
     connection_url: connectionUrl,
     ...(connectionToken && { connection_token: connectionToken }),

--- a/apps/mesh/src/web/components/details/connection/settings-tab/schema.ts
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/schema.ts
@@ -11,6 +11,7 @@ export const connectionFormSchema = z
   .object({
     title: z.string().min(1, "Name is required"),
     description: z.string().nullable().optional(),
+    icon: z.string().nullable().optional(),
     // UI type for display
     // - NPX: convenience wrapper for npm packages
     // - STDIO: custom command for local servers

--- a/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
@@ -2,6 +2,7 @@ import type { VirtualMCPEntity } from "@/tools/virtual/schema";
 import { useChatStable } from "@/web/components/chat/context";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { IconPicker } from "@/web/components/icon-picker.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
 import { Badge } from "@deco/ui/components/badge.tsx";
@@ -318,12 +319,19 @@ function VirtualMcpDetailViewWithData({
           {/* Header section */}
           <div className="flex items-start justify-between gap-4 p-6 shrink-0">
             <div className="flex items-start gap-4 flex-1 min-w-0">
-              <IntegrationIcon
-                icon={virtualMcp.icon}
-                name={form.watch("title") || "Agent"}
-                size="lg"
-                className="shrink-0 shadow-sm"
-                fallbackIcon={<Users03 />}
+              <Controller
+                control={form.control}
+                name="icon"
+                render={({ field }) => (
+                  <IconPicker
+                    value={field.value}
+                    onChange={field.onChange}
+                    name={form.watch("title") || "Agent"}
+                    size="lg"
+                    className="shrink-0 shadow-sm"
+                    fallbackIcon={<Users03 />}
+                  />
+                )}
               />
               <div className="flex flex-col flex-1 min-w-0">
                 <Input

--- a/apps/mesh/src/web/components/details/virtual-mcp/types.ts
+++ b/apps/mesh/src/web/components/details/virtual-mcp/types.ts
@@ -12,6 +12,7 @@ import type { UseFormReturn } from "react-hook-form";
 export const VirtualMcpFormSchema = VirtualMCPEntitySchema.pick({
   title: true,
   description: true,
+  icon: true,
   status: true,
   metadata: true,
   connections: true,

--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -1,0 +1,192 @@
+import { getAllCapybaraIcons } from "@/constants/capybara-icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { Container, Edit05, Link01, XClose } from "@untitledui/icons";
+import { useState, type ReactNode } from "react";
+
+const SIZE_CLASSES = {
+  sm: "h-8 w-8",
+  md: "h-12 w-12",
+  lg: "h-16 w-16",
+};
+
+type Size = keyof typeof SIZE_CLASSES;
+
+interface IconPickerProps {
+  value: string | null | undefined;
+  onChange: (icon: string | null) => void;
+  name: string;
+  size?: Size;
+  className?: string;
+  fallbackIcon?: ReactNode;
+}
+
+const capybaraIcons = getAllCapybaraIcons();
+
+export function IconPicker({
+  value,
+  onChange,
+  name,
+  size = "lg",
+  className,
+  fallbackIcon,
+}: IconPickerProps) {
+  const [customUrl, setCustomUrl] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const handleSelectIcon = (icon: string) => {
+    onChange(icon);
+    setOpen(false);
+    setCustomUrl("");
+  };
+
+  const handleApplyCustomUrl = () => {
+    const trimmed = customUrl.trim();
+    if (trimmed) {
+      onChange(trimmed);
+      setOpen(false);
+      setCustomUrl("");
+    }
+  };
+
+  const handleClearIcon = () => {
+    onChange(null);
+    setOpen(false);
+    setCustomUrl("");
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "relative group rounded-lg border border-border shrink-0 overflow-hidden cursor-pointer",
+            SIZE_CLASSES[size],
+            className,
+          )}
+        >
+          <IconPreview
+            key={value ?? "no-icon"}
+            icon={value}
+            name={name}
+            fallbackIcon={fallbackIcon}
+          />
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
+            <Edit05 size={16} className="text-white" />
+          </div>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-80 p-0"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="flex flex-col">
+          <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+            <span className="text-sm font-medium">Choose icon</span>
+            {value && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-1.5 text-xs text-muted-foreground"
+                onClick={handleClearIcon}
+              >
+                <XClose size={12} />
+                Remove
+              </Button>
+            )}
+          </div>
+
+          <ScrollArea className="h-48">
+            <div className="grid grid-cols-7 gap-1 p-2">
+              {capybaraIcons.map((icon) => (
+                <button
+                  key={icon}
+                  type="button"
+                  onClick={() => handleSelectIcon(icon)}
+                  className={cn(
+                    "h-9 w-9 rounded-md overflow-hidden border transition-colors hover:border-primary cursor-pointer",
+                    value === icon
+                      ? "border-primary ring-1 ring-primary"
+                      : "border-transparent",
+                  )}
+                >
+                  <img
+                    src={icon}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+
+          <div className="flex items-center gap-1.5 p-2 border-t border-border">
+            <Link01 size={14} className="text-muted-foreground shrink-0" />
+            <Input
+              value={customUrl}
+              onChange={(e) => setCustomUrl(e.target.value)}
+              placeholder="Paste image URL..."
+              className="h-7 text-xs"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleApplyCustomUrl();
+                }
+              }}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 px-2 text-xs shrink-0"
+              onClick={handleApplyCustomUrl}
+              disabled={!customUrl.trim()}
+            >
+              Apply
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function IconPreview({
+  icon,
+  name,
+  fallbackIcon,
+}: {
+  icon: string | null | undefined;
+  name: string;
+  fallbackIcon?: ReactNode;
+}) {
+  const [errored, setErrored] = useState(false);
+
+  if (!icon || errored) {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-muted/20">
+        {fallbackIcon ?? (
+          <Container size={24} className="text-muted-foreground" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={icon}
+      alt={name}
+      className="h-full w-full object-cover"
+      onError={() => setErrored(true)}
+    />
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -119,6 +119,7 @@ const connectionFormSchema = z
   .object({
     title: z.string().min(1, "Name is required"),
     description: z.string().nullable().optional(),
+    icon: z.string().nullable().optional(),
     // UI type - includes "NPX" and "STDIO" which both map to STDIO internally
     ui_type: z.enum(["HTTP", "SSE", "Websocket", "NPX", "STDIO"]),
     // For HTTP/SSE/Websocket
@@ -466,6 +467,7 @@ function OrgMcpsContent() {
     defaultValues: {
       title: "",
       description: null,
+      icon: null,
       ui_type: "HTTP",
       connection_url: "",
       connection_token: null,
@@ -517,6 +519,7 @@ function OrgMcpsContent() {
           form.reset({
             title: editingConnection.title,
             description: editingConnection.description,
+            icon: editingConnection.icon ?? null,
             ui_type: "NPX",
             connection_url: "",
             connection_token: null,
@@ -532,6 +535,7 @@ function OrgMcpsContent() {
           form.reset({
             title: editingConnection.title,
             description: editingConnection.description,
+            icon: editingConnection.icon ?? null,
             ui_type: "STDIO",
             connection_url: "",
             connection_token: null,
@@ -547,6 +551,7 @@ function OrgMcpsContent() {
         form.reset({
           title: editingConnection.title,
           description: editingConnection.description,
+          icon: editingConnection.icon ?? null,
           ui_type: editingConnection.connection_type as
             | "HTTP"
             | "SSE"
@@ -564,6 +569,7 @@ function OrgMcpsContent() {
       form.reset({
         title: "",
         description: null,
+        icon: null,
         ui_type: "HTTP",
         connection_url: "",
         connection_token: null,
@@ -721,6 +727,7 @@ function OrgMcpsContent() {
         data: {
           title: data.title,
           description: data.description || null,
+          icon: data.icon ?? null,
           connection_type: connectionType,
           connection_url: connectionUrl,
           ...(connectionToken && { connection_token: connectionToken }),
@@ -748,7 +755,7 @@ function OrgMcpsContent() {
       updated_at: new Date().toISOString(),
       created_by: session?.user?.id || "system",
       organization_id: org.id,
-      icon: null,
+      icon: data.icon ?? null,
       app_name: null,
       app_id: null,
       connection_headers: connectionParameters,


### PR DESCRIPTION
## Summary

- Adds a reusable `IconPicker` component with a popover grid of 39 capybara avatars and a custom URL input field
- Integrates the picker into the agent (Virtual MCP) detail page, allowing users to choose or change the agent icon
- Integrates the picker into the custom MCP connection sidebar for connections without a pre-existing icon (store-installed connections with icons remain non-editable)
- Adds `icon` field to all relevant form schemas, form resets, and update payloads

## Test plan

- [ ] Open an agent detail page, click the icon, select a capybara — verify preview updates immediately
- [ ] Paste a custom image URL, click Apply — verify the icon updates
- [ ] Click Remove — verify the icon reverts to fallback
- [ ] Save and reload — verify the icon persists
- [ ] Open a custom MCP connection (no store icon), verify the picker appears
- [ ] Open a store-installed connection with an existing icon, verify the icon is **not** editable
- [ ] Verify `bun run fmt`, `bun run lint`, `bun run check` pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an icon picker so users can set avatars for agents and custom MCP connections. Icons can be chosen from capybara avatars or a custom URL, and changes persist; store-installed connection icons remain read-only.

- **New Features**
  - Reusable IconPicker with a popover grid, custom URL input, and Remove action.
  - Agent (Virtual MCP) detail: editable icon with live preview and fallback.
  - Custom MCP connections: editable only when no store-provided icon is present.
  - Added icon to form schemas, defaults/resets, and update payloads to persist across reloads.

<sup>Written for commit 874603e3f3e4a5109f81ca25a3108263663261b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

