### PR TITLE
feat(agents): add grouping, bulk selection, stats, filters and creator avatars

### DIFF
--- a/apps/mesh/src/web/routes/orgs/agents.tsx
+++ b/apps/mesh/src/web/routes/orgs/agents.tsx
@@ -7,8 +7,8 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
 } from "@deco/ui/components/breadcrumb.tsx";
-import { CollectionTableWrapper } from "@/web/components/collections/collection-table-wrapper.tsx";
 import { ConnectionCard } from "@/web/components/connections/connection-card.tsx";
+import { ConnectionStatus } from "@/web/components/connections/connection-status.tsx";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
@@ -32,26 +32,132 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
 import { type TableColumn } from "@/web/components/collections/collection-table.tsx";
+import {
+  Table as UITable,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@deco/ui/components/table.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import {
+  ArrowDown,
+  ArrowUp,
+  CheckSquare,
+  ChevronDown,
   DotsVertical,
   Eye,
-  Trash01,
   Loading01,
+  Trash01,
   Users03,
+  XClose,
 } from "@untitledui/icons";
 import { useNavigate } from "@tanstack/react-router";
-import { Suspense, useReducer } from "react";
+import { Fragment, Suspense, useReducer, useState } from "react";
 import { User } from "@/web/components/user/user.tsx";
 import { AgentConnectionsPreview } from "@/web/components/connections/agent-connections-preview.tsx";
 import { formatTimeAgo } from "@/web/lib/format-time";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// Grouping helpers
+// ---------------------------------------------------------------------------
+
+interface AgentGroup {
+  type: "group";
+  key: string;
+  icon: string | null;
+  title: string;
+  agents: VirtualMCPEntity[];
+}
+
+interface SingleAgent {
+  type: "single";
+  agent: VirtualMCPEntity;
+}
+
+type GroupedItem = SingleAgent | AgentGroup;
+
+function getGroupKey(a: VirtualMCPEntity): string {
+  return a.title.trim().replace(/\s+\(\d+\)$/, "");
+}
+
+function groupAgents(agents: VirtualMCPEntity[]): GroupedItem[] {
+  const buckets = new Map<string, VirtualMCPEntity[]>();
+  for (const a of agents) {
+    const key = getGroupKey(a);
+    const list = buckets.get(key);
+    if (list) {
+      list.push(a);
+    } else {
+      buckets.set(key, [a]);
+    }
+  }
+
+  const items: GroupedItem[] = [];
+  const seen = new Set<string>();
+
+  for (const a of agents) {
+    const key = getGroupKey(a);
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const bucket = buckets.get(key)!;
+    const first = bucket[0]!;
+    if (bucket.length === 1) {
+      items.push({ type: "single", agent: first });
+    } else {
+      items.push({
+        type: "group",
+        key,
+        icon: first.icon,
+        title: first.title.replace(/\s*\(\d+\)\s*$/, ""),
+        agents: bucket,
+      });
+    }
+  }
+  return items;
+}
+
+function getUniqueCreators(agents: VirtualMCPEntity[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const a of agents) {
+    if (a.created_by && !seen.has(a.created_by)) {
+      seen.add(a.created_by);
+      result.push(a.created_by);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Status filter
+// ---------------------------------------------------------------------------
+
+type AgentStatusFilter = "ALL" | "active" | "inactive";
+
+// ---------------------------------------------------------------------------
+// Dialog state
+// ---------------------------------------------------------------------------
 
 type DialogState =
   | { mode: "idle" }
@@ -70,11 +176,569 @@ function dialogReducer(_state: DialogState, action: DialogAction): DialogState {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Agent group card (cards view — same size as ConnectionCard, opens dialog)
+// ---------------------------------------------------------------------------
+
+function AgentGroupCard({
+  group,
+  onNavigate,
+  onDelete,
+  selectionMode,
+  selectedIds,
+  onToggleSelect,
+}: {
+  group: AgentGroup;
+  onNavigate: (id: string) => void;
+  onDelete: (agent: VirtualMCPEntity) => void;
+  selectionMode: boolean;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const allSelected = group.agents.every((a) => selectedIds.has(a.id));
+  const someSelected = group.agents.some((a) => selectedIds.has(a.id));
+  const creators = getUniqueCreators(group.agents);
+
+  const mostRecent = group.agents.reduce((latest, a) => {
+    const t = a.updated_at ?? a.created_at;
+    const l = latest.updated_at ?? latest.created_at;
+    if (!t) return latest;
+    if (!l) return a;
+    return new Date(t) > new Date(l) ? a : latest;
+  }, group.agents[0]!);
+  const recentTs = mostRecent.updated_at ?? mostRecent.created_at;
+
+  return (
+    <>
+      <ConnectionCard
+        connection={{
+          title: group.title,
+          icon: group.icon,
+          description: `${group.agents.length} instances`,
+        }}
+        onClick={() =>
+          selectionMode
+            ? (() => {
+                for (const a of group.agents) {
+                  if (allSelected) {
+                    if (selectedIds.has(a.id)) onToggleSelect(a.id);
+                  } else {
+                    if (!selectedIds.has(a.id)) onToggleSelect(a.id);
+                  }
+                }
+              })()
+            : setDialogOpen(true)
+        }
+        className={cn(
+          selectionMode && allSelected && "ring-2 ring-primary",
+          selectionMode &&
+            someSelected &&
+            !allSelected &&
+            "ring-1 ring-primary/50",
+        )}
+        fallbackIcon={<Users03 />}
+        headerActions={
+          selectionMode ? (
+            <Checkbox
+              checked={
+                allSelected ? true : someSelected ? "indeterminate" : false
+              }
+              onCheckedChange={() => {
+                for (const a of group.agents) {
+                  if (allSelected) {
+                    if (selectedIds.has(a.id)) onToggleSelect(a.id);
+                  } else {
+                    if (!selectedIds.has(a.id)) onToggleSelect(a.id);
+                  }
+                }
+              }}
+            />
+          ) : (
+            <Badge variant="secondary" className="text-xs tabular-nums">
+              x{group.agents.length}
+            </Badge>
+          )
+        }
+        body={
+          <div className="flex items-center gap-1">
+            {group.agents.slice(0, 6).map((a) => (
+              <ConnectionStatus key={a.id} status={a.status} />
+            ))}
+          </div>
+        }
+        footer={
+          <div className="flex items-center justify-between text-xs text-muted-foreground w-full min-w-0">
+            <div className="flex items-center -space-x-1.5">
+              {creators.map((id) => (
+                <User
+                  key={id}
+                  id={id}
+                  size="3xs"
+                  avatarOnly={creators.length > 1}
+                />
+              ))}
+            </div>
+            <span className="shrink-0 ml-2">
+              {recentTs ? formatTimeAgo(new Date(recentTs)) : "—"}
+            </span>
+          </div>
+        }
+      />
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-lg p-0 gap-0">
+          <DialogHeader className="px-6 pt-6 pb-4">
+            <div className="flex items-center gap-3">
+              <IntegrationIcon
+                icon={group.icon}
+                name={group.title}
+                size="md"
+                className="shrink-0 shadow-sm"
+                fallbackIcon={<Users03 />}
+              />
+              <div>
+                <DialogTitle>
+                  {group.title}
+                  <Badge
+                    variant="secondary"
+                    className="ml-2 text-xs tabular-nums"
+                  >
+                    x{group.agents.length}
+                  </Badge>
+                </DialogTitle>
+                <DialogDescription>
+                  {group.agents.length} instances
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+          <div className="divide-y max-h-80 overflow-auto">
+            {group.agents.map((a) => (
+              <div
+                key={a.id}
+                className="flex items-center gap-3 px-6 py-3 hover:bg-muted/30 cursor-pointer transition-colors"
+                onClick={() => {
+                  setDialogOpen(false);
+                  onNavigate(a.id);
+                }}
+              >
+                <IntegrationIcon
+                  icon={a.icon}
+                  name={a.title}
+                  size="sm"
+                  className="shrink-0"
+                  fallbackIcon={<Users03 />}
+                />
+                <div className="flex-1 min-w-0 flex items-center gap-2">
+                  <span className="text-sm font-medium text-foreground truncate">
+                    {a.title}
+                  </span>
+                  <ConnectionStatus status={a.status} />
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
+                  <User id={a.created_by} size="3xs" />
+                  <span>
+                    {a.created_at ? formatTimeAgo(new Date(a.created_at)) : "—"}
+                  </span>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <DotsVertical size={16} />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setDialogOpen(false);
+                        onNavigate(a.id);
+                      }}
+                    >
+                      <Eye size={16} />
+                      Open
+                    </DropdownMenuItem>
+                    {!isDecopilot(a.id) && (
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => onDelete(a)}
+                      >
+                        <Trash01 size={16} />
+                        Delete
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Floating bulk action bar
+// ---------------------------------------------------------------------------
+
+function BulkActionBar({
+  count,
+  total,
+  onSelectAll,
+  onDeselectAll,
+  onDelete,
+  onCancel,
+}: {
+  count: number;
+  total: number;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onDelete: () => void;
+  onCancel: () => void;
+}) {
+  if (count === 0) return null;
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 flex items-center gap-3 rounded-xl border border-border bg-background/95 backdrop-blur px-4 py-2.5 shadow-lg">
+      <span className="text-sm font-medium tabular-nums">{count} selected</span>
+      <div className="h-4 w-px bg-border" />
+      {count < total ? (
+        <Button variant="ghost" size="sm" onClick={onSelectAll}>
+          Select all ({total})
+        </Button>
+      ) : (
+        <Button variant="ghost" size="sm" onClick={onDeselectAll}>
+          Clear selection
+        </Button>
+      )}
+      <div className="h-4 w-px bg-border" />
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-destructive hover:text-destructive"
+        onClick={onDelete}
+      >
+        <Trash01 size={14} />
+        Delete
+      </Button>
+      <div className="h-4 w-px bg-border" />
+      <Button variant="ghost" size="sm" onClick={onCancel}>
+        <XClose size={14} />
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grouped agent table (table view with accordion)
+// ---------------------------------------------------------------------------
+
+function GroupedAgentTable({
+  columns,
+  grouped,
+  sortKey,
+  sortDirection,
+  onSort,
+  onRowClick,
+  selectionMode,
+  selectedIds,
+  onToggleSelect,
+  emptyState,
+}: {
+  columns: TableColumn<VirtualMCPEntity>[];
+  grouped: GroupedItem[];
+  sortKey?: string;
+  sortDirection?: "asc" | "desc" | null;
+  onSort?: (key: string) => void;
+  onRowClick: (agent: VirtualMCPEntity) => void;
+  selectionMode: boolean;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  emptyState?: React.ReactNode;
+}) {
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  const toggleGroup = (key: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  if (grouped.length === 0 && emptyState) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        {emptyState}
+      </div>
+    );
+  }
+
+  const colCount = columns.length;
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <UITable className="w-full border-collapse">
+        <TableHeader className="border-b-0">
+          <TableRow className="h-9 hover:bg-transparent border-b border-border">
+            {columns.map((col, idx) => {
+              const isActiveSort = sortKey === col.id;
+              const headerBase =
+                "px-4 py-2 text-left font-mono font-normal text-muted-foreground text-[11px] h-9 uppercase tracking-wider";
+              const isLast = idx === colCount - 1;
+              return (
+                <TableHead
+                  key={col.id}
+                  className={cn(
+                    headerBase,
+                    isLast && "w-8",
+                    "group transition-colors select-none",
+                    col.sortable && "hover:bg-accent cursor-pointer",
+                    col.cellClassName,
+                  )}
+                  onClick={
+                    col.sortable && onSort ? () => onSort(col.id) : undefined
+                  }
+                >
+                  <span className="flex items-center gap-1">
+                    {col.header}
+                    {col.sortable && (
+                      <span className="w-4 flex items-center justify-center">
+                        {isActiveSort &&
+                          sortDirection &&
+                          (sortDirection === "asc" ? (
+                            <ArrowUp
+                              size={16}
+                              className="text-muted-foreground"
+                            />
+                          ) : (
+                            <ArrowDown
+                              size={16}
+                              className="text-muted-foreground"
+                            />
+                          ))}
+                      </span>
+                    )}
+                  </span>
+                </TableHead>
+              );
+            })}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {grouped.map((item) => {
+            if (item.type === "single") {
+              const a = item.agent;
+              return (
+                <TableRow
+                  key={a.id}
+                  className={cn(
+                    "group/data-row transition-colors border-b-0 hover:bg-accent/50 cursor-pointer",
+                    selectionMode && selectedIds.has(a.id) && "bg-primary/5",
+                  )}
+                  onClick={() => onRowClick(a)}
+                >
+                  {columns.map((col) => (
+                    <TableCell
+                      key={col.id}
+                      className={cn(
+                        "px-5 py-4 h-16 align-middle text-sm text-foreground",
+                        col.cellClassName,
+                      )}
+                    >
+                      <div className="min-w-0 w-full truncate overflow-hidden whitespace-nowrap">
+                        {col.render ? col.render(a) : null}
+                      </div>
+                    </TableCell>
+                  ))}
+                </TableRow>
+              );
+            }
+
+            const group = item;
+            const isExpanded = expandedGroups.has(group.key);
+            const allSelected = group.agents.every((a) =>
+              selectedIds.has(a.id),
+            );
+            const someSelected = group.agents.some((a) =>
+              selectedIds.has(a.id),
+            );
+            const creators = getUniqueCreators(group.agents);
+
+            const mostRecent = group.agents.reduce((latest, a) => {
+              const t = a.updated_at ?? a.created_at;
+              const l = latest.updated_at ?? latest.created_at;
+              if (!t) return latest;
+              if (!l) return a;
+              return new Date(t) > new Date(l) ? a : latest;
+            }, group.agents[0]!);
+
+            return (
+              <Fragment key={group.key}>
+                <TableRow
+                  className="border-b-0 hover:bg-accent/50 cursor-pointer transition-colors"
+                  onClick={() => toggleGroup(group.key)}
+                >
+                  {columns.map((col) => {
+                    const base = cn(
+                      "px-5 py-3 h-14 align-middle text-sm",
+                      col.cellClassName,
+                    );
+
+                    if (col.id === "select") {
+                      return (
+                        <TableCell key={col.id} className={base}>
+                          <Checkbox
+                            checked={
+                              allSelected
+                                ? true
+                                : someSelected
+                                  ? "indeterminate"
+                                  : false
+                            }
+                            onCheckedChange={() => {
+                              for (const a of group.agents) {
+                                if (allSelected) {
+                                  if (selectedIds.has(a.id))
+                                    onToggleSelect(a.id);
+                                } else {
+                                  if (!selectedIds.has(a.id))
+                                    onToggleSelect(a.id);
+                                }
+                              }
+                            }}
+                            onClick={(e: React.MouseEvent) =>
+                              e.stopPropagation()
+                            }
+                          />
+                        </TableCell>
+                      );
+                    }
+
+                    if (col.id === "title") {
+                      return (
+                        <TableCell key={col.id} className={base}>
+                          <div className="flex items-center gap-2 min-w-0">
+                            <IntegrationIcon
+                              icon={group.icon}
+                              name={group.title}
+                              size="sm"
+                              className="shrink-0 shadow-sm"
+                              fallbackIcon={<Users03 size={16} />}
+                            />
+                            <span className="text-sm font-medium text-foreground truncate">
+                              {group.title}
+                            </span>
+                            <Badge
+                              variant="secondary"
+                              className="text-xs tabular-nums"
+                            >
+                              x{group.agents.length}
+                            </Badge>
+                          </div>
+                        </TableCell>
+                      );
+                    }
+
+                    if (col.id === "updated_by") {
+                      return (
+                        <TableCell key={col.id} className={base}>
+                          <div className="flex items-center -space-x-1.5">
+                            {creators.map((id) => (
+                              <User
+                                key={id}
+                                id={id}
+                                size="3xs"
+                                avatarOnly={creators.length > 1}
+                              />
+                            ))}
+                          </div>
+                        </TableCell>
+                      );
+                    }
+
+                    if (col.id === "updated_at") {
+                      const ts = mostRecent.updated_at ?? mostRecent.created_at;
+                      return (
+                        <TableCell key={col.id} className={base}>
+                          <span className="text-xs text-muted-foreground whitespace-nowrap">
+                            {ts ? formatTimeAgo(new Date(ts)) : "—"}
+                          </span>
+                        </TableCell>
+                      );
+                    }
+
+                    if (col.id === "actions") {
+                      return (
+                        <TableCell key={col.id} className={base}>
+                          <ChevronDown
+                            size={16}
+                            className={cn(
+                              "text-muted-foreground transition-transform",
+                              isExpanded && "rotate-180",
+                            )}
+                          />
+                        </TableCell>
+                      );
+                    }
+
+                    return <TableCell key={col.id} className={base} />;
+                  })}
+                </TableRow>
+
+                {isExpanded &&
+                  group.agents.map((a) => (
+                    <TableRow
+                      key={a.id}
+                      className={cn(
+                        "group/data-row transition-colors border-b-0 hover:bg-accent/50 cursor-pointer bg-muted/20",
+                        selectionMode &&
+                          selectedIds.has(a.id) &&
+                          "bg-primary/5",
+                      )}
+                      onClick={() => onRowClick(a)}
+                    >
+                      {columns.map((col) => (
+                        <TableCell
+                          key={col.id}
+                          className={cn(
+                            "px-5 py-3 h-14 align-middle text-sm text-foreground",
+                            col.cellClassName,
+                            col.id === "title" && "pl-12",
+                          )}
+                        >
+                          <div className="min-w-0 w-full truncate overflow-hidden whitespace-nowrap">
+                            {col.render ? col.render(a) : null}
+                          </div>
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+              </Fragment>
+            );
+          })}
+        </TableBody>
+      </UITable>
+    </div>
+  );
+}
+
+// ===========================================================================
+
 function OrgAgentsContent() {
   const { org } = useProjectContext();
   const navigate = useNavigate();
 
-  // Consolidated list UI state (search, filters, sorting, view mode)
   const listState = useListState<VirtualMCPEntity>({
     namespace: org.slug,
     resource: "agents",
@@ -88,22 +752,106 @@ function OrgAgentsContent() {
 
   const [dialogState, dispatch] = useReducer(dialogReducer, { mode: "idle" });
 
+  // Bulk selection state
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+
+  // Status filter
+  const [statusFilter, setStatusFilter] = useState<AgentStatusFilter>("ALL");
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const exitSelectionMode = () => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  // Filtered agents
+  const filteredAgents = virtualMcps.filter((a) => {
+    if (statusFilter !== "ALL" && a.status !== statusFilter) return false;
+    return true;
+  });
+
+  // Grouped items
+  const grouped = groupAgents(filteredAgents);
+
+  // Stats
+  const stats = {
+    total: virtualMcps.length,
+    active: virtualMcps.filter((a) => a.status === "active").length,
+    inactive: virtualMcps.filter((a) => a.status === "inactive").length,
+  };
+
+  // Delete handlers
   const confirmDelete = async () => {
     if (dialogState.mode !== "deleting") return;
-
     const id = dialogState.virtualMcp.id;
     dispatch({ type: "close" });
-
-    if (!id || isDecopilot(id)) return; // Can't delete Decopilot
-
+    if (!id || isDecopilot(id)) return;
     try {
       await actions.delete.mutateAsync(id);
     } catch {
-      // Error toast is handled by the mutation's onError
+      // Error toast handled by mutation
     }
   };
 
+  const handleBulkDelete = async () => {
+    setBulkDeleteOpen(false);
+    let deleted = 0;
+    for (const id of selectedIds) {
+      if (isDecopilot(id)) continue;
+      try {
+        await actions.delete.mutateAsync(id);
+        deleted++;
+      } catch {
+        // continue
+      }
+    }
+    toast.success(`Deleted ${deleted} agent${deleted !== 1 ? "s" : ""}`);
+    exitSelectionMode();
+  };
+
+  const navigateToAgent = (agentId: string) => {
+    if (selectionMode) {
+      toggleSelect(agentId);
+      return;
+    }
+    navigate({
+      to: "/$org/$project/agents/$agentId",
+      params: {
+        org: org.slug,
+        project: ORG_ADMIN_PROJECT_SLUG,
+        agentId,
+      },
+    });
+  };
+
+  // Columns
   const columns: TableColumn<VirtualMCPEntity>[] = [
+    ...(selectionMode
+      ? [
+          {
+            id: "select",
+            header: "",
+            render: (agent: VirtualMCPEntity) => (
+              <Checkbox
+                checked={selectedIds.has(agent.id)}
+                onCheckedChange={() => toggleSelect(agent.id)}
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              />
+            ),
+            cellClassName: "w-10 shrink-0",
+          } satisfies TableColumn<VirtualMCPEntity>,
+        ]
+      : []),
     {
       id: "title",
       header: "Name",
@@ -150,6 +898,12 @@ function OrgAgentsContent() {
       cellClassName: "w-28 shrink-0",
     },
     {
+      id: "status",
+      header: "Status",
+      render: (virtualMcp) => <ConnectionStatus status={virtualMcp.status} />,
+      cellClassName: "w-24 shrink-0",
+    },
+    {
       id: "updated_by",
       header: "Updated by",
       render: (virtualMcp) => (
@@ -190,29 +944,24 @@ function OrgAgentsContent() {
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();
-                navigate({
-                  to: "/$org/$project/agents/$agentId",
-                  params: {
-                    org: org.slug,
-                    project: ORG_ADMIN_PROJECT_SLUG,
-                    agentId: virtualMcp.id,
-                  },
-                });
+                navigateToAgent(virtualMcp.id);
               }}
             >
               <Eye size={16} />
               Open
             </DropdownMenuItem>
-            <DropdownMenuItem
-              variant="destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                dispatch({ type: "delete", virtualMcp });
-              }}
-            >
-              <Trash01 size={16} />
-              Delete
-            </DropdownMenuItem>
+            {!isDecopilot(virtualMcp.id) && (
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dispatch({ type: "delete", virtualMcp });
+                }}
+              >
+                <Trash01 size={16} />
+                Delete
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       ),
@@ -221,19 +970,44 @@ function OrgAgentsContent() {
   ];
 
   const ctaButton = (
-    <Button
-      onClick={createVirtualMCP}
-      size="sm"
-      className="h-7 px-3 rounded-lg text-sm font-medium"
-      disabled={isCreating}
-    >
-      {isCreating ? "Creating..." : "Create Agent"}
-    </Button>
+    <div className="flex items-center gap-2">
+      {selectionMode ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 px-3 rounded-lg text-sm font-medium"
+          onClick={exitSelectionMode}
+        >
+          <XClose size={14} />
+          Cancel
+        </Button>
+      ) : (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-3 rounded-lg text-sm font-medium"
+            onClick={() => setSelectionMode(true)}
+          >
+            <CheckSquare size={14} />
+            Select
+          </Button>
+          <Button
+            onClick={createVirtualMCP}
+            size="sm"
+            className="h-7 px-3 rounded-lg text-sm font-medium"
+            disabled={isCreating}
+          >
+            {isCreating ? "Creating..." : "Create Agent"}
+          </Button>
+        </>
+      )}
+    </div>
   );
 
   return (
     <Page>
-      {/* Delete Confirmation Dialog */}
+      {/* Delete Confirmation Dialog (single) */}
       <AlertDialog
         open={dialogState.mode === "deleting"}
         onOpenChange={(open) => !open && dispatch({ type: "close" })}
@@ -262,13 +1036,45 @@ function OrgAgentsContent() {
         </AlertDialogContent>
       </AlertDialog>
 
+      {/* Bulk Delete Confirmation Dialog */}
+      <AlertDialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {selectedIds.size} agent{selectedIds.size !== 1 ? "s" : ""}
+              ?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete the
+              selected agents.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleBulkDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       {/* Page Header */}
       <Page.Header>
         <Page.Header.Left>
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem>
-                <BreadcrumbPage>Agents</BreadcrumbPage>
+                <BreadcrumbPage className="flex items-center gap-2">
+                  Agents
+                  <span className="text-xs font-normal text-muted-foreground tabular-nums">
+                    {stats.total} total
+                    {stats.active > 0 && ` · ${stats.active} active`}
+                    {stats.inactive > 0 && ` · ${stats.inactive} inactive`}
+                  </span>
+                </BreadcrumbPage>
               </BreadcrumbItem>
             </BreadcrumbList>
           </Breadcrumb>
@@ -286,29 +1092,46 @@ function OrgAgentsContent() {
               { id: "updated_by", label: "Updated by" },
               { id: "updated_at", label: "Updated" },
             ]}
+            filters={[
+              {
+                label: "Status",
+                value: statusFilter,
+                onChange: (v) =>
+                  setStatusFilter((v as AgentStatusFilter) || "ALL"),
+                options: [
+                  { id: "ALL", label: "All" },
+                  { id: "active", label: "Active" },
+                  { id: "inactive", label: "Inactive" },
+                ],
+              },
+            ]}
           />
           {ctaButton}
         </Page.Header.Right>
       </Page.Header>
 
       {/* Search Bar */}
-      <CollectionSearch
-        value={listState.search}
-        onChange={listState.setSearch}
-        placeholder="Search for an agent..."
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            listState.setSearch("");
-            (event.target as HTMLInputElement).blur();
-          }
-        }}
-      />
+      <div className="flex items-center gap-3 px-5 pb-0">
+        <div className="flex-1">
+          <CollectionSearch
+            value={listState.search}
+            onChange={listState.setSearch}
+            placeholder="Search for an agent..."
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                listState.setSearch("");
+                (event.target as HTMLInputElement).blur();
+              }
+            }}
+          />
+        </div>
+      </div>
 
       {/* Content: Cards or Table */}
       <Page.Content>
         {listState.viewMode === "cards" ? (
           <div className="flex-1 overflow-auto p-5">
-            {virtualMcps.length === 0 ? (
+            {filteredAgents.length === 0 ? (
               <EmptyState
                 image={<Users03 size={36} className="text-muted-foreground" />}
                 title={listState.search ? "No agents found" : "No agents yet"}
@@ -320,127 +1143,176 @@ function OrgAgentsContent() {
               />
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
-                {virtualMcps.map((virtualMcp) => (
-                  <ConnectionCard
-                    key={virtualMcp.id ?? "default"}
-                    connection={{
-                      id: virtualMcp.id ?? "",
-                      title: virtualMcp.title,
-                      description: virtualMcp.description,
-                      icon: virtualMcp.icon,
-                      status: virtualMcp.status,
-                    }}
-                    fallbackIcon={<Users03 />}
-                    onClick={() =>
-                      navigate({
-                        to: "/$org/$project/agents/$agentId",
-                        params: {
-                          org: org.slug,
-                          project: ORG_ADMIN_PROJECT_SLUG,
-                          agentId: virtualMcp.id,
-                        },
-                      })
-                    }
-                    footer={
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                        <span>
-                          {virtualMcp.connections.length} connection
-                          {virtualMcp.connections.length !== 1 ? "s" : ""}
-                        </span>
-                      </div>
-                    }
-                    headerActions={
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <DotsVertical size={20} />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent
-                          align="end"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <DropdownMenuItem
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              navigate({
-                                to: "/$org/$project/agents/$agentId",
-                                params: {
-                                  org: org.slug,
-                                  project: ORG_ADMIN_PROJECT_SLUG,
-                                  agentId: virtualMcp.id,
-                                },
-                              });
-                            }}
-                          >
-                            <Eye size={16} />
-                            Open
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            variant="destructive"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              dispatch({ type: "delete", virtualMcp });
-                            }}
-                          >
-                            <Trash01 size={16} />
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    }
-                  />
-                ))}
+                {grouped.map((item) => {
+                  if (item.type === "group") {
+                    return (
+                      <AgentGroupCard
+                        key={item.key}
+                        group={item}
+                        onNavigate={navigateToAgent}
+                        onDelete={(a) =>
+                          dispatch({ type: "delete", virtualMcp: a })
+                        }
+                        selectionMode={selectionMode}
+                        selectedIds={selectedIds}
+                        onToggleSelect={toggleSelect}
+                      />
+                    );
+                  }
+
+                  const agent = item.agent;
+                  return (
+                    <div key={agent.id} className="relative">
+                      {selectionMode && (
+                        <div className="absolute top-3 left-3 z-10">
+                          <Checkbox
+                            checked={selectedIds.has(agent.id)}
+                            onCheckedChange={() => toggleSelect(agent.id)}
+                          />
+                        </div>
+                      )}
+                      <ConnectionCard
+                        connection={{
+                          id: agent.id ?? "",
+                          title: agent.title,
+                          description: agent.description,
+                          icon: agent.icon,
+                          status: agent.status,
+                        }}
+                        fallbackIcon={<Users03 />}
+                        onClick={() => navigateToAgent(agent.id)}
+                        className={cn(
+                          selectionMode &&
+                            selectedIds.has(agent.id) &&
+                            "ring-2 ring-primary",
+                        )}
+                        body={<ConnectionStatus status={agent.status} />}
+                        footer={
+                          <div className="flex items-center justify-between text-xs text-muted-foreground w-full min-w-0">
+                            <div className="flex-1 min-w-0">
+                              <User
+                                id={agent.updated_by ?? agent.created_by}
+                                size="3xs"
+                              />
+                            </div>
+                            <span className="shrink-0 ml-2">
+                              {agent.updated_at
+                                ? formatTimeAgo(new Date(agent.updated_at))
+                                : "—"}
+                            </span>
+                          </div>
+                        }
+                        headerActions={
+                          !selectionMode ? (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-8 w-8 p-0"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <DotsVertical size={20} />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent
+                                align="end"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <DropdownMenuItem
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    navigateToAgent(agent.id);
+                                  }}
+                                >
+                                  <Eye size={16} />
+                                  Open
+                                </DropdownMenuItem>
+                                {!isDecopilot(agent.id) && (
+                                  <DropdownMenuItem
+                                    variant="destructive"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      dispatch({
+                                        type: "delete",
+                                        virtualMcp: agent,
+                                      });
+                                    }}
+                                  >
+                                    <Trash01 size={16} />
+                                    Delete
+                                  </DropdownMenuItem>
+                                )}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          ) : undefined
+                        }
+                      />
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
         ) : (
           <div className="h-full flex flex-col overflow-hidden">
-            <CollectionTableWrapper
-              columns={columns}
-              data={virtualMcps}
-              isLoading={false}
-              sortKey={listState.sortKey}
-              sortDirection={listState.sortDirection}
-              onSort={listState.handleSort}
-              onRowClick={(virtualMcp) =>
-                navigate({
-                  to: "/$org/$project/agents/$agentId",
-                  params: {
-                    org: org.slug,
-                    project: ORG_ADMIN_PROJECT_SLUG,
-                    agentId: virtualMcp.id,
-                  },
-                })
-              }
-              emptyState={
-                listState.search ? (
-                  <EmptyState
-                    image={
-                      <Users03 size={36} className="text-muted-foreground" />
-                    }
-                    title="No agents found"
-                    description={`No agents match "${listState.search}"`}
-                  />
-                ) : (
-                  <EmptyState
-                    image={
-                      <Users03 size={36} className="text-muted-foreground" />
-                    }
-                    title="No agents yet"
-                    description="Create an agent to aggregate tools from multiple Connections."
-                  />
-                )
-              }
-            />
+            <div className="flex-1 overflow-auto min-w-0">
+              <div className="min-w-[1000px]">
+                <GroupedAgentTable
+                  columns={columns}
+                  grouped={grouped}
+                  sortKey={listState.sortKey}
+                  sortDirection={listState.sortDirection}
+                  onSort={listState.handleSort}
+                  onRowClick={(agent) => navigateToAgent(agent.id)}
+                  selectionMode={selectionMode}
+                  selectedIds={selectedIds}
+                  onToggleSelect={toggleSelect}
+                  emptyState={
+                    listState.search ? (
+                      <EmptyState
+                        image={
+                          <Users03
+                            size={36}
+                            className="text-muted-foreground"
+                          />
+                        }
+                        title="No agents found"
+                        description={`No agents match "${listState.search}"`}
+                      />
+                    ) : (
+                      <EmptyState
+                        image={
+                          <Users03
+                            size={36}
+                            className="text-muted-foreground"
+                          />
+                        }
+                        title="No agents yet"
+                        description="Create an agent to aggregate tools from multiple Connections."
+                      />
+                    )
+                  }
+                />
+              </div>
+            </div>
           </div>
         )}
       </Page.Content>
+
+      {/* Bulk Action Bar */}
+      {selectionMode && (
+        <BulkActionBar
+          count={selectedIds.size}
+          total={filteredAgents.length}
+          onSelectAll={() =>
+            setSelectedIds(new Set(filteredAgents.map((a) => a.id)))
+          }
+          onDeselectAll={() => setSelectedIds(new Set())}
+          onDelete={() => setBulkDeleteOpen(true)}
+          onCancel={exitSelectionMode}
+        />
+      )}
     </Page>
   );
 }


### PR DESCRIPTION
## Summary

- **Grouping by name**: Agents with identical names are grouped using inline accordion (table view) and dialog (cards view), matching the connections page pattern
- **Bulk selection mode**: "Select" button enables multi-select with a floating action bar for bulk delete
- **Header stats**: Display total, active, and inactive agent counts in the breadcrumb
- **Status filter**: Add active/inactive filter to the CollectionDisplayButton dropdown
- **Creator avatars**: Show creator avatar and most recent update date in card footer

Ports the relevant UX features from the connections page (#2576) to the agents page for consistency.

## Test plan

- [ ] Verify agents with identical names are grouped correctly in both table and cards view
- [ ] Test bulk selection: select multiple agents, delete them via the floating action bar
- [ ] Confirm header shows correct total/active/inactive counts
- [ ] Test status filter filters agents correctly
- [ ] Verify creator avatar and update date appear in card footer
- [ ] Confirm single agents (not grouped) render normally
- [ ] Test that the "Select" button uses the `outline` variant for visual consistency


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances the Agents page with grouping by name, multi-select with bulk delete, header stats, status filters, and creator avatars to streamline management and align with the Connections UX.

- **New Features**
  - Group agents with the same name; accordion in table view, dialog in cards.
  - Bulk selection mode with a floating action bar (select all, clear, delete).
  - Breadcrumb shows total, active, and inactive counts.
  - Status filter (All/Active/Inactive) in the display dropdown.
  - Creator avatars and most recent update time in cards and grouped rows.
  - Hide “Delete” for Decopilot agents.

<sup>Written for commit 675eef8013f40815ef7fcbfe48489637af7c1c59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

