### PR TITLE
fix(docker): switch to debian-slim for glibc (duckdb compatibility)

### DIFF
--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -1,12 +1,17 @@
 # Simplified Dockerfile - uses pre-built npm package
-FROM oven/bun:1-alpine
+# Uses debian-slim (not alpine) because @duckdb/node-bindings requires glibc
+FROM oven/bun:1-slim
 
 # Version to install (override with --build-arg MESH_VERSION=1.0.0)
 ARG MESH_VERSION=latest
 
+# Install runtime dependencies (unzip needed by embedded-postgres)
+RUN apt-get update && apt-get install -y --no-install-recommends unzip && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create non-root user and app directories
-RUN addgroup -g 1001 -S bunapp && \
-    adduser -u 1001 -S -G bunapp bunuser && \
+RUN groupadd -g 1001 bunapp && \
+    useradd -u 1001 -g bunapp -m -s /bin/sh bunuser && \
     mkdir -p /app/data /app/apps/mesh && \
     chown -R bunuser:bunapp /app
 


### PR DESCRIPTION
## What is this contribution about?

The Docker image used `oven/bun:1-alpine` (musl libc), but `@duckdb/node-bindings` ships `libduckdb.so` compiled against glibc. This caused a startup crash (`TypeError: undefined is not an object evaluating 'Y.create'`) for users deploying without `CLICKHOUSE_URL`, since the DuckDB monitoring code path fails to load the native bindings on Alpine.

Switches the base image to `oven/bun:1-slim` (Debian, glibc) and adapts user creation commands accordingly. Image size increases ~23MB (43→66MB).

## How to Test

1. Build the Docker image: `docker build --build-arg MESH_VERSION=2.227.1 -t mesh-test apps/mesh/`
2. Run without `CLICKHOUSE_URL`: `docker run -p 3000:3000 mesh-test`
3. Server should start without crashing — DuckDB monitoring engine initializes successfully

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Docker base from `oven/bun:1-alpine` (musl) to `oven/bun:1-slim` (glibc) so `@duckdb/node-bindings` loads correctly, fixing the DuckDB startup crash when `CLICKHOUSE_URL` is not set. Also install `unzip` for `embedded-postgres` and update user/group creation for Debian; image size increases ~23MB.

<sup>Written for commit bca4e6a9cf91dd32ca2bacc414dc1c78e356818c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

