### PR TITLE
fix(cli): reduce gap between header and content in TUI

### DIFF
--- a/apps/mesh/src/cli/header.tsx
+++ b/apps/mesh/src/cli/header.tsx
@@ -61,7 +61,7 @@ export function Header({
         <Text dimColor> v{pkg.version}</Text>
       </Box>
 
-      <Box marginTop={2}>
+      <Box marginTop={1}>
         <Text dimColor>Home: {home}</Text>
       </Box>
 


### PR DESCRIPTION
## What is this contribution about?
Reduces the extra blank line between the TUI header (logo + version) and the rest of the content by changing `marginTop` from 2 to 1 on the Home line.

## Screenshots/Demonstration
N/A

## How to Test
1. Run `bun run dev` 
2. Observe the TUI header — there should be exactly one blank line between the version and the "Home:" line, not two

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce the gap between the CLI TUI header (logo and version) and the content. There is now exactly one blank line before the “Home:” line by changing marginTop from 2 to 1.

<sup>Written for commit 85671dfd3539235fae74bc10a26dfcabe5b07f18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

