### PR TITLE
fix(decopilot): increase tool output token limits to reduce round trips

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/read-tool-output.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/read-tool-output.ts
@@ -78,9 +78,9 @@ export function createReadToolOutputTool(params: ReadToolOutputParams) {
   });
 }
 /** Maximum tokens for the full result returned to the model */
-export const MAX_RESULT_TOKENS = 4000;
+export const MAX_RESULT_TOKENS = 32_000;
 
-const MAX_PREVIEW_TOKENS = 120;
+const MAX_PREVIEW_TOKENS = 400;
 
 /**
  * Create a head+tail preview of a large text output.


### PR DESCRIPTION
## What is this contribution about?

Deco Pilot is ~10x slower than Claude Code on simple queries (e.g. "list recent commits" takes ~150s vs ~18s). The root cause is `MAX_RESULT_TOKENS = 4000` which truncates nearly every non-trivial tool output, forcing the model into repeated `read_tool_output` round trips (~3-5s each). This PR increases the limit to 32,000 tokens (~128KB) and the preview limit from 120 to 400 tokens, eliminating most truncation while still being a small fraction of the model's context window.

## How to Test

1. Start dev server: `bun run --cwd=apps/mesh dev:server`
2. In Deco Pilot, query a GitHub agent: "what are the recent commits on decocms/studio?"
3. Verify commits appear without multiple `read_tool_output` round trips — response should be significantly faster
4. Verify very large outputs (>32k tokens) still get truncated gracefully

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `read_tool_output` token limits to prevent truncation and cut repeated round trips, making Deco Pilot responses much faster on common queries.

- **Bug Fixes**
  - Raised `MAX_RESULT_TOKENS` from 4,000 to 32,000 to avoid repeated `read_tool_output` calls.
  - Raised `MAX_PREVIEW_TOKENS` from 120 to 400 for a more useful preview.

<sup>Written for commit 2a36fd0e1569fd90bbc64b616f973133924c0e54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

