### PR TITLE
fix(decopilot): make model title optional in stream request

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/schemas.ts
@@ -36,7 +36,7 @@ const ProviderSchema = ProviderEnum.optional().nullable();
 
 const ModelInfoSchema = z.object({
   id: z.string(),
-  title: z.string(),
+  title: z.string().optional(),
   capabilities: z
     .object({
       vision: z.boolean().optional(),

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -807,6 +807,8 @@ async function streamCoreInner(
                   credentialId: input.models.credentialId,
                   thinking: {
                     ...input.models.thinking,
+                    title:
+                      input.models.thinking.title ?? input.models.thinking.id,
                     provider: input.models.thinking.provider ?? undefined,
                   },
                 },

--- a/apps/mesh/src/api/routes/decopilot/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/types.ts
@@ -50,7 +50,7 @@ export type ChatMessage = UIMessage<
 
 export interface ModelInfo {
   id: string;
-  title: string;
+  title?: string;
   capabilities?: {
     vision?: boolean;
     text?: boolean;


### PR DESCRIPTION
## What is this contribution about?

The frontend sends `models.thinking` without a `title` field, causing Zod validation to reject the request with `invalid_type: expected string, received undefined` at path `models.thinking.title`. This makes `title` optional in the schema, interface, and defaults it to the model `id` in the metadata callback — consistent with how the persisted schema and all other usages already handle it.

## How to Test

1. Send a decopilot stream request with `models.thinking` containing only `{ "id": "anthropic/claude-opus-4.6" }` (no `title`)
2. The request should succeed instead of returning a validation error
3. The model title in message metadata should fall back to the model id

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `models.thinking.title` optional in Decopilot stream requests to match the persisted schema and frontend behavior. Requests without a title no longer fail validation; we now fall back to the model id in message metadata.

- **Bug Fixes**
  - Marked `title` optional in the request Zod schema.
  - Updated `ModelInfo` to `title?`.
  - Default `title = id` during stream processing.

<sup>Written for commit e45e3c9caf21b60eea57af79fec57ae65753fd2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

