### PR TITLE
fix(helm): reduce s3-sync sidecar CPU usage

### DIFF
--- a/deploy/helm/templates/configmap-s3-sync.yaml
+++ b/deploy/helm/templates/configmap-s3-sync.yaml
@@ -30,7 +30,7 @@ data:
     while true; do
       for dir in $DIRS; do
         if [ -d "${DATA_DIR}/${dir}" ]; then
-          aws s3 sync "${DATA_DIR}/${dir}" "${S3_BASE}/${dir}/" --quiet
+          aws s3 sync "${DATA_DIR}/${dir}" "${S3_BASE}/${dir}/" --size-only --quiet
         fi
       done
       sleep "$INTERVAL"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -197,7 +197,7 @@ s3Sync:
   bucket: ""               # Required when enabled
   region: "us-east-1"
   prefix: ""               # S3 key prefix (e.g. "studio/production")
-  interval: 30             # Polling interval in seconds
+  interval: 60             # Polling interval in seconds
   roleArn: ""              # IRSA role ARN — adds eks.amazonaws.com/role-arn to ServiceAccount
   syncDirs:                # Directories under /app/data to sync
     - logs


### PR DESCRIPTION
## What is this contribution about?

The S3 sync sidecar was consuming excessive CPU because `aws s3 sync` performs full checksum comparisons on every file each polling cycle. Two changes to reduce CPU usage:

- **Add `--size-only` flag** to `aws s3 sync` — skips expensive MD5/ETag checksum computation and only compares file sizes, which is sufficient for append-only data (logs, traces, metrics)
- **Increase default interval from 30s to 60s** — reduces how often the Python-based AWS CLI spins up

## Screenshots/Demonstration

N/A

## How to Test

1. Deploy with `s3Sync.enabled: true` and a valid S3 bucket
2. Monitor sidecar CPU usage — should be noticeably lower than before
3. Verify files still sync correctly to S3

## Migration Notes

Default `s3Sync.interval` changed from `30` to `60`. Users who explicitly set `interval` in their values are unaffected. Users relying on the 30s default will now sync every 60s instead.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce CPU usage of the S3 sync sidecar by skipping checksum comparisons and increasing the default polling interval to 60s. This keeps append-only data syncing while reducing CPU spikes.

- **Performance**
  - Add `--size-only` to `aws s3 sync` to avoid MD5/ETag checks; compare file sizes only (safe for logs/traces/metrics).
  - Increase default `s3Sync.interval` from 30s to 60s to run the CLI less often.

- **Migration**
  - Default `s3Sync.interval` is now `60`. Users who set `s3Sync.interval` explicitly are unaffected.

<sup>Written for commit b04e165671d10d3e79e96268326523a88a1ea865. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

