### PR TITLE
fix(build): copy PGlite WASM alongside bundled server scripts

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -21,7 +21,10 @@ const SCRIPT_DIR =
   import.meta.dir || dirname(new URL(import.meta.url).pathname);
 const SERVER_ENTRY_POINT = join(SCRIPT_DIR, "../src/index.ts");
 const CLI_ENTRY_POINT = join(SCRIPT_DIR, "../src/cli.ts");
-const ALWAYS_INCLUDE = ["@jitl/quickjs-wasmfile-release-sync", "@electric-sql/pglite"];
+const ALWAYS_INCLUDE = [
+  "@jitl/quickjs-wasmfile-release-sync",
+  "@electric-sql/pglite",
+];
 const ALWAYS_EXCLUDE = ["kysely-codegen"];
 
 // Parse command line arguments


### PR DESCRIPTION
## Summary

- **Root cause:** `@electric-sql/pglite` loads its WASM via `new URL('./emscripten-module.wasm', import.meta.url)`. When bun bundles pglite into `dist/server/cli.js`, that URL resolves to `dist/server/emscripten-module.wasm` — but the file was never copied there, only to `dist/server/node_modules/@electric-sql/pglite/...`
- **Production symptom:** `ENOENT: no such file or directory, open '/app/apps/mesh/node_modules/@decocms/mesh/dist/server/emscripten-module.wasm'`
- **Why it works locally:** dev mode runs straight from source (`src/index.ts`), so pglite finds its WASM in its own `node_modules/` directory with the correct relative path
- **Fix:** added `copyPgliteWasm()` step to `bundle-server-script.ts` that copies `emscripten-module.wasm` (and `postgres.wasm` as a fallback for other pglite versions) into `dist/server/` alongside the generated bundles

## Test plan

- [ ] Run `bun run build:server` locally and confirm `dist/server/emscripten-module.wasm` exists
- [ ] Deploy to staging and verify the WASM error is gone
- [ ] Confirm PGlite-backed code steps work end-to-end in production after republishing the `decocms` npm package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a production crash by ensuring PGlite WASM is present and correctly resolved in bundled server scripts. Prevents ENOENT for `emscripten-module.wasm` when `@electric-sql/pglite` is bundled by `bun`.

- **Bug Fixes**
  - Added `@electric-sql/pglite` to `ALWAYS_INCLUDE` so bun externalizes it and copies the full package (including WASM) to `dist/server/node_modules/`.
  - Added `copyPgliteWasm()` in `apps/mesh/scripts/bundle-server-script.ts` to copy `emscripten-module.wasm` and `postgres.wasm` into `dist/server/` alongside `server.js` and `cli.js`.
  - Ensures `new URL(..., import.meta.url)` resolves at runtime across different `@electric-sql/pglite` layouts.

<sup>Written for commit 00e9d8d86f65a69007196de52b2713a07d1d0a4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

