### PR TITLE
fix(cli): reset ENCRYPTION_KEY to an empty string if not found in sav…

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -183,7 +183,7 @@ if (!process.env.ENCRYPTION_KEY) {
   if (savedSecrets.ENCRYPTION_KEY) {
     process.env.ENCRYPTION_KEY = savedSecrets.ENCRYPTION_KEY;
   } else {
-    savedSecrets.ENCRYPTION_KEY = '';
+    savedSecrets.ENCRYPTION_KEY = "";
     process.env.ENCRYPTION_KEY = savedSecrets.ENCRYPTION_KEY;
     secretsModified = true;
   }


### PR DESCRIPTION
…ed secrets

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The CLI no longer auto-generates `ENCRYPTION_KEY`; if it’s missing in saved secrets, it’s set to an empty string so users must provide a real key.

<sup>Written for commit 141def5540ffe33dadabb3e8630c8d402e680178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

