### PR TITLE
ui: add 'test' label inside automation's prompt

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -561,7 +561,7 @@ export function ChatInput({
                     size="icon"
                     disabled={!canSubmit && !showStopOrCancel}
                     className={cn(
-                      "size-8 rounded-full transition-all",
+                      "size-8 rounded-md transition-all",
                       !canSubmit &&
                         !showStopOrCancel &&
                         "bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground cursor-not-allowed",

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -911,7 +911,7 @@ function SelectedModelDisplay({
     <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
       <img
         src={providerLogo}
-        className="w-5 h-5 shrink-0 rounded-sm"
+        className="w-3.5 h-3.5 shrink-0 rounded-sm"
         alt={model.title}
       />
       <span className="text-sm truncate whitespace-nowrap hidden md:inline text-muted-foreground">

--- a/apps/mesh/src/web/routes/orgs/automation-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/automation-detail.tsx
@@ -979,12 +979,12 @@ function SettingsTab({
                 <Button
                   type="button"
                   variant="default"
-                  size="icon"
-                  className="size-8 rounded-full"
+                  className="h-8 gap-1.5 rounded-md px-3 text-sm font-medium"
                   onClick={handleRunClick}
                   title="Test Automation"
                 >
-                  <ArrowUp size={20} />
+                  <ArrowUp size={16} />
+                  Test
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## What is this contribution about?
Refined button styling across the UI and improved clarity of test automation functionality.

- Changed send button and test button from rounded-full to rounded-md for consistency
- Added "Test" label to the automation test button for clarity
- Scaled down the model selector provider icon for better proportions

## Screenshots/Demonstration
Changes affect the chat input send button, automation settings test button, and model selector dropdown.

## How to Test
1. Navigate to an automation and open its settings
2. Verify the "Test" button appears with rounded corners (not fully circular)
3. In any chat interface, verify the send button (arrow) also has rounded corners
4. Click the model selector and verify the provider icon is smaller and less prominent

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined button styles for consistency and clearer test actions. Chat send and automation test buttons now use rounded-md, the automation test button includes a "Test" label, and the model selector provider icon is smaller for better balance.

<sup>Written for commit c26f2f44c89fb9a6a39483b6b8a1d25a3c966ba4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

