### PR TITLE
fix(automations): clean up zombie runs blocking concurrency

### DIFF
--- a/apps/mesh/src/automations/cron-worker.test.ts
+++ b/apps/mesh/src/automations/cron-worker.test.ts
@@ -58,6 +58,7 @@ interface MockStorage extends AutomationsStorage {
   findAllCronTriggersForRecompute: ReturnType<typeof mock>;
   updateTriggerLastRunAt: ReturnType<typeof mock>;
   updateNextRunAt: ReturnType<typeof mock>;
+  failZombieAutomationRuns: ReturnType<typeof mock>;
 }
 
 function makeStorage(overrides?: Partial<MockStorage>): MockStorage {
@@ -70,6 +71,7 @@ function makeStorage(overrides?: Partial<MockStorage>): MockStorage {
     tryAcquireRunSlot: mock(() => Promise.resolve("thrd_1")),
     deactivateAutomation: mock(() => Promise.resolve()),
     markRunFailed: mock(() => Promise.resolve()),
+    failZombieAutomationRuns: mock(() => Promise.resolve(0)),
     ...overrides,
   } as unknown as MockStorage;
 }
@@ -361,6 +363,46 @@ describe("AutomationCronWorker", () => {
       await Promise.all([p1, p2, p3]);
 
       expect(processNowCallCount).toBe(2);
+    });
+  });
+
+  describe("zombie run cleanup", () => {
+    it("calls failZombieAutomationRuns before processing triggers", async () => {
+      const callOrder: string[] = [];
+      const storage = makeStorage({
+        failZombieAutomationRuns: mock(() => {
+          callOrder.push("zombieCleanup");
+          return Promise.resolve(0);
+        }),
+        findDueCronTriggers: mock(() => {
+          callOrder.push("findDueTriggers");
+          return Promise.resolve([]);
+        }),
+      });
+
+      const { worker } = makeWorker({ storage });
+      await worker.start();
+      await worker.processNow();
+
+      expect(storage.failZombieAutomationRuns).toHaveBeenCalled();
+      expect(callOrder.indexOf("zombieCleanup")).toBeLessThan(
+        callOrder.indexOf("findDueTriggers"),
+      );
+    });
+
+    it("continues processing triggers when zombie cleanup fails", async () => {
+      const storage = makeStorage({
+        failZombieAutomationRuns: mock(() =>
+          Promise.reject(new Error("db error")),
+        ),
+      });
+
+      const { worker } = makeWorker({ storage });
+      await worker.start();
+      await worker.processNow();
+
+      // Should still query for due triggers despite zombie cleanup failure
+      expect(storage.findDueCronTriggers).toHaveBeenCalled();
     });
   });
 

--- a/apps/mesh/src/automations/cron-worker.ts
+++ b/apps/mesh/src/automations/cron-worker.ts
@@ -24,6 +24,14 @@ import type { AutomationJobPayload } from "./job-stream";
 
 export type PublishFn = (payload: AutomationJobPayload) => Promise<void>;
 
+/**
+ * Zombie runs are threads created by tryAcquireRunSlot that never got picked
+ * up by streamCore (e.g. pod crashed between thread creation and RUN_STARTED).
+ * They have status=in_progress but no run_config, so orphan recovery cannot
+ * find them — they permanently block per-automation concurrency slots.
+ */
+const ZOMBIE_RUN_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
+
 export class AutomationCronWorker {
   private running = false;
   private processing = false;
@@ -128,6 +136,21 @@ export class AutomationCronWorker {
   }
 
   private async processDueTriggers(): Promise<void> {
+    // Sweep zombie runs before processing triggers so freed concurrency
+    // slots are immediately available for the current batch.
+    try {
+      const reaped = await this.storage.failZombieAutomationRuns(
+        ZOMBIE_RUN_MAX_AGE_MS,
+      );
+      if (reaped > 0) {
+        console.warn(
+          `[AutomationCronWorker] Force-failed ${reaped} zombie automation run(s)`,
+        );
+      }
+    } catch (err) {
+      console.error("[AutomationCronWorker] Zombie run cleanup failed:", err);
+    }
+
     const now = this.now();
     const batchSize = 20;
 

--- a/apps/mesh/src/storage/automations.ts
+++ b/apps/mesh/src/storage/automations.ts
@@ -103,6 +103,18 @@ export interface AutomationsStorage {
   markRunFailed(taskId: string): Promise<void>;
   updateTriggerLastRunAt(triggerId: string, lastRunAt: string): Promise<void>;
   deactivateAutomation(id: string): Promise<void>;
+  /**
+   * Force-fail zombie automation runs: threads that are in_progress with no
+   * run_config (never picked up by streamCore) and linked to an automation
+   * trigger, older than `maxAgeMs`.
+   *
+   * These threads are invisible to orphan recovery (which requires run_config)
+   * and the reaper (which only checks in-memory state). They permanently block
+   * per-automation concurrency slots after a crash or rolling deploy.
+   *
+   * @returns number of threads force-failed
+   */
+  failZombieAutomationRuns(maxAgeMs: number): Promise<number>;
 }
 
 // ============================================================================
@@ -681,6 +693,20 @@ class KyselyAutomationsStorage implements AutomationsStorage {
       .where("id", "=", id)
       .where("active", "=", true)
       .execute();
+  }
+
+  async failZombieAutomationRuns(maxAgeMs: number): Promise<number> {
+    const cutoff = new Date(Date.now() - maxAgeMs);
+    const result = await this.db
+      .updateTable("threads")
+      .set({ status: "failed", updated_at: new Date().toISOString() })
+      .where("status", "=", "in_progress")
+      .where("run_config", "is", null)
+      .where("trigger_id", "is not", null)
+      .where("created_at", "<=", cutoff.toISOString() as unknown as Date)
+      .executeTakeFirst();
+
+    return Number(result.numUpdatedRows ?? 0n);
   }
 }
 


### PR DESCRIPTION
## Summary

- Automation runs created by `tryAcquireRunSlot` that never reach `streamCore` (e.g. pod crash during rolling deploy) become zombie threads: `status=in_progress`, `run_config=NULL`, `run_owner_pod=NULL`
- These zombies are invisible to all existing recovery mechanisms (orphan recovery requires `run_config IS NOT NULL`, the reaper only checks in-memory state, pod-death handler requires `run_owner_pod`)
- They permanently block per-automation concurrency slots — observed in prod with "Meeting notification" stuck at 3/3 for hours
- Adds a `failZombieAutomationRuns` sweep to the cron worker cycle that force-fails `in_progress` threads older than 10 minutes with no `run_config` and a `trigger_id`

## Test plan

- [x] New unit tests for zombie cleanup in `cron-worker.test.ts`
- [x] Verifies cleanup runs before trigger processing (so freed slots are immediately available)
- [x] Verifies trigger processing continues even if cleanup fails
- [x] All existing automation tests pass (`bun test` — 34 tests)
- [x] `bun run check` passes
- [ ] After deploy: verify "Meeting notification" automation resumes running within ~10 minutes
- [ ] Monitor logs for `[AutomationCronWorker] Force-failed N zombie automation run(s)` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zombie automation runs that were blocking concurrency slots. The cron worker now force-fails stale in-progress threads with no `run_config`, freeing slots within ~10 minutes.

- **Bug Fixes**
  - Added `failZombieAutomationRuns` sweep in `AutomationCronWorker` to force-fail `in_progress` threads older than 10 minutes with no `run_config` and a `trigger_id`.
  - Cleanup runs before trigger processing; processing continues even if cleanup fails. Unit tests added.

<sup>Written for commit 2ce19d024466607a8993ec16edddbfbd2152b150. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

