### PR TITLE
chore: deprecate llm-binding in favor of native AI SDK providers

### DIFF
--- a/apps/mesh/src/api/llm-provider.ts
+++ b/apps/mesh/src/api/llm-provider.ts
@@ -99,6 +99,10 @@ type LLMBindingClient = ReturnType<
   (typeof LanguageModelBinding)["forConnection"]
 >;
 
+/**
+ * @deprecated Use native AI SDK provider adapters instead. The llm-binding
+ * abstraction produces v2 spec models; the AI SDK now expects v3.
+ */
 export interface LLMProvider extends ProviderV2 {
   listModels: LLMBindingClient["COLLECTION_LLM_LIST"];
 }
@@ -184,12 +188,25 @@ function convertCallOptionsForBinding(
   return result;
 }
 
+let _llmProviderDeprecationWarned = false;
+
 /**
  * Creates an AI SDK compatible provider for the given LLM binding
  * @param binding - The binding client to create the provider from
  * @returns The provider
+ *
+ * @deprecated Use native AI SDK provider adapters instead. This function
+ * produces v2 spec language models, which trigger AI SDK compatibility
+ * warnings. The decopilot stream path already uses native providers.
  */
 export const createLLMProvider = (binding: LLMBindingClient): LLMProvider => {
+  if (!_llmProviderDeprecationWarned) {
+    _llmProviderDeprecationWarned = true;
+    console.warn(
+      "[llm-provider] DEPRECATED: createLLMProvider wraps MCP connections as AI SDK v2 language models. " +
+        "Migrate to native AI SDK provider adapters (v3). This function will be removed in a future release.",
+    );
+  }
   return {
     imageModel: () => {
       throw new Error("Image models are not supported by this provider");

--- a/apps/mesh/src/api/routes/openai-compat.ts
+++ b/apps/mesh/src/api/routes/openai-compat.ts
@@ -589,6 +589,7 @@ app.post("/:org/v1/chat/completions", async (c) => {
           ctx,
           { superUser: false },
         );
+        // @deprecated: llm-binding path — migrate to native AI SDK providers
         const llmBinding = LanguageModelBinding.forClient(
           toServerClient(streamableClient),
         );
@@ -724,6 +725,7 @@ app.post("/:org/v1/chat/completions", async (c) => {
     } else {
       // Non-streaming response
       // Note: No need for await using - client pool manages lifecycle
+      // @deprecated: llm-binding path — migrate to native AI SDK providers
       const client = await clientFromConnection(connection, ctx, false);
       const llmBinding = LanguageModelBinding.forClient(toServerClient(client));
       const provider = createLLMProvider(llmBinding).languageModel(modelId);

--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -52,7 +52,9 @@ const REGISTRY_BINDING: Binder = [
 ] as unknown as Binder;
 
 const BUILTIN_BINDING_CHECKERS: Record<string, Binder> = {
+  /** @deprecated llm-binding — migrate to native AI SDK providers */
   LLM: LANGUAGE_MODEL_BINDING,
+  /** @deprecated llm-binding — migrate to native AI SDK providers */
   LLMS: LANGUAGE_MODEL_BINDING,
   ASSISTANTS: ASSISTANTS_BINDING,
   MCP: MCP_BINDING,

--- a/packages/bindings/src/well-known/language-model.ts
+++ b/packages/bindings/src/well-known/language-model.ts
@@ -695,6 +695,11 @@ const LLM_COLLECTION_BINDING = createCollectionBindings(
  * - LLM_DO_GENERATE: Generate a language model response
  * - COLLECTION_LLM_LIST: List available AI models with their capabilities
  * - COLLECTION_LLM_GET: Get a single model by ID
+ *
+ * @deprecated Use native AI SDK provider adapters instead. The llm-binding
+ * abstraction wraps MCP connections as AI SDK v2 language models, but the
+ * AI SDK now expects v3. The decopilot stream path already uses native
+ * providers. This binding will be removed in a future release.
  */
 export const LANGUAGE_MODEL_BINDING = [
   {
@@ -717,4 +722,7 @@ export const LANGUAGE_MODEL_BINDING = [
   ...LLM_COLLECTION_BINDING,
 ] satisfies ToolBinder[];
 
+/**
+ * @deprecated Use native AI SDK provider adapters instead. See {@link LANGUAGE_MODEL_BINDING}.
+ */
 export const LanguageModelBinding = bindingClient(LANGUAGE_MODEL_BINDING);


### PR DESCRIPTION
## What is this contribution about?

The `createLLMProvider` wraps MCP connections as AI SDK v2 language models, but the AI SDK now expects v3. This produces noisy compatibility warnings (e.g. `AI SDK Warning (llm-binding / google/gemini-3-flash-preview): The feature "specificationVersion" is used in a compatibility mode`). The decopilot stream path already uses native v3 providers and is unaffected.

This PR adds `@deprecated` JSDoc annotations to `LANGUAGE_MODEL_BINDING`, `LanguageModelBinding`, `LLMProvider`, and `createLLMProvider`, plus a one-time runtime `console.warn` in `createLLMProvider`. The openai-compat route and connection list binding filter usages are also marked as deprecated.

## How to Test

1. `bun run check` — no new type errors
2. `bun run lint` — no new lint issues
3. `bun test apps/mesh/src/api/llm-provider.test.ts` — existing tests pass
4. IDE hover over `createLLMProvider` or `LANGUAGE_MODEL_BINDING` shows strikethrough + deprecation notice

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the `llm-binding` abstraction in favor of native AI SDK v3 providers to stop compatibility warnings. Adds a one-time runtime warning; existing paths keep working.

- **Refactors**
  - Marked `LANGUAGE_MODEL_BINDING`, `LanguageModelBinding`, `LLMProvider`, and `createLLMProvider` as `@deprecated`.
  - Added a one-time deprecation `console.warn` in `createLLMProvider`.
  - Noted deprecated usage in the `openai-compat` route and connection list checks.

- **Migration**
  - Use native AI SDK provider adapters (v3) instead of `llm-binding`.
  - The decopilot stream path already uses native providers; the deprecated binding will be removed in a future release.

<sup>Written for commit c1db4840327f3c99de0f47b5b6737464ffc03184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

