### PR TITLE
refactor(config): move deco import flag to runtime

### DIFF
--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { getThemeConfig, type ThemeConfig } from "@/core/config";
 import { isLocalMode } from "@/auth/local-mode";
 import { getInternalUrl } from "@/core/server-constants";
+import { env } from "@/env";
 
 const app = new Hono();
 
@@ -27,6 +28,11 @@ export type PublicConfig = {
    * (e.g. tokyo.localhost) that external OAuth servers may not accept.
    */
   internalUrl?: string;
+  /**
+   * Whether the deco.cx import feature is enabled.
+   * Controlled by the ENABLE_DECO_IMPORT environment variable.
+   */
+  enableDecoImport?: boolean;
 };
 
 /**
@@ -42,6 +48,7 @@ app.get("/", (c) => {
     theme: getThemeConfig(),
     // Only expose internalUrl in local mode — production uses the public URL directly
     ...(isLocalMode() && { internalUrl: getInternalUrl() }),
+    ...(env.ENABLE_DECO_IMPORT && { enableDecoImport: true }),
   };
 
   return c.json({ success: true, config });

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -47,6 +47,9 @@ const envSchema = z
     DECO_AI_GATEWAY_ENABLED: zBooleanString,
     DECO_AI_GATEWAY_URL: z.string().default("https://ai-site.decocache.com"),
 
+    // Feature Flags
+    ENABLE_DECO_IMPORT: zBooleanString,
+
     // Debug / K8s
     DEBUG_PORT: z.coerce.number().default(9090),
     ENABLE_DEBUG_SERVER: zBooleanString,
@@ -169,6 +172,9 @@ function logConfiguration(e: Env) {
   sect("AI Gateway");
   r("DECO_AI_GATEWAY_ENABLED", e.DECO_AI_GATEWAY_ENABLED);
   r("DECO_AI_GATEWAY_URL", e.DECO_AI_GATEWAY_URL);
+
+  sect("Feature Flags");
+  r("ENABLE_DECO_IMPORT", e.ENABLE_DECO_IMPORT);
 
   sect("Debug / K8s");
   r("DEBUG_PORT", e.DEBUG_PORT);

--- a/apps/mesh/src/web/globals.d.ts
+++ b/apps/mesh/src/web/globals.d.ts
@@ -1,2 +1,1 @@
 declare const __MESH_VERSION__: string;
-declare const __ENABLE_DECO_IMPORT__: boolean;

--- a/apps/mesh/src/web/hooks/use-public-config.ts
+++ b/apps/mesh/src/web/hooks/use-public-config.ts
@@ -1,0 +1,12 @@
+import { useQueryClient } from "@tanstack/react-query";
+import type { PublicConfig } from "@/api/routes/public-config";
+import { KEYS } from "@/web/lib/query-keys";
+
+/**
+ * Reads the public config from the query cache.
+ * The data is populated by ThemeProvider's useSuspenseQuery on app load.
+ */
+export function usePublicConfig(): PublicConfig {
+  const queryClient = useQueryClient();
+  return queryClient.getQueryData<PublicConfig>(KEYS.publicConfig()) ?? {};
+}

--- a/apps/mesh/src/web/routes/projects-list.tsx
+++ b/apps/mesh/src/web/routes/projects-list.tsx
@@ -8,6 +8,7 @@ import { ProjectCard } from "@/web/components/project-card";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { CreateProjectDialog } from "@/web/components/create-project-dialog";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -37,6 +38,7 @@ function ImportFromDecoButton() {
 export default function ProjectsListPage() {
   const { org } = useProjectContext();
   const { data: projects, isLoading } = useProjects(org.id);
+  const { enableDecoImport } = usePublicConfig();
   const [search, setSearch] = useState("");
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const navigate = useNavigate();
@@ -79,7 +81,7 @@ export default function ProjectsListPage() {
           </Breadcrumb>
         </Page.Header.Left>
         <Page.Header.Right>
-          {__ENABLE_DECO_IMPORT__ && <ImportFromDecoButton />}
+          {enableDecoImport && <ImportFromDecoButton />}
           <Button onClick={handleCreateProject} size="sm">
             <Plus size={14} />
             Create Project

--- a/apps/mesh/vite.config.ts
+++ b/apps/mesh/vite.config.ts
@@ -8,9 +8,6 @@ import pkg from "./package.json" with { type: "json" };
 export default defineConfig({
   define: {
     __MESH_VERSION__: JSON.stringify(pkg.version),
-    __ENABLE_DECO_IMPORT__: JSON.stringify(
-      process.env.ENABLE_DECO_IMPORT === "true",
-    ),
   },
   server: {
     hmr: {


### PR DESCRIPTION
## What is this contribution about?

Convert `ENABLE_DECO_IMPORT` from a Vite build-time constant to a runtime environment variable. This allows self-hosted instances and Kubernetes deployments to control the feature without rebuilding the client image.

**Before:** The flag was read from `process.env` during the Vite build and hardcoded into the bundle, making it impossible for self-hosted users to enable the feature.

**After:** The flag is stored in `env.ts`, exposed via `GET /api/config` endpoint, and consumed at runtime by the UI component via a new `usePublicConfig()` hook.

## How to Test

1. In production (or any deployment), set `ENABLE_DECO_IMPORT=true` as an environment variable
2. Restart the pods to pick up the new env var
3. Navigate to the Projects page
4. Verify the "Import from deco.cx" button appears in the top right
5. Set `ENABLE_DECO_IMPORT=false` and restart pods
6. Verify the button disappears

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working (type check and format pass)
- [x] No breaking changes (config endpoint is backward compatible — `enableDecoImport` is optional)
- [x] Self-hosted instances can now control this feature via env var

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `ENABLE_DECO_IMPORT` from a build-time define to a runtime env flag exposed via `GET /api/config` so self-hosted and Kubernetes deployments can toggle the deco import feature without rebuilding. The UI reads the flag via `usePublicConfig()` to show or hide the "Import from deco.cx" button at runtime.

- **Refactors**
  - Add `ENABLE_DECO_IMPORT` to the server env schema.
  - Expose `enableDecoImport` in public config via `GET /api/config`.
  - Add `usePublicConfig()` hook to read cached config.
  - Gate the import button in `projects-list.tsx` using `enableDecoImport`.
  - Remove `__ENABLE_DECO_IMPORT__` from `vite.config.ts` and `globals.d.ts` (no rebuild needed to toggle).

<sup>Written for commit 3b541b75790442a92bfdf42d62d5d538c9cb2801. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

