### PR TITLE
fix(ui): navigate to project settings page instead of org settings modal

### DIFF
--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -5,7 +5,6 @@ import type {
 } from "@/web/components/sidebar/types";
 import { useDecoTasksOpen } from "@/web/hooks/use-deco-tasks-open";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { useSettingsModal } from "@/web/hooks/use-settings-modal";
 import {
   BarChart10,
   CheckDone01,
@@ -26,7 +25,6 @@ export function useProjectSidebarItems(options?: {
   const { org: orgContext } = useProjectContext();
   const navigate = useNavigate();
   const routerState = useRouterState();
-  const settingsModal = useSettingsModal();
   const org = orgContext.slug;
   const isOrgAdminProject = useIsOrgAdmin();
   const currentProject = useProjectContext().project;
@@ -344,8 +342,12 @@ export function useProjectSidebarItems(options?: {
     key: "configure",
     label: "Settings",
     icon: <Settings01 />,
-    isActive: settingsModal.isOpen,
-    onClick: () => settingsModal.open("org.general"),
+    isActive: isActiveRoute("settings"),
+    onClick: () =>
+      navigate({
+        to: "/$org/projects/$virtualMcpId/settings",
+        params: { org, virtualMcpId },
+      }),
   };
 
   // Regular project sidebar layout (matching Figma):


### PR DESCRIPTION
## Summary

- Fix project sidebar "Settings" button navigating to the org settings modal instead of the project settings page
- Changed `configureItem` in `useProjectSidebarItems` to navigate to `/$org/projects/$virtualMcpId/settings` instead of calling `settingsModal.open("org.general")`
- Removed unused `useSettingsModal` import and variable

## Test plan

- [ ] Open a project page
- [ ] Click "Settings" in the sidebar
- [ ] Verify it navigates to `/$org/projects/$virtualMcpId/settings` (project settings page)
- [ ] Verify the "Settings" sidebar item highlights correctly when on the project settings page


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the project sidebar “Settings” to open the project settings page instead of the org settings modal. Also ensures the item highlights correctly on the project settings route.

- **Bug Fixes**
  - Route the “Settings” item to "/$org/projects/$virtualMcpId/settings" and set active via isActiveRoute("settings").
  - Remove the unused settings modal integration (useSettingsModal import and variable).

<sup>Written for commit 945edc136aeeb052ccc58c7b63b98b7963c44a09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

