### PR TITLE
refactor(plugins): use bindingName string instead of Binder schema

### DIFF
--- a/apps/mesh/src/web/layouts/dynamic-plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/dynamic-plugin-layout.tsx
@@ -19,8 +19,8 @@ export default function DynamicPluginLayout() {
   // Find the plugin by ID
   const plugin = sourcePlugins.find((p) => p.id === pluginId);
 
-  // If plugin has render props and a binding, use PluginLayout with those
-  if (plugin?.renderHeader && plugin?.renderEmptyState && plugin?.binding) {
+  // If plugin has render props and a binding name, use PluginLayout with those
+  if (plugin?.renderHeader && plugin?.renderEmptyState && plugin?.bindingName) {
     return (
       <Suspense
         fallback={
@@ -34,7 +34,7 @@ export default function DynamicPluginLayout() {
         }
       >
         <PluginLayout
-          binding={plugin.binding}
+          bindingName={plugin.bindingName}
           renderHeader={plugin.renderHeader}
           renderEmptyState={plugin.renderEmptyState}
         />

--- a/apps/mesh/src/web/layouts/plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/plugin-layout.tsx
@@ -11,7 +11,6 @@
 
 import {
   Binder,
-  connectionImplementsBinding,
   PluginConnectionEntity,
   PluginContext,
   PluginContextPartial,
@@ -38,10 +37,9 @@ import { Page } from "@/web/components/page";
 
 interface PluginLayoutProps {
   /**
-   * The binding to filter connections by.
-   * Only connections implementing this binding will be available.
+   * Server-side binding name to filter connections (e.g., "WORKFLOW").
    */
-  binding: Binder;
+  bindingName: string;
 
   /**
    * Render the header with connection selector.
@@ -53,19 +51,6 @@ interface PluginLayoutProps {
    * Render the empty state when no valid connections are available.
    */
   renderEmptyState: () => ReactNode;
-}
-
-/**
- * Filters connections that implement the given binding.
- */
-function filterConnectionsByBinding(
-  connections: ConnectionEntity[] | undefined,
-  binding: Binder,
-): ConnectionEntity[] {
-  if (!connections) return [];
-  return connections.filter((conn) =>
-    connectionImplementsBinding(conn, binding),
-  );
 }
 
 /**
@@ -105,7 +90,7 @@ type PluginConfigOutput = {
 };
 
 export function PluginLayout({
-  binding,
+  bindingName,
   renderHeader,
   renderEmptyState,
 }: PluginLayoutProps) {
@@ -117,7 +102,8 @@ export function PluginLayout({
   } = useParams({
     strict: false,
   }) as { org: string; virtualMcpId: string; pluginId: string };
-  const allConnections = useConnections();
+  // Server-side binding filter — no need to load all connections
+  const validConnections = useConnections({ binding: bindingName });
   const { data: authSession } = authClient.useSession();
 
   // Fetch project's plugin config to get configured connection
@@ -140,9 +126,6 @@ export function PluginLayout({
     },
     enabled: !!project.id && !!pluginId,
   });
-
-  // Filter connections by the plugin's binding
-  const validConnections = filterConnectionsByBinding(allConnections, binding);
 
   // Connection is determined solely by project config
   const configuredConnectionId = pluginConfig?.config?.connectionId;

--- a/packages/bindings/src/core/plugins.ts
+++ b/packages/bindings/src/core/plugins.ts
@@ -67,8 +67,14 @@ export interface ClientPlugin<TBinding extends Binder = Binder> {
   /**
    * Binding schema used to filter compatible connections.
    * Omit for plugins that manage their own connection (e.g. self MCP).
+   * @deprecated Use bindingName for server-side filtering instead.
    */
   binding?: TBinding;
+  /**
+   * Server-side binding name to filter connections (e.g., "WORKFLOW", "LLM").
+   * Preferred over `binding` as it avoids loading all connections client-side.
+   */
+  bindingName?: string;
   setup?: PluginSetup;
   /**
    * Optional custom layout component for this plugin.

--- a/packages/mesh-plugin-workflows/client/index.tsx
+++ b/packages/mesh-plugin-workflows/client/index.tsx
@@ -4,7 +4,6 @@
  * Exports the ClientPlugin implementation.
  */
 
-import type { Binder } from "@decocms/bindings";
 import type { ClientPlugin } from "@decocms/bindings/plugins";
 import { lazy } from "react";
 import { PLUGIN_ID, PLUGIN_DESCRIPTION } from "../shared";
@@ -16,9 +15,10 @@ const PluginEmptyState = lazy(() => import("./components/plugin-empty-state"));
 /**
  * Workflows Client Plugin Definition
  */
-export const clientPlugin: ClientPlugin<Binder> = {
+export const clientPlugin: ClientPlugin = {
   id: PLUGIN_ID,
   description: PLUGIN_DESCRIPTION,
+  bindingName: "WORKFLOW",
   renderHeader: (props) => <PluginHeader {...props} />,
   renderEmptyState: () => <PluginEmptyState />,
 };


### PR DESCRIPTION
## Summary
- Add `bindingName` field to `ClientPlugin` interface
- Change `PluginLayout` prop from `binding: Binder` to `bindingName: string`
- Use `useConnections({ binding: bindingName })` for server-side filtering instead of loading all connections and filtering with `connectionImplementsBinding`
- Update workflows plugin to use `bindingName: "WORKFLOW"` instead of `binding: WORKFLOW_BINDING`

## Stack
**PR 3/5** — Plugin binding refactor (base: PR 2)

## Test plan
- [ ] Verify workflows plugin still filters connections correctly
- [ ] Verify plugin empty state still shows when no matching connections exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor plugin binding to use a `bindingName` string with server-side connection filtering. This simplifies plugin APIs and avoids loading all connections on the client.

- **Refactors**
  - Added `bindingName` to `ClientPlugin`; deprecated `binding` in `@decocms/bindings`.
  - Replaced `binding` with `bindingName` in `PluginLayout`/`DynamicPluginLayout`.
  - Use `useConnections({ binding: bindingName })` for server-side filtering; removed client-side filtering and `connectionImplementsBinding`.
  - Updated Workflows client plugin to `bindingName: "WORKFLOW"` and removed the `<Binder>` generic.

- **Migration**
  - In client plugins, use `bindingName` instead of `binding`; use `ClientPlugin` without `<Binder>`.
  - Pass `bindingName="..."` to `PluginLayout`; remove any `connectionImplementsBinding` filtering.

<sup>Written for commit bf9d79445073ebeda8a7c97bd9d7ab260f1b54ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

