### PR TITLE
WIP - feat(github-import): provision deco.cx site and admin MCP on GitHub i…

### DIFF
--- a/apps/mesh/migrations/063-github-credentials.ts
+++ b/apps/mesh/migrations/063-github-credentials.ts
@@ -1,0 +1,27 @@
+/**
+ * GitHub Credentials Migration
+ *
+ * Stores GitHub OAuth access tokens per user, encrypted at rest via the vault.
+ * Scoped to the user (not the org) since a GitHub OAuth token is a personal
+ * authorization that spans all orgs the user belongs to.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("github_credentials")
+    .addColumn("user_id", "text", (col) => col.primaryKey())
+    .addColumn("access_token", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("github_credentials").execute();
+}

--- a/apps/mesh/migrations/064-github-installation-id.ts
+++ b/apps/mesh/migrations/064-github-installation-id.ts
@@ -1,0 +1,31 @@
+/**
+ * Adds installation_id to github_credentials and makes access_token nullable.
+ *
+ * When using the GitHub App installation flow without OAuth, we store the
+ * installation_id instead of a user access token. The installation_id is used
+ * to generate short-lived installation access tokens via the GitHub App JWT.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("github_credentials")
+    .addColumn("installation_id", "text")
+    .execute();
+
+  await sql`ALTER TABLE github_credentials ALTER COLUMN access_token DROP NOT NULL`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE github_credentials ALTER COLUMN access_token SET NOT NULL`.execute(
+    db,
+  );
+
+  await db.schema
+    .alterTable("github_credentials")
+    .dropColumn("installation_id")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -61,6 +61,8 @@ import * as migration059kv from "./059-kv.ts";
 import * as migration060memberindex from "./060-member-index.ts";
 import * as migration061downstreamtokenconnectionindex from "./061-downstream-token-connection-index.ts";
 import * as migration062privateregistry from "./062-private-registry.ts";
+import * as migration063githubcredentials from "./063-github-credentials.ts";
+import * as migration064githubinstallationid from "./064-github-installation-id.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -135,6 +137,8 @@ const migrations: Record<string, Migration> = {
   "061-downstream-token-connection-index":
     migration061downstreamtokenconnectionindex,
   "062-private-registry": migration062privateregistry,
+  "063-github-credentials": migration063githubcredentials,
+  "064-github-installation-id": migration064githubinstallationid,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -38,6 +38,7 @@ import orgSsoRoutes from "./routes/org-sso";
 import { createDecopilotRoutes } from "./routes/decopilot";
 import downstreamTokenRoutes from "./routes/downstream-token";
 import decoSitesRoutes from "./routes/deco-sites";
+import githubReposRoutes from "./routes/github-repos";
 import virtualMcpRoutes from "./routes/virtual-mcp";
 import oauthProxyRoutes, {
   fetchAuthorizationServerMetadata,
@@ -1390,6 +1391,9 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Deco.cx sites list (requires meshContext / auth)
   app.route("/api/deco-sites", decoSitesRoutes);
+
+  // GitHub repos OAuth + listing (requires meshContext / auth)
+  app.route("/api/github-repos", githubReposRoutes);
 
   // ============================================================================
   // Server Plugin Routes

--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -14,6 +14,13 @@ import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 import { getUserId } from "../../core/mesh-context";
 import { fetchToolsFromMCP } from "../../tools/connection/fetch-tools";
+import {
+  ADMIN_MCP,
+  getSupabaseConfig,
+  supabaseGet,
+  resolveProfileId,
+  getOrCreateDecoApiKey,
+} from "./deco-supabase";
 
 type Variables = { meshContext: MeshContext };
 
@@ -23,104 +30,6 @@ interface SupabaseSite {
   name: string;
   domains: { domain: string; production: boolean }[] | null;
   thumb_url: string | null;
-}
-
-async function supabaseGet<T>(
-  supabaseUrl: string,
-  serviceKey: string,
-  path: string,
-): Promise<T[]> {
-  const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
-    headers: {
-      apikey: serviceKey,
-      Authorization: `Bearer ${serviceKey}`,
-      Accept: "application/json",
-    },
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    console.error(`[deco-sites] Supabase error (${res.status}): ${text}`);
-    throw new Error(`External service error (${res.status})`);
-  }
-  return res.json() as Promise<T[]>;
-}
-
-async function supabasePost<T>(
-  supabaseUrl: string,
-  serviceKey: string,
-  table: string,
-  body: Record<string, unknown>,
-): Promise<T> {
-  const res = await fetch(`${supabaseUrl}/rest/v1/${table}`, {
-    method: "POST",
-    headers: {
-      apikey: serviceKey,
-      Authorization: `Bearer ${serviceKey}`,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      Prefer: "return=representation",
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    console.error(`[deco-sites] Supabase POST error (${res.status}): ${text}`);
-    throw new Error(`External service error (${res.status})`);
-  }
-  const rows = (await res.json()) as T[];
-  if (!rows[0]) {
-    throw new Error("Supabase POST returned no rows");
-  }
-  return rows[0];
-}
-
-import { getSettings } from "../../settings";
-
-function getSupabaseConfig(): {
-  supabaseUrl: string;
-  serviceKey: string;
-} | null {
-  const settings = getSettings();
-  const supabaseUrl = settings.decoSupabaseUrl;
-  const serviceKey = settings.decoSupabaseServiceKey;
-  if (!supabaseUrl || !serviceKey) return null;
-  return { supabaseUrl, serviceKey };
-}
-
-async function resolveProfileId(
-  supabaseUrl: string,
-  serviceKey: string,
-  email: string,
-): Promise<string | null> {
-  const profiles = await supabaseGet<{ user_id: string }>(
-    supabaseUrl,
-    serviceKey,
-    `profiles?email=eq.${encodeURIComponent(email)}&select=user_id`,
-  );
-  return profiles[0]?.user_id ?? null;
-}
-
-async function getOrCreateDecoApiKey(
-  supabaseUrl: string,
-  serviceKey: string,
-  profileId: string,
-): Promise<string> {
-  const existing = await supabaseGet<{ id: string }>(
-    supabaseUrl,
-    serviceKey,
-    `api_key?user_id=eq.${encodeURIComponent(profileId)}&select=id&limit=1`,
-  );
-  if (existing[0]?.id) {
-    return existing[0].id;
-  }
-
-  const created = await supabasePost<{ id: string }>(
-    supabaseUrl,
-    serviceKey,
-    "api_key",
-    { user_id: profileId },
-  );
-  return created.id;
 }
 
 // Require an authenticated user on every handler in this router.
@@ -211,8 +120,6 @@ app.get("/", async (c) => {
     return c.json({ error: "Failed to fetch sites" }, 502);
   }
 });
-
-const ADMIN_MCP = "https://sites-admin-mcp.decocache.com/api/mcp";
 
 async function fetchFaviconAsDataUrl(domain: string): Promise<string | null> {
   try {

--- a/apps/mesh/src/api/routes/deco-supabase.ts
+++ b/apps/mesh/src/api/routes/deco-supabase.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared Supabase helpers for deco.cx integration.
+ *
+ * Used by both the deco-sites and github-repos routes to interact
+ * with the admin.deco.cx Supabase project (profiles, teams, sites, API keys).
+ */
+
+import { getSettings } from "../../settings";
+
+export const ADMIN_MCP = "http://localhost:3001/api/mcp";
+
+export function getSupabaseConfig(): {
+  supabaseUrl: string;
+  serviceKey: string;
+} | null {
+  const settings = getSettings();
+  const supabaseUrl = settings.decoSupabaseUrl;
+  const serviceKey = settings.decoSupabaseServiceKey;
+  if (!supabaseUrl || !serviceKey) return null;
+  return { supabaseUrl, serviceKey };
+}
+
+export async function supabaseGet<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  path: string,
+): Promise<T[]> {
+  const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      Accept: "application/json",
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    console.error(`[deco-supabase] Supabase error (${res.status}): ${text}`);
+    throw new Error(`External service error (${res.status})`);
+  }
+  return res.json() as Promise<T[]>;
+}
+
+export async function supabasePost<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  table: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${supabaseUrl}/rest/v1/${table}`, {
+    method: "POST",
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    console.error(
+      `[deco-supabase] Supabase POST error (${res.status}): ${text}`,
+    );
+    throw new Error(`External service error (${res.status})`);
+  }
+  const rows = (await res.json()) as T[];
+  if (!rows[0]) {
+    throw new Error("Supabase POST returned no rows");
+  }
+  return rows[0];
+}
+
+export async function resolveProfileId(
+  supabaseUrl: string,
+  serviceKey: string,
+  email: string,
+): Promise<string | null> {
+  const profiles = await supabaseGet<{ user_id: string }>(
+    supabaseUrl,
+    serviceKey,
+    `profiles?email=eq.${encodeURIComponent(email)}&select=user_id`,
+  );
+  return profiles[0]?.user_id ?? null;
+}
+
+export async function getOrCreateDecoApiKey(
+  supabaseUrl: string,
+  serviceKey: string,
+  profileId: string,
+): Promise<string> {
+  const existing = await supabaseGet<{ id: string }>(
+    supabaseUrl,
+    serviceKey,
+    `api_key?user_id=eq.${encodeURIComponent(profileId)}&select=id&limit=1`,
+  );
+  if (existing[0]?.id) {
+    return existing[0].id;
+  }
+
+  const created = await supabasePost<{ id: string }>(
+    supabaseUrl,
+    serviceKey,
+    "api_key",
+    { user_id: profileId },
+  );
+  return created.id;
+}
+
+/**
+ * Find or create a deco.cx site by name.
+ *
+ * If a site with the given name already exists, ensures the user is a member
+ * of its team and returns the existing site. Otherwise creates a new team,
+ * membership, and site.
+ *
+ * TODO: In the future, instead of creating a new team per site, allow the
+ * user to pick an existing team or use their personal team.
+ */
+export async function getOrCreateDecoSite(
+  supabaseUrl: string,
+  serviceKey: string,
+  opts: {
+    siteName: string;
+    profileId: string;
+    repoOwner: string;
+    repoName: string;
+    installationId: string;
+  },
+): Promise<{ siteId: number; siteName: string }> {
+  const { siteName, profileId, repoOwner, repoName, installationId } = opts;
+
+  const existing = await supabaseGet<{
+    id: number;
+    name: string;
+    team: number;
+  }>(
+    supabaseUrl,
+    serviceKey,
+    `sites?name=eq.${encodeURIComponent(siteName)}&select=id,name,team`,
+  );
+
+  if (existing[0]) {
+    const site = existing[0];
+
+    const membership = await supabaseGet<{ id: number }>(
+      supabaseUrl,
+      serviceKey,
+      `members?user_id=eq.${encodeURIComponent(profileId)}&team_id=eq.${site.team}&deleted_at=is.null&select=id&limit=1`,
+    );
+
+    if (membership.length === 0) {
+      await supabasePost<{ id: number }>(supabaseUrl, serviceKey, "members", {
+        user_id: profileId,
+        team_id: site.team,
+      });
+    }
+
+    return { siteId: site.id, siteName: site.name };
+  }
+
+  // TODO: Let the user pick an existing team instead of always creating a new one.
+  const team = await supabasePost<{ id: number }>(
+    supabaseUrl,
+    serviceKey,
+    "teams",
+    {
+      name: siteName,
+      slug: siteName,
+      owner_user_id: profileId,
+    },
+  );
+
+  const member = await supabasePost<{ id: number }>(
+    supabaseUrl,
+    serviceKey,
+    "members",
+    {
+      user_id: profileId,
+      team_id: team.id,
+      admin: true,
+    },
+  );
+
+  const ADMIN_ROLE_ID = 4;
+
+  await supabasePost<{ id: number }>(supabaseUrl, serviceKey, "member_roles", {
+    member_id: member.id,
+    role_id: ADMIN_ROLE_ID,
+  });
+
+  const site = await supabasePost<{ id: number; name: string }>(
+    supabaseUrl,
+    serviceKey,
+    "sites",
+    {
+      name: siteName,
+      team: team.id,
+      domains: [{ domain: `${siteName}.deco.site`, production: true }],
+      metadata: {
+        adminVersion: 2,
+        selfHosting: {
+          enabled: true,
+          repoName,
+          repoOwner,
+          connectedAt: new Date().toISOString(),
+          githubInstallationId: installationId,
+        },
+      },
+    },
+  );
+
+  return { siteId: site.id, siteName: site.name };
+}

--- a/apps/mesh/src/api/routes/github-repos.ts
+++ b/apps/mesh/src/api/routes/github-repos.ts
@@ -1,0 +1,608 @@
+/**
+ * GitHub Repos API Route
+ *
+ * Lets users install the GitHub App, select repositories, and import them
+ * as projects during Site Editor onboarding.
+ *
+ * Required env vars:
+ *   GITHUB_APP_SLUG        – App slug (for installation URL)
+ *   GITHUB_APP_ID          – Numeric App ID (for JWT generation)
+ *   GITHUB_APP_PRIVATE_KEY – PEM private key (for JWT signing)
+ *
+ * Flow:
+ *   1. GET    /auth/url        → returns { url } to open GitHub App installation
+ *   2. GET    /auth/callback   → stores installation_id, closes popup
+ *   3. GET    /status          → { connected: boolean }
+ *   4. DELETE /auth/disconnect → removes stored installation
+ *   5. GET    /                → lists repos via installation access token
+ *   6. POST   /connection      → creates a connection for a selected repo
+ */
+
+import { createSign } from "node:crypto";
+import { Hono } from "hono";
+import type { MeshContext } from "../../core/mesh-context";
+import { getUserId } from "../../core/mesh-context";
+import { getSettings } from "../../settings";
+import { fetchToolsFromMCP } from "../../tools/connection/fetch-tools";
+import {
+  ADMIN_MCP,
+  getSupabaseConfig,
+  resolveProfileId,
+  getOrCreateDecoApiKey,
+  getOrCreateDecoSite,
+} from "./deco-supabase";
+
+type Variables = { meshContext: MeshContext };
+
+const app = new Hono<{ Variables: Variables }>();
+
+// ---------------------------------------------------------------------------
+// In-memory state map for CSRF protection (short-lived, process-scoped)
+// ---------------------------------------------------------------------------
+
+interface StateEntry {
+  userId: string;
+  expiresAt: number;
+}
+
+const stateMap = new Map<string, StateEntry>();
+const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function pruneExpiredStates() {
+  const now = Date.now();
+  for (const [k, v] of stateMap) {
+    if (v.expiresAt < now) stateMap.delete(k);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub App JWT + Installation Access Token
+// ---------------------------------------------------------------------------
+
+function base64url(input: string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function normalizePem(raw: string): string {
+  const trimmed = raw.replace(/\\n/g, "\n").trim();
+  const match = trimmed.match(
+    /-----BEGIN ([A-Z ]+)-----(.+?)-----END ([A-Z ]+)-----/s,
+  );
+  if (!match) return trimmed;
+  const tag = match[1]!;
+  const b64 = match[2]!.replace(/\s/g, "");
+  const lines = b64.match(/.{1,64}/g) ?? [];
+  return `-----BEGIN ${tag}-----\n${lines.join("\n")}\n-----END ${tag}-----\n`;
+}
+
+function generateGitHubAppJWT(appId: string, privateKeyPem: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64url(
+    JSON.stringify({ iss: appId, iat: now - 60, exp: now + 600 }),
+  );
+  const unsigned = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsigned);
+  return `${unsigned}.${signer.sign(privateKeyPem, "base64url")}`;
+}
+
+function getAppConfig() {
+  const { githubAppSlug, githubAppId, githubAppPrivateKey } = getSettings();
+  if (!githubAppSlug || !githubAppId || !githubAppPrivateKey) return null;
+  return {
+    slug: githubAppSlug,
+    id: githubAppId,
+    pem: normalizePem(githubAppPrivateKey),
+  };
+}
+
+async function createInstallationToken(
+  installationId: string,
+): Promise<string> {
+  const cfg = getAppConfig();
+  if (!cfg) {
+    throw new Error(
+      "GITHUB_APP_SLUG, GITHUB_APP_ID, and GITHUB_APP_PRIVATE_KEY are required",
+    );
+  }
+  const jwt = generateGitHubAppJWT(cfg.id, cfg.pem);
+  const res = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Installation token request failed: ${res.status} – ${body}`,
+    );
+  }
+  const data = (await res.json()) as { token: string };
+  return data.token;
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers — read/write/delete the installation_id for a user
+// ---------------------------------------------------------------------------
+
+async function getInstallationId(
+  ctx: MeshContext,
+  userId: string,
+): Promise<string | null> {
+  const row = await ctx.db
+    .selectFrom("github_credentials")
+    .select("installation_id")
+    .where("user_id", "=", userId)
+    .executeTakeFirst();
+  return row?.installation_id ?? null;
+}
+
+async function upsertInstallation(
+  ctx: MeshContext,
+  userId: string,
+  installationId: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+  await ctx.db
+    .insertInto("github_credentials")
+    .values({
+      user_id: userId,
+      installation_id: installationId,
+      access_token: null,
+      created_at: now,
+      updated_at: now,
+    })
+    .onConflict((oc) =>
+      oc
+        .column("user_id")
+        .doUpdateSet({ installation_id: installationId, updated_at: now }),
+    )
+    .execute();
+}
+
+async function deleteInstallation(
+  ctx: MeshContext,
+  userId: string,
+): Promise<void> {
+  await ctx.db
+    .deleteFrom("github_credentials")
+    .where("user_id", "=", userId)
+    .execute();
+}
+
+// ---------------------------------------------------------------------------
+// Auth guard (every handler except the callback which is a GitHub redirect)
+// ---------------------------------------------------------------------------
+
+for (const path of [
+  "/auth/url",
+  "/auth/disconnect",
+  "/status",
+  "/",
+  "/connection",
+]) {
+  app.use(path, async (c, next) => {
+    if (!c.get("meshContext").auth.user?.id)
+      return c.json({ error: "Unauthorized" }, 401);
+    return next();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GET /auth/url
+// ---------------------------------------------------------------------------
+
+app.get("/auth/url", (c) => {
+  const cfg = getAppConfig();
+  if (!cfg) {
+    return c.json({ error: "GitHub integration is not configured" }, 503);
+  }
+
+  const ctx = c.get("meshContext");
+  const userId = ctx.auth.user!.id;
+
+  pruneExpiredStates();
+  const nonce = crypto.randomUUID();
+  stateMap.set(nonce, { userId, expiresAt: Date.now() + STATE_TTL_MS });
+
+  const callbackUrl = new URL(
+    "/api/github-repos/auth/callback",
+    c.req.url,
+  ).toString();
+
+  const params = new URLSearchParams({
+    state: nonce,
+    redirect_uri: callbackUrl,
+  });
+  const url = `https://github.com/apps/${cfg.slug}/installations/new?${params.toString()}`;
+
+  return c.json({ url });
+});
+
+// ---------------------------------------------------------------------------
+// GET /auth/callback
+//
+// GitHub redirects here after the user installs (or updates) the App.
+//
+// Possible parameter combinations:
+//  a) state + installation_id              → fresh install
+//  b) installation_id + setup_action=update → repo access change (no state)
+// ---------------------------------------------------------------------------
+
+app.get("/auth/callback", async (c) => {
+  const state = c.req.query("state");
+  const installationId = c.req.query("installation_id");
+  const setupAction = c.req.query("setup_action"); // "install" | "update"
+
+  const successHtml = /* html */ `<!DOCTYPE html>
+<html>
+<head><title>GitHub Connected</title></head>
+<body>
+<script>
+  if (window.opener) {
+    window.opener.postMessage({ type: 'github-oauth-success' }, '*');
+    window.close();
+  } else {
+    document.body.innerText = 'Connected! You can close this window.';
+  }
+</script>
+</body>
+</html>`;
+
+  const errorHtml = (msg: string) => /* html */ `<!DOCTYPE html>
+<html>
+<head><title>GitHub Error</title></head>
+<body>
+<script>
+  if (window.opener) {
+    window.opener.postMessage({ type: 'github-oauth-error', error: ${JSON.stringify(msg)} }, '*');
+    window.close();
+  } else {
+    document.body.innerText = 'Error: ${msg.replace(/'/g, "\\'")}';
+  }
+</script>
+</body>
+</html>`;
+
+  // (b) Updating an existing installation (changing repo access).
+  if (!state && installationId && setupAction === "update") {
+    console.info(`[github-repos] installation updated: ${installationId}`);
+    return c.html(successHtml);
+  }
+
+  // (a) Fresh install: state + installation_id.
+  if (!state) return c.html(errorHtml("Missing state parameter"), 400);
+  if (!installationId) {
+    return c.html(errorHtml("Missing installation_id"), 400);
+  }
+
+  pruneExpiredStates();
+  const entry = stateMap.get(state);
+  if (!entry || entry.expiresAt < Date.now()) {
+    return c.html(errorHtml("Invalid or expired state"), 400);
+  }
+  stateMap.delete(state);
+
+  const ctx = c.get("meshContext");
+  if (!ctx) return c.html(errorHtml("Session context unavailable"), 500);
+
+  try {
+    await upsertInstallation(ctx, entry.userId, installationId);
+  } catch (err) {
+    console.error("[github-repos] failed to persist installation:", err);
+    return c.html(errorHtml("Failed to save installation"), 500);
+  }
+
+  return c.html(successHtml);
+});
+
+// ---------------------------------------------------------------------------
+// GET /status
+// ---------------------------------------------------------------------------
+
+app.get("/status", async (c) => {
+  const ctx = c.get("meshContext");
+  const userId = ctx.auth.user!.id;
+  const instId = await getInstallationId(ctx, userId);
+
+  if (!instId) {
+    return c.json({ connected: false, configureUrl: null });
+  }
+
+  let configureUrl = `https://github.com/settings/installations/${instId}`;
+
+  const cfg = getAppConfig();
+  if (cfg) {
+    try {
+      const jwt = generateGitHubAppJWT(cfg.id, cfg.pem);
+      const res = await fetch(
+        `https://api.github.com/app/installations/${instId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        },
+      );
+      if (res.ok) {
+        const data = (await res.json()) as {
+          account: { login: string; type: string };
+        };
+        const { login, type } = data.account;
+        configureUrl =
+          type === "Organization"
+            ? `https://github.com/organizations/${login}/settings/installations/${instId}`
+            : `https://github.com/settings/installations/${instId}`;
+      }
+    } catch {
+      // Fall back to the personal-account URL format.
+    }
+  }
+
+  return c.json({ connected: true, configureUrl });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /auth/disconnect
+// ---------------------------------------------------------------------------
+
+app.delete("/auth/disconnect", async (c) => {
+  const ctx = c.get("meshContext");
+  const userId = ctx.auth.user!.id;
+  await deleteInstallation(ctx, userId);
+  return c.json({ ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// GET /
+// Lists repositories accessible through the stored installation.
+// ---------------------------------------------------------------------------
+
+interface GitHubRepo {
+  id: number;
+  full_name: string;
+  name: string;
+  description: string | null;
+  private: boolean;
+  html_url: string;
+  default_branch: string;
+  owner: { login: string; avatar_url: string };
+  updated_at: string | null;
+}
+
+app.get("/", async (c) => {
+  const ctx = c.get("meshContext");
+  const userId = ctx.auth.user!.id;
+  const installationId = await getInstallationId(ctx, userId);
+
+  if (!installationId) {
+    return c.json({ connected: false, repos: [] });
+  }
+
+  const cfg = getAppConfig();
+  if (!cfg) {
+    return c.json({ error: "GitHub integration is not configured" }, 503);
+  }
+
+  try {
+    const token = await createInstallationToken(installationId);
+    const res = await fetch(
+      "https://api.github.com/installation/repositories?per_page=100",
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(
+        `[github-repos] installation repos error: ${res.status}`,
+        body,
+      );
+      return c.json({ error: "Failed to fetch repositories" }, 502);
+    }
+    const data = (await res.json()) as {
+      repositories: GitHubRepo[];
+      total_count: number;
+    };
+    return c.json({
+      connected: true,
+      repos: data.repositories ?? [],
+      configureUrl: `https://github.com/settings/installations/${installationId}`,
+      installUrl: `https://github.com/apps/${cfg.slug}/installations/new`,
+    });
+  } catch (err) {
+    console.error("[github-repos] GET repos error:", err);
+    return c.json({ error: "Failed to fetch repositories" }, 502);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /connection
+// Creates a GitHub connection and, when Supabase is configured, also
+// provisions a deco.cx site and an admin MCP connection for it.
+// ---------------------------------------------------------------------------
+
+app.post("/connection", async (c) => {
+  const ctx = c.get("meshContext");
+  const userId = getUserId(ctx);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const email = ctx.auth.user?.email;
+
+  const installationId = await getInstallationId(ctx, userId);
+  if (!installationId) {
+    return c.json({ error: "GitHub App not installed" }, 401);
+  }
+
+  const connectionToken = await createInstallationToken(installationId);
+
+  let body: {
+    repoFullName: string;
+    connId: string;
+    adminConnId: string;
+    orgId: string;
+  };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid request body" }, 400);
+  }
+
+  const { repoFullName, connId, adminConnId, orgId } = body;
+  if (!repoFullName || !connId || !orgId) {
+    return c.json(
+      { error: "repoFullName, connId, and orgId are required" },
+      400,
+    );
+  }
+
+  if (!/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(repoFullName)) {
+    return c.json({ error: "Invalid repoFullName" }, 400);
+  }
+
+  const membership = await ctx.db
+    .selectFrom("member")
+    .select("member.id")
+    .where("member.userId", "=", userId)
+    .where("member.organizationId", "=", orgId)
+    .executeTakeFirst();
+
+  if (!membership) return c.json({ error: "Forbidden" }, 403);
+
+  const [owner, repoName] = repoFullName.split("/");
+
+  try {
+    const connection = await ctx.storage.connections.create({
+      id: connId,
+      organization_id: orgId,
+      created_by: userId,
+      title: `GitHub — ${repoFullName}`,
+      description: `GitHub repository: ${repoFullName}`,
+      connection_type: "HTTP",
+      connection_url: "https://api.githubcopilot.com/mcp/",
+      connection_token: connectionToken,
+      connection_headers: null,
+      oauth_config: null,
+      configuration_state: {
+        GITHUB_REPO_OWNER: owner,
+        GITHUB_REPO_NAME: repoName,
+        GITHUB_REPO_FULL_NAME: repoFullName,
+      },
+      metadata: { source: "github-import" },
+      icon: null,
+      app_name: "GitHub",
+      app_id: null,
+      tools: null,
+      configuration_scopes: null,
+    });
+
+    // -----------------------------------------------------------------------
+    // Deco.cx site + admin MCP connection (best-effort).
+    // Skipped when Supabase isn't configured or the user has no deco profile.
+    // -----------------------------------------------------------------------
+    let createdAdminConnId: string | null = null;
+    let decoSiteName: string | null = null;
+
+    const sbConfig = getSupabaseConfig();
+    if (sbConfig && email && adminConnId) {
+      try {
+        const { supabaseUrl, serviceKey } = sbConfig;
+        const profileId = await resolveProfileId(
+          supabaseUrl,
+          serviceKey,
+          email,
+        );
+
+        if (profileId) {
+          const siteName = `${owner}-${repoName}`
+            .toLowerCase()
+            .replace(/[^a-z0-9-]/g, "-")
+            .replace(/-+/g, "-")
+            .replace(/^-|-$/g, "")
+            .slice(0, 38);
+
+          const { siteName: finalSiteName } = await getOrCreateDecoSite(
+            supabaseUrl,
+            serviceKey,
+            {
+              siteName,
+              profileId,
+              repoOwner: owner!,
+              repoName: repoName!,
+              installationId,
+            },
+          );
+          decoSiteName = finalSiteName;
+
+          const apiKey = await getOrCreateDecoApiKey(
+            supabaseUrl,
+            serviceKey,
+            profileId,
+          );
+
+          const fetchResult = await fetchToolsFromMCP({
+            id: `pending-${adminConnId}`,
+            title: `deco.cx — ${finalSiteName}`,
+            connection_type: "HTTP",
+            connection_url: ADMIN_MCP,
+            connection_token: apiKey,
+          }).catch(() => null);
+          const tools = fetchResult?.tools?.length ? fetchResult.tools : null;
+          const configuration_scopes = fetchResult?.scopes?.length
+            ? fetchResult.scopes
+            : null;
+
+          const adminConn = await ctx.storage.connections.create({
+            id: adminConnId,
+            organization_id: orgId,
+            created_by: userId,
+            title: `deco.cx — ${finalSiteName}`,
+            description: `Admin MCP for deco.cx site: ${finalSiteName}`,
+            connection_type: "HTTP",
+            connection_url: ADMIN_MCP,
+            connection_token: apiKey,
+            connection_headers: null,
+            oauth_config: null,
+            configuration_state: { SITE_NAME: finalSiteName },
+            metadata: { source: "github-import-deco" },
+            icon: null,
+            app_name: "deco.cx",
+            app_id: null,
+            tools,
+            configuration_scopes,
+          });
+
+          createdAdminConnId = adminConn.id;
+        }
+      } catch (err) {
+        console.warn(
+          "[github-repos] deco.cx site/admin-mcp creation failed (non-fatal):",
+          err,
+        );
+      }
+    }
+
+    return c.json({
+      connId: connection.id,
+      adminConnId: createdAdminConnId,
+      decoSiteName,
+    });
+  } catch (err) {
+    console.error("[github-repos] POST /connection error:", err);
+    return c.json({ error: "Failed to create connection" }, 500);
+  }
+});
+
+export default app;

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -110,6 +110,11 @@ export function resolveConfig(
     // External service credentials
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,
     decoSupabaseServiceKey: envVars.DECO_SUPABASE_SERVICE_KEY,
+
+    // GitHub App
+    githubAppSlug: envVars.GITHUB_APP_SLUG,
+    githubAppId: envVars.GITHUB_APP_ID,
+    githubAppPrivateKey: envVars.GITHUB_APP_PRIVATE_KEY,
   };
 
   return {

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -62,6 +62,11 @@ export interface Settings {
   // External service credentials (optional)
   decoSupabaseUrl: string | undefined;
   decoSupabaseServiceKey: string | undefined;
+
+  // GitHub App (optional — enables GitHub import in onboarding)
+  githubAppSlug: string | undefined;
+  githubAppId: string | undefined;
+  githubAppPrivateKey: string | undefined;
 }
 
 export interface CliFlags {

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -914,6 +914,18 @@ export interface AutomationTrigger {
   created_at: string;
 }
 
+// ============================================================================
+// GitHub Credentials
+// ============================================================================
+
+export interface GitHubCredentialTable {
+  user_id: string;
+  access_token: string | null; // Encrypted via vault (null when using installation-only flow)
+  installation_id: string | null; // GitHub App installation ID
+  created_at: ColumnType<string, string | undefined, never>;
+  updated_at: ColumnType<string, string | undefined, string>;
+}
+
 /**
  * Trigger callback token table - stores hashed tokens for external MCP callbacks
  */
@@ -995,4 +1007,7 @@ export interface Database {
 
   // Generic org-scoped KV store
   kv: KVTable;
+
+  // GitHub OAuth credentials (per user, encrypted)
+  github_credentials: GitHubCredentialTable;
 }

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useMatch } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Popover,
   PopoverContent,
@@ -41,6 +42,73 @@ import { authClient } from "@/web/lib/auth-client";
 import { CreateOrganizationDialog } from "@/web/components/create-organization-dialog";
 import { usePreferences, type ThemeMode } from "@/web/hooks/use-preferences.ts";
 import { toast } from "@deco/ui/components/sonner.js";
+import { KEYS } from "@/web/lib/query-keys";
+
+function GitHubConnectedControl({ userId }: { userId: string | undefined }) {
+  const queryClient = useQueryClient();
+
+  const { data: statusData, isLoading } = useQuery({
+    queryKey: KEYS.githubStatus(userId),
+    queryFn: async () => {
+      const res = await fetch("/api/github-repos/status");
+      if (!res.ok) throw new Error("Failed to check GitHub status");
+      return res.json() as Promise<{
+        connected: boolean;
+        configureUrl: string | null;
+      }>;
+    },
+    enabled: Boolean(userId),
+    staleTime: 30_000,
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/github-repos/auth/disconnect", {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to disconnect");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.githubStatus(userId) });
+      queryClient.invalidateQueries({ queryKey: KEYS.githubRepos(userId) });
+      toast.success("GitHub disconnected");
+    },
+    onError: () => {
+      toast.error("Failed to disconnect GitHub");
+    },
+  });
+
+  if (isLoading) {
+    return <span className="text-xs text-muted-foreground">Checking…</span>;
+  }
+
+  if (!statusData?.connected) {
+    return <span className="text-xs text-muted-foreground">Not connected</span>;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {statusData.configureUrl && (
+        <a
+          href={statusData.configureUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Manage
+        </a>
+      )}
+      <button
+        type="button"
+        onClick={() => disconnectMutation.mutate()}
+        disabled={disconnectMutation.isPending}
+        className="text-xs text-destructive hover:text-destructive/80 transition-colors disabled:opacity-50"
+      >
+        {disconnectMutation.isPending ? "Disconnecting…" : "Disconnect"}
+      </button>
+    </div>
+  );
+}
 
 function getOrgColorStyle(name: string): {
   backgroundColor: string;
@@ -297,6 +365,20 @@ function AccountPopoverContent({
             ))}
             <MenuItemButton item={signOutItem} onClose={close} />
           </nav>
+
+          {/* Connected accounts */}
+          <div className="px-4 py-2 border-t border-border/50">
+            <p className="text-xs font-medium text-muted-foreground/60 mb-1.5">
+              Connected accounts
+            </p>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <GitHubIcon className="size-3.5" />
+                <span className="text-sm text-foreground">GitHub</span>
+              </div>
+              <GitHubConnectedControl userId={user?.id} />
+            </div>
+          </div>
         </div>
 
         {/* Bottom bar: theme + sound + version */}
@@ -408,6 +490,20 @@ function AccountPopoverContent({
           ))}
           <MenuItemButton item={signOutItem} onClose={close} />
         </nav>
+
+        {/* Connected accounts */}
+        <div className="px-3 py-2 border-t border-border/50">
+          <p className="text-xs font-medium text-muted-foreground/60 mb-1.5">
+            Connected accounts
+          </p>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <GitHubIcon className="size-3.5" />
+              <span className="text-sm text-foreground">GitHub</span>
+            </div>
+            <GitHubConnectedControl userId={user?.id} />
+          </div>
+        </div>
 
         {/* Bottom bar: theme toggles + sound + version */}
         <div className="flex items-center justify-between px-2 py-1.5 border-t border-border/50">

--- a/apps/mesh/src/web/components/home/site-editor-onboarding-modal.tsx
+++ b/apps/mesh/src/web/components/home/site-editor-onboarding-modal.tsx
@@ -25,6 +25,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
+import { ImportFromGitHubDialog } from "@/web/components/import-from-github-dialog.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 
 interface OnboardingCard {
@@ -46,8 +47,8 @@ const CARDS: OnboardingCard[] = [
   {
     id: "github",
     title: "Existing GitHub project",
-    buttonLabel: "Coming Soon",
-    comingSoon: true,
+    buttonLabel: "Import repository",
+    comingSoon: false,
     image: "/import-github.png",
   },
   {
@@ -145,13 +146,17 @@ export function SiteEditorOnboardingModal({
   open,
   onOpenChange,
 }: SiteEditorOnboardingModalProps) {
-  const [importOpen, setImportOpen] = useState(false);
+  const [importDecoOpen, setImportDecoOpen] = useState(false);
+  const [importGitHubOpen, setImportGitHubOpen] = useState(false);
   const isMobile = useIsMobile();
 
   const handleCardAction = (cardId: string) => {
     if (cardId === "deco") {
       onOpenChange(false);
-      setImportOpen(true);
+      setImportDecoOpen(true);
+    } else if (cardId === "github") {
+      onOpenChange(false);
+      setImportGitHubOpen(true);
     }
   };
 
@@ -190,10 +195,19 @@ export function SiteEditorOnboardingModal({
       )}
 
       <ImportFromDecoDialog
-        open={importOpen}
-        onOpenChange={setImportOpen}
+        open={importDecoOpen}
+        onOpenChange={setImportDecoOpen}
         onBack={() => {
-          setImportOpen(false);
+          setImportDecoOpen(false);
+          onOpenChange(true);
+        }}
+      />
+
+      <ImportFromGitHubDialog
+        open={importGitHubOpen}
+        onOpenChange={setImportGitHubOpen}
+        onBack={() => {
+          setImportGitHubOpen(false);
           onOpenChange(true);
         }}
       />

--- a/apps/mesh/src/web/components/import-from-github-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-github-dialog.tsx
@@ -1,0 +1,640 @@
+import { useState, useRef, useCallback } from "react";
+import { toast } from "sonner";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ArrowLeft } from "@untitledui/icons";
+import { authClient } from "@/web/lib/auth-client";
+import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { KEYS } from "@/web/lib/query-keys";
+import { generateSlug } from "@/web/lib/slug";
+import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
+
+interface GitHubRepo {
+  id: number;
+  full_name: string;
+  name: string;
+  description: string | null;
+  private: boolean;
+  html_url: string;
+  owner: { login: string; avatar_url: string };
+  updated_at: string | null;
+}
+
+interface GitHubReposResponse {
+  connected: boolean;
+  repos: GitHubRepo[];
+  configureUrl: string | null;
+  installUrl: string | null;
+  needsInstall?: boolean; // no installation found — user must install the app first
+  error?: string;
+}
+
+interface GitHubStatusResponse {
+  connected: boolean;
+}
+
+async function loadGitHubStatus(): Promise<GitHubStatusResponse> {
+  const res = await fetch("/api/github-repos/status");
+  if (!res.ok) throw new Error("Failed to check GitHub status");
+  return res.json() as Promise<GitHubStatusResponse>;
+}
+
+async function loadGitHubRepos(): Promise<GitHubReposResponse> {
+  const res = await fetch("/api/github-repos");
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(
+      body.error ?? `Failed to load repositories (${res.status})`,
+    );
+  }
+  return res.json() as Promise<GitHubReposResponse>;
+}
+
+interface ImportFromGitHubDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onBack?: () => void;
+}
+
+type VirtualMCPCreateOutput = {
+  item: {
+    id: string;
+    title: string;
+    metadata?: {
+      ui?: { slug?: string } | null;
+      migrated_project_slug?: string;
+    } | null;
+  };
+};
+
+export function ImportFromGitHubDialog({
+  open,
+  onOpenChange,
+  onBack,
+}: ImportFromGitHubDialogProps) {
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [connectingOAuth, setConnectingOAuth] = useState(false);
+  const [waitingForInstall, setWaitingForInstall] = useState(false);
+  const popupRef = useRef<Window | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  const {
+    data: statusData,
+    isLoading: isStatusLoading,
+    refetch: refetchStatus,
+  } = useQuery({
+    queryKey: KEYS.githubStatus(userId),
+    queryFn: loadGitHubStatus,
+    enabled: open && Boolean(userId),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const isConnected = statusData?.connected ?? false;
+
+  const {
+    data: reposData,
+    isLoading: isReposLoading,
+    error: reposError,
+    refetch: refetchRepos,
+  } = useQuery({
+    queryKey: KEYS.githubRepos(userId),
+    queryFn: loadGitHubRepos,
+    enabled: open && isConnected,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const repos = reposData?.repos ?? [];
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    setWaitingForInstall(false);
+  }, []);
+
+  const startPollingForRepos = useCallback(() => {
+    setWaitingForInstall(true);
+    stopPolling();
+    pollRef.current = setInterval(async () => {
+      const result = await refetchRepos();
+      if ((result.data?.repos?.length ?? 0) > 0) {
+        stopPolling();
+      }
+    }, 4000);
+  }, [refetchRepos, stopPolling]);
+
+  const handleClose = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setSelectedRepo(null);
+      setSearch("");
+      setConnectingOAuth(false);
+      stopPolling();
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const filteredRepos = repos.filter(
+    (r) =>
+      r.full_name.toLowerCase().includes(search.toLowerCase()) ||
+      (r.description ?? "").toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const isSelectedVisible =
+    !selectedRepo || filteredRepos.some((r) => r.full_name === selectedRepo);
+
+  const handleConnectGitHub = async () => {
+    setConnectingOAuth(true);
+    try {
+      const res = await fetch("/api/github-repos/auth/url");
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        toast.error(body.error ?? "Failed to start GitHub OAuth");
+        return;
+      }
+      const data = (await res.json()) as { url: string };
+
+      const popup = window.open(
+        data.url,
+        "github-oauth",
+        "width=600,height=700,left=200,top=100",
+      );
+      popupRef.current = popup;
+
+      const handleMessage = (event: MessageEvent) => {
+        if (event.data?.type === "github-oauth-success") {
+          window.removeEventListener("message", handleMessage);
+          setConnectingOAuth(false);
+          queryClient.invalidateQueries({
+            queryKey: KEYS.githubStatus(userId),
+          });
+          queryClient.invalidateQueries({
+            queryKey: KEYS.githubRepos(userId),
+          });
+          refetchStatus();
+
+          // Repo selection happened inside the popup (installation flow).
+          // The repos list will refresh via the query invalidation above.
+        } else if (event.data?.type === "github-oauth-error") {
+          window.removeEventListener("message", handleMessage);
+          setConnectingOAuth(false);
+          toast.error(event.data.error ?? "GitHub OAuth failed");
+        }
+      };
+
+      window.addEventListener("message", handleMessage);
+
+      // Detect popup closed without completing OAuth
+      const pollClosed = setInterval(() => {
+        if (popup?.closed) {
+          clearInterval(pollClosed);
+          window.removeEventListener("message", handleMessage);
+          setConnectingOAuth(false);
+        }
+      }, 500);
+    } catch {
+      setConnectingOAuth(false);
+      toast.error("Failed to start GitHub OAuth");
+    }
+  };
+
+  const disconnectMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/github-repos/auth/disconnect", {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to disconnect");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.githubStatus(userId) });
+      queryClient.invalidateQueries({ queryKey: KEYS.githubRepos(userId) });
+      setSelectedRepo(null);
+      setSearch("");
+    },
+    onError: () => {
+      toast.error("Failed to disconnect GitHub account");
+    },
+  });
+
+  const importMutation = useMutation({
+    mutationFn: async (repoFullName: string) => {
+      const connId = generatePrefixedId("conn");
+      const adminConnId = generatePrefixedId("conn");
+
+      const connRes = await fetch("/api/github-repos/connection", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          repoFullName,
+          connId,
+          adminConnId,
+          orgId: org.id,
+        }),
+      });
+      const connBody = (await connRes.json().catch(() => ({}))) as {
+        connId?: string;
+        adminConnId?: string | null;
+        decoSiteName?: string | null;
+        error?: string;
+      };
+      if (!connRes.ok) {
+        throw new Error(
+          connBody.error ?? `Failed to create connection (${connRes.status})`,
+        );
+      }
+
+      const hasAdminConn = Boolean(connBody.adminConnId);
+
+      const repoName = repoFullName.split("/")[1] ?? repoFullName;
+      const slug = generateSlug(repoName);
+
+      const connections = [{ connection_id: connId }];
+      if (hasAdminConn) {
+        connections.push({ connection_id: connBody.adminConnId! });
+      }
+
+      const adminId = connBody.adminConnId;
+      const pinnedViews = hasAdminConn
+        ? [
+            {
+              connectionId: adminId,
+              toolName: "file_explorer",
+              label: "Preview",
+              icon: null,
+            },
+            {
+              connectionId: adminId,
+              toolName: "fetch_assets",
+              label: "Assets",
+              icon: null,
+            },
+            {
+              connectionId: adminId,
+              toolName: "get_monitor_data",
+              label: "Monitor",
+              icon: null,
+            },
+          ]
+        : [];
+
+      const defaultMainView = hasAdminConn
+        ? {
+            type: "ext-apps",
+            id: adminId,
+            toolName: "file_explorer",
+          }
+        : null;
+
+      const result = (await client.callTool({
+        name: "COLLECTION_VIRTUAL_MCP_CREATE",
+        arguments: {
+          data: {
+            title: repoFullName,
+            description: `GitHub repository: ${repoFullName}`,
+            pinned: true,
+            icon: "icon://Code02?color=slate",
+            subtype: "project",
+            metadata: {
+              instructions: null,
+              enabled_plugins: [],
+              ui: {
+                banner: null,
+                bannerColor: "#1F2328",
+                icon: null,
+                themeColor: "#1F2328",
+                slug,
+                pinnedViews,
+                layout: { defaultMainView },
+              },
+            },
+            connections,
+          },
+        },
+      })) as { structuredContent?: unknown };
+
+      const payload = (result.structuredContent ??
+        result) as VirtualMCPCreateOutput;
+
+      return {
+        slug,
+        virtualMcpId: payload.item.id,
+        connId,
+        item: payload.item,
+      };
+    },
+    onSuccess: ({ slug, virtualMcpId, item }) => {
+      queryClient.setQueryData(
+        KEYS.collectionItem(client, org.id, "", "VIRTUAL_MCP", virtualMcpId),
+        { item },
+      );
+
+      queryClient.invalidateQueries({
+        predicate: (query) => {
+          const key = query.queryKey;
+          return (
+            key[1] === org.id &&
+            key[3] === "collection" &&
+            key[4] === "VIRTUAL_MCP"
+          );
+        },
+      });
+      queryClient.invalidateQueries({ queryKey: KEYS.projects(org.id) });
+      toast.success(`Imported ${slug} from GitHub`);
+      handleClose(false);
+      localStorage.setItem("mesh:sidebar-open", JSON.stringify(false));
+      navigate({
+        to: "/$org/$virtualMcpId",
+        params: {
+          org: org.slug,
+          virtualMcpId,
+        },
+      });
+    },
+    onError: (err) => {
+      toast.error(
+        "Import failed: " +
+          (err instanceof Error ? err.message : "Unknown error"),
+      );
+    },
+  });
+
+  const isLoading = isStatusLoading || (isConnected && isReposLoading);
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[900px] p-0 gap-0 overflow-hidden">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Import from GitHub</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex items-center h-12 border-b border-border px-4 gap-3">
+          <button
+            type="button"
+            onClick={() => (onBack ? onBack() : handleClose(false))}
+            className="flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Go back"
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <span className="text-sm font-medium text-foreground">
+            Import from GitHub
+          </span>
+        </div>
+
+        {!isStatusLoading && !isConnected ? (
+          <div className="flex flex-col items-center justify-center gap-4 py-16 px-8">
+            <div className="flex flex-col items-center gap-2 text-center">
+              <p className="text-sm font-medium text-foreground">
+                Connect your GitHub account
+              </p>
+              <p className="text-sm text-muted-foreground max-w-xs">
+                Authorize the GitHub App to list repositories you&apos;ve given
+                access to.
+              </p>
+            </div>
+            <Button
+              onClick={handleConnectGitHub}
+              disabled={connectingOAuth}
+              className="gap-2"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                className="size-4 fill-current"
+                aria-hidden="true"
+              >
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              {connectingOAuth ? "Connecting…" : "Connect with GitHub"}
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center border-b border-border">
+              <div className="flex-1">
+                <CollectionSearch
+                  value={search}
+                  onChange={setSearch}
+                  placeholder="Search repositories..."
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") setSearch("");
+                  }}
+                />
+              </div>
+              {(reposData?.configureUrl ?? reposData?.installUrl) && (
+                <a
+                  href={reposData.configureUrl ?? reposData.installUrl ?? ""}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 flex items-center gap-1.5 px-4 text-xs text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
+                >
+                  {reposData.configureUrl
+                    ? "Configure access on GitHub"
+                    : "Install GitHub App"}
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="size-3 fill-none stroke-current stroke-2"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14 21 3"
+                    />
+                  </svg>
+                </a>
+              )}
+            </div>
+
+            <div className="pb-0 min-h-[300px]">
+              {isLoading && (
+                <div className="flex items-center justify-center h-48 text-sm text-muted-foreground">
+                  Loading repositories...
+                </div>
+              )}
+
+              {!isLoading && !reposError && repos.length === 0 && (
+                <div className="flex flex-col items-center justify-center h-48 gap-4 px-8 text-center">
+                  {reposData?.needsInstall ? (
+                    <>
+                      <div className="flex flex-col gap-1">
+                        <p className="text-sm font-medium text-foreground">
+                          No repository access yet
+                        </p>
+                        <p className="text-xs text-muted-foreground max-w-xs">
+                          Install the GitHub App on your account and select
+                          which repositories to grant access to.
+                        </p>
+                      </div>
+                      {reposData.installUrl && (
+                        <a
+                          href={reposData.installUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => {
+                            // Invalidate after user returns from GitHub
+                            setTimeout(() => {
+                              queryClient.invalidateQueries({
+                                queryKey: KEYS.githubRepos(userId),
+                              });
+                            }, 3000);
+                          }}
+                        >
+                          <Button size="sm" variant="outline" className="gap-2">
+                            <svg
+                              viewBox="0 0 24 24"
+                              className="size-3.5 fill-current"
+                              aria-hidden="true"
+                            >
+                              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+                            </svg>
+                            Install GitHub App
+                          </Button>
+                        </a>
+                      )}
+                    </>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No repositories found.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {!isLoading && reposError && (
+                <div className="flex items-center justify-center h-48 text-sm text-destructive">
+                  {reposError instanceof Error
+                    ? reposError.message
+                    : "Failed to load repositories"}
+                </div>
+              )}
+
+              {!isLoading && repos.length > 0 && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 max-h-[420px] overflow-y-auto py-4 px-8 [scrollbar-gutter:stable]">
+                  {filteredRepos.length === 0 && (
+                    <p className="col-span-3 text-sm text-muted-foreground text-center py-8">
+                      No repositories match &ldquo;{search}&rdquo;
+                    </p>
+                  )}
+                  {filteredRepos.map((repo) => {
+                    const isSelected = selectedRepo === repo.full_name;
+                    return (
+                      <button
+                        key={repo.id}
+                        type="button"
+                        onClick={() => setSelectedRepo(repo.full_name)}
+                        className={cn(
+                          "flex flex-col rounded-xl border overflow-hidden text-left transition-all cursor-pointer",
+                          isSelected
+                            ? "border-primary ring-1 ring-primary"
+                            : "border-border hover:border-muted-foreground/40",
+                        )}
+                      >
+                        {/* Owner avatar banner */}
+                        <div className="w-full h-20 bg-muted overflow-hidden flex items-center justify-center">
+                          <img
+                            src={repo.owner.avatar_url}
+                            alt={repo.owner.login}
+                            className="size-12 rounded-full"
+                            loading="lazy"
+                          />
+                        </div>
+                        {/* Info */}
+                        <div className="px-4 py-3">
+                          <p className="text-sm font-medium text-foreground truncate">
+                            {repo.name}
+                          </p>
+                          <p className="text-xs text-muted-foreground truncate mt-0.5">
+                            {repo.owner.login}
+                            {repo.private ? " · Private" : " · Public"}
+                          </p>
+                          {repo.description && (
+                            <p className="text-xs text-muted-foreground truncate mt-1">
+                              {repo.description}
+                            </p>
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter className="px-8 py-5 border-t border-border">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mr-auto text-muted-foreground hover:text-destructive"
+                onClick={() => disconnectMutation.mutate()}
+                disabled={
+                  disconnectMutation.isPending || importMutation.isPending
+                }
+              >
+                {disconnectMutation.isPending
+                  ? "Disconnecting…"
+                  : "Disconnect GitHub"}
+              </Button>
+              {reposData?.needsInstall && (
+                <Button
+                  variant="outline"
+                  onClick={() => refetchRepos()}
+                  disabled={isReposLoading}
+                >
+                  {isReposLoading ? "Checking…" : "Refresh"}
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={importMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  !selectedRepo ||
+                  !isSelectedVisible ||
+                  importMutation.isPending ||
+                  isLoading
+                }
+                onClick={() =>
+                  selectedRepo && importMutation.mutate(selectedRepo)
+                }
+              >
+                {importMutation.isPending ? "Importing..." : "Import"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -275,4 +275,10 @@ export const KEYS = {
 
   // Deco sites (scoped by user email)
   decoSites: (email: string | undefined) => ["deco-sites", email] as const,
+
+  // GitHub repos (scoped by user id)
+  githubStatus: (userId: string | undefined) =>
+    ["github-status", userId] as const,
+  githubRepos: (userId: string | undefined) =>
+    ["github-repos", userId] as const,
 } as const;


### PR DESCRIPTION
…mport

When importing a GitHub repository, the flow now also:
- Creates a deco.cx site on Supabase with selfHosting metadata
- Creates an admin MCP connection pointing to sites-admin-mcp
- Links both GitHub and admin connections to the Virtual MCP project
- Sets up pinned views (Preview, Assets, Monitor) when admin conn is available

Also:
- Extracts shared Supabase helpers into deco-supabase.ts
- Adds "Manage" link to GitHub connected accounts (org-aware URL)
- Gracefully skips deco.cx provisioning when Supabase is not configured

Made-with: Cursor

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub repository import via a GitHub App and auto‑provisions a matching deco.cx site with an admin MCP, linking both connections to the new Virtual MCP project for a ready-to-use workflow.

- **New Features**
  - GitHub App flow: install, check status, disconnect; list repos and create a GitHub connection via `/api/github-repos`; “Manage” link in account popover uses org-aware URL.
  - On import (when Supabase is configured): create a deco.cx site with selfHosting metadata, create an admin MCP connection to `ADMIN_MCP`, link both connections to the project, and pin Preview/Assets/Monitor views.
  - Extracted shared Supabase helpers into `deco-supabase.ts` and refactored `deco-sites` to use them.
  - New UI: GitHub import dialog in onboarding, GitHub card enabled, and “Manage/Disconnect” controls in the account popover.

- **Migration**
  - Run new DB migrations 063 and 064.
  - Set GitHub App envs: `GITHUB_APP_SLUG`, `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`.
  - Optional for deco provisioning: `DECO_SUPABASE_URL`, `DECO_SUPABASE_SERVICE_KEY`.
  - Ensure the admin MCP URL is reachable; update `ADMIN_MCP` in `deco-supabase.ts` if your endpoint differs.

<sup>Written for commit 5cddbc6267edb6d71dc2fa857dda7d092424d5cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

