### PR TITLE
chore: remove stale Tailwind @source for deleted reports plugin

### DIFF
--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -34,7 +34,6 @@
 /* Scan mesh-plugin components for Tailwind classes */
 @source "../../../mesh-plugin-object-storage/**/*.tsx";
 @source "../../../mesh-plugin-private-registry/**/*.tsx";
-@source "../../../mesh-plugin-reports/**/*.tsx";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## What is this contribution about?

Removes the stale `@source` directive in `packages/ui/src/styles/global.css` that referenced the deleted `mesh-plugin-reports` package. Left over from #2742.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] No breaking changes

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale Tailwind `@source` in `packages/ui/src/styles/global.css` that pointed to the deleted `mesh-plugin-reports` plugin, avoiding unnecessary scanning and potential build warnings. No functional changes.

<sup>Written for commit 44f6906c411014a0e266a8188e5355b89c2dcf3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

