### PR TITLE
[release]: bump @decocms/runtime to 1.3.0 and @decocms/bindings to 1.4.0

### DIFF
--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/bindings",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.2.15",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Bump `@decocms/runtime` from 1.2.15 → 1.3.0 (new `createTriggers` SDK, `StudioKV`, `JsonFileStorage`)
- Bump `@decocms/bindings` from 1.3.4 → 1.4.0 (new `callbackUrl`/`callbackToken` fields on `TRIGGER_CONFIGURE` schema)

## Test plan
- [ ] CI publishes new package versions
- [ ] GitHub MCP can depend on `@decocms/runtime@^1.3.0` and `@decocms/bindings@^1.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/runtime` to 1.3.0 and `@decocms/bindings` to 1.4.0 to ship the new trigger SDK and configuration fields. Enables easier trigger creation and callback handling.

- **New Features**
  - `@decocms/runtime@1.3.0`: `createTriggers()` SDK with `TriggerStorage`, plus built-in `StudioKV` and `JsonFileStorage` (exported from `@decocms/runtime/triggers` and `@decocms/runtime/trigger-storage`).
  - `@decocms/bindings@1.4.0`: `callbackUrl` and `callbackToken` added to the `TRIGGER_CONFIGURE` schema.

<sup>Written for commit 32a21c3d948027526dc510faa223ba328541a9ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

