### PR TITLE
fix(decopilot): set Claude Code cwd to server process directory

### DIFF
--- a/apps/mesh/src/ai-providers/coding-agents/claude-code/index.ts
+++ b/apps/mesh/src/ai-providers/coding-agents/claude-code/index.ts
@@ -34,6 +34,7 @@ export function createClaudeCodeModel(
     NonNullable<Parameters<typeof createClaudeCode>[0]>["defaultSettings"]
   > = {
     mcpServers: options?.mcpServers,
+    cwd: process.cwd(),
   };
 
   switch (options?.toolApprovalLevel) {


### PR DESCRIPTION
## What is this contribution about?

When the Claude Code provider is used via the decopilot backend, it was spawning without a working directory set. This meant Claude Code couldn't access files in the user's project. This fix passes `process.cwd()` as the `cwd` setting so Claude Code runs in the same directory where `bunx decocms@latest` was invoked.

## How to Test

1. Run `bunx decocms@latest` from a project directory
2. Use the decopilot chat with the Claude Code provider
3. Claude Code should be able to read/write files in the project directory

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Code spawning without a working directory when used via the decopilot backend. Sets cwd to process.cwd() so it runs in the server process directory and can access project files when started with `bunx decocms@latest`.

<sup>Written for commit 244c6f89ec28386de16a5ffdfe6be27e8a1cad6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

