### PR TITLE
refactor(agent-detail): improve prompt template with XML-structured sections

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/index.tsx
@@ -590,7 +590,32 @@ function VirtualMcpDetailViewWithData({
 
   const handleInsertTemplate = () => {
     const current = form.getValues("metadata.instructions") ?? "";
-    const template = `Goal\nEdit this text to describe how your agent should work...\n\nRules\nIf your agent isn't working like you want it to, prompting is how can you can guide it!\n\nMake sure you always...\n\nMake sure you never...`;
+    const template = `<role>
+Define who this agent is and what it specializes in.
+Example: You are a support triage agent for B2B merchants.
+</role>
+
+<capabilities>
+List what this agent can do using its connected tools.
+- Investigate issues using connected data sources.
+- Summarize findings and recommend next steps.
+</capabilities>
+
+<constraints>
+Set clear boundaries on what the agent must not do.
+- Do not perform destructive actions without confirmation.
+- Escalate to a human when the request is outside your expertise.
+</constraints>
+
+<workflows>
+Define step-by-step how the agent should handle requests.
+
+## Default workflow
+1. Read the user's request and gather context.
+2. Use the appropriate tools to investigate or act.
+3. Summarize the result and propose next steps.
+4. Ask for confirmation before making any changes.
+</workflows>`;
     const next = current.trim() ? `${current}\n\n${template}` : template;
     form.setValue("metadata.instructions", next, { shouldDirty: true });
   };


### PR DESCRIPTION
## What is this contribution about?

Replaces the basic "Goal / Rules / Make sure you always/never" prompt template on the agent detail Instructions tab with a state-of-the-art XML-structured template aligned with the `writing-prompts` guide and `docs://agents.md` resource.

The new template uses `<role>`, `<capabilities>`, `<constraints>`, and `<workflows>` XML sections with inline guidance and a numbered workflow example, matching the prompt engineering patterns already recommended by the platform's own guide system.

## Screenshots/Demonstration
N/A — text-only change to a template string.

## How to Test
1. Open the Mesh admin UI and navigate to any agent detail page.
2. Clear the Instructions field (or create a new agent).
3. Click the **[+ Prompt template]** button.
4. Verify the inserted template contains XML-tagged sections: `<role>`, `<capabilities>`, `<constraints>`, `<workflows>`.
5. Confirm the workflow section includes a numbered step-by-step example.

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the basic “Goal/Rules” prompt template in the agent Instructions tab with an XML-structured template (`<role>`, `<capabilities>`, `<constraints>`, `<workflows>`) aligned with the writing-prompts guide. This provides clearer scaffolding and a numbered default workflow for agent behavior.

- **Refactors**
  - Inserts XML-tagged sections with inline guidance.
  - Adds a 4-step default workflow under `<workflows>`.
  - Appends the template if the field already has content to preserve existing notes.

<sup>Written for commit 5081581e46a64963ec53287872fe08e3aa978da0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

