### PR TITLE
fix(settings): clarify misleading ENCRYPTION_KEY log message

### DIFF
--- a/apps/mesh/src/settings/pipeline.ts
+++ b/apps/mesh/src/settings/pipeline.ts
@@ -37,7 +37,7 @@ export async function buildSettings(flags: CliFlags): Promise<BuildResult> {
     );
   } else {
     console.log(
-      "[settings] ENCRYPTION_KEY is not set (will be auto-generated)",
+      "[settings] ENCRYPTION_KEY is not set (using deterministic fallback, 32 chars) — set ENCRYPTION_KEY for production",
     );
   }
 


### PR DESCRIPTION
## What is this contribution about?

The startup log said `ENCRYPTION_KEY is not set (will be auto-generated)`, which implies a random key is generated each time. In reality, when `ENCRYPTION_KEY` is unset, `CredentialVault` hashes an empty string with SHA-256 to derive a deterministic key. The updated log accurately describes this as a deterministic fallback and warns about setting the env var for production.

## How to Test
1. Start the mesh server without `ENCRYPTION_KEY` set
2. Observe the log now reads: `[settings] ENCRYPTION_KEY is not set (using deterministic fallback, 32 chars) — set ENCRYPTION_KEY for production`

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the startup log for ENCRYPTION_KEY: when unset, it now states we use a deterministic fallback (not a random key) and warns to set ENCRYPTION_KEY for production. Removes the misleading "will be auto-generated" message.

<sup>Written for commit 321e36144354dd1860174d495cd725e51b0949ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

