### PR TITLE
fix(monitoring): silence NoopEngine warning when query is disabled

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -838,8 +838,8 @@ export async function createMeshContextFactory(
   let metricEngine: QueryEngine;
 
   if (getSettings().disableMonitoringQuery) {
-    monitoringEngine = new NoopEngine();
-    metricEngine = new NoopEngine();
+    monitoringEngine = new NoopEngine({ silent: true });
+    metricEngine = new NoopEngine({ silent: true });
   } else if (isClickHouse) {
     monitoringEngine = new ClickHouseClientEngine(clickhouseUrl!);
     metricEngine = new ClickHouseClientEngine(clickhouseUrl!);

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -130,9 +130,14 @@ export interface MonitoringEngineConfig {
  */
 export class NoopEngine implements QueryEngine {
   private warned = false;
+  private silent: boolean;
+
+  constructor(options?: { silent?: boolean }) {
+    this.silent = options?.silent ?? false;
+  }
 
   async query(): Promise<Record<string, unknown>[]> {
-    if (!this.warned) {
+    if (!this.warned && !this.silent) {
       this.warned = true;
       console.warn(
         "\n⚠️  WARNING: Monitoring query skipped — @duckdb/node-api native module is not available.\n" +


### PR DESCRIPTION
## What is this contribution about?

When `DISABLE_MONITORING_QUERY=true` is set, the `NoopEngine` was still emitting a misleading warning about `@duckdb/node-api` not being available on the first query. The actual reason monitoring is disabled is the env var, not a missing native module. This adds a `silent` option to `NoopEngine` and uses it when monitoring is intentionally disabled via config.

## How to Test
1. Deploy with `DISABLE_MONITORING_QUERY=true`
2. Trigger a monitoring query (e.g. open the dashboard)
3. Confirm no `@duckdb/node-api native module is not available` warning in logs

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences misleading `NoopEngine` warnings when monitoring is disabled, so logs don’t claim `@duckdb/node-api` is missing. Adds a `silent` option to `NoopEngine` and enables it when `DISABLE_MONITORING_QUERY=true`.

- **Bug Fixes**
  - Added `silent` flag to `NoopEngine` to suppress the first-run warning when monitoring is intentionally disabled.
  - Create `NoopEngine({ silent: true })` for monitoring and metrics in the context factory when `disableMonitoringQuery` is set.

<sup>Written for commit dbfce00db692960037ae250cced31a40d1a381b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

