### PR TITLE
fix(chat): guard prompts array before mapping in ToolsPopover

### DIFF
--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -94,7 +94,7 @@ export function ToolsPopover({
     staleTime: 60000,
     enabled: open && !!client,
   });
-  const prompts = data?.prompts ?? [];
+  const prompts = Array.isArray(data?.prompts) ? data.prompts : [];
 
   const [activePrompt, setActivePrompt] = useState<Prompt | null>(null);
 


### PR DESCRIPTION
## Summary

- Replaces `data?.prompts ?? []` with `Array.isArray(data?.prompts) ? data.prompts : []` in `ToolsPopover`
- Prevents `TypeError: I.map is not a function` crash when the production virtual MCP endpoint returns a non-array value for `prompts`
- The `??` operator only catches `null`/`undefined` — any other non-array shape (like an empty object) slips through and explodes on `.map`

## Root cause

When a `vir_*` virtual MCP endpoint is used (instead of a direct `conn_*` connection), the production server can return a different response shape for `prompts/list` where `prompts` is not an array. Locally this does not reproduce because the local virtual MCP returns a proper array or nothing at all.

## Test plan

- [ ] Open the chat Tools popover and expand the Prompts submenu — no crash
- [ ] Verify prompts still list correctly when the endpoint returns a valid array
- [ ] Verify no crash when the endpoint returns `{}`, `null`, or `undefined` for `prompts`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard prompts before mapping in `ToolsPopover` to prevent a chat crash when the production virtual MCP endpoint returns a non-array `prompts` value. Replaces `data?.prompts ?? []` with `Array.isArray(data?.prompts) ? data.prompts : []` so non-array shapes don’t break `.map`.

<sup>Written for commit b6838e19da2db4c7e191320c3470c8734f0c4449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

