### PR TITLE
fix(decopilot): prune stale reasoning to prevent invalid thinking signatures

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/conversation.ts
+++ b/apps/mesh/src/api/routes/decopilot/conversation.ts
@@ -151,9 +151,17 @@ export async function processConversation(
     messages: nonSystemModelMessages,
   } = splitMessages(modelMessages);
 
+  // Strip reasoning from all previous assistant messages.
+  // Reasoning parts carry provider-specific metadata (e.g. OpenRouter
+  // reasoning_details with cryptographic signatures). When OpenRouter
+  // load-balances across backends (Anthropic direct, Azure, GCP), the
+  // signatures from one backend are invalid on another, causing
+  // "Invalid signature in thinking block" errors on subsequent turns.
+  // Pruning reasoning from prior turns prevents sending stale signatures
+  // while the current turn generates fresh thinking blocks.
   const prunedModelMessages = pruneMessages({
     messages: nonSystemModelMessages,
-    reasoning: "none",
+    reasoning: "all",
     emptyMessages: "remove",
     toolCalls: "none",
   });


### PR DESCRIPTION
## What is this contribution about?

Fixes intermittent `Invalid 'signature' in 'thinking' block` errors when using Claude models through OpenRouter on Azure backends.

**Root cause:** OpenRouter load-balances Claude requests across different backends (Anthropic direct, Azure, GCP). Each backend signs thinking blocks with different cryptographic keys. When `reasoning_details` (containing signatures from a previous turn's backend) were sent back on the next turn — which might be routed to a different backend — the stale signatures failed validation.

**Fix:** Changed `pruneMessages` from `reasoning: "none"` to `reasoning: "all"` in `processConversation`. This strips reasoning parts from all previous assistant messages before sending to the model. Each turn generates fresh thinking blocks with valid signatures for whichever backend handles the request.

This mirrors the existing workaround in `convertCallOptionsForBinding` (binding/openai-compat path) which strips `providerOptions` for the same class of bug (xAI rejecting encrypted reasoning blobs).

## Screenshots/Demonstration

N/A — backend-only change, no UI impact.

## How to Test

1. Configure OpenRouter as the AI provider with a Claude model that supports extended thinking
2. Start a multi-turn conversation in the Decopilot chat UI
3. Verify the conversation works across multiple turns without "Invalid signature in thinking block" errors
4. Previously this would fail intermittently when OpenRouter routed consecutive turns to different backends (e.g., Azure vs Anthropic direct)

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent "Invalid signature in thinking block" errors with Claude via OpenRouter by pruning stale reasoning from previous turns.

- **Bug Fixes**
  - Set `reasoning: "all"` in `pruneMessages` within `processConversation` to strip reasoning from earlier assistant messages.
  - Prevents sending `reasoning_details` signed by a different backend when OpenRouter routes across Anthropic/Azure/GCP, ensuring fresh, valid thinking blocks each turn.

<sup>Written for commit 1b59c41d402084ff15412f5f21904fb4b1b139dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

