### PR TITLE
fix(web): wrap no-org fallback in SidebarProvider

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -878,14 +878,16 @@ function ShellLayoutContent() {
 
   if (!activeOrg) {
     return (
-      <div className="min-h-screen bg-background">
-        <header className="h-12 flex items-center justify-end px-4 border-b border-border">
-          <div className="w-fit">
-            <MeshUserMenu />
-          </div>
-        </header>
-        <Outlet />
-      </div>
+      <SidebarProvider>
+        <div className="min-h-screen bg-background">
+          <header className="h-12 flex items-center justify-end px-4 border-b border-border">
+            <div className="w-fit">
+              <MeshUserMenu />
+            </div>
+          </header>
+          <Outlet />
+        </div>
+      </SidebarProvider>
     );
   }
 


### PR DESCRIPTION
## What is this contribution about?

Fixes a crash on the `/` route caused by `MeshUserMenu` using `SidebarMenuButton`, which internally calls `useSidebar()`. The early return path in `ShellLayoutContent` (when no active org exists) was missing a `SidebarProvider` ancestor, causing the error: `useSidebar must be used within a SidebarProvider`. This wraps that fallback UI in a `SidebarProvider`.

## How to Test

1. Navigate to the `/` route (homepage) without an active organization
2. Verify the page renders without errors
3. Verify the user menu in the top-right corner works correctly

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on `/` when no active org is selected by wrapping the no-org fallback UI in `SidebarProvider`. This ensures `MeshUserMenu` (via `SidebarMenuButton` → `useSidebar()`) has a provider, so the homepage and user menu render without errors.

<sup>Written for commit a254ed30337ae171bc788ad27cd1e38763c40d3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

