### PR TITLE
fix: handle null provider in built-in tools for Claude Code

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -20,7 +20,8 @@ import type { ModelsConfig } from "../types";
 import { MeshProvider } from "@/ai-providers/types";
 
 export interface BuiltinToolParams {
-  provider: MeshProvider;
+  /** Provider — null for Claude Code (subtask tool is omitted when null) */
+  provider: MeshProvider | null;
   organization: OrganizationScope;
   models: ModelsConfig;
   toolApprovalLevel?: ToolApprovalLevel;
@@ -48,19 +49,9 @@ function buildAllTools(
     toolOutputMap,
     passthroughClient,
   } = params;
-  return {
+  const tools: Record<string, unknown> = {
     user_ask: userAskTool,
     propose_plan: proposePlanTool,
-    subtask: createSubtaskTool(
-      writer,
-      {
-        provider,
-        organization,
-        models,
-        needsApproval: toolNeedsApproval(toolApprovalLevel, false) !== false,
-      },
-      ctx,
-    ),
     agent_search: createAgentSearchTool(
       writer,
       {
@@ -85,7 +76,30 @@ function buildAllTools(
       passthroughClient,
       toolOutputMap,
     }),
-  } as const;
+  };
+  // subtask requires a provider (LLM calls) — skip when provider is null (Claude Code)
+  if (provider) {
+    tools.subtask = createSubtaskTool(
+      writer,
+      {
+        provider,
+        organization,
+        models,
+        needsApproval: toolNeedsApproval(toolApprovalLevel, false) !== false,
+      },
+      ctx,
+    );
+  }
+  return tools as {
+    user_ask: typeof userAskTool;
+    propose_plan: typeof proposePlanTool;
+    subtask: ReturnType<typeof createSubtaskTool>;
+    agent_search: ReturnType<typeof createAgentSearchTool>;
+    read_tool_output: ReturnType<typeof createReadToolOutputTool>;
+    sandbox: ReturnType<typeof createSandboxTool>;
+    read_resource: ReturnType<typeof createReadResourceTool>;
+    read_prompt: ReturnType<typeof createReadPromptTool>;
+  };
 }
 
 /**

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/subtask.test.ts
@@ -6,24 +6,19 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { BuiltinToolParams } from "./index";
 import {
   buildSubagentSystemPrompt,
   createSubtaskTool,
   SubtaskInputSchema,
+  type SubtaskParams,
 } from "./subtask";
 
-const mockParams: BuiltinToolParams = {
+const mockParams: SubtaskParams = {
   provider: { thinkingModel: {} as never } as never,
   organization: { id: "org_test" } as never,
   models: {
     connectionId: "conn_test",
     thinking: { id: "model_test", limits: {} },
-  } as never,
-  toolOutputMap: new Map(),
-  passthroughClient: {
-    listTools: () => Promise.resolve({ tools: [] }),
-    callTool: () => Promise.resolve({ content: [] }),
   } as never,
 };
 

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -371,7 +371,7 @@ async function streamCoreInner(
           : await getBuiltInTools(
               writer,
               {
-                provider: provider!,
+                provider,
                 organization,
                 models: input.models,
                 toolApprovalLevel: input.toolApprovalLevel,


### PR DESCRIPTION
## Summary
- Claude Code sets `provider=null` since it uses its own LLM for inference
- `createSubtaskTool` requires a real provider to make LLM calls — it crashes with null dereference
- Make `BuiltinToolParams.provider` nullable (`MeshProvider | null`)
- Skip subtask tool creation when provider is null
- Remove `provider!` assertion in stream-core.ts

## Changes
- `built-in-tools/index.ts`: nullable provider, conditional subtask
- `stream-core.ts`: pass `provider` instead of `provider!`
- `subtask.test.ts`: use `SubtaskParams` type directly

## Test plan
- [x] `bun test` passes (66 tests in built-in-tools)
- [x] Type check passes
- [ ] Manual: select Claude Code provider, send message — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash when using Claude Code by allowing a null `provider` and skipping the `subtask` tool when no provider is available. Also removes an unsafe non-null assertion and aligns tests with the new types.

- **Bug Fixes**
  - Make `BuiltinToolParams.provider` accept `MeshProvider | null`.
  - Skip creating `subtask` when `provider` is null (Claude Code uses its own LLM).
  - Pass `provider` without `!` in `stream-core`.
  - Update subtask tests to use `SubtaskParams`.

<sup>Written for commit a7a8b5fd3488e7396395e739efcb9cd2b6173b3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

