### PR TITLE
fix(auth,automations): fix local mode seeding and task list cache

### DIFF
--- a/apps/mesh/src/auth/local-mode.ts
+++ b/apps/mesh/src/auth/local-mode.ts
@@ -19,7 +19,7 @@ import { auth } from "./index";
  * no file I/O, no secrets.json, same value across restarts.
  */
 export async function getLocalAdminPassword(): Promise<string> {
-  return getSettings().betterAuthSecret || "local";
+  return getSettings().betterAuthSecret || "local-mode-default";
 }
 
 function getLocalUserName(): string {

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -437,7 +437,7 @@ function IncomingSection({ virtualMcpId }: { virtualMcpId: string }) {
       >
         <RefreshCcw01 size={14} className="text-purple-500" />
         <span className="text-sm font-medium text-muted-foreground">
-          Incoming
+          Automations
         </span>
         <span className="text-xs text-muted-foreground/60 tabular-nums">
           {automations.filter((a) => a.active && a.trigger_count > 0).length}/

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -157,7 +157,7 @@ export function useAutomationCreate() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: KEYS.automations(org.id),
+        queryKey: KEYS.automationsAll(org.id),
       });
     },
   });
@@ -182,7 +182,7 @@ export function useAutomationUpdate() {
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: KEYS.automations(org.id),
+        queryKey: KEYS.automationsAll(org.id),
       });
       if (typeof variables.id === "string") {
         queryClient.invalidateQueries({
@@ -211,7 +211,7 @@ export function useAutomationDelete() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: KEYS.automations(org.id),
+        queryKey: KEYS.automationsAll(org.id),
       });
     },
   });
@@ -235,7 +235,7 @@ export function useAutomationTriggerAdd() {
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: KEYS.automations(org.id),
+        queryKey: KEYS.automationsAll(org.id),
       });
       if (typeof variables.automation_id === "string") {
         queryClient.invalidateQueries({
@@ -267,7 +267,7 @@ export function useAutomationTriggerRemove() {
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: KEYS.automations(org.id),
+        queryKey: KEYS.automationsAll(org.id),
       });
       queryClient.invalidateQueries({
         queryKey: KEYS.automation(org.id, variables.automation_id),

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -202,6 +202,8 @@ export const KEYS = {
     [locator, "member-tags", memberId] as const,
 
   // Automations (scoped by organization, optionally by project)
+  automationsAll: (organizationId: string) =>
+    ["automations", organizationId] as const,
   automations: (organizationId: string, virtualMcpId?: string | null) =>
     ["automations", organizationId, virtualMcpId ?? null] as const,
   automation: (organizationId: string, id: string) =>


### PR DESCRIPTION
## What is this contribution about?

Two fixes:

1. **Local mode password too short** — The fallback password `"local"` (5 chars) in `getLocalAdminPassword()` was rejected by Better Auth's minimum password length requirement. Changed to `"local-mode-default"` (18 chars) so local mode seeding succeeds.

2. **Automations cache invalidation** — Mutation hooks (create, update, delete, trigger add/remove) were invalidating `KEYS.automations(org.id)` which includes a `null` third element, missing queries scoped to a specific `virtualMcpId`. Added `KEYS.automationsAll(org.id)` as a broader prefix key and use it in all mutation `onSuccess` handlers so all automation queries are properly invalidated. Also renamed the "Incoming" section label to "Automations".

## How to Test

1. Delete local database and start dev server — should seed without `PASSWORD_TOO_SHORT` error
2. Create/update/delete an automation in the tasks panel — the list should refresh immediately without needing a manual reload

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix local mode seeding by using a longer default admin password. Also ensure automation mutations refresh the task list by invalidating all relevant queries.

- **Bug Fixes**
  - Local mode: change fallback password to "local-mode-default" to meet Better Auth’s minimum length.
  - Automations: invalidate `KEYS.automationsAll(org.id)` on create/update/delete/trigger so queries scoped by `virtualMcpId` also refresh.
  - UI: rename "Incoming" label to "Automations".

<sup>Written for commit 62ff6e6e8619606db970cf7324d33a2b5004a8d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

