### PR TITLE
refactor(db): use standard PostgreSQL defaults for local dev

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,19 +17,19 @@ jobs:
       postgres:
         image: postgres:16
         env:
-          POSTGRES_USER: deco
-          POSTGRES_PASSWORD: deco
-          POSTGRES_DB: deco_dev
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U deco"
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
 
     env:
-      DATABASE_URL: postgresql://deco:deco@localhost:5432/deco_dev
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 
     steps:
       - name: Checkout repository

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -67,7 +67,7 @@ Options:
 Environment Variables:
   PORT                  Port to listen on (default: 3000)
   DATA_DIR              Data directory (default: ~/deco/)
-  DATABASE_URL          Database connection URL (default: postgresql://deco:deco@localhost:5432/deco_dev)
+  DATABASE_URL          Database connection URL (default: postgresql://postgres:postgres@localhost:5432/postgres)
   NODE_ENV              Set to 'production' for production mode
   BETTER_AUTH_SECRET    Secret for authentication (auto-generated if not set)
   ENCRYPTION_KEY        Key for encrypting secrets (auto-generated if not set)

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -54,7 +54,8 @@ const envSchema = z
   .transform((e) => ({
     ...e,
     DATABASE_URL:
-      e.DATABASE_URL ?? "postgresql://deco:deco@localhost:5432/deco_dev",
+      e.DATABASE_URL ??
+      "postgresql://postgres:postgres@localhost:5432/postgres",
   }));
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -24,9 +24,9 @@ import { join } from "path";
 const SERVICES_DIR = join(homedir(), "deco", "services");
 
 const PG_PORT = 5432;
-const PG_USER = "deco";
-const PG_PASSWORD = "deco";
-const PG_DATABASE = "deco_dev";
+const PG_USER = "postgres";
+const PG_PASSWORD = "postgres";
+const PG_DATABASE = "postgres";
 const PG_CONNECTION_STRING = `postgresql://${PG_USER}:${PG_PASSWORD}@localhost:${PG_PORT}/${PG_DATABASE}`;
 
 const NATS_PORT = 4222;


### PR DESCRIPTION
## What is this contribution about?

Replaces custom `deco:deco@localhost:5432/deco_dev` PostgreSQL defaults with the standard `postgres:postgres@localhost:5432/postgres` that PostgreSQL ships with out of the box. This removes the need for custom user/database setup when running locally.

**Changed files:**
- `apps/mesh/src/env.ts` — default `DATABASE_URL`
- `apps/mesh/src/services/ensure-services.ts` — `PG_USER`, `PG_PASSWORD`, `PG_DATABASE` constants
- `apps/mesh/src/cli.ts` — help text
- `.github/workflows/e2e.yml` — CI postgres service config

## Screenshots/Demonstration

N/A

## How to Test

1. Remove any `DATABASE_URL` from your environment
2. Run `bun run dev` — confirm it connects to `postgres:postgres@localhost:5432/postgres`
3. Verify the CLI help (`bun run --cwd=apps/mesh src/cli.ts --help`) shows the updated default

## Migration Notes

Developers with an existing local `deco_dev` database will need to either:
- Set `DATABASE_URL` explicitly to keep using it, or
- Run against the default `postgres` database going forward

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch local PostgreSQL defaults to `postgres:postgres@localhost:5432/postgres` across env, services, CLI help, and CI. This removes custom setup and uses PostgreSQL’s out-of-the-box settings.

- **Migration**
  - To keep using your existing `deco_dev` database, set `DATABASE_URL` explicitly.
  - Otherwise, unset `DATABASE_URL` and the app will use the new default.

<sup>Written for commit 07e7c080470bd89b6f94745257eb8f7cfed5d2af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

