### PR TITLE
feat(runtime): include organization name and slug in MCP request context

### DIFF
--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -59,6 +59,10 @@ export interface MeshTokenPayload {
     connectionId: string;
     /** Organization ID */
     organizationId?: string;
+    /** Organization display name */
+    organizationName?: string;
+    /** Organization URL slug */
+    organizationSlug?: string;
   };
   /** Permissions per connection: { [connectionId]: [scopes] } */
   permissions: Record<string, string[]>;

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -59,6 +59,8 @@ export async function buildRequestHeaders(
           meshUrl: ctx.baseUrl,
           connectionId,
           organizationId: ctx.organization?.id,
+          organizationName: ctx.organization?.name,
+          organizationSlug: ctx.organization?.slug,
         },
         permissions,
       })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -112,6 +112,8 @@ export interface RequestContext<
   callerApp?: string;
   connectionId?: string;
   organizationId?: string;
+  organizationName?: string;
+  organizationSlug?: string;
 }
 
 const withDefaultBindings = ({
@@ -191,6 +193,8 @@ export const withBindings = <TEnv>({
         meshUrl?: string;
         connectionId?: string;
         organizationId?: string;
+        organizationName?: string;
+        organizationSlug?: string;
       }) ?? {};
 
     context = {
@@ -201,6 +205,10 @@ export const withBindings = <TEnv>({
       connectionId: (decoded.connectionId as string) ?? metadata.connectionId,
       organizationId:
         (decoded.organizationId as string) ?? metadata.organizationId,
+      organizationName:
+        (decoded.organizationName as string) ?? metadata.organizationName,
+      organizationSlug:
+        (decoded.organizationSlug as string) ?? metadata.organizationSlug,
       ensureAuthenticated: AUTHENTICATED(decoded.user ?? decoded.sub),
     } as RequestContext<any>;
   } else if (typeof tokenOrContext === "object") {


### PR DESCRIPTION
## Summary

- Adds `organizationName` and `organizationSlug` to the JWT metadata emitted by the Mesh proxy to downstream MCPs
- Exposes both fields in `MESH_REQUEST_CONTEXT` so MCPs can access organization name/slug without extra queries
- Zero performance cost: data is already in memory at token emission time

## Changes

- **`apps/mesh/src/auth/jwt.ts`** — Added `organizationName` and `organizationSlug` to `MeshTokenPayload.metadata`
- **`apps/mesh/src/mcp-clients/outbound/headers.ts`** — Passes `ctx.organization.name` and `ctx.organization.slug` in JWT metadata
- **`packages/runtime/src/index.ts`** — Added fields to `RequestContext` interface and JWT decoding logic

## Usage

```typescript
const orgName = env.MESH_REQUEST_CONTEXT?.organizationName;
const orgSlug = env.MESH_REQUEST_CONTEXT?.organizationSlug;
```

## Test plan

- [x] `bun run fmt` — no changes
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run check` — all workspaces pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose organizationName and organizationSlug in JWT metadata and MESH_REQUEST_CONTEXT so MCPs can read org info without extra queries.

- **New Features**
  - JWT metadata now includes organizationName and organizationSlug.
  - Runtime RequestContext and JWT decoding updated to surface both fields.
  - MCPs can read env.MESH_REQUEST_CONTEXT.organizationName and env.MESH_REQUEST_CONTEXT.organizationSlug.

<sup>Written for commit 81b18413e81dae1e200eba487fba0008509f4074. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

