### PR TITLE
feat(runtime): add serverInfo option to withRuntime

### DIFF
--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -822,7 +822,11 @@ export const createMCPServer = <
 
     const { instructions, ...serverInfoOverrides } = options.serverInfo ?? {};
     const server = new McpServer(
-      { name: "@deco/mcp-api", version: "1.0.0", ...serverInfoOverrides },
+      {
+        ...serverInfoOverrides,
+        name: serverInfoOverrides.name ?? "@deco/mcp-api",
+        version: serverInfoOverrides.version ?? "1.0.0",
+      },
       {
         capabilities: { tools: {}, prompts: {}, resources: {} },
         ...(instructions && { instructions }),


### PR DESCRIPTION
## What is this contribution about?

Adds a `serverInfo` option to `CreateMCPServerOptions` (and by extension `withRuntime`) that lets MCP App authors customize the MCP server metadata and instructions sent to clients during initialization.

The new `serverInfo` field accepts:
- All `Implementation` fields from the MCP SDK (`name`, `version`, `title`, `description`, `websiteUrl`, `icons`) — with sensible defaults for `name` and `version`
- An `instructions` string passed through to `ServerOptions`

Example usage:
```ts
export default withRuntime({
  serverInfo: {
    name: "my-mcp-app",
    description: "A custom MCP app",
    instructions: "You are a site diagnostics agent...",
  },
  tools,
});
```

## Screenshots/Demonstration

N/A — no UI changes.

## How to Test

1. Create an MCP app using `withRuntime` and pass a `serverInfo` object with `instructions` and/or other fields like `name`, `description`
2. Connect an MCP client to the server
3. Verify the `initialize` response includes the custom server info and instructions

## Migration Notes

N/A — additive change, no migration needed.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `serverInfo` option to `CreateMCPServerOptions` (used by `withRuntime`) to customize MCP server metadata and initialization instructions sent to clients. Supports all `Implementation` fields and an `instructions` string, with safe defaults for `name` and `version` using nullish coalescing so undefined values don’t override them.

<sup>Written for commit abc0b1e53ba5f464f4ab945853da7a1990136cb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

