### PR TITLE
fix(connections): use MCP SDK ToolSchema for tool definitions

### DIFF
--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -56,12 +56,12 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
               inputSchema: z.toJSONSchema(
                 tool.inputSchema as Parameters<typeof z.toJSONSchema>[0],
                 { unrepresentable: "any" },
-              ),
+              ) as unknown as ToolDefinition["inputSchema"],
               outputSchema: tool.outputSchema
-                ? z.toJSONSchema(
+                ? (z.toJSONSchema(
                     tool.outputSchema as Parameters<typeof z.toJSONSchema>[0],
                     { unrepresentable: "any" },
-                  )
+                  ) as unknown as ToolDefinition["outputSchema"])
                 : undefined,
               description: tool.description,
             };

--- a/apps/mesh/src/tools/connection/connection-tools.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.test.ts
@@ -200,7 +200,7 @@ describe("Connection Tools", () => {
               {
                 name: "COLLECTION_LLM_LIST",
                 description: "List models",
-                inputSchema: {},
+                inputSchema: { type: "object" as const },
               },
             ],
             scopes: null,

--- a/apps/mesh/src/tools/connection/dev-assets.ts
+++ b/apps/mesh/src/tools/connection/dev-assets.ts
@@ -23,11 +23,12 @@ const DEV_ASSETS_TOOLS: ToolDefinition[] = OBJECT_STORAGE_BINDING.map(
   (binding: (typeof OBJECT_STORAGE_BINDING)[number]) => ({
     name: binding.name,
     description: `${binding.name} operation for local file storage`,
-    inputSchema: z.toJSONSchema(binding.inputSchema) as Record<string, unknown>,
-    outputSchema: z.toJSONSchema(binding.outputSchema) as Record<
-      string,
-      unknown
-    >,
+    inputSchema: z.toJSONSchema(
+      binding.inputSchema,
+    ) as ToolDefinition["inputSchema"],
+    outputSchema: z.toJSONSchema(
+      binding.outputSchema,
+    ) as ToolDefinition["outputSchema"],
   }),
 );
 

--- a/apps/mesh/src/web/hooks/use-binding.test.ts
+++ b/apps/mesh/src/web/hooks/use-binding.test.ts
@@ -9,7 +9,7 @@ import { LANGUAGE_MODEL_BINDING } from "@decocms/bindings/llm";
 import { describe, expect, it } from "bun:test";
 
 function makeConnection(
-  tools: Array<{ name: string; inputSchema: Record<string, unknown> }>,
+  tools: ConnectionEntity["tools"],
   overrides?: Partial<ConnectionEntity>,
 ): ConnectionEntity {
   return {
@@ -41,43 +41,48 @@ function makeConnection(
 describe("connectionImplementsBinding", () => {
   it("should detect MCP binding when tools match", () => {
     const conn = makeConnection([
-      { name: "MCP_CONFIGURATION", inputSchema: {} },
+      { name: "MCP_CONFIGURATION", inputSchema: { type: "object" as const } },
     ]);
     expect(connectionImplementsBinding(conn, MCP_BINDING)).toBe(true);
   });
 
   it("should not detect MCP binding when tools do not match", () => {
-    const conn = makeConnection([{ name: "SOME_OTHER_TOOL", inputSchema: {} }]);
+    const conn = makeConnection([
+      { name: "SOME_OTHER_TOOL", inputSchema: { type: "object" as const } },
+    ]);
     expect(connectionImplementsBinding(conn, MCP_BINDING)).toBe(false);
   });
 
   it("should detect EVENT_BUS binding when connection has all event bus tools", () => {
     const conn = makeConnection([
-      { name: "EVENT_PUBLISH", inputSchema: {} },
-      { name: "EVENT_SUBSCRIBE", inputSchema: {} },
-      { name: "EVENT_UNSUBSCRIBE", inputSchema: {} },
-      { name: "EVENT_CANCEL", inputSchema: {} },
-      { name: "EVENT_ACK", inputSchema: {} },
-      { name: "EVENT_SYNC_SUBSCRIPTIONS", inputSchema: {} },
+      { name: "EVENT_PUBLISH", inputSchema: { type: "object" as const } },
+      { name: "EVENT_SUBSCRIBE", inputSchema: { type: "object" as const } },
+      { name: "EVENT_UNSUBSCRIBE", inputSchema: { type: "object" as const } },
+      { name: "EVENT_CANCEL", inputSchema: { type: "object" as const } },
+      { name: "EVENT_ACK", inputSchema: { type: "object" as const } },
+      {
+        name: "EVENT_SYNC_SUBSCRIPTIONS",
+        inputSchema: { type: "object" as const },
+      },
     ]);
     expect(connectionImplementsBinding(conn, EVENT_BUS_BINDING)).toBe(true);
   });
 
   it("should not detect EVENT_BUS binding when missing required tools", () => {
     const conn = makeConnection([
-      { name: "EVENT_PUBLISH", inputSchema: {} },
-      { name: "EVENT_SUBSCRIBE", inputSchema: {} },
+      { name: "EVENT_PUBLISH", inputSchema: { type: "object" as const } },
+      { name: "EVENT_SUBSCRIBE", inputSchema: { type: "object" as const } },
     ]);
     expect(connectionImplementsBinding(conn, EVENT_BUS_BINDING)).toBe(false);
   });
 
   it("should detect LANGUAGE_MODEL binding when connection has LLM tools", () => {
     const conn = makeConnection([
-      { name: "LLM_METADATA", inputSchema: {} },
-      { name: "LLM_DO_STREAM", inputSchema: {} },
-      { name: "LLM_DO_GENERATE", inputSchema: {} },
-      { name: "COLLECTION_LLM_LIST", inputSchema: {} },
-      { name: "COLLECTION_LLM_GET", inputSchema: {} },
+      { name: "LLM_METADATA", inputSchema: { type: "object" as const } },
+      { name: "LLM_DO_STREAM", inputSchema: { type: "object" as const } },
+      { name: "LLM_DO_GENERATE", inputSchema: { type: "object" as const } },
+      { name: "COLLECTION_LLM_LIST", inputSchema: { type: "object" as const } },
+      { name: "COLLECTION_LLM_GET", inputSchema: { type: "object" as const } },
     ]);
     expect(connectionImplementsBinding(conn, LANGUAGE_MODEL_BINDING)).toBe(
       true,
@@ -86,8 +91,8 @@ describe("connectionImplementsBinding", () => {
 
   it("should not detect LANGUAGE_MODEL binding when missing LLM tools", () => {
     const conn = makeConnection([
-      { name: "LLM_METADATA", inputSchema: {} },
-      { name: "SOME_OTHER_TOOL", inputSchema: {} },
+      { name: "LLM_METADATA", inputSchema: { type: "object" as const } },
+      { name: "SOME_OTHER_TOOL", inputSchema: { type: "object" as const } },
     ]);
     expect(connectionImplementsBinding(conn, LANGUAGE_MODEL_BINDING)).toBe(
       false,

--- a/packages/mesh-sdk/src/types/connection.ts
+++ b/packages/mesh-sdk/src/types/connection.ts
@@ -5,6 +5,7 @@
  * Uses snake_case field names matching the database schema directly.
  */
 
+import { ToolSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
 /**
@@ -23,27 +24,11 @@ const OAuthConfigSchema = z.object({
 export type OAuthConfig = z.infer<typeof OAuthConfigSchema>;
 
 /**
- * Tool annotations schema from MCP spec
+ * Tool definition schema from MCP discovery.
+ * Re-uses the canonical ToolSchema from the MCP SDK so new fields
+ * (execution, icons, title, etc.) are automatically supported.
  */
-const ToolAnnotationsSchema = z.object({
-  title: z.string().optional(),
-  readOnlyHint: z.boolean().optional(),
-  destructiveHint: z.boolean().optional(),
-  idempotentHint: z.boolean().optional(),
-  openWorldHint: z.boolean().optional(),
-});
-
-/**
- * Tool definition schema from MCP discovery
- */
-const ToolDefinitionSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  inputSchema: z.record(z.string(), z.unknown()),
-  outputSchema: z.record(z.string(), z.unknown()).optional(),
-  annotations: ToolAnnotationsSchema.optional(),
-  _meta: z.record(z.string(), z.unknown()).optional(),
-});
+const ToolDefinitionSchema = ToolSchema;
 
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
 


### PR DESCRIPTION
## What is this contribution about?

Fixes `COLLECTION_CONNECTIONS_LIST` (and `COLLECTION_CONNECTIONS_GET`) returning validation errors: `"Structured content does not match the tool's output schema: data/items/*/tools/* must NOT have additional properties"`.

**Root cause:** The hand-rolled `ToolDefinitionSchema` in `packages/mesh-sdk` only allowed 6 properties (`name`, `description`, `inputSchema`, `outputSchema`, `annotations`, `_meta`). The MCP SDK v1.27.1 `ToolSchema` includes additional fields (`execution`, `icons`, `title`). When tools fetched from MCP servers included these newer fields, the output schema validation rejected them with `additionalProperties: false`.

**Fix:** Replace the custom `ToolDefinitionSchema` with the canonical `ToolSchema` from `@modelcontextprotocol/sdk/types.js`. This ensures our schema stays in sync with the MCP protocol spec automatically.

## Screenshots/Demonstration

N/A

## How to Test

1. Start the dev environment with `bun run dev`
2. Call `COLLECTION_CONNECTIONS_LIST` with `{}` as input
3. Verify it returns the list of connections without validation errors
4. Call `COLLECTION_CONNECTIONS_GET` with a valid connection ID
5. Verify it also returns without errors

## Migration Notes

N/A — no database or configuration changes required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom tool schema with the MCP SDK’s `ToolSchema` to stop validation errors when listing or fetching connections. This fixes “must NOT have additional properties” errors for `COLLECTION_CONNECTIONS_LIST` and `COLLECTION_CONNECTIONS_GET`.

- Bug Fixes
  - Use `ToolSchema` from `@modelcontextprotocol/sdk/types.js` for `ToolDefinition`.
  - Support MCP fields like `execution`, `icons`, and `title`.
  - Update tests/dev assets to use valid JSON Schema for `inputSchema`/`outputSchema` (e.g., `{ type: "object" }`).

<sup>Written for commit f5badc606b273f3783da87265f290c03e009354b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

