### PR TITLE
fix(ui): filter useConnections by agent IDs in tasks panel

### DIFF
--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -478,13 +478,25 @@ export function TaskListContent({ onTaskSelect }: TaskListContentProps) {
   const { tasks, virtualMcps } = useChatStable();
   const { org } = useProjectContext();
 
-  const connections = useConnections();
+  // Compute needed agent IDs from tasks
+  const agentIds = [
+    ...new Set(
+      tasks.filter((t) => !t.hidden).flatMap((t) => t.agent_ids ?? []),
+    ),
+  ];
+
+  const connections = useConnections({
+    additionalToolArgs:
+      agentIds.length > 0
+        ? { where: { field: ["id"], operator: "in", value: agentIds } }
+        : undefined,
+  });
   // Build a unified agent lookup: connections + virtual MCPs
   const connectionMap = new Map<
     string,
     { icon: string | null | undefined; title: string }
   >();
-  for (const c of connections ?? []) {
+  for (const c of connections) {
     connectionMap.set(c.id, { icon: c.icon, title: c.title });
   }
   for (const v of virtualMcps) {


### PR DESCRIPTION
## Summary
- Replace bare `useConnections()` call in `TaskListContent` with a filtered query that only fetches connections matching task agent IDs
- Computes unique agent IDs from visible tasks and passes a server-side `where` filter with `id IN (...)` 
- When no agent IDs exist, falls back to fetching all connections (same as before)
- Remove unnecessary `?? []` fallback since `useConnections` always returns an array

## Test plan
- [ ] Open the tasks panel with tasks that have agent IDs — verify only those connections are fetched
- [ ] Open the tasks panel with no tasks — verify connections still load without errors
- [ ] Verify the agent icons/titles still render correctly in the task list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter `useConnections` by task agent IDs in the tasks panel to only fetch connections used by visible tasks. This reduces unnecessary data and keeps agent icons/titles accurate.

- **Bug Fixes**
  - Query `useConnections` with a server-side filter: `where: { field: ["id"], operator: "in", value: agentIds }`.
  - Fallback to fetching all connections when no agent IDs exist.
  - Remove the `?? []` fallback since `useConnections` always returns an array.

<sup>Written for commit e744cee054ec04dffa1e2b8a0914e0b04b2577ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

