### PR TITLE
fix(storage): add connection context to decryption error logs

### DIFF
--- a/apps/mesh/src/storage/connection.ts
+++ b/apps/mesh/src/storage/connection.ts
@@ -481,7 +481,10 @@ export class ConnectionStorage implements ConnectionStoragePort {
       try {
         decryptedToken = await this.vault.decrypt(row.connection_token);
       } catch (error) {
-        console.error("Failed to decrypt connection token:", error);
+        console.error(
+          `Failed to decrypt connection token for connection ${row.id} (org: ${row.organization_id}, type: ${row.connection_type}, title: ${row.title}):`,
+          error,
+        );
       }
     }
 
@@ -492,7 +495,10 @@ export class ConnectionStorage implements ConnectionStoragePort {
         const decryptedJson = await this.vault.decrypt(row.configuration_state);
         decryptedConfigState = JSON.parse(decryptedJson);
       } catch (error) {
-        console.error("Failed to decrypt configuration state:", error);
+        console.error(
+          `Failed to decrypt configuration state for connection ${row.id} (org: ${row.organization_id}, type: ${row.connection_type}, title: ${row.title}):`,
+          error,
+        );
       }
     }
 
@@ -522,7 +528,10 @@ export class ConnectionStorage implements ConnectionStoragePort {
           connectionParameters = parsed;
         }
       } catch (error) {
-        console.error("Failed to parse connection_headers:", error);
+        console.error(
+          `Failed to parse connection_headers for connection ${row.id} (org: ${row.organization_id}, type: ${row.connection_type}, title: ${row.title}):`,
+          error,
+        );
       }
     }
 


### PR DESCRIPTION
## What is this contribution about?

Adds connection ID, organization ID, connection type, and title to error log messages when connection token/config/header decryption fails. Previously these logs only said "Failed to decrypt connection token:" with no identifying information, making it hard to debug which connection or org was affected.

## Screenshots/Demonstration

N/A

## How to Test

1. Trigger a decryption failure (e.g. rotate `ENCRYPTION_KEY` without re-encrypting existing connections)
2. Check error logs — they should now include connection ID, org ID, type, and title
3. Example: `Failed to decrypt connection token for connection conn_abc (org: org_xyz, type: HTTP, title: My Connection): [error]`

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add connection and org context to decryption and header-parse error logs to make failures traceable. Logs now include connection ID, organization ID, connection type, and title for token, configuration state, and header parsing errors.

<sup>Written for commit bd3f0cef4973725a0bf0c0a17925d0c5b93a7cb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

