### PR TITLE
fix(billing): default Breakdown tab to 7d period

### DIFF
--- a/apps/mesh/src/web/components/settings-modal/pages/org-billing.tsx
+++ b/apps/mesh/src/web/components/settings-modal/pages/org-billing.tsx
@@ -1216,7 +1216,7 @@ function mergeGroups(
 
 function BillingBreakdown() {
   const { org } = useProjectContext();
-  const [period, setPeriod] = useState<BillingStatsPeriod>("30d");
+  const [period, setPeriod] = useState<BillingStatsPeriod>("7d");
   const timeRange = periodToTimeRange(period);
   const { data: membersData } = useMembers();
   const members = membersData?.data?.members ?? [];


### PR DESCRIPTION
The Breakdown tab was still defaulting to 30d while Summary was already changed to 7d. This aligns both tabs to 7d for faster initial load.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Billing Breakdown tab’s default period to 7 days to match Summary and speed up initial load. Replaces the initial state from "30d" to "7d" for the Breakdown view.

<sup>Written for commit c3c9f25698818946ce74a183f5a7b832966543a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

