### PR TITLE
Optimize database connection settings and error handling

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -127,20 +127,33 @@ const defaultPoolOptions = {
   connectionTimeoutMillis: 30000,
   // Allow the process to exit even with idle connections
   allowExitOnIdle: true,
+  // PROTECTION: Kill queries that run too long (prevents runaway queries)
+  // Configurable via DATABASE_PG_STATEMENT_TIMEOUT (default 30s)
+  statement_timeout:
+    parseInt(process.env.DATABASE_PG_STATEMENT_TIMEOUT ?? "", 10) || 30000,
+  // PROTECTION: Kill idle transactions (prevents connection hoarding)
+  // Transactions sitting open lock resources and prevent autovacuum
+  idle_in_transaction_session_timeout:
+    parseInt(process.env.DATABASE_PG_IDLE_TX_TIMEOUT ?? "", 10) || 10000,
 };
 
 function createPostgresDatabase(config: DatabaseConfig): PostgresDatabase {
   const maxConnections =
     config.options?.maxConnections ??
-    parseInt(process.env.DATABASE_PG_MAX_CONNECTIONS ?? "", 10) ||
-    5; // FIX: Reduced from 10. With multiple K8s pods, total = pods × max.
-       // Tune via DATABASE_PG_MAX_CONNECTIONS env var without code changes.
+    (process.env.DATABASE_PG_MAX_CONNECTIONS
+      ? parseInt(process.env.DATABASE_PG_MAX_CONNECTIONS, 10)
+      : 5); // FIX: Reduced from 10. With multiple K8s pods, total = pods × max.
+  // Tune via DATABASE_PG_MAX_CONNECTIONS env var without code changes.
 
   const pool = new Pool({
     connectionString: config.connectionString,
     max: maxConnections,
     ssl: process.env.DATABASE_PG_SSL === "true" ? true : false,
     ...defaultPoolOptions,
+    // Set default session parameters for all connections
+    // These apply via "SET" on connection initialization
+    idle_in_transaction_session_timeout:
+      parseInt(process.env.DATABASE_PG_IDLE_TX_TIMEOUT ?? "", 10) || 10000,
   });
 
   // FIX: Handle async pool errors to prevent silent process crashes
@@ -313,14 +326,17 @@ export function getDbDialect(databaseUrl?: string): Dialect {
     const config = parseDatabaseUrl(databaseUrl ?? getDatabaseUrl());
 
     if (config.type === "postgres") {
-      const maxConnections =
-        parseInt(process.env.DATABASE_PG_MAX_CONNECTIONS ?? "", 10) || 5;
+      const maxConnections = process.env.DATABASE_PG_MAX_CONNECTIONS
+        ? parseInt(process.env.DATABASE_PG_MAX_CONNECTIONS, 10)
+        : 5;
 
       const pool = new Pool({
         connectionString: config.connectionString,
         max: maxConnections,
         ssl: process.env.DATABASE_PG_SSL === "true" ? true : false,
         ...defaultPoolOptions,
+        idle_in_transaction_session_timeout:
+          parseInt(process.env.DATABASE_PG_IDLE_TX_TIMEOUT ?? "", 10) || 10000,
       });
 
       pool.on("error", (err) => {
@@ -337,7 +353,6 @@ export function getDbDialect(databaseUrl?: string): Dialect {
 
   return dialectInstance;
 }
-
 
 /**
  * Create MeshDatabase instance with auto-detected dialect


### PR DESCRIPTION
This pull request improves the reliability and efficiency of database connection management in Kubernetes environments by tuning connection pool settings and fixing resource leaks. The key changes focus on reducing connection errors during pod shutdown and preventing connection leaks by ensuring singleton usage of database pools.

**Connection Pool Configuration Improvements:**
- Reduced the `idleTimeoutMillis` setting in `defaultPoolOptions` from 5 minutes (300000 ms) to 30 seconds (30000 ms) to proactively release idle connections before Kubernetes pod shutdown, preventing "Connection reset by peer" errors on RDS.
- Decreased the default maximum number of database connections per pod from 10 to 5, and made this configurable via the `DATABASE_PG_MAX_CONNECTIONS` environment variable to better support scaling with multiple pods.
- Added an event handler for pool errors (`pool.on("error", ...)`) to log unexpected client errors and prevent silent process crashes.

**Resource Leak Fixes:**
- Refactored the `getDbDialect` function to use a singleton pattern for the database dialect instance, ensuring that only one connection pool is created and reused, rather than leaking connections by creating a new pool on every invocation.
- Applied the same connection pool configuration and error handling improvements to the dialect creation logic in `getDbDialect`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized Postgres connection pooling for Kubernetes to reduce "Connection reset by peer" errors, stop connection leaks, and add safety limits to prevent runaway queries and idle transactions.

- **Bug Fixes**
  - Lowered idleTimeoutMillis from 5m to 30s to release idle connections before pod shutdown.
  - Set default max connections per pod to 5; configurable via DATABASE_PG_MAX_CONNECTIONS.
  - Added pool.on("error") logging to catch unexpected client errors in both database and dialect pools.
  - Made getDbDialect a singleton to reuse one pool and prevent connection leaks.
  - Added statement_timeout (default 30s, DATABASE_PG_STATEMENT_TIMEOUT) and idle_in_transaction_session_timeout (default 10s, DATABASE_PG_IDLE_TX_TIMEOUT).

- **Migration**
  - Optional: Tune DATABASE_PG_MAX_CONNECTIONS, DATABASE_PG_STATEMENT_TIMEOUT, and DATABASE_PG_IDLE_TX_TIMEOUT for your workload.

<sup>Written for commit ae8323f6674b448f7b454003c09215d16a30f45e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

