### PR TITLE
fix(monitoring): allow threads tab when query is disabled

### DIFF
--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -761,7 +761,20 @@ function MonitoringDashboardContent({
         </div>
       </Page.Body>
 
-      {!monitoringQueryEnabled ? (
+      {tab === "threads" ? (
+        <ThreadsTabContent
+          client={client}
+          locator={locator}
+          membersData={membersData}
+          allConnections={allConnections}
+          allVirtualMcps={allVirtualMcps}
+          dateRange={dateRange}
+          searchQuery={searchQuery}
+          filterAgentIds={threadFilterAgentIds}
+          filterUserIds={threadFilterUserIds}
+          filterStatus={threadFilterStatus}
+        />
+      ) : !monitoringQueryEnabled ? (
         <div className="flex-1 flex items-center justify-center">
           <EmptyState
             image={
@@ -777,19 +790,6 @@ function MonitoringDashboardContent({
             description="Monitoring is not enabled for this instance. Contact your administrator for more information."
           />
         </div>
-      ) : tab === "threads" ? (
-        <ThreadsTabContent
-          client={client}
-          locator={locator}
-          membersData={membersData}
-          allConnections={allConnections}
-          allVirtualMcps={allVirtualMcps}
-          dateRange={dateRange}
-          searchQuery={searchQuery}
-          filterAgentIds={threadFilterAgentIds}
-          filterUserIds={threadFilterUserIds}
-          filterStatus={threadFilterStatus}
-        />
       ) : tab === "audit" ? (
         <AuditTabContent
           client={client}


### PR DESCRIPTION
## What is this contribution about?

Threads tab uses Postgres collections (`COLLECTION_THREADS_LIST`), not the monitoring engines. The empty state from #2975 was blocking all three tabs — this fix only blocks overview and audit, keeping threads accessible.

## How to Test

1. Set `DISABLE_MONITORING_QUERY=true`
2. Navigate to Monitoring dashboard
3. Overview and Audit tabs should show "Monitoring is not available"
4. Threads tab should work normally

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow disabling monitoring queries via `DISABLE_MONITORING_QUERY` without blocking the Threads tab. Overview and Audit now show “Monitoring is not enabled” when queries are disabled.

- **New Features**
  - Added `DISABLE_MONITORING_QUERY`; when set, use a `NoopEngine` to skip queries, keep NDJSON export, and override `CLICKHOUSE_URL`.
  - Exposed `monitoringQueryEnabled` in public config for the web app to gate tabs.
  - UI shows an empty state for Overview and Audit when disabled.

- **Bug Fixes**
  - Render Threads tab regardless of `monitoringQueryEnabled`; only gate Overview and Audit.

<sup>Written for commit 0268068f349047052c01f695f9ad7bd53664e4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

