### PR TITLE
fix(auth): bump @decocms/better-auth to 1.5.19

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -52,7 +52,7 @@
     "@better-auth/sso": "1.4.1",
     "@daveyplate/better-auth-ui": "^3.2.7",
     "@deco/ui": "workspace:*",
-    "@decocms/better-auth": "1.5.17",
+    "@decocms/better-auth": "1.5.19",
     "@decocms/bindings": "workspace:*",
     "@decocms/mesh-sdk": "workspace:*",
     "@decocms/runtime": "workspace:*",


### PR DESCRIPTION
## Summary
- Bumps `@decocms/better-auth` from `1.5.17` to `1.5.19`
- Fixes `SyntaxError: Export named 'ms' not found` when running `bunx @decocms/mesh@latest`

The previous version depended on `ms@4.0.0-nightly` (ESM with named exports), which conflicted with `ms@2.1.3` (CJS default export) used by `debug`. The bundle script copied only `ms@2.1.3` to `node_modules/`, causing the named import `{ ms }` from better-auth code to fail at runtime. The new version no longer depends on `ms` directly.

## Test plan
- [ ] Run `bunx @decocms/mesh@latest` and verify no `ms` export error
- [ ] Run `bun test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated @decocms/better-auth to 1.5.19 to fix the “Export named 'ms' not found” runtime error when running bunx @decocms/mesh@latest. The new version removes the ESM ms dependency that conflicted with debug’s CJS ms, preventing import failures.

<sup>Written for commit 168dadb77d0af0fbd82adbe840465b3114874566. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

