### PR TITLE
fix(chat): animate user message expand with larger max-height

### DIFF
--- a/apps/mesh/src/web/components/chat/message/user.tsx
+++ b/apps/mesh/src/web/components/chat/message/user.tsx
@@ -104,11 +104,11 @@ export function MessageUser<T extends Metadata>({
           <div
             ref={setContentRef}
             className={cn(
-              "z-10 px-4 py-2 transition-opacity max-h-[84px] flex-1",
+              "z-10 px-4 py-2 flex-1 transition-[max-height,opacity] duration-300 ease-out",
               isFocused
-                ? "overflow-auto opacity-100"
+                ? "max-h-[50vh] overflow-auto opacity-100"
                 : cn(
-                    "overflow-hidden opacity-99",
+                    "max-h-[84px] overflow-hidden opacity-99",
                     isOverflowing && "mask-b-from-1%",
                   ),
             )}


### PR DESCRIPTION
## What is this contribution about?
When clicking a truncated user message in chat, it now smoothly animates to a larger max-height (`50vh`) instead of staying at `84px` with internal scroll. The expand/collapse uses a 300ms ease-out transition on `max-height` and `opacity` for a polished feel.

## How to Test
1. Open a chat and send a long multi-line message
2. Observe the message is truncated at ~84px with a fade mask
3. Click the message — it should smoothly animate open to reveal more content
4. Click away — it should animate back to the collapsed state

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes