### PR TITLE
fix(nats): add retry with backoff to NATS deferred start

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -875,12 +875,28 @@ export async function createApp(options: CreateAppOptions = {}) {
       await cronWorker.start();
     };
 
+    const startJobStreamWithRetry = async (maxRetries = 5) => {
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          await startJobStream();
+          return;
+        } catch (err) {
+          if (attempt === maxRetries) throw err;
+          const delay = Math.min(1000 * 2 ** (attempt - 1), 10_000);
+          console.warn(
+            `[AutomationJobStream] Start attempt ${attempt}/${maxRetries} failed, retrying in ${delay}ms`,
+          );
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+    };
+
     // Attempt immediate start
-    startJobStream().catch(() => {});
+    startJobStreamWithRetry().catch(() => {});
 
     // Re-start when NATS connects
     natsProvider.onReady(() => {
-      startJobStream().catch((err: unknown) => {
+      startJobStreamWithRetry().catch((err: unknown) => {
         console.error("[AutomationJobStream] Deferred start failed:", err);
       });
     });

--- a/apps/mesh/src/event-bus/index.ts
+++ b/apps/mesh/src/event-bus/index.ts
@@ -54,6 +54,29 @@ export type { NotifyStrategy } from "./notify-strategy";
 
 export { sseHub, type SSEEvent } from "./sse-hub";
 
+async function startWithRetry(
+  label: string,
+  fn: () => Promise<void>,
+  maxRetries = 5,
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await fn();
+      return;
+    } catch (err) {
+      if (attempt === maxRetries) {
+        console.error(`${label} Deferred start failed:`, err);
+        return;
+      }
+      const delay = Math.min(1000 * 2 ** (attempt - 1), 10_000);
+      console.warn(
+        `${label} Start attempt ${attempt}/${maxRetries} failed, retrying in ${delay}ms`,
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
 /**
  * Create an EventBus instance and start the SSE hub with NATS broadcast.
  *
@@ -94,12 +117,8 @@ export function createEventBus(
 
   // Re-start NATS-dependent subscriptions when NATS connects
   natsProvider.onReady(() => {
-    natsNotify.start().catch((err) => {
-      console.error("[NatsNotify] Deferred start failed:", err);
-    });
-    sseBroadcast.start().catch((err) => {
-      console.error("[NatsSSEBroadcast] Deferred start failed:", err);
-    });
+    startWithRetry("[NatsNotify]", () => natsNotify.start());
+    startWithRetry("[NatsSSEBroadcast]", () => sseBroadcast.start());
   });
 
   return new EventBusImpl({


### PR DESCRIPTION
## What is this contribution about?

Fixes `[AutomationJobStream] Deferred start failed: NatsError: TIMEOUT` errors in production.

The NATS `onReady` callback fires exactly once when the TCP connection is established, but JetStream management operations can still timeout if JetStream isn't fully ready on the server. When this happens, the AutomationJobStream (and NatsNotify/NatsSSEBroadcast) never start and are never retried — the `onReady` callbacks are drained via `splice(0)` and never fire again.

This PR adds exponential backoff retry (up to 5 attempts, delays: 1s → 2s → 4s → 8s → 10s) to all three NATS deferred start paths:
- `AutomationJobStream` in `apps/mesh/src/api/app.ts`
- `NatsNotify` and `NatsSSEBroadcast` in `apps/mesh/src/event-bus/index.ts`

## Screenshots/Demonstration
N/A — backend-only change.

## How to Test
1. Deploy to an environment where NATS is slow to initialize JetStream
2. Observe logs — should see retry warnings like `[AutomationJobStream] Start attempt 1/5 failed, retrying in 1000ms` instead of a single fatal `Deferred start failed` error
3. After retries, the job stream should start successfully

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exponential backoff retries to NATS deferred starts so services recover if JetStream isn’t ready on initial connect. Prevents TIMEOUTs from leaving `AutomationJobStream`, `NatsNotify`, and `NatsSSEBroadcast` permanently stopped.

- **Bug Fixes**
  - Retries deferred starts with exponential backoff (up to 5 attempts, 1s–10s cap).
  - Applies to `AutomationJobStream` (apps/mesh/src/api/app.ts) and `NatsNotify`/`NatsSSEBroadcast` (apps/mesh/src/event-bus/index.ts).
  - Adds a shared `startWithRetry` helper and clearer retry logs to avoid one-shot failures.

<sup>Written for commit 03afeb27eadad87b50099b02eafa2023019eac7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

