### PR TITLE
docs(agents): add knip and CI guidelines to common gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,8 @@ PRs should include:
 3. **Database migrations**: Remember to run both Kysely migrations (`bun run migrate`) and Better Auth migrations (`bun run better-auth:migrate`)
 4. **Event bus**: The worker doesn't poll internally—it relies on NotifyStrategy to trigger processing
 5. **Formatting**: The pre-commit hook will reject commits if code isn't formatted with Biome
+6. **Never modify knip configuration** (`knip.json`, `knip.config.ts`, etc.) to silence warnings. Knip warnings indicate dead code, unused exports, or unused dependencies—these are code smells that should be fixed by removing the unused code/export/dependency, not by adding exclusions to the knip config.
+7. **CI errors are always on your branch**. The `main` branch CI always passes. When CI fails, the problem is in the code you changed—do not assume it's a pre-existing issue or a flaky test. Investigate and fix your code.
 
 ## License
 


### PR DESCRIPTION
## What is this contribution about?

Adds two new guidelines to the AGENTS.md "Common Gotchas" section:
- **Never modify knip config** to silence warnings — knip warnings indicate code smells (dead code, unused exports/deps) that should be fixed at the source
- **CI errors are always on your branch** — `main` always passes, so CI failures should be investigated and fixed in your code

## Screenshots/Demonstration

N/A — documentation-only change.

## How to Test

1. Open `AGENTS.md` and verify items 6 and 7 in the "Common Gotchas" section
2. Confirm the guidance is clear and actionable

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two guidelines to AGENTS.md “Common Gotchas” to prevent masking issues and speed up CI debugging.
Don’t modify `knip` config to silence warnings, and treat CI failures as coming from your branch since `main` always passes.

<sup>Written for commit 9b9651f54f9411570fe9ba9ac079209e536cc662. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

