### PR TITLE
fix(chat): fallback to decopilot ID when no agent is selected

### DIFF
--- a/apps/mesh/src/web/components/chat/ice-breakers.tsx
+++ b/apps/mesh/src/web/components/chat/ice-breakers.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   getPrompt,
+  getWellKnownDecopilotVirtualMCP,
   useMCPClient,
   useMCPPromptsList,
   useProjectContext,
@@ -337,7 +338,9 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
  */
 export function IceBreakers({ className }: IceBreakersProps) {
   const { selectedVirtualMcp } = useChatStable();
-  const connectionId = selectedVirtualMcp?.id ?? null;
+  const { org } = useProjectContext();
+  const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+  const connectionId = selectedVirtualMcp?.id ?? decopilotId;
 
   return (
     <div

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -381,6 +381,9 @@ export function ChatInput({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
+  const { org } = useProjectContext();
+  const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+
   const task = tasks.find((task) => task.id === activeTaskId);
 
   // tiptapDoc lives here (not in context) so keystrokes don't re-render
@@ -578,7 +581,7 @@ export function ChatInput({
                 <TiptapInput
                   ref={tiptapRef}
                   disabled={isStreaming || !model}
-                  virtualMcpId={selectedVirtualMcp?.id ?? null}
+                  virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
                   showFileUploader={true}
                   selectedModel={model}
                 />
@@ -597,7 +600,7 @@ export function ChatInput({
                       Run in progress
                     </span>
                   )}
-                  {selectedVirtualMcp && isDecopilot(selectedVirtualMcp.id) ? (
+                  {!selectedVirtualMcp || isDecopilot(selectedVirtualMcp.id) ? (
                     <DecopilotIconButton
                       onVirtualMcpChange={setVirtualMcpId}
                       virtualMcps={virtualMcps}


### PR DESCRIPTION
## What is this contribution about?

When no virtual MCP agent is selected in the UI, the `virtualMcpId` was passed as `null` to icebreakers, slash command (`/`) prompts, and resource (`@`) mentions. This caused these features to not load any data since they queried with a null connection ID.

This fix ensures all three code paths fall back to the well-known decopilot virtual MCP ID instead of `null`:

- **`ice-breakers.tsx`**: `connectionId` now falls back to `decopilotId` so icebreaker prompts load correctly
- **`input.tsx`**: `virtualMcpId` passed to `TiptapInput` (and thus to `PromptsMention` / `ResourcesMention`) now falls back to `decopilotId`
- **`input.tsx`**: The agent selector condition now treats a null `selectedVirtualMcp` as decopilot, showing the `DecopilotIconButton` instead of the generic `VirtualMCPSelector`

## Screenshots/Demonstration

N/A

## How to Test

1. Open the chat UI without selecting any agent (no virtual MCP selected)
2. Verify icebreaker prompts appear (they should load from decopilot)
3. Type `/` in the chat input and verify slash command prompts appear
4. Type `@` in the chat input and verify resource mentions appear
5. Verify the bottom-left of the input shows the Decopilot icon button (dashed border with gradient), not a generic "Agent" selector
6. Select a non-decopilot agent, verify it works as before
7. Reset back to no agent, verify it falls back to decopilot behavior

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat prompts when no agent is selected by falling back to the well-known decopilot virtual MCP ID instead of null. Icebreakers, slash (/) commands, and resource (@) mentions now load correctly, and the input shows the Decopilot button.

- **Bug Fixes**
  - Icebreakers: use `decopilotId` as `connectionId` fallback.
  - Input: pass `decopilotId` to `TiptapInput` as `virtualMcpId`.
  - Input: treat no selected agent as decopilot; show `DecopilotIconButton`.

<sup>Written for commit b1706ea17c89d74a9b26e4fb3b3c3204f06aadc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

