### PR TITLE
fix(cli): refresh env before migrations so DATABASE_URL is available

### DIFF
--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -145,6 +145,12 @@ export async function startServer(options: ServeOptions): Promise<void> {
     updateService(svc);
   }
 
+  // ── Env ──────────────────────────────────────────────────────────────
+  // In bundled builds, env.ts is evaluated at bundle-load time with Zod
+  // defaults. Re-parse now that process.env has the resolved secrets
+  // and the dynamic DATABASE_URL from ensureServices.
+  setEnv(refreshEnv());
+
   // ── Migrations ───────────────────────────────────────────────────────
   if (!skipMigrations) {
     try {
@@ -155,11 +161,6 @@ export async function startServer(options: ServeOptions): Promise<void> {
     }
   }
   setMigrationsDone();
-
-  // ── Env ──────────────────────────────────────────────────────────────
-  // In bundled builds, env.ts is evaluated at bundle-load time with Zod
-  // defaults. Re-parse now that process.env has the resolved secrets.
-  setEnv(refreshEnv());
 
   // ── Start server ─────────────────────────────────────────────────────
   process.env.DECO_CLI = "1";


### PR DESCRIPTION
## Summary
- Move `setEnv(refreshEnv())` **before** `migrateToLatest()` in the `serve` command
- `ensureServices` dynamically sets `DATABASE_URL` in `process.env`, but the env was only re-parsed after migrations ran — causing Better Auth migrations to use the Zod default instead of the resolved PostgreSQL URL

## Test plan
- [ ] Run `bun run dev` locally and verify migrations connect to the correct database
- [ ] Confirm Better Auth migrations succeed on first launch with no pre-existing `DATABASE_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)