### PR TITLE
feat(ref-resolver): support bracket notation in reference parsing and…

### DIFF
--- a/packages/mesh-plugin-workflows/server/engine/__tests__/ref-resolver.test.ts
+++ b/packages/mesh-plugin-workflows/server/engine/__tests__/ref-resolver.test.ts
@@ -101,6 +101,32 @@ describe("parseAtRef", () => {
     expect(result.path).toBe("users.0");
   });
 
+  it("parses bracket notation @step.items[0].x", () => {
+    const result = parseAtRef("@myStep.items[0].x");
+    expect(result.type).toBe("step");
+    expect(result.stepName).toBe("myStep");
+    expect(result.path).toBe("items.0.x");
+  });
+
+  it("parses consecutive brackets @step.matrix[0][1]", () => {
+    const result = parseAtRef("@myStep.matrix[0][1]");
+    expect(result.type).toBe("step");
+    expect(result.stepName).toBe("myStep");
+    expect(result.path).toBe("matrix.0.1");
+  });
+
+  it("parses @input with bracket notation @input.users[0]", () => {
+    const result = parseAtRef("@input.users[0]");
+    expect(result.type).toBe("input");
+    expect(result.path).toBe("users.0");
+  });
+
+  it("parses @item with bracket notation @item[0].name", () => {
+    const result = parseAtRef("@item[0].name");
+    expect(result.type).toBe("item");
+    expect(result.path).toBe("0.name");
+  });
+
   it("parses @inputData.field as step type, not input type", () => {
     const result = parseAtRef("@inputData.field");
     expect(result.type).toBe("step");
@@ -191,6 +217,28 @@ describe("getValueByPath", () => {
     const obj = { items: [{ id: "a" }, { id: "b" }] };
     expect(getValueByPath(obj, "items.0.id")).toBe("a");
     expect(getValueByPath(obj, "items.1.id")).toBe("b");
+  });
+
+  it("handles bracket notation items[0].id", () => {
+    const obj = { items: [{ id: "a" }, { id: "b" }] };
+    expect(getValueByPath(obj, "items[0].id")).toBe("a");
+    expect(getValueByPath(obj, "items[1].id")).toBe("b");
+  });
+
+  it("handles consecutive brackets matrix[0][1]", () => {
+    const obj = {
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+    };
+    expect(getValueByPath(obj, "matrix[0][1]")).toBe(2);
+    expect(getValueByPath(obj, "matrix[1][0]")).toBe(3);
+  });
+
+  it("handles mixed dot and bracket notation", () => {
+    const obj = { data: { items: [{ nested: { value: 42 } }] } };
+    expect(getValueByPath(obj, "data.items[0].nested.value")).toBe(42);
   });
 });
 
@@ -285,6 +333,38 @@ describe("resolveRef", () => {
     });
     const result = resolveRef("@item.0.name", ctx);
     expect(result.value).toBe("Alice");
+  });
+
+  it("resolves bracket notation @step.items[0].id", () => {
+    const stepOutputs = new Map<string, unknown>();
+    stepOutputs.set("fetch", { items: [{ id: "first" }, { id: "second" }] });
+    const ctx = makeCtx({ stepOutputs });
+
+    const result = resolveRef("@fetch.items[0].id", ctx);
+    expect(result.value).toBe("first");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("resolves consecutive brackets @step.matrix[1][0]", () => {
+    const stepOutputs = new Map<string, unknown>();
+    stepOutputs.set("data", {
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+    });
+    const ctx = makeCtx({ stepOutputs });
+
+    const result = resolveRef("@data.matrix[1][0]", ctx);
+    expect(result.value).toBe(3);
+  });
+
+  it("resolves @input with bracket notation", () => {
+    const ctx = makeCtx({
+      workflowInput: { users: [{ name: "Alice" }, { name: "Bob" }] },
+    });
+    const result = resolveRef("@input.users[1].name", ctx);
+    expect(result.value).toBe("Bob");
   });
 
   it("returns error for missing input path", () => {
@@ -405,6 +485,31 @@ describe("resolveAllRefs", () => {
     expect(resolved).toEqual({ msg: "First user: Alice" });
   });
 
+  it("resolves direct @ref with bracket notation", () => {
+    const stepOutputs = new Map<string, unknown>();
+    stepOutputs.set("fetch", { items: [{ id: "a" }, { id: "b" }] });
+    const ctx = makeCtx({ stepOutputs });
+
+    const { resolved, errors } = resolveAllRefs(
+      { firstId: "@fetch.items[0].id" },
+      ctx,
+    );
+    expect(resolved).toEqual({ firstId: "a" });
+    expect(errors).toBeUndefined();
+  });
+
+  it("interpolates @refs with bracket notation in strings", () => {
+    const stepOutputs = new Map<string, unknown>();
+    stepOutputs.set("fetch", { users: [{ name: "Alice" }, { name: "Bob" }] });
+    const ctx = makeCtx({ stepOutputs });
+
+    const { resolved } = resolveAllRefs(
+      { msg: "First user: @fetch.users[0].name" },
+      ctx,
+    );
+    expect(resolved).toEqual({ msg: "First user: Alice" });
+  });
+
   it("handles object traversal with mixed refs and literals", () => {
     const stepOutputs = new Map<string, unknown>();
     stepOutputs.set("fetch", { users: [{ name: "Bob" }] });
@@ -479,6 +584,19 @@ describe("extractRefs", () => {
     });
     expect(refs).toContain("@fetch.users.0.name");
     expect(refs).toContain("@fetch.items.2.title");
+  });
+
+  it("extracts @refs with bracket notation", () => {
+    const refs = extractRefs({ first: "@step.items[0].id" });
+    expect(refs).toContain("@step.items[0].id");
+  });
+
+  it("extracts @refs with bracket notation from interpolated strings", () => {
+    const refs = extractRefs({
+      msg: "User: @fetch.users[0].name, Item: @fetch.items[2].title",
+    });
+    expect(refs).toContain("@fetch.users[0].name");
+    expect(refs).toContain("@fetch.items[2].title");
   });
 
   it("extracts real refs from interpolated strings that start with @", () => {

--- a/packages/mesh-plugin-workflows/server/engine/ref-resolver.ts
+++ b/packages/mesh-plugin-workflows/server/engine/ref-resolver.ts
@@ -35,6 +35,13 @@ export interface RefResolution {
 }
 
 /**
+ * Normalize bracket notation to dot notation: `items[0].x` → `items.0.x`
+ */
+function normalizePath(path: string): string {
+  return path.replace(/\[(\d+)\]/g, ".$1");
+}
+
+/**
  * Check if a value is an @ref string
  */
 export function isAtRef(value: unknown): value is `@${string}` {
@@ -49,9 +56,9 @@ export function parseAtRef(ref: `@${string}`): {
   stepName?: string;
   path?: string;
 } {
-  const refStr = ref.substring(1); // Remove @ prefix
+  const refStr = normalizePath(ref.substring(1)); // Remove @ prefix, normalize brackets
 
-  // ForEach item reference: @item or @item.path
+  // ForEach item reference: @item or @item.path or @item[0].path
   if (refStr === "item" || refStr.startsWith("item.")) {
     const path = refStr.length > 4 ? refStr.substring(5) : "";
     return { type: "item", path };
@@ -62,7 +69,7 @@ export function parseAtRef(ref: `@${string}`): {
     return { type: "index" };
   }
 
-  // Input reference: @input.path.to.value
+  // Input reference: @input.path.to.value or @input[0].path
   if (refStr === "input" || refStr.startsWith("input.")) {
     const path = refStr.length > 5 ? refStr.substring(6) : "";
     return { type: "input", path };
@@ -74,7 +81,7 @@ export function parseAtRef(ref: `@${string}`): {
     return { type: "ctx", path };
   }
 
-  // Step output reference: @stepName.path
+  // Step output reference: @stepName.path or @stepName[0].path
   const parts = refStr.split(".");
   const stepName = parts[0];
   const path = parts.slice(1).join(".");
@@ -92,7 +99,7 @@ export function parseAtRef(ref: `@${string}`): {
 export function getValueByPath(obj: unknown, path: string): unknown {
   if (!path) return obj;
 
-  const keys = path.split(".");
+  const keys = normalizePath(path).split(".");
   let current = obj;
 
   for (let i = 0; i < keys.length; i++) {
@@ -202,17 +209,19 @@ export interface ResolveResult {
 
 /**
  * Regex to match @refs in strings for interpolation.
- * Path segments can be identifiers (a-z, A-Z, _, 0-9 starting with letter/_)
- * or numeric indices (e.g. 0, 1, 42) to support array access like @step.items.0.id
+ * Path segments can be identifiers, numeric indices, or bracket notation:
+ *   @step.items.0.id       (dot-numeric)
+ *   @step.items[0].id      (bracket notation)
+ *   @step.matrix[0][1]     (consecutive brackets)
  */
 const AT_REF_PATTERN =
-  /@([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)/g;
+  /@([a-zA-Z_][a-zA-Z0-9_]*(?:(?:\.[a-zA-Z_][a-zA-Z0-9_]*|\.[0-9]+|\[[0-9]+\]))*)/g;
 
 /**
  * Regex to match a COMPLETE @ref (entire string is one reference)
  */
 const SINGLE_AT_REF_PATTERN =
-  /^@([a-zA-Z_][a-zA-Z0-9_]*(?:\.(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+))*)$/;
+  /^@([a-zA-Z_][a-zA-Z0-9_]*(?:(?:\.[a-zA-Z_][a-zA-Z0-9_]*|\.[0-9]+|\[[0-9]+\]))*)$/;
 
 /**
  * Check if a value is a COMPLETE @ref string (the entire value is one reference)


### PR DESCRIPTION
… resolution

- Added a `normalizePath` function to convert bracket notation to dot notation for reference paths.
- Updated `parseAtRef` to handle references with bracket notation, including cases like `@item[0].path` and `@input.users[0]`.
- Enhanced regex patterns to match both dot and bracket notation in references.
- Added unit tests to verify parsing and resolution of references using bracket notation in various scenarios.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bracket notation support for reference parsing and resolution, so expressions like `@step.items[0].id` and `@matrix[0][1]` work consistently in strings and objects. Improves parser, resolver, and ref extraction to handle mixed dot/bracket paths.

- **New Features**
  - Support bracket notation for `@item`, `@input`, and step refs, including consecutive brackets.
  - Added `normalizePath` to convert brackets to dots for parsing and traversal.
  - Expanded regex to match both dot and bracket paths.
  - Added tests for parsing, resolution, extraction, and interpolation with brackets.

<sup>Written for commit da38a522e55e9e383b890421c30b6f2aeda214d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

