### PR TITLE
feat(tasks): make automations section configurable by route

### DIFF
--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -245,9 +245,11 @@ function SpaceIdentityHeader({ project }: { project: VirtualMCPEntity }) {
 function TasksPanelContent({
   virtualMcpId: virtualMcpIdProp,
   hideProjectHeader,
+  showAutomations,
 }: {
   virtualMcpId?: string;
   hideProjectHeader?: boolean;
+  showAutomations?: boolean;
 }) {
   const [chatOpen, setChatOpen] = useChatPanel();
   const { createTask, openTask } = useChatTask();
@@ -318,6 +320,7 @@ function TasksPanelContent({
       {/* Task list */}
       <TaskListContent
         virtualMcpId={virtualMcpId}
+        showAutomations={showAutomations}
         onTaskSelect={(taskId) => {
           openTask(taskId);
           setChatOpen(true);
@@ -367,9 +370,11 @@ function TasksPanelSkeleton() {
 export function TasksSidePanel({
   virtualMcpId,
   hideProjectHeader,
+  showAutomations,
 }: {
   virtualMcpId?: string;
   hideProjectHeader?: boolean;
+  showAutomations?: boolean;
 }) {
   return (
     <ErrorBoundary fallback={<Chat.Skeleton />}>
@@ -377,6 +382,7 @@ export function TasksSidePanel({
         <TasksPanelContent
           virtualMcpId={virtualMcpId}
           hideProjectHeader={hideProjectHeader}
+          showAutomations={showAutomations}
         />
       </Suspense>
     </ErrorBoundary>

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -531,12 +531,14 @@ function GroupedTaskList({
   activeGroupKey,
   activeTaskId,
   virtualMcpId,
+  showAutomations = true,
   onTaskSelect,
 }: {
   groups: ReturnType<typeof buildDisplayGroups>;
   activeGroupKey: string | null;
   activeTaskId: string | null;
   virtualMcpId?: string | null;
+  showAutomations?: boolean;
   onTaskSelect: (task: Task) => void;
 }) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>(() => {
@@ -584,7 +586,7 @@ function GroupedTaskList({
             </div>
           );
         })}
-      {virtualMcpId && (
+      {virtualMcpId && showAutomations && (
         <div className="mt-3">
           <IncomingSection virtualMcpId={virtualMcpId} />
         </div>
@@ -631,11 +633,13 @@ function GroupedTaskList({
 interface TaskListContentProps {
   onTaskSelect?: (taskId: string) => void;
   virtualMcpId?: string | null;
+  showAutomations?: boolean;
 }
 
 export function TaskListContent({
   onTaskSelect,
   virtualMcpId,
+  showAutomations = true,
 }: TaskListContentProps) {
   const { openTask, ownerFilter } = useChatTask();
 
@@ -685,6 +689,7 @@ export function TaskListContent({
         activeGroupKey={activeGroupKey}
         activeTaskId={taskId}
         virtualMcpId={virtualMcpId}
+        showAutomations={showAutomations}
         onTaskSelect={handleSelect}
       />
     </div>

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -373,6 +373,7 @@ function AgentPanelGroup({
                 <TasksSidePanel
                   virtualMcpId={tasksVirtualMcpId}
                   hideProjectHeader={isOrgHome}
+                  showAutomations={!isOrgHome}
                 />
               </div>
             </div>
@@ -603,6 +604,7 @@ function ShellLayoutInner({
                 <TasksSidePanel
                   virtualMcpId={showThreePanels ? tasksVirtualMcpId : undefined}
                   hideProjectHeader={isOrgHome}
+                  showAutomations={!isOrgHome}
                 />
               </div>
             </div>


### PR DESCRIPTION
## What is this contribution about?
Adds a `showAutomations` prop to the task panel component tree (`TasksSidePanel` → `TasksPanelContent` → `TaskListContent` → `GroupedTaskList`) to control whether the automations section is rendered. The prop defaults to `true` for backward compatibility. In `shell-layout.tsx`, it's set to `!isOrgHome` — hiding automations on the `/org` route and showing them on `/org/$virtualMcpId`.

## How to Test
1. Navigate to the org home page (`/org`) — the Automations section should **not** appear in the task panel
2. Navigate to a virtual MCP page (`/org/<virtualMcpId>`) — the Automations section should appear as before
3. Verify both desktop and mobile layouts behave consistently

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Automations section in the task panel configurable by route. It’s hidden on `/org` and shown on `/org/$virtualMcpId`.

- **New Features**
  - Added `showAutomations` prop through `TasksSidePanel` → `TasksPanelContent` → `TaskListContent` → `GroupedTaskList` (defaults to true).
  - In `shell-layout.tsx`, set `showAutomations={!isOrgHome}` to control visibility per route.

<sup>Written for commit 5cf16f1e3107bd259f4fcdf0d5676288c20a0b01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

