### PR TITLE
fix(services): use createRequire for embedded-postgres dylib symlinks

### DIFF
--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -200,13 +200,14 @@ function fixEmbeddedPostgresLibSymlinks() {
       const targetDir = join(absTarget, "..");
       const sourceName = source.split("/").pop()!;
       const targetName = target.split("/").pop()!;
+      const cwd = process.cwd();
       try {
-        const cwd = process.cwd();
         process.chdir(targetDir);
         symlinkSync(sourceName, targetName);
-        process.chdir(cwd);
       } catch {
         // Symlink may already exist from a concurrent run
+      } finally {
+        process.chdir(cwd);
       }
     }
   } catch {


### PR DESCRIPTION
## Summary
- Fixes `bunx decocms@latest` crashing on macOS with `Postgres init script exited with code null`
- The dylib symlink fix function (`fixEmbeddedPostgresLibSymlinks`) hard-coded a `.bun` cache directory layout (navigating up exactly 5 levels from `require.resolve`), which silently failed under `bunx` where the directory structure differs
- Replaced with `createRequire` scoped to `embedded-postgres`'s module path, which resolves its platform-specific optional dependency (`@embedded-postgres/darwin-arm64`) from the correct package context, working across all layouts (`.bun` cache, flat `node_modules`, `bunx` temporary installs)

## Test plan
- [ ] Run `rm -r ~/deco && bunx decocms@latest` on macOS arm64 — should start without postgres init errors
- [ ] Run `bun run dev` from the repo — should still work with the `.bun` cache layout
- [ ] Verify `bun run check` and `bun run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash on macOS when running `bunx decocms@latest` by resolving `embedded-postgres`’s platform package with `createRequire`, so dylib symlinks are recreated correctly. Postgres now initializes reliably across `.bun` cache, `bunx` temp installs, and flat `node_modules`.

- **Bug Fixes**
  - Replaced hard-coded `.bun` cache traversal with `createRequire` scoped to `embedded-postgres` to resolve `@embedded-postgres/<platform>` across all layouts.
  - Rehydrated dylib symlinks from `native/pg-symlinks.json` using the resolved package root; safely restores `cwd` after linking and no-ops if the symlink manifest is missing.

<sup>Written for commit 5bc9022f05280af7df874f6d076d2939facd3a28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

