### PR TITLE
fix(tools): add readOnlyHint and idempotentHint to read-only tools

### DIFF
--- a/apps/mesh/src/tools/ai-providers/key-list.ts
+++ b/apps/mesh/src/tools/ai-providers/key-list.ts
@@ -11,6 +11,10 @@ export const AI_PROVIDER_KEY_LIST = defineTool({
   name: "AI_PROVIDER_KEY_LIST",
   description:
     "List stored AI provider API keys. Returns metadata only — secrets are never exposed.",
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
   inputSchema: z.object({
     providerId: z.enum(PROVIDER_IDS).optional(),
   }),

--- a/apps/mesh/src/tools/ai-providers/list-models.ts
+++ b/apps/mesh/src/tools/ai-providers/list-models.ts
@@ -11,6 +11,10 @@ export const AI_PROVIDERS_LIST_MODELS = defineTool({
   name: "AI_PROVIDERS_LIST_MODELS",
   description:
     "List models available from an AI provider. Requires a valid stored API key.",
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
   inputSchema: z.object({
     keyId: z.string().describe("The provider key ID to use"),
   }),

--- a/apps/mesh/src/tools/ai-providers/list.ts
+++ b/apps/mesh/src/tools/ai-providers/list.ts
@@ -7,6 +7,10 @@ export const AI_PROVIDERS_LIST = defineTool({
   name: "AI_PROVIDERS_LIST",
   description:
     "List all supported AI providers and their connection methods (API key, OAuth).",
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
   inputSchema: z.object({}),
   outputSchema: z.object({
     providers: z.array(

--- a/packages/mesh-plugin-private-registry/server/routes/public-mcp-server.ts
+++ b/packages/mesh-plugin-private-registry/server/routes/public-mcp-server.ts
@@ -22,6 +22,10 @@ function createPublicMCPTools(storage: RegistryItemStorage, orgId: string) {
   const LIST_TOOL = createTool({
     id: "COLLECTION_REGISTRY_APP_LIST",
     description: "List public registry items",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: RegistryListInputSchema,
     outputSchema: RegistryListOutputSchema,
     execute: async ({ context }) => {
@@ -40,6 +44,10 @@ function createPublicMCPTools(storage: RegistryItemStorage, orgId: string) {
   const GET_TOOL = createTool({
     id: "COLLECTION_REGISTRY_APP_GET",
     description: "Get a public registry item by ID or name",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: RegistryGetInputSchema,
     outputSchema: RegistryGetOutputSchema,
     execute: async ({ context }) => {
@@ -59,6 +67,10 @@ function createPublicMCPTools(storage: RegistryItemStorage, orgId: string) {
   const VERSIONS_TOOL = createTool({
     id: "COLLECTION_REGISTRY_APP_VERSIONS",
     description: "Get available versions of a public registry item",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: RegistryGetInputSchema,
     outputSchema: z.object({
       versions: z.array(RegistryGetOutputSchema.shape.item),
@@ -82,6 +94,10 @@ function createPublicMCPTools(storage: RegistryItemStorage, orgId: string) {
     description:
       "Search public registry items returning minimal data (id, title, tags, categories, is_public). " +
       "Use this instead of LIST when you need to find items efficiently without loading full details.",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: RegistrySearchInputSchema,
     outputSchema: RegistrySearchOutputSchema,
     execute: async ({ context }) => {
@@ -92,6 +108,10 @@ function createPublicMCPTools(storage: RegistryItemStorage, orgId: string) {
   const FILTERS_TOOL = createTool({
     id: "COLLECTION_REGISTRY_APP_FILTERS",
     description: "Get available tags and categories for public registry items",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: z.object({}),
     outputSchema: RegistryFiltersOutputSchema,
     execute: async () => {


### PR DESCRIPTION
## What is this contribution about?
Adds missing `readOnlyHint: true` and `idempotentHint: true` MCP tool annotations to 7 read-only tools that were missing them. This ensures MCP clients can safely auto-approve or cache these tool calls.

**Registry plugin** (`public-mcp-server.ts`): `COLLECTION_REGISTRY_APP_LIST`, `COLLECTION_REGISTRY_APP_GET`, `COLLECTION_REGISTRY_APP_VERSIONS`, `COLLECTION_REGISTRY_APP_SEARCH`, `COLLECTION_REGISTRY_APP_FILTERS`

**AI providers**: `AI_PROVIDERS_LIST`, `AI_PROVIDER_KEY_LIST`, `AI_PROVIDERS_LIST_MODELS`

## Screenshots/Demonstration
N/A — no UI changes.

## How to Test
1. Inspect the MCP tool listings and verify the 7 tools above now include `readOnlyHint: true` and `idempotentHint: true` in their annotations.
2. Confirm no other tool behavior has changed.

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add readOnlyHint and idempotentHint annotations to seven read‑only MCP tools so clients can auto-approve and cache these calls. No behavior or UI changes.

- **Bug Fixes**
  - Registry tools: `COLLECTION_REGISTRY_APP_LIST`, `COLLECTION_REGISTRY_APP_GET`, `COLLECTION_REGISTRY_APP_VERSIONS`, `COLLECTION_REGISTRY_APP_SEARCH`, `COLLECTION_REGISTRY_APP_FILTERS`
  - AI provider tools: `AI_PROVIDERS_LIST`, `AI_PROVIDER_KEY_LIST`, `AI_PROVIDERS_LIST_MODELS`

<sup>Written for commit 462c727443abb3c98a62ea0d9a97f8a6ac93064b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

