### PR TITLE
fix(ui): prevent layout shift in ice breakers

### DIFF
--- a/apps/mesh/src/web/components/chat/ice-breakers.tsx
+++ b/apps/mesh/src/web/components/chat/ice-breakers.tsx
@@ -3,7 +3,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
 import {
   Tooltip,
@@ -173,16 +172,11 @@ interface IceBreakersProps {
 }
 
 /**
- * Fallback component for Suspense that maintains min-height to prevent layout shift
- * Shows skeleton pills matching the actual IceBreakers appearance
+ * Fallback component for Suspense — renders nothing while loading
+ * The parent container maintains fixed height to prevent layout shift
  */
 function IceBreakersFallback() {
-  return (
-    <>
-      <Skeleton className="h-6 w-20 rounded-full border border-border" />
-      <Skeleton className="h-6 w-24 rounded-full border border-border" />
-    </>
-  );
+  return null;
 }
 
 /**
@@ -313,7 +307,7 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
   }
 
   return (
-    <div className="relative w-full mb-3">
+    <>
       <IceBreakersUI
         prompts={prompts}
         onSelect={handlePromptSelection}
@@ -327,7 +321,7 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
         }}
         onSubmit={handleDialogSubmit}
       />
-    </div>
+    </>
   );
 }
 
@@ -345,7 +339,7 @@ export function IceBreakers({ className }: IceBreakersProps) {
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center justify-center gap-2",
+        "flex flex-wrap items-center justify-center gap-2 min-h-[34px] mb-3",
         className,
       )}
     >


### PR DESCRIPTION
## What is this contribution about?

Fixes layout shift in the chat ice breakers component when prompts are loading or when no ice breakers are found. The outer container now reserves a fixed `min-h-[34px]` so the layout stays stable across all states (loading, empty, loaded). Also removes the skeleton loading fallback in favor of rendering nothing, and adds `mb-3` spacing between ice breakers and the chat input.

## Screenshots/Demonstration

N/A

## How to Test

1. Open the chat UI with an empty state (no messages)
2. Observe the ice breakers area — it should not cause a layout jump when prompts load or when no prompts are found
3. Verify there is consistent spacing between the ice breakers and the chat input below

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents layout shift in the chat ice breakers by reserving a fixed min height and simplifying the loading state, keeping the input area stable across loading, empty, and loaded states.

- **Bug Fixes**
  - Add `min-h-[34px]` to the outer container and move `mb-3` spacing there to keep consistent layout.
  - Remove skeleton fallback; render `null` during loading since the parent maintains space.
  - Drop the inner wrapper to avoid redundant spacing and positioning.

<sup>Written for commit 4923a802794a94c316476eb09ba77a5732ba0345. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

