### PR TITLE
fix(cli): intercept console output for TUI in serve mode

### DIFF
--- a/apps/mesh/src/api/utils/dev-logger.ts
+++ b/apps/mesh/src/api/utils/dev-logger.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from "hono";
+import { isTuiConsoleIntercepted } from "../../cli/cli-store";
 import { logEmitter } from "../../cli/log-emitter";
 
 // ANSI color codes for elegant logging
@@ -127,12 +128,14 @@ export function devLogger() {
       displayPath = `${colors.mcp}/mcp/registry${colors.reset}`;
     }
 
-    // Log incoming request
+    // Log incoming request (skip when TUI intercepts console to avoid duplicates)
     const methodColor = getMethodColor(method);
     const arrow = isMcpCall ? "◀" : "←";
-    console.log(
-      `${colors.dim}${arrow}${colors.reset} ${methodColor}${method}${colors.reset} ${displayPath}${mcpInfo ? ` ${mcpInfo}` : ""}`,
-    );
+    if (!isTuiConsoleIntercepted()) {
+      console.log(
+        `${colors.dim}${arrow}${colors.reset} ${methodColor}${method}${colors.reset} ${displayPath}${mcpInfo ? ` ${mcpInfo}` : ""}`,
+      );
+    }
 
     // Wrap next() in try/finally to ensure completion logs always run
     // even if downstream throws an error
@@ -146,9 +149,11 @@ export function devLogger() {
         duration < 1000 ? `${duration}ms` : `${(duration / 1000).toFixed(1)}s`;
       const outArrow = isMcpCall ? "▶" : "→";
 
-      console.log(
-        `${colors.dim}${outArrow}${colors.reset} ${methodColor}${method}${colors.reset} ${displayPath}${mcpInfo ? ` ${mcpInfo}` : ""} ${statusColor}${status}${colors.reset} ${colors.duration}${durationStr}${colors.reset}`,
-      );
+      if (!isTuiConsoleIntercepted()) {
+        console.log(
+          `${colors.dim}${outArrow}${colors.reset} ${methodColor}${method}${colors.reset} ${displayPath}${mcpInfo ? ` ${mcpInfo}` : ""} ${statusColor}${status}${colors.reset} ${colors.duration}${durationStr}${colors.reset}`,
+        );
+      }
 
       // Emit to Ink UI log emitter
       logEmitter.emit("request", {

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -253,7 +253,7 @@ const serveOptions = {
   port: values.port!,
   home: decoHome,
   skipMigrations: values["skip-migrations"] === true,
-  localMode: values["local-mode"] === true,
+  localMode: values["no-local-mode"] !== true,
 };
 
 const noTui = values["no-tui"] === true || !process.stdout.isTTY;
@@ -275,9 +275,12 @@ if (noTui) {
   const { render } = await import("ink");
   const { createElement } = await import("react");
   const { App } = await import("./cli/app");
-  const { startServer } = await import("./cli/commands/serve");
+  const { startServer, interceptConsoleForTui } = await import(
+    "./cli/commands/serve"
+  );
 
   const displayHome = decoHome.replace(homedir(), "~");
+  interceptConsoleForTui();
   render(createElement(App, { home: displayHome }));
 
   await startServer(serveOptions);

--- a/apps/mesh/src/cli/cli-store.ts
+++ b/apps/mesh/src/cli/cli-store.ts
@@ -91,3 +91,17 @@ export function toggleViewMode() {
   };
   emit();
 }
+
+/**
+ * When true, console output is being intercepted for TUI rendering.
+ * devLogger should skip its own console.log calls to avoid duplicates.
+ */
+let tuiConsoleIntercepted = false;
+
+export function setTuiConsoleIntercepted(value: boolean) {
+  tuiConsoleIntercepted = value;
+}
+
+export function isTuiConsoleIntercepted(): boolean {
+  return tuiConsoleIntercepted;
+}

--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -8,9 +8,11 @@ import { chmod, mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { resolveSecrets, type SecretsFile } from "./resolve-secrets";
 import {
+  addLogEntry,
   setEnv,
   setMigrationsDone,
   setServerUrl,
+  setTuiConsoleIntercepted,
   updateService,
 } from "../cli-store";
 import type { ServiceStatus } from "../header";
@@ -20,6 +22,57 @@ export interface ServeOptions {
   home: string;
   skipMigrations: boolean;
   localMode: boolean;
+}
+
+// Strip ANSI escape codes from a string
+function stripAnsi(str: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI codes requires matching control chars
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/**
+ * Intercept console.log/warn/error so in-process server output
+ * (e.g. Better Auth errors, library logs) is routed through the CLI store
+ * instead of corrupting the Ink TUI rendering.
+ *
+ * We patch console methods (not process.stdout.write) because Ink manages
+ * stdout.write directly for its own rendering.
+ */
+export function interceptConsoleForTui() {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  function capture(...args: unknown[]) {
+    const text = args
+      .map((a) => (typeof a === "string" ? a : Bun.inspect(a)))
+      .join(" ");
+
+    for (const raw of text.split("\n")) {
+      const stripped = stripAnsi(raw).trim();
+      if (!stripped) continue;
+      addLogEntry({
+        method: "",
+        path: "",
+        status: 0,
+        duration: 0,
+        timestamp: new Date(),
+        rawLine: stripped,
+      });
+    }
+  }
+
+  console.log = capture;
+  console.warn = capture;
+  console.error = capture;
+  setTuiConsoleIntercepted(true);
+
+  return () => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+    setTuiConsoleIntercepted(false);
+  };
 }
 
 export async function startServer(options: ServeOptions): Promise<void> {


### PR DESCRIPTION
## What is this contribution about?

When running `bunx decocms@latest` (serve mode), server log lines from libraries like Better Auth were written directly to stdout via `console.log`/`console.error`, corrupting the Ink TUI rendering. This happened because in serve mode the server runs in-process (unlike dev mode which spawns a child process with piped stdio).

This PR:
- Adds a `interceptConsoleForTui()` function that patches `console.log`, `console.warn`, and `console.error` to route output through the CLI store's log entries, so they render properly in the TUI
- Guards `devLogger` middleware's `console.log` calls to avoid duplicate entries when the TUI interceptor is active
- Changes serve mode to default to local mode (auto-login), matching dev mode behavior

## Screenshots/Demonstration
N/A

## How to Test
1. Run `bunx decocms` (or `bun run apps/mesh/src/cli.ts`)
2. Observe that server startup logs (e.g., Better Auth errors, migration output) appear within the TUI log panel instead of corrupting the terminal
3. Verify HTTP request logs still display correctly in the TUI
4. Run with `--no-tui` and confirm plain console output still works
5. Confirm local mode is enabled by default (auto-login without needing `--local-mode` flag)

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Intercepts server console output in serve mode so logs render in the Ink TUI without corrupting the UI. Serve now defaults to local mode (auto-login); use `--no-local-mode` to opt out.

- **Bug Fixes**
  - Added `interceptConsoleForTui()` to patch `console.log`/`console.warn`/`console.error` and route lines to the CLI store for TUI rendering.
  - Guarded `devLogger` to skip console writes when interception is active, avoiding duplicate entries.
  - Kept plain console output unchanged when `--no-tui` is used or no TTY is detected.

- **New Features**
  - Serve mode defaults to local mode; disable with `--no-local-mode`.

<sup>Written for commit f24623ec863371c0934385323b47d9774d8dcb96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

