### PR TITLE
fix(ui): default add-connection modal to Connected tab in agent

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/add-connection-dialog.tsx
@@ -168,7 +168,7 @@ function AddConnectionDialogContent({
 
   const [activeTab, setActiveTab] = useLocalStorage<ConnectionTab>(
     LOCALSTORAGE_KEYS.connectionsTab(org.slug) + ":agent-modal",
-    () => "all",
+    (existing) => existing ?? "connected",
   );
 
   // Connections - server-side search (VIRTUAL excluded by default)


### PR DESCRIPTION
## What is this contribution about?
The "Add Connection" modal in the agent detail page now defaults to the **Connected** tab instead of **All**, so users immediately see their already-connected integrations rather than the full catalog.

The initializer uses `(existing) => existing ?? "connected"` so users who have already selected a different tab will have their preference preserved, and only first-time openers get the new default.

## Screenshots/Demonstration
Open an agent → click "Add Connection" → modal opens on the **Connected** tab by default.

## How to Test
1. Open an agent detail page.
2. Click the "Add Connection" button.
3. Verify the modal opens on the **Connected** tab.
4. Switch to **All**, close, and reopen — it should stay on **All** (preference preserved).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The agent "Add Connection" modal now opens on the Connected tab by default instead of All. The modal remembers the last selected tab via local storage, so existing preferences are preserved.

<sup>Written for commit 5b44634576d826fdb99562499990e695af2b6dc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

