### PR TITLE
chore: bump version to 2.139.0

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/mesh",
-  "version": "2.137.3",
+  "version": "2.139.0",
   "description": "MCP Mesh - Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps `@decocms/mesh` version from 2.137.3 to 2.139.0
- After reverting the 2.138.x releases, CI kept re-bumping from 2.137.x which conflicted with already-published npm versions
- Jumping to 2.139.0 establishes a clean version sequence going forward

## Important
- **Do NOT react on the Release Options comment** — the version is already set to 2.139.0
- When merged, the `release.yaml` workflow will automatically publish 2.139.0 to npm, Docker, and create a GitHub Release

## Test plan
- [ ] Verify `apps/mesh/package.json` version is `2.139.0`
- [ ] After merge, confirm `release.yaml` workflow runs and publishes successfully
- [ ] Verify npm: `npm view @decocms/mesh@2.139.0`
- [ ] Verify Docker image is pushed to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps @decocms/mesh from 2.137.3 to 2.139.0 to skip the reverted 2.138.x range and align CI with already-published npm versions. This restores a clean release sequence; on merge, the release workflow will publish 2.139.0 to npm, GHCR, and create the GitHub Release.

<sup>Written for commit ec20daeb7b36b38e77459dbbc24976f057398ca9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

