### PR TITLE
fix(registry): add missing is_unlisted to search output schema

### DIFF
--- a/packages/mesh-plugin-private-registry/server/tools/schema.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/schema.ts
@@ -212,6 +212,7 @@ const RegistrySearchItemSchema = z.object({
   tags: z.array(z.string()),
   categories: z.array(z.string()),
   is_public: z.boolean(),
+  is_unlisted: z.boolean(),
 });
 
 export const RegistrySearchOutputSchema = z.object({

--- a/packages/mesh-plugin-private-registry/server/tools/search.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/search.ts
@@ -8,7 +8,7 @@ import { getPluginStorage, orgHandler } from "./utils";
 export const REGISTRY_ITEM_SEARCH: ServerPluginToolDefinition = {
   name: "REGISTRY_ITEM_SEARCH",
   description:
-    "Search registry items returning minimal data (id, title, tags, categories, is_public). " +
+    "Search registry items returning minimal data (id, title, tags, categories, is_public, is_unlisted). " +
     "Use this instead of LIST when you need to find items efficiently without loading full details. " +
     "Supports free-text search across id, title, description, and server name, " +
     "plus filtering by tags and categories.",


### PR DESCRIPTION
## Summary
- The `REGISTRY_ITEM_SEARCH` tool's storage layer returns `is_unlisted` in each search result item, but the Zod output schema (`RegistrySearchItemSchema`) didn't include that field
- This caused MCP structured content validation to fail with: `data/items/0 must NOT have additional properties`
- Added `is_unlisted: z.boolean()` to the schema to match the actual response shape

## Test plan
- [ ] Call `REGISTRY_ITEM_SEARCH` with a simple query (e.g. `gmail`) and verify no schema validation error
- [ ] Confirm `is_unlisted` is always `false` in results (unlisted items are filtered out by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a schema mismatch in `REGISTRY_ITEM_SEARCH` that caused structured content validation errors. Added `is_unlisted` to `RegistrySearchItemSchema` and updated the tool description to include it.

<sup>Written for commit ca78b0eae3fb6465c23bfca22e0e8569cdc9fac1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

