### PR TITLE
chore: remove verbose console.log calls from runtime server code

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -931,12 +931,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   for (const dir of SIGNAL_DIRS) {
     cleanupOldMonitoringFiles(dir)
-      .then((deleted) => {
-        if (deleted > 0)
-          console.log(
-            `[monitoring] Cleaned up ${deleted} old partitions from ${dir}`,
-          );
-      })
+      .then(() => {})
       .catch((err) =>
         console.error("[monitoring] Retention cleanup failed:", err),
       );
@@ -948,12 +943,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       .deleteFrom("apikey" as any)
       .where("expiresAt" as any, "<", new Date())
       .execute()
-      .then((result) => {
-        const deleted = Number(result[0]?.numDeletedRows ?? 0);
-        if (deleted > 0) {
-          console.log(`[auth] Cleaned up ${deleted} expired API keys`);
-        }
-      })
+      .then(() => {})
       .catch((err: unknown) =>
         console.error("[auth] Expired API key cleanup failed:", err),
       );

--- a/apps/mesh/src/api/routes/decopilot/automation-context.ts
+++ b/apps/mesh/src/api/routes/decopilot/automation-context.ts
@@ -54,10 +54,6 @@ export function createAutomationContextFactory(
       return null;
     }
 
-    console.log(
-      `[automationContextFactory] Resolved context: user=${userId}, org=${orgId}, role=${membership.role}`,
-    );
-
     // Create a base context (unauthenticated) and override auth/org/access fields
     const ctx = await ContextFactory.create();
     ctx.auth.user = { id: userId, role: membership.role };

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -232,6 +232,5 @@ export class NatsStreamBuffer implements StreamBuffer {
   teardown(): void {
     this.js = null;
     this.jsm = null;
-    console.log("[Decopilot] JetStream stream buffer torn down");
   }
 }

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -256,27 +256,13 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
     try {
       const { threadId, thread, organization } = await validateThreadAccess(c);
 
-      console.log("[decopilot:attach] Entry", {
-        threadId,
-        threadStatus: thread.status,
-        runOwnerPod: thread.run_owner_pod,
-        createdBy: thread.created_by,
-        hasRunConfig: !!thread.run_config,
-        isRunning: runRegistry.isRunning(threadId),
-      });
-
       // ── Fast path: run is active on this pod → replay buffer ──
       if (runRegistry.isRunning(threadId)) {
         const replayChunkStream =
           await streamBuffer.createReplayStream(threadId);
         if (!replayChunkStream) {
-          console.log("[decopilot:attach] Running but no replay stream", {
-            threadId,
-          });
           return c.body(null, 204);
         }
-
-        console.log("[decopilot:attach] Replaying active run", { threadId });
 
         const replayStream = createUIMessageStream({
           execute: async ({ writer }) => {
@@ -305,28 +291,16 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
 
       // Not in_progress → nothing to resume
       if (thread.status !== "in_progress") {
-        console.log("[decopilot:attach] 204: not in_progress", {
-          threadId,
-          status: thread.status,
-        });
         return c.body(null, 204);
       }
 
       // Only the thread owner can trigger orphan resume
       if (thread.created_by !== userId) {
-        console.log("[decopilot:attach] 204: not thread owner", {
-          threadId,
-          createdBy: thread.created_by,
-          userId,
-        });
         return c.body(null, 204);
       }
 
       // No persisted config → can't resume; force-fail so user can retry
       if (!thread.run_config) {
-        console.log("[decopilot:attach] 204: no run_config, force-failing", {
-          threadId,
-        });
         await threadStorage.forceFailIfInProgress(threadId, organization.id);
         return c.body(null, 204);
       }
@@ -334,10 +308,6 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       // Validate stored config (schema drift protection)
       const parsed = PersistedRunConfigSchema.safeParse(thread.run_config);
       if (!parsed.success) {
-        console.log(
-          "[decopilot:attach] 204: invalid run_config, force-failing",
-          { threadId, errors: parsed.error.issues },
-        );
         await threadStorage.forceFailIfInProgress(threadId, organization.id);
         return c.body(null, 204);
       }
@@ -357,12 +327,6 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           config.models.thinking.id,
         )
       ) {
-        console.log("[decopilot:attach] 403: model permission denied", {
-          threadId,
-          credentialId: config.models.credentialId,
-          modelId: config.models.thinking.id,
-          role: ctx.auth.user?.role,
-        });
         throw new HTTPException(403, {
           message: "Model not allowed for your role",
         });
@@ -375,18 +339,8 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         POD_ID,
       );
       if (!claimed) {
-        console.log("[decopilot:attach] 204: CAS claim failed", {
-          threadId,
-          podId: POD_ID,
-        });
         return c.body(null, 204);
       }
-
-      console.log("[decopilot:attach] Orphan claimed, resuming", {
-        threadId,
-        podId: POD_ID,
-        previousPod: thread.run_owner_pod,
-      });
 
       // Resume the run — identity from auth context, NOT stored config
       const result = await streamCore(

--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -122,13 +122,7 @@ export class RunRegistry {
     // 1. DB: orphan all runs owned by this pod FIRST
     //    (if process dies after this, runs are resumable)
     try {
-      const orphaned = await this.deps.storage.orphanRunsByPod(this.podId);
-      if (orphaned.length > 0) {
-        console.log(
-          `[RunRegistry] Orphaned ${orphaned.length} runs on shutdown:`,
-          orphaned,
-        );
-      }
+      await this.deps.storage.orphanRunsByPod(this.podId);
     } catch (err) {
       console.error("[RunRegistry] Failed to orphan runs in DB:", err);
     }
@@ -153,8 +147,6 @@ export class RunRegistry {
     const orphans = await this.deps.storage.listOrphanedRuns(this.podId);
     if (orphans.length === 0) return;
 
-    console.log(`[RunRegistry] Found ${orphans.length} orphaned runs`);
-
     // Concurrency cap: max 5 concurrent resumes
     const CONCURRENCY = 5;
     for (let i = 0; i < orphans.length; i += CONCURRENCY) {
@@ -168,7 +160,6 @@ export class RunRegistry {
           );
           if (!claimed) return; // Another pod got it
 
-          console.log(`[RunRegistry] Auto-resuming orphaned run ${thread.id}`);
           try {
             await resumeFn(thread);
           } catch (err) {
@@ -195,10 +186,6 @@ export class RunRegistry {
     const orphans = await this.deps.storage.listOrphanedRunsByPod(deadPodId);
     if (orphans.length === 0) return;
 
-    console.log(
-      `[RunRegistry] Pod ${deadPodId} died, recovering ${orphans.length} orphans`,
-    );
-
     // Cancel running threads on the dead pod (in case it's alive but partitioned)
     for (const thread of orphans) {
       cancelBroadcast?.broadcast(thread.id);
@@ -217,9 +204,6 @@ export class RunRegistry {
           );
           if (!claimed) return;
 
-          console.log(
-            `[RunRegistry] Resuming orphan ${thread.id} from dead pod ${deadPodId}`,
-          );
           try {
             await resumeFn(thread);
           } catch (err) {

--- a/apps/mesh/src/auth/sso.ts
+++ b/apps/mesh/src/auth/sso.ts
@@ -100,10 +100,6 @@ async function mergeDuplicateSSOUser(data: {
 
   if (!originalUser) return;
 
-  console.info(
-    `[SSO] Merging duplicate user ${user.id} (${user.email}) into original ${originalUser.id} (${originalUser.email})`,
-  );
-
   try {
     await db.transaction().execute(async (tx) => {
       // Move all accounts from the duplicate to the original user
@@ -133,10 +129,6 @@ async function mergeDuplicateSSOUser(data: {
       // Delete the duplicate user
       await sql`DELETE FROM "user" WHERE "id" = ${user.id}`.execute(tx);
     });
-
-    console.info(
-      `[SSO] Successfully merged duplicate user into ${originalUser.id}`,
-    );
   } catch (error) {
     console.error("[SSO] Failed to merge duplicate user:", error);
   }

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -39,16 +39,5 @@ export function buildStreamRequest(
     threadId,
   };
 
-  console.log(`[buildStreamRequest] automation="${automation.name}":`, {
-    threadId,
-    triggerId,
-    agentId: request.agent?.id,
-    credentialId: request.models?.credentialId,
-    modelId: request.models?.thinking?.id,
-    messageCount: request.messages.length,
-    userId: request.userId,
-    orgId: request.organizationId,
-  });
-
   return request;
 }

--- a/apps/mesh/src/automations/cron-worker.ts
+++ b/apps/mesh/src/automations/cron-worker.ts
@@ -126,12 +126,6 @@ export class AutomationCronWorker {
       );
       updated++;
     }
-
-    if (updated > 0) {
-      console.log(
-        `[AutomationCron] Startup sweep: recomputed next_run_at for ${updated} trigger(s)`,
-      );
-    }
   }
 
   private async processDueTriggers(): Promise<void> {

--- a/apps/mesh/src/automations/event-trigger-engine.ts
+++ b/apps/mesh/src/automations/event-trigger-engine.ts
@@ -69,10 +69,6 @@ export class EventTriggerEngine {
       return;
     }
 
-    console.log(
-      `[EventTrigger] Processing event: type=${event.type}, source=${event.source}, org=${event.organizationId}, depth=${depth}`,
-    );
-
     // 1. Find matching triggers
     const matchingTriggers = await this.storage.findActiveEventTriggers(
       event.source,
@@ -80,25 +76,10 @@ export class EventTriggerEngine {
       event.organizationId,
     );
 
-    console.log(
-      `[EventTrigger] Found ${matchingTriggers.length} matching trigger(s) for ${event.type}`,
-      matchingTriggers.map((t) => ({
-        triggerId: t.id,
-        automationId: t.automation_id,
-        automationName: t.automation.name,
-      })),
-    );
-
     // 2. Filter by params
     const triggersToFire = matchingTriggers.filter((trigger) =>
       this.paramsMatch(trigger.params, event.data),
     );
-
-    if (triggersToFire.length !== matchingTriggers.length) {
-      console.log(
-        `[EventTrigger] After param filter: ${triggersToFire.length}/${matchingTriggers.length} triggers will fire`,
-      );
-    }
 
     // 3. Fire each
     const results = await Promise.allSettled(
@@ -119,12 +100,7 @@ export class EventTriggerEngine {
 
     for (const [i, result] of results.entries()) {
       const trigger = triggersToFire[i]!;
-      if (result.status === "fulfilled") {
-        console.log(
-          `[EventTrigger] Trigger ${trigger.id} ("${trigger.automation.name}") result:`,
-          result.value,
-        );
-      } else {
+      if (result.status === "rejected") {
         console.error(
           `[EventTrigger] Trigger ${trigger.id} ("${trigger.automation.name}") REJECTED:`,
           result.reason,

--- a/apps/mesh/src/automations/fire.ts
+++ b/apps/mesh/src/automations/fire.ts
@@ -76,10 +76,6 @@ export async function fireAutomation(opts: {
     deps,
   } = opts;
 
-  console.log(
-    `[fireAutomation] Starting for automation "${automation.name}" (${automation.id}), triggerId=${triggerId}`,
-  );
-
   // 0. Acquire global semaphore
   const globalSlot = globalSemaphore.tryAcquire();
   if (!globalSlot) {
@@ -116,10 +112,6 @@ export async function fireAutomation(opts: {
       );
       return { skipped: "concurrency_limit" };
     }
-
-    console.log(
-      `[fireAutomation] Acquired run slot threadId=${threadId} for "${automation.name}"`,
-    );
 
     // 3. Build request & fire with timeout
     const abortController = new AbortController();
@@ -165,9 +157,6 @@ export async function fireAutomation(opts: {
     }
 
     if (runError) return { threadId, error: runError };
-    console.log(
-      `[fireAutomation] SUCCESS "${automation.name}" threadId=${threadId}`,
-    );
     return { threadId };
   } finally {
     globalSlot.release();

--- a/apps/mesh/src/event-bus/worker.ts
+++ b/apps/mesh/src/event-bus/worker.ts
@@ -153,12 +153,7 @@ export class EventBusWorker {
     if (this.running) return;
 
     // Reset any deliveries that were stuck in 'processing' state from previous crash
-    const resetCount = await this.storage.resetStuckDeliveries();
-    if (resetCount > 0) {
-      console.log(
-        `[EventBus] Reset ${resetCount} stuck deliveries from previous shutdown`,
-      );
-    }
+    await this.storage.resetStuckDeliveries();
 
     // Recover orphaned cron events: "delivered" with no pending future deliveries.
     // This happens when the process crashes between updateEventStatus and
@@ -166,14 +161,6 @@ export class EventBusWorker {
     const orphanedCrons = await this.storage.findOrphanedCronEvents();
     for (const event of orphanedCrons) {
       await this.scheduleNextCronDelivery(event);
-      console.log(
-        `[EventBus] Recovered orphaned cron event ${event.id} (${event.type}, cron: ${event.cron})`,
-      );
-    }
-    if (orphanedCrons.length > 0) {
-      console.log(
-        `[EventBus] Recovered ${orphanedCrons.length} orphaned cron event(s)`,
-      );
     }
 
     this.running = true;
@@ -507,9 +494,6 @@ export class EventBusWorker {
       const nextRun = cron.nextRun();
 
       if (!nextRun) {
-        console.log(
-          `[EventBus] Cron expression for event ${event.id} has no more runs`,
-        );
         return;
       }
 
@@ -518,9 +502,6 @@ export class EventBusWorker {
       // Get the subscriptions that match this event
       const subscriptions = await this.storage.getMatchingSubscriptions(event);
       if (subscriptions.length === 0) {
-        console.log(
-          `[EventBus] No subscriptions for cron event ${event.id}, skipping next delivery`,
-        );
         return;
       }
 
@@ -529,10 +510,6 @@ export class EventBusWorker {
         event.id,
         subscriptions.map((s) => s.id),
         nextDeliveryTime,
-      );
-
-      console.log(
-        `[EventBus] Scheduled next cron delivery for event ${event.id} at ${nextDeliveryTime}`,
       );
     } catch (error) {
       console.error(

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { createApp } from "./api/app";
 import { isServerPath } from "./api/utils/paths";
 import { env, logConfiguration } from "./env";
-import { green, red } from "./fmt";
+import { red } from "./fmt";
 
 const port = env.PORT;
 
@@ -104,9 +104,7 @@ if (env.DECOCMS_LOCAL_MODE) {
     .then(async ({ seedLocalMode, markSeedComplete }) => {
       try {
         const seeded = await seedLocalMode();
-        if (seeded) {
-          console.log(`\n${green("Local environment initialized.")}`);
-        }
+        void seeded;
       } catch (error) {
         console.error("Failed to seed local mode:", error);
       } finally {

--- a/apps/mesh/src/mcp-clients/decorators/with-mcp-caching.ts
+++ b/apps/mesh/src/mcp-clients/decorators/with-mcp-caching.ts
@@ -52,20 +52,9 @@ export function withMcpCaching(
     ): Promise<Record<string, unknown>> => {
       // Bypass cache for VIRTUAL connections or paginated requests
       if (isVirtual || !cache || shouldBypassCache(params, options)) {
-        const reason = isVirtual
-          ? "VIRTUAL"
-          : !cache
-            ? "no-cache"
-            : "has-params/options";
-        console.log(
-          `[withMcpCaching] ${method} ${connection.id} bypass (${reason})`,
-        );
         return (original as any)(params, options);
       }
 
-      console.log(
-        `[withMcpCaching] ${method} ${connection.id} delegating to fetchWithCache`,
-      );
       const data = await fetchWithCache(
         type,
         connection.id,

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -100,9 +100,6 @@ export async function buildRequestHeaders(
     if (isExpired) {
       // Try to refresh if we have refresh capability
       if (canRefresh) {
-        console.log(
-          `[Proxy] Token expired for ${connectionId}, attempting refresh`,
-        );
         const refreshResult = await refreshAccessToken(cachedToken);
 
         if (refreshResult.success && refreshResult.accessToken) {
@@ -122,7 +119,6 @@ export async function buildRequestHeaders(
           });
 
           accessToken = refreshResult.accessToken;
-          console.log(`[Proxy] Token refreshed for ${connectionId}`);
         } else {
           // Refresh failed - token is invalid
           // Delete the cached token so user gets prompted to re-auth
@@ -134,9 +130,6 @@ export async function buildRequestHeaders(
       } else {
         // Token expired but no refresh capability - delete it
         await tokenStorage.delete(connectionId);
-        console.log(
-          `[Proxy] Token expired without refresh capability for ${connectionId}`,
-        );
       }
     } else {
       // Token is still valid

--- a/apps/mesh/src/sandbox/run-code.ts
+++ b/apps/mesh/src/sandbox/run-code.ts
@@ -140,7 +140,6 @@ export async function runCode({
 
     return { returnValue: value, consoleLogs: consoleBuiltin.logs };
   } catch (err) {
-    console.log(err);
     return { error: inspect(err), consoleLogs: consoleBuiltin.logs };
   }
 }

--- a/apps/mesh/src/storage/automations.ts
+++ b/apps/mesh/src/storage/automations.ts
@@ -625,10 +625,6 @@ class KyselyAutomationsStorage implements AutomationsStorage {
         })
         .execute();
 
-      console.log(
-        `[tryAcquireRunSlot] Created thread ${threadId} for "${automation.name}" (${automationId}), trigger_id=${triggerId}, org=${automation.organization_id}`,
-      );
-
       return threadId;
     });
   }


### PR DESCRIPTION
## What is this contribution about?

Removes ~60 informational/success `console.log` and `console.info` calls from production server runtime paths to reduce TTY noise. Only `console.error` and `console.warn` remain for actionable diagnostics.

**Preserved:** CLI command output (help text, service management, migrations, init scaffolding), startup banners, dev-mode request logger, and test helpers — these are user-facing and intentional.

**16 files cleaned across:**
- Automations: build-stream-request, fire, cron-worker, event-trigger-engine
- Decopilot: routes (attach endpoint), run-registry, automation-context, nats-stream-buffer
- MCP clients: outbound headers (token refresh), caching decorator
- Event bus: worker (startup recovery, cron scheduling)
- Auth: SSO user merge
- Storage: automations (thread creation)
- API: app (retention cleanup), sandbox/run-code
- Entry point: index.ts (local seed message)

## Screenshots/Demonstration

N/A — no UI changes.

## How to Test

1. Run `bun run check` — all workspaces should pass type checking
2. Run `bun test` — all tests should pass (1257 pass, 32 skip)
3. Run `bun run fmt:check` — formatting should be clean
4. Start the server with `bun run dev` and trigger automations/events — verify the production TTY is significantly quieter (no `[buildStreamRequest]`, `[fireAutomation]`, `[EventTrigger]`, `[automationContextFactory]`, `[AutomationCron]`, `[tryAcquireRunSlot]` etc. logs)
5. Verify `console.error` and `console.warn` still fire for actual error conditions

## Migration Notes

N/A — no database migrations or configuration changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed ~60 success/info `console.log`/`console.info` calls from production server runtime to reduce TTY noise and keep logs focused on errors and warnings. `console.error` and `console.warn` remain; CLI output, startup banners, dev-mode request logger, and test helpers are unchanged.

<sup>Written for commit 6ef423f13c1c644862643b37a1a00a0e359a3089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

