### PR TITLE
fix(access-control): include 'user' role in built-in role bypass

### DIFF
--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -160,8 +160,9 @@ export class AccessControl implements Disposable {
       return false;
     }
 
-    // Admin and owner roles bypass all checks (they have full access)
-    if (this.role === "admin" || this.role === "owner") {
+    // Built-in roles bypass all checks (they have full access)
+    // Must match BUILTIN_ROLES from auth/roles.ts: owner, admin, user
+    if (this.role === "admin" || this.role === "owner" || this.role === "user") {
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Fixes "Access denied" errors when Claude Code CLI (or any MCP OAuth session with "user" role) tries to call tools on MCP connections
- `AccessControl.checkResource()` only bypassed for `admin`/`owner` but `BUILTIN_ROLES` includes `user` too
- The web UI worked because it uses a different auth path (browser session cookies)

## Root Cause

`access-control.ts:164` checked:
```typescript
if (this.role === "admin" || this.role === "owner")
```

But `auth/roles.ts` defines:
```typescript
export const BUILTIN_ROLES = ["owner", "admin", "user"] as const;
// Comment: "Built-in roles that have full access"
```

And `context-factory.ts` `boundAuth.hasPermission()` already bypasses for all `BUILTIN_ROLES`.

## Fix

Add `"user"` to the bypass check in `checkResource()`, aligning with `BUILTIN_ROLES`.

## Test plan

- [ ] Claude Code CLI can now call tools on MCP connections without "Access denied"
- [ ] Web UI continues to work as before
- [ ] Custom roles (non-built-in) still require explicit permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the `user` role in the built-in role bypass in `AccessControl.checkResource()` to match `BUILTIN_ROLES`, fixing “Access denied” errors for MCP OAuth sessions. This allows Claude Code CLI and other MCP connections to call tools as expected, with custom roles still requiring explicit permissions.

<sup>Written for commit 1a4cee854bd1360688f878c231547e569cc9e93e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

