### PR TITLE
remove slugify for app_name

### DIFF
--- a/apps/mesh/src/web/utils/connection-slug.ts
+++ b/apps/mesh/src/web/utils/connection-slug.ts
@@ -7,7 +7,7 @@ export function getConnectionSlug(connection: {
   id?: string;
 }): string {
   if (connection.app_name) {
-    return slugify(connection.app_name);
+    return connection.app_name;
   }
   if (connection.connection_url) {
     try {


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop slugifying connection slugs derived from `app_name`. `getConnectionSlug` now returns `app_name` as-is to preserve the exact name and avoid unwanted normalization.

- **Migration**
  - Update any routes, lookups, or IDs that expect slugified values to handle raw `app_name`.
  - If you store slugs, backfill or add a fallback to accept both old slugified and new raw values.

<sup>Written for commit 7587aecf9936f9581b10d64a0a288176494c8722. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

