### PR TITLE
fix(auth-transport): forward authenticated users, skip per-tool checks

### DIFF
--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -149,23 +149,28 @@ export class AuthTransport extends WrapperTransport {
       );
     }
 
-    // Create getToolMeta callback for AccessControl
+    // Authenticated users (browser session or MCP OAuth) are forwarded directly.
+    // The downstream MCP server handles its own authorization.
+    // Granular per-tool permission checks only apply to API keys.
+    if (ctx.auth.user?.id && !ctx.auth.apiKey?.id) {
+      return;
+    }
+
+    // API key path: check granular per-tool permissions
     const getToolMeta = async () => {
       const toolsMap = await this.ensureToolsMap();
       const tool = toolsMap.get(toolName);
       return tool?._meta as Record<string, unknown> | undefined;
     };
 
-    // Create AccessControl with connectionId set
-    // This checks: does user have permission for this TOOL on this CONNECTION?
     const connectionAccessControl = new AccessControl(
       ctx.authInstance,
-      ctx.auth.user?.id ?? ctx.auth.apiKey?.userId,
-      toolName, // Tool being called
-      ctx.boundAuth, // Bound auth client (encapsulates headers)
-      ctx.auth.user?.role, // Role for built-in role bypass
-      connection.id, // Connection ID for permission check
-      getToolMeta, // Callback for public tool check
+      ctx.auth.apiKey?.userId,
+      toolName,
+      ctx.boundAuth,
+      ctx.auth.user?.role,
+      connection.id,
+      getToolMeta,
     );
 
     await connectionAccessControl.check(toolName);


### PR DESCRIPTION
## Summary

- Authenticated users (browser session or MCP OAuth) are forwarded directly to downstream MCP servers
- Per-tool `AccessControl` checks are preserved only for API keys
- Fixes "Access denied" when Claude Code CLI calls tools through Mesh connections

## The Problem

`AuthTransport.authorizeToolCall()` ran per-tool permission checks for ALL callers, including authenticated users. For MCP OAuth sessions (Claude Code CLI), the org context wasn't properly resolved, causing `AccessControl` to deny access.

## The Fix

If the caller has a `user.id` (authenticated via browser session or MCP OAuth), just forward the call — the downstream MCP server handles its own auth. Only run granular `AccessControl` checks for API keys, where fine-grained permissions are the expected model.

```diff
+    // Authenticated users are forwarded directly.
+    // Granular per-tool permission checks only apply to API keys.
+    if (ctx.auth.user?.id && !ctx.auth.apiKey?.id) {
+      return;
+    }
```

## Test plan

- [ ] Claude Code CLI can call tools on MCP connections without "Access denied"
- [ ] Browser session tool calls continue to work
- [ ] API keys with granular permissions still enforce per-tool checks
- [ ] Unauthenticated requests still get "Authentication required" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticated users are now forwarded directly to downstream MCP servers; per-tool checks only run for API keys. Fixes "Access denied" for Claude Code CLI via MCP OAuth over Mesh.

- **Bug Fixes**
  - Skip per-tool `AccessControl` when a `user.id` is present and no API key is used.
  - Keep granular per-tool checks for API keys using `apiKey.userId`.
  - Unauthenticated requests still return "Authentication required".

<sup>Written for commit 54d330b23d2e6d204c382db043886f7a45d1906b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

