### PR TITLE
fix(automations): re-initialize NATS consumer on 503 no-responders

### DIFF
--- a/apps/mesh/src/automations/job-stream.ts
+++ b/apps/mesh/src/automations/job-stream.ts
@@ -27,6 +27,8 @@ const MAX_DELIVER = 3;
 const ACK_WAIT_NS = 6 * 60 * 1_000_000_000; // 6 min (> 5 min automation timeout)
 const PULL_BATCH_SIZE = 5;
 const PULL_EXPIRES_MS = 10_000;
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 60_000;
 
 export interface AutomationJobPayload {
   triggerId: string;
@@ -109,62 +111,49 @@ export class AutomationJobStream {
     if (!this.js) throw new Error("AutomationJobStream not initialized");
     this.running = true;
 
-    let consumer = await this.js.consumers.get(STREAM_NAME, CONSUMER_NAME);
-
     (async () => {
+      let backoff = RECONNECT_BASE_MS;
+
       while (this.running) {
         try {
-          const messages = await consumer.fetch({
-            max_messages: PULL_BATCH_SIZE,
-            expires: PULL_EXPIRES_MS,
-          });
+          await this.init();
+          if (!this.running) break;
+          const consumer = await this.js!.consumers.get(
+            STREAM_NAME,
+            CONSUMER_NAME,
+          );
 
-          for await (const msg of messages) {
-            try {
-              const payload: AutomationJobPayload = JSON.parse(
-                this.decoder.decode(msg.data),
-              );
-              await handler(payload);
-              msg.ack();
-            } catch (err) {
-              console.error(
-                "[AutomationJobStream] Handler error, nacking:",
-                err,
-              );
-              msg.nak();
+          while (this.running) {
+            const messages = await consumer.fetch({
+              max_messages: PULL_BATCH_SIZE,
+              expires: PULL_EXPIRES_MS,
+            });
+            backoff = RECONNECT_BASE_MS;
+
+            for await (const msg of messages) {
+              try {
+                const payload: AutomationJobPayload = JSON.parse(
+                  this.decoder.decode(msg.data),
+                );
+                await handler(payload);
+                msg.ack();
+              } catch (err) {
+                console.error(
+                  "[AutomationJobStream] Handler error, nacking:",
+                  err,
+                );
+                msg.nak();
+              }
             }
           }
         } catch (err) {
           if (this.running) {
-            const isNoResponders =
-              err instanceof Error && "code" in err && err.code === "503";
-            if (isNoResponders) {
-              console.warn(
-                "[AutomationJobStream] Consumer lost (NATS restart?), re-initializing...",
-              );
-              try {
-                await this.init();
-                consumer = await this.js!.consumers.get(
-                  STREAM_NAME,
-                  CONSUMER_NAME,
-                );
-                console.info(
-                  "[AutomationJobStream] Consumer re-initialized successfully",
-                );
-                continue;
-              } catch (reinitErr) {
-                console.error(
-                  "[AutomationJobStream] Re-init failed:",
-                  reinitErr,
-                );
-              }
-            } else {
-              console.error(
-                "[AutomationJobStream] Consumer fetch error:",
-                err,
-              );
-            }
-            await new Promise((r) => setTimeout(r, 1000));
+            console.error(
+              `[AutomationJobStream] Consumer error, retrying in ${backoff}ms:`,
+              err,
+            );
+            await new Promise((r) => setTimeout(r, backoff));
+            backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
           }
         }
       }


### PR DESCRIPTION
## Summary
- When NATS pods restart (memory storage), the durable `automation-worker` consumer is lost
- The consumer loop was retrying `fetch()` with a stale handle indefinitely, logging `[AutomationJobStream] Consumer fetch error` every second
- Now detects `503 no responders` errors specifically and re-runs `init()` to recreate the stream and consumer before resuming the loop

## Test plan
- [x] Existing automation tests pass
- [ ] Deploy to staging and verify the error loop stops after NATS pod restart
- [ ] Verify automation jobs resume processing after consumer re-initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-initializes the NATS JetStream consumer on errors (including `503 no responders`) and adds capped exponential backoff, so automation jobs recover after NATS restarts and error spam stops.

- **Bug Fixes**
  - Runs `init()` on each retry cycle, then fetches a fresh `automation-worker` consumer before resuming.
  - On consumer errors, logs and waits with exponential backoff (1s up to 60s), then retries; backoff resets after a successful fetch.

<sup>Written for commit d18b06a61a7d17501a8c4c8eccefb8096769fdb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

