### PR TITLE
feat(server): add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -201,6 +201,7 @@ export interface CreateAppOptions {
  */
 export async function createApp(options: CreateAppOptions = {}) {
   const database = options.database ?? getDb();
+  let isShuttingDown = false;
 
   // Clear previous monitoring retention timer (cleanup during HMR)
   if (currentRetentionTimer) {
@@ -410,13 +411,62 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Health Check & Metrics
   // ============================================================================
 
-  // Health check endpoint (no auth required)
+  // Health check endpoint (no auth required) — kept for backwards compatibility
   app.get(SYSTEM_PATHS.HEALTH, (c) => {
     return c.json({
       status: "ok",
       timestamp: new Date().toISOString(),
       version: "1.0.0",
     });
+  });
+
+  // Liveness probe — the process is alive and the event loop is not stuck
+  app.get(SYSTEM_PATHS.HEALTH_LIVE, (c) => {
+    return c.json({ status: "ok" });
+  });
+
+  // Readiness probe — returns 503 during shutdown so K8s drains traffic before liveness fails,
+  // and checks that DB and NATS are reachable
+  app.get(SYSTEM_PATHS.HEALTH_READY, async (c) => {
+    if (isShuttingDown) {
+      return c.json({ status: "shutting_down" }, 503);
+    }
+
+    const [dbResult, natsResult] = await Promise.allSettled([
+      Promise.race([
+        database.db
+          .selectFrom("connections")
+          .select("id")
+          .limit(1)
+          .executeTakeFirst(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("timeout")), 2_000),
+        ),
+      ]),
+      Promise.resolve().then(() => {
+        if (!natsProvider) return "ok"; // local mode: no NATS
+        const nc = natsProvider.getConnection();
+        if (nc.isClosed() || nc.isDraining()) {
+          throw new Error("NATS connection unavailable");
+        }
+        return "ok";
+      }),
+    ]);
+
+    const dbOk = dbResult.status === "fulfilled";
+    const natsOk = natsResult.status === "fulfilled";
+    const ready = dbOk && natsOk;
+
+    return c.json(
+      {
+        status: ready ? "ready" : "not_ready",
+        checks: {
+          db: dbOk ? "ok" : "error",
+          nats: natsOk ? "ok" : "error",
+        },
+      },
+      ready ? 200 : 503,
+    );
   });
 
   // Prometheus metrics endpoint
@@ -1278,6 +1328,10 @@ export async function createApp(options: CreateAppOptions = {}) {
     );
   });
 
+  const markShuttingDown = () => {
+    isShuttingDown = true;
+  };
+
   const shutdown = async () => {
     console.log("[shutdown] Stopping workers...");
 
@@ -1327,5 +1381,5 @@ export async function createApp(options: CreateAppOptions = {}) {
     console.log("[shutdown] Cleanup complete.");
   };
 
-  return Object.assign(app, { shutdown });
+  return Object.assign(app, { markShuttingDown, shutdown });
 }

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -8,6 +8,8 @@
 /** System paths that don't require authentication or special handling */
 export const SYSTEM_PATHS = {
   HEALTH: "/health",
+  HEALTH_LIVE: "/health/live",
+  HEALTH_READY: "/health/ready",
   METRICS: "/metrics",
 } as const;
 
@@ -29,6 +31,8 @@ const STATIC_FILE_PATTERN =
 function isSystemPath(path: string): boolean {
   return (
     path === SYSTEM_PATHS.HEALTH ||
+    path === SYSTEM_PATHS.HEALTH_LIVE ||
+    path === SYSTEM_PATHS.HEALTH_READY ||
     path === SYSTEM_PATHS.METRICS ||
     path.startsWith(PATH_PREFIXES.WELL_KNOWN)
   );

--- a/apps/mesh/src/env.ts
+++ b/apps/mesh/src/env.ts
@@ -34,7 +34,10 @@ const envSchema = z
     OTEL_SERVICE_NAME: z.string().default("mesh"),
 
     // Event Bus & Networking
-    NATS_URL: z.string().default("nats://localhost:4222"),
+    NATS_URL: z
+      .string()
+      .default("nats://localhost:4222")
+      .transform((s) => s.split(",").map((u) => u.trim())),
 
     // Config files
     CONFIG_PATH: z.string().default("./config.json"),
@@ -173,7 +176,7 @@ function logConfiguration(e: Env) {
   r("OTEL_SERVICE_NAME", e.OTEL_SERVICE_NAME);
 
   sect("Event Bus & Networking");
-  r("NATS_URL", e.NATS_URL);
+  r("NATS_URL", e.NATS_URL.join(", "));
 
   sect("Config Files");
   r("CONFIG_PATH", e.CONFIG_PATH);

--- a/apps/mesh/src/fmt.ts
+++ b/apps/mesh/src/fmt.ts
@@ -6,7 +6,6 @@
  */
 
 export const dim = (s: string) => `\x1b[2m${s}\x1b[22m`;
-export const underline = (s: string) => `\x1b[4m${s}\x1b[24m`;
 export const green = (s: string) => `\x1b[32m${s}\x1b[39m`;
 export const yellow = (s: string) => `\x1b[33m${s}\x1b[39m`;
 export const cyan = (s: string) => `\x1b[36m${s}\x1b[39m`;

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -15,13 +15,10 @@ import {
 } from "@decocms/runtime/asset-server";
 import { createApp } from "./api/app";
 import { isServerPath } from "./api/utils/paths";
-import { startDebugServer } from "./debug";
 import { env, logConfiguration } from "./env";
-import { cyan, dim, red, underline } from "./fmt";
+import { red } from "./fmt";
 
 const port = env.PORT;
-const debugPort = env.DEBUG_PORT;
-const enableDebugServer = env.ENABLE_DEBUG_SERVER;
 
 // Refuse local mode in production — it disables authentication
 if (
@@ -127,17 +124,6 @@ if (env.DECOCMS_LOCAL_MODE) {
     });
 }
 
-// Internal debug server (only enabled via ENABLE_DEBUG_SERVER=true)
-let debugServer: ReturnType<typeof Bun.serve> | undefined;
-if (enableDebugServer) {
-  debugServer = startDebugServer({ port: debugPort });
-
-  console.log(
-    `  ${dim("Debug server:")}     ${cyan(underline(`http://localhost:${debugPort}`))}`,
-  );
-  console.log("");
-}
-
 // ============================================================================
 // Graceful Shutdown
 // ============================================================================
@@ -150,19 +136,25 @@ async function gracefulShutdown(signal: string) {
   console.log(`\n[shutdown] Received ${signal}, shutting down gracefully...`);
 
   const forceExitTimer = setTimeout(() => {
-    console.error("[shutdown] Timed out after 10s, forcing exit.");
+    console.error("[shutdown] Timed out after 55s, forcing exit.");
     process.exit(1);
-  }, 10_000);
+  }, 55_000);
   forceExitTimer.unref?.();
 
   let exitCode = 0;
   try {
-    // Stop accepting new connections, force-close active ones
-    // (SSE streams are long-lived and would block graceful drain indefinitely)
-    await server.stop(true);
-    await debugServer?.stop(true);
+    // 1. Mark as shutting down — readiness returns 503 immediately
+    app.markShuttingDown();
 
-    // Stop workers, flush telemetry, close DB
+    // 2. Give K8s time to notice the 503 and stop routing traffic before
+    //    we close connections (~2s is enough for most configurations)
+    await new Promise((r) => setTimeout(r, 2_000));
+
+    // 3. Stop accepting new connections, force-close active ones
+    //    (SSE streams are long-lived and would block graceful drain indefinitely)
+    await server.stop(true);
+
+    // 3. Stop workers, flush telemetry, close DB
     await app.shutdown();
   } catch (err) {
     console.error("[shutdown] Error during shutdown:", err);

--- a/deploy/docker-compose/docker-compose.dev.yml
+++ b/deploy/docker-compose/docker-compose.dev.yml
@@ -1,0 +1,88 @@
+# Local development infrastructure
+#
+# Starts PostgreSQL and a 3-node NATS JetStream cluster — mirrors production topology.
+# The studio server itself runs from source via: bun run --cwd=apps/mesh dev:server
+#
+# Usage:
+#   docker compose -f deploy/docker-compose/docker-compose.dev.yml up -d
+#
+# Connection strings to use when running the server locally:
+#   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+#   NATS_URL=nats://localhost:4222   (client_advertise propaga os outros nós automaticamente)
+#
+# Example:
+#   DECOCMS_LOCAL_MODE=true bun run --cwd=apps/mesh dev:server
+
+services:
+  # ============================================================================
+  # PostgreSQL
+  # ============================================================================
+  postgres:
+    image: postgres:15-alpine
+    container_name: decocms-dev-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-dev-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ============================================================================
+  # NATS JetStream cluster (3 nodes — mirrors production)
+  # ============================================================================
+  nats-1:
+    image: nats:latest
+    container_name: decocms-dev-nats-1
+    restart: unless-stopped
+    ports:
+      - "4222:4222"   # client
+      - "8222:8222"   # monitoring (http://localhost:8222)
+    command: >
+      -js
+      -n nats-1
+      -cluster_name decocms-dev
+      -client_advertise localhost:4222
+      -cluster nats://0.0.0.0:6222
+      -routes nats://nats-2:6222,nats://nats-3:6222
+      -m 8222
+
+  nats-2:
+    image: nats:latest
+    container_name: decocms-dev-nats-2
+    restart: unless-stopped
+    ports:
+      - "4223:4222"   # client
+    command: >
+      -js
+      -n nats-2
+      -cluster_name decocms-dev
+      -client_advertise localhost:4223
+      -cluster nats://0.0.0.0:6222
+      -routes nats://nats-1:6222,nats://nats-3:6222
+
+  nats-3:
+    image: nats:latest
+    container_name: decocms-dev-nats-3
+    restart: unless-stopped
+    ports:
+      - "4224:4222"   # client
+    command: >
+      -js
+      -n nats-3
+      -cluster_name decocms-dev
+      -client_advertise localhost:4224
+      -cluster nats://0.0.0.0:6222
+      -routes nats://nats-1:6222,nats://nats-2:6222
+
+
+volumes:
+  postgres-dev-data:
+    driver: local

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: A Helm chart for deco Studio self-hosted deployment
 type: application
-version: 0.1.40
+version: 0.1.41
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -97,7 +97,7 @@ securityContext:
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /health/live
     port: http
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -105,12 +105,14 @@ livenessProbe:
   failureThreshold: 3
 readinessProbe:
   httpGet:
-    path: /health
+    path: /health/ready
     port: http
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 3
   failureThreshold: 4
+
+terminationGracePeriodSeconds: 60
 
 # Optional lifecycle hooks (preStop, postStart)
 # lifecycle: {}


### PR DESCRIPTION
## What is this contribution about?

Adds graceful shutdown handling when the MCP Mesh server receives SIGTERM (K8s pod termination) or SIGINT (Ctrl+C). Previously, all resources — database connections, NATS subscriptions, event bus workers, in-flight telemetry — were abandoned without cleanup.

The shutdown sequence follows a strict order: stop HTTP servers → stop workers in parallel (EventBus, SSE hub, cron, decopilot) → drain NATS (after all consumers stopped) → flush telemetry → close database. A 10-second force-exit timeout prevents the process from hanging indefinitely.

Two-file change using `Object.assign(app, { shutdown })` to preserve backward compatibility with existing tests.

## How to Test

1. `bun run dev`, then press Ctrl+C
2. Should see `[shutdown] Received SIGINT...` → `[shutdown] Stopping workers...` → `[shutdown] Cleanup complete.`
3. `bun run dev`, then in another terminal `kill -TERM <pid>` — same clean shutdown behavior
4. `bun run check` passes, `bun test apps/mesh/src/api/` passes (317 tests)

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add graceful shutdown on SIGTERM/SIGINT and separate liveness/readiness probes. Ensures clean shutdown, prevents lost data, and improves K8s draining during rollouts.

- New Features
  - Shutdown sequence: stop HTTP server first (force-close SSE), stop workers in parallel (EventBus, SSE hub, cron, decopilot), drain NATS, flush telemetry, then close the DB.
  - Added `/health/live` and `/health/ready`; readiness checks DB and NATS, returns 503 during shutdown via `app.markShuttingDown()`. `/health` kept for compatibility.
  - Installed SIGTERM/SIGINT handlers with a 2s pre-stop delay and a 55s force-exit timeout; exposes `app.shutdown()`.
  - `NATS_URL` now accepts comma-separated URLs for cluster failover.
  - Helm chart bumped to 0.1.41 with new probe paths and `terminationGracePeriodSeconds=60`; added `deploy/docker-compose/docker-compose.dev.yml` for local Postgres and a 3-node NATS cluster.

<sup>Written for commit fee6fc493589af56b750374e161ec1de90d4a796. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

