### PR TITLE
fix(store): include community registry in well-known registry discovery

### DIFF
--- a/apps/mesh/src/web/hooks/use-registry-connections.ts
+++ b/apps/mesh/src/web/hooks/use-registry-connections.ts
@@ -20,9 +20,10 @@ export function useRegistryConnections() {
   const { org } = useProjectContext();
   const { registryConfig } = useRegistrySettings();
 
-  // Deco Store is always a known registry
+  // Well-known registries are always included
   const decoStoreId = WellKnownOrgMCPId.REGISTRY(org.id);
-  const registryIds = new Set<string>([decoStoreId]);
+  const communityRegistryId = WellKnownOrgMCPId.COMMUNITY_REGISTRY(org.id);
+  const registryIds = new Set<string>([decoStoreId, communityRegistryId]);
 
   // Add any registries from registry_config (community, private, etc.)
   if (registryConfig?.registries) {


### PR DESCRIPTION
## Summary
- `useRegistryConnections()` only had Deco Store as a well-known registry, so the community registry connection was invisible in store settings until manually toggled (which would add it to `registry_config`)
- Now both Deco Store and Community Registry are always discovered, so the settings page shows the real card with icon and working toggle

## Test plan
- [ ] Open store settings in a fresh org — community registry should show with its icon and a working toggle (not the "not yet added" fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the Community Registry in well-known registry discovery so it appears in Store Settings with the proper card, icon, and working toggle. Both Deco Store and the Community Registry are now discovered by default, removing the need to manually add the community registry to registry_config.

<sup>Written for commit 7b75b74a43e88df2aacd003d917e33bf0ec757fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

