### PR TITLE
refactor(workflow-binding): improve appSlug handling in connection re…

### DIFF
--- a/apps/mesh/src/web/components/details/workflow/hooks/use-workflow-binding-connection.ts
+++ b/apps/mesh/src/web/components/details/workflow/hooks/use-workflow-binding-connection.ts
@@ -1,20 +1,24 @@
 import { useConnections } from "@decocms/mesh-sdk";
 import { useParams } from "@tanstack/react-router";
 
-const SELF_CONNECTION = { id: "self" } as const;
-
 export function useWorkflowBindingConnection() {
   const params = useParams({ strict: false });
   const appSlug = (params as { appSlug?: string }).appSlug;
 
+  // Always call the hook to satisfy React's rules of hooks.
+  // When appSlug is undefined the slug filter is omitted, but we ignore the
+  // result below and fall back to "self".
+  const connections = useConnections({ slug: appSlug });
+
   // When accessed via the workflows route (/settings/workflows/$itemId),
-  // appSlug is undefined — return "self" (the workflow plugin's own
+  // appSlug is undefined — fall back to "self" (the workflow plugin's own
   // connection), which matches the default used by useCollectionWorkflow.
   if (!appSlug) {
-    return SELF_CONNECTION;
+    return { id: "self" as const };
   }
 
   // When accessed via the connections route, appSlug identifies the connection.
-  const connections = useConnections({ slug: appSlug });
-  return connections[0] ?? SELF_CONNECTION;
+  // If the slug-filtered query hasn't resolved yet, preserve the requested slug
+  // rather than incorrectly falling back to "self".
+  return connections[0] ?? { id: appSlug };
 }


### PR DESCRIPTION
…trieval

- Updated the useWorkflowBindingConnection hook to handle appSlug more robustly by allowing it to fall back to "self" when undefined, ensuring consistent connection retrieval across different routes.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `useWorkflowBindingConnection` more robust by returning `self` only when `appSlug` is missing, and otherwise returning the matched connection or `{id: appSlug}`, keeping workflows and connections routes consistent with `useCollectionWorkflow`.

<sup>Written for commit 0127d0be1bc9a7620a56bb65faaa3de5f89baedd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

