### PR TITLE
fix(mesh-sdk): resolve Zod 4 JSON Schema error for connection tool schemas

### DIFF
--- a/packages/mesh-sdk/src/types/connection.ts
+++ b/packages/mesh-sdk/src/types/connection.ts
@@ -24,11 +24,27 @@ const OAuthConfigSchema = z.object({
 export type OAuthConfig = z.infer<typeof OAuthConfigSchema>;
 
 /**
- * Tool definition schema from MCP discovery.
- * Re-uses the canonical ToolSchema from the MCP SDK so new fields
- * (execution, icons, title, etc.) are automatically supported.
+ * JSON-Schema-safe JSON Schema object.
+ *
+ * The MCP SDK's ToolSchema uses z.custom() (AssertObjectSchema) for property
+ * values inside inputSchema/outputSchema. Zod 4's toJSONSchema() cannot
+ * represent z.custom(), throwing "Custom types cannot be represented in JSON
+ * Schema". We override only these two fields with a safe equivalent so that
+ * all other ToolSchema fields (name, annotations, execution, icons, _meta, …)
+ * still flow through automatically when the MCP SDK is updated.
  */
-const ToolDefinitionSchema = ToolSchema;
+const JsonSchemaObjectSchema = z
+  .object({
+    type: z.literal("object"),
+    properties: z.record(z.string(), z.unknown()).optional(),
+    required: z.array(z.string()).optional(),
+  })
+  .catchall(z.unknown());
+
+const ToolDefinitionSchema = ToolSchema.extend({
+  inputSchema: JsonSchemaObjectSchema,
+  outputSchema: JsonSchemaObjectSchema.optional(),
+});
 
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
 


### PR DESCRIPTION
## What is this contribution about?

Fixes `McpError: MCP error -32603: Custom types cannot be represented in JSON Schema` when listing tools via `POST /mcp/self`.

**Root cause:** The MCP SDK's `ToolSchema` uses `z.custom()` (via `AssertObjectSchema`) for property values in `inputSchema`/`outputSchema`. When Zod 4's `toJSONSchema()` encounters `z.custom()` types, it throws because `$ZodCustom` has no JSON Schema representation.

`ConnectionEntitySchema` embedded `ToolSchema` directly in its `tools` field, so all connection tool schemas (CREATE, LIST, GET, UPDATE, DELETE) failed JSON Schema conversion.

**Fix:** Extends `ToolSchema` via `.extend()` to override only `inputSchema` and `outputSchema` with JSON-Schema-safe equivalents (`z.record(z.string(), z.unknown())` instead of `z.custom()`). All other `ToolSchema` fields (name, annotations, execution, icons, `_meta`, etc.) flow through automatically when the MCP SDK is updated.

## Screenshots/Demonstration

N/A — backend-only fix, no UI changes.

## How to Test

1. Deploy and call `POST /mcp/self` with a `tools/list` request
2. Verify no `McpError -32603: Custom types cannot be represented in JSON Schema` in logs
3. Confirm connection tools (CREATE, LIST, GET, UPDATE, DELETE) appear in the tool list with valid JSON Schema for their input/output schemas

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Zod 4 JSON Schema error when listing MCP connection tools by making `ToolSchema`’s `inputSchema`/`outputSchema` JSON-Schema-safe. This removes the “Custom types cannot be represented in JSON Schema” failure in `POST /mcp/self`.

- **Bug Fixes**
  - Root cause: Zod 4 `toJSONSchema()` cannot serialize `z.custom()` used in the MCP SDK’s `ToolSchema`.
  - Change: Extended `ToolSchema` to replace `inputSchema` and `outputSchema` with a safe `JsonSchemaObjectSchema` (`z.object(...).catchall(z.unknown())`).
  - Result: Connection tool schemas (CREATE, LIST, GET, UPDATE, DELETE) now serialize to valid JSON Schema without errors, while all other `ToolSchema` fields remain intact.

<sup>Written for commit ebcd0e2a9a3e825e28500b5439ae2959f9ccbd42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

