### PR TITLE
fix(chat): navigate to agent route when selecting from input button

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -366,18 +366,25 @@ export function ChatInput({
   const { messages, isStreaming, isRunInProgress, sendMessage, stop } =
     useChatStream();
   const { taskId, tasks } = useChatTask();
-  const {
-    selectedModel,
-    selectedVirtualMcp,
-    setVirtualMcpId,
-    isModelsLoading,
-    tiptapDocRef,
-  } = useChatPrefs();
+  const { selectedModel, selectedVirtualMcp, isModelsLoading, tiptapDocRef } =
+    useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
+  const navigate = useNavigate();
   const { org } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+
+  // Navigate to the agent route (like the sidebar does) instead of only
+  // setting an ephemeral search-param override, so the thread list re-scopes.
+  const handleAgentChange = (virtualMcpId: string | null) => {
+    if (virtualMcpId) {
+      navigate({
+        to: "/$org/$virtualMcpId/",
+        params: { org: org.slug, virtualMcpId },
+      });
+    }
+  };
 
   const task = tasks.find((task) => task.id === taskId);
 
@@ -547,7 +554,7 @@ export function ChatInput({
             {badgeVirtualMcp && (
               <VirtualMCPBadge
                 virtualMcp={badgeVirtualMcp}
-                onVirtualMcpChange={setVirtualMcpId}
+                onVirtualMcpChange={handleAgentChange}
                 disabled={isStreaming}
               />
             )}
@@ -599,14 +606,14 @@ export function ChatInput({
                 <div className="flex items-center gap-1.5 min-w-0 overflow-visible">
                   {!selectedVirtualMcp || isDecopilot(selectedVirtualMcp.id) ? (
                     <DecopilotIconButton
-                      onVirtualMcpChange={setVirtualMcpId}
+                      onVirtualMcpChange={handleAgentChange}
                       disabled={isStreaming}
                     />
                   ) : (
                     <VirtualMCPSelector
                       selectedVirtualMcpId={selectedVirtualMcp?.id ?? null}
                       selectedVirtualMcp={selectedVirtualMcp}
-                      onVirtualMcpChange={setVirtualMcpId}
+                      onVirtualMcpChange={handleAgentChange}
                       placeholder="Agent"
                       disabled={isStreaming}
                     />


### PR DESCRIPTION
## What is this contribution about?

When selecting an agent from the chat input button (DecopilotIconButton / VirtualMCPSelector), it only set a `virtualMcpOverride` search param instead of navigating to the agent's route. This meant the thread list stayed scoped to the previous agent and the agent page didn't load — unlike clicking the agent from the sidebar, which worked correctly.

This fix replaces the `setVirtualMcpId` (search-param override) with a proper route navigation to `/$org/$virtualMcpId/`, matching the sidebar behavior so both entry points are consistent.

## How to Test

1. Open Decopilot chat
2. Click the agent selector button below the input box and pick an agent
3. Expected: navigates to the agent's page with its threads showing in the sidebar — same as clicking the agent from the sidebar

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selecting an agent from the chat input now navigates to the agent’s route (`/$org/$virtualMcpId/`), matching the sidebar behavior and fixing stale thread lists.

- **Bug Fixes**
  - Navigate to `/$org/$virtualMcpId/` on agent selection from `DecopilotIconButton`/`VirtualMCPSelector`/`VirtualMCPBadge` so the agent page and threads load correctly.
  - Replace the transient `virtualMcpOverride` search param with a `handleAgentChange` that uses `useNavigate`.

<sup>Written for commit 958df13e2218a88a3fd03aa7fdb51fa272a00a3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

