### PR TITLE
fix(ci): decouple Docker build from npm publish check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,18 +99,27 @@ jobs:
           for i in $(seq 1 12); do
             if npm view decocms@${{ steps.version-check.outputs.current-version }} version >/dev/null 2>&1; then
               echo "✅ Version available on npm after $((i * 10))s"
-              break
+              exit 0
             fi
             echo "⏳ Attempt $i/12 - not yet available, waiting 10s..."
             sleep 10
           done
+          echo "❌ Version not available on npm after 120s"
+          exit 1
 
       # ==================== DOCKER BUILD & PUSH ====================
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check if Docker image exists
         id: image-check
         run: |
           VERSION="${{ steps.version-check.outputs.current-version }}"
-          # Check if image already exists in GHCR
+          # Check if image already exists in GHCR (requires login above for private packages)
           if docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION} >/dev/null 2>&1; then
             echo "image-exists=true" >> $GITHUB_OUTPUT
             echo "⏭️ Docker image ${VERSION} already exists in GHCR"
@@ -122,14 +131,6 @@ jobs:
       - name: Set up Docker Buildx
         if: steps.image-check.outputs.image-exists == 'false'
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        if: steps.image-check.outputs.image-exists == 'false'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         if: steps.image-check.outputs.image-exists == 'false'


### PR DESCRIPTION
## Summary
- Docker image build now checks GHCR independently instead of being gated on the npm version check
- Fixes the scenario where npm publish succeeds but Docker build fails — re-runs were skipping everything because npm already had the version
- Replaced fixed 30s npm propagation sleep with polling (up to 2min) to avoid the race condition that caused this

## Context
The v2.175.6 release failed: npm got the package but the Docker image was never pushed because the 30s propagation wait wasn't enough. Re-triggering the workflow skipped everything since npm already had the version.

## Test plan
- [ ] Merge and trigger `workflow_dispatch` — should detect npm has 2.175.6 but GHCR doesn't, and build the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples `Docker` image build from the `npm` publish check to avoid skipped re-runs and ensure images are built when missing. Adds `npm` propagation polling, logs in to `GHCR` before manifest checks, and fails if the version isn’t visible after 2 minutes.

- **Bug Fixes**
  - `Docker` build/push now keyed off a `GHCR` manifest check; login happens before inspect.
  - Replaced fixed 30s wait with `npm view` polling (up to 2m), and the job fails on timeout.
  - Re-runs build/push when `npm` is published but `GHCR` lacks the tag.
  - GitHub Release and deploy steps run when an image is built even if the `npm` version didn’t change.

<sup>Written for commit 1e215b0824f8a9f63ea55083995ce06f5fe0ef00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

