### PR TITLE
fix(typegen): add repository.url for npm provenance

### DIFF
--- a/packages/typegen/package.json
+++ b/packages/typegen/package.json
@@ -32,6 +32,11 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decocms/studio",
+    "directory": "packages/typegen"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary
- Adds `repository` field to `packages/typegen/package.json` so npm sigstore provenance verification can match the GitHub repo URL during publish.
- Fixes `E422 Unprocessable Entity` error on `npm publish` from GitHub Actions.

## Test plan
- [ ] Verify `npm publish` succeeds in CI without provenance mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `repository` (url + directory) to `packages/typegen/package.json` so npm sigstore provenance matches the GitHub repo. This fixes the E422 Unprocessable Entity error on `npm publish` in CI.

<sup>Written for commit b5eb126e5eedd8ce7684e108f9625e232c1b274c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

