### PR TITLE
feat(connections): embed sanitized title in connection IDs

### DIFF
--- a/apps/mesh/src/shared/utils/generate-id.ts
+++ b/apps/mesh/src/shared/utils/generate-id.ts
@@ -21,3 +21,15 @@ type IdPrefixes =
 export function generatePrefixedId(prefix: IdPrefixes) {
   return `${prefix}_${nanoid()}`;
 }
+
+export function generateConnectionId(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 20)
+    .replace(/_+$/g, "");
+
+  const suffix = nanoid();
+  return slug ? `conn_${slug}_${suffix}` : `conn_${suffix}`;
+}

--- a/apps/mesh/src/storage/connection.ts
+++ b/apps/mesh/src/storage/connection.ts
@@ -15,7 +15,7 @@ import type {
   ToolDefinition,
 } from "../tools/connection/schema";
 import { isStdioParameters } from "../tools/connection/schema";
-import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { generateConnectionId } from "@/shared/utils/generate-id";
 import {
   getWellKnownDecopilotConnection,
   isDecopilot,
@@ -65,7 +65,7 @@ export class ConnectionStorage implements ConnectionStoragePort {
   ) {}
 
   async create(data: Partial<ConnectionEntity>): Promise<ConnectionEntity> {
-    const id = data.id ?? generatePrefixedId("conn");
+    const id = data.id ?? generateConnectionId(data.title ?? "");
     const now = new Date().toISOString();
 
     const existing = await this.findById(id);

--- a/apps/mesh/src/web/components/details/connection/collection-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/collection-tab.tsx
@@ -1,4 +1,4 @@
-import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { generateConnectionId } from "@/shared/utils/generate-id";
 import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import {
@@ -114,7 +114,7 @@ export function CollectionTab({
     const now = new Date().toISOString();
     await actions.create.mutateAsync({
       ...item,
-      id: generatePrefixedId("conn"),
+      id: generateConnectionId(`${item.title} (Copy)`),
       title: `${item.title} (Copy)`,
       created_at: now,
       updated_at: now,
@@ -153,7 +153,7 @@ export function CollectionTab({
 
     const now = new Date().toISOString();
     const newItem: BaseCollectionEntity = {
-      id: generatePrefixedId("conn"),
+      id: generateConnectionId("New Item"),
       title: "New Item",
       description: "A brief description of the item",
       created_at: now,

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -1,4 +1,4 @@
-import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { generateConnectionId } from "@/shared/utils/generate-id";
 import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { type TableColumn } from "@/web/components/collections/collection-table.tsx";
@@ -1724,7 +1724,7 @@ function OrgMcpsContent() {
       return;
     }
 
-    const newId = generatePrefixedId("conn");
+    const newId = generateConnectionId(data.title);
     // Create new connection
     await actions.create.mutateAsync({
       id: newId,

--- a/apps/mesh/src/web/utils/extract-connection-data.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.ts
@@ -11,7 +11,7 @@ import type {
 import { MCP_MESH_DECOCMS_KEY } from "@/web/utils/constants";
 import { getGitHubAvatarUrl } from "@/web/utils/github";
 import { getConnectionTypeLabel } from "@/web/utils/registry-utils";
-import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { generateConnectionId } from "@/shared/utils/generate-id";
 
 /**
  * Get a display name for a remote endpoint
@@ -177,7 +177,7 @@ export function extractConnectionData(
   const title = baseName + titleSuffix;
 
   return {
-    id: generatePrefixedId("conn"),
+    id: generateConnectionId(title),
     title,
     description,
     icon,


### PR DESCRIPTION
## Summary

Connection IDs now include a slug derived from the MCP title, making them **much easier to identify** when debugging logs, URLs, database queries, and traces.

**Before:** `conn_a1b2c3d4e5f6g7h8i9j0k`
**After:** `conn_gmail_a1b2c3d4e5f6g7h8i9j0k`

### How it works

A new `generateConnectionId(title)` function sanitizes the title into a slug (lowercase, non-alphanumeric → `_`, max 20 chars) and embeds it between the `conn_` prefix and the nanoid suffix. If the title sanitizes to empty, it falls back to the original `conn_<nanoid>` format.

Examples:
| Title | Generated ID |
|-------|-------------|
| `Gmail` | `conn_gmail_<nanoid>` |
| `My Cool MCP!!!` | `conn_my_cool_mcp_<nanoid>` |
| `Slack Integration` | `conn_slack_integration_<nanoid>` |
| `🎉` (emoji-only) | `conn_<nanoid>` (fallback) |

### Changes

- **`apps/mesh/src/shared/utils/generate-id.ts`** — Added `generateConnectionId(title)` helper
- **`apps/mesh/src/storage/connection.ts`** — Server-side creation uses title-based IDs
- **`apps/mesh/src/web/routes/orgs/connections.tsx`** — Manual creation form
- **`apps/mesh/src/web/utils/extract-connection-data.ts`** — Store/registry installation
- **`apps/mesh/src/web/components/details/connection/collection-tab.tsx`** — Duplicate & new item flows

### Backward compatibility

- Existing connections keep their current IDs — no migration needed
- All IDs still start with `conn_` so existing prefix checks, routing, and parsing continue to work
- The storage layer still respects explicitly provided IDs (`data.id ?? generateConnectionId(...)`)

## How to test

1. **Create a connection via the UI** — go to MCPs → Add MCP, fill in a title like "Gmail", save. Check the URL bar — the ID should now contain `gmail` (e.g. `/mcps/conn_gmail_abc123`)
2. **Install from the store** — pick any MCP from the store, install it. The connection ID in the URL should reflect the MCP name
3. **Duplicate a connection** — click duplicate on an existing connection. The new ID should contain the title slug (with `_copy` appended)
4. **Edge cases** — try creating a connection with special characters in the title (e.g. `My MCP @#$!`) and verify the ID only contains safe alphanumeric + underscore characters
5. **Existing connections** — verify existing connections still load and work normally (their IDs are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connection IDs now include a sanitized title slug (e.g., `conn_gmail_<nanoid>`) to make logs, URLs, and queries easier to read. Backward compatible: existing IDs stay the same and all IDs still start with `conn_`.

- **New Features**
  - Added `generateConnectionId(title)` that lowercases, replaces non-alphanumerics with `_`, trims edges, caps to 20 chars, and falls back to `conn_<nanoid>` if empty.
  - Adopted across create flows (server storage, UI new/duplicate, store installs); explicit IDs are still respected.

<sup>Written for commit 7631f36de1ef7d6f9bdb8e0dc70be994a5a032ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

