### PR TITLE
fix(store): prefer Deco Store over Mesh MCP as default registry

### DIFF
--- a/apps/mesh/src/web/components/store/mcp-server-card.tsx
+++ b/apps/mesh/src/web/components/store/mcp-server-card.tsx
@@ -325,7 +325,7 @@ function extractCardDisplayData(
   }
 
   // Fallback to item.id when it contains a scope (e.g. "provider/name")
-  if (!scopeName && item.id.includes("/")) {
+  if (!scopeName && item.id?.includes("/")) {
     scopeName = item.id;
   }
 

--- a/apps/mesh/src/web/routes/orgs/store/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/store/page.tsx
@@ -96,10 +96,16 @@ export default function StorePage() {
     enabledPlugins === undefined ||
     enabledPlugins.includes(PRIVATE_REGISTRY_PLUGIN_ID);
 
-  const registryConnections = allRegistryConnections.filter((c) => {
-    if (c.id !== selfMcpId) return true;
-    return isPrivateRegistryEnabled;
-  });
+  const registryConnections = allRegistryConnections
+    .filter((c) => {
+      if (c.id !== selfMcpId) return true;
+      return isPrivateRegistryEnabled;
+    })
+    .sort((a, b) => {
+      if (a.id === selfMcpId) return 1;
+      if (b.id === selfMcpId) return -1;
+      return 0;
+    });
 
   const hasSelfMcpRegistry = registryConnections.some(
     (c) => c.id === selfMcpId,
@@ -164,9 +170,16 @@ export default function StorePage() {
   );
 
   // If there's only one registry, use it; otherwise use the selected one if it still exists.
-  // If not found, that's fine: the connection may have been deleted/changed.
+  // Prefer a non-self registry as default so the Deco Store (or Community Registry)
+  // is shown instead of the Mesh MCP when nothing is explicitly selected.
+  const firstNonSelfRegistry = registryConnections.find(
+    (c) => c.id !== selfMcpId,
+  );
   const effectiveRegistry =
-    selectedRegistry?.id || registryConnections[0]?.id || "";
+    selectedRegistry?.id ||
+    firstNonSelfRegistry?.id ||
+    registryConnections[0]?.id ||
+    "";
   const storePrivateOnlyForSelf =
     effectiveRegistry === selfMcpId &&
     registryBranding?.storePrivateOnly === true;


### PR DESCRIPTION
## Summary

- **Sort registry connections** so the Self MCP (Mesh MCP) always appears last in the dropdown list
- **Default to Deco Store** (or Community Registry) instead of Mesh MCP when no registry is explicitly selected
- **Fix crash** in mcp-server-card.tsx by adding null safety for item.id

## Context

When a new org is created, enabledPlugins is null (meaning all plugins visible). The Self MCP has cached COLLECTION_REGISTRY_APP_* tools from the private-registry plugin, so it gets detected as a registry. Since it is the first in the list, it becomes the default store — but it has no actual registry data, causing the crash: Cannot read properties of undefined (reading includes).

## Test plan

- [ ] Create a new organization and navigate to the Store page
- [ ] Verify the Deco Store (or Community Registry) is selected by default, not Mesh MCP
- [ ] Verify Mesh MCP appears last in the registry dropdown
- [ ] Verify no crash occurs when the private-registry plugin is not enabled

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Deco Store (Community Registry) as the default registry and move Mesh MCP (Self MCP) to the end of the list to avoid selecting it by mistake in new orgs. Also fixed a Store page crash by adding a null check on item IDs.

- **Bug Fixes**
  - Sort registry connections so Self MCP appears last; still shown only when the private-registry plugin is enabled.
  - Default selection prefers a non-self registry (Deco Store/Community Registry) when none is chosen.
  - Add null safety to item.id in mcp-server-card to prevent "includes" crash.

<sup>Written for commit be5328fdb4daaa9451f9bf7a0e566f4d2237b6a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

