### PR TITLE
feat(stream-core): enhance error handling with sanitized messages

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -450,6 +450,7 @@ export async function streamCore(
         const uiMessageStream = result.toUIMessageStream({
           originalMessages,
           generateMessageId,
+          onError: (error) => sanitizeStreamError(error),
           messageMetadata: ({ part }) => {
             if (part.type === "start") {
               return {
@@ -577,7 +578,7 @@ export async function streamCore(
         streamFinished = true;
         closeClients?.();
         if (registrySignal.aborted) {
-          return error instanceof Error ? error.message : String(error);
+          return sanitizeStreamError(error);
         }
         console.error("[decopilot] stream error:", error);
 
@@ -591,7 +592,7 @@ export async function streamCore(
             console.error("[decopilot:stream] onError reactor failed", e);
           });
 
-        return error instanceof Error ? error.message : String(error);
+        return sanitizeStreamError(error);
       },
     });
 
@@ -621,6 +622,33 @@ export async function streamCore(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+function stripProviderSpecificDetails(message: string): string {
+  const sentences = message.split(/\.\s+/);
+  const cleaned = sentences.filter(
+    (s) => !/https?:\/\//i.test(s) && !/openrouter/i.test(s),
+  );
+  if (cleaned.length === 0) return message;
+  const result = cleaned.join(". ").trim();
+  return result.endsWith(".") ? result : `${result}.`;
+}
+
+/**
+ * Returns a sanitized, user-facing error message.
+ * Provider-specific URLs and branding are stripped so they are never
+ * surfaced to the client.
+ */
+// TODO @pedrofrxncx: remove this code in favor of a better solution
+function sanitizeStreamError(error: unknown): string {
+  if (error instanceof Error) {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    if (statusCode === 402 || error.message.toLowerCase().includes("credit")) {
+      return stripProviderSpecificDetails(error.message);
+    }
+    return error.message;
+  }
+  return String(error);
+}
 
 /**
  * Consume a StreamCoreResult by draining its ReadableStream.


### PR DESCRIPTION
- Added a new function `sanitizeStreamError` to provide user-friendly error messages by stripping provider-specific details.
- Updated error handling in `streamCore` to utilize the new sanitization function, ensuring consistent and safe error reporting.
- Introduced a helper function `stripProviderSpecificDetails` to clean up error messages further.

This improves the user experience by preventing sensitive information from being exposed in error messages.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized stream error messages in `streamCore` to strip provider-specific details and URLs. This prevents leaking sensitive info and shows users clear, safe messages, with better handling for 402/credit errors.

- **New Features**
  - Added `sanitizeStreamError` for user-facing errors, with special handling for 402/credit cases.
  - Added `stripProviderSpecificDetails` to remove URLs and provider branding.
  - Routed `toUIMessageStream` `onError` and error returns in `streamCore` through the sanitizer for consistent output.

<sup>Written for commit 7790435bf470ec23cb578f2e3c3e8c7ca50c6a1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

