### PR TITLE
fix(connections): deduplicate search results

### DIFF
--- a/apps/mesh/src/web/hooks/use-merged-store-discovery.ts
+++ b/apps/mesh/src/web/hooks/use-merged-store-discovery.ts
@@ -55,6 +55,23 @@ function isCommunityRegistry(registry: RegistrySource): boolean {
 }
 
 /**
+ * Build a where expression for server-side search on registry items.
+ */
+function buildRegistrySearchWhere(
+  search: string | undefined,
+): Record<string, unknown> | undefined {
+  const trimmed = search?.trim();
+  if (!trimmed) return undefined;
+  return {
+    operator: "or",
+    conditions: [
+      { field: ["title"], operator: "contains", value: trimmed },
+      { field: ["description"], operator: "contains", value: trimmed },
+    ],
+  };
+}
+
+/**
  * Fetches a page from a group of registries in parallel.
  * Each registry tracks its own cursor independently.
  */
@@ -62,15 +79,18 @@ function useRegistryGroupQuery(
   registries: RegistrySource[],
   orgId: string,
   enabled: boolean,
+  search?: string,
 ) {
   const groupKey = registries
     .map((r) => r.id)
     .sort()
     .join(",");
 
+  const where = buildRegistrySearchWhere(search);
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteQuery({
-      queryKey: KEYS.storeDiscovery(orgId, groupKey),
+      queryKey: KEYS.storeDiscovery(orgId, `${groupKey}:${search ?? ""}`),
       queryFn: async ({ pageParam }): Promise<RegistryPageResult[]> => {
         const cursors: PageParam = pageParam ?? {};
 
@@ -103,6 +123,9 @@ function useRegistryGroupQuery(
                 const params: Record<string, unknown> = { limit: PAGE_SIZE };
                 if (cursor) {
                   params.cursor = cursor;
+                }
+                if (where) {
+                  params.where = where;
                 }
 
                 const result = (await client.callTool({
@@ -212,6 +235,7 @@ function useRegistryGroupQuery(
 
 export function useMergedStoreDiscovery(
   registries: RegistrySource[],
+  search?: string,
 ): MergedDiscoveryResult {
   const { org } = useProjectContext();
 
@@ -221,7 +245,12 @@ export function useMergedStoreDiscovery(
   const communityRegistries = registries.filter((r) => isCommunityRegistry(r));
 
   // Query 1: all non-community registries in parallel (always enabled)
-  const ncQuery = useRegistryGroupQuery(nonCommunityRegistries, org.id, true);
+  const ncQuery = useRegistryGroupQuery(
+    nonCommunityRegistries,
+    org.id,
+    true,
+    search,
+  );
 
   // Query 2: community registries, deferred until non-community is exhausted
   const allNonCommunityExhausted =
@@ -230,21 +259,22 @@ export function useMergedStoreDiscovery(
     communityRegistries,
     org.id,
     allNonCommunityExhausted,
+    search,
   );
 
-  // Stable key to detect registry list changes and reset committed items
-  const registryKey = registries
+  // Stable key to detect registry list or search changes and reset committed items
+  const stableKey = `${registries
     .map((r) => r.id)
     .sort()
-    .join(",");
-  const prevRegistryKeyRef = useRef(registryKey);
+    .join(",")}:${search ?? ""}`;
+  const prevStableKeyRef = useRef(stableKey);
   const committedItemsRef = useRef<RegistryItem[]>([]);
   const seenIdsRef = useRef<Set<string>>(new Set());
 
-  if (prevRegistryKeyRef.current !== registryKey) {
+  if (prevStableKeyRef.current !== stableKey) {
     committedItemsRef.current = [];
     seenIdsRef.current = new Set();
-    prevRegistryKeyRef.current = registryKey;
+    prevStableKeyRef.current = stableKey;
   }
 
   // Collect all available items in priority order

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -1002,9 +1002,12 @@ function OrgMcpsContent() {
     setSelectedIds(new Set());
   };
 
-  // Registry / catalog - merge all enabled registries
+  // Registry / catalog - merge all enabled registries (server-side search)
   const enabledRegistries = useEnabledRegistries();
-  const mergedDiscovery = useMergedStoreDiscovery(enabledRegistries);
+  const mergedDiscovery = useMergedStoreDiscovery(
+    enabledRegistries,
+    listState.searchTerm,
+  );
   const registryItems = mergedDiscovery.items;
 
   const catalogSentinelRef = useInfiniteScroll(
@@ -1029,7 +1032,7 @@ function OrgMcpsContent() {
   const catalogItems =
     activeTab === "all" || searchLower
       ? registryItems.filter((item) => {
-          // Registry filter
+          // Registry source filter
           if (
             effectiveRegistryFilter !== "ALL" &&
             item._registryId !== effectiveRegistryFilter
@@ -1042,32 +1045,7 @@ function OrgMcpsContent() {
             const appName = item.server?.name || item.name || item.id || "";
             if (connectedAppNames.has(appName)) return false;
           }
-          if (!searchLower) return true;
-          const meshMeta = item._meta?.["mcp.mesh"] as
-            | Record<string, string>
-            | undefined;
-          const title = [
-            meshMeta?.friendly_name,
-            item.server?.name,
-            item.server?.title,
-            item.name,
-            item.title,
-            item.id,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          const desc = [
-            meshMeta?.short_description,
-            meshMeta?.mesh_description,
-            item.server?.description,
-            item.description,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return (
-            title.toLowerCase().includes(searchLower) ||
-            desc.toLowerCase().includes(searchLower)
-          );
+          return true;
         })
       : [];
 

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -253,9 +253,12 @@ function AddConnectionDialogContent({
     ) ?? [];
   const grouped = groupConnections(allConnections);
 
-  // Registry / catalog - merge all enabled registries (same as connections page)
+  // Registry / catalog - merge all enabled registries (server-side search)
   const enabledRegistries = useEnabledRegistries();
-  const mergedDiscovery = useMergedStoreDiscovery(enabledRegistries);
+  const mergedDiscovery = useMergedStoreDiscovery(
+    enabledRegistries,
+    deferredSearch,
+  );
 
   const catalogSentinelRef = useInfiniteScroll(
     mergedDiscovery.loadMore,
@@ -276,32 +279,12 @@ function AddConnectionDialogContent({
   const catalogItems =
     activeTab === "all" || searchLower
       ? mergedDiscovery.items.filter((item: RegistryItem) => {
-          if (!searchLower) return true;
-          const meshMeta = item._meta?.["mcp.mesh"] as
-            | Record<string, string>
-            | undefined;
-          const title = [
-            meshMeta?.friendly_name,
-            item.server?.name,
-            item.server?.title,
-            item.name,
-            item.title,
-            item.id,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          const desc = [
-            meshMeta?.short_description,
-            meshMeta?.mesh_description,
-            item.server?.description,
-            item.description,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return (
-            title.toLowerCase().includes(searchLower) ||
-            desc.toLowerCase().includes(searchLower)
-          );
+          // When searching, connected items are already shown via groupedForDisplay
+          if (searchLower) {
+            const appName = item.server?.name || item.name || item.id || "";
+            if (connectedAppNames.has(appName)) return false;
+          }
+          return true;
         })
       : [];
 


### PR DESCRIPTION
## Summary
- When searching on the connections settings page, connected items were appearing twice: once from the DB query (groupedForDisplay) and once from the registry catalog
- Added a filter to exclude already-connected items from catalog results during search

## Test plan
- [ ] Search for a connected app (e.g. "gmail") on `/settings/connections` — verify no duplicate cards
- [ ] Verify "All" tab without search still shows catalog items with "Connected" badge as before
- [ ] Verify "Connected" tab still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate cards when searching in `/settings/connections` and the Add Connection dialog. Moves registry search server-side and excludes already-connected apps from catalog results so each app shows once.

- **Bug Fixes**
  - Run text search server-side in registry tools and reset pagination when the search term changes.
  - Remove client-side text filtering in both views to avoid incomplete results.
  - Exclude connected apps from catalog items only during search; the "All" tab still shows a "Connected" badge, and the "Connected" tab is unchanged.

<sup>Written for commit 4f6eabc0082c5e324613f866886322db85072964. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

