### PR TITLE
Remove unused OpenRouter model key from default model preferences in …

### DIFF
--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -11,7 +11,6 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
     anthropic: ["claude-sonnet-4-6", "claude-sonnet", "claude"],
     openrouter: [
-      "qwen",
       "anthropic/claude-sonnet-4-6",
       "anthropic/claude-sonnet",
       "anthropic/claude",


### PR DESCRIPTION
…mesh-sdk.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `qwen` model key from the `openrouter` default preferences in `mesh-sdk`. This avoids attempts to select an unsupported model.

<sup>Written for commit a9316209900340b8f5520a263510864323d37ee9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

