### PR TITLE
fix(automations): use org slug instead of UUID for navigation

### DIFF
--- a/apps/mesh/src/web/routes/orgs/automations.tsx
+++ b/apps/mesh/src/web/routes/orgs/automations.tsx
@@ -65,7 +65,7 @@ import { toast } from "sonner";
 
 export default function AutomationsPage() {
   const navigate = useNavigate();
-  const { org, locator } = useProjectContext();
+  const { org } = useProjectContext();
   const { data: automations, isLoading } = useAutomationsList();
   const createMutation = useAutomationCreate();
   const deleteMutation = useAutomationDelete();
@@ -79,8 +79,6 @@ export default function AutomationsPage() {
     resource: "automations",
     defaultViewMode: "table",
   });
-
-  const orgSlug = locator.split("/")[0] ?? org.slug ?? "org-admin";
 
   const handleCreate = async () => {
     try {
@@ -98,7 +96,7 @@ export default function AutomationsPage() {
       navigate({
         to: "/$org/automations/$automationId",
         params: {
-          org: orgSlug,
+          org: org.slug,
           automationId: result.id,
         },
       });
@@ -123,7 +121,7 @@ export default function AutomationsPage() {
     navigate({
       to: "/$org/automations/$automationId",
       params: {
-        org: orgSlug,
+        org: org.slug,
         automationId,
       },
     });


### PR DESCRIPTION
## What is this contribution about?

The automations list page was using `locator.split("/")[0]` to get the org identifier for navigation, which returns the org **UUID** instead of the **slug**. When clicking on an automation row, the app navigated to `/${UUID}/automations/$id`, causing the shell layout's `setActive({ organizationSlug: UUID })` call to fail and redirect to the org home (`/`).

Fixed by using `org.slug` directly, consistent with how `agents.tsx` and `automation-detail.tsx` already handle navigation.

## Screenshots/Demonstration

N/A — no visual changes, fixes a navigation redirect bug.

## How to Test

1. Enable experimental automations in preferences
2. Navigate to the Automations list page
3. Create an automation (or use an existing one)
4. Click on an automation row in the table
5. **Expected**: navigates to the automation detail page
6. **Previously**: redirected to the org home page

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes navigation from the Automations list by using the org slug instead of the UUID, so clicking a row takes you to the automation detail page instead of redirecting to the org home. Aligns routing with the agents and automation-detail pages for consistent behavior.

<sup>Written for commit a9602f73bc666356df81c094bc8732a327cc01b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

