### PR TITLE
perf(storage): add index on downstream_tokens.connectionId

### DIFF
--- a/apps/mesh/migrations/061-downstream-token-connection-index.ts
+++ b/apps/mesh/migrations/061-downstream-token-connection-index.ts
@@ -1,0 +1,25 @@
+/**
+ * Add unique index on downstream_tokens.connectionId
+ *
+ * This column is queried on every outbound MCP request (hot path)
+ * but had no index, causing full table scans under load.
+ * The relationship is 1:1 (one token per connection), so a unique index is appropriate.
+ */
+
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex("idx_downstream_tokens_connectionId")
+    .on("downstream_tokens")
+    .column("connectionId")
+    .unique()
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .dropIndex("idx_downstream_tokens_connectionId")
+    .ifExists()
+    .execute();
+}


### PR DESCRIPTION
## What is this contribution about?
The `downstream_tokens` table is queried by `connectionId` on every outbound MCP request (hot path) but had no index, causing full table scans. Under load (e.g. all pods restarting simultaneously), this saturates the PG connection pool, cascading into 17s+ query times across all tables and eventually OOM-killing pods.

Adds a unique index on `downstream_tokens.connectionId` since the relationship is 1:1 (one token per connection).

## How to Test
1. Deploy and run `bun run migrate`
2. Verify index exists: `\d downstream_tokens` should show `idx_downstream_tokens_connectionId`
3. Under load, `select * from downstream_tokens where "connectionId" = $1` should use index scan instead of seq scan

## Migration Notes
- New Kysely migration `061-downstream-token-connection-index.ts`
- Run `bun run --cwd=apps/mesh migrate` after deploy

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unique index on downstream_tokens.connectionId to eliminate full table scans on the MCP outbound hot path. This reduces load on Postgres and avoids slow queries during spikes.

- **Migration**
  - Adds Kysely migration `061-downstream-token-connection-index.ts`.
  - After deploy, run `bun run --cwd=apps/mesh migrate` and verify `idx_downstream_tokens_connectionId` exists on `downstream_tokens`.

<sup>Written for commit f4cc9ce614530330c6510b16ab09817eb66a84f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

