### PR TITLE
feat(context-repo): GitHub context repo for organizations

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -156,3 +156,61 @@ Good examples:
 Bad (too vague): {"title": "Help with task"}
 Bad (too long): {"title": "Investigate and fix the issue where the login button does not respond on mobile devices"}
 Bad (wrong case): {"title": "Fix Login Button On Mobile"}`;
+
+/**
+ * Build a context-repo prompt section if a GITHUB context repo connection exists.
+ * Returns null if no context repo is configured.
+ */
+export function buildContextRepoPrompt(
+  connections: Array<{
+    connection_type: string;
+    metadata: unknown;
+  }>,
+): string | null {
+  for (const conn of connections) {
+    if (conn.connection_type !== "GITHUB") continue;
+
+    let metadata: Record<string, unknown> | null = null;
+    try {
+      metadata =
+        typeof conn.metadata === "string"
+          ? JSON.parse(conn.metadata)
+          : (conn.metadata as Record<string, unknown>);
+    } catch {
+      continue;
+    }
+
+    if (metadata?.type !== "context-repo") continue;
+
+    const owner = metadata.owner as string;
+    const repo = metadata.repo as string;
+    const fileCount = (metadata.fileCount as number) || 0;
+
+    return `<context-repo>
+This organization has a connected context repository: ${owner}/${repo} (${fileCount} files indexed)
+
+You have access to these context tools — use them to find information and collaborate:
+
+**Search & Read:**
+- CONTEXT_REPO_SEARCH: Full-text search across all indexed files. Use to find relevant docs, configs, or code.
+- CONTEXT_REPO_READ: Read any file from the context repo by path.
+- CONTEXT_REPO_LIST_SKILLS: List available skills (markdown instructions in skills/ directory).
+
+**GitHub Issues (team communication):**
+- CONTEXT_ISSUE_CREATE: Create issues for findings, problems, or reports. This is the PRIMARY way to share discoveries with the team and other agents.
+- CONTEXT_ISSUE_LIST: Search and list existing issues.
+- CONTEXT_ISSUE_GET: Read issue details and comments.
+- CONTEXT_ISSUE_COMMENT: Participate in issue discussions.
+
+**Agent Versioning:**
+- CONTEXT_AGENT_SAVE: Save an agent definition to agents/<name>.md in the context repo via PR.
+
+IMPORTANT GUIDELINES:
+- When you discover a problem, insight, or finding worth sharing, CREATE AN ISSUE. Use labels to categorize (e.g., "bug", "finding", "improvement"). Issues are how agents and humans collaborate.
+- Before starting complex work, SEARCH the context repo for relevant documentation and prior findings.
+- Check existing issues to avoid duplicate reports and to build on prior discussions.
+</context-repo>`;
+  }
+
+  return null;
+}

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -17,6 +17,7 @@ import { getBuiltInTools } from "./built-in-tools";
 import { createEnableToolsTool } from "./built-in-tools/enable-tools";
 import {
   buildBasePlatformPrompt,
+  buildContextRepoPrompt,
   buildDecopilotAgentPrompt,
   DEFAULT_MAX_TOKENS,
   DEFAULT_THREAD_TITLE,
@@ -446,11 +447,19 @@ async function streamCoreInner(
               "</plan-mode>"
             : null;
 
+        // Context repo prompt: inject if a GITHUB context repo is configured
+        const orgConnections = await ctx.storage.connections.list(
+          input.organizationId,
+          { includeVirtual: true },
+        );
+        const contextRepoPrompt = buildContextRepoPrompt(orgConnections);
+
         const systemPrompts = [
           basePrompt,
           planModePrompt,
           toolCatalog,
           promptCatalog,
+          contextRepoPrompt,
           agentPrompt,
         ].filter((s): s is string => Boolean(s?.trim()));
 

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -448,11 +448,16 @@ async function streamCoreInner(
             : null;
 
         // Context repo prompt: inject if a GITHUB context repo is configured
-        const orgConnections = await ctx.storage.connections.list(
-          input.organizationId,
-          { includeVirtual: true },
-        );
-        const contextRepoPrompt = buildContextRepoPrompt(orgConnections);
+        let contextRepoPrompt: string | null = null;
+        try {
+          const orgConnections = await ctx.storage.connections.list(
+            input.organizationId,
+            { includeVirtual: true },
+          );
+          contextRepoPrompt = buildContextRepoPrompt(orgConnections);
+        } catch {
+          // Non-critical — skip context repo prompt if lookup fails
+        }
 
         const systemPrompts = [
           basePrompt,

--- a/apps/mesh/src/mcp-clients/client.ts
+++ b/apps/mesh/src/mcp-clients/client.ts
@@ -31,5 +31,10 @@ export async function clientFromConnection(
   if (connection.connection_type === "VIRTUAL") {
     return createVirtualClient(connection, ctx, superUser);
   }
+  if (connection.connection_type === "GITHUB") {
+    throw new Error(
+      "GITHUB connections are not MCP servers — they cannot be used as MCP clients.",
+    );
+  }
   return createOutboundClient(connection, ctx, superUser);
 }

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -287,10 +287,32 @@ export class PassthroughClient extends Client {
       "selected_tools",
     );
 
+    // Inject tools from GITHUB connections (context-repo tools served locally)
+    const githubTools: ToolWithConnection[] = [];
+    for (const connection of this.options.connections) {
+      if (connection.connection_type !== "GITHUB") continue;
+      const { getContextRepoTools } = await import(
+        "../../tools/context-repo/tool-defs"
+      );
+      for (const tool of getContextRepoTools()) {
+        githubTools.push({
+          ...tool,
+          _meta: {
+            connectionId: connection.id,
+            connectionTitle: connection.title,
+          },
+        });
+      }
+    }
+
     // Virtual tools take precedence — prepend them and merge mappings
     const mappings = new Map<string, string>();
     for (const vt of virtualItems) {
       mappings.set(vt.name, "__VIRTUAL__");
+    }
+    // GitHub tools map to their connection ID
+    for (const gt of githubTools) {
+      mappings.set(gt.name, gt._meta.connectionId);
     }
     for (const [key, connId] of downstream.mappings) {
       if (!mappings.has(key)) {
@@ -304,7 +326,7 @@ export class PassthroughClient extends Client {
     );
 
     return {
-      data: [...virtualItems, ...filteredDownstream],
+      data: [...virtualItems, ...githubTools, ...filteredDownstream],
       mappings,
       virtualTools: virtualToolsMap,
     };
@@ -347,6 +369,12 @@ export class PassthroughClient extends Client {
       );
     }
 
+    // GITHUB connections execute tools locally (not via MCP client)
+    const connection = this._connections.get(connectionId);
+    if (connection?.connection_type === "GITHUB") {
+      return this.executeGitHubTool(params.name, params.arguments ?? {});
+    }
+
     const client = clients.get(connectionId);
     if (!client) {
       return {
@@ -366,6 +394,34 @@ export class PassthroughClient extends Client {
     });
 
     return result as CallToolResult;
+  }
+
+  /**
+   * Execute a context-repo tool locally (GITHUB connections don't use MCP transport)
+   */
+  private async executeGitHubTool(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    try {
+      const { executeContextRepoTool } = await import(
+        "../../tools/context-repo/tool-defs"
+      );
+      const result = await executeContextRepoTool(toolName, args, this.ctx);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+      };
+    } catch (e) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
   }
 
   private async executeVirtualTool(

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -72,6 +72,9 @@ function createClientMap(
   const clientMap = new Map<string, Client>();
 
   for (const connection of connections) {
+    // Skip non-MCP connection types (e.g., GITHUB) — they don't speak MCP protocol
+    if (connection.connection_type === "GITHUB") continue;
+
     clientMap.set(
       connection.id,
       createLazyClient(connection, ctx, superUser, cache),

--- a/apps/mesh/src/storage/connection.ts
+++ b/apps/mesh/src/storage/connection.ts
@@ -42,7 +42,13 @@ type RawConnectionRow = {
   icon: string | null;
   app_name: string | null;
   app_id: string | null;
-  connection_type: "HTTP" | "SSE" | "Websocket" | "STDIO" | "VIRTUAL";
+  connection_type:
+    | "HTTP"
+    | "SSE"
+    | "Websocket"
+    | "STDIO"
+    | "VIRTUAL"
+    | "GITHUB";
   connection_url: string | null;
   connection_token: string | null;
   connection_headers: string | null; // JSON, envVars encrypted for STDIO
@@ -128,9 +134,11 @@ export class ConnectionStorage implements ConnectionStoragePort {
       .selectAll()
       .where("organization_id", "=", organizationId);
 
-    // By default, exclude VIRTUAL connections unless explicitly requested
+    // By default, exclude VIRTUAL and GITHUB connections unless explicitly requested
     if (!options?.includeVirtual) {
-      query = query.where("connection_type", "!=", "VIRTUAL");
+      query = query
+        .where("connection_type", "!=", "VIRTUAL")
+        .where("connection_type", "!=", "GITHUB");
     }
 
     const rows = await query.execute();

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -158,7 +158,13 @@ export interface MCPConnectionTable {
   app_id: string | null;
 
   // Connection details
-  connection_type: "HTTP" | "SSE" | "Websocket" | "STDIO" | "VIRTUAL";
+  connection_type:
+    | "HTTP"
+    | "SSE"
+    | "Websocket"
+    | "STDIO"
+    | "VIRTUAL"
+    | "GITHUB";
   connection_url: string | null; // Null for STDIO, virtual://$id for VIRTUAL
   connection_token: string | null; // Encrypted
   connection_headers: string | null; // JSON - encrypted envVars for STDIO

--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -22,7 +22,13 @@ import { isStdioParameters } from "./schema";
 export interface ConnectionForToolFetch {
   id: string;
   title: string;
-  connection_type: "HTTP" | "SSE" | "Websocket" | "STDIO" | "VIRTUAL";
+  connection_type:
+    | "HTTP"
+    | "SSE"
+    | "Websocket"
+    | "STDIO"
+    | "VIRTUAL"
+    | "GITHUB";
   connection_url?: string | null;
   connection_token?: string | null;
   connection_headers?: ConnectionParameters | null;
@@ -58,6 +64,9 @@ export async function fetchToolsFromMCP(
     case "VIRTUAL":
       // VIRTUAL connections aggregate tools from their underlying Virtual MCP
       // Tools are fetched dynamically at runtime, not cached at creation time
+      return null;
+    case "GITHUB":
+      // GITHUB connections are context repos — tools are provided by CORE_TOOLS, not the connection itself
       return null;
     default:
       return null;

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -294,6 +294,8 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     await Promise.all(
       connections.map(async (connection) => {
         if (connection.tools !== null) return;
+        // Skip non-MCP connections — they don't have tools to discover
+        if (connection.connection_type === "GITHUB") return;
         // The self MCP requires session auth, so an HTTP round-trip would
         // fail without forwarding cookies. Use in-process transport instead.
         const fetchLive =

--- a/apps/mesh/src/tools/context-repo/agent-save.ts
+++ b/apps/mesh/src/tools/context-repo/agent-save.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { findContextRepo, getContextRepoPath } from "./helpers";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export const CONTEXT_AGENT_SAVE = defineTool({
+  name: "CONTEXT_AGENT_SAVE",
+  description:
+    "Save an agent definition to the context repo as agents/<name>.md and open a PR.",
+  annotations: {
+    title: "Save Agent to Context Repo",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    agentId: z.string().describe("Virtual MCP (agent) ID"),
+    commitMessage: z.string().optional().describe("Custom commit message"),
+  }),
+  outputSchema: z.object({
+    prUrl: z.string(),
+    branch: z.string(),
+    path: z.string(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config) throw new Error("No context repo configured.");
+
+    // Load agent connection
+    const connections = await ctx.storage.connections.list(orgId, {
+      includeVirtual: true,
+    });
+    const agentConn = connections.find(
+      (c) => c.id === input.agentId && c.connection_type === "VIRTUAL",
+    );
+    if (!agentConn) throw new Error(`Agent not found: ${input.agentId}`);
+
+    const agentMeta =
+      typeof agentConn.metadata === "string"
+        ? JSON.parse(agentConn.metadata || "{}")
+        : ((agentConn.metadata || {}) as Record<string, unknown>);
+    const instructions =
+      (agentMeta as { instructions?: string }).instructions || "";
+
+    const title = agentConn.title || "Unnamed Agent";
+    const description = agentConn.description || "";
+    const icon = agentConn.icon || "";
+    const slug = slugify(title);
+
+    // Build markdown
+    const lines = ["---", `name: ${title}`, `description: ${description}`];
+    if (icon) lines.push(`icon: ${icon}`);
+    if (instructions) {
+      lines.push("instructions: |");
+      for (const line of instructions.split("\n")) {
+        lines.push(`  ${line}`);
+      }
+    }
+    lines.push("---");
+    lines.push("");
+    lines.push(`# ${title}`);
+    lines.push("");
+    if (description) {
+      lines.push(description);
+      lines.push("");
+    }
+
+    const markdown = lines.join("\n");
+    const repoPath = getContextRepoPath(orgId, config.owner, config.repo);
+    const filePath = `agents/${slug}.md`;
+    const fullFilePath = join(repoPath, filePath);
+
+    mkdirSync(join(repoPath, "agents"), { recursive: true });
+    writeFileSync(fullFilePath, markdown, "utf-8");
+
+    const branchName = `agent/${slug}-${Date.now()}`;
+    const message = input.commitMessage || `Update agent: ${title}`;
+
+    const git = (args: string[]) =>
+      Bun.spawn(["git", "-C", repoPath, ...args], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+    await git(["checkout", "-b", branchName]).exited;
+    await git(["add", filePath]).exited;
+    await git(["commit", "-m", message]).exited;
+    await git(["push", "-u", "origin", branchName]).exited;
+
+    // Switch back to tracked branch
+    await git(["checkout", config.branch]).exited;
+
+    const prProc = Bun.spawn(
+      [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        `${config.owner}/${config.repo}`,
+        "--head",
+        branchName,
+        "--title",
+        message,
+        "--body",
+        `Saves agent **${title}** definition to \`${filePath}\`.\n\nCreated via Deco Mesh.`,
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    const prUrl = (await new Response(prProc.stdout).text()).trim();
+    const prExit = await prProc.exited;
+
+    if (prExit !== 0) {
+      const stderr = await new Response(prProc.stderr).text();
+      throw new Error(`Failed to create PR: ${stderr.trim()}`);
+    }
+
+    return { prUrl, branch: branchName, path: filePath };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/disconnect.ts
+++ b/apps/mesh/src/tools/context-repo/disconnect.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { rm } from "node:fs/promises";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { getRepoPath } from "./gh-cli";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_REPO_DISCONNECT = defineTool({
+  name: "CONTEXT_REPO_DISCONNECT",
+  description:
+    "Disconnect the context repo: deletes the connection and cleans up the local clone and index.",
+  annotations: {
+    title: "Disconnect Context Repo",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    disconnected: z.boolean(),
+  }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const existing = await findContextRepo(ctx);
+    if (!existing) {
+      return { disconnected: false };
+    }
+
+    // Delete the connection
+    await ctx.storage.connections.delete(existing.connectionId);
+
+    // Clean up local clone + index
+    const repoPath = getRepoPath(orgId, existing.owner, existing.repo);
+    try {
+      await rm(repoPath, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
+
+    return { disconnected: true };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/gh-cli.ts
+++ b/apps/mesh/src/tools/context-repo/gh-cli.ts
@@ -96,7 +96,7 @@ export async function cloneOrPull(
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(REPOS_BASE, orgId, owner), { recursive: true });
 
-    // Clone using gh CLI (handles auth for both HTTPS and SSH transparently)
+    // Shallow clone using gh CLI (handles auth for both HTTPS and SSH)
     const proc = Bun.spawn(
       [
         "gh",

--- a/apps/mesh/src/tools/context-repo/gh-cli.ts
+++ b/apps/mesh/src/tools/context-repo/gh-cli.ts
@@ -96,11 +96,15 @@ export async function cloneOrPull(
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(REPOS_BASE, orgId, owner), { recursive: true });
 
-    // Shallow clone with security flags
+    // Clone using gh CLI (handles auth for both HTTPS and SSH transparently)
     const proc = Bun.spawn(
       [
-        "git",
+        "gh",
+        "repo",
         "clone",
+        fullName,
+        repoPath,
+        "--",
         "--depth",
         "1",
         "--branch",
@@ -109,8 +113,6 @@ export async function cloneOrPull(
         "-c",
         "core.hooksPath=/dev/null",
         "--no-recurse-submodules",
-        `git@github.com:${fullName}.git`,
-        repoPath,
       ],
       {
         stdout: "pipe",

--- a/apps/mesh/src/tools/context-repo/gh-cli.ts
+++ b/apps/mesh/src/tools/context-repo/gh-cli.ts
@@ -1,0 +1,183 @@
+/**
+ * GitHub CLI Access Layer
+ *
+ * Uses the `gh` CLI for GitHub operations. Only works when gh is installed
+ * and authenticated locally (gh auth login).
+ *
+ * Security:
+ * - All subprocess calls use array args (never shell strings)
+ * - Owner/repo validated against strict regex
+ * - Clone paths are org-scoped to prevent cross-org collisions
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const VALID_NAME_RE = /^[a-zA-Z0-9._-]+$/;
+const REPOS_BASE = join(homedir(), "deco", "repos");
+
+/** Validate a GitHub owner or repo name */
+function validateName(value: string, label: string): string {
+  if (!VALID_NAME_RE.test(value)) {
+    throw new Error(
+      `Invalid GitHub ${label}: "${value}". Only alphanumeric, dots, hyphens, and underscores allowed.`,
+    );
+  }
+  return value;
+}
+
+/** Check if gh CLI is available and authenticated */
+export async function checkGhAccess(): Promise<{
+  available: boolean;
+  user?: string;
+}> {
+  try {
+    const proc = Bun.spawn(
+      ["gh", "auth", "status", "--hostname", "github.com"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return { available: false };
+    // Parse username from output like "Logged in to github.com account username"
+    const match = stderr.match(/account\s+(\S+)/);
+    return { available: true, user: match?.[1] };
+  } catch {
+    return { available: false };
+  }
+}
+
+/** Get the local clone path for a repo (org-scoped) */
+export function getRepoPath(
+  orgId: string,
+  owner: string,
+  repo: string,
+): string {
+  validateName(owner, "owner");
+  validateName(repo, "repo");
+  return join(REPOS_BASE, orgId, owner, repo);
+}
+
+/** Clone or pull a GitHub repo. Returns the local path. */
+export async function cloneOrPull(
+  orgId: string,
+  owner: string,
+  repo: string,
+  branch: string = "main",
+): Promise<{ path: string; headCommit: string }> {
+  validateName(owner, "owner");
+  validateName(repo, "repo");
+  // Branch can have slashes
+  if (!/^[a-zA-Z0-9._\/-]+$/.test(branch)) {
+    throw new Error(`Invalid branch name: "${branch}"`);
+  }
+
+  const repoPath = getRepoPath(orgId, owner, repo);
+  const fullName = `${owner}/${repo}`;
+
+  // Check if already cloned
+  const exists = await Bun.file(join(repoPath, ".git", "HEAD")).exists();
+
+  if (exists) {
+    // Pull latest
+    const proc = Bun.spawn(
+      ["git", "-C", repoPath, "pull", "--ff-only", "origin", branch],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    await proc.exited;
+  } else {
+    // Create parent directory
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(REPOS_BASE, orgId, owner), { recursive: true });
+
+    // Shallow clone with security flags
+    const proc = Bun.spawn(
+      [
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        branch,
+        "--single-branch",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "--no-recurse-submodules",
+        `https://github.com/${fullName}.git`,
+        repoPath,
+      ],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`Failed to clone ${fullName}: ${stderr.trim()}`);
+    }
+  }
+
+  // Get HEAD commit SHA
+  const shaProc = Bun.spawn(["git", "-C", repoPath, "rev-parse", "HEAD"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const sha = (await new Response(shaProc.stdout).text()).trim();
+  await shaProc.exited;
+
+  return { path: repoPath, headCommit: sha };
+}
+
+/** List changed files between two commits */
+export async function diffFiles(
+  repoPath: string,
+  oldCommit: string,
+  newCommit: string,
+): Promise<{ added: string[]; modified: string[]; deleted: string[] }> {
+  const proc = Bun.spawn(
+    [
+      "git",
+      "-C",
+      repoPath,
+      "diff",
+      "--name-status",
+      `${oldCommit}..${newCommit}`,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const output = (await new Response(proc.stdout).text()).trim();
+  await proc.exited;
+
+  const added: string[] = [];
+  const modified: string[] = [];
+  const deleted: string[] = [];
+
+  for (const line of output.split("\n")) {
+    if (!line.trim()) continue;
+    const [status, ...pathParts] = line.split("\t");
+    const filePath = pathParts.join("\t");
+    if (status === "A") added.push(filePath);
+    else if (status === "M") modified.push(filePath);
+    else if (status === "D") deleted.push(filePath);
+  }
+
+  return { added, modified, deleted };
+}
+
+/** List all files in the repo (for initial index) */
+export async function listAllFiles(repoPath: string): Promise<string[]> {
+  const proc = Bun.spawn(["git", "-C", repoPath, "ls-files"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = (await new Response(proc.stdout).text()).trim();
+  await proc.exited;
+  return output ? output.split("\n") : [];
+}

--- a/apps/mesh/src/tools/context-repo/gh-cli.ts
+++ b/apps/mesh/src/tools/context-repo/gh-cli.ts
@@ -109,7 +109,7 @@ export async function cloneOrPull(
         "-c",
         "core.hooksPath=/dev/null",
         "--no-recurse-submodules",
-        `https://github.com/${fullName}.git`,
+        `git@github.com:${fullName}.git`,
         repoPath,
       ],
       {

--- a/apps/mesh/src/tools/context-repo/helpers.ts
+++ b/apps/mesh/src/tools/context-repo/helpers.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared helpers for context repo tools
+ */
+
+import type { MeshContext } from "@/core/mesh-context";
+import { getRepoPath } from "./gh-cli";
+
+export interface ContextRepoConfig {
+  connectionId: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  lastSyncedCommit: string | null;
+  fileCount: number;
+  indexSizeBytes: number;
+}
+
+/**
+ * Find the context repo connection for the current organization.
+ * Returns null if no context repo is configured.
+ */
+export async function findContextRepo(
+  ctx: MeshContext,
+): Promise<ContextRepoConfig | null> {
+  const orgId = ctx.organization?.id;
+  if (!orgId) return null;
+
+  const connections = await ctx.storage.connections.list(orgId, {
+    includeVirtual: true,
+  });
+
+  for (const conn of connections) {
+    if (conn.connection_type !== "GITHUB") continue;
+
+    let metadata: Record<string, unknown> | null = null;
+    try {
+      metadata =
+        typeof conn.metadata === "string"
+          ? JSON.parse(conn.metadata)
+          : (conn.metadata as Record<string, unknown>);
+    } catch {
+      continue;
+    }
+
+    if (metadata?.type !== "context-repo") continue;
+
+    return {
+      connectionId: conn.id,
+      owner: metadata.owner as string,
+      repo: metadata.repo as string,
+      branch: (metadata.branch as string) || "main",
+      lastSyncedCommit: (metadata.lastSyncedCommit as string) || null,
+      fileCount: (metadata.fileCount as number) || 0,
+      indexSizeBytes: (metadata.indexSizeBytes as number) || 0,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Get the local disk path for the context repo
+ */
+export function getContextRepoPath(
+  orgId: string,
+  owner: string,
+  repo: string,
+): string {
+  return getRepoPath(orgId, owner, repo);
+}

--- a/apps/mesh/src/tools/context-repo/helpers.ts
+++ b/apps/mesh/src/tools/context-repo/helpers.ts
@@ -2,7 +2,6 @@
  * Shared helpers for context repo tools
  */
 
-import { readdir } from "node:fs/promises";
 import type { MeshContext } from "@/core/mesh-context";
 import { getRepoPath } from "./gh-cli";
 
@@ -74,16 +73,73 @@ export function getContextRepoPath(
   return getRepoPath(orgId, owner, repo);
 }
 
+export interface FolderInfo {
+  name: string; // "<root>" for root-level files, or folder name
+  fileCount: number;
+  totalBytes: number;
+}
+
 /**
- * List top-level directories in a cloned repo (excludes .git and hidden dirs).
+ * List top-level directories in a cloned repo with file counts and sizes.
+ * Includes a "<root>" entry for files directly in the repo root.
+ * Excludes .git and hidden dirs.
  */
-export async function listRepoFolders(repoPath: string): Promise<string[]> {
+export async function listRepoFolders(repoPath: string): Promise<FolderInfo[]> {
+  const { listAllFiles } = await import("./gh-cli");
+  const { stat } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+
   try {
-    const entries = await readdir(repoPath, { withFileTypes: true });
-    return entries
-      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
-      .map((e) => e.name)
-      .sort();
+    const allFiles = await listAllFiles(repoPath);
+    const folderMap = new Map<string, { count: number; bytes: number }>();
+
+    for (const filePath of allFiles) {
+      const parts = filePath.split("/");
+      const folderName = parts.length === 1 ? "<root>" : parts[0]!;
+
+      // Skip hidden dirs and .git
+      if (folderName.startsWith(".") && folderName !== "<root>") continue;
+
+      if (!folderMap.has(folderName)) {
+        folderMap.set(folderName, { count: 0, bytes: 0 });
+      }
+      const entry = folderMap.get(folderName)!;
+      entry.count++;
+
+      try {
+        const fileStat = await stat(join(repoPath, filePath));
+        entry.bytes += fileStat.size;
+      } catch {
+        // Skip files we can't stat
+      }
+    }
+
+    const results: FolderInfo[] = [];
+
+    // Root files first
+    const rootEntry = folderMap.get("<root>");
+    if (rootEntry) {
+      results.push({
+        name: "<root>",
+        fileCount: rootEntry.count,
+        totalBytes: rootEntry.bytes,
+      });
+      folderMap.delete("<root>");
+    }
+
+    // Then folders sorted alphabetically
+    const sortedFolders = [...folderMap.entries()].sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    for (const [name, info] of sortedFolders) {
+      results.push({
+        name,
+        fileCount: info.count,
+        totalBytes: info.bytes,
+      });
+    }
+
+    return results;
   } catch {
     return [];
   }

--- a/apps/mesh/src/tools/context-repo/helpers.ts
+++ b/apps/mesh/src/tools/context-repo/helpers.ts
@@ -2,6 +2,7 @@
  * Shared helpers for context repo tools
  */
 
+import { readdir } from "node:fs/promises";
 import type { MeshContext } from "@/core/mesh-context";
 import { getRepoPath } from "./gh-cli";
 
@@ -14,6 +15,7 @@ export interface ContextRepoConfig {
   fileCount: number;
   indexSizeBytes: number;
   lastSyncedAt: string | null;
+  indexedFolders: string[] | null;
 }
 
 /**
@@ -54,6 +56,7 @@ export async function findContextRepo(
       fileCount: (metadata.fileCount as number) || 0,
       indexSizeBytes: (metadata.indexSizeBytes as number) || 0,
       lastSyncedAt: (metadata.lastSyncedAt as string) || null,
+      indexedFolders: (metadata.indexedFolders as string[]) || null,
     };
   }
 
@@ -69,4 +72,19 @@ export function getContextRepoPath(
   repo: string,
 ): string {
   return getRepoPath(orgId, owner, repo);
+}
+
+/**
+ * List top-level directories in a cloned repo (excludes .git and hidden dirs).
+ */
+export async function listRepoFolders(repoPath: string): Promise<string[]> {
+  try {
+    const entries = await readdir(repoPath, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
 }

--- a/apps/mesh/src/tools/context-repo/helpers.ts
+++ b/apps/mesh/src/tools/context-repo/helpers.ts
@@ -13,6 +13,7 @@ export interface ContextRepoConfig {
   lastSyncedCommit: string | null;
   fileCount: number;
   indexSizeBytes: number;
+  lastSyncedAt: string | null;
 }
 
 /**
@@ -52,6 +53,7 @@ export async function findContextRepo(
       lastSyncedCommit: (metadata.lastSyncedCommit as string) || null,
       fileCount: (metadata.fileCount as number) || 0,
       indexSizeBytes: (metadata.indexSizeBytes as number) || 0,
+      lastSyncedAt: (metadata.lastSyncedAt as string) || null,
     };
   }
 

--- a/apps/mesh/src/tools/context-repo/index.ts
+++ b/apps/mesh/src/tools/context-repo/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Context Repo Tools
+ *
+ * Tools for managing a GitHub repository as shared organizational context.
+ * Provides file search, reading, skills discovery, GitHub issues, and agent versioning.
+ */
+
+export { CONTEXT_REPO_SETUP } from "./setup";
+export { CONTEXT_REPO_SYNC } from "./sync";
+export { CONTEXT_REPO_SEARCH } from "./search";
+export { CONTEXT_REPO_READ } from "./read";
+export { CONTEXT_REPO_LIST_SKILLS } from "./list-skills";
+export { CONTEXT_ISSUE_CREATE } from "./issue-create";
+export { CONTEXT_ISSUE_LIST } from "./issue-list";
+export { CONTEXT_ISSUE_GET } from "./issue-get";
+export { CONTEXT_ISSUE_COMMENT } from "./issue-comment";
+export { CONTEXT_AGENT_SAVE } from "./agent-save";

--- a/apps/mesh/src/tools/context-repo/index.ts
+++ b/apps/mesh/src/tools/context-repo/index.ts
@@ -5,6 +5,7 @@
  * Provides file search, reading, skills discovery, GitHub issues, and agent versioning.
  */
 
+export { CONTEXT_REPO_STATUS } from "./status";
 export { CONTEXT_REPO_SETUP } from "./setup";
 export { CONTEXT_REPO_SYNC } from "./sync";
 export { CONTEXT_REPO_SEARCH } from "./search";

--- a/apps/mesh/src/tools/context-repo/index.ts
+++ b/apps/mesh/src/tools/context-repo/index.ts
@@ -7,6 +7,7 @@
 
 export { CONTEXT_REPO_STATUS } from "./status";
 export { CONTEXT_REPO_SETUP } from "./setup";
+export { CONTEXT_REPO_UPDATE_FOLDERS } from "./update-folders";
 export { CONTEXT_REPO_SYNC } from "./sync";
 export { CONTEXT_REPO_SEARCH } from "./search";
 export { CONTEXT_REPO_READ } from "./read";

--- a/apps/mesh/src/tools/context-repo/index.ts
+++ b/apps/mesh/src/tools/context-repo/index.ts
@@ -8,6 +8,7 @@
 export { CONTEXT_REPO_STATUS } from "./status";
 export { CONTEXT_REPO_SETUP } from "./setup";
 export { CONTEXT_REPO_UPDATE_FOLDERS } from "./update-folders";
+export { CONTEXT_REPO_DISCONNECT } from "./disconnect";
 export { CONTEXT_REPO_SYNC } from "./sync";
 export { CONTEXT_REPO_SEARCH } from "./search";
 export { CONTEXT_REPO_READ } from "./read";

--- a/apps/mesh/src/tools/context-repo/indexer.ts
+++ b/apps/mesh/src/tools/context-repo/indexer.ts
@@ -98,7 +98,10 @@ function shouldSkipFile(filePath: string): boolean {
   return false;
 }
 
-export async function buildIndex(repoPath: string): Promise<RepoIndex> {
+export async function buildIndex(
+  repoPath: string,
+  folderFilter?: string[] | null,
+): Promise<RepoIndex> {
   const allFiles = await listAllFiles(repoPath);
   const files: IndexedFile[] = [];
   let totalSize = 0;
@@ -106,6 +109,12 @@ export async function buildIndex(repoPath: string): Promise<RepoIndex> {
   for (const filePath of allFiles) {
     if (files.length >= MAX_FILES) break;
     if (shouldSkipFile(filePath)) continue;
+    // If folder filter is set, only index files in selected folders (or root files)
+    if (folderFilter && folderFilter.length > 0) {
+      const topDir = filePath.split("/")[0];
+      const isRootFile = !filePath.includes("/");
+      if (!isRootFile && topDir && !folderFilter.includes(topDir)) continue;
+    }
 
     const fullPath = join(repoPath, filePath);
     try {

--- a/apps/mesh/src/tools/context-repo/indexer.ts
+++ b/apps/mesh/src/tools/context-repo/indexer.ts
@@ -109,11 +109,16 @@ export async function buildIndex(
   for (const filePath of allFiles) {
     if (files.length >= MAX_FILES) break;
     if (shouldSkipFile(filePath)) continue;
-    // If folder filter is set, only index files in selected folders (or root files)
+    // If folder filter is set, only index files in selected folders
     if (folderFilter && folderFilter.length > 0) {
-      const topDir = filePath.split("/")[0];
       const isRootFile = !filePath.includes("/");
-      if (!isRootFile && topDir && !folderFilter.includes(topDir)) continue;
+      if (isRootFile) {
+        // Root files only included if "<root>" is in the filter
+        if (!folderFilter.includes("<root>")) continue;
+      } else {
+        const topDir = filePath.split("/")[0];
+        if (topDir && !folderFilter.includes(topDir)) continue;
+      }
     }
 
     const fullPath = join(repoPath, filePath);

--- a/apps/mesh/src/tools/context-repo/indexer.ts
+++ b/apps/mesh/src/tools/context-repo/indexer.ts
@@ -1,0 +1,213 @@
+/**
+ * Context Repo File Indexer
+ *
+ * Indexes repository files for fast search. Stores index as JSON on disk
+ * alongside the cloned repo (NOT in the database).
+ */
+
+import { join } from "node:path";
+import { stat, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { listAllFiles } from "./gh-cli";
+
+const BINARY_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".ico",
+  ".svg",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".eot",
+  ".otf",
+  ".mp3",
+  ".mp4",
+  ".wav",
+  ".ogg",
+  ".webm",
+  ".zip",
+  ".tar",
+  ".gz",
+  ".bz2",
+  ".7z",
+  ".rar",
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".wasm",
+  ".pyc",
+  ".class",
+  ".o",
+  ".so",
+  ".dylib",
+  ".map",
+]);
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "vendor",
+  "__pycache__",
+  ".next",
+  ".nuxt",
+  ".output",
+  "coverage",
+  ".cache",
+  ".turbo",
+  ".vercel",
+]);
+
+const MAX_FILE_SIZE = 100 * 1024;
+const MAX_FILES = 10_000;
+const SNIPPET_LENGTH = 500;
+
+export interface IndexedFile {
+  path: string;
+  size: number;
+  hash: string;
+  snippets: string[];
+}
+
+export interface RepoIndex {
+  version: 1;
+  indexedAt: string;
+  fileCount: number;
+  totalSizeBytes: number;
+  files: IndexedFile[];
+}
+
+function shouldSkipFile(filePath: string): boolean {
+  const parts = filePath.split("/");
+  for (const part of parts) {
+    if (SKIP_DIRS.has(part)) return true;
+  }
+  const lastDot = filePath.lastIndexOf(".");
+  if (lastDot >= 0) {
+    const ext = filePath.substring(lastDot).toLowerCase();
+    if (BINARY_EXTENSIONS.has(ext)) return true;
+  }
+  if (filePath.endsWith(".min.js") || filePath.endsWith(".min.css"))
+    return true;
+  return false;
+}
+
+export async function buildIndex(repoPath: string): Promise<RepoIndex> {
+  const allFiles = await listAllFiles(repoPath);
+  const files: IndexedFile[] = [];
+  let totalSize = 0;
+
+  for (const filePath of allFiles) {
+    if (files.length >= MAX_FILES) break;
+    if (shouldSkipFile(filePath)) continue;
+
+    const fullPath = join(repoPath, filePath);
+    try {
+      const fileStat = await stat(fullPath);
+      if (!fileStat.isFile() || fileStat.size > MAX_FILE_SIZE) continue;
+
+      const content = await readFile(fullPath, "utf-8");
+      const hash = createHash("sha256")
+        .update(content)
+        .digest("hex")
+        .slice(0, 16);
+      const snippets = [content.slice(0, SNIPPET_LENGTH)];
+
+      files.push({ path: filePath, size: fileStat.size, hash, snippets });
+      totalSize += fileStat.size;
+    } catch {
+      // Skip files we can't read
+    }
+  }
+
+  return {
+    version: 1,
+    indexedAt: new Date().toISOString(),
+    fileCount: files.length,
+    totalSizeBytes: totalSize,
+    files,
+  };
+}
+
+export async function saveIndex(
+  repoPath: string,
+  index: RepoIndex,
+): Promise<void> {
+  await writeFile(
+    join(repoPath, ".deco-index.json"),
+    JSON.stringify(index),
+    "utf-8",
+  );
+}
+
+export async function loadIndex(repoPath: string): Promise<RepoIndex | null> {
+  try {
+    const content = await readFile(join(repoPath, ".deco-index.json"), "utf-8");
+    return JSON.parse(content) as RepoIndex;
+  } catch {
+    return null;
+  }
+}
+
+export interface SearchResult {
+  path: string;
+  snippet: string;
+  rank: number;
+}
+
+export function searchIndex(
+  index: RepoIndex,
+  query: string,
+  limit = 20,
+): SearchResult[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return [];
+
+  const results: SearchResult[] = [];
+
+  for (const file of index.files) {
+    const pathLower = file.path.toLowerCase();
+    const allText = [
+      pathLower,
+      ...file.snippets.map((s) => s.toLowerCase()),
+    ].join("\n");
+
+    let matchCount = 0;
+    for (const term of terms) {
+      if (allText.includes(term)) matchCount++;
+    }
+
+    if (matchCount > 0) {
+      const bestSnippet =
+        file.snippets.find((s) =>
+          terms.some((t) => s.toLowerCase().includes(t)),
+        ) ||
+        file.snippets[0] ||
+        "";
+
+      const idx = bestSnippet.toLowerCase().indexOf(terms[0]!);
+      const start = Math.max(0, idx - 100);
+      const end = Math.min(bestSnippet.length, idx + 200);
+      const snippet =
+        (start > 0 ? "..." : "") +
+        bestSnippet.slice(start, end) +
+        (end < bestSnippet.length ? "..." : "");
+
+      results.push({
+        path: file.path,
+        snippet: snippet.trim(),
+        rank:
+          matchCount / terms.length + (pathLower.includes(terms[0]!) ? 0.5 : 0),
+      });
+    }
+  }
+
+  results.sort((a, b) => b.rank - a.rank);
+  return results.slice(0, limit);
+}

--- a/apps/mesh/src/tools/context-repo/issue-comment.ts
+++ b/apps/mesh/src/tools/context-repo/issue-comment.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_ISSUE_COMMENT = defineTool({
+  name: "CONTEXT_ISSUE_COMMENT",
+  description: "Add a comment to a GitHub issue in the context repo.",
+  annotations: {
+    title: "Comment on Context Issue",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    number: z.number().int().positive().describe("Issue number"),
+    body: z.string().min(1).describe("Comment body (markdown)"),
+  }),
+  outputSchema: z.object({
+    url: z.string(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config) throw new Error("No context repo configured.");
+
+    const agentName = ctx.auth.user?.name || "Decopilot";
+    const footer = `\n\n---\n_Comment by ${agentName} via Deco Mesh_`;
+    const fullBody = input.body + footer;
+
+    const proc = Bun.spawn(
+      [
+        "gh",
+        "issue",
+        "comment",
+        String(input.number),
+        "--repo",
+        `${config.owner}/${config.repo}`,
+        "--body",
+        fullBody,
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(
+        `Failed to comment on issue #${input.number}: ${stderr.trim()}`,
+      );
+    }
+
+    return {
+      url:
+        stdout.trim() ||
+        `https://github.com/${config.owner}/${config.repo}/issues/${input.number}`,
+    };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/issue-create.ts
+++ b/apps/mesh/src/tools/context-repo/issue-create.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_ISSUE_CREATE = defineTool({
+  name: "CONTEXT_ISSUE_CREATE",
+  description:
+    "Create a GitHub issue in the context repo. Use this to report findings, problems, or share information with the team.",
+  annotations: {
+    title: "Create Context Issue",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    title: z.string().min(1).max(256).describe("Issue title"),
+    body: z.string().min(1).describe("Issue body (markdown)"),
+    labels: z.array(z.string()).optional().describe("Labels to apply"),
+  }),
+  outputSchema: z.object({
+    number: z.number(),
+    url: z.string(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config) throw new Error("No context repo configured.");
+
+    const agentName = ctx.auth.user?.name || "Decopilot";
+    const footer = `\n\n---\n_Created by ${agentName} via Deco Mesh_`;
+    const fullBody = input.body + footer;
+
+    const args = [
+      "gh",
+      "issue",
+      "create",
+      "--repo",
+      `${config.owner}/${config.repo}`,
+      "--title",
+      input.title,
+      "--body",
+      fullBody,
+    ];
+    if (input.labels?.length) {
+      for (const label of input.labels) {
+        args.push("--label", label);
+      }
+    }
+
+    const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      throw new Error(`Failed to create issue: ${stderr.trim()}`);
+    }
+
+    const url = stdout.trim();
+    const numberMatch = url.match(/\/issues\/(\d+)/);
+    const number = numberMatch ? parseInt(numberMatch[1]!, 10) : 0;
+
+    return { number, url };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/issue-get.ts
+++ b/apps/mesh/src/tools/context-repo/issue-get.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_ISSUE_GET = defineTool({
+  name: "CONTEXT_ISSUE_GET",
+  description: "Get a GitHub issue with its comments from the context repo.",
+  annotations: {
+    title: "Get Context Issue",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    number: z.number().int().positive().describe("Issue number"),
+  }),
+  outputSchema: z.object({
+    number: z.number(),
+    title: z.string(),
+    body: z.string(),
+    state: z.string(),
+    labels: z.array(z.string()),
+    author: z.string(),
+    createdAt: z.string(),
+    comments: z.array(
+      z.object({
+        author: z.string(),
+        body: z.string(),
+        createdAt: z.string(),
+      }),
+    ),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config) throw new Error("No context repo configured.");
+
+    const proc = Bun.spawn(
+      [
+        "gh",
+        "issue",
+        "view",
+        String(input.number),
+        "--repo",
+        `${config.owner}/${config.repo}`,
+        "--json",
+        "number,title,body,state,labels,author,comments,createdAt",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`Failed to get issue #${input.number}: ${stderr.trim()}`);
+    }
+
+    const raw = JSON.parse(stdout) as {
+      number: number;
+      title: string;
+      body: string;
+      state: string;
+      labels: Array<{ name: string }>;
+      author: { login: string };
+      comments: Array<{
+        author: { login: string };
+        body: string;
+        createdAt: string;
+      }>;
+      createdAt: string;
+    };
+
+    return {
+      number: raw.number,
+      title: raw.title,
+      body: raw.body || "",
+      state: raw.state,
+      labels: raw.labels.map((l) => l.name),
+      author: raw.author.login,
+      createdAt: raw.createdAt,
+      comments: raw.comments.map((c) => ({
+        author: c.author.login,
+        body: c.body,
+        createdAt: c.createdAt,
+      })),
+    };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/issue-list.ts
+++ b/apps/mesh/src/tools/context-repo/issue-list.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_ISSUE_LIST = defineTool({
+  name: "CONTEXT_ISSUE_LIST",
+  description: "List or search GitHub issues in the context repo.",
+  annotations: {
+    title: "List Context Issues",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    state: z
+      .enum(["open", "closed", "all"])
+      .default("open")
+      .describe("Issue state filter"),
+    labels: z
+      .string()
+      .optional()
+      .describe("Comma-separated labels to filter by"),
+    query: z.string().optional().describe("Search query"),
+    limit: z.number().min(1).max(100).default(30).describe("Max results"),
+  }),
+  outputSchema: z.object({
+    issues: z.array(
+      z.object({
+        number: z.number(),
+        title: z.string(),
+        state: z.string(),
+        labels: z.array(z.string()),
+        author: z.string(),
+        createdAt: z.string(),
+      }),
+    ),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config) throw new Error("No context repo configured.");
+
+    const args = [
+      "gh",
+      "issue",
+      "list",
+      "--repo",
+      `${config.owner}/${config.repo}`,
+      "--json",
+      "number,title,state,labels,author,createdAt",
+      "--state",
+      input.state,
+      "--limit",
+      String(input.limit),
+    ];
+    if (input.labels) args.push("--label", input.labels);
+    if (input.query) args.push("--search", input.query);
+
+    const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`Failed to list issues: ${stderr.trim()}`);
+    }
+
+    const raw = JSON.parse(stdout || "[]") as Array<{
+      number: number;
+      title: string;
+      state: string;
+      labels: Array<{ name: string }>;
+      author: { login: string };
+      createdAt: string;
+    }>;
+
+    return {
+      issues: raw.map((issue) => ({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels: issue.labels.map((l) => l.name),
+        author: issue.author.login,
+        createdAt: issue.createdAt,
+      })),
+    };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/list-skills.ts
+++ b/apps/mesh/src/tools/context-repo/list-skills.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { join } from "node:path";
+import { readdir, readFile } from "node:fs/promises";
+import { findContextRepo, getContextRepoPath } from "./helpers";
+
+function parseFrontmatter(content: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)/);
+  if (!match) return { frontmatter: {}, body: content };
+
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1]!.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, body: match[2]!.trim() };
+}
+
+export const CONTEXT_REPO_LIST_SKILLS = defineTool({
+  name: "CONTEXT_REPO_LIST_SKILLS",
+  description:
+    "List available skills from the context repo's skills/ directory.",
+  annotations: {
+    title: "List Context Skills",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    skills: z.array(
+      z.object({
+        name: z.string(),
+        description: z.string(),
+        path: z.string(),
+      }),
+    ),
+    repoFullName: z.string(),
+  }),
+  handler: async (_, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config)
+      throw new Error(
+        "No context repo configured. Use CONTEXT_REPO_SETUP first.",
+      );
+
+    const repoPath = getContextRepoPath(orgId, config.owner, config.repo);
+    const skillsDir = join(repoPath, "skills");
+
+    const skills: { name: string; description: string; path: string }[] = [];
+    try {
+      const entries = await readdir(skillsDir);
+      for (const entry of entries) {
+        if (!entry.endsWith(".md")) continue;
+        try {
+          const content = await readFile(join(skillsDir, entry), "utf-8");
+          const { frontmatter } = parseFrontmatter(content);
+          skills.push({
+            name: frontmatter.name || entry.replace(/\.md$/, ""),
+            description: frontmatter.description || "",
+            path: `skills/${entry}`,
+          });
+        } catch {
+          // Skip unreadable files
+        }
+      }
+    } catch {
+      // skills/ directory doesn't exist — that's fine
+    }
+
+    return { skills, repoFullName: `${config.owner}/${config.repo}` };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/read.ts
+++ b/apps/mesh/src/tools/context-repo/read.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { join, resolve } from "node:path";
+import { readFile, stat } from "node:fs/promises";
+import { findContextRepo, getContextRepoPath } from "./helpers";
+
+export const CONTEXT_REPO_READ = defineTool({
+  name: "CONTEXT_REPO_READ",
+  description: "Read a specific file from the context repo.",
+  annotations: {
+    title: "Read Context Repo File",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({
+    path: z.string().min(1).describe("Relative file path within the repo"),
+  }),
+  outputSchema: z.object({
+    path: z.string(),
+    content: z.string(),
+    size: z.number(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config)
+      throw new Error(
+        "No context repo configured. Use CONTEXT_REPO_SETUP first.",
+      );
+
+    const repoPath = getContextRepoPath(orgId, config.owner, config.repo);
+
+    // Path traversal protection
+    const fullPath = resolve(join(repoPath, input.path));
+    const resolvedRoot = resolve(repoPath);
+    if (!fullPath.startsWith(resolvedRoot + "/") && fullPath !== resolvedRoot) {
+      throw new Error("Invalid path: must be within the repository");
+    }
+
+    const fileStat = await stat(fullPath).catch(() => null);
+    if (!fileStat || !fileStat.isFile()) {
+      throw new Error(`File not found: ${input.path}`);
+    }
+
+    if (fileStat.size > 500 * 1024) {
+      throw new Error(
+        `File too large (${Math.round(fileStat.size / 1024)}KB). Max 500KB.`,
+      );
+    }
+
+    const content = await readFile(fullPath, "utf-8");
+
+    return { path: input.path, content, size: fileStat.size };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/search.ts
+++ b/apps/mesh/src/tools/context-repo/search.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { loadIndex, searchIndex } from "./indexer";
+import { findContextRepo, getContextRepoPath } from "./helpers";
+
+export const CONTEXT_REPO_SEARCH = defineTool({
+  name: "CONTEXT_REPO_SEARCH",
+  description:
+    "Search across all indexed files in the context repo. Returns matching file paths with relevant snippets.",
+  annotations: {
+    title: "Search Context Repo",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({
+    query: z.string().min(1).describe("Search query (space-separated terms)"),
+    limit: z.number().min(1).max(50).default(20).describe("Max results"),
+  }),
+  outputSchema: z.object({
+    results: z.array(
+      z.object({
+        path: z.string(),
+        snippet: z.string(),
+        rank: z.number(),
+      }),
+    ),
+    totalIndexed: z.number(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config)
+      throw new Error(
+        "No context repo configured. Use CONTEXT_REPO_SETUP first.",
+      );
+
+    const repoPath = getContextRepoPath(orgId, config.owner, config.repo);
+    const index = await loadIndex(repoPath);
+    if (!index)
+      throw new Error("Index not found. Run CONTEXT_REPO_SYNC to rebuild.");
+
+    const results = searchIndex(index, input.query, input.limit);
+
+    return { results, totalIndexed: index.fileCount };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/setup.ts
+++ b/apps/mesh/src/tools/context-repo/setup.ts
@@ -32,7 +32,13 @@ export const CONTEXT_REPO_SETUP = defineTool({
     repo: z.string(),
     branch: z.string(),
     headCommit: z.string(),
-    folders: z.array(z.string()),
+    folders: z.array(
+      z.object({
+        name: z.string(),
+        fileCount: z.number(),
+        totalBytes: z.number(),
+      }),
+    ),
     ghUser: z.string().optional(),
   }),
   handler: async (input, ctx) => {

--- a/apps/mesh/src/tools/context-repo/setup.ts
+++ b/apps/mesh/src/tools/context-repo/setup.ts
@@ -1,14 +1,13 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/mesh-context";
-import { checkGhAccess, cloneOrPull } from "./gh-cli";
-import { buildIndex, saveIndex } from "./indexer";
-import { findContextRepo } from "./helpers";
+import { checkGhAccess, cloneOrPull, getRepoPath } from "./gh-cli";
+import { findContextRepo, listRepoFolders } from "./helpers";
 
 export const CONTEXT_REPO_SETUP = defineTool({
   name: "CONTEXT_REPO_SETUP",
   description:
-    "Connect a GitHub repository as the context repo for this organization. Requires gh CLI to be installed and authenticated.",
+    "Clone a GitHub repository as the context repo for this organization. Does NOT index — call CONTEXT_REPO_UPDATE_FOLDERS after to select folders and index.",
   annotations: {
     title: "Setup Context Repo",
     readOnlyHint: false,
@@ -32,9 +31,8 @@ export const CONTEXT_REPO_SETUP = defineTool({
     owner: z.string(),
     repo: z.string(),
     branch: z.string(),
-    fileCount: z.number(),
-    indexSizeBytes: z.number(),
     headCommit: z.string(),
+    folders: z.array(z.string()),
     ghUser: z.string().optional(),
   }),
   handler: async (input, ctx) => {
@@ -57,16 +55,18 @@ export const CONTEXT_REPO_SETUP = defineTool({
       );
     }
 
-    const { path: repoPath, headCommit } = await cloneOrPull(
+    // Clone only — no indexing yet
+    const { headCommit } = await cloneOrPull(
       orgId,
       input.owner,
       input.repo,
       input.branch,
     );
 
-    const index = await buildIndex(repoPath);
-    await saveIndex(repoPath, index);
+    const repoPath = getRepoPath(orgId, input.owner, input.repo);
+    const folders = await listRepoFolders(repoPath);
 
+    // Create connection with zero index stats (will be updated by UPDATE_FOLDERS)
     const connection = await ctx.storage.connections.create({
       organization_id: orgId,
       title: `Context: ${input.owner}/${input.repo}`,
@@ -79,9 +79,10 @@ export const CONTEXT_REPO_SETUP = defineTool({
         repo: input.repo,
         branch: input.branch,
         lastSyncedCommit: headCommit,
-        fileCount: index.fileCount,
-        indexSizeBytes: index.totalSizeBytes,
-        lastSyncedAt: new Date().toISOString(),
+        fileCount: 0,
+        indexSizeBytes: 0,
+        indexedFolders: null,
+        lastSyncedAt: null,
       },
       status: "active",
       created_by: ctx.auth.user?.id || "system",
@@ -92,9 +93,8 @@ export const CONTEXT_REPO_SETUP = defineTool({
       owner: input.owner,
       repo: input.repo,
       branch: input.branch,
-      fileCount: index.fileCount,
-      indexSizeBytes: index.totalSizeBytes,
       headCommit,
+      folders,
       ghUser: ghStatus.user,
     };
   },

--- a/apps/mesh/src/tools/context-repo/setup.ts
+++ b/apps/mesh/src/tools/context-repo/setup.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { checkGhAccess, cloneOrPull } from "./gh-cli";
+import { buildIndex, saveIndex } from "./indexer";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_REPO_SETUP = defineTool({
+  name: "CONTEXT_REPO_SETUP",
+  description:
+    "Connect a GitHub repository as the context repo for this organization. Requires gh CLI to be installed and authenticated.",
+  annotations: {
+    title: "Setup Context Repo",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    owner: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+$/)
+      .describe("GitHub owner (user or org)"),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+$/)
+      .describe("GitHub repository name"),
+    branch: z.string().default("main").describe("Branch to track"),
+  }),
+  outputSchema: z.object({
+    connectionId: z.string(),
+    owner: z.string(),
+    repo: z.string(),
+    branch: z.string(),
+    fileCount: z.number(),
+    indexSizeBytes: z.number(),
+    headCommit: z.string(),
+    ghUser: z.string().optional(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const ghStatus = await checkGhAccess();
+    if (!ghStatus.available) {
+      throw new Error(
+        "GitHub CLI (gh) is not installed or not authenticated. Run: brew install gh && gh auth login",
+      );
+    }
+
+    const existing = await findContextRepo(ctx);
+    if (existing) {
+      throw new Error(
+        `Context repo already configured: ${existing.owner}/${existing.repo}. Disconnect first.`,
+      );
+    }
+
+    const { path: repoPath, headCommit } = await cloneOrPull(
+      orgId,
+      input.owner,
+      input.repo,
+      input.branch,
+    );
+
+    const index = await buildIndex(repoPath);
+    await saveIndex(repoPath, index);
+
+    const connection = await ctx.storage.connections.create({
+      organization_id: orgId,
+      title: `Context: ${input.owner}/${input.repo}`,
+      description: "GitHub context repository for this organization",
+      connection_type: "GITHUB",
+      connection_url: `https://github.com/${input.owner}/${input.repo}`,
+      metadata: {
+        type: "context-repo",
+        owner: input.owner,
+        repo: input.repo,
+        branch: input.branch,
+        lastSyncedCommit: headCommit,
+        fileCount: index.fileCount,
+        indexSizeBytes: index.totalSizeBytes,
+        lastSyncedAt: new Date().toISOString(),
+      },
+      status: "active",
+      created_by: ctx.auth.user?.id || "system",
+    });
+
+    return {
+      connectionId: connection.id,
+      owner: input.owner,
+      repo: input.repo,
+      branch: input.branch,
+      fileCount: index.fileCount,
+      indexSizeBytes: index.totalSizeBytes,
+      headCommit,
+      ghUser: ghStatus.user,
+    };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/status.ts
+++ b/apps/mesh/src/tools/context-repo/status.ts
@@ -32,7 +32,13 @@ export const CONTEXT_REPO_STATUS = defineTool({
         indexSizeBytes: z.number(),
         lastSyncedAt: z.string().nullable(),
         indexedFolders: z.array(z.string()).nullable(),
-        folders: z.array(z.string()),
+        folders: z.array(
+          z.object({
+            name: z.string(),
+            fileCount: z.number(),
+            totalBytes: z.number(),
+          }),
+        ),
       })
       .nullable(),
   }),

--- a/apps/mesh/src/tools/context-repo/status.ts
+++ b/apps/mesh/src/tools/context-repo/status.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/mesh-context";
-import { checkGhAccess } from "./gh-cli";
-import { findContextRepo } from "./helpers";
+import { checkGhAccess, getRepoPath } from "./gh-cli";
+import { findContextRepo, listRepoFolders } from "./helpers";
 
 export const CONTEXT_REPO_STATUS = defineTool({
   name: "CONTEXT_REPO_STATUS",
   description:
-    "Get context repo status: GitHub CLI auth status and current context repo configuration.",
+    "Get context repo status: GitHub CLI auth status, current config, and available folders.",
   annotations: {
     title: "Context Repo Status",
     readOnlyHint: true,
@@ -31,6 +31,8 @@ export const CONTEXT_REPO_STATUS = defineTool({
         fileCount: z.number(),
         indexSizeBytes: z.number(),
         lastSyncedAt: z.string().nullable(),
+        indexedFolders: z.array(z.string()).nullable(),
+        folders: z.array(z.string()),
       })
       .nullable(),
   }),
@@ -43,18 +45,25 @@ export const CONTEXT_REPO_STATUS = defineTool({
       findContextRepo(ctx),
     ]);
 
-    const contextRepo = existing
-      ? {
-          connectionId: existing.connectionId,
-          owner: existing.owner,
-          repo: existing.repo,
-          branch: existing.branch,
-          lastSyncedCommit: existing.lastSyncedCommit,
-          fileCount: existing.fileCount,
-          indexSizeBytes: existing.indexSizeBytes,
-          lastSyncedAt: existing.lastSyncedAt,
-        }
-      : null;
+    let contextRepo = null;
+    if (existing) {
+      const orgId = ctx.organization!.id;
+      const repoPath = getRepoPath(orgId, existing.owner, existing.repo);
+      const folders = await listRepoFolders(repoPath);
+
+      contextRepo = {
+        connectionId: existing.connectionId,
+        owner: existing.owner,
+        repo: existing.repo,
+        branch: existing.branch,
+        lastSyncedCommit: existing.lastSyncedCommit,
+        fileCount: existing.fileCount,
+        indexSizeBytes: existing.indexSizeBytes,
+        lastSyncedAt: existing.lastSyncedAt,
+        indexedFolders: existing.indexedFolders,
+        folders,
+      };
+    }
 
     return {
       gh: {

--- a/apps/mesh/src/tools/context-repo/status.ts
+++ b/apps/mesh/src/tools/context-repo/status.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { checkGhAccess } from "./gh-cli";
+import { findContextRepo } from "./helpers";
+
+export const CONTEXT_REPO_STATUS = defineTool({
+  name: "CONTEXT_REPO_STATUS",
+  description:
+    "Get context repo status: GitHub CLI auth status and current context repo configuration.",
+  annotations: {
+    title: "Context Repo Status",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    gh: z.object({
+      available: z.boolean(),
+      user: z.string().optional(),
+    }),
+    contextRepo: z
+      .object({
+        connectionId: z.string(),
+        owner: z.string(),
+        repo: z.string(),
+        branch: z.string(),
+        lastSyncedCommit: z.string().nullable(),
+        fileCount: z.number(),
+        indexSizeBytes: z.number(),
+        lastSyncedAt: z.string().nullable(),
+      })
+      .nullable(),
+  }),
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+
+    const [ghStatus, existing] = await Promise.all([
+      checkGhAccess(),
+      findContextRepo(ctx),
+    ]);
+
+    const contextRepo = existing
+      ? {
+          connectionId: existing.connectionId,
+          owner: existing.owner,
+          repo: existing.repo,
+          branch: existing.branch,
+          lastSyncedCommit: existing.lastSyncedCommit,
+          fileCount: existing.fileCount,
+          indexSizeBytes: existing.indexSizeBytes,
+          lastSyncedAt: existing.lastSyncedAt,
+        }
+      : null;
+
+    return {
+      gh: {
+        available: ghStatus.available,
+        user: ghStatus.user,
+      },
+      contextRepo,
+    };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/sync.ts
+++ b/apps/mesh/src/tools/context-repo/sync.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { cloneOrPull } from "./gh-cli";
+import { buildIndex, saveIndex } from "./indexer";
+import { findContextRepo, getContextRepoPath } from "./helpers";
+
+export const CONTEXT_REPO_SYNC = defineTool({
+  name: "CONTEXT_REPO_SYNC",
+  description: "Pull latest changes from the context repo and reindex.",
+  annotations: {
+    title: "Sync Context Repo",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    owner: z.string(),
+    repo: z.string(),
+    headCommit: z.string(),
+    fileCount: z.number(),
+    indexSizeBytes: z.number(),
+  }),
+  handler: async (_, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const config = await findContextRepo(ctx);
+    if (!config)
+      throw new Error(
+        "No context repo configured. Use CONTEXT_REPO_SETUP first.",
+      );
+
+    const { headCommit } = await cloneOrPull(
+      orgId,
+      config.owner,
+      config.repo,
+      config.branch,
+    );
+
+    const repoPath = getContextRepoPath(orgId, config.owner, config.repo);
+    const index = await buildIndex(repoPath);
+    await saveIndex(repoPath, index);
+
+    await ctx.storage.connections.update(config.connectionId, {
+      metadata: {
+        type: "context-repo",
+        owner: config.owner,
+        repo: config.repo,
+        branch: config.branch,
+        lastSyncedCommit: headCommit,
+        fileCount: index.fileCount,
+        indexSizeBytes: index.totalSizeBytes,
+        lastSyncedAt: new Date().toISOString(),
+      },
+    });
+
+    return {
+      owner: config.owner,
+      repo: config.repo,
+      headCommit,
+      fileCount: index.fileCount,
+      indexSizeBytes: index.totalSizeBytes,
+    };
+  },
+});

--- a/apps/mesh/src/tools/context-repo/tool-defs.ts
+++ b/apps/mesh/src/tools/context-repo/tool-defs.ts
@@ -1,0 +1,202 @@
+/**
+ * Context Repo Tool Definitions
+ *
+ * Provides MCP-compatible tool metadata and execution for GITHUB connections.
+ * Used by the passthrough client to expose context-repo tools without MCP transport.
+ */
+
+import type { Tool as MCPTool } from "@modelcontextprotocol/sdk/types.js";
+import type { MeshContext } from "@/core/mesh-context";
+
+// Lazy imports to avoid circular dependencies
+async function getTools() {
+  const { CONTEXT_REPO_SEARCH } = await import("./search");
+  const { CONTEXT_REPO_READ } = await import("./read");
+  const { CONTEXT_REPO_LIST_SKILLS } = await import("./list-skills");
+  const { CONTEXT_REPO_SYNC } = await import("./sync");
+  const { CONTEXT_REPO_STATUS } = await import("./status");
+  const { CONTEXT_ISSUE_CREATE } = await import("./issue-create");
+  const { CONTEXT_ISSUE_LIST } = await import("./issue-list");
+  const { CONTEXT_ISSUE_GET } = await import("./issue-get");
+  const { CONTEXT_ISSUE_COMMENT } = await import("./issue-comment");
+  const { CONTEXT_AGENT_SAVE } = await import("./agent-save");
+  return {
+    CONTEXT_REPO_SEARCH,
+    CONTEXT_REPO_READ,
+    CONTEXT_REPO_LIST_SKILLS,
+    CONTEXT_REPO_SYNC,
+    CONTEXT_REPO_STATUS,
+    CONTEXT_ISSUE_CREATE,
+    CONTEXT_ISSUE_LIST,
+    CONTEXT_ISSUE_GET,
+    CONTEXT_ISSUE_COMMENT,
+    CONTEXT_AGENT_SAVE,
+  };
+}
+
+/**
+ * Get MCP-compatible tool definitions for context-repo tools.
+ * These are injected into the passthrough client's tool list for GITHUB connections.
+ */
+export function getContextRepoTools(): MCPTool[] {
+  // We need synchronous access, so use a static list of tool metadata.
+  // This avoids importing the actual tool modules (which have heavy deps).
+  return [
+    {
+      name: "CONTEXT_REPO_SEARCH",
+      description:
+        "Full-text search across all indexed files in the context repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          query: { type: "string", description: "Search query" },
+          limit: {
+            type: "number",
+            description: "Max results (default 20)",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "CONTEXT_REPO_READ",
+      description: "Read a file from the context repository by path.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          path: {
+            type: "string",
+            description: "File path relative to repo root",
+          },
+        },
+        required: ["path"],
+      },
+    },
+    {
+      name: "CONTEXT_REPO_LIST_SKILLS",
+      description:
+        "List available skills from the skills/ directory in the context repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "CONTEXT_REPO_SYNC",
+      description:
+        "Pull latest changes from GitHub and reindex the context repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "CONTEXT_REPO_STATUS",
+      description:
+        "Get context repo status: GitHub CLI auth, current config, and available folders.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
+    {
+      name: "CONTEXT_ISSUE_CREATE",
+      description:
+        "Create a GitHub issue in the context repository. Use this to report findings, problems, or share information with the team.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          title: { type: "string", description: "Issue title" },
+          body: { type: "string", description: "Issue body (markdown)" },
+          labels: {
+            type: "array",
+            items: { type: "string" },
+            description: "Labels to apply",
+          },
+        },
+        required: ["title", "body"],
+      },
+    },
+    {
+      name: "CONTEXT_ISSUE_LIST",
+      description: "List and search GitHub issues in the context repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          state: {
+            type: "string",
+            enum: ["open", "closed", "all"],
+            description: "Filter by state (default: open)",
+          },
+          labels: {
+            type: "string",
+            description: "Filter by labels (comma-separated)",
+          },
+          query: { type: "string", description: "Search query" },
+          limit: { type: "number", description: "Max results (default 30)" },
+        },
+      },
+    },
+    {
+      name: "CONTEXT_ISSUE_GET",
+      description:
+        "Get a GitHub issue with its comments from the context repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          number: { type: "number", description: "Issue number" },
+        },
+        required: ["number"],
+      },
+    },
+    {
+      name: "CONTEXT_ISSUE_COMMENT",
+      description: "Add a comment to a GitHub issue in the context repository.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          number: { type: "number", description: "Issue number" },
+          body: { type: "string", description: "Comment body (markdown)" },
+        },
+        required: ["number", "body"],
+      },
+    },
+    {
+      name: "CONTEXT_AGENT_SAVE",
+      description:
+        "Save an agent definition to agents/<name>.md in the context repository via a PR.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          agentId: {
+            type: "string",
+            description: "ID of the agent (virtual MCP) to export",
+          },
+        },
+        required: ["agentId"],
+      },
+    },
+  ];
+}
+
+/**
+ * Execute a context-repo tool by name with the given arguments.
+ * Routes to the actual tool handler.
+ */
+export async function executeContextRepoTool(
+  toolName: string,
+  args: Record<string, unknown>,
+  ctx: MeshContext,
+): Promise<unknown> {
+  const tools = await getTools();
+  const tool = (
+    tools as Record<
+      string,
+      { execute: (input: unknown, ctx: MeshContext) => Promise<unknown> }
+    >
+  )[toolName];
+  if (!tool) {
+    throw new Error(`Unknown context-repo tool: ${toolName}`);
+  }
+  return tool.execute(args, ctx);
+}

--- a/apps/mesh/src/tools/context-repo/update-folders.ts
+++ b/apps/mesh/src/tools/context-repo/update-folders.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import { requireAuth } from "@/core/mesh-context";
+import { findContextRepo, getContextRepoPath } from "./helpers";
+import { buildIndex, saveIndex } from "./indexer";
+
+export const CONTEXT_REPO_UPDATE_FOLDERS = defineTool({
+  name: "CONTEXT_REPO_UPDATE_FOLDERS",
+  description:
+    "Update which folders are indexed in the context repo. Reindexes with the new folder selection.",
+  annotations: {
+    title: "Update Indexed Folders",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({
+    folders: z
+      .array(z.string())
+      .describe(
+        "Folders to index. Empty array means index all folders (no filter).",
+      ),
+  }),
+  outputSchema: z.object({
+    fileCount: z.number(),
+    indexSizeBytes: z.number(),
+    indexedFolders: z.array(z.string()),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const orgId = ctx.organization?.id;
+    if (!orgId) throw new Error("Organization required");
+
+    const existing = await findContextRepo(ctx);
+    if (!existing) throw new Error("No context repo configured");
+
+    const repoPath = getContextRepoPath(orgId, existing.owner, existing.repo);
+    const folderFilter = input.folders.length > 0 ? input.folders : null;
+
+    const index = await buildIndex(repoPath, folderFilter);
+    await saveIndex(repoPath, index);
+
+    // Update connection metadata
+    const connections = await ctx.storage.connections.list(orgId, {
+      includeVirtual: true,
+    });
+    const conn = connections.find((c) => c.id === existing.connectionId);
+    if (conn) {
+      const metadata =
+        typeof conn.metadata === "string"
+          ? JSON.parse(conn.metadata)
+          : (conn.metadata ?? {});
+
+      await ctx.storage.connections.update(existing.connectionId, {
+        metadata: {
+          ...metadata,
+          indexedFolders: folderFilter,
+          fileCount: index.fileCount,
+          indexSizeBytes: index.totalSizeBytes,
+          lastSyncedAt: new Date().toISOString(),
+        },
+      });
+    }
+
+    return {
+      fileCount: index.fileCount,
+      indexSizeBytes: index.totalSizeBytes,
+      indexedFolders: input.folders,
+    };
+  },
+});

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -130,20 +130,13 @@ const CORE_TOOLS = [
   AiProvidersTools.AI_PROVIDER_CREDITS,
   AiProvidersTools.AI_PROVIDER_CLI_ACTIVATE,
 
-  // Context repo tools
+  // Context repo management tools (always available for setup/teardown)
   ContextRepoTools.CONTEXT_REPO_STATUS,
   ContextRepoTools.CONTEXT_REPO_SETUP,
   ContextRepoTools.CONTEXT_REPO_UPDATE_FOLDERS,
   ContextRepoTools.CONTEXT_REPO_DISCONNECT,
-  ContextRepoTools.CONTEXT_REPO_SYNC,
-  ContextRepoTools.CONTEXT_REPO_SEARCH,
-  ContextRepoTools.CONTEXT_REPO_READ,
-  ContextRepoTools.CONTEXT_REPO_LIST_SKILLS,
-  ContextRepoTools.CONTEXT_ISSUE_CREATE,
-  ContextRepoTools.CONTEXT_ISSUE_LIST,
-  ContextRepoTools.CONTEXT_ISSUE_GET,
-  ContextRepoTools.CONTEXT_ISSUE_COMMENT,
-  ContextRepoTools.CONTEXT_AGENT_SAVE,
+  // Operational context-repo tools (search, read, issues, etc.) are exposed
+  // through the GITHUB connection — see tools/context-repo/tool-defs.ts
 ] as const satisfies { name: ToolName }[];
 
 // Plugin tools - collected at startup, gated by org settings at runtime

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -133,6 +133,7 @@ const CORE_TOOLS = [
   // Context repo tools
   ContextRepoTools.CONTEXT_REPO_STATUS,
   ContextRepoTools.CONTEXT_REPO_SETUP,
+  ContextRepoTools.CONTEXT_REPO_UPDATE_FOLDERS,
   ContextRepoTools.CONTEXT_REPO_SYNC,
   ContextRepoTools.CONTEXT_REPO_SEARCH,
   ContextRepoTools.CONTEXT_REPO_READ,

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -30,6 +30,7 @@ import * as ThreadTools from "./thread";
 import * as AutomationTools from "./automations";
 import * as UserTools from "./user";
 import * as AiProvidersTools from "./ai-providers";
+import * as ContextRepoTools from "./context-repo";
 import { getPrompts, getResources } from "./guides";
 import { ToolName } from "./registry";
 // Core tools - always available
@@ -128,6 +129,18 @@ const CORE_TOOLS = [
   AiProvidersTools.AI_PROVIDER_TOPUP_URL,
   AiProvidersTools.AI_PROVIDER_CREDITS,
   AiProvidersTools.AI_PROVIDER_CLI_ACTIVATE,
+
+  // Context repo tools
+  ContextRepoTools.CONTEXT_REPO_SETUP,
+  ContextRepoTools.CONTEXT_REPO_SYNC,
+  ContextRepoTools.CONTEXT_REPO_SEARCH,
+  ContextRepoTools.CONTEXT_REPO_READ,
+  ContextRepoTools.CONTEXT_REPO_LIST_SKILLS,
+  ContextRepoTools.CONTEXT_ISSUE_CREATE,
+  ContextRepoTools.CONTEXT_ISSUE_LIST,
+  ContextRepoTools.CONTEXT_ISSUE_GET,
+  ContextRepoTools.CONTEXT_ISSUE_COMMENT,
+  ContextRepoTools.CONTEXT_AGENT_SAVE,
 ] as const satisfies { name: ToolName }[];
 
 // Plugin tools - collected at startup, gated by org settings at runtime

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -131,6 +131,7 @@ const CORE_TOOLS = [
   AiProvidersTools.AI_PROVIDER_CLI_ACTIVATE,
 
   // Context repo tools
+  ContextRepoTools.CONTEXT_REPO_STATUS,
   ContextRepoTools.CONTEXT_REPO_SETUP,
   ContextRepoTools.CONTEXT_REPO_SYNC,
   ContextRepoTools.CONTEXT_REPO_SEARCH,

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -134,6 +134,7 @@ const CORE_TOOLS = [
   ContextRepoTools.CONTEXT_REPO_STATUS,
   ContextRepoTools.CONTEXT_REPO_SETUP,
   ContextRepoTools.CONTEXT_REPO_UPDATE_FOLDERS,
+  ContextRepoTools.CONTEXT_REPO_DISCONNECT,
   ContextRepoTools.CONTEXT_REPO_SYNC,
   ContextRepoTools.CONTEXT_REPO_SEARCH,
   ContextRepoTools.CONTEXT_REPO_READ,

--- a/apps/mesh/src/tools/registry.ts
+++ b/apps/mesh/src/tools/registry.ts
@@ -125,6 +125,7 @@ const ALL_TOOL_NAMES = [
   "CONTEXT_REPO_STATUS",
   "CONTEXT_REPO_SETUP",
   "CONTEXT_REPO_UPDATE_FOLDERS",
+  "CONTEXT_REPO_DISCONNECT",
   "CONTEXT_REPO_SYNC",
   "CONTEXT_REPO_SEARCH",
   "CONTEXT_REPO_READ",
@@ -563,6 +564,12 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     category: "Context Repo",
   },
   {
+    name: "CONTEXT_REPO_DISCONNECT",
+    description: "Disconnect context repo and clean up local clone",
+    category: "Context Repo",
+    dangerous: true,
+  },
+  {
     name: "CONTEXT_REPO_SYNC",
     description: "Pull latest changes and reindex the context repo",
     category: "Context Repo",
@@ -690,6 +697,7 @@ const TOOL_LABELS: Record<ToolName, string> = {
   CONTEXT_REPO_STATUS: "Context repo status",
   CONTEXT_REPO_SETUP: "Setup context repo",
   CONTEXT_REPO_UPDATE_FOLDERS: "Update indexed folders",
+  CONTEXT_REPO_DISCONNECT: "Disconnect context repo",
   CONTEXT_REPO_SYNC: "Sync context repo",
   CONTEXT_REPO_SEARCH: "Search context repo",
   CONTEXT_REPO_READ: "Read context file",

--- a/apps/mesh/src/tools/registry.ts
+++ b/apps/mesh/src/tools/registry.ts
@@ -122,6 +122,7 @@ const ALL_TOOL_NAMES = [
   "AI_PROVIDER_CLI_ACTIVATE",
 
   // Context repo tools
+  "CONTEXT_REPO_STATUS",
   "CONTEXT_REPO_SETUP",
   "CONTEXT_REPO_SYNC",
   "CONTEXT_REPO_SEARCH",
@@ -546,6 +547,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
 
   // Context repo tools
   {
+    name: "CONTEXT_REPO_STATUS",
+    description: "Get context repo status and GitHub CLI auth status",
+    category: "Context Repo",
+  },
+  {
     name: "CONTEXT_REPO_SETUP",
     description: "Connect a GitHub repository as the context repo",
     category: "Context Repo",
@@ -675,6 +681,7 @@ const TOOL_LABELS: Record<ToolName, string> = {
   AI_PROVIDER_CLI_ACTIVATE: "Activate Claude Code CLI",
 
   // Context repo tools
+  CONTEXT_REPO_STATUS: "Context repo status",
   CONTEXT_REPO_SETUP: "Setup context repo",
   CONTEXT_REPO_SYNC: "Sync context repo",
   CONTEXT_REPO_SEARCH: "Search context repo",

--- a/apps/mesh/src/tools/registry.ts
+++ b/apps/mesh/src/tools/registry.ts
@@ -124,6 +124,7 @@ const ALL_TOOL_NAMES = [
   // Context repo tools
   "CONTEXT_REPO_STATUS",
   "CONTEXT_REPO_SETUP",
+  "CONTEXT_REPO_UPDATE_FOLDERS",
   "CONTEXT_REPO_SYNC",
   "CONTEXT_REPO_SEARCH",
   "CONTEXT_REPO_READ",
@@ -557,6 +558,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     category: "Context Repo",
   },
   {
+    name: "CONTEXT_REPO_UPDATE_FOLDERS",
+    description: "Update which folders are indexed in the context repo",
+    category: "Context Repo",
+  },
+  {
     name: "CONTEXT_REPO_SYNC",
     description: "Pull latest changes and reindex the context repo",
     category: "Context Repo",
@@ -683,6 +689,7 @@ const TOOL_LABELS: Record<ToolName, string> = {
   // Context repo tools
   CONTEXT_REPO_STATUS: "Context repo status",
   CONTEXT_REPO_SETUP: "Setup context repo",
+  CONTEXT_REPO_UPDATE_FOLDERS: "Update indexed folders",
   CONTEXT_REPO_SYNC: "Sync context repo",
   CONTEXT_REPO_SEARCH: "Search context repo",
   CONTEXT_REPO_READ: "Read context file",

--- a/apps/mesh/src/tools/registry.ts
+++ b/apps/mesh/src/tools/registry.ts
@@ -29,7 +29,8 @@ export type ToolCategory =
   | "Event Bus"
   | "Tags"
   | "AI Providers"
-  | "Automations";
+  | "Automations"
+  | "Context Repo";
 
 /**
  * All tool names - keep in sync with ALL_TOOLS in index.ts
@@ -119,6 +120,18 @@ const ALL_TOOL_NAMES = [
   "AI_PROVIDER_TOPUP_URL",
   "AI_PROVIDER_CREDITS",
   "AI_PROVIDER_CLI_ACTIVATE",
+
+  // Context repo tools
+  "CONTEXT_REPO_SETUP",
+  "CONTEXT_REPO_SYNC",
+  "CONTEXT_REPO_SEARCH",
+  "CONTEXT_REPO_READ",
+  "CONTEXT_REPO_LIST_SKILLS",
+  "CONTEXT_ISSUE_CREATE",
+  "CONTEXT_ISSUE_LIST",
+  "CONTEXT_ISSUE_GET",
+  "CONTEXT_ISSUE_COMMENT",
+  "CONTEXT_AGENT_SAVE",
 ] as const;
 
 /**
@@ -530,6 +543,58 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     description: "Activate Claude Code via local CLI",
     category: "AI Providers",
   },
+
+  // Context repo tools
+  {
+    name: "CONTEXT_REPO_SETUP",
+    description: "Connect a GitHub repository as the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_REPO_SYNC",
+    description: "Pull latest changes and reindex the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_REPO_SEARCH",
+    description: "Search files in the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_REPO_READ",
+    description: "Read a file from the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_REPO_LIST_SKILLS",
+    description: "List skills from the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_ISSUE_CREATE",
+    description: "Create a GitHub issue in the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_ISSUE_LIST",
+    description: "List issues in the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_ISSUE_GET",
+    description: "Get an issue with comments from the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_ISSUE_COMMENT",
+    description: "Comment on an issue in the context repo",
+    category: "Context Repo",
+  },
+  {
+    name: "CONTEXT_AGENT_SAVE",
+    description: "Save an agent definition to the context repo via PR",
+    category: "Context Repo",
+  },
 ];
 
 /**
@@ -608,6 +673,18 @@ const TOOL_LABELS: Record<ToolName, string> = {
   AI_PROVIDER_TOPUP_URL: "Get top-up checkout URL",
   AI_PROVIDER_CREDITS: "Get credit balance",
   AI_PROVIDER_CLI_ACTIVATE: "Activate Claude Code CLI",
+
+  // Context repo tools
+  CONTEXT_REPO_SETUP: "Setup context repo",
+  CONTEXT_REPO_SYNC: "Sync context repo",
+  CONTEXT_REPO_SEARCH: "Search context repo",
+  CONTEXT_REPO_READ: "Read context file",
+  CONTEXT_REPO_LIST_SKILLS: "List context skills",
+  CONTEXT_ISSUE_CREATE: "Create context issue",
+  CONTEXT_ISSUE_LIST: "List context issues",
+  CONTEXT_ISSUE_GET: "Get context issue",
+  CONTEXT_ISSUE_COMMENT: "Comment on context issue",
+  CONTEXT_AGENT_SAVE: "Save agent to context repo",
 };
 
 // ============================================================================

--- a/apps/mesh/src/web/components/context-repo/context-repo-listener.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-listener.tsx
@@ -1,0 +1,24 @@
+/**
+ * Context Repo Modal Listener
+ *
+ * Listens for the "open-context-repo-modal" custom event (dispatched from sidebar)
+ * and manages the modal open state. Mounted in the project layout.
+ */
+
+import { useRef, useState } from "react";
+import { ContextRepoModal } from "./context-repo-modal";
+
+export function ContextRepoModalListener() {
+  const [open, setOpen] = useState(false);
+  const registeredRef = useRef(false);
+
+  // Register event listener once
+  if (!registeredRef.current && typeof window !== "undefined") {
+    registeredRef.current = true;
+    window.addEventListener("open-context-repo-modal", () => {
+      setOpen(true);
+    });
+  }
+
+  return <ContextRepoModal open={open} onOpenChange={setOpen} />;
+}

--- a/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
@@ -275,9 +275,7 @@ function FolderPickerView({
   };
 
   const handleIndex = async () => {
-    const foldersToIndex = allSelected
-      ? []
-      : [...selected].filter((f) => f !== "<root>");
+    const foldersToIndex = allSelected ? [] : [...selected];
     try {
       await updateFoldersMutation.mutateAsync(foldersToIndex);
       toast.success("Repository indexed");
@@ -415,9 +413,7 @@ function ConfiguredView({
     [...selectedFolders].some((f) => !savedSet.has(f));
 
   const handleSaveFolders = async () => {
-    const folders = allSelected
-      ? []
-      : [...selectedFolders].filter((f) => f !== "<root>");
+    const folders = allSelected ? [] : [...selectedFolders];
     try {
       await updateFoldersMutation.mutateAsync(folders);
       toast.success("Indexed folders updated");

--- a/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
@@ -44,7 +44,11 @@ export function ContextRepoModal({
 }: ContextRepoModalProps) {
   const { gh, config, isLoading } = useContextRepo();
   // After setup (clone), we hold the folders for the picker step
-  const [pendingFolders, setPendingFolders] = useState<string[] | null>(null);
+  const [pendingFolders, setPendingFolders] = useState<Array<{
+    name: string;
+    fileCount: number;
+    totalBytes: number;
+  }> | null>(null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -127,12 +131,18 @@ function GhStatusBadge({ gh }: { gh: { available: boolean; user?: string } }) {
   );
 }
 
+interface FolderInfo {
+  name: string;
+  fileCount: number;
+  totalBytes: number;
+}
+
 function SetupView({
   gh,
   onCloned,
 }: {
   gh: { available: boolean; user?: string };
-  onCloned: (folders: string[]) => void;
+  onCloned: (folders: FolderInfo[]) => void;
 }) {
   const [repoInput, setRepoInput] = useState("");
   const [branch, setBranch] = useState("main");
@@ -155,7 +165,7 @@ function SetupView({
       }>;
       const text = content?.find((c) => c.type === "text")?.text;
       const data = text ? JSON.parse(text) : null;
-      const folders = (data?.folders as string[]) ?? [];
+      const folders = (data?.folders as FolderInfo[]) ?? [];
       toast.success(`Cloned ${owner}/${repo} — now pick folders to index`);
       onCloned(folders);
     } catch (e) {
@@ -225,31 +235,49 @@ function SetupView({
   );
 }
 
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 function FolderPickerView({
   folders,
   onIndexed,
 }: {
-  folders: string[];
+  folders: FolderInfo[];
   onIndexed: () => void;
 }) {
   const updateFoldersMutation = useContextRepoUpdateFolders();
-  const [selected, setSelected] = useState<Set<string>>(() => new Set(folders));
+  const folderNames = folders.map((f) => f.name);
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(folderNames),
+  );
 
   const allSelected = selected.size === folders.length;
 
-  const toggle = (folder: string) => {
+  const selectedFiles = folders
+    .filter((f) => selected.has(f.name))
+    .reduce((sum, f) => sum + f.fileCount, 0);
+  const selectedBytes = folders
+    .filter((f) => selected.has(f.name))
+    .reduce((sum, f) => sum + f.totalBytes, 0);
+
+  const toggle = (name: string) => {
     const next = new Set(selected);
-    if (next.has(folder)) next.delete(folder);
-    else next.add(folder);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
     setSelected(next);
   };
 
   const toggleAll = () => {
-    setSelected(allSelected ? new Set() : new Set(folders));
+    setSelected(allSelected ? new Set() : new Set(folderNames));
   };
 
   const handleIndex = async () => {
-    const foldersToIndex = allSelected ? [] : [...selected];
+    const foldersToIndex = allSelected
+      ? []
+      : [...selected].filter((f) => f !== "<root>");
     try {
       await updateFoldersMutation.mutateAsync(foldersToIndex);
       toast.success("Repository indexed");
@@ -279,23 +307,42 @@ function FolderPickerView({
         </button>
       </div>
 
-      <div className="rounded-lg border border-border max-h-64 overflow-y-auto">
+      <div className="rounded-lg border border-border max-h-64 overflow-y-auto divide-y divide-border">
         {folders.map((folder) => (
           <label
-            key={folder}
-            className="flex items-center gap-2 px-3 py-1.5 hover:bg-accent cursor-pointer text-sm"
+            key={folder.name}
+            className="flex items-center gap-2 px-3 py-2 hover:bg-accent cursor-pointer text-sm"
           >
             <input
               type="checkbox"
-              checked={selected.has(folder)}
-              onChange={() => toggle(folder)}
+              checked={selected.has(folder.name)}
+              onChange={() => toggle(folder.name)}
               className="rounded border-border"
             />
-            <span className="text-muted-foreground">/</span>
-            <span>{folder}</span>
+            <span className="flex-1 min-w-0">
+              {folder.name === "<root>" ? (
+                <span className="text-muted-foreground italic">root files</span>
+              ) : (
+                <>
+                  <span className="text-muted-foreground">/</span>
+                  {folder.name}
+                </>
+              )}
+            </span>
+            <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+              {folder.fileCount} files
+            </span>
+            <span className="text-xs text-muted-foreground tabular-nums shrink-0 w-16 text-right">
+              {formatSize(folder.totalBytes)}
+            </span>
           </label>
         ))}
       </div>
+
+      <p className="text-xs text-muted-foreground">
+        {selectedFiles.toLocaleString()} files, {formatSize(selectedBytes)}{" "}
+        selected
+      </p>
 
       <Button
         onClick={handleIndex}
@@ -328,7 +375,7 @@ function ConfiguredView({
     indexSizeBytes: number;
     lastSyncedAt: string | null;
     indexedFolders: string[] | null;
-    folders: string[];
+    folders: FolderInfo[];
   };
   gh: { available: boolean; user?: string };
 }) {
@@ -337,37 +384,40 @@ function ConfiguredView({
   const updateFoldersMutation = useContextRepoUpdateFolders();
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
 
+  const folderNames = config.folders.map((f) => f.name);
   const [selectedFolders, setSelectedFolders] = useState<Set<string>>(() => {
     if (config.indexedFolders && config.indexedFolders.length > 0) {
       return new Set(config.indexedFolders);
     }
-    return new Set(config.folders);
+    return new Set(folderNames);
   });
 
   const allSelected = selectedFolders.size === config.folders.length;
 
-  const toggleFolder = (folder: string) => {
+  const toggleFolder = (name: string) => {
     const next = new Set(selectedFolders);
-    if (next.has(folder)) next.delete(folder);
-    else next.add(folder);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
     setSelectedFolders(next);
   };
 
   const toggleAll = () => {
-    setSelectedFolders(allSelected ? new Set() : new Set(config.folders));
+    setSelectedFolders(allSelected ? new Set() : new Set(folderNames));
   };
 
   const savedSet = new Set(
     config.indexedFolders && config.indexedFolders.length > 0
       ? config.indexedFolders
-      : config.folders,
+      : folderNames,
   );
   const selectionChanged =
     selectedFolders.size !== savedSet.size ||
     [...selectedFolders].some((f) => !savedSet.has(f));
 
   const handleSaveFolders = async () => {
-    const folders = allSelected ? [] : [...selectedFolders];
+    const folders = allSelected
+      ? []
+      : [...selectedFolders].filter((f) => f !== "<root>");
     try {
       await updateFoldersMutation.mutateAsync(folders);
       toast.success("Indexed folders updated");
@@ -467,20 +517,36 @@ function ConfiguredView({
               {allSelected ? "Deselect all" : "Select all"}
             </button>
           </div>
-          <div className="rounded-lg border border-border max-h-48 overflow-y-auto">
+          <div className="rounded-lg border border-border max-h-48 overflow-y-auto divide-y divide-border">
             {config.folders.map((folder) => (
               <label
-                key={folder}
-                className="flex items-center gap-2 px-3 py-1.5 hover:bg-accent cursor-pointer text-sm"
+                key={folder.name}
+                className="flex items-center gap-2 px-3 py-2 hover:bg-accent cursor-pointer text-sm"
               >
                 <input
                   type="checkbox"
-                  checked={selectedFolders.has(folder)}
-                  onChange={() => toggleFolder(folder)}
+                  checked={selectedFolders.has(folder.name)}
+                  onChange={() => toggleFolder(folder.name)}
                   className="rounded border-border"
                 />
-                <span className="text-muted-foreground">/</span>
-                <span>{folder}</span>
+                <span className="flex-1 min-w-0">
+                  {folder.name === "<root>" ? (
+                    <span className="text-muted-foreground italic">
+                      root files
+                    </span>
+                  ) : (
+                    <>
+                      <span className="text-muted-foreground">/</span>
+                      {folder.name}
+                    </>
+                  )}
+                </span>
+                <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                  {folder.fileCount} files
+                </span>
+                <span className="text-xs text-muted-foreground tabular-nums shrink-0 w-16 text-right">
+                  {formatSize(folder.totalBytes)}
+                </span>
               </label>
             ))}
           </div>

--- a/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
@@ -1,0 +1,304 @@
+/**
+ * Context Repo Modal
+ *
+ * Modal for setting up and managing the GitHub context repository.
+ * Three states: setup instructions, repo form, or status view.
+ */
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  AlertCircle,
+  Check,
+  GitBranch01,
+  Loading01,
+  RefreshCcw01,
+  Trash01,
+} from "@untitledui/icons";
+import { toast } from "sonner";
+import {
+  useContextRepo,
+  useContextRepoSetup,
+  useContextRepoSync,
+  useContextRepoDisconnect,
+} from "@/web/hooks/use-context-repo";
+
+interface ContextRepoModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ContextRepoModal({
+  open,
+  onOpenChange,
+}: ContextRepoModalProps) {
+  const contextRepo = useContextRepo();
+  const config = contextRepo.config;
+  const isLoading = contextRepo.isLoading;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitBranch01 className="size-5" />
+            Context Repo
+          </DialogTitle>
+        </DialogHeader>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loading01 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : config ? (
+          <ConfiguredView config={config} />
+        ) : (
+          <SetupView onSuccess={() => {}} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SetupView({ onSuccess }: { onSuccess: () => void }) {
+  const [repoInput, setRepoInput] = useState("");
+  const [branch, setBranch] = useState("main");
+  const setupMutation = useContextRepoSetup();
+
+  const handleSetup = async () => {
+    const parts = repoInput.trim().split("/");
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      toast.error("Enter a valid owner/repo (e.g., decocms/context)");
+      return;
+    }
+    const [owner, repo] = parts;
+
+    try {
+      await setupMutation.mutateAsync({ owner, repo, branch });
+      toast.success(`Connected ${owner}/${repo} as context repo`);
+      onSuccess();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "Failed to set up context repo",
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Connect a GitHub repository as the shared context for this organization.
+        All files will be indexed for search, skills in{" "}
+        <code className="text-xs bg-muted px-1 rounded">skills/</code> will be
+        discoverable by agents, and issues can be used for agent communication.
+      </p>
+
+      <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+        <p className="font-medium text-foreground mb-1">Prerequisites</p>
+        <p>
+          Install GitHub CLI:{" "}
+          <code className="bg-muted px-1 rounded">brew install gh</code>
+        </p>
+        <p>
+          Authenticate:{" "}
+          <code className="bg-muted px-1 rounded">gh auth login</code>
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Repository</label>
+        <Input
+          placeholder="owner/repo (e.g., decocms/context)"
+          value={repoInput}
+          onChange={(e) => setRepoInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSetup()}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Branch</label>
+        <Input
+          placeholder="main"
+          value={branch}
+          onChange={(e) => setBranch(e.target.value)}
+        />
+      </div>
+
+      <Button
+        onClick={handleSetup}
+        disabled={setupMutation.isPending || !repoInput.trim()}
+      >
+        {setupMutation.isPending ? (
+          <>
+            <Loading01 className="size-4 animate-spin" />
+            Cloning & indexing...
+          </>
+        ) : (
+          "Connect"
+        )}
+      </Button>
+
+      {setupMutation.isError && (
+        <div className="flex items-start gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-xs text-destructive">
+          <AlertCircle className="size-4 shrink-0 mt-0.5" />
+          <p>
+            {setupMutation.error instanceof Error
+              ? setupMutation.error.message
+              : "Setup failed"}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConfiguredView({
+  config,
+}: {
+  config: {
+    connectionId: string;
+    owner: string;
+    repo: string;
+    branch: string;
+    lastSyncedCommit: string | null;
+    fileCount: number;
+    indexSizeBytes: number;
+    lastSyncedAt: string | null;
+  };
+}) {
+  const syncMutation = useContextRepoSync();
+  const disconnectMutation = useContextRepoDisconnect();
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false);
+
+  const handleSync = async () => {
+    try {
+      await syncMutation.mutateAsync();
+      toast.success("Context repo synced");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Sync failed");
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnectMutation.mutateAsync(config.connectionId);
+      toast.success("Context repo disconnected");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Disconnect failed");
+    }
+  };
+
+  const sizeKB = Math.round(config.indexSizeBytes / 1024);
+  const sizeMB = (config.indexSizeBytes / (1024 * 1024)).toFixed(1);
+  const sizeDisplay =
+    config.indexSizeBytes > 1024 * 1024 ? `${sizeMB} MB` : `${sizeKB} KB`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Repo info */}
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10">
+          <GitBranch01 className="size-5 text-primary" />
+        </div>
+        <div>
+          <p className="text-sm font-medium">
+            {config.owner}/{config.repo}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            branch: {config.branch}
+          </p>
+        </div>
+        <Check className="ml-auto size-4 text-green-500" />
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-lg border border-border p-3">
+          <p className="text-xs text-muted-foreground">Files</p>
+          <p className="text-lg font-semibold">
+            {config.fileCount.toLocaleString()}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border p-3">
+          <p className="text-xs text-muted-foreground">Index Size</p>
+          <p className="text-lg font-semibold">{sizeDisplay}</p>
+        </div>
+        <div className="rounded-lg border border-border p-3">
+          <p className="text-xs text-muted-foreground">Last Synced</p>
+          <p className="text-sm font-medium">
+            {config.lastSyncedAt
+              ? new Date(config.lastSyncedAt).toLocaleDateString()
+              : "Never"}
+          </p>
+        </div>
+      </div>
+
+      {config.lastSyncedCommit && (
+        <p className="text-xs text-muted-foreground">
+          HEAD:{" "}
+          <code className="bg-muted px-1 rounded">
+            {config.lastSyncedCommit.slice(0, 8)}
+          </code>
+        </p>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 border-t border-border pt-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSync}
+          disabled={syncMutation.isPending}
+        >
+          {syncMutation.isPending ? (
+            <Loading01 className="size-4 animate-spin" />
+          ) : (
+            <RefreshCcw01 className="size-4" />
+          )}
+          Sync Now
+        </Button>
+
+        {confirmDisconnect ? (
+          <div className="flex items-center gap-2 ml-auto">
+            <span className="text-xs text-muted-foreground">Are you sure?</span>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDisconnect}
+              disabled={disconnectMutation.isPending}
+            >
+              {disconnectMutation.isPending ? (
+                <Loading01 className="size-4 animate-spin" />
+              ) : (
+                "Yes, disconnect"
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirmDisconnect(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto text-muted-foreground"
+            onClick={() => setConfirmDisconnect(true)}
+          >
+            <Trash01 className="size-4" />
+            Disconnect
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
@@ -30,6 +30,7 @@ import {
   useContextRepoSetup,
   useContextRepoSync,
   useContextRepoDisconnect,
+  useContextRepoUpdateFolders,
 } from "@/web/hooks/use-context-repo";
 
 interface ContextRepoModalProps {
@@ -213,12 +214,64 @@ function ConfiguredView({
     fileCount: number;
     indexSizeBytes: number;
     lastSyncedAt: string | null;
+    indexedFolders: string[] | null;
+    folders: string[];
   };
   gh: { available: boolean; user?: string };
 }) {
   const syncMutation = useContextRepoSync();
   const disconnectMutation = useContextRepoDisconnect();
+  const updateFoldersMutation = useContextRepoUpdateFolders();
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
+
+  // Track selected folders locally — null means "all folders"
+  const [selectedFolders, setSelectedFolders] = useState<Set<string>>(() => {
+    if (config.indexedFolders && config.indexedFolders.length > 0) {
+      return new Set(config.indexedFolders);
+    }
+    // Default: all folders selected
+    return new Set(config.folders);
+  });
+
+  const allSelected = selectedFolders.size === config.folders.length;
+
+  const toggleFolder = (folder: string) => {
+    const next = new Set(selectedFolders);
+    if (next.has(folder)) {
+      next.delete(folder);
+    } else {
+      next.add(folder);
+    }
+    setSelectedFolders(next);
+  };
+
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelectedFolders(new Set());
+    } else {
+      setSelectedFolders(new Set(config.folders));
+    }
+  };
+
+  // Check if selection changed from what's saved
+  const savedSet = new Set(
+    config.indexedFolders && config.indexedFolders.length > 0
+      ? config.indexedFolders
+      : config.folders,
+  );
+  const selectionChanged =
+    selectedFolders.size !== savedSet.size ||
+    [...selectedFolders].some((f) => !savedSet.has(f));
+
+  const handleSaveFolders = async () => {
+    const folders = allSelected ? [] : [...selectedFolders];
+    try {
+      await updateFoldersMutation.mutateAsync(folders);
+      toast.success("Indexed folders updated");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update folders");
+    }
+  };
 
   const handleSync = async () => {
     try {
@@ -293,6 +346,58 @@ function ConfiguredView({
             {config.lastSyncedCommit.slice(0, 8)}
           </code>
         </p>
+      )}
+
+      {/* Folder selection */}
+      {config.folders.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium">Indexed Folders</label>
+            <button
+              type="button"
+              onClick={toggleAll}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {allSelected ? "Deselect all" : "Select all"}
+            </button>
+          </div>
+          <div className="rounded-lg border border-border max-h-48 overflow-y-auto">
+            {config.folders.map((folder) => (
+              <label
+                key={folder}
+                className="flex items-center gap-2 px-3 py-1.5 hover:bg-accent cursor-pointer text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedFolders.has(folder)}
+                  onChange={() => toggleFolder(folder)}
+                  className="rounded border-border"
+                />
+                <span className="text-muted-foreground">/</span>
+                <span>{folder}</span>
+              </label>
+            ))}
+          </div>
+          {selectionChanged && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSaveFolders}
+              disabled={
+                updateFoldersMutation.isPending || selectedFolders.size === 0
+              }
+            >
+              {updateFoldersMutation.isPending ? (
+                <>
+                  <Loading01 className="size-4 animate-spin" />
+                  Reindexing...
+                </>
+              ) : (
+                `Reindex ${selectedFolders.size} folder${selectedFolders.size !== 1 ? "s" : ""}`
+              )}
+            </Button>
+          )}
+        </div>
       )}
 
       {/* Actions */}

--- a/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
@@ -2,7 +2,7 @@
  * Context Repo Modal
  *
  * Modal for setting up and managing the GitHub context repository.
- * Three states: setup instructions, repo form, or status view.
+ * Shows live gh CLI auth status with green checkmark when authenticated.
  */
 
 import { useState } from "react";
@@ -17,10 +17,12 @@ import { Input } from "@deco/ui/components/input.tsx";
 import {
   AlertCircle,
   Check,
+  CheckCircle,
   GitBranch01,
   Loading01,
   RefreshCcw01,
   Trash01,
+  XCircle,
 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -39,9 +41,7 @@ export function ContextRepoModal({
   open,
   onOpenChange,
 }: ContextRepoModalProps) {
-  const contextRepo = useContextRepo();
-  const config = contextRepo.config;
-  const isLoading = contextRepo.isLoading;
+  const { gh, config, isLoading } = useContextRepo();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -57,16 +57,66 @@ export function ContextRepoModal({
             <Loading01 className="size-5 animate-spin text-muted-foreground" />
           </div>
         ) : config ? (
-          <ConfiguredView config={config} />
+          <ConfiguredView config={config} gh={gh} />
         ) : (
-          <SetupView onSuccess={() => {}} />
+          <SetupView gh={gh} onSuccess={() => {}} />
         )}
       </DialogContent>
     </Dialog>
   );
 }
 
-function SetupView({ onSuccess }: { onSuccess: () => void }) {
+function GhStatusBadge({ gh }: { gh: { available: boolean; user?: string } }) {
+  if (gh.available) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30 p-3 text-sm">
+        <CheckCircle className="size-4 text-green-600 dark:text-green-400 shrink-0" />
+        <span className="text-green-800 dark:text-green-300">
+          GitHub CLI authenticated
+          {gh.user && (
+            <>
+              {" "}
+              as <span className="font-medium">{gh.user}</span>
+            </>
+          )}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30 p-3 text-sm">
+      <div className="flex items-center gap-2">
+        <XCircle className="size-4 text-amber-600 dark:text-amber-400 shrink-0" />
+        <span className="text-amber-800 dark:text-amber-300">
+          GitHub CLI not authenticated
+        </span>
+      </div>
+      <div className="text-xs text-amber-700 dark:text-amber-400 pl-6 space-y-1">
+        <p>
+          Install:{" "}
+          <code className="bg-amber-100 dark:bg-amber-900/50 px-1 rounded">
+            brew install gh
+          </code>
+        </p>
+        <p>
+          Login:{" "}
+          <code className="bg-amber-100 dark:bg-amber-900/50 px-1 rounded">
+            gh auth login
+          </code>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SetupView({
+  gh,
+  onSuccess,
+}: {
+  gh: { available: boolean; user?: string };
+  onSuccess: () => void;
+}) {
   const [repoInput, setRepoInput] = useState("");
   const [branch, setBranch] = useState("main");
   const setupMutation = useContextRepoSetup();
@@ -99,17 +149,7 @@ function SetupView({ onSuccess }: { onSuccess: () => void }) {
         discoverable by agents, and issues can be used for agent communication.
       </p>
 
-      <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
-        <p className="font-medium text-foreground mb-1">Prerequisites</p>
-        <p>
-          Install GitHub CLI:{" "}
-          <code className="bg-muted px-1 rounded">brew install gh</code>
-        </p>
-        <p>
-          Authenticate:{" "}
-          <code className="bg-muted px-1 rounded">gh auth login</code>
-        </p>
-      </div>
+      <GhStatusBadge gh={gh} />
 
       <div className="flex flex-col gap-2">
         <label className="text-sm font-medium">Repository</label>
@@ -118,6 +158,7 @@ function SetupView({ onSuccess }: { onSuccess: () => void }) {
           value={repoInput}
           onChange={(e) => setRepoInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleSetup()}
+          disabled={!gh.available}
         />
       </div>
 
@@ -127,12 +168,13 @@ function SetupView({ onSuccess }: { onSuccess: () => void }) {
           placeholder="main"
           value={branch}
           onChange={(e) => setBranch(e.target.value)}
+          disabled={!gh.available}
         />
       </div>
 
       <Button
         onClick={handleSetup}
-        disabled={setupMutation.isPending || !repoInput.trim()}
+        disabled={setupMutation.isPending || !repoInput.trim() || !gh.available}
       >
         {setupMutation.isPending ? (
           <>
@@ -160,6 +202,7 @@ function SetupView({ onSuccess }: { onSuccess: () => void }) {
 
 function ConfiguredView({
   config,
+  gh,
 }: {
   config: {
     connectionId: string;
@@ -171,6 +214,7 @@ function ConfiguredView({
     indexSizeBytes: number;
     lastSyncedAt: string | null;
   };
+  gh: { available: boolean; user?: string };
 }) {
   const syncMutation = useContextRepoSync();
   const disconnectMutation = useContextRepoDisconnect();
@@ -216,6 +260,9 @@ function ConfiguredView({
         </div>
         <Check className="ml-auto size-4 text-green-500" />
       </div>
+
+      {/* GitHub auth status */}
+      <GhStatusBadge gh={gh} />
 
       {/* Stats */}
       <div className="grid grid-cols-3 gap-3">

--- a/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
+++ b/apps/mesh/src/web/components/context-repo/context-repo-modal.tsx
@@ -1,8 +1,7 @@
 /**
  * Context Repo Modal
  *
- * Modal for setting up and managing the GitHub context repository.
- * Shows live gh CLI auth status with green checkmark when authenticated.
+ * Flow: Setup (clone) → Pick Folders → Index → Configured view
  */
 
 import { useState } from "react";
@@ -18,6 +17,7 @@ import {
   AlertCircle,
   Check,
   CheckCircle,
+  Folder,
   GitBranch01,
   Loading01,
   RefreshCcw01,
@@ -43,6 +43,8 @@ export function ContextRepoModal({
   onOpenChange,
 }: ContextRepoModalProps) {
   const { gh, config, isLoading } = useContextRepo();
+  // After setup (clone), we hold the folders for the picker step
+  const [pendingFolders, setPendingFolders] = useState<string[] | null>(null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -57,10 +59,24 @@ export function ContextRepoModal({
           <div className="flex items-center justify-center py-8">
             <Loading01 className="size-5 animate-spin text-muted-foreground" />
           </div>
-        ) : config ? (
+        ) : config && config.fileCount > 0 ? (
           <ConfiguredView config={config} gh={gh} />
+        ) : config && pendingFolders === null ? (
+          // Cloned but not indexed yet — fetch folders from status
+          <FolderPickerView
+            folders={config.folders}
+            onIndexed={() => setPendingFolders(null)}
+          />
+        ) : pendingFolders ? (
+          <FolderPickerView
+            folders={pendingFolders}
+            onIndexed={() => setPendingFolders(null)}
+          />
         ) : (
-          <SetupView gh={gh} onSuccess={() => {}} />
+          <SetupView
+            gh={gh}
+            onCloned={(folders) => setPendingFolders(folders)}
+          />
         )}
       </DialogContent>
     </Dialog>
@@ -113,10 +129,10 @@ function GhStatusBadge({ gh }: { gh: { available: boolean; user?: string } }) {
 
 function SetupView({
   gh,
-  onSuccess,
+  onCloned,
 }: {
   gh: { available: boolean; user?: string };
-  onSuccess: () => void;
+  onCloned: (folders: string[]) => void;
 }) {
   const [repoInput, setRepoInput] = useState("");
   const [branch, setBranch] = useState("main");
@@ -131,12 +147,20 @@ function SetupView({
     const [owner, repo] = parts;
 
     try {
-      await setupMutation.mutateAsync({ owner, repo, branch });
-      toast.success(`Connected ${owner}/${repo} as context repo`);
-      onSuccess();
+      const result = await setupMutation.mutateAsync({ owner, repo, branch });
+      // Extract folders from result
+      const content = result?.content as Array<{
+        type: string;
+        text?: string;
+      }>;
+      const text = content?.find((c) => c.type === "text")?.text;
+      const data = text ? JSON.parse(text) : null;
+      const folders = (data?.folders as string[]) ?? [];
+      toast.success(`Cloned ${owner}/${repo} — now pick folders to index`);
+      onCloned(folders);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to set up context repo",
+        e instanceof Error ? e.message : "Failed to clone repository",
       );
     }
   };
@@ -180,10 +204,10 @@ function SetupView({
         {setupMutation.isPending ? (
           <>
             <Loading01 className="size-4 animate-spin" />
-            Cloning & indexing...
+            Cloning...
           </>
         ) : (
-          "Connect"
+          "Clone Repository"
         )}
       </Button>
 
@@ -193,10 +217,99 @@ function SetupView({
           <p>
             {setupMutation.error instanceof Error
               ? setupMutation.error.message
-              : "Setup failed"}
+              : "Clone failed"}
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+function FolderPickerView({
+  folders,
+  onIndexed,
+}: {
+  folders: string[];
+  onIndexed: () => void;
+}) {
+  const updateFoldersMutation = useContextRepoUpdateFolders();
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(folders));
+
+  const allSelected = selected.size === folders.length;
+
+  const toggle = (folder: string) => {
+    const next = new Set(selected);
+    if (next.has(folder)) next.delete(folder);
+    else next.add(folder);
+    setSelected(next);
+  };
+
+  const toggleAll = () => {
+    setSelected(allSelected ? new Set() : new Set(folders));
+  };
+
+  const handleIndex = async () => {
+    const foldersToIndex = allSelected ? [] : [...selected];
+    try {
+      await updateFoldersMutation.mutateAsync(foldersToIndex);
+      toast.success("Repository indexed");
+      onIndexed();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Indexing failed");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Repository cloned. Select which folders to index for search.
+      </p>
+
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium flex items-center gap-2">
+          <Folder className="size-4 text-muted-foreground" />
+          Folders
+        </label>
+        <button
+          type="button"
+          onClick={toggleAll}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {allSelected ? "Deselect all" : "Select all"}
+        </button>
+      </div>
+
+      <div className="rounded-lg border border-border max-h-64 overflow-y-auto">
+        {folders.map((folder) => (
+          <label
+            key={folder}
+            className="flex items-center gap-2 px-3 py-1.5 hover:bg-accent cursor-pointer text-sm"
+          >
+            <input
+              type="checkbox"
+              checked={selected.has(folder)}
+              onChange={() => toggle(folder)}
+              className="rounded border-border"
+            />
+            <span className="text-muted-foreground">/</span>
+            <span>{folder}</span>
+          </label>
+        ))}
+      </div>
+
+      <Button
+        onClick={handleIndex}
+        disabled={updateFoldersMutation.isPending || selected.size === 0}
+      >
+        {updateFoldersMutation.isPending ? (
+          <>
+            <Loading01 className="size-4 animate-spin" />
+            Indexing...
+          </>
+        ) : (
+          `Index ${selected.size} folder${selected.size !== 1 ? "s" : ""}`
+        )}
+      </Button>
     </div>
   );
 }
@@ -224,12 +337,10 @@ function ConfiguredView({
   const updateFoldersMutation = useContextRepoUpdateFolders();
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
 
-  // Track selected folders locally — null means "all folders"
   const [selectedFolders, setSelectedFolders] = useState<Set<string>>(() => {
     if (config.indexedFolders && config.indexedFolders.length > 0) {
       return new Set(config.indexedFolders);
     }
-    // Default: all folders selected
     return new Set(config.folders);
   });
 
@@ -237,23 +348,15 @@ function ConfiguredView({
 
   const toggleFolder = (folder: string) => {
     const next = new Set(selectedFolders);
-    if (next.has(folder)) {
-      next.delete(folder);
-    } else {
-      next.add(folder);
-    }
+    if (next.has(folder)) next.delete(folder);
+    else next.add(folder);
     setSelectedFolders(next);
   };
 
   const toggleAll = () => {
-    if (allSelected) {
-      setSelectedFolders(new Set());
-    } else {
-      setSelectedFolders(new Set(config.folders));
-    }
+    setSelectedFolders(allSelected ? new Set() : new Set(config.folders));
   };
 
-  // Check if selection changed from what's saved
   const savedSet = new Set(
     config.indexedFolders && config.indexedFolders.length > 0
       ? config.indexedFolders
@@ -284,7 +387,7 @@ function ConfiguredView({
 
   const handleDisconnect = async () => {
     try {
-      await disconnectMutation.mutateAsync(config.connectionId);
+      await disconnectMutation.mutateAsync();
       toast.success("Context repo disconnected");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Disconnect failed");
@@ -352,7 +455,10 @@ function ConfiguredView({
       {config.folders.length > 0 && (
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium">Indexed Folders</label>
+            <label className="text-sm font-medium flex items-center gap-2">
+              <Folder className="size-4 text-muted-foreground" />
+              Indexed Folders
+            </label>
             <button
               type="button"
               onClick={toggleAll}

--- a/apps/mesh/src/web/hooks/use-context-repo.ts
+++ b/apps/mesh/src/web/hooks/use-context-repo.ts
@@ -28,7 +28,7 @@ interface ContextRepoConfig {
   indexSizeBytes: number;
   lastSyncedAt: string | null;
   indexedFolders: string[] | null;
-  folders: string[];
+  folders: Array<{ name: string; fileCount: number; totalBytes: number }>;
 }
 
 interface ContextRepoStatus {

--- a/apps/mesh/src/web/hooks/use-context-repo.ts
+++ b/apps/mesh/src/web/hooks/use-context-repo.ts
@@ -166,10 +166,10 @@ export function useContextRepoDisconnect() {
   });
 
   return useMutation({
-    mutationFn: async (connectionId: string) => {
+    mutationFn: async () => {
       await client.callTool({
-        name: "COLLECTION_CONNECTIONS_DELETE",
-        arguments: { id: connectionId },
+        name: "CONTEXT_REPO_DISCONNECT",
+        arguments: {},
       });
     },
     onSuccess: () => {

--- a/apps/mesh/src/web/hooks/use-context-repo.ts
+++ b/apps/mesh/src/web/hooks/use-context-repo.ts
@@ -27,6 +27,8 @@ interface ContextRepoConfig {
   fileCount: number;
   indexSizeBytes: number;
   lastSyncedAt: string | null;
+  indexedFolders: string[] | null;
+  folders: string[];
 }
 
 interface ContextRepoStatus {
@@ -120,6 +122,30 @@ export function useContextRepoSync() {
       return await client.callTool({
         name: "CONTEXT_REPO_SYNC",
         arguments: {},
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
+  });
+}
+
+/**
+ * Update which folders are indexed
+ */
+export function useContextRepoUpdateFolders() {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  return useMutation({
+    mutationFn: async (folders: string[]) => {
+      return await client.callTool({
+        name: "CONTEXT_REPO_UPDATE_FOLDERS",
+        arguments: { folders },
       });
     },
     onSuccess: () => {

--- a/apps/mesh/src/web/hooks/use-context-repo.ts
+++ b/apps/mesh/src/web/hooks/use-context-repo.ts
@@ -1,18 +1,22 @@
 /**
  * Hooks for Context Repo feature
  *
- * Finds the GITHUB context repo connection and provides
- * setup/sync mutations via MCP tool calls.
+ * Uses CONTEXT_REPO_STATUS tool to get both gh CLI status
+ * and current context repo config in a single call.
  */
 
 import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,
   useProjectContext,
-  type ConnectionEntity,
 } from "@decocms/mesh-sdk";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
+
+interface GhStatus {
+  available: boolean;
+  user?: string;
+}
 
 interface ContextRepoConfig {
   connectionId: string;
@@ -25,11 +29,25 @@ interface ContextRepoConfig {
   lastSyncedAt: string | null;
 }
 
+interface ContextRepoStatus {
+  gh: GhStatus;
+  contextRepo: ContextRepoConfig | null;
+}
+
+function extractToolResult(result: unknown): unknown {
+  const content = (
+    result as { content?: Array<{ type: string; text?: string }> }
+  )?.content;
+  const text = content?.find((c) => c.type === "text")?.text;
+  return text ? JSON.parse(text) : null;
+}
+
 /**
- * Find the GITHUB context repo connection for this org.
- * Calls COLLECTION_CONNECTIONS_LIST with include_virtual=true to include GITHUB connections.
+ * Get context repo status: gh CLI auth + current config.
+ * Single call to CONTEXT_REPO_STATUS tool.
  */
 export function useContextRepo(): {
+  gh: GhStatus;
   config: ContextRepoConfig | null;
   isLoading: boolean;
 } {
@@ -43,39 +61,19 @@ export function useContextRepo(): {
     queryKey: KEYS.contextRepo(org.id),
     queryFn: async () => {
       const result = await client.callTool({
-        name: "COLLECTION_CONNECTIONS_LIST",
-        arguments: { include_virtual: true },
+        name: "CONTEXT_REPO_STATUS",
+        arguments: {},
       });
-      const content = result?.content as Array<{
-        type: string;
-        text?: string;
-      }>;
-      const text = content?.find((c) => c.type === "text")?.text;
-      if (!text) return null;
-      const payload = JSON.parse(text) as { items?: ConnectionEntity[] };
-      const connections = payload.items ?? [];
-
-      for (const conn of connections) {
-        if (conn.connection_type !== "GITHUB") continue;
-        const metadata = conn.metadata as Record<string, unknown> | null;
-        if (!metadata || metadata.type !== "context-repo") continue;
-        return {
-          connectionId: conn.id,
-          owner: metadata.owner as string,
-          repo: metadata.repo as string,
-          branch: (metadata.branch as string) || "main",
-          lastSyncedCommit: (metadata.lastSyncedCommit as string) || null,
-          fileCount: (metadata.fileCount as number) || 0,
-          indexSizeBytes: (metadata.indexSizeBytes as number) || 0,
-          lastSyncedAt: (metadata.lastSyncedAt as string) || null,
-        };
-      }
-      return null;
+      return extractToolResult(result) as ContextRepoStatus;
     },
     staleTime: 30_000,
   });
 
-  return { config: data ?? null, isLoading };
+  return {
+    gh: data?.gh ?? { available: false },
+    config: data?.contextRepo ?? null,
+    isLoading,
+  };
 }
 
 /**

--- a/apps/mesh/src/web/hooks/use-context-repo.ts
+++ b/apps/mesh/src/web/hooks/use-context-repo.ts
@@ -1,0 +1,155 @@
+/**
+ * Hooks for Context Repo feature
+ *
+ * Finds the GITHUB context repo connection and provides
+ * setup/sync mutations via MCP tool calls.
+ */
+
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+  type ConnectionEntity,
+} from "@decocms/mesh-sdk";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+interface ContextRepoConfig {
+  connectionId: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  lastSyncedCommit: string | null;
+  fileCount: number;
+  indexSizeBytes: number;
+  lastSyncedAt: string | null;
+}
+
+/**
+ * Find the GITHUB context repo connection for this org.
+ * Calls COLLECTION_CONNECTIONS_LIST with include_virtual=true to include GITHUB connections.
+ */
+export function useContextRepo(): {
+  config: ContextRepoConfig | null;
+  isLoading: boolean;
+} {
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  const { data, isLoading } = useQuery({
+    queryKey: KEYS.contextRepo(org.id),
+    queryFn: async () => {
+      const result = await client.callTool({
+        name: "COLLECTION_CONNECTIONS_LIST",
+        arguments: { include_virtual: true },
+      });
+      const content = result?.content as Array<{
+        type: string;
+        text?: string;
+      }>;
+      const text = content?.find((c) => c.type === "text")?.text;
+      if (!text) return null;
+      const payload = JSON.parse(text) as { items?: ConnectionEntity[] };
+      const connections = payload.items ?? [];
+
+      for (const conn of connections) {
+        if (conn.connection_type !== "GITHUB") continue;
+        const metadata = conn.metadata as Record<string, unknown> | null;
+        if (!metadata || metadata.type !== "context-repo") continue;
+        return {
+          connectionId: conn.id,
+          owner: metadata.owner as string,
+          repo: metadata.repo as string,
+          branch: (metadata.branch as string) || "main",
+          lastSyncedCommit: (metadata.lastSyncedCommit as string) || null,
+          fileCount: (metadata.fileCount as number) || 0,
+          indexSizeBytes: (metadata.indexSizeBytes as number) || 0,
+          lastSyncedAt: (metadata.lastSyncedAt as string) || null,
+        };
+      }
+      return null;
+    },
+    staleTime: 30_000,
+  });
+
+  return { config: data ?? null, isLoading };
+}
+
+/**
+ * Setup a new context repo
+ */
+export function useContextRepoSetup() {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  return useMutation({
+    mutationFn: async (input: {
+      owner: string;
+      repo: string;
+      branch?: string;
+    }) => {
+      return await client.callTool({
+        name: "CONTEXT_REPO_SETUP",
+        arguments: input,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
+  });
+}
+
+/**
+ * Sync the context repo (pull + reindex)
+ */
+export function useContextRepoSync() {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  return useMutation({
+    mutationFn: async () => {
+      return await client.callTool({
+        name: "CONTEXT_REPO_SYNC",
+        arguments: {},
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
+  });
+}
+
+/**
+ * Disconnect context repo (delete the GITHUB connection)
+ */
+export function useContextRepoDisconnect() {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  return useMutation({
+    mutationFn: async (connectionId: string) => {
+      await client.callTool({
+        name: "COLLECTION_CONNECTIONS_DELETE",
+        arguments: { id: connectionId },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
+  });
+}

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -11,6 +11,7 @@ import {
   Container,
   Dataflow03,
   Folder,
+  GitBranch01,
   Home02,
   LayoutLeft,
   RefreshCcw01,
@@ -290,7 +291,21 @@ export function useProjectSidebarItems(options?: {
         group: {
           id: "manage",
           label: "Manage",
-          items: [monitorItem, settingsItem],
+          items: [
+            monitorItem,
+            {
+              key: "context-repo",
+              label: "Context Repo",
+              icon: <GitBranch01 />,
+              isActive: false,
+              onClick: () => {
+                window.dispatchEvent(
+                  new CustomEvent("open-context-repo-modal"),
+                );
+              },
+            },
+            settingsItem,
+          ],
           defaultExpanded: true,
         },
       },

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -257,4 +257,7 @@ export const KEYS = {
     ["org-sso-config", organizationId] as const,
   orgSsoStatus: (organizationId: string) =>
     ["org-sso-status", organizationId] as const,
+
+  // Context repo
+  contextRepo: (orgId: string) => ["context-repo", orgId] as const,
 } as const;

--- a/packages/mesh-sdk/src/types/connection.ts
+++ b/packages/mesh-sdk/src/types/connection.ts
@@ -104,7 +104,7 @@ export const ConnectionEntitySchema = z.object({
   app_id: z.string().nullable().describe("Associated app ID"),
 
   connection_type: z
-    .enum(["HTTP", "SSE", "Websocket", "STDIO", "VIRTUAL"])
+    .enum(["HTTP", "SSE", "Websocket", "STDIO", "VIRTUAL", "GITHUB"])
     .describe("Type of connection"),
   connection_url: z
     .string()


### PR DESCRIPTION
## Summary

Adds **Context Repo** — connect a GitHub repository as the shared knowledge base for an organization. This is a foundational feature that enables:

- **Full-text search** across all indexed repo files by agents
- **Skills discovery** from `skills/` directory (markdown with YAML frontmatter)
- **GitHub Issues** as the native communication channel for agents to report findings
- **Agent versioning** — save agent definitions to `agents/<name>.md` via PR

### Architecture

Context repos are stored as connections with `connection_type: "GITHUB"` — no new migrations needed. Repo files are cloned locally to `~/deco/repos/{orgId}/{owner}/{repo}/` and indexed to a `.deco-index.json` file for search.

### New MCP Tools (10)

| Tool | Access | Purpose |
|------|--------|---------|
| `CONTEXT_REPO_SETUP` | Admin | Connect a GitHub repo, clone & index |
| `CONTEXT_REPO_SYNC` | Admin | Pull latest + reindex |
| `CONTEXT_REPO_SEARCH` | Member | Full-text search across indexed files |
| `CONTEXT_REPO_READ` | Member | Read any file from the repo |
| `CONTEXT_REPO_LIST_SKILLS` | Member | List skills from `skills/*.md` |
| `CONTEXT_ISSUE_CREATE` | Member | Create GitHub issue (agent reports) |
| `CONTEXT_ISSUE_LIST` | Member | List/search issues |
| `CONTEXT_ISSUE_GET` | Member | Get issue + comments |
| `CONTEXT_ISSUE_COMMENT` | Member | Comment on issue |
| `CONTEXT_AGENT_SAVE` | Admin | Save agent def to `agents/<name>.md` via PR |

### Decopilot Integration

When a context repo is configured, a `<context-repo>` block is injected into the system prompt, instructing agents to:
- Search context before starting complex work
- Create issues for findings worth sharing
- Check existing issues to avoid duplicates

### UI

"Context Repo" item in sidebar Manage group opens a modal with:
- GitHub CLI setup instructions
- Repo connection form (owner/repo + branch)
- Status view with index stats, sync button, disconnect

## Test plan
- [ ] Sidebar → "Context Repo" → modal opens
- [ ] Enter `owner/repo` → Connect → clones + indexes
- [ ] Status view shows file count, index size, last synced
- [ ] Sync Now → pulls + reindexes
- [ ] Decopilot chat → `<context-repo>` in system prompt
- [ ] Ask decopilot to search context → works
- [ ] Ask decopilot to create an issue → appears on GitHub
- [ ] Ask decopilot to list issues → returns results
- [ ] Save agent to context repo → PR created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect a GitHub repository as an organization-wide context repo with search, skills discovery, and GitHub Issues; operational tools are exposed via the `GITHUB` connection and a `<context-repo>` prompt is injected into Decopilot.

- **New Features**
  - New `GITHUB` connection; clones to `~/deco/repos/{orgId}/{owner}/{repo}` via `gh repo clone`; indexes to `.deco-index.json`.
  - Management tools (core): `CONTEXT_REPO_STATUS`, `CONTEXT_REPO_SETUP`, `CONTEXT_REPO_UPDATE_FOLDERS`, `CONTEXT_REPO_DISCONNECT`.
  - Operational tools (served by the `GITHUB` connection): `CONTEXT_REPO_SYNC`, `CONTEXT_REPO_SEARCH`, `CONTEXT_REPO_READ`, `CONTEXT_REPO_LIST_SKILLS`, `CONTEXT_ISSUE_CREATE|LIST|GET|COMMENT`, `CONTEXT_AGENT_SAVE` (PR).
  - Pre-index folder picker with per-folder file counts/sizes and a selection summary; persists "<root>" selection.
  - Decopilot injects a `<context-repo>` section when connected; lookup is try/catched to avoid stream crashes.
  - MCP integration: skip MCP client creation and tool discovery for `GITHUB` connections; passthrough client injects context-repo tools and executes them locally.
  - Sidebar “Context Repo” modal with live `gh` auth badge (via `CONTEXT_REPO_STATUS`); disables setup inputs until authenticated; supports clone, pick folders, index/reindex, sync, and disconnect (cleans up clone and index).

- **Migration**
  - Install and authenticate GitHub CLI: `gh auth login`.
  - In the project sidebar, open “Context Repo” → connect `owner/repo` and branch → pick folders to index and run the first index.
  - Use Sync to pull updates and reindex; Disconnect removes the connection and cleans up the local clone and index.

<sup>Written for commit 88d25b84a831f9e131aea5637bea9e211f34d8a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

