### PR TITLE
feat(deploy): move Helm chart into monorepo

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: chart-deco-mcp-mesh
+description: A Helm chart for deco-mcp-mesh self-hosted deployment
+type: application
+version: 0.1.22
+appVersion: "latest"

--- a/deploy/helm/examples/secrets-example.yaml
+++ b/deploy/helm/examples/secrets-example.yaml
@@ -1,0 +1,50 @@
+# Example Secrets to create manually
+# 
+# IMPORTANT: This file contains example values and should NOT be applied directly.
+# Use the create-secrets.sh script or create the Secrets manually with your real values.
+#
+# To create the Secrets manually:
+#
+# 1. Main Secret (BETTER_AUTH_SECRET and DATABASE_URL):
+#    kubectl create secret generic deco-mcp-mesh-secrets \
+#      --from-literal=BETTER_AUTH_SECRET='your-secret-here' \
+#      --from-literal=DATABASE_URL='postgresql://user:pass@host:5432/db' \
+#      -n deco-mcp-mesh
+#
+# 2. Secret for sensitive authConfig values:
+#    kubectl create secret generic deco-mcp-mesh-auth-secrets \
+#      --from-literal=googleClientId='your-google-client-id' \
+#      --from-literal=googleClientSecret='your-google-client-secret' \
+#      --from-literal=githubClientId='your-github-client-id' \
+#      --from-literal=githubClientSecret='your-github-client-secret' \
+#      --from-literal=resendApiKey='your-resend-api-key' \
+#      -n deco-mcp-mesh
+
+---
+# Main Secret - BETTER_AUTH_SECRET and DATABASE_URL
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deco-mcp-mesh-secrets
+  namespace: deco-mcp-mesh
+type: Opaque
+stringData:
+  BETTER_AUTH_SECRET: "SUBSTITUA_PELO_SEU_SECRET_AQUI"
+  DATABASE_URL: "postgresql://usuario:senha@host:5432/database"
+
+---
+# Secret for sensitive authConfig values
+# Contains clientId and clientSecret to keep everything in one place
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deco-mcp-mesh-auth-secrets
+  namespace: deco-mcp-mesh
+type: Opaque
+stringData:
+  googleClientId: "SUBSTITUA_PELO_CLIENT_ID_DO_GOOGLE"
+  googleClientSecret: "SUBSTITUA_PELO_CLIENT_SECRET_DO_GOOGLE"
+  githubClientId: "SUBSTITUA_PELO_CLIENT_ID_DO_GITHUB"
+  githubClientSecret: "SUBSTITUA_PELO_CLIENT_SECRET_DO_GITHUB"
+  resendApiKey: "SUBSTITUA_PELA_API_KEY_DO_RESEND"
+

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,0 +1,18 @@
+1. Get the application URL by running these commands:
+
+{{- if contains "ClusterIP" .Values.service.type }}
+  export SERVICE_NAME={{ include "chart-deco-mcp-mesh.fullname" . }}
+  echo "To access the application, run:"
+  echo "  kubectl --namespace {{ .Release.Namespace }} port-forward svc/$SERVICE_NAME 8080:{{ .Values.service.port }}"
+  echo ""
+  echo "Then visit http://localhost:8080 in your browser"
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "chart-deco-mcp-mesh.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "Visit http://$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "chart-deco-mcp-mesh.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "chart-deco-mcp-mesh.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "Visit http://$SERVICE_IP:{{ .Values.service.port }}"
+{{- end }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,198 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart-deco-mcp-mesh.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Uses only the release name, ignoring the chart name.
+*/}}
+{{- define "chart-deco-mcp-mesh.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart-deco-mcp-mesh.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart-deco-mcp-mesh.labels" -}}
+helm.sh/chart: {{ include "chart-deco-mcp-mesh.chart" . }}
+{{ include "chart-deco-mcp-mesh.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart-deco-mcp-mesh.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart-deco-mcp-mesh.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart-deco-mcp-mesh.serviceAccountName" -}}
+{{- if and .Values.serviceAccount .Values.serviceAccount.create -}}
+{{- default (include "chart-deco-mcp-mesh.fullname" .) .Values.serviceAccount.name | trim -}}
+{{- else if .Values.serviceAccount -}}
+{{- default "default" .Values.serviceAccount.name | trim -}}
+{{- else -}}
+default
+{{- end -}}
+{{- end }}
+
+{{/*
+Checks if persistence configuration supports distributed writes.
+*/}}
+{{- define "chart-deco-mcp-mesh.isDistributedStorage" -}}
+{{- $p := .Values.persistence -}}
+{{- if not $p -}}
+false
+{{- else if not $p.enabled -}}
+false
+{{- else -}}
+{{- $accessMode := lower (default "" $p.accessMode) -}}
+{{- $isReadWriteMany := eq $accessMode "readwritemany" -}}
+{{- $isDistributed := $p.distributed | default false -}}
+{{- if or $isReadWriteMany $isDistributed -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Checks if database engine is PostgreSQL.
+*/}}
+{{- define "chart-deco-mcp-mesh.usesPostgres" -}}
+{{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" }}
+true
+{{- else }}
+false
+{{- end }}
+{{- end }}
+
+{{/*
+Resolves DATABASE_URL honoring database engine configuration.
+*/}}
+{{- define "chart-deco-mcp-mesh.databaseUrl" -}}
+{{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" -}}
+{{- required "database.url deve ser definido quando database.engine=postgresql" .Values.database.url | trim -}}
+{{- else -}}
+/app/data/mesh.db
+{{- end -}}
+{{- end }}
+
+{{/*
+Global validations to ensure scaling requirements are met.
+*/}}
+{{- define "chart-deco-mcp-mesh.validate" -}}
+{{- $distributedStr := include "chart-deco-mcp-mesh.isDistributedStorage" . | trim -}}
+{{- $distributed := eq $distributedStr "true" -}}
+{{- $usesPostgresStr := include "chart-deco-mcp-mesh.usesPostgres" . | trim -}}
+{{- $usesPostgres := eq $usesPostgresStr "true" -}}
+{{- $replicas := int (default 1 .Values.replicaCount) -}}
+{{- if and (not .Values.autoscaling.enabled) (not $distributed) (not $usesPostgres) (gt $replicas 1) }}
+{{- fail "chart-deco-mcp-mesh: replicaCount > 1 exige storage distribuído (persistence.distributed=true ou accessMode=ReadWriteMany) ou database.engine=postgresql" -}}
+{{- end }}
+{{- if and .Values.autoscaling.enabled (not (or $distributed $usesPostgres)) }}
+{{- fail "chart-deco-mcp-mesh: autoscaling.enabled=true exige storage distribuído (persistence.distributed=true ou accessMode=ReadWriteMany) ou database.engine=postgresql" -}}
+{{- end }}
+{{- if and $usesPostgres (not .Values.database.url) (not .Values.secret.secretName) }}
+{{- fail "chart-deco-mcp-mesh: defina database.url quando database.engine=postgresql ou use secret.secretName para fornecer DATABASE_URL via Secret" -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns podSecurityContext with fsGroupChangePolicy adjusted for volumes.
+*/}}
+{{- define "chart-deco-mcp-mesh.podSecurityContext" -}}
+{{- if .Values.podSecurityContext }}
+{{- toYaml .Values.podSecurityContext }}
+{{- else }}
+fsGroup: 1001
+fsGroupChangePolicy: "OnRootMismatch"
+{{- end }}
+{{- end }}
+
+{{/*
+Determines the deployment strategy based on database and storage configuration.
+Uses RollingUpdate if PostgreSQL or distributed storage, otherwise Recreate.
+*/}}
+{{- define "chart-deco-mcp-mesh.deploymentStrategy" -}}
+{{- $distributed := eq (include "chart-deco-mcp-mesh.isDistributedStorage" .) "true" -}}
+{{- $usesPostgres := eq (include "chart-deco-mcp-mesh.usesPostgres" .) "true" -}}
+{{- if and .Values.strategy .Values.strategy.type -}}
+{{- .Values.strategy.type | trim -}}
+{{- else if or $distributed $usesPostgres -}}
+RollingUpdate
+{{- else -}}
+Recreate
+{{- end -}}
+{{- end }}
+
+{{/*
+Returns the secret name to use. If secret.secretName is defined, uses it.
+Otherwise, uses the generated name.
+*/}}
+{{- define "chart-deco-mcp-mesh.secretName" -}}
+{{- if .Values.secret.secretName -}}
+{{- .Values.secret.secretName | trim -}}
+{{- else -}}
+{{- include "chart-deco-mcp-mesh.fullname" . }}-secrets
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate OTel collector/S3 configuration.
+*/}}
+{{- define "chart-deco-mcp-mesh.validateOtel" -}}
+{{- if and .Values.otel.s3.enabled (not .Values.otel.collector.enabled) }}
+{{- fail "chart-deco-mcp-mesh: otel.s3.enabled=true requires otel.collector.enabled=true" -}}
+{{- end }}
+{{- if and .Values.otel.s3.roleArn (ne .Values.otel.s3.roleArn "") }}
+{{- if not (and .Values.serviceAccount .Values.serviceAccount.create) }}
+{{- fail "chart-deco-mcp-mesh: otel.s3.roleArn requires serviceAccount.create=true" -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Formats OTEL headers map as key=value,key2=value2 format.
+*/}}
+{{- define "chart-deco-mcp-mesh.otelHeaders" -}}
+{{- $headers := list -}}
+{{- range $key, $value := .Values.otel.headers -}}
+{{- $headers = append $headers (printf "%s=%s" $key $value) -}}
+{{- end -}}
+{{- join "," $headers -}}
+{{- end }}
+
+{{/*
+Formats OTEL resource attributes map as key=value,key2=value2 format.
+*/}}
+{{- define "chart-deco-mcp-mesh.otelAttributes" -}}
+{{- $attrs := list -}}
+{{- range $key, $value := .Values.otel.attributes -}}
+{{- $attrs = append $attrs (printf "%s=%s" $key $value) -}}
+{{- end -}}
+{{- join "," $attrs -}}
+{{- end }}

--- a/deploy/helm/templates/configmap-auth.yaml
+++ b/deploy/helm/templates/configmap-auth.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-auth-config
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+data:
+  auth-config.json: |
+{{- $authConfig := .Values.configMap.authConfig | deepCopy }}
+{{- if .Values.secret.authConfigSecretName }}
+{{- $authSecrets := lookup "v1" "Secret" .Release.Namespace .Values.secret.authConfigSecretName }}
+{{- if $authSecrets }}
+{{- if $authSecrets.data }}
+{{- /* Google OAuth - clientId and clientSecret from Secret only if empty in values.yaml */}}
+{{- if hasKey $authConfig.socialProviders "google" }}
+{{- $googleClientId := index $authConfig.socialProviders.google "clientId" | default "" }}
+{{- $googleClientSecret := index $authConfig.socialProviders.google "clientSecret" | default "" }}
+{{- if and $authSecrets.data.googleClientId (eq $googleClientId "") }}
+{{- $_ := set $authConfig.socialProviders.google "clientId" (b64dec $authSecrets.data.googleClientId) }}
+{{- end }}
+{{- if and $authSecrets.data.googleClientSecret (eq $googleClientSecret "") }}
+{{- $_ := set $authConfig.socialProviders.google "clientSecret" (b64dec $authSecrets.data.googleClientSecret) }}
+{{- end }}
+{{- end }}
+{{- /* GitHub OAuth - clientId and clientSecret from Secret only if empty in values.yaml */}}
+{{- if hasKey $authConfig.socialProviders "github" }}
+{{- $githubClientId := index $authConfig.socialProviders.github "clientId" | default "" }}
+{{- $githubClientSecret := index $authConfig.socialProviders.github "clientSecret" | default "" }}
+{{- if and $authSecrets.data.githubClientId (eq $githubClientId "") }}
+{{- $_ := set $authConfig.socialProviders.github "clientId" (b64dec $authSecrets.data.githubClientId) }}
+{{- end }}
+{{- if and $authSecrets.data.githubClientSecret (eq $githubClientSecret "") }}
+{{- $_ := set $authConfig.socialProviders.github "clientSecret" (b64dec $authSecrets.data.githubClientSecret) }}
+{{- end }}
+{{- end }}
+{{- /* Resend API Key from Secret only if empty in values.yaml */}}
+{{- if $authSecrets.data.resendApiKey }}
+{{- range $authConfig.emailProviders }}
+{{- if and (eq .id "resend-primary") (hasKey .config "apiKey") }}
+{{- $resendApiKey := index .config "apiKey" | default "" }}
+{{- if eq $resendApiKey "" }}
+{{- $_ := set .config "apiKey" (b64dec $authSecrets.data.resendApiKey) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{ $authConfig | toJson | indent 4 }}

--- a/deploy/helm/templates/configmap-ca-cert.yaml
+++ b/deploy/helm/templates/configmap-ca-cert.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-ca-cert
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+data:
+  ca-cert.pem: |
+{{ .Values.database.caCert | indent 4 }}
+{{- end }}
+

--- a/deploy/helm/templates/configmap-otel-collector.yaml
+++ b/deploy/helm/templates/configmap-otel-collector.yaml
@@ -1,0 +1,73 @@
+{{- if and .Values.otel.enabled .Values.otel.collector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-otel-collector
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+
+    processors:
+      batch:
+        send_batch_size: 1024
+        timeout: 5s
+
+    exporters:
+      {{- if .Values.otel.s3.enabled }}
+      awss3:
+        s3uploader:
+          region: {{ .Values.otel.s3.region | quote }}
+          s3_bucket: {{ required "otel.s3.bucket is required when otel.s3.enabled=true" .Values.otel.s3.bucket | quote }}
+          s3_prefix: {{ .Values.otel.s3.prefix | quote }}
+          file_prefix: {{ .Values.otel.s3.filePrefix | quote }}
+        marshaler: {{ .Values.otel.s3.marshaler | quote }}
+        {{- if ne .Values.otel.s3.compression "none" }}
+        compression: {{ .Values.otel.s3.compression | quote }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.otel.endpoint }}
+      otlphttp/remote:
+        endpoint: {{ .Values.otel.endpoint | quote }}
+        {{- if .Values.otel.headers }}
+        headers:
+          {{- range $key, $value := .Values.otel.headers }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        {{- $exporters := list }}
+        {{- if .Values.otel.s3.enabled }}
+        {{- $exporters = append $exporters "awss3" }}
+        {{- end }}
+        {{- if .Values.otel.endpoint }}
+        {{- $exporters = append $exporters "otlphttp/remote" }}
+        {{- end }}
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [{{ join ", " $exporters }}]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [{{ join ", " $exporters }}]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [{{ join ", " $exporters }}]
+{{- end }}

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.configMap.meshConfig.NODE_ENV | quote }}
+  PORT: {{ .Values.configMap.meshConfig.PORT | quote }}
+  HOST: {{ .Values.configMap.meshConfig.HOST | quote }}
+  BETTER_AUTH_URL: {{ .Values.configMap.meshConfig.BETTER_AUTH_URL | quote }}
+  BASE_URL: {{ .Values.configMap.meshConfig.BASE_URL | quote }}
+  {{- if .Values.configMap.meshConfig.DATABASE_PG_SSL }}
+  DATABASE_PG_SSL: {{ .Values.configMap.meshConfig.DATABASE_PG_SSL | quote }}
+  {{- end }}
+  {{- if and .Values.configMap.meshConfig.NODE_EXTRA_CA_CERTS .Values.database.caCert }}
+  NODE_EXTRA_CA_CERTS: {{ .Values.configMap.meshConfig.NODE_EXTRA_CA_CERTS | quote }}
+  {{- end }}
+  {{- if .Values.configMap.meshConfig.ENABLE_DEBUG_SERVER }}
+  ENABLE_DEBUG_SERVER: {{ .Values.configMap.meshConfig.ENABLE_DEBUG_SERVER | quote }}
+  {{- end }}
+  {{- if .Values.configMap.meshConfig.DEBUG_PORT }}
+  DEBUG_PORT: {{ .Values.configMap.meshConfig.DEBUG_PORT | quote }}
+  {{- end }}
+  {{- if .Values.configMap.meshConfig.PRESTOP_HEAP_SNAPSHOT_DIR }}
+  PRESTOP_HEAP_SNAPSHOT_DIR: {{ .Values.configMap.meshConfig.PRESTOP_HEAP_SNAPSHOT_DIR | quote }}
+  {{- end }}
+  {{- if ne (lower (default "sqlite" .Values.database.engine)) "postgresql" }}
+  # DATABASE_URL only goes in ConfigMap when SQLite (file path, not sensitive)
+  DATABASE_URL: {{ include "chart-deco-mcp-mesh.databaseUrl" . | trim | quote }}
+
+  {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,393 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: {{ include "chart-deco-mcp-mesh.deploymentStrategy" . }}
+    {{- $strategyType := include "chart-deco-mcp-mesh.deploymentStrategy" . }}
+    {{- if eq $strategyType "RollingUpdate" }}
+    rollingUpdate:
+      {{- if and .Values.strategy .Values.strategy.rollingUpdate }}
+      {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+      {{- else }}
+      maxSurge: 1
+      maxUnavailable: 0
+      {{- end }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart-deco-mcp-mesh.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart-deco-mcp-mesh.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chart-deco-mcp-mesh.serviceAccountName" . }}
+      securityContext:
+        {{- include "chart-deco-mcp-mesh.podSecurityContext" . | nindent 8 }}
+      {{- if .Values.secret.authConfigSecretName }}
+      initContainers:
+        - name: build-auth-config
+          image: alpine:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache jq > /dev/null 2>&1
+              
+              # Read values from Secret volume
+              GOOGLE_CLIENT_ID=$(cat /secrets/googleClientId 2>/dev/null || echo "")
+              GOOGLE_CLIENT_SECRET=$(cat /secrets/googleClientSecret 2>/dev/null || echo "")
+              GITHUB_CLIENT_ID=$(cat /secrets/githubClientId 2>/dev/null || echo "")
+              GITHUB_CLIENT_SECRET=$(cat /secrets/githubClientSecret 2>/dev/null || echo "")
+              RESEND_API_KEY=$(cat /secrets/resendApiKey 2>/dev/null || echo "")
+              
+              # Read base config from ConfigMap (non-sensitive values)
+              BASE_CONFIG=$(cat /base-config/auth-config.json 2>/dev/null || echo "{}")
+              
+              # Merge Secret values into base config - preserve entire structure
+              UPDATED_CONFIG=$(echo "$BASE_CONFIG" | jq --arg gid "$GOOGLE_CLIENT_ID" --arg gsec "$GOOGLE_CLIENT_SECRET" --arg ghid "$GITHUB_CLIENT_ID" --arg ghsec "$GITHUB_CLIENT_SECRET" --arg rkey "$RESEND_API_KEY" '
+                # Update Google OAuth if values provided
+                (if $gid != "" then .socialProviders.google.clientId = $gid else . end) |
+                (if $gsec != "" then .socialProviders.google.clientSecret = $gsec else . end) |
+                # Update GitHub OAuth if values provided
+                (if $ghid != "" then .socialProviders.github.clientId = $ghid else . end) |
+                (if $ghsec != "" then .socialProviders.github.clientSecret = $ghsec else . end) |
+                # Update Resend API Key if provided - this must return the full object
+                (if $rkey != "" then 
+                  .emailProviders = (.emailProviders | map(if .id == "resend-primary" then .config.apiKey = $rkey else . end))
+                else . end)
+              ')
+              
+              # Write merged config to shared volume (compact format)
+              echo "$UPDATED_CONFIG" | jq -c . > /shared/auth-config.json
+              
+              # Verify the output
+              if [ -s /shared/auth-config.json ]; then
+                echo "Auth config built successfully"
+                echo "Verification: socialProviders present: $(echo "$UPDATED_CONFIG" | jq -r 'has("socialProviders")')"
+              else
+                echo "ERROR: Failed to build auth config"
+                exit 1
+              fi
+          volumeMounts:
+            - name: auth-secrets
+              mountPath: /secrets
+              readOnly: true
+            - name: auth-config-base
+              mountPath: /base-config
+              readOnly: true
+            - name: auth-config-shared
+              mountPath: /shared
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}{{- if and .Values.image.tag (hasPrefix "sha256:" .Values.image.tag) }}@{{ .Values.image.tag }}{{- else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- end }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.image.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort | default 3000 }}
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: NODE_ENV
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: PORT
+            - name: HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: HOST
+            - name: BETTER_AUTH_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: BETTER_AUTH_URL
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.secretName" . }}
+                  key: BETTER_AUTH_SECRET
+            - name: CLICKHOUSE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.secretName" . }}
+                  key: CLICKHOUSE_URL
+            - name: DATABASE_URL
+              {{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.secretName" . }}
+                  key: DATABASE_URL
+              {{- else }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: DATABASE_URL
+              {{- end }}
+            - name: BASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: BASE_URL
+            {{- if .Values.configMap.meshConfig.DATABASE_PG_SSL }}
+            - name: DATABASE_PG_SSL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: DATABASE_PG_SSL
+            {{- end }}
+            {{- if and .Values.configMap.meshConfig.NODE_EXTRA_CA_CERTS .Values.database.caCert }}
+            - name: NODE_EXTRA_CA_CERTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: NODE_EXTRA_CA_CERTS
+            {{- end }}
+            {{- if .Values.configMap.meshConfig.ENABLE_DEBUG_SERVER }}
+            - name: ENABLE_DEBUG_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: ENABLE_DEBUG_SERVER
+            {{- end }}
+            {{- if .Values.configMap.meshConfig.DEBUG_PORT }}
+            - name: DEBUG_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: DEBUG_PORT
+            {{- end }}
+            {{- if .Values.configMap.meshConfig.PRESTOP_HEAP_SNAPSHOT_DIR }}
+            - name: PRESTOP_HEAP_SNAPSHOT_DIR
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-config
+                  key: PRESTOP_HEAP_SNAPSHOT_DIR
+            {{- end }}
+            {{- if .Values.otel.enabled }}
+            {{- if .Values.otel.protocol }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.otel.protocol | quote }}
+            {{- end }}
+            {{- if .Values.otel.service }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.otel.service | quote }}
+            {{- end }}
+            {{- if .Values.otel.collector.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://localhost:4318"
+            {{- else if .Values.otel.endpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            {{- end }}
+            {{- if and .Values.otel.headers (not .Values.otel.collector.enabled) }}
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: {{ include "chart-deco-mcp-mesh.otelHeaders" . | quote }}
+            {{- end }}
+            {{- if .Values.otel.attributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "chart-deco-mcp-mesh.otelAttributes" . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.secret.authConfigSecretName }}
+            - name: auth-config-shared
+              mountPath: /app/apps/mesh/auth-config.json
+              subPath: auth-config.json
+              readOnly: true
+            {{- else }}
+            - name: auth-config
+              mountPath: /app/apps/mesh/auth-config.json
+              subPath: auth-config.json
+              readOnly: true
+            {{- end }}
+            - name: data
+              mountPath: /app/data
+            {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
+            - name: ca-cert
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            {{- end }}
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if and .Values.otel.enabled .Values.otel.collector.enabled }}
+        - name: otel-collector
+          image: "{{ .Values.otel.collector.image.repository }}:{{ .Values.otel.collector.image.tag }}"
+          imagePullPolicy: {{ .Values.otel.collector.image.pullPolicy }}
+          command:
+            - "/otelcol-contrib"
+            - "--config=/etc/otel/config.yaml"
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          {{- with .Values.otel.collector.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /etc/otel
+              readOnly: true
+      {{- end }}
+      {{- with .Values.extraContainers }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.secret.authConfigSecretName }}
+        - name: auth-secrets
+          secret:
+            secretName: {{ .Values.secret.authConfigSecretName }}
+        - name: auth-config-base
+          configMap:
+            name: {{ include "chart-deco-mcp-mesh.fullname" . }}-auth-config
+            items:
+              - key: auth-config.json
+                path: auth-config.json
+        - name: auth-config-shared
+          emptyDir: {}
+        {{- else }}
+        - name: auth-config
+          configMap:
+            name: {{ include "chart-deco-mcp-mesh.fullname" . }}-auth-config
+            items:
+              - key: auth-config.json
+                path: auth-config.json
+        {{- end }}
+        {{- if and (eq (lower (default "sqlite" .Values.database.engine)) "postgresql") .Values.database.caCert }}
+        - name: ca-cert
+          configMap:
+            name: {{ include "chart-deco-mcp-mesh.fullname" . }}-ca-cert
+            items:
+              - key: ca-cert.pem
+                path: ca-cert.pem
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          {{- if .Values.persistence.claimName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.claimName }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "chart-deco-mcp-mesh.fullname" . }}-data
+          {{- end }}
+        {{- else }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if and .Values.otel.enabled .Values.otel.collector.enabled }}
+        - name: otel-collector-config
+          configMap:
+            name: {{ include "chart-deco-mcp-mesh.fullname" . }}-otel-collector
+            items:
+              - key: config.yaml
+                path: config.yaml
+        {{- end }}
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.topologySpreadConstraints (gt (len .Values.topologySpreadConstraints) 0) }}
+      topologySpreadConstraints:
+        {{- range .Values.topologySpreadConstraints }}
+        - {{- if not .labelSelector }}
+          {{- fail "labelSelector é obrigatório em topologySpreadConstraints. Especifique explicitamente os labels." }}
+          {{- else }}
+          labelSelector:
+            {{- toYaml .labelSelector | nindent 12 }}
+          {{- end }}
+          maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+        {{- end }}
+      {{- end }}

--- a/deploy/helm/templates/hpa.yaml
+++ b/deploy/helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart-deco-mcp-mesh.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/templates/pvc.yaml
+++ b/deploy/helm/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.claimName }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-data
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- else }}
+  storageClassName: ""  # Use default storage class
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.secret.secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}-secrets
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  BETTER_AUTH_SECRET: {{ .Values.secret.BETTER_AUTH_SECRET | quote }}
+  {{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" }}
+  # DATABASE_URL goes in Secret when PostgreSQL (contains sensitive credentials)
+  DATABASE_URL: {{ include "chart-deco-mcp-mesh.databaseUrl" . | trim | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.fullname" . }}
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chart-deco-mcp-mesh.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+    {{- toYaml .Values.service.sessionAffinityConfig | nindent 4 }}
+  {{- end }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.serviceAccount .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart-deco-mcp-mesh.serviceAccountName" . }}
+  labels:
+    {{- include "chart-deco-mcp-mesh.labels" . | nindent 4 }}
+  {{- $annotations := dict }}
+  {{- if .Values.serviceAccount.annotations }}
+  {{- $annotations = merge $annotations .Values.serviceAccount.annotations }}
+  {{- end }}
+  {{- if and .Values.otel .Values.otel.s3 .Values.otel.s3.roleArn }}
+  {{- $_ := set $annotations "eks.amazonaws.com/role-arn" .Values.otel.s3.roleArn }}
+  {{- end }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount | default true }}
+{{- end }}

--- a/deploy/helm/templates/validations.yaml
+++ b/deploy/helm/templates/validations.yaml
@@ -1,0 +1,6 @@
+{{- /*
+This file only runs chart-level validations and renders no resources.
+*/ -}}
+{{- include "chart-deco-mcp-mesh.validate" . -}}
+{{- include "chart-deco-mcp-mesh.validateOtel" . -}}
+

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,211 @@
+# Default values for chart-deco-mcp-mesh.
+# The value below is only considered if autoscaling is disabled.
+replicaCount: 1
+
+strategy:
+  # type: ""  # Leave empty for auto-detection:
+  #   - RollingUpdate: if database.engine=postgresql OR persistence.distributed=true OR accessMode=ReadWriteMany
+  #   - Recreate: if SQLite with ReadWriteOnce (default)
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
+image:
+  repository: ghcr.io/decocms/studio/mesh
+  pullPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+resources:
+  requests:
+    memory: "300Mi"
+    cpu: "250m"
+  limits:
+    memory: "600Mi"
+    cpu: "500m"
+
+database:
+  engine: sqlite # sqlite | postgresql
+  url: ""        # Required when engine=postgresql
+  caCert: ""     # Optional: Specify existing CA certificate in PEM format
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  storageClass: "gp3"  # Empty string applies default storage class.
+  size: 10Gi
+  claimName: ""  # Optional: Specify existing PVC name
+  distributed: false  # Mark as true if storage offers ReadWriteMany
+
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 6
+  #targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+configMap:
+  meshConfig:
+    NODE_ENV: "production"
+    PORT: "3000"
+    HOST: "0.0.0.0"
+    BETTER_AUTH_URL: "http://localhost:8080"
+    BASE_URL: "http://localhost:8080"
+    # PRESTOP_HEAP_SNAPSHOT_DIR: ""  # Optional: Directory for heap snapshots during preStop hook
+  
+  authConfig:
+    emailAndPassword:
+      enabled: true
+
+
+secret:
+  # secretName: ""  # If defined, uses this existing secret (does not create new secret)
+  # Generate secret with the following command: openssl rand -base64 32
+  BETTER_AUTH_SECRET: "define_your_secret_with_command_above"
+
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+extraContainers: []
+# - name: cloudsql-proxy
+#   image: gcr.io/cloudsql-docker/gce-proxy:1.33.1
+#   args:
+#     - "/cloud_sql_proxy"
+#     - "-instances=PROJECT:REGION:INSTANCE=tcp:5432"
+
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 4
+
+# Optional lifecycle hooks (preStop, postStart)
+# lifecycle:
+#   preStop:
+#     exec:
+#       command:
+#         - /bin/sh
+#         - -c
+#         - "wget -q -O - http://localhost:9229/prestop-hook || true"
+
+nodeSelector:
+  kubernetes.io/arch: amd64
+
+tolerations: []
+# Example:
+# tolerations:
+#   - key: "env"
+#     operator: "Equal"
+#     value: "dev"
+#     effect: "NoSchedule"
+
+affinity: {}
+# Example:
+# affinity:
+#   podAntiAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         podAffinityTerm:
+#           labelSelector:
+#             matchLabels:
+#               app.kubernetes.io/name: chart-deco-mcp-mesh
+#           topologyKey: kubernetes.io/hostname
+
+# Topology Spread Constraints (optional - leave empty [] to disable)
+# IMPORTANT: labelSelector is required when topologySpreadConstraints is configured
+#topologySpreadConstraints: []
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: chart-deco-mcp-mesh
+        app.kubernetes.io/instance: deco-mcp-mesh
+
+# OpenTelemetry configuration (optional)
+otel:
+  enabled: false
+  protocol: "http/protobuf"  # http/protobuf | grpc
+  service: ""                # OTEL_SERVICE_NAME
+  endpoint: ""               # Remote OTLP endpoint (direct export OR collector fan-out target)
+  headers: {}                # OTEL_EXPORTER_OTLP_HEADERS (key=value format)
+  # headers:
+  #   authorization: "Bearer your-token"
+  #   x-custom-header: "value"
+  attributes: {}             # OTEL_RESOURCE_ATTRIBUTES (key=value format)
+  # attributes:
+  #   deployment.environment: "production"
+  #   service.namespace: "my-namespace"
+
+  # OTel Collector sidecar — when enabled, app exports to localhost:4318
+  collector:
+    enabled: false
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.115.1"
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "250m"
+
+  # S3 exporter (requires collector.enabled: true)
+  s3:
+    enabled: false
+    bucket: ""               # Required when enabled
+    region: "us-east-1"
+    prefix: "otel"
+    filePrefix: "otel"
+    marshaler: "otlp_json"   # otlp_json | sumo_ic
+    compression: "none"      # none | gzip
+    roleArn: ""              # IRSA role ARN — adds eks.amazonaws.com/role-arn to ServiceAccount
+
+# Additional environment variables (merged with existing envs)
+env: []
+# env:
+#   - name: MY_CUSTOM_VAR
+#     value: "my-value"
+#   - name: MY_SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key


### PR DESCRIPTION
## Summary
- Moves the self-hosted Helm chart from the standalone `decocms/helm-chart-deco-mcp-mesh` repo into `deploy/helm/`
- Co-locates deployment config with the app code, keeping chart and app versions in sync
- Includes all templates, values, examples, and helpers

## Notes
- Once merged, the standalone `decocms/helm-chart-deco-mcp-mesh` repo can be archived
- No changes to chart content — this is a straight copy

## Test plan
- [ ] `helm template deploy/helm/` renders correctly
- [ ] `helm lint deploy/helm/` passes
- [ ] Deploy to a test cluster using the chart from the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the self-hosted Helm chart into `deploy/helm/` to keep deployment config with the app and keep versions in sync. No chart content changes; this is a straight copy from `decocms/helm-chart-deco-mcp-mesh`.

- **Migration**
  - Install from the new path: `helm install <release> ./deploy/helm`
  - Update CI/docs to use `deploy/helm/` for `helm lint` and `helm template`
  - Verify with `helm template ./deploy/helm`, `helm lint ./deploy/helm`, and a test cluster deploy

<sup>Written for commit 5ddc00034d1142247ffc05a9728d0be0026cd60f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

