### PR TITLE
fix(billing): default to 7d period and count only billed calls

### DIFF
--- a/apps/mesh/src/web/components/settings-modal/pages/org-billing.tsx
+++ b/apps/mesh/src/web/components/settings-modal/pages/org-billing.tsx
@@ -849,7 +849,7 @@ const chartConfig = {
 
 function UsageSection() {
   const { org } = useProjectContext();
-  const [period, setPeriod] = useState<BillingStatsPeriod>("30d");
+  const [period, setPeriod] = useState<BillingStatsPeriod>("7d");
   const timeRange = periodToTimeRange(period);
 
   const selfClient = useMCPClient({


### PR DESCRIPTION
## Summary

- **Default period changed from 30d to 7d** in the Summary tab -- the 30d query was taking ~9 seconds; 7d is much faster and a better default
- **History and Summary call count changed from count_all to count** -- count_all was counting ALL tool calls (including ones without OpenRouter cost), inflating the calls number while cost showed $0.00. count only counts rows where the cost JSONPath has a value, so calls now match the displayed cost

## Root cause

count_all generates COUNT(*) which counts every row regardless of whether it has a cost value. Most tool calls do not go through OpenRouter and have no cost metadata. count generates COUNT(valueExpr) which skips NULL values, only counting calls that actually have billing data.

## Test plan

- [ ] Open Billing > Summary -- verify default is 7d, loads fast, tool calls count matches cost
- [ ] Open Billing > History -- verify monthly calls are non-zero only for months with actual cost
- [ ] Breakdown tab unchanged (count_all is intentional there -- shows all calls per connection/user/tool)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default Billing Summary period is now 7d for faster load. Summary and History now count only billed calls (use count, not count_all) so totals match the displayed cost.

<sup>Written for commit e76d237a2e3a9a6c74b0c420e8614fd5cc4c3a8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

