### PR TITLE
fix(runtime): propagate organizationName and organizationSlug from JWT metadata

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -128,7 +128,16 @@ async function createMCPProxyDoNotUseDirectly(
   if (ctx.organization && connection.organization_id !== ctx.organization.id) {
     throw new Error("Connection does not belong to the active organization");
   }
-  ctx.organization ??= { id: connection.organization_id };
+  if (!ctx.organization) {
+    const org = await ctx.db
+      .selectFrom("organization")
+      .select(["id", "slug", "name"])
+      .where("id", "=", connection.organization_id)
+      .executeTakeFirst();
+    ctx.organization = org
+      ? { id: org.id, slug: org.slug, name: org.name }
+      : { id: connection.organization_id };
+  }
 
   // Check connection status
   if (connection.status !== "active") {

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -545,6 +545,29 @@ async function authenticateRequest(
           role = membership?.role;
         }
 
+        let organization: OrganizationContext | undefined;
+        const metaOrgId = meshJwtPayload.metadata?.organizationId;
+        if (metaOrgId) {
+          const metaName = meshJwtPayload.metadata?.organizationName;
+          const metaSlug = meshJwtPayload.metadata?.organizationSlug;
+          if (metaName || metaSlug) {
+            organization = { id: metaOrgId, name: metaName, slug: metaSlug };
+          } else {
+            const orgRow = await timings.measure(
+              "auth_query_org_for_mesh_jwt",
+              () =>
+                db
+                  .selectFrom("organization")
+                  .select(["id", "slug", "name"])
+                  .where("id", "=", metaOrgId)
+                  .executeTakeFirst(),
+            );
+            organization = orgRow
+              ? { id: orgRow.id, slug: orgRow.slug, name: orgRow.name }
+              : { id: metaOrgId };
+          }
+        }
+
         return {
           user: {
             id: meshJwtPayload.sub,
@@ -553,11 +576,7 @@ async function authenticateRequest(
           },
           role,
           permissions: meshJwtPayload.permissions,
-          organization: meshJwtPayload.metadata?.organizationId
-            ? {
-                id: meshJwtPayload.metadata?.organizationId,
-              }
-            : undefined,
+          organization,
         };
       }
     } catch {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -220,12 +220,21 @@ export const withBindings = <TEnv>({
         state?: Record<string, unknown>;
         meshUrl?: string;
         connectionId?: string;
+        organizationId?: string;
+        organizationName?: string;
+        organizationSlug?: string;
       }) ?? {};
     const appName = decoded.appName as string | undefined;
     context.authorization ??= authorization;
     context.callerApp = appName;
     context.connectionId ??=
       (decoded.connectionId as string) ?? metadata.connectionId;
+    context.organizationId ??=
+      (decoded.organizationId as string) ?? metadata.organizationId;
+    context.organizationName ??=
+      (decoded.organizationName as string) ?? metadata.organizationName;
+    context.organizationSlug ??=
+      (decoded.organizationSlug as string) ?? metadata.organizationSlug;
     context.ensureAuthenticated = AUTHENTICATED(decoded.user ?? decoded.sub);
   } else {
     context = {


### PR DESCRIPTION
## Summary
Re-applies the fix from #2580 which was lost during the v2.137.0 rollback (#2582).

- **packages/runtime/src/index.ts**: Extract `organizationId`, `organizationName`, and `organizationSlug` from JWT metadata in the `withBindings()` object branch — previously only `connectionId` was extracted, leaving org fields as `null` in `MESH_REQUEST_CONTEXT`
- **packages/runtime/package.json**: Bump to 1.2.11 for npm publish
- **apps/mesh/src/core/context-factory.ts**: Enrich the Mesh JWT auth flow to include org `name`/`slug` from JWT metadata before falling back to a DB query (zero extra queries on the happy path)
- **apps/mesh/src/api/routes/proxy.ts**: Fetch full org data (name, slug) in `createMCPProxyDoNotUseDirectly` when `ctx.organization` is undefined (programmatic proxy only, not the HTTP hot path)

## Test plan
- [x] Verified locally that `deco-ai-gateway` receives `organizationName` and `organizationSlug` in `MESH_REQUEST_CONTEXT`
- [x] Confirmed no extra DB queries on the HTTP proxy hot path
- [x] JWT payload already contains org metadata from `headers.ts` — this fix ensures it is propagated correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing propagation of organizationId, organizationName, and organizationSlug from Mesh JWT metadata so MCPs get full org context. Avoids extra DB queries on the HTTP proxy path.

- **Bug Fixes**
  - Runtime withBindings now reads org fields from decoded JWT metadata when tokenOrContext is an object.
  - Mesh context-factory uses org name/slug from JWT metadata; falls back to a single DB query only if absent.
  - Programmatic proxy fetches org name/slug when ctx.organization is undefined (not on the HTTP hot path).

- **Dependencies**
  - Bump @decocms/runtime to 1.2.11.

<sup>Written for commit 46941bc84e7d90034af9a5815444c35d057374e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

