### PR TITLE
fix(ui): resolve connections by slug instead of exact app_name match

### DIFF
--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -74,6 +74,7 @@ import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
+import { getConnectionSlug } from "@/web/utils/connection-slug";
 import { ViewLayout } from "../layout";
 import { ConnectionActivity } from "./connection-activity.tsx";
 import { ConnectionAgentsPanel } from "./connection-agents-panel.tsx";
@@ -754,10 +755,14 @@ function ConnectionInspectorViewContent() {
 
   const actions = useConnectionActions();
 
-  // Resolve appSlug → matching connections (server-side filter by app_name, excludes VIRTUAL by default)
-  const siblings = useConnections({
-    filters: [{ column: "app_name", value: appSlug }],
-  });
+  // Resolve appSlug → matching connections.
+  // Fetch all connections then match client-side by slug, because the URL slug
+  // is a slugified version of app_name (e.g. "deco.cx" → "decocx") which won't
+  // match an exact server-side app_name filter.
+  const allConnections = useConnections();
+  const siblings = allConnections.filter(
+    (c) => getConnectionSlug(c) === appSlug,
+  );
   const connection = siblings[0] ?? null;
   const connectionId = connection?.id ?? "";
 

--- a/apps/mesh/src/web/components/details/workflow/index.tsx
+++ b/apps/mesh/src/web/components/details/workflow/index.tsx
@@ -43,6 +43,7 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 
+import { getConnectionSlug } from "@/web/utils/connection-slug";
 import { EmptyState } from "@deco/ui/components/empty-state.js";
 import { usePollingWorkflowExecution } from "./hooks";
 import { useWorkflowSSE } from "./hooks/use-workflow-sse";
@@ -57,9 +58,10 @@ export function useCollectionWorkflow({ itemId }: { itemId: string }) {
   const { appSlug } = useParams({
     from: "/shell/$org/mcps/$appSlug/$collectionName/$itemId",
   });
-  const slugConnections = useConnections({
-    filters: [{ column: "app_name", value: appSlug }],
-  });
+  const allConnections = useConnections();
+  const slugConnections = allConnections.filter(
+    (c) => getConnectionSlug(c) === appSlug,
+  );
   const connection = slugConnections[0] ?? null;
   const connectionId = connection?.id ?? appSlug;
   const scopeKey = connectionId ?? "no-connection";
@@ -395,9 +397,10 @@ function useCollectionWorkflowExecution({ itemId }: { itemId: string }) {
   const { appSlug } = useParams({
     from: "/shell/$org/mcps/$appSlug/$collectionName/$itemId",
   });
-  const slugConnections = useConnections({
-    filters: [{ column: "app_name", value: appSlug }],
-  });
+  const allConnections = useConnections();
+  const slugConnections = allConnections.filter(
+    (c) => getConnectionSlug(c) === appSlug,
+  );
   const connection = slugConnections[0] ?? null;
   const connectionId = connection?.id ?? appSlug;
   const scopeKey = connectionId ?? "no-connection";

--- a/apps/mesh/src/web/routes/orgs/collection-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/collection-detail.tsx
@@ -6,8 +6,9 @@ import {
   useConnections,
   useMCPClient,
   useProjectContext,
+  type ConnectionEntity,
 } from "@decocms/mesh-sdk";
-
+import { getConnectionSlug } from "@/web/utils/connection-slug";
 import { EmptyState } from "@deco/ui/components/empty-state.tsx";
 import {
   Breadcrumb,
@@ -50,9 +51,10 @@ function ToolDetailsContent() {
 
   const itemId = decodeURIComponent(params.itemId);
 
-  const siblings = useConnections({
-    filters: [{ column: "app_name", value: params.appSlug }],
-  });
+  const allConnections = useConnections();
+  const siblings = allConnections.filter(
+    (c: ConnectionEntity) => getConnectionSlug(c) === params.appSlug,
+  );
 
   const handleBack = () => {
     router.history.back();
@@ -100,9 +102,10 @@ function CollectionDetailsContent() {
   };
 
   const { org } = useProjectContext();
-  const slugConnections = useConnections({
-    filters: [{ column: "app_name", value: params.appSlug }],
-  });
+  const allConns = useConnections();
+  const slugConnections = allConns.filter(
+    (c: ConnectionEntity) => getConnectionSlug(c) === params.appSlug,
+  );
   const connection = slugConnections[0] ?? null;
   const connectionId = connection?.id ?? "";
   const scopeKey = connectionId || "no-connection";


### PR DESCRIPTION
The connection detail page was filtering by `app_name = slugifiedValue`, but slugify strips special characters (e.g. "deco.cx" → "decocx"), so the exact match never found the connection. Now fetches all connections and matches client-side using the same getConnectionSlug() that generated the URL slug.

Made-with: Cursor

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix connection lookup by matching URL slug instead of exact `app_name`, so apps with special characters (e.g. "deco.cx") resolve correctly across detail and workflow views.

- **Bug Fixes**
  - Fetch all connections with `useConnections()` and filter client-side using `getConnectionSlug(c) === appSlug`.
  - Applied in connection details, workflow hooks, and org collection detail routes.

<sup>Written for commit 6e54be76ec5581bb4a04539aa632c8bdf6fac930. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

