### PR TITLE
fix(cli): disable HTTP route logs when --no-tui is set

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -15,7 +15,6 @@ import { PrometheusSerializer } from "@opentelemetry/exporter-prometheus";
 import { Hono } from "hono";
 import { getCookie } from "hono/cookie";
 import { cors } from "hono/cors";
-import { logger } from "hono/logger";
 import { endTime, startTime, timing } from "hono/timing";
 import { auth } from "../auth";
 import {
@@ -370,9 +369,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     c.header("Content-Security-Policy", "frame-ancestors 'none'");
   });
 
-  if (env.NODE_ENV === "production") {
-    app.use("*", logger());
-  } else {
+  if (process.env.DECO_NO_TUI !== "true") {
     app.use("*", devLogger());
   }
 

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -266,7 +266,7 @@ if (noTui) {
   console.log("");
 
   const { startServer } = await import("./cli/commands/serve");
-  await startServer(serveOptions);
+  await startServer({ ...serveOptions, noTui: true });
 } else {
   // Ink UI mode
   const { render } = await import("ink");

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -135,6 +135,9 @@ export async function startDevServer(
   }
 
   // ── Environment ─────────────────────────────────────────────────────
+  if (noTui) {
+    process.env.DECO_NO_TUI = "true";
+  }
   process.env.DECOCMS_HOME = home;
   process.env.DATA_DIR = home;
   process.env.PORT = port;

--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -22,6 +22,7 @@ export interface ServeOptions {
   home: string;
   skipMigrations: boolean;
   localMode: boolean;
+  noTui?: boolean;
 }
 
 // Strip ANSI escape codes from a string
@@ -76,9 +77,12 @@ export function interceptConsoleForTui() {
 }
 
 export async function startServer(options: ServeOptions): Promise<void> {
-  const { port, home, skipMigrations, localMode } = options;
+  const { port, home, skipMigrations, localMode, noTui } = options;
 
   // Set env vars before any imports that read them
+  if (noTui) {
+    process.env.DECO_NO_TUI = "true";
+  }
   process.env.DECOCMS_HOME = home;
   process.env.DATA_DIR = home;
   process.env.PORT = port;


### PR DESCRIPTION
## What is this contribution about?

When running in k8s/Docker (headless mode), Hono's route logger floods stdout with per-request logs that are redundant when OTel is already providing observability. This PR propagates `--no-tui` as a `DECO_NO_TUI` env var so `app.ts` skips the logger middleware entirely in headless mode. It also removes the unused Hono `logger()` middleware in favor of a single `devLogger()` for both dev and production.

## How to Test

1. Run `bunx decocms` locally — verify route logs still appear in the TUI
2. Run `bunx decocms --no-tui` — verify no route logs are printed to stdout
3. Run in Docker (no TTY) — same as `--no-tui`, no route logs

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables HTTP route logs when `--no-tui` is set by propagating `DECO_NO_TUI` so the app skips the logger middleware. Keeps route logs in TUI mode and reduces noise in Docker/k8s when OTel is used.

- **Bug Fixes**
  - Skip `devLogger()` when `DECO_NO_TUI` is `true`, suppressing per-request logs in headless mode.
  - Propagate `--no-tui` to `startServer()` and set `DECO_NO_TUI` in both `dev` and `serve` commands.

- **Refactors**
  - Remove `logger()` from `hono` and use a single `devLogger()` across environments.

<sup>Written for commit e88f34cb1818cf8951d86a37c995c2d1210b00bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

