### PR TITLE
feat(mcp-apps): forward host theme CSS variables to iframed apps

### DIFF
--- a/apps/mesh/src/mcp-apps/host-styles.test.ts
+++ b/apps/mesh/src/mcp-apps/host-styles.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { HOST_TO_SPEC_VAR_MAP, readHostStyles } from "./host-styles";
+
+describe("HOST_TO_SPEC_VAR_MAP", () => {
+  it("has no duplicate target (spec) keys", () => {
+    const specKeys = HOST_TO_SPEC_VAR_MAP.map(([, key]) => key);
+    const unique = new Set(specKeys);
+    expect(unique.size).toBe(specKeys.length);
+  });
+
+  it("has no duplicate source (host) keys", () => {
+    const hostKeys = HOST_TO_SPEC_VAR_MAP.map(([key]) => key);
+    const unique = new Set(hostKeys);
+    expect(unique.size).toBe(hostKeys.length);
+  });
+});
+
+describe("readHostStyles", () => {
+  it("returns {} when document is undefined (SSR)", () => {
+    // document is already undefined in Bun's default env
+    expect(readHostStyles()).toEqual({});
+  });
+
+  // Helper to set up a minimal DOM mock for tests that need document
+  function withDom(fakeGetPropertyValue: (prop: string) => string) {
+    const origDoc = globalThis.document;
+    const origGCS = globalThis.getComputedStyle;
+
+    // @ts-expect-error — minimal document mock for testing
+    globalThis.document = { documentElement: {} };
+    globalThis.getComputedStyle = (() => ({
+      getPropertyValue: fakeGetPropertyValue,
+    })) as unknown as typeof getComputedStyle;
+
+    return () => {
+      globalThis.document = origDoc;
+      globalThis.getComputedStyle = origGCS;
+    };
+  }
+
+  it("reads computed CSS variables and maps them to spec keys", () => {
+    const fakeValues: Record<string, string> = {
+      "--background": "oklch(1 0 0)",
+      "--foreground": "oklch(0.145 0.01 60)",
+      "--border": "oklch(0.915 0.005 80)",
+      "--font-sans": '"Inter var", sans-serif',
+    };
+
+    const restore = withDom((prop) => fakeValues[prop] ?? "");
+    try {
+      const result = readHostStyles();
+      expect(result.variables).toBeDefined();
+      expect(result.variables!["--color-background-primary"]).toBe(
+        "oklch(1 0 0)",
+      );
+      expect(result.variables!["--color-text-primary"]).toBe(
+        "oklch(0.145 0.01 60)",
+      );
+      expect(result.variables!["--color-border-primary"]).toBe(
+        "oklch(0.915 0.005 80)",
+      );
+      expect(result.variables!["--font-sans"]).toBe('"Inter var", sans-serif');
+    } finally {
+      restore();
+    }
+  });
+
+  it("skips empty/missing values", () => {
+    const restore = withDom((prop) =>
+      prop === "--background" ? "oklch(1 0 0)" : "",
+    );
+    try {
+      const result = readHostStyles();
+      expect(result.variables!["--color-background-primary"]).toBe(
+        "oklch(1 0 0)",
+      );
+      // Unmapped values should be undefined
+      expect(result.variables!["--color-text-primary"]).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/mesh/src/mcp-apps/host-styles.ts
+++ b/apps/mesh/src/mcp-apps/host-styles.ts
@@ -1,0 +1,75 @@
+import type {
+  McpUiHostStyles,
+  McpUiStyleVariableKey,
+  McpUiStyles,
+} from "@modelcontextprotocol/ext-apps";
+
+/**
+ * Maps host CSS variables (from packages/ui/src/styles/global.css) to
+ * ext-apps spec keys (McpUiStyleVariableKey).
+ */
+export const HOST_TO_SPEC_VAR_MAP: Array<[string, McpUiStyleVariableKey]> = [
+  // Background colors
+  ["--background", "--color-background-primary"],
+  ["--muted", "--color-background-secondary"],
+  ["--accent", "--color-background-tertiary"],
+  ["--destructive", "--color-background-danger"],
+  ["--success", "--color-background-success"],
+  ["--warning", "--color-background-warning"],
+
+  // Text colors
+  ["--foreground", "--color-text-primary"],
+  ["--muted-foreground", "--color-text-secondary"],
+  ["--accent-foreground", "--color-text-tertiary"],
+  ["--destructive-foreground", "--color-text-danger"],
+  ["--success-foreground", "--color-text-success"],
+  ["--warning-foreground", "--color-text-warning"],
+
+  // Border colors
+  ["--border", "--color-border-primary"],
+  ["--input", "--color-border-secondary"],
+
+  // Ring
+  ["--ring", "--color-ring-primary"],
+
+  // Fonts
+  ["--font-sans", "--font-sans"],
+  ["--font-mono", "--font-mono"],
+
+  // Font weights (from @theme inline in global.css)
+  ["--font-weight-normal", "--font-weight-normal"],
+  ["--font-weight-medium", "--font-weight-medium"],
+  ["--font-weight-semibold", "--font-weight-semibold"],
+  ["--font-weight-bold", "--font-weight-bold"],
+
+  // Border radius (base value only — calc()-based variants are excluded)
+  ["--radius", "--border-radius-md"],
+
+  // Border width
+  ["--default-border-width", "--border-width-regular"],
+
+  // Shadows
+  ["--shadow-sm", "--shadow-sm"],
+  ["--shadow-md", "--shadow-md"],
+  ["--shadow-lg", "--shadow-lg"],
+];
+
+/**
+ * Reads the host's computed CSS variable values and returns them mapped
+ * to the ext-apps spec keys.
+ */
+export function readHostStyles(): McpUiHostStyles {
+  if (typeof document === "undefined") return {};
+
+  const computed = getComputedStyle(document.documentElement);
+  const variables: Partial<Record<McpUiStyleVariableKey, string>> = {};
+
+  for (const [hostVar, specKey] of HOST_TO_SPEC_VAR_MAP) {
+    const value = computed.getPropertyValue(hostVar).trim();
+    if (value) {
+      variables[specKey] = value;
+    }
+  }
+
+  return { variables: variables as McpUiStyles };
+}

--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -8,10 +8,12 @@ import type {
   McpUiHostContext,
   McpUiMessageRequest,
 } from "@modelcontextprotocol/ext-apps";
+import { getDocumentTheme } from "@modelcontextprotocol/ext-apps";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 // eslint-disable-next-line ban-use-effect/ban-use-effect
 import { useEffect, useRef, useSyncExternalStore } from "react";
+import { readHostStyles } from "./host-styles";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -33,13 +35,6 @@ const INIT_TIMEOUT_MS = 15_000;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function detectTheme(): "light" | "dark" {
-  if (typeof window === "undefined") return "light";
-  return window.matchMedia?.("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
-}
 
 function detectLocale(): string {
   if (typeof navigator === "undefined") return "en";
@@ -65,7 +60,8 @@ function buildHostContext(
   maxHeight?: number,
 ): McpUiHostContext {
   return {
-    theme: detectTheme(),
+    theme: getDocumentTheme(),
+    styles: readHostStyles(),
     displayMode,
     availableDisplayModes: ["inline", "fullscreen"],
     locale: detectLocale(),
@@ -76,6 +72,37 @@ function buildHostContext(
       containerDimensions: { maxHeight },
     }),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Shared theme observer (singleton) — watches <html> class/data-theme changes
+// and system preference, notifies all BridgeStore instances.
+// ---------------------------------------------------------------------------
+
+type ThemeListener = () => void;
+const themeListeners = new Set<ThemeListener>();
+let observerStarted = false;
+
+function startThemeObserver() {
+  if (observerStarted || typeof document === "undefined") return;
+  observerStarted = true;
+
+  const notify = () => themeListeners.forEach((fn) => fn());
+
+  new MutationObserver(notify).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class", "data-theme"],
+  });
+
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", notify);
+}
+
+function subscribeThemeChange(fn: ThemeListener): () => void {
+  themeListeners.add(fn);
+  startThemeObserver();
+  return () => themeListeners.delete(fn);
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +136,7 @@ class BridgeStore {
   private bridge: AppBridge | null = null;
   private timeout: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
+  private unsubTheme: (() => void) | null = null;
 
   // --- observable snapshot (React subscribes to this) ---
   private snapshot: BridgeSnapshot;
@@ -157,6 +185,15 @@ class BridgeStore {
     }
   }
 
+  /** Rebuild and push full host context to the bridge (e.g. on theme change). */
+  private pushHostContext() {
+    if (!this.bridge || this.disposed) return;
+    const { displayMode, maxHeight, toolInfo } = this.config;
+    this.bridge.setHostContext(
+      buildHostContext(displayMode, toolInfo, maxHeight),
+    );
+  }
+
   // ---- snapshot mutations ----
 
   private set(partial: Partial<BridgeSnapshot>) {
@@ -182,6 +219,8 @@ class BridgeStore {
   /** Tear down the current bridge and clear timers. */
   teardown() {
     this.disposed = true;
+    this.unsubTheme?.();
+    this.unsubTheme = null;
     if (this.bridge) {
       this.bridge.teardownResource({}).catch(() => {});
       this.bridge.close();
@@ -227,6 +266,8 @@ class BridgeStore {
       this.startInitTimeout();
       this.registerInitHandler(bridge);
       this.connectTransport(bridge, iframe);
+
+      this.unsubTheme = subscribeThemeChange(() => this.pushHostContext());
     } catch (err) {
       this.clearTimeout();
       console.error("Failed to create AppBridge:", err);


### PR DESCRIPTION
## What is this contribution about?

Adds CSS variable forwarding to MCP App iframes via the ext-apps `McpUiHostContext.styles` protocol field. Extracts the host's design system variables (colors, fonts, sizing) and maps them to standardized `McpUiStyleVariableKey` names that the view-side SDK's `useHostStyles()` / `applyHostStyleVariables()` functions expect. 

This allows MCP Apps rendered in sandboxed iframes to inherit the host's theme colors, fonts, and other design tokens without losing isolation. Replaces the custom `detectTheme()` implementation with the SDK's `getDocumentTheme()` for correct detection of both Tailwind `.dark` class and system preference changes. Uses a singleton theme observer to detect changes and push updates via `bridge.setHostContext()`.

## How to Test

1. Start the dev server: `bun run dev`
2. Open a conversation and use a tool with a UI resource (e.g., a tool with an MCP App)
3. Open DevTools, select the iframe element, and inspect `document.documentElement.style` — verify CSS custom properties like `--color-background-primary`, `--color-text-primary`, `--font-sans` are set
4. Toggle dark mode (system settings or dev tools emulation) — verify the iframe receives `host-context-changed` notifications with updated style values
5. Run tests: `bun test` — verify new style-reading tests pass

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested (unit tests for mapping + style reading)
- [x] No breaking changes (styles field is optional on McpUiHostContext)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward host theme CSS variables to MCP App iframes so apps match the host’s colors, fonts, and tokens while staying sandboxed. Theme updates now propagate live to apps.

- **New Features**
  - Expose host design tokens to iframes via `McpUiHostContext.styles`, mapping host CSS vars to `McpUiStyleVariableKey` (colors, fonts, radius, shadows).
  - Compute and send style values on bridge init and on theme changes; tests cover map uniqueness and SSR safety.

- **Refactors**
  - Replace custom theme detection with `getDocumentTheme()` from `@modelcontextprotocol/ext-apps`.
  - Add a shared theme observer that watches `<html>` class/data-theme and system preference, pushing updates via `bridge.setHostContext()`.

<sup>Written for commit ed6c9e40011254080e23f3acbc182b8a9cfcc03f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

