### PR TITLE
feat: local dev agents — project detection, agent team, dev server preview

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -47,6 +47,7 @@ import proxyRoutes from "./routes/proxy";
 import { createKVRoutes } from "./routes/kv";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import publicConfigRoutes from "./routes/public-config";
+import projectRoutes from "./routes/project";
 import filesRoutes from "./routes/files";
 import selfRoutes from "./routes/self";
 import { shouldSkipMeshContext, SYSTEM_PATHS } from "./utils/paths";
@@ -566,6 +567,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Public Configuration (no auth required)
   // ============================================================================
   app.route("/api/config", publicConfigRoutes);
+  app.route("/api/project", projectRoutes);
 
   // ============================================================================
   // Better Auth Routes

--- a/apps/mesh/src/api/routes/project.ts
+++ b/apps/mesh/src/api/routes/project.ts
@@ -1,0 +1,143 @@
+/**
+ * Project API Routes
+ *
+ * Exposes project scan results and dev server control endpoints.
+ * Only available in local mode when a project directory is detected.
+ */
+
+import { Hono } from "hono";
+import { getScanResult } from "@/project/state";
+import {
+  getDevServerState,
+  startProjectDevServer,
+  stopProjectDevServer,
+  restartProjectDevServer,
+} from "@/project/dev-server";
+
+const app = new Hono();
+
+/**
+ * GET /api/project
+ * Returns project scan result and dev server state
+ */
+app.get("/", (c) => {
+  const scan = getScanResult();
+  if (!scan) {
+    return c.json({ success: false, error: "No project detected" }, 404);
+  }
+
+  return c.json({
+    success: true,
+    scan,
+    devServer: getDevServerState(),
+  });
+});
+
+/**
+ * GET /api/project/dev-server
+ * Returns just the dev server state (for lightweight polling)
+ */
+app.get("/dev-server", (c) => {
+  return c.json({
+    success: true,
+    devServer: getDevServerState(),
+  });
+});
+
+/**
+ * POST /api/project/dev-server/start
+ * Starts the project dev server
+ */
+app.post("/dev-server/start", async (c) => {
+  const scan = getScanResult();
+  if (!scan) {
+    return c.json({ success: false, error: "No project detected" }, 404);
+  }
+
+  await startProjectDevServer(scan);
+  return c.json({ success: true, devServer: getDevServerState() });
+});
+
+/**
+ * POST /api/project/dev-server/stop
+ * Stops the project dev server
+ */
+app.post("/dev-server/stop", async (c) => {
+  await stopProjectDevServer();
+  return c.json({ success: true, devServer: getDevServerState() });
+});
+
+/**
+ * POST /api/project/dev-server/restart
+ * Restarts the project dev server
+ */
+app.post("/dev-server/restart", async (c) => {
+  await restartProjectDevServer();
+  return c.json({ success: true, devServer: getDevServerState() });
+});
+
+/**
+ * GET /api/project/dev-server/logs
+ * Returns dev server logs
+ */
+app.get("/dev-server/logs", (c) => {
+  const state = getDevServerState();
+  return c.json({ success: true, logs: state.logs });
+});
+
+/**
+ * Reverse proxy to the project dev server, stripping frame-blocking headers.
+ * This allows the preview iframe to load the dev server content.
+ * Handles both /api/project/preview and /api/project/preview/* paths.
+ */
+app.all("/preview", (c) => handlePreviewProxy(c));
+app.all("/preview/*", (c) => handlePreviewProxy(c));
+
+async function handlePreviewProxy(c: {
+  req: { path: string; url: string; method: string; raw: Request };
+  text: (body: string, status: number) => Response;
+}) {
+  const devServer = getDevServerState();
+  if (!devServer.url) {
+    return c.text("Dev server not running", 503);
+  }
+
+  // Reconstruct the target URL from the wildcard path
+  const path = c.req.path.replace(/^\/api\/project\/preview\/?/, "/");
+  const targetUrl = new URL(path || "/", devServer.url);
+
+  // Forward query string
+  const reqUrl = new URL(c.req.url);
+  targetUrl.search = reqUrl.search;
+
+  try {
+    const headers = new Headers(c.req.raw.headers);
+    // Remove host header to avoid conflicts
+    headers.delete("host");
+
+    const response = await fetch(targetUrl.toString(), {
+      method: c.req.method,
+      headers,
+      body:
+        c.req.method !== "GET" && c.req.method !== "HEAD"
+          ? c.req.raw.body
+          : undefined,
+      redirect: "manual",
+    });
+
+    // Clone response and strip frame-blocking headers
+    const responseHeaders = new Headers(response.headers);
+    responseHeaders.delete("x-frame-options");
+    responseHeaders.delete("content-security-policy");
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  } catch {
+    return c.text("Failed to proxy to dev server", 502);
+  }
+}
+
+export default app;

--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -6,6 +6,7 @@
  */
 
 import { Hono } from "hono";
+import { basename } from "path";
 import { getConfig, getThemeConfig, type ThemeConfig } from "@/core/config";
 import { isLocalMode } from "@/auth/local-mode";
 import { getInternalUrl } from "@/core/server-constants";
@@ -43,6 +44,15 @@ export type PublicConfig = {
    * Requires FIRECRAWL_API_KEY to be configured.
    */
   brandExtractEnabled?: boolean;
+  /**
+   * Absolute path to the user's project directory.
+   * Only set in local mode when running inside a project.
+   */
+  projectDir?: string;
+  /**
+   * Human-readable project name (basename of projectDir).
+   */
+  projectName?: string;
 };
 
 /**
@@ -61,6 +71,11 @@ app.get("/", (c) => {
     ...(isLocalMode() && { internalUrl: getInternalUrl() }),
     ...(getSettings().enableDecoImport && { enableDecoImport: true }),
     brandExtractEnabled: !!getSettings().firecrawlApiKey,
+    ...(isLocalMode() &&
+      getSettings().projectDir != null && {
+        projectDir: getSettings().projectDir as string,
+        projectName: basename(getSettings().projectDir as string),
+      }),
   };
 
   return c.json({ success: true, config });

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -15,6 +15,18 @@
 import { parseArgs } from "util";
 import { homedir } from "os";
 import { join } from "path";
+import { existsSync } from "fs";
+
+/** Check if a directory contains a project marker (package.json, deno.json, etc.) */
+function detectProjectDir(dir: string): string | undefined {
+  const markers = ["package.json", "deno.json", "deno.jsonc"];
+  for (const marker of markers) {
+    if (existsSync(join(dir, marker))) {
+      return dir;
+    }
+  }
+  return undefined;
+}
 
 const { values, positionals } = parseArgs({
   args: process.argv.slice(2),
@@ -60,6 +72,9 @@ const { values, positionals } = parseArgs({
       type: "string",
       default: "1",
     },
+    project: {
+      type: "string",
+    },
     vibe: {
       type: "boolean",
       default: false,
@@ -94,6 +109,7 @@ Server Options:
 Dev Options:
   --vite-port <port>    Vite dev server port (default: 4000)
   --base-url <url>      Base URL for the server
+  --project <path>      Project directory to manage (default: auto-detect CWD)
 
 Environment Variables:
   PORT                  Port to listen on (default: 3000)
@@ -203,6 +219,7 @@ if (command === "dev") {
     skipMigrations: values["skip-migrations"] === true,
     noTui,
     localMode: values["no-local-mode"] !== true,
+    projectDir: values.project || detectProjectDir(process.cwd()),
   };
 
   if (noTui) {
@@ -270,6 +287,7 @@ const serveOptions = {
     const n = Number(values["num-threads"]);
     return Number.isInteger(n) && n > 0 ? n : 1;
   })(),
+  projectDir: values.project || detectProjectDir(process.cwd()),
 };
 
 const noTui = values["no-tui"] === true || !process.stdout.isTTY;

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -25,6 +25,7 @@ export interface DevOptions {
   skipMigrations: boolean;
   noTui?: boolean;
   localMode: boolean;
+  projectDir?: string;
 }
 
 // Strip ANSI escape codes from a string
@@ -102,6 +103,7 @@ export async function startDevServer(
     skipMigrations: options.skipMigrations,
     noTui: options.noTui,
     vitePort: options.vitePort,
+    projectDir: options.projectDir,
   });
 
   for (const s of services) {
@@ -130,6 +132,9 @@ export async function startDevServer(
       DECOCMS_HOME: settings.dataDir,
       DATA_DIR: settings.dataDir,
       DECO_CLI: "1",
+      ...(settings.projectDir
+        ? { DECOCMS_PROJECT_DIR: settings.projectDir }
+        : {}),
       ...(settings.baseUrl ? { BASE_URL: settings.baseUrl } : {}),
     },
     stdio: [

--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -25,6 +25,7 @@ export interface ServeOptions {
   localMode: boolean;
   noTui?: boolean;
   numThreads?: number;
+  projectDir?: string;
 }
 
 // Strip ANSI escape codes from a string
@@ -143,6 +144,7 @@ export async function startServer(options: ServeOptions): Promise<void> {
     skipMigrations: options.skipMigrations,
     noTui: options.noTui,
     nodeEnv: "production",
+    projectDir: options.projectDir,
   });
 
   for (const s of services) {

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -125,6 +125,45 @@ if (settings.localMode && !isWorker) {
       try {
         const seeded = await seedLocalMode();
         void seeded;
+
+        // Bootstrap project agents if running in a project directory
+        if (settings.projectDir) {
+          try {
+            const { getDb } = await import("./database");
+            const { getLocalAdminUser } = await import("./auth/local-mode");
+            const database = getDb();
+            const user = await getLocalAdminUser();
+            if (user) {
+              // Get the user's organization
+              const membership = await database.db
+                .selectFrom("member")
+                .select("organizationId")
+                .where("userId", "=", user.id)
+                .executeTakeFirst();
+
+              if (membership) {
+                const { bootstrapProjectAgents } = await import(
+                  "./project/bootstrap"
+                );
+                const { scan } = await bootstrapProjectAgents(
+                  settings.projectDir,
+                  membership.organizationId,
+                  user.id,
+                );
+
+                // Auto-start the project dev server, remembering the org/user
+                // so it can publish previewUrl into each project agent's
+                // metadata.activeVms — which is what upstream's PreviewContent reads.
+                const { startProjectDevServer, setProjectSyncContext } =
+                  await import("./project/dev-server");
+                setProjectSyncContext(membership.organizationId, user.id);
+                await startProjectDevServer(scan);
+              }
+            }
+          } catch (error) {
+            console.error("[project] Failed to bootstrap project:", error);
+          }
+        }
       } catch (error) {
         console.error("Failed to seed local mode:", error);
       } finally {

--- a/apps/mesh/src/project/agent-templates.ts
+++ b/apps/mesh/src/project/agent-templates.ts
@@ -284,4 +284,90 @@ When the user asks to deploy, guide them through the process step by step.`;
     },
     applicableWhen: (scan) => scan.deployTarget !== null,
   },
+  {
+    id: "project-writer",
+    title: "Article Writer",
+    description: "Write, edit, and publish articles with your voice",
+    icon: "icon://Edit05?color=emerald",
+    instructions: (scan) => {
+      const blogDir = scan.contentDirs.find((d) => d.type === "blog");
+      const contentDir = scan.contentDirs.find((d) => d.type === "content");
+      const dir = blogDir ?? contentDir;
+
+      return `You are the Article Writer agent for "${scan.projectName}".
+
+Project directory: ${scan.projectDir}
+${dir ? `Content directory: ${dir.path}/` : ""}
+${dir?.configFile ? `Blog config: ${dir.configFile}` : ""}
+
+## Your Role
+
+You help write, edit, and publish articles. You work with markdown files that have YAML frontmatter. The dev server preview shows the rendered article in real-time — edits are visible immediately.
+
+## Article Format
+
+Articles are markdown files with this frontmatter:
+\`\`\`yaml
+---
+slug: my-article-slug
+title: "Article Title"
+description: "Brief description for SEO and previews"
+date: YYYY-MM-DD
+status: published | draft
+coverImage: /images/articles/slug.png
+tags:
+  - tag1
+  - tag2
+---
+
+# Article content in markdown...
+\`\`\`
+
+## Content Pipeline
+
+${
+  dir?.type === "blog"
+    ? `- **Published articles**: ${dir.path}/articles/
+- **Drafts**: content/drafts/ (subdirectories with BRIEF.md, OUTLINE.md, RESEARCH.md)
+- **Briefs**: content/briefs/ (article planning before drafting)`
+    : `- **Content**: ${dir?.path ?? "content/"}/`
+}
+${
+  dir?.configFile
+    ? `- **Tone of voice**: Check ${dir.path}/tone-of-voice.md for writing style guide
+- **Visual style**: Check ${dir.path}/visual-style.md for image/design guidelines`
+    : ""
+}
+
+## Workflows
+
+### New Article
+1. Start with a brief — understand the topic, angle, audience, key message
+2. Research if needed — gather facts, references, examples
+3. Create an outline — structure before prose
+4. Draft the article following the tone of voice guide
+5. Set status to "draft" initially, "published" when ready
+
+### Edit Article
+1. Read the current article
+2. Understand what needs to change (the user might select text in the preview)
+3. Make targeted edits preserving the author's voice
+4. The preview updates in real-time
+
+### SEO & Polish
+- Ensure title, description, and tags are optimized
+- Check readability and flow
+- Suggest cover image concepts
+- Verify slug is URL-friendly
+
+## Important Rules
+- Always read the tone-of-voice guide before writing or editing
+- Preserve the author's authentic voice — you enhance, not replace
+- Use the frontmatter schema exactly as specified
+- Date format is always YYYY-MM-DD
+- Tags are lowercase strings
+- Slugs are kebab-case`;
+    },
+    applicableWhen: (scan) => scan.contentDirs.length > 0,
+  },
 ];

--- a/apps/mesh/src/project/agent-templates.ts
+++ b/apps/mesh/src/project/agent-templates.ts
@@ -1,0 +1,287 @@
+/**
+ * Project Agent Templates
+ *
+ * Defines the team of agents auto-created when a project is detected.
+ * Each template's `instructions` is a function that interpolates scan results.
+ */
+
+import type { ProjectScanResult, FrameworkId } from "./scanner";
+
+export interface ProjectAgentTemplate {
+  id: string;
+  title: string | ((scan: ProjectScanResult) => string);
+  description: string;
+  icon: string;
+  instructions: (scan: ProjectScanResult) => string;
+  applicableWhen?: (scan: ProjectScanResult) => boolean;
+}
+
+const FRAMEWORK_NAMES: Record<FrameworkId, string> = {
+  nextjs: "Next.js",
+  fresh: "Fresh (Deno)",
+  astro: "Astro",
+  vite: "Vite",
+  remix: "Remix",
+  nuxt: "Nuxt",
+  bun: "Bun",
+};
+
+export const PROJECT_AGENT_TEMPLATES: ProjectAgentTemplate[] = [
+  {
+    id: "project-overview",
+    title: (scan) => `${scan.projectName}`,
+    description:
+      "Your project hub — understands the full project and routes to specialists",
+    icon: "icon://Globe01?color=violet",
+    instructions: (
+      scan,
+    ) => `You are the project overview agent for "${scan.projectName}".
+
+Project directory: ${scan.projectDir}
+Framework: ${scan.framework ? FRAMEWORK_NAMES[scan.framework] : "Unknown"}
+Package manager: ${scan.packageManager}
+Dev command: ${scan.devCommand}
+${scan.deployTarget ? `Deploy target: ${scan.deployTarget}` : ""}
+${scan.hasGit ? "Git repository: yes" : ""}
+
+You are the main agent for this project. You understand the full codebase and can help with any task. You can:
+- Navigate and explain the project structure
+- Help with code changes, new features, and bug fixes
+- Coordinate with specialist agents (Dependencies, Performance, Deploy)
+- Answer questions about the framework and architecture
+
+When a user asks something specific to dependencies, performance, or deployment, suggest they talk to the specialist agent for deeper analysis.`,
+  },
+  {
+    id: "project-dev-server",
+    title: "Dev Server",
+    description: "Manages your dev server and shows a live preview",
+    icon: "icon://Terminal?color=green",
+    instructions: (
+      scan,
+    ) => `You manage the local development server for "${scan.projectName}".
+
+Dev command: ${scan.devCommand}
+Default port: ${scan.devPort}
+Framework: ${scan.framework ? FRAMEWORK_NAMES[scan.framework] : "Unknown"}
+
+You can help with:
+- Starting, stopping, and restarting the dev server
+- Diagnosing build errors and dev server issues
+- Understanding dev server output and logs
+- Hot reload issues and cache problems
+- Environment variable configuration
+
+The dev server preview is shown in the main panel. If the user reports the preview not loading, check the dev server logs and status.`,
+  },
+  {
+    id: "project-dependencies",
+    title: "Dependencies",
+    description: "Audits outdated and vulnerable dependencies",
+    icon: "icon://Package?color=amber",
+    instructions: (scan) => `You audit dependencies for "${scan.projectName}".
+
+Package manager: ${scan.packageManager}
+Project directory: ${scan.projectDir}
+
+You can help with:
+- Checking for outdated dependencies
+- Finding security vulnerabilities (npm audit, etc.)
+- Recommending dependency upgrades with breaking change analysis
+- Identifying unused dependencies
+- Resolving dependency conflicts
+- License compliance checking
+
+When analyzing dependencies:
+1. Check the lock file for the current dependency tree
+2. Identify outdated packages and their latest versions
+3. Flag any known security vulnerabilities
+4. Suggest a prioritized upgrade plan (security fixes first, then major updates)
+
+Package manager commands:
+${scan.packageManager === "deno" ? "- deno info: Show dependency tree" : ""}
+${scan.packageManager === "bun" ? "- bun outdated: Check outdated deps\n- bun update: Update deps" : ""}
+${scan.packageManager === "npm" ? "- npm outdated: Check outdated deps\n- npm audit: Security audit" : ""}
+${scan.packageManager === "pnpm" ? "- pnpm outdated: Check outdated deps\n- pnpm audit: Security audit" : ""}
+${scan.packageManager === "yarn" ? "- yarn outdated: Check outdated deps\n- yarn audit: Security audit" : ""}`,
+  },
+  {
+    id: "project-performance",
+    title: "Performance",
+    description: "PageSpeed, Lighthouse, and bundle analysis",
+    icon: "icon://Zap?color=cyan",
+    instructions: (scan) => `You analyze performance for "${scan.projectName}".
+
+Framework: ${scan.framework ? FRAMEWORK_NAMES[scan.framework] : "Unknown"}
+Dev command: ${scan.devCommand}
+Project directory: ${scan.projectDir}
+
+You can help with:
+- Running PageSpeed / Lighthouse audits
+- Bundle size analysis
+- Identifying performance bottlenecks
+- Image optimization recommendations
+- Code splitting opportunities
+- Core Web Vitals improvement
+- Font loading optimization
+- Third-party script analysis
+
+When the dev server is running, you can analyze the local site for performance issues. Provide actionable recommendations with estimated impact.`,
+  },
+  {
+    id: "project-framework",
+    title: (scan) =>
+      scan.framework
+        ? `${FRAMEWORK_NAMES[scan.framework]} Expert`
+        : "Framework Expert",
+    description: "Stack-specific guidance and best practices",
+    icon: "icon://BookOpen01?color=blue",
+    instructions: (scan) => {
+      const name = scan.framework
+        ? FRAMEWORK_NAMES[scan.framework]
+        : "your framework";
+      return `You are a ${name} expert for "${scan.projectName}".
+
+Framework: ${name}
+Package manager: ${scan.packageManager}
+Project directory: ${scan.projectDir}
+
+You provide deep, framework-specific guidance:
+${
+  scan.framework === "nextjs"
+    ? `- App Router vs Pages Router patterns
+- Server Components and Client Components
+- Data fetching (Server Actions, Route Handlers)
+- Middleware and edge runtime
+- Image and font optimization
+- ISR and static generation`
+    : ""
+}
+${
+  scan.framework === "fresh"
+    ? `- Islands architecture
+- Route handlers and middleware
+- Preact signals for state management
+- Plugin system
+- Deno Deploy configuration`
+    : ""
+}
+${
+  scan.framework === "astro"
+    ? `- Content Collections
+- Islands architecture and partial hydration
+- View Transitions
+- SSR adapters
+- Integrations (React, Vue, Svelte)`
+    : ""
+}
+${
+  scan.framework === "vite"
+    ? `- Plugin configuration
+- Build optimization
+- HMR and dev server
+- Library mode
+- Environment variables`
+    : ""
+}
+${
+  scan.framework === "remix"
+    ? `- Loader and Action patterns
+- Nested routing
+- Error boundaries
+- Form handling
+- Streaming`
+    : ""
+}
+${
+  scan.framework === "nuxt"
+    ? `- Auto-imports and composables
+- Nitro server engine
+- Nuxt modules
+- State management (Pinia)
+- SEO and meta management`
+    : ""
+}
+
+Help the user follow framework best practices and conventions.`;
+    },
+    applicableWhen: (scan) => scan.framework !== null,
+  },
+  {
+    id: "project-deploy",
+    title: (scan) => {
+      const targets: Record<string, string> = {
+        vercel: "Vercel Deploy",
+        netlify: "Netlify Deploy",
+        "deno-deploy": "Deno Deploy",
+        cloudflare: "Cloudflare Deploy",
+      };
+      return scan.deployTarget
+        ? (targets[scan.deployTarget] ?? "Deploy")
+        : "Deploy";
+    },
+    description: "Deployment management and CI/CD",
+    icon: "icon://Rocket01?color=rose",
+    instructions: (scan) => {
+      const target = scan.deployTarget ?? "unknown";
+      return `You manage deployments for "${scan.projectName}".
+
+Deploy target: ${target}
+${scan.hasGit ? "Git: yes — branches and PRs can trigger preview deploys" : ""}
+Build command: ${scan.buildCommand ?? "not configured"}
+Project directory: ${scan.projectDir}
+
+You can help with:
+- Creating and managing deployments
+- Setting up preview deploys for branches
+- Environment variable management on the platform
+- Build configuration and optimization
+- Domain and DNS configuration
+- Monitoring deployment status
+- Rollback procedures
+${
+  target === "vercel"
+    ? `
+Vercel-specific:
+- vercel.json configuration
+- Edge and Serverless function configuration
+- ISR and revalidation settings
+- Vercel Analytics and Speed Insights`
+    : ""
+}
+${
+  target === "netlify"
+    ? `
+Netlify-specific:
+- netlify.toml configuration
+- Netlify Functions
+- Edge Functions
+- Forms and Identity`
+    : ""
+}
+${
+  target === "cloudflare"
+    ? `
+Cloudflare-specific:
+- wrangler.toml configuration
+- Workers and Pages
+- D1 Database
+- R2 Storage`
+    : ""
+}
+${
+  target === "deno-deploy"
+    ? `
+Deno Deploy-specific:
+- deployctl configuration
+- KV storage
+- Cron jobs
+- GitHub integration`
+    : ""
+}
+
+When the user asks to deploy, guide them through the process step by step.`;
+    },
+    applicableWhen: (scan) => scan.deployTarget !== null,
+  },
+];

--- a/apps/mesh/src/project/bootstrap.ts
+++ b/apps/mesh/src/project/bootstrap.ts
@@ -1,0 +1,131 @@
+/**
+ * Project Bootstrap
+ *
+ * Orchestrates project scanning and agent creation on startup.
+ * Runs after local-mode seeding when a projectDir is detected.
+ */
+
+import { join } from "path";
+import { scanProject, type ProjectScanResult } from "./scanner";
+import { PROJECT_AGENT_TEMPLATES } from "./agent-templates";
+import { setScanResult } from "./state";
+import { getDb } from "@/database";
+
+/**
+ * Bootstrap project agents for a detected project directory.
+ *
+ * - Scans the project to detect its stack
+ * - Writes scan result to .deco/project.json
+ * - Creates Virtual MCP agents for each applicable template (idempotent)
+ */
+export async function bootstrapProjectAgents(
+  projectDir: string,
+  organizationId: string,
+  userId: string,
+): Promise<{ scan: ProjectScanResult; agentIds: string[] }> {
+  // 1. Scan the project
+  const scan = await scanProject(projectDir);
+  setScanResult(scan);
+
+  console.log(
+    `[project] Detected: ${scan.projectName} (${scan.framework ?? "unknown framework"}, ${scan.packageManager})`,
+  );
+
+  // 2. Write scan result to .deco/project.json for reference
+  try {
+    const decoDir = join(projectDir, ".deco");
+    await Bun.write(
+      join(decoDir, "project.json"),
+      JSON.stringify(scan, null, 2),
+    );
+  } catch {
+    // Non-fatal — .deco dir might not exist yet
+  }
+
+  // 3. Filter applicable templates
+  const applicable = PROJECT_AGENT_TEMPLATES.filter(
+    (t) => !t.applicableWhen || t.applicableWhen(scan),
+  );
+
+  // 4. Check existing agents and create missing ones
+  const database = getDb();
+  const agentIds: string[] = [];
+
+  // Get existing project agents for this org
+  const existingAgents = await database.db
+    .selectFrom("connections")
+    .select(["id", "metadata"])
+    .where("organization_id", "=", organizationId)
+    .where("connection_type", "=", "VIRTUAL")
+    .execute();
+
+  const existingTypes = new Set<string>();
+  for (const agent of existingAgents) {
+    if (agent.metadata) {
+      try {
+        const meta =
+          typeof agent.metadata === "string"
+            ? JSON.parse(agent.metadata)
+            : agent.metadata;
+        if (meta.projectAgentType) {
+          existingTypes.add(meta.projectAgentType);
+          agentIds.push(agent.id);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }
+
+  // Import the storage class and ID generator
+  const { VirtualMCPStorage } = await import("@/storage/virtual");
+  const storage = new VirtualMCPStorage(database.db);
+
+  for (const template of applicable) {
+    if (existingTypes.has(template.id)) {
+      console.log(`[project] Agent "${template.id}" already exists, skipping`);
+      continue;
+    }
+
+    const title =
+      typeof template.title === "function"
+        ? template.title(scan)
+        : template.title;
+
+    const instructions = template.instructions(scan);
+
+    const showPreview =
+      template.id === "project-overview" ||
+      template.id === "project-dev-server";
+
+    const entity = await storage.create(organizationId, userId, {
+      title,
+      description: template.description,
+      icon: template.icon,
+      status: "active",
+      pinned: true,
+      metadata: {
+        instructions,
+        projectAgentType: template.id,
+        ui: showPreview
+          ? {
+              layout: {
+                defaultMainView: { type: "preview" },
+                chatDefaultOpen: true,
+              },
+            }
+          : null,
+      },
+      connections: [],
+    });
+
+    agentIds.push(entity.id);
+    console.log(`[project] Created agent: ${title} (${entity.id})`);
+  }
+
+  console.log(
+    `[project] Bootstrap complete: ${agentIds.length} agents for ${scan.projectName}`,
+  );
+
+  return { scan, agentIds };
+}

--- a/apps/mesh/src/project/dev-server.ts
+++ b/apps/mesh/src/project/dev-server.ts
@@ -1,0 +1,269 @@
+/**
+ * Project Dev Server Management
+ *
+ * Manages the user's project dev server as a subprocess.
+ * Provides start/stop/restart controls and status reporting.
+ */
+
+import type { Subprocess } from "bun";
+import type { ProjectScanResult } from "./scanner";
+import { findAvailablePort } from "@/cli/find-available-port";
+import { getDb } from "@/database";
+
+export interface DevServerState {
+  status: "stopped" | "starting" | "running" | "error";
+  port: number | null;
+  url: string | null;
+  pid: number | null;
+  error: string | null;
+  logs: string[];
+}
+
+const MAX_LOG_LINES = 200;
+
+let _state: DevServerState = {
+  status: "stopped",
+  port: null,
+  url: null,
+  pid: null,
+  error: null,
+  logs: [],
+};
+
+let _process: Subprocess | null = null;
+let _scan: ProjectScanResult | null = null;
+
+function addLog(line: string) {
+  _state.logs.push(line);
+  if (_state.logs.length > MAX_LOG_LINES) {
+    _state.logs = _state.logs.slice(-MAX_LOG_LINES);
+  }
+}
+
+// Strip ANSI escape codes
+function stripAnsi(str: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI codes requires matching control chars
+  // oxlint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function pipeOutput(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  (async () => {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const raw of lines) {
+        const stripped = stripAnsi(raw).trim();
+        if (stripped) addLog(stripped);
+      }
+    }
+    if (buffer.trim()) {
+      addLog(stripAnsi(buffer).trim());
+    }
+  })();
+}
+
+export function getDevServerState(): DevServerState {
+  return { ..._state };
+}
+
+/**
+ * Write the dev server's preview URL into each project agent's
+ * `metadata.activeVms[userId]` entry. This lets the upstream `PreviewContent`
+ * component (which reads activeVms) render our local dev server iframe —
+ * sharing the same preview UI used by cloud VMs (Freestyle) without
+ * reimplementing it locally.
+ *
+ * @param organizationId - Org the project agents belong to
+ * @param userId - User whose activeVms entry to set (local mode has one user)
+ * @param previewUrl - URL of the running local dev server, or null to clear
+ */
+async function syncActiveVmForProjectAgents(
+  organizationId: string,
+  userId: string,
+  previewUrl: string | null,
+): Promise<void> {
+  try {
+    const db = getDb().db;
+    const agents = await db
+      .selectFrom("connections")
+      .select(["id", "metadata"])
+      .where("organization_id", "=", organizationId)
+      .where("connection_type", "=", "VIRTUAL")
+      .execute();
+
+    for (const agent of agents) {
+      if (!agent.metadata) continue;
+      let meta: Record<string, unknown>;
+      try {
+        meta =
+          typeof agent.metadata === "string"
+            ? JSON.parse(agent.metadata)
+            : (agent.metadata as Record<string, unknown>);
+      } catch {
+        continue;
+      }
+      if (!meta.projectAgentType) continue;
+
+      const activeVms =
+        (meta.activeVms as Record<string, unknown> | undefined) ?? {};
+      if (previewUrl) {
+        activeVms[userId] = { previewUrl, vmId: null, terminalUrl: null };
+      } else {
+        delete activeVms[userId];
+      }
+      meta.activeVms = activeVms;
+
+      await db
+        .updateTable("connections")
+        .set({ metadata: JSON.stringify(meta) })
+        .where("id", "=", agent.id)
+        .execute();
+    }
+  } catch (error) {
+    console.error("[project] Failed to sync activeVms metadata:", error);
+  }
+}
+
+let _syncCtx: { organizationId: string; userId: string } | null = null;
+
+/**
+ * Remember the org/user for the current session so we can update agents
+ * when the dev server state changes.
+ */
+export function setProjectSyncContext(
+  organizationId: string,
+  userId: string,
+): void {
+  _syncCtx = { organizationId, userId };
+}
+
+export async function startProjectDevServer(
+  scan: ProjectScanResult,
+): Promise<void> {
+  if (_state.status === "running" || _state.status === "starting") {
+    return;
+  }
+
+  _scan = scan;
+  _state = {
+    status: "starting",
+    port: null,
+    url: null,
+    pid: null,
+    error: null,
+    logs: [],
+  };
+
+  try {
+    const port = await findAvailablePort(scan.devPort);
+    _state.port = port;
+
+    // Parse the dev command into parts
+    const parts = scan.devCommand.split(/\s+/);
+    const cmd = parts[0]!;
+    const args = parts.slice(1);
+
+    console.log(
+      `[project] Starting dev server: ${scan.devCommand} (port ${port})`,
+    );
+
+    const child = Bun.spawn([cmd, ...args], {
+      cwd: scan.projectDir,
+      env: {
+        ...process.env,
+        PORT: String(port),
+        // Some frameworks use different env vars for port
+        DEV_PORT: String(port),
+      },
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+
+    _process = child;
+    _state.pid = child.pid;
+    _state.url = `http://localhost:${port}`;
+
+    // Pipe output
+    if (child.stdout) pipeOutput(child.stdout as ReadableStream<Uint8Array>);
+    if (child.stderr) pipeOutput(child.stderr as ReadableStream<Uint8Array>);
+
+    // Monitor process exit
+    child.exited.then((code) => {
+      if (_state.status === "running" || _state.status === "starting") {
+        if (code === 0 || code === null) {
+          _state.status = "stopped";
+        } else {
+          _state.status = "error";
+          _state.error = `Dev server exited with code ${code}`;
+        }
+      }
+      _process = null;
+      _state.pid = null;
+    });
+
+    // Wait a moment for the server to start, then mark as running
+    // (We can't know exactly when it's ready without health checking,
+    // so we use a reasonable delay)
+    setTimeout(() => {
+      if (_state.status === "starting") {
+        _state.status = "running";
+        console.log(`[project] Dev server running at ${_state.url}`);
+        // Publish previewUrl to project agents so the main panel preview renders.
+        if (_syncCtx && _state.url) {
+          void syncActiveVmForProjectAgents(
+            _syncCtx.organizationId,
+            _syncCtx.userId,
+            _state.url,
+          );
+        }
+      }
+    }, 3000);
+  } catch (error) {
+    _state.status = "error";
+    _state.error =
+      error instanceof Error ? error.message : "Failed to start dev server";
+    console.error("[project] Failed to start dev server:", error);
+  }
+}
+
+export async function stopProjectDevServer(): Promise<void> {
+  if (_process) {
+    _process.kill("SIGTERM");
+    // Give it a moment to clean up
+    await Promise.race([
+      _process.exited,
+      new Promise((r) => setTimeout(r, 5000)),
+    ]);
+    if (_process) {
+      _process.kill("SIGKILL");
+    }
+  }
+  _state.status = "stopped";
+  _state.pid = null;
+  _process = null;
+}
+
+export async function restartProjectDevServer(): Promise<void> {
+  await stopProjectDevServer();
+  if (_scan) {
+    await startProjectDevServer(_scan);
+  }
+}
+
+// Register cleanup handlers
+function cleanup() {
+  if (_process) {
+    _process.kill("SIGTERM");
+    _process = null;
+  }
+}
+
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);

--- a/apps/mesh/src/project/scanner.ts
+++ b/apps/mesh/src/project/scanner.ts
@@ -20,6 +20,13 @@ export type PackageManager = "bun" | "npm" | "yarn" | "pnpm" | "deno";
 
 export type DeployTarget = "vercel" | "netlify" | "deno-deploy" | "cloudflare";
 
+export interface ContentDir {
+  path: string;
+  type: "blog" | "content" | "docs";
+  /** Config file (e.g., blog/config.json) if found */
+  configFile: string | null;
+}
+
 export interface ProjectScanResult {
   projectDir: string;
   projectName: string;
@@ -31,6 +38,7 @@ export interface ProjectScanResult {
   deployTarget: DeployTarget | null;
   configFiles: string[];
   hasGit: boolean;
+  contentDirs: ContentDir[];
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -280,6 +288,28 @@ export async function scanProject(
   const { existsSync } = await import("fs");
   const hasGit = existsSync(join(projectDir, ".git"));
 
+  // Detect content directories (blog, content, docs)
+  const contentDirs: ContentDir[] = [];
+  const contentCandidates: Array<{ dir: string; type: ContentDir["type"] }> = [
+    { dir: "blog", type: "blog" },
+    { dir: "content", type: "content" },
+    { dir: "docs", type: "docs" },
+  ];
+  for (const candidate of contentCandidates) {
+    if (existsSync(join(projectDir, candidate.dir))) {
+      const configFile = (await fileExists(
+        join(projectDir, candidate.dir, "config.json"),
+      ))
+        ? join(candidate.dir, "config.json")
+        : null;
+      contentDirs.push({
+        path: candidate.dir,
+        type: candidate.type,
+        configFile,
+      });
+    }
+  }
+
   return {
     projectDir,
     projectName: basename(projectDir),
@@ -291,5 +321,6 @@ export async function scanProject(
     deployTarget,
     configFiles,
     hasGit,
+    contentDirs,
   };
 }

--- a/apps/mesh/src/project/scanner.ts
+++ b/apps/mesh/src/project/scanner.ts
@@ -1,0 +1,295 @@
+/**
+ * Project Scanner
+ *
+ * Detects the tech stack of a project directory by reading config files.
+ * Pure function — no side effects, no subprocesses.
+ */
+
+import { join, basename } from "path";
+
+export type FrameworkId =
+  | "nextjs"
+  | "fresh"
+  | "astro"
+  | "vite"
+  | "remix"
+  | "nuxt"
+  | "bun";
+
+export type PackageManager = "bun" | "npm" | "yarn" | "pnpm" | "deno";
+
+export type DeployTarget = "vercel" | "netlify" | "deno-deploy" | "cloudflare";
+
+export interface ProjectScanResult {
+  projectDir: string;
+  projectName: string;
+  framework: FrameworkId | null;
+  packageManager: PackageManager;
+  devCommand: string;
+  devPort: number;
+  buildCommand: string | null;
+  deployTarget: DeployTarget | null;
+  configFiles: string[];
+  hasGit: boolean;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    return await Bun.file(path).exists();
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(path: string): Promise<Record<string, unknown> | null> {
+  try {
+    if (!(await fileExists(path))) return null;
+    return JSON.parse(await Bun.file(path).text());
+  } catch {
+    return null;
+  }
+}
+
+async function readText(path: string): Promise<string | null> {
+  try {
+    if (!(await fileExists(path))) return null;
+    return await Bun.file(path).text();
+  } catch {
+    return null;
+  }
+}
+
+const FRAMEWORK_DEFAULTS: Record<
+  FrameworkId,
+  { devPort: number; devCommand: string; buildCommand: string }
+> = {
+  nextjs: { devPort: 3000, devCommand: "next dev", buildCommand: "next build" },
+  fresh: {
+    devPort: 8000,
+    devCommand: "deno task dev",
+    buildCommand: "deno task build",
+  },
+  astro: {
+    devPort: 4321,
+    devCommand: "astro dev",
+    buildCommand: "astro build",
+  },
+  vite: {
+    devPort: 5173,
+    devCommand: "vite dev",
+    buildCommand: "vite build",
+  },
+  remix: {
+    devPort: 5173,
+    devCommand: "remix vite:dev",
+    buildCommand: "remix vite:build",
+  },
+  nuxt: { devPort: 3000, devCommand: "nuxt dev", buildCommand: "nuxt build" },
+  bun: { devPort: 3000, devCommand: "bun dev", buildCommand: "bun run build" },
+};
+
+async function detectPackageManager(dir: string): Promise<PackageManager> {
+  if (await fileExists(join(dir, "bun.lock"))) return "bun";
+  if (await fileExists(join(dir, "bun.lockb"))) return "bun";
+  if (await fileExists(join(dir, "pnpm-lock.yaml"))) return "pnpm";
+  if (await fileExists(join(dir, "yarn.lock"))) return "yarn";
+  return "npm";
+}
+
+async function detectDeployTarget(dir: string): Promise<DeployTarget | null> {
+  if (await fileExists(join(dir, "vercel.json"))) return "vercel";
+  if (await fileExists(join(dir, "netlify.toml"))) return "netlify";
+  if (await fileExists(join(dir, "wrangler.toml"))) return "cloudflare";
+  if (await fileExists(join(dir, "wrangler.jsonc"))) return "cloudflare";
+
+  // Check deno.json for deploy config
+  const denoJson = await readJson(join(dir, "deno.json"));
+  if (denoJson?.deploy) return "deno-deploy";
+
+  return null;
+}
+
+async function detectFramework(
+  dir: string,
+  configFiles: string[],
+): Promise<{ framework: FrameworkId | null; packageManager: PackageManager }> {
+  // 1. Deno / Fresh
+  const denoJsonPath = (await fileExists(join(dir, "deno.json")))
+    ? "deno.json"
+    : (await fileExists(join(dir, "deno.jsonc")))
+      ? "deno.jsonc"
+      : null;
+
+  if (denoJsonPath) {
+    configFiles.push(denoJsonPath);
+    const content = await readText(join(dir, denoJsonPath));
+    if (content && content.includes("$fresh")) {
+      return { framework: "fresh", packageManager: "deno" };
+    }
+    return { framework: null, packageManager: "deno" };
+  }
+
+  // 2. Next.js
+  for (const ext of ["js", "ts", "mjs"]) {
+    const file = `next.config.${ext}`;
+    if (await fileExists(join(dir, file))) {
+      configFiles.push(file);
+      return {
+        framework: "nextjs",
+        packageManager: await detectPackageManager(dir),
+      };
+    }
+  }
+
+  // 3. Astro
+  for (const ext of ["js", "ts", "mjs"]) {
+    const file = `astro.config.${ext}`;
+    if (await fileExists(join(dir, file))) {
+      configFiles.push(file);
+      return {
+        framework: "astro",
+        packageManager: await detectPackageManager(dir),
+      };
+    }
+  }
+
+  // 4. Nuxt
+  for (const ext of ["js", "ts"]) {
+    const file = `nuxt.config.${ext}`;
+    if (await fileExists(join(dir, file))) {
+      configFiles.push(file);
+      return {
+        framework: "nuxt",
+        packageManager: await detectPackageManager(dir),
+      };
+    }
+  }
+
+  // 5. Remix — config file or deps
+  for (const ext of ["js", "ts"]) {
+    const file = `remix.config.${ext}`;
+    if (await fileExists(join(dir, file))) {
+      configFiles.push(file);
+      return {
+        framework: "remix",
+        packageManager: await detectPackageManager(dir),
+      };
+    }
+  }
+  const pkg = await readJson(join(dir, "package.json"));
+  if (pkg) {
+    const deps = {
+      ...(pkg.dependencies as Record<string, string> | undefined),
+      ...(pkg.devDependencies as Record<string, string> | undefined),
+    };
+    if (deps["@remix-run/react"] || deps["@remix-run/node"]) {
+      return {
+        framework: "remix",
+        packageManager: await detectPackageManager(dir),
+      };
+    }
+  }
+
+  // 6. Vite (generic)
+  for (const ext of ["js", "ts", "mjs"]) {
+    const file = `vite.config.${ext}`;
+    if (await fileExists(join(dir, file))) {
+      configFiles.push(file);
+      return {
+        framework: "vite",
+        packageManager: await detectPackageManager(dir),
+      };
+    }
+  }
+
+  // 7. Fallback — check package.json for a dev script
+  if (pkg || (await fileExists(join(dir, "package.json")))) {
+    const pm = await detectPackageManager(dir);
+    return { framework: pm === "bun" ? "bun" : null, packageManager: pm };
+  }
+
+  return { framework: null, packageManager: await detectPackageManager(dir) };
+}
+
+function resolveDevCommand(
+  framework: FrameworkId | null,
+  packageManager: PackageManager,
+  pkgScripts: Record<string, string> | undefined,
+): { devCommand: string; devPort: number; buildCommand: string | null } {
+  // If the project has explicit dev/build scripts in package.json, prefer those
+  if (pkgScripts?.dev) {
+    const defaults = framework ? FRAMEWORK_DEFAULTS[framework] : null;
+    const runner =
+      packageManager === "deno"
+        ? "deno task"
+        : packageManager === "bun"
+          ? "bun run"
+          : packageManager === "pnpm"
+            ? "pnpm"
+            : packageManager === "yarn"
+              ? "yarn"
+              : "npm run";
+
+    return {
+      devCommand: `${runner} dev`,
+      devPort: defaults?.devPort ?? 3000,
+      buildCommand: pkgScripts.build ? `${runner} build` : null,
+    };
+  }
+
+  if (framework && FRAMEWORK_DEFAULTS[framework]) {
+    const d = FRAMEWORK_DEFAULTS[framework];
+    return {
+      devCommand: d.devCommand,
+      devPort: d.devPort,
+      buildCommand: d.buildCommand,
+    };
+  }
+
+  return {
+    devCommand:
+      packageManager === "deno" ? "deno task dev" : `${packageManager} run dev`,
+    devPort: 3000,
+    buildCommand: null,
+  };
+}
+
+export async function scanProject(
+  projectDir: string,
+): Promise<ProjectScanResult> {
+  const configFiles: string[] = [];
+
+  // Check for package.json
+  const pkg = await readJson(join(projectDir, "package.json"));
+  if (pkg) configFiles.push("package.json");
+
+  const { framework, packageManager } = await detectFramework(
+    projectDir,
+    configFiles,
+  );
+
+  const pkgScripts = pkg?.scripts as Record<string, string> | undefined;
+  const { devCommand, devPort, buildCommand } = resolveDevCommand(
+    framework,
+    packageManager,
+    pkgScripts,
+  );
+
+  const deployTarget = await detectDeployTarget(projectDir);
+  // .git can be a directory or a file (worktrees), use existsSync for both
+  const { existsSync } = await import("fs");
+  const hasGit = existsSync(join(projectDir, ".git"));
+
+  return {
+    projectDir,
+    projectName: basename(projectDir),
+    framework,
+    packageManager,
+    devCommand,
+    devPort,
+    buildCommand,
+    deployTarget,
+    configFiles,
+    hasGit,
+  };
+}

--- a/apps/mesh/src/project/state.ts
+++ b/apps/mesh/src/project/state.ts
@@ -1,0 +1,18 @@
+/**
+ * Project State
+ *
+ * Module-level holder for the project scan result.
+ * Set once during bootstrap, read by API routes.
+ */
+
+import type { ProjectScanResult } from "./scanner";
+
+let _scanResult: ProjectScanResult | null = null;
+
+export function setScanResult(result: ProjectScanResult): void {
+  _scanResult = result;
+}
+
+export function getScanResult(): ProjectScanResult | null {
+  return _scanResult;
+}

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -102,6 +102,9 @@ export function resolveConfig(
       envVars.S3_FORCE_PATH_STYLE === "true" ||
       envVars.S3_FORCE_PATH_STYLE === "1",
 
+    // Project
+    projectDir: flags.projectDir ?? envVars.DECOCMS_PROJECT_DIR ?? null,
+
     // Runtime flags
     isCli: true,
     noTui: flags.noTui === true,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -54,6 +54,10 @@ export interface Settings {
   s3SecretAccessKey: string | undefined;
   s3ForcePathStyle: boolean;
 
+  // Project
+  /** Absolute path to the user's project directory (CWD where CLI was invoked). Null when not running against a project. */
+  projectDir: string | null;
+
   // Runtime flags (set by CLI)
   isCli: boolean;
   noTui: boolean;
@@ -74,6 +78,7 @@ export interface CliFlags {
   noTui?: boolean;
   vitePort?: string;
   nodeEnv?: "production" | "development" | "test";
+  projectDir?: string;
 }
 
 export interface ServiceInputs {

--- a/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
@@ -13,6 +13,7 @@ import { KEYS } from "@/web/lib/query-keys";
 import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
 import { useQuery } from "@tanstack/react-query";
 import type { BrandContext } from "@/storage/types";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
 
 interface NoAiProviderEmptyStateProps {
   title?: string;
@@ -75,15 +76,19 @@ export function NoAiProviderEmptyState({
   const { org } = useProjectContext();
   const { localMode } = useAuthConfig();
   const brand = useDefaultBrand();
+  const config = usePublicConfig();
 
-  const orgName = org.name;
+  // Prefer project name (from local dev `bunx decocms`) over org name.
+  // When running locally against a specific project, we want the subject to
+  // be the project, not the seeded local org.
+  const subject = config.projectName ?? org.name;
   const primaryColor = brand ? extractPrimaryColor(brand) : null;
   const brandIcon = brand?.favicon ?? brand?.logo ?? null;
 
   const heading =
     title ??
-    (orgName
-      ? `${orgName} is ready for agents`
+    (subject
+      ? `${subject} is ready for agents`
       : "Your agents are almost ready");
   const subtitle = description ?? "Choose how to power your AI team.";
 

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -15,6 +15,7 @@ import {
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
 import type { ProjectLocator } from "@decocms/mesh-sdk";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
 
 function readRecentAgentIds(locator: ProjectLocator): string[] {
   try {
@@ -153,6 +154,10 @@ function CreateAgentButton() {
   );
 }
 
+function isProjectAgent(agent: { metadata?: Record<string, unknown> | null }) {
+  return !!(agent.metadata as Record<string, unknown> | null)?.projectAgentType;
+}
+
 function AgentsListContent() {
   const virtualMcps = useVirtualMCPs();
   const { locator } = useProjectContext();
@@ -160,6 +165,8 @@ function AgentsListContent() {
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
   const navigateToAgent = useNavigateToAgent();
+  const config = usePublicConfig();
+  const isProjectMode = !!config.projectDir;
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "site-editor",
@@ -173,12 +180,17 @@ function AgentsListContent() {
 
   const recentIds = readRecentAgentIds(locator);
 
-  // Filter out Decopilot, sort by most recently used (from localStorage), then take top 5
-  const agents = virtualMcps
-    .filter(
-      (agent): agent is typeof agent & { id: string } =>
-        agent.id !== null && !isDecopilot(agent.id),
-    )
+  // Separate project agents from regular agents
+  const allAgents = virtualMcps.filter(
+    (agent): agent is typeof agent & { id: string } =>
+      agent.id !== null && !isDecopilot(agent.id),
+  );
+
+  const projectAgents = allAgents.filter(isProjectAgent);
+  const regularAgents = allAgents.filter((a) => !isProjectAgent(a));
+
+  // Sort regular agents by most recently used, then take top 5
+  const sortedRegular = regularAgents
     .sort((a, b) => {
       const aIdx = recentIds.indexOf(a.id);
       const bIdx = recentIds.indexOf(b.id);
@@ -209,36 +221,50 @@ function AgentsListContent() {
         a.title === leanCanvasAgent.title),
   );
 
-  const hasAgents = agents.length > 0;
+  const hasAgents = sortedRegular.length > 0 || projectAgents.length > 0;
 
   return (
     <>
       <div className="w-full max-md:overflow-x-auto max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden">
         <div className="flex flex-wrap justify-center gap-1.5 max-md:flex-nowrap max-md:justify-start md:max-h-52 md:overflow-hidden">
-          <AgentPreview
-            key={siteEditorAgent.id}
-            agent={siteEditorAgent}
-            onSpecialClick={() => setImportDecoOpen(true)}
-          />
-          <AgentPreview
-            key={siteDiagnosticsAgent.id}
-            agent={existingDiagnostics ?? siteDiagnosticsAgent}
-            onSpecialClick={
-              existingDiagnostics
-                ? () => navigateToAgent(existingDiagnostics.id)
-                : () => setDiagnosticsModalOpen(true)
-            }
-          />
-          <AgentPreview
-            key={leanCanvasAgent.id}
-            agent={existingLeanCanvas ?? leanCanvasAgent}
-            onSpecialClick={
-              existingLeanCanvas
-                ? () => navigateToAgent(existingLeanCanvas.id)
-                : () => setLeanCanvasModalOpen(true)
-            }
-          />
-          {agents
+          {/* Show project agents first when in project mode */}
+          {isProjectMode &&
+            projectAgents.map((agent) => (
+              <AgentPreview
+                key={agent.id}
+                agent={agent}
+                onSpecialClick={() => navigateToAgent(agent.id)}
+              />
+            ))}
+          {/* Well-known agents (only show when not in project mode) */}
+          {!isProjectMode && (
+            <>
+              <AgentPreview
+                key={siteEditorAgent.id}
+                agent={siteEditorAgent}
+                onSpecialClick={() => setImportDecoOpen(true)}
+              />
+              <AgentPreview
+                key={siteDiagnosticsAgent.id}
+                agent={existingDiagnostics ?? siteDiagnosticsAgent}
+                onSpecialClick={
+                  existingDiagnostics
+                    ? () => navigateToAgent(existingDiagnostics.id)
+                    : () => setDiagnosticsModalOpen(true)
+                }
+              />
+              <AgentPreview
+                key={leanCanvasAgent.id}
+                agent={existingLeanCanvas ?? leanCanvasAgent}
+                onSpecialClick={
+                  existingLeanCanvas
+                    ? () => navigateToAgent(existingLeanCanvas.id)
+                    : () => setLeanCanvasModalOpen(true)
+                }
+              />
+            </>
+          )}
+          {sortedRegular
             .filter(
               (a) =>
                 a.id !== existingDiagnostics?.id &&

--- a/apps/mesh/src/web/components/topbar-project-info.tsx
+++ b/apps/mesh/src/web/components/topbar-project-info.tsx
@@ -1,0 +1,77 @@
+/**
+ * Topbar Project Info
+ *
+ * Shows the project name, path, and dev server status in the topbar.
+ * Only renders when running in project mode (publicConfig.projectDir is set).
+ */
+
+import { usePublicConfig } from "@/web/hooks/use-public-config";
+import { useDevServerState } from "@/web/hooks/use-project-info";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+
+function StatusDot({ status }: { status: string }) {
+  const color =
+    status === "running"
+      ? "bg-green-500"
+      : status === "starting"
+        ? "bg-yellow-500 animate-pulse"
+        : status === "error"
+          ? "bg-red-500"
+          : "bg-muted-foreground/50";
+
+  const label =
+    status === "running"
+      ? "Dev server running"
+      : status === "starting"
+        ? "Dev server starting..."
+        : status === "error"
+          ? "Dev server error"
+          : "Dev server stopped";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("size-2 rounded-full shrink-0", color)} />
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="text-xs">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function shortenPath(path: string): string {
+  const home = path.match(/^\/Users\/[^/]+/)?.[0];
+  if (home) {
+    return path.replace(home, "~");
+  }
+  return path;
+}
+
+export function TopbarProjectInfo() {
+  const config = usePublicConfig();
+
+  if (!config.projectDir) return null;
+
+  return <TopbarProjectInfoContent />;
+}
+
+function TopbarProjectInfoContent() {
+  const config = usePublicConfig();
+  const { data: devServer } = useDevServerState();
+
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <StatusDot status={devServer?.status ?? "stopped"} />
+      <span className="font-medium text-foreground">{config.projectName}</span>
+      <span className="text-muted-foreground text-xs hidden sm:inline">
+        {shortenPath(config.projectDir ?? "")}
+      </span>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/hooks/use-pinned-agents.ts
+++ b/apps/mesh/src/web/hooks/use-pinned-agents.ts
@@ -1,15 +1,36 @@
 import { authClient } from "@/web/lib/auth-client";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { useRef } from "react";
 
-export function usePinnedAgents(orgId: string, initialPinnedIds: string[]) {
+export function usePinnedAgents(orgId: string, serverPinnedIds: string[]) {
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "anon";
   const storageKey = `mesh:pinned-agents:${orgId}:${userId}`;
 
   const [pinnedIds, setPinnedIds] = useLocalStorage<string[]>(
     storageKey,
-    (existing) => existing ?? initialPinnedIds,
+    (existing) => existing ?? serverPinnedIds,
   );
+
+  // Track which server IDs we've already synced to avoid re-running
+  const syncedRef = useRef<Set<string>>(new Set(pinnedIds));
+
+  // Sync new server-pinned IDs into the local list.
+  // This handles agents created after the initial localStorage was set
+  // (e.g. project agents created at startup while the user already had a session).
+  const newIds = serverPinnedIds.filter(
+    (id) => !pinnedIds.includes(id) && !syncedRef.current.has(id),
+  );
+  if (newIds.length > 0) {
+    for (const id of newIds) syncedRef.current.add(id);
+    // Schedule the state update after render to avoid updating during render
+    queueMicrotask(() => {
+      setPinnedIds((prev) => {
+        const toAdd = newIds.filter((id) => !prev.includes(id));
+        return toAdd.length > 0 ? [...prev, ...toAdd] : prev;
+      });
+    });
+  }
 
   const pin = (id: string) => {
     setPinnedIds((prev) => (prev.includes(id) ? prev : [...prev, id]));

--- a/apps/mesh/src/web/hooks/use-project-info.ts
+++ b/apps/mesh/src/web/hooks/use-project-info.ts
@@ -1,0 +1,70 @@
+/**
+ * Hook for fetching project info and dev server state.
+ * Only active when running in project mode (publicConfig.projectDir is set).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+import { usePublicConfig } from "./use-public-config";
+
+export interface ProjectScanResult {
+  projectDir: string;
+  projectName: string;
+  framework: string | null;
+  packageManager: string;
+  devCommand: string;
+  devPort: number;
+  buildCommand: string | null;
+  deployTarget: string | null;
+  configFiles: string[];
+  hasGit: boolean;
+  contentDirs: Array<{
+    path: string;
+    type: "blog" | "content" | "docs";
+    configFile: string | null;
+  }>;
+}
+
+export interface DevServerState {
+  status: "stopped" | "starting" | "running" | "error";
+  port: number | null;
+  url: string | null;
+  pid: number | null;
+  error: string | null;
+  logs: string[];
+}
+
+export interface ProjectInfo {
+  scan: ProjectScanResult;
+  devServer: DevServerState;
+}
+
+export function useProjectInfo() {
+  const config = usePublicConfig();
+  return useQuery<ProjectInfo>({
+    queryKey: KEYS.projectInfo(),
+    queryFn: async () => {
+      const response = await fetch("/api/project");
+      const data = await response.json();
+      if (!data.success) throw new Error(data.error);
+      return { scan: data.scan, devServer: data.devServer };
+    },
+    refetchInterval: 5000,
+    enabled: !!config.projectDir,
+  });
+}
+
+export function useDevServerState() {
+  const config = usePublicConfig();
+  return useQuery<DevServerState>({
+    queryKey: KEYS.projectDevServer(),
+    queryFn: async () => {
+      const response = await fetch("/api/project/dev-server");
+      const data = await response.json();
+      if (!data.success) throw new Error(data.error);
+      return data.devServer;
+    },
+    refetchInterval: 3000,
+    enabled: !!config.projectDir,
+  });
+}

--- a/apps/mesh/src/web/layouts/agent-shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout.tsx
@@ -6,11 +6,19 @@
  * This layout wraps all agent and org-home routes via a pathless id route.
  */
 
-import { createContext, use, useEffect, useLayoutEffect, useRef } from "react";
+import {
+  createContext,
+  Suspense as ReactSuspense,
+  use,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import { Chat, useChatTask } from "@/web/components/chat/index";
 import { ChatPanel } from "@/web/components/chat/side-panel-chat";
 import { TasksSidePanel } from "@/web/components/chat/side-panel-tasks";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { TopbarProjectInfo } from "@/web/components/topbar-project-info";
 import { isMac, isModKey } from "@/web/lib/keyboard-shortcuts";
 import { StudioSidebar, StudioSidebarMobile } from "@/web/components/sidebar";
 import { useLocalStorage } from "@/web/hooks/use-local-storage";
@@ -659,6 +667,11 @@ function AgentInsetProvider() {
                 </>
               );
             })()}
+        </div>
+        <div className="flex-1 flex items-center justify-center min-w-0">
+          <ReactSuspense fallback={null}>
+            <TopbarProjectInfo />
+          </ReactSuspense>
         </div>
         <div className="flex items-center gap-0.5">
           {showThreePanels && (

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -339,6 +339,10 @@ export const KEYS = {
       installationLogin,
       query,
     ] as const,
+
+  // Project info (local dev mode — set via `bunx decocms`)
+  projectInfo: () => ["project-info"] as const,
+  projectDevServer: () => ["project-dev-server"] as const,
 } as const;
 
 export function invalidateVirtualMcpQueries(

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -50,10 +50,10 @@ function useResolvedMainView(): MainView & {} {
       return def.id
         ? { type: "ext-apps", id: def.id, toolName: def.toolName }
         : { type: "chat" };
-    case "settings":
-      return { type: "settings" };
     case "preview":
       return { type: "preview" };
+    case "settings":
+      return { type: "settings" };
     default:
       return { type: "chat" };
   }

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -54,6 +54,9 @@ import {
 import { KEYS } from "@/web/lib/query-keys";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
+import { useNavigate } from "@tanstack/react-router";
+import { useVirtualMCPs } from "@decocms/mesh-sdk";
 
 function ErrorFallback({ error }: { error: Error }) {
   return (
@@ -407,9 +410,11 @@ export type AiProvider = {
 function ProviderCard({
   provider,
   keys,
+  onActivated,
 }: {
   provider: AiProvider;
   keys: AiProviderKey[];
+  onActivated?: () => void;
 }) {
   const { org } = useProjectContext();
   const client = useMCPClient({
@@ -507,6 +512,7 @@ function ProviderCard({
         queryKey: KEYS.aiProviders(org.id),
       });
       toast.success(`${provider.name} activated`);
+      onActivated?.();
     },
     onError: (err) => toast.error(err.message),
   });
@@ -750,12 +756,36 @@ export function ProviderCardGrid({
   const providers: AiProvider[] = (aiProviders?.providers ?? []).filter(
     (p) => p.id !== hideProviderId,
   );
+  const config = usePublicConfig();
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const virtualMcps = useVirtualMCPs();
+
   const localProviders = providers.filter((p) =>
     p.supportedMethods.includes("cli-activate"),
   );
   const cloudProviders = providers.filter(
     (p) => !p.supportedMethods.includes("cli-activate"),
   );
+
+  const handleActivated = () => {
+    if (!config.projectDir) return;
+    // Find the hub agent (project-overview) and navigate to it
+    const hubAgent = virtualMcps.find(
+      (a) =>
+        a.id !== null &&
+        (a.metadata as Record<string, unknown> | null)?.projectAgentType ===
+          "project-overview",
+    );
+    if (hubAgent?.id) {
+      navigate({
+        to: "/$org/$virtualMcpId",
+        params: { org: org.slug, virtualMcpId: hubAgent.id },
+      });
+    } else {
+      navigate({ to: "/$org", params: { org: org.slug } });
+    }
+  };
 
   return (
     <div className="flex flex-col gap-5 w-full">
@@ -771,6 +801,7 @@ export function ProviderCardGrid({
                 key={provider.id}
                 provider={provider}
                 keys={allKeys.filter((k) => k.providerId === provider.id)}
+                onActivated={handleActivated}
               />
             ))}
           </div>
@@ -782,6 +813,7 @@ export function ProviderCardGrid({
             key={provider.id}
             provider={provider}
             keys={allKeys.filter((k) => k.providerId === provider.id)}
+            onActivated={handleActivated}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary

**One command to optimize your site with AI.** Run `bunx decocms` in any project directory → choose Claude Code → a team of AI agents starts working on your project.

### What it does

- **Project Scanner** — Auto-detects framework (Next.js, Fresh, Astro, Vite, Remix, Nuxt), package manager, dev command, deploy target from filesystem config files
- **Agent Team** — Creates specialized agents on startup: Project Hub, Dev Server, Dependencies, Performance, Framework Expert, Deploy
- **Dev Server** — Auto-starts the project's dev server as a managed subprocess with start/stop/restart API
- **Live Preview** — iframe-based preview panel showing the running dev server, with toolbar (refresh, open external)
- **Topbar** — Shows project name, path, and dev server status (green/yellow/red dot) in the center of the topbar
- **Onboarding** — Redesigned provider selection: "decocms is ready for agents" with Claude Code/Codex highlighted as "Local models"
- **Sidebar Fix** — Server-pinned agents now sync into localStorage so new agents appear without clearing cache

### WIP / Next steps

- [ ] Hub agent chat should show setup messages as persistent conversation (agents appearing one by one)
- [ ] Each agent mention in chat should be clickable to navigate
- [ ] Agents should proactively start working (dep audit, perf check, etc.)
- [ ] Setup sequence as real AI conversation, not scripted animation

### Test plan

- [ ] Run `bun run apps/mesh/src/cli.ts dev --project ~/Projects/decocms` from worktree root
- [ ] Verify topbar shows project name with green status dot
- [ ] Click Claude Code → navigates to hub agent with preview
- [ ] Preview iframe loads the running dev server
- [ ] Project agents appear in sidebar (may need to clear localStorage)
- [ ] `GET /api/project` returns scan result and dev server state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local dev agents that auto-detect your project, spin up a specialist team, manage your dev server, and show a live preview in-app. Introduces `/api/project` endpoints, a new `--project` CLI flag for explicit directory selection, and an Article Writer agent for content-rich projects.

- New Features
  - Project detection: scans framework, package manager, dev/build commands, deploy target; shows project name/path with a status dot in the topbar.
  - Agent team: auto-creates Overview, Dev Server, Dependencies, Performance, Framework Expert, Deploy, and Article Writer (when content dirs exist) agents when `projectDir` is set.
  - Article Writer: created when `blog/`, `content/`, or `docs/` is present; writes/edits markdown with frontmatter and tone-of-voice guidance; live preview via the dev server.
  - Dev server: start/stop/restart with logs; auto-start on bootstrap; iframe preview with refresh/open external; preview proxy under `/api/project/preview/*` strips frame-blocking headers; publishes `previewUrl` into agents’ metadata to power the preview UI.
  - API: `/api/project` (scan + state), `/api/project/dev-server` (start/stop/restart/logs), lightweight polling for dev server state, and `GET /api/config` now includes `projectDir` and `projectName`.
  - CLI/UX: `--project` flag and CWD auto-detection; “Local models” highlighted in provider selection; clearer empty states using the detected project name; project agents prioritized in lists; after provider activation, navigate to the Overview agent.

- Bug Fixes
  - Server-pinned agents now sync into localStorage so new agents appear without clearing cache.

<sup>Written for commit b5f78e61d89c0bf0fdbcaf87bcd8318eb0cda622. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

