### PR TITLE
Fix formatting of vibe-dex entry in MAINTAINERS.txt

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -6,4 +6,4 @@ JonasJesus42
 aka-sacci-ccr
 vibegui
 tlgimenes
-vibe-dex 
+vibe-dex


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the formatting for the “vibe-dex” entry in MAINTAINERS.txt by removing a trailing space. This keeps the list consistent and avoids false diffs or tooling warnings.

<sup>Written for commit c7cf1058a80f734e8b79966ff21e381bd8dfb122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

