### PR TITLE
fix(automations): prevent duplicate consumer loops

### DIFF
--- a/apps/mesh/src/automations/job-stream.ts
+++ b/apps/mesh/src/automations/job-stream.ts
@@ -42,6 +42,7 @@ export interface AutomationJobStreamOptions {
 // Module-level state (singleton)
 let js: JetStreamClient | null = null;
 let subscription: ConsumerMessages | null = null;
+let starting = false;
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -52,6 +53,7 @@ export async function init(opts: AutomationJobStreamOptions): Promise<void> {
     subscription.stop();
     subscription = null;
   }
+  starting = false;
 
   const nc = opts.getConnection();
   if (!nc) {
@@ -123,10 +125,15 @@ export async function startConsumer(
   handler: (payload: AutomationJobPayload) => Promise<void>,
 ): Promise<void> {
   if (!js) return;
-  if (subscription) return; // Already consuming
+  if (subscription || starting) return; // Already consuming or in progress
+  starting = true;
 
-  const consumer = await js.consumers.get(STREAM_NAME, CONSUMER_NAME);
-  subscription = await consumer.consume({ max_messages: PULL_BATCH_SIZE });
+  try {
+    const consumer = await js.consumers.get(STREAM_NAME, CONSUMER_NAME);
+    subscription = await consumer.consume({ max_messages: PULL_BATCH_SIZE });
+  } finally {
+    starting = false;
+  }
 
   (async () => {
     for await (const msg of subscription!) {


### PR DESCRIPTION
## Summary
- Add a synchronous `starting` flag in `startConsumer()` to prevent two concurrent calls from racing past the `subscription` guard and creating duplicate consumer loops
- `init()` resets the flag so reconnection flows can start a fresh consumer

## Context
When NATS is already connected at startup, `startJobStreamWithRetry()` is called eagerly and also registered via `onReady()`, which fires the callback immediately if connected. Both calls race through `startConsumer()` — the async gap between the guard check and subscription assignment allowed duplicates.

## Test plan
- [x] `bun test` passes
- [x] `bun run check` passes
- [x] Manually tested NATS kill/restart cycle — no duplicate consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate consumer loops by adding a synchronous start guard in `startConsumer()` and resetting it in `init()`. This removes a startup race that could create two loops when NATS is already connected and during reconnects.

- **Bug Fixes**
  - Guard start with `subscription || starting`, setting `starting` before any await to block concurrent calls.
  - Reset `starting` in `init()` so reconnections can safely start a fresh consumer.

<sup>Written for commit 10b1b67808be411d3996d1678364fc5e85114372. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

