### PR TITLE
feat(store): add Share button for universal MCP deep links

### DIFF
--- a/apps/mesh/src/web/components/store/mcp-server-detail/mcp-server-detail-header.tsx
+++ b/apps/mesh/src/web/components/store/mcp-server-detail/mcp-server-detail-header.tsx
@@ -1,16 +1,63 @@
 import { Page } from "@/web/components/page";
-import type { ReactNode } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { Check, Copy01 } from "@untitledui/icons";
+import { type ReactNode, useState } from "react";
+import { toast } from "sonner";
 
 interface MCPServerDetailHeaderProps {
   breadcrumb?: ReactNode;
+  shareUrl?: string;
 }
 
 export function MCPServerDetailHeader({
   breadcrumb,
+  shareUrl,
 }: MCPServerDetailHeaderProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    toast.success("Share link copied to clipboard");
+    setTimeout(() => setCopied(false), 2000);
+  };
+
   return (
     <Page.Header>
       <Page.Header.Left>{breadcrumb}</Page.Header.Left>
+      {shareUrl && (
+        <Page.Header.Right>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleShare}
+                  className="gap-1.5 cursor-pointer"
+                >
+                  {copied ? (
+                    <Check size={16} className="text-green-600" />
+                  ) : (
+                    <Copy01 size={16} />
+                  )}
+                  <span>{copied ? "Copied!" : "Share"}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Copy a universal link anyone can use to find this MCP</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </Page.Header.Right>
+      )}
     </Page.Header>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/store/mcp-server-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/store/mcp-server-detail.tsx
@@ -698,6 +698,15 @@ function StoreMCPServerDetailContent() {
     </Breadcrumb>
   );
 
+  const shareUrl = (() => {
+    const url = new URL(
+      `/store/${encodeURIComponent(serverSlug || "")}`,
+      window.location.origin,
+    );
+    if (serverName) url.searchParams.set("serverName", serverName);
+    return url.href;
+  })();
+
   return (
     <div className="flex flex-col h-full border-l border-border">
       {/* Duplicate warning dialog (two steps) */}
@@ -826,7 +835,7 @@ function StoreMCPServerDetailContent() {
       )}
 
       {/* Header */}
-      <MCPServerDetailHeader breadcrumb={breadcrumb} />
+      <MCPServerDetailHeader breadcrumb={breadcrumb} shareUrl={shareUrl} />
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto h-full">


### PR DESCRIPTION
## Summary

- Adds a **Share** button to the store MCP server detail page header
- Clicking it copies a universal deep link (`/store/{appName}?serverName=...`) to clipboard
- The link works for **any logged-in user** regardless of their organization — the existing `storeInviteRoute` (`/store/$appName`) handles redirecting to the user's org automatically

## How it works

The share URL strips the org-specific path (`/:org/org-admin/store/:appName`) and generates a universal path (`/store/:appName?serverName=...`). When someone clicks the link:

1. If logged in → redirected to their first org's store page for that MCP
2. If not logged in → redirected to login, then to the store page

## Files changed

| File | Change |
|------|--------|
| `mcp-server-detail-header.tsx` | Added `shareUrl` prop, Share button with copy-to-clipboard + tooltip |
| `mcp-server-detail.tsx` | Builds the universal deep link URL and passes it to the header |

## Test plan

- [ ] Open any MCP detail page in the store (e.g. `/org/org-admin/store/vtex-commerce-apis?serverName=deco%2Fvtex-mcp`)
- [ ] Verify the "Share" button appears in the header (right side)
- [ ] Click Share → verify toast "Share link copied to clipboard" appears
- [ ] Verify the copied URL is in the format `https://studio.decocms.com/store/{appName}?serverName={serverName}`
- [ ] Open the copied URL in an incognito/different session → verify it redirects correctly to the MCP detail page
- [ ] Verify the button shows green checkmark and "Copied!" for ~2s after clicking


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Share button to MCP store detail pages that copies an org-agnostic deep link (`/store/{appName}?serverName=...`) to the clipboard with a success toast and brief “Copied!” state. Opening the link redirects a logged-in user to their org’s MCP page, or to login first.

<sup>Written for commit b9c5783ccb3f96957faf28bf8154d486ad139f26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

