### PR TITLE
feat(virtual-mcp): improve agent layout tab with card-based UI

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -24,7 +24,9 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Card, CardContent, CardHeader } from "@deco/ui/components/card.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
 import {
   Select,
   SelectContent,
@@ -62,7 +64,6 @@ import {
   Stars01,
   Trash01,
   XClose,
-  ZapCircle,
 } from "@untitledui/icons";
 import { Suspense, useReducer, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -742,125 +743,169 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
   }
 
   return (
-    <div className="px-6 py-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <span className="text-sm text-foreground">Main view</span>
-        <Select
-          value={defaultMainView}
-          onValueChange={handleDefaultMainViewChange}
-        >
-          <SelectTrigger className="w-48 h-8 text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {defaultMainOptions.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="flex items-center justify-between">
-        <span className="text-sm text-foreground">Show chat</span>
-        <Tooltip delayDuration={0}>
-          <TooltipTrigger asChild>
-            <span>
-              <Switch
-                checked={defaultMainView === "chat" ? true : chatDefaultOpen}
-                disabled={defaultMainView === "chat"}
-                onCheckedChange={(checked) => {
-                  setChatDefaultOpen(checked);
-                  saveLayout(pinnedViews, defaultMainView, checked);
-                }}
-              />
-            </span>
-          </TooltipTrigger>
-          {defaultMainView === "chat" && (
-            <TooltipContent side="top">
-              Chat is always shown when it is the default view
-            </TooltipContent>
-          )}
-        </Tooltip>
-      </div>
-
-      {/* Pinned views */}
-      {noConnections && (
-        <p className="text-sm text-muted-foreground">
-          No connections yet. Add connections in the Connections tab to
-          configure pinned views.
-        </p>
-      )}
-      {noInteractiveTools && !noConnections && (
-        <p className="text-sm text-muted-foreground">
-          None of the connected servers have interactive tools available.
-        </p>
-      )}
-      {connectionsData.map((conn) => (
-        <div key={conn.id} className="mt-2">
-          <div className="flex items-center gap-2 mb-2">
-            <IntegrationIcon
-              icon={conn.icon}
-              name={conn.title}
-              size="xs"
-              className="shrink-0"
-            />
-            <span className="text-sm font-medium text-muted-foreground">
-              {conn.title}
-            </span>
-          </div>
-          {conn.uiTools.length > 0 && (
-            <div className="flex flex-col">
-              {conn.uiTools.map((tool) => {
-                const pinned = pinnedViews.some(
-                  (v) => v.connectionId === conn.id && v.toolName === tool.name,
-                );
-                const pinnedView = pinnedViews.find(
-                  (v) => v.connectionId === conn.id && v.toolName === tool.name,
-                );
-                return (
-                  <div
-                    key={tool.name}
-                    className="flex items-center justify-between gap-3 py-1.5"
+    <div className="space-y-3">
+      {/* Default view card */}
+      <Card className="hover:bg-card p-6 gap-6">
+        <CardContent className="p-0 space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label className="font-normal text-foreground">Main view</Label>
+              <p className="text-xs text-muted-foreground">
+                Configure what users see when they first open this agent.
+              </p>
+            </div>
+            <Select
+              value={defaultMainView}
+              onValueChange={handleDefaultMainViewChange}
+            >
+              <SelectTrigger className="w-44 h-8 text-sm capitalize">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {defaultMainOptions.map((opt) => (
+                  <SelectItem
+                    key={opt.value}
+                    value={opt.value}
+                    className="capitalize"
                   >
-                    <div className="min-w-0 flex-1 flex items-center gap-2">
-                      <SimpleIconPicker
-                        value={pinnedView?.icon ?? null}
-                        onChange={(icon) =>
-                          handleIconChange(conn.id, tool.name, icon)
-                        }
-                        disabled={!pinned || isSaving}
-                      />
-                      <Input
-                        value={
-                          pinned && pinnedView
-                            ? pinnedView.label
-                            : tool.name.replace(/_/g, " ")
-                        }
-                        onChange={(e) =>
-                          handleLabelChange(conn.id, tool.name, e.target.value)
-                        }
-                        onBlur={handleLabelBlur}
-                        className="h-7 text-sm w-40 capitalize"
-                        disabled={!pinned || isSaving}
-                        readOnly={!pinned}
-                      />
-                    </div>
-                    <Switch
-                      checked={pinned}
-                      onCheckedChange={() =>
-                        handleTogglePin(conn.id, tool.name)
-                      }
-                      disabled={isSaving}
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label className="font-normal text-foreground">Show chat</Label>
+              <p className="text-xs text-muted-foreground">
+                Display the chat panel alongside the main view
+              </p>
+            </div>
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <span>
+                  <Switch
+                    checked={
+                      defaultMainView === "chat" ? true : chatDefaultOpen
+                    }
+                    disabled={defaultMainView === "chat"}
+                    onCheckedChange={(checked) => {
+                      setChatDefaultOpen(checked);
+                      saveLayout(pinnedViews, defaultMainView, checked);
+                    }}
+                  />
+                </span>
+              </TooltipTrigger>
+              {defaultMainView === "chat" && (
+                <TooltipContent side="top">
+                  Chat is always shown when it is the default view
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Pinned views card */}
+      <Card className="hover:bg-card p-6 gap-4">
+        <CardHeader className="p-0">
+          <span className="text-sm font-normal">Pinned views</span>
+        </CardHeader>
+        <CardContent className="p-0">
+          {noConnections && (
+            <p className="text-sm text-muted-foreground">
+              No connections yet. Add connections in the Connections tab to
+              configure pinned views.
+            </p>
+          )}
+          {noInteractiveTools && !noConnections && (
+            <p className="text-sm text-muted-foreground">
+              None of the connected servers have interactive tools available.
+            </p>
+          )}
+          {connectionsData.length > 0 && (
+            <div className="space-y-4">
+              {connectionsData.map((conn, connIdx) => (
+                <div key={conn.id}>
+                  {connIdx > 0 && (
+                    <div className="border-t border-border -mx-6 mb-4" />
+                  )}
+                  <div className="flex items-center gap-2 mb-3">
+                    <IntegrationIcon
+                      icon={conn.icon}
+                      name={conn.title}
+                      size="xs"
+                      className="shrink-0"
                     />
+                    <span className="text-sm font-medium text-muted-foreground">
+                      {conn.title}
+                    </span>
                   </div>
-                );
-              })}
+                  <div className="space-y-2">
+                    {conn.uiTools.map((tool) => {
+                      const pinned = pinnedViews.some(
+                        (v) =>
+                          v.connectionId === conn.id &&
+                          v.toolName === tool.name,
+                      );
+                      const pinnedView = pinnedViews.find(
+                        (v) =>
+                          v.connectionId === conn.id &&
+                          v.toolName === tool.name,
+                      );
+                      return (
+                        <div
+                          key={tool.name}
+                          className={cn(
+                            "flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg border border-border transition-colors",
+                            pinned ? "bg-accent/30" : "bg-muted/20",
+                          )}
+                        >
+                          <div className="min-w-0 flex-1 flex items-center gap-2">
+                            <SimpleIconPicker
+                              value={pinnedView?.icon ?? null}
+                              onChange={(icon) =>
+                                handleIconChange(conn.id, tool.name, icon)
+                              }
+                              disabled={!pinned || isSaving}
+                            />
+                            <Input
+                              value={
+                                pinned && pinnedView
+                                  ? pinnedView.label
+                                  : tool.name.replace(/_/g, " ")
+                              }
+                              onChange={(e) =>
+                                handleLabelChange(
+                                  conn.id,
+                                  tool.name,
+                                  e.target.value,
+                                )
+                              }
+                              onBlur={handleLabelBlur}
+                              className="h-7 text-sm w-40 capitalize"
+                              disabled={!pinned || isSaving}
+                              readOnly={!pinned}
+                            />
+                          </div>
+                          <Switch
+                            checked={pinned}
+                            onCheckedChange={() =>
+                              handleTogglePin(conn.id, tool.name)
+                            }
+                            disabled={isSaving}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
             </div>
           )}
-        </div>
-      ))}
+        </CardContent>
+      </Card>
 
       <div className="flex justify-end">
         <Tooltip delayDuration={0}>
@@ -1168,12 +1213,13 @@ Define step-by-step how the agent should handle requests.
             <Page.Title
               actions={
                 <div className="flex items-center gap-2">
-                  <Button variant="outline" onClick={handleTestAgent}>
-                    <Play size={14} />
+                  <Button variant="outline" size="sm" onClick={handleTestAgent}>
+                    <Play size={14} className="!size-[14px]" />
                     Test Agent
                   </Button>
                   <Button
                     variant="outline"
+                    size="sm"
                     onClick={() =>
                       dispatch({
                         type: "SET_SHARE_DIALOG_OPEN",
@@ -1181,7 +1227,27 @@ Define step-by-step how the agent should handle requests.
                       })
                     }
                   >
-                    <ZapCircle size={14} />
+                    <span className="flex items-center -space-x-1.5 mr-0.5">
+                      {/* Cursor — behind */}
+                      <span className="inline-flex items-center justify-center size-4 rounded-full bg-black ring-1 ring-white/20 shrink-0">
+                        <img
+                          src="/logos/cursor.svg"
+                          alt="Cursor"
+                          className="size-2.5 brightness-0 invert"
+                        />
+                      </span>
+                      {/* Claude — on top */}
+                      <span
+                        className="relative z-10 inline-flex items-center justify-center size-4 rounded-full ring-1 ring-background shrink-0"
+                        style={{ backgroundColor: "#D97757" }}
+                      >
+                        <img
+                          src="/logos/Claude Code.svg"
+                          alt="Claude"
+                          className="size-2.5 brightness-0 invert"
+                        />
+                      </span>
+                    </span>
                     Connect
                   </Button>
                   <Button

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.213.1",
+      "version": "2.224.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -156,7 +156,6 @@
         "kysely-pglite": "^0.6.1",
         "lucide-react": "^0.468.0",
         "marked": "^15.0.6",
-        "mesh-plugin-private-registry": "workspace:*",
         "mesh-plugin-workflows": "workspace:*",
         "nanoid": "^5.1.6",
         "pg": "^8.16.3",
@@ -183,7 +182,7 @@
     },
     "packages/bindings": {
       "name": "@decocms/bindings",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
         "@tanstack/react-router": "1.139.7",
@@ -201,31 +200,6 @@
       "version": "1.1.4",
       "bin": {
         "create-deco": "./index.js",
-      },
-    },
-    "packages/mesh-plugin-private-registry": {
-      "name": "mesh-plugin-private-registry",
-      "version": "0.1.0",
-      "dependencies": {
-        "@deco/ui": "workspace:*",
-        "@decocms/bindings": "workspace:*",
-        "@decocms/mesh-sdk": "workspace:*",
-        "@decocms/runtime": "workspace:*",
-        "@modelcontextprotocol/sdk": "1.27.1",
-        "@tanstack/react-query": "5.90.11",
-        "@untitledui/icons": "^0.0.19",
-        "ai": "^6.0.116",
-        "hono": "^4.7.10",
-        "kysely": "^0.28.12",
-        "sonner": "^2.0.7",
-        "zod": "^4.0.0",
-      },
-      "devDependencies": {
-        "@types/bun": "latest",
-        "typescript": "^5.8.3",
-      },
-      "peerDependencies": {
-        "react": "^19.2.0",
       },
     },
     "packages/mesh-plugin-workflows": {
@@ -275,7 +249,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "1.2.15",
+      "version": "1.3.0",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
         "@cloudflare/workers-types": "^4.20250617.0",
@@ -2423,8 +2397,6 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "mesh-plugin-private-registry": ["mesh-plugin-private-registry@workspace:packages/mesh-plugin-private-registry"],
-
     "mesh-plugin-workflows": ["mesh-plugin-workflows@workspace:packages/mesh-plugin-workflows"],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
@@ -3625,8 +3597,6 @@
 
     "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
-    "mesh-plugin-private-registry/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
-
     "mesh-plugin-workflows/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3844,8 +3814,6 @@
     "mdast-util-mdx-jsx/parse-entities/is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "mdast-util-mdx-jsx/parse-entities/is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
-
-    "mesh-plugin-private-registry/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "mesh-plugin-workflows/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 


### PR DESCRIPTION
## What is this contribution about?

Redesigns the Layout tab in the agent configuration view for better visual organization:

- Wraps "Main view" and "Show chat" settings in a Card with descriptive labels and subtitles
- Wraps pinned views in a separate Card with styled bordered rows and conditional backgrounds
- Replaces the ZapCircle icon in the Connect button with stacked Cursor/Claude avatar icons
- Makes header action buttons use `size="sm"` for consistency
- Removes `mesh-plugin-private-registry` workspace (promoted to first-class feature) and bumps dependency versions

## Screenshots/Demonstration

> UI changes — screenshots recommended before merge.

## How to Test

1. Run `bun run dev` and navigate to an agent's configuration page
2. Open the Layout tab
3. Verify the "Main view" and "Show chat" settings are grouped in a card with labels and descriptions
4. Verify pinned views appear in a separate card with bordered rows
5. Check the "Connect" button shows stacked Cursor/Claude avatars instead of the old ZapCircle icon

## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Agent Layout tab with a card-based UI that groups main settings and improves pinned views for faster scanning and editing. Also refreshed header actions and the Connect button visuals for consistency.

- **New Features**
  - Grouped “Main view” and “Show chat” into a card with clear labels and help text.
  - Added a “Pinned views” card with styled rows, conditional backgrounds, and editable icon/label when pinned.
  - Updated header actions to `size="sm"` and replaced the Connect icon with stacked Cursor/Claude avatars.

- **Dependencies**
  - Removed the `mesh-plugin-private-registry` workspace (promoted to first-class).
  - Bumped `decocms` to 2.224.0, `@decocms/bindings` to 1.4.0, and `@decocms/runtime` to 1.3.0.

<sup>Written for commit 4d598386729f0502326dfd7092cf5e95aecc2833. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

