### PR TITLE
refactor(chat): show line-based thinking summary instead of full text

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -118,15 +118,23 @@ function ThoughtSummary({
       : "Thought"
     : "Thought";
 
+  // Join with newlines (not spaces) so we can extract individual lines
   const rawText = parts
     .map((p) => p.text ?? "")
-    .join(" ")
+    .join("\n")
     .trim();
+  const lines = rawText.split("\n").filter(Boolean);
+
+  // Streaming: show last line (latest thinking). Done: show first line (topic).
+  const summaryLine = isStreaming
+    ? (lines[lines.length - 1] ?? "")
+    : (lines[0] ?? "");
+
   const summary =
-    !allPartsRedacted && rawText
-      ? rawText.length > 100
-        ? rawText.slice(0, 100) + "…"
-        : rawText
+    !allPartsRedacted && summaryLine
+      ? summaryLine.length > 100
+        ? summaryLine.slice(0, 100) + "…"
+        : summaryLine
       : undefined;
 
   const fullText = parts.map((p) => p.text ?? "").join("\n\n");
@@ -150,7 +158,6 @@ function ThoughtSummary({
       state={isStreaming ? "loading" : "idle"}
       detailVariant="prose"
       latency={latency}
-      forceOpen={isStreaming}
     />
   );
 }


### PR DESCRIPTION
## What is this contribution about?

Refactors the `ThoughtSummary` component in the chat UI to improve the thinking section UX:

- **Keeps thinking panel collapsed during streaming** — removes `forceOpen={isStreaming}` so users aren't forced to see the full reasoning text while the model is thinking
- **Line-based summary** — instead of showing the first 100 chars of concatenated reasoning text, the summary now shows a meaningful single line: the **last line** while streaming (latest thought) and the **first line** when done (topic)

## Screenshots/Demonstration

N/A — behavioral change only, no layout changes.

## How to Test

1. Open a chat conversation that triggers model thinking/reasoning
2. While the model is streaming, confirm the thinking section stays **collapsed**
3. Verify the inline summary text shows the **last line** of reasoning during streaming
4. After streaming completes, verify the summary switches to the **first line** of reasoning
5. Confirm you can still manually expand/collapse the thinking detail

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the chat thinking section to show a single-line summary and keep the panel collapsed while streaming for a cleaner UX. The summary shows the latest thought during streaming and the topic when complete.

- **Refactors**
  - Removed forced open during streaming so the thinking panel stays collapsed.
  - Switched to line-based summaries: show last line while streaming, first line when done, truncated to 100 chars; full text stays in the expandable detail.

<sup>Written for commit b0058a75e833846cc4d69ee29fba059235ee97c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

