### PR TITLE
feat(cli): add skip song shortcut to vibe mode

### DIFF
--- a/apps/mesh/src/cli/app.tsx
+++ b/apps/mesh/src/cli/app.tsx
@@ -10,7 +10,7 @@ import {
   toggleViewMode,
   toggleVibeState,
 } from "./cli-store";
-import { toggleVibe } from "./vibe/vibe-player";
+import { skipTrack, toggleVibe } from "./vibe/vibe-player";
 
 const HEADER_HEIGHT = 15;
 const HEADER_HEIGHT_VIBE = 17;
@@ -28,6 +28,9 @@ export function App({ home }: { home: string }) {
     if ((_input === "v" || _input === "V") && state.dataDir) {
       toggleVibe(state.dataDir);
       toggleVibeState();
+    }
+    if ((_input === "n" || _input === "N") && state.vibe) {
+      skipTrack();
     }
   });
 

--- a/apps/mesh/src/cli/header.tsx
+++ b/apps/mesh/src/cli/header.tsx
@@ -188,6 +188,14 @@ export function Header({
           </Text>{" "}
           toggle vibe {vibe ? "♪ Nihilore · CC BY 4.0" : ""}
         </Text>
+        {vibe && (
+          <Text dimColor>
+            <Text bold dimColor>
+              N
+            </Text>{" "}
+            skip song
+          </Text>
+        )}
       </Box>
     </Box>
   );

--- a/apps/mesh/src/cli/vibe/vibe-player.ts
+++ b/apps/mesh/src/cli/vibe/vibe-player.ts
@@ -126,6 +126,11 @@ function stopVibe(): void {
   stopMatrixRain();
 }
 
+export function skipTrack(): void {
+  if (!playing || !currentProcess) return;
+  currentProcess.kill();
+}
+
 export function toggleVibe(dataDir: string): void {
   if (playing) {
     stopVibe();


### PR DESCRIPTION
## What is this contribution about?

Adds a keyboard shortcut (`N`) to skip to the next song while in vibe mode. When pressed, the current track's process is killed, which triggers the player to advance to the next track in the playlist. The shortcut hint is shown in the header when vibe mode is active.

## How to Test

1. Run `bun run dev` and press `V` to enter vibe mode
2. While music is playing, press `N`
3. The current song should stop and the next one should start

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `N` shortcut in vibe mode to skip the current song by killing the active track process, advancing to the next track. The header now shows a “N skip song” hint when vibe mode is on.

- New Features
  - Press `N` in vibe mode to skip the current song and play the next one.
  - Header displays the `N` shortcut hint only while vibe mode is active.

<sup>Written for commit 58e8d7161f8f1261ac1fc31c3139bcde596bf08a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

