### PR TITLE
feat(registry): update Deco Store URL and add official/verified MCP sorting

### DIFF
--- a/apps/mesh/migrations/036-update-registry-url.ts
+++ b/apps/mesh/migrations/036-update-registry-url.ts
@@ -1,0 +1,31 @@
+/**
+ * Update Deco Store Registry URL
+ *
+ * This migration updates the Deco Store registry connection URL from
+ * the old api.decocms.com endpoint to the new studio.decocms.com endpoint.
+ *
+ * It also resets tools to NULL so they are fetched fresh from the new endpoint.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE connections
+    SET connection_url = 'https://studio.decocms.com/org/deco/registry/mcp',
+        tools = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE connection_url = 'https://api.decocms.com/mcp/registry'
+      AND app_name = 'deco-registry'
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    UPDATE connections
+    SET connection_url = 'https://api.decocms.com/mcp/registry',
+        updated_at = CURRENT_TIMESTAMP
+    WHERE connection_url = 'https://studio.decocms.com/org/deco/registry/mcp'
+      AND app_name = 'deco-registry'
+  `.execute(db);
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -34,6 +34,7 @@ import * as migration032projects from "./032-projects.ts";
 import * as migration033threadstatus from "./033-thread-status.ts";
 import * as migration034monitoringdashboards from "./034-monitoring-dashboards.ts";
 import * as migration035projectconnections from "./035-project-connections.ts";
+import * as migration036updateregistryurl from "./036-update-registry-url.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -80,6 +81,7 @@ const migrations: Record<string, Migration> = {
   "033-thread-status": migration033threadstatus,
   "034-monitoring-dashboards": migration034monitoringdashboards,
   "035-project-connections": migration035projectconnections,
+  "036-update-registry-url": migration036updateregistryurl,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/oauth-proxy.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.test.ts
@@ -727,7 +727,9 @@ describe("Deco-Hosted MCP Detection", () => {
   });
 
   test("DECO_STORE_URL is correct", () => {
-    expect(DECO_STORE_URL).toBe("https://api.decocms.com/mcp/registry");
+    expect(DECO_STORE_URL).toBe(
+      "https://studio.decocms.com/org/deco/registry/mcp",
+    );
   });
 
   describe("isDecoHostedMcp", () => {
@@ -745,9 +747,6 @@ describe("Deco-Hosted MCP Detection", () => {
 
     test("returns false for Deco Store registry (public, no OAuth)", () => {
       expect(isDecoHostedMcp(DECO_STORE_URL)).toBe(false);
-      expect(isDecoHostedMcp("https://api.decocms.com/mcp/registry")).toBe(
-        false,
-      );
     });
 
     test("returns false for non-deco-hosted URLs", () => {

--- a/apps/mesh/src/core/deco-constants.ts
+++ b/apps/mesh/src/core/deco-constants.ts
@@ -8,7 +8,8 @@
 export const DECO_CMS_API_HOST = "api.decocms.com";
 
 /** The Deco Store registry URL (public, no OAuth) */
-export const DECO_STORE_URL = "https://api.decocms.com/mcp/registry";
+export const DECO_STORE_URL =
+  "https://studio.decocms.com/org/deco/registry/mcp";
 
 /** OpenRouter MCP URL (deco-hosted) */
 export const OPENROUTER_MCP_URL = "https://sites-openrouter.decocache.com/mcp";

--- a/apps/mesh/src/web/components/store/mcp-server-card.tsx
+++ b/apps/mesh/src/web/components/store/mcp-server-card.tsx
@@ -98,6 +98,7 @@ interface MCPServerCardStoreProps extends MCPServerCardBaseProps {
   variant?: "store";
   scopeName: string | null;
   isVerified: boolean;
+  isOfficial: boolean;
   canInstall: boolean;
 }
 
@@ -148,6 +149,9 @@ export function MCPServerCard(props: MCPServerCardProps) {
   const isVerified = !isServer
     ? (props as MCPServerCardStoreProps).isVerified
     : false;
+  const isOfficial = !isServer
+    ? (props as MCPServerCardStoreProps).isOfficial
+    : false;
   const canInstall = !isServer
     ? (props as MCPServerCardStoreProps).canInstall
     : true;
@@ -189,7 +193,13 @@ export function MCPServerCard(props: MCPServerCardProps) {
                     <span className="truncate">{displayName}</span>
 
                     {/* Store variant badges */}
-                    {!isServer && isVerified && (
+                    {!isServer && isOfficial && (
+                      <CheckVerified02
+                        size={16}
+                        className="text-primary shrink-0"
+                      />
+                    )}
+                    {!isServer && !isOfficial && isVerified && (
                       <CheckVerified02
                         size={16}
                         className="text-success shrink-0"
@@ -296,6 +306,7 @@ function extractCardDisplayData(
   const icon =
     server?.icons?.[0]?.src || getGitHubAvatarUrl(server?.repository) || null;
   const isVerified = meshMeta?.verified ?? false;
+  const isOfficial = meshMeta?.official ?? false;
   const hasRemotes = (server?.remotes?.length ?? 0) > 0;
   const hasPackages = (server?.packages?.length ?? 0) > 0;
   const canInstall = hasRemotes || hasPackages;
@@ -340,6 +351,7 @@ function extractCardDisplayData(
     displayName,
     description,
     isVerified,
+    isOfficial,
     canInstall,
   };
 }

--- a/apps/mesh/src/web/components/store/store-discovery.tsx
+++ b/apps/mesh/src/web/components/store/store-discovery.tsx
@@ -59,6 +59,13 @@ function isItemVerified(item: RegistryItem): boolean {
 }
 
 /**
+ * Check if an item is official (made and hosted by the service provider)
+ */
+function isItemOfficial(item: RegistryItem): boolean {
+  return item._meta?.["mcp.mesh"]?.official === true;
+}
+
+/**
  * Store discovery content - handles data display and interactions
  */
 function StoreDiscoveryContent({
@@ -120,10 +127,13 @@ function StoreDiscoveryContent({
     !isInitialLoading &&
     Boolean(search);
 
-  // Separate verified and non-verified items
-  const verifiedItems = visibleItems.filter(isItemVerified);
+  // Separate items into official, verified, and all
+  const officialItems = visibleItems.filter(isItemOfficial);
+  const verifiedItems = visibleItems.filter(
+    (item) => isItemVerified(item) && !isItemOfficial(item),
+  );
   const allItems = visibleItems.filter(
-    (item) => !verifiedItems.find((v) => v.id === item.id),
+    (item) => !isItemVerified(item) && !isItemOfficial(item),
   );
 
   const handleItemClick = (item: RegistryItem) => {
@@ -280,6 +290,14 @@ function StoreDiscoveryContent({
                   </div>
                 )}
 
+                {officialItems.length > 0 && (
+                  <MCPServerCardGrid
+                    items={officialItems}
+                    title="Official"
+                    onItemClick={handleItemClick}
+                  />
+                )}
+
                 {verifiedItems.length > 0 && (
                   <MCPServerCardGrid
                     items={verifiedItems}
@@ -291,7 +309,11 @@ function StoreDiscoveryContent({
                 {allItems.length > 0 && (
                   <MCPServerCardGrid
                     items={allItems}
-                    title={verifiedItems.length > 0 ? "All" : ""}
+                    title={
+                      officialItems.length > 0 || verifiedItems.length > 0
+                        ? "All"
+                        : ""
+                    }
                     onItemClick={handleItemClick}
                   />
                 )}

--- a/packages/mesh-plugin-private-registry/client/components/registry-item-card.tsx
+++ b/packages/mesh-plugin-private-registry/client/components/registry-item-card.tsx
@@ -7,7 +7,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
-import { DotsVertical, Globe01, Trash01 } from "@untitledui/icons";
+import {
+  CheckVerified02,
+  DotsVertical,
+  Globe01,
+  Trash01,
+} from "@untitledui/icons";
 import type { RegistryItem } from "../lib/types";
 
 function extractProvider(item: RegistryItem): string {
@@ -31,14 +36,20 @@ interface RegistryItemCardProps {
   item: RegistryItem;
   onEdit: (item: RegistryItem) => void;
   onDelete: (item: RegistryItem) => void;
+  onToggleVerified: (item: RegistryItem) => void;
+  onToggleOfficial: (item: RegistryItem) => void;
 }
 
 export function RegistryItemCard({
   item,
   onEdit,
   onDelete,
+  onToggleVerified,
+  onToggleOfficial,
 }: RegistryItemCardProps) {
   const icon = extractIcon(item);
+  const isVerified = item._meta?.["mcp.mesh"]?.verified === true;
+  const isOfficial = item._meta?.["mcp.mesh"]?.official === true;
   const badges = [...extractTags(item), ...extractCategories(item)];
   const visibleBadges = badges.slice(0, 3);
   const hiddenBadgesCount = Math.max(0, badges.length - visibleBadges.length);
@@ -75,6 +86,18 @@ export function RegistryItemCard({
               ) : (
                 <Badge variant="secondary">Private</Badge>
               )}
+              {isOfficial && (
+                <Badge variant="outline" className="gap-1 text-primary">
+                  <CheckVerified02 size={10} />
+                  Official
+                </Badge>
+              )}
+              {!isOfficial && isVerified && (
+                <Badge variant="outline" className="gap-1 text-success">
+                  <CheckVerified02 size={10} />
+                  Verified
+                </Badge>
+              )}
             </div>
           </div>
         </div>
@@ -88,6 +111,12 @@ export function RegistryItemCard({
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={() => onEdit(item)}>
               Edit
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onToggleVerified(item)}>
+              {isVerified ? "Unmark as Verified" : "Mark as Verified"}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onToggleOfficial(item)}>
+              {isOfficial ? "Unmark as Official" : "Mark as Official"}
             </DropdownMenuItem>
             <DropdownMenuItem
               variant="destructive"

--- a/packages/mesh-plugin-private-registry/client/components/registry-item-dialog.tsx
+++ b/packages/mesh-plugin-private-registry/client/components/registry-item-dialog.tsx
@@ -490,6 +490,10 @@ export function RegistryItemDialog({
   const initialTools =
     item?._meta?.["mcp.mesh"]?.tools ?? draftMeta?.tools ?? [];
   const initialIsPublic = item?.is_public ?? draft?.is_public ?? false;
+  const initialIsVerified =
+    item?._meta?.["mcp.mesh"]?.verified ?? draftMeta?.verified ?? false;
+  const initialIsOfficial =
+    item?._meta?.["mcp.mesh"]?.official ?? draftMeta?.official ?? false;
 
   /* ── wizard step ── */
   const [step, setStep] = useState<WizardStep>(1);
@@ -515,6 +519,8 @@ export function RegistryItemDialog({
   const [imageUrl, setImageUrl] = useState(initialImageUrl);
   const [tools, setTools] = useState<RegistryToolMeta[]>(initialTools);
   const [isPublic, setIsPublic] = useState(initialIsPublic);
+  const [isVerified, setIsVerified] = useState(initialIsVerified);
+  const [isOfficial, setIsOfficial] = useState(initialIsOfficial);
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
   const hasAIConfigured = Boolean(defaultLLMConnectionId && defaultLLMModelId);
 
@@ -537,6 +543,8 @@ export function RegistryItemDialog({
     setImageUrl(initialImageUrl);
     setTools(initialTools);
     setIsPublic(initialIsPublic);
+    setIsVerified(initialIsVerified);
+    setIsOfficial(initialIsOfficial);
     setErrors({});
     resetDiscover();
     lastDiscoveredUrlRef.current = "";
@@ -814,6 +822,8 @@ export function RegistryItemDialog({
       is_public: isPublic,
       _meta: {
         "mcp.mesh": {
+          verified: isVerified,
+          official: isOfficial,
           tags: parsedTags,
           categories: parsedCategories,
           short_description: parsedShortDescription || null,
@@ -1177,6 +1187,40 @@ export function RegistryItemDialog({
           id="registry-is-public"
           checked={isPublic}
           onCheckedChange={setIsPublic}
+        />
+      </div>
+
+      {/* Verified toggle */}
+      <div className="flex items-center justify-between rounded-xl border border-border px-4 py-3">
+        <div className="grid gap-0.5">
+          <Label htmlFor="registry-is-verified" className="text-sm">
+            Verified
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Curated and approved by deco.
+          </p>
+        </div>
+        <Switch
+          id="registry-is-verified"
+          checked={isVerified}
+          onCheckedChange={setIsVerified}
+        />
+      </div>
+
+      {/* Official toggle */}
+      <div className="flex items-center justify-between rounded-xl border border-border px-4 py-3">
+        <div className="grid gap-0.5">
+          <Label htmlFor="registry-is-official" className="text-sm">
+            Official
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Made and hosted by the service provider.
+          </p>
+        </div>
+        <Switch
+          id="registry-is-official"
+          checked={isOfficial}
+          onCheckedChange={setIsOfficial}
         />
       </div>
     </div>

--- a/packages/mesh-plugin-private-registry/client/components/registry-items-page.tsx
+++ b/packages/mesh-plugin-private-registry/client/components/registry-items-page.tsx
@@ -154,6 +154,56 @@ export default function RegistryItemsPage() {
     }
   };
 
+  const handleToggleVerified = async (item: RegistryItem) => {
+    const currentVerified = item._meta?.["mcp.mesh"]?.verified === true;
+    try {
+      await updateMutation.mutateAsync({
+        id: item.id,
+        data: {
+          _meta: {
+            ...item._meta,
+            "mcp.mesh": {
+              ...item._meta?.["mcp.mesh"],
+              verified: !currentVerified,
+            },
+          },
+        },
+      });
+      toast.success(
+        currentVerified ? "Removed verified status" : "Marked as verified",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update item",
+      );
+    }
+  };
+
+  const handleToggleOfficial = async (item: RegistryItem) => {
+    const currentOfficial = item._meta?.["mcp.mesh"]?.official === true;
+    try {
+      await updateMutation.mutateAsync({
+        id: item.id,
+        data: {
+          _meta: {
+            ...item._meta,
+            "mcp.mesh": {
+              ...item._meta?.["mcp.mesh"],
+              official: !currentOfficial,
+            },
+          },
+        },
+      });
+      toast.success(
+        currentOfficial ? "Removed official status" : "Marked as official",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update item",
+      );
+    }
+  };
+
   const handleDelete = async () => {
     if (!deletingItem) return;
     try {
@@ -363,6 +413,8 @@ export default function RegistryItemsPage() {
                   item={item}
                   onEdit={setEditingItem}
                   onDelete={setDeletingItem}
+                  onToggleVerified={handleToggleVerified}
+                  onToggleOfficial={handleToggleOfficial}
                 />
               ))}
             </div>

--- a/packages/mesh-plugin-private-registry/client/lib/types.ts
+++ b/packages/mesh-plugin-private-registry/client/lib/types.ts
@@ -29,6 +29,7 @@ export interface RegistryToolMeta {
 
 export interface RegistryMeshMeta {
   verified?: boolean;
+  official?: boolean;
   tags?: string[];
   categories?: string[];
   friendly_name?: string | null;

--- a/packages/mesh-plugin-private-registry/server/storage/registry-item.ts
+++ b/packages/mesh-plugin-private-registry/server/storage/registry-item.ts
@@ -49,6 +49,22 @@ function getMeshMeta(meta?: RegistryItemMeta): MeshRegistryMeta {
   return meta?.["mcp.mesh"] ?? {};
 }
 
+/**
+ * Sort items so official items appear first, then verified, then the rest.
+ * Within each group the original (created_at desc) order is preserved.
+ */
+function sortByOfficialAndVerified(
+  items: PrivateRegistryItemEntity[],
+): PrivateRegistryItemEntity[] {
+  return [...items].sort((a, b) => {
+    const aM = getMeshMeta(a._meta);
+    const bM = getMeshMeta(b._meta);
+    const aScore = (aM.official ? 2 : 0) + (aM.verified ? 1 : 0);
+    const bScore = (bM.official ? 2 : 0) + (bM.verified ? 1 : 0);
+    return bScore - aScore;
+  });
+}
+
 function toCsv(values: string[]): string | null {
   return values.length ? values.join(",") : null;
 }
@@ -300,16 +316,17 @@ export class RegistryItemStorage {
       return matchesTags && matchesCategories && matchesWhere;
     });
 
+    const sorted = sortByOfficialAndVerified(filtered);
     const cursorOffset = decodeCursor(query.cursor);
     const offset = cursorOffset ?? query.offset ?? 0;
     const limit = query.limit ?? 24;
-    const page = filtered.slice(offset, offset + limit);
-    const hasMore = offset + limit < filtered.length;
+    const page = sorted.slice(offset, offset + limit);
+    const hasMore = offset + limit < sorted.length;
     const nextCursor = hasMore ? encodeCursor(offset + limit) : undefined;
 
     return {
       items: page,
-      totalCount: filtered.length,
+      totalCount: sorted.length,
       hasMore,
       nextCursor,
     };
@@ -354,17 +371,17 @@ export class RegistryItemStorage {
       return matchesTags && matchesCategories && matchesWhere;
     });
 
-    // Apply pagination
+    const sorted = sortByOfficialAndVerified(filtered);
     const cursorOffset = decodeCursor(query.cursor);
     const offset = cursorOffset ?? query.offset ?? 0;
     const limit = query.limit ?? 24;
-    const page = filtered.slice(offset, offset + limit);
-    const hasMore = offset + limit < filtered.length;
+    const page = sorted.slice(offset, offset + limit);
+    const hasMore = offset + limit < sorted.length;
     const nextCursor = hasMore ? encodeCursor(offset + limit) : undefined;
 
     return {
       items: page,
-      totalCount: filtered.length,
+      totalCount: sorted.length,
       hasMore,
       nextCursor,
     };

--- a/packages/mesh-plugin-private-registry/server/storage/types.ts
+++ b/packages/mesh-plugin-private-registry/server/storage/types.ts
@@ -118,6 +118,7 @@ export interface RegistryToolMeta {
 
 export interface MeshRegistryMeta {
   verified?: boolean;
+  official?: boolean;
   tags?: string[];
   categories?: string[];
   friendly_name?: string | null;

--- a/packages/mesh-plugin-private-registry/server/tools/schema.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/schema.ts
@@ -52,6 +52,7 @@ const RegistryItemMetaSchema = z
     "mcp.mesh": z
       .object({
         verified: z.boolean().optional(),
+        official: z.boolean().optional(),
         tags: z.array(z.string()).optional(),
         categories: z.array(z.string()).optional(),
         friendly_name: z.string().nullable().optional(),

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -56,7 +56,7 @@ export function getWellKnownRegistryConnection(
     title: "Deco Store",
     description: "Official deco MCP registry with curated integrations",
     connection_type: "HTTP",
-    connection_url: "https://api.decocms.com/mcp/registry",
+    connection_url: "https://studio.decocms.com/org/deco/registry/mcp",
     icon: "https://assets.decocache.com/decocms/00ccf6c3-9e13-4517-83b0-75ab84554bb9/596364c63320075ca58483660156b6d9de9b526e.png",
     app_name: "deco-registry",
     app_id: null,


### PR DESCRIPTION
## Summary

- **URL Migration**: Atualiza a URL do Deco Store Registry de `https://api.decocms.com/mcp/registry` para `https://studio.decocms.com/org/deco/registry/mcp` em constantes, SDK e testes
- **Database Migration**: Migration 036 atualiza conexões existentes no banco com a URL antiga, resetando tools para forçar re-fetch
- **Campo `official`**: Novo campo nos schemas e types do private registry para identificar MCPs feitos e hospedados pelo provedor do serviço (ex: Cloudflare)
- **Sorting server-side**: MCPs são ordenados antes da paginação — official primeiro, depois verified, depois os demais — garantindo que não se percam em páginas posteriores
- **UI badges**: Badge azul para official, verde para verified no `MCPServerCard`
- **Admin UI**: Toggles no dialog de criação/edição e ações rápidas no dropdown do card para marcar/desmarcar verified e official

## Files Changed

| Area | Files |
|---|---|
| Constants | `deco-constants.ts`, `mesh-sdk/constants.ts` |
| Migration | `036-update-registry-url.ts`, `migrations/index.ts` |
| Tests | `oauth-proxy.test.ts` |
| Backend schemas | `schema.ts`, `storage/types.ts`, `client/lib/types.ts` |
| Backend sorting | `storage/registry-item.ts` |
| Store UI | `store-discovery.tsx`, `mcp-server-card.tsx` |
| Admin UI | `registry-item-dialog.tsx`, `registry-item-card.tsx`, `registry-items-page.tsx` |

## Test plan

- [x] `bun run check` — all workspaces pass
- [x] `bun run fmt` — formatted
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run knip` — clean
- [x] `bun test oauth-proxy.test.ts` — 25/25 pass
- [x] Manual: store da org de teste exibe official > verified > regular na primeira página


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Deco Store Registry URL to https://studio.decocms.com/org/deco/registry/mcp and adds an “official” MCP flag with server-side sorting (official > verified > others). Also adds badges and admin controls, and migrates existing connections to the new URL.

- New Features
  - Added `official` to registry schemas/types and UI.
  - Server sorts items before pagination: official first, then verified, then others.
  - UI: blue “Official” badge; green “Verified” badge; Store groups into Official, Verified, All.
  - Admin: toggles in the dialog and quick actions on cards to mark/unmark verified/official.
  - Updated `mesh-sdk` well-known registry URL and related constants/tests.

- Migration
  - Migration 036 updates existing `deco-registry` connections from https://api.decocms.com/mcp/registry to https://studio.decocms.com/org/deco/registry/mcp and resets `tools` to refetch.

<sup>Written for commit 808322f5fbb60d745be37ac3ca6bf04cd5c8c33e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

