### PR TITLE
fix(build): copy PGlite WASM assets to dist for bundled CLI

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -22,7 +22,7 @@ const SCRIPT_DIR =
 const SERVER_ENTRY_POINT = join(SCRIPT_DIR, "../src/index.ts");
 const CLI_ENTRY_POINT = join(SCRIPT_DIR, "../src/cli.ts");
 const MIGRATE_ENTRY_POINTS = ["@jitl/quickjs-wasmfile-release-sync"];
-const ALWAYS_EXTERNAL = ["kysely-codegen"];
+const ALWAYS_EXTERNAL = ["kysely-codegen", "@electric-sql/pglite"];
 
 // Parse command line arguments
 function parseArgs() {


### PR DESCRIPTION
The bundled CLI (`dist/server/cli.js`) failed at runtime because `pglite.wasm` and `pglite.data` weren't copied to the output directory. `@vercel/nft` doesn't detect these files since PGlite loads them via filesystem at runtime, not through `require()`/`import`.

This is a follow-up fix to #2598 (PGlite migration).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bundled CLI runtime errors by ensuring PGlite WASM assets are available at runtime. Copies the assets to dist and marks @electric-sql/pglite as external so the bundler doesn’t inline it.

- **Bug Fixes**
  - Copy step moves pglite.wasm and pglite.data from node_modules/@electric-sql/pglite/dist to dist, with clear logs and safe skips if missing.
  - Externalized @electric-sql/pglite so CLI loads assets from node_modules in npm/npx installs; production (PostgreSQL) path unchanged.

<sup>Written for commit 31420ffa24af5851d93bf9b4294c1bd8a59d2467. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

