### PR TITLE
chore: remove verbose debug logging

### DIFF
--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -114,28 +114,10 @@ export async function startServer(options: ServeOptions): Promise<void> {
 
   const rawEnvEncKey = process.env.ENCRYPTION_KEY;
   const rawEnvAuthSecret = process.env.BETTER_AUTH_SECRET;
-  const savedEncKey = savedSecrets.ENCRYPTION_KEY;
-
-  const {
-    secrets,
-    modified: secretsModified,
-    sources,
-  } = resolveSecrets(savedSecrets, {
+  const { secrets, modified: secretsModified } = resolveSecrets(savedSecrets, {
     BETTER_AUTH_SECRET: rawEnvAuthSecret,
     ENCRYPTION_KEY: rawEnvEncKey,
   });
-
-  console.log(
-    `[secrets] ENCRYPTION_KEY source=${sources.ENCRYPTION_KEY} length=${secrets.ENCRYPTION_KEY.length} empty=${secrets.ENCRYPTION_KEY === ""} envWasSet=${rawEnvEncKey !== undefined} savedWasSet=${savedEncKey !== undefined}`,
-  );
-  console.log(
-    `[secrets] BETTER_AUTH_SECRET source=${sources.BETTER_AUTH_SECRET} length=${secrets.BETTER_AUTH_SECRET.length} empty=${secrets.BETTER_AUTH_SECRET === ""} envWasSet=${rawEnvAuthSecret !== undefined}`,
-  );
-  if (sources.ENCRYPTION_KEY === "generated") {
-    console.warn(
-      "[secrets] WARNING: ENCRYPTION_KEY was auto-generated. Set ENCRYPTION_KEY in your Kubernetes Secret or env vars to use a stable key across restarts.",
-    );
-  }
 
   process.env.BETTER_AUTH_SECRET = secrets.BETTER_AUTH_SECRET;
   process.env.ENCRYPTION_KEY = secrets.ENCRYPTION_KEY;

--- a/packages/mesh-plugin-private-registry/server/routes/public-mcp-server.ts
+++ b/packages/mesh-plugin-private-registry/server/routes/public-mcp-server.ts
@@ -138,10 +138,6 @@ export function publicMCPServerRoutes(
   app.all("/org/:orgSlug/registry/*", async (c) => {
     const orgSlug = c.req.param("orgSlug");
 
-    console.log(
-      `[Public Registry MCP] Request for org slug: ${orgSlug}, path: ${c.req.path}`,
-    );
-
     // Lookup organization by slug
     const org = await db
       .selectFrom("organization")
@@ -149,10 +145,7 @@ export function publicMCPServerRoutes(
       .where("slug", "=", orgSlug)
       .executeTakeFirst();
 
-    console.log(`[Public Registry MCP] Found org:`, org);
-
     if (!org) {
-      console.log(`[Public Registry MCP] Organization not found: ${orgSlug}`);
       return c.json({ error: "Organization not found" }, 404);
     }
 
@@ -172,10 +165,6 @@ export function publicMCPServerRoutes(
     originalUrl.searchParams.forEach((value, key) => {
       newUrl.searchParams.set(key, value);
     });
-
-    console.log(
-      `[Public Registry MCP] Rewriting ${originalUrl.pathname} to ${newUrl.pathname}`,
-    );
 
     // Create a new request with the rewritten URL
     const newRequest = new Request(newUrl.toString(), {

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -1050,9 +1050,6 @@ export const createMCPServer = <
 
       // Only close transport for non-streaming responses
       if (!isStreaming) {
-        console.debug(
-          "[MCP Transport] Closing transport for non-streaming response",
-        );
         try {
           await transport.close?.();
         } catch {
@@ -1063,10 +1060,6 @@ export const createMCPServer = <
       return response;
     } catch (error) {
       // On error, always try to close transport to prevent leaks
-      console.debug(
-        "[MCP Transport] Closing transport due to error:",
-        error instanceof Error ? error.message : error,
-      );
       try {
         await transport.close?.();
       } catch {


### PR DESCRIPTION
## What is this contribution about?

Remove noisy `console.log`/`console.debug` statements that were printing internal details to stdout:

- **Public Registry MCP** (`public-mcp-server.ts`): removed logs for org lookups, URL rewrites, and org-not-found paths
- **MCP Transport** (`tools.ts`): removed debug logs for transport close events
- **Secrets** (`serve.ts`): removed logs exposing encryption key metadata (source, length, empty status) and the auto-generated key warning. Also cleaned up now-unused `savedEncKey` and `sources` variables.

## Screenshots/Demonstration

N/A

## How to Test

1. Start the dev server with `bun run dev`
2. Verify the removed log lines no longer appear in stdout
3. Confirm MCP registry, transport, and secrets functionality still works as expected

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes noisy debug logs across registry, transport, and secrets to reduce stdout noise and avoid leaking internal details. Also stops printing encryption key metadata.

- **Refactors**
  - `packages/mesh-plugin-private-registry/server/routes/public-mcp-server.ts`: removed org lookup, not-found, and URL rewrite logs.
  - `packages/runtime/src/tools.ts`: removed transport close debug logs on normal and error paths.
  - `apps/mesh/src/cli/commands/serve.ts`: removed secret metadata logs and cleaned up unused variables.

<sup>Written for commit c943744b36421c98fce043fe7f5efe38b2396b60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

