### PR TITLE
Revert "fix(automations): re-initialize NATS consumer on 503 no-responders"

### DIFF
--- a/apps/mesh/src/automations/job-stream.ts
+++ b/apps/mesh/src/automations/job-stream.ts
@@ -27,8 +27,6 @@ const MAX_DELIVER = 3;
 const ACK_WAIT_NS = 6 * 60 * 1_000_000_000; // 6 min (> 5 min automation timeout)
 const PULL_BATCH_SIZE = 5;
 const PULL_EXPIRES_MS = 10_000;
-const RECONNECT_BASE_MS = 1_000;
-const RECONNECT_MAX_MS = 60_000;
 
 export interface AutomationJobPayload {
   triggerId: string;
@@ -111,49 +109,35 @@ export class AutomationJobStream {
     if (!this.js) throw new Error("AutomationJobStream not initialized");
     this.running = true;
 
-    (async () => {
-      let backoff = RECONNECT_BASE_MS;
+    const consumer = await this.js.consumers.get(STREAM_NAME, CONSUMER_NAME);
 
+    (async () => {
       while (this.running) {
         try {
-          await this.init();
-          if (!this.running) break;
-          const consumer = await this.js!.consumers.get(
-            STREAM_NAME,
-            CONSUMER_NAME,
-          );
+          const messages = await consumer.fetch({
+            max_messages: PULL_BATCH_SIZE,
+            expires: PULL_EXPIRES_MS,
+          });
 
-          while (this.running) {
-            const messages = await consumer.fetch({
-              max_messages: PULL_BATCH_SIZE,
-              expires: PULL_EXPIRES_MS,
-            });
-            backoff = RECONNECT_BASE_MS;
-
-            for await (const msg of messages) {
-              try {
-                const payload: AutomationJobPayload = JSON.parse(
-                  this.decoder.decode(msg.data),
-                );
-                await handler(payload);
-                msg.ack();
-              } catch (err) {
-                console.error(
-                  "[AutomationJobStream] Handler error, nacking:",
-                  err,
-                );
-                msg.nak();
-              }
+          for await (const msg of messages) {
+            try {
+              const payload: AutomationJobPayload = JSON.parse(
+                this.decoder.decode(msg.data),
+              );
+              await handler(payload);
+              msg.ack();
+            } catch (err) {
+              console.error(
+                "[AutomationJobStream] Handler error, nacking:",
+                err,
+              );
+              msg.nak();
             }
           }
         } catch (err) {
           if (this.running) {
-            console.error(
-              `[AutomationJobStream] Consumer error, retrying in ${backoff}ms:`,
-              err,
-            );
-            await new Promise((r) => setTimeout(r, backoff));
-            backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
+            console.error("[AutomationJobStream] Consumer fetch error:", err);
+            await new Promise((r) => setTimeout(r, 1000));
           }
         }
       }


### PR DESCRIPTION
Reverts decocms/studio#2843

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that re-initialized the NATS JetStream consumer with exponential backoff on 503 no-responders. Restores the previous behavior: create the consumer once and keep fetching, retrying after 1s on fetch errors.

<sup>Written for commit 7baa2f3da184220bcdef1c066479d5c9955c932f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

