### PR TITLE
debug(automations): add timing logs to diagnose job stream NATS timeout

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -851,7 +851,11 @@ export async function createApp(options: CreateAppOptions = {}) {
     const cronPollIntervalMs = 10_000;
 
     const startJobStream = async () => {
+      const t0 = Date.now();
       await automationJobStream.init();
+      console.log(
+        `[AutomationJobStream] init completed in ${Date.now() - t0}ms`,
+      );
       await automationJobStream.startConsumer(async (payload) => {
         const automation = await automationsStorage.findById(
           payload.automationId,
@@ -872,7 +876,11 @@ export async function createApp(options: CreateAppOptions = {}) {
           deps: { runRegistry, cancelBroadcast },
         });
       });
+      const t1 = Date.now();
       await cronWorker.start();
+      console.log(
+        `[AutomationJobStream] cronWorker.start() completed in ${Date.now() - t1}ms`,
+      );
     };
 
     const startJobStreamWithRetry = async (maxRetries = 5) => {

--- a/apps/mesh/src/automations/job-stream.ts
+++ b/apps/mesh/src/automations/job-stream.ts
@@ -49,8 +49,20 @@ export class AutomationJobStream {
 
   async init(): Promise<void> {
     const nc = this.options.getConnection();
-    if (!nc) return; // NATS not ready — job stream disabled until re-init
+    if (!nc) {
+      console.warn("[AutomationJobStream] init: getConnection() returned null");
+      return;
+    }
+    console.log(
+      "[AutomationJobStream] init: got connection to",
+      nc.getServer(),
+    );
+
+    const t0 = Date.now();
     const jsm = await nc.jetstreamManager();
+    console.log(
+      `[AutomationJobStream] init: jetstreamManager() took ${Date.now() - t0}ms`,
+    );
 
     const config = {
       name: STREAM_NAME,
@@ -63,8 +75,16 @@ export class AutomationJobStream {
     };
 
     try {
+      const t1 = Date.now();
       await jsm.streams.info(STREAM_NAME);
+      console.log(
+        `[AutomationJobStream] init: streams.info() took ${Date.now() - t1}ms`,
+      );
+      const t2 = Date.now();
       await jsm.streams.update(STREAM_NAME, config);
+      console.log(
+        `[AutomationJobStream] init: streams.update() took ${Date.now() - t2}ms`,
+      );
     } catch (err: unknown) {
       const isNotFound =
         err instanceof Error && err.message.includes("stream not found");

--- a/apps/mesh/src/nats/connection.ts
+++ b/apps/mesh/src/nats/connection.ts
@@ -61,6 +61,9 @@ export function createNatsConnectionProvider(
   }
 
   function fireReady(): void {
+    console.log(
+      `[NatsProvider] fireReady: ${readyCallbacks.length} callbacks queued`,
+    );
     for (const cb of readyCallbacks.splice(0)) {
       try {
         cb();
@@ -80,6 +83,9 @@ export function createNatsConnectionProvider(
           reconnect: true,
           maxReconnectAttempts: -1,
         });
+        console.log(
+          `[NatsProvider] Connected to ${nc.getServer()} after ${attempt} attempt(s)`,
+        );
         js = null; // invalidate cached JetStream client for fresh connection
         fireReady();
         return;


### PR DESCRIPTION
## Summary
- Adds targeted `console.log` timing to NATS connection provider (`fireReady`, connect success) and `AutomationJobStream.init()` (jetstreamManager, streams.info, streams.update)
- Staging pods consistently fail with `NatsError: TIMEOUT` on every deploy — prod (v2.207.5) works fine
- Standalone NATS tests from within the pod succeed instantly, so the timeout only happens during actual app startup
- This logging will pinpoint exactly which JetStream API call times out

## Context
Staging logs show:
```
[AutomationJobStream] Start attempt 1/5 failed, retrying in 1000ms
...
[AutomationJobStream] Deferred start failed: NatsError: TIMEOUT
```

## Test plan
- [ ] Deploy to staging, check pod logs for the new `[AutomationJobStream]` and `[NatsProvider]` lines
- [ ] Identify which step times out, then follow up with a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add timing logs around NATS connection and AutomationJobStream init to diagnose staging TIMEOUTs during startup. Logs capture callback queue size on fireReady, connection attempts and server, and durations for jetstreamManager(), streams.info(), streams.update(), init(), and cronWorker.start().

<sup>Written for commit 3638a0580124a174e00e21f245f7ba550c4ba1d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

