### PR TITLE
fix(connection): enhance connection resolution logic to include slug …

### DIFF
--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -1,4 +1,5 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { getConnectionSlug } from "@/web/utils/connection-slug";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import {
@@ -754,10 +755,18 @@ function ConnectionInspectorViewContent() {
 
   const actions = useConnectionActions();
 
-  // Resolve appSlug → matching connections (server-side filter by app_name, excludes VIRTUAL by default)
-  const siblings = useConnections({
+  // Resolve appSlug → matching connections.
+  // First try app_name (registry connections), then fall back to slug matching
+  // for custom connections where app_name is null and the slug is derived from
+  // connection_url or title.
+  const appNameSiblings = useConnections({
     filters: [{ column: "app_name", value: appSlug }],
   });
+  const allConnections = useConnections({});
+  const siblings =
+    appNameSiblings.length > 0
+      ? appNameSiblings
+      : allConnections.filter((c) => getConnectionSlug(c) === appSlug);
   const connection = siblings[0] ?? null;
   const connectionId = connection?.id ?? "";
 


### PR DESCRIPTION
…matching for custom connections

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves connection lookup in the inspector by falling back to slug matching when no `app_name` match is found. This makes custom connections resolve correctly in deep links and navigation.

- **Bug Fixes**
  - Query by `app_name` first; if no results, filter all connections by `getConnectionSlug(app) === appSlug`.
  - Handles custom connections with no `app_name` (slug derived from URL/title) to prevent empty inspector views.

<sup>Written for commit 922c19a26290c067ef15b8d31c2c58db8e9ee52b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

