### PR TITLE
fix(monitoring): normalize chdb timestamps and reduce logs payload

### DIFF
--- a/apps/mesh/src/storage/monitoring-clickhouse.ts
+++ b/apps/mesh/src/storage/monitoring-clickhouse.ts
@@ -130,10 +130,13 @@ function toMonitoringLog(row: Record<string, unknown>): MonitoringLog {
       row.is_error === 1 || row.is_error === true || row.is_error === "1",
     errorMessage: row.error_message != null ? String(row.error_message) : null,
     durationMs: Number(row.duration_ms ?? 0),
-    timestamp:
-      row.timestamp instanceof Date
-        ? row.timestamp.toISOString()
-        : String(row.timestamp ?? ""),
+    timestamp: (() => {
+      if (row.timestamp instanceof Date) return row.timestamp.toISOString();
+      const str = String(row.timestamp ?? "");
+      // chdb returns "YYYY-MM-DD HH:MM:SS.nnnnnnnnn" — convert to ISO 8601
+      const d = new Date(str.includes("T") ? str : str.replace(" ", "T") + "Z");
+      return Number.isNaN(d.getTime()) ? str : d.toISOString();
+    })(),
     userId: row.user_id != null ? String(row.user_id) : null,
     requestId: String(row.request_id ?? ""),
     userAgent: row.user_agent != null ? String(row.user_agent) : null,

--- a/apps/mesh/src/tools/monitoring/list.ts
+++ b/apps/mesh/src/tools/monitoring/list.ts
@@ -139,13 +139,35 @@ export const MONITORING_LOGS_LIST = defineTool({
     const result = await ctx.storage.monitoring.query(filters);
 
     return {
-      logs: result.logs.map((log) => ({
-        ...log,
-        timestamp:
-          log.timestamp instanceof Date
-            ? log.timestamp.toISOString()
-            : log.timestamp,
-      })),
+      logs: result.logs.map((log) => {
+        // Strip redundant MCP content wrapper from output to reduce payload size
+        const output = log.output;
+        let cleanOutput = output;
+        if (
+          output &&
+          typeof output === "object" &&
+          "structuredContent" in output
+        ) {
+          const { content, ...rest } = output as Record<string, unknown>;
+          cleanOutput = rest;
+        } else if (
+          output &&
+          typeof output === "object" &&
+          "content" in output &&
+          Array.isArray((output as Record<string, unknown>).content)
+        ) {
+          const { content, ...rest } = output as Record<string, unknown>;
+          cleanOutput = Object.keys(rest).length > 0 ? rest : output;
+        }
+        return {
+          ...log,
+          output: cleanOutput,
+          timestamp:
+            log.timestamp instanceof Date
+              ? log.timestamp.toISOString()
+              : log.timestamp,
+        };
+      }),
       total: result.total,
       offset: input.offset,
       limit: input.limit,


### PR DESCRIPTION
## What is this contribution about?

Fixes two monitoring bugs:

1. **Timeseries chart clustering**: chdb/ClickHouse returns timestamps as `"2026-03-11 03:28:26.933000000"` (space-separated, no `T`, no `Z`). The frontend `new Date()` fails to parse these, causing `NaN` timestamps that cluster all data points at one end of the chart. Fixed by normalizing timestamps to ISO 8601 in `toMonitoringLog()`.

2. **Oversized MONITORING_LOGS_LIST responses**: When logs contain both `content` and `structuredContent`, the `content` field is a redundant large stringified blob. Now strips `content` when `structuredContent` is present, reducing payload size.

## Screenshots/Demonstration

N/A

## How to Test

1. Start dev server with `bun run dev`
2. Open the monitoring dashboard and navigate to "Top Tools — Calls" chart
3. Verify data points are distributed across the time axis (not clustered at one end)
4. Call `MONITORING_LOGS_LIST` via MCP and verify logs no longer contain the redundant `content` array in their `output` field when `structuredContent` is present

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes timeseries chart clustering by normalizing chdb timestamps to ISO 8601 and reduces monitoring logs payload by stripping redundant `content` when `structuredContent` is present.

- **Bug Fixes**
  - Convert space-separated ClickHouse timestamps to ISO 8601 in `toMonitoringLog()` to avoid NaN dates in charts.
  - Trim `content` from `MONITORING_LOGS_LIST` output when `structuredContent` exists, keeping other fields to lower response size.

<sup>Written for commit 0ada31f5516d2dd3eee728d17f5b86e1c7f4ec34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

