### PR TITLE
fix(web): enable scrolling in project app view

### DIFF
--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -97,7 +97,7 @@ export default function ProjectAppView() {
   return (
     <Page>
       <Page.Header />
-      <Page.Content className="overflow-hidden">
+      <Page.Content>
         <ErrorBoundary key={`${connectionId}:${toolName}`} fallback={undefined}>
           <Suspense
             fallback={


### PR DESCRIPTION
## What is this contribution about?
Fixes scroll blocking in MCP app views. The `overflow-hidden` class on `Page.Content` was preventing scrolling when app content exceeded the viewport height. Removing this override restores the default `overflow-auto` behavior.

## How to Test
1. Open any project in the mesh UI
2. Navigate to a collection or other MCP app view
3. Verify that the page scrolls when content overflows the viewport
4. Check that no visual regressions occur in app rendering

## Migration Notes
No database migrations or configuration changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore scrolling in project app views by removing the `overflow-hidden` class from `Page.Content`. The page now uses its default `overflow-auto`, allowing content to scroll when it exceeds the viewport.

<sup>Written for commit e1ccedf303cc5f150c9e45f485dc52d21e14bb17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

