### PR TITLE
fix(ui): add infinite scroll for connected tab in add-connection dialog

### DIFF
--- a/apps/mesh/src/web/components/details/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/components/details/virtual-mcp/add-connection-dialog.tsx
@@ -173,6 +173,7 @@ function AddConnectionDialogContent({
   const { org } = useProjectContext();
   // Defer search so React keeps showing old results instead of suspense fallback
   const deferredSearch = useDeferredValue(search);
+  const isSearchStale = search !== deferredSearch;
   const searchLower = deferredSearch.toLowerCase();
 
   const [activeTab, setActiveTab] = useLocalStorage<ConnectionTab>(
@@ -504,7 +505,12 @@ function AddConnectionDialogContent({
       </div>
 
       {/* Content grid */}
-      <div className="flex-1 overflow-auto p-5">
+      <div
+        className={cn(
+          "flex-1 overflow-auto p-5 transition-opacity duration-150",
+          isSearchStale && "opacity-50 pointer-events-none",
+        )}
+      >
         <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4">
           {/* Connected connections (shown in Connected tab, or in All when searching) */}
           {groupedForDisplay.map((item) => {


### PR DESCRIPTION
## Summary
- Replaces the single-page `useConnections()` call with `useSuspenseInfiniteQuery` for the connected connections list in the add-connection dialog
- Adds a scroll sentinel and loading spinner for the "Connected" tab, matching the existing infinite scroll pattern used in the catalog tab
- Connections are now fetched in pages of 100, with automatic loading of subsequent pages as the user scrolls

Closes #2852

## Test plan
- [ ] Open an agent/virtual MCP and click "Add Connection"
- [ ] Switch to the "Connected" tab and verify connections load correctly
- [ ] If >100 connections exist, verify scrolling triggers loading of additional pages
- [ ] Verify the "All" tab and catalog infinite scroll still work as before
- [ ] Test search filtering works across paginated results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds infinite scroll to connected results in the Add Connection dialog, loading 100 items per page as you scroll. Keeps the search input stable during refetches and shows a subtle loading hint while search updates. Matches the catalog tab pattern and addresses Linear #2852.

- **New Features**
  - Replaced `useConnections()` with `useSuspenseInfiniteQuery` from `@tanstack/react-query` to paginate connected results.
  - Fetches 100-item pages via `COLLECTION_CONNECTIONS_LIST` and auto-loads on scroll.
  - Shows scroll sentinel and loading spinner on Connected and when searching from All. Server-side search (title and description) works across pages.

- **Bug Fixes**
  - Moved the search input outside Suspense and used `useDeferredValue` to prevent focus loss and flicker; dims the content grid while search results load.

<sup>Written for commit 4db746fc0a1520ad6c1b16213801264a033e0e4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

