### PR TITLE
[release]: bump to 2.160.3

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decocms",
-  "version": "2.160.2",
+  "version": "2.160.3",
   "description": "Deco Studio — Self-hostable MCP Gateway for managing AI connections and tools",
   "author": "Deco team",
   "license": "MIT",


### PR DESCRIPTION
## What is this contribution about?
Bump version from 2.160.2 to 2.160.3.

## How to Test
Verify the version is correctly updated in `apps/mesh/package.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the `decocms` package version from 2.160.2 to 2.160.3 to publish a patch release.

<sup>Written for commit 02dd7636ca6cdd6f724d39d5f0ea7b84ffa9c6e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

