### PR TITLE
fix: revert npm propagation wait back to 30s

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,8 +95,8 @@ jobs:
       - name: Wait for npm propagation
         if: steps.version-check.outputs.version-changed == 'true'
         run: |
-          echo "Waiting 120s for npm registry propagation..."
-          sleep 120
+          echo "Waiting 30s for npm registry propagation..."
+          sleep 30
 
       # ==================== DOCKER BUILD & PUSH ====================
       - name: Set up Docker Buildx


### PR DESCRIPTION
## What is this contribution about?
Reverts the npm registry propagation wait time from 120s back to 30s in the release workflow. The extended wait was causing unnecessarily long release times.

## How to Test
The change only affects the release workflow. The npm propagation wait will now wait 30 seconds before proceeding to the Docker build step, which should reduce overall release time.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested (workflow change)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted `npm` registry propagation wait from 120s to 30s in the release workflow to speed up releases. When the version changes, the job now proceeds to the Docker build about 90s sooner.

<sup>Written for commit e0354b0bc43eaefe85265fe3216da3f0f8eb9132. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

