### PR TITLE
feat(proxy): add granular server timing metrics to MCP proxy

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -28,6 +28,7 @@ import {
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { Context, Hono } from "hono";
+import { endTime, startTime } from "hono/timing";
 import type { MeshContext } from "../../core/mesh-context";
 import { managementMCP } from "../../tools";
 import { handleAuthError } from "./oauth-proxy";
@@ -255,10 +256,12 @@ app.all("/:connectionId", async (c) => {
   try {
     try {
       // Fetch connection
+      startTime(c, "mcp.find_connection");
       const connection = await ctx.storage.connections.findById(
         connectionId,
         ctx.organization?.id,
       );
+      endTime(c, "mcp.find_connection");
       if (!connection) {
         throw new Error("Connection not found");
       }
@@ -287,11 +290,15 @@ app.all("/:connectionId", async (c) => {
       // On success this also warms the per-request client pool, so the
       // lazy client reuses the same connection instead of double-connecting.
       if (connection.connection_url) {
+        startTime(c, "mcp.client_handshake");
         await clientFromConnection(connection, ctx, false);
+        endTime(c, "mcp.client_handshake");
       }
 
       // Create enhanced server directly (no need for bridge - server is used directly!)
+      startTime(c, "mcp.create_server");
       const server = serverFromConnection(connection, ctx, false);
+      endTime(c, "mcp.create_server");
 
       // Create HTTP transport
       const transport = new WebStandardStreamableHTTPServerTransport({
@@ -301,10 +308,15 @@ app.all("/:connectionId", async (c) => {
       });
 
       // Connect server to transport
+      startTime(c, "mcp.server_connect");
       await server.connect(transport);
+      endTime(c, "mcp.server_connect");
 
       // Handle request and cleanup
-      return await transport.handleRequest(c.req.raw);
+      startTime(c, "mcp.handle_request");
+      const response = await transport.handleRequest(c.req.raw);
+      endTime(c, "mcp.handle_request");
+      return response;
     } catch (error) {
       // Check if this is an auth error - if so, return appropriate 401
       // Note: This only applies to HTTP connections


### PR DESCRIPTION
## What is this contribution about?

Adds granular `Server-Timing` sub-metrics to the `/mcp/:connectionId` proxy route. Previously the entire route was measured as a single `mcp` timing, making it hard to identify bottlenecks. Now it breaks down into `mcp.find_connection`, `mcp.client_handshake`, `mcp.create_server`, `mcp.server_connect`, and `mcp.handle_request`.

Server timings are already gated behind `debug=1` cookie in production.

## How to Test

1. Set `debug=1` cookie in browser or pass `-b "debug=1"` via curl
2. Make a request to `/mcp/:connectionId`
3. Check `Server-Timing` response header — you should see the new sub-timings alongside the existing `mcp` timing

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add granular Server-Timing metrics to the `/mcp/:connectionId` proxy so we can pinpoint bottlenecks instead of seeing a single `mcp` timing. This does not change behavior and remains gated behind the `debug=1` cookie in production.

- **New Features**
  - Instrumented with `hono/timing` to capture: `mcp.find_connection`, `mcp.client_handshake`, `mcp.create_server`, `mcp.server_connect`, `mcp.handle_request`.
  - Timings are returned in the `Server-Timing` header when `debug=1` is set.

<sup>Written for commit d0cb745e795dc71d48300e0068e6199ef2301372. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

