### PR TITLE
feat(workflow): enhance resume execution logic for successful workflo…

### DIFF
--- a/packages/mesh-plugin-workflows/server/storage/__tests__/workflow-execution.test.ts
+++ b/packages/mesh-plugin-workflows/server/storage/__tests__/workflow-execution.test.ts
@@ -290,6 +290,91 @@ describe("WorkflowExecutionStorage", () => {
       expect(resumed).toBe(false);
     });
 
+    it("resumes successful execution with failed forEach iterations", async () => {
+      const { id } = await createTestExecution({
+        steps: [
+          {
+            name: "upload",
+            action: { toolName: "UPLOAD" },
+            input: {},
+            forEach: { ref: "@input.items" },
+          },
+        ],
+        input: { items: ["a", "b", "c"] },
+      });
+      await storage.claimExecution(id);
+
+      // Simulate: iterations 0 and 1 succeeded, iteration 2 failed (rate limited)
+      await storage.createStepResult({
+        execution_id: id,
+        step_id: "upload[0]",
+        output: { ok: true },
+        completed_at_epoch_ms: Date.now(),
+      });
+      await storage.createStepResult({
+        execution_id: id,
+        step_id: "upload[1]",
+        output: { ok: true },
+        completed_at_epoch_ms: Date.now(),
+      });
+      await storage.createStepResult({
+        execution_id: id,
+        step_id: "upload[2]",
+        error: "Rate limited (429)",
+        completed_at_epoch_ms: Date.now(),
+      });
+      // Parent step finalized with nulls for failed iterations
+      await storage.createStepResult({
+        execution_id: id,
+        step_id: "upload",
+        output: [{ ok: true }, { ok: true }, null],
+        completed_at_epoch_ms: Date.now(),
+      });
+
+      // Mark execution as success (onError: continue)
+      await storage.updateExecution(id, {
+        status: "success",
+        output: [{ ok: true }, { ok: true }, null],
+        completed_at_epoch_ms: Date.now(),
+      });
+
+      const resumed = await storage.resumeExecution(id, TEST_ORG_ID);
+      expect(resumed).toBe(true);
+
+      const execution = await storage.getExecution(id, TEST_ORG_ID);
+      expect(execution!.status).toBe("enqueued");
+
+      // Successful iterations preserved
+      expect(await storage.getStepResult(id, "upload[0]")).not.toBeNull();
+      expect(await storage.getStepResult(id, "upload[1]")).not.toBeNull();
+
+      // Failed iteration deleted (will be re-dispatched)
+      expect(await storage.getStepResult(id, "upload[2]")).toBeNull();
+
+      // Parent result deleted (will be re-finalized after retries)
+      expect(await storage.getStepResult(id, "upload")).toBeNull();
+    });
+
+    it("rejects resume on success execution with no failed steps", async () => {
+      const { id } = await createTestExecution();
+      await storage.claimExecution(id);
+
+      await storage.createStepResult({
+        execution_id: id,
+        step_id: "step1",
+        output: { done: true },
+        completed_at_epoch_ms: Date.now(),
+      });
+
+      await storage.updateExecution(id, {
+        status: "success",
+        completed_at_epoch_ms: Date.now(),
+      });
+
+      const resumed = await storage.resumeExecution(id, TEST_ORG_ID);
+      expect(resumed).toBe(false);
+    });
+
     it("does not delete step results when organizationId does not match", async () => {
       const { id } = await createTestExecution();
       await storage.claimExecution(id);

--- a/packages/mesh-plugin-workflows/server/storage/workflow-execution.ts
+++ b/packages/mesh-plugin-workflows/server/storage/workflow-execution.ts
@@ -357,9 +357,35 @@ export class WorkflowExecutionStorage {
     return this.db.transaction().execute(async (trx) => {
       const now = Date.now();
 
-      // Validate org ownership and resumable status first — bail before
-      // touching step results if the execution doesn't qualify.
-      const result = await trx
+      // Check current status and org ownership.
+      const execution = await trx
+        .selectFrom("workflow_execution")
+        .where("id", "=", executionId)
+        .where("organization_id", "=", organizationId)
+        .select(["status"])
+        .executeTakeFirst();
+
+      if (!execution) return false;
+
+      const { status } = execution;
+
+      // For "success" executions, only allow resume when there are failed steps
+      // to retry (e.g. forEach iterations that failed with onError: "continue").
+      if (status === "success") {
+        const failedCount = await trx
+          .selectFrom("workflow_execution_step_result")
+          .where("execution_id", "=", executionId)
+          .where("error", "is not", null)
+          .select(trx.fn.countAll<number>().as("count"))
+          .executeTakeFirstOrThrow();
+
+        if (Number(failedCount.count) === 0) return false;
+      } else if (status !== "cancelled" && status !== "error") {
+        return false;
+      }
+
+      // Reset execution to enqueued.
+      await trx
         .updateTable("workflow_execution")
         .set({
           status: "enqueued",
@@ -368,14 +394,23 @@ export class WorkflowExecutionStorage {
           error: null,
         })
         .where("id", "=", executionId)
-        .where("organization_id", "=", organizationId)
-        .where((eb) =>
-          eb.or([eb("status", "=", "cancelled"), eb("status", "=", "error")]),
-        )
-        .returningAll()
-        .executeTakeFirst();
+        .execute();
 
-      if (!result) return false;
+      // Collect parent step names from failed forEach iterations before deleting.
+      // We need to also delete their parent results so the orchestrator re-dispatches
+      // only the missing iterations (the forEach dispatch already handles partial recovery).
+      const failedIterations = await trx
+        .selectFrom("workflow_execution_step_result")
+        .where("execution_id", "=", executionId)
+        .where("error", "is not", null)
+        .where("step_id", "like", "%[%")
+        .select("step_id")
+        .execute();
+
+      const forEachParentNames = new Set<string>();
+      for (const row of failedIterations) {
+        forEachParentNames.add(row.step_id.replace(/\[\d+\]$/, ""));
+      }
 
       // Clear incomplete and failed step results in one pass; successful results
       // are preserved and their outputs will be reused by the orchestrator.
@@ -389,6 +424,16 @@ export class WorkflowExecutionStorage {
           ]),
         )
         .execute();
+
+      // Delete forEach parent results whose children had errors, so the parent
+      // gets re-dispatched and re-collects iteration outputs.
+      if (forEachParentNames.size > 0) {
+        await trx
+          .deleteFrom("workflow_execution_step_result")
+          .where("execution_id", "=", executionId)
+          .where("step_id", "in", [...forEachParentNames])
+          .execute();
+      }
 
       return true;
     });

--- a/packages/mesh-plugin-workflows/server/tools/workflow-execution.ts
+++ b/packages/mesh-plugin-workflows/server/tools/workflow-execution.ts
@@ -269,7 +269,7 @@ export const WORKFLOW_EXECUTION_CANCEL: ServerPluginToolDefinition = {
 export const WORKFLOW_EXECUTION_RESUME: ServerPluginToolDefinition = {
   name: "RESUME_EXECUTION",
   description:
-    "Resume a cancelled or failed workflow execution. Already-succeeded steps are preserved and their outputs reused; only failed steps are retried.",
+    "Resume a workflow execution. Works on cancelled, failed, or successful executions that have failed steps (e.g. forEach iterations that errored with onError: continue). Already-succeeded steps are preserved and their outputs reused; only failed steps are retried.",
   inputSchema: z.object({
     executionId: z.string().describe("The execution ID to resume"),
   }),


### PR DESCRIPTION
…ws with failed steps

Updated the resumeExecution method to allow resuming successful workflows that have failed steps, specifically for forEach iterations. Added checks to ensure that only executions with failed steps can be resumed, and implemented logic to delete parent results of failed iterations for re-dispatching. Enhanced test coverage to validate these changes.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow resuming “successful” workflow executions when some steps failed (e.g., forEach iterations), retrying only the failed parts and keeping successful outputs. Improves reliability for workflows that continue on error.

- **New Features**
  - Allow resume for `success` executions only when failed step results exist (e.g., forEach with onError: continue); otherwise reject resume.
  - On resume, reset execution to `enqueued`, delete failed/incomplete step results, and keep successful results.
  - Remove parent results for failed forEach iterations so the orchestrator re-dispatches only missing iterations.
  - Updated `RESUME_EXECUTION` tool description and added tests for successful-with-failures resume and rejection when no failed steps.

<sup>Written for commit 2ab281af89d83f770cf3c9fe3a48cabc92b0e25e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

