### PR TITLE
feat(cli): add L key toggle for log flow mode

### DIFF
--- a/apps/mesh/src/cli/app.tsx
+++ b/apps/mesh/src/cli/app.tsx
@@ -3,7 +3,12 @@ import { useSyncExternalStore } from "react";
 import { ConfigView } from "./config-view";
 import { Header } from "./header";
 import { RequestLog } from "./request-log";
-import { getCliState, subscribeCliState, toggleViewMode } from "./cli-store";
+import {
+  getCliState,
+  subscribeCliState,
+  toggleLogFlow,
+  toggleViewMode,
+} from "./cli-store";
 
 const HEADER_HEIGHT = 13;
 
@@ -11,8 +16,11 @@ export function App({ home }: { home: string }) {
   const state = useSyncExternalStore(subscribeCliState, getCliState);
 
   useInput((_input) => {
-    if (_input === "k") {
+    if (_input === "k" || _input === "K") {
       toggleViewMode();
+    }
+    if (_input === "l" || _input === "L") {
+      toggleLogFlow();
     }
   });
 

--- a/apps/mesh/src/cli/cli-store.ts
+++ b/apps/mesh/src/cli/cli-store.ts
@@ -15,6 +15,7 @@ interface CliState {
   env: Env | null;
   logs: LogEntry[];
   viewMode: "requests" | "config";
+  logFlow: boolean;
 }
 
 let state: CliState = {
@@ -27,6 +28,7 @@ let state: CliState = {
   env: null,
   logs: [],
   viewMode: "requests",
+  logFlow: false,
 };
 
 const listeners = new Set<() => void>();
@@ -88,6 +90,14 @@ export function toggleViewMode() {
   state = {
     ...state,
     viewMode: state.viewMode === "requests" ? "config" : "requests",
+  };
+  emit();
+}
+
+export function toggleLogFlow() {
+  state = {
+    ...state,
+    logFlow: !state.logFlow,
   };
   emit();
 }

--- a/apps/mesh/src/cli/header.tsx
+++ b/apps/mesh/src/cli/header.tsx
@@ -91,6 +91,13 @@ export function Header({
               </Text>{" "}
               toggle config
             </Text>
+            {"  "}
+            <Text dimColor>
+              <Text bold dimColor>
+                L
+              </Text>{" "}
+              toggle log flow
+            </Text>
           </Text>
         ) : (
           <Text dimColor>Starting...</Text>

--- a/apps/mesh/src/cli/request-log.tsx
+++ b/apps/mesh/src/cli/request-log.tsx
@@ -1,4 +1,6 @@
 import { Box, Text } from "ink";
+import { useSyncExternalStore } from "react";
+import { getCliState, subscribeCliState } from "./cli-store";
 import type { LogEntry } from "./log-emitter";
 import { useTerminalSize } from "./use-terminal-size";
 
@@ -16,8 +18,9 @@ interface RequestLogProps {
 
 export function RequestLog({ logs, headerHeight }: RequestLogProps) {
   const { rows } = useTerminalSize();
+  const { logFlow } = useSyncExternalStore(subscribeCliState, getCliState);
   const visibleCount = Math.max(1, rows - headerHeight - 1);
-  const visible = logs.slice(-visibleCount);
+  const visible = logFlow ? logs : logs.slice(-visibleCount);
 
   return (
     <Box flexDirection="column">


### PR DESCRIPTION
## What is this contribution about?

Adds a new `L` key toggle to the CLI TUI that switches between:
- **Windowed mode** (default): logs are sliced to fit terminal height
- **Flow mode**: logs render without height constraint, letting the terminal scroll naturally

Also fixes the existing `K` keybinding to be case-insensitive (handles both `k` and `K`).

### Changes
- `cli-store.ts`: Added `logFlow` boolean state and `toggleLogFlow()` function
- `app.tsx`: Added `L`/`l` keybinding, fixed `K`/`k` case-insensitivity
- `request-log.tsx`: Reads `logFlow` from store via `useSyncExternalStore`, skips windowing when enabled
- `header.tsx`: Added `L toggle log flow` help text in the header

## Screenshots/Demonstration

N/A — CLI TUI change, test manually.

## How to Test

1. Run `bun run dev`
2. Generate some HTTP traffic to populate the log
3. Press `L` — logs should switch to flow mode (all logs rendered, terminal scrolls)
4. Press `L` again — logs return to windowed mode (sliced to terminal height)
5. Verify `K` and `k` both toggle config view (case-insensitive fix)

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an L key toggle to switch the CLI TUI between windowed logs and flow mode. Also makes the K keybinding case-insensitive.

- **New Features**
  - L/l toggles log flow mode: shows all logs and lets the terminal scroll; header shows the new shortcut.
  - Added `logFlow` state and `toggleLogFlow()` in the CLI store; `request-log.tsx` skips windowing when enabled.

- **Bug Fixes**
  - K/k now both toggle the config view.

<sup>Written for commit c76b2638f36c8504759bdc378890892bed10e81e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

