### PR TITLE
fix(mesh-sdk): default prompt arguments to empty object in server-client bridge

### DIFF
--- a/packages/mesh-sdk/src/lib/server-client-bridge.ts
+++ b/packages/mesh-sdk/src/lib/server-client-bridge.ts
@@ -126,7 +126,10 @@ export function createServerFromClient(
     );
 
     server.server.setRequestHandler(GetPromptRequestSchema, (request) =>
-      client.getPrompt(request.params),
+      client.getPrompt({
+        ...request.params,
+        arguments: request.params.arguments ?? {},
+      }),
     );
   }
 


### PR DESCRIPTION
## What is this contribution about?

When an MCP client (e.g. an LLM) calls `prompts/get` without passing `arguments`, the server-client bridge forwards `arguments: undefined` to the downstream MCP server. Some servers validate `arguments` as a required object, causing a Zod validation error:

```
MCP error -32602: Invalid arguments for prompt review:
[{ "expected": "object", "code": "invalid_type", "path": [], "message": "Invalid input: expected object, received undefined" }]
```

This fix defaults `arguments` to `{}` in the `createServerFromClient` bridge when the client omits it, matching the MCP spec where `arguments` is optional (`ZodOptional<ZodRecord>`).

## Screenshots/Demonstration

N/A

## How to Test

1. Connect to an MCP server that exposes prompts with optional arguments
2. Call `prompts/get` with only `{ name: "review" }` (no `arguments` field)
3. Verify the prompt is returned successfully instead of a `-32602` error

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default prompt arguments to an empty object in `mesh-sdk`’s server-client bridge so `prompts/get` succeeds when clients omit arguments, avoiding `-32602` validation errors.

- **Bug Fixes**
  - In `createServerFromClient`, forward `{ ...params, arguments: params.arguments ?? {} }` to `client.getPrompt`, matching MCP’s optional `arguments` contract.

<sup>Written for commit c8a8cf040bc53dd197d760f201aaca29c9ea6743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

