### PR TITLE
fix(chat): sync activeTaskId with server thread ID after org-scoped c…

### DIFF
--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -804,9 +804,16 @@ export function ChatProvider({ children }: PropsWithChildren) {
   }) => {
     chatDispatch({ type: "SET_FINISH_REASON", payload: finishReason ?? null });
 
-    const taskId =
-      (message.metadata as Metadata | undefined)?.thread_id ??
-      taskManager.activeTaskId;
+    const serverTaskId = (message.metadata as Metadata | undefined)?.thread_id;
+    const taskId = serverTaskId ?? taskManager.activeTaskId;
+
+    // The server may assign a different thread ID than the client's optimistic
+    // UUID (e.g. when a new thread is created with org-scoped storage). Sync
+    // the active task to the server-assigned ID so subsequent message queries
+    // target the correct thread instead of the empty optimistic one.
+    if (serverTaskId && serverTaskId !== taskManager.activeTaskId) {
+      taskManager.setActiveTaskId(serverTaskId);
+    }
 
     if (isAbort || isDisconnect || isError) {
       // Persist partial messages so the UI doesn't flash back to stale

--- a/apps/mesh/src/web/components/chat/task/use-task-manager.ts
+++ b/apps/mesh/src/web/components/chat/task/use-task-manager.ts
@@ -395,6 +395,7 @@ export function useTaskManager() {
   return {
     tasks,
     activeTaskId,
+    setActiveTaskId,
     messages,
     hasNextPage,
     isFetchingNextPage,


### PR DESCRIPTION
…reation

When a new task is created client-side, the active task ID is an optimistic UUID (crypto.randomUUID()) that never exists in the DB. After the thread storage refactor (#2639) introduced org-scoped storage, the server now always generates a fresh `thrd_xxx` ID instead of preserving the caller's thread_id when the thread is not found in the org.

This caused the chat to appear empty after the AI finished responding: messages were saved under the server's new `thrd_xxx` ID but the client kept querying by the original UUID, returning no results.

Fix by detecting the mismatch in `onFinish` and calling `setActiveTaskId` with the server-assigned thread ID so subsequent message queries target the correct thread. Also exposes `setActiveTaskId` from `useTaskManager` for this purpose.

Made-with: Cursor

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty chat after org-scoped thread creation by syncing the client’s active task to the server-assigned `thrd_xxx` ID when a response completes. Detects the mismatch in `onFinish` and updates via `setActiveTaskId`, which is now exposed from `useTaskManager`.

<sup>Written for commit 7fa0375394b3d6d29df757ebe94922ec98cf98fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

