### PR TITLE
change name actions to tools and remove unecessary filter

### DIFF
--- a/apps/mesh/src/web/components/connections/connection-instances-modal.tsx
+++ b/apps/mesh/src/web/components/connections/connection-instances-modal.tsx
@@ -169,7 +169,7 @@ export function ConnectionInstancesModal({
               <div className="flex items-center gap-2 px-6 py-3">
                 <Tool01 size={14} className="text-muted-foreground" />
                 <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                  Actions ({tools.length})
+                  Tools ({tools.length})
                 </span>
               </div>
               <div className="pb-2">

--- a/apps/mesh/src/web/components/details/connection/connection-capabilities.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-capabilities.tsx
@@ -100,7 +100,6 @@ export function ConnectionCapabilities({
       },
     });
   }
-  const regularTools = tools.filter((t) => !/^COLLECTION_/i.test(t.name));
   const hasUiTools =
     connectionId && org && tools.some((t) => getUIResourceUri(t._meta));
 
@@ -126,7 +125,7 @@ export function ConnectionCapabilities({
         <div className="px-5 flex items-center justify-between border-b border-border">
           <TabsList variant="underline" className="gap-1">
             <TabsTrigger value="tools" variant="underline">
-              Tools
+              Tools ({tools.length})
             </TabsTrigger>
             {hasUiTools && (
               <TabsTrigger value="apps" variant="underline">
@@ -144,8 +143,8 @@ export function ConnectionCapabilities({
 
         <TabsContent value="tools" className="h-auto">
           <div className="divide-y divide-border">
-            {regularTools.length > 0 ? (
-              regularTools.map((tool) => (
+            {tools.length > 0 ? (
+              tools.map((tool) => (
                 <button
                   key={tool.name}
                   type="button"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rename “Actions” to “Tools” and display all tools in connection details by removing the unused `COLLECTION_` filter. The Tools tab now shows the total count and lists every tool.

<sup>Written for commit ce26e5d3155608886b1635e1a1a512beb0be3efb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

