### PR TITLE
docs(automations): add automations documentation page

### DIFF
--- a/apps/docs/client/src/content/2026-03-10/en/mcp-mesh/agents.mdx
+++ b/apps/docs/client/src/content/2026-03-10/en/mcp-mesh/agents.mdx
@@ -98,4 +98,4 @@ Agents provide focused capabilities with clear advantages:
 
 ---
 
-**Next steps**: Learn about [Virtual MCPs](/en/mcp-mesh/virtual-mcps) to understand the foundation, or explore [decopilot](/en/mcp-mesh/decopilot/overview) to see how agents are spawned dynamically.
+**Next steps**: Learn about [Virtual MCPs](/en/mcp-mesh/virtual-mcps) to understand the foundation, explore [decopilot](/en/mcp-mesh/decopilot/overview) to see how agents are spawned dynamically, or set up [Automations](/en/mcp-mesh/automations) for unattended agent execution on schedules and events.

--- a/apps/docs/client/src/content/2026-03-10/en/mcp-mesh/automations.mdx
+++ b/apps/docs/client/src/content/2026-03-10/en/mcp-mesh/automations.mdx
@@ -1,0 +1,107 @@
+---
+title: Automations
+description: Unattended AI agent runs triggered by schedules or events
+icon: Zap
+---
+
+import Callout from "../../../../components/ui/Callout.astro";
+
+<Callout type="info">
+  Automations is an experimental feature. Enable it in **Settings → Account → Preferences → experimentalAutomations**.
+</Callout>
+
+## What Are Automations?
+
+Automations are **unattended agent runs** — AI agents that execute on a schedule or in response to events, without a human in the loop. Each automation configures:
+
+- **Agent** — which [Virtual MCP](/en/mcp-mesh/virtual-mcps) (agent) to run
+- **Messages** — the prompt/instructions the agent receives each run
+- **Model** — which AI model and credentials to use
+- **Triggers** — when the automation fires (cron schedule, connection event, or manual)
+
+Automations run in **passthrough mode**, meaning all tool calls are auto-approved. This is what makes them unattended — but it also means you should scope agent tools carefully.
+
+**Automations vs Decopilot**: [Decopilot](/en/mcp-mesh/decopilot/overview) is interactive — a human converses with the agent and approves actions. Automations are fire-and-forget: the agent runs, completes its task, and the result appears in [Monitoring](/en/mcp-mesh/monitoring).
+
+## When to Use Automations
+
+- **Scheduled tasks** — daily reports, periodic data syncs, cleanup jobs
+- **Event-driven workflows** — new order → fulfillment, new ticket → triage, deployment → notification
+- **Any workflow that should run without human approval**
+
+## Creating an Automation
+
+1. Navigate to **Automations** in the sidebar
+2. Click **New Automation**
+3. Choose an [agent](/en/mcp-mesh/agents) — the Virtual MCP that will execute
+4. Write the prompt/messages — what the agent should do each run
+5. Select a model and credentials
+6. Set temperature (default 0.5)
+7. Add one or more triggers (cron or event)
+8. Activate the automation
+
+## Triggers
+
+### Cron Triggers
+
+Cron triggers run the automation on a recurring schedule using standard cron expression syntax. All times are in **UTC**.
+
+| Expression | Schedule |
+|---|---|
+| `0 9 * * *` | Daily at 9:00 AM UTC |
+| `0 */6 * * *` | Every 6 hours |
+| `0 9 * * 1` | Every Monday at 9:00 AM UTC |
+| `*/5 * * * *` | Every 5 minutes |
+
+**Minimum interval**: 60 seconds. Expressions that resolve to intervals shorter than 60 seconds are rejected.
+
+**Crash-safe scheduling**: The system records `last_run_at` for each trigger. If the server restarts, missed runs are detected and fired on the next poll cycle (every 30 seconds).
+
+### Event Triggers
+
+Event triggers fire the automation when a connected MCP server publishes a matching event.
+
+- The connection must implement `TRIGGER_CONFIGURE` (so the mesh can register/unregister interest in events)
+- You specify the **connection**, **event type**, and optional **params** for filtering
+- **Fail-atomic**: if configuring the trigger on the connection fails, the trigger is not created
+- When the automation is deactivated or deleted, event triggers are disabled on their connections (best-effort)
+
+**Param filtering**: If you specify params, only events whose data contains all matching key-value pairs will fire the automation. Extra fields in the event data are ignored.
+
+## Running and Testing
+
+- Use the **AUTOMATION_RUN** tool or the UI to manually trigger a run at any time
+- Each run creates a thread visible in [Monitoring](/en/mcp-mesh/monitoring)
+- Runs that error are marked as failed in the thread
+
+## Safety and Limits
+
+<Callout type="warning">
+  Automations run in passthrough mode — all tool calls are auto-approved. Scope your agent's tools carefully to prevent unintended actions.
+</Callout>
+
+- **Per-automation concurrency**: Maximum 3 concurrent runs per automation. Additional triggers are skipped until a slot opens.
+- **Global concurrency**: Maximum 10 concurrent automation runs across the entire system.
+- **Run timeout**: Each run is capped at 5 minutes.
+- **Recursion prevention**: Event trigger chains are limited to a depth of 3. If an automation's actions trigger events that fire other automations, the chain stops after 3 levels.
+- **Payload limit**: Event data is capped at 1 MB. Larger payloads are truncated to mitigate prompt injection risks.
+- **Creator validation**: If the automation's creator leaves the organization, the automation is automatically deactivated.
+
+## Automation MCP Tools
+
+These tools are available for managing automations programmatically via the MCP interface:
+
+| Tool | Description |
+|---|---|
+| `AUTOMATION_CREATE` | Create a new automation with agent, messages, model, and triggers |
+| `AUTOMATION_GET` | Get a single automation by ID with full configuration |
+| `AUTOMATION_LIST` | List all automations in the current organization |
+| `AUTOMATION_UPDATE` | Update automation fields (partial update supported) |
+| `AUTOMATION_DELETE` | Delete an automation and disable its event triggers |
+| `AUTOMATION_TRIGGER_ADD` | Add a cron or event trigger to an automation |
+| `AUTOMATION_TRIGGER_REMOVE` | Remove a trigger from an automation |
+| `AUTOMATION_RUN` | Manually trigger an automation run |
+
+---
+
+**Next steps**: Learn about [Agents](/en/mcp-mesh/agents) to understand how to design the Virtual MCPs that automations execute, or explore [Monitoring](/en/mcp-mesh/monitoring) to track automation runs.

--- a/apps/docs/client/src/content/2026-03-10/en/mcp-mesh/concepts.mdx
+++ b/apps/docs/client/src/content/2026-03-10/en/mcp-mesh/concepts.mdx
@@ -11,6 +11,7 @@ icon: BookOpen
 - **Connection**: a configured upstream MCP endpoint (usually HTTP), optionally with stored credentials. See [Connections](/en/mcp-mesh/connections).
 - **Virtual MCP**: aggregates tools/resources/prompts from connected servers into a single MCP. See [Virtual MCPs](/en/mcp-mesh/virtual-mcps).
 - **Agent**: single-purpose Virtual MCPs optimized for specific tasks. See [Agents](/en/mcp-mesh/agents).
+- **Automation**: unattended agent runs on a schedule or event trigger. See [Automations](/en/mcp-mesh/automations).
 - **Project**: Virtual MCPs to organize project-specific tools, resources, prompts, and config. See [Projects](/en/mcp-mesh/projects).
 
 ## Understanding Agents vs. Projects

--- a/apps/docs/client/src/content/2026-03-10/pt-br/mcp-mesh/agents.mdx
+++ b/apps/docs/client/src/content/2026-03-10/pt-br/mcp-mesh/agents.mdx
@@ -98,4 +98,4 @@ Agentes fornecem capacidades focadas com vantagens claras:
 
 ---
 
-**Próximos passos**: Aprenda sobre [MCPs Virtuais](/pt-br/mcp-mesh/virtual-mcps) para entender a fundação, ou explore o [decopilot](/pt-br/mcp-mesh/decopilot/overview) para ver como agentes são iniciados dinamicamente.
+**Próximos passos**: Aprenda sobre [MCPs Virtuais](/pt-br/mcp-mesh/virtual-mcps) para entender a fundação, explore o [decopilot](/pt-br/mcp-mesh/decopilot/overview) para ver como agentes são iniciados dinamicamente, ou configure [Automações](/pt-br/mcp-mesh/automations) para execução autônoma de agentes em agendamentos e eventos.

--- a/apps/docs/client/src/content/2026-03-10/pt-br/mcp-mesh/automations.mdx
+++ b/apps/docs/client/src/content/2026-03-10/pt-br/mcp-mesh/automations.mdx
@@ -1,0 +1,107 @@
+---
+title: Automações
+description: Execuções autônomas de agentes IA disparadas por agendamentos ou eventos
+icon: Zap
+---
+
+import Callout from "../../../../components/ui/Callout.astro";
+
+<Callout type="info">
+  Automações é um recurso experimental. Ative em **Configurações → Conta → Preferências → experimentalAutomations**.
+</Callout>
+
+## O Que São Automações?
+
+Automações são **execuções autônomas de agentes** — agentes de IA que executam em um agendamento ou em resposta a eventos, sem intervenção humana. Cada automação configura:
+
+- **Agente** — qual [MCP Virtual](/pt-br/mcp-mesh/virtual-mcps) (agente) executar
+- **Mensagens** — o prompt/instruções que o agente recebe em cada execução
+- **Modelo** — qual modelo de IA e credenciais usar
+- **Gatilhos** — quando a automação dispara (agendamento cron, evento de conexão ou manual)
+
+Automações executam em **modo passthrough**, o que significa que todas as chamadas de ferramentas são auto-aprovadas. É isso que as torna autônomas — mas também significa que você deve definir cuidadosamente o escopo das ferramentas do agente.
+
+**Automações vs Decopilot**: O [Decopilot](/pt-br/mcp-mesh/decopilot/overview) é interativo — um humano conversa com o agente e aprova ações. Automações são disparar-e-esquecer: o agente executa, completa sua tarefa, e o resultado aparece no [Monitoramento](/pt-br/mcp-mesh/monitoring).
+
+## Quando Usar Automações
+
+- **Tarefas agendadas** — relatórios diários, sincronizações periódicas, tarefas de limpeza
+- **Fluxos orientados a eventos** — novo pedido → processamento, novo ticket → triagem, deploy → notificação
+- **Qualquer fluxo que deve executar sem aprovação humana**
+
+## Criando uma Automação
+
+1. Navegue até **Automações** na barra lateral
+2. Clique em **Nova Automação**
+3. Escolha um [agente](/pt-br/mcp-mesh/agents) — o MCP Virtual que será executado
+4. Escreva o prompt/mensagens — o que o agente deve fazer em cada execução
+5. Selecione um modelo e credenciais
+6. Defina a temperatura (padrão 0.5)
+7. Adicione um ou mais gatilhos (cron ou evento)
+8. Ative a automação
+
+## Gatilhos
+
+### Gatilhos Cron
+
+Gatilhos cron executam a automação em um agendamento recorrente usando sintaxe padrão de expressão cron. Todos os horários são em **UTC**.
+
+| Expressão | Agendamento |
+|---|---|
+| `0 9 * * *` | Diariamente às 9:00 UTC |
+| `0 */6 * * *` | A cada 6 horas |
+| `0 9 * * 1` | Toda segunda-feira às 9:00 UTC |
+| `*/5 * * * *` | A cada 5 minutos |
+
+**Intervalo mínimo**: 60 segundos. Expressões que resultam em intervalos menores que 60 segundos são rejeitadas.
+
+**Agendamento à prova de falhas**: O sistema registra `last_run_at` para cada gatilho. Se o servidor reiniciar, execuções perdidas são detectadas e disparadas no próximo ciclo de verificação (a cada 30 segundos).
+
+### Gatilhos de Evento
+
+Gatilhos de evento disparam a automação quando um servidor MCP conectado publica um evento correspondente.
+
+- A conexão deve implementar `TRIGGER_CONFIGURE` (para que o mesh possa registrar/desregistrar interesse em eventos)
+- Você especifica a **conexão**, **tipo de evento** e **parâmetros** opcionais para filtragem
+- **Fail-atomic**: se a configuração do gatilho na conexão falhar, o gatilho não é criado
+- Quando a automação é desativada ou excluída, os gatilhos de evento são desabilitados nas conexões (melhor esforço)
+
+**Filtragem por parâmetros**: Se você especificar parâmetros, apenas eventos cujos dados contenham todos os pares chave-valor correspondentes dispararão a automação. Campos extras nos dados do evento são ignorados.
+
+## Executando e Testando
+
+- Use a ferramenta **AUTOMATION_RUN** ou a interface para disparar uma execução manualmente a qualquer momento
+- Cada execução cria um thread visível no [Monitoramento](/pt-br/mcp-mesh/monitoring)
+- Execuções com erro são marcadas como falhas no thread
+
+## Segurança e Limites
+
+<Callout type="warning">
+  Automações executam em modo passthrough — todas as chamadas de ferramentas são auto-aprovadas. Defina cuidadosamente o escopo das ferramentas do seu agente para prevenir ações indesejadas.
+</Callout>
+
+- **Concorrência por automação**: Máximo de 3 execuções simultâneas por automação. Gatilhos adicionais são ignorados até que um slot abra.
+- **Concorrência global**: Máximo de 10 execuções simultâneas de automação em todo o sistema.
+- **Timeout de execução**: Cada execução é limitada a 5 minutos.
+- **Prevenção de recursão**: Cadeias de gatilhos de evento são limitadas a uma profundidade de 3. Se as ações de uma automação disparam eventos que ativam outras automações, a cadeia para após 3 níveis.
+- **Limite de payload**: Dados de evento são limitados a 1 MB. Payloads maiores são truncados para mitigar riscos de injeção de prompt.
+- **Validação do criador**: Se o criador da automação sair da organização, a automação é automaticamente desativada.
+
+## Ferramentas MCP de Automação
+
+Estas ferramentas estão disponíveis para gerenciar automações programaticamente via interface MCP:
+
+| Ferramenta | Descrição |
+|---|---|
+| `AUTOMATION_CREATE` | Criar uma nova automação com agente, mensagens, modelo e gatilhos |
+| `AUTOMATION_GET` | Obter uma automação por ID com configuração completa |
+| `AUTOMATION_LIST` | Listar todas as automações na organização atual |
+| `AUTOMATION_UPDATE` | Atualizar campos da automação (atualização parcial suportada) |
+| `AUTOMATION_DELETE` | Excluir uma automação e desabilitar seus gatilhos de evento |
+| `AUTOMATION_TRIGGER_ADD` | Adicionar um gatilho cron ou evento a uma automação |
+| `AUTOMATION_TRIGGER_REMOVE` | Remover um gatilho de uma automação |
+| `AUTOMATION_RUN` | Disparar manualmente uma execução de automação |
+
+---
+
+**Próximos passos**: Aprenda sobre [Agentes](/pt-br/mcp-mesh/agents) para entender como projetar os MCPs Virtuais que as automações executam, ou explore o [Monitoramento](/pt-br/mcp-mesh/monitoring) para acompanhar execuções de automações.

--- a/apps/docs/client/src/content/2026-03-10/pt-br/mcp-mesh/concepts.mdx
+++ b/apps/docs/client/src/content/2026-03-10/pt-br/mcp-mesh/concepts.mdx
@@ -11,6 +11,7 @@ icon: BookOpen
 - **Conexão**: um endpoint MCP upstream configurado (geralmente HTTP), opcionalmente com credenciais armazenadas. Veja [Conexões](/pt-br/mcp-mesh/connections).
 - **MCP Virtual**: agrega ferramentas/recursos/prompts de servidores conectados em um único MCP. Veja [MCPs Virtuais](/pt-br/mcp-mesh/virtual-mcps).
 - **Agente**: MCPs Virtuais de propósito único otimizados para tarefas específicas. Veja [Agentes](/pt-br/mcp-mesh/agents).
+- **Automação**: execuções autônomas de agentes em agendamento ou gatilho de evento. Veja [Automações](/pt-br/mcp-mesh/automations).
 - **Projeto**: MCPs Virtuais para organizar ferramentas, recursos, prompts e configurações específicas de projeto. Veja [Projetos](/pt-br/mcp-mesh/projects).
 
 ## Entendendo Agentes vs. Projetos

--- a/apps/docs/client/src/utils/navigation.ts
+++ b/apps/docs/client/src/utils/navigation.ts
@@ -37,6 +37,7 @@ export async function getNavigationLinks(
     "mcp-mesh/virtual-mcps",
     "mcp-mesh/projects",
     "mcp-mesh/agents",
+    "mcp-mesh/automations",
 
     // 6. Decopilot
     "mcp-mesh/decopilot/overview",


### PR DESCRIPTION
## Summary
- Add new Automations docs page (EN + PT-BR) covering unattended agent runs with cron/event triggers, manual runs, and monitoring
- Update concepts and agents pages to reference automations
- Add automations to docs navigation

## Test plan
- [ ] Verify docs site builds (`bun run docs:dev`)
- [ ] Check EN and PT-BR pages render correctly
- [ ] Verify navigation links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Automations docs page for unattended agent runs triggered by schedules or events. Updates Agents and Concepts to reference Automations and adds it to the docs navigation.

- **New Features**
  - New Automations page (EN and PT-BR) covering setup, cron/event triggers, manual runs, and monitoring.
  - Documents safety limits: passthrough mode, concurrency, timeouts, and payload caps.
  - Lists automation MCP tools (`AUTOMATION_CREATE`, `AUTOMATION_RUN`, etc.).
  - Updates Agents/Concepts pages with links; adds `mcp-mesh/automations` to navigation.

<sup>Written for commit 5ea932d5246791133ccce9b1c8dcebe4aaa11668. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

