### PR TITLE
feat(monitoring): add DISABLE_MONITORING_QUERY to skip dashboard queries

### DIFF
--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -38,6 +38,11 @@ export type PublicConfig = {
    * Controlled by the ENABLE_DECO_IMPORT environment variable.
    */
   enableDecoImport?: boolean;
+  /**
+   * Whether monitoring querying is enabled.
+   * When false, NDJSON data is still exported to disk but dashboard queries are skipped.
+   */
+  monitoringQueryEnabled?: boolean;
 };
 
 /**
@@ -55,6 +60,7 @@ app.get("/", (c) => {
     // Only expose internalUrl in local mode — production uses the public URL directly
     ...(isLocalMode() && { internalUrl: getInternalUrl() }),
     ...(getSettings().enableDecoImport && { enableDecoImport: true }),
+    monitoringQueryEnabled: !getSettings().disableMonitoringQuery,
   };
 
   return c.json({ success: true, config });

--- a/apps/mesh/src/cli/config-view.tsx
+++ b/apps/mesh/src/cli/config-view.tsx
@@ -98,6 +98,7 @@ function getConfigSections(e: Settings): ConfigSection[] {
       entries: [
         { key: "clickhouseUrl", value: e.clickhouseUrl },
         { key: "otelServiceName", value: e.otelServiceName },
+        { key: "disableMonitoringQuery", value: e.disableMonitoringQuery },
       ],
     },
     {

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -21,8 +21,11 @@ import {
   SqlMonitoringStorage,
   type SqlDialect,
 } from "../storage/monitoring-sql";
-import { createMonitoringEngine } from "../monitoring/query-engine";
-import { ClickHouseClientEngine } from "../monitoring/query-engine";
+import {
+  createMonitoringEngine,
+  ClickHouseClientEngine,
+  NoopEngine,
+} from "../monitoring/query-engine";
 import type { QueryEngine } from "../monitoring/query-engine";
 import { getLogsDir, getMetricsDir } from "../monitoring/schema";
 import { OrganizationSettingsStorage } from "../storage/organization-settings";
@@ -834,7 +837,10 @@ export async function createMeshContextFactory(
   let monitoringEngine: QueryEngine;
   let metricEngine: QueryEngine;
 
-  if (isClickHouse) {
+  if (getSettings().disableMonitoringQuery) {
+    monitoringEngine = new NoopEngine();
+    metricEngine = new NoopEngine();
+  } else if (isClickHouse) {
     monitoringEngine = new ClickHouseClientEngine(clickhouseUrl!);
     metricEngine = new ClickHouseClientEngine(clickhouseUrl!);
   } else {

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -128,7 +128,7 @@ export interface MonitoringEngineConfig {
  * No-op engine returned when @duckdb/node-api is unavailable (e.g. CI,
  * environments without the native module). Monitoring queries return empty results.
  */
-class NoopEngine implements QueryEngine {
+export class NoopEngine implements QueryEngine {
   private warned = false;
 
   async query(): Promise<Record<string, unknown>[]> {

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -74,6 +74,7 @@ export function resolveConfig(
     // Observability
     clickhouseUrl: envVars.CLICKHOUSE_URL,
     otelServiceName: envVars.OTEL_SERVICE_NAME || "mesh",
+    disableMonitoringQuery: toBool(envVars.DISABLE_MONITORING_QUERY),
 
     // Config files
     configPath: envVars.CONFIG_PATH || "./config.json",

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -28,6 +28,7 @@ export interface Settings {
   // Observability
   clickhouseUrl: string | undefined;
   otelServiceName: string;
+  disableMonitoringQuery: boolean;
 
   // Event Bus & Networking
   natsUrls: string[];

--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -67,6 +67,7 @@ import { Label } from "@deco/ui/components/label.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 
+import { usePublicConfig } from "@/web/hooks/use-public-config.ts";
 import { OverviewTabContent, OverviewTabSkeleton } from "./overview.tsx";
 import { AuditTabContent, MonitoringLogsTable } from "./audit.tsx";
 import { ThreadsTabContent, ThreadsFiltersPopover } from "./threads.tsx";
@@ -556,6 +557,9 @@ function MonitoringDashboardContent({
   onStreamingToggle,
   onTabChange,
 }: MonitoringDashboardContentProps) {
+  const publicConfig = usePublicConfig();
+  const monitoringQueryEnabled = publicConfig.monitoringQueryEnabled !== false;
+
   const allConnections = useConnections();
   const allVirtualMcps = useVirtualMCPs();
   const { data: membersData } = useMembers();
@@ -757,7 +761,23 @@ function MonitoringDashboardContent({
         </div>
       </Page.Body>
 
-      {tab === "threads" ? (
+      {!monitoringQueryEnabled ? (
+        <div className="flex-1 flex items-center justify-center">
+          <EmptyState
+            image={
+              <img
+                src="/empty-state-logs.svg"
+                alt=""
+                width={336}
+                height={320}
+                aria-hidden="true"
+              />
+            }
+            title="Monitoring is not available"
+            description="Monitoring is not enabled for this instance. Contact your administrator for more information."
+          />
+        </div>
+      ) : tab === "threads" ? (
         <ThreadsTabContent
           client={client}
           locator={locator}


### PR DESCRIPTION
## What is this contribution about?

Adds a `DISABLE_MONITORING_QUERY` env var that disables monitoring querying while keeping NDJSON data export to disk. When set to `true`, the monitoring engines are replaced with a NoopEngine (returns empty results), and the dashboard shows a clean "Monitoring is not available" empty state. This takes precedence over `CLICKHOUSE_URL` — useful for testing production behavior without a ClickHouse instance.

## How to Test

1. Set `DISABLE_MONITORING_QUERY=true` in your environment
2. Start the dev server with `bun run dev`
3. Navigate to the Monitoring dashboard — should show a centered empty state with "Monitoring is not available"
4. Verify NDJSON files are still being written to `~/deco/`
5. Remove the env var and restart — dashboard should work normally again

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `DISABLE_MONITORING_QUERY` to turn off monitoring queries while still exporting NDJSON to disk. When enabled, the UI shows “Monitoring is not available” and this overrides `CLICKHOUSE_URL`.

- **New Features**
  - New `DISABLE_MONITORING_QUERY` env var (mapped to `disableMonitoringQuery` in settings).
  - Uses `NoopEngine` for monitoring/metrics when disabled; NDJSON export continues.
  - Exposes `monitoringQueryEnabled` in public config and shows a clean empty state in the dashboard.
  - CLI config view now lists `disableMonitoringQuery`.

<sup>Written for commit a1c7bc0b262ab2c7bec704c75fc1f30ef20ff12c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

