### PR TITLE
fix(cli): use deterministic default for ENCRYPTION_KEY in multi-pod deployments

### DIFF
--- a/apps/mesh/src/cli/commands/resolve-secrets.test.ts
+++ b/apps/mesh/src/cli/commands/resolve-secrets.test.ts
@@ -50,6 +50,14 @@ describe("resolveSecrets", () => {
 
       expect(secrets.ENCRYPTION_KEY).toBe("env-value");
     });
+
+    it("should preserve env ENCRYPTION_KEY empty string over saved value", () => {
+      const saved: SecretsFile = { ENCRYPTION_KEY: "saved-value" };
+      const env = { ENCRYPTION_KEY: "" };
+      const { secrets } = resolveSecrets(saved, env);
+
+      expect(secrets.ENCRYPTION_KEY).toBe("");
+    });
   });
 
   describe("generation of missing secrets", () => {
@@ -61,12 +69,10 @@ describe("resolveSecrets", () => {
       expect(modified).toBe(true);
     });
 
-    it("should generate ENCRYPTION_KEY when missing from both env and file", () => {
-      const { secrets, modified } = resolveSecrets({}, emptyEnv);
+    it("should default ENCRYPTION_KEY to empty string when missing from both env and file", () => {
+      const { secrets } = resolveSecrets({}, emptyEnv);
 
-      expect(secrets.ENCRYPTION_KEY).toBeTruthy();
-      expect(Buffer.from(secrets.ENCRYPTION_KEY, "base64").length).toBe(32);
-      expect(modified).toBe(true);
+      expect(secrets.ENCRYPTION_KEY).toBe("");
     });
 
     it("should generate LOCAL_ADMIN_PASSWORD when missing", () => {

--- a/apps/mesh/src/cli/commands/resolve-secrets.ts
+++ b/apps/mesh/src/cli/commands/resolve-secrets.ts
@@ -43,14 +43,19 @@ export function resolveSecrets(
   }
 
   // ENCRYPTION_KEY
+  // Use != null (not truthy) so that an empty-string env var is preserved.
+  // When neither env nor saved provides a value, default to "" rather than a
+  // random key — CredentialVault hashes "" deterministically via SHA-256,
+  // which keeps all replicas / restarts consistent.  A random fallback would
+  // silently produce a different key on every pod start, making previously
+  // encrypted data unreadable.
   let encryptionKey: string;
-  if (env.ENCRYPTION_KEY) {
+  if (env.ENCRYPTION_KEY != null) {
     encryptionKey = env.ENCRYPTION_KEY;
   } else if (saved.ENCRYPTION_KEY != null) {
     encryptionKey = saved.ENCRYPTION_KEY;
   } else {
-    encryptionKey = crypto.randomBytes(32).toString("base64");
-    modified = true;
+    encryptionKey = "";
   }
 
   // LOCAL_ADMIN_PASSWORD


### PR DESCRIPTION
## What is this contribution about?

Fixes the persistent "Unsupported state or unable to authenticate data" error in `fireAutomation` on staging/production Kubernetes deployments.

**Root cause:** `resolveSecrets()` used a truthy check for `env.ENCRYPTION_KEY` (line 47). In K8s pods where `ENCRYPTION_KEY` is either unset or set to `""`, each pod generated a **new random encryption key** on every startup. With 3 replicas, data encrypted by one pod couldn't be decrypted by another — causing AES-256-GCM authentication failures.

**Fixes:**
1. Changed `env.ENCRYPTION_KEY` check from truthy to `!= null` (consistent with the saved-file check from #2785)
2. Default to `""` instead of `crypto.randomBytes(32)` when no key exists — `CredentialVault` hashes `""` deterministically via SHA-256, keeping all pods/restarts consistent

This is the follow-up to #2785 which only fixed the `saved` check but left the `env` check as truthy.

## Screenshots/Demonstration

N/A

## How to Test

1. Run `bun test apps/mesh/src/cli/commands/resolve-secrets.test.ts` — all 11 tests pass
2. Verify that `resolveSecrets({}, {})` returns `ENCRYPTION_KEY: ""` (not a random base64 string)
3. Verify that `resolveSecrets({}, { ENCRYPTION_KEY: "" })` returns `ENCRYPTION_KEY: ""` (not falling through to random generation)
4. Deploy to staging and confirm `fireAutomation` no longer throws "Unsupported state or unable to authenticate data"

## Migration Notes

**Important:** If `ENCRYPTION_KEY` was previously unset in the K8s secret and data was encrypted with random keys, that data is already unrecoverable. After this fix, all new encryption will use the deterministic empty-string-derived key. For production, you should still set a proper `ENCRYPTION_KEY` value in the K8s secret (`openssl rand -base64 32`).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AES-GCM decryption errors in multi-pod deployments by making `ENCRYPTION_KEY` resolution deterministic across pods and restarts.

- **Bug Fixes**
  - Preserve `env.ENCRYPTION_KEY` when it is an empty string (`!= null` check).
  - Default `ENCRYPTION_KEY` to `""` when missing from env and file; `CredentialVault` derives a stable SHA-256 key.
  - Updated tests to cover the empty-string case and deterministic default.

- **Migration**
  - Any data encrypted while `ENCRYPTION_KEY` was unset and randomly generated is unrecoverable.
  - Set a real `ENCRYPTION_KEY` in your K8s secret for production (e.g., `openssl rand -base64 32`).

<sup>Written for commit 7498390d2b29d58b4753aaaa8cd5ce60bb6b4778. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

