### PR TITLE
fix(cli): disable Ink patchConsole to fix TUI layout in serve mode

### DIFF
--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -229,7 +229,9 @@ if (command === "dev") {
 
     const displayHome = decoHome.replace(homedir(), "~");
     setDevMode();
-    render(createElement(App, { home: displayHome }));
+    render(createElement(App, { home: displayHome }), {
+      patchConsole: false,
+    });
 
     const result = await startDevServer(devOptions);
     const code = await result.process.exited;
@@ -281,7 +283,9 @@ if (noTui) {
 
   const displayHome = decoHome.replace(homedir(), "~");
   interceptConsoleForTui();
-  render(createElement(App, { home: displayHome }));
+  render(createElement(App, { home: displayHome }), {
+    patchConsole: false,
+  });
 
   await startServer(serveOptions);
 }


### PR DESCRIPTION
## What is this contribution about?

Ink v6 defaults to `patchConsole: true`, which overwrites our `interceptConsoleForTui()` and renders server console output as static text **above** the header, pushing the TUI down over time. This passes `patchConsole: false` to both `render()` calls (serve and dev mode) so our own console interceptor stays active and routes output through the `RequestLog` component below the header.

## How to Test

1. Run `bunx decocms@latest` (or build locally and run serve mode)
2. Observe the TUI: header should stay fixed at the top
3. Trigger some requests — logs should appear below the header in the request log area, not above it

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `ink` v6 console patching in dev and serve to stop server logs from pushing the TUI header down. Logs now go through our console interceptor and render in the RequestLog below the header.

<sup>Written for commit 8f901bc68d57a6a217e2010eed98f37cee2a51ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

