### PR TITLE
fix(database): auto-clear stale PGlite postmaster.pid on startup

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -180,8 +180,10 @@ function clearStalePGliteLock(dataDir: string): void {
         try {
           process.kill(pid, 0);
           return true;
-        } catch {
-          return false;
+        } catch (err) {
+          // EPERM means the process exists but we cannot signal it — treat as alive.
+          // Only ESRCH means no such process, i.e. genuinely stale.
+          return (err as NodeJS.ErrnoException).code === "EPERM";
         }
       })();
 


### PR DESCRIPTION
## Summary

- PGlite writes a `postmaster.pid` lock file on startup and removes it on clean shutdown
- Crashes, SIGKILL, or VM snapshots leave a stale lock, causing `RuntimeError: Aborted()` on the next start
- Added `clearStalePGliteLock()` which runs before every PGlite instantiation: reads the PID, checks if the process is alive via `process.kill(pid, 0)`, and deletes the file if the PID is invalid or not running
- Live PIDs are left untouched to protect against genuine concurrent access

## Test plan

- [ ] Start the server normally, kill it with `kill -9`, restart — no crash
- [ ] Manually write an invalid PID (e.g. `-42`) to `~/deco/db.pglite/postmaster.pid` and confirm startup recovers with a warning log
- [ ] Confirm `:memory:` databases are unaffected (no file check attempted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically clears stale `postmaster.pid` files to prevent `@electric-sql/pglite` startup failures after crashes. Improves PID checks to avoid removing locks for running processes.

- **Bug Fixes**
  - Run `clearStalePGliteLock()` before each start: parse PID from the first line, treat negative/NaN as stale; check with `process.kill(pid, 0)` and consider `EPERM` as alive; remove only when the process is truly gone and log a warning.
  - Skip checks for `:memory:` databases.

<sup>Written for commit 1dbe27976ed7e3a51465c7113916318ebabe8f8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

