### PR TITLE
fix(auth): disable auto-login in production deployments

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -119,15 +119,22 @@ const decoHome =
 process.env.DECOCMS_HOME = decoHome;
 process.env.PORT = values.port;
 
+// Capture before CLI sets NODE_ENV — if it was already "production" (e.g., Docker/K8s),
+// we should NOT default to local mode since this is a real production deployment.
+const nodeEnvWasProduction = process.env.NODE_ENV === "production";
+
 if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = "production";
 }
 
 // Determine if local mode should be active
+// Local mode is for `bunx decocms` running locally — disable when NODE_ENV was
+// already set to production (indicates a container/cloud deployment).
 const hasCustomAuthConfig =
   process.env.AUTH_CONFIG_PATH &&
   process.env.AUTH_CONFIG_PATH !== "./auth-config.json";
-const localMode = !values["no-local-mode"] && !hasCustomAuthConfig;
+const localMode =
+  !values["no-local-mode"] && !hasCustomAuthConfig && !nodeEnvWasProduction;
 process.env.MESH_LOCAL_MODE = localMode ? "true" : "false";
 
 // CLI is the intended local runner — allow local mode even when NODE_ENV=production


### PR DESCRIPTION
## Summary
- The CLI enables local mode (auto-login) by default, intended for `bunx decocms` local usage
- Docker/K8s deployments also use the CLI (`bun run deco`) and pre-set `NODE_ENV=production`, causing production to incorrectly get auto-login + `MESH_ALLOW_LOCAL_PROD=true`
- Fix: capture whether `NODE_ENV` was already `"production"` before the CLI sets it, and factor that into the `localMode` decision

## How it works
- `bunx decocms` locally → `NODE_ENV` is unset → CLI sets it → local mode ON (unchanged)
- Docker (`ENV NODE_ENV=production`) → `NODE_ENV` already set → local mode OFF (fixed)

## Test plan
- [ ] Verify `bunx decocms` still auto-logins locally
- [ ] Verify Docker deployments no longer auto-login
- [ ] Verify `--no-local-mode` flag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable auto-login (local mode) in production containers by checking if `NODE_ENV` was already `production` before the CLI runs. Local `bunx decocms` auto-login remains unchanged.

- **Bug Fixes**
  - Skip local mode when `NODE_ENV` was pre-set to `production` (Docker/K8s).
  - Keep local auto-login when `NODE_ENV` was unset and set by the CLI.
  - `--no-local-mode` flag still respected.

<sup>Written for commit 212ed9c1f8d860d2236e7505419dc096af616b86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

