### PR TITLE
fix(plugins): update private-registry queries after projects table removal

### DIFF
--- a/packages/mesh-plugin-private-registry/server/routes/public-publish-request.ts
+++ b/packages/mesh-plugin-private-registry/server/routes/public-publish-request.ts
@@ -169,6 +169,7 @@ async function getPluginSettings(
     )
     .select(["virtual_mcp_plugin_configs.settings as settings"])
     .where("connections.organization_id", "=", orgId)
+    .where("connections.subtype", "=", "project")
     .where("virtual_mcp_plugin_configs.plugin_id", "=", PLUGIN_ID)
     .execute();
 

--- a/packages/mesh-plugin-private-registry/server/tools/utils.ts
+++ b/packages/mesh-plugin-private-registry/server/tools/utils.ts
@@ -82,6 +82,7 @@ export async function getRegistryPluginSettings(
     )
     .select(["virtual_mcp_plugin_configs.settings as settings"])
     .where("connections.organization_id", "=", organizationId)
+    .where("connections.subtype", "=", "project")
     .where("virtual_mcp_plugin_configs.plugin_id", "=", PLUGIN_ID)
     .execute();
 


### PR DESCRIPTION
## What is this contribution about?

The `mesh-plugin-private-registry` plugin had two functions that still queried the dropped `projects` and `project_plugin_configs` tables (removed by migration 048 `merge-projects-agents`), causing `relation "projects" does not exist` 500 errors when:

- Fetching tools for the self MCP connection during automation execution
- Accessing private registry plugin settings via the public publish request endpoint

Updated both queries to use `virtual_mcp_plugin_configs` joined with `connections` — the replacement tables created by migration 048.

**Files changed:**
- `packages/mesh-plugin-private-registry/server/tools/utils.ts` — `getRegistryPluginSettings()`
- `packages/mesh-plugin-private-registry/server/routes/public-publish-request.ts` — `getPluginSettings()`

## Screenshots/Demonstration
N/A — backend-only fix, no UI changes.

## How to Test
1. Deploy to an environment where migration 048 has been applied (projects table dropped)
2. Fire an automation that uses the private-registry plugin
3. Verify the `[fetchWithCache] tools:*_self cache-miss live FAILED` error no longer occurs
4. Verify private registry publish requests work without 500 errors

## Migration Notes
N/A — no new migrations needed. This fix aligns the plugin queries with the existing migration 048 schema.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `mesh-plugin-private-registry` to query `virtual_mcp_plugin_configs` joined with `connections`, restricted to project subtype. Fixes 500s (“relation 'projects' does not exist”) when fetching self MCP tools and reading plugin settings via the public publish endpoint.

- **Bug Fixes**
  - Switched query sources in getRegistryPluginSettings and getPluginSettings to `virtual_mcp_plugin_configs` + `connections`.
  - Added `connections.subtype = 'project'` filter to preserve project-only behavior and exclude agent configs.

<sup>Written for commit 90bfb9b7ab5a603901ad7771739ab257c9c71fd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

