### PR TITLE
feat(cache): add observability metrics for MCP list cache fetch outcomes

### DIFF
--- a/apps/mesh/src/mcp-clients/mcp-list-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-list-cache.ts
@@ -8,6 +8,12 @@
 
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { JSONCodec, StorageType, type JetStreamClient, type KV } from "nats";
+import { meter } from "../observability";
+
+const cacheCounter = meter.createCounter("mcp_list_cache.fetches", {
+  description: "MCP list cache fetch outcomes (hit, miss, error)",
+  unit: "{fetches}",
+});
 
 export type McpListType = "tools" | "resources" | "prompts";
 
@@ -117,10 +123,11 @@ export async function fetchWithCache(
       return await fetchLive();
     } catch (err) {
       if (isMethodNotFound(err)) return [];
-      console.warn(
-        `[fetchWithCache] ${type}:${connectionId} no-cache live FAILED:`,
-        err,
-      );
+      cacheCounter.add(1, {
+        type,
+        outcome: "error",
+        stage: "no_cache",
+      });
       return null;
     }
   }
@@ -133,20 +140,23 @@ export async function fetchWithCache(
     try {
       const data = await fetchLive();
       cache.set(type, connectionId, data).catch(() => {});
+      cacheCounter.add(1, { type, outcome: "miss", stage: "miss" });
       return data;
     } catch (err) {
       if (isMethodNotFound(err)) {
         cache.set(type, connectionId, []).catch(() => {});
         return [];
       }
-      console.warn(
-        `[fetchWithCache] ${type}:${connectionId} cache-miss live FAILED:`,
-        err,
-      );
+      cacheCounter.add(1, {
+        type,
+        outcome: "error",
+        stage: "miss",
+      });
       return null;
     }
   }
 
+  cacheCounter.add(1, { type, outcome: "hit", stage: "hit" });
   // Cache hit: return immediately, revalidate in background
   const revalKey = `${type}:${connectionId}`;
   if (!revalidating.has(revalKey)) {
@@ -160,10 +170,11 @@ export async function fetchWithCache(
           }
           return;
         }
-        console.warn(
-          `[fetchWithCache] ${type}:${connectionId} background revalidation FAILED:`,
-          err,
-        );
+        cacheCounter.add(1, {
+          type,
+          outcome: "error",
+          stage: "revalidation",
+        });
       })
       .finally(() => revalidating.delete(revalKey));
 


### PR DESCRIPTION
- Introduced a counter metric to track fetch outcomes (hit, miss, error) in the MCP list cache.
- Updated `fetchWithCache` function to increment the counter based on the fetch result stage.
- Enhanced error handling by logging fetch errors through the new metric instead of console warnings.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an observability counter for MCP list cache fetches, replacing console warnings and tracking hits, misses, and errors. This makes cache behavior measurable across normal, no-cache, and revalidation flows.

- **New Features**
  - Added `mcp_list_cache.fetches` counter with attributes: `type`, `outcome` (hit|miss|error), and `stage` (hit|miss|no_cache|revalidation).
  - Updated `fetchWithCache` to increment the counter on each outcome, including background revalidation errors.

<sup>Written for commit 9225af7e25d7b49be0e20d1b18f92df87fb84851. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

