### PR TITLE
fix(cli): disable local-mode by default in Docker deployments

### DIFF
--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -26,4 +26,4 @@ ENV DATABASE_URL=file:/app/data/mesh.db
 
 # The CLI handles migrations automatically on startup
 # Use --skip-migrations if you want to manage migrations separately
-CMD ["bun", "run", "deco"]
+CMD ["bun", "run", "deco", "--no-local-mode"]

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -51,10 +51,6 @@ const { values, positionals } = parseArgs({
       type: "boolean",
       default: false,
     },
-    "local-mode": {
-      type: "boolean",
-      default: false,
-    },
     "no-tui": {
       type: "boolean",
       default: false,
@@ -82,7 +78,7 @@ Usage:
 Server Options:
   -p, --port <port>     Port to listen on (default: 3000, or PORT env var)
   --home <path>         Data directory (default: ~/deco/, or DATA_DIR env var)
-  --local-mode          Enable local mode (auto-login, no auth required)
+  --no-local-mode       Disable auto-login (use cloud/SSO auth)
   --skip-migrations     Skip database migrations on startup
   --no-tui              Disable Ink UI, plain stdout (CI mode)
   -h, --help            Show this help message
@@ -92,7 +88,6 @@ Dev Options:
   --vite-port <port>    Vite dev server port (default: 4000)
   --base-url <url>      Base URL for the server
   --env-file <path>     Path to .env file to load
-  --no-local-mode       Disable auto-login (use cloud/SSO auth)
 
 Environment Variables:
   PORT                  Port to listen on (default: 3000)
@@ -106,7 +101,7 @@ Examples:
   deco                            Start with defaults (~/deco/)
   deco -p 8080                    Start on port 8080
   deco --home ~/my-project        Custom data directory
-  deco --local-mode               Enable auto-login (local dev)
+  deco --no-local-mode             Disable auto-login (production)
   deco dev                        Start dev server
   deco dev --vite-port 5000       Dev server with custom Vite port
   deco dev --env-file .env        Dev server with env file

--- a/apps/mesh/src/cli/commands/completion.ts
+++ b/apps/mesh/src/cli/commands/completion.ts
@@ -23,7 +23,7 @@ _deco_completion() {
       return 0
       ;;
     *)
-      COMPREPLY=($(compgen -W "init completion --help --version --port --home --skip-migrations --no-tui --local-mode --no-local-mode" -- "$cur"))
+      COMPREPLY=($(compgen -W "init completion --help --version --port --home --skip-migrations --no-tui --no-local-mode" -- "$cur"))
       ;;
   esac
 }
@@ -47,8 +47,7 @@ _deco() {
     '--home[Data directory]:directory:_directories' \\
     '--skip-migrations[Skip database migrations]' \\
     '--no-tui[Disable Ink UI]' \\
-    '--local-mode[Enable local mode]' \\
-    '--no-local-mode[Disable local mode (dev)]' \\
+    '--no-local-mode[Disable auto-login]' \\
     '-h[Show help]' \\
     '--help[Show help]' \\
     '-v[Show version]' \\


### PR DESCRIPTION
## What is this contribution about?

Fixes production login failure ("Auto-login failed: Forbidden") caused by local-mode being enabled by default. When local-mode is on, the login page auto-logs in via `/api/auth/custom/local-session`, which rejects non-loopback requests with 403. This PR adds `--no-local-mode` to the Dockerfile CMD so Docker/Helm deployments use proper authentication, while keeping local-mode as the default for `bunx decocms@latest` (local dev).

Also removes the redundant `--local-mode` flag since it's the default behavior — only `--no-local-mode` is needed to opt out.

## Screenshots/Demonstration

N/A

## How to Test

1. Build and run the Docker image — verify the login page shows the normal auth form (not auto-login)
2. Run `bunx decocms@latest` locally — verify auto-login still works
3. Run `bunx decocms@latest --no-local-mode` — verify the login form is shown

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable local-mode by default in Docker deployments to fix “Auto-login failed: Forbidden” and use proper auth in production. Local dev still defaults to auto-login; only containers pass `--no-local-mode`.

- **Bug Fixes**
  - Add `--no-local-mode` to `apps/mesh/Dockerfile` CMD so Docker/Helm use real auth.
  - Remove redundant `--local-mode` flag; local mode remains default for `bunx decocms@latest`.
  - Update CLI help and shell completion to reflect `--no-local-mode` only.

<sup>Written for commit 56cf9e09e90f5c0976710ac71b41f86f67746150. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

