### PR TITLE
feat(auth): enhance AuthContext for server-side handling

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -209,6 +209,7 @@ export interface AuthContext {
   role?: string; // User's role (for built-in role bypass)
   permissions?: Permission; // Permissions from API key or custom role (MCP OAuth)
   userId?: string; // User ID for server-side API key operations
+  serverSide?: boolean; // MCP OAuth / API key — BA session APIs can't resolve these tokens
 }
 
 /**
@@ -220,7 +221,12 @@ export interface AuthContext {
  * 2. Browser sessions → delegate to Better Auth's hasPermission API
  */
 export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
-  const { auth, headers, role, permissions, userId } = ctx;
+  const { auth, headers, role, permissions, userId, serverSide } = ctx;
+
+  // For MCP OAuth / API key auth, the Bearer token in headers confuses BA's
+  // session middleware (it tries cookie or API key resolution, both fail).
+  // Use empty headers for server-side calls — BA still works via query/body params.
+  const serverHeaders = new Headers();
 
   // Get hasPermission from Better Auth's organization plugin (for browser sessions)
   const hasPermissionApi = (auth.api as { hasPermission?: HasPermissionAPI })
@@ -303,15 +309,16 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 
       get: async (organizationId) => {
         return auth.api.getFullOrganization({
-          headers,
+          headers: serverSide ? serverHeaders : headers,
           query: organizationId ? { organizationId } : undefined,
         });
       },
 
-      list: async (userId?: string) => {
+      list: async (targetUserId?: string) => {
+        const uid = serverSide ? (targetUserId ?? userId) : targetUserId;
         return auth.api.listOrganizations({
-          headers,
-          query: userId ? { userId } : undefined,
+          headers: serverSide ? serverHeaders : headers,
+          query: uid ? { userId: uid } : undefined,
         });
       },
 
@@ -331,7 +338,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 
       listMembers: async (options) => {
         return auth.api.listMembers({
-          headers,
+          headers: serverSide ? serverHeaders : headers,
           query: options
             ? {
                 organizationId: options.organizationId,
@@ -460,6 +467,7 @@ async function authenticateRequest(
   permissions?: Permission; // Permissions from API key or custom role (for non-browser sessions)
   apiKeyId?: string;
   organization?: OrganizationContext;
+  isMcpOAuthSession?: boolean;
 }> {
   const authHeader = req.headers.get("Authorization");
 
@@ -521,6 +529,7 @@ async function authenticateRequest(
         role,
         permissions,
         organization,
+        isMcpOAuthSession: true,
       };
     }
   } catch (error) {
@@ -850,12 +859,17 @@ export async function createMeshContextFactory(
       : { user: undefined };
 
     // Create bound auth client (encapsulates HTTP headers and auth context)
+    // MCP OAuth / API key tokens aren't resolvable by BA's session middleware,
+    // so flag those as serverSide to use empty headers + explicit userId/query params.
+    const isServerSide =
+      !!authResult.isMcpOAuthSession || !!authResult.apiKeyId;
     const boundAuth = createBoundAuthClient({
       auth: config.auth,
       headers: req?.headers ?? new Headers(),
       role: authResult.role,
       permissions: authResult.permissions,
-      userId: authResult.user?.id, // For server-side API key operations
+      userId: authResult.user?.id,
+      serverSide: isServerSide,
     });
 
     // Build auth object for MeshContext


### PR DESCRIPTION
Added a new `serverSide` property to the `AuthContext` interface to manage MCP OAuth and API key sessions more effectively. Updated the `createBoundAuthClient` function to conditionally use empty headers for server-side calls, ensuring compatibility with Better Auth's session middleware. Adjusted related functions to utilize the new property for user ID resolution and header management.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `serverSide` flag to `AuthContext` and routes server-side MCP OAuth/API key flows without `Authorization` headers to keep Better Auth session middleware from mis-resolving tokens. This fixes org/member queries on the server by using query/body params and correct user scoping.

- **Bug Fixes**
  - `createBoundAuthClient`: when `serverSide`, sends empty headers to Better Auth and relies on query/body params instead of Bearer tokens.
  - Corrects user scoping: for server-side org listing, prefers the provided `userId` or falls back to context `userId`.
  - Marks MCP OAuth sessions in `authenticateRequest` and sets `serverSide` in `createMeshContextFactory` when MCP OAuth or API key is detected.

<sup>Written for commit 6fdb139f94145c11b7fbedbfc9ad455bd3eb23ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

