### PR TITLE
fix(security): block SSRF via OAuth metadata discovery endpoints

### DIFF
--- a/apps/mesh/src/api/routes/oauth-proxy.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.test.ts
@@ -238,7 +238,7 @@ describe("OAuth Proxy Routes", () => {
       expect(res.status).toBe(200);
     });
 
-    test("returns 502 when origin fetch fails", async () => {
+    test("returns 404 when origin fetch fails to prevent connection enumeration", async () => {
       mockConnectionStorage({
         connection_url: "https://origin.example.com/mcp",
       });
@@ -251,9 +251,10 @@ describe("OAuth Proxy Routes", () => {
         "/.well-known/oauth-protected-resource/mcp/conn_123",
       );
 
-      expect(res.status).toBe(502);
+      // Returns 404 (same as "not found") to avoid leaking connection existence
+      expect(res.status).toBe(404);
       const body = await res.json();
-      expect(body.error).toBe("Failed to proxy OAuth metadata");
+      expect(body.error).toBe("Connection not found");
     });
 
     test("passes through error responses from origin", async () => {
@@ -442,6 +443,56 @@ describe("OAuth Proxy Routes", () => {
       expect(body.issuer).toBeUndefined();
       expect(body.authorization_endpoint).toBeUndefined();
     });
+
+    test("blocks SSRF to loopback addresses", async () => {
+      mockConnectionStorage({
+        connection_url: "http://127.0.0.1:51388",
+      });
+
+      const res = await app.request(
+        "/.well-known/oauth-protected-resource/mcp/conn_ssrf",
+      );
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe("Connection not found");
+    });
+
+    test("blocks SSRF to AWS IMDS endpoint", async () => {
+      mockConnectionStorage({
+        connection_url: "http://169.254.169.254/latest/meta-data/",
+      });
+
+      const res = await app.request(
+        "/.well-known/oauth-protected-resource/mcp/conn_imds",
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    test("blocks SSRF to private network addresses", async () => {
+      mockConnectionStorage({
+        connection_url: "http://10.0.0.1:8080/internal-api",
+      });
+
+      const res = await app.request(
+        "/.well-known/oauth-protected-resource/mcp/conn_private",
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    test("blocks SSRF to localhost", async () => {
+      mockConnectionStorage({
+        connection_url: "http://localhost:3000/mcp",
+      });
+
+      const res = await app.request(
+        "/.well-known/oauth-protected-resource/mcp/conn_localhost",
+      );
+
+      expect(res.status).toBe(404);
+    });
   });
 
   describe("Authorization Server Metadata Proxy", () => {
@@ -486,6 +537,18 @@ describe("OAuth Proxy Routes", () => {
 
       const res = await app.request(
         "/.well-known/oauth-authorization-server/oauth-proxy/conn_notfound",
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    test("blocks SSRF to internal addresses via auth server metadata", async () => {
+      mockConnectionWithAuthServer({
+        connection_url: "http://127.0.0.1:51388",
+      });
+
+      const res = await app.request(
+        "/.well-known/oauth-authorization-server/oauth-proxy/conn_ssrf",
       );
 
       expect(res.status).toBe(404);

--- a/apps/mesh/src/api/routes/oauth-proxy.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.test.ts
@@ -238,7 +238,7 @@ describe("OAuth Proxy Routes", () => {
       expect(res.status).toBe(200);
     });
 
-    test("returns 404 when origin fetch fails to prevent connection enumeration", async () => {
+    test("returns 502 when origin fetch fails", async () => {
       mockConnectionStorage({
         connection_url: "https://origin.example.com/mcp",
       });
@@ -251,10 +251,9 @@ describe("OAuth Proxy Routes", () => {
         "/.well-known/oauth-protected-resource/mcp/conn_123",
       );
 
-      // Returns 404 (same as "not found") to avoid leaking connection existence
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(502);
       const body = await res.json();
-      expect(body.error).toBe("Connection not found");
+      expect(body.error).toBe("Failed to proxy OAuth metadata");
     });
 
     test("passes through error responses from origin", async () => {

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -15,6 +15,7 @@
 import { Hono } from "hono";
 import { ContextFactory } from "../../core/context-factory";
 import type { MeshContext } from "../../core/mesh-context";
+import { getSettings } from "../../settings";
 import { isPrivateNetworkUrl } from "../../shared/utils/url-validation";
 
 // Define Hono variables type
@@ -53,7 +54,11 @@ async function getConnectionUrl(
 ): Promise<string | null> {
   const connection = await ctx.storage.connections.findById(connectionId);
   const url = connection?.connection_url ?? null;
-  if (url && isPrivateNetworkUrl(url)) {
+  if (
+    url &&
+    !getSettings().allowPrivateNetworkConnections &&
+    isPrivateNetworkUrl(url)
+  ) {
     return null;
   }
   return url;

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -15,6 +15,7 @@
 import { Hono } from "hono";
 import { ContextFactory } from "../../core/context-factory";
 import type { MeshContext } from "../../core/mesh-context";
+import { isPrivateNetworkUrl } from "../../shared/utils/url-validation";
 
 // Define Hono variables type
 type Variables = {
@@ -43,15 +44,23 @@ const NO_METADATA_STATUSES = [404, 401, 406];
 // ============================================================================
 
 /**
- * Get connection URL from storage by connection ID
- * Does not require organization ID - connections are globally unique
+ * Get connection URL from storage by connection ID.
+ * Scopes lookup by organization when auth context is available.
+ * Blocks private/internal network URLs to prevent SSRF.
  */
 async function getConnectionUrl(
   connectionId: string,
   ctx: MeshContext,
 ): Promise<string | null> {
-  const connection = await ctx.storage.connections.findById(connectionId);
-  return connection?.connection_url ?? null;
+  const connection = await ctx.storage.connections.findById(
+    connectionId,
+    ctx.organization?.id,
+  );
+  const url = connection?.connection_url ?? null;
+  if (url && isPrivateNetworkUrl(url)) {
+    return null;
+  }
+  return url;
 }
 
 /**
@@ -467,10 +476,8 @@ const protectedResourceMetadataHandler = async (c: {
       "[oauth-proxy] Failed to proxy OAuth protected resource metadata:",
       err,
     );
-    return c.json(
-      { error: "Failed to proxy OAuth metadata", message: err.message },
-      502,
-    );
+    // Return 404 (same as "not found") to avoid leaking connection existence
+    return c.json({ error: "Connection not found" }, 404);
   }
 };
 
@@ -623,10 +630,8 @@ app.get(
     } catch (error) {
       const err = error as Error;
       console.error("[oauth-proxy] Failed to proxy auth server metadata:", err);
-      return c.json(
-        { error: "Failed to proxy auth server metadata", message: err.message },
-        502,
-      );
+      // Return 404 (same as "not found") to avoid leaking connection existence
+      return c.json({ error: "Connection not found or no auth server" }, 404);
     }
   },
 );

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -45,17 +45,13 @@ const NO_METADATA_STATUSES = [404, 401, 406];
 
 /**
  * Get connection URL from storage by connection ID.
- * Scopes lookup by organization when auth context is available.
  * Blocks private/internal network URLs to prevent SSRF.
  */
 async function getConnectionUrl(
   connectionId: string,
   ctx: MeshContext,
 ): Promise<string | null> {
-  const connection = await ctx.storage.connections.findById(
-    connectionId,
-    ctx.organization?.id,
-  );
+  const connection = await ctx.storage.connections.findById(connectionId);
   const url = connection?.connection_url ?? null;
   if (url && isPrivateNetworkUrl(url)) {
     return null;
@@ -476,8 +472,10 @@ const protectedResourceMetadataHandler = async (c: {
       "[oauth-proxy] Failed to proxy OAuth protected resource metadata:",
       err,
     );
-    // Return 404 (same as "not found") to avoid leaking connection existence
-    return c.json({ error: "Connection not found" }, 404);
+    return c.json(
+      { error: "Failed to proxy OAuth metadata", message: err.message },
+      502,
+    );
   }
 };
 
@@ -630,8 +628,10 @@ app.get(
     } catch (error) {
       const err = error as Error;
       console.error("[oauth-proxy] Failed to proxy auth server metadata:", err);
-      // Return 404 (same as "not found") to avoid leaking connection existence
-      return c.json({ error: "Connection not found or no auth server" }, 404);
+      return c.json(
+        { error: "Failed to proxy auth server metadata", message: err.message },
+        502,
+      );
     }
   },
 );

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -82,6 +82,11 @@ export function resolveConfig(
     // Transport
     unsafeAllowStdioTransport: toBool(envVars.UNSAFE_ALLOW_STDIO_TRANSPORT),
 
+    // Security
+    allowPrivateNetworkConnections: toBool(
+      envVars.ALLOW_PRIVATE_NETWORK_CONNECTIONS,
+    ),
+
     // AI Gateway
     aiGatewayEnabled: toBool(envVars.DECO_AI_GATEWAY_ENABLED),
     aiGatewayUrl:

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -39,6 +39,9 @@ export interface Settings {
   // Transport
   unsafeAllowStdioTransport: boolean;
 
+  // Security
+  allowPrivateNetworkConnections: boolean;
+
   // AI Gateway
   aiGatewayEnabled: boolean;
   aiGatewayUrl: string;

--- a/apps/mesh/src/shared/utils/url-validation.test.ts
+++ b/apps/mesh/src/shared/utils/url-validation.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "bun:test";
+import { isPrivateNetworkUrl } from "./url-validation";
+
+describe("isPrivateNetworkUrl", () => {
+  describe("blocks private IPv4 ranges", () => {
+    it("blocks loopback (127.x.x.x)", () => {
+      expect(isPrivateNetworkUrl("http://127.0.0.1/mcp")).toBe(true);
+      expect(isPrivateNetworkUrl("http://127.0.0.1:51388")).toBe(true);
+      expect(isPrivateNetworkUrl("http://127.255.255.255")).toBe(true);
+    });
+
+    it("blocks 10.x.x.x", () => {
+      expect(isPrivateNetworkUrl("http://10.0.0.1")).toBe(true);
+      expect(isPrivateNetworkUrl("http://10.255.255.255")).toBe(true);
+    });
+
+    it("blocks 172.16.x.x - 172.31.x.x", () => {
+      expect(isPrivateNetworkUrl("http://172.16.0.1")).toBe(true);
+      expect(isPrivateNetworkUrl("http://172.31.255.255")).toBe(true);
+    });
+
+    it("blocks 192.168.x.x", () => {
+      expect(isPrivateNetworkUrl("http://192.168.0.1")).toBe(true);
+      expect(isPrivateNetworkUrl("http://192.168.1.100:8080")).toBe(true);
+    });
+
+    it("blocks link-local / IMDS (169.254.x.x)", () => {
+      expect(
+        isPrivateNetworkUrl("http://169.254.169.254/latest/meta-data/"),
+      ).toBe(true);
+      expect(isPrivateNetworkUrl("http://169.254.0.1")).toBe(true);
+    });
+
+    it("blocks 0.0.0.0/8", () => {
+      expect(isPrivateNetworkUrl("http://0.0.0.0")).toBe(true);
+    });
+  });
+
+  describe("blocks private hostnames", () => {
+    it("blocks localhost", () => {
+      expect(isPrivateNetworkUrl("http://localhost")).toBe(true);
+      expect(isPrivateNetworkUrl("http://localhost:3000/mcp")).toBe(true);
+    });
+  });
+
+  describe("blocks IPv6 private addresses", () => {
+    it("blocks ::1 loopback", () => {
+      expect(isPrivateNetworkUrl("http://[::1]")).toBe(true);
+    });
+
+    it("blocks unique local (fc/fd)", () => {
+      expect(isPrivateNetworkUrl("http://[fc00::1]")).toBe(true);
+      expect(isPrivateNetworkUrl("http://[fd12:3456::1]")).toBe(true);
+    });
+
+    it("blocks link-local (fe80)", () => {
+      expect(isPrivateNetworkUrl("http://[fe80::1]")).toBe(true);
+    });
+
+    it("blocks IPv4-mapped IPv6", () => {
+      expect(isPrivateNetworkUrl("http://[::ffff:127.0.0.1]")).toBe(true);
+      expect(isPrivateNetworkUrl("http://[::ffff:169.254.169.254]")).toBe(true);
+    });
+  });
+
+  describe("allows public URLs", () => {
+    it("allows public domains", () => {
+      expect(isPrivateNetworkUrl("https://example.com/mcp")).toBe(false);
+      expect(isPrivateNetworkUrl("https://api.stripe.com")).toBe(false);
+      expect(isPrivateNetworkUrl("https://mcp.clickhouse.cloud/mcp")).toBe(
+        false,
+      );
+    });
+
+    it("allows public IPs", () => {
+      expect(isPrivateNetworkUrl("http://8.8.8.8")).toBe(false);
+      expect(isPrivateNetworkUrl("https://1.1.1.1")).toBe(false);
+    });
+
+    it("does not block 172.32+ (outside private range)", () => {
+      expect(isPrivateNetworkUrl("http://172.32.0.1")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("blocks unparseable URLs", () => {
+      expect(isPrivateNetworkUrl("not-a-url")).toBe(true);
+      expect(isPrivateNetworkUrl("")).toBe(true);
+    });
+  });
+});

--- a/apps/mesh/src/shared/utils/url-validation.ts
+++ b/apps/mesh/src/shared/utils/url-validation.ts
@@ -1,0 +1,116 @@
+/**
+ * URL validation utilities to prevent SSRF attacks.
+ *
+ * Blocks outbound requests to private/internal network ranges
+ * from endpoints that accept user-controlled URLs.
+ */
+
+/**
+ * IPv4 private and reserved CIDR ranges that should not be
+ * reachable from server-side fetches triggered by user input.
+ */
+const BLOCKED_IPV4_RANGES: Array<{ network: number; mask: number }> = [
+  // 127.0.0.0/8 — loopback
+  { network: 0x7f000000 >>> 0, mask: 0xff000000 >>> 0 },
+  // 10.0.0.0/8 — private
+  { network: 0x0a000000 >>> 0, mask: 0xff000000 >>> 0 },
+  // 172.16.0.0/12 — private
+  { network: 0xac100000 >>> 0, mask: 0xfff00000 >>> 0 },
+  // 192.168.0.0/16 — private
+  { network: 0xc0a80000 >>> 0, mask: 0xffff0000 >>> 0 },
+  // 169.254.0.0/16 — link-local (AWS IMDS, etc.)
+  { network: 0xa9fe0000 >>> 0, mask: 0xffff0000 >>> 0 },
+  // 0.0.0.0/8 — "this" network
+  { network: 0x00000000 >>> 0, mask: 0xff000000 >>> 0 },
+];
+
+/**
+ * Hostnames that always resolve to loopback/internal addresses.
+ */
+const BLOCKED_HOSTNAMES = new Set(["localhost", "localhost."]);
+
+function parseIPv4(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let result = 0;
+  for (const part of parts) {
+    const num = Number(part);
+    if (!Number.isInteger(num) || num < 0 || num > 255) return null;
+    result = (result << 8) | num;
+  }
+  return result >>> 0;
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const addr = parseIPv4(ip);
+  if (addr === null) return false;
+  return BLOCKED_IPV4_RANGES.some(
+    ({ network, mask }) => (addr & mask) >>> 0 === network,
+  );
+}
+
+/**
+ * Parse an IPv4-mapped IPv6 address in either dotted or hex notation.
+ * The URL parser normalizes `::ffff:127.0.0.1` to `::ffff:7f00:1`,
+ * so we need to handle both forms.
+ */
+function extractIPv4FromMappedIPv6(ip: string): string | null {
+  const normalized = ip.toLowerCase();
+
+  // Dotted form: ::ffff:127.0.0.1
+  const dotted = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (dotted) return dotted[1];
+
+  // Hex form: ::ffff:7f00:1 (URL parser normalizes to this)
+  const hex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hex) {
+    const hi = parseInt(hex[1], 16);
+    const lo = parseInt(hex[2], 16);
+    return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+  }
+
+  return null;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  // ::1 — loopback
+  if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") return true;
+  // fc00::/7 — unique local
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  // fe80::/10 — link-local
+  if (normalized.startsWith("fe80")) return true;
+  // ::ffff:x.x.x.x — IPv4-mapped IPv6 (dotted or hex form)
+  const v4 = extractIPv4FromMappedIPv6(normalized);
+  if (v4) return isPrivateIPv4(v4);
+  return false;
+}
+
+/**
+ * Check whether a URL targets a private or internal network address.
+ *
+ * This performs a **syntactic** check on the hostname — it does NOT
+ * do DNS resolution, so it cannot catch DNS-rebinding attacks. For
+ * that, a resolving proxy or connect-time check would be needed.
+ *
+ * Returns `true` if the URL should be blocked.
+ */
+export function isPrivateNetworkUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return true;
+  }
+
+  const hostname = parsed.hostname;
+
+  // Strip brackets from IPv6
+  const bare = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+
+  if (BLOCKED_HOSTNAMES.has(bare.toLowerCase())) return true;
+  if (isPrivateIPv4(bare)) return true;
+  if (isPrivateIPv6(bare)) return true;
+
+  return false;
+}

--- a/apps/mesh/src/shared/utils/url-validation.ts
+++ b/apps/mesh/src/shared/utils/url-validation.ts
@@ -59,11 +59,11 @@ function extractIPv4FromMappedIPv6(ip: string): string | null {
 
   // Dotted form: ::ffff:127.0.0.1
   const dotted = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (dotted) return dotted[1];
+  if (dotted?.[1]) return dotted[1];
 
   // Hex form: ::ffff:7f00:1 (URL parser normalizes to this)
   const hex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (hex) {
+  if (hex?.[1] && hex[2]) {
     const hi = parseInt(hex[1], 16);
     const lo = parseInt(hex[2], 16);
     return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;


### PR DESCRIPTION
## Summary
- **SSRF-VULN-03**: Unauthenticated OAuth discovery endpoints (`/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`) proxied outbound requests to any URL stored in a connection record, enabling internal service data retrieval and IMDS access
- Adds `isPrivateNetworkUrl()` utility that blocks private/internal network ranges before any outbound fetch:
  - IPv4: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `0.0.0.0/8`
  - IPv6: `::1`, `fc00::/7`, `fe80::/10`, IPv4-mapped (`::ffff:x.x.x.x` in both dotted and hex form)
  - Hostnames: `localhost`
- Applied in `getConnectionUrl()` — the gateway for all outbound fetches in the OAuth proxy
- Connections pointing to private IPs are treated as "not found" so no outbound request is made

## Test plan
- [x] `bun test apps/mesh/src/shared/utils/url-validation.test.ts` — 15/15 pass (loopback, RFC 1918, IMDS, IPv6, public URLs, edge cases)
- [x] `bun test apps/mesh/src/api/routes/oauth-proxy.test.ts` — 30/30 pass (5 new SSRF tests + all existing tests)
- [x] `bun run lint` — passes (0 errors)
- [x] `bun run fmt` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)