### PR TITLE
fix: override fast-xml-parser to 5.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   ],
   "trustedDependencies": [
     "chdb"
-  ]
+  ],
+  "overrides": {
+    "fast-xml-parser": "5.4.2"
+  }
 }


### PR DESCRIPTION
## Summary
- `fast-xml-parser@5.5.0` was published with a broken `file:../../fxp-builder` dependency, causing `bun install` to fail
- Adds an `overrides` field in root `package.json` to pin `fast-xml-parser` to `5.4.2` (last working version)

## Test plan
- [ ] `bun install` completes without errors
- [ ] `bun run dev` starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `fast-xml-parser` to `5.4.2` via root `overrides` to work around the broken `5.5.0` release that references `file:../../fxp-builder`. Restores successful `bun install` and allows `bun run dev` to start.

<sup>Written for commit e1b643cca545bf6e66ae6403dec376725bea95e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

