### PR TITLE
fix(inbox): update button action to open AI providers instead of billing

### DIFF
--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -185,7 +185,7 @@ function CreditChip() {
   return (
     <button
       type="button"
-      onClick={() => open("org.billing")}
+      onClick={() => open("org.ai-providers")}
       className="group-data-[collapsible=icon]:hidden flex items-center justify-between w-full px-2 py-1.5 rounded-md hover:bg-sidebar-accent transition-colors"
     >
       <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the credit chip click action in the sidebar inbox: it now opens `org.ai-providers` instead of billing. This sends users to the right screen to set up providers for credits.

<sup>Written for commit 26f3d06084e65f40d58096ca9abe51fc05c7097f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

