### PR TITLE
perf(monitoring): use COUNT(*) instead of COUNT(id)

### DIFF
--- a/apps/mesh/src/storage/monitoring.ts
+++ b/apps/mesh/src/storage/monitoring.ts
@@ -149,7 +149,7 @@ export class SqlMonitoringStorage implements MonitoringStorage {
     let query = this.db.selectFrom("monitoring_logs").selectAll();
     let countQuery = this.db
       .selectFrom("monitoring_logs")
-      .select((eb) => eb.fn.count("id").as("count"));
+      .select((eb) => eb.fn.countAll().as("count"));
 
     // Apply filters to both queries
     if (filters.organizationId) {
@@ -283,7 +283,7 @@ export class SqlMonitoringStorage implements MonitoringStorage {
     // Get total count, error count, and average duration using SQL aggregations
     const stats = await query
       .select([
-        (eb) => eb.fn.count("id").as("total_count"),
+        (eb) => eb.fn.countAll().as("total_count"),
         (eb) => eb.fn.sum(eb.ref("is_error")).as("error_count"),
         (eb) => eb.fn.avg("duration_ms").as("avg_duration"),
       ])
@@ -504,7 +504,7 @@ export class SqlMonitoringStorage implements MonitoringStorage {
     const valueExpr = this.jsonExtractPathText(sourceColumn, path);
     const result = await query
       .where(sql`${valueExpr}`, "is not", null)
-      .select((eb) => eb.fn.count("id").as("count"))
+      .select((eb) => eb.fn.countAll().as("count"))
       .executeTakeFirst();
 
     return Number(result?.count || 0);


### PR DESCRIPTION
## Summary

- Replace `eb.fn.count("id")` with `eb.fn.countAll()` in 3 locations in `monitoring.ts` (methods `query`, `getStats`, `countMatched`)
- `id` is PRIMARY KEY (never NULL), so `COUNT(id)` and `COUNT(*)` return the same result
- `COUNT(*)` is more efficient: the engine skips per-row column evaluation and can leverage index-only scans

## Test plan

- [ ] Verify billing page loads correctly (Summary, Breakdown, History)
- [ ] Verify monitoring logs list pagination still works
- [ ] `bun run fmt && bun run lint && bun run check` pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use COUNT(*) instead of COUNT(id) in monitoring queries to speed up aggregations. No behavior change: id is the primary key, so counts are identical.

<sup>Written for commit f6bcca7cd5b417515f38df2f6c57fb21f01be551. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

