### PR TITLE
feat(automations): enable inline title editing on double-click

### DIFF
--- a/apps/mesh/src/web/routes/orgs/automation-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/automation-detail.tsx
@@ -640,6 +640,63 @@ function AgentPicker({
 }
 
 // ============================================================================
+// Editable Title
+// ============================================================================
+
+function EditableTitle({
+  form,
+}: {
+  form: ReturnType<typeof useForm<SettingsFormData>>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const name = form.watch("name");
+
+  const startEditing = () => {
+    setIsEditing(true);
+    setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+  };
+
+  const stopEditing = () => {
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <Input
+        {...form.register("name")}
+        ref={(el) => {
+          form.register("name").ref(el);
+          (
+            inputRef as React.MutableRefObject<HTMLInputElement | null>
+          ).current = el;
+        }}
+        placeholder="Automation name"
+        className="border-0 shadow-none px-0 text-2xl md:text-2xl font-semibold h-auto focus-visible:ring-0 bg-transparent"
+        onBlur={stopEditing}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === "Escape") {
+            stopEditing();
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <h1
+      className="text-2xl md:text-2xl font-semibold cursor-default select-none truncate"
+      onDoubleClick={startEditing}
+    >
+      {name || "Automation name"}
+    </h1>
+  );
+}
+
+// ============================================================================
 // Settings Tab
 // ============================================================================
 
@@ -800,11 +857,7 @@ function SettingsTab({
       <div className="max-w-2xl mx-auto w-full px-6 py-6 flex flex-col gap-8">
         {/* Header: Name + Status + Creator */}
         <div className="flex flex-col gap-1.5">
-          <Input
-            {...form.register("name")}
-            placeholder="Automation name"
-            className="border-0 shadow-none px-0 text-2xl md:text-2xl font-semibold h-auto focus-visible:ring-0 bg-transparent"
-          />
+          <EditableTitle form={form} />
           <div className="flex items-center gap-2">
             <Controller
               control={form.control}


### PR DESCRIPTION
## What is this contribution about?

Replaces the always-editable `<Input>` for the automation title with a read-only `<h1>` heading that switches to an inline editable input on double-click. This prevents accidental edits and provides a cleaner detail view.

- Default state: title renders as static `<h1>` text
- Double-click: switches to a focused `<Input>` with text pre-selected
- Blur / Enter / Escape: exits edit mode back to the heading
- Integrates with existing react-hook-form save/undo flow

## Screenshots/Demonstration

N/A

## How to Test

1. Navigate to an automation detail page
2. Verify the title displays as static text (not an input)
3. Double-click the title — it should switch to an editable input with text selected
4. Edit the title and press Enter or click away — it should return to static text
5. Press Escape while editing — should also exit edit mode
6. Confirm the Save/Undo buttons reflect the dirty state after editing

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the automation title input with a read-only heading that becomes editable on double-click, reducing accidental edits and cleaning up the detail view.

- **New Features**
  - Double-click the title to edit; input auto-focuses with text selected.
  - Exit edit mode on blur, Enter, or Escape.
  - Integrated with existing `react-hook-form` dirty/save/undo flow.

<sup>Written for commit eeda8f11864748f8d1b7adc8b3a3aa805036b7f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

