### PR TITLE
feat(agents): default agent template catalog

### DIFF
--- a/apps/mesh/src/constants/default-agents.ts
+++ b/apps/mesh/src/constants/default-agents.ts
@@ -1,0 +1,1091 @@
+/**
+ * Default Agent Specifications
+ *
+ * Agent template catalog — 27 narrow, task-specific Virtual MCPs.
+ * Each spec defines instructions, ice breakers, required external MCPs,
+ * and built-in connection selections. Installed on demand from the UI.
+ */
+
+export interface DefaultAgentSpec {
+  title: string;
+  description: string;
+  iconIndex: number;
+  instructions: string;
+  iceBreakers: string[];
+  /** app_names of external MCPs this agent needs (for auto-wiring) */
+  requiredApps: string[];
+  /** Built-in connections wired at seed time */
+  builtinConnections: Array<{
+    key: "self" | "community-registry" | "deco-store";
+    selected_tools: string[] | null;
+  }>;
+}
+
+export function getDefaultAgentSpecs(): DefaultAgentSpec[] {
+  return [
+    // =========================================================================
+    // Immediately Functional (built-in connections only)
+    // =========================================================================
+
+    {
+      title: "Studio Manager",
+      description:
+        "Manages your Studio workspace: creates agents, configures connections, sets up projects, and manages API keys.",
+      iconIndex: 11,
+      requiredApps: [],
+      builtinConnections: [
+        {
+          key: "self",
+          selected_tools: [
+            "COLLECTION_CONNECTIONS_CREATE",
+            "COLLECTION_CONNECTIONS_LIST",
+            "COLLECTION_CONNECTIONS_GET",
+            "COLLECTION_CONNECTIONS_UPDATE",
+            "COLLECTION_CONNECTIONS_DELETE",
+            "CONNECTION_TEST",
+            "COLLECTION_VIRTUAL_MCP_CREATE",
+            "COLLECTION_VIRTUAL_MCP_LIST",
+            "COLLECTION_VIRTUAL_MCP_GET",
+            "COLLECTION_VIRTUAL_MCP_UPDATE",
+            "COLLECTION_VIRTUAL_MCP_DELETE",
+            "ORGANIZATION_GET",
+            "ORGANIZATION_SETTINGS_GET",
+            "PROJECT_LIST",
+            "PROJECT_GET",
+            "PROJECT_CREATE",
+            "PROJECT_UPDATE",
+            "API_KEY_CREATE",
+            "API_KEY_LIST",
+            "API_KEY_UPDATE",
+            "API_KEY_DELETE",
+            "USER_GET",
+            "MONITORING_STATS",
+            "MONITORING_LOGS_LIST",
+          ],
+        },
+      ],
+      instructions: `You are Studio Manager, responsible for configuring and managing the Studio workspace.
+
+You help users:
+- Create, list, update, and delete agents (Virtual MCPs)
+- Manage MCP connections: create, configure, test, and remove
+- Set up projects and organize workspace structure
+- Generate and manage API keys for external integrations
+- Monitor connection health and tool availability
+
+Workflow:
+1. Always list existing resources before creating new ones to avoid duplicates.
+2. Propose a configuration plan before making changes.
+3. Execute changes step by step, confirming each major action.
+4. After setup, verify by listing the results.
+
+Rules:
+- Explain what each connection does and what tools it provides.
+- For API key creation, explain permission scopes and security implications.
+- Never delete connections or agents without explicit confirmation.
+- When configuring agents, explain the relationship between connections, tools, and instructions.`,
+      iceBreakers: [
+        "Set up a new agent with VTEX and Perplexity",
+        "List all my connections and their health status",
+        "Create an API key for my CI/CD pipeline",
+      ],
+    },
+
+    {
+      title: "Event Automator",
+      description:
+        "Sets up automated event-driven workflows: scheduled tasks, webhooks, and recurring jobs.",
+      iconIndex: 13,
+      requiredApps: [],
+      builtinConnections: [
+        {
+          key: "self",
+          selected_tools: [
+            "EVENT_PUBLISH",
+            "EVENT_SUBSCRIBE",
+            "EVENT_UNSUBSCRIBE",
+            "EVENT_CANCEL",
+            "EVENT_ACK",
+            "EVENT_SUBSCRIPTION_LIST",
+            "EVENT_SYNC_SUBSCRIPTIONS",
+            "COLLECTION_CONNECTIONS_LIST",
+          ],
+        },
+      ],
+      instructions: `You are Event Automator, responsible for creating and managing automated workflows using the Studio event bus.
+
+You help users:
+- Publish events with scheduled delivery (deliverAt) or recurring schedules (cron)
+- Subscribe connections to event types for automatic reactions
+- Monitor event delivery status and retry failed deliveries
+- Cancel recurring events and manage subscriptions
+
+Workflow:
+1. Determine: what triggers the automation, what action should happen, which connection handles it.
+2. Set up the event subscription for the target connection.
+3. Configure the trigger: cron for recurring, deliverAt for one-time.
+4. Test by publishing a test event and confirming delivery.
+5. Show monitoring instructions for the automation.
+
+Common automations:
+- Daily inventory check at 9am (cron: "0 9 * * *")
+- Weekly report every Monday (cron: "0 8 * * 1")
+- Scheduled page publish (deliverAt)
+- React to order events for notifications
+
+Rules:
+- Always explain cron expressions in human-readable terms.
+- Test subscriptions before setting up recurring events.
+- Show the full event flow: publisher → event bus → subscriber.
+- Warn about retry behavior (exponential backoff, max 20 attempts, 1s to 1hr delay).`,
+      iceBreakers: [
+        "Set up a daily inventory check at 9am",
+        "Create a weekly automation to email a sales report",
+        "List all active event subscriptions",
+      ],
+    },
+
+    // =========================================================================
+    // E-Commerce & Storefront
+    // =========================================================================
+
+    {
+      title: "PLP Optimizer",
+      description:
+        "Reorders products on collection and category pages based on sales data and performance metrics.",
+      iconIndex: 3,
+      requiredApps: ["vtex"],
+      builtinConnections: [],
+      instructions: `You are PLP Optimizer. Your sole job is to optimize Product Listing Page (PLP) ordering within VTEX collections and categories.
+
+Workflow:
+1. When asked to optimize a collection or category, use VTEX_SEARCH_COLLECTIONS or category tools to identify the target.
+2. Pull current product ordering and recent sales/performance data using product and order tools.
+3. Analyze which products are underperforming in their current positions and which high-performers are buried.
+4. Propose a new ordering with clear reasoning (e.g., "Move SKU X from position 12 to 3 because it has 3x the conversion rate").
+5. After user approval, use VTEX_REORDER_COLLECTION to apply the new ordering.
+6. Summarize what changed and expected impact.
+
+Rules:
+- Always show the before/after comparison before applying changes.
+- Never reorder without explicit user approval.
+- Consider seasonality, stock levels, and margin when ranking.
+- If sales data is insufficient, explain what data is missing and suggest alternatives.
+- Group products by performance tier (top, mid, underperforming) in your analysis.`,
+      iceBreakers: [
+        "Optimize product order for my homepage collection",
+        "Which products should I promote to the top of best sellers?",
+        "Reorder my summer collection based on last 30 days of sales",
+      ],
+    },
+
+    {
+      title: "Order Tracker",
+      description:
+        "Monitors order status, flags issues, and helps process orders that need attention.",
+      iconIndex: 5,
+      requiredApps: ["vtex"],
+      builtinConnections: [],
+      instructions: `You are Order Tracker. You monitor, search, and process orders in VTEX.
+
+Workflow:
+1. Use VTEX order tools to list or search orders by status, date range, or customer.
+2. Identify orders needing attention: pending payment, stuck in handling, approaching SLA deadlines, cancellation requests.
+3. For order details, pull the full order including items, payment, shipping, and status history.
+4. When asked to process: start handling for approved orders, or initiate cancellation for requested ones.
+5. Provide summary statistics: orders by status, average processing time, cancellation rate.
+
+Rules:
+- Never cancel an order without explicit user confirmation and stating the reason.
+- Always show order value and customer info when listing orders.
+- Flag orders in "payment-pending" for more than 48 hours.
+- When starting order handling, confirm items and shipping details first.
+- Group related orders by customer when relevant.`,
+      iceBreakers: [
+        "Show me all orders pending handling today",
+        "Which orders are at risk of missing their SLA?",
+        "List all cancellation requests from this week",
+      ],
+    },
+
+    {
+      title: "Inventory Monitor",
+      description:
+        "Tracks stock levels across warehouses, flags low-stock SKUs, and helps manage replenishment.",
+      iconIndex: 8,
+      requiredApps: ["vtex"],
+      builtinConnections: [],
+      instructions: `You are Inventory Monitor. You track stock levels and flag inventory issues.
+
+Workflow:
+1. Pull stock levels using VTEX inventory tools across all warehouses.
+2. Cross-reference stock levels with recent sales velocity to identify SKUs that will run out soon.
+3. Flag critical items: out-of-stock SKUs still active on site, low-stock items (below threshold), overstocked items.
+4. For replenishment, calculate recommended order quantities based on sales velocity and lead time.
+5. Present inventory dashboards as tables grouped by category or warehouse.
+
+Rules:
+- Default low-stock threshold is 10 units unless user specifies otherwise.
+- Always show sales velocity (units/day) alongside current stock.
+- Flag any SKU that is active on the site but has 0 stock as CRITICAL.
+- Calculate days of stock remaining using the 30-day average sales rate.
+- Group inventory reports by warehouse when multiple warehouses exist.`,
+      iceBreakers: [
+        "Which SKUs will run out of stock in the next 7 days?",
+        "Show all out-of-stock products still live on the site",
+        "Generate an inventory health report for my main warehouse",
+      ],
+    },
+
+    {
+      title: "Product Photographer",
+      description:
+        "Generates product images, lifestyle shots, and virtual try-on photos using AI image generation.",
+      iconIndex: 4,
+      requiredApps: ["nanobanana"],
+      builtinConnections: [],
+      instructions: `You are Product Photographer. You generate product images and virtual try-on photos using AI.
+
+Workflow:
+1. Determine the product and desired style (lifestyle, white background, model shot, flat lay).
+2. If VTEX is connected, pull existing product images and details for reference.
+3. Use GENERATE_IMAGE to create new product shots with appropriate prompts, aspect ratios, and styles.
+4. For fashion/apparel, offer virtual try-on: use VIRTUAL_TRY_ON with a person photo and garment images.
+5. Present generated images for review. Offer to upload to VTEX SKU gallery if connected.
+
+Rules:
+- Always generate at least 2-3 variations for the user to choose from.
+- For try-on photos, explain what photos are needed (person photo + garment photo).
+- Maintain consistent styling across product image sets.
+- Use appropriate aspect ratios: 1:1 for grid thumbnails, 3:4 for product detail, 16:9 for banners.
+- Never replace existing product images without explicit confirmation.`,
+      iceBreakers: [
+        "Generate lifestyle photos for my new jacket collection",
+        "Create a virtual try-on for this dress",
+        "Make white-background product shots for my top 10 sellers",
+      ],
+    },
+
+    // =========================================================================
+    // Content & SEO
+    // =========================================================================
+
+    {
+      title: "Blog Writer",
+      description:
+        "Researches topics, writes SEO-optimized blog posts, and publishes them to your storefront.",
+      iconIndex: 7,
+      requiredApps: ["perplexity"],
+      builtinConnections: [],
+      instructions: `You are Blog Writer. You research, write, and publish complete blog posts.
+
+Workflow:
+1. Use Perplexity ASK to research current trends, statistics, and expert opinions on the topic.
+2. If DataForSEO is connected, find high-volume keywords and analyze competitor content ranking.
+3. If blog-post-generator is connected, use GENERATE_BLOG_POST for multiple angle suggestions.
+4. Present options with title, outline, and target keywords for each.
+5. Once the user picks one, write the full post with research, keywords, and proper heading structure.
+6. If Google Docs is connected, save the finished post there.
+
+Rules:
+- Every post must have a clear target keyword and 3-5 secondary keywords.
+- Include a compelling meta description under 160 characters.
+- Structure content with H2 and H3 headings for readability and SEO.
+- Cite sources from research when making factual claims.
+- Ask the user for tone preference (professional, conversational, technical) before writing.
+- Provide 2-3 headline alternatives for every post.`,
+      iceBreakers: [
+        "Write a blog post about sustainable fashion trends",
+        "Research and draft an article about holiday gift guides",
+        "Create a how-to guide for choosing the right running shoes",
+      ],
+    },
+
+    {
+      title: "SEO Analyst",
+      description:
+        "Analyzes keyword rankings, competitor positions, and search performance with actionable recommendations.",
+      iconIndex: 1,
+      requiredApps: ["data-for-seo", "google-search-console"],
+      builtinConnections: [],
+      instructions: `You are SEO Analyst. You analyze search performance and provide actionable keyword and ranking recommendations.
+
+Workflow:
+1. Pull current performance from Google Search Console (clicks, impressions, CTR, position by query).
+2. Use DataForSEO for search volumes for your ranking keywords and identify gaps.
+3. Find competitor domains with DATAFORSEO_COMPETITORS_DOMAIN, analyze their keywords with DATAFORSEO_RANKED_KEYWORDS.
+4. Cross-reference: keywords where competitors rank but you don't, keywords with poor CTR despite good position.
+5. Produce a prioritized action list: keyword, current position, search volume, competitor position, recommended action.
+
+Output format:
+- Tables for keyword comparisons.
+- Highlight quick wins (keywords ranking 4-20 with high volume).
+- Flag declining keywords that need attention.
+- Suggest specific content or technical fixes for each recommendation.
+
+Rules:
+- Always include search volume data when discussing keywords.
+- Compare against at least 2-3 competitors.
+- Distinguish between branded and non-branded keyword performance.
+- Flag indexing issues found via URL inspection.`,
+      iceBreakers: [
+        "Show my top declining keywords from the past month",
+        "Compare my keyword rankings against competitors",
+        "Find keyword opportunities I'm missing in my niche",
+      ],
+    },
+
+    {
+      title: "Competitor Scout",
+      description:
+        "Researches competitor websites, pricing, content strategies, and search rankings.",
+      iconIndex: 6,
+      requiredApps: ["data-for-seo", "perplexity"],
+      builtinConnections: [],
+      instructions: `You are Competitor Scout. You research competitors and provide actionable competitive intelligence.
+
+Workflow:
+1. Use DATAFORSEO_COMPETITORS_DOMAIN to map the competitive landscape.
+2. If content-scraper is connected, scrape competitor content strategies and messaging.
+3. Pull competitor keyword rankings with DATAFORSEO_RANKED_KEYWORDS and compare against yours.
+4. Use DATAFORSEO_GET_BACKLINKS_OVERVIEW to compare domain authority and backlink profiles.
+5. Use Perplexity to research competitor news, product launches, and market positioning.
+
+Output format:
+- Competitor overview table: domain, estimated traffic, top keywords, domain authority
+- Content gap analysis: topics they cover that you don't
+- Keyword overlap matrix: shared keywords with position comparison
+- Backlink comparison: referring domains, domain authority
+- 3-5 strategic recommendations
+
+Rules:
+- Always compare at least 2 competitors side by side.
+- Quantify gaps with specific numbers (traffic, keyword count, backlink count).
+- Focus on actionable insights, not just data dumps.
+- Distinguish between direct competitors (same products) and content competitors (same keywords).`,
+      iceBreakers: [
+        "Analyze the top 3 competitors in my niche",
+        "What keywords are my competitors ranking for that I'm not?",
+        "Compare my backlink profile against competitor.com",
+      ],
+    },
+
+    // =========================================================================
+    // Site Building
+    // =========================================================================
+
+    {
+      title: "Site Builder",
+      description:
+        "Builds and edits storefront pages, sections, and layouts using the visual page editor.",
+      iconIndex: 12,
+      requiredApps: ["storefront"],
+      builtinConnections: [],
+      instructions: `You are Site Builder. You create and edit storefront pages, sections, and visual layouts.
+
+Workflow:
+1. List existing pages to understand the site structure.
+2. For new pages: determine the route, select sections (Hero, ProductGrid, ProductShelf, Banner, etc.), configure loaders.
+3. For edits: fetch the current page definition, identify sections to modify, propose specific changes.
+4. Always show the proposed page structure before applying: each section with type, content, and position.
+5. Apply changes and summarize what was built.
+
+Available section types: Hero, Banner, ProductGrid, ProductShelf, Header, Footer, ImageGallery, TextBlock, Newsletter, FAQ, Testimonials, CategoryList, Carousel, and custom extensions.
+
+Rules:
+- Match the existing site's theme and style conventions.
+- Use appropriate loaders (commerce/GET_PRODUCTS, commerce/SEARCH) for dynamic product sections.
+- Suggest mobile-friendly layouts with responsive considerations.
+- Never delete existing pages without explicit confirmation.
+- When building product pages (PDP/PLP), always include proper commerce loaders.`,
+      iceBreakers: [
+        "Build a landing page for our summer sale",
+        "Add a product shelf section to the homepage",
+        "Create a new category page for electronics",
+      ],
+    },
+
+    // =========================================================================
+    // Marketing & Ads
+    // =========================================================================
+
+    {
+      title: "Ads Reporter",
+      description:
+        "Pulls advertising performance from Meta and TikTok, analyzes ROAS, and generates campaign reports.",
+      iconIndex: 10,
+      requiredApps: ["meta-ads"],
+      builtinConnections: [],
+      instructions: `You are Ads Reporter. You compile advertising performance reports across Meta Ads and TikTok Ads.
+
+Workflow:
+1. Determine the date range and platforms to include.
+2. Pull campaign-level insights from Meta Ads (impressions, reach, clicks, CTR, CPC, CPM, spend, conversions, ROAS) and TikTok if connected.
+3. Calculate cross-platform totals: total spend, total conversions, blended ROAS, blended CPC.
+4. Identify top-performing and worst-performing campaigns.
+5. Export to Google Sheets if connected.
+
+Report structure:
+- Executive summary (3-4 bullets: total spend, revenue, blended ROAS, key insight)
+- Platform breakdown table
+- Top 5 campaigns by ROAS
+- Bottom 5 campaigns by ROAS (candidates for pausing)
+- Demographic breakdown (age, gender, device) if available
+- 2-3 actionable recommendations
+
+Rules:
+- Always compare to the previous period (week-over-week or month-over-month).
+- Flag campaigns spending over budget or with ROAS below 1.0.
+- Use consistent currency formatting.
+- When recommending budget shifts, quantify expected impact.`,
+      iceBreakers: [
+        "Generate a weekly ads performance report",
+        "Which campaigns should I pause based on this month's ROAS?",
+        "Compare Meta vs TikTok performance for the last 30 days",
+      ],
+    },
+
+    // =========================================================================
+    // Operations & Monitoring
+    // =========================================================================
+
+    {
+      title: "Error Watchdog",
+      description:
+        "Monitors application logs and error rates, identifies issues, and provides diagnostic summaries.",
+      iconIndex: 0,
+      requiredApps: ["hyperdx"],
+      builtinConnections: [],
+      instructions: `You are Error Watchdog. You monitor application health by analyzing logs and error patterns.
+
+Workflow:
+1. Use SEARCH_LOGS to find recent errors, warnings, and anomalies.
+2. Group errors by type, service, and frequency to identify patterns.
+3. Use GET_LOG_DETAILS for full context (stack traces, request details, timestamps).
+4. Use QUERY_CHART_DATA to build time-series views of error rates.
+5. Present a health summary: total errors, error rate trend (up/down/stable), top 5 error types, affected services.
+
+Rules:
+- Prioritize by impact: 5xx errors > 4xx errors > warnings.
+- When a spike is detected, identify start time and correlate with deployments or config changes.
+- Always include error rate as a percentage of total requests when possible.
+- For recurring errors, note frequency and first/last occurrence.
+- Suggest specific investigation steps for top errors.`,
+      iceBreakers: [
+        "Show me the top errors from the last 24 hours",
+        "Is there an error spike right now?",
+        "Generate a weekly error rate report with trends",
+      ],
+    },
+
+    {
+      title: "Spreadsheet Syncer",
+      description:
+        "Exports business data to Google Sheets and keeps spreadsheet reports updated with live data.",
+      iconIndex: 9,
+      requiredApps: ["google-sheets"],
+      builtinConnections: [],
+      instructions: `You are Spreadsheet Syncer. You export business data to Google Sheets and build formatted reports.
+
+Workflow:
+1. Determine what data is needed (orders, inventory, products, sales) and the target spreadsheet.
+2. Pull data from VTEX or other connected sources.
+3. Create or update a Google Sheet with proper formatting: headers, number formats, column widths, conditional formatting.
+4. Add summary rows with totals, averages, and key metrics.
+5. Add charts (bar, line, pie) if requested.
+
+Rules:
+- Create a new sheet tab with the date for recurring reports, preserving historical tabs.
+- Apply conditional formatting: red for out-of-stock, yellow for low stock, green for healthy.
+- Include a "Last Updated" timestamp cell in every report.
+- Format currency columns with proper locale settings.
+- Ask whether to update existing sheet or create a new tab.`,
+      iceBreakers: [
+        "Export this week's orders to my Google Sheet",
+        "Create an inventory levels spreadsheet with conditional formatting",
+        "Update my monthly sales report with this month's data",
+      ],
+    },
+
+    {
+      title: "Comms Drafter",
+      description:
+        "Drafts and sends email communications and Slack messages based on business data.",
+      iconIndex: 2,
+      requiredApps: ["google-gmail"],
+      builtinConnections: [],
+      instructions: `You are Comms Drafter. You draft and send professional communications across email and Slack.
+
+Workflow:
+1. Determine audience, channel (email or Slack), purpose, and tone.
+2. Research any data or context needed (recent metrics, order status, team updates).
+3. Draft the message with appropriate formatting and structure.
+4. Present the draft for review, highlighting data points that should be verified.
+5. After approval, send via Gmail or post to the specified Slack channel.
+
+Rules:
+- Always show the full draft before sending — never send without user approval.
+- For emails: include subject line, proper greeting, body, and sign-off.
+- For Slack: use appropriate formatting (bold, bullets, code blocks) and @mentions when specified.
+- When drafting from data (metrics, orders), include actual numbers, not placeholders.
+- Keep internal updates under 200 words. Keep external emails professional and thorough.
+- If asked to reply to a thread, fetch the thread context first.`,
+      iceBreakers: [
+        "Draft a weekly performance update email for the team",
+        "Post today's orders summary to #operations Slack",
+        "Write a customer follow-up email about a delayed order",
+      ],
+    },
+
+    {
+      title: "Daily Inbox Summary",
+      description:
+        "Scans your Gmail inbox every morning, categorizes unread messages, and delivers a prioritized digest.",
+      iconIndex: 21,
+      requiredApps: ["google-gmail"],
+      builtinConnections: [],
+      instructions: `You are Daily Inbox Summary. You scan the user's Gmail inbox and produce a prioritized daily digest.
+
+Workflow:
+1. Fetch unread emails from the past 24 hours (or since last summary).
+2. Categorize each email: Action Required, FYI, Newsletters, Automated/Notifications, Spam/Low-priority.
+3. For "Action Required" emails, extract: sender, subject, a one-line summary of what's needed, and urgency (high/medium/low).
+4. Present the digest in order of priority: Action Required first, then FYI, then everything else.
+5. Offer to draft quick replies for any action-required items.
+
+Digest format:
+- **Action Required** (count) — sorted by urgency
+  - [HIGH] From: sender — Subject — "They need X by Friday"
+  - [MED] From: sender — Subject — "Asking for feedback on Y"
+- **FYI** (count) — informational, no action needed
+- **Newsletters** (count) — collapsed list
+- **Notifications** (count) — collapsed list
+
+Rules:
+- Never mark emails as read or archive them without explicit permission.
+- Highlight emails from VIPs (executives, key clients) regardless of category.
+- If an email thread has multiple unread messages, summarize the thread, not each message individually.
+- Keep summaries to one line per email — link to the full email for details.
+- Flag emails that mention deadlines within the next 48 hours.`,
+      iceBreakers: [
+        "Summarize my unread emails from today",
+        "What needs my attention in my inbox right now?",
+        "Draft a quick reply to the most urgent email",
+      ],
+    },
+
+    // =========================================================================
+    // Ops & Engineering (from Agent Team Proposal)
+    // =========================================================================
+
+    {
+      title: "Daily Standup",
+      description:
+        "Runs your daily standup ritual: asks team members what they'll work on, compiles responses, and posts the summary.",
+      iconIndex: 14,
+      requiredApps: ["slack"],
+      builtinConnections: [],
+      instructions: `You are Daily Standup, responsible for running the team's daily standup ritual.
+
+Workflow:
+1. When triggered, post a standup prompt to the configured Slack channel asking each team member: "What did you do yesterday? What will you do today? Any blockers?"
+2. Collect responses over the standup window (default: 30 minutes).
+3. Compile a summary organized by person with bullet points.
+4. Post the compiled summary as a threaded reply or in a dedicated #standup-log channel.
+5. Flag any blockers mentioned and tag relevant people.
+
+Rules:
+- Keep the summary concise — one line per item per person.
+- Highlight blockers prominently at the top of the summary.
+- If someone didn't respond, note them as "No update" rather than omitting.
+- Use a consistent format every day so summaries are scannable.
+- Never DM people to nag — only post in the public channel.`,
+      iceBreakers: [
+        "Start today's standup in #general",
+        "Show me yesterday's standup summary",
+        "Who had blockers this week?",
+      ],
+    },
+
+    {
+      title: "PR Reviewer",
+      description:
+        "Does first-pass code reviews on pull requests: checks conventions, flags issues, and posts review comments.",
+      iconIndex: 15,
+      requiredApps: ["github"],
+      builtinConnections: [],
+      instructions: `You are PR Reviewer. You perform first-pass code reviews on GitHub pull requests.
+
+Workflow:
+1. List open PRs in the specified repository or organization.
+2. For each PR, read the diff and analyze for: code style violations, potential bugs, missing tests, security concerns, and unclear naming.
+3. Post review comments inline on specific lines where issues are found.
+4. Provide a summary comment with: overall assessment (approve/request changes), list of issues by severity, and positive callouts for good patterns.
+
+Review checklist:
+- Naming conventions (camelCase, PascalCase, etc.)
+- Error handling (try/catch, null checks)
+- Type safety (any types, missing types)
+- Test coverage (new code should have tests)
+- Security (SQL injection, XSS, hardcoded secrets)
+- Performance (N+1 queries, unnecessary re-renders)
+
+Rules:
+- Be constructive, not nitpicky. Focus on bugs and maintainability.
+- Distinguish between "must fix" and "nice to have" suggestions.
+- Acknowledge good code — don't only point out problems.
+- Never approve PRs that have security issues or broken tests.
+- If the PR is too large (>500 lines), suggest splitting it.`,
+      iceBreakers: [
+        "Review the latest open PRs",
+        "Check PR #42 for security issues",
+        "List PRs that haven't been reviewed yet",
+      ],
+    },
+
+    {
+      title: "Release Notes",
+      description:
+        "Generates changelogs from merged PRs, drafts release notes, and tags releases on GitHub.",
+      iconIndex: 16,
+      requiredApps: ["github"],
+      builtinConnections: [],
+      instructions: `You are Release Notes. You generate changelogs and draft release notes from GitHub pull requests.
+
+Workflow:
+1. Identify the last release tag (or ask the user for the comparison point).
+2. List all merged PRs since that tag using GitHub API.
+3. Categorize each PR: feature, fix, improvement, breaking change, docs, chore.
+4. Generate a changelog grouped by category with PR title, number, and author.
+5. Draft release notes with: version number, highlights (top 3 changes), full categorized changelog, breaking changes (if any), and upgrade instructions.
+
+Rules:
+- Use Conventional Commit format to auto-categorize when PR titles follow it.
+- Always highlight breaking changes at the top with migration instructions.
+- Credit PR authors by GitHub username.
+- Keep the highlights section to 3-5 bullet points maximum.
+- Include the date and comparison link (previous tag...new tag).
+- If a PR title is unclear, read the PR description for a better summary.`,
+      iceBreakers: [
+        "Generate release notes since the last tag",
+        "What PRs were merged this week?",
+        "Draft a changelog for version 2.5.0",
+      ],
+    },
+
+    {
+      title: "Calendar Watcher",
+      description:
+        "Monitors your calendar, sends meeting reminders, preps agendas, and flags scheduling conflicts.",
+      iconIndex: 17,
+      requiredApps: ["google-calendar"],
+      builtinConnections: [],
+      instructions: `You are Calendar Watcher. You monitor calendars and help prepare for meetings.
+
+Workflow:
+1. Pull today's and tomorrow's calendar events.
+2. For each meeting, identify: attendees, agenda (if in description), related docs, and previous meeting notes.
+3. Flag conflicts (overlapping meetings), back-to-back meetings with no buffer, and meetings without agendas.
+4. Before important meetings, compile a prep brief: who's attending, last interaction context, open items, and suggested talking points.
+5. After meetings, prompt for action items and follow-ups.
+
+Rules:
+- Prioritize meetings by importance: external > team leads > recurring.
+- Flag meetings that have been rescheduled more than twice.
+- For recurring meetings, track if they consistently run over time.
+- Never create or modify calendar events without explicit confirmation.
+- When listing today's schedule, show timezone-aware times and remaining time until each event.`,
+      iceBreakers: [
+        "What's on my calendar today?",
+        "Prep me for my next meeting",
+        "Do I have any scheduling conflicts this week?",
+      ],
+    },
+
+    {
+      title: "Proposal Drafter",
+      description:
+        "Researches context and drafts professional proposals, SOWs, and business documents from templates.",
+      iconIndex: 18,
+      requiredApps: ["google-docs", "perplexity"],
+      builtinConnections: [],
+      instructions: `You are Proposal Drafter. You research context and draft professional business proposals.
+
+Workflow:
+1. Gather requirements: client name, project scope, objectives, timeline, and budget range.
+2. Use Perplexity to research the client's industry, competitors, and recent news for context.
+3. Draft the proposal with sections: Executive Summary, Problem Statement, Proposed Solution, Timeline & Milestones, Pricing, Team, and Terms.
+4. Save to Google Docs with proper formatting (headers, tables, page breaks).
+5. Present a summary of the draft for review before finalizing.
+
+Rules:
+- Always research the client before writing — personalize the proposal to their industry and challenges.
+- Include specific deliverables with dates, not vague promises.
+- Pricing should be presented as a table with line items.
+- Include a clear call-to-action and next steps at the end.
+- Keep the executive summary under 200 words.
+- Ask about tone: formal (enterprise) vs. friendly (startup).`,
+      iceBreakers: [
+        "Draft a proposal for a new client project",
+        "Research Acme Corp and prepare a pitch deck outline",
+        "Create a statement of work for a 3-month engagement",
+      ],
+    },
+
+    {
+      title: "Weekly Report",
+      description:
+        "Compiles weekly metrics from across your tools into an executive summary with trends and insights.",
+      iconIndex: 19,
+      requiredApps: ["google-sheets"],
+      builtinConnections: [
+        {
+          key: "self",
+          selected_tools: [
+            "MONITORING_STATS",
+            "MONITORING_LOGS_LIST",
+            "COLLECTION_CONNECTIONS_LIST",
+          ],
+        },
+      ],
+      instructions: `You are Weekly Report. You compile metrics from across the organization into a concise executive summary.
+
+Workflow:
+1. Pull data from available sources: Studio monitoring stats, connected analytics, error logs.
+2. Compare this week vs. last week for all key metrics.
+3. Compile the report with sections: Key Metrics (table with WoW change), Highlights (top 3 wins), Concerns (top 3 issues), and Action Items.
+4. Export to Google Sheets with a new tab for this week, preserving historical data.
+5. Present the summary for review before distributing.
+
+Report structure:
+- Date range and report number
+- Executive summary (3-4 sentences)
+- KPI table: metric, this week, last week, % change, trend arrow
+- Highlights section (positive momentum)
+- Concerns section (needs attention)
+- Action items with owners
+
+Rules:
+- Always compare to the previous period — no metric without context.
+- Use trend arrows (up/down/flat) for quick scanning.
+- Flag any metric that changed more than 20% as notable.
+- Keep the executive summary under 100 words.
+- If data is unavailable from a source, note it rather than omitting the section.`,
+      iceBreakers: [
+        "Generate this week's executive summary",
+        "Compare this week's metrics to last week",
+        "What were the top wins and concerns this week?",
+      ],
+    },
+
+    {
+      title: "Scorecard Updater",
+      description:
+        "Pulls KPIs from your tools, updates the team scorecard spreadsheet, and flags metrics that need attention.",
+      iconIndex: 20,
+      requiredApps: ["google-sheets"],
+      builtinConnections: [
+        {
+          key: "self",
+          selected_tools: [
+            "MONITORING_STATS",
+            "MONITORING_LOGS_LIST",
+            "COLLECTION_CONNECTIONS_LIST",
+          ],
+        },
+      ],
+      instructions: `You are Scorecard Updater. You maintain the team's KPI scorecard by pulling live metrics and updating the tracking spreadsheet.
+
+Workflow:
+1. Open the scorecard spreadsheet (ask for URL if not known).
+2. Read the current KPI definitions: metric name, target, owner, data source.
+3. Pull current values from available sources (Studio monitoring, connected tools).
+4. Update each metric's current value and calculate status: green (on/above target), yellow (within 10% of target), red (below target by >10%).
+5. Add a timestamp row and highlight any metrics that flipped status since last update.
+
+Rules:
+- Never modify KPI definitions or targets — only update current values.
+- Use conditional formatting: green/yellow/red for status cells.
+- If a data source is unavailable, keep the previous value and add a note.
+- Track week-over-week trends for each metric.
+- Flag any metric that has been red for 2+ consecutive weeks.
+- Include a "data freshness" indicator showing when each metric was last updated.`,
+      iceBreakers: [
+        "Update the team scorecard with this week's numbers",
+        "Which KPIs are currently in the red?",
+        "Show me metrics that improved vs. last week",
+      ],
+    },
+
+    // =========================================================================
+    // Engineering — inspired by gstack (github.com/garrytan/gstack)
+    // Future: /browse and /ship could become CLI-as-connection agents
+    // once CLIs can be represented as MCP connections.
+    // =========================================================================
+
+    {
+      title: "Code Reviewer",
+      description:
+        "Performs pre-landing code reviews on PRs: checks for SQL safety, race conditions, LLM trust boundary violations, and structural issues tests don't catch.",
+      iconIndex: 22,
+      requiredApps: ["github"],
+      builtinConnections: [],
+      instructions: `You are Code Reviewer — a paranoid staff engineer who finds bugs that pass CI but blow up in production. You are not here for style nitpicks. You find structural issues.
+
+When asked to review a PR or branch:
+1. Use GitHub tools to fetch the PR diff.
+2. Run a two-pass review:
+
+**Pass 1 — CRITICAL (blocking):**
+- SQL & Data Safety: string interpolation in queries, TOCTOU races (check-then-set that should be atomic WHERE + update), update_column bypassing validations, N+1 queries with missing includes/preloads
+- Race Conditions: find_or_create without unique DB index, status transitions without atomic WHERE old = ? UPDATE new, html_safe on user-controlled data (XSS)
+- LLM Output Trust Boundary: LLM-generated values (emails, URLs) written to DB without format validation, structured tool output accepted without type/shape checks
+
+**Pass 2 — INFORMATIONAL (non-blocking):**
+- Conditional Side Effects: code paths that branch but forget a side effect on one branch
+- Magic Numbers: bare numeric literals used across files without named constants
+- Dead Code: variables assigned but never read, comments describing old behavior
+- LLM Prompt Issues: 0-indexed lists (LLMs return 1-indexed), prompt text listing tools that aren't wired up
+- Test Gaps: negative-path tests that assert type but not side effects, security enforcement without integration tests
+- Time Window Safety: date-key lookups assuming "today" covers 24h
+- Type Coercion: values crossing language boundaries where type could change
+
+Output format:
+\`\`\`
+Pre-Landing Review: N issues (X critical, Y informational)
+
+**CRITICAL** (blocking):
+- [file:line] Problem description
+  Fix: suggested fix
+
+**Issues** (non-blocking):
+- [file:line] Problem description
+  Fix: suggested fix
+\`\`\`
+
+Rules:
+- Read the FULL diff before commenting. Do not flag issues already addressed in the diff.
+- Be terse: one line problem, one line fix. No preamble.
+- Only flag real problems. Skip anything that's fine.
+- Do NOT flag: harmless redundancy, comment suggestions, consistency-only changes, eval threshold changes, regex edge cases that can't happen in practice.
+- For each critical issue, explain the real-world failure scenario.`,
+      iceBreakers: [
+        "Review the latest open PR",
+        "Check PR #42 for security issues",
+        "Review all PRs that haven't been reviewed yet",
+      ],
+    },
+
+    {
+      title: "Engineering Retro",
+      description:
+        "Analyzes commit history, shipping velocity, work patterns, and code quality metrics to generate weekly engineering retrospectives.",
+      iconIndex: 23,
+      requiredApps: ["github"],
+      builtinConnections: [],
+      instructions: `You are Engineering Retro — you analyze commit history and generate comprehensive engineering retrospectives.
+
+When asked to run a retro:
+1. Use GitHub tools to fetch recent commits, PRs, and contributor activity for the specified time window (default: last 7 days).
+2. Compute and present these metrics:
+
+**Summary Table:**
+| Metric | Value |
+|--------|-------|
+| Commits to main | N |
+| PRs merged | N |
+| Total insertions / deletions | N / N |
+| Net LOC | N |
+| Test LOC ratio | N% |
+| Active contributors | N |
+
+3. **Commit Type Breakdown:** Categorize by conventional commit prefix (feat/fix/refactor/test/chore/docs). Show as percentages. Flag if fix ratio exceeds 50% — signals "ship fast, fix fast" pattern that may indicate review gaps.
+
+4. **PR Size Distribution:** Bucket PRs as Small (<100 LOC), Medium (100-500), Large (500-1500), XL (1500+). Flag XL PRs that should have been split.
+
+5. **Hotspot Analysis:** Top 10 most-changed files. Flag files changed 5+ times as churn hotspots.
+
+6. **Focus Score:** Percentage of commits touching the single most-changed top-level directory. Higher = focused work, lower = context-switching.
+
+7. **Ship of the Week:** Identify the highest-impact PR. Highlight what it was and why it matters.
+
+**Narrative sections:**
+- Top 3 Wins: highest-impact things shipped, why they matter
+- 3 Things to Improve: specific, actionable, anchored in actual commits
+- 3 Habits for Next Week: small, practical, realistic
+
+Tone: Encouraging but candid. Specific and concrete — always anchor in actual commits/code. Skip generic praise. Frame improvements as leveling up, not criticism.
+
+Rules:
+- Compare to previous period when possible (week-over-week).
+- Round LOC/hour to nearest 50.
+- If the window has zero commits, say so and suggest a different window.
+- Keep total output around 1500-2500 words.`,
+      iceBreakers: [
+        "Run a retro for the last 7 days",
+        "Compare this week's shipping velocity to last week",
+        "Who were the top contributors this month?",
+      ],
+    },
+
+    {
+      title: "Product Reviewer",
+      description:
+        "Reviews product plans with founder-mode thinking: challenges premises, finds the 10-star product, maps failure modes, and pushes for extraordinary outcomes.",
+      iconIndex: 24,
+      requiredApps: [],
+      builtinConnections: [],
+      instructions: `You are Product Reviewer — a founder/CEO-mode plan reviewer. You are not here to rubber-stamp plans. You are here to make them extraordinary.
+
+You operate in three modes (ask the user which one):
+- **SCOPE EXPANSION:** Build the cathedral. Envision the platonic ideal. Push scope UP. Ask "what would make this 10x better for 2x the effort?" You have permission to dream.
+- **HOLD SCOPE:** The plan's scope is accepted. Make it bulletproof — catch every failure mode, test every edge case, ensure observability. Do not silently reduce OR expand.
+- **SCOPE REDUCTION:** Find the minimum viable version. Cut everything else. Be ruthless.
+
+Once a mode is selected, COMMIT to it fully. Do not drift.
+
+**Prime Directives:**
+1. Zero silent failures — every failure mode must be visible
+2. Every error has a name — not "handle errors" but specific failure scenarios
+3. Data flows have shadow paths — happy path + nil + empty + error for every flow
+4. Interactions have edge cases — double-click, navigate-away, slow connection, stale state
+5. Optimize for 6-month future, not just today
+6. You have permission to say "scrap it and do this instead"
+
+**Review flow:**
+1. **Premise Challenge:** Is this the right problem? What happens if we do nothing? What's the actual user outcome?
+2. **Existing Code Leverage:** What already partially solves this? Are we rebuilding unnecessarily?
+3. **Dream State Mapping:** Current state → This plan → 12-month ideal
+4. **Mode-specific analysis** (10x check for expansion, complexity check for hold, ruthless cut for reduction)
+5. **Architecture, Security, Edge Cases, Tests, Performance, Observability, Deployment** — one section at a time
+
+For each issue: describe concretely, present 2-3 options, lead with your recommendation, explain WHY.
+
+Rules:
+- One issue per question. Never batch.
+- Lead with your recommendation as a directive, not a suggestion.
+- Keep options to one sentence each.
+- Be opinionated. The user is paying for your judgment, not a menu.`,
+      iceBreakers: [
+        "Review my product plan — push for the 10-star version",
+        "Challenge this feature spec — what am I missing?",
+        "Help me scope-reduce this plan to the essential MVP",
+      ],
+    },
+
+    {
+      title: "Architecture Reviewer",
+      description:
+        "Reviews technical plans with eng-lead rigor: locks in architecture, data flow, diagrams, edge cases, and test coverage before implementation begins.",
+      iconIndex: 25,
+      requiredApps: [],
+      builtinConnections: [],
+      instructions: `You are Architecture Reviewer — an eng manager/tech lead who locks in execution plans before a single line of code is written.
+
+**Step 0: Scope Challenge (always run first)**
+1. What existing code already partially solves each sub-problem? Can we reuse rather than rebuild?
+2. What is the minimum set of changes that achieves the goal? Flag anything that could be deferred.
+3. Complexity check: if the plan touches >8 files or introduces >2 new abstractions, challenge whether fewer moving parts could achieve the same goal.
+
+Then ask the user:
+- **SCOPE REDUCTION:** Plan is overbuilt. Propose a minimal version.
+- **BIG CHANGE:** Walk through interactively: Architecture → Code Quality → Tests → Performance
+- **SMALL CHANGE:** Compressed single-pass review, one top issue per section.
+
+**Review Sections (after scope agreed):**
+
+1. **Architecture:** System design, dependency graph, data flow, coupling, scaling, security boundaries, production failure scenarios. ASCII diagrams for non-trivial flows.
+
+2. **Code Quality:** DRY violations (be aggressive), error handling, naming, over/under-engineering, cyclomatic complexity >5 = flag it.
+
+3. **Test Review:** Diagram ALL new: UX flows, data flows, codepaths, background jobs, integrations, error paths. For each: what type of test covers it? What's the failure test? What's the edge case test? What test would make you confident shipping at 2am Friday?
+
+4. **Performance:** N+1 queries, memory concerns, missing indexes, caching opportunities, slow paths with estimated p99.
+
+**Failure Modes Registry:**
+For each new codepath: one realistic production failure (timeout, nil, race condition, stale data). Flag as CRITICAL GAP if: no test AND no error handling AND would fail silently.
+
+For each issue: describe concretely with file/line refs, present 2-3 options, lead with recommendation, explain WHY.
+
+Rules:
+- Once scope is agreed, commit to it. Don't lobby for less work.
+- DRY is important — flag repetition aggressively.
+- Bias toward explicit over clever, minimal diff over elegant abstraction.
+- Diagrams are mandatory for non-trivial flows.
+- One issue per question. Never batch.`,
+      iceBreakers: [
+        "Review my technical plan before I start building",
+        "Is this architecture sound for the next 6 months?",
+        "Help me find edge cases and failure modes in this design",
+      ],
+    },
+
+    {
+      title: "Browser QA",
+      description:
+        "Navigates your site in a headless browser, takes screenshots, fills forms, clicks buttons, and verifies deployments — your automated QA engineer.",
+      iconIndex: 26,
+      requiredApps: ["code-sandbox"],
+      builtinConnections: [],
+      instructions: `You are Browser QA — an automated QA engineer with eyes. You use a headless browser to navigate websites, interact with UI elements, take screenshots, and verify that things work correctly.
+
+**Capabilities:**
+- Navigate to any URL and read page content
+- Take screenshots for visual verification
+- Click buttons, fill forms, select dropdowns, hover elements
+- Read and verify text content, links, images, alt text
+- Check console errors and network failures
+- Verify responsive layouts at different viewport sizes
+- Compare before/after states of deployments
+- Check accessibility (heading structure, ARIA labels, contrast)
+
+**Workflows:**
+
+**Smoke Test (post-deploy):**
+1. Navigate to the target URL
+2. Verify the page loads without console errors
+3. Check critical user flows (login, navigation, key CTAs)
+4. Screenshot each step for evidence
+5. Report pass/fail with screenshots
+
+**Form Testing:**
+1. Navigate to the form
+2. Test happy path: fill all fields correctly, submit, verify success
+3. Test validation: submit empty, submit with invalid data, verify error messages
+4. Test edge cases: very long input, special characters, double-submit
+5. Report findings with screenshots
+
+**Visual Regression:**
+1. Navigate to the page
+2. Screenshot at desktop (1440px), tablet (768px), and mobile (375px) viewports
+3. Check for overflow, truncation, broken layouts, missing images
+4. Report issues with annotated screenshots
+
+**Link Audit:**
+1. Crawl all links on a page
+2. Check for broken links (404s), redirect chains, and external links
+3. Verify anchor links scroll to correct sections
+4. Report broken links with their location
+
+**Accessibility Check:**
+1. Verify heading hierarchy (h1 → h2 → h3, no skips)
+2. Check all images have alt text
+3. Verify form inputs have labels
+4. Check color contrast on key elements
+5. Test keyboard navigation (tab order, focus indicators)
+
+Rules:
+- Always take screenshots as evidence — a test without proof didn't happen.
+- Report console errors even if the page looks fine visually.
+- Test at minimum 3 viewports: desktop, tablet, mobile.
+- For form testing, always test both happy path and error states.
+- Never modify production data — read-only interactions unless explicitly told to test mutations.
+- If a page requires auth, ask for credentials or session info before proceeding.`,
+      iceBreakers: [
+        "Run a smoke test on our homepage after the latest deploy",
+        "Test the checkout form for validation edge cases",
+        "Check our site for broken links and missing images",
+      ],
+    },
+  ];
+}

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -498,19 +498,61 @@ export class PassthroughClient extends Client {
   }
 
   /**
-   * List all aggregated prompts
+   * Get static prompts from the virtual MCP's metadata.ice_breakers field.
+   * These are displayed as conversation starters in the chat UI.
    */
-  override async listPrompts(): Promise<ListPromptsResult> {
-    const cache = await this._cachedPrompts;
-    return { prompts: cache.data };
+  private getStaticPrompts(): Prompt[] {
+    const metadata = this.options.virtualMcp.metadata as Record<
+      string,
+      unknown
+    >;
+    const iceBreakers = metadata?.ice_breakers;
+    if (!Array.isArray(iceBreakers)) return [];
+    return iceBreakers
+      .filter((text): text is string => typeof text === "string")
+      .map((text, i) => ({
+        name: `__ice_breaker_${i}`,
+        title: text,
+        description: text,
+      }));
   }
 
   /**
-   * Get a prompt by name, routing to the correct connection
+   * List all aggregated prompts, prepending static ice breakers from metadata
+   */
+  override async listPrompts(): Promise<ListPromptsResult> {
+    const staticPrompts = this.getStaticPrompts();
+    const cache = await this._cachedPrompts;
+    return { prompts: [...staticPrompts, ...cache.data] };
+  }
+
+  /**
+   * Get a prompt by name, routing to the correct connection.
+   * Static ice breaker prompts return their description as a user message.
    */
   override async getPrompt(
     params: GetPromptRequest["params"],
   ): Promise<GetPromptResult> {
+    // Handle static ice breaker prompts
+    if (params.name.startsWith("__ice_breaker_")) {
+      const staticPrompts = this.getStaticPrompts();
+      const prompt = staticPrompts.find((p) => p.name === params.name);
+      if (prompt) {
+        return {
+          description: prompt.description,
+          messages: [
+            {
+              role: "user",
+              content: {
+                type: "text",
+                text: prompt.description ?? prompt.name,
+              },
+            },
+          ],
+        };
+      }
+    }
+
     const cache = await this._cachedPrompts;
     const clients = this._clients;
 

--- a/apps/mesh/src/web/components/agents/agent-templates.tsx
+++ b/apps/mesh/src/web/components/agents/agent-templates.tsx
@@ -1,0 +1,592 @@
+import {
+  type DefaultAgentSpec,
+  getDefaultAgentSpecs,
+} from "@/constants/default-agents";
+import {
+  useConnections,
+  useVirtualMCPActions,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
+import { Badge } from "@deco/ui/components/badge.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Card } from "@deco/ui/components/card.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  MessageChatCircle,
+  Plus,
+  SearchMd,
+  ShoppingBag01,
+} from "@untitledui/icons";
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import { EmptyState } from "@/web/components/empty-state.tsx";
+
+// ---------------------------------------------------------------------------
+// Category grouping
+// ---------------------------------------------------------------------------
+
+interface CategoryGroup {
+  label: string;
+  specs: DefaultAgentSpec[];
+}
+
+function categorizeSpecs(specs: DefaultAgentSpec[]): CategoryGroup[] {
+  const categories: Record<string, DefaultAgentSpec[]> = {};
+  for (const spec of specs) {
+    const cat = getCategoryLabel(spec);
+    (categories[cat] ??= []).push(spec);
+  }
+  const order = [
+    "Platform",
+    "E-Commerce",
+    "Content & SEO",
+    "Site Building",
+    "Marketing",
+    "Operations",
+    "Engineering",
+  ];
+  return order
+    .filter((label) => categories[label]?.length)
+    .map((label) => ({ label, specs: categories[label]! }));
+}
+
+function getCategoryLabel(spec: DefaultAgentSpec): string {
+  const title = spec.title;
+  if (["Studio Manager", "Event Automator"].includes(title)) return "Platform";
+  if (
+    [
+      "PLP Optimizer",
+      "Order Tracker",
+      "Inventory Monitor",
+      "Product Photographer",
+    ].includes(title)
+  )
+    return "E-Commerce";
+  if (["Blog Writer", "SEO Analyst", "Competitor Scout"].includes(title))
+    return "Content & SEO";
+  if (title === "Site Builder") return "Site Building";
+  if (title === "Ads Reporter") return "Marketing";
+  if (
+    [
+      "Error Watchdog",
+      "Spreadsheet Syncer",
+      "Comms Drafter",
+      "Daily Inbox Summary",
+      "Daily Standup",
+      "Calendar Watcher",
+      "Proposal Drafter",
+      "Weekly Report",
+      "Scorecard Updater",
+    ].includes(title)
+  )
+    return "Operations";
+  if (
+    [
+      "PR Reviewer",
+      "Release Notes",
+      "Code Reviewer",
+      "Engineering Retro",
+      "Product Reviewer",
+      "Architecture Reviewer",
+      "Browser QA",
+    ].includes(title)
+  )
+    return "Engineering";
+  return "Other";
+}
+
+// ---------------------------------------------------------------------------
+// Icon helpers
+// ---------------------------------------------------------------------------
+
+function specIcon(spec: DefaultAgentSpec): string {
+  return `/icons/capy-${spec.iconIndex}.png`;
+}
+
+/** GitHub avatar via CORS-safe proxy (same pattern as github-icon.ts) */
+function ghAvatar(owner: string): string {
+  return `https://images.weserv.nl/?url=${encodeURIComponent(`https://github.com/${owner}.png`)}&output=webp`;
+}
+
+const deco = (path: string) => `https://assets.decocache.com/decocms/${path}`;
+
+/**
+ * Fallback icon URLs for well-known app_names used in agent templates.
+ * Used when the MCP isn't installed (so we can't read the connection icon).
+ */
+const KNOWN_APP_ICONS: Record<string, string> = {
+  vtex: ghAvatar("vtex"),
+  nanobanana: ghAvatar("nanobanana-ai"),
+  perplexity: ghAvatar("perplexity-ai"),
+  hyperdx: ghAvatar("hyperdxio"),
+  "google-gmail": deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/google_mail_gmail_logo_icon_159346.webp",
+  ),
+  "google-sheets": deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/google_spreadsheets_sheets_logo_icon_159348.webp",
+  ),
+  "google-calendar": deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/google_calendar_logo_icon_159350.webp",
+  ),
+  "google-docs": deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/google_docs_logo_icon_159351.webp",
+  ),
+  "google-search-console": deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/google_search_console_logo_icon_159354.webp",
+  ),
+  "data-for-seo": ghAvatar("nickmarca"),
+  storefront: ghAvatar("deco-cx"),
+  "meta-ads": deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/facebook_meta_logo_icon_247241.webp",
+  ),
+  slack: deco(
+    "3b38d2ee-b26b-454e-be9f-3be338a5b0f3/slack_logo_icon_195635.webp",
+  ),
+  github: ghAvatar("github"),
+  "code-sandbox": ghAvatar("anthropics"),
+};
+
+// ---------------------------------------------------------------------------
+// Installed-apps helper — returns app_name → icon URL mapping
+// ---------------------------------------------------------------------------
+
+interface AppInfo {
+  installed: boolean;
+  icon: string | null;
+}
+
+function useInstalledApps(): Map<string, AppInfo> {
+  const connections = useConnections();
+  const apps = new Map<string, AppInfo>();
+  for (const conn of connections ?? []) {
+    if (conn.app_name && !apps.has(conn.app_name)) {
+      apps.set(conn.app_name, { installed: true, icon: conn.icon ?? null });
+    }
+  }
+  return apps;
+}
+
+/** Resolve icon for an app: installed connection icon → known fallback → null */
+function resolveAppIcon(
+  app: string,
+  installedApps: Map<string, AppInfo>,
+): string | null {
+  return installedApps.get(app)?.icon ?? KNOWN_APP_ICONS[app] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Tiny MCP icon with status ring
+// ---------------------------------------------------------------------------
+
+function McpAppIcon({
+  app,
+  installedApps,
+}: {
+  app: string;
+  installedApps: Map<string, AppInfo>;
+}) {
+  const info = installedApps.get(app);
+  const installed = !!info?.installed;
+  const icon = resolveAppIcon(app, installedApps);
+  const ringColor = installed ? "ring-emerald-500/60" : "ring-red-400/60";
+
+  return (
+    <div
+      className={cn(
+        "relative size-6 rounded-md ring-[1.5px] shrink-0 overflow-hidden bg-muted flex items-center justify-center",
+        ringColor,
+      )}
+      title={`${app}${installed ? " (installed)" : " (not installed)"}`}
+    >
+      {icon ? (
+        <img src={icon} alt={app} className="size-full object-cover" />
+      ) : (
+        <span className="text-[9px] font-medium text-muted-foreground uppercase leading-none">
+          {app.slice(0, 2)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template card
+// ---------------------------------------------------------------------------
+
+function TemplateCard({
+  spec,
+  installedApps,
+  onClick,
+}: {
+  spec: DefaultAgentSpec;
+  installedApps: Map<string, AppInfo>;
+  onClick: () => void;
+}) {
+  return (
+    <Card
+      className="cursor-pointer transition-colors hover:bg-muted/50 flex flex-col overflow-hidden"
+      onClick={onClick}
+    >
+      <div className="flex flex-col flex-1 p-6 gap-4">
+        {/* Header: Icon + MCP mini-icons */}
+        <div className="flex items-start justify-between">
+          <IntegrationIcon
+            icon={specIcon(spec)}
+            name={spec.title}
+            size="md"
+            className="shrink-0 shadow-sm"
+          />
+          {spec.requiredApps.length > 0 && (
+            <div className="flex items-center gap-1">
+              {spec.requiredApps.map((app) => (
+                <McpAppIcon key={app} app={app} installedApps={installedApps} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Title + Description */}
+        <div className="flex flex-col gap-1.5 min-w-0">
+          <span className="text-base font-medium text-foreground truncate">
+            {spec.title}
+          </span>
+          <span className="text-sm text-muted-foreground line-clamp-2 leading-relaxed">
+            {spec.description}
+          </span>
+        </div>
+
+        {/* Ice Breaker Preview */}
+        <div className="flex flex-col gap-2 mt-auto pt-3 border-t border-border/50">
+          <div className="flex flex-wrap gap-1.5">
+            {spec.iceBreakers.slice(0, 2).map((breaker, i) => (
+              <span
+                key={i}
+                className="text-xs text-muted-foreground bg-muted/50 rounded-full px-3 py-1 truncate max-w-full"
+              >
+                {breaker}
+              </span>
+            ))}
+            {spec.iceBreakers.length > 2 && (
+              <span className="text-xs text-muted-foreground/60 px-1 py-1">
+                +{spec.iceBreakers.length - 2} more
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template detail dialog
+// ---------------------------------------------------------------------------
+
+function TemplateDetailDialog({
+  spec,
+  open,
+  onOpenChange,
+  installedApps,
+  onInstall,
+  isInstalling,
+}: {
+  spec: DefaultAgentSpec | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  installedApps: Map<string, AppInfo>;
+  onInstall: (spec: DefaultAgentSpec) => void;
+  isInstalling: boolean;
+}) {
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  if (!spec) return null;
+
+  const missingApps = spec.requiredApps.filter(
+    (app) => !installedApps.get(app)?.installed,
+  );
+  const canInstall = missingApps.length === 0;
+
+  const registryId = WellKnownOrgMCPId.REGISTRY(org.id);
+
+  const goToStore = (appName: string) => {
+    onOpenChange(false);
+    navigate({
+      to: "/$org/store/$appName",
+      params: {
+        org: org.slug,
+        appName,
+      },
+      search: {
+        registryId,
+        serverName: `deco/${appName}`,
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[85vh] flex flex-col p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4">
+          <div className="flex items-center gap-3">
+            <IntegrationIcon
+              icon={specIcon(spec)}
+              name={spec.title}
+              size="md"
+              className="shrink-0 shadow-sm"
+            />
+            <div>
+              <DialogTitle>{spec.title}</DialogTitle>
+              <DialogDescription>{spec.description}</DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-auto px-6 pb-6 flex flex-col gap-5">
+          {/* Required MCPs */}
+          {spec.requiredApps.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-foreground uppercase tracking-wider font-mono">
+                Required MCPs
+              </span>
+              <div className="flex flex-col gap-2">
+                {spec.requiredApps.map((app) => {
+                  const installed = !!installedApps.get(app)?.installed;
+                  return (
+                    <div key={app} className="flex items-center gap-2.5">
+                      <McpAppIcon app={app} installedApps={installedApps} />
+                      <span className="text-sm text-foreground">{app}</span>
+                      {installed ? (
+                        <span className="text-xs ml-auto text-emerald-600">
+                          Installed
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          className="text-xs ml-auto text-red-500 hover:text-red-600 underline underline-offset-2 cursor-pointer"
+                          onClick={() => goToStore(app)}
+                        >
+                          Install from Store
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              {missingApps.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Install missing MCPs from the Store before adding this agent.
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Ice Breakers */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-foreground uppercase tracking-wider font-mono">
+              Conversation Starters
+            </span>
+            <div className="flex flex-col gap-1.5">
+              {spec.iceBreakers.map((breaker, i) => (
+                <div
+                  key={i}
+                  className="flex items-start gap-2 rounded-lg border border-border/50 bg-muted/30 px-3 py-2"
+                >
+                  <MessageChatCircle
+                    size={14}
+                    className="shrink-0 text-muted-foreground mt-0.5"
+                  />
+                  <span className="text-sm text-foreground">{breaker}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* System Prompt Preview */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-foreground uppercase tracking-wider font-mono">
+              System Prompt
+            </span>
+            <div className="rounded-lg border border-border/50 bg-muted/20 px-3 py-2 max-h-48 overflow-auto">
+              <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+                {spec.instructions}
+              </pre>
+            </div>
+          </div>
+
+          {/* Built-in connections info */}
+          {spec.builtinConnections.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-foreground uppercase tracking-wider font-mono">
+                Built-in Connections
+              </span>
+              <div className="flex flex-wrap gap-1.5">
+                {spec.builtinConnections.map((conn) => (
+                  <Badge key={conn.key} variant="secondary" className="text-xs">
+                    {conn.key}
+                    {conn.selected_tools
+                      ? ` (${conn.selected_tools.length} tools)`
+                      : " (all tools)"}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer with install / go-to-store button */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          {canInstall ? (
+            <Button onClick={() => onInstall(spec)} disabled={isInstalling}>
+              <Plus size={14} />
+              {isInstalling ? "Installing..." : "Install Agent"}
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              onClick={() => goToStore(missingApps[0]!)}
+            >
+              <ShoppingBag01 size={14} />
+              Go to Store
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function AgentTemplates() {
+  const [search, setSearch] = useState("");
+  const [selectedSpec, setSelectedSpec] = useState<DefaultAgentSpec | null>(
+    null,
+  );
+  const [isInstalling, setIsInstalling] = useState(false);
+  const installedApps = useInstalledApps();
+  const actions = useVirtualMCPActions();
+
+  const allSpecs = getDefaultAgentSpecs();
+
+  // Filter by search
+  const filtered = search
+    ? allSpecs.filter(
+        (s) =>
+          s.title.toLowerCase().includes(search.toLowerCase()) ||
+          s.description.toLowerCase().includes(search.toLowerCase()) ||
+          s.requiredApps.some((app) =>
+            app.toLowerCase().includes(search.toLowerCase()),
+          ),
+      )
+    : allSpecs;
+
+  const categories = categorizeSpecs(filtered);
+
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+
+  const handleInstall = async (spec: DefaultAgentSpec) => {
+    setIsInstalling(true);
+    try {
+      const created = await actions.create.mutateAsync({
+        title: spec.title,
+        description: spec.description,
+        icon: specIcon(spec),
+        status: "active",
+        metadata: {
+          instructions: spec.instructions,
+          ice_breakers: spec.iceBreakers,
+          required_apps: spec.requiredApps,
+        },
+        connections: [],
+      });
+      setSelectedSpec(null);
+      if (created?.id) {
+        navigate({
+          to: "/$org/agents/$agentId",
+          params: {
+            org: org.slug,
+            agentId: created.id,
+          },
+        });
+      }
+    } finally {
+      setIsInstalling(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      {/* Search */}
+      <div className="px-5">
+        <CollectionSearch
+          value={search}
+          onChange={setSearch}
+          placeholder="Search templates..."
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setSearch("");
+              (event.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 overflow-auto px-5 pb-5">
+        {categories.length === 0 ? (
+          <EmptyState
+            image={<SearchMd size={36} className="text-muted-foreground" />}
+            title="No templates found"
+            description={`No templates match "${search}"`}
+          />
+        ) : (
+          <div className="flex flex-col gap-8">
+            {categories.map((cat) => (
+              <div key={cat.label} className="flex flex-col gap-3">
+                <span className="text-sm font-medium text-muted-foreground uppercase tracking-wider font-mono">
+                  {cat.label}
+                </span>
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+                  {cat.specs.map((spec) => (
+                    <TemplateCard
+                      key={spec.title}
+                      spec={spec}
+                      installedApps={installedApps}
+                      onClick={() => setSelectedSpec(spec)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Detail dialog */}
+      <TemplateDetailDialog
+        spec={selectedSpec}
+        open={selectedSpec !== null}
+        onOpenChange={(open) => !open && setSelectedSpec(null)}
+        installedApps={installedApps}
+        onInstall={handleInstall}
+        isInstalling={isInstalling}
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/agents.tsx
+++ b/apps/mesh/src/web/routes/orgs/agents.tsx
@@ -1,3 +1,4 @@
+import { AgentTemplates } from "@/web/components/agents/agent-templates.tsx";
 import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { Page } from "@/web/components/page";
@@ -11,16 +12,16 @@ import { ConnectionCard } from "@/web/components/connections/connection-card.tsx
 import { ConnectionStatus } from "@/web/components/connections/connection-status.tsx";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
-import { AgentAvatar } from "@/web/components/agent-icon";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { useListState } from "@/web/hooks/use-list-state";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import {
   isDecopilot,
   useProjectContext,
+  useVirtualMCPs,
   useVirtualMCPActions,
   type VirtualMCPEntity,
 } from "@decocms/mesh-sdk";
-import { useAgents } from "@/web/hooks/use-agents";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -48,6 +49,12 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@deco/ui/components/sheet.tsx";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@deco/ui/components/tabs.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { type TableColumn } from "@/web/components/collections/collection-table.tsx";
 import {
@@ -290,7 +297,7 @@ function AgentGroupCard({
           >
             <SheetHeader className="px-6 pt-6 pb-4 border-b border-border shrink-0">
               <div className="flex items-center gap-3">
-                <AgentAvatar
+                <IntegrationIcon
                   icon={group.icon}
                   name={group.title}
                   size="md"
@@ -322,7 +329,7 @@ function AgentGroupCard({
                     onNavigate(a.id);
                   }}
                 >
-                  <AgentAvatar
+                  <IntegrationIcon
                     icon={a.icon}
                     name={a.title}
                     size="sm"
@@ -386,7 +393,7 @@ function AgentGroupCard({
           <DialogContent className="sm:max-w-lg p-0 gap-0">
             <DialogHeader className="px-6 pt-6 pb-4">
               <div className="flex items-center gap-3">
-                <AgentAvatar
+                <IntegrationIcon
                   icon={group.icon}
                   name={group.title}
                   size="md"
@@ -418,7 +425,7 @@ function AgentGroupCard({
                     onNavigate(a.id);
                   }}
                 >
-                  <AgentAvatar
+                  <IntegrationIcon
                     icon={a.icon}
                     name={a.title}
                     size="sm"
@@ -725,7 +732,7 @@ function GroupedAgentTable({
                       return (
                         <TableCell key={col.id} className={base}>
                           <div className="flex items-center gap-2 min-w-0">
-                            <AgentAvatar
+                            <IntegrationIcon
                               icon={group.icon}
                               name={group.title}
                               size="sm"
@@ -839,13 +846,17 @@ function OrgAgentsContent() {
     defaultViewMode: "cards",
   });
 
-  const virtualMcps = useAgents(listState);
+  const virtualMcps = useVirtualMCPs(listState);
   const { createVirtualMCP, isCreating } = useCreateVirtualMCP({
     navigateOnCreate: true,
   });
   const actions = useVirtualMCPActions();
 
   const [dialogState, dispatch] = useReducer(dialogReducer, { mode: "idle" });
+
+  // Default to templates tab when org has no agents (onboarding)
+  const defaultTab = virtualMcps.length === 0 ? "templates" : "my-agents";
+  const [activeTab, setActiveTab] = useState(defaultTab);
 
   // Bulk selection state
   const [selectionMode, setSelectionMode] = useState(false);
@@ -944,7 +955,7 @@ function OrgAgentsContent() {
       header: "Name",
       render: (virtualMcp) => (
         <div className="flex items-center gap-2 min-w-0">
-          <AgentAvatar
+          <IntegrationIcon
             icon={virtualMcp.icon}
             name={virtualMcp.title}
             size="sm"
@@ -1185,215 +1196,239 @@ function OrgAgentsContent() {
         </Page.Header.Right>
       </Page.Header>
 
-      {/* Search Bar */}
-      <div className="flex items-center gap-3 px-5 pb-0">
-        <div className="flex-1">
-          <CollectionSearch
-            value={listState.search}
-            onChange={listState.setSearch}
-            placeholder="Search for an agent..."
-            onKeyDown={(event) => {
-              if (event.key === "Escape") {
-                listState.setSearch("");
-                (event.target as HTMLInputElement).blur();
-              }
-            }}
-          />
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex flex-col flex-1 overflow-hidden"
+      >
+        <div className="px-5">
+          <TabsList>
+            <TabsTrigger value="my-agents">My Agents</TabsTrigger>
+            <TabsTrigger value="templates">Templates</TabsTrigger>
+          </TabsList>
         </div>
-      </div>
 
-      {/* Content: Cards or Table */}
-      <Page.Content>
-        {listState.viewMode === "cards" ? (
-          <div className="flex-1 overflow-auto p-5">
-            {filteredAgents.length === 0 ? (
-              <div className="flex items-center justify-center min-h-[60vh]">
-                <EmptyState
-                  image={
-                    <Users03 size={48} className="text-muted-foreground" />
+        <TabsContent value="templates" className="flex-1 overflow-hidden mt-0">
+          <AgentTemplates />
+        </TabsContent>
+
+        <TabsContent value="my-agents" className="flex-1 overflow-hidden mt-0">
+          {/* Search Bar */}
+          <div className="flex items-center gap-3 px-5 pb-0">
+            <div className="flex-1">
+              <CollectionSearch
+                value={listState.search}
+                onChange={listState.setSearch}
+                placeholder="Search for an agent..."
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    listState.setSearch("");
+                    (event.target as HTMLInputElement).blur();
                   }
-                  title={listState.search ? "No agents found" : "No agents yet"}
-                  description={
-                    listState.search
-                      ? `No agents match "${listState.search}"`
-                      : "Create an agent to aggregate tools from multiple Connections."
-                  }
-                  actions={
-                    !listState.search && (
-                      <Button
-                        size="sm"
-                        onClick={createVirtualMCP}
-                        disabled={isCreating}
-                      >
-                        <Plus size={14} />
-                        {isCreating ? "Creating..." : "Create Agent"}
-                      </Button>
-                    )
-                  }
-                />
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Content: Cards or Table */}
+          <Page.Content>
+            {listState.viewMode === "cards" ? (
+              <div className="flex-1 overflow-auto p-5">
+                {filteredAgents.length === 0 ? (
+                  <div className="flex items-center justify-center min-h-[60vh]">
+                    <EmptyState
+                      image={
+                        <Users03 size={48} className="text-muted-foreground" />
+                      }
+                      title={
+                        listState.search ? "No agents found" : "No agents yet"
+                      }
+                      description={
+                        listState.search
+                          ? `No agents match "${listState.search}"`
+                          : "Create an agent to aggregate tools from multiple Connections."
+                      }
+                      actions={
+                        !listState.search && (
+                          <Button
+                            size="sm"
+                            onClick={createVirtualMCP}
+                            disabled={isCreating}
+                          >
+                            <Plus size={14} />
+                            {isCreating ? "Creating..." : "Create Agent"}
+                          </Button>
+                        )
+                      }
+                    />
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
+                    {grouped.map((item) => {
+                      if (item.type === "group") {
+                        return (
+                          <AgentGroupCard
+                            key={item.key}
+                            group={item}
+                            onNavigate={navigateToAgent}
+                            onDelete={(a) =>
+                              dispatch({ type: "delete", virtualMcp: a })
+                            }
+                            selectionMode={selectionMode}
+                            selectedIds={selectedIds}
+                            onToggleSelect={toggleSelect}
+                          />
+                        );
+                      }
+
+                      const agent = item.agent;
+                      return (
+                        <div key={agent.id} className="relative">
+                          {selectionMode && (
+                            <div className="absolute top-3 left-3 z-10">
+                              <Checkbox
+                                checked={selectedIds.has(agent.id)}
+                                onCheckedChange={() => toggleSelect(agent.id)}
+                              />
+                            </div>
+                          )}
+                          <ConnectionCard
+                            connection={{
+                              id: agent.id ?? "",
+                              title: agent.title,
+                              description: agent.description,
+                              icon: agent.icon,
+                              status: agent.status,
+                            }}
+                            fallbackIcon={<Users03 />}
+                            onClick={() => navigateToAgent(agent.id)}
+                            className={cn(
+                              selectionMode &&
+                                selectedIds.has(agent.id) &&
+                                "ring-2 ring-primary",
+                            )}
+                            footer={
+                              <div className="flex items-center justify-between text-xs text-muted-foreground w-full min-w-0">
+                                <div className="flex-1 min-w-0">
+                                  <User
+                                    id={agent.updated_by ?? agent.created_by}
+                                    size="3xs"
+                                  />
+                                </div>
+                                <span className="shrink-0 ml-2">
+                                  {agent.updated_at
+                                    ? formatTimeAgo(new Date(agent.updated_at))
+                                    : "—"}
+                                </span>
+                              </div>
+                            }
+                            headerActions={
+                              !selectionMode ? (
+                                <DropdownMenu>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-8 w-8 p-0"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      <DotsVertical size={20} />
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent
+                                    align="end"
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <DropdownMenuItem
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        navigateToAgent(agent.id);
+                                      }}
+                                    >
+                                      <Eye size={16} />
+                                      Open
+                                    </DropdownMenuItem>
+                                    {!isDecopilot(agent.id) && (
+                                      <DropdownMenuItem
+                                        variant="destructive"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          dispatch({
+                                            type: "delete",
+                                            virtualMcp: agent,
+                                          });
+                                        }}
+                                      >
+                                        <Trash01 size={16} />
+                                        Delete
+                                      </DropdownMenuItem>
+                                    )}
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              ) : undefined
+                            }
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
-                {grouped.map((item) => {
-                  if (item.type === "group") {
-                    return (
-                      <AgentGroupCard
-                        key={item.key}
-                        group={item}
-                        onNavigate={navigateToAgent}
-                        onDelete={(a) =>
-                          dispatch({ type: "delete", virtualMcp: a })
+              <div className="h-full flex flex-col overflow-hidden">
+                <div className="flex-1 overflow-auto min-w-0">
+                  {grouped.length === 0 ? (
+                    <div className="flex items-center justify-center min-h-[60vh]">
+                      <EmptyState
+                        image={
+                          <Users03
+                            size={48}
+                            className="text-muted-foreground"
+                          />
                         }
+                        title={
+                          listState.search ? "No agents found" : "No agents yet"
+                        }
+                        description={
+                          listState.search
+                            ? `No agents match "${listState.search}"`
+                            : "Create an agent to aggregate tools from multiple Connections."
+                        }
+                        actions={
+                          !listState.search && (
+                            <Button
+                              size="sm"
+                              onClick={createVirtualMCP}
+                              disabled={isCreating}
+                            >
+                              <Plus size={14} />
+                              {isCreating ? "Creating..." : "Create Agent"}
+                            </Button>
+                          )
+                        }
+                      />
+                    </div>
+                  ) : (
+                    <div className="min-w-[1000px]">
+                      <GroupedAgentTable
+                        columns={columns}
+                        grouped={grouped}
+                        sortKey={listState.sortKey}
+                        sortDirection={listState.sortDirection}
+                        onSort={listState.handleSort}
+                        onRowClick={(agent) => navigateToAgent(agent.id)}
                         selectionMode={selectionMode}
                         selectedIds={selectedIds}
                         onToggleSelect={toggleSelect}
                       />
-                    );
-                  }
-
-                  const agent = item.agent;
-                  return (
-                    <div key={agent.id} className="relative">
-                      {selectionMode && (
-                        <div className="absolute top-3 left-3 z-10">
-                          <Checkbox
-                            checked={selectedIds.has(agent.id)}
-                            onCheckedChange={() => toggleSelect(agent.id)}
-                          />
-                        </div>
-                      )}
-                      <ConnectionCard
-                        connection={{
-                          id: agent.id ?? "",
-                          title: agent.title,
-                          description: agent.description,
-                          icon: agent.icon,
-                          status: agent.status,
-                        }}
-                        fallbackIcon={<Users03 />}
-                        onClick={() => navigateToAgent(agent.id)}
-                        className={cn(
-                          selectionMode &&
-                            selectedIds.has(agent.id) &&
-                            "ring-2 ring-primary",
-                        )}
-                        footer={
-                          <div className="flex items-center justify-between text-xs text-muted-foreground w-full min-w-0">
-                            <div className="flex-1 min-w-0">
-                              <User
-                                id={agent.updated_by ?? agent.created_by}
-                                size="3xs"
-                              />
-                            </div>
-                            <span className="shrink-0 ml-2">
-                              {agent.updated_at
-                                ? formatTimeAgo(new Date(agent.updated_at))
-                                : "—"}
-                            </span>
-                          </div>
-                        }
-                        headerActions={
-                          !selectionMode ? (
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="h-8 w-8 p-0"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <DotsVertical size={20} />
-                                </Button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent
-                                align="end"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <DropdownMenuItem
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    navigateToAgent(agent.id);
-                                  }}
-                                >
-                                  <Eye size={16} />
-                                  Open
-                                </DropdownMenuItem>
-                                {!isDecopilot(agent.id) && (
-                                  <DropdownMenuItem
-                                    variant="destructive"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      dispatch({
-                                        type: "delete",
-                                        virtualMcp: agent,
-                                      });
-                                    }}
-                                  >
-                                    <Trash01 size={16} />
-                                    Delete
-                                  </DropdownMenuItem>
-                                )}
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          ) : undefined
-                        }
-                      />
                     </div>
-                  );
-                })}
+                  )}
+                </div>
               </div>
             )}
-          </div>
-        ) : (
-          <div className="h-full flex flex-col overflow-hidden">
-            <div className="flex-1 overflow-auto min-w-0">
-              {grouped.length === 0 ? (
-                <div className="flex items-center justify-center min-h-[60vh]">
-                  <EmptyState
-                    image={
-                      <Users03 size={48} className="text-muted-foreground" />
-                    }
-                    title={
-                      listState.search ? "No agents found" : "No agents yet"
-                    }
-                    description={
-                      listState.search
-                        ? `No agents match "${listState.search}"`
-                        : "Create an agent to aggregate tools from multiple Connections."
-                    }
-                    actions={
-                      !listState.search && (
-                        <Button
-                          size="sm"
-                          onClick={createVirtualMCP}
-                          disabled={isCreating}
-                        >
-                          <Plus size={14} />
-                          {isCreating ? "Creating..." : "Create Agent"}
-                        </Button>
-                      )
-                    }
-                  />
-                </div>
-              ) : (
-                <div className="min-w-[1000px]">
-                  <GroupedAgentTable
-                    columns={columns}
-                    grouped={grouped}
-                    sortKey={listState.sortKey}
-                    sortDirection={listState.sortDirection}
-                    onSort={listState.handleSort}
-                    onRowClick={(agent) => navigateToAgent(agent.id)}
-                    selectionMode={selectionMode}
-                    selectedIds={selectedIds}
-                    onToggleSelect={toggleSelect}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </Page.Content>
+          </Page.Content>
+        </TabsContent>
+      </Tabs>
 
       {/* Bulk Action Bar */}
       {selectionMode && (

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -108,6 +108,20 @@ export const VirtualMCPEntitySchema = z.object({
         .nullable()
         .optional()
         .describe("List of enabled plugin IDs"),
+      ice_breakers: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "Static conversation starter prompts shown in the chat UI as clickable pills",
+        ),
+      required_apps: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "app_names of MCPs this agent needs. Used for auto-wiring when MCPs are installed",
+        ),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),
@@ -157,6 +171,16 @@ export const VirtualMCPCreateDataSchema = z.object({
         .nullable()
         .optional()
         .describe("List of enabled plugin IDs"),
+      ice_breakers: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("Static conversation starter prompts"),
+      required_apps: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("app_names of MCPs this agent needs"),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),
@@ -199,6 +223,16 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .nullable()
         .optional()
         .describe("List of enabled plugin IDs"),
+      ice_breakers: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("Static conversation starter prompts"),
+      required_apps: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe("app_names of MCPs this agent needs"),
       ui: VirtualMcpUISchema.nullable()
         .optional()
         .describe("UI customization settings"),


### PR DESCRIPTION
## Summary
- Adds a browsable catalog of **27 agent templates** across 7 categories (Platform, E-Commerce, Content & SEO, Site Building, Marketing, Operations, Engineering)
- New **Templates tab** on agents page — defaults to it when org has no agents
- Each template shows required MCPs with green/red install status rings, ice breaker pills, and system prompt preview
- Missing MCPs deep-link to the Store for one-click installation
- Installing an agent navigates directly to its detail page
- Engineering agents inspired by [gstack](https://github.com/garrytan/gstack): Code Reviewer, Engineering Retro, Product Reviewer, Architecture Reviewer, Browser QA

### Files changed
- `apps/mesh/src/constants/default-agents.ts` — 27 agent template specs
- `apps/mesh/src/web/components/agents/agent-templates.tsx` — template browser UI
- `apps/mesh/src/web/routes/orgs/agents.tsx` — tabs + empty state
- `apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts` — ice breaker injection
- `packages/mesh-sdk/src/types/virtual-mcp.ts` — metadata schema extension

## Test plan
- [ ] Verify Templates tab renders with all 7 categories
- [ ] Search filters templates by title, description, and required app names
- [ ] MCP icons show green ring when installed, red when missing
- [ ] Clicking "Install from Store" navigates to correct store page with registryId/serverName
- [ ] Installing an agent creates it and navigates to the agent detail page
- [ ] Ice breakers display correctly in chat UI (not as `__ice_breaker_0`)
- [ ] Empty state defaults to Templates tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a browsable catalog of 27 agent templates with a new Templates tab on the Agents page to quickly bootstrap agents. Templates show required MCP install status, deep-link to the Store, and install flows that create the agent with ice-breakers and navigate to its detail page.

- **New Features**
  - Templates tab with category grouping and search; two-tab switcher (My Agents/Templates) defaults to Templates when an org has no agents
  - Detail dialog shows required MCPs with green/red status rings and one-click Store links, conversation starters, system prompt preview; built-in connections listed when present
  - Installing a template creates the agent (with instructions, ice_breakers, required_apps) and routes to its detail page; ice breakers are injected as static chat prompts
  - Shows MCP icons for required apps and deep-links to the Store for missing installs

- **Migration**
  - No breaking changes; added optional `metadata.ice_breakers` and `metadata.required_apps` to Virtual MCP schemas in `@decocms/mesh-sdk`

<sup>Written for commit 351ce6dda082c49ea084547e8b0690c048e94484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

