### PR TITLE
fix(plugins): initialize storage before event bus startup hooks

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -667,6 +667,13 @@ export async function createApp(options: CreateAppOptions = {}) {
   });
   ContextFactory.set(factory);
 
+  // Initialize plugin storage BEFORE starting the event bus, because the
+  // startup hooks (runPluginStartupHooks) need storage to be ready and they
+  // run as soon as eventBus.start() resolves — which can happen during any
+  // `await` between here and where initializePluginStorage used to live.
+  const vault = new CredentialVault(env.ENCRYPTION_KEY);
+  initializePluginStorage(database.db, vault);
+
   // Start the event bus worker (async - resets stuck deliveries from previous crashes)
   // Then run plugin startup hooks (e.g., recover stuck workflow executions)
   Promise.resolve(eventBus.start())
@@ -1150,10 +1157,8 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Mount routes from registered server plugins
   // - Public routes are mounted at root level (e.g., /connect/:sessionId)
   // - Authenticated routes are mounted at /api/plugins/:pluginId/*
-  const vault = new CredentialVault(env.ENCRYPTION_KEY);
-
-  // Initialize plugin storage (creates storage instances for all plugins)
-  initializePluginStorage(database.db, vault);
+  // Note: vault and initializePluginStorage are called earlier (before eventBus.start)
+  // to avoid race conditions with plugin onStartup hooks.
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mountPluginRoutes(app, { db: database.db as any, vault });


### PR DESCRIPTION
## What is this contribution about?

Fixes a race condition where the "MCP Workflows" plugin's `onStartup` hook would fail with `Plugin storage not initialized` error.

**Root cause:** `initializePluginStorage()` was called late in `createApp()` (line ~1156), but `runPluginStartupHooks()` was triggered earlier via a fire-and-forget `eventBus.start().then(...)` chain (line ~672). Multiple `await` points between these two locations (automation job stream init, consumer start, cron worker start) allowed the event bus promise to resolve and execute startup hooks before plugin storage was initialized.

**Fix:** Move `initializePluginStorage()` (and its `CredentialVault` dependency) to just before the `eventBus.start()` chain, guaranteeing storage is always ready when `onStartup` hooks run.

## Screenshots/Demonstration
N/A — no UI changes.

## How to Test
1. Start the mesh server with the workflows plugin enabled (`bun run dev`)
2. Verify no `[PluginLoader] Plugin "MCP Workflows" onStartup hook failed` errors in the console
3. Verify workflow execution recovery on startup still works (create a workflow execution, restart the server, check logs for recovery messages)

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize plugin storage and the `CredentialVault` before starting the event bus to prevent a startup race that broke plugin `onStartup` hooks (e.g., MCP Workflows). This ensures storage is ready when hooks run.

- **Bug Fixes**
  - Moved storage initialization to run before `eventBus.start()`, preventing "Plugin storage not initialized" errors during startup.
  - Preserves workflow execution recovery on boot; no UI or migration changes.

<sup>Written for commit 8b9c87342bb79fb20744949e3adc8fc31b5f59d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

