### PR TITLE
fix(chat): show provider empty state in model selector when no API ke…

### DIFF
--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -49,6 +49,7 @@ import { ErrorBoundary } from "../error-boundary";
 import { useChat } from "./context";
 import { getProviderLogo } from "@/web/utils/ai-providers-logos";
 import { useSettingsModal } from "@/web/hooks/use-settings-modal";
+import { NoLlmBindingEmptyState } from "./no-llm-binding-empty-state";
 
 function parseModelTitle(model: { title: string; modelId: string }): {
   provider: string;
@@ -1030,6 +1031,17 @@ function ModelSelectorInner({
     setSearchTerm("");
     onClose();
   };
+
+  if (keys.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-8 w-full sm:w-[740px]">
+        <NoLlmBindingEmptyState
+          title="Connect an AI provider"
+          description="Connect to a model provider to unlock AI-powered features."
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col md:flex-row h-[460px]">


### PR DESCRIPTION
- When a user opens the model selector dialog without any AI provider API keys configured, the dialog now shows the \`NoLlmBindingEmptyState\` component with provider cards instead of an empty search list
- Reuses the same empty state already used in the chat side panel for consistency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a provider empty state in the model selector when no API keys are configured, guiding users to connect a provider. Reuses `NoLlmBindingEmptyState` for consistency with the chat side panel.

<sup>Written for commit c9bb589136abfd67fc0e6bfbeb082bed9cd85fea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

