### PR TITLE
fix(registry): remove references to dropped connections.subtype column

### DIFF
--- a/apps/mesh/src/api/routes/registry/public-publish-request.ts
+++ b/apps/mesh/src/api/routes/registry/public-publish-request.ts
@@ -169,7 +169,6 @@ async function getPluginSettings(
     )
     .select(["virtual_mcp_plugin_configs.settings as settings"])
     .where("connections.organization_id", "=", orgId)
-    .where("connections.subtype", "=", "project")
     .where("virtual_mcp_plugin_configs.plugin_id", "=", PLUGIN_ID)
     .execute();
 

--- a/apps/mesh/src/tools/registry/utils.ts
+++ b/apps/mesh/src/tools/registry/utils.ts
@@ -36,7 +36,6 @@ export async function getRegistryPluginSettings(
     )
     .select(["virtual_mcp_plugin_configs.settings as settings"])
     .where("connections.organization_id", "=", organizationId)
-    .where("connections.subtype", "=", "project")
     .where("virtual_mcp_plugin_configs.plugin_id", "=", PLUGIN_ID)
     .execute();
 


### PR DESCRIPTION
## What is this contribution about?

The `connections.subtype` column was dropped in migration 055 but two registry queries still referenced it, causing a 500 error when publishing to the mesh registry. This removes the stale `.where("connections.subtype", "=", "project")` clauses from both `getPluginSettings()` and `getRegistryPluginSettings()`.

## How to Test

1. Publish an MCP to the mesh registry (e.g. via the GitHub Actions publish flow)
2. Verify the publish succeeds without a 500 error about `column connections.subtype does not exist`

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove leftover references to the dropped `connections.subtype` column to stop 500 errors when publishing to the mesh registry. Removed the `.where("connections.subtype", "=", "project")` filter from `getPluginSettings()` and `getRegistryPluginSettings()`.

<sup>Written for commit 2209e46a512836dda836dc04d4601d611933504e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

