### PR TITLE
Rename MCP Mesh to deco Studio in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Token spend per connection — OpenRouter, Perplexity, Firecrawl, all of it. Lat
 
 | | |
 |---|---|
-| **Local** | `bunx decocms` on your laptop. SQLite. Private. |
+| **Local** | `bunx decocms` on your laptop. PGlite. Private. |
 | **Cloud** | Log in to studio.decocms.com. Control local projects from any browser. |
 | **Team** | Invite people. Roles. Shared connections. Cost attribution. |
 | **Enterprise** | Self-hosted. Your infra. Your rules. |
@@ -223,7 +223,7 @@ bun run dev:conductor
 ## Deploy Anywhere
 
 ```bash
-# Docker (SQLite)
+# Docker (PGlite)
 docker compose -f deploy/docker-compose.yml up
 
 # Docker (PostgreSQL)
@@ -247,7 +247,7 @@ No vendor lock-in. Runs on Docker, Kubernetes, AWS, GCP, or local runtimes.
 | Runtime | Bun / Node |
 | Language | TypeScript + Zod |
 | Framework | Hono (API) + Vite + React 19 |
-| Database | Kysely → SQLite / PostgreSQL |
+| Database | Kysely → PGlite / PostgreSQL |
 | Auth | Better Auth (OAuth 2.1 + API keys) |
 | Observability | OpenTelemetry |
 | UI | React 19 + Tailwind v4 + shadcn |


### PR DESCRIPTION
## Summary
- Reposition README from MCP-routing infrastructure to the full deco Studio experience
- MCP connections remain a core capability but are no longer the sole focus
- Aligns with [decocms.com/studio](https://decocms.com/studio) landing page messaging
- New tagline: "Open-source control plane for your AI agents"
- Added Agents, Projects, and Store to core capabilities
- Updated Quick Start to lead with `bunx decocms`
- Removed "Part of deco CMS" section (Studio IS the product now)
- Updated roadmap to reflect Studio-era priorities

**Proposed GitHub repo description:** "Open-source control plane for your AI agents. Connect tools, hire agents, track every token and dollar."

## Test plan
- [ ] Review rendered README on GitHub
- [ ] Verify links resolve (decocms.com/studio, docs.deco.page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed MCP Mesh to deco Studio in the README and removed the banner. Updated messaging (agents, connections, projects), tightened the TL;DR, trimmed Development/Deploy/Contributing, switched DB refs to PGlite, and refreshed quick start (`bunx decocms`), links, roadmap, and license.

- **Migration**
  - Use `bunx decocms` for local setup; if cloning, use `decocms/studio`.
  - Docker examples now default to PGlite (not SQLite); use PGlite or PostgreSQL.

<sup>Written for commit a09d55dabce00aaf3b92f22b655d1b62b9fb36c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

