### PR TITLE
fix(docs): use bunx to invoke wrangler in deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -26,7 +26,7 @@ jobs:
         working-directory: apps/docs
 
       - name: Deploy to Cloudflare Pages
-        run: wrangler pages deploy dist/client --project-name=decocms-docs
+        run: bunx wrangler pages deploy dist/client --project-name=decocms-docs
         working-directory: apps/docs
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
## What is this contribution about?
Fixes the failing Cloudflare Pages deploy workflow by using `bunx wrangler` instead of bare `wrangler`. The workflow was failing with "command not found" because wrangler wasn't available on the system PATH despite being installed as a workspace dependency.

## How to Test
The docs deploy workflow should now succeed on future pushes to main that modify files under `apps/docs/**`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs deploy workflow by invoking Wrangler through Bun (`bunx wrangler`) so the command resolves in CI. This unblocks Cloudflare Pages deploys for changes under `apps/docs/**`.

<sup>Written for commit 3ce65a8f65f69d78635ef75de9a7a7bac83ec6fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

