### PR TITLE
fix(sidebar): fix home button content overflow with padding

### DIFF
--- a/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
@@ -21,7 +21,7 @@ function MobileLogoHeader() {
   const darkSrc = typeof logo === "string" ? logo : logo.dark;
 
   return (
-    <SidebarHeader className="flex items-center justify-center h-14 shrink-0 px-2">
+    <SidebarHeader className="flex items-center justify-center shrink-0 px-2 pb-0">
       <div className="flex w-full aspect-square items-center justify-center">
         <img
           src={lightSrc}
@@ -131,10 +131,10 @@ export function MobileNavigationSidebar({
       className="bg-sidebar flex h-full w-full flex-col"
       data-sidebar="sidebar"
     >
-      <Suspense fallback={<div className="h-14 shrink-0" />}>
+      <Suspense fallback={<div className="h-10 shrink-0" />}>
         <MobileLogoHeader />
       </Suspense>
-      <SidebarContent className="flex flex-col flex-1 overflow-x-hidden px-2 pb-2 gap-0">
+      <SidebarContent className="flex flex-col flex-1 overflow-x-hidden px-2 py-2 gap-0">
         {sections.map((section, index) => (
           <MobileSectionRenderer
             key={index}

--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -24,7 +24,7 @@ function SidebarLogoHeader() {
   const darkSrc = typeof logo === "string" ? logo : logo.dark;
 
   return (
-    <SidebarHeader className="flex items-center justify-center h-14 shrink-0 px-2">
+    <SidebarHeader className="flex items-center justify-center shrink-0 px-2 pb-0">
       <div className="flex w-full aspect-square items-center justify-center">
         <img
           src={lightSrc}
@@ -125,7 +125,7 @@ function NavigationSidebarInner({
       {header}
       <SidebarContent
         className={cn(
-          "flex flex-col flex-1 overflow-x-hidden px-2 pb-2 gap-0",
+          "flex flex-col flex-1 overflow-x-hidden px-2 py-2 gap-0",
           contentClassName,
         )}
       >


### PR DESCRIPTION
## What is this contribution about?
Fixes two sidebar layout issues in both desktop and mobile navigation components:
- Removes `h-14` from the logo header which was causing the logo to be vertically centered instead of top-aligned
- Adds `pb-0` to the logo header to remove unintended bottom padding
- Changes `pb-2` to `py-2` in the content area so it has equal top and bottom padding

## Screenshots/Demonstration
> UI changes to sidebar logo alignment and content area padding.

## How to Test
1. Open the sidebar in both desktop and mobile views
2. Verify the logo is aligned to the top rather than centered
3. Verify the content area has equal top and bottom padding

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Top-aligns the sidebar logo and normalizes content padding in desktop and mobile sidebars for consistent spacing. Removes unintended vertical centering and fixes uneven padding.

- **Bug Fixes**
  - Removed h-14 from the logo header and added pb-0 to prevent vertical centering and extra bottom padding.
  - Changed content padding from pb-2 to py-2 for equal top and bottom spacing.
  - Adjusted mobile Suspense fallback height from h-14 to h-10 to match the new header spacing.

<sup>Written for commit 53c87e2fa4cf2c9d4e537a2b2a88257c0af3d23c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

