### PR TITLE
 feat(store): make Deco Store first and default in registry select and default to 'All' in connections

### DIFF
--- a/apps/mesh/src/web/hooks/use-store-discovery.ts
+++ b/apps/mesh/src/web/hooks/use-store-discovery.ts
@@ -27,6 +27,8 @@ interface UseStoreDiscoveryOptions {
   filtersToolName?: string;
   /** Search term for server-side filtering */
   search?: string;
+  /** Whether to enable fetching. Defaults to true. */
+  enabled?: boolean;
 }
 
 interface UseStoreDiscoveryResult {
@@ -72,6 +74,7 @@ export function useStoreDiscovery({
   listToolName,
   filtersToolName,
   search,
+  enabled = true,
 }: UseStoreDiscoveryOptions): UseStoreDiscoveryResult {
   const { org } = useProjectContext();
   // Filter state
@@ -99,6 +102,7 @@ export function useStoreDiscovery({
       })) as { structuredContent?: unknown };
       return (result.structuredContent ?? result) as RegistryFiltersResponse;
     },
+    enabled: enabled && hasFiltersSupport,
     staleTime: 60 * 60 * 1000, // 1 hour - filters don't change often
     retry: 2,
   });
@@ -165,6 +169,7 @@ export function useStoreDiscovery({
       }
       return undefined;
     },
+    enabled,
     staleTime: 60 * 60 * 1000,
     placeholderData: keepPreviousData,
     retry: 2,

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -83,6 +83,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import {
   ORG_ADMIN_PROJECT_SLUG,
   SELF_MCP_ALIAS_ID,
+  WellKnownOrgMCPId,
   useConnectionActions,
   useConnections,
   useMCPClient,
@@ -93,7 +94,8 @@ import {
 } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { PLUGIN_ID as PRIVATE_REGISTRY_PLUGIN_ID } from "mesh-plugin-private-registry/shared";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
   CheckSquare,
@@ -788,7 +790,7 @@ function BulkDeleteDialog({
 // ===========================================================================
 
 function OrgMcpsContent() {
-  const { org } = useProjectContext();
+  const { org, project } = useProjectContext();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as {
@@ -826,7 +828,7 @@ function OrgMcpsContent() {
     (existing) =>
       search.tab === "all" || search.tab === "connected"
         ? search.tab
-        : (existing ?? "all"),
+        : (existing ?? "connected"),
   );
 
   // Type & status filters
@@ -863,30 +865,44 @@ function OrgMcpsContent() {
   };
 
   // Optional registry lookup: support multiple registries, let user pick on "All" tab
-  // Sort so the self/management MCP (Mesh MCP) appears last — external registries like
-  // Deco Store / MCP Registry should be the default catalog source.
-  const registryConnections = useRegistryConnections(allConnections).sort(
-    (a, b) => {
-      const isSelfA = a.app_name === "@deco/management-mcp";
-      const isSelfB = b.app_name === "@deco/management-mcp";
-      if (isSelfA && !isSelfB) return 1;
-      if (!isSelfA && isSelfB) return -1;
-      return 0;
-    },
+  // Sort so the Deco Store appears first, and self/management MCP appears last.
+  // Filter out self MCP unless private registry plugin is enabled.
+  const decoStoreRegistryId = WellKnownOrgMCPId.REGISTRY(org.id);
+  const selfMcpId = WellKnownOrgMCPId.SELF(org.id);
+  const isPrivateRegistryEnabled = (project.enabledPlugins ?? []).includes(
+    PRIVATE_REGISTRY_PLUGIN_ID,
   );
+  const registryConnections = useRegistryConnections(allConnections)
+    .filter((c) => {
+      if (c.id !== selfMcpId) return true;
+      return isPrivateRegistryEnabled;
+    })
+    .sort((a, b) => {
+      if (a.id === decoStoreRegistryId) return -1;
+      if (b.id === decoStoreRegistryId) return 1;
+      if (a.id === selfMcpId) return 1;
+      if (b.id === selfMcpId) return -1;
+      return 0;
+    });
   const [selectedRegistryId, setSelectedRegistryId] = useLocalStorage<string>(
     LOCALSTORAGE_KEYS.selectedRegistry(org.slug),
     (existing) => existing ?? "",
   );
+  const decoStoreRegistry = registryConnections.find(
+    (r) => r.id === decoStoreRegistryId,
+  );
   const registryConnection =
     (selectedRegistryId
       ? registryConnections.find((r) => r.id === selectedRegistryId)
-      : undefined) ?? registryConnections[0];
+      : undefined) ??
+    decoStoreRegistry ??
+    registryConnections[0];
   const registryId = registryConnection?.id ?? "";
   const registryListToolName = findListToolName(registryConnection?.tools);
   const registryDiscovery = useStoreDiscovery({
     registryId,
     listToolName: registryListToolName,
+    enabled: activeTab === "all" || Boolean(listState.search),
   });
   const registryItems = registryDiscovery.items;
 
@@ -1234,6 +1250,48 @@ function OrgMcpsContent() {
   const selfClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
+  });
+
+  const hasSelfMcpRegistry = registryConnections.some(
+    (c) => c.id === selfMcpId,
+  );
+  const { data: registryPluginConfig } = useQuery({
+    queryKey: KEYS.projectPluginConfig(
+      project.id ?? "",
+      PRIVATE_REGISTRY_PLUGIN_ID,
+    ),
+    queryFn: async () => {
+      const result = (await selfClient.callTool({
+        name: "PROJECT_PLUGIN_CONFIG_GET",
+        arguments: {
+          projectId: project.id,
+          pluginId: PRIVATE_REGISTRY_PLUGIN_ID,
+        },
+      })) as { structuredContent?: Record<string, unknown> };
+      return (result.structuredContent ?? result) as {
+        config?: {
+          settings?: {
+            registryName?: string;
+            registryIcon?: string;
+          };
+        };
+      };
+    },
+    enabled: hasSelfMcpRegistry && !!project.id,
+    staleTime: 60_000,
+  });
+  const registryBranding = registryPluginConfig?.config?.settings;
+
+  // Build display options with branding overrides for the self MCP
+  const registryDisplayOptions = registryConnections.map((c) => {
+    if (c.id === selfMcpId && registryBranding) {
+      return {
+        ...c,
+        title: registryBranding.registryName || c.title,
+        icon: registryBranding.registryIcon || c.icon || undefined,
+      };
+    }
+    return c;
   });
 
   const invalidateConnections = () => {
@@ -2188,7 +2246,7 @@ function OrgMcpsContent() {
               activeTab={activeTab}
               onTabChange={(id) => setActiveTab(id as ConnectionTab)}
             />
-            {registryConnections.length > 0 && (
+            {registryDisplayOptions.length > 0 && (
               <div
                 className={cn(
                   activeTab !== "all" && "invisible pointer-events-none",
@@ -2203,12 +2261,12 @@ function OrgMcpsContent() {
                     >
                       {(() => {
                         const active =
-                          registryConnections.find(
+                          registryDisplayOptions.find(
                             (rc) =>
                               rc.id ===
                               (selectedRegistryId ||
-                                registryConnections[0]?.id),
-                          ) ?? registryConnections[0];
+                                registryDisplayOptions[0]?.id),
+                          ) ?? registryDisplayOptions[0];
                         return (
                           <>
                             <IntegrationIcon
@@ -2228,14 +2286,14 @@ function OrgMcpsContent() {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    {registryConnections.map((rc) => (
+                    {registryDisplayOptions.map((rc) => (
                       <DropdownMenuItem
                         key={rc.id}
                         onClick={() => setSelectedRegistryId(rc.id)}
                         className={cn(
                           selectedRegistryId === rc.id ||
                             (!selectedRegistryId &&
-                              rc.id === registryConnections[0]?.id)
+                              rc.id === registryDisplayOptions[0]?.id)
                             ? "bg-accent"
                             : "",
                         )}

--- a/apps/mesh/src/web/routes/orgs/store/page.tsx
+++ b/apps/mesh/src/web/routes/orgs/store/page.tsx
@@ -88,13 +88,10 @@ export default function StorePage() {
   // tools still appear in the cached array, so the self MCP would incorrectly
   // show up as a registry. Filter it out unless the plugin is actually enabled.
   const selfMcpId = WellKnownOrgMCPId.SELF(org.id);
-  // When enabledPlugins is null (no explicit config), the server treats all
-  // plugins as visible, so we mirror that by not filtering the self MCP.
-  const enabledPlugins = project.enabledPlugins;
-  const isPrivateRegistryEnabled =
-    enabledPlugins === null ||
-    enabledPlugins === undefined ||
-    enabledPlugins.includes(PRIVATE_REGISTRY_PLUGIN_ID);
+  const decoStoreId = WellKnownOrgMCPId.REGISTRY(org.id);
+  const isPrivateRegistryEnabled = (project.enabledPlugins ?? []).includes(
+    PRIVATE_REGISTRY_PLUGIN_ID,
+  );
 
   const registryConnections = allRegistryConnections
     .filter((c) => {
@@ -102,6 +99,8 @@ export default function StorePage() {
       return isPrivateRegistryEnabled;
     })
     .sort((a, b) => {
+      if (a.id === decoStoreId) return -1;
+      if (b.id === decoStoreId) return 1;
       if (a.id === selfMcpId) return 1;
       if (b.id === selfMcpId) return -1;
       return 0;
@@ -170,13 +169,16 @@ export default function StorePage() {
   );
 
   // If there's only one registry, use it; otherwise use the selected one if it still exists.
-  // Prefer a non-self registry as default so the Deco Store (or Community Registry)
-  // is shown instead of the Mesh MCP when nothing is explicitly selected.
+  // Prefer the Deco Store as default, then any non-self registry, then fall back to first.
+  const decoStoreRegistry = registryConnections.find(
+    (c) => c.id === decoStoreId,
+  );
   const firstNonSelfRegistry = registryConnections.find(
     (c) => c.id !== selfMcpId,
   );
   const effectiveRegistry =
     selectedRegistry?.id ||
+    decoStoreRegistry?.id ||
     firstNonSelfRegistry?.id ||
     registryConnections[0]?.id ||
     "";


### PR DESCRIPTION
## What is this contribution about?

Ensures the Deco Store registry always appears first in the registry selector across both the Store page and Connections page, and is set as the default selection when no preference is saved in localStorage.

Changes:
- Updated sort in `store/page.tsx` to prioritize Deco Store first (before other non-self registries)
- Updated default selection logic to prefer Deco Store when no registry is selected
- Applied the same sorting and default selection logic to `connections.tsx`

## How to Test

1. Create a new organization (or clear localStorage for an existing org)
2. Navigate to the Store page — Deco Store should appear first in the registry selector and be automatically selected
3. Navigate to Connections page — the registry dropdown should show Deco Store first and pre-selected by default
4. Verify that manually selecting a different registry persists the choice in localStorage
5. Verify that the self MCP (Deco CMS) still appears last in both views

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Deco Store appear first and be the default registry in Store and Connections when no preference exists. Hide `@deco/management-mcp` unless the `mesh-plugin-private-registry` plugin is enabled; when shown, keep it last and apply plugin branding.

- **New Features**
  - Sort order: Deco Store first; self MCP last when visible.
  - Default selection: prefer Deco Store; else any non-self registry; else first option.
  - Connections: apply `mesh-plugin-private-registry` branding (name/icon) to the self MCP in the dropdown.
  - Discovery: added `enabled` to `useStoreDiscovery` and only fetch on the “All” tab or when searching.

<sup>Written for commit 6d65fe6dd97b5120c7fb0b68868170f2f36e70bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

