### PR TITLE
fix(virtual): harden pinned view reconciliation

### DIFF
--- a/apps/mesh/src/storage/virtual.ts
+++ b/apps/mesh/src/storage/virtual.ts
@@ -334,6 +334,17 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
 
     // Update aggregations if provided
     if (data.connections !== undefined) {
+      // Collect current direct connection IDs before removing them
+      const currentAggs = await this.db
+        .selectFrom("connection_aggregations")
+        .select("child_connection_id")
+        .where("parent_connection_id", "=", id)
+        .where("dependency_mode", "=", "direct")
+        .execute();
+      const previousIds = new Set(
+        currentAggs.map((a) => a.child_connection_id),
+      );
+
       // Only delete 'direct' dependencies - preserve 'indirect' ones from virtual tools
       await this.db
         .deleteFrom("connection_aggregations")
@@ -364,6 +375,14 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
           )
           .execute();
       }
+
+      // Clean up pinned views for removed connections
+      const newIds = new Set(data.connections.map((c) => c.connection_id));
+      for (const prevId of previousIds) {
+        if (!newIds.has(prevId)) {
+          await this.cleanOrphanedPinnedViews([id], prevId);
+        }
+      }
     }
 
     const virtualMcp = await this.findById(id);
@@ -390,10 +409,70 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
   }
 
   async removeConnectionReferences(connectionId: string): Promise<void> {
+    // Find all virtual MCPs that reference this connection
+    const parentRows = await this.db
+      .selectFrom("connection_aggregations")
+      .select("parent_connection_id")
+      .where("child_connection_id", "=", connectionId)
+      .execute();
+
+    // Remove aggregation rows
     await this.db
       .deleteFrom("connection_aggregations")
       .where("child_connection_id", "=", connectionId)
       .execute();
+
+    // Clean up pinned views referencing this connection
+    await this.cleanOrphanedPinnedViews(
+      parentRows.map((r) => r.parent_connection_id),
+      connectionId,
+    );
+  }
+
+  /**
+   * Remove pinned views that reference a specific connection from the given virtual MCPs.
+   */
+  private async cleanOrphanedPinnedViews(
+    virtualMcpIds: string[],
+    removedConnectionId: string,
+  ): Promise<void> {
+    for (const parentId of virtualMcpIds) {
+      const row = await this.db
+        .selectFrom("connections")
+        .select("metadata")
+        .where("id", "=", parentId)
+        .executeTakeFirst();
+
+      if (!row?.metadata) continue;
+
+      const metadata =
+        typeof row.metadata === "string"
+          ? JSON.parse(row.metadata)
+          : row.metadata;
+      const pinnedViews = metadata?.ui?.pinnedViews;
+      if (!Array.isArray(pinnedViews)) continue;
+
+      const filtered = pinnedViews.filter(
+        (pv: { connectionId: string }) =>
+          pv.connectionId !== removedConnectionId,
+      );
+
+      if (filtered.length === pinnedViews.length) continue;
+
+      const updatedMetadata = {
+        ...metadata,
+        ui: {
+          ...metadata.ui,
+          pinnedViews: filtered.length > 0 ? filtered : null,
+        },
+      };
+
+      await this.db
+        .updateTable("connections")
+        .set({ metadata: JSON.stringify(updatedMetadata) })
+        .where("id", "=", parentId)
+        .execute();
+    }
   }
 
   /**

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -419,6 +419,7 @@ interface PinnedView {
 }
 
 interface ConnectionWithTools {
+  fetchOk: boolean;
   id: string;
   title: string;
   icon: string | null;
@@ -465,6 +466,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
               .filter((t) => !!getUIResourceUri(t._meta))
               .map((t) => ({ name: t.name, description: t.description }));
             return {
+              fetchOk: true,
               id: connId,
               title: item?.title ?? connId,
               icon: item?.icon ?? null,
@@ -472,6 +474,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
             };
           } catch {
             return {
+              fetchOk: false,
               id: connId,
               title: connId,
               icon: null,
@@ -480,12 +483,14 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
           }
         }),
       );
-      // Only include connections that have interactive tools
-      return results.filter((c) => c.uiTools.length > 0);
+      return results;
     },
   });
 
-  const connectionsData: ConnectionWithTools[] = connectionsWithTools ?? [];
+  // Only show connections with interactive tools in the UI
+  const connectionsData: ConnectionWithTools[] = (
+    connectionsWithTools ?? []
+  ).filter((c) => c.uiTools.length > 0);
 
   // Current pinned views from virtual MCP metadata
   const uiMeta = virtualMcp?.metadata?.ui as
@@ -526,6 +531,80 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
       return { type: "ext-apps" as const, id, toolName: toolName || undefined };
     return null;
   };
+
+  // Reconcile orphaned pinned views once tool data is available.
+  // Only remove pins whose connection was successfully fetched but no longer
+  // exposes the pinned tool. Pins for connections that failed to fetch are
+  // kept to avoid permanent deletion from transient errors.
+  const reconciledRef = useRef(false);
+  if (
+    connectionsWithTools &&
+    connectionsWithTools.length > 0 &&
+    !reconciledRef.current
+  ) {
+    reconciledRef.current = true;
+
+    // Build set of connection IDs that were successfully fetched.
+    // Pins for connections that failed to fetch are kept to avoid
+    // permanent deletion from transient errors.
+    const fetchedOkIds = new Set(
+      (connectionsWithTools ?? []).filter((c) => c.fetchOk).map((c) => c.id),
+    );
+    const validKeys = new Set(
+      connectionsData.flatMap((c) => c.uiTools.map((t) => `${c.id}:${t.name}`)),
+    );
+
+    // Only filter pins for connections we successfully got data for
+    const validPinned = serverPinned.filter(
+      (pv) =>
+        !fetchedOkIds.has(pv.connectionId) ||
+        validKeys.has(`${pv.connectionId}:${pv.toolName}`),
+    );
+
+    if (validPinned.length !== serverPinned.length) {
+      setPinnedViews(validPinned);
+
+      // If the default view was an ext-app that got removed, reset to chat
+      let nextDefault = defaultMainView;
+      if (
+        serverDefaultMain?.type === "ext-apps" &&
+        !validPinned.some(
+          (pv) =>
+            pv.connectionId === serverDefaultMain.id &&
+            pv.toolName === serverDefaultMain.toolName,
+        )
+      ) {
+        nextDefault = "chat";
+        setDefaultMainView(nextDefault);
+      }
+
+      // Persist cleaned pins; revert local state on failure
+      client
+        .callTool({
+          name: "VIRTUAL_MCP_PINNED_VIEWS_UPDATE",
+          arguments: {
+            virtualMcpId,
+            pinnedViews: validPinned,
+            layout: {
+              defaultMainView: parseDefaultMainView(nextDefault),
+            },
+          },
+        })
+        .then((result) => {
+          unwrapToolResult(result);
+          queryClient.invalidateQueries({
+            predicate: (query) =>
+              Array.isArray(query.queryKey) &&
+              query.queryKey.includes("collection") &&
+              query.queryKey.includes("VIRTUAL_MCP"),
+          });
+        })
+        .catch(() => {
+          // Revert to server state so UI stays consistent
+          setPinnedViews(serverPinned);
+        });
+    }
+  }
 
   // Auto-save helper that persists given state
   const saveLayout = (nextPinned: PinnedView[], nextDefaultMain: string) => {


### PR DESCRIPTION
## Summary
- **Transient fetch errors no longer wipe valid pins**: tracks `fetchOk` per connection so pins for connections that failed to fetch are preserved — only pins for successfully-fetched connections that no longer expose the tool are removed
- **Empty array guard**: reconciliation only runs when there are actual results (`connectionsWithTools.length > 0`)
- **Revert on save failure**: if the auto-save call fails, local state reverts to server state so UI stays consistent

## Test plan
- [ ] Connection fetch fails transiently → pinned views for that connection are preserved
- [ ] Connection fetched OK but tool removed → orphaned pin is cleaned
- [ ] All connections have no UI tools → pins are preserved (empty array guard)
- [ ] Auto-save call fails → pins revert to original server state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental deletion of pinned views and cleans up ghost pins in Virtual MCP. Pins are preserved on transient fetch failures and removed only when a connection or tool is truly gone.

- **Bug Fixes**
  - Track `fetchOk` per connection and only reconcile pins for successfully fetched connections.
  - Clean orphaned pinned views when connections/tools are removed (storage cleanup in `update`/`removeConnectionReferences`, plus UI reconciliation on load).
  - Guard against empty results so an empty `connectionsWithTools` doesn’t wipe pins.
  - Persist cleaned pins and reset the default view to chat if a removed ext-app was set as default; revert local state to server state if the save fails.

<sup>Written for commit b10af5b27787609f1e5d4e5941768ec1fb3e4698. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

