### PR TITLE
fix(chat): use null connection ID for icebreaker prompts

### DIFF
--- a/apps/mesh/src/web/components/chat/ice-breakers.tsx
+++ b/apps/mesh/src/web/components/chat/ice-breakers.tsx
@@ -14,7 +14,6 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   getPrompt,
-  getWellKnownDecopilotVirtualMCP,
   useMCPClient,
   useMCPPromptsList,
   useProjectContext,
@@ -338,10 +337,7 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
  */
 export function IceBreakers({ className }: IceBreakersProps) {
   const { selectedVirtualMcp } = useChatStable();
-  // When selectedVirtualMcp is null, use decopilot ID (default agent)
-  const { org } = useProjectContext();
-  const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
-  const connectionId = selectedVirtualMcp?.id ?? decopilotId;
+  const connectionId = selectedVirtualMcp?.id ?? null;
 
   return (
     <div


### PR DESCRIPTION
## What is this contribution about?

Fixes inconsistency between icebreaker prompts and the `/` mention input when no virtual MCP is selected.

- **IceBreakers** was falling back to `decopilot_${orgId}` as the connection ID
- **`/` mention input** was falling back to `null` (which maps to `self`)
- This caused them to query different MCP connections for prompts

Now both consistently use `null` when no virtual MCP is selected.

## Screenshots/Demonstration
N/A

## How to Test
1. Open a chat with no virtual MCP selected
2. Verify icebreaker prompts appear and match the prompts shown when typing `/`
3. Select a virtual MCP and verify icebreakers update to that MCP's prompts
4. Deselect the virtual MCP and verify icebreakers return to the default prompts

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns icebreaker prompts with the `/` mention input by using `null` as the connection ID when no virtual MCP is selected. Removes the `decopilot_${orgId}` fallback so both paths query the same default (self) prompts.

<sup>Written for commit 21f0050c08cf7fa2311d6c40d4fbfefe0306f450. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

