### PR TITLE
fix(ui): add server-side search to monitoring connection filter

### DIFF
--- a/apps/mesh/src/web/routes/orgs/monitoring.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring.tsx
@@ -817,6 +817,8 @@ interface FiltersPopoverProps {
   virtualMcpOptions: Array<{ value: string; label: string }>;
   activeFiltersCount: number;
   onUpdateFilters: (updates: Partial<MonitoringSearchParams>) => void;
+  connectionSearchTerm?: string;
+  onConnectionSearchChange?: (term: string) => void;
 }
 
 const OPERATOR_OPTIONS: Array<{
@@ -840,6 +842,7 @@ function FiltersPopover({
   virtualMcpOptions,
   activeFiltersCount,
   onUpdateFilters,
+  onConnectionSearchChange,
 }: FiltersPopoverProps) {
   const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
   const [propertyFilterMode, setPropertyFilterMode] = useState<"raw" | "form">(
@@ -993,6 +996,7 @@ function FiltersPopover({
                 onValueChange={(values) =>
                   onUpdateFilters({ connectionId: values })
                 }
+                onSearchChange={onConnectionSearchChange}
                 placeholder="All servers"
                 variant="secondary"
                 className="w-full"
@@ -1691,7 +1695,13 @@ function MonitoringDashboardContent({
   const allConnections = useConnections();
   const allVirtualMcps = useVirtualMCPs();
   const { data: membersData } = useMembers();
-  const connectionOptions = (allConnections ?? []).map((conn) => ({
+
+  // Separate search-filtered connections for the dropdown
+  const [connectionSearch, setConnectionSearch] = useState("");
+  const searchFilteredConnections = useConnections({
+    searchTerm: connectionSearch || undefined,
+  });
+  const connectionOptions = (searchFilteredConnections ?? []).map((conn) => ({
     value: conn.id,
     label: conn.title || conn.id,
   }));
@@ -1774,6 +1784,8 @@ function MonitoringDashboardContent({
                 virtualMcpOptions={virtualMcpOptions}
                 activeFiltersCount={activeFiltersCount}
                 onUpdateFilters={onUpdateFilters}
+                connectionSearchTerm={connectionSearch}
+                onConnectionSearchChange={setConnectionSearch}
               />
 
               {/* AI Only Toggle (Audit tab only) */}

--- a/packages/ui/src/components/multi-select.tsx
+++ b/packages/ui/src/components/multi-select.tsx
@@ -36,6 +36,8 @@ interface MultiSelectProps {
   asChild?: boolean;
   className?: string;
   disabled?: boolean;
+  /** When provided, disables client-side filtering and delegates search to the caller. */
+  onSearchChange?: (term: string) => void;
 }
 
 export function MultiSelect({
@@ -50,6 +52,7 @@ export function MultiSelect({
   asChild = false,
   className,
   disabled = false,
+  onSearchChange,
 }: MultiSelectProps) {
   const [selectedValues, setSelectedValues] =
     React.useState<string[]>(defaultValue);
@@ -172,10 +175,11 @@ export function MultiSelect({
         align="start"
         onEscapeKeyDown={() => setIsPopoverOpen(false)}
       >
-        <Command className="rounded-xl">
+        <Command shouldFilter={!onSearchChange} className="rounded-xl">
           <CommandInput
             placeholder="Search..."
             onKeyDown={handleInputKeyDown}
+            onValueChange={onSearchChange}
             className="rounded-t-xl"
           />
           <CommandList className="rounded-b-xl">


### PR DESCRIPTION
## Summary
- Adds `onSearchChange` prop to the `MultiSelect` component, which disables client-side filtering (`shouldFilter={false}`) and delegates search to the caller via `CommandInput.onValueChange`
- Adds a separate `useConnections({ searchTerm })` call in `MonitoringDashboardContent` for the connection filter dropdown, so it fetches server-filtered results
- Keeps the existing bare `useConnections()` for child components (AuditTabContent, ConnectionLeaderboard, MonitoringStats) that need all connections for ID-to-name resolution

## Test plan
- [ ] Open the Monitoring page with >100 connections
- [ ] Open the connection filter dropdown and type a search term
- [ ] Verify the dropdown options update with server-filtered results
- [ ] Verify selecting a connection still works correctly
- [ ] Verify the stats/audit tabs still resolve connection names properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side search to the Monitoring connection filter so the dropdown returns complete results for large orgs. The dropdown now queries the backend as you type instead of filtering only the first page.

- **Bug Fixes**
  - Added optional `onSearchChange` to `MultiSelect` to delegate search and disable client-side filtering.
  - Switched the connection filter dropdown to `useConnections({ searchTerm })`; kept the existing `useConnections()` for name resolution in other tabs.
  - Wired search term handling through `FiltersPopover` to the dropdown.
  - No longer limited to the first page of connections; works with >100 connections.

<sup>Written for commit a982ea968595c12493f02d4f15fb2dbc9a1b877f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

