### PR TITLE
fix: fix npm package name and CMD in Dockerfile

### DIFF
--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -15,7 +15,7 @@ USER bunuser
 WORKDIR /app/apps/mesh
 
 # Install the package locally during build (cached in image layer)
-RUN bun add @decocms/mesh@${MESH_VERSION}
+RUN bun add decocms@${MESH_VERSION}
 
 # Expose the default port
 EXPOSE 3000
@@ -26,4 +26,4 @@ ENV DATABASE_URL=file:/app/data/mesh.db
 
 # The CLI handles migrations automatically on startup
 # Use --skip-migrations if you want to manage migrations separately
-CMD ["bun", "run", "mesh"]
+CMD ["bun", "run", "deco"]

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decocms",
-  "version": "2.160.1",
+  "version": "2.160.2",
   "description": "Deco Studio — Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Fix `bun add @decocms/mesh` → `bun add decocms` (package is published as `decocms` on npm, not `@decocms/mesh`)
- Fix `CMD ["bun", "run", "mesh"]` → `CMD ["bun", "run", "deco"]` (bin exposed by the package is `deco`)
- Bump to `2.160.2` to force Docker image rebuild

These issues were causing `ImagePullBackOff` after the repo rename from `decocms/mesh` to `decocms/studio`.

## Test plan
- [ ] Confirm workflow builds and pushes `ghcr.io/decocms/studio/mesh:2.160.2`
- [ ] Confirm container starts correctly with `deco` bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Dockerfile to install the correct npm package `decocms` and run the `deco` binary, resolving ImagePullBackOff after the repo rename. Bump version to 2.160.2 to trigger a fresh Docker image build.

<sup>Written for commit 2e6163ea1294dae2ee77edaebbd1b15e09c36409. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

