### PR TITLE
fix(auth): prevent login redirect loop causing HTTP 431

### DIFF
--- a/apps/mesh/src/web/layouts/required-auth-layout.tsx
+++ b/apps/mesh/src/web/layouts/required-auth-layout.tsx
@@ -6,7 +6,14 @@ function RedirectToLogin() {
   const routerState = useRouterState();
   const currentUrl = routerState.location.href;
 
-  return <Navigate to="/login" search={{ next: currentUrl }} replace />;
+  // Don't set next to /login itself — that creates an infinite redirect loop
+  // where each cycle double-encodes the previous next param until the URL
+  // exceeds header size limits (HTTP 431).
+  const isLoginUrl =
+    currentUrl === "/login" || currentUrl.startsWith("/login?");
+  const search = isLoginUrl ? {} : { next: currentUrl };
+
+  return <Navigate to="/login" search={search} replace />;
 }
 
 export default function RequiredAuthLayout({


### PR DESCRIPTION
## What is this contribution about?
When an unauthenticated user lands on `/login`, the `RequiredAuthLayout` auth guard sets `next=/login`, which on the next render becomes `next=/login?next=/login`, compounding with double-encoding on each cycle. The URL grows exponentially until the server returns HTTP 431 (Request Header Fields Too Large).

Fix: skip setting the `next` param when already on the login page.

## How to Test
1. Visit `https://studio.decocms.com/login` while signed out
2. Verify the URL stays as `/login` without accumulating `next` params
3. Visit a protected route like `/settings` while signed out — verify it redirects to `/login?next=/settings` and returns you to `/settings` after login

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a redirect loop on `/login` that grew the URL via repeated, double-encoded `next` params and triggered HTTP 431. The guard now skips `next` on the login page while keeping normal redirects from protected pages.

- **Bug Fixes**
  - In `RequiredAuthLayout`, detect `/login` (exact or with query) and navigate to `/login` without a `search` param.
  - For non-login pages, continue to set `search={{ next: currentUrl }}` so users return after sign-in.

<sup>Written for commit 3ce3c74a562c89511d3f4917095b4c74a1073eba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

