### PR TITLE
fix(runtime): close MCP transport after streaming responses + cache tool resolution

### DIFF
--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -817,52 +817,118 @@ export const createMCPServer = <
 >(
   options: CreateMCPServerOptions<TEnv, TSchema, TBindings>,
 ): MCPServer<TEnv, TSchema, TBindings> => {
-  const createServer = async (bindings: TEnv) => {
-    await options.before?.(bindings);
+  // Tool/prompt/resource definitions are resolved once on first request and
+  // cached for the lifetime of the process. Tool *execution* reads per-request
+  // context from State (AsyncLocalStorage), so reusing definitions is safe.
+  type Registrations = {
+    tools: CreatedTool[];
+    prompts: CreatedPrompt[];
+    resources: CreatedResource[];
+    workflows?: WorkflowDefinition[];
+  };
 
-    const { instructions, ...serverInfoOverrides } = options.serverInfo ?? {};
-    const server = new McpServer(
-      {
-        ...serverInfoOverrides,
-        name: serverInfoOverrides.name ?? "@deco/mcp-api",
-        version: serverInfoOverrides.version ?? "1.0.0",
-      },
-      {
-        capabilities: { tools: {}, prompts: {}, resources: {} },
-        ...(instructions && { instructions }),
-      },
-    );
+  let cached: Registrations | null = null;
+  let inflightResolve: Promise<Registrations> | null = null;
 
-    const toolsFn =
-      typeof options.tools === "function"
-        ? options.tools
-        : async (bindings: TEnv) => {
-            if (typeof options.tools === "function") {
-              return await options.tools(bindings);
-            }
-            return await Promise.all(
-              options.tools?.flatMap(async (tool) => {
-                const toolResult = tool(bindings);
-                const awaited = await toolResult;
-                if (Array.isArray(awaited)) {
-                  return awaited;
+  const resolveRegistrations = async (
+    bindings: TEnv,
+  ): Promise<Registrations> => {
+    if (cached) return cached;
+    if (inflightResolve) return inflightResolve;
+
+    inflightResolve = (async (): Promise<Registrations> => {
+      try {
+        const toolsFn =
+          typeof options.tools === "function"
+            ? options.tools
+            : async (bindings: TEnv) => {
+                if (typeof options.tools === "function") {
+                  return await options.tools(bindings);
                 }
-                return [awaited];
-              }) ?? [],
-            ).then((t) => t.flat());
-          };
-    const tools = await toolsFn(bindings);
+                return await Promise.all(
+                  options.tools?.flatMap(async (tool) => {
+                    const toolResult = tool(bindings);
+                    const awaited = await toolResult;
+                    if (Array.isArray(awaited)) {
+                      return awaited;
+                    }
+                    return [awaited];
+                  }) ?? [],
+                ).then((t) => t.flat());
+              };
+        const tools = await toolsFn(bindings);
 
-    const resolvedWorkflows =
-      typeof options.workflows === "function"
-        ? await options.workflows(bindings)
-        : options.workflows;
+        const resolvedWorkflows =
+          typeof options.workflows === "function"
+            ? await options.workflows(bindings)
+            : options.workflows;
 
-    tools.push(
-      ...toolsFor<TSchema>({ ...options, workflows: resolvedWorkflows }),
-    );
+        tools.push(
+          ...toolsFor<TSchema>({ ...options, workflows: resolvedWorkflows }),
+        );
 
-    for (const tool of tools) {
+        const promptsFn =
+          typeof options.prompts === "function"
+            ? options.prompts
+            : async (bindings: TEnv) => {
+                if (typeof options.prompts === "function") {
+                  return await options.prompts(bindings);
+                }
+                return await Promise.all(
+                  options.prompts?.flatMap(async (prompt) => {
+                    const promptResult = prompt(bindings);
+                    const awaited = await promptResult;
+                    if (Array.isArray(awaited)) {
+                      return awaited;
+                    }
+                    return [awaited];
+                  }) ?? [],
+                ).then((p) => p.flat());
+              };
+        const prompts = await promptsFn(bindings);
+
+        const resourcesFn =
+          typeof options.resources === "function"
+            ? options.resources
+            : async (bindings: TEnv) => {
+                if (typeof options.resources === "function") {
+                  return await options.resources(bindings);
+                }
+                return await Promise.all(
+                  options.resources?.flatMap(async (resource) => {
+                    const resourceResult = resource(bindings);
+                    const awaited = await resourceResult;
+                    if (Array.isArray(awaited)) {
+                      return awaited;
+                    }
+                    return [awaited];
+                  }) ?? [],
+                ).then((r) => r.flat());
+              };
+        const resources = await resourcesFn(bindings);
+
+        const result = {
+          tools,
+          prompts,
+          resources,
+          workflows: resolvedWorkflows,
+        };
+        cached = result;
+        return result;
+      } catch (err) {
+        inflightResolve = null;
+        throw err;
+      }
+    })();
+
+    return inflightResolve;
+  };
+
+  const registerAll = (
+    server: McpServer,
+    registrations: Registrations,
+  ) => {
+    for (const tool of registrations.tools) {
       server.registerTool(
         tool.id,
         {
@@ -890,9 +956,8 @@ export const createMCPServer = <
             runtimeContext: createRuntimeContext(),
           });
 
-          // For streamable tools, the Response is handled at the transport layer
-          // Do NOT call result.bytes() - it buffers the entire response in memory
-          // causing massive memory leaks (2GB+ Uint8Array accumulation)
+          // For streamable tools, the Response is handled at the transport layer.
+          // Do NOT call result.bytes() — it buffers the entire body in memory.
           if (isStreamableTool(tool) && result instanceof Response) {
             return {
               structuredContent: {
@@ -921,28 +986,7 @@ export const createMCPServer = <
       );
     }
 
-    // Resolve and register prompts
-    const promptsFn =
-      typeof options.prompts === "function"
-        ? options.prompts
-        : async (bindings: TEnv) => {
-            if (typeof options.prompts === "function") {
-              return await options.prompts(bindings);
-            }
-            return await Promise.all(
-              options.prompts?.flatMap(async (prompt) => {
-                const promptResult = prompt(bindings);
-                const awaited = await promptResult;
-                if (Array.isArray(awaited)) {
-                  return awaited;
-                }
-                return [awaited];
-              }) ?? [],
-            ).then((p) => p.flat());
-          };
-    const prompts = await promptsFn(bindings);
-
-    for (const prompt of prompts) {
+    for (const prompt of registrations.prompts) {
       server.registerPrompt(
         prompt.name,
         {
@@ -961,28 +1005,7 @@ export const createMCPServer = <
       );
     }
 
-    // Resolve and register resources
-    const resourcesFn =
-      typeof options.resources === "function"
-        ? options.resources
-        : async (bindings: TEnv) => {
-            if (typeof options.resources === "function") {
-              return await options.resources(bindings);
-            }
-            return await Promise.all(
-              options.resources?.flatMap(async (resource) => {
-                const resourceResult = resource(bindings);
-                const awaited = await resourceResult;
-                if (Array.isArray(awaited)) {
-                  return awaited;
-                }
-                return [awaited];
-              }) ?? [],
-            ).then((r) => r.flat());
-          };
-    const resources = await resourcesFn(bindings);
-
-    for (const resource of resources) {
+    for (const resource of registrations.resources) {
       server.resource(
         resource.name,
         resource.uri,
@@ -995,19 +1018,7 @@ export const createMCPServer = <
             uri,
             runtimeContext: createRuntimeContext(),
           });
-          // Build content object based on what's provided (text or blob, not both)
-          const content: {
-            uri: string;
-            mimeType?: string;
-            text?: string;
-            blob?: string;
-          } = { uri: result.uri };
 
-          if (result.mimeType) {
-            content.mimeType = result.mimeType;
-          }
-
-          // MCP SDK expects either text or blob content, not both
           const meta =
             (result as { _meta?: Record<string, unknown> | null })._meta ??
             undefined;
@@ -1035,7 +1046,6 @@ export const createMCPServer = <
             };
           }
 
-          // Fallback to empty text if neither provided
           return {
             contents: [
               { uri: result.uri, mimeType: result.mimeType, text: "" },
@@ -1044,8 +1054,28 @@ export const createMCPServer = <
         },
       );
     }
+  };
 
-    return { server, tools, prompts, resources };
+  const createServer = async (bindings: TEnv) => {
+    await options.before?.(bindings);
+
+    const { instructions, ...serverInfoOverrides } = options.serverInfo ?? {};
+    const server = new McpServer(
+      {
+        ...serverInfoOverrides,
+        name: serverInfoOverrides.name ?? "@deco/mcp-api",
+        version: serverInfoOverrides.version ?? "1.0.0",
+      },
+      {
+        capabilities: { tools: {}, prompts: {}, resources: {} },
+        ...(instructions && { instructions }),
+      },
+    );
+
+    const registrations = await resolveRegistrations(bindings);
+    registerAll(server, registrations);
+
+    return { server, ...registrations };
   };
 
   const fetch = async (req: Request, env: TEnv) => {
@@ -1054,34 +1084,45 @@ export const createMCPServer = <
 
     await server.connect(transport);
 
+    const cleanup = () => {
+      try {
+        transport.close?.();
+      } catch {
+        /* ignore */
+      }
+      try {
+        server.close?.();
+      } catch {
+        /* ignore */
+      }
+    };
+
     try {
       const response = await transport.handleRequest(req);
 
-      // Check if this is a streaming response (SSE or streamable tool)
-      // SSE responses have text/event-stream content-type
-      // Note: response.body is always non-null for all HTTP responses, so we can't use it to detect streaming
       const contentType = response.headers.get("content-type");
       const isStreaming =
         contentType?.includes("text/event-stream") ||
         contentType?.includes("application/json-rpc");
 
-      // Only close transport for non-streaming responses
-      if (!isStreaming) {
-        try {
-          await transport.close?.();
-        } catch {
-          // Ignore close errors
-        }
+      if (!isStreaming || !response.body) {
+        cleanup();
+        return response;
       }
 
-      return response;
+      // Pipe the SSE body through a passthrough so that when the stream
+      // finishes (server sent the response) or the client disconnects
+      // (cancel), the server and transport are always cleaned up.
+      const { readable, writable } = new TransformStream();
+      response.body.pipeTo(writable).catch(() => {}).finally(cleanup);
+
+      return new Response(readable, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
     } catch (error) {
-      // On error, always try to close transport to prevent leaks
-      try {
-        await transport.close?.();
-      } catch {
-        // Ignore close errors
-      }
+      cleanup();
       throw error;
     }
   };
@@ -1092,7 +1133,9 @@ export const createMCPServer = <
       throw new Error("Missing state, did you forget to call State.bind?");
     }
     const env = currentState?.env;
-    const { tools } = await createServer(env as TEnv & DefaultEnv<TSchema>);
+    const { tools } = await resolveRegistrations(
+      env as TEnv & DefaultEnv<TSchema>,
+    );
     const tool = tools.find((t) => t.id === toolCallId);
     const execute = tool?.execute;
     if (!execute) {


### PR DESCRIPTION
## Summary

Fixes OOMKilled crashes on MCP servers (observed on `sites-vtex` / vtex-mcp) caused by two issues in `createMCPServer`:

- **Streaming SSE responses never cleaned up server/transport** — each `POST /mcp` that returns `text/event-stream` created a `McpServer` + `HttpServerTransport`, connected them, and then deliberately kept them alive. After the MCP SDK sent the response and closed the SSE stream controller, neither `transport.close()` nor `server.close()` were called, so the full object graph (Protocol with 7+ Maps, registered tools with schema closures, transport stream mappings) was retained until the process was killed. At the observed request rate (~multiple/sec), this leaked ~28 MB/min → OOM at 512Mi in ~18 min, at 1Gi in ~35 min.

- **Tool/prompt/resource resolution repeated on every request** — `createServer(env)` called tool factory functions, resolved workflows, parsed Zod schemas, and registered everything on a fresh `McpServer` for every single HTTP request. Tool *execution* already reads per-request context from `State` (AsyncLocalStorage), so these definitions are identical across requests.

### Changes

1. **Streaming cleanup via pipeTo().finally()**: SSE response bodies are piped through a `TransformStream`. When the stream completes normally (server sent response) or the client disconnects (cancel), the `finally` callback closes both transport and server. Non-streaming responses (202 notifications, 405/406 rejections) are closed immediately as before.

2. **Cached registrations**: tool, prompt, and resource factories are resolved once on the first request and reused. Concurrent first-call resolution is deduplicated via an inflight promise. On failure, the cache is cleared to allow retry. The `McpServer` instance is still created per-request (SDK constraint: one transport per server), but the expensive async resolution is amortized.

3. **callTool() uses cache directly**: the `/mcp/call-tool/*` endpoint now reads from cached tool definitions instead of creating a throwaway `McpServer`.

### What stays per-request (by design)

| Component | Lifecycle | Why |
|---|---|---|
| McpServer instance | Per-request | SDK requires one transport per server instance |
| HttpServerTransport | Per-request | SDK stateless mode: one request per transport |
| options.before?.(bindings) | Per-request | User hook for per-request setup |
| withBindings() / binding proxies | Per-request | Auth tokens differ per request |
| Tool execution context | Per-request | createRuntimeContext() reads from AsyncLocalStorage |

## Test plan

- [ ] Deploy to a staging MCP server and verify memory stays flat under sustained load
- [ ] Verify streaming tool calls (SSE responses) complete and clean up
- [ ] Verify non-streaming responses (notifications, errors) still work
- [ ] Verify callTool direct endpoint (/mcp/call-tool/*) works
- [ ] Monitor for any regressions in tool discovery (tools/list)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OOM crashes in the MCP runtime by cleaning up streaming responses and caching tool/prompt/resource resolution to avoid repeated work per request.

- **Bug Fixes**
  - Always close `McpServer` and transport after streaming (`text/event-stream` / `application/json-rpc`) via `TransformStream.pipeTo(...).finally(...)`.
  - Keep immediate cleanup for non-streaming responses and on errors.
  - Prevents unbounded memory growth during sustained SSE traffic.

- **Refactors**
  - Cache tool, prompt, and resource registrations on first request with in-flight dedupe; reuse across requests.
  - Still create a fresh `McpServer` and transport per request (SDK constraint).
  - Update `/mcp/call-tool/*` to read from the cache directly.

<sup>Written for commit d35b01f4add9d6d26e563491b18c5aed56f4ae3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

