### PR TITLE
fix(auth): update GitHub OAuth login icon

### DIFF
--- a/apps/mesh/src/auth/oauth-providers.ts
+++ b/apps/mesh/src/auth/oauth-providers.ts
@@ -5,7 +5,7 @@ export const KNOWN_OAUTH_PROVIDERS = {
   },
   github: {
     name: "GitHub",
-    icon: "https://assets.decocache.com/webdraw/5f999dcb-c8a6-4572-948c-9996ef1d502f/github.svg",
+    icon: "https://assets.decocache.com/decocms/e02ce92e-6684-41a6-acfc-432977eb4878/github.png",
   },
   microsoft: {
     name: "Microsoft",


### PR DESCRIPTION
## What is this contribution about?
Updates the GitHub OAuth provider icon URL on the `/login` page from the old SVG to a new PNG asset.

## Screenshots/Demonstration
The GitHub "Continue with GitHub" button on the login page will display the updated icon.

## How to Test
1. Navigate to `/login`
2. Verify the GitHub login button displays the new icon
3. Confirm the icon loads correctly

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the GitHub OAuth icon on the /login button to a new PNG asset for consistent branding and clearer rendering. Replaced the old SVG URL with the new PNG in apps/mesh/src/auth/oauth-providers.ts.

<sup>Written for commit 2bdeff61ecdc332f4dfd338a1d87008f420ac03a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

