### PR TITLE
fix(ai-providers): coerce OpenRouter pricing to numbers

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/openrouter.ts
+++ b/apps/mesh/src/ai-providers/adapters/openrouter.ts
@@ -87,8 +87,8 @@ export const openrouterAdapter: ProviderAdapter = {
               maxOutputTokens: m.top_provider.max_completion_tokens || null,
             },
             costs: {
-              input: m.pricing.prompt ?? 0,
-              output: m.pricing.completion ?? 0,
+              input: Number(m.pricing.prompt) || 0,
+              output: Number(m.pricing.completion) || 0,
             },
           };
         };

--- a/apps/mesh/src/ai-providers/factory.ts
+++ b/apps/mesh/src/ai-providers/factory.ts
@@ -32,7 +32,10 @@ function mapOpenRouterModel(m: OpenRouterAPIModel): ModelInfo {
       contextWindow: m.context_length,
       maxOutputTokens: m.top_provider.max_completion_tokens || null,
     },
-    costs: { input: m.pricing.prompt, output: m.pricing.completion },
+    costs: {
+      input: Number(m.pricing.prompt) || 0,
+      output: Number(m.pricing.completion) || 0,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- OpenRouter API returns pricing fields (`prompt`, `completion`) as strings
- Without coercion, cost calculations produce NaN or string concatenation
- Added `Number()` coercion in both `openrouter.ts` adapter and `factory.ts`

## Test plan
- [ ] Verify model list shows correct pricing after change
- [ ] Confirm cost tracking works with OpenRouter models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerced OpenRouter pricing fields to numbers to fix incorrect cost calculations and pricing display. This ensures cost tracking uses numeric math and the model list shows correct prices.

- **Bug Fixes**
  - Parse `pricing.prompt` and `pricing.completion` with `Number()` in `openrouter.ts` and `factory.ts`, defaulting to 0.
  - Prevent NaN and string concatenation in cost tracking and pricing UI.

<sup>Written for commit e9a96b31f6ba2f2ae61f2d02a25f35de9548b1ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

