### PR TITLE
fix(ci): suggest patch instead of prerelease for non-feat commits

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -97,15 +97,15 @@ jobs:
                 echo "suggested_prefix=feat:" >> $GITHUB_OUTPUT
                 ;;
               *)
-                echo "suggested_type=Prerelease" >> $GITHUB_OUTPUT
-                echo "suggested_version=${{ steps.calculate_versions.outputs.prerelease_version }}" >> $GITHUB_OUTPUT
+                echo "suggested_type=Patch" >> $GITHUB_OUTPUT
+                echo "suggested_version=${{ steps.calculate_versions.outputs.patch_version }}" >> $GITHUB_OUTPUT
                 echo "suggested_prefix=${PREFIX}:" >> $GITHUB_OUTPUT
                 ;;
             esac
           else
-            # No conventional commit prefix matched — default to minor
-            echo "suggested_type=Minor" >> $GITHUB_OUTPUT
-            echo "suggested_version=${{ steps.calculate_versions.outputs.minor_version }}" >> $GITHUB_OUTPUT
+            # No conventional commit prefix matched — default to patch
+            echo "suggested_type=Patch" >> $GITHUB_OUTPUT
+            echo "suggested_version=${{ steps.calculate_versions.outputs.patch_version }}" >> $GITHUB_OUTPUT
             echo "suggested_prefix=" >> $GITHUB_OUTPUT
           fi
 
@@ -133,7 +133,7 @@ jobs:
 
             Current version: `${{ steps.calculate_versions.outputs.current_version }}`
 
-            > **Note**: If multiple reactions exist, the smallest bump wins. If no reactions, the suggested bump is used (default: minor).
+            > **Note**: If multiple reactions exist, the smallest bump wins. If no reactions, the suggested bump is used (default: patch).
 
   determine-tag:
     if: github.event_name == 'push'
@@ -205,10 +205,10 @@ jobs:
             case "$PREFIX" in
               fix) SUGGESTED_BUMP="patch" ;;
               feat) SUGGESTED_BUMP="minor" ;;
-              *) SUGGESTED_BUMP="prerelease" ;;
+              *) SUGGESTED_BUMP="patch" ;;
             esac
           else
-            SUGGESTED_BUMP="minor"
+            SUGGESTED_BUMP="patch"
           fi
           echo "Suggested bump from PR title: $SUGGESTED_BUMP"
 
@@ -276,13 +276,6 @@ jobs:
             # No maintainer reactions — use suggested bump from PR title
             echo "No maintainer reactions found. Using suggested bump: $SUGGESTED_BUMP"
             case "$SUGGESTED_BUMP" in
-              prerelease)
-                if [ -n "$PRERELEASE_TAG" ]; then
-                  NEW_VERSION="$MAJOR.$MINOR.$PATCH-$PRERELEASE_TAG.$((PRERELEASE_NUM + 1))"
-                else
-                  NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))-alpha.1"
-                fi
-                ;;
               patch)
                 NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
                 ;;


### PR DESCRIPTION
## What is this contribution about?

Fixes the release version suggestion logic in the CI workflow. Previously, non-feat/non-fix conventional commit prefixes (chore, docs, refactor, ci, test, perf, build, style) suggested a **prerelease** bump. Now they correctly suggest a **patch** bump.

Changes:
- `feat:` → Minor (unchanged)
- `fix:` → Patch (unchanged)  
- Everything else (`chore:`, `docs:`, etc.) → **Patch** (was Prerelease)
- No prefix detected → **Patch** (was Minor)
- Removed dead `prerelease` case from post-merge fallback logic

Prerelease is still available via 👍 emoji reaction on the PR comment.

## Screenshots/Demonstration

N/A

## How to Test

1. Open a PR with a `chore:` prefix title
2. Verify the Release Options comment suggests **Patch** instead of Prerelease
3. Merge a PR with a `chore:` prefix and no emoji reactions
4. Verify the version bump is a patch (e.g., 2.204.3 → 2.204.4, not 2.204.4-alpha.1)

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI release suggestion logic. Non-feat commits and missing prefixes now default to Patch; removed prerelease fallback for consistency.

- **Bug Fixes**
  - Mapping: feat → Minor; fix → Patch; everything else → Patch.
  - Updated PR comment note to show default is Patch.
  - Removed unused prerelease path in post-merge logic; prerelease still selectable via 👍 reaction.

<sup>Written for commit bd965a5e8724fdac6db35117953d0dc0e182cfc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

