### PR TITLE
fix(cli): default local mode to off

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -9,7 +9,7 @@
  *   deco
  *   npx decocms --port 8080
  *   npx decocms --home ~/my-project
- *   npx decocms --no-local-mode
+ *   npx decocms --local-mode
  */
 
 import { parseArgs } from "util";
@@ -41,7 +41,7 @@ const { values } = parseArgs({
       type: "boolean",
       default: false,
     },
-    "no-local-mode": {
+    "local-mode": {
       type: "boolean",
       default: false,
     },
@@ -59,7 +59,7 @@ Usage:
 Options:
   -p, --port <port>     Port to listen on (default: 3000, or PORT env var)
   --home <path>         Data directory (default: ~/deco/, or DECOCMS_HOME env var)
-  --no-local-mode       Disable local mode (require login, no auto-setup)
+  --local-mode          Enable local mode (auto-login, no auth required)
   -h, --help            Show this help message
   -v, --version         Show version
   --skip-migrations     Skip database migrations on startup
@@ -78,7 +78,7 @@ Examples:
   deco                            # Start with defaults (~/deco/)
   deco -p 8080                    # Start on port 8080
   deco --home ~/my-project        # Custom data directory
-  deco --no-local-mode            # Require login (SaaS mode)
+  deco --local-mode               # Enable auto-login (local dev)
 
 Documentation:
   https://decocms.com/studio
@@ -123,11 +123,8 @@ if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = "production";
 }
 
-// Determine if local mode should be active
-const hasCustomAuthConfig =
-  process.env.AUTH_CONFIG_PATH &&
-  process.env.AUTH_CONFIG_PATH !== "./auth-config.json";
-const localMode = !values["no-local-mode"] && !hasCustomAuthConfig;
+// Determine if local mode should be active (opt-in only)
+const localMode = values["local-mode"] === true;
 process.env.MESH_LOCAL_MODE = localMode ? "true" : "false";
 
 // CLI is the intended local runner — allow local mode even when NODE_ENV=production


### PR DESCRIPTION
## Summary

- Local mode was **opt-out** (`--no-local-mode`) — any production deployment using the CLI without explicitly disabling it got auto-login enabled, bypassing authentication
- Changes local mode to **opt-in** (`--local-mode`) so it must be explicitly requested
- Removes the fragile `AUTH_CONFIG_PATH` heuristic that was supposed to detect non-local deployments

## Root cause

The CLI defaulted `localMode = true` unless `--no-local-mode` was passed or `AUTH_CONFIG_PATH` was set to a non-default value. The Dockerfile uses `CMD ["bun", "run", "deco"]` without `--no-local-mode`, so production deployments got:

1. `MESH_LOCAL_MODE=true`
2. `MESH_ALLOW_LOCAL_PROD=true` (bypassing the safety guard in `index.ts`)
3. Frontend renders `<AutoLogin>` instead of the normal login form
4. `/local-session` POST fails the loopback check (request comes through ingress) → 403
5. Users see "Auto-login failed" with no way to reach the real login form

## Test plan

- [ ] `deco` without flags → local mode OFF, normal login form shown
- [ ] `deco --local-mode` → local mode ON, auto-login works locally
- [ ] Production Docker deployment → no auto-login behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CLI local mode to opt-in to prevent accidental auto-login in production. Use `--local-mode` to enable; default is off.

- **Bug Fixes**
  - Removed `AUTH_CONFIG_PATH` heuristic; local mode is only enabled via `--local-mode`.
  - Updated help text and examples to use `--local-mode`.
  - Production runs (including Docker) now show the normal login; no auto-login.

- **Migration**
  - Replace `--no-local-mode` with `--local-mode`.
  - CI/containers: no changes needed unless you rely on auto-login; add `--local-mode` when desired.

<sup>Written for commit 2d0c5745510b820ccf61c55f21cab8d567fad56e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

