### PR TITLE
fix(cli): restore truthy checks for ENCRYPTION_KEY to fix production decryption

### DIFF
--- a/apps/mesh/src/cli/commands/resolve-secrets.test.ts
+++ b/apps/mesh/src/cli/commands/resolve-secrets.test.ts
@@ -4,38 +4,58 @@ import { resolveSecrets, type SecretsFile } from "./resolve-secrets";
 describe("resolveSecrets", () => {
   const emptyEnv = {};
 
-  describe("empty string preservation (regression test)", () => {
-    it("should preserve ENCRYPTION_KEY empty string from secrets.json", () => {
+  describe("ENCRYPTION_KEY uses truthy checks (critical production behavior)", () => {
+    // ⚠️ These tests document the intentional truthy-check behavior.
+    // Empty-string env/saved values are treated as "not set" so that
+    // the generated random key in secrets.json is used instead.
+    // Changing this broke production decryption — see PRs #2785 / #2790.
+
+    it("should ignore empty-string ENCRYPTION_KEY env and use saved value", () => {
+      const saved: SecretsFile = { ENCRYPTION_KEY: "saved-key" };
+      const env = { ENCRYPTION_KEY: "" };
+      const { secrets } = resolveSecrets(saved, env);
+
+      expect(secrets.ENCRYPTION_KEY).toBe("saved-key");
+    });
+
+    it("should generate random ENCRYPTION_KEY when saved is empty string and env is empty string", () => {
       const saved: SecretsFile = { ENCRYPTION_KEY: "" };
-      const { secrets } = resolveSecrets(saved, emptyEnv);
+      const env = { ENCRYPTION_KEY: "" };
+      const { secrets, modified } = resolveSecrets(saved, env);
 
-      expect(secrets.ENCRYPTION_KEY).toBe("");
+      // Both are falsy → generates a new random key
+      expect(secrets.ENCRYPTION_KEY).toBeTruthy();
+      expect(Buffer.from(secrets.ENCRYPTION_KEY, "base64").length).toBe(32);
+      expect(modified).toBe(true);
     });
 
-    it("should preserve BETTER_AUTH_SECRET empty string from secrets.json", () => {
-      const saved: SecretsFile = { BETTER_AUTH_SECRET: "" };
-      const { secrets } = resolveSecrets(saved, emptyEnv);
-
-      expect(secrets.BETTER_AUTH_SECRET).toBe("");
-    });
-
-    it("should preserve both empty strings (pre-refactor secrets.json)", () => {
-      const saved: SecretsFile = {
-        BETTER_AUTH_SECRET: "",
-        ENCRYPTION_KEY: "",
-        LOCAL_ADMIN_PASSWORD: "existing-password",
-      };
+    it("should generate random ENCRYPTION_KEY when saved is empty string and env is unset", () => {
+      const saved: SecretsFile = { ENCRYPTION_KEY: "" };
       const { secrets, modified } = resolveSecrets(saved, emptyEnv);
 
-      expect(secrets.BETTER_AUTH_SECRET).toBe("");
-      expect(secrets.ENCRYPTION_KEY).toBe("");
-      expect(secrets.LOCAL_ADMIN_PASSWORD).toBe("existing-password");
-      expect(modified).toBe(false);
+      expect(secrets.ENCRYPTION_KEY).toBeTruthy();
+      expect(Buffer.from(secrets.ENCRYPTION_KEY, "base64").length).toBe(32);
+      expect(modified).toBe(true);
+    });
+
+    it("should use truthy env ENCRYPTION_KEY over saved value", () => {
+      const saved: SecretsFile = { ENCRYPTION_KEY: "saved-key" };
+      const env = { ENCRYPTION_KEY: "env-key" };
+      const { secrets } = resolveSecrets(saved, env);
+
+      expect(secrets.ENCRYPTION_KEY).toBe("env-key");
+    });
+
+    it("should use saved ENCRYPTION_KEY when env is not set", () => {
+      const saved: SecretsFile = { ENCRYPTION_KEY: "saved-key" };
+      const { secrets } = resolveSecrets(saved, emptyEnv);
+
+      expect(secrets.ENCRYPTION_KEY).toBe("saved-key");
     });
   });
 
-  describe("env var precedence", () => {
-    it("should use env BETTER_AUTH_SECRET over saved value", () => {
+  describe("BETTER_AUTH_SECRET", () => {
+    it("should use env over saved value", () => {
       const saved: SecretsFile = { BETTER_AUTH_SECRET: "saved-value" };
       const env = { BETTER_AUTH_SECRET: "env-value" };
       const { secrets } = resolveSecrets(saved, env);
@@ -43,36 +63,29 @@ describe("resolveSecrets", () => {
       expect(secrets.BETTER_AUTH_SECRET).toBe("env-value");
     });
 
-    it("should use env ENCRYPTION_KEY over saved value", () => {
-      const saved: SecretsFile = { ENCRYPTION_KEY: "saved-value" };
-      const env = { ENCRYPTION_KEY: "env-value" };
-      const { secrets } = resolveSecrets(saved, env);
+    it("should use saved value when env is not set", () => {
+      const saved: SecretsFile = { BETTER_AUTH_SECRET: "saved-value" };
+      const { secrets } = resolveSecrets(saved, emptyEnv);
 
-      expect(secrets.ENCRYPTION_KEY).toBe("env-value");
+      expect(secrets.BETTER_AUTH_SECRET).toBe("saved-value");
     });
 
-    it("should preserve env ENCRYPTION_KEY empty string over saved value", () => {
-      const saved: SecretsFile = { ENCRYPTION_KEY: "saved-value" };
-      const env = { ENCRYPTION_KEY: "" };
-      const { secrets } = resolveSecrets(saved, env);
-
-      expect(secrets.ENCRYPTION_KEY).toBe("");
-    });
-  });
-
-  describe("generation of missing secrets", () => {
-    it("should generate BETTER_AUTH_SECRET when missing from both env and file", () => {
+    it("should generate when missing from both", () => {
       const { secrets, modified } = resolveSecrets({}, emptyEnv);
 
       expect(secrets.BETTER_AUTH_SECRET).toBeTruthy();
       expect(Buffer.from(secrets.BETTER_AUTH_SECRET, "base64").length).toBe(32);
       expect(modified).toBe(true);
     });
+  });
 
-    it("should default ENCRYPTION_KEY to empty string when missing from both env and file", () => {
-      const { secrets } = resolveSecrets({}, emptyEnv);
+  describe("generation of missing secrets", () => {
+    it("should generate ENCRYPTION_KEY when missing from both env and file", () => {
+      const { secrets, modified } = resolveSecrets({}, emptyEnv);
 
-      expect(secrets.ENCRYPTION_KEY).toBe("");
+      expect(secrets.ENCRYPTION_KEY).toBeTruthy();
+      expect(Buffer.from(secrets.ENCRYPTION_KEY, "base64").length).toBe(32);
+      expect(modified).toBe(true);
     });
 
     it("should generate LOCAL_ADMIN_PASSWORD when missing", () => {

--- a/apps/mesh/src/cli/commands/resolve-secrets.ts
+++ b/apps/mesh/src/cli/commands/resolve-secrets.ts
@@ -3,7 +3,24 @@
  *
  * Pure function that resolves BETTER_AUTH_SECRET, ENCRYPTION_KEY, and
  * LOCAL_ADMIN_PASSWORD from a saved secrets file, generating new values
- * only when a key is truly missing (undefined), NOT when it's an empty string.
+ * only when a key is truly missing.
+ *
+ * ╔══════════════════════════════════════════════════════════════════════╗
+ * ║  WARNING — ENCRYPTION_KEY RESOLUTION IS LOAD-BEARING               ║
+ * ║                                                                    ║
+ * ║  The ENCRYPTION_KEY logic below uses TRUTHY checks (not != null).  ║
+ * ║  This is intentional and critical for production correctness.      ║
+ * ║                                                                    ║
+ * ║  Many deployments pass ENCRYPTION_KEY="" (empty string) via env    ║
+ * ║  vars. A truthy check treats "" as "not set", which falls through  ║
+ * ║  to the saved secrets.json — where the real random key lives.      ║
+ * ║  Changing to != null would make "" win over the saved key,         ║
+ * ║  producing SHA-256("") instead of the saved random key, instantly  ║
+ * ║  breaking decryption of all existing data in production.           ║
+ * ║                                                                    ║
+ * ║  DO NOT "fix" the truthy checks to != null. This was tried in     ║
+ * ║  PRs #2785 and #2790 and broke production AES-GCM decryption.     ║
+ * ╚══════════════════════════════════════════════════════════════════════╝
  */
 import crypto from "crypto";
 
@@ -21,9 +38,15 @@ export interface ResolvedSecrets {
 /**
  * Resolve secrets from saved file and environment.
  *
- * - If an env var is set, it takes precedence (the saved value is kept as-is).
- * - If the saved value is present (including empty string ""), it is used.
- * - Only when the saved value is undefined/null is a new random value generated.
+ * Priority for each secret:
+ *   1. Truthy env var (non-empty string)
+ *   2. Truthy saved value from secrets.json (non-empty string)
+ *   3. Generate a new random value and mark modified=true
+ *
+ * The generated ENCRYPTION_KEY is saved to secrets.json so that subsequent
+ * boots (and all replicas sharing the same volume) reuse the same key.
+ * If you need a stable key across pods without a shared volume, set a
+ * non-empty ENCRYPTION_KEY env var explicitly.
  */
 export function resolveSecrets(
   saved: SecretsFile,
@@ -31,34 +54,32 @@ export function resolveSecrets(
 ): ResolvedSecrets {
   let modified = false;
 
-  // BETTER_AUTH_SECRET
+  // BETTER_AUTH_SECRET — truthy check (empty string = not set)
   let betterAuthSecret: string;
   if (env.BETTER_AUTH_SECRET) {
     betterAuthSecret = env.BETTER_AUTH_SECRET;
-  } else if (saved.BETTER_AUTH_SECRET != null) {
+  } else if (saved.BETTER_AUTH_SECRET) {
     betterAuthSecret = saved.BETTER_AUTH_SECRET;
   } else {
     betterAuthSecret = crypto.randomBytes(32).toString("base64");
     modified = true;
   }
 
-  // ENCRYPTION_KEY
-  // Use != null (not truthy) so that an empty-string env var is preserved.
-  // When neither env nor saved provides a value, default to "" rather than a
-  // random key — CredentialVault hashes "" deterministically via SHA-256,
-  // which keeps all replicas / restarts consistent.  A random fallback would
-  // silently produce a different key on every pod start, making previously
-  // encrypted data unreadable.
+  // ── ENCRYPTION_KEY ──────────────────────────────────────────────────
+  // TRUTHY checks here are INTENTIONAL. See the big warning at the top.
+  // An empty-string env var ("") must fall through so the saved random
+  // key from secrets.json is used. Do NOT change to != null.
   let encryptionKey: string;
-  if (env.ENCRYPTION_KEY != null) {
+  if (env.ENCRYPTION_KEY) {
     encryptionKey = env.ENCRYPTION_KEY;
-  } else if (saved.ENCRYPTION_KEY != null) {
+  } else if (saved.ENCRYPTION_KEY) {
     encryptionKey = saved.ENCRYPTION_KEY;
   } else {
-    encryptionKey = "";
+    encryptionKey = crypto.randomBytes(32).toString("base64");
+    modified = true;
   }
 
-  // LOCAL_ADMIN_PASSWORD
+  // LOCAL_ADMIN_PASSWORD — use != null so empty string is preserved
   let localAdminPassword: string;
   if (saved.LOCAL_ADMIN_PASSWORD != null) {
     localAdminPassword = saved.LOCAL_ADMIN_PASSWORD;


### PR DESCRIPTION
## What is this contribution about?

PRs #2785 and #2790 changed ENCRYPTION_KEY resolution from truthy checks to `!= null` checks. This caused deployments with `ENCRYPTION_KEY=""` (common in Docker/K8s) to use `SHA-256("")` instead of the saved random key from `secrets.json`, breaking AES-256-GCM decryption of all existing data in production.

This PR restores the original truthy-check behavior:
- Empty-string env vars fall through (treated as "not set")
- Empty-string saved values fall through (treated as "not set")  
- A random key is generated, saved to `secrets.json`, and reused across restarts
- Adds prominent warning comments so this doesn't get "fixed" again

## Screenshots/Demonstration
N/A

## How to Test
1. Run `bun test apps/mesh/src/cli/commands/resolve-secrets.test.ts` — all 12 tests pass
2. Verify that `resolveSecrets({ ENCRYPTION_KEY: "saved-key" }, { ENCRYPTION_KEY: "" })` returns `"saved-key"` (empty env falls through to saved)
3. Verify that `resolveSecrets({ ENCRYPTION_KEY: "" }, {})` generates a random key (empty saved falls through to generation)
4. Deploy and confirm existing encrypted connections can be decrypted

## Migration Notes
N/A — this restores the original behavior, no migration needed.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores truthy checks for ENCRYPTION_KEY in the CLI so ENCRYPTION_KEY="" falls through to the saved random key in `secrets.json`, fixing production AES‑GCM decryption. Also generates and persists a 32‑byte base64 key when missing and updates tests to lock this behavior.

- **Bug Fixes**
  - ENCRYPTION_KEY precedence: truthy env > truthy saved > generate; empty string is treated as not set.
  - Generate and persist ENCRYPTION_KEY when missing (no longer default to ""), reusing across restarts.
  - Keep `LOCAL_ADMIN_PASSWORD` using != null (preserve empty string). Use truthy checks for `BETTER_AUTH_SECRET` and generate when missing.
  - Add warning comments and expand tests for empty-string and precedence cases.

<sup>Written for commit 28df4aa69056acd790aed4af6f77f265bfb9a8c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

