### PR TITLE
fix(cli): externalize claude-agent-sdk in bundle

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -23,6 +23,7 @@ const SERVER_ENTRY_POINT = join(SCRIPT_DIR, "../src/index.ts");
 const CLI_ENTRY_POINT = join(SCRIPT_DIR, "../src/cli.ts");
 const ALWAYS_INCLUDE = [
   "@jitl/quickjs-wasmfile-release-sync",
+  "@anthropic-ai/claude-agent-sdk",
   "embedded-postgres",
   "ink",
   "react",


### PR DESCRIPTION
## What is this contribution about?

When running `bunx decocms@latest`, clicking the Claude Code AI provider fails with "Claude Code is not available" even though Claude Code is installed. This happens because `@anthropic-ai/claude-agent-sdk` was being bundled inline into `server.js`. The SDK resolves its embedded `cli.js` (the 12MB Claude Code CLI) via `import.meta.url`, but when bundled inline, that resolves to the app's `cli.js` instead — causing the subprocess to fail.

Adding the SDK to `ALWAYS_INCLUDE` in the bundle script externalizes it to `dist/server/node_modules/`, so `import.meta.url` resolves correctly and the SDK finds its own `cli.js`.

## How to Test

1. Run `bun run --cwd=apps/mesh build:server`
2. Verify `dist/server/node_modules/@anthropic-ai/claude-agent-sdk/cli.js` exists (~12MB)
3. Run `bunx decocms@latest` and click the Claude Code AI provider — it should activate successfully

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Externalized `@anthropic-ai/claude-agent-sdk` from the server bundle to fix the Claude Code provider failing to start. This prevents the SDK from resolving the wrong `cli.js` and restores provider activation in `bunx decocms@latest`.

- **Bug Fixes**
  - Added `@anthropic-ai/claude-agent-sdk` to ALWAYS_INCLUDE so it stays in dist/server/node_modules.
  - Ensures `import.meta.url` points to the SDK’s own 12MB cli.js, resolving “Claude Code is not available.”

<sup>Written for commit 23b5d2b2aa80cf178b9d41a5c8e1dcacc4a0e6fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

