### PR TITLE
fix(helm): add ENCRYPTION_KEY to secret template and improve diagnostic logging

### DIFF
--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -112,21 +112,30 @@ export async function startServer(options: ServeOptions): Promise<void> {
     // File doesn't exist or is invalid
   }
 
+  const rawEnvEncKey = process.env.ENCRYPTION_KEY;
+  const rawEnvAuthSecret = process.env.BETTER_AUTH_SECRET;
+  const savedEncKey = savedSecrets.ENCRYPTION_KEY;
+
   const {
     secrets,
     modified: secretsModified,
     sources,
   } = resolveSecrets(savedSecrets, {
-    BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
-    ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+    BETTER_AUTH_SECRET: rawEnvAuthSecret,
+    ENCRYPTION_KEY: rawEnvEncKey,
   });
 
   console.log(
-    `[secrets] ENCRYPTION_KEY source=${sources.ENCRYPTION_KEY} length=${secrets.ENCRYPTION_KEY.length} empty=${secrets.ENCRYPTION_KEY === ""}`,
+    `[secrets] ENCRYPTION_KEY source=${sources.ENCRYPTION_KEY} length=${secrets.ENCRYPTION_KEY.length} empty=${secrets.ENCRYPTION_KEY === ""} envWasSet=${rawEnvEncKey !== undefined} savedWasSet=${savedEncKey !== undefined}`,
   );
   console.log(
-    `[secrets] BETTER_AUTH_SECRET source=${sources.BETTER_AUTH_SECRET} length=${secrets.BETTER_AUTH_SECRET.length} empty=${secrets.BETTER_AUTH_SECRET === ""}`,
+    `[secrets] BETTER_AUTH_SECRET source=${sources.BETTER_AUTH_SECRET} length=${secrets.BETTER_AUTH_SECRET.length} empty=${secrets.BETTER_AUTH_SECRET === ""} envWasSet=${rawEnvAuthSecret !== undefined}`,
   );
+  if (sources.ENCRYPTION_KEY === "generated") {
+    console.warn(
+      "[secrets] WARNING: ENCRYPTION_KEY was auto-generated. Set ENCRYPTION_KEY in your Kubernetes Secret or env vars to use a stable key across restarts.",
+    );
+  }
 
   process.env.BETTER_AUTH_SECRET = secrets.BETTER_AUTH_SECRET;
   process.env.ENCRYPTION_KEY = secrets.ENCRYPTION_KEY;

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -8,6 +8,7 @@ metadata:
 type: Opaque
 stringData:
   BETTER_AUTH_SECRET: {{ .Values.secret.BETTER_AUTH_SECRET | quote }}
+  ENCRYPTION_KEY: {{ .Values.secret.ENCRYPTION_KEY | default "" | quote }}
   {{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" }}
   # DATABASE_URL goes in Secret when PostgreSQL (contains sensitive credentials)
   DATABASE_URL: {{ include "chart-deco-studio.databaseUrl" . | trim | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -63,6 +63,11 @@ secret:
   # secretName: ""  # If defined, uses this existing secret (does not create new secret)
   # Generate secret with the following command: openssl rand -base64 32
   BETTER_AUTH_SECRET: "define_your_secret_with_command_above"
+  # ENCRYPTION_KEY for CredentialVault (AES-256-GCM).
+  # Empty string "" is valid — derives key via SHA-256("").
+  # If omitted, the server auto-generates a random key on each boot (breaks across restarts).
+  # Generate with: openssl rand -base64 32
+  ENCRYPTION_KEY: ""
 
 volumes: []
 # - name: foo


### PR DESCRIPTION
## What is this contribution about?

ENCRYPTION_KEY was completely absent from the Helm chart's `secret.yaml` and `values.yaml`. In Kubernetes deployments, `process.env.ENCRYPTION_KEY` was always `undefined`, causing `resolve-secrets` to auto-generate a random key on every pod boot — breaking AES-256-GCM decryption of existing encrypted data (connection tokens, OAuth secrets, etc).

**Changes:**
- Add `ENCRYPTION_KEY` to `deploy/helm/templates/secret.yaml` (defaults to `""`)
- Add `ENCRYPTION_KEY` to `deploy/helm/values.yaml` with documentation
- Improve `serve.ts` logging: show `envWasSet`/`savedWasSet` flags for each secret
- Add `WARNING` log when ENCRYPTION_KEY is auto-generated

## Screenshots/Demonstration
N/A — backend + helm chart change.

## How to Test
1. `bun test apps/mesh/src/cli/commands/resolve-secrets.test.ts` — all 15 tests pass
2. Deploy with the updated helm chart and verify logs show:
   - `[secrets] ENCRYPTION_KEY source=env length=0 empty=true envWasSet=true savedWasSet=false`
   - No `WARNING: ENCRYPTION_KEY was auto-generated` message
3. Verify existing encrypted data (connection tokens) can still be decrypted

## Migration Notes
- Add `ENCRYPTION_KEY` to the pre-existing Kubernetes Secret (`deco-mcp-mesh-secrets`). Use `""` to match the old SHA-256("") derived key.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes