### PR TITLE
feat(mesh-sdk): add server-side filtering to useConnections

### DIFF
--- a/packages/mesh-sdk/src/hooks/use-collections.ts
+++ b/packages/mesh-sdk/src/hooks/use-collections.ts
@@ -65,6 +65,8 @@ export interface UseCollectionListOptions<T extends CollectionEntity> {
   defaultSortKey?: keyof T;
   /** Page size for pagination (default: 100) */
   pageSize?: number;
+  /** Additional arguments forwarded to the collection tool call (e.g., binding, include_virtual) */
+  additionalToolArgs?: Record<string, unknown>;
 }
 
 /**
@@ -254,6 +256,7 @@ export function useCollectionList<T extends CollectionEntity>(
     searchFields = ["title", "description"] satisfies (keyof T)[],
     defaultSortKey = "updated_at" satisfies keyof T,
     pageSize = 100,
+    additionalToolArgs,
   } = options;
 
   const upperName = collectionName.toUpperCase();
@@ -266,11 +269,12 @@ export function useCollectionList<T extends CollectionEntity>(
     defaultSortKey,
   );
 
-  const toolArguments: CollectionListInput = {
+  const toolArguments: CollectionListInput & Record<string, unknown> = {
     ...(where && { where }),
     ...(orderBy && { orderBy }),
     limit: pageSize,
     offset: 0,
+    ...additionalToolArgs,
   };
 
   const argsKey = JSON.stringify(toolArguments);
@@ -329,6 +333,7 @@ export function buildCollectionQueryKey<T extends CollectionEntity>(
     searchFields = ["title", "description"] satisfies (keyof T)[],
     defaultSortKey = "updated_at" satisfies keyof T,
     pageSize = 100,
+    additionalToolArgs,
   } = options;
 
   const upperName = collectionName.toUpperCase();
@@ -340,11 +345,12 @@ export function buildCollectionQueryKey<T extends CollectionEntity>(
     defaultSortKey,
   );
 
-  const toolArguments: CollectionListInput = {
+  const toolArguments: CollectionListInput & Record<string, unknown> = {
     ...(where && { where }),
     ...(orderBy && { orderBy }),
     limit: pageSize,
     offset: 0,
+    ...additionalToolArgs,
   };
 
   const argsKey = JSON.stringify(toolArguments);

--- a/packages/mesh-sdk/src/hooks/use-connection.ts
+++ b/packages/mesh-sdk/src/hooks/use-connection.ts
@@ -25,15 +25,50 @@ export type ConnectionFilter = CollectionFilter;
 /**
  * Options for useConnections hook
  */
-export type UseConnectionsOptions = UseCollectionListOptions<ConnectionEntity>;
+export interface UseConnectionsOptions
+  extends UseCollectionListOptions<ConnectionEntity> {
+  /**
+   * Server-side binding filter. Only returns connections whose tools satisfy the binding.
+   * Can be a well-known binding name (e.g., "LLM", "ASSISTANTS", "OBJECT_STORAGE")
+   * or a custom binding schema object.
+   */
+  binding?: string | Record<string, unknown>;
+  /**
+   * Whether to include VIRTUAL connections in results. Defaults to false (server default).
+   */
+  includeVirtual?: boolean;
+}
 
 /**
- * Hook to get all connections
+ * Hook to get connections with server-side filtering.
  *
- * @param options - Filter and configuration options
+ * @param options - Filter and configuration options (binding, search, etc.)
  * @returns Suspense query result with connections as ConnectionEntity[]
  */
 export function useConnections(options: UseConnectionsOptions = {}) {
+  const { binding, includeVirtual, ...collectionOptions } = options;
+
+  // Build additional tool args for the COLLECTION_CONNECTIONS_LIST tool
+  const additionalToolArgs: Record<string, unknown> = {
+    ...collectionOptions.additionalToolArgs,
+  };
+
+  if (binding !== undefined) {
+    additionalToolArgs.binding = binding;
+  }
+
+  if (includeVirtual !== undefined) {
+    additionalToolArgs.include_virtual = includeVirtual;
+  }
+
+  const finalOptions: UseCollectionListOptions<ConnectionEntity> = {
+    ...collectionOptions,
+    additionalToolArgs:
+      Object.keys(additionalToolArgs).length > 0
+        ? additionalToolArgs
+        : undefined,
+  };
+
   const { org } = useProjectContext();
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -43,7 +78,7 @@ export function useConnections(options: UseConnectionsOptions = {}) {
     org.id,
     "CONNECTIONS",
     client,
-    options,
+    finalOptions,
   );
 }
 


### PR DESCRIPTION
## Summary
- Add `extraArguments` option to `useCollectionList` that gets spread into tool call arguments
- Extend `useConnections` with `binding` and `includeVirtual` options that map to server-side `COLLECTION_CONNECTIONS_LIST` parameters
- Pure additive API change — no consumers modified yet

## Stack
**PR 1/5** — SDK infrastructure (this PR)

## Test plan
- [ ] Verify `useConnections({ binding: "LLM" })` returns only LLM-capable connections
- [ ] Verify `useConnections({ includeVirtual: true })` includes VIRTUAL connections
- [ ] Verify bare `useConnections()` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side filtering to `useConnections` and forward extra tool args via `useCollectionList`. This enables server-driven binding filters and optional VIRTUAL connections.

- **New Features**
  - `useConnections({ binding, includeVirtual })` filters on the server and can include VIRTUAL connections (maps to `COLLECTION_CONNECTIONS_LIST`).
  - `useCollectionList({ additionalToolArgs })` forwards extra params (e.g., `binding`, `include_virtual`) to collection tool calls.

<sup>Written for commit 1b09ce121503559c225fbc1885186c72c2eb09e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

