### PR TITLE
feat(observability): add decopilot.stream.inflight gauge metric

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/run-registry.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-registry.ts
@@ -33,6 +33,7 @@ const INFLIGHT_END_EVENTS = new Set([
   "RUN_COMPLETED",
   "RUN_FAILED",
   "RUN_REQUIRES_ACTION",
+  "PREVIOUS_RUN_ABORTED",
 ]);
 
 const inflightRuns = meter.createUpDownCounter("decopilot.stream.inflight", {
@@ -100,10 +101,14 @@ export class RunRegistry {
 
       transitions.push({ event, state: newState });
 
-      // Update inflight metric
+      // Update inflight metric — only decrement when this registry had a
+      // running state; ghost FORCE_FAIL events have no prior increment.
       if (INFLIGHT_START_EVENTS.has(event.type)) {
         inflightRuns.add(1, { "org.id": event.orgId });
-      } else if (INFLIGHT_END_EVENTS.has(event.type)) {
+      } else if (
+        INFLIGHT_END_EVENTS.has(event.type) &&
+        stateBeforeEvent?.status.tag === "running"
+      ) {
         inflightRuns.add(-1, { "org.id": event.orgId });
       }
     }


### PR DESCRIPTION
## Summary

Expose inflight decopilot stream request count via Prometheus metric for Kubernetes-level monitoring, alerting, and KEDA autoscaling.

## Changes

- Added `decopilot.stream.inflight` UpDownCounter to RunRegistry
- Increments on RUN_STARTED/RUN_RESUMED, decrements on terminal states
- Includes `org.id` attribute for per-organization filtering
- Scraped by existing /metrics endpoint

## Testing

- All 35 RunRegistry tests pass
- Metric properly increments/decrements through run lifecycle transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an UpDownCounter metric `decopilot.stream.inflight` to track in‑flight decopilot stream requests. Exposed on the existing `/metrics` endpoint for Prometheus/Kubernetes monitoring and KEDA autoscaling.

- **New Features**
  - +1 on RUN_STARTED/RUN_RESUMED; −1 on RUN_COMPLETED/RUN_FAILED/RUN_REQUIRES_ACTION/PREVIOUS_RUN_ABORTED.
  - Adds `org.id` label for per‑organization filtering and alerting.

- **Bug Fixes**
  - Guard decrement to only apply when the prior state was running, preventing negative drift on ghost events and ensuring aborted/replaced runs are decremented before the next start.

<sup>Written for commit 4ddb2f5a142434c774c0b15113a8107b6b36b197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

