### PR TITLE
Revert "fix(ui): remove full-page loading on connections page"

### DIFF
--- a/apps/mesh/src/tools/connection/create.ts
+++ b/apps/mesh/src/tools/connection/create.ts
@@ -14,7 +14,7 @@ import {
   requireOrganization,
 } from "../../core/mesh-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
-import { fetchToolsFromMCP, findRegistryListTool } from "./fetch-tools";
+import { fetchToolsFromMCP } from "./fetch-tools";
 import {
   buildVirtualUrl,
   ConnectionCreateDataSchema,
@@ -111,20 +111,11 @@ export const COLLECTION_CONNECTIONS_CREATE = defineTool({
       ? fetchResult.scopes
       : null;
 
-    // Detect if this connection is a registry/store based on its tools
-    const registryListTool = findRegistryListTool(tools);
-
     // Create the connection with the fetched tools and scopes
     const connection = await ctx.storage.connections.create({
       ...connectionData,
       tools: null,
       configuration_scopes,
-      metadata: {
-        ...((connectionData.metadata as Record<string, unknown>) ?? {}),
-        ...(registryListTool
-          ? { is_registry: true, registry_list_tool: registryListTool }
-          : { is_registry: false, registry_list_tool: null }),
-      },
     });
 
     // Eagerly populate NATS KV cache with fetched tools

--- a/apps/mesh/src/tools/connection/fetch-tools.ts
+++ b/apps/mesh/src/tools/connection/fetch-tools.ts
@@ -17,32 +17,6 @@ import type {
 import { isStdioParameters } from "./schema";
 
 /**
- * Find the registry list tool name from a tools array.
- * Returns the tool name if found, null otherwise.
- */
-export function findRegistryListTool(
-  tools: ToolDefinition[] | null | undefined,
-): string | null {
-  if (!tools || tools.length === 0) return null;
-
-  const preferred = tools.find(
-    (t) => t.name === "COLLECTION_REGISTRY_APP_LIST",
-  );
-  if (preferred) return preferred.name;
-
-  const privateRegistry = tools.find((t) => t.name === "REGISTRY_ITEM_LIST");
-  if (privateRegistry) return privateRegistry.name;
-
-  const generic = tools.find(
-    (t) =>
-      t.name.startsWith("COLLECTION_REGISTRY_APP_") && t.name.endsWith("_LIST"),
-  );
-  if (generic) return generic.name;
-
-  return null;
-}
-
-/**
  * Minimal connection data needed for tool fetching
  */
 export interface ConnectionForToolFetch {

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -205,12 +205,6 @@ const ConnectionListInputSchema = CollectionListInputSchema.extend({
     .describe(
       "Whether to include VIRTUAL connections in the results. Defaults to false.",
     ),
-  include_tools: z
-    .boolean()
-    .optional()
-    .describe(
-      "Whether to fetch and include tools for each connection. Defaults to false. Automatically true when binding is specified.",
-    ),
 });
 
 /**
@@ -263,48 +257,43 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
       includeVirtual: input.include_virtual ?? false,
     });
 
-    // Only fetch tools when explicitly requested or when binding filtering requires them
-    const shouldFetchTools = input.include_tools === true || !!input.binding;
-
-    if (shouldFetchTools) {
-      const cache = getMcpListCache();
-      const selfId = WellKnownOrgMCPId.SELF(organization.id);
-      await Promise.all(
-        connections.map(async (connection) => {
-          if (connection.tools !== null) return;
-          // The self MCP requires session auth, so an HTTP round-trip would
-          // fail without forwarding cookies. Use in-process transport instead.
-          const fetchLive =
-            connection.id === selfId
-              ? async () => {
-                  const { listManagementTools } = await import("../../tools");
-                  return listManagementTools(ctx) as Promise<unknown[]>;
+    const cache = getMcpListCache();
+    const selfId = WellKnownOrgMCPId.SELF(organization.id);
+    await Promise.all(
+      connections.map(async (connection) => {
+        if (connection.tools !== null) return;
+        // The self MCP requires session auth, so an HTTP round-trip would
+        // fail without forwarding cookies. Use in-process transport instead.
+        const fetchLive =
+          connection.id === selfId
+            ? async () => {
+                const { listManagementTools } = await import("../../tools");
+                return listManagementTools(ctx) as Promise<unknown[]>;
+              }
+            : async () => {
+                const client = await clientFromConnection(
+                  connection,
+                  ctx,
+                  true,
+                );
+                try {
+                  const result = await client.listTools();
+                  return result.tools;
+                } finally {
+                  await client.close().catch(() => {});
                 }
-              : async () => {
-                  const client = await clientFromConnection(
-                    connection,
-                    ctx,
-                    true,
-                  );
-                  try {
-                    const result = await client.listTools();
-                    return result.tools;
-                  } finally {
-                    await client.close().catch(() => {});
-                  }
-                };
-          const tools = await fetchWithCache(
-            "tools",
-            connection.id,
-            fetchLive,
-            cache,
-          );
-          if (tools !== null) {
-            connection.tools = tools as Tool[];
-          }
-        }),
-      );
-    }
+              };
+        const tools = await fetchWithCache(
+          "tools",
+          connection.id,
+          fetchLive,
+          cache,
+        );
+        if (tools !== null) {
+          connection.tools = tools as Tool[];
+        }
+      }),
+    );
 
     // In dev mode, inject the dev-assets connection for local file storage
     // This provides object storage functionality without requiring an external S3 bucket

--- a/apps/mesh/src/tools/connection/update.ts
+++ b/apps/mesh/src/tools/connection/update.ts
@@ -20,7 +20,7 @@ import {
   requireOrganization,
 } from "../../core/mesh-context";
 import { getMcpListCache } from "../../mcp-clients/mcp-list-cache";
-import { fetchToolsFromMCP, findRegistryListTool } from "./fetch-tools";
+import { fetchToolsFromMCP } from "./fetch-tools";
 import { prop } from "./json-path";
 import {
   buildVirtualUrl,
@@ -274,20 +274,6 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       organization.id,
     );
 
-    // Detect if this connection is a registry/store based on its tools.
-    // Only update registry flags when the fetch succeeded (fetchResult !== null).
-    // When fetch fails, preserve existing metadata to avoid declassifying a
-    // registry on transient errors.
-    const registryListTool = findRegistryListTool(tools);
-    const existingMetadata =
-      (existing.metadata as Record<string, unknown>) ?? {};
-    const incomingMetadata = (data.metadata as Record<string, unknown>) ?? {};
-    const registryMeta = registryListTool
-      ? { is_registry: true, registry_list_tool: registryListTool }
-      : fetchResult !== null
-        ? { is_registry: false, registry_list_tool: null }
-        : {};
-
     // Update the connection with the refreshed tools and configuration
     const updatePayload: Partial<ConnectionEntity> = {
       ...data,
@@ -296,11 +282,6 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       configuration_state: finalState,
       configuration_scopes: finalScopes,
       updated_by: userId,
-      metadata: {
-        ...existingMetadata,
-        ...incomingMetadata,
-        ...registryMeta,
-      },
     };
     const connection = await ctx.storage.connections.update(id, updatePayload);
 

--- a/apps/mesh/src/web/hooks/use-binding.ts
+++ b/apps/mesh/src/web/hooks/use-binding.ts
@@ -277,11 +277,8 @@ export function useRegistryConnections(
   return !connections
     ? []
     : connections.filter((conn) => {
-        // Fast path: check metadata flag set at create/update time
-        const meta = conn.metadata as Record<string, unknown> | null;
-        if (meta?.is_registry === true) return true;
-
-        // Fallback: check tools for connections that haven't been re-saved yet
+        // Any connection exposing REGISTRY_APP collection tools can act as a store registry.
+        // This includes the org self MCP when private-registry tools are enabled.
         return (
           extractCollectionNames(conn.tools).includes("REGISTRY_APP") ||
           hasRegistryListTool(conn.tools)

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -83,8 +83,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import {
   SELF_MCP_ALIAS_ID,
   useConnectionActions,
-  useConnectionsAsync,
-  useConnectionsInfinite,
+  useConnections,
   useMCPClient,
   useProjectContext,
   type ConnectionEntity,
@@ -109,7 +108,7 @@ import {
   Trash01,
   XClose,
 } from "@untitledui/icons";
-import { useEffect, useReducer, useState } from "react";
+import { Suspense, useEffect, useReducer, useState } from "react";
 import { useForm } from "react-hook-form";
 import {
   connectionFormSchema,
@@ -805,33 +804,11 @@ function OrgMcpsContent() {
     resource: "connections",
   });
 
-  // Tab state (before queries so we can skip unnecessary fetches per tab)
-  type ConnectionTab = "connected" | "all";
-  const [activeTab, setActiveTab] = useLocalStorage<ConnectionTab>(
-    LOCALSTORAGE_KEYS.connectionsTab(org.slug),
-    (existing) =>
-      search.tab === "all" || search.tab === "connected"
-        ? search.tab
-        : (existing ?? "all"),
-  );
-
   const actions = useConnectionActions();
-
-  // Paginated connections for the "Connected" tab grid.
-  // On "All" tab this is skipped — the store query provides connections for badges.
-  const needsConnectedQuery =
-    activeTab === "connected" || !!listState.searchTerm;
-  const {
-    items: paginatedConnections,
-    isLoading: isLoadingConnections,
-    hasMore: hasMoreConnections,
-    isLoadingMore: isLoadingMoreConnections,
-    loadMore: loadMoreConnections,
-  } = useConnectionsInfinite({
-    ...listState,
-    enabled: needsConnectedQuery,
-  });
-  const connections = needsConnectedQuery ? paginatedConnections : [];
+  const connections = useConnections(listState);
+  // Unfiltered connections for catalog metadata (connectedAppNames, appInstances)
+  // so the "Connected" badge and modal aren't affected by the search term
+  const allConnections = useConnections();
 
   const [dialogState, dispatch] = useReducer(dialogReducer, { mode: "idle" });
 
@@ -840,6 +817,16 @@ function OrgMcpsContent() {
   const selectionMode = selectedIds.size > 0;
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [addToAgentOpen, setAddToAgentOpen] = useState(false);
+
+  // Tab state
+  type ConnectionTab = "connected" | "all";
+  const [activeTab, setActiveTab] = useLocalStorage<ConnectionTab>(
+    LOCALSTORAGE_KEYS.connectionsTab(org.slug),
+    (existing) =>
+      search.tab === "all" || search.tab === "connected"
+        ? search.tab
+        : (existing ?? "all"),
+  );
 
   // Type & status filters
   const [typeFilter, setTypeFilter] = useState<ConnectionTypeFilter>("ALL");
@@ -874,27 +861,18 @@ function OrgMcpsContent() {
     setSelectedIds(new Set());
   };
 
-  // Fetch all connections (without tools) for the "All" tab.
-  // Registry discovery uses metadata.is_registry flag backfilled by migration 048.
-  const needsStore = activeTab === "all" || !!listState.searchTerm;
-  const { data: allConnectionsData, isLoading: isLoadingTools } =
-    useConnectionsAsync({
-      enabled: needsStore,
-    });
-  const allConnections = allConnectionsData ?? connections;
-
   // Optional registry lookup: support multiple registries, let user pick on "All" tab
   // Sort so the self/management MCP (Mesh MCP) appears last — external registries like
   // Deco Store / MCP Registry should be the default catalog source.
-  const registryConnections = useRegistryConnections(
-    allConnectionsData ?? [],
-  ).sort((a, b) => {
-    const isSelfA = a.app_name === "@deco/management-mcp";
-    const isSelfB = b.app_name === "@deco/management-mcp";
-    if (isSelfA && !isSelfB) return 1;
-    if (!isSelfA && isSelfB) return -1;
-    return 0;
-  });
+  const registryConnections = useRegistryConnections(allConnections).sort(
+    (a, b) => {
+      const isSelfA = a.app_name === "@deco/management-mcp";
+      const isSelfB = b.app_name === "@deco/management-mcp";
+      if (isSelfA && !isSelfB) return 1;
+      if (!isSelfA && isSelfB) return -1;
+      return 0;
+    },
+  );
   const [selectedRegistryId, setSelectedRegistryId] = useLocalStorage<string>(
     LOCALSTORAGE_KEYS.selectedRegistry(org.slug),
     (existing) => existing ?? "",
@@ -904,14 +882,7 @@ function OrgMcpsContent() {
       ? registryConnections.find((r) => r.id === selectedRegistryId)
       : undefined) ?? registryConnections[0];
   const registryId = registryConnection?.id ?? "";
-  const registryMeta = registryConnection?.metadata as Record<
-    string,
-    unknown
-  > | null;
-  const registryListToolName =
-    (registryMeta?.registry_list_tool as string) ||
-    findListToolName(registryConnection?.tools);
-
+  const registryListToolName = findListToolName(registryConnection?.tools);
   const registryDiscovery = useStoreDiscovery({
     registryId,
     listToolName: registryListToolName,
@@ -922,12 +893,6 @@ function OrgMcpsContent() {
     registryDiscovery.loadMore,
     registryDiscovery.hasMore,
     registryDiscovery.isLoadingMore,
-  );
-
-  const connectedSentinelRef = useInfiniteScroll(
-    loadMoreConnections,
-    hasMoreConnections,
-    isLoadingMoreConnections,
   );
 
   // "All" tab: catalog items from registry (includes already-connected ones)
@@ -2292,18 +2257,14 @@ function OrgMcpsContent() {
         <Page.Content>
           <div className="flex-1 overflow-auto p-5">
             {(
-              isLoadingConnections
-                ? false
-                : searchLower
+              searchLower
+                ? verifiedCatalogItems.length === 0 &&
+                  otherCatalogItems.length === 0 &&
+                  tabFilteredConnections.length === 0
+                : activeTab === "all"
                   ? verifiedCatalogItems.length === 0 &&
-                    otherCatalogItems.length === 0 &&
-                    tabFilteredConnections.length === 0 &&
-                    !isLoadingTools
-                  : activeTab === "all"
-                    ? verifiedCatalogItems.length === 0 &&
-                      otherCatalogItems.length === 0 &&
-                      !isLoadingTools
-                    : tabFilteredConnections.length === 0
+                    otherCatalogItems.length === 0
+                  : tabFilteredConnections.length === 0
             ) ? (
               <EmptyState
                 image={
@@ -2324,22 +2285,6 @@ function OrgMcpsContent() {
               />
             ) : (
               <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
-                {/* Skeleton cards while connections are loading */}
-                {isLoadingConnections &&
-                  Array.from({ length: 6 }).map((_, i) => (
-                    <div
-                      key={`skeleton-${i}`}
-                      className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 animate-pulse"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="h-10 w-10 rounded-lg bg-muted" />
-                        <div className="flex-1 space-y-2">
-                          <div className="h-4 w-24 rounded bg-muted" />
-                          <div className="h-3 w-40 rounded bg-muted" />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
                 {groupedForDisplay.map((item) => {
                   if (item.type === "group") {
                     return (
@@ -2464,31 +2409,6 @@ function OrgMcpsContent() {
                     />
                   );
                 })}
-                {/* Infinite scroll sentinel for connected items */}
-                {hasMoreConnections && (
-                  <div
-                    ref={connectedSentinelRef}
-                    className="col-span-full h-4"
-                  />
-                )}
-                {isLoadingMoreConnections && (
-                  <div className="col-span-full flex items-center justify-center gap-2 py-4 text-muted-foreground">
-                    <Loading01 size={16} className="animate-spin" />
-                    <span className="text-sm">Loading more connections...</span>
-                  </div>
-                )}
-                {/* Loading indicator while registry tools are being discovered */}
-                {activeTab === "all" &&
-                  isLoadingTools &&
-                  verifiedCatalogItems.length === 0 &&
-                  otherCatalogItems.length === 0 && (
-                    <div className="col-span-full flex items-center justify-center gap-2 py-8 text-muted-foreground">
-                      <Loading01 size={16} className="animate-spin" />
-                      <span className="text-sm">
-                        Loading available connections...
-                      </span>
-                    </div>
-                  )}
                 {/* Catalog items (uninstalled) — only on "All" tab */}
                 {activeTab === "all" && verifiedCatalogItems.length > 0 && (
                   <div className="col-span-full flex items-center gap-2 mt-2">
@@ -2700,7 +2620,18 @@ function OrgMcpsContent() {
 export default function OrgMcps() {
   return (
     <ErrorBoundary>
-      <OrgMcpsContent />
+      <Suspense
+        fallback={
+          <div className="flex h-full items-center justify-center">
+            <Loading01
+              size={32}
+              className="animate-spin text-muted-foreground"
+            />
+          </div>
+        }
+      >
+        <OrgMcpsContent />
+      </Suspense>
     </ErrorBoundary>
   );
 }

--- a/packages/mesh-sdk/src/hooks/index.ts
+++ b/packages/mesh-sdk/src/hooks/index.ts
@@ -2,8 +2,6 @@
 export {
   useCollectionItem,
   useCollectionList,
-  useCollectionListAsync,
-  useCollectionListInfinite,
   useCollectionActions,
   buildWhereExpression,
   buildOrderByExpression,
@@ -18,8 +16,6 @@ export {
 // Connection hooks
 export {
   useConnections,
-  useConnectionsAsync,
-  useConnectionsInfinite,
   useConnection,
   useConnectionActions,
   type ConnectionFilter,

--- a/packages/mesh-sdk/src/hooks/use-collections.ts
+++ b/packages/mesh-sdk/src/hooks/use-collections.ts
@@ -22,9 +22,7 @@ import {
 } from "@decocms/bindings/collections";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
-  useInfiniteQuery,
   useMutation,
-  useQuery,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
@@ -67,10 +65,6 @@ export interface UseCollectionListOptions<T extends CollectionEntity> {
   defaultSortKey?: keyof T;
   /** Page size for pagination (default: 100) */
   pageSize?: number;
-  /** Extra arguments to pass to the collection tool (e.g., include_tools for connections) */
-  extraArguments?: Record<string, unknown>;
-  /** Whether to enable the query (default: true). When false, the query is skipped. */
-  enabled?: boolean;
 }
 
 /**
@@ -260,7 +254,6 @@ export function useCollectionList<T extends CollectionEntity>(
     searchFields = ["title", "description"] satisfies (keyof T)[],
     defaultSortKey = "updated_at" satisfies keyof T,
     pageSize = 100,
-    extraArguments,
   } = options;
 
   const upperName = collectionName.toUpperCase();
@@ -278,7 +271,6 @@ export function useCollectionList<T extends CollectionEntity>(
     ...(orderBy && { orderBy }),
     limit: pageSize,
     offset: 0,
-    ...extraArguments,
   };
 
   const argsKey = JSON.stringify(toolArguments);
@@ -314,175 +306,6 @@ export function useCollectionList<T extends CollectionEntity>(
 }
 
 /**
- * Non-suspense variant of useCollectionList for background/lazy loading.
- * Returns { data, isLoading } instead of blocking render.
- */
-export function useCollectionListAsync<T extends CollectionEntity>(
-  scopeKey: string,
-  collectionName: string,
-  client: Client | null | undefined,
-  options: UseCollectionListOptions<T> = {},
-) {
-  const {
-    searchTerm,
-    filters,
-    sortKey,
-    sortDirection,
-    searchFields = ["title", "description"] satisfies (keyof T)[],
-    defaultSortKey = "updated_at" satisfies keyof T,
-    pageSize = 100,
-    extraArguments,
-    enabled,
-  } = options;
-
-  const upperName = collectionName.toUpperCase();
-  const listToolName = `COLLECTION_${upperName}_LIST`;
-
-  const where = buildWhereExpression(searchTerm, filters, searchFields);
-  const orderBy = buildOrderByExpression(
-    sortKey,
-    sortDirection,
-    defaultSortKey,
-  );
-
-  const toolArguments: CollectionListInput = {
-    ...(where && { where }),
-    ...(orderBy && { orderBy }),
-    limit: pageSize,
-    offset: 0,
-    ...extraArguments,
-  };
-
-  const argsKey = JSON.stringify(toolArguments);
-  const queryKey = KEYS.collectionList(
-    client,
-    scopeKey,
-    "",
-    upperName,
-    argsKey,
-  );
-
-  const { data, isLoading } = useQuery({
-    queryKey,
-    queryFn: async () => {
-      if (!client) {
-        return EMPTY_COLLECTION_LIST_RESULT;
-      }
-      const result = await client.callTool({
-        name: listToolName,
-        arguments: toolArguments,
-      });
-      return result;
-    },
-    staleTime: 30_000,
-    retry: false,
-    enabled: enabled ?? true,
-    select: (result) => {
-      const payload = extractPayload<CollectionListOutput<T>>(result ?? {});
-      return payload?.items ?? [];
-    },
-  });
-
-  return { data, isLoading };
-}
-
-/**
- * Infinite-scroll variant of useCollectionList.
- * Uses offset-based pagination via useInfiniteQuery.
- * Returns flattened items, loadMore, hasMore, and loading states.
- */
-export function useCollectionListInfinite<T extends CollectionEntity>(
-  scopeKey: string,
-  collectionName: string,
-  client: Client | null | undefined,
-  options: UseCollectionListOptions<T> = {},
-) {
-  const {
-    searchTerm,
-    filters,
-    sortKey,
-    sortDirection,
-    searchFields = ["title", "description"] satisfies (keyof T)[],
-    defaultSortKey = "updated_at" satisfies keyof T,
-    pageSize = 20,
-    extraArguments,
-    enabled,
-  } = options;
-
-  const upperName = collectionName.toUpperCase();
-  const listToolName = `COLLECTION_${upperName}_LIST`;
-
-  const where = buildWhereExpression(searchTerm, filters, searchFields);
-  const orderBy = buildOrderByExpression(
-    sortKey,
-    sortDirection,
-    defaultSortKey,
-  );
-
-  const baseArgs = {
-    ...(where && { where }),
-    ...(orderBy && { orderBy }),
-    limit: pageSize,
-    ...extraArguments,
-  };
-
-  const argsKey = JSON.stringify(baseArgs);
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useInfiniteQuery({
-      queryKey: KEYS.collectionListInfinite(
-        client,
-        scopeKey,
-        "",
-        upperName,
-        argsKey,
-      ),
-      queryFn: async ({ pageParam = 0 }) => {
-        if (!client) {
-          return { items: [] as T[], hasMore: false };
-        }
-        const toolArguments: CollectionListInput = {
-          ...baseArgs,
-          offset: pageParam,
-        };
-        const result = await client.callTool({
-          name: listToolName,
-          arguments: toolArguments,
-        });
-        const payload = extractPayload<CollectionListOutput<T>>(result);
-        return {
-          items: payload?.items ?? [],
-          hasMore: payload?.hasMore ?? false,
-        };
-      },
-      initialPageParam: 0,
-      getNextPageParam: (lastPage, _allPages, lastPageParam) => {
-        if (!lastPage.hasMore) return undefined;
-        return (lastPageParam as number) + pageSize;
-      },
-      staleTime: 30_000,
-      retry: false,
-      enabled: enabled ?? true,
-    });
-
-  const items = data?.pages.flatMap((p) => p.items) ?? [];
-
-  const loadMore = () => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  };
-
-  return {
-    items,
-    isLoading,
-    hasMore: hasNextPage ?? false,
-    isLoadingMore: isFetchingNextPage,
-    loadMore,
-  };
-}
-
-/**
  * Builds a query key for a collection list query
  * Matches the internal logic of useCollectionList exactly
  *
@@ -506,7 +329,6 @@ export function buildCollectionQueryKey<T extends CollectionEntity>(
     searchFields = ["title", "description"] satisfies (keyof T)[],
     defaultSortKey = "updated_at" satisfies keyof T,
     pageSize = 100,
-    extraArguments,
   } = options;
 
   const upperName = collectionName.toUpperCase();
@@ -523,7 +345,6 @@ export function buildCollectionQueryKey<T extends CollectionEntity>(
     ...(orderBy && { orderBy }),
     limit: pageSize,
     offset: 0,
-    ...extraArguments,
   };
 
   const argsKey = JSON.stringify(toolArguments);

--- a/packages/mesh-sdk/src/hooks/use-connection.ts
+++ b/packages/mesh-sdk/src/hooks/use-connection.ts
@@ -12,8 +12,6 @@ import {
   useCollectionActions,
   useCollectionItem,
   useCollectionList,
-  useCollectionListAsync,
-  useCollectionListInfinite,
   type UseCollectionListOptions,
 } from "./use-collections";
 import { useMCPClient } from "./use-mcp-client";
@@ -42,42 +40,6 @@ export function useConnections(options: UseConnectionsOptions = {}) {
     orgId: org.id,
   });
   return useCollectionList<ConnectionEntity>(
-    org.id,
-    "CONNECTIONS",
-    client,
-    options,
-  );
-}
-
-/**
- * Non-suspense variant of useConnections for background/lazy loading.
- * Returns { data, isLoading } instead of blocking render.
- */
-export function useConnectionsAsync(options: UseConnectionsOptions = {}) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-  });
-  return useCollectionListAsync<ConnectionEntity>(
-    org.id,
-    "CONNECTIONS",
-    client,
-    options,
-  );
-}
-
-/**
- * Infinite-scroll variant of useConnections.
- * Loads connections in pages of 20, with loadMore/hasMore for scroll-driven pagination.
- */
-export function useConnectionsInfinite(options: UseConnectionsOptions = {}) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-  });
-  return useCollectionListInfinite<ConnectionEntity>(
     org.id,
     "CONNECTIONS",
     client,

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -19,7 +19,6 @@ export {
   // Collection hooks
   useCollectionItem,
   useCollectionList,
-  useCollectionListAsync,
   useCollectionActions,
   buildWhereExpression,
   buildOrderByExpression,
@@ -31,8 +30,6 @@ export {
   type CollectionQueryKey,
   // Connection hooks
   useConnections,
-  useConnectionsAsync,
-  useConnectionsInfinite,
   useConnection,
   useConnectionActions,
   type ConnectionFilter,

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -68,8 +68,6 @@ export function getWellKnownRegistryConnection(
     metadata: {
       isDefault: true,
       type: "registry",
-      is_registry: true,
-      registry_list_tool: "COLLECTION_REGISTRY_APP_LIST",
     },
   };
 }
@@ -98,8 +96,6 @@ export function getWellKnownCommunityRegistryConnection(): ConnectionCreateData 
     metadata: {
       isDefault: true,
       type: "registry",
-      is_registry: true,
-      registry_list_tool: "COLLECTION_REGISTRY_APP_LIST",
     },
   };
 }


### PR DESCRIPTION
Reverts decocms/studio#2810

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Suspense-based full-page loading for the Connections page and simplify connection/tool fetching by reverting incremental loading and registry metadata flags.

- **Refactors**
  - UI: Reinstates full-page spinner with React Suspense on the Connections page; removes infinite scroll, skeletons, and paginated fetching in favor of `useConnections`.
  - Data: Always fetches tools in `COLLECTION_CONNECTIONS_LIST`; removes `include_tools` option and registry metadata detection/writes on create/update; `useRegistryConnections` now relies only on tool inspection.
  - SDK: Removes async/infinite hooks (`useCollectionListAsync`, `useCollectionListInfinite`, `useConnectionsAsync`, `useConnectionsInfinite`) and their exports from `packages/mesh-sdk`; cleans up registry metadata from well-known constants.

- **Migration**
  - Replace removed hooks with `useConnections` or `useCollectionList` and wrap screens in `<Suspense>` with a fallback.
  - Stop passing `include_tools` to list tools; tools are fetched by default.
  - Do not rely on `metadata.is_registry` or `metadata.registry_list_tool`; check available tools instead.

<sup>Written for commit d3896c1667f2fdafc0c65095a4339c79e968c02c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

