### PR TITLE
fix(virtual): clean up orphaned pinned views

### DIFF
--- a/apps/mesh/src/storage/virtual.ts
+++ b/apps/mesh/src/storage/virtual.ts
@@ -334,6 +334,17 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
 
     // Update aggregations if provided
     if (data.connections !== undefined) {
+      // Collect current direct connection IDs before removing them
+      const currentAggs = await this.db
+        .selectFrom("connection_aggregations")
+        .select("child_connection_id")
+        .where("parent_connection_id", "=", id)
+        .where("dependency_mode", "=", "direct")
+        .execute();
+      const previousIds = new Set(
+        currentAggs.map((a) => a.child_connection_id),
+      );
+
       // Only delete 'direct' dependencies - preserve 'indirect' ones from virtual tools
       await this.db
         .deleteFrom("connection_aggregations")
@@ -364,6 +375,14 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
           )
           .execute();
       }
+
+      // Clean up pinned views for removed connections
+      const newIds = new Set(data.connections.map((c) => c.connection_id));
+      for (const prevId of previousIds) {
+        if (!newIds.has(prevId)) {
+          await this.cleanOrphanedPinnedViews([id], prevId);
+        }
+      }
     }
 
     const virtualMcp = await this.findById(id);
@@ -390,10 +409,70 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
   }
 
   async removeConnectionReferences(connectionId: string): Promise<void> {
+    // Find all virtual MCPs that reference this connection
+    const parentRows = await this.db
+      .selectFrom("connection_aggregations")
+      .select("parent_connection_id")
+      .where("child_connection_id", "=", connectionId)
+      .execute();
+
+    // Remove aggregation rows
     await this.db
       .deleteFrom("connection_aggregations")
       .where("child_connection_id", "=", connectionId)
       .execute();
+
+    // Clean up pinned views referencing this connection
+    await this.cleanOrphanedPinnedViews(
+      parentRows.map((r) => r.parent_connection_id),
+      connectionId,
+    );
+  }
+
+  /**
+   * Remove pinned views that reference a specific connection from the given virtual MCPs.
+   */
+  private async cleanOrphanedPinnedViews(
+    virtualMcpIds: string[],
+    removedConnectionId: string,
+  ): Promise<void> {
+    for (const parentId of virtualMcpIds) {
+      const row = await this.db
+        .selectFrom("connections")
+        .select("metadata")
+        .where("id", "=", parentId)
+        .executeTakeFirst();
+
+      if (!row?.metadata) continue;
+
+      const metadata =
+        typeof row.metadata === "string"
+          ? JSON.parse(row.metadata)
+          : row.metadata;
+      const pinnedViews = metadata?.ui?.pinnedViews;
+      if (!Array.isArray(pinnedViews)) continue;
+
+      const filtered = pinnedViews.filter(
+        (pv: { connectionId: string }) =>
+          pv.connectionId !== removedConnectionId,
+      );
+
+      if (filtered.length === pinnedViews.length) continue;
+
+      const updatedMetadata = {
+        ...metadata,
+        ui: {
+          ...metadata.ui,
+          pinnedViews: filtered.length > 0 ? filtered : null,
+        },
+      };
+
+      await this.db
+        .updateTable("connections")
+        .set({ metadata: JSON.stringify(updatedMetadata) })
+        .where("id", "=", parentId)
+        .execute();
+    }
   }
 
   /**

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -527,6 +527,59 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
     return null;
   };
 
+  // Reconcile orphaned pinned views once tool data is available.
+  // If a pinned view references a connection or tool that no longer exists,
+  // remove it and persist the cleaned list.
+  const reconciledRef = useRef(false);
+  if (connectionsWithTools && !reconciledRef.current) {
+    reconciledRef.current = true;
+    const validKeys = new Set(
+      connectionsData.flatMap((c) => c.uiTools.map((t) => `${c.id}:${t.name}`)),
+    );
+    const validPinned = serverPinned.filter((pv) =>
+      validKeys.has(`${pv.connectionId}:${pv.toolName}`),
+    );
+    if (validPinned.length !== serverPinned.length) {
+      setPinnedViews(validPinned);
+
+      // If the default view was an ext-app that got removed, reset to chat
+      let nextDefault = defaultMainView;
+      if (
+        serverDefaultMain?.type === "ext-apps" &&
+        !validPinned.some(
+          (pv) =>
+            pv.connectionId === serverDefaultMain.id &&
+            pv.toolName === serverDefaultMain.toolName,
+        )
+      ) {
+        nextDefault = "chat";
+        setDefaultMainView(nextDefault);
+      }
+
+      // Auto-save cleaned pins (fire-and-forget)
+      client
+        .callTool({
+          name: "VIRTUAL_MCP_PINNED_VIEWS_UPDATE",
+          arguments: {
+            virtualMcpId,
+            pinnedViews: validPinned,
+            layout: {
+              defaultMainView: parseDefaultMainView(nextDefault),
+            },
+          },
+        })
+        .then(() => {
+          queryClient.invalidateQueries({
+            predicate: (query) =>
+              Array.isArray(query.queryKey) &&
+              query.queryKey.includes("collection") &&
+              query.queryKey.includes("VIRTUAL_MCP"),
+          });
+        })
+        .catch(() => {});
+    }
+  }
+
   // Auto-save helper that persists given state
   const saveLayout = (nextPinned: PinnedView[], nextDefaultMain: string) => {
     setIsSaving(true);


### PR DESCRIPTION
## Summary
- **Storage layer**: `removeConnectionReferences()` and `update()` in `virtual.ts` now clean up `metadata.ui.pinnedViews` entries that reference removed connections
- **UI layer**: The Layout settings tab reconciles pinned views against live tool data on load, auto-removing pins for tools that no longer exist
- Fixes ghost sidebar entries that couldn't be removed when connections were deleted or MCPs stopped returning certain tools

## Test plan
- [ ] Remove a connection from a virtual MCP → verify its pinned views are cleaned up
- [ ] Force-delete a connection referenced by pinned views → verify pins are removed
- [ ] Change an MCP so it no longer returns a previously-pinned tool → open Layout settings → verify orphaned pin is auto-removed
- [ ] Verify default main view resets to "chat" if it pointed to a removed pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes orphaned pinned views when virtual MCP connections or tools are removed, fixing ghost sidebar entries and keeping the Layout defaults consistent.

- **Bug Fixes**
  - Storage: `update()` now detects removed direct dependencies and removes related entries from `metadata.ui.pinnedViews`.
  - Storage: `removeConnectionReferences()` cleans up aggregations and purges pins referencing the deleted connection.
  - UI: The Layout tab reconciles pins against current tools on load, auto-saves the cleaned list, and resets the default main view to "chat" if it pointed to a removed pin.

<sup>Written for commit ae6db0c988ba202fa47123f2b5ef78aa673b3d19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

