### PR TITLE
chore(database): env configurable pool size

### DIFF
--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -76,10 +76,18 @@ function getSsl(): boolean {
   }
 }
 
+function getPoolMax(): number {
+  try {
+    return getSettings().databasePoolMax;
+  } catch {
+    return 10; // Settings not yet initialized (e.g., during pipeline migrations)
+  }
+}
+
 function createPostgresDatabase(connectionString: string): MeshDatabase {
   const pool = new Pool({
     connectionString,
-    max: 10,
+    max: getPoolMax(),
     ssl: getSsl(),
     ...defaultPoolOptions,
   });
@@ -107,7 +115,7 @@ export function getDbDialect(databaseUrl?: string): Dialect {
   return new PostgresDialect({
     pool: new Pool({
       connectionString: url,
-      max: 10,
+      max: getPoolMax(),
       ssl: getSsl(),
       ...defaultPoolOptions,
     }),

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -61,6 +61,7 @@ export function resolveConfig(
 
     // Database (url resolved after services start)
     databasePgSsl: toBool(envVars.DATABASE_PG_SSL),
+    databasePoolMax: Number(envVars.DATABASE_POOL_MAX) || 10,
 
     // Auth & Secrets
     betterAuthSecret: envVars.BETTER_AUTH_SECRET || "",

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -15,6 +15,7 @@ export interface Settings {
   // Database
   databaseUrl: string;
   databasePgSsl: boolean;
+  databasePoolMax: number;
 
   // Auth & Secrets
   betterAuthSecret: string;


### PR DESCRIPTION
## What is this contribution about?
Two changes to improve database resilience under load:

1. **Add unique index on `downstream_tokens.connectionId`** — This column is queried on every outbound MCP request but had no index, causing full table scans. Under load this saturates the PG connection pool, cascading into 17s+ query times and OOM-killing pods.

2. **Make PG pool size configurable via `DATABASE_POOL_MAX` env var** — Defaults to 10 (unchanged behavior). Allows tuning per-pod connection pool size without code changes.

## How to Test
1. Deploy and run `bun run migrate`
2. Verify index: `\d downstream_tokens` should show `idx_downstream_tokens_connectionId`
3. Set `DATABASE_POOL_MAX=20` to test configurable pool size

## Migration Notes
- New Kysely migration `061-downstream-token-connection-index.ts`
- Run `bun run --cwd=apps/mesh migrate` after deploy
- New optional env var `DATABASE_POOL_MAX` (default: 10)

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unique index on downstream_tokens.connectionId and makes the Postgres pool size configurable via `DATABASE_POOL_MAX`. This removes full table scans on token lookups and lets us tune connections to keep queries fast under load.

- **Migration**
  - Run `bun run --cwd=apps/mesh migrate` (includes `061-downstream-token-connection-index.ts`).
  - Optionally set `DATABASE_POOL_MAX` (default: 10; safe fallback used if settings aren’t initialized, e.g., during migrations).

<sup>Written for commit afd1f43fdd5c4002e5d7044031f7bce5fd08caa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

