### PR TITLE
feat(decopilot): add Claude Code session resume across turns

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/claude-code.ts
+++ b/apps/mesh/src/ai-providers/adapters/claude-code.ts
@@ -1,6 +1,7 @@
 import { createClaudeCode } from "ai-sdk-provider-claude-code";
-import type { ToolApprovalLevel } from "../../api/routes/decopilot/helpers";
 import type { MeshProvider, ModelInfo, ProviderAdapter } from "../types";
+
+export { createClaudeCodeModel } from "../coding-agents/claude-code";
 
 export const CLAUDE_CODE_MODELS: ModelInfo[] = [
   {
@@ -42,67 +43,6 @@ const CLAUDE_CODE_SDK_MODELS: Record<string, string> = {
 /** Resolve a composite claude-code model ID to the SDK model name. */
 export function resolveClaudeCodeModelId(modelId: string): string {
   return CLAUDE_CODE_SDK_MODELS[modelId] ?? modelId;
-}
-
-/**
- * Create a Claude Code language model with MCP servers attached.
- * This is separate from the adapter's create() because it needs
- * runtime config (mcpServers, permissionMode) that varies per request.
- */
-export function createClaudeCodeModel(
-  modelId: string,
-  options?: {
-    mcpServers?: Record<
-      string,
-      {
-        type: "sse" | "http";
-        url: string;
-        headers?: Record<string, string>;
-      }
-    >;
-    toolApprovalLevel?: ToolApprovalLevel;
-  },
-) {
-  // Tools that require a TTY, manage local state, or are not useful in headless mode
-  const HEADLESS_DISALLOWED_TOOLS = [
-    "AskUserQuestion",
-    "ExitPlanMode",
-    "EnterWorktree",
-    "ExitWorktree",
-    "Config",
-  ];
-
-  const settings: NonNullable<
-    NonNullable<Parameters<typeof createClaudeCode>[0]>["defaultSettings"]
-  > = {
-    mcpServers: options?.mcpServers,
-  };
-
-  switch (options?.toolApprovalLevel) {
-    case "plan":
-      settings.permissionMode = "plan";
-      settings.disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
-      break;
-    case "readonly":
-      settings.permissionMode = "bypassPermissions";
-      settings.disallowedTools = [
-        ...HEADLESS_DISALLOWED_TOOLS,
-        "Write",
-        "Edit",
-        "Bash",
-        "NotebookEdit",
-      ];
-      break;
-    default:
-      settings.permissionMode = "bypassPermissions";
-      settings.disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
-      break;
-  }
-
-  const provider = createClaudeCode({
-    defaultSettings: settings,
-  });
-  return provider(modelId);
 }
 
 export const claudeCodeAdapter: ProviderAdapter = {

--- a/apps/mesh/src/ai-providers/coding-agents/claude-code/index.ts
+++ b/apps/mesh/src/ai-providers/coding-agents/claude-code/index.ts
@@ -1,0 +1,68 @@
+import { createClaudeCode } from "ai-sdk-provider-claude-code";
+import type { ToolApprovalLevel } from "@/api/routes/decopilot/helpers";
+
+/**
+ * Create a Claude Code language model with MCP servers attached.
+ * This is separate from the adapter's create() because it needs
+ * runtime config (mcpServers, permissionMode, resume) that varies per request.
+ */
+export function createClaudeCodeModel(
+  modelId: string,
+  options?: {
+    mcpServers?: Record<
+      string,
+      {
+        type: "sse" | "http";
+        url: string;
+        headers?: Record<string, string>;
+      }
+    >;
+    toolApprovalLevel?: ToolApprovalLevel;
+    resume?: string;
+  },
+) {
+  // Tools that require a TTY, manage local state, or are not useful in headless mode
+  const HEADLESS_DISALLOWED_TOOLS = [
+    "AskUserQuestion",
+    "ExitPlanMode",
+    "EnterWorktree",
+    "ExitWorktree",
+    "Config",
+  ];
+
+  const settings: NonNullable<
+    NonNullable<Parameters<typeof createClaudeCode>[0]>["defaultSettings"]
+  > = {
+    mcpServers: options?.mcpServers,
+  };
+
+  switch (options?.toolApprovalLevel) {
+    case "plan":
+      settings.permissionMode = "plan";
+      settings.disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
+      break;
+    case "readonly":
+      settings.permissionMode = "bypassPermissions";
+      settings.disallowedTools = [
+        ...HEADLESS_DISALLOWED_TOOLS,
+        "Write",
+        "Edit",
+        "Bash",
+        "NotebookEdit",
+      ];
+      break;
+    default:
+      settings.permissionMode = "bypassPermissions";
+      settings.disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
+      break;
+  }
+
+  if (options?.resume) {
+    settings.resume = options.resume;
+  }
+
+  const provider = createClaudeCode({
+    defaultSettings: settings,
+  });
+  return provider(modelId);
+}

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -265,6 +265,23 @@ export async function streamCore(
       windowSize,
     );
 
+    // Find the last Claude Code sessionId for session resume
+    let resumeSessionId: string | undefined;
+    if (isClaudeCode) {
+      for (let i = allMessages.length - 1; i >= 0; i--) {
+        const msg = allMessages[i];
+        if (
+          msg?.role === "assistant" &&
+          (msg.metadata as { claudeCodeSessionId?: string })
+            ?.claudeCodeSessionId
+        ) {
+          resumeSessionId = (msg.metadata as { claudeCodeSessionId: string })
+            .claudeCodeSessionId;
+          break;
+        }
+      }
+    }
+
     const toolOutputMap = new Map<string, string>();
     const organization = ctx.organization!;
 
@@ -426,6 +443,7 @@ export async function streamCore(
 
         let reasoningStartAt: Date | null = null;
         let lastProviderMetadata: Record<string, unknown> | undefined;
+        let claudeCodeSessionId: string | undefined;
         llmCallStartTime = Date.now();
 
         // Build language model based on provider type
@@ -460,6 +478,7 @@ export async function streamCore(
                 },
               },
               toolApprovalLevel: input.toolApprovalLevel,
+              resume: resumeSessionId,
             },
           );
         } else {
@@ -632,6 +651,13 @@ export async function streamCore(
 
             if (part.type === "finish-step") {
               lastProviderMetadata = part.providerMetadata;
+              if (isClaudeCode && part.providerMetadata?.["claude-code"]) {
+                claudeCodeSessionId = (
+                  part.providerMetadata["claude-code"] as {
+                    sessionId?: string;
+                  }
+                ).sessionId;
+              }
               return;
             }
 
@@ -664,6 +690,7 @@ export async function streamCore(
 
               return {
                 ...(usage && { usage }),
+                ...(claudeCodeSessionId && { claudeCodeSessionId }),
               };
             }
 


### PR DESCRIPTION
## What is this contribution about?

Currently, every message in a Claude Code conversation starts a brand-new session — Claude Code loses its internal session state (file context, memory) between turns and relies entirely on thread message history for context.

This PR adds session resume by capturing `sessionId` from Claude Code's `providerMetadata` on stream finish, storing it in assistant message metadata, and passing it as `resume` on subsequent requests. It also moves `createClaudeCodeModel()` into a new `coding-agents/claude-code/` directory to prepare for future Codex support and tool approval bridging.

## How to Test

1. Start a conversation with Claude Code provider in the Mesh UI
2. Send a first message (e.g., "read the README")
3. Send a follow-up message (e.g., "what was in it?")
4. Verify Claude Code has session context from the first turn (faster response, references prior work)
5. Check assistant message metadata contains `claudeCodeSessionId`

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes
- [x] No database migrations needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable session continuity for Claude Code by persisting and resuming `sessionId` across turns. Responses are faster and keep prior file/work context.

- **New Features**
  - Capture `sessionId` from Claude Code `providerMetadata` on `finish-step` and store as `claudeCodeSessionId` in assistant message metadata.
  - Look up the last `claudeCodeSessionId` and pass it as `resume` on the next Claude Code request.
  - Applies only to Claude Code; other providers are unchanged.

- **Refactors**
  - Moved `createClaudeCodeModel` to `apps/mesh/src/ai-providers/coding-agents/claude-code/` and re-exported from the adapter.
  - Added `resume` support to `createClaudeCodeModel` while keeping existing tool approval settings; continues to use `ai-sdk-provider-claude-code`.

<sup>Written for commit 9dc86e84f0b3628b49b5cd0a81a0b3c5aa16feae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

