### PR TITLE
fix(auth): show social OAuth buttons in email OTP view

### DIFF
--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -304,7 +304,7 @@ export function UnifiedAuthForm({
       )}
 
       {/* Social Provider Buttons */}
-      {!isForgotPassword && !isEmailOtp && socialProviders.enabled && (
+      {!isForgotPassword && socialProviders.enabled && (
         <div className="grid gap-3">
           {socialProviders.providers.map((provider) => (
             <Button
@@ -338,7 +338,6 @@ export function UnifiedAuthForm({
 
       {/* Divider between social and email-based auth */}
       {!isForgotPassword &&
-        !isEmailOtp &&
         socialProviders.enabled &&
         (emailAndPassword.enabled || emailOtp.enabled) && (
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## What is this contribution about?
> When email+password is disabled and email OTP is the default login view, social provider buttons (Google, GitHub) were hidden due to a `!isEmailOtp` guard on the render condition. This removes that guard so OAuth buttons always appear alongside any email-based auth method.

## How to Test
> 1. Configure `emailAndPassword.enabled: false`, `emailOtpConfig.enabled: true`, and a social provider (e.g. Google)
> 2. Navigate to `/login`
> 3. Both the email OTP form and the Google OAuth button should be visible
> 4. Verify the "or" divider appears between social buttons and OTP form

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show social OAuth buttons in the email OTP login view by removing the `!isEmailOtp` guard in `UnifiedAuthForm`. Also render the "or" divider when OTP is active, so OAuth appears alongside any email-based flow.

<sup>Written for commit 78c84627b0e59f7b60f63c4f4e12a2d3517eef64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

