### PR TITLE
fix(npm): update repository URLs for sigstore provenance

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -4,14 +4,14 @@
   "description": "MCP Mesh - Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "license": "MIT",
-  "homepage": "https://github.com/decocms/mesh",
+  "homepage": "https://github.com/decocms/studio",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "apps/mesh"
   },
   "bugs": {
-    "url": "https://github.com/decocms/mesh/issues"
+    "url": "https://github.com/decocms/studio/issues"
   },
   "type": "module",
   "bin": {

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "packages/bindings"
   },
   "publishConfig": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/decocms/admin",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "packages/cli"
   },
   "bugs": {

--- a/packages/create-deco/package.json
+++ b/packages/create-deco/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "packages/create-deco"
   },
   "publishConfig": {

--- a/packages/mesh-sdk/package.json
+++ b/packages/mesh-sdk/package.json
@@ -43,7 +43,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "packages/mesh-sdk"
   },
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "packages/runtime"
   },
   "publishConfig": {

--- a/packages/vite-plugin-deco/package.json
+++ b/packages/vite-plugin-deco/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decocms/mesh.git",
+    "url": "git+https://github.com/decocms/studio.git",
     "directory": "packages/vite-plugin-deco"
   },
   "publishConfig": {


### PR DESCRIPTION
## What is this contribution about?

Fixes npm error 422 Unprocessable Entity when publishing packages with sigstore provenance. npm's provenance verification requires `package.json`'s `repository.url` to match the GitHub repository from the OIDC token during CI/CD publish.

Updated all 7 package.json files to point to `decocms/studio` instead of `decocms/mesh` to align with the actual publishing repository.

## How to Test

These changes will allow npm publish workflows to complete successfully with provenance bundles. The fix resolves the sigstore validation error: "package.json: 'repository.url' is 'git+https://github.com/decocms/mesh.git', expected to match 'https://github.com/decocms/studio'".

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes align with npm sigstore provenance requirements
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates repository metadata to align with `decocms/studio` so npm sigstore provenance checks pass. CI publishes with provenance no longer fail with 422.

- **Bug Fixes**
  - Set `"repository.url"` to `git+https://github.com/decocms/studio.git` in: `apps/mesh`, `packages/bindings`, `packages/cli`, `packages/create-deco`, `packages/mesh-sdk`, `packages/runtime`, `packages/vite-plugin-deco`.
  - Updated `apps/mesh` `"homepage"` and `"bugs.url"` to `https://github.com/decocms/studio` and `https://github.com/decocms/studio/issues`.
  - Aligns `package.json` metadata with the OIDC repo to satisfy npm provenance checks.

<sup>Written for commit c0ba7509caa4bee7df090c5757273dfa8b5f783f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

