### PR TITLE
fix(migrations): remove leftover org-admin projects after project/agent merge

### DIFF
--- a/apps/mesh/migrations/049-remove-org-admin-projects.ts
+++ b/apps/mesh/migrations/049-remove-org-admin-projects.ts
@@ -1,0 +1,27 @@
+/**
+ * Remove Organization Admin Projects
+ *
+ * Migration 048 converted all projects (including the "Organization Admin"
+ * org-admin project) into VIRTUAL connections with subtype='project'.
+ * The org-admin project is no longer needed — the org-level context is now
+ * handled synthetically in the UI. This migration removes those leftover
+ * connections by matching on metadata.migrated_project_slug = 'org-admin'.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Delete VIRTUAL connections that were migrated from the old org-admin project.
+  // CASCADE on connection_aggregations and virtual_mcp_plugin_configs will clean up related rows.
+  await sql`
+    DELETE FROM connections
+    WHERE connection_type = 'VIRTUAL'
+      AND subtype = 'project'
+      AND metadata::json->>'migrated_project_slug' = 'org-admin'
+  `.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // The org-admin connections cannot be reliably restored.
+  // No-op: the UI already handles org-level context synthetically.
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -47,6 +47,7 @@ import * as migration045threadcontextstartmessage from "./045-thread-context-sta
 import * as migration046removeobjectstorageplugin from "./046-remove-object-storage-plugin.ts";
 import * as migration047addnextrunat from "./047-add-next-run-at.ts";
 import * as migration048mergeprojectsagents from "./048-merge-projects-agents.ts";
+import * as migration049removeorgadminprojects from "./049-remove-org-admin-projects.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -108,6 +109,7 @@ const migrations: Record<string, Migration> = {
   "046-remove-object-storage-plugin": migration046removeobjectstorageplugin,
   "047-add-next-run-at": migration047addnextrunat,
   "048-merge-projects-agents": migration048mergeprojectsagents,
+  "049-remove-org-admin-projects": migration049removeorgadminprojects,
 };
 
 export default migrations;


### PR DESCRIPTION
## What is this contribution about?

After migration 048 merged projects into virtual MCPs, the old "Organization Admin" (`org-admin`) project was converted into a VIRTUAL connection with `subtype='project'`. This causes it to appear as a regular project in the projects list on staging, which is incorrect — the org-level context is now handled synthetically in the UI via `org-layout.tsx`.

This PR adds migration 049 that deletes these leftover org-admin connections by matching on `metadata->>'migrated_project_slug' = 'org-admin'`. CASCADE constraints clean up related `connection_aggregations` and `virtual_mcp_plugin_configs` rows automatically.

## Screenshots/Demonstration

N/A

## How to Test

1. Deploy to a staging environment that has existing organizations with migrated org-admin projects
2. Run database migrations (`bun run migrate`)
3. Verify the "Organization Admin" project no longer appears in the projects list
4. Verify org-level views still work correctly (they use a synthetic project context, not a DB record)

## Migration Notes

- New migration `049-remove-org-admin-projects` will run automatically
- Deletes VIRTUAL connections where `metadata->>'migrated_project_slug' = 'org-admin'`
- Related rows in `connection_aggregations` and `virtual_mcp_plugin_configs` are cleaned up via CASCADE

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes leftover "Organization Admin" projects after the project/agent merge. Adds a migration to delete their VIRTUAL connections so they no longer appear in the projects list.

- **Migration**
  - Adds `049-remove-org-admin-projects` and registers it.
  - Deletes connections with `connection_type='VIRTUAL'`, `subtype='project'`, and `metadata->>'migrated_project_slug'='org-admin'`.
  - Related `connection_aggregations` and `virtual_mcp_plugin_configs` rows are removed via CASCADE; down migration is a no-op.

<sup>Written for commit c0bd9394ee625b79d38e3e944d592308cd0e0de4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

