### PR TITLE
fix(automations): show border on name input focus without layout shift

### DIFF
--- a/apps/mesh/src/web/routes/orgs/automation-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/automation-detail.tsx
@@ -803,7 +803,7 @@ function SettingsTab({
           <Input
             {...form.register("name")}
             placeholder="Automation name"
-            className="border-0 shadow-none px-0 text-2xl md:text-2xl font-semibold h-auto focus-visible:ring-0 bg-transparent"
+            className="border border-transparent shadow-none px-0 text-2xl md:text-2xl font-semibold h-auto focus-visible:ring-0 focus-visible:border-border bg-transparent"
           />
           <div className="flex items-center gap-2">
             <Controller


### PR DESCRIPTION
## What is this contribution about?
When editing the automation name in the detail page, there was no visual indicator that the field was in edit mode. This PR adds a border that appears when the input is focused, using a transparent border at rest to avoid any layout shift.

## Screenshots/Demonstration
- Rest state: no visible border (transparent 1px border reserves the space)
- Focused/editing: border appears via `focus-visible:border-border`

## How to Test
1. Navigate to any automation detail page
2. Click on the automation name field at the top
3. Verify a border appears around the input when focused
4. Verify no layout shift occurs when clicking in/out of the field

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes