### PR TITLE
fix(tasks-panel): prevent layout shift when toggling search

### DIFF
--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -764,7 +764,7 @@ export function TaskListContent({
           </button>
         </div>
       ) : (
-        <div className="px-2 py-1 flex items-center gap-0.5 min-h-[36px]">
+        <div className="px-2 py-1 flex items-center gap-0.5 min-h-12">
           <span className="flex-1 text-xs font-medium text-muted-foreground px-2">
             Tasks
           </span>


### PR DESCRIPTION
## What is this contribution about?

The Tasks panel header had a layout shift when clicking the search icon. The title bar (`min-h-[36px]`) was shorter than the `CollectionSearch` component (`h-12` / 48px), so toggling between them caused content below to jump. This sets the title bar to `min-h-12` to match.

## How to Test

1. Open a project with tasks in the sidebar
2. Click the search icon in the Tasks panel header
3. Verify there is no layout shift — the content below stays in place
4. Click the X to close search — again no shift

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent layout shift when toggling search in the Tasks panel header. Set the title bar to min-h-12 (48px) to match the `CollectionSearch` height so content below stays in place.

<sup>Written for commit e1df6db20f6e3060cd138b5e8cb6e440e2a3f3cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

