### PR TITLE
feat(webhooks): add SEED_ORG_WEBHOOK_URL for organization creation no…

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -186,7 +186,12 @@ const plugins = [
   organization({
     organizationCreation: {
       afterCreate: async (data) => {
-        await seedOrgDb(data.organization.id, data.member.userId);
+        await seedOrgDb(
+          data.organization.id,
+          data.member.userId,
+          data.organization.slug,
+          data.organization.name,
+        );
       },
     },
     ac,

--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -54,8 +54,10 @@ export interface MeshTokenPayload {
     state?: Record<string, unknown>;
     /** Mesh instance URL */
     meshUrl: string;
-    /** Connection ID this token was issued for */
-    connectionId: string;
+    /** Connection ID this token was issued for (absent for system tokens) */
+    connectionId?: string;
+    /** Purpose for system-level tokens that have no connection context */
+    purpose?: string;
     /** Organization ID */
     organizationId?: string;
     /** Organization display name */
@@ -118,4 +120,31 @@ export async function verifyMeshToken(
  */
 export function decodeMeshToken(token: string): MeshJwtPayload {
   return decodeJwt<MeshTokenPayload>(token);
+}
+
+/**
+ * Issue a signed JWT for system-level calls that have no connection context
+ * (e.g., outbound webhooks, internal service-to-service calls).
+ *
+ * @param purpose - Identifies the call site (e.g., "org-created-webhook")
+ * @param organizationId - Optional org context
+ * @param expiresIn - Expiration time (default: 5 minutes)
+ */
+export async function issueSystemToken(
+  purpose: string,
+  organizationId?: string,
+  expiresIn: string = "5m",
+): Promise<string> {
+  return issueMeshToken(
+    {
+      sub: "system",
+      metadata: {
+        meshUrl: (await import("@/core/server-constants")).getBaseUrl(),
+        purpose,
+        organizationId,
+      },
+      permissions: {},
+    },
+    expiresIn,
+  );
 }

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -90,9 +90,11 @@ interface OrgCreatedEvent {
   timestamp: string;
 }
 
+// maybe should be an event bus event (port Bus to NATS)
 async function notifyOrgCreated(event: OrgCreatedEvent): Promise<void> {
   const webhookUrl = env.SEED_ORG_WEBHOOK_URL;
-  if (!webhookUrl) return;
+  const webhookSecret = env.SEED_ORG_WEBHOOK_SECRET;
+  if (!webhookUrl || !webhookSecret) return;
 
   try {
     const token = await issueSystemToken(
@@ -104,6 +106,7 @@ async function notifyOrgCreated(event: OrgCreatedEvent): Promise<void> {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
+        "X-Webhook-Secret": webhookSecret,
       },
       body: JSON.stringify(event),
     });

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -81,12 +81,40 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
   ];
 }
 
+interface OrgCreatedEvent {
+  organizationId: string;
+  slug: string;
+  name: string;
+  createdBy: string;
+  timestamp: string;
+}
+
+async function notifyOrgCreated(event: OrgCreatedEvent): Promise<void> {
+  const webhookUrl = env.SEED_ORG_WEBHOOK_URL;
+  if (!webhookUrl) return;
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+    });
+  } catch (err) {
+    console.warn("Failed to notify SEED_ORG_WEBHOOK_URL:", err);
+  }
+}
+
 /**
  * Create default MCP connections and org-admin project for a new organization
  * This is deferred to run after the Better Auth request completes
  * to avoid deadlocks when issuing tokens
  */
-export async function seedOrgDb(organizationId: string, createdBy: string) {
+export async function seedOrgDb(
+  organizationId: string,
+  createdBy: string,
+  slug: string,
+  name: string,
+) {
   try {
     const database = getDb();
     const vault = new CredentialVault(env.ENCRYPTION_KEY);
@@ -164,6 +192,13 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
         });
       }),
     );
+    notifyOrgCreated({
+      organizationId,
+      slug,
+      name,
+      createdBy,
+      timestamp: new Date().toISOString(),
+    }).catch(() => {});
   } catch (err) {
     console.error("Error creating default MCP connections:", err);
   }

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -94,11 +94,16 @@ async function notifyOrgCreated(event: OrgCreatedEvent): Promise<void> {
   if (!webhookUrl) return;
 
   try {
-    await fetch(webhookUrl, {
+    const response = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(event),
     });
+    if (!response.ok) {
+      console.warn(
+        `SEED_ORG_WEBHOOK_URL returned non-OK status: ${response.status} ${response.statusText}`,
+      );
+    }
   } catch (err) {
     console.warn("Failed to notify SEED_ORG_WEBHOOK_URL:", err);
   }

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -5,6 +5,7 @@ import {
   ORG_ADMIN_PROJECT_NAME,
   ORG_ADMIN_PROJECT_SLUG,
 } from "@decocms/mesh-sdk";
+import { issueSystemToken } from "./jwt";
 import { getBaseUrl } from "@/core/server-constants";
 import { getDb } from "@/database";
 import { CredentialVault } from "@/encryption/credential-vault";
@@ -94,9 +95,16 @@ async function notifyOrgCreated(event: OrgCreatedEvent): Promise<void> {
   if (!webhookUrl) return;
 
   try {
+    const token = await issueSystemToken(
+      "org-created-webhook",
+      event.organizationId,
+    );
     const response = await fetch(webhookUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
       body: JSON.stringify(event),
     });
     if (!response.ok) {
@@ -108,6 +116,10 @@ async function notifyOrgCreated(event: OrgCreatedEvent): Promise<void> {
     console.warn("Failed to notify SEED_ORG_WEBHOOK_URL:", err);
   }
 }
+
+const SHOULD_NOTIFY_ORG_CREATED =
+  env.SEED_ORG_WEBHOOK_URL !== undefined &&
+  typeof env.SEED_ORG_WEBHOOK_URL === "string";
 
 /**
  * Create default MCP connections and org-admin project for a new organization
@@ -197,13 +209,15 @@ export async function seedOrgDb(
         });
       }),
     );
-    notifyOrgCreated({
-      organizationId,
-      slug,
-      name,
-      createdBy,
-      timestamp: new Date().toISOString(),
-    }).catch(() => {});
+    if (SHOULD_NOTIFY_ORG_CREATED) {
+      notifyOrgCreated({
+        organizationId,
+        slug,
+        name,
+        createdBy,
+        timestamp: new Date().toISOString(),
+      }).catch(() => {});
+    }
   } catch (err) {
     console.error("Error creating default MCP connections:", err);
   }

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -47,6 +47,7 @@ const envSchema = z
       .optional()
       .transform((v) => (v === "" ? undefined : v))
       .pipe(z.string().url().optional()),
+    SEED_ORG_WEBHOOK_SECRET: z.string().default(""),
 
     // Transport
     UNSAFE_ALLOW_STDIO_TRANSPORT: zBooleanString,
@@ -180,6 +181,7 @@ function logConfiguration(e: Env) {
 
   section("Webhooks");
   row("SEED_ORG_WEBHOOK_URL", redactUrl(e.SEED_ORG_WEBHOOK_URL));
+  row("SEED_ORG_WEBHOOK_SECRET", redactUrl(e.SEED_ORG_WEBHOOK_SECRET));
 
   section("Transport");
   row("UNSAFE_ALLOW_STDIO_TRANSPORT", e.UNSAFE_ALLOW_STDIO_TRANSPORT);

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -181,7 +181,10 @@ function logConfiguration(e: Env) {
 
   section("Webhooks");
   row("SEED_ORG_WEBHOOK_URL", redactUrl(e.SEED_ORG_WEBHOOK_URL));
-  row("SEED_ORG_WEBHOOK_SECRET", redactUrl(e.SEED_ORG_WEBHOOK_SECRET));
+  row(
+    "SEED_ORG_WEBHOOK_SECRET",
+    e.SEED_ORG_WEBHOOK_SECRET ? "[redacted]" : "not set",
+  );
 
   section("Transport");
   row("UNSAFE_ALLOW_STDIO_TRANSPORT", e.UNSAFE_ALLOW_STDIO_TRANSPORT);

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -41,6 +41,9 @@ const envSchema = z
     CONFIG_PATH: z.string().default("./config.json"),
     AUTH_CONFIG_PATH: z.string().default("./auth-config.json"),
 
+    // Webhooks
+    SEED_ORG_WEBHOOK_URL: z.string().url().optional(),
+
     // Transport
     UNSAFE_ALLOW_STDIO_TRANSPORT: zBooleanString,
 
@@ -170,6 +173,9 @@ function logConfiguration(e: Env) {
   section("Config Files");
   row("CONFIG_PATH", e.CONFIG_PATH);
   row("AUTH_CONFIG_PATH", e.AUTH_CONFIG_PATH);
+
+  section("Webhooks");
+  row("SEED_ORG_WEBHOOK_URL", e.SEED_ORG_WEBHOOK_URL);
 
   section("Transport");
   row("UNSAFE_ALLOW_STDIO_TRANSPORT", e.UNSAFE_ALLOW_STDIO_TRANSPORT);

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -42,7 +42,11 @@ const envSchema = z
     AUTH_CONFIG_PATH: z.string().default("./auth-config.json"),
 
     // Webhooks
-    SEED_ORG_WEBHOOK_URL: z.string().url().optional(),
+    SEED_ORG_WEBHOOK_URL: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v))
+      .pipe(z.string().url().optional()),
 
     // Transport
     UNSAFE_ALLOW_STDIO_TRANSPORT: zBooleanString,
@@ -175,7 +179,7 @@ function logConfiguration(e: Env) {
   row("AUTH_CONFIG_PATH", e.AUTH_CONFIG_PATH);
 
   section("Webhooks");
-  row("SEED_ORG_WEBHOOK_URL", e.SEED_ORG_WEBHOOK_URL);
+  row("SEED_ORG_WEBHOOK_URL", redactUrl(e.SEED_ORG_WEBHOOK_URL));
 
   section("Transport");
   row("UNSAFE_ALLOW_STDIO_TRANSPORT", e.UNSAFE_ALLOW_STDIO_TRANSPORT);


### PR DESCRIPTION
…tifications

- Introduced SEED_ORG_WEBHOOK_URL in the environment schema to allow optional webhook configuration.
- Enhanced seedOrgDb function to include organization slug and name, and notify via webhook upon organization creation.
- Implemented notifyOrgCreated function to handle the webhook notification logic, improving integration capabilities for external services.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional, authenticated webhook for organization creation. On new orgs, we POST org details to `SEED_ORG_WEBHOOK_URL` with a short‑lived system JWT and `X-Webhook-Secret`, plus safer env handling and clearer logging.

- **New Features**
  - Added `SEED_ORG_WEBHOOK_URL` and `SEED_ORG_WEBHOOK_SECRET` to env schema and config output; empty string is treated as unset; secret logs as "[redacted]" when set or "not set".
  - Webhook calls send `Authorization: Bearer <system JWT>` from `issueSystemToken` with purpose "org-created-webhook" and optional org context, plus `X-Webhook-Secret`.
  - On org creation, `seedOrgDb` posts {organizationId, slug, name, createdBy, timestamp}; warns on non‑OK responses; no‑op unless both URL and secret are set.

<sup>Written for commit cec3fd6f1e44c597e5230b51d969eac4168c4322. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

