### PR TITLE
chore(bindings): bump version to 1.3.4

### DIFF
--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/bindings",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Bumps `@decocms/bindings` from 1.3.3 to 1.3.4
- This publishes `TRIGGER_BINDING` which was added in #2684 (March 13) but missed the 1.3.3 release (March 8)

## Test plan
- [ ] Verify `@decocms/bindings@1.3.4` includes `./trigger` export after publish
- [ ] Confirm consumers can import `TRIGGER_BINDING` from `@decocms/bindings/trigger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/bindings` to 1.3.4 to publish the new TRIGGER_BINDING and expose the `./trigger` entry. Consumers can now import TRIGGER_BINDING from `@decocms/bindings/trigger`.

<sup>Written for commit 154930ef574c60dc1c50e9ed5c98a37bcc8e400f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

