### PR TITLE
feat(claude-code): add --scope user flag to sharing command

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -157,7 +157,7 @@ function InstallClaudeButton({ url, serverName }: ShareWithNameProps) {
       },
     };
     const configJson = JSON.stringify(connectionConfig, null, 2);
-    const command = `claude mcp add-json "${slugifiedServerName}" '${configJson.replace(/'/g, "'\\''")}'`;
+    const command = `claude mcp add-json "${slugifiedServerName}" '${configJson.replace(/'/g, "'\\''")}'  --scope user`;
 
     await navigator.clipboard.writeText(command);
     setCopied(true);


### PR DESCRIPTION
## What is this contribution about?
Adds the `--scope user` flag to the Claude Code MCP installation command generated in the sharing modal. This ensures MCP instances are installed at user scope by default rather than workspace scope.

## How to Test
1. Open the virtual MCP share modal in Claude Code
2. Click "Install on Claude" to generate the sharing command
3. Verify the command includes `--scope user` at the end

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--scope user` to the `claude mcp add-json` command generated by the Virtual MCP share modal, so Claude Code MCP installations default to user scope instead of workspace scope.

<sup>Written for commit e67fb40ce6a24693c337f6663a920c819cca80f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

