### PR TITLE
fix(ui): rename sidebar agent section labels

### DIFF
--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -271,10 +271,10 @@ function PinAgentPopoverContent({
 
       {/* Scrollable content */}
       <div className="overflow-y-auto flex-1 min-h-0 px-3 pb-3">
-        {/* Your Agents section */}
+        {/* Agents section */}
         <div className="px-1 pt-3 pb-2">
           <span className="text-xs font-medium text-muted-foreground">
-            Your Agents
+            Agents
           </span>
         </div>
         <div className="grid grid-cols-3 gap-1">
@@ -306,12 +306,12 @@ function PinAgentPopoverContent({
           ))}
         </div>
 
-        {/* Default Agents section */}
+        {/* Agent templates section */}
         {filteredDefaults.length > 0 && (
           <>
             <div className="px-1 pt-4 pb-2">
               <span className="text-xs font-medium text-muted-foreground">
-                Agents
+                Agent templates
               </span>
             </div>
             <div className="grid grid-cols-3 gap-1">


### PR DESCRIPTION
## What is this contribution about?

Renames the labels in the sidebar's "add agent" popover for clearer terminology:
- **"Your Agents"** → **"Agents"**
- **"Agents"** → **"Agent templates"**

## How to Test

1. Open the sidebar and click the "+" button to add a new agent
2. Verify the first section is now labeled "Agents"
3. Verify the second section (default agents) is now labeled "Agent templates"

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the sidebar add-agent popover labels for clarity. “Your Agents” is now “Agents,” and the default section “Agents” is now “Agent templates.”

<sup>Written for commit ae64c4482597c233de532db3c6c956122200df5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

