### PR TITLE
feat(local-dev): native folder picker and simplified project creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ apps/benchmark/data
 # AI planning files (root-level only, not docs/plans/)
 /plans
 .cursor/plans
+.claude/
+.planning/
 
 # Local demo/prototype directories
 studio-demo/

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -63,6 +63,7 @@
     "@deco/ui": "workspace:*",
     "@decocms/better-auth": "1.5.17",
     "@decocms/bindings": "workspace:*",
+    "@decocms/local-dev": "workspace:*",
     "@decocms/mesh-sdk": "workspace:*",
     "@decocms/runtime": "workspace:*",
     "@decocms/vite-plugin": "workspace:*",

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -43,6 +43,8 @@ import oauthProxyRoutes, {
 } from "./routes/oauth-proxy";
 import openaiCompatRoutes from "./routes/openai-compat";
 import proxyRoutes from "./routes/proxy";
+import { isLocalMode } from "../auth/local-mode";
+import localDevProjectRoutes from "./routes/local-dev-project";
 import publicConfigRoutes from "./routes/public-config";
 import selfRoutes from "./routes/self";
 import { shouldSkipMeshContext, SYSTEM_PATHS } from "./utils/paths";
@@ -920,6 +922,13 @@ export async function createApp(options: CreateAppOptions = {}) {
 
     return next();
   });
+
+  // ============================================================================
+  // Local Dev Routes (local mode only, needs MeshContext)
+  // ============================================================================
+  if (isLocalMode()) {
+    app.route("/api/local-dev", localDevProjectRoutes);
+  }
 
   // Get all management tools (for OAuth consent UI)
   app.get("/api/tools/management", (c) => {

--- a/apps/mesh/src/api/routes/dev-assets-mcp.ts
+++ b/apps/mesh/src/api/routes/dev-assets-mcp.ts
@@ -28,7 +28,7 @@ import {
 import { Hono } from "hono";
 import { createHmac } from "node:crypto";
 import { mkdir, readdir, rm, stat } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -49,8 +49,11 @@ interface ToolDefinition {
   _meta?: Record<string, unknown>;
 }
 
-// Base directory for dev assets (relative to cwd)
-const DEV_ASSETS_BASE_DIR = "./data/assets";
+// Base directory for assets.
+// Uses DECOCMS_HOME/assets when available (local mode), falls back to ./data/assets
+const DEV_ASSETS_BASE_DIR = process.env.DECOCMS_HOME
+  ? `${process.env.DECOCMS_HOME}/assets`
+  : "./data/assets";
 
 // Default URL expiration time in seconds (1 hour)
 const DEFAULT_EXPIRES_IN = 3600;
@@ -84,21 +87,26 @@ function getOrgAssetsDir(orgId: string): string {
 }
 
 /**
- * Sanitize a file key to prevent directory traversal
+ * Sanitize a file key — strips leading slashes only.
+ * Actual traversal prevention is enforced by getFilePath's containment check.
  */
 function sanitizeKey(key: string): string {
-  // Remove leading slashes and normalize path
-  const normalized = key.replace(/^\/+/, "").replace(/\.\./g, "");
-  return normalized;
+  return key.replace(/^\/+/, "");
 }
 
 /**
- * Get the full file path for a key within an org's assets
+ * Get the full file path for a key within an org's assets.
+ * Throws if the resolved path escapes the org's base directory.
  */
 function getFilePath(orgId: string, key: string): string {
   const baseDir = getOrgAssetsDir(orgId);
   const sanitizedKey = sanitizeKey(key);
-  return join(baseDir, sanitizedKey);
+  const resolved = resolve(join(baseDir, sanitizedKey));
+  const realBase = resolve(baseDir);
+  if (resolved !== realBase && !resolved.startsWith(realBase + sep)) {
+    throw new Error("Path traversal detected");
+  }
+  return resolved;
 }
 
 /**

--- a/apps/mesh/src/api/routes/dev-assets.ts
+++ b/apps/mesh/src/api/routes/dev-assets.ts
@@ -12,7 +12,7 @@
  */
 
 import { Hono } from "hono";
-import { createHmac } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { env } from "../../env";
@@ -39,9 +39,7 @@ function getOrgAssetsDir(orgId: string): string {
  * Sanitize a file key to prevent directory traversal
  */
 function sanitizeKey(key: string): string {
-  // Remove leading slashes and normalize path
-  const normalized = key.replace(/^\/+/, "").replace(/\.\./g, "");
-  return normalized;
+  return key.replace(/^\/+/, "");
 }
 
 /**
@@ -68,7 +66,9 @@ function verifySignature(
   const expectedSignature = createHmac("sha256", secret)
     .update(data)
     .digest("hex");
-  return signature === expectedSignature;
+  const expected = Buffer.from(expectedSignature, "hex");
+  const actual = Buffer.from(signature, "hex");
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
 }
 
 /**

--- a/apps/mesh/src/api/routes/local-dev-project.ts
+++ b/apps/mesh/src/api/routes/local-dev-project.ts
@@ -205,6 +205,7 @@ app.post("/create-project", async (c) => {
     name: string;
     description?: string;
     inputSchema?: unknown;
+    _meta?: Record<string, unknown>;
   }> | null = null;
   try {
     const client = await createLocalClient(tempConnection as any, resolvedPath);
@@ -213,6 +214,7 @@ app.post("/create-project", async (c) => {
       name: t.name,
       description: t.description,
       inputSchema: t.inputSchema,
+      ...((t as any)._meta ? { _meta: (t as any)._meta } : {}),
     }));
     await client.close();
   } catch (err) {
@@ -261,12 +263,15 @@ app.post("/create-project", async (c) => {
     },
   });
 
-  // 4. Bind object-storage plugin to the connection
+  // 4. Add connection to the project
+  await ctx.storage.projectConnections.add(project.id, connection.id);
+
+  // 5. Bind object-storage plugin to the connection
   await ctx.storage.projectPluginConfigs.upsert(project.id, "object-storage", {
     connectionId: connection.id,
   });
 
-  // 5. Create Virtual MCP so tools are available in chat
+  // 6. Create Virtual MCP so tools are available in chat
   const virtualMcp = await ctx.storage.virtualMcps.create(
     organizationId,
     userId,

--- a/apps/mesh/src/api/routes/local-dev-project.ts
+++ b/apps/mesh/src/api/routes/local-dev-project.ts
@@ -1,0 +1,442 @@
+/**
+ * Local Dev Project Routes (local mode only)
+ *
+ * POST /pick-folder     — open native OS folder picker
+ * POST /validate-folder — validate folder path + derive name/slug
+ * POST /create-project  — create project + connection + virtual MCP + bind plugins
+ * GET  /watch/:id       — SSE filesystem watch for a local connection
+ * GET  /files/:id/*     — serve files for presigned URLs
+ */
+
+import { Hono } from "hono";
+import { stat } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { createReadStream } from "node:fs";
+import { extname } from "node:path";
+import { Readable } from "node:stream";
+import { requireAuth, getUserId } from "../../core/mesh-context";
+import { pickRandomCapybaraIcon } from "../../constants/capybara-icons";
+import { LocalFileStorage } from "@decocms/local-dev";
+import type { Env } from "../hono-env";
+import {
+  createLocalClient,
+  getLocalStorage,
+  PREVIEW_TOOL_NAME,
+} from "../../mcp-clients/local";
+
+const app = new Hono<Env>();
+
+// ---- Native Folder Picker ----
+
+app.post("/pick-folder", async (c) => {
+  const ctx = c.var.meshContext;
+  requireAuth(ctx);
+
+  try {
+    const proc = Bun.spawn(
+      [
+        "osascript",
+        "-e",
+        'set selectedFolder to choose folder with prompt "Select a project folder"',
+        "-e",
+        "return POSIX path of selectedFolder",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      // User cancelled the dialog
+      return c.json({ cancelled: true });
+    }
+    const path = (await new Response(proc.stdout).text()).trim();
+    // Remove trailing slash
+    const cleaned = path.endsWith("/") ? path.slice(0, -1) : path;
+    return c.json({ path: cleaned });
+  } catch {
+    return c.json({ error: "Failed to open folder picker" }, 500);
+  }
+});
+
+// ---- Validate Folder ----
+
+app.post("/validate-folder", async (c) => {
+  const ctx = c.var.meshContext;
+  requireAuth(ctx);
+
+  const { folderPath } = (await c.req.json()) as { folderPath: string };
+  if (!folderPath) {
+    return c.json({ valid: false, error: "Missing folderPath" }, 400);
+  }
+
+  const resolvedPath = resolve(folderPath);
+
+  try {
+    const info = await stat(resolvedPath);
+    if (!info.isDirectory()) {
+      return c.json({ valid: false, error: "Not a directory" });
+    }
+  } catch {
+    return c.json({ valid: false, error: "Path not found" });
+  }
+
+  const name = basename(resolvedPath);
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  // Check if a project already exists for this folder
+  const organizationId = ctx.organization?.id;
+  let existingProjectSlug: string | undefined;
+
+  if (organizationId) {
+    const connections = await ctx.storage.connections.list(organizationId);
+    const existing = connections.find(
+      (conn: { metadata: Record<string, unknown> | null }) => {
+        const meta = conn.metadata as { localDevRoot?: string } | null;
+        return meta?.localDevRoot === resolvedPath;
+      },
+    );
+    if (existing) {
+      // Find project that binds to this connection
+      const projects = await ctx.storage.projects.list(organizationId);
+      // Check plugin configs for binding
+      for (const project of projects) {
+        const configs = await ctx.storage.projectPluginConfigs.list(project.id);
+        if (configs.some((cfg) => cfg.connectionId === existing.id)) {
+          existingProjectSlug = project.slug;
+          break;
+        }
+      }
+    }
+  }
+
+  return c.json({
+    valid: true,
+    name,
+    slug: slug || "project",
+    folderPath: resolvedPath,
+    existingProjectSlug,
+  });
+});
+
+// ---- Create Project ----
+
+app.post("/create-project", async (c) => {
+  const ctx = c.var.meshContext;
+  requireAuth(ctx);
+
+  const organizationId = ctx.organization?.id;
+  const userId = getUserId(ctx);
+  if (!organizationId || !userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const body = (await c.req.json()) as {
+    folderPath: string;
+    name?: string;
+    slug?: string;
+    bannerColor?: string;
+  };
+
+  const resolvedPath = resolve(body.folderPath);
+
+  // Validate folder exists
+  try {
+    const info = await stat(resolvedPath);
+    if (!info.isDirectory()) {
+      return c.json({ error: "Not a directory" }, 400);
+    }
+  } catch {
+    return c.json({ error: "Folder not found" }, 404);
+  }
+
+  const folderName = basename(resolvedPath);
+  const name = body.name || folderName;
+  const slug =
+    body.slug ||
+    folderName
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") ||
+    "project";
+  const bannerColor = body.bannerColor || "#10B981";
+
+  // Idempotency: check if connection already exists for this folder
+  const connections = await ctx.storage.connections.list(organizationId);
+  const existingConn = connections.find((conn) => {
+    const meta = conn.metadata as { localDevRoot?: string } | null;
+    return meta?.localDevRoot === resolvedPath;
+  });
+
+  if (existingConn) {
+    // Find the associated project and virtual MCP
+    const projects = await ctx.storage.projects.list(organizationId);
+    for (const project of projects) {
+      const configs = await ctx.storage.projectPluginConfigs.list(project.id);
+      if (configs.some((cfg) => cfg.connectionId === existingConn.id)) {
+        return c.json({
+          project: { id: project.id, slug: project.slug, name: project.name },
+          connectionId: existingConn.id,
+          existing: true,
+        });
+      }
+    }
+  }
+
+  // 1. Create a temporary local client to discover tools
+  const tempConnection = {
+    id: `pending-${Date.now()}`,
+    title: name,
+    connection_type: "HTTP" as const,
+    connection_url: "",
+    metadata: {
+      sourceProvider: "local-filesystem",
+      localDevRoot: resolvedPath,
+    },
+  };
+  let toolsList: Array<{
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+  }> | null = null;
+  try {
+    const client = await createLocalClient(tempConnection as any, resolvedPath);
+    const result = await client.listTools();
+    toolsList = result.tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }));
+    await client.close();
+  } catch (err) {
+    console.error("[local-dev] Failed to list tools:", err);
+  }
+
+  // 2. Create connection
+  const connection = await ctx.storage.connections.create({
+    title: name,
+    connection_type: "HTTP",
+    connection_url: "",
+    organization_id: organizationId,
+    created_by: userId,
+    tools: toolsList?.length
+      ? toolsList.map((t) => ({
+          ...t,
+          inputSchema: (t.inputSchema ?? {}) as Record<string, unknown>,
+        }))
+      : null,
+    metadata: {
+      sourceProvider: "local-filesystem",
+      localDevRoot: resolvedPath,
+    },
+  });
+
+  // 3. Create project
+  const project = await ctx.storage.projects.create({
+    organizationId,
+    slug,
+    name,
+    description: `Local project (${resolvedPath})`,
+    enabledPlugins: ["object-storage"],
+    ui: {
+      banner: null,
+      bannerColor,
+      icon: null,
+      themeColor: bannerColor,
+      pinnedViews: [
+        {
+          connectionId: connection.id,
+          toolName: PREVIEW_TOOL_NAME,
+          label: "Preview",
+          icon: null,
+        },
+      ],
+    },
+  });
+
+  // 4. Bind object-storage plugin to the connection
+  await ctx.storage.projectPluginConfigs.upsert(project.id, "object-storage", {
+    connectionId: connection.id,
+  });
+
+  // 5. Create Virtual MCP so tools are available in chat
+  const virtualMcp = await ctx.storage.virtualMcps.create(
+    organizationId,
+    userId,
+    {
+      title: name,
+      description: `Local development agent for ${resolvedPath}`,
+      icon: pickRandomCapybaraIcon(),
+      status: "active",
+      connections: [{ connection_id: connection.id }],
+      metadata: {},
+    },
+  );
+
+  return c.json({
+    project: {
+      id: project.id,
+      slug: project.slug,
+      name: project.name,
+    },
+    connectionId: connection.id,
+    virtualMcpId: virtualMcp.id,
+  });
+});
+
+// ---- File Watch (SSE) ----
+
+app.get("/watch/:connectionId", async (c) => {
+  const ctx = c.var.meshContext;
+  requireAuth(ctx);
+
+  const connectionId = c.req.param("connectionId");
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const connection = await ctx.storage.connections.findById(connectionId);
+  if (!connection || connection.organization_id !== organizationId) {
+    return c.json({ error: "Connection not found" }, 404);
+  }
+
+  const meta = connection.metadata as { localDevRoot?: string } | null;
+  if (!meta?.localDevRoot) {
+    return c.json({ error: "Not a local connection" }, 400);
+  }
+
+  // Use Hono's streaming response for SSE
+  return c.newResponse(
+    new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        const rootPath = meta.localDevRoot!;
+
+        // Use node:fs.watch for filesystem events
+        const watcher = require("node:fs").watch(
+          rootPath,
+          { recursive: true },
+          (eventType: string, filename: string | null) => {
+            if (!filename) return;
+            const data = JSON.stringify({
+              path: filename,
+              type: eventType,
+              timestamp: Date.now(),
+            });
+            try {
+              controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+            } catch {
+              // Stream closed
+            }
+          },
+        );
+
+        // Keepalive every 30s
+        const keepalive = setInterval(() => {
+          try {
+            controller.enqueue(encoder.encode(": keepalive\n\n"));
+          } catch {
+            clearInterval(keepalive);
+          }
+        }, 30_000);
+
+        // Cleanup on close
+        c.req.raw.signal.addEventListener("abort", () => {
+          watcher.close();
+          clearInterval(keepalive);
+          controller.close();
+        });
+      },
+    }),
+    {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Access-Control-Allow-Origin": "*",
+      },
+    },
+  );
+});
+
+// ---- File Serving (Presigned URLs) ----
+
+app.get("/files/:connectionId/*", async (c) => {
+  const ctx = c.var.meshContext;
+  requireAuth(ctx);
+
+  const connectionId = c.req.param("connectionId");
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const connection = await ctx.storage.connections.findById(connectionId);
+  if (!connection || connection.organization_id !== organizationId) {
+    return c.json({ error: "Connection not found" }, 404);
+  }
+
+  const meta = connection.metadata as { localDevRoot?: string } | null;
+  if (!meta?.localDevRoot) {
+    return c.json({ error: "Not a local connection" }, 400);
+  }
+
+  // Extract file key from URL (everything after /files/:connectionId/)
+  const url = new URL(c.req.url);
+  const prefix = `/api/local-dev/files/${connectionId}/`;
+  const key = decodeURIComponent(url.pathname.slice(prefix.length));
+  if (!key) {
+    return c.json({ error: "Missing file key" }, 400);
+  }
+
+  const storage =
+    getLocalStorage(meta.localDevRoot) ??
+    new LocalFileStorage(meta.localDevRoot);
+
+  try {
+    const absolutePath = storage.resolvePath(key);
+    const mimeTypes: Record<string, string> = {
+      ".html": "text/html",
+      ".css": "text/css",
+      ".js": "application/javascript",
+      ".json": "application/json",
+      ".png": "image/png",
+      ".jpg": "image/jpeg",
+      ".jpeg": "image/jpeg",
+      ".gif": "image/gif",
+      ".svg": "image/svg+xml",
+      ".webp": "image/webp",
+      ".ico": "image/x-icon",
+      ".woff2": "font/woff2",
+      ".woff": "font/woff",
+      ".txt": "text/plain",
+      ".md": "text/markdown",
+      ".ts": "text/typescript",
+      ".tsx": "text/typescript",
+    };
+    const ext = extname(absolutePath).toLowerCase();
+    const contentType = mimeTypes[ext] ?? "application/octet-stream";
+
+    const nodeStream = createReadStream(absolutePath);
+    const webStream = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+
+    return c.newResponse(webStream, {
+      headers: {
+        "Content-Type": contentType,
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+});
+
+export default app;

--- a/apps/mesh/src/api/routes/local-dev-project.ts
+++ b/apps/mesh/src/api/routes/local-dev-project.ts
@@ -375,17 +375,14 @@ app.get("/watch/:connectionId", async (c) => {
 // ---- File Serving (Presigned URLs) ----
 
 app.get("/files/:connectionId/*", async (c) => {
+  // In local mode, the connection ID acts as a capability token.
+  // Skip auth because this is loaded inside sandboxed iframes that
+  // may not carry session cookies.
   const ctx = c.var.meshContext;
-  requireAuth(ctx);
-
   const connectionId = c.req.param("connectionId");
-  const organizationId = ctx.organization?.id;
-  if (!organizationId) {
-    return c.json({ error: "Unauthorized" }, 401);
-  }
 
   const connection = await ctx.storage.connections.findById(connectionId);
-  if (!connection || connection.organization_id !== organizationId) {
+  if (!connection) {
     return c.json({ error: "Connection not found" }, 404);
   }
 

--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -27,6 +27,11 @@ export type PublicConfig = {
    * (e.g. tokyo.localhost) that external OAuth servers may not accept.
    */
   internalUrl?: string;
+  /**
+   * Whether the server is running in local mode (via CLI).
+   * Used to show local-only features like "Add Project > From Folder".
+   */
+  localMode?: boolean;
 };
 
 /**
@@ -42,6 +47,7 @@ app.get("/", (c) => {
     theme: getThemeConfig(),
     // Only expose internalUrl in local mode — production uses the public URL directly
     ...(isLocalMode() && { internalUrl: getInternalUrl() }),
+    localMode: isLocalMode(),
   };
 
   return c.json({ success: true, config });

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -83,6 +83,7 @@ export function shouldSkipMeshContext(path: string): boolean {
   return (
     path === "/" ||
     path.startsWith(PATH_PREFIXES.API_AUTH) ||
+    path.startsWith("/api/cli/") ||
     isSystemPath(path) ||
     isStaticFilePath(path)
   );

--- a/apps/mesh/src/auth/local-mode.ts
+++ b/apps/mesh/src/auth/local-mode.ts
@@ -15,14 +15,14 @@ import { userInfo } from "os";
 import { join } from "path";
 import { auth } from "./index";
 
+let _cachedPassword: string | undefined;
+
 /**
  * Get the per-install local admin password from secrets.json.
  *
  * Reads from DECOCMS_HOME (set by CLI) or the default ~/deco directory.
  * Throws if no password is found — never falls back to a hardcoded credential.
  */
-let _cachedPassword: string | null = null;
-
 export async function getLocalAdminPassword(): Promise<string> {
   if (_cachedPassword) return _cachedPassword;
 

--- a/apps/mesh/src/mcp-apps/csp-injector.ts
+++ b/apps/mesh/src/mcp-apps/csp-injector.ts
@@ -64,8 +64,9 @@ export function injectCSP(
   return "<head>\n" + metaTag + "\n</head>\n" + html;
 }
 
-// Supports exact domains and wildcard subdomains (e.g. https://*.decocdn.com)
-const DOMAIN_RE = /^https?:\/\/(\*\.)?[a-zA-Z0-9._-]+(:\d+)?\/?$/;
+// Supports exact domains, wildcard subdomains (e.g. https://*.decocdn.com),
+// wildcard ports (e.g. http://localhost:*), and ws/wss schemes for connect-src.
+const DOMAIN_RE = /^(https?|wss?):\/\/(\*\.)?[a-zA-Z0-9._-]+(:\d+|:\*)?\/?$/;
 
 function validateDomains(domains: string[] | undefined): string[] {
   if (!domains || domains.length === 0) return [];

--- a/apps/mesh/src/mcp-clients/client.ts
+++ b/apps/mesh/src/mcp-clients/client.ts
@@ -8,6 +8,7 @@
 import type { MeshContext } from "@/core/mesh-context";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createLocalClient } from "./local";
 import { createOutboundClient } from "./outbound";
 import { createVirtualClient } from "./virtual-mcp";
 
@@ -16,6 +17,7 @@ import { createVirtualClient } from "./virtual-mcp";
  *
  * Routes to the appropriate factory based on connection type:
  * - VIRTUAL: Creates a virtual MCP aggregator client
+ * - Local folder (metadata.localDevRoot): Creates an in-process client
  * - STDIO, HTTP, Websocket, SSE: Creates an outbound client
  *
  * @param connection - Connection entity from database
@@ -30,6 +32,11 @@ export async function clientFromConnection(
 ): Promise<Client> {
   if (connection.connection_type === "VIRTUAL") {
     return createVirtualClient(connection, ctx, superUser);
+  }
+  // Local filesystem connections — handle in-process (no HTTP round-trip)
+  const meta = connection.metadata as { localDevRoot?: string } | null;
+  if (meta?.localDevRoot) {
+    return createLocalClient(connection, meta.localDevRoot);
   }
   return createOutboundClient(connection, ctx, superUser);
 }

--- a/apps/mesh/src/mcp-clients/local/index.ts
+++ b/apps/mesh/src/mcp-clients/local/index.ts
@@ -65,7 +65,19 @@ function detectPreview(
   rootPath: string,
   baseFileUrl: string,
 ): PreviewDetection {
-  // 1. Check .deco/preview.json first (user-configured)
+  const hasIndexHtml = existsSync(join(rootPath, "index.html"));
+  const hasPackageJson = existsSync(join(rootPath, "package.json"));
+
+  // 1. Static site: has index.html but no package.json — always serve directly
+  if (hasIndexHtml && !hasPackageJson) {
+    return {
+      mode: "static",
+      staticUrl: `${baseFileUrl}/index.html`,
+      hasConfig: false,
+    };
+  }
+
+  // 2. Check .deco/preview.json (user-configured, only relevant for dev-server projects)
   const configPath = join(rootPath, ".deco", "preview.json");
   let savedConfig: PreviewConfig | null = null;
   if (existsSync(configPath)) {
@@ -80,19 +92,6 @@ function detectPreview(
       command: savedConfig.command,
       port: savedConfig.port,
       hasConfig: true,
-    };
-  }
-
-  // 2. Check for static index.html (no build step needed)
-  const hasIndexHtml = existsSync(join(rootPath, "index.html"));
-  const hasPackageJson = existsSync(join(rootPath, "package.json"));
-
-  if (hasIndexHtml && !hasPackageJson) {
-    // Pure static site — serve via file route
-    return {
-      mode: "static",
-      staticUrl: `${baseFileUrl}/index.html`,
-      hasConfig: false,
     };
   }
 

--- a/apps/mesh/src/mcp-clients/local/index.ts
+++ b/apps/mesh/src/mcp-clients/local/index.ts
@@ -1,0 +1,422 @@
+/**
+ * Local MCP Client
+ *
+ * Creates an in-process MCP client for local folder connections.
+ * Instead of proxying HTTP requests to an external server, this registers
+ * filesystem + bash + object-storage tools directly and communicates
+ * via an in-memory bridge transport (zero serialization overhead).
+ *
+ * LocalFileStorage is cached per rootPath. McpServer instances are created
+ * fresh per client because the MCP SDK only allows one transport per server.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { createBridgeTransportPair } from "@decocms/mesh-sdk";
+import {
+  LocalFileStorage,
+  registerTools,
+  registerBashTool,
+} from "@decocms/local-dev";
+import type { ConnectionEntity } from "@/tools/connection/schema";
+import { getInternalUrl } from "@/core/server-constants";
+
+/** Name of the preview tool — used for sidebar pinning */
+export const PREVIEW_TOOL_NAME = "dev_server_preview";
+
+/**
+ * Cache of LocalFileStorage instances per rootPath.
+ * Storage is the expensive part (filesystem state); McpServer is cheap to create.
+ */
+const storageCache = new Map<string, LocalFileStorage>();
+
+function getOrCreateStorage(rootPath: string): LocalFileStorage {
+  const cached = storageCache.get(rootPath);
+  if (cached) return cached;
+
+  const storage = new LocalFileStorage(rootPath);
+  storageCache.set(rootPath, storage);
+  return storage;
+}
+
+/**
+ * Register a preview tool that exposes an MCP UI resource.
+ * The UI is an HTML page with an iframe pointing to the local dev server.
+ * Config is read from `.deco/preview.json` in the project root.
+ */
+function registerPreviewTool(server: McpServer, rootPath: string) {
+  const previewResourceUri = "ui://local-dev/preview";
+
+  // Register the UI resource that serves the preview HTML
+  server.registerResource(
+    "preview",
+    previewResourceUri,
+    {
+      description: "Dev server preview",
+      mimeType: "text/html;profile=mcp-app",
+    },
+    async () => ({
+      contents: [
+        {
+          uri: previewResourceUri,
+          mimeType: "text/html;profile=mcp-app",
+          text: getPreviewHtml(rootPath),
+        },
+      ],
+    }),
+  );
+
+  // Register the tool with UI metadata so Mesh discovers it
+  server.registerTool(
+    PREVIEW_TOOL_NAME,
+    {
+      title: "Dev Server Preview",
+      description:
+        "Preview your local dev server in an iframe. " +
+        "Configure via .deco/preview.json with { command, port }.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+      _meta: {
+        ui: {
+          resourceUri: previewResourceUri,
+          csp: {
+            // Allow connecting to any localhost port for dev servers
+            connectDomains: [
+              "http://localhost:*",
+              "http://127.0.0.1:*",
+              "ws://localhost:*",
+              "ws://127.0.0.1:*",
+            ],
+            frameDomains: ["http://localhost:*", "http://127.0.0.1:*"],
+          },
+        },
+      },
+    },
+    async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "Preview tool — use the UI tab to see the dev server iframe.",
+        },
+      ],
+    }),
+  );
+}
+
+/**
+ * Create an in-process MCP client for a local folder connection.
+ *
+ * The connection must have metadata.localDevRoot set to the folder path.
+ * Tools (filesystem, bash, object storage, preview) execute directly in
+ * the mesh server process — no HTTP round-trip.
+ */
+export async function createLocalClient(
+  connection: ConnectionEntity,
+  rootPath: string,
+): Promise<Client> {
+  const storage = getOrCreateStorage(rootPath);
+
+  // Create a fresh McpServer per client — MCP SDK only allows one transport per server
+  const mcpServer = new McpServer({
+    name: `local-dev-${rootPath}`,
+    version: "1.0.0",
+  });
+
+  const internalUrl = getInternalUrl();
+  const baseFileUrl = `${internalUrl}/api/local-dev/files/${connection.id}`;
+
+  registerTools(mcpServer, storage, baseFileUrl);
+  registerBashTool(mcpServer, rootPath);
+  registerPreviewTool(mcpServer, rootPath);
+
+  const { client: clientTransport, server: serverTransport } =
+    createBridgeTransportPair();
+
+  await mcpServer.connect(serverTransport);
+
+  const client = new Client({
+    name: "local-mcp-client",
+    version: "1.0.0",
+  });
+  await client.connect(clientTransport);
+
+  return client;
+}
+
+/**
+ * Get the LocalFileStorage instance for a connection's root path.
+ * Used by API routes (file serving, watch) to access the filesystem.
+ */
+export function getLocalStorage(
+  rootPath: string,
+): LocalFileStorage | undefined {
+  return storageCache.get(rootPath);
+}
+
+/**
+ * Returns the HTML for the preview UI resource.
+ * This is a self-contained page that:
+ * 1. Reads .deco/preview.json config via the bash tool (through AppBridge)
+ * 2. Starts the dev server if not running
+ * 3. Shows the dev server in an iframe
+ */
+function getPreviewHtml(rootPath: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: system-ui, -apple-system, sans-serif; height: 100vh; display: flex; flex-direction: column; background: var(--app-background, #fff); color: var(--app-foreground, #111); }
+  .toolbar { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--app-border, #e5e5e5); background: var(--app-surface, #fafafa); flex-shrink: 0; }
+  .toolbar button { padding: 4px 12px; border-radius: 6px; border: 1px solid var(--app-border, #e5e5e5); background: var(--app-surface, #fff); cursor: pointer; font-size: 13px; color: inherit; }
+  .toolbar button:hover { background: var(--app-muted, #f0f0f0); }
+  .toolbar button.primary { background: var(--app-primary, #2563eb); color: white; border-color: transparent; }
+  .toolbar button.primary:hover { opacity: 0.9; }
+  .toolbar button.danger { color: #dc2626; }
+  .url-bar { flex: 1; padding: 4px 10px; border-radius: 6px; border: 1px solid var(--app-border, #e5e5e5); background: var(--app-background, #fff); font-size: 13px; font-family: monospace; color: var(--app-muted-foreground, #666); }
+  .status { font-size: 12px; color: var(--app-muted-foreground, #888); }
+  .status.running { color: #16a34a; }
+  .status.stopped { color: #dc2626; }
+  iframe { flex: 1; border: none; width: 100%; }
+  .setup { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 16px; padding: 32px; text-align: center; }
+  .setup h2 { font-size: 18px; font-weight: 600; }
+  .setup p { font-size: 14px; color: var(--app-muted-foreground, #666); max-width: 400px; }
+  .setup .config-form { display: flex; flex-direction: column; gap: 12px; width: 100%; max-width: 360px; text-align: left; }
+  .setup label { font-size: 13px; font-weight: 500; }
+  .setup input { padding: 8px 12px; border-radius: 6px; border: 1px solid var(--app-border, #e5e5e5); font-size: 14px; font-family: monospace; background: var(--app-background, #fff); color: inherit; }
+  .detecting { animation: pulse 1.5s ease-in-out infinite; }
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+</style>
+</head>
+<body>
+<div id="app"></div>
+<script type="module">
+const ROOT = ${JSON.stringify(rootPath)};
+const CONFIG_PATH = ".deco/preview.json";
+
+let config = null;
+let serverRunning = false;
+let serverUrl = "";
+
+// AppBridge communication — call tools on the host
+async function callTool(name, args) {
+  return new Promise((resolve, reject) => {
+    const id = crypto.randomUUID();
+    const handler = (e) => {
+      const msg = e.data;
+      if (msg?.id === id && msg?.jsonrpc === "2.0") {
+        window.removeEventListener("message", handler);
+        if (msg.error) reject(new Error(msg.error.message));
+        else resolve(msg.result);
+      }
+    };
+    window.addEventListener("message", handler);
+    window.parent.postMessage({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name, arguments: args }
+    }, "*");
+  });
+}
+
+async function bash(cmd) {
+  const result = await callTool("bash", { cmd, timeout: 30000 });
+  const text = result?.content?.[0]?.text || "{}";
+  return JSON.parse(text);
+}
+
+async function loadConfig() {
+  try {
+    const result = await bash("cat " + CONFIG_PATH + " 2>/dev/null || echo '{}'");
+    const parsed = JSON.parse(result.stdout || "{}");
+    if (parsed.command && parsed.port) {
+      config = parsed;
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
+async function saveConfig(command, port) {
+  await bash("mkdir -p .deco && cat > " + CONFIG_PATH + " << 'DECO_EOF'\\n" + JSON.stringify({ command, port }, null, 2) + "\\nDECO_EOF");
+  config = { command, port };
+}
+
+async function checkServer() {
+  if (!config) return false;
+  try {
+    const result = await bash("curl -s -o /dev/null -w '%{http_code}' --connect-timeout 2 http://localhost:" + config.port + " 2>/dev/null || echo 000");
+    const code = parseInt(result.stdout || "000");
+    return code > 0 && code < 500;
+  } catch { return false; }
+}
+
+async function startServer() {
+  if (!config) return;
+  await bash("cd " + ROOT + " && nohup " + config.command + " > .deco/preview.log 2>&1 &");
+  // Poll until server is up
+  for (let i = 0; i < 30; i++) {
+    await new Promise(r => setTimeout(r, 1000));
+    if (await checkServer()) { serverRunning = true; render(); return; }
+  }
+  render();
+}
+
+async function stopServer() {
+  if (!config) return;
+  await bash("lsof -ti:" + config.port + " | xargs kill -9 2>/dev/null || true");
+  serverRunning = false;
+  render();
+}
+
+async function detectConfig() {
+  const result = await bash(\`
+    if [ -f package.json ]; then
+      cat package.json
+    else
+      echo '{}'
+    fi
+  \`);
+  try {
+    const pkg = JSON.parse(result.stdout || "{}");
+    const scripts = pkg.scripts || {};
+
+    // Detect package manager
+    let pm = "npm run";
+    const pmResult = await bash("[ -f bun.lockb ] && echo bun || ([ -f pnpm-lock.yaml ] && echo pnpm || ([ -f yarn.lock ] && echo yarn || echo npm))");
+    const detected = (pmResult.stdout || "npm").trim();
+    if (detected === "bun") pm = "bun run";
+    else if (detected === "pnpm") pm = "pnpm";
+    else if (detected === "yarn") pm = "yarn";
+
+    // Detect dev command and port
+    let command = "";
+    let port = 3000;
+
+    for (const key of ["dev", "start", "serve"]) {
+      if (scripts[key]) {
+        command = pm + " " + key;
+        // Try to extract port from script
+        const portMatch = scripts[key].match(/(?:--port|PORT=|:)(\\d{4,5})/);
+        if (portMatch) port = parseInt(portMatch[1]);
+        break;
+      }
+    }
+
+    // Framework-specific port defaults
+    if (scripts.dev) {
+      if (scripts.dev.includes("vite")) port = 5173;
+      else if (scripts.dev.includes("next")) port = 3000;
+      else if (scripts.dev.includes("astro")) port = 4321;
+      else if (scripts.dev.includes("nuxt")) port = 3000;
+    }
+
+    return { command, port };
+  } catch { return { command: "", port: 3000 }; }
+}
+
+function render() {
+  const app = document.getElementById("app");
+  if (!config) {
+    renderSetup(app);
+  } else if (!serverRunning) {
+    renderStopped(app);
+  } else {
+    renderRunning(app);
+  }
+}
+
+function renderSetup(el) {
+  el.innerHTML = \`
+    <div class="setup">
+      <h2>Configure Dev Server</h2>
+      <p>Set the command and port for your local development server.</p>
+      <div class="config-form">
+        <label>Command</label>
+        <input id="cmd" placeholder="bun run dev" />
+        <label>Port</label>
+        <input id="port" type="number" placeholder="3000" />
+        <button class="primary" id="save-btn" style="padding:8px 16px; border-radius:6px; border:none; background:var(--app-primary,#2563eb); color:white; cursor:pointer; font-size:14px;">Save & Start</button>
+        <button id="detect-btn" style="padding:8px 16px; border-radius:6px; border:1px solid var(--app-border,#e5e5e5); background:transparent; cursor:pointer; font-size:13px; color:var(--app-muted-foreground,#666);">Auto-detect from package.json</button>
+      </div>
+    </div>
+  \`;
+  document.getElementById("detect-btn").onclick = async () => {
+    const btn = document.getElementById("detect-btn");
+    btn.textContent = "Detecting...";
+    btn.classList.add("detecting");
+    const detected = await detectConfig();
+    btn.classList.remove("detecting");
+    btn.textContent = "Auto-detect from package.json";
+    if (detected.command) {
+      document.getElementById("cmd").value = detected.command;
+      document.getElementById("port").value = detected.port;
+    }
+  };
+  document.getElementById("save-btn").onclick = async () => {
+    const cmd = document.getElementById("cmd").value.trim();
+    const port = parseInt(document.getElementById("port").value) || 3000;
+    if (!cmd) return;
+    await saveConfig(cmd, port);
+    await startServer();
+  };
+}
+
+function renderStopped(el) {
+  el.innerHTML = \`
+    <div class="toolbar">
+      <span class="status stopped">● Stopped</span>
+      <span class="url-bar">http://localhost:\${config.port}</span>
+      <button class="primary" id="start-btn">Start Server</button>
+      <button id="edit-btn">Edit</button>
+    </div>
+    <div class="setup">
+      <p>Dev server is not running.</p>
+      <button class="primary" id="start-btn2" style="padding:10px 24px; border-radius:8px; border:none; background:var(--app-primary,#2563eb); color:white; cursor:pointer; font-size:14px;">Start Dev Server</button>
+    </div>
+  \`;
+  const start = async () => {
+    document.querySelectorAll("#start-btn, #start-btn2").forEach(b => { b.textContent = "Starting..."; b.disabled = true; });
+    await startServer();
+  };
+  document.getElementById("start-btn").onclick = start;
+  document.getElementById("start-btn2").onclick = start;
+  document.getElementById("edit-btn").onclick = () => { config = null; render(); };
+}
+
+function renderRunning(el) {
+  serverUrl = "http://localhost:" + config.port;
+  el.innerHTML = \`
+    <div class="toolbar">
+      <span class="status running">● Running</span>
+      <span class="url-bar">\${serverUrl}</span>
+      <button id="refresh-btn">↻ Refresh</button>
+      <button id="open-btn">↗ Open</button>
+      <button class="danger" id="stop-btn">Stop</button>
+    </div>
+    <iframe id="preview-frame" src="\${serverUrl}"></iframe>
+  \`;
+  document.getElementById("refresh-btn").onclick = () => {
+    document.getElementById("preview-frame").src = serverUrl;
+  };
+  document.getElementById("open-btn").onclick = () => {
+    window.open(serverUrl, "_blank");
+  };
+  document.getElementById("stop-btn").onclick = stopServer;
+}
+
+// Initialize
+(async () => {
+  const hasConfig = await loadConfig();
+  if (hasConfig) {
+    serverRunning = await checkServer();
+  }
+  render();
+})();
+</script>
+</body>
+</html>`;
+}

--- a/apps/mesh/src/mcp-clients/local/index.ts
+++ b/apps/mesh/src/mcp-clients/local/index.ts
@@ -68,8 +68,9 @@ function detectPreview(
   const hasIndexHtml = existsSync(join(rootPath, "index.html"));
   const hasPackageJson = existsSync(join(rootPath, "package.json"));
 
-  // 1. Static site: has index.html but no package.json — always serve directly
-  if (hasIndexHtml && !hasPackageJson) {
+  // 1. Static site: has index.html at root — serve directly
+  //    Even if there's a package.json, a root index.html means it can be previewed as-is.
+  if (hasIndexHtml) {
     return {
       mode: "static",
       staticUrl: `${baseFileUrl}/index.html`,

--- a/apps/mesh/src/mcp-clients/local/index.ts
+++ b/apps/mesh/src/mcp-clients/local/index.ts
@@ -166,6 +166,19 @@ function registerPreviewTool(
           uri: previewResourceUri,
           mimeType: "text/html;profile=mcp-app",
           text: getPreviewHtml(rootPath, baseFileUrl),
+          _meta: {
+            ui: {
+              csp: {
+                frameDomains: ["http://localhost:*", "http://127.0.0.1:*"],
+                connectDomains: [
+                  "http://localhost:*",
+                  "http://127.0.0.1:*",
+                  "ws://localhost:*",
+                  "ws://127.0.0.1:*",
+                ],
+              },
+            },
+          },
         },
       ],
     }),

--- a/apps/mesh/src/mcp-clients/local/index.ts
+++ b/apps/mesh/src/mcp-clients/local/index.ts
@@ -18,6 +18,8 @@ import {
   registerTools,
   registerBashTool,
 } from "@decocms/local-dev";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { getInternalUrl } from "@/core/server-constants";
 
@@ -39,12 +41,115 @@ function getOrCreateStorage(rootPath: string): LocalFileStorage {
   return storage;
 }
 
-/**
- * Register a preview tool that exposes an MCP UI resource.
- * The UI is an HTML page with an iframe pointing to the local dev server.
- * Config is read from `.deco/preview.json` in the project root.
- */
-function registerPreviewTool(server: McpServer, rootPath: string) {
+// ---- Preview detection ----
+
+interface PreviewConfig {
+  command?: string;
+  port?: number;
+}
+
+interface PreviewDetection {
+  /** "static" = has index.html, no dev server needed; "dev-server" = has a dev command; "needs-config" = can't detect */
+  mode: "static" | "dev-server" | "needs-config";
+  /** For static mode: URL to iframe directly */
+  staticUrl?: string;
+  /** Suggested dev command (from package.json or .deco/preview.json) */
+  command?: string;
+  /** Suggested port */
+  port?: number;
+  /** Whether .deco/preview.json exists */
+  hasConfig: boolean;
+}
+
+function detectPreview(
+  rootPath: string,
+  baseFileUrl: string,
+): PreviewDetection {
+  // 1. Check .deco/preview.json first (user-configured)
+  const configPath = join(rootPath, ".deco", "preview.json");
+  let savedConfig: PreviewConfig | null = null;
+  if (existsSync(configPath)) {
+    try {
+      savedConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+    } catch {}
+  }
+
+  if (savedConfig?.command && savedConfig?.port) {
+    return {
+      mode: "dev-server",
+      command: savedConfig.command,
+      port: savedConfig.port,
+      hasConfig: true,
+    };
+  }
+
+  // 2. Check for static index.html (no build step needed)
+  const hasIndexHtml = existsSync(join(rootPath, "index.html"));
+  const hasPackageJson = existsSync(join(rootPath, "package.json"));
+
+  if (hasIndexHtml && !hasPackageJson) {
+    // Pure static site — serve via file route
+    return {
+      mode: "static",
+      staticUrl: `${baseFileUrl}/index.html`,
+      hasConfig: false,
+    };
+  }
+
+  // 3. Check package.json for dev scripts
+  if (hasPackageJson) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(join(rootPath, "package.json"), "utf-8"),
+      );
+      const scripts = pkg.scripts || {};
+
+      // Detect package manager
+      let pm = "npm run";
+      if (existsSync(join(rootPath, "bun.lockb"))) pm = "bun run";
+      else if (existsSync(join(rootPath, "pnpm-lock.yaml"))) pm = "pnpm";
+      else if (existsSync(join(rootPath, "yarn.lock"))) pm = "yarn";
+
+      // Find a dev command
+      for (const key of ["dev", "start", "serve"]) {
+        if (scripts[key]) {
+          let port = 3000;
+          const portMatch = scripts[key].match(/(?:--port|PORT=|:)(\d{4,5})/);
+          if (portMatch) port = parseInt(portMatch[1]);
+          else if (scripts[key].includes("vite")) port = 5173;
+          else if (scripts[key].includes("astro")) port = 4321;
+
+          return {
+            mode: "dev-server",
+            command: `${pm} ${key}`,
+            port,
+            hasConfig: false,
+          };
+        }
+      }
+    } catch {}
+
+    // Has package.json but no dev script — if there's an index.html, serve it statically
+    if (hasIndexHtml) {
+      return {
+        mode: "static",
+        staticUrl: `${baseFileUrl}/index.html`,
+        hasConfig: false,
+      };
+    }
+  }
+
+  // 4. Can't detect — user needs to configure
+  return { mode: "needs-config", hasConfig: false };
+}
+
+// ---- Preview tool registration ----
+
+function registerPreviewTool(
+  server: McpServer,
+  rootPath: string,
+  baseFileUrl: string,
+) {
   const previewResourceUri = "ui://local-dev/preview";
 
   // Register the UI resource that serves the preview HTML
@@ -60,7 +165,7 @@ function registerPreviewTool(server: McpServer, rootPath: string) {
         {
           uri: previewResourceUri,
           mimeType: "text/html;profile=mcp-app",
-          text: getPreviewHtml(rootPath),
+          text: getPreviewHtml(rootPath, baseFileUrl),
         },
       ],
     }),
@@ -72,7 +177,7 @@ function registerPreviewTool(server: McpServer, rootPath: string) {
     {
       title: "Dev Server Preview",
       description:
-        "Preview your local dev server in an iframe. " +
+        "Preview your local project. Auto-detects static sites and dev servers. " +
         "Configure via .deco/preview.json with { command, port }.",
       inputSchema: {},
       annotations: { readOnlyHint: true },
@@ -80,7 +185,6 @@ function registerPreviewTool(server: McpServer, rootPath: string) {
         ui: {
           resourceUri: previewResourceUri,
           csp: {
-            // Allow connecting to any localhost port for dev servers
             connectDomains: [
               "http://localhost:*",
               "http://127.0.0.1:*",
@@ -92,23 +196,22 @@ function registerPreviewTool(server: McpServer, rootPath: string) {
         },
       },
     },
-    async () => ({
-      content: [
-        {
-          type: "text" as const,
-          text: "Preview tool — use the UI tab to see the dev server iframe.",
-        },
-      ],
-    }),
+    async () => {
+      const detection = detectPreview(rootPath, baseFileUrl);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(detection),
+          },
+        ],
+      };
+    },
   );
 }
 
 /**
  * Create an in-process MCP client for a local folder connection.
- *
- * The connection must have metadata.localDevRoot set to the folder path.
- * Tools (filesystem, bash, object storage, preview) execute directly in
- * the mesh server process — no HTTP round-trip.
  */
 export async function createLocalClient(
   connection: ConnectionEntity,
@@ -116,7 +219,6 @@ export async function createLocalClient(
 ): Promise<Client> {
   const storage = getOrCreateStorage(rootPath);
 
-  // Create a fresh McpServer per client — MCP SDK only allows one transport per server
   const mcpServer = new McpServer({
     name: `local-dev-${rootPath}`,
     version: "1.0.0",
@@ -127,7 +229,7 @@ export async function createLocalClient(
 
   registerTools(mcpServer, storage, baseFileUrl);
   registerBashTool(mcpServer, rootPath);
-  registerPreviewTool(mcpServer, rootPath);
+  registerPreviewTool(mcpServer, rootPath, baseFileUrl);
 
   const { client: clientTransport, server: serverTransport } =
     createBridgeTransportPair();
@@ -145,7 +247,6 @@ export async function createLocalClient(
 
 /**
  * Get the LocalFileStorage instance for a connection's root path.
- * Used by API routes (file serving, watch) to access the filesystem.
  */
 export function getLocalStorage(
   rootPath: string,
@@ -154,13 +255,22 @@ export function getLocalStorage(
 }
 
 /**
- * Returns the HTML for the preview UI resource.
- * This is a self-contained page that:
- * 1. Reads .deco/preview.json config via the bash tool (through AppBridge)
- * 2. Starts the dev server if not running
- * 3. Shows the dev server in an iframe
+ * Returns the HTML for the preview MCP App.
+ *
+ * Implements the MCP ext-apps protocol:
+ * 1. PostMessageTransport handshake (ui/initialize → ui/notifications/initialized)
+ * 2. Receives tool result with preview detection info
+ * 3. Can call tools (bash) via tools/call JSON-RPC
+ *
+ * Detection modes:
+ * - static: iframe the file serving URL directly (e.g. index.html)
+ * - dev-server: start the dev server via bash, then iframe localhost:port
+ * - needs-config: show a form for the user to fill in command + port
  */
-function getPreviewHtml(rootPath: string): string {
+function getPreviewHtml(rootPath: string, baseFileUrl: string): string {
+  // Do server-side detection to bake initial state into HTML
+  const detection = detectPreview(rootPath, baseFileUrl);
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -192,46 +302,117 @@ function getPreviewHtml(rootPath: string): string {
 </head>
 <body>
 <div id="app"></div>
-<script type="module">
-const ROOT = ${JSON.stringify(rootPath)};
-const CONFIG_PATH = ".deco/preview.json";
+<script>
+// ---- Minimal MCP App protocol ----
+// Implements the JSON-RPC handshake required by ext-apps AppBridge.
 
-let config = null;
-let serverRunning = false;
-let serverUrl = "";
+var _msgId = 0;
+var _pending = {};
 
-// AppBridge communication — call tools on the host
-async function callTool(name, args) {
-  return new Promise((resolve, reject) => {
-    const id = crypto.randomUUID();
-    const handler = (e) => {
-      const msg = e.data;
-      if (msg?.id === id && msg?.jsonrpc === "2.0") {
-        window.removeEventListener("message", handler);
-        if (msg.error) reject(new Error(msg.error.message));
-        else resolve(msg.result);
-      }
+// Listen for messages from the host
+window.addEventListener("message", function(e) {
+  var msg = e.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+
+  // Response to a request we sent
+  if (msg.id != null && _pending[msg.id]) {
+    _pending[msg.id](msg);
+    delete _pending[msg.id];
+    return;
+  }
+
+  // Notification from host (tool result, context changes, etc.)
+  if (msg.method === "ui/notifications/tool-result" && msg.params) {
+    onToolResult(msg.params);
+  }
+  if (msg.method === "ui/notifications/host-context-changed" && msg.params) {
+    if (msg.params.theme) {
+      document.documentElement.className = msg.params.theme === "dark" ? "dark" : "";
+    }
+  }
+  // Resource teardown — just respond OK
+  if (msg.method === "ui/resource-teardown" && msg.id != null) {
+    window.parent.postMessage({ jsonrpc: "2.0", id: msg.id, result: {} }, "*");
+  }
+  // Ping
+  if (msg.method === "ping" && msg.id != null) {
+    window.parent.postMessage({ jsonrpc: "2.0", id: msg.id, result: {} }, "*");
+  }
+});
+
+function sendRequest(method, params) {
+  return new Promise(function(resolve, reject) {
+    var id = ++_msgId;
+    _pending[id] = function(msg) {
+      if (msg.error) reject(new Error(msg.error.message));
+      else resolve(msg.result);
     };
-    window.addEventListener("message", handler);
     window.parent.postMessage({
       jsonrpc: "2.0",
-      id,
-      method: "tools/call",
-      params: { name, arguments: args }
+      id: id,
+      method: method,
+      params: params
     }, "*");
   });
 }
 
+function sendNotification(method, params) {
+  window.parent.postMessage({
+    jsonrpc: "2.0",
+    method: method,
+    params: params || {}
+  }, "*");
+}
+
+// Initialize the MCP App protocol handshake
+async function initApp() {
+  try {
+    await sendRequest("ui/initialize", {
+      appInfo: { name: "Local Dev Preview", version: "1.0.0" },
+      appCapabilities: { tools: {} },
+      protocolVersion: "2025-03-26"
+    });
+    sendNotification("ui/notifications/initialized");
+  } catch (err) {
+    console.error("MCP App init failed:", err);
+  }
+}
+
+// Call a tool on the host MCP server
+async function callTool(name, args) {
+  return sendRequest("tools/call", { name: name, arguments: args });
+}
+
 async function bash(cmd) {
-  const result = await callTool("bash", { cmd, timeout: 30000 });
-  const text = result?.content?.[0]?.text || "{}";
+  var result = await callTool("bash", { cmd: cmd, timeout: 30000 });
+  var text = result && result.content && result.content[0] && result.content[0].text || "{}";
   return JSON.parse(text);
 }
 
+// ---- Preview state ----
+
+var ROOT = ${JSON.stringify(rootPath)};
+var BASE_FILE_URL = ${JSON.stringify(baseFileUrl)};
+var detection = ${JSON.stringify(detection)};
+var config = null;
+var serverRunning = false;
+
+function onToolResult(params) {
+  // Tool result may contain updated detection
+  try {
+    if (params.content && params.content[0] && params.content[0].text) {
+      var d = JSON.parse(params.content[0].text);
+      if (d.mode) detection = d;
+    }
+  } catch {}
+}
+
+// ---- Config management ----
+
 async function loadConfig() {
   try {
-    const result = await bash("cat " + CONFIG_PATH + " 2>/dev/null || echo '{}'");
-    const parsed = JSON.parse(result.stdout || "{}");
+    var result = await bash("cat .deco/preview.json 2>/dev/null || echo '{}'");
+    var parsed = JSON.parse(result.stdout || "{}");
     if (parsed.command && parsed.port) {
       config = parsed;
       return true;
@@ -241,15 +422,16 @@ async function loadConfig() {
 }
 
 async function saveConfig(command, port) {
-  await bash("mkdir -p .deco && cat > " + CONFIG_PATH + " << 'DECO_EOF'\\n" + JSON.stringify({ command, port }, null, 2) + "\\nDECO_EOF");
-  config = { command, port };
+  var json = JSON.stringify({ command: command, port: port }, null, 2);
+  await bash("mkdir -p .deco && printf '%s' " + JSON.stringify(json) + " > .deco/preview.json");
+  config = { command: command, port: port };
 }
 
 async function checkServer() {
   if (!config) return false;
   try {
-    const result = await bash("curl -s -o /dev/null -w '%{http_code}' --connect-timeout 2 http://localhost:" + config.port + " 2>/dev/null || echo 000");
-    const code = parseInt(result.stdout || "000");
+    var result = await bash("curl -s -o /dev/null -w '%{http_code}' --connect-timeout 2 http://localhost:" + config.port + " 2>/dev/null || echo 000");
+    var code = parseInt(result.stdout || "000");
     return code > 0 && code < 500;
   } catch { return false; }
 }
@@ -257,9 +439,8 @@ async function checkServer() {
 async function startServer() {
   if (!config) return;
   await bash("cd " + ROOT + " && nohup " + config.command + " > .deco/preview.log 2>&1 &");
-  // Poll until server is up
-  for (let i = 0; i < 30; i++) {
-    await new Promise(r => setTimeout(r, 1000));
+  for (var i = 0; i < 30; i++) {
+    await new Promise(function(r) { setTimeout(r, 1000); });
     if (await checkServer()) { serverRunning = true; render(); return; }
   }
   render();
@@ -272,148 +453,132 @@ async function stopServer() {
   render();
 }
 
-async function detectConfig() {
-  const result = await bash(\`
-    if [ -f package.json ]; then
-      cat package.json
-    else
-      echo '{}'
-    fi
-  \`);
-  try {
-    const pkg = JSON.parse(result.stdout || "{}");
-    const scripts = pkg.scripts || {};
-
-    // Detect package manager
-    let pm = "npm run";
-    const pmResult = await bash("[ -f bun.lockb ] && echo bun || ([ -f pnpm-lock.yaml ] && echo pnpm || ([ -f yarn.lock ] && echo yarn || echo npm))");
-    const detected = (pmResult.stdout || "npm").trim();
-    if (detected === "bun") pm = "bun run";
-    else if (detected === "pnpm") pm = "pnpm";
-    else if (detected === "yarn") pm = "yarn";
-
-    // Detect dev command and port
-    let command = "";
-    let port = 3000;
-
-    for (const key of ["dev", "start", "serve"]) {
-      if (scripts[key]) {
-        command = pm + " " + key;
-        // Try to extract port from script
-        const portMatch = scripts[key].match(/(?:--port|PORT=|:)(\\d{4,5})/);
-        if (portMatch) port = parseInt(portMatch[1]);
-        break;
-      }
-    }
-
-    // Framework-specific port defaults
-    if (scripts.dev) {
-      if (scripts.dev.includes("vite")) port = 5173;
-      else if (scripts.dev.includes("next")) port = 3000;
-      else if (scripts.dev.includes("astro")) port = 4321;
-      else if (scripts.dev.includes("nuxt")) port = 3000;
-    }
-
-    return { command, port };
-  } catch { return { command: "", port: 3000 }; }
-}
+// ---- Rendering ----
 
 function render() {
-  const app = document.getElementById("app");
-  if (!config) {
-    renderSetup(app);
-  } else if (!serverRunning) {
-    renderStopped(app);
-  } else {
-    renderRunning(app);
+  var el = document.getElementById("app");
+
+  // Static mode: just iframe the files directly
+  if (detection.mode === "static" && detection.staticUrl) {
+    renderStatic(el, detection.staticUrl);
+    return;
   }
+
+  // Dev server mode with config (from detection or loaded)
+  if (config) {
+    if (serverRunning) {
+      renderRunning(el);
+    } else {
+      renderStopped(el);
+    }
+    return;
+  }
+
+  // Needs config
+  renderSetup(el);
+}
+
+function renderStatic(el, url) {
+  el.innerHTML =
+    '<div class="toolbar">' +
+      '<span class="status running">● Static</span>' +
+      '<span class="url-bar">' + url + '</span>' +
+      '<button id="refresh-btn">↻ Refresh</button>' +
+      '<button id="open-btn">↗ Open</button>' +
+    '</div>' +
+    '<iframe id="preview-frame" src="' + url + '"></iframe>';
+  document.getElementById("refresh-btn").onclick = function() {
+    document.getElementById("preview-frame").src = url;
+  };
+  document.getElementById("open-btn").onclick = function() {
+    window.open(url, "_blank");
+  };
+  sendNotification("ui/notifications/size-changed", { height: window.innerHeight });
+}
+
+function renderRunning(el) {
+  var url = "http://localhost:" + config.port;
+  el.innerHTML =
+    '<div class="toolbar">' +
+      '<span class="status running">● Running</span>' +
+      '<span class="url-bar">' + url + '</span>' +
+      '<button id="refresh-btn">↻ Refresh</button>' +
+      '<button id="open-btn">↗ Open</button>' +
+      '<button class="danger" id="stop-btn">Stop</button>' +
+    '</div>' +
+    '<iframe id="preview-frame" src="' + url + '"></iframe>';
+  document.getElementById("refresh-btn").onclick = function() {
+    document.getElementById("preview-frame").src = url;
+  };
+  document.getElementById("open-btn").onclick = function() { window.open(url, "_blank"); };
+  document.getElementById("stop-btn").onclick = stopServer;
+  sendNotification("ui/notifications/size-changed", { height: window.innerHeight });
+}
+
+function renderStopped(el) {
+  el.innerHTML =
+    '<div class="toolbar">' +
+      '<span class="status stopped">● Stopped</span>' +
+      '<span class="url-bar">http://localhost:' + config.port + '</span>' +
+      '<button class="primary" id="start-btn">Start Server</button>' +
+      '<button id="edit-btn">Edit</button>' +
+    '</div>' +
+    '<div class="setup">' +
+      '<p>Dev server is not running.</p>' +
+      '<button class="primary" id="start-btn2" style="padding:10px 24px; border-radius:8px; border:none; background:var(--app-primary,#2563eb); color:white; cursor:pointer; font-size:14px;">Start Dev Server</button>' +
+    '</div>';
+  var start = async function() {
+    document.querySelectorAll("#start-btn, #start-btn2").forEach(function(b) { b.textContent = "Starting..."; b.disabled = true; });
+    await startServer();
+  };
+  document.getElementById("start-btn").onclick = start;
+  document.getElementById("start-btn2").onclick = start;
+  document.getElementById("edit-btn").onclick = function() { config = null; render(); };
 }
 
 function renderSetup(el) {
-  el.innerHTML = \`
-    <div class="setup">
-      <h2>Configure Dev Server</h2>
-      <p>Set the command and port for your local development server.</p>
-      <div class="config-form">
-        <label>Command</label>
-        <input id="cmd" placeholder="bun run dev" />
-        <label>Port</label>
-        <input id="port" type="number" placeholder="3000" />
-        <button class="primary" id="save-btn" style="padding:8px 16px; border-radius:6px; border:none; background:var(--app-primary,#2563eb); color:white; cursor:pointer; font-size:14px;">Save & Start</button>
-        <button id="detect-btn" style="padding:8px 16px; border-radius:6px; border:1px solid var(--app-border,#e5e5e5); background:transparent; cursor:pointer; font-size:13px; color:var(--app-muted-foreground,#666);">Auto-detect from package.json</button>
-      </div>
-    </div>
-  \`;
-  document.getElementById("detect-btn").onclick = async () => {
-    const btn = document.getElementById("detect-btn");
-    btn.textContent = "Detecting...";
-    btn.classList.add("detecting");
-    const detected = await detectConfig();
-    btn.classList.remove("detecting");
-    btn.textContent = "Auto-detect from package.json";
-    if (detected.command) {
-      document.getElementById("cmd").value = detected.command;
-      document.getElementById("port").value = detected.port;
-    }
-  };
-  document.getElementById("save-btn").onclick = async () => {
-    const cmd = document.getElementById("cmd").value.trim();
-    const port = parseInt(document.getElementById("port").value) || 3000;
+  var suggestedCmd = detection.command || "";
+  var suggestedPort = detection.port || 3000;
+  el.innerHTML =
+    '<div class="setup">' +
+      '<h2>Configure Dev Server</h2>' +
+      '<p>Set the command and port for your local development server.</p>' +
+      '<div class="config-form">' +
+        '<label>Command</label>' +
+        '<input id="cmd" placeholder="bun run dev" value="' + suggestedCmd + '" />' +
+        '<label>Port</label>' +
+        '<input id="port" type="number" placeholder="3000" value="' + suggestedPort + '" />' +
+        '<button class="primary" id="save-btn" style="padding:8px 16px; border-radius:6px; border:none; background:var(--app-primary,#2563eb); color:white; cursor:pointer; font-size:14px;">Save & Start</button>' +
+      '</div>' +
+    '</div>';
+  document.getElementById("save-btn").onclick = async function() {
+    var cmd = document.getElementById("cmd").value.trim();
+    var port = parseInt(document.getElementById("port").value) || 3000;
     if (!cmd) return;
     await saveConfig(cmd, port);
     await startServer();
   };
 }
 
-function renderStopped(el) {
-  el.innerHTML = \`
-    <div class="toolbar">
-      <span class="status stopped">● Stopped</span>
-      <span class="url-bar">http://localhost:\${config.port}</span>
-      <button class="primary" id="start-btn">Start Server</button>
-      <button id="edit-btn">Edit</button>
-    </div>
-    <div class="setup">
-      <p>Dev server is not running.</p>
-      <button class="primary" id="start-btn2" style="padding:10px 24px; border-radius:8px; border:none; background:var(--app-primary,#2563eb); color:white; cursor:pointer; font-size:14px;">Start Dev Server</button>
-    </div>
-  \`;
-  const start = async () => {
-    document.querySelectorAll("#start-btn, #start-btn2").forEach(b => { b.textContent = "Starting..."; b.disabled = true; });
-    await startServer();
-  };
-  document.getElementById("start-btn").onclick = start;
-  document.getElementById("start-btn2").onclick = start;
-  document.getElementById("edit-btn").onclick = () => { config = null; render(); };
-}
+// ---- Boot ----
 
-function renderRunning(el) {
-  serverUrl = "http://localhost:" + config.port;
-  el.innerHTML = \`
-    <div class="toolbar">
-      <span class="status running">● Running</span>
-      <span class="url-bar">\${serverUrl}</span>
-      <button id="refresh-btn">↻ Refresh</button>
-      <button id="open-btn">↗ Open</button>
-      <button class="danger" id="stop-btn">Stop</button>
-    </div>
-    <iframe id="preview-frame" src="\${serverUrl}"></iframe>
-  \`;
-  document.getElementById("refresh-btn").onclick = () => {
-    document.getElementById("preview-frame").src = serverUrl;
-  };
-  document.getElementById("open-btn").onclick = () => {
-    window.open(serverUrl, "_blank");
-  };
-  document.getElementById("stop-btn").onclick = stopServer;
-}
+(async function() {
+  // Initialize MCP App protocol first
+  await initApp();
 
-// Initialize
-(async () => {
-  const hasConfig = await loadConfig();
-  if (hasConfig) {
-    serverRunning = await checkServer();
+  // If detection says dev-server, load saved config or use detection
+  if (detection.mode === "dev-server") {
+    var hasConfig = await loadConfig();
+    if (!hasConfig && detection.command) {
+      config = { command: detection.command, port: detection.port || 3000 };
+    }
+    if (config) {
+      serverRunning = await checkServer();
+    }
+  } else if (detection.mode === "needs-config") {
+    await loadConfig();
   }
+
   render();
 })();
 </script>

--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -110,6 +110,7 @@ export interface ProjectPluginConfigStoragePort {
     },
   ): Promise<ProjectPluginConfig>;
   delete(projectId: string, pluginId: string): Promise<boolean>;
+  listByConnectionId(connectionId: string): Promise<ProjectPluginConfig[]>;
 }
 
 // ============================================================================

--- a/apps/mesh/src/storage/project-plugin-configs.ts
+++ b/apps/mesh/src/storage/project-plugin-configs.ts
@@ -135,6 +135,17 @@ export class ProjectPluginConfigsStorage
     return (result.numDeletedRows ?? 0n) > 0n;
   }
 
+  async listByConnectionId(
+    connectionId: string,
+  ): Promise<ProjectPluginConfig[]> {
+    const rows = await this.db
+      .selectFrom("project_plugin_configs")
+      .selectAll()
+      .where("connection_id", "=", connectionId)
+      .execute();
+    return rows.map((row) => this.parseRow(row));
+  }
+
   /**
    * Get bound connections for multiple projects (for list display)
    * Returns a map of project ID to array of connection summaries

--- a/apps/mesh/src/tools/projects/delete.ts
+++ b/apps/mesh/src/tools/projects/delete.ts
@@ -47,6 +47,41 @@ export const PROJECT_DELETE = defineTool({
       return { success: false, message: "Cannot delete the org-admin project" };
     }
 
+    // Before deleting, clean up localhost connections and their Virtual MCPs
+    // Only delete connections that are exclusively used by this project
+    const pluginConfigs =
+      await ctx.storage.projectPluginConfigs.list(projectId);
+    for (const config of pluginConfigs) {
+      if (!config.connectionId) continue;
+      const conn = await ctx.storage.connections.findById(config.connectionId);
+      if (
+        conn?.connection_url &&
+        /^https?:\/\/(?:localhost|127\.0\.0\.1):/.test(conn.connection_url)
+      ) {
+        // Check if any other project references this connection
+        const allConfigs =
+          await ctx.storage.projectPluginConfigs.listByConnectionId(conn.id);
+        const otherProjectRefs = allConfigs.filter(
+          (c) => c.projectId !== projectId,
+        );
+        if (otherProjectRefs.length > 0) {
+          // Another project uses this connection — skip deletion
+          continue;
+        }
+
+        // Delete Virtual MCPs that use this connection
+        const virtualMcps = await ctx.storage.virtualMcps.listByConnectionId(
+          project.organizationId,
+          conn.id,
+        );
+        for (const vmcp of virtualMcps) {
+          await ctx.storage.virtualMcps.delete(vmcp.id);
+        }
+        // Delete the connection itself
+        await ctx.storage.connections.delete(conn.id);
+      }
+    }
+
     const success = await ctx.storage.projects.delete(projectId);
     return { success };
   },

--- a/apps/mesh/src/web/components/create-project-dialog.tsx
+++ b/apps/mesh/src/web/components/create-project-dialog.tsx
@@ -32,7 +32,6 @@ import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { KEYS } from "@/web/lib/query-keys";
-import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { generateSlug, isValidSlug } from "@/web/lib/slug";
 import { ColorPicker } from "./color-picker";
 import type { Project } from "@/web/hooks/use-project";
@@ -40,29 +39,7 @@ import type { PublicConfig } from "@/api/routes/public-config";
 
 // ---- Types ----
 
-export type Step = "select" | "folder" | "blank";
-
-interface PickFolderResult {
-  path?: string;
-  cancelled?: boolean;
-  error?: string;
-}
-
-interface ValidateResult {
-  valid: boolean;
-  name?: string;
-  slug?: string;
-  folderPath?: string;
-  existingProjectSlug?: string;
-  error?: string;
-}
-
-interface CreateFromFolderResult {
-  project: { id: string; slug: string; name: string };
-  connectionId: string;
-  virtualMcpId?: string;
-  existing?: boolean;
-}
+type Step = "select" | "blank";
 
 // ---- Blank Project Form Schema ----
 
@@ -81,14 +58,14 @@ type ProjectCreateOutput = { project: Project };
 interface CreateProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Override the initial step (e.g. "folder" to skip mode selection) */
-  initialStep?: Step;
+  /** Called when "From Folder" is selected — triggers native OS picker directly */
+  onPickFolder?: () => void;
 }
 
 export function CreateProjectDialog({
   open,
   onOpenChange,
-  initialStep,
+  onPickFolder,
 }: CreateProjectDialogProps) {
   const { org } = useProjectContext();
 
@@ -98,7 +75,7 @@ export function CreateProjectDialog({
   });
   const isLocal = publicConfig?.localMode === true;
 
-  const getDefaultStep = () => initialStep ?? (isLocal ? "select" : "blank");
+  const getDefaultStep = (): Step => (isLocal ? "select" : "blank");
   const [step, setStep] = useState<Step>(getDefaultStep());
 
   // Reset step when dialog opens/closes
@@ -109,20 +86,20 @@ export function CreateProjectDialog({
     onOpenChange(newOpen);
   };
 
+  const handleSelectFolder = () => {
+    if (onPickFolder) {
+      handleOpenChange(false);
+      onPickFolder();
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
         {step === "select" && (
           <ModeSelectionInDialog
-            onSelectFolder={() => setStep("folder")}
+            onSelectFolder={handleSelectFolder}
             onSelectBlank={() => setStep("blank")}
-          />
-        )}
-        {step === "folder" && (
-          <FolderStep
-            org={org}
-            onBack={() => setStep("select")}
-            onClose={() => handleOpenChange(false)}
           />
         )}
         {step === "blank" && (
@@ -165,16 +142,19 @@ function ModeSelectionInDialog({
 export function ModeSelectionCards({
   onSelectFolder,
   onSelectBlank,
+  folderPicking,
 }: {
   onSelectFolder: () => void;
   onSelectBlank: () => void;
+  folderPicking?: boolean;
 }) {
   return (
     <div className="grid gap-3">
       <button
         type="button"
         onClick={onSelectFolder}
-        className="flex items-center gap-4 p-4 rounded-lg border border-border hover:border-foreground/20 hover:bg-accent/50 transition-colors text-left"
+        disabled={folderPicking}
+        className="flex items-center gap-4 p-4 rounded-lg border border-border hover:border-foreground/20 hover:bg-accent/50 transition-colors text-left disabled:opacity-50 disabled:cursor-wait"
       >
         <div className="flex items-center justify-center size-10 rounded-lg bg-emerald-500/10 text-emerald-600 shrink-0">
           <svg
@@ -191,7 +171,9 @@ export function ModeSelectionCards({
           </svg>
         </div>
         <div>
-          <div className="text-sm font-medium">From Folder</div>
+          <div className="text-sm font-medium">
+            {folderPicking ? "Opening…" : "From Folder"}
+          </div>
           <div className="text-xs text-muted-foreground">
             Connect a local directory
           </div>
@@ -249,306 +231,6 @@ export function ModeSelectionCards({
         </div>
       </button>
     </div>
-  );
-}
-
-// ---- Folder Step ----
-
-function FolderStep({
-  org,
-  onBack,
-  onClose,
-}: {
-  org: { id: string; slug: string; name: string };
-  onBack: () => void;
-  onClose: () => void;
-}) {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [folderName, setFolderName] = useState("");
-  const [folderSlug, setFolderSlug] = useState("");
-  const [bannerColor, setBannerColor] = useState("#10B981");
-  const [picking, setPicking] = useState(false);
-
-  // Validate selected folder
-  const { data: validation } = useQuery<ValidateResult>({
-    queryKey: ["local-dev", "validate", selectedPath],
-    queryFn: async () => {
-      const res = await fetch("/api/local-dev/validate-folder", {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ folderPath: selectedPath }),
-      });
-      return res.json();
-    },
-    enabled: !!selectedPath,
-  });
-
-  // Auto-fill name/slug when validation succeeds
-  const validationName = validation?.name;
-  const validationSlug = validation?.slug;
-  if (validationName && !folderName) {
-    setFolderName(validationName);
-  }
-  if (validationSlug && !folderSlug) {
-    setFolderSlug(validationSlug);
-  }
-
-  // Open native folder picker
-  const pickFolder = async () => {
-    setPicking(true);
-    try {
-      const res = await fetch("/api/local-dev/pick-folder", {
-        method: "POST",
-        credentials: "include",
-      });
-      const data: PickFolderResult = await res.json();
-      if (data.path) {
-        setSelectedPath(data.path);
-        setFolderName("");
-        setFolderSlug("");
-      }
-    } catch {
-      toast.error("Failed to open folder picker");
-    } finally {
-      setPicking(false);
-    }
-  };
-
-  // Create project mutation
-  const createMutation = useMutation({
-    mutationFn: async (): Promise<CreateFromFolderResult> => {
-      const res = await fetch("/api/local-dev/create-project", {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          folderPath: selectedPath,
-          name: folderName,
-          slug: folderSlug,
-          bannerColor,
-        }),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: "Unknown error" }));
-        throw new Error(err.error || `HTTP ${res.status}`);
-      }
-      return res.json();
-    },
-    onSuccess: async (result) => {
-      const locator =
-        `${org.slug}/${result.project.slug}` as `${string}/${string}`;
-      if (result.virtualMcpId) {
-        localStorage.setItem(
-          `${locator}:selected-virtual-mcp-id`,
-          JSON.stringify(result.virtualMcpId),
-        );
-      }
-      localStorage.setItem(
-        LOCALSTORAGE_KEYS.chatSelectedMode(locator),
-        JSON.stringify("passthrough"),
-      );
-
-      toast.success(`Project "${result.project.name}" created`);
-      await queryClient.invalidateQueries();
-      onClose();
-      navigate({
-        to: "/$org/$project",
-        params: { org: org.slug, project: result.project.slug },
-      });
-    },
-    onError: (error) => {
-      toast.error(
-        `Failed to create project: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
-    },
-  });
-
-  return (
-    <>
-      <DialogHeader>
-        <DialogTitle className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onBack}
-            className="inline-flex items-center justify-center size-6 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-          </button>
-          From Folder
-        </DialogTitle>
-        <DialogDescription>
-          Select a local directory to create your project.
-        </DialogDescription>
-      </DialogHeader>
-
-      {/* Folder picker card */}
-      <button
-        type="button"
-        onClick={pickFolder}
-        disabled={picking}
-        className="flex flex-col items-center justify-center gap-3 w-full rounded-lg border-2 border-dashed border-border py-8 px-4 text-muted-foreground hover:border-foreground/20 hover:bg-accent/30 hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait"
-      >
-        <svg
-          width="32"
-          height="32"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          className="text-amber-500"
-        >
-          <path d="M2 6a2 2 0 0 1 2-2h4.586a1 1 0 0 1 .707.293L11 6h9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
-        </svg>
-        <span className="text-sm font-medium">
-          {picking ? "Opening picker…" : "Click to select a folder"}
-        </span>
-      </button>
-
-      {/* Selected folder display */}
-      {selectedPath && (
-        <div className="space-y-3">
-          <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              className="shrink-0 text-amber-500"
-            >
-              <path d="M2 6a2 2 0 0 1 2-2h4.586a1 1 0 0 1 .707.293L11 6h9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
-            </svg>
-            <span className="text-sm font-mono truncate flex-1">
-              {selectedPath}
-            </span>
-            <button
-              type="button"
-              onClick={pickFolder}
-              className="text-xs text-muted-foreground hover:text-foreground underline shrink-0"
-            >
-              Change
-            </button>
-          </div>
-
-          {validation?.existingProjectSlug && (
-            <div className="flex items-center gap-2 text-sm text-amber-600 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 rounded-md">
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="shrink-0"
-              >
-                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-                <line x1="12" y1="9" x2="12" y2="13" />
-                <line x1="12" y1="17" x2="12.01" y2="17" />
-              </svg>
-              <span className="flex-1">
-                Project already exists.{" "}
-                <button
-                  type="button"
-                  className="underline font-medium"
-                  onClick={() => {
-                    onClose();
-                    navigate({
-                      to: "/$org/$project",
-                      params: {
-                        org: org.slug,
-                        project: validation.existingProjectSlug!,
-                      },
-                    });
-                  }}
-                >
-                  Open it
-                </button>
-              </span>
-            </div>
-          )}
-
-          {validation?.valid && !validation.existingProjectSlug && (
-            <>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label className="text-xs">Name</Label>
-                  <Input
-                    value={folderName}
-                    onChange={(e) => setFolderName(e.target.value)}
-                    disabled={createMutation.isPending}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label className="text-xs">Slug</Label>
-                  <Input
-                    value={folderSlug}
-                    onChange={(e) =>
-                      setFolderSlug(
-                        e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""),
-                      )
-                    }
-                    disabled={createMutation.isPending}
-                  />
-                </div>
-              </div>
-              <div className="space-y-1.5">
-                <Label className="text-xs">Color</Label>
-                <ColorPicker
-                  value={bannerColor}
-                  onChange={(c) => setBannerColor(c ?? "#10B981")}
-                />
-              </div>
-            </>
-          )}
-        </div>
-      )}
-
-      <DialogFooter>
-        <Button variant="outline" onClick={onBack}>
-          Back
-        </Button>
-        {validation?.existingProjectSlug ? (
-          <Button
-            onClick={() => {
-              onClose();
-              navigate({
-                to: "/$org/$project",
-                params: {
-                  org: org.slug,
-                  project: validation.existingProjectSlug!,
-                },
-              });
-            }}
-          >
-            Open Project
-          </Button>
-        ) : (
-          <Button
-            onClick={() => createMutation.mutate()}
-            disabled={
-              !selectedPath ||
-              !validation?.valid ||
-              !folderName ||
-              !folderSlug ||
-              createMutation.isPending
-            }
-          >
-            {createMutation.isPending ? "Creating…" : "Create Project"}
-          </Button>
-        )}
-      </DialogFooter>
-    </>
   );
 }
 

--- a/apps/mesh/src/web/components/create-project-dialog.tsx
+++ b/apps/mesh/src/web/components/create-project-dialog.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { toast } from "sonner";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ORG_ADMIN_PROJECT_SLUG,
@@ -30,10 +30,41 @@ import {
 import { Input } from "@deco/ui/components/input.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
 import { KEYS } from "@/web/lib/query-keys";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { generateSlug, isValidSlug } from "@/web/lib/slug";
 import { ColorPicker } from "./color-picker";
 import type { Project } from "@/web/hooks/use-project";
+import type { PublicConfig } from "@/api/routes/public-config";
+
+// ---- Types ----
+
+export type Step = "select" | "folder" | "blank";
+
+interface PickFolderResult {
+  path?: string;
+  cancelled?: boolean;
+  error?: string;
+}
+
+interface ValidateResult {
+  valid: boolean;
+  name?: string;
+  slug?: string;
+  folderPath?: string;
+  existingProjectSlug?: string;
+  error?: string;
+}
+
+interface CreateFromFolderResult {
+  project: { id: string; slug: string; name: string };
+  connectionId: string;
+  virtualMcpId?: string;
+  existing?: boolean;
+}
+
+// ---- Blank Project Form Schema ----
 
 const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(200),
@@ -43,19 +74,495 @@ const formSchema = z.object({
 });
 
 type FormData = z.infer<typeof formSchema>;
+type ProjectCreateOutput = { project: Project };
+
+// ---- Dialog Props ----
 
 interface CreateProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Override the initial step (e.g. "folder" to skip mode selection) */
+  initialStep?: Step;
 }
-
-type ProjectCreateOutput = { project: Project };
 
 export function CreateProjectDialog({
   open,
   onOpenChange,
+  initialStep,
 }: CreateProjectDialogProps) {
   const { org } = useProjectContext();
+
+  // Check if local mode
+  const { data: publicConfig } = useQuery<PublicConfig>({
+    queryKey: KEYS.publicConfig(),
+  });
+  const isLocal = publicConfig?.localMode === true;
+
+  const getDefaultStep = () => initialStep ?? (isLocal ? "select" : "blank");
+  const [step, setStep] = useState<Step>(getDefaultStep());
+
+  // Reset step when dialog opens/closes
+  const handleOpenChange = (newOpen: boolean) => {
+    if (newOpen) {
+      setStep(getDefaultStep());
+    }
+    onOpenChange(newOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        {step === "select" && (
+          <ModeSelectionInDialog
+            onSelectFolder={() => setStep("folder")}
+            onSelectBlank={() => setStep("blank")}
+          />
+        )}
+        {step === "folder" && (
+          <FolderStep
+            org={org}
+            onBack={() => setStep("select")}
+            onClose={() => handleOpenChange(false)}
+          />
+        )}
+        {step === "blank" && (
+          <BlankStep
+            org={org}
+            onBack={isLocal ? () => setStep("select") : undefined}
+            onClose={() => handleOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---- Mode Selection Step ----
+
+function ModeSelectionInDialog({
+  onSelectFolder,
+  onSelectBlank,
+}: {
+  onSelectFolder: () => void;
+  onSelectBlank: () => void;
+}) {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>New Project</DialogTitle>
+        <DialogDescription>
+          Choose how to create your project.
+        </DialogDescription>
+      </DialogHeader>
+      <ModeSelectionCards
+        onSelectFolder={onSelectFolder}
+        onSelectBlank={onSelectBlank}
+      />
+    </>
+  );
+}
+
+export function ModeSelectionCards({
+  onSelectFolder,
+  onSelectBlank,
+}: {
+  onSelectFolder: () => void;
+  onSelectBlank: () => void;
+}) {
+  return (
+    <div className="grid gap-3">
+      <button
+        type="button"
+        onClick={onSelectFolder}
+        className="flex items-center gap-4 p-4 rounded-lg border border-border hover:border-foreground/20 hover:bg-accent/50 transition-colors text-left"
+      >
+        <div className="flex items-center justify-center size-10 rounded-lg bg-emerald-500/10 text-emerald-600 shrink-0">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+          </svg>
+        </div>
+        <div>
+          <div className="text-sm font-medium">From Folder</div>
+          <div className="text-xs text-muted-foreground">
+            Connect a local directory
+          </div>
+        </div>
+      </button>
+
+      <button
+        type="button"
+        disabled
+        className="flex items-center gap-4 p-4 rounded-lg border border-border opacity-50 cursor-not-allowed text-left"
+      >
+        <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground shrink-0">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+          </svg>
+        </div>
+        <div className="flex items-center gap-2">
+          <div>
+            <div className="text-sm font-medium">From GitHub</div>
+            <div className="text-xs text-muted-foreground">
+              Import from repository
+            </div>
+          </div>
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+            Soon
+          </Badge>
+        </div>
+      </button>
+
+      <button
+        type="button"
+        onClick={onSelectBlank}
+        className="flex items-center gap-4 p-4 rounded-lg border border-border hover:border-foreground/20 hover:bg-accent/50 transition-colors text-left"
+      >
+        <div className="flex items-center justify-center size-10 rounded-lg bg-muted text-muted-foreground shrink-0">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </div>
+        <div>
+          <div className="text-sm font-medium">Blank Project</div>
+          <div className="text-xs text-muted-foreground">
+            Start from scratch
+          </div>
+        </div>
+      </button>
+    </div>
+  );
+}
+
+// ---- Folder Step ----
+
+function FolderStep({
+  org,
+  onBack,
+  onClose,
+}: {
+  org: { id: string; slug: string; name: string };
+  onBack: () => void;
+  onClose: () => void;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [folderName, setFolderName] = useState("");
+  const [folderSlug, setFolderSlug] = useState("");
+  const [bannerColor, setBannerColor] = useState("#10B981");
+  const [picking, setPicking] = useState(false);
+
+  // Validate selected folder
+  const { data: validation } = useQuery<ValidateResult>({
+    queryKey: ["local-dev", "validate", selectedPath],
+    queryFn: async () => {
+      const res = await fetch("/api/local-dev/validate-folder", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ folderPath: selectedPath }),
+      });
+      return res.json();
+    },
+    enabled: !!selectedPath,
+  });
+
+  // Auto-fill name/slug when validation succeeds
+  const validationName = validation?.name;
+  const validationSlug = validation?.slug;
+  if (validationName && !folderName) {
+    setFolderName(validationName);
+  }
+  if (validationSlug && !folderSlug) {
+    setFolderSlug(validationSlug);
+  }
+
+  // Open native folder picker
+  const pickFolder = async () => {
+    setPicking(true);
+    try {
+      const res = await fetch("/api/local-dev/pick-folder", {
+        method: "POST",
+        credentials: "include",
+      });
+      const data: PickFolderResult = await res.json();
+      if (data.path) {
+        setSelectedPath(data.path);
+        setFolderName("");
+        setFolderSlug("");
+      }
+    } catch {
+      toast.error("Failed to open folder picker");
+    } finally {
+      setPicking(false);
+    }
+  };
+
+  // Create project mutation
+  const createMutation = useMutation({
+    mutationFn: async (): Promise<CreateFromFolderResult> => {
+      const res = await fetch("/api/local-dev/create-project", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          folderPath: selectedPath,
+          name: folderName,
+          slug: folderSlug,
+          bannerColor,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: "Unknown error" }));
+        throw new Error(err.error || `HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: async (result) => {
+      const locator =
+        `${org.slug}/${result.project.slug}` as `${string}/${string}`;
+      if (result.virtualMcpId) {
+        localStorage.setItem(
+          `${locator}:selected-virtual-mcp-id`,
+          JSON.stringify(result.virtualMcpId),
+        );
+      }
+      localStorage.setItem(
+        LOCALSTORAGE_KEYS.chatSelectedMode(locator),
+        JSON.stringify("passthrough"),
+      );
+
+      toast.success(`Project "${result.project.name}" created`);
+      await queryClient.invalidateQueries();
+      onClose();
+      navigate({
+        to: "/$org/$project",
+        params: { org: org.slug, project: result.project.slug },
+      });
+    },
+    onError: (error) => {
+      toast.error(
+        `Failed to create project: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    },
+  });
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex items-center justify-center size-6 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          From Folder
+        </DialogTitle>
+        <DialogDescription>
+          Select a local directory to create your project.
+        </DialogDescription>
+      </DialogHeader>
+
+      {/* Folder picker card */}
+      <button
+        type="button"
+        onClick={pickFolder}
+        disabled={picking}
+        className="flex flex-col items-center justify-center gap-3 w-full rounded-lg border-2 border-dashed border-border py-8 px-4 text-muted-foreground hover:border-foreground/20 hover:bg-accent/30 hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait"
+      >
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="text-amber-500"
+        >
+          <path d="M2 6a2 2 0 0 1 2-2h4.586a1 1 0 0 1 .707.293L11 6h9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
+        </svg>
+        <span className="text-sm font-medium">
+          {picking ? "Opening picker…" : "Click to select a folder"}
+        </span>
+      </button>
+
+      {/* Selected folder display */}
+      {selectedPath && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="shrink-0 text-amber-500"
+            >
+              <path d="M2 6a2 2 0 0 1 2-2h4.586a1 1 0 0 1 .707.293L11 6h9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6Z" />
+            </svg>
+            <span className="text-sm font-mono truncate flex-1">
+              {selectedPath}
+            </span>
+            <button
+              type="button"
+              onClick={pickFolder}
+              className="text-xs text-muted-foreground hover:text-foreground underline shrink-0"
+            >
+              Change
+            </button>
+          </div>
+
+          {validation?.existingProjectSlug && (
+            <div className="flex items-center gap-2 text-sm text-amber-600 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 rounded-md">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="shrink-0"
+              >
+                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+              <span className="flex-1">
+                Project already exists.{" "}
+                <button
+                  type="button"
+                  className="underline font-medium"
+                  onClick={() => {
+                    onClose();
+                    navigate({
+                      to: "/$org/$project",
+                      params: {
+                        org: org.slug,
+                        project: validation.existingProjectSlug!,
+                      },
+                    });
+                  }}
+                >
+                  Open it
+                </button>
+              </span>
+            </div>
+          )}
+
+          {validation?.valid && !validation.existingProjectSlug && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Name</Label>
+                  <Input
+                    value={folderName}
+                    onChange={(e) => setFolderName(e.target.value)}
+                    disabled={createMutation.isPending}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-xs">Slug</Label>
+                  <Input
+                    value={folderSlug}
+                    onChange={(e) =>
+                      setFolderSlug(
+                        e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""),
+                      )
+                    }
+                    disabled={createMutation.isPending}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Color</Label>
+                <ColorPicker
+                  value={bannerColor}
+                  onChange={(c) => setBannerColor(c ?? "#10B981")}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        {validation?.existingProjectSlug ? (
+          <Button
+            onClick={() => {
+              onClose();
+              navigate({
+                to: "/$org/$project",
+                params: {
+                  org: org.slug,
+                  project: validation.existingProjectSlug!,
+                },
+              });
+            }}
+          >
+            Open Project
+          </Button>
+        ) : (
+          <Button
+            onClick={() => createMutation.mutate()}
+            disabled={
+              !selectedPath ||
+              !validation?.valid ||
+              !folderName ||
+              !folderSlug ||
+              createMutation.isPending
+            }
+          >
+            {createMutation.isPending ? "Creating…" : "Create Project"}
+          </Button>
+        )}
+      </DialogFooter>
+    </>
+  );
+}
+
+// ---- Blank Step (existing form) ----
+
+function BlankStep({
+  org,
+  onBack,
+  onClose,
+}: {
+  org: { id: string; slug: string; name: string };
+  onBack?: () => void;
+  onClose: () => void;
+}) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
@@ -100,15 +607,9 @@ export function CreateProjectDialog({
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: KEYS.projects(org.id) });
       toast.success("Project created successfully");
-      onOpenChange(false);
-      form.reset({
-        name: "",
-        slug: "",
-        description: "",
-        bannerColor: "#3B82F6",
-      });
+      onClose();
+      form.reset();
       setSlugManuallyEdited(false);
-      // Navigate to the new project
       navigate({
         to: "/$org/$project",
         params: { org: org.slug, project: result.project.slug },
@@ -123,7 +624,6 @@ export function CreateProjectDialog({
   });
 
   const onSubmit = async (data: FormData) => {
-    // Validate slug before submitting
     if (!isValidSlug(data.slug)) {
       form.setError("slug", {
         message: "Slug must be lowercase alphanumeric with hyphens only",
@@ -139,14 +639,11 @@ export function CreateProjectDialog({
     await mutation.mutateAsync(data);
   };
 
-  // Auto-generate slug from name
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const name = e.target.value;
     form.setValue("name", name);
-
     if (!slugManuallyEdited) {
-      const slug = generateSlug(name);
-      form.setValue("slug", slug);
+      form.setValue("slug", generateSlug(name));
     }
   };
 
@@ -161,149 +658,174 @@ export function CreateProjectDialog({
   const bannerColor = form.watch("bannerColor");
   const slug = form.watch("slug");
   const name = form.watch("name");
-
   const isSlugReserved = slug === ORG_ADMIN_PROJECT_SLUG;
   const isSlugInvalid = slug.length > 0 && !isValidSlug(slug);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Create New Project</DialogTitle>
-          <DialogDescription>
-            Set up a new project in {org.name}. You can configure plugins and
-            settings after creation.
-          </DialogDescription>
-        </DialogHeader>
-
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            {/* Banner Preview */}
-            <div
-              className="h-20 rounded-lg relative"
-              style={{ backgroundColor: bannerColor ?? "#3B82F6" }}
+    <>
+      <DialogHeader>
+        <DialogTitle>
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground mr-2"
             >
-              <div className="absolute -bottom-4 left-4">
-                <div
-                  className="size-12 rounded-lg border-2 border-background flex items-center justify-center text-lg font-semibold text-white"
-                  style={{ backgroundColor: bannerColor ?? "#3B82F6" }}
-                >
-                  {name?.charAt(0)?.toUpperCase() || "P"}
-                </div>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+          )}
+          Create New Project
+        </DialogTitle>
+        <DialogDescription>
+          Set up a new project in {org.name}. You can configure plugins and
+          settings after creation.
+        </DialogDescription>
+      </DialogHeader>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          {/* Banner Preview */}
+          <div
+            className="h-20 rounded-lg relative"
+            style={{ backgroundColor: bannerColor ?? "#3B82F6" }}
+          >
+            <div className="absolute -bottom-4 left-4">
+              <div
+                className="size-12 rounded-lg border-2 border-background flex items-center justify-center text-lg font-semibold text-white"
+                style={{ backgroundColor: bannerColor ?? "#3B82F6" }}
+              >
+                {name?.charAt(0)?.toUpperCase() || "P"}
               </div>
             </div>
+          </div>
 
-            {/* Banner Color */}
-            <div className="space-y-2 pt-4">
-              <Label>Banner Color</Label>
-              <ColorPicker
-                value={bannerColor ?? null}
-                onChange={(color) => form.setValue("bannerColor", color)}
-              />
-            </div>
+          <div className="space-y-2 pt-4">
+            <Label>Banner Color</Label>
+            <ColorPicker
+              value={bannerColor ?? null}
+              onChange={(color) => form.setValue("bannerColor", color)}
+            />
+          </div>
 
-            {/* Name */}
-            <FormField
-              control={form.control}
-              name="name"
-              render={() => (
-                <FormItem>
-                  <FormLabel>Project Name *</FormLabel>
+          <FormField
+            control={form.control}
+            name="name"
+            render={() => (
+              <FormItem>
+                <FormLabel>Project Name *</FormLabel>
+                <FormControl>
+                  <Input
+                    value={name}
+                    onChange={handleNameChange}
+                    placeholder="My Awesome Project"
+                    autoFocus
+                    disabled={mutation.isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="slug"
+            render={() => (
+              <FormItem>
+                <FormLabel>Slug *</FormLabel>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    /{org.slug}/
+                  </span>
                   <FormControl>
                     <Input
-                      value={name}
-                      onChange={handleNameChange}
-                      placeholder="My Awesome Project"
-                      autoFocus
+                      value={slug}
+                      onChange={handleSlugChange}
+                      placeholder="my-awesome-project"
+                      className="flex-1"
                       disabled={mutation.isPending}
                     />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                </div>
+                {isSlugReserved && (
+                  <p className="text-xs text-destructive">
+                    &quot;{ORG_ADMIN_PROJECT_SLUG}&quot; is a reserved slug
+                  </p>
+                )}
+                {isSlugInvalid && !isSlugReserved && (
+                  <p className="text-xs text-destructive">
+                    Slug must be lowercase alphanumeric with hyphens only
+                  </p>
+                )}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            {/* Slug */}
-            <FormField
-              control={form.control}
-              name="slug"
-              render={() => (
-                <FormItem>
-                  <FormLabel>Slug *</FormLabel>
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-muted-foreground">
-                      /{org.slug}/
-                    </span>
-                    <FormControl>
-                      <Input
-                        value={slug}
-                        onChange={handleSlugChange}
-                        placeholder="my-awesome-project"
-                        className="flex-1"
-                        disabled={mutation.isPending}
-                      />
-                    </FormControl>
-                  </div>
-                  {isSlugReserved && (
-                    <p className="text-xs text-destructive">
-                      "{ORG_ADMIN_PROJECT_SLUG}" is a reserved slug
-                    </p>
-                  )}
-                  {isSlugInvalid && !isSlugReserved && (
-                    <p className="text-xs text-destructive">
-                      Slug must be lowercase alphanumeric with hyphens only
-                    </p>
-                  )}
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    placeholder="What is this project for?"
+                    rows={2}
+                    disabled={mutation.isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            {/* Description */}
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Description</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      placeholder="What is this project for?"
-                      rows={2}
-                      disabled={mutation.isPending}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <DialogFooter>
+          <DialogFooter>
+            {onBack && (
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => onOpenChange(false)}
+                onClick={onBack}
                 disabled={mutation.isPending}
               >
-                Cancel
+                Back
               </Button>
-              <Button
-                type="submit"
-                disabled={
-                  mutation.isPending ||
-                  isSlugReserved ||
-                  isSlugInvalid ||
-                  !name ||
-                  !slug
-                }
-              >
-                {mutation.isPending ? "Creating..." : "Create Project"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                mutation.isPending ||
+                isSlugReserved ||
+                isSlugInvalid ||
+                !name ||
+                !slug
+              }
+            >
+              {mutation.isPending ? "Creating..." : "Create Project"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </>
   );
 }

--- a/apps/mesh/src/web/components/git-panel.tsx
+++ b/apps/mesh/src/web/components/git-panel.tsx
@@ -1,0 +1,916 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  SELF_MCP_ALIAS_ID,
+  useChatBridge,
+  useMCPClientOptional,
+  useProjectContext,
+  Locator,
+} from "@decocms/mesh-sdk";
+import { useAiProviderKeyList } from "@/web/hooks/collections/use-llm";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useConnectionWatch } from "@/web/hooks/use-connection-watch";
+import { KEYS } from "@/web/lib/query-keys";
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  gitBranch,
+  gitBranchList,
+  gitCheckoutBranch,
+  gitStatus,
+  gitDiff,
+  gitLog,
+  gitCommit,
+  gitCheckoutNewBranch,
+  type ChangedFile,
+} from "@/web/lib/git-api";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@deco/ui/components/command.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
+import {
+  AlertTriangle,
+  Check,
+  GitBranch01,
+  GitCommit as GitCommitIcon,
+  Loading01,
+  File06,
+  Plus,
+  Minus,
+  Edit04,
+  RefreshCw01,
+  ChevronDown,
+  ChevronRight,
+  Stars01,
+} from "@untitledui/icons";
+
+const GIT_QUERY_KEYS = {
+  branch: KEYS.gitBranch,
+  branchList: KEYS.gitBranchList,
+  status: KEYS.gitStatus,
+  diff: KEYS.gitDiff,
+  log: KEYS.gitLog,
+};
+
+// ============================================================================
+// AI Helpers
+// ============================================================================
+
+/** Keywords to match cheap/fast models, in priority order */
+const FAST_MODEL_KEYWORDS = [
+  "haiku",
+  "gemini-2.5-flash-lite",
+  "gemini-2.5-flash",
+  "gemini-3-flash",
+  "flash-lite",
+  "ministral",
+];
+
+/**
+ * Call LLM_DO_GENERATE on a model connection's MCP client.
+ */
+async function llmGenerate(
+  modelClient: Client,
+  modelId: string,
+  systemPrompt: string,
+  userMessage: string,
+): Promise<string> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("LLM generation timed out")), 15_000),
+  );
+  const result = await Promise.race([
+    modelClient.callTool({
+      name: "LLM_DO_GENERATE",
+      arguments: {
+        modelId,
+        callOptions: {
+          prompt: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: [{ type: "text", text: userMessage }] },
+          ],
+          maxOutputTokens: 500,
+          temperature: 0,
+          providerOptions: {
+            openrouter: { reasoning: { exclude: true } },
+          },
+        },
+      },
+    }),
+    timeout,
+  ]);
+
+  // structuredContent follows LanguageModelGenerateOutputSchema:
+  // { content: [{ type: "text", text: "..." }, ...], finishReason, usage }
+  const structured = result.structuredContent as
+    | { content?: { type: string; text?: string }[] }
+    | undefined;
+  if (structured?.content) {
+    const textPart = structured.content.find((p) => p.type === "text");
+    if (textPart?.text) return textPart.text.trim();
+  }
+
+  // Fallback: parse from MCP text content envelope
+  if (result.content && Array.isArray(result.content)) {
+    const textEntry = result.content.find(
+      (c: { type: string }) => c.type === "text",
+    );
+    if (textEntry) {
+      try {
+        const parsed = JSON.parse((textEntry as { text: string }).text);
+        // Could be the full output schema wrapped in text
+        const inner = parsed.content ?? parsed;
+        if (Array.isArray(inner)) {
+          const tp = inner.find((p: { type: string }) => p.type === "text");
+          if (tp?.text) return tp.text.trim();
+        }
+        if (parsed.text) return parsed.text.trim();
+      } catch {
+        return (textEntry as { text: string }).text.trim();
+      }
+    }
+  }
+  return "";
+}
+
+/**
+ * List available models from the model connection and pick the cheapest fast one.
+ */
+async function pickFastModel(modelClient: Client): Promise<string | null> {
+  try {
+    const result = await modelClient.callTool({
+      name: "COLLECTION_LLM_LIST",
+      arguments: {},
+    });
+    const structured = result.structuredContent as
+      | { items?: { id: string }[] }
+      | undefined;
+    const items = structured?.items ?? [];
+    const ids = items.map((m) => m.id);
+
+    for (const keyword of FAST_MODEL_KEYWORDS) {
+      const match = ids.find((id) => id.toLowerCase().includes(keyword));
+      if (match) return match;
+    }
+    // Fallback to first available model
+    return ids[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const COMMIT_MESSAGE_PROMPT = `You generate concise git commit messages. Given a diff and list of changed files, write a single-line commit message following conventional commits format (e.g. "feat: ...", "fix: ...", "chore: ..."). No explanation, just the message. Max 72 characters.`;
+
+/**
+ * Hook to check if AI commit messages are available.
+ * Uses the new AI provider key system — if there's at least one key,
+ * we can use the self MCP's LLM_DO_GENERATE tool.
+ */
+function useModelClient(): {
+  modelClient: Client | null;
+  modelId: string | null;
+} {
+  const { org } = useProjectContext();
+  let keys: { id: string }[] = [];
+  try {
+    keys = useAiProviderKeyList();
+  } catch {
+    // Suspense boundary may not be present; treat as no keys
+  }
+  const hasKeys = keys.length > 0;
+
+  const modelClient = useMCPClientOptional({
+    connectionId: hasKeys ? SELF_MCP_ALIAS_ID : undefined,
+    orgId: org.id,
+  });
+
+  return { modelClient: hasKeys ? modelClient : null, modelId: null };
+}
+
+// ============================================================================
+// Status helpers
+// ============================================================================
+
+function statusIcon(status: ChangedFile["status"]) {
+  switch (status) {
+    case "M":
+      return <Edit04 size={14} className="text-yellow-500" />;
+    case "A":
+    case "?":
+      return <Plus size={14} className="text-green-500" />;
+    case "D":
+      return <Minus size={14} className="text-red-500" />;
+    default:
+      return <File06 size={14} className="text-muted-foreground" />;
+  }
+}
+
+function statusLabel(status: ChangedFile["status"]) {
+  switch (status) {
+    case "M":
+      return "Modified";
+    case "A":
+      return "Added";
+    case "D":
+      return "Deleted";
+    case "?":
+      return "Untracked";
+    case "R":
+      return "Renamed";
+    default:
+      return status;
+  }
+}
+
+// ============================================================================
+// Branch Section
+// ============================================================================
+
+function BranchSection({
+  client,
+  connectionId,
+  watcher,
+}: {
+  client: Client;
+  connectionId: string;
+  watcher: { pause: () => void; resume: () => void };
+}) {
+  const queryClient = useQueryClient();
+
+  const { data: branch, isLoading } = useQuery({
+    queryKey: GIT_QUERY_KEYS.branch(connectionId),
+    queryFn: () => gitBranch(client),
+    staleTime: 10_000,
+  });
+
+  const { data: branches = [] } = useQuery({
+    queryKey: GIT_QUERY_KEYS.branchList(connectionId),
+    queryFn: () => gitBranchList(client),
+    staleTime: 30_000,
+  });
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.branch(connectionId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.branchList(connectionId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.status(connectionId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.log(connectionId),
+    });
+  };
+
+  const switchBranch = useMutation({
+    mutationFn: async (name: string) => {
+      watcher.pause();
+      const result = await gitCheckoutBranch(client, name);
+      if (result.exitCode !== 0) {
+        throw new Error(
+          result.stderr.trim() ||
+            result.stdout.trim() ||
+            "Failed to switch branch",
+        );
+      }
+      return result;
+    },
+    onSettled: () => {
+      setTimeout(() => watcher.resume(), 1000);
+      invalidateAll();
+    },
+  });
+
+  const createBranch = useMutation({
+    mutationFn: async (name: string) => {
+      watcher.pause();
+      const result = await gitCheckoutNewBranch(client, name);
+      if (result.exitCode !== 0) {
+        throw new Error(
+          result.stderr.trim() ||
+            result.stdout.trim() ||
+            "Failed to create branch",
+        );
+      }
+      return result;
+    },
+    onSettled: () => {
+      setTimeout(() => watcher.resume(), 1000);
+      invalidateAll();
+    },
+  });
+
+  const isMain = branch === "main" || branch === "master";
+  const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loading01 size={14} className="animate-spin" />
+        Loading branch...
+      </div>
+    );
+  }
+
+  // Determine if search value could be a new branch name (no exact match)
+  const trimmedSearch = searchValue.trim();
+  const isNewBranch =
+    trimmedSearch.length > 0 &&
+    !branches.some((b) => b.toLowerCase() === trimmedSearch.toLowerCase());
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 min-w-0">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={switchBranch.isPending}
+              className="flex items-center gap-2 min-w-0 text-sm font-medium hover:bg-muted/50 rounded px-1.5 py-1 -ml-1.5 transition-colors"
+            >
+              <GitBranch01
+                size={16}
+                className="text-muted-foreground shrink-0"
+              />
+              <span className="truncate">{branch}</span>
+              <ChevronDown
+                size={14}
+                className="text-muted-foreground shrink-0"
+              />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[280px] p-0" align="start">
+            <Command shouldFilter={true}>
+              <CommandInput
+                placeholder="Switch or create branch..."
+                value={searchValue}
+                onValueChange={setSearchValue}
+              />
+              <CommandList>
+                <CommandEmpty>No branches found.</CommandEmpty>
+                <CommandGroup heading="Branches">
+                  {branches.map((b) => (
+                    <CommandItem
+                      key={b}
+                      value={b}
+                      onSelect={() => {
+                        if (b !== branch) {
+                          switchBranch.mutate(b);
+                        }
+                        setOpen(false);
+                        setSearchValue("");
+                      }}
+                    >
+                      <GitBranch01 size={14} className="shrink-0" />
+                      <span className="truncate">{b}</span>
+                      {b === branch && (
+                        <Check
+                          size={14}
+                          className="ml-auto shrink-0 text-foreground"
+                        />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+                {isNewBranch && (
+                  <>
+                    <CommandSeparator />
+                    <CommandGroup heading="Create">
+                      <CommandItem
+                        value={`create:${trimmedSearch}`}
+                        onSelect={() => {
+                          createBranch.mutate(trimmedSearch);
+                          setOpen(false);
+                          setSearchValue("");
+                        }}
+                      >
+                        <Plus size={14} className="shrink-0" />
+                        <span className="truncate">
+                          Create <strong>{trimmedSearch}</strong>
+                        </span>
+                      </CommandItem>
+                    </CommandGroup>
+                  </>
+                )}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+        {isMain && (
+          <Badge
+            variant="outline"
+            className="text-yellow-600 border-yellow-600/30 text-xs shrink-0"
+          >
+            <AlertTriangle size={12} className="mr-1" />
+            main
+          </Badge>
+        )}
+      </div>
+
+      {(switchBranch.isError || createBranch.isError) && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3 text-sm">
+          <p className="text-destructive font-medium mb-1">
+            <AlertTriangle size={12} className="inline mr-1.5" />
+            {switchBranch.isError
+              ? "Cannot switch branch"
+              : "Cannot create branch"}
+          </p>
+          <pre className="text-muted-foreground text-xs whitespace-pre-wrap break-words">
+            {(switchBranch.error ?? createBranch.error)?.message}
+          </pre>
+        </div>
+      )}
+
+      {isMain && (
+        <div className="rounded-md bg-yellow-500/10 border border-yellow-500/20 p-3 text-sm">
+          <p className="text-yellow-600 font-medium mb-2">
+            You're on the main branch
+          </p>
+          <p className="text-muted-foreground text-xs mb-2">
+            Create a new branch before committing changes.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Changed Files List
+// ============================================================================
+
+function ChangedFilesList({
+  client,
+  connectionId,
+  onFileClick,
+}: {
+  client: Client;
+  connectionId: string;
+  onFileClick?: (filePath: string) => void;
+}) {
+  const [showDiff, setShowDiff] = useState(false);
+
+  const { data: files = [], isLoading } = useQuery({
+    queryKey: GIT_QUERY_KEYS.status(connectionId),
+    queryFn: () => gitStatus(client),
+    staleTime: 10_000,
+  });
+
+  const { data: diff } = useQuery({
+    queryKey: GIT_QUERY_KEYS.diff(connectionId),
+    queryFn: () => gitDiff(client),
+    enabled: showDiff && files.length > 0,
+    staleTime: 5000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+        <Loading01 size={14} className="animate-spin" />
+        Checking for changes...
+      </div>
+    );
+  }
+
+  if (files.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground py-2">
+        <Check size={14} className="inline mr-1.5 text-green-500" />
+        No uncommitted changes
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 min-w-0">
+      <button
+        type="button"
+        onClick={() => setShowDiff(!showDiff)}
+        className="flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-foreground/80"
+      >
+        {showDiff ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        {files.length} changed {files.length === 1 ? "file" : "files"}
+      </button>
+      <div className="space-y-0.5">
+        {files.map((file) => (
+          <button
+            key={file.path}
+            type="button"
+            onClick={() => onFileClick?.(file.path)}
+            className="flex items-center gap-2 text-xs py-1 px-2 rounded hover:bg-muted/50 min-w-0 w-full text-left"
+          >
+            <span className="shrink-0">{statusIcon(file.status)}</span>
+            <span className="truncate flex-1 font-mono">{file.path}</span>
+            <span className="text-muted-foreground shrink-0">
+              {statusLabel(file.status)}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {showDiff && diff && (
+        <pre className="text-xs font-mono bg-muted/50 rounded-md p-3 overflow-x-auto max-h-60 whitespace-pre-wrap break-all">
+          {diff}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Commit Form
+// ============================================================================
+
+function CommitForm({
+  client,
+  connectionId,
+  modelClient,
+  watcher,
+  onCommitted,
+}: {
+  client: Client;
+  connectionId: string;
+  modelClient: Client | null;
+  watcher: { pause: () => void; resume: () => void };
+  onCommitted?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const chatBridge = useChatBridge();
+  const [message, setMessage] = useState("");
+
+  const { data: files = [] } = useQuery({
+    queryKey: GIT_QUERY_KEYS.status(connectionId),
+    queryFn: () => gitStatus(client),
+    staleTime: 10_000,
+  });
+
+  const { data: branch } = useQuery({
+    queryKey: GIT_QUERY_KEYS.branch(connectionId),
+    queryFn: () => gitBranch(client),
+    staleTime: 10_000,
+  });
+
+  const invalidateAfterCommit = () => {
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.status(connectionId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.log(connectionId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: GIT_QUERY_KEYS.diff(connectionId),
+    });
+  };
+
+  const commit = useMutation({
+    mutationFn: async (msg: string) => {
+      watcher.pause();
+      const result = await gitCommit(client, msg);
+      if (result.exitCode !== 0) {
+        const errorMsg =
+          result.stderr.trim() || result.stdout.trim() || "Commit failed";
+        throw new Error(errorMsg);
+      }
+      return result;
+    },
+    onSuccess: () => {
+      setMessage("");
+      // Cancel in-flight refetches (e.g. from the topbar watcher reacting to
+      // pre-commit hook file writes) so they don't overwrite the optimistic data.
+      queryClient.cancelQueries({
+        queryKey: GIT_QUERY_KEYS.status(connectionId),
+      });
+      queryClient.cancelQueries({
+        queryKey: GIT_QUERY_KEYS.diff(connectionId),
+      });
+      // Optimistically clear status so the topbar button updates instantly
+      queryClient.setQueryData(GIT_QUERY_KEYS.status(connectionId), []);
+      queryClient.setQueryData(GIT_QUERY_KEYS.diff(connectionId), "");
+      onCommitted?.();
+    },
+    onSettled: () => {
+      // Resume watcher after a delay to let filesystem settle, then
+      // invalidate so the real status is fetched once things are stable.
+      setTimeout(() => {
+        watcher.resume();
+        invalidateAfterCommit();
+      }, 1000);
+    },
+  });
+
+  const generateMessage = useMutation({
+    mutationFn: async () => {
+      if (!modelClient || files.length === 0) return "";
+      const modelId = await pickFastModel(modelClient);
+      if (!modelId) return "";
+
+      const diff = await gitDiff(client);
+      const fileList = files.map((f) => `${f.status} ${f.path}`).join("\n");
+      const context = `Changed files:\n${fileList}\n\nDiff (truncated):\n${diff.slice(0, 3000)}`;
+
+      const result = await llmGenerate(
+        modelClient,
+        modelId,
+        COMMIT_MESSAGE_PROMPT,
+        context,
+      );
+      return result ? result.replace(/^["']|["']$/g, "") : "";
+    },
+    onSuccess: (msg) => {
+      if (msg) setMessage(msg);
+    },
+  });
+
+  const isMain = branch === "main" || branch === "master";
+  const canCommit = files.length > 0 && message.trim() && !isMain;
+  const hasChanges = files.length > 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="relative">
+        <Textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder={
+            generateMessage.isPending
+              ? "Generating commit message..."
+              : "Describe your changes..."
+          }
+          className="text-sm min-h-[80px] resize-none"
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && canCommit) {
+              commit.mutate(message.trim());
+            }
+          }}
+        />
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-muted-foreground shrink-0">
+          {navigator.platform.includes("Mac") ? "Cmd" : "Ctrl"}+Enter
+        </span>
+        <div className="flex items-center gap-1.5">
+          {modelClient && hasChanges && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={generateMessage.isPending}
+              onClick={() => generateMessage.mutate()}
+              title="Generate commit message with AI"
+            >
+              {generateMessage.isPending ? (
+                <Loading01 size={14} className="animate-spin" />
+              ) : (
+                <Stars01 size={14} />
+              )}
+            </Button>
+          )}
+          <Button
+            size="sm"
+            disabled={!canCommit || commit.isPending}
+            onClick={() => commit.mutate(message.trim())}
+          >
+            {commit.isPending ? (
+              <Loading01 size={14} className="animate-spin mr-1.5" />
+            ) : (
+              <GitCommitIcon size={14} className="mr-1.5" />
+            )}
+            Commit
+          </Button>
+        </div>
+      </div>
+      {commit.isError && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-3 space-y-2">
+          <p className="text-destructive font-medium text-xs">
+            <AlertTriangle size={12} className="inline mr-1.5" />
+            Commit failed
+          </p>
+          <pre className="text-muted-foreground text-xs font-mono whitespace-pre-wrap break-words max-h-[40vh] overflow-y-auto bg-background/50 rounded p-2">
+            {commit.error.message}
+          </pre>
+          {chatBridge && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                chatBridge.sendMessage(
+                  `My pre-commit hook failed with the following error. Help me fix it:\n\n\`\`\`\n${commit.error.message}\n\`\`\``,
+                );
+              }}
+            >
+              <Stars01 size={14} className="mr-1.5" />
+              Help me fix
+            </Button>
+          )}
+        </div>
+      )}
+      {generateMessage.isError && (
+        <p className="text-xs text-muted-foreground">
+          Could not generate message — write one manually.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Commit History
+// ============================================================================
+
+function CommitHistory({
+  client,
+  connectionId,
+}: {
+  client: Client;
+  connectionId: string;
+}) {
+  const { data: commits = [], isLoading } = useQuery({
+    queryKey: GIT_QUERY_KEYS.log(connectionId),
+    queryFn: () => gitLog(client, 15),
+    staleTime: 10_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+        <Loading01 size={14} className="animate-spin" />
+        Loading history...
+      </div>
+    );
+  }
+
+  if (commits.length === 0) {
+    return <p className="text-sm text-muted-foreground py-2">No commits yet</p>;
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {commits.map((commit) => (
+        <div
+          key={commit.hash}
+          className="flex items-start gap-2 py-2 px-2 rounded hover:bg-muted/50 text-xs min-w-0"
+        >
+          <span className="font-mono text-muted-foreground shrink-0 pt-0.5">
+            {commit.shortHash}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-medium">{commit.message}</p>
+            <p className="text-muted-foreground truncate">
+              {commit.author} &middot; {formatRelativeDate(commit.date)}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatRelativeDate(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHrs = Math.floor(diffMins / 60);
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  const diffDays = Math.floor(diffHrs / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+// ============================================================================
+// Main Panel
+// ============================================================================
+
+export function GitPanel({
+  client,
+  connectionId,
+  connectionUrl,
+  onClose,
+}: {
+  client: Client;
+  connectionId: string;
+  connectionUrl?: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const { modelClient } = useModelClient();
+  const navigate = useNavigate();
+  const { locator } = useProjectContext();
+  const { org, project } = Locator.parse(locator);
+
+  const handleFileClick = (filePath: string) => {
+    navigate({
+      to: "/$org/$project/$pluginId/viewer",
+      params: { org, project, pluginId: "object-storage" },
+      search: { key: filePath },
+    });
+    onClose();
+  };
+
+  const refreshAll = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["git"],
+      predicate: (q) =>
+        Array.isArray(q.queryKey) && q.queryKey[2] === connectionId,
+    });
+  };
+
+  // Invalidate git queries reactively via SSE file watch
+  const watcher = useConnectionWatch(connectionId, connectionUrl, refreshAll);
+
+  return (
+    <div className="flex flex-col h-full bg-background overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+        <h2 className="text-sm font-semibold">Save Changes</h2>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={refreshAll}
+            className="h-7 w-7 p-0"
+          >
+            <RefreshCw01 size={14} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className="h-7 w-7 p-0"
+          >
+            <span className="sr-only">Close</span>
+            &times;
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+        <div className="p-4 space-y-6">
+          {/* Branch */}
+          <section>
+            <BranchSection
+              client={client}
+              connectionId={connectionId}
+              watcher={watcher}
+            />
+          </section>
+
+          {/* Changed Files */}
+          <section>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              Changes
+            </h3>
+            <ChangedFilesList
+              client={client}
+              connectionId={connectionId}
+              onFileClick={handleFileClick}
+            />
+          </section>
+
+          {/* Commit Form */}
+          <section>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              Commit
+            </h3>
+            <CommitForm
+              client={client}
+              connectionId={connectionId}
+              modelClient={modelClient}
+              watcher={watcher}
+              onCommitted={onClose}
+            />
+          </section>
+
+          {/* History */}
+          <section>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              History
+            </h3>
+            <CommitHistory client={client} connectionId={connectionId} />
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sidebar/header/account-switcher/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/header/account-switcher/index.tsx
@@ -263,7 +263,7 @@ export function MeshAccountSwitcher({
 
           <DropdownMenuSeparator />
 
-          {/* Footer actions — equal weight */}
+          {/* Footer actions */}
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="gap-2.5">
               <Building02

--- a/apps/mesh/src/web/hooks/use-connection-watch.ts
+++ b/apps/mesh/src/web/hooks/use-connection-watch.ts
@@ -1,0 +1,123 @@
+/**
+ * SSE file-watch hook for local-dev connections.
+ *
+ * Connects to the watch endpoint and fires a callback whenever files change.
+ * Used to invalidate git queries reactively instead of polling.
+ *
+ * Supports both:
+ * - Local connections (via /api/local-dev/watch/:connectionId)
+ * - External localhost connections (via connection_url derived /watch)
+ */
+
+// oxlint-disable-next-line ban-use-effect/ban-use-effect
+import { useEffect, useRef } from "react";
+
+interface WatchEvent {
+  path: string;
+  type: string;
+  timestamp: number;
+}
+
+/**
+ * Derive the watch SSE URL.
+ * - For local connections (connectionId provided, no URL): use /api/local-dev/watch/:id
+ * - For external localhost connections: derive from connection URL
+ */
+function getWatchUrl(
+  connectionId: string | undefined,
+  connectionUrl: string | undefined,
+): string | null {
+  // Local connection — use our API endpoint
+  if (connectionId && !connectionUrl) {
+    return `/api/local-dev/watch/${connectionId}`;
+  }
+  // External connection — derive from URL
+  if (connectionUrl) {
+    try {
+      const url = new URL(connectionUrl);
+      if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+        return null;
+      }
+      return `${url.protocol}//${url.host}/watch`;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Subscribe to a local-dev watch SSE endpoint.
+ * Calls `onChange` when file changes are detected.
+ * Debounces rapid bursts (e.g. git operations) to a single callback.
+ *
+ * Returns a `pause`/`resume` control object so callers can suppress
+ * events during bulk git operations (e.g. branch checkout).
+ */
+export function useConnectionWatch(
+  connectionId: string | undefined,
+  connectionUrl: string | undefined,
+  onChange: () => void,
+): { pause: () => void; resume: () => void } {
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const pausedRef = useRef(false);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    const watchUrl = getWatchUrl(connectionId, connectionUrl);
+    if (!watchUrl) return;
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let es: EventSource | null = null;
+
+    try {
+      es = new EventSource(watchUrl);
+
+      es.onmessage = (event) => {
+        if (pausedRef.current) return;
+
+        try {
+          const data = JSON.parse(event.data) as WatchEvent;
+          // Ignore node_modules, .git internals, etc.
+          if (
+            data.path.includes("node_modules") ||
+            data.path.startsWith(".git/")
+          ) {
+            return;
+          }
+        } catch {
+          // Not JSON — skip
+          return;
+        }
+
+        // Debounce: wait 500ms after last change before firing
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          onChangeRef.current();
+        }, 500);
+      };
+
+      es.onerror = () => {
+        // EventSource auto-reconnects, nothing to do
+      };
+    } catch {
+      // EventSource not available or URL invalid
+    }
+
+    return () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      es?.close();
+    };
+  }, [connectionId, connectionUrl]);
+
+  return {
+    pause: () => {
+      pausedRef.current = true;
+    },
+    resume: () => {
+      pausedRef.current = false;
+    },
+  };
+}

--- a/apps/mesh/src/web/hooks/use-git-panel.ts
+++ b/apps/mesh/src/web/hooks/use-git-panel.ts
@@ -1,0 +1,11 @@
+import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+
+export function useGitPanel() {
+  const [open, setOpen] = useLocalStorage<boolean>(
+    LOCALSTORAGE_KEYS.gitPanelOpen(),
+    false,
+  );
+
+  return [open, setOpen] as const;
+}

--- a/apps/mesh/src/web/hooks/use-local-storage.ts
+++ b/apps/mesh/src/web/hooks/use-local-storage.ts
@@ -1,3 +1,5 @@
+// oxlint-disable-next-line ban-use-effect/ban-use-effect
+import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 function safeParse<T>(value: string): T | undefined {
@@ -53,6 +55,22 @@ export function useLocalStorage<T>(
     staleTime: Infinity, // localStorage doesn't change unless we update it
     gcTime: Infinity, // Keep in cache indefinitely
   });
+
+  // Listen for external storage changes (e.g. from plugin components)
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    const qk = ["localStorage", key] as const;
+    const handler = (e: StorageEvent) => {
+      if (e.key === key && e.newValue !== null) {
+        const parsed = safeParse<T>(e.newValue);
+        if (parsed !== undefined) {
+          queryClientInstance.setQueryData(qk, parsed);
+        }
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [key, queryClientInstance]);
 
   // Mutation to write to localStorage
   const mutation = useMutation({

--- a/apps/mesh/src/web/hooks/use-project-bash.ts
+++ b/apps/mesh/src/web/hooks/use-project-bash.ts
@@ -1,0 +1,90 @@
+import {
+  useConnections,
+  useMCPClient,
+  useMCPClientOptional,
+  useProjectContext,
+  SELF_MCP_ALIAS_ID,
+} from "@decocms/mesh-sdk";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useQuery } from "@tanstack/react-query";
+import { useProject } from "@/web/hooks/use-project";
+import { KEYS } from "@/web/lib/query-keys";
+
+/** Plugin IDs that use a local-dev bash connection, in priority order */
+const BASH_PLUGIN_IDS = ["object-storage", "preview"];
+
+interface PluginConfigOutput {
+  config: { connectionId: string | null } | null;
+}
+
+/**
+ * Find the bash-capable connection configured for the current project.
+ *
+ * Looks up the project's plugin configs (object-storage, preview) to find
+ * the correct connection, avoiding cross-project collisions.
+ */
+export function useProjectBash(): {
+  client: Client | null;
+  connectionId: string | undefined;
+  connectionUrl: string | undefined;
+} {
+  const { org, project } = useProjectContext();
+  const allConnections = useConnections();
+
+  // Fetch project data to get the ID (likely cached by ProjectLayout)
+  const { data: projectData } = useProject(org.id, project.slug);
+  const projectId = projectData?.id;
+
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  // Fetch plugin configs to find the project-specific connection
+  const { data: projectConnectionId } = useQuery({
+    queryKey: KEYS.projectPluginConfigs(projectId ?? ""),
+    queryFn: async () => {
+      if (!projectId) return null;
+
+      // Check each plugin for a configured connection
+      for (const pluginId of BASH_PLUGIN_IDS) {
+        try {
+          const result = await selfClient.callTool({
+            name: "PROJECT_PLUGIN_CONFIG_GET",
+            arguments: { projectId, pluginId },
+          });
+          const data = (result.structuredContent ??
+            result) as PluginConfigOutput;
+          if (data?.config?.connectionId) {
+            return data.config.connectionId;
+          }
+        } catch {
+          // Plugin not configured, try next
+        }
+      }
+      return null;
+    },
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+
+  // Find the connection matching the project config
+  const bashConnection = projectConnectionId
+    ? allConnections.find(
+        (c) =>
+          c.id === projectConnectionId &&
+          c.tools?.some((t) => t.name === "bash"),
+      )
+    : null;
+
+  const client = useMCPClientOptional({
+    connectionId: bashConnection?.id,
+    orgId: org.id,
+  });
+
+  return {
+    client,
+    connectionId: bashConnection?.id,
+    connectionUrl: bashConnection?.connection_url ?? undefined,
+  };
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -51,6 +51,8 @@ const loginRoute = createRoute({
     z.object({
       // Regular login redirect
       next: z.string().optional(),
+      // CLI auth callback URL (deco link)
+      redirectTo: z.string().optional(),
       // OAuth flow params (passed by Better Auth MCP plugin)
       client_id: z.string().optional(),
       redirect_uri: z.string().optional(),

--- a/apps/mesh/src/web/layouts/dynamic-plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/dynamic-plugin-layout.tsx
@@ -5,14 +5,20 @@
  * Uses the plugin's renderHeader/renderEmptyState if defined, otherwise falls back to Outlet.
  */
 
-import { Outlet, useParams } from "@tanstack/react-router";
+import { Outlet, useParams, useRouteContext } from "@tanstack/react-router";
 import { Suspense } from "react";
 import { Loading01 } from "@untitledui/icons";
 import { sourcePlugins } from "../plugins";
 import { PluginLayout } from "./plugin-layout";
 
 export default function DynamicPluginLayout() {
-  const { pluginId } = useParams({ strict: false }) as { pluginId: string };
+  // Static plugin routes set pluginId in route context via beforeLoad.
+  // The $pluginId fallback route provides it as a URL param instead.
+  const routeContext = useRouteContext({ strict: false }) as {
+    pluginId?: string;
+  };
+  const params = useParams({ strict: false }) as { pluginId?: string };
+  const pluginId = routeContext?.pluginId ?? params?.pluginId ?? "";
 
   // Find the plugin by ID
   const plugin = sourcePlugins.find((p) => p.id === pluginId);

--- a/apps/mesh/src/web/layouts/plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/plugin-layout.tsx
@@ -28,7 +28,12 @@ import {
   type ConnectionEntity,
 } from "@decocms/mesh-sdk";
 import { authClient } from "@/web/lib/auth-client";
-import { Outlet, useParams, Link } from "@tanstack/react-router";
+import {
+  Outlet,
+  useParams,
+  useRouteContext,
+  Link,
+} from "@tanstack/react-router";
 import { Loading01, Settings01 } from "@untitledui/icons";
 import { Suspense, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -113,10 +118,14 @@ export function PluginLayout({
   const {
     org: orgParam,
     project: projectParam,
-    pluginId,
+    pluginId: pluginIdParam,
   } = useParams({
     strict: false,
-  }) as { org: string; project: string; pluginId: string };
+  }) as { org: string; project: string; pluginId?: string };
+  const routeContext = useRouteContext({ strict: false }) as {
+    pluginId?: string;
+  };
+  const pluginId = routeContext?.pluginId ?? pluginIdParam ?? "";
   const allConnections = useConnections();
   const { data: authSession } = authClient.useSession();
 

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
-import { Chat } from "@/web/components/chat/index";
+import { Chat, useChat } from "@/web/components/chat/index";
 import { ChatPanel } from "@/web/components/chat/side-panel-chat";
 import { CreateProjectDialog } from "@/web/components/create-project-dialog";
+import { GitPanel } from "@/web/components/git-panel";
 import { MeshSidebar } from "@/web/components/sidebar";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { MeshUserMenu } from "@/web/components/user-menu.tsx";
 import { useDecoChatOpen } from "@/web/hooks/use-deco-chat-open";
+import { useGitPanel } from "@/web/hooks/use-git-panel";
+import { useProjectBash } from "@/web/hooks/use-project-bash";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
 import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
 import { authClient } from "@/web/lib/auth-client";
@@ -22,6 +25,7 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import {
+  ChatBridgeProvider,
   ORG_ADMIN_PROJECT_SLUG,
   ProjectContextProvider,
   ProjectContextProviderProps,
@@ -77,6 +81,28 @@ function PersistentSidebarProvider({ children }: PropsWithChildren) {
   );
 }
 
+/**
+ * Git panel overlay — slides in from the right as a fixed-width panel.
+ * Rendered inside ProjectContextProvider so it has access to connections.
+ */
+/**
+ * The git panel content — only renders internals when connection is available.
+ */
+function GitPanelContent({ onClose }: { onClose: () => void }) {
+  const { client, connectionId, connectionUrl } = useProjectBash();
+
+  if (!client || !connectionId) return null;
+
+  return (
+    <GitPanel
+      client={client}
+      connectionId={connectionId}
+      connectionUrl={connectionUrl}
+      onClose={onClose}
+    />
+  );
+}
+
 function ShellLayoutInner({
   isHomeRoute,
   onCreateProject,
@@ -85,11 +111,11 @@ function ShellLayoutInner({
   onCreateProject: () => void;
 }) {
   const [chatOpen] = useDecoChatOpen();
+  const [gitPanelOpen, setGitPanelOpen] = useGitPanel();
   const [chatPanelWidth] = useLocalStorage(
     LOCALSTORAGE_KEYS.decoChatPanelWidth(),
     30,
   );
-
   return (
     <SidebarLayout
       className="flex-1 bg-sidebar"
@@ -113,8 +139,7 @@ function ShellLayoutInner({
           className="h-full"
           style={{ overflow: "visible" }}
         >
-          {/* overflow:visible overrides the library's inline overflow:hidden
-              so the card's thin border-l at x=0 isn't clipped at the boundary */}
+          {/* Main content card */}
           <ResizablePanel
             className="min-w-0 flex flex-col"
             style={{ overflow: "visible" }}
@@ -125,7 +150,7 @@ function ShellLayoutInner({
                 "border-t border-l border-sidebar-border",
                 "rounded-tl-[0.75rem]",
                 "transition-[border-radius] duration-200 ease-[var(--ease-out-quart)]",
-                chatOpen && "rounded-tr-[0.75rem] border-r",
+                (chatOpen || gitPanelOpen) && "rounded-tr-[0.75rem] border-r",
               )}
             >
               <div className="flex-1 overflow-hidden">
@@ -134,7 +159,26 @@ function ShellLayoutInner({
             </div>
           </ResizablePanel>
 
-          {/* Chat card — separate floating card, no shared border with main content */}
+          {/* Git panel card — slides in/out */}
+          <ResizableHandle className="bg-sidebar" />
+          <ResizablePanel
+            defaultSize={25}
+            minSize={gitPanelOpen ? 20 : 0}
+            className={cn(
+              "transition-[max-width] duration-200 ease-[var(--ease-out-quart)] overflow-hidden",
+              gitPanelOpen ? "max-w-[480px] bg-sidebar" : "max-w-0",
+            )}
+          >
+            <div className="h-full pl-1.5 pb-1.5">
+              <div className="h-full bg-background rounded-[0.75rem] overflow-hidden border border-sidebar-border shadow-sm">
+                <Suspense>
+                  <GitPanelContent onClose={() => setGitPanelOpen(false)} />
+                </Suspense>
+              </div>
+            </div>
+          </ResizablePanel>
+
+          {/* Chat card — slides in/out */}
           {!isHomeRoute && (
             <>
               <ResizableHandle className="bg-sidebar" />
@@ -157,6 +201,33 @@ function ShellLayoutInner({
         </ResizablePanelGroup>
       </SidebarInset>
     </SidebarLayout>
+  );
+}
+
+/**
+ * Bridges the chat context to packages via ChatBridgeProvider.
+ * Must be rendered inside Chat.Provider.
+ */
+function ChatBridgeWrapper({ children }: PropsWithChildren) {
+  const { sendMessage } = useChat();
+  const [, setChatOpen] = useDecoChatOpen();
+
+  const handleSend = (text: string) => {
+    const doc = {
+      type: "doc" as const,
+      content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+    };
+    setChatOpen(true);
+    void sendMessage(doc);
+  };
+
+  return (
+    <ChatBridgeProvider
+      sendMessage={handleSend}
+      openChat={() => setChatOpen(true)}
+    >
+      {children}
+    </ChatBridgeProvider>
   );
 }
 
@@ -192,7 +263,6 @@ function ShellLayoutContent() {
 
       return {
         org: data,
-        // Project slug comes from URL param, actual project data is fetched in project-layout
         project: {
           slug: projectSlug,
           isOrgAdmin: projectSlug === ORG_ADMIN_PROJECT_SLUG,
@@ -218,16 +288,13 @@ function ShellLayoutContent() {
     );
   }
 
-  // If org parameter exists but organization is invalid/doesn't exist, redirect to home
   if (!projectContext.org) {
-    // Prevent infinite redirect loop - only redirect if not already at home
     if (window.location.pathname !== "/") {
       window.location.href = "/";
     }
     return null;
   }
 
-  // Update project context with current project slug from URL
   const contextWithCurrentProject = {
     ...projectContext,
     project: {
@@ -242,15 +309,16 @@ function ShellLayoutContent() {
       <PersistentSidebarProvider>
         <div className="flex flex-col h-screen overflow-hidden">
           <Chat.Provider>
-            <ShellLayoutInner
-              isHomeRoute={isHomeRoute}
-              onCreateProject={() => setCreateProjectDialogOpen(true)}
-            />
+            <ChatBridgeWrapper>
+              <ShellLayoutInner
+                isHomeRoute={isHomeRoute}
+                onCreateProject={() => setCreateProjectDialogOpen(true)}
+              />
+            </ChatBridgeWrapper>
           </Chat.Provider>
         </div>
       </PersistentSidebarProvider>
 
-      {/* Create Project Dialog */}
       <CreateProjectDialog
         open={createProjectDialogOpen}
         onOpenChange={setCreateProjectDialogOpen}

--- a/apps/mesh/src/web/lib/git-api.ts
+++ b/apps/mesh/src/web/lib/git-api.ts
@@ -1,0 +1,171 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+export interface BashResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface GitCommit {
+  hash: string;
+  shortHash: string;
+  author: string;
+  date: string;
+  message: string;
+}
+
+export interface ChangedFile {
+  status: "M" | "A" | "D" | "?" | "R";
+  path: string;
+}
+
+/**
+ * Run a bash command via MCP connection and extract structured result.
+ */
+async function bash(
+  client: Client,
+  cmd: string,
+  timeout = 30000,
+): Promise<BashResult> {
+  const result = await client.callTool({
+    name: "bash",
+    arguments: { cmd, timeout },
+  });
+  // structuredContent is the parsed { stdout, stderr, exitCode }
+  if (
+    result.structuredContent &&
+    typeof result.structuredContent === "object"
+  ) {
+    return result.structuredContent as BashResult;
+  }
+  // Fallback: parse from text content
+  const text =
+    result.content &&
+    Array.isArray(result.content) &&
+    result.content[0]?.type === "text"
+      ? (result.content[0] as { text: string }).text
+      : "{}";
+  return JSON.parse(text) as BashResult;
+}
+
+/**
+ * Get current branch name.
+ */
+export async function gitBranch(client: Client): Promise<string> {
+  const r = await bash(client, "git branch --show-current");
+  return r.stdout.trim();
+}
+
+/**
+ * Get list of changed files from git status.
+ */
+export async function gitStatus(client: Client): Promise<ChangedFile[]> {
+  const r = await bash(client, "git status --porcelain");
+  if (!r.stdout.trim()) return [];
+  return r.stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      // git status --porcelain format: XY<space>path
+      // But MCP bash output may have inconsistent whitespace,
+      // so split on first space-then-non-space transition.
+      const match = line.match(/^(.{1,2})\s+(.+)$/);
+      const code = (match?.[1] ?? line.slice(0, 2)).trim();
+      const path = match?.[2] ?? line.slice(3);
+      const status =
+        code === "M" || code === "MM"
+          ? "M"
+          : code === "A" || code === "AM"
+            ? "A"
+            : code === "D"
+              ? "D"
+              : code.startsWith("R")
+                ? "R"
+                : "?";
+      return { status: status as ChangedFile["status"], path };
+    });
+}
+
+/**
+ * Get unified diff of all unstaged + staged changes.
+ */
+export async function gitDiff(client: Client): Promise<string> {
+  // Show both staged and unstaged changes
+  const [unstaged, staged] = await Promise.all([
+    bash(client, "git diff"),
+    bash(client, "git diff --cached"),
+  ]);
+  return [unstaged.stdout, staged.stdout].filter(Boolean).join("\n");
+}
+
+/**
+ * Get recent commit history.
+ */
+export async function gitLog(client: Client, limit = 10): Promise<GitCommit[]> {
+  const r = await bash(client, `git log -${limit} --format="%H|%h|%an|%aI|%s"`);
+  if (r.exitCode !== 0 || !r.stdout.trim()) return [];
+  return r.stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [hash, shortHash, author, date, ...msgParts] = line.split("|");
+      return {
+        hash: hash ?? "",
+        shortHash: shortHash ?? "",
+        author: author ?? "",
+        date: date ?? "",
+        message: msgParts.join("|"),
+      };
+    });
+}
+
+/**
+ * Stage all changes and commit.
+ */
+export async function gitCommit(
+  client: Client,
+  message: string,
+): Promise<BashResult> {
+  const escaped = message.replace(/'/g, "'\\''");
+  return bash(client, `git add -A && git commit -m '${escaped}'`);
+}
+
+/**
+ * List local branches sorted by most recent commit (newest first).
+ */
+export async function gitBranchList(client: Client): Promise<string[]> {
+  const r = await bash(
+    client,
+    "git branch --sort=-committerdate --format='%(refname:short)'",
+  );
+  if (!r.stdout.trim()) return [];
+  return r.stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((b) => b.trim());
+}
+
+/**
+ * Switch to an existing branch.
+ */
+export async function gitCheckoutBranch(
+  client: Client,
+  name: string,
+): Promise<BashResult> {
+  const sanitized = name.replace(/[^a-zA-Z0-9/_.-]/g, "-");
+  return bash(client, `git checkout ${sanitized}`);
+}
+
+/**
+ * Create and switch to a new branch.
+ */
+export async function gitCheckoutNewBranch(
+  client: Client,
+  name: string,
+): Promise<BashResult> {
+  const sanitized = name.replace(/[^a-zA-Z0-9/_-]/g, "-");
+  return bash(client, `git checkout -b ${sanitized}`);
+}

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -23,6 +23,7 @@ export const LOCALSTORAGE_KEYS = {
   sidebarOpen: () => `mesh:sidebar-open`,
   selectedRegistry: (org: string) => `mesh:store:selected-registry:${org}`,
   orgHomeQuickstart: (org: string) => `mesh:org-home:quickstart:${org}`,
+  gitPanelOpen: () => `mesh:git-panel:open`,
   storeShowStdio: () => `mesh:store:show-stdio`,
   preferences: () => `mesh:user:preferences`,
   pluginConnection: (org: string, pluginId: string) =>

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -260,4 +260,11 @@ export const KEYS = {
 
   // AI provider stored keys (scoped by locator)
   aiProviderKeys: (locator: string) => ["ai-provider-keys", locator] as const,
+
+  // Git panel (scoped by connection)
+  gitBranch: (connId: string) => ["git", "branch", connId] as const,
+  gitBranchList: (connId: string) => ["git", "branchList", connId] as const,
+  gitStatus: (connId: string) => ["git", "status", connId] as const,
+  gitDiff: (connId: string) => ["git", "diff", connId] as const,
+  gitLog: (connId: string) => ["git", "log", connId] as const,
 } as const;

--- a/apps/mesh/src/web/routes/login.tsx
+++ b/apps/mesh/src/web/routes/login.tsx
@@ -123,11 +123,27 @@ function RunSSO({
   return <SplashScreen />;
 }
 
+/**
+ * Validate that a URL targets localhost only (prevents open redirect attacks).
+ */
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "http:" &&
+      (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export default function LoginRoute() {
   const session = authClient.useSession();
   const searchParams = useSearch({ from: "/login" });
   const {
     next = "/",
+    redirectTo,
     client_id,
     redirect_uri,
     response_type,
@@ -150,14 +166,23 @@ export default function LoginRoute() {
     code_challenge_method,
   });
 
+  // CLI auth callback URL (deco link) — only allow localhost targets
+  const cliCallbackUrl =
+    redirectTo && isLocalhostUrl(redirectTo) ? redirectTo : null;
+
   // Determine where to redirect after login
-  // If OAuth flow, redirect to authorize endpoint; otherwise use `next` param
-  const redirectAfterLogin = oauthAuthorizeUrl || next;
+  // Priority: OAuth flow > CLI callback > next param
+  const redirectAfterLogin = oauthAuthorizeUrl || cliCallbackUrl || next;
 
   if (session.data) {
     // If OAuth flow, redirect to authorize endpoint to complete the flow
     if (oauthAuthorizeUrl) {
       window.location.href = oauthAuthorizeUrl;
+      return <SplashScreen />;
+    }
+    // If CLI auth flow, redirect browser to CLI's local callback server
+    if (cliCallbackUrl) {
+      window.location.href = cliCallbackUrl;
       return <SplashScreen />;
     }
     return <Navigate to={next} />;
@@ -198,7 +223,7 @@ export default function LoginRoute() {
           <div className="absolute left-0 top-1/2 -translate-y-1/2 w-px h-screen bg-brand-foreground/15" />
           <div className="absolute right-0 top-1/2 -translate-y-1/2 w-px h-screen bg-brand-foreground/15" />
 
-          <UnifiedAuthForm redirectUrl={oauthAuthorizeUrl} />
+          <UnifiedAuthForm redirectUrl={oauthAuthorizeUrl || cliCallbackUrl} />
         </div>
       </main>
     );

--- a/apps/mesh/src/web/routes/projects-list.tsx
+++ b/apps/mesh/src/web/routes/projects-list.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ORG_ADMIN_PROJECT_SLUG, useProjectContext } from "@decocms/mesh-sdk";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { useProjects } from "@/web/hooks/use-project";
 import { Page } from "@/web/components/page";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
@@ -10,9 +11,9 @@ import { EmptyState } from "@/web/components/empty-state.tsx";
 import {
   CreateProjectDialog,
   ModeSelectionCards,
-  type Step as CreateStep,
 } from "@/web/components/create-project-dialog";
 import { KEYS } from "@/web/lib/query-keys";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -27,15 +28,108 @@ export default function ProjectsListPage() {
   const { data: projects, isLoading } = useProjects(org.id);
   const [search, setSearch] = useState("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [createDialogStep, setCreateDialogStep] = useState<
-    CreateStep | undefined
-  >(undefined);
+  const [folderPicking, setFolderPicking] = useState(false);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { data: publicConfig } = useQuery<PublicConfig>({
     queryKey: KEYS.publicConfig(),
   });
   const isLocal = publicConfig?.localMode === true;
+
+  // Pick folder → validate → create project → navigate (no dialog)
+  const pickFolderAndCreate = async () => {
+    if (folderPicking) return;
+    setFolderPicking(true);
+    try {
+      // 1. Open native OS folder picker
+      const pickRes = await fetch("/api/local-dev/pick-folder", {
+        method: "POST",
+        credentials: "include",
+      });
+      const pick: { path?: string; cancelled?: boolean; error?: string } =
+        await pickRes.json();
+      if (!pick.path) return;
+
+      // 2. Validate folder (gets name/slug, checks for existing project)
+      const valRes = await fetch("/api/local-dev/validate-folder", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ folderPath: pick.path }),
+      });
+      const val: {
+        valid: boolean;
+        name?: string;
+        slug?: string;
+        existingProjectSlug?: string;
+        error?: string;
+      } = await valRes.json();
+
+      // If project already exists for this folder, navigate to it
+      if (val.existingProjectSlug) {
+        navigate({
+          to: "/$org/$project",
+          params: { org: org.slug, project: val.existingProjectSlug },
+        });
+        return;
+      }
+
+      if (!val.valid) {
+        toast.error(val.error || "Invalid folder");
+        return;
+      }
+
+      // 3. Create project automatically
+      const createRes = await fetch("/api/local-dev/create-project", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          folderPath: pick.path,
+          name: val.name,
+          slug: val.slug,
+        }),
+      });
+      if (!createRes.ok) {
+        const err = await createRes
+          .json()
+          .catch(() => ({ error: "Unknown error" }));
+        throw new Error(err.error || `HTTP ${createRes.status}`);
+      }
+      const result: {
+        project: { id: string; slug: string; name: string };
+        virtualMcpId?: string;
+      } = await createRes.json();
+
+      // 4. Set localStorage keys and navigate
+      const locator =
+        `${org.slug}/${result.project.slug}` as `${string}/${string}`;
+      if (result.virtualMcpId) {
+        localStorage.setItem(
+          `${locator}:selected-virtual-mcp-id`,
+          JSON.stringify(result.virtualMcpId),
+        );
+      }
+      localStorage.setItem(
+        LOCALSTORAGE_KEYS.chatSelectedMode(locator),
+        JSON.stringify("passthrough"),
+      );
+
+      toast.success(`Project "${result.project.name}" created`);
+      await queryClient.invalidateQueries();
+      navigate({
+        to: "/$org/$project",
+        params: { org: org.slug, project: result.project.slug },
+      });
+    } catch (err) {
+      toast.error(
+        `Failed to create project: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    } finally {
+      setFolderPicking(false);
+    }
+  };
 
   // Filter out org-admin and apply search
   const userProjects =
@@ -75,24 +169,16 @@ export default function ProjectsListPage() {
                 </p>
               </div>
               <ModeSelectionCards
-                onSelectFolder={() => {
-                  setCreateDialogStep("folder");
-                  setCreateDialogOpen(true);
-                }}
-                onSelectBlank={() => {
-                  setCreateDialogStep("blank");
-                  setCreateDialogOpen(true);
-                }}
+                onSelectFolder={pickFolderAndCreate}
+                onSelectBlank={() => setCreateDialogOpen(true)}
+                folderPicking={folderPicking}
               />
             </div>
           </div>
           <CreateProjectDialog
             open={createDialogOpen}
-            onOpenChange={(open) => {
-              setCreateDialogOpen(open);
-              if (!open) setCreateDialogStep(undefined);
-            }}
-            initialStep={createDialogStep}
+            onOpenChange={setCreateDialogOpen}
+            onPickFolder={pickFolderAndCreate}
           />
         </Page.Content>
       </Page>
@@ -199,6 +285,7 @@ export default function ProjectsListPage() {
       <CreateProjectDialog
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
+        onPickFolder={pickFolderAndCreate}
       />
     </Page>
   );

--- a/apps/mesh/src/web/routes/projects-list.tsx
+++ b/apps/mesh/src/web/routes/projects-list.tsx
@@ -1,12 +1,18 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { ORG_ADMIN_PROJECT_SLUG, useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
 import { useProjects } from "@/web/hooks/use-project";
 import { Page } from "@/web/components/page";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { ProjectCard } from "@/web/components/project-card";
 import { EmptyState } from "@/web/components/empty-state.tsx";
-import { CreateProjectDialog } from "@/web/components/create-project-dialog";
+import {
+  CreateProjectDialog,
+  ModeSelectionCards,
+  type Step as CreateStep,
+} from "@/web/components/create-project-dialog";
+import { KEYS } from "@/web/lib/query-keys";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -14,13 +20,22 @@ import {
   BreadcrumbPage,
 } from "@deco/ui/components/breadcrumb.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
+import type { PublicConfig } from "@/api/routes/public-config";
 
 export default function ProjectsListPage() {
   const { org } = useProjectContext();
   const { data: projects, isLoading } = useProjects(org.id);
   const [search, setSearch] = useState("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createDialogStep, setCreateDialogStep] = useState<
+    CreateStep | undefined
+  >(undefined);
   const navigate = useNavigate();
+
+  const { data: publicConfig } = useQuery<PublicConfig>({
+    queryKey: KEYS.publicConfig(),
+  });
+  const isLocal = publicConfig?.localMode === true;
 
   // Filter out org-admin and apply search
   const userProjects =
@@ -31,6 +46,9 @@ export default function ProjectsListPage() {
           p.name.toLowerCase().includes(search.toLowerCase()) ||
           p.description?.toLowerCase().includes(search.toLowerCase()),
       ) ?? [];
+
+  const hasProjects = !isLoading && userProjects.length > 0;
+  const isEmpty = !isLoading && userProjects.length === 0 && !search;
 
   const handleSettingsClick = (projectSlug: string) => {
     navigate({
@@ -43,9 +61,43 @@ export default function ProjectsListPage() {
     });
   };
 
-  const handleCreateProject = () => {
-    setCreateDialogOpen(true);
-  };
+  // Empty state in local mode: show creation cards centered, no header/search
+  if (isEmpty && isLocal) {
+    return (
+      <Page>
+        <Page.Content>
+          <div className="flex items-center justify-center h-full">
+            <div className="w-full max-w-sm">
+              <div className="text-center mb-6">
+                <h2 className="text-lg font-semibold">Add a project</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Choose how to get started.
+                </p>
+              </div>
+              <ModeSelectionCards
+                onSelectFolder={() => {
+                  setCreateDialogStep("folder");
+                  setCreateDialogOpen(true);
+                }}
+                onSelectBlank={() => {
+                  setCreateDialogStep("blank");
+                  setCreateDialogOpen(true);
+                }}
+              />
+            </div>
+          </div>
+          <CreateProjectDialog
+            open={createDialogOpen}
+            onOpenChange={(open) => {
+              setCreateDialogOpen(open);
+              if (!open) setCreateDialogStep(undefined);
+            }}
+            initialStep={createDialogStep}
+          />
+        </Page.Content>
+      </Page>
+    );
+  }
 
   return (
     <Page>
@@ -62,7 +114,7 @@ export default function ProjectsListPage() {
         </Page.Header.Left>
         <Page.Header.Right>
           <Button
-            onClick={handleCreateProject}
+            onClick={() => setCreateDialogOpen(true)}
             size="sm"
             className="h-7 px-3 rounded-lg text-sm font-medium"
           >
@@ -72,17 +124,19 @@ export default function ProjectsListPage() {
       </Page.Header>
 
       {/* Search Bar */}
-      <CollectionSearch
-        value={search}
-        onChange={setSearch}
-        placeholder="Search for a project..."
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            setSearch("");
-            (event.target as HTMLInputElement).blur();
-          }
-        }}
-      />
+      {hasProjects && (
+        <CollectionSearch
+          value={search}
+          onChange={setSearch}
+          placeholder="Search for a project..."
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setSearch("");
+              (event.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+      )}
 
       {/* Content */}
       <Page.Content className="@container">
@@ -110,14 +164,14 @@ export default function ProjectsListPage() {
           </div>
         )}
 
-        {/* Empty State - No projects at all */}
-        {!isLoading && userProjects.length === 0 && !search && (
+        {/* Empty State - No projects (non-local mode) */}
+        {isEmpty && !isLocal && (
           <div className="flex items-center justify-center h-full">
             <EmptyState
               title="No projects yet"
               description="Create a project to get started."
               actions={
-                <Button onClick={handleCreateProject}>
+                <Button onClick={() => setCreateDialogOpen(true)}>
                   Create new project
                 </Button>
               }
@@ -126,7 +180,7 @@ export default function ProjectsListPage() {
         )}
 
         {/* Card Grid */}
-        {!isLoading && userProjects.length > 0 && (
+        {hasProjects && (
           <div className="p-5">
             <div className="grid grid-cols-1 @lg:grid-cols-2 @4xl:grid-cols-3 @6xl:grid-cols-4 gap-4">
               {userProjects.map((project) => (

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "bun install",
-    "run": "bun run dev:conductor",
+    "run": "bun run dev:local:conductor",
     "archive": "rm -rf node_modules"
   }
 }

--- a/packages/bindings/src/core/plugin-router.tsx
+++ b/packages/bindings/src/core/plugin-router.tsx
@@ -7,6 +7,7 @@ import {
   useParams,
   useSearch,
   useLocation,
+  useRouteContext,
   Link as TanStackLink,
   type AnyRoute,
   type RouteIds,
@@ -123,11 +124,17 @@ export function createPluginRouter<TRoutes extends AnyRoute | AnyRoute[]>(
      */
     useNavigate: () => {
       const navigate = useNavigate();
-      const { org, project, pluginId } = useParams({ strict: false }) as {
+      const params = useParams({ strict: false }) as {
         org: string;
         project: string;
-        pluginId: string;
+        pluginId?: string;
       };
+      const routeContext = useRouteContext({ strict: false }) as {
+        pluginId?: string;
+      };
+      const org = params.org;
+      const project = params.project;
+      const pluginId = params.pluginId ?? routeContext?.pluginId ?? "";
 
       return <TTo extends TRouteId>(
         options: Omit<NavigateOptions, "to" | "params"> & {
@@ -171,11 +178,17 @@ export function createPluginRouter<TRoutes extends AnyRoute | AnyRoute[]>(
         children?: ReactNode;
       },
     ) {
-      const { org, project, pluginId } = useParams({ strict: false }) as {
+      const linkParams = useParams({ strict: false }) as {
         org: string;
         project: string;
-        pluginId: string;
+        pluginId?: string;
       };
+      const linkRouteContext = useRouteContext({ strict: false }) as {
+        pluginId?: string;
+      };
+      const org = linkParams.org;
+      const project = linkParams.project;
+      const pluginId = linkParams.pluginId ?? linkRouteContext?.pluginId ?? "";
 
       const to = prependBasePath(props.to as string, org, project, pluginId);
 

--- a/packages/local-dev/package.json
+++ b/packages/local-dev/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@decocms/local-dev",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Local filesystem, object storage, and bash tools for MCP",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.26.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.5",
+    "@types/node": "^24.6.2"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/decocms/mesh.git",
+    "directory": "packages/local-dev"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/local-dev/src/bash.ts
+++ b/packages/local-dev/src/bash.ts
@@ -1,0 +1,99 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const activeChildren = new Set<ChildProcess>();
+
+export function registerBashTool(server: McpServer, rootPath: string): void {
+  server.registerTool(
+    "bash",
+    {
+      title: "Bash",
+      description:
+        "Execute a bash command in the project folder. Unrestricted — can run git, bun, npm, deno, " +
+        "arbitrary scripts, and dev servers. Commands run with cwd set to the project root. " +
+        "For background processes, use bash & syntax (e.g. 'bun dev &'). " +
+        "Use timeout: 0 for commands with no time limit.",
+      inputSchema: {
+        cmd: z.string().describe("Bash command to execute"),
+        timeout: z
+          .number()
+          .optional()
+          .default(120000)
+          .describe(
+            "Timeout in milliseconds. Default 120s. Use 0 for no timeout.",
+          ),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+      },
+    },
+    async ({ cmd, timeout }) => {
+      return new Promise((resolve) => {
+        const child = spawn("bash", ["-c", cmd], {
+          cwd: rootPath,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        activeChildren.add(child);
+
+        let stdout = "";
+        let stderr = "";
+
+        child.stdout?.on("data", (chunk: Buffer) => {
+          stdout += chunk.toString();
+        });
+        child.stderr?.on("data", (chunk: Buffer) => {
+          stderr += chunk.toString();
+        });
+
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        if (timeout && timeout > 0) {
+          timer = setTimeout(() => {
+            child.kill("SIGTERM");
+          }, timeout);
+        }
+
+        child.on("exit", (code) => {
+          activeChildren.delete(child);
+          if (timer) clearTimeout(timer);
+          const structured = {
+            stdout: stdout.trim(),
+            stderr: stderr.trim(),
+            exitCode: code ?? -1,
+          };
+          resolve({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(structured),
+              },
+            ],
+            structuredContent: structured,
+          });
+        });
+
+        child.on("error", (err) => {
+          activeChildren.delete(child);
+          if (timer) clearTimeout(timer);
+          const structured = {
+            stdout: "",
+            stderr: err.message,
+            exitCode: -1,
+          };
+          resolve({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(structured),
+              },
+            ],
+            structuredContent: structured,
+            isError: true,
+          });
+        });
+      });
+    },
+  );
+}

--- a/packages/local-dev/src/index.ts
+++ b/packages/local-dev/src/index.ts
@@ -1,0 +1,5 @@
+export { LocalFileStorage } from "./storage.ts";
+export type { FileEntity } from "./storage.ts";
+export { registerTools } from "./tools.ts";
+export { registerBashTool } from "./bash.ts";
+export { handleWatch } from "./watch.ts";

--- a/packages/local-dev/src/logger.ts
+++ b/packages/local-dev/src/logger.ts
@@ -1,0 +1,147 @@
+/**
+ * MCP Local Dev - Logger
+ *
+ * Nice formatted logging that goes to stderr (to not interfere with stdio protocol)
+ * but uses colors/formatting that indicate it's informational, not an error.
+ */
+
+// ANSI color codes
+const colors = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+
+  // Foreground colors
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  gray: "\x1b[90m",
+  white: "\x1b[37m",
+};
+
+// Operation type colors
+const opColors: Record<string, string> = {
+  READ: colors.cyan,
+  WRITE: colors.green,
+  DELETE: colors.yellow,
+  MOVE: colors.magenta,
+  COPY: colors.blue,
+  MKDIR: colors.blue,
+  LIST: colors.gray,
+  STAT: colors.gray,
+  EDIT: colors.green,
+  SEARCH: colors.cyan,
+};
+
+function timestamp(): string {
+  const now = new Date();
+  return `${colors.dim}${now.toLocaleTimeString("en-US", { hour12: false })}${colors.reset}`;
+}
+
+function formatPath(path: string): string {
+  return `${colors.white}${path}${colors.reset}`;
+}
+
+function formatOp(op: string): string {
+  const color = opColors[op] || colors.white;
+  return `${color}${colors.bold}${op.padEnd(6)}${colors.reset}`;
+}
+
+function formatSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${colors.dim}(${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]})${colors.reset}`;
+}
+
+const prefix = `${colors.cyan}◆${colors.reset}`;
+
+/**
+ * Log a file operation
+ */
+export function logOp(
+  op: string,
+  path: string,
+  extra?: {
+    size?: number;
+    to?: string;
+    count?: number;
+    recursive?: boolean;
+    error?: string;
+  },
+): void {
+  let msg = `${prefix} ${timestamp()} ${formatOp(op)} ${formatPath(path)}`;
+
+  if (extra?.to) {
+    msg += ` ${colors.dim}→${colors.reset} ${formatPath(extra.to)}`;
+  }
+
+  if (extra?.size !== undefined) {
+    msg += ` ${formatSize(extra.size)}`;
+  }
+
+  if (extra?.count !== undefined) {
+    const recursiveLabel = extra.recursive ? " recursive" : "";
+    msg += ` ${colors.dim}(${extra.count}${recursiveLabel} items)${colors.reset}`;
+  }
+
+  if (extra?.error) {
+    msg += ` ${colors.yellow}[${extra.error}]${colors.reset}`;
+  }
+
+  console.error(msg);
+}
+
+/**
+ * Log a tool call
+ */
+export function logTool(
+  toolName: string,
+  args: Record<string, unknown>,
+  result?: { isError?: boolean },
+): void {
+  const argsStr = formatArgs(args);
+  const status = result?.isError
+    ? `${colors.yellow}✗${colors.reset}`
+    : `${colors.green}✓${colors.reset}`;
+
+  if (result) {
+    console.error(
+      `${prefix} ${timestamp()} ${colors.magenta}${colors.bold}TOOL${colors.reset}  ${colors.white}${toolName}${colors.reset}${argsStr} ${status}`,
+    );
+  } else {
+    console.error(
+      `${prefix} ${timestamp()} ${colors.magenta}${colors.bold}TOOL${colors.reset}  ${colors.white}${toolName}${colors.reset}${argsStr}`,
+    );
+  }
+}
+
+function formatArgs(args: Record<string, unknown>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return "";
+
+  const parts = entries.map(([key, value]) => {
+    let valStr: string;
+    if (typeof value === "string") {
+      // Truncate long strings
+      valStr = value.length > 50 ? `"${value.slice(0, 47)}..."` : `"${value}"`;
+    } else if (Array.isArray(value)) {
+      valStr = `[${value.length} items]`;
+    } else if (typeof value === "object" && value !== null) {
+      valStr = "{...}";
+    } else {
+      valStr = String(value);
+    }
+    return `${colors.dim}${key}=${colors.reset}${valStr}`;
+  });
+
+  return ` ${parts.join(" ")}`;
+}

--- a/packages/local-dev/src/storage.ts
+++ b/packages/local-dev/src/storage.ts
@@ -1,0 +1,448 @@
+/**
+ * Local File Storage Implementation
+ *
+ * Portable filesystem operations that work with any mounted path.
+ */
+
+import {
+  mkdir,
+  readFile,
+  writeFile,
+  unlink,
+  stat,
+  readdir,
+  rename,
+  copyFile,
+  rm,
+  open,
+} from "node:fs/promises";
+import { dirname, basename, extname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { logOp } from "./logger.ts";
+
+/**
+ * File entity returned by listing/metadata operations
+ */
+export interface FileEntity {
+  id: string;
+  title: string;
+  path: string;
+  parent: string;
+  mimeType: string;
+  size: number;
+  isDirectory: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * MIME type lookup based on file extension
+ */
+const MIME_TYPES: Record<string, string> = {
+  // Text
+  ".txt": "text/plain",
+  ".html": "text/html",
+  ".htm": "text/html",
+  ".css": "text/css",
+  ".csv": "text/csv",
+  // JavaScript/TypeScript
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".jsx": "text/javascript",
+  ".ts": "text/typescript",
+  ".tsx": "text/typescript",
+  // Data formats
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".yaml": "text/yaml",
+  ".yml": "text/yaml",
+  ".toml": "text/toml",
+  // Markdown
+  ".md": "text/markdown",
+  ".mdx": "text/mdx",
+  ".markdown": "text/markdown",
+  // Images
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".avif": "image/avif",
+  // Documents
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  // Archives
+  ".zip": "application/zip",
+  ".tar": "application/x-tar",
+  ".gz": "application/gzip",
+  // Audio
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  // Video
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+};
+
+function getMimeType(filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+function sanitizePath(path: string): string {
+  // Normalize backslashes to forward slashes (Windows compatibility)
+  return path
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((segment) => segment !== ".." && segment !== ".")
+    .join("/")
+    .replace(/^\/+/, "");
+}
+
+/**
+ * Local File Storage class
+ */
+export class LocalFileStorage {
+  private rootDir: string;
+
+  constructor(rootDir: string) {
+    this.rootDir = resolve(rootDir);
+  }
+
+  get root(): string {
+    return this.rootDir;
+  }
+
+  /**
+   * Normalize a path by stripping the root directory prefix if present.
+   * This handles cases where AI agents mistakenly include the full root path.
+   */
+  normalizePath(path: string): string {
+    let normalizedPath = path;
+
+    // Strip root directory prefix if the path starts with it
+    // Must check for trailing slash, colon, or exact match to avoid matching paths like
+    // /tmp/rootEvil when root is /tmp/root
+    const rootWithSlash = this.rootDir + "/";
+    const rootWithColon = this.rootDir + ":";
+    if (normalizedPath.startsWith(rootWithSlash)) {
+      normalizedPath = normalizedPath.slice(rootWithSlash.length);
+    } else if (normalizedPath.startsWith(rootWithColon)) {
+      // Handle colon separator (e.g., "/path/to/root:filename.png")
+      normalizedPath = normalizedPath.slice(rootWithColon.length);
+    } else if (normalizedPath === this.rootDir) {
+      // Exact match - return root
+      normalizedPath = "";
+    }
+
+    // Handle standalone colon at start (edge case)
+    if (normalizedPath.startsWith(":")) {
+      normalizedPath = normalizedPath.slice(1);
+    }
+
+    // Strip leading slashes
+    normalizedPath = normalizedPath.replace(/^\/+/, "");
+
+    return normalizedPath;
+  }
+
+  /**
+   * Resolve a relative path to an absolute path within the storage root.
+   * Public for use by tools that need the absolute path (e.g., GET_PRESIGNED_URL).
+   */
+  resolvePath(path: string): string {
+    const normalizedPath = this.normalizePath(path);
+    const sanitized = sanitizePath(normalizedPath);
+    const resolved = resolve(this.rootDir, sanitized);
+
+    // Defense-in-depth: verify resolved path is within rootDir
+    if (!resolved.startsWith(this.rootDir)) {
+      throw new Error("Path traversal attempt detected");
+    }
+
+    return resolved;
+  }
+
+  private async ensureDir(dir: string): Promise<void> {
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+  }
+
+  async getMetadata(path: string): Promise<FileEntity> {
+    const fullPath = this.resolvePath(path);
+    const stats = await stat(fullPath);
+    const name = basename(path) || path;
+    const parentPath = dirname(path);
+    const parent = parentPath === "." || parentPath === "/" ? "" : parentPath;
+    const isDirectory = stats.isDirectory();
+    const mimeType = isDirectory ? "inode/directory" : getMimeType(name);
+
+    return {
+      id: path || "/",
+      title: parent ? path : name || "Root",
+      path: path || "/",
+      parent,
+      mimeType,
+      size: stats.size,
+      isDirectory,
+      created_at: stats.birthtime.toISOString(),
+      updated_at: stats.mtime.toISOString(),
+    };
+  }
+
+  async read(
+    path: string,
+    encoding: "utf-8" | "base64" = "utf-8",
+  ): Promise<{ content: string; metadata: FileEntity }> {
+    const fullPath = this.resolvePath(path);
+    const buffer = await readFile(fullPath);
+    const content =
+      encoding === "base64"
+        ? buffer.toString("base64")
+        : buffer.toString("utf-8");
+    const metadata = await this.getMetadata(path);
+    logOp("READ", path, { size: buffer.length });
+    return { content, metadata };
+  }
+
+  async write(
+    path: string,
+    content: string,
+    options: {
+      encoding?: "utf-8" | "base64";
+      createParents?: boolean;
+      overwrite?: boolean;
+    } = {},
+  ): Promise<{ file: FileEntity }> {
+    const fullPath = this.resolvePath(path);
+
+    if (options.createParents !== false) {
+      await this.ensureDir(dirname(fullPath));
+    }
+
+    if (options.overwrite === false && existsSync(fullPath)) {
+      throw new Error(`File already exists: ${path}`);
+    }
+
+    const buffer =
+      options.encoding === "base64"
+        ? Buffer.from(content, "base64")
+        : Buffer.from(content, "utf-8");
+
+    await writeFile(fullPath, buffer);
+    const file = await this.getMetadata(path);
+    logOp("WRITE", path, { size: buffer.length });
+    return { file };
+  }
+
+  async delete(
+    path: string,
+    recursive = false,
+  ): Promise<{ success: boolean; path: string }> {
+    const fullPath = this.resolvePath(path);
+    const stats = await stat(fullPath);
+
+    if (stats.isDirectory()) {
+      if (!recursive) {
+        throw new Error("Cannot delete directory without recursive flag");
+      }
+      await rm(fullPath, { recursive: true, force: true });
+    } else {
+      await unlink(fullPath);
+    }
+
+    logOp("DELETE", path);
+    return { success: true, path };
+  }
+
+  async list(
+    folder = "",
+    options: { recursive?: boolean; filesOnly?: boolean } = {},
+  ): Promise<FileEntity[]> {
+    const fullPath = this.resolvePath(folder);
+
+    if (!existsSync(fullPath)) {
+      return [];
+    }
+
+    if (options.recursive) {
+      const files = await this.listRecursive(folder, options.filesOnly);
+      logOp("LIST", folder || "/", { count: files.length, recursive: true });
+      return files;
+    }
+
+    const entries = await readdir(fullPath, { withFileTypes: true });
+    let files: FileEntity[] = [];
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+
+      // Skip directories if filesOnly is true
+      if (options.filesOnly && entry.isDirectory()) continue;
+
+      const entryPath = folder ? `${folder}/${entry.name}` : entry.name;
+      try {
+        const metadata = await this.getMetadata(entryPath);
+        files.push(metadata);
+      } catch {
+        continue;
+      }
+    }
+
+    // Sort: directories first, then by name (only relevant if not filesOnly)
+    files = files.sort((a, b) => {
+      if (a.isDirectory && !b.isDirectory) return -1;
+      if (!a.isDirectory && b.isDirectory) return 1;
+      return a.title.localeCompare(b.title);
+    });
+
+    logOp("LIST", folder || "/", { count: files.length });
+    return files;
+  }
+
+  private async listRecursive(
+    folder = "",
+    filesOnly = false,
+  ): Promise<FileEntity[]> {
+    const fullPath = this.resolvePath(folder);
+
+    if (!existsSync(fullPath)) {
+      return [];
+    }
+
+    const entries = await readdir(fullPath, { withFileTypes: true });
+    const files: FileEntity[] = [];
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+
+      const entryPath = folder ? `${folder}/${entry.name}` : entry.name;
+
+      try {
+        const metadata = await this.getMetadata(entryPath);
+
+        if (entry.isDirectory()) {
+          if (!filesOnly) {
+            files.push(metadata);
+          }
+          const subFiles = await this.listRecursive(entryPath, filesOnly);
+          files.push(...subFiles);
+        } else {
+          files.push(metadata);
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return files;
+  }
+
+  async mkdir(path: string, recursive = true): Promise<{ folder: FileEntity }> {
+    const fullPath = this.resolvePath(path);
+    await mkdir(fullPath, { recursive });
+    const metadata = await this.getMetadata(path);
+    logOp("MKDIR", path);
+    return { folder: metadata };
+  }
+
+  async move(
+    from: string,
+    to: string,
+    overwrite = false,
+  ): Promise<{ file: FileEntity }> {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+
+    if (!overwrite && existsSync(toPath)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+
+    await this.ensureDir(dirname(toPath));
+    await rename(fromPath, toPath);
+    const file = await this.getMetadata(to);
+    logOp("MOVE", from, { to });
+    return { file };
+  }
+
+  async copy(
+    from: string,
+    to: string,
+    overwrite = false,
+  ): Promise<{ file: FileEntity }> {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+
+    if (!overwrite && existsSync(toPath)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+
+    await this.ensureDir(dirname(toPath));
+    await copyFile(fromPath, toPath);
+    const file = await this.getMetadata(to);
+    logOp("COPY", from, { to });
+    return { file };
+  }
+
+  /**
+   * Write a readable stream directly to disk without buffering in memory.
+   * Used for streaming large downloads directly to filesystem.
+   */
+  async writeStream(
+    path: string,
+    stream: ReadableStream<Uint8Array> | NodeJS.ReadableStream,
+    options: {
+      createParents?: boolean;
+      overwrite?: boolean;
+    } = {},
+  ): Promise<{ file: FileEntity; bytesWritten: number }> {
+    const fullPath = this.resolvePath(path);
+
+    if (options.createParents !== false) {
+      await this.ensureDir(dirname(fullPath));
+    }
+
+    if (options.overwrite === false && existsSync(fullPath)) {
+      throw new Error(`File already exists: ${path}`);
+    }
+
+    // Convert Web ReadableStream to Node.js Readable if needed
+    const nodeStream =
+      stream instanceof Readable
+        ? stream
+        : Readable.fromWeb(
+            stream as unknown as import("stream/web").ReadableStream,
+          );
+
+    // Track bytes written
+    let bytesWritten = 0;
+
+    // Create write stream
+    const fileHandle = await open(fullPath, "w");
+    const writeStream = fileHandle.createWriteStream();
+
+    // Create a transform stream that counts bytes with proper backpressure
+    const countingStream = new Transform({
+      transform(chunk, _encoding, callback) {
+        bytesWritten += chunk.length;
+        callback(null, chunk);
+      },
+    });
+
+    await pipeline(nodeStream, countingStream, writeStream);
+
+    const file = await this.getMetadata(path);
+    logOp("WRITE_STREAM", path, { size: bytesWritten });
+    return { file, bytesWritten };
+  }
+}

--- a/packages/local-dev/src/tools.ts
+++ b/packages/local-dev/src/tools.ts
@@ -1,0 +1,503 @@
+/**
+ * MCP Local Dev - Tool Definitions
+ *
+ * Minimal tool set:
+ * - edit_file: Reliable search/replace code edits with diff preview
+ * - OBJECT_STORAGE_BINDING tools: Required by the file browser plugin
+ *
+ * Filesystem reads/writes, git, dev servers, etc. are all handled by the
+ * bash tool (registered separately via registerBashTool).
+ *
+ * NOTE: The HTTP /files/<key> handler must call storage.resolvePath(key)
+ * and verify the result starts with storage.root before serving.
+ * This prevents path traversal attacks on presigned URLs.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { LocalFileStorage } from "./storage.ts";
+import { logTool } from "./logger.ts";
+
+/**
+ * Wrap a tool handler with logging
+ */
+function withLogging<T extends Record<string, unknown>>(
+  toolName: string,
+  handler: (args: T) => Promise<CallToolResult>,
+): (args: T) => Promise<CallToolResult> {
+  return async (args: T) => {
+    logTool(toolName, args as Record<string, unknown>);
+    const result = await handler(args);
+    return result;
+  };
+}
+
+/**
+ * Register edit_file and object storage tools on an MCP server.
+ *
+ * @param server - The MCP server instance
+ * @param storage - The LocalFileStorage instance (scopes all paths to root)
+ * @param baseFileUrl - Base URL for presigned file URLs (e.g. "/api/local-dev/files/conn_xxx")
+ */
+export function registerTools(
+  server: McpServer,
+  storage: LocalFileStorage,
+  baseFileUrl: string,
+) {
+  // ============================================================
+  // EDIT FILE - Reliable search/replace for code changes
+  // ============================================================
+
+  server.registerTool(
+    "edit_file",
+    {
+      title: "Edit File",
+      description:
+        "Make line-based edits to a text file. Each edit replaces exact text sequences " +
+        "with new content. Returns a git-style diff showing the changes made. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path to the file to edit"),
+        edits: z.array(
+          z.object({
+            oldText: z
+              .string()
+              .describe("Text to search for - must match exactly"),
+            newText: z.string().describe("Text to replace with"),
+          }),
+        ),
+        dryRun: z
+          .boolean()
+          .default(false)
+          .describe("Preview changes using git-style diff format"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: true,
+      },
+    },
+    withLogging("edit_file", async (args): Promise<CallToolResult> => {
+      try {
+        const result = await storage.read(args.path, "utf-8");
+        let content = result.content;
+        const originalContent = content;
+
+        // Apply all edits
+        for (const edit of args.edits) {
+          if (!content.includes(edit.oldText)) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Error: Could not find text to replace: "${edit.oldText.slice(0, 50)}..."`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          content = content.replace(edit.oldText, edit.newText);
+        }
+
+        // Generate diff
+        const diff = generateDiff(args.path, originalContent, content);
+
+        if (args.dryRun) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Dry run - changes not applied:\n\n${diff}`,
+              },
+            ],
+            structuredContent: { content: diff, dryRun: true },
+          };
+        }
+
+        // Apply changes
+        await storage.write(args.path, content, {
+          encoding: "utf-8",
+          createParents: false,
+          overwrite: true,
+        });
+
+        return {
+          content: [{ type: "text", text: diff }],
+          structuredContent: { content: diff },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // ============================================================
+  // OBJECT STORAGE BINDING TOOLS
+  // Required by the file browser plugin (mesh-plugin-object-storage)
+  // ============================================================
+
+  // LIST_OBJECTS - List files with S3-like interface
+  server.registerTool(
+    "LIST_OBJECTS",
+    {
+      title: "List Objects",
+      description:
+        "List files and folders with S3-compatible interface. " +
+        "Use prefix to filter by folder path, delimiter '/' to group by folders.",
+      inputSchema: {
+        prefix: z
+          .string()
+          .optional()
+          .default("")
+          .describe(
+            "Filter objects by prefix (e.g., 'folder/' for folder contents)",
+          ),
+        maxKeys: z
+          .number()
+          .optional()
+          .default(1000)
+          .describe("Maximum number of keys to return"),
+        continuationToken: z
+          .string()
+          .optional()
+          .describe("Token for pagination (offset as string)"),
+        delimiter: z
+          .string()
+          .optional()
+          .describe("Delimiter for grouping keys (typically '/')"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("LIST_OBJECTS", async (args): Promise<CallToolResult> => {
+      try {
+        const prefix = args.prefix || "";
+        const maxKeys = args.maxKeys || 1000;
+        const offset = args.continuationToken
+          ? parseInt(args.continuationToken, 10)
+          : 0;
+        const useDelimiter = args.delimiter === "/";
+
+        const allItems = await storage.list(prefix, {
+          recursive: !useDelimiter,
+          filesOnly: false,
+        });
+
+        const objects: Array<{
+          key: string;
+          size: number;
+          lastModified: string;
+          etag: string;
+        }> = [];
+
+        const commonPrefixes: string[] = [];
+        const seenPrefixes = new Set<string>();
+
+        for (const item of allItems) {
+          if (item.isDirectory) {
+            if (useDelimiter) {
+              const folderPath = item.path.endsWith("/")
+                ? item.path
+                : item.path + "/";
+              if (!seenPrefixes.has(folderPath)) {
+                seenPrefixes.add(folderPath);
+                commonPrefixes.push(folderPath);
+              }
+            }
+          } else {
+            objects.push({
+              key: item.path,
+              size: item.size,
+              lastModified: item.updated_at || new Date().toISOString(),
+              etag: `"${item.id}"`,
+            });
+          }
+        }
+
+        const paginatedObjects = objects.slice(offset, offset + maxKeys);
+        const hasMore = offset + maxKeys < objects.length;
+
+        const result = {
+          objects: paginatedObjects,
+          commonPrefixes: useDelimiter ? commonPrefixes : undefined,
+          isTruncated: hasMore,
+          nextContinuationToken: hasMore ? String(offset + maxKeys) : undefined,
+        };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // GET_OBJECT_METADATA - Get file metadata
+  server.registerTool(
+    "GET_OBJECT_METADATA",
+    {
+      title: "Get Object Metadata",
+      description: "Get metadata for a file (size, type, modified time).",
+      inputSchema: {
+        key: z.string().describe("Object key/path to get metadata for"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "GET_OBJECT_METADATA",
+      async (args): Promise<CallToolResult> => {
+        try {
+          const metadata = await storage.getMetadata(args.key);
+
+          const result = {
+            contentType: metadata.mimeType,
+            contentLength: metadata.size,
+            lastModified: metadata.updated_at || new Date().toISOString(),
+            etag: `"${metadata.id}"`,
+            metadata: {},
+          };
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${(error as Error).message}` },
+            ],
+            isError: true,
+          };
+        }
+      },
+    ),
+  );
+
+  // GET_PRESIGNED_URL - Return HTTP URL for file download
+  server.registerTool(
+    "GET_PRESIGNED_URL",
+    {
+      title: "Get Presigned URL",
+      description:
+        "Get a URL for downloading a file. Returns an HTTP URL served by the mesh server.",
+      inputSchema: {
+        key: z.string().describe("Object key/path to generate URL for"),
+        expiresIn: z
+          .number()
+          .optional()
+          .describe("Ignored for local filesystem"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("GET_PRESIGNED_URL", async (args): Promise<CallToolResult> => {
+      try {
+        storage.resolvePath(args.key);
+
+        const encodedKey = encodeURIComponent(args.key);
+        const result = {
+          url: `${baseFileUrl}/${encodedKey}`,
+          expiresIn: 3600,
+        };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // PUT_PRESIGNED_URL - Upload instructions for local filesystem
+  server.registerTool(
+    "PUT_PRESIGNED_URL",
+    {
+      title: "Put Presigned URL",
+      description:
+        "Get a URL for uploading a file. For local filesystem, use bash to write files directly.",
+      inputSchema: {
+        key: z.string().describe("Object key/path for the upload"),
+        expiresIn: z
+          .number()
+          .optional()
+          .describe("Ignored for local filesystem"),
+        contentType: z.string().optional().describe("MIME type (optional)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("PUT_PRESIGNED_URL", async (args): Promise<CallToolResult> => {
+      const encodedKey = encodeURIComponent(args.key);
+      const result = {
+        url: `${baseFileUrl}/${encodedKey}`,
+        expiresIn: 3600,
+        _note: "Use bash to write content to this path directly",
+      };
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        structuredContent: result,
+      };
+    }),
+  );
+
+  // DELETE_OBJECT - Delete a single file
+  server.registerTool(
+    "DELETE_OBJECT",
+    {
+      title: "Delete Object",
+      description: "Delete a single file or empty directory.",
+      inputSchema: {
+        key: z.string().describe("Object key/path to delete"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: true,
+      },
+    },
+    withLogging("DELETE_OBJECT", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.delete(args.key, false);
+
+        const result = { success: true, key: args.key };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        const result = {
+          success: false,
+          key: args.key,
+          error: (error as Error).message,
+        };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      }
+    }),
+  );
+
+  // DELETE_OBJECTS - Batch delete files
+  server.registerTool(
+    "DELETE_OBJECTS",
+    {
+      title: "Delete Objects",
+      description: "Delete multiple files in batch.",
+      inputSchema: {
+        keys: z
+          .array(z.string())
+          .max(1000)
+          .describe("Array of object keys/paths to delete"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: true,
+      },
+    },
+    withLogging("DELETE_OBJECTS", async (args): Promise<CallToolResult> => {
+      const deleted: string[] = [];
+      const errors: Array<{ key: string; message: string }> = [];
+
+      for (const key of args.keys) {
+        try {
+          await storage.delete(key, false);
+          deleted.push(key);
+        } catch (error) {
+          errors.push({
+            key,
+            message: (error as Error).message,
+          });
+        }
+      }
+
+      const result = { deleted, errors };
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        structuredContent: result,
+      };
+    }),
+  );
+}
+
+// ============================================================
+// HELPER FUNCTIONS
+// ============================================================
+
+/**
+ * Generate a simple diff between two strings
+ */
+function generateDiff(
+  path: string,
+  original: string,
+  modified: string,
+): string {
+  const originalLines = original.split("\n");
+  const modifiedLines = modified.split("\n");
+
+  const lines: string[] = [`--- a/${path}`, `+++ b/${path}`];
+
+  const maxLen = Math.max(originalLines.length, modifiedLines.length);
+  let inHunk = false;
+  let hunkStart = 0;
+  let hunkLines: string[] = [];
+
+  for (let i = 0; i < maxLen; i++) {
+    const orig = originalLines[i];
+    const mod = modifiedLines[i];
+
+    if (orig !== mod) {
+      if (!inHunk) {
+        inHunk = true;
+        hunkStart = i + 1;
+        if (i > 0) hunkLines.push(` ${originalLines[i - 1]}`);
+      }
+
+      if (orig !== undefined) {
+        hunkLines.push(`-${orig}`);
+      }
+      if (mod !== undefined) {
+        hunkLines.push(`+${mod}`);
+      }
+    } else if (inHunk) {
+      hunkLines.push(` ${orig}`);
+      lines.push(
+        `@@ -${hunkStart},${hunkLines.length} +${hunkStart},${hunkLines.length} @@`,
+      );
+      lines.push(...hunkLines);
+      hunkLines = [];
+      inHunk = false;
+    }
+  }
+
+  if (hunkLines.length > 0) {
+    lines.push(
+      `@@ -${hunkStart},${hunkLines.length} +${hunkStart},${hunkLines.length} @@`,
+    );
+    lines.push(...hunkLines);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/local-dev/src/watch.ts
+++ b/packages/local-dev/src/watch.ts
@@ -1,0 +1,46 @@
+import { watch } from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export function handleWatch(
+  req: IncomingMessage,
+  res: ServerResponse,
+  rootPath: string,
+): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+  });
+
+  // Send initial keepalive
+  res.write(": connected\n\n");
+
+  const watcher = watch(
+    rootPath,
+    { recursive: true },
+    (eventType, filename) => {
+      if (!filename) return;
+      const event = JSON.stringify({
+        path: filename,
+        type: eventType,
+        timestamp: Date.now(),
+      });
+      res.write(`data: ${event}\n\n`);
+    },
+  );
+
+  watcher.on("error", (err) => {
+    process.stderr.write("[watch] watcher error: " + err.message + "\n");
+  });
+
+  // Keepalive ping every 30s to prevent proxy timeouts
+  const pingInterval = setInterval(() => {
+    res.write(": ping\n\n");
+  }, 30000);
+
+  req.on("close", () => {
+    watcher.close();
+    clearInterval(pingInterval);
+  });
+}

--- a/packages/local-dev/tsconfig.json
+++ b/packages/local-dev/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@types/node", "bun"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mesh-plugin-object-storage/components/file-browser.tsx
+++ b/packages/mesh-plugin-object-storage/components/file-browser.tsx
@@ -51,6 +51,7 @@ interface FileRowProps {
   showFullPath?: boolean;
   onSelect: (selected: boolean) => void;
   onNavigate: (path: string) => void;
+  onViewFile: (key: string) => void;
   onDownload: (key: string) => void;
   onDelete: (key: string) => void;
 }
@@ -61,6 +62,7 @@ function FileRow({
   showFullPath = false,
   onSelect,
   onNavigate,
+  onViewFile,
   onDownload,
   onDelete,
 }: FileRowProps) {
@@ -76,11 +78,10 @@ function FileRow({
 
       <button
         type="button"
-        onClick={() => (item.isFolder ? onNavigate(item.key) : undefined)}
-        className={cn(
-          "flex items-center gap-2 flex-1 min-w-0 text-left",
-          item.isFolder && "cursor-pointer hover:text-primary",
-        )}
+        onClick={() =>
+          item.isFolder ? onNavigate(item.key) : onViewFile(item.key)
+        }
+        className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer hover:text-primary"
       >
         {item.isFolder ? (
           <Folder size={18} className="text-amber-500 shrink-0" />
@@ -173,6 +174,10 @@ export default function FileBrowser() {
   const navigate = objectStorageRouter.useNavigate();
 
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+
+  const viewFile = (key: string) => {
+    navigate({ to: "/viewer", search: { key } });
+  };
 
   const setPrefix = (newPath: string) => {
     setSelectedKeys(new Set()); // Clear selection when navigating folders
@@ -579,6 +584,7 @@ export default function FileBrowser() {
                 showFullPath={flat}
                 onSelect={(selected) => handleSelect(item.key, selected)}
                 onNavigate={setPrefix}
+                onViewFile={viewFile}
                 onDownload={handleDownload}
                 onDelete={(key) => deleteMutation.mutate([key])}
               />

--- a/packages/mesh-plugin-object-storage/components/file-viewer.tsx
+++ b/packages/mesh-plugin-object-storage/components/file-viewer.tsx
@@ -1,0 +1,326 @@
+/**
+ * File Viewer Route Component
+ *
+ * Dedicated route for viewing a single file's content.
+ * Navigated to via /viewer?key=path/to/file.ext
+ * Markdown files get a Raw/Preview toggle.
+ */
+
+import { useState, lazy, Suspense } from "react";
+import { OBJECT_STORAGE_BINDING } from "@decocms/bindings";
+import { usePluginContext } from "@decocms/mesh-sdk/plugins";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  ArrowLeft,
+  Loading01,
+  AlertCircle,
+  Download01,
+} from "@untitledui/icons";
+import { getFileName } from "../lib/utils";
+import { KEYS } from "../lib/query-keys";
+import { objectStorageRouter } from "../lib/router";
+
+const LazyMarkdown = lazy(() =>
+  import("@deco/ui/components/markdown.tsx").then((m) => ({
+    default: m.Markdown,
+  })),
+);
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "ico",
+  "bmp",
+  "avif",
+]);
+
+const MARKDOWN_EXTENSIONS = new Set(["md", "mdx"]);
+const JSON_EXTENSIONS = new Set(["json", "jsonl", "jsonc"]);
+
+/**
+ * Pretty-print JSON with syntax coloring via spans.
+ * Returns an array of React elements with colored tokens.
+ */
+function JsonPrettyView({ content }: { content: string }) {
+  let formatted: string;
+  try {
+    formatted = JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    // Not valid JSON — render as-is
+    return (
+      <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words">
+        {content}
+      </pre>
+    );
+  }
+
+  // Tokenize for syntax coloring
+  const lines = formatted.split("\n");
+
+  return (
+    <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words">
+      {lines.map((line, i) => (
+        <span key={i}>
+          {colorizeJsonLine(line)}
+          {i < lines.length - 1 ? "\n" : ""}
+        </span>
+      ))}
+    </pre>
+  );
+}
+
+function colorizeJsonLine(line: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let remaining = line;
+  let keyIdx = 0;
+
+  while (remaining.length > 0) {
+    // Match leading whitespace
+    const wsMatch = remaining.match(/^(\s+)/);
+    if (wsMatch) {
+      const ws = wsMatch[1]!;
+      parts.push(ws);
+      remaining = remaining.slice(ws.length);
+      continue;
+    }
+
+    // Match JSON key: "key":
+    const keyMatch = remaining.match(/^("(?:[^"\\]|\\.)*")\s*:/);
+    if (keyMatch) {
+      const keyText = keyMatch[1]!;
+      parts.push(
+        <span key={`k${keyIdx++}`} className="text-primary">
+          {keyText}
+        </span>,
+      );
+      parts.push(":");
+      remaining = remaining.slice(keyMatch[0].length);
+      continue;
+    }
+
+    // Match string value: "value"
+    const strMatch = remaining.match(/^("(?:[^"\\]|\\.)*")/);
+    if (strMatch) {
+      const strText = strMatch[1]!;
+      parts.push(
+        <span
+          key={`s${keyIdx++}`}
+          className="text-green-600 dark:text-green-400"
+        >
+          {strText}
+        </span>,
+      );
+      remaining = remaining.slice(strText.length);
+      continue;
+    }
+
+    // Match number
+    const numMatch = remaining.match(/^(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/);
+    if (numMatch) {
+      const numText = numMatch[1]!;
+      parts.push(
+        <span
+          key={`n${keyIdx++}`}
+          className="text-amber-600 dark:text-amber-400"
+        >
+          {numText}
+        </span>,
+      );
+      remaining = remaining.slice(numText.length);
+      continue;
+    }
+
+    // Match boolean/null
+    const boolMatch = remaining.match(/^(true|false|null)/);
+    if (boolMatch) {
+      const boolText = boolMatch[1]!;
+      parts.push(
+        <span
+          key={`b${keyIdx++}`}
+          className="text-violet-600 dark:text-violet-400"
+        >
+          {boolText}
+        </span>,
+      );
+      remaining = remaining.slice(boolText.length);
+      continue;
+    }
+
+    // Consume one character (brackets, commas, etc.)
+    parts.push(remaining[0]);
+    remaining = remaining.slice(1);
+  }
+
+  return parts;
+}
+
+export default function FileViewer() {
+  const { key } = objectStorageRouter.useSearch({ from: "/viewer" });
+  const navigate = objectStorageRouter.useNavigate();
+  const { connectionId, toolCaller } =
+    usePluginContext<typeof OBJECT_STORAGE_BINDING>();
+
+  const ext = key.split(".").pop()?.toLowerCase() ?? "";
+  const isImage = IMAGE_EXTENSIONS.has(ext);
+  const isMarkdown = MARKDOWN_EXTENSIONS.has(ext);
+  const isJson = JSON_EXTENSIONS.has(ext);
+  const hasPreview = isMarkdown || isJson;
+  const fileName = getFileName(key);
+
+  const [viewMode, setViewMode] = useState<"raw" | "preview">(
+    hasPreview ? "preview" : "raw",
+  );
+
+  const goBack = () => {
+    navigate({ to: "/", search: {} });
+  };
+
+  // For images: fetch only the presigned URL
+  const {
+    data: presignedUrl,
+    isLoading: isLoadingUrl,
+    error: urlError,
+  } = useQuery({
+    queryKey: KEYS.imagePreview(connectionId, key),
+    queryFn: async () => {
+      const result = await toolCaller("GET_PRESIGNED_URL", { key });
+      return result.url;
+    },
+    enabled: isImage,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // For non-images: fetch content as text
+  const {
+    data: fileData,
+    isLoading: isLoadingContent,
+    error: contentError,
+  } = useQuery({
+    queryKey: KEYS.fileContent(connectionId, key),
+    queryFn: async () => {
+      const result = await toolCaller("GET_PRESIGNED_URL", { key });
+      const response = await fetch(result.url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch file: ${response.statusText}`);
+      }
+      const text = await response.text();
+      return { text, downloadUrl: result.url };
+    },
+    enabled: !isImage,
+    staleTime: 60 * 1000,
+  });
+
+  const isLoading = isImage ? isLoadingUrl : isLoadingContent;
+  const error = isImage ? urlError : contentError;
+  const downloadUrl = isImage ? presignedUrl : fileData?.downloadUrl;
+  const textContent = fileData?.text;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border bg-background shrink-0">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="size-8 p-0"
+          onClick={goBack}
+        >
+          <ArrowLeft size={16} />
+        </Button>
+        <div className="flex flex-col min-w-0 flex-1">
+          <span className="text-sm font-medium truncate">{fileName}</span>
+          <span className="text-xs text-muted-foreground truncate">{key}</span>
+        </div>
+
+        {/* Raw / Preview toggle for markdown and JSON files */}
+        {hasPreview && textContent != null && (
+          <div className="flex items-center gap-1 rounded-md border border-border p-0.5">
+            <Button
+              variant={viewMode === "raw" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 px-2.5 text-xs"
+              onClick={() => setViewMode("raw")}
+            >
+              Raw
+            </Button>
+            <Button
+              variant={viewMode === "preview" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-7 px-2.5 text-xs"
+              onClick={() => setViewMode("preview")}
+            >
+              Preview
+            </Button>
+          </div>
+        )}
+
+        {downloadUrl && (
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={downloadUrl}
+              download={fileName}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Download01 size={14} className="mr-1" />
+              Download
+            </a>
+          </Button>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <Loading01
+              size={32}
+              className="animate-spin text-muted-foreground mb-4"
+            />
+            <p className="text-sm text-muted-foreground">Loading file...</p>
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <AlertCircle size={48} className="text-destructive mb-4" />
+            <h3 className="text-lg font-medium mb-2">Error loading file</h3>
+            <p className="text-muted-foreground text-center">
+              {error instanceof Error ? error.message : "Unknown error"}
+            </p>
+          </div>
+        ) : isImage && presignedUrl ? (
+          <div className="flex items-center justify-center p-8">
+            <img
+              src={presignedUrl}
+              alt={fileName}
+              className="max-w-full max-h-[80vh] object-contain rounded-lg"
+            />
+          </div>
+        ) : isMarkdown && textContent != null && viewMode === "preview" ? (
+          <div className="p-6 max-w-3xl mx-auto">
+            <Suspense
+              fallback={
+                <Loading01
+                  size={24}
+                  className="animate-spin text-muted-foreground"
+                />
+              }
+            >
+              <LazyMarkdown>{textContent}</LazyMarkdown>
+            </Suspense>
+          </div>
+        ) : isJson && textContent != null && viewMode === "preview" ? (
+          <JsonPrettyView content={textContent} />
+        ) : textContent != null ? (
+          <pre className="p-6 text-sm font-mono whitespace-pre-wrap break-words">
+            {textContent}
+          </pre>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/mesh-plugin-object-storage/index.tsx
+++ b/packages/mesh-plugin-object-storage/index.tsx
@@ -25,19 +25,12 @@ export const objectStoragePlugin: Plugin<typeof OBJECT_STORAGE_BINDING> = {
   renderHeader: (props) => <PluginHeader {...props} />,
   renderEmptyState: () => <PluginEmptyState />,
   setup: (context: PluginSetupContext) => {
-    const { registerSidebarGroup, registerPluginRoutes } = context;
+    const { registerRootSidebarItem, registerPluginRoutes } = context;
 
-    // Register sidebar group with items
-    registerSidebarGroup({
-      id: "object-storage",
-      label: "Object Storage",
-      items: [
-        {
-          icon: <Folder size={16} />,
-          label: "File browser",
-        },
-      ],
-      defaultExpanded: true,
+    // Register as a flat sidebar item (single entry, no accordion needed)
+    registerRootSidebarItem({
+      icon: <Folder size={16} />,
+      label: "File browser",
     });
 
     // Create and register plugin routes using the typed router

--- a/packages/mesh-plugin-object-storage/lib/query-keys.ts
+++ b/packages/mesh-plugin-object-storage/lib/query-keys.ts
@@ -20,4 +20,6 @@ export const KEYS = {
     ["object-storage", "metadata", connectionId, key] as const,
   imagePreview: (connectionId: string, key: string) =>
     ["object-storage", "image-preview", connectionId, key] as const,
+  fileContent: (connectionId: string, key: string) =>
+    ["object-storage", "file-content", connectionId, key] as const,
 } as const;

--- a/packages/mesh-plugin-object-storage/lib/router.ts
+++ b/packages/mesh-plugin-object-storage/lib/router.ts
@@ -15,10 +15,19 @@ import * as z from "zod";
 const fileBrowserSearchSchema = z.object({
   path: z.string().optional().default(""),
   flat: z.boolean().optional().default(false),
-  view: z.enum(["table", "grid"]).optional().default("grid"),
+  view: z.enum(["table", "grid"]).optional().default("table"),
 });
 
 export type FileBrowserSearch = z.infer<typeof fileBrowserSearchSchema>;
+
+/**
+ * Search schema for the file viewer route.
+ */
+const fileViewerSearchSchema = z.object({
+  key: z.string(),
+});
+
+export type FileViewerSearch = z.infer<typeof fileViewerSearchSchema>;
 
 /**
  * Plugin router with typed hooks for navigation and search params.
@@ -33,5 +42,12 @@ export const objectStorageRouter = createPluginRouter((ctx) => {
     validateSearch: fileBrowserSearchSchema,
   });
 
-  return [indexRoute];
+  const viewerRoute = createRoute({
+    getParentRoute: () => ctx.parentRoute,
+    path: "/viewer",
+    component: lazyRouteComponent(() => import("../components/file-viewer")),
+    validateSearch: fileViewerSearchSchema,
+  });
+
+  return [indexRoute, viewerRoute];
 });

--- a/packages/mesh-sdk/src/hooks/index.ts
+++ b/packages/mesh-sdk/src/hooks/index.ts
@@ -78,3 +78,6 @@ export {
   type VirtualMCPFilter,
   type UseVirtualMCPsOptions,
 } from "./use-virtual-mcp";
+
+// Chat bridge
+export { ChatBridgeProvider, useChatBridge } from "./use-chat-bridge";

--- a/packages/mesh-sdk/src/hooks/use-chat-bridge.tsx
+++ b/packages/mesh-sdk/src/hooks/use-chat-bridge.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, type PropsWithChildren } from "react";
+
+interface ChatBridge {
+  sendMessage: (text: string) => void;
+  openChat: () => void;
+}
+
+const ChatBridgeContext = createContext<ChatBridge | null>(null);
+
+export function ChatBridgeProvider({
+  children,
+  sendMessage,
+  openChat,
+}: PropsWithChildren<ChatBridge>) {
+  return (
+    <ChatBridgeContext value={{ sendMessage, openChat }}>
+      {children}
+    </ChatBridgeContext>
+  );
+}
+
+export function useChatBridge(): ChatBridge | null {
+  return useContext(ChatBridgeContext);
+}

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -78,6 +78,9 @@ export {
   useVirtualMCPActions,
   type VirtualMCPFilter,
   type UseVirtualMCPsOptions,
+  // Chat bridge
+  ChatBridgeProvider,
+  useChatBridge,
 } from "./hooks";
 
 // Types


### PR DESCRIPTION
## What is this contribution about?

Simplifies local folder project creation from complex daemon discovery to a single-click native folder picker. Users can now:
- Click "Add Project > From Folder" in the Projects UI
- Select a directory via native macOS Finder
- Automatically validates folder, derives project name/slug, and creates everything needed (project, connection, plugins, virtual MCP)

Includes a complete **Git Panel** for branch management, commit history, diffs, and AI-powered commit messages. File watching via SSE, file serving for preview/storage plugins, and bash tool integration.

## Screenshots/Demonstration

- Native folder picker dialog (osascript on macOS)
- Git panel with branch switcher, commit log, diff viewer, AI commit generation
- File watch notifications (SSE) for reactive UI updates
- Object storage file viewer in sidebar
- Preview plugin iframe in sidebar

## How to Test

1. Start local mode: `MESH_LOCAL_MODE=true bun run dev`
2. Navigate to Projects → "Create new project"
3. Select "From Folder" card
4. Click dashed card → macOS Finder opens
5. Select a local directory (e.g., `~/my-project`)
6. Name/slug auto-fills from folder name
7. Click "Create Project"
8. Project loads with git panel, file browser, preview plugin
9. Edit files → git panel shows changes (SSE watch)
10. Switch branches, commit, view history
11. Preview plugin shows dev server iframe (if configured)

## Migration Notes

- No database migrations needed (uses existing connection/project schema)
- Local connections stored with `metadata: { sourceProvider: "local-filesystem", localDevRoot: "/path" }`
- Empty `connection_url: ""` (not null) for local connections
- Presigned URLs routed to `/api/local-dev/files/:connectionId/*`

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working (0 TS errors, 0 lint errors)
- [x] No breaking changes to existing APIs
- [x] Git panel gracefully degrades if AI provider keys unavailable
- [x] SSE watch filters node_modules and .git directories
- [x] Path traversal protected in file serving via LocalFileStorage

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one‑click “From Folder” flow with a native macOS folder picker that auto‑creates the project, binds a local filesystem connection, and starts an in‑process MCP for zero‑config dev. Also ships a Git panel, live SSE file watching, secure local file serving, and a smarter preview/file viewer; root index.html is always treated as a static preview.

- **New Features**
  - “Add Project > From Folder” opens the OS picker and creates everything in one step (project, local filesystem connection, plugin binds, in‑process MCP), then links the connection in project settings.
  - Local‑dev API: `/api/local-dev/pick-folder`, `/validate-folder`, `/create-project`, SSE watch at `/api/local-dev/watch/:connectionId`, and presigned file serving at `/api/local-dev/files/:connectionId/*` with path traversal protection.
  - In‑process local MCP: filesystem + object storage tools and `bash`, SSE file watch, secure path resolution; clients created in‑process for local connections (no HTTP proxy).
  - Git Panel: branch switch, history, diffs, and commit message generation; live updates via SSE; works without provider keys; topbar “Save” shows change count and toggles the panel.
  - Preview: rewritten to the MCP ext‑apps protocol (JSON‑RPC handshake). Root `index.html` always renders as a static preview (even with a `package.json`), detected before any `.deco/preview.json`; starts/stops via `bash`; sets CSP to allow `localhost:*` and `ws/wss`; unauthenticated file serving for sandboxed iframes; preserves `_meta` so the UI can discover the preview resource URI.
  - Object Storage: new viewer route (`/viewer?key=...`) with Markdown preview and image rendering; clicking a file opens the viewer; sidebar item simplified.
  - Public config exposes `localMode` to show local‑only UI like “From Folder”; login accepts a localhost‑only `redirectTo` for CLI auth.
  - Security/ops: dev asset signatures use timing‑safe comparison; assets default to `DECOCMS_HOME/assets` in local mode; deleting a project cleans up unused localhost connections and virtual MCPs.

- **Dependencies**
  - Adds `@decocms/local-dev`.

<sup>Written for commit e3e6a1c1f75cfd8c67b70e74eee0cd32b100444c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

