### PR TITLE
fix(settings): resolve infinite loading on Features tab at org level

### DIFF
--- a/apps/mesh/src/web/components/settings-modal/index.tsx
+++ b/apps/mesh/src/web/components/settings-modal/index.tsx
@@ -86,7 +86,7 @@ function ProjectContextWrapper({
 }
 
 function SettingsContent({ section }: { section: SettingsSection }) {
-  const { org } = useProjectContext();
+  const { project } = useProjectContext();
   switch (section) {
     case "account.profile":
       return <AccountProfilePage />;
@@ -95,8 +95,16 @@ function SettingsContent({ section }: { section: SettingsSection }) {
     case "org.general":
       return <OrgGeneralPage />;
     case "org.plugins":
+      // When on a project route, project.id is a real virtual MCP ID — wrap
+      // in ProjectContextWrapper to fetch the full entity.
+      // On org-level routes (isOrgAdmin), project.id is just the org ID and
+      // there is no backing virtual MCP, so render directly with the existing
+      // project context.
+      if (project.isOrgAdmin) {
+        return <ProjectPluginsPage />;
+      }
       return (
-        <ProjectContextWrapper projectId={org.id}>
+        <ProjectContextWrapper projectId={project.id}>
           <ProjectPluginsPage />
         </ProjectContextWrapper>
       );


### PR DESCRIPTION
## What is this contribution about?

After the project/agent merge (#2799) and the org-admin cleanup migration (#2815), the **Features tab** in the Settings popup hangs on a loading skeleton forever when accessed from an org-level route (e.g. `?settings=org.plugins`).

**Root cause:** `SettingsContent` passed `org.id` (the organization ID) to `ProjectContextWrapper`, which called `useVirtualMCP(org.id)`. No virtual MCP entity has the organization's ID, so the hook returned `null` and the guard `if (!entity) return <ContentSkeleton />` rendered the skeleton indefinitely.

**Fix:**
- When `project.isOrgAdmin` is true (org-level route), skip the `ProjectContextWrapper` entirely — the synthetic project context from `OrgLayoutContent` is already sufficient.
- When on a project route, use `project.id` (the real virtual MCP ID) instead of `org.id`.

## Screenshots/Demonstration

N/A

## How to Test

1. Navigate to an org-level page (e.g. `https://studio-stg.decocms.com/<workspace>`)
2. Open Settings → Features tab (or append `?settings=org.plugins` to the URL)
3. **Before fix:** The tab shows a loading skeleton forever
4. **After fix:** The tab renders the plugin list immediately

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the infinite loading on the Settings → Features tab when opened from an org-level route by skipping the project wrapper for org admins and using the correct project ID on project routes. The tab now renders immediately instead of showing a skeleton forever.

- **Bug Fixes**
  - Skip `ProjectContextWrapper` when `project.isOrgAdmin` to use the existing org-level context.
  - Use `project.id` (not `org.id`) when wrapping so `useVirtualMCP` resolves the correct entity.
  - Features tab now loads plugin list on org-level pages without hanging.

<sup>Written for commit 30186c61ce28b4638f78fea6cbe2f0b322b96552. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

