### PR TITLE
refactor(index): adjust observability initialization and dynamic imports

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -6,20 +6,26 @@
  * Or: bun run src/index.ts
  */
 
-import {
-  createAssetHandler,
-  resolveClientDir,
-} from "@decocms/runtime/asset-server";
-import { createApp } from "./api/app";
-import { isServerPath } from "./api/utils/paths";
 import { getSettings } from "./settings";
-import { red } from "./fmt";
+import { initObservability } from "./observability";
 
 const settings = getSettings();
 
-// Initialize OpenTelemetry SDK (must be called after getSettings())
-import { initObservability } from "./observability";
+// Initialize OpenTelemetry SDK BEFORE importing any app modules.
+// Modules like database/index.ts and run-registry.ts create OTel instruments
+// (histograms, counters) at import time via `meter.createX()`. If the SDK
+// hasn't started yet, those calls hit the NoopMeter and silently discard all
+// data forever. Dynamic-importing the app tree after `initObservability()`
+// ensures every `meter.createX()` call hits the real MeterProvider.
 initObservability();
+
+const { createApp } = await import("./api/app");
+const { isServerPath } = await import("./api/utils/paths");
+const { createAssetHandler, resolveClientDir } = await import(
+  "@decocms/runtime/asset-server"
+);
+const { red } = await import("./fmt");
+
 const port = settings.port;
 
 // Refuse local mode in production — it disables authentication


### PR DESCRIPTION
- Moved the initialization of the OpenTelemetry SDK to occur before importing app modules to ensure proper instrumentation.
- Updated imports to use dynamic loading for app-related modules, enhancing performance and modularity.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the OpenTelemetry SDK before any app modules load and switch key imports to dynamic imports. This ensures import-time instruments bind to the real MeterProvider and prevents lost metrics.

- **Refactors**
  - Call `initObservability()` before importing `./api/app`, `./api/utils/paths`, `@decocms/runtime/asset-server`, and `./fmt` to avoid NoopMeter and dropped data.
  - Replace top-level static imports with `await import(...)` to control module load order.

<sup>Written for commit bd0525e57a12fe0b23aa66e37f1b5aae6e3b19f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

