### PR TITLE
fix(ui): filter useConnections by metric IDs in analytics top tools

### DIFF
--- a/apps/mesh/src/web/components/monitoring/analytics-top-tools.tsx
+++ b/apps/mesh/src/web/components/monitoring/analytics-top-tools.tsx
@@ -319,7 +319,6 @@ function TopToolsContent({
 }: TopToolsContentProps) {
   const { org } = useProjectContext();
   const navigate = useNavigate();
-  const connections = useConnections() ?? [];
 
   const dateRange = externalDateRange;
   if (!dateRange) {
@@ -364,6 +363,28 @@ function TopToolsContent({
       refetchInterval: isStreaming ? streamingRefetchInterval : false,
     },
   );
+
+  // Extract unique connection IDs from metric data to filter the connections query
+  const metricConnectionIds = [
+    ...new Set(
+      (metricData?.topTools ?? [])
+        .map((t) => t.connectionId)
+        .filter(Boolean) as string[],
+    ),
+  ];
+
+  const connections = useConnections({
+    additionalToolArgs:
+      metricConnectionIds.length > 0
+        ? {
+            where: {
+              field: ["id"],
+              operator: "in",
+              value: metricConnectionIds,
+            },
+          }
+        : undefined,
+  });
 
   const topTools = metricData?.topTools ?? [];
 


### PR DESCRIPTION
## Summary
- Replaces bare `useConnections()` call in `analytics-top-tools.tsx` that loaded ALL connections with a filtered query
- Extracts unique connection IDs from the top tools metric response and passes them as a `where: { field: ["id"], operator: "in", value: [...] }` filter
- When metric data hasn't loaded yet, falls back to unfiltered (same behavior as before); once data arrives, only fetches the needed connections

## Test plan
- [ ] Verify the analytics top tools chart still renders connection icons and names correctly
- [ ] Confirm network requests show filtered connection queries once metric data loads
- [ ] Check that the chart works correctly on initial load (before metric data arrives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter `useConnections` in `analytics-top-tools.tsx` to only fetch connections referenced by the Top Tools metric data, instead of loading all connections. Falls back to the unfiltered query until metric data is available.

<sup>Written for commit a2a0b98748f148eab11e0f40f1a7b324eb193f16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

