### PR TITLE
feat(chat): use Claude Code labels for model names and tiers

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/claude-code.ts
+++ b/apps/mesh/src/ai-providers/adapters/claude-code.ts
@@ -5,8 +5,8 @@ import type { MeshProvider, ModelInfo, ProviderAdapter } from "../types";
 export const CLAUDE_CODE_MODELS: ModelInfo[] = [
   {
     providerId: "claude-code",
-    modelId: "haiku",
-    title: "Claude Haiku",
+    modelId: "claude-code:haiku",
+    title: "Claude Code Haiku",
     description: "Fast and lightweight",
     capabilities: ["text"],
     limits: null,
@@ -14,8 +14,8 @@ export const CLAUDE_CODE_MODELS: ModelInfo[] = [
   },
   {
     providerId: "claude-code",
-    modelId: "sonnet",
-    title: "Claude Sonnet",
+    modelId: "claude-code:sonnet",
+    title: "Claude Code Sonnet",
     description: "Balanced performance",
     capabilities: ["text", "reasoning"],
     limits: null,
@@ -23,14 +23,26 @@ export const CLAUDE_CODE_MODELS: ModelInfo[] = [
   },
   {
     providerId: "claude-code",
-    modelId: "opus",
-    title: "Claude Opus",
+    modelId: "claude-code:opus",
+    title: "Claude Code Opus",
     description: "Most capable",
     capabilities: ["text", "reasoning"],
     limits: null,
     costs: null,
   },
 ];
+
+/** Map composite model IDs (e.g. "claude-code:sonnet") to SDK model names. */
+const CLAUDE_CODE_SDK_MODELS: Record<string, string> = {
+  "claude-code:opus": "opus",
+  "claude-code:sonnet": "sonnet",
+  "claude-code:haiku": "haiku",
+};
+
+/** Resolve a composite claude-code model ID to the SDK model name. */
+export function resolveClaudeCodeModelId(modelId: string): string {
+  return CLAUDE_CODE_SDK_MODELS[modelId] ?? modelId;
+}
 
 /**
  * Create a Claude Code language model with MCP servers attached.

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -40,7 +40,10 @@ import type { ChatMessage, ModelInfo, ModelsConfig } from "./types";
 import type { CancelBroadcast } from "./cancel-broadcast";
 import { ThreadMessage } from "@/storage/types";
 import type { MeshProvider } from "@/ai-providers/types";
-import { createClaudeCodeModel } from "@/ai-providers/adapters/claude-code";
+import {
+  createClaudeCodeModel,
+  resolveClaudeCodeModelId,
+} from "@/ai-providers/adapters/claude-code";
 import { getInternalUrl } from "@/core/server-constants";
 
 /**
@@ -436,19 +439,22 @@ export async function streamCore(
           });
 
           const mcpUrl = `${getInternalUrl()}/mcp/virtual-mcp/${input.agent.id}`;
-          languageModel = createClaudeCodeModel(input.models.thinking.id, {
-            mcpServers: {
-              mesh: {
-                type: "http",
-                url: mcpUrl,
-                headers: {
-                  Authorization: `Bearer ${apiKey.key}`,
-                  "x-org-id": input.organizationId,
+          languageModel = createClaudeCodeModel(
+            resolveClaudeCodeModelId(input.models.thinking.id),
+            {
+              mcpServers: {
+                mesh: {
+                  type: "http",
+                  url: mcpUrl,
+                  headers: {
+                    Authorization: `Bearer ${apiKey.key}`,
+                    "x-org-id": input.organizationId,
+                  },
                 },
               },
+              toolApprovalLevel: input.toolApprovalLevel,
             },
-            toolApprovalLevel: input.toolApprovalLevel,
-          });
+          );
         } else {
           languageModel = createLanguageModel(provider!, input.models.thinking);
         }

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -91,6 +91,7 @@ const TIER_PATTERNS: Array<{ tier: TierId; prefixes: string[] }> = [
   {
     tier: "smarter",
     prefixes: [
+      "claude-code:opus",
       "anthropic/claude-4.6-opus",
       "anthropic/claude-opus-4.6",
       "anthropic/claude-sonnet-4.6",
@@ -105,6 +106,7 @@ const TIER_PATTERNS: Array<{ tier: TierId; prefixes: string[] }> = [
   {
     tier: "faster",
     prefixes: [
+      "claude-code:sonnet",
       "anthropic/claude-haiku-4.5",
       "anthropic/claude-4.5-haiku",
       "google/gemini-3-flash",
@@ -120,6 +122,7 @@ const TIER_PATTERNS: Array<{ tier: TierId; prefixes: string[] }> = [
   {
     tier: "cheaper",
     prefixes: [
+      "claude-code:haiku",
       "google/gemini-2.5-flash-lite",
       "google/gemini-2.5-flash",
       "google/gemini-2.0-flash",

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -23,6 +23,11 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       "anthropic/claude",
     ],
     google: ["gemini-3-flash"],
+    "claude-code": [
+      "claude-code:sonnet",
+      "claude-code:opus",
+      "claude-code:haiku",
+    ],
   };
 
 /**


### PR DESCRIPTION
## What is this contribution about?
Updates Claude Code model IDs to use composite format (`claude-code:opus`, `claude-code:sonnet`, `claude-code:haiku`) and model titles to "Claude Code Opus/Sonnet/Haiku" to match vibegui's labeling from #2767. Adds tier classification (smarter/faster/cheaper) in the model selector and a default model preference for the claude-code provider.

## How to Test
1. Activate Claude Code provider via CLI
2. Open the chat model selector — models should show as "Claude Code Opus", "Claude Code Sonnet", "Claude Code Haiku"
3. Verify tier badges: Opus → Smarter, Sonnet → Faster, Haiku → Cheaper
4. Send a message using any Claude Code model and confirm it routes correctly

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Claude Code models to composite IDs (e.g., `claude-code:opus`) and update titles to "Claude Code ...", with tier badges in the model selector. Adds a resolver for SDK compatibility and default preferences for the `claude-code` provider.

- **New Features**
  - Updated IDs/titles: `claude-code:opus/sonnet/haiku` → "Claude Code Opus/Sonnet/Haiku".
  - Tier badges in selector: Opus → Smarter, Sonnet → Faster, Haiku → Cheaper.
  - Added `resolveClaudeCodeModelId` and used it in stream-core to map composite IDs to SDK names.
  - Set `claude-code` default model preferences to `claude-code:sonnet`, `claude-code:opus`, `claude-code:haiku`.

<sup>Written for commit db7e118fb0dec809d5103ffce804130e2f8e6bb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

