### PR TITLE
[chore]: format code with Biome

### DIFF
--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -216,7 +216,12 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       if (finalScopes.length > 0) {
         const stateObj = finalState as Record<string, unknown>;
         injectSelfSentinel(stateObj, finalScopes, organization.id);
-        await validateConfiguration(stateObj, finalScopes, organization.id, ctx);
+        await validateConfiguration(
+          stateObj,
+          finalScopes,
+          organization.id,
+          ctx,
+        );
       }
     }
 


### PR DESCRIPTION
## What is this contribution about?
Applied automatic formatting with Biome to ensure consistent code style. This fix aligns with the pre-commit hook configuration to maintain uniform formatting across the codebase.

## How to Test
- Run `bun run fmt` to verify no additional formatting changes are needed
- Run `bun run fmt:check` to confirm formatting compliance

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied automatic formatting with `Biome` to enforce consistent code style and keep fmt checks green. Reformatted a long `validateConfiguration` call in `apps/mesh/src/tools/connection/update.ts` to multi-line for readability; no behavior changes.

<sup>Written for commit f7d6234e865b9ff77cc0be5964031efefcba95e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

