### PR TITLE
fix(cli): force NODE_ENV=production in local mode to serve built UI

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -123,17 +123,17 @@ process.env.DECOCMS_HOME = decoHome;
 process.env.DATA_DIR = decoHome;
 process.env.PORT = values.port;
 
-if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = "production";
-}
-
 // Determine if local mode should be active (opt-in only)
 const localMode = values["local-mode"] === true;
 process.env.MESH_LOCAL_MODE = localMode ? "true" : "false";
 
-// CLI is the intended local runner — allow local mode even when NODE_ENV=production
+// Local mode always runs as production so the built UI is served
+// instead of proxying to a Vite dev server on port 4000
 if (localMode) {
+  process.env.NODE_ENV = "production";
   process.env.MESH_ALLOW_LOCAL_PROD = "true";
+} else if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = "production";
 }
 
 // ============================================================================


### PR DESCRIPTION
## What is this contribution about?

When running `bunx decocms --local-mode`, if `NODE_ENV=development` is set in the environment, the server proxies all frontend requests to a Vite dev server on port 4000 instead of serving the built static assets. This causes `ConnectionRefused` errors since no Vite server is running.

This fix forces `NODE_ENV=production` when `--local-mode` is set, ensuring the built UI from `dist/client/` is always served in local mode.

## Screenshots/Demonstration
N/A

## How to Test
1. Set `NODE_ENV=development` in your shell
2. Run `bun run --cwd=apps/mesh src/cli.ts --local-mode --port 3002`
3. Open `http://localhost:3002/` in a browser
4. Expected: The UI loads correctly (no `ConnectionRefused` errors for port 4000)

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `NODE_ENV=production` when running `--local-mode`. This serves the built UI from `dist/client/` and avoids proxying to a Vite dev server on port 4000, preventing ConnectionRefused errors.

<sup>Written for commit 0d8b1c38ee9222cf9292139e81bc5b5ff16cdae3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

