### PR TITLE
fix(cli): use != null for env var check to forward empty-string ENCRYPTION_KEY

### DIFF
--- a/apps/mesh/src/cli/commands/resolve-secrets.test.ts
+++ b/apps/mesh/src/cli/commands/resolve-secrets.test.ts
@@ -4,34 +4,33 @@ import { resolveSecrets, type SecretsFile } from "./resolve-secrets";
 describe("resolveSecrets", () => {
   const emptyEnv = {};
 
-  describe("ENCRYPTION_KEY: truthy env check + != null saved check", () => {
+  describe("ENCRYPTION_KEY: != null env check + != null saved check", () => {
     // ⚠️ These tests document the critical resolution behavior.
-    // Env check is TRUTHY: empty-string env vars fall through to saved.
-    // Saved check is != null: empty-string in secrets.json is PRESERVED.
+    // Both env and saved checks use != null so "" is preserved from either source.
     // The old CLI saved ENCRYPTION_KEY="" — all existing data is encrypted
     // with SHA-256(""). Discarding "" would break decryption.
-    // See PRs #2785, #2790, #2862, #2868 for history.
+    // See PRs #2785, #2790, #2862, #2871 for history.
 
-    it("should ignore empty-string ENCRYPTION_KEY env and use saved value", () => {
+    it("should use empty-string ENCRYPTION_KEY from env (not fall through)", () => {
       const saved: SecretsFile = { ENCRYPTION_KEY: "saved-key" };
       const env = { ENCRYPTION_KEY: "" };
-      const { secrets } = resolveSecrets(saved, env);
+      const { secrets, sources } = resolveSecrets(saved, env);
 
-      expect(secrets.ENCRYPTION_KEY).toBe("saved-key");
+      // "" from env must be used — cloud deployments set ENCRYPTION_KEY=""
+      // as env var and have no secrets.json
+      expect(secrets.ENCRYPTION_KEY).toBe("");
+      expect(sources.ENCRYPTION_KEY).toBe("env");
     });
 
-    it("should preserve empty-string saved ENCRYPTION_KEY (critical for old deployments)", () => {
-      const saved: SecretsFile = {
-        ENCRYPTION_KEY: "",
-        BETTER_AUTH_SECRET: "auth",
-        LOCAL_ADMIN_PASSWORD: "pass",
-      };
-      const env = { ENCRYPTION_KEY: "" };
-      const { secrets, modified } = resolveSecrets(saved, env);
+    it("should preserve empty-string ENCRYPTION_KEY from env even without saved (critical for cloud)", () => {
+      const saved: SecretsFile = { LOCAL_ADMIN_PASSWORD: "pass" };
+      const env = { ENCRYPTION_KEY: "", BETTER_AUTH_SECRET: "auth" };
+      const { secrets, modified, sources } = resolveSecrets(saved, env);
 
-      // Saved "" must be preserved — data is encrypted with SHA-256("")
+      // "" from env must be used — not generate a random key
       expect(secrets.ENCRYPTION_KEY).toBe("");
       expect(modified).toBe(false);
+      expect(sources.ENCRYPTION_KEY).toBe("env");
     });
 
     it("should preserve empty-string saved ENCRYPTION_KEY when env is unset", () => {
@@ -40,34 +39,38 @@ describe("resolveSecrets", () => {
         BETTER_AUTH_SECRET: "auth",
         LOCAL_ADMIN_PASSWORD: "pass",
       };
-      const { secrets, modified } = resolveSecrets(saved, emptyEnv);
+      const { secrets, modified, sources } = resolveSecrets(saved, emptyEnv);
 
       // Saved "" must be preserved — data is encrypted with SHA-256("")
       expect(secrets.ENCRYPTION_KEY).toBe("");
       expect(modified).toBe(false);
+      expect(sources.ENCRYPTION_KEY).toBe("saved");
     });
 
-    it("should use truthy env ENCRYPTION_KEY over saved value", () => {
+    it("should use non-empty env ENCRYPTION_KEY over saved value", () => {
       const saved: SecretsFile = { ENCRYPTION_KEY: "saved-key" };
       const env = { ENCRYPTION_KEY: "env-key" };
-      const { secrets } = resolveSecrets(saved, env);
+      const { secrets, sources } = resolveSecrets(saved, env);
 
       expect(secrets.ENCRYPTION_KEY).toBe("env-key");
+      expect(sources.ENCRYPTION_KEY).toBe("env");
     });
 
     it("should use saved ENCRYPTION_KEY when env is not set", () => {
       const saved: SecretsFile = { ENCRYPTION_KEY: "saved-key" };
-      const { secrets } = resolveSecrets(saved, emptyEnv);
+      const { secrets, sources } = resolveSecrets(saved, emptyEnv);
 
       expect(secrets.ENCRYPTION_KEY).toBe("saved-key");
+      expect(sources.ENCRYPTION_KEY).toBe("saved");
     });
 
-    it("should use truthy env ENCRYPTION_KEY over empty-string saved value", () => {
+    it("should use non-empty env ENCRYPTION_KEY over empty-string saved value", () => {
       const saved: SecretsFile = { ENCRYPTION_KEY: "" };
       const env = { ENCRYPTION_KEY: "explicit-key" };
-      const { secrets } = resolveSecrets(saved, env);
+      const { secrets, sources } = resolveSecrets(saved, env);
 
       expect(secrets.ENCRYPTION_KEY).toBe("explicit-key");
+      expect(sources.ENCRYPTION_KEY).toBe("env");
     });
   });
 
@@ -75,16 +78,18 @@ describe("resolveSecrets", () => {
     it("should use env over saved value", () => {
       const saved: SecretsFile = { BETTER_AUTH_SECRET: "saved-value" };
       const env = { BETTER_AUTH_SECRET: "env-value" };
-      const { secrets } = resolveSecrets(saved, env);
+      const { secrets, sources } = resolveSecrets(saved, env);
 
       expect(secrets.BETTER_AUTH_SECRET).toBe("env-value");
+      expect(sources.BETTER_AUTH_SECRET).toBe("env");
     });
 
     it("should use saved value when env is not set", () => {
       const saved: SecretsFile = { BETTER_AUTH_SECRET: "saved-value" };
-      const { secrets } = resolveSecrets(saved, emptyEnv);
+      const { secrets, sources } = resolveSecrets(saved, emptyEnv);
 
       expect(secrets.BETTER_AUTH_SECRET).toBe("saved-value");
+      expect(sources.BETTER_AUTH_SECRET).toBe("saved");
     });
 
     it("should preserve empty-string saved value", () => {
@@ -93,28 +98,40 @@ describe("resolveSecrets", () => {
         ENCRYPTION_KEY: "enc",
         LOCAL_ADMIN_PASSWORD: "pass",
       };
-      const { secrets, modified } = resolveSecrets(saved, emptyEnv);
+      const { secrets, modified, sources } = resolveSecrets(saved, emptyEnv);
 
       expect(secrets.BETTER_AUTH_SECRET).toBe("");
       expect(modified).toBe(false);
+      expect(sources.BETTER_AUTH_SECRET).toBe("saved");
+    });
+
+    it("should preserve empty-string env value", () => {
+      const saved: SecretsFile = { BETTER_AUTH_SECRET: "saved-value" };
+      const env = { BETTER_AUTH_SECRET: "" };
+      const { secrets, sources } = resolveSecrets(saved, env);
+
+      expect(secrets.BETTER_AUTH_SECRET).toBe("");
+      expect(sources.BETTER_AUTH_SECRET).toBe("env");
     });
 
     it("should generate when missing from both", () => {
-      const { secrets, modified } = resolveSecrets({}, emptyEnv);
+      const { secrets, modified, sources } = resolveSecrets({}, emptyEnv);
 
       expect(secrets.BETTER_AUTH_SECRET).toBeTruthy();
       expect(Buffer.from(secrets.BETTER_AUTH_SECRET, "base64").length).toBe(32);
       expect(modified).toBe(true);
+      expect(sources.BETTER_AUTH_SECRET).toBe("generated");
     });
   });
 
   describe("generation of missing secrets", () => {
     it("should generate ENCRYPTION_KEY when missing from both env and file", () => {
-      const { secrets, modified } = resolveSecrets({}, emptyEnv);
+      const { secrets, modified, sources } = resolveSecrets({}, emptyEnv);
 
       expect(secrets.ENCRYPTION_KEY).toBeTruthy();
       expect(Buffer.from(secrets.ENCRYPTION_KEY, "base64").length).toBe(32);
       expect(modified).toBe(true);
+      expect(sources.ENCRYPTION_KEY).toBe("generated");
     });
 
     it("should generate LOCAL_ADMIN_PASSWORD when missing", () => {

--- a/apps/mesh/src/cli/commands/resolve-secrets.ts
+++ b/apps/mesh/src/cli/commands/resolve-secrets.ts
@@ -8,18 +8,16 @@
  * ╔══════════════════════════════════════════════════════════════════════╗
  * ║  WARNING — ENCRYPTION_KEY RESOLUTION IS LOAD-BEARING               ║
  * ║                                                                    ║
- * ║  The env var check uses TRUTHY so that ENCRYPTION_KEY="" from the  ║
- * ║  environment falls through to the saved value.                     ║
+ * ║  Both the env var check AND the saved value check use != null      ║
+ * ║  so that ENCRYPTION_KEY="" is PRESERVED regardless of source.      ║
+ * ║  The old CLI (pre-#2776) saved ENCRYPTION_KEY as "" —              ║
+ * ║  CredentialVault hashes this via SHA-256("") and all existing      ║
+ * ║  data is encrypted with that key. Cloud deployments that set       ║
+ * ║  ENCRYPTION_KEY="" as an env var (no secrets.json) also need       ║
+ * ║  the empty string forwarded, not discarded.                        ║
  * ║                                                                    ║
- * ║  The saved value check uses != null so that ENCRYPTION_KEY=""      ║
- * ║  persisted in secrets.json is PRESERVED. The old CLI (pre-#2776)   ║
- * ║  saved ENCRYPTION_KEY as "" — CredentialVault hashes this via      ║
- * ║  SHA-256("") and all existing data is encrypted with that key.     ║
- * ║  Using a truthy check on the saved value would silently discard    ║
- * ║  the "" and generate a random key, breaking AES-GCM decryption.   ║
- * ║                                                                    ║
- * ║  Summary:  env check = TRUTHY  |  saved check = != null           ║
- * ║  See PRs #2785, #2790, #2862 for the history of this logic.       ║
+ * ║  Summary:  env check = != null  |  saved check = != null          ║
+ * ║  See PRs #2785, #2790, #2862, #2871 for the history.              ║
  * ╚══════════════════════════════════════════════════════════════════════╝
  */
 import crypto from "crypto";
@@ -33,20 +31,24 @@ export interface SecretsFile {
 export interface ResolvedSecrets {
   secrets: Required<SecretsFile>;
   modified: boolean;
+  sources: {
+    ENCRYPTION_KEY: "env" | "saved" | "generated";
+    BETTER_AUTH_SECRET: "env" | "saved" | "generated";
+  };
 }
 
 /**
  * Resolve secrets from saved file and environment.
  *
  * Priority for each secret:
- *   1. Truthy env var (non-empty string) — env override wins
+ *   1. Env var (including "" — checked with != null, not truthy)
  *   2. Saved value from secrets.json (including "" via != null check)
  *   3. Generate a new random value and mark modified=true
  *
  * The generated ENCRYPTION_KEY is saved to secrets.json so that subsequent
  * boots (and all replicas sharing the same volume) reuse the same key.
- * If you need a stable key across pods without a shared volume, set a
- * non-empty ENCRYPTION_KEY env var explicitly.
+ * If you need a stable key across pods without a shared volume, set
+ * ENCRYPTION_KEY as an env var (even "" is valid — derives key via SHA-256).
  */
 export function resolveSecrets(
   saved: SecretsFile,
@@ -54,28 +56,35 @@ export function resolveSecrets(
 ): ResolvedSecrets {
   let modified = false;
 
-  // BETTER_AUTH_SECRET — truthy env check, != null saved check
+  // BETTER_AUTH_SECRET — != null env check, != null saved check
   let betterAuthSecret: string;
-  if (env.BETTER_AUTH_SECRET) {
+  let betterAuthSecretSource: string;
+  if (env.BETTER_AUTH_SECRET != null) {
     betterAuthSecret = env.BETTER_AUTH_SECRET;
+    betterAuthSecretSource = "env";
   } else if (saved.BETTER_AUTH_SECRET != null) {
     betterAuthSecret = saved.BETTER_AUTH_SECRET;
+    betterAuthSecretSource = "saved";
   } else {
     betterAuthSecret = crypto.randomBytes(32).toString("base64");
+    betterAuthSecretSource = "generated";
     modified = true;
   }
 
   // ── ENCRYPTION_KEY ──────────────────────────────────────────────────
-  // Env check is TRUTHY so "" from env falls through to the saved value.
-  // Saved check is != null so "" persisted in secrets.json is preserved.
-  // See the big warning at the top of this file.
+  // Both env and saved checks use != null so "" is preserved from either
+  // source. See the big warning at the top of this file.
   let encryptionKey: string;
-  if (env.ENCRYPTION_KEY) {
+  let encryptionKeySource: string;
+  if (env.ENCRYPTION_KEY != null) {
     encryptionKey = env.ENCRYPTION_KEY;
+    encryptionKeySource = "env";
   } else if (saved.ENCRYPTION_KEY != null) {
     encryptionKey = saved.ENCRYPTION_KEY;
+    encryptionKeySource = "saved";
   } else {
     encryptionKey = crypto.randomBytes(32).toString("base64");
+    encryptionKeySource = "generated";
     modified = true;
   }
 
@@ -95,5 +104,12 @@ export function resolveSecrets(
       LOCAL_ADMIN_PASSWORD: localAdminPassword,
     },
     modified,
+    sources: {
+      ENCRYPTION_KEY: encryptionKeySource as "env" | "saved" | "generated",
+      BETTER_AUTH_SECRET: betterAuthSecretSource as
+        | "env"
+        | "saved"
+        | "generated",
+    },
   };
 }

--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -112,10 +112,21 @@ export async function startServer(options: ServeOptions): Promise<void> {
     // File doesn't exist or is invalid
   }
 
-  const { secrets, modified: secretsModified } = resolveSecrets(savedSecrets, {
+  const {
+    secrets,
+    modified: secretsModified,
+    sources,
+  } = resolveSecrets(savedSecrets, {
     BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
     ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
   });
+
+  console.log(
+    `[secrets] ENCRYPTION_KEY source=${sources.ENCRYPTION_KEY} length=${secrets.ENCRYPTION_KEY.length} empty=${secrets.ENCRYPTION_KEY === ""}`,
+  );
+  console.log(
+    `[secrets] BETTER_AUTH_SECRET source=${sources.BETTER_AUTH_SECRET} length=${secrets.BETTER_AUTH_SECRET.length} empty=${secrets.BETTER_AUTH_SECRET === ""}`,
+  );
 
   process.env.BETTER_AUTH_SECRET = secrets.BETTER_AUTH_SECRET;
   process.env.ENCRYPTION_KEY = secrets.ENCRYPTION_KEY;


### PR DESCRIPTION
## What is this contribution about?

PR #2871 fixed the saved-value check (`secrets.json`) to use `!= null` but left the **env var check as truthy**. In cloud deployments with no persistent filesystem (no `secrets.json`), setting `ENCRYPTION_KEY=""` as an env var caused the empty string to be discarded and a random key generated on every boot, breaking AES-256-GCM decryption.

**Fix:**
- Change both env and saved checks to `!= null` so `""` is preserved regardless of source
- Add `sources` field to `ResolvedSecrets` tracking where each secret came from (`env`, `saved`, or `generated`)
- Add diagnostic logging in `serve.ts` showing the source, length, and emptiness of resolved secrets

## Screenshots/Demonstration
N/A — backend-only change.

## How to Test
1. Run `bun test apps/mesh/src/cli/commands/resolve-secrets.test.ts` — all 15 tests pass
2. Key test cases:
   - `ENCRYPTION_KEY=""` from env with no secrets.json → resolves to `""` (not random)
   - `ENCRYPTION_KEY=""` from env with saved value → env wins with `""`
   - Unset env with saved `""` → preserves saved `""`
   - Non-empty env overrides saved value
3. Deploy to staging with `ENCRYPTION_KEY=""` env var and verify existing encrypted data decrypts correctly
4. Check logs for `[secrets] ENCRYPTION_KEY source=env length=0 empty=true`

## Migration Notes
N/A — no database or config changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves empty-string `ENCRYPTION_KEY` from env or secrets file to prevent random key generation and broken AES-256-GCM decryption in stateless/cloud deployments. Adds source tracking and debug logs for easier diagnostics.

- **Bug Fixes**
  - Use `!= null` for env and saved checks on `ENCRYPTION_KEY` and `BETTER_AUTH_SECRET` so `""` is forwarded, not discarded.
  - Add `sources` to `ResolvedSecrets` (`env` | `saved` | `generated`) and log source/length in `serve.ts`.
  - Extend tests to cover env `""`, saved `""`, overrides, and generation.

<sup>Written for commit 7b16fe5056f73c6dc8b6e6142a957b91a27d4c0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

