### PR TITLE
fix(monitoring): use parseDateTime64BestEffort for ClickHouse timestamps

### DIFF
--- a/apps/mesh/src/storage/monitoring-clickhouse.ts
+++ b/apps/mesh/src/storage/monitoring-clickhouse.ts
@@ -100,7 +100,7 @@ function intervalToSQL(interval: string): string {
     d: "DAY",
   };
   const sqlUnit = unitMap[unit];
-  return `toStartOfInterval(parseDateTimeBestEffort(timestamp), INTERVAL ${amount} ${sqlUnit})`;
+  return `toStartOfInterval(parseDateTime64BestEffort(toString(timestamp)), INTERVAL ${amount} ${sqlUnit})`;
 }
 
 // ---------------------------------------------------------------------------
@@ -229,11 +229,11 @@ function buildCommonFilterClauses(filters?: {
 }
 
 function tsGte(date: Date): string {
-  return `parseDateTimeBestEffort(timestamp) >= parseDateTimeBestEffort('${date.toISOString()}')`;
+  return `parseDateTime64BestEffort(toString(timestamp)) >= parseDateTime64BestEffort('${date.toISOString()}')`;
 }
 
 function tsLte(date: Date): string {
-  return `parseDateTimeBestEffort(timestamp) <= parseDateTimeBestEffort('${date.toISOString()}')`;
+  return `parseDateTime64BestEffort(toString(timestamp)) <= parseDateTime64BestEffort('${date.toISOString()}')`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Switch from `parseDateTimeBestEffort(timestamp)` to `parseDateTime64BestEffort(toString(timestamp))` in ClickHouse monitoring queries
- Fixes timestamp parsing for DateTime64 column types by first converting to string before parsing
- Affects interval grouping (`intervalToSQL`) and time range filters (`tsGte`/`tsLte`)

## Test plan
- [ ] Verify ClickHouse monitoring queries return correct results with DateTime64 columns
- [ ] Confirm time-range filtering and interval grouping work as expected in the monitoring dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ClickHouse monitoring by parsing DateTime64 timestamps with parseDateTime64BestEffort(toString(timestamp)). This restores correct interval grouping and time-range filtering in the dashboard.

<sup>Written for commit fe11c729c2a6bcd128f9e5cd026f486f72919e66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

