### PR TITLE
fix(registry): push filtering, sorting, and pagination to SQL

### DIFF
--- a/apps/mesh/src/storage/registry/registry-item.ts
+++ b/apps/mesh/src/storage/registry/registry-item.ts
@@ -142,7 +142,7 @@ function applyRegistryWhereToSql(
       case "or":
         return sql<SqlBool>`(${sql.join(parts, sql` OR `)})`;
       case "not":
-        return sql<SqlBool>`NOT (${sql.join(parts, sql` AND `)})`;
+        return sql<SqlBool>`NOT (${sql.join(parts, sql` OR `)})`;
       default:
         return sql<SqlBool>`true`;
     }


### PR DESCRIPTION
## What is this contribution about?

Moves registry `list` and `listPublic` from in-memory filtering, sorting, and pagination to SQL-level `WHERE` clauses, `ORDER BY`, and `LIMIT`/`OFFSET`. Previously, all rows were fetched into memory and then filtered/sorted/paginated in JS — this doesn't scale as registries grow.

Key changes:
- Tags and categories filtering now uses SQL `LIKE` patterns against the CSV columns
- `RegistryWhereExpression` tree is translated into a Kysely `RawBuilder<SqlBool>` for database-level evaluation (supports nested AND/OR/NOT, all comparison operators, JSON column traversal)
- Official/verified sorting uses a SQL `CASE` expression instead of in-memory sort
- `totalCount` is computed via a `COUNT(*)` subquery before applying `LIMIT`/`OFFSET`
- Removes now-unused helpers: `sortByOfficialAndVerified`, `getPathValue`, `compareExpression`, `evaluateWhere`

## How to Test

1. Start dev server with `bun run dev`
2. Open the registry and verify listing, filtering by tags/categories, and pagination all work correctly
3. Test with `where` expressions (eq, contains, in, etc.) via the MCP tools
4. Verify official/verified items still appear first in results

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move registry list and listPublic filtering, sorting, and pagination into SQL to remove in-memory work and scale better. Improves latency and memory use on large registries without changing results.

- **Refactors**
  - Push tag/category filters to SQL using CSV `LIKE` checks.
  - Translate `RegistryWhereExpression` into `kysely` SQL with AND/OR/NOT, comparisons, JSON path access, and boolean→int handling.
  - Order by official/verified via SQL `CASE`, then `created_at desc`.
  - Compute `totalCount` with a `COUNT(*)` subquery before `LIMIT/OFFSET`.
  - Apply pagination in SQL and return `nextCursor` based on total count.
  - Remove unused helpers: `sortByOfficialAndVerified`, `getPathValue`, `compareExpression`, `evaluateWhere`.

- **Bug Fixes**
  - Correct NOT operator semantics in the SQL where builder to match prior logic: NOT(c1 OR c2 …).

<sup>Written for commit 520b0e9a14e31b840249adc9ae4355ef906b21bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

