### PR TITLE
fix(connections): use canonical app_name for connection display titles

### DIFF
--- a/apps/mesh/src/shared/utils/group-connections.ts
+++ b/apps/mesh/src/shared/utils/group-connections.ts
@@ -2,10 +2,17 @@ import type { ConnectionEntity } from "@decocms/mesh-sdk";
 import { getConnectionSlug } from "./connection-slug";
 
 /**
+ * Strip auto-generated instance suffixes like "(2)" or "(a1b2)" from a title.
+ * Matches 1-6 character parenthesized suffixes at the end of the string, which
+ * covers numeric instance numbers and short base-36 clone IDs. Longer
+ * parenthesized qualifiers (e.g., "(Desktop)") are preserved.
+ */
+const INSTANCE_SUFFIX_RE = /\s*\([^)]{1,6}\)\s*$/;
+
+/**
  * Returns the canonical display title for a connection in catalog/card/header contexts.
- * For registry-installed connections (those with app_name set), the canonical name is
- * derived from the stable app_name slug so that user-renamed instances don't pollute
- * the group title. For custom connections (no app_name), the user-set title is used.
+ * Strips auto-generated instance suffixes from the connection title so that
+ * "Vercel MCP (2)" displays as "Vercel MCP".
  *
  * Use the raw connection.title only when showing the specific instance matters
  * (e.g., the instance list inside a connection detail, or the binding selector).
@@ -13,13 +20,24 @@ import { getConnectionSlug } from "./connection-slug";
 export function getConnectionDisplayTitle(
   connection: ConnectionEntity,
 ): string {
-  if (connection.app_name) {
-    // Convert slug → display title: "google-gmail" → "Google Gmail"
-    // Strip optional scope prefix like "@scope/name" first.
-    const slug = connection.app_name.replace(/^@[^/]+\//, "");
-    return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return connection.title.replace(INSTANCE_SUFFIX_RE, "");
+}
+
+/**
+ * For a group of connections sharing the same app, pick the best canonical title.
+ * Uses the shortest stripped title among all instances so that user-renamed
+ * instances (e.g., "Google Gmail adsfadsfa") don't pollute the group title
+ * when a sibling still has the clean original name.
+ */
+export function getGroupDisplayTitle(connections: ConnectionEntity[]): string {
+  let best = getConnectionDisplayTitle(connections[0]!);
+  for (let i = 1; i < connections.length; i++) {
+    const candidate = getConnectionDisplayTitle(connections[i]!);
+    if (candidate.length < best.length) {
+      best = candidate;
+    }
   }
-  return connection.title;
+  return best;
 }
 
 export interface ConnectionGroup {
@@ -68,7 +86,7 @@ export function groupConnections(
         type: "group",
         key,
         icon: first.icon,
-        title: getConnectionDisplayTitle(first),
+        title: getGroupDisplayTitle(bucket),
         connections: bucket,
       });
     }

--- a/apps/mesh/src/shared/utils/group-connections.ts
+++ b/apps/mesh/src/shared/utils/group-connections.ts
@@ -8,12 +8,17 @@ import { getConnectionSlug } from "./connection-slug";
 const INSTANCE_SUFFIX_RE = /\s*\([^)]{1,6}\)\s*$/;
 
 /**
- * Strip instance suffix from a connection title.
- * "Vercel (2)" → "Vercel", "Gmail (a1b2)" → "Gmail"
+ * Returns the canonical display title for a connection.
+ * Checks metadata.displayName first (set at install time, never changes),
+ * then falls back to stripping instance suffixes from the title.
  */
 export function getConnectionDisplayTitle(
   connection: ConnectionEntity,
 ): string {
+  const metadata = connection.metadata as Record<string, unknown> | null;
+  if (metadata?.displayName && typeof metadata.displayName === "string") {
+    return metadata.displayName;
+  }
   return connection.title.replace(INSTANCE_SUFFIX_RE, "");
 }
 

--- a/apps/mesh/src/shared/utils/group-connections.ts
+++ b/apps/mesh/src/shared/utils/group-connections.ts
@@ -1,18 +1,28 @@
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
 import { getConnectionSlug } from "./connection-slug";
+import { slugify } from "./slugify";
 
 /**
  * Strip auto-generated instance suffixes like "(2)" or "(a1b2)" from a title.
- * Matches 1-6 character parenthesized suffixes at the end of the string, which
- * covers numeric instance numbers and short base-36 clone IDs. Longer
- * parenthesized qualifiers (e.g., "(Desktop)") are preserved.
  */
 const INSTANCE_SUFFIX_RE = /\s*\([^)]{1,6}\)\s*$/;
 
 /**
+ * Convert an app_name slug to a display title as a last resort.
+ * "google-gmail" → "Google Gmail", "@scope/tool" → "Tool"
+ */
+function slugToTitle(appName: string): string {
+  const slug = appName.replace(/^@[^/]+\//, "");
+  return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
  * Returns the canonical display title for a connection in catalog/card/header contexts.
- * Strips auto-generated instance suffixes from the connection title so that
- * "Vercel MCP (2)" displays as "Vercel MCP".
+ *
+ * Strategy:
+ * 1. Strip auto-generated instance suffixes from the title ("Vercel MCP (2)" → "Vercel MCP")
+ * 2. If the stripped title still matches the app_name slug, use it (preserves original casing)
+ * 3. If it doesn't match (user renamed the instance), fall back to slug → title conversion
  *
  * Use the raw connection.title only when showing the specific instance matters
  * (e.g., the instance list inside a connection detail, or the binding selector).
@@ -20,16 +30,40 @@ const INSTANCE_SUFFIX_RE = /\s*\([^)]{1,6}\)\s*$/;
 export function getConnectionDisplayTitle(
   connection: ConnectionEntity,
 ): string {
-  return connection.title.replace(INSTANCE_SUFFIX_RE, "");
+  const stripped = connection.title.replace(INSTANCE_SUFFIX_RE, "");
+  if (!connection.app_name) return stripped;
+
+  // If slugifying the stripped title matches app_name, the title is original — use it
+  if (slugify(stripped) === connection.app_name) {
+    return stripped;
+  }
+
+  // Title was renamed — fall back to slug conversion
+  return slugToTitle(connection.app_name);
 }
 
 /**
  * For a group of connections sharing the same app, pick the best canonical title.
- * Uses the shortest stripped title among all instances so that user-renamed
- * instances (e.g., "Google Gmail adsfadsfa") don't pollute the group title
- * when a sibling still has the clean original name.
+ * Prefers the original (non-renamed) title from any instance to preserve correct
+ * casing. Falls back to the shortest stripped title.
  */
 export function getGroupDisplayTitle(connections: ConnectionEntity[]): string {
+  const appName = connections[0]!.app_name;
+
+  // First pass: look for an instance whose title still matches the app_name
+  // (i.e. hasn't been renamed). This preserves original casing like "Vercel MCP".
+  if (appName) {
+    for (const c of connections) {
+      const stripped = c.title.replace(INSTANCE_SUFFIX_RE, "");
+      if (slugify(stripped) === appName) {
+        return stripped;
+      }
+    }
+    // All instances were renamed — fall back to slug conversion
+    return slugToTitle(appName);
+  }
+
+  // No app_name — pick the shortest stripped title
   let best = getConnectionDisplayTitle(connections[0]!);
   for (let i = 1; i < connections.length; i++) {
     const candidate = getConnectionDisplayTitle(connections[i]!);

--- a/apps/mesh/src/shared/utils/group-connections.ts
+++ b/apps/mesh/src/shared/utils/group-connections.ts
@@ -1,6 +1,27 @@
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
 import { getConnectionSlug } from "./connection-slug";
 
+/**
+ * Returns the canonical display title for a connection in catalog/card/header contexts.
+ * For registry-installed connections (those with app_name set), the canonical name is
+ * derived from the stable app_name slug so that user-renamed instances don't pollute
+ * the group title. For custom connections (no app_name), the user-set title is used.
+ *
+ * Use the raw connection.title only when showing the specific instance matters
+ * (e.g., the instance list inside a connection detail, or the binding selector).
+ */
+export function getConnectionDisplayTitle(
+  connection: ConnectionEntity,
+): string {
+  if (connection.app_name) {
+    // Convert slug → display title: "google-gmail" → "Google Gmail"
+    // Strip optional scope prefix like "@scope/name" first.
+    const slug = connection.app_name.replace(/^@[^/]+\//, "");
+    return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  return connection.title;
+}
+
 export interface ConnectionGroup {
   type: "group";
   key: string;
@@ -47,9 +68,7 @@ export function groupConnections(
         type: "group",
         key,
         icon: first.icon,
-        title: first.app_name
-          ? first.title.replace(/\s*\(\d+\)\s*$/, "")
-          : first.title,
+        title: getConnectionDisplayTitle(first),
         connections: bucket,
       });
     }

--- a/apps/mesh/src/shared/utils/group-connections.ts
+++ b/apps/mesh/src/shared/utils/group-connections.ts
@@ -17,11 +17,26 @@ function slugToTitle(appName: string): string {
 }
 
 /**
+ * Check whether a stripped title looks like the original (not user-renamed)
+ * by comparing its slug against app_name. Allows partial matches at word
+ * boundaries so that "Vercel" matches "vercel-mcp" and "Vercel MCP Server"
+ * matches "vercel-mcp".
+ */
+function isOriginalTitle(titleSlug: string, appName: string): boolean {
+  return (
+    titleSlug === appName ||
+    appName.startsWith(titleSlug + "-") ||
+    titleSlug.startsWith(appName + "-")
+  );
+}
+
+/**
  * Returns the canonical display title for a connection in catalog/card/header contexts.
  *
  * Strategy:
  * 1. Strip auto-generated instance suffixes from the title ("Vercel MCP (2)" → "Vercel MCP")
- * 2. If the stripped title still matches the app_name slug, use it (preserves original casing)
+ * 2. If the stripped title still matches the app_name slug (exact or word-boundary prefix),
+ *    use it — this preserves the original casing from the registry (e.g., "Vercel MCP")
  * 3. If it doesn't match (user renamed the instance), fall back to slug → title conversion
  *
  * Use the raw connection.title only when showing the specific instance matters
@@ -33,8 +48,7 @@ export function getConnectionDisplayTitle(
   const stripped = connection.title.replace(INSTANCE_SUFFIX_RE, "");
   if (!connection.app_name) return stripped;
 
-  // If slugifying the stripped title matches app_name, the title is original — use it
-  if (slugify(stripped) === connection.app_name) {
+  if (isOriginalTitle(slugify(stripped), connection.app_name)) {
     return stripped;
   }
 
@@ -55,7 +69,7 @@ export function getGroupDisplayTitle(connections: ConnectionEntity[]): string {
   if (appName) {
     for (const c of connections) {
       const stripped = c.title.replace(INSTANCE_SUFFIX_RE, "");
-      if (slugify(stripped) === appName) {
+      if (isOriginalTitle(slugify(stripped), appName)) {
         return stripped;
       }
     }

--- a/apps/mesh/src/shared/utils/group-connections.ts
+++ b/apps/mesh/src/shared/utils/group-connections.ts
@@ -1,91 +1,20 @@
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
 import { getConnectionSlug } from "./connection-slug";
-import { slugify } from "./slugify";
 
 /**
  * Strip auto-generated instance suffixes like "(2)" or "(a1b2)" from a title.
+ * Matches 1-6 character parenthesized suffixes at the end of the string.
  */
 const INSTANCE_SUFFIX_RE = /\s*\([^)]{1,6}\)\s*$/;
 
 /**
- * Convert an app_name slug to a display title as a last resort.
- * "google-gmail" → "Google Gmail", "@scope/tool" → "Tool"
- */
-function slugToTitle(appName: string): string {
-  const slug = appName.replace(/^@[^/]+\//, "");
-  return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-/**
- * Check whether a stripped title looks like the original (not user-renamed)
- * by comparing its slug against app_name. Allows partial matches at word
- * boundaries so that "Vercel" matches "vercel-mcp" and "Vercel MCP Server"
- * matches "vercel-mcp".
- */
-function isOriginalTitle(titleSlug: string, appName: string): boolean {
-  return (
-    titleSlug === appName ||
-    appName.startsWith(titleSlug + "-") ||
-    titleSlug.startsWith(appName + "-")
-  );
-}
-
-/**
- * Returns the canonical display title for a connection in catalog/card/header contexts.
- *
- * Strategy:
- * 1. Strip auto-generated instance suffixes from the title ("Vercel MCP (2)" → "Vercel MCP")
- * 2. If the stripped title still matches the app_name slug (exact or word-boundary prefix),
- *    use it — this preserves the original casing from the registry (e.g., "Vercel MCP")
- * 3. If it doesn't match (user renamed the instance), fall back to slug → title conversion
- *
- * Use the raw connection.title only when showing the specific instance matters
- * (e.g., the instance list inside a connection detail, or the binding selector).
+ * Strip instance suffix from a connection title.
+ * "Vercel (2)" → "Vercel", "Gmail (a1b2)" → "Gmail"
  */
 export function getConnectionDisplayTitle(
   connection: ConnectionEntity,
 ): string {
-  const stripped = connection.title.replace(INSTANCE_SUFFIX_RE, "");
-  if (!connection.app_name) return stripped;
-
-  if (isOriginalTitle(slugify(stripped), connection.app_name)) {
-    return stripped;
-  }
-
-  // Title was renamed — fall back to slug conversion
-  return slugToTitle(connection.app_name);
-}
-
-/**
- * For a group of connections sharing the same app, pick the best canonical title.
- * Prefers the original (non-renamed) title from any instance to preserve correct
- * casing. Falls back to the shortest stripped title.
- */
-export function getGroupDisplayTitle(connections: ConnectionEntity[]): string {
-  const appName = connections[0]!.app_name;
-
-  // First pass: look for an instance whose title still matches the app_name
-  // (i.e. hasn't been renamed). This preserves original casing like "Vercel MCP".
-  if (appName) {
-    for (const c of connections) {
-      const stripped = c.title.replace(INSTANCE_SUFFIX_RE, "");
-      if (isOriginalTitle(slugify(stripped), appName)) {
-        return stripped;
-      }
-    }
-    // All instances were renamed — fall back to slug conversion
-    return slugToTitle(appName);
-  }
-
-  // No app_name — pick the shortest stripped title
-  let best = getConnectionDisplayTitle(connections[0]!);
-  for (let i = 1; i < connections.length; i++) {
-    const candidate = getConnectionDisplayTitle(connections[i]!);
-    if (candidate.length < best.length) {
-      best = candidate;
-    }
-  }
-  return best;
+  return connection.title.replace(INSTANCE_SUFFIX_RE, "");
 }
 
 export interface ConnectionGroup {
@@ -103,8 +32,14 @@ export interface SingleConnection {
 
 export type GroupedItem = SingleConnection | ConnectionGroup;
 
+/**
+ * Groups connections by their slug (app_name or derived from URL/title).
+ * Accepts an optional registry title lookup so group/single cards show
+ * the canonical registry name instead of the (possibly renamed) instance title.
+ */
 export function groupConnections(
   connections: ConnectionEntity[],
+  registryTitles?: Map<string, string>,
 ): GroupedItem[] {
   const buckets = new Map<string, ConnectionEntity[]>();
   for (const c of connections) {
@@ -127,6 +62,8 @@ export function groupConnections(
 
     const bucket = buckets.get(key)!;
     const first = bucket[0]!;
+    const registryTitle = first.app_name && registryTitles?.get(first.app_name);
+
     if (bucket.length === 1) {
       items.push({ type: "single", connection: first });
     } else {
@@ -134,7 +71,7 @@ export function groupConnections(
         type: "group",
         key,
         icon: first.icon,
-        title: getGroupDisplayTitle(bucket),
+        title: registryTitle || getConnectionDisplayTitle(first),
         connections: bucket,
       });
     }

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -11,6 +11,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import {
   getWellKnownDecopilotVirtualMCP,
   isDecopilot,
+  useConnections,
   useProjectContext,
 } from "@decocms/mesh-sdk";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
@@ -320,6 +321,8 @@ export function ChatInput({
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const playSwitchSound = useSound(question004Sound);
   const [connectionsOpen, setConnectionsOpen] = useState(false);
+  const existingConnections = useConnections();
+  const existingConnectionIds = new Set(existingConnections.map((c) => c.id));
 
   // Navigate to the agent route (like the sidebar does) instead of only
   // setting an ephemeral search-param override, so the thread list re-scopes.
@@ -651,8 +654,8 @@ export function ChatInput({
       <AddConnectionDialog
         open={connectionsOpen}
         onOpenChange={setConnectionsOpen}
-        addedConnectionIds={new Set()}
-        onAdd={() => {}}
+        addedConnectionIds={existingConnectionIds}
+        onAdd={() => setConnectionsOpen(false)}
         defaultTab="all"
       />
     </>

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -14,6 +14,7 @@ import {
   useConnections,
   useProjectContext,
 } from "@decocms/mesh-sdk";
+
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import {
   ArrowUp,
@@ -56,6 +57,26 @@ import { useSound } from "@/web/hooks/use-sound.ts";
 import { question004Sound } from "@deco/ui/lib/question-004.ts";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { ConnectionsBanner } from "./connections-banner";
+
+function HomeConnectionsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const existingConnections = useConnections();
+  const existingConnectionIds = new Set(existingConnections.map((c) => c.id));
+  return (
+    <AddConnectionDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      addedConnectionIds={existingConnectionIds}
+      onAdd={() => onOpenChange(false)}
+      defaultTab="all"
+    />
+  );
+}
 
 // ============================================================================
 // VirtualMCPBadge - Internal component for displaying selected virtual MCP
@@ -321,8 +342,6 @@ export function ChatInput({
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const playSwitchSound = useSound(question004Sound);
   const [connectionsOpen, setConnectionsOpen] = useState(false);
-  const existingConnections = useConnections();
-  const existingConnectionIds = new Set(existingConnections.map((c) => c.id));
 
   // Navigate to the agent route (like the sidebar does) instead of only
   // setting an ephemeral search-param override, so the thread list re-scopes.
@@ -651,13 +670,12 @@ export function ChatInput({
         </div>
       </div>
 
-      <AddConnectionDialog
-        open={connectionsOpen}
-        onOpenChange={setConnectionsOpen}
-        addedConnectionIds={existingConnectionIds}
-        onAdd={() => setConnectionsOpen(false)}
-        defaultTab="all"
-      />
+      {showConnectionsBanner && (
+        <HomeConnectionsDialog
+          open={connectionsOpen}
+          onOpenChange={setConnectionsOpen}
+        />
+      )}
     </>
   );
 }

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -597,7 +597,7 @@ function ConnectionInspectorViewWithConnection({
                         connection_headers: base.connection_headers ?? null,
                         oauth_config: null,
                         configuration_state: base.configuration_state ?? null,
-                        metadata: null,
+                        metadata: base.metadata ?? null,
                         tools: null,
                         bindings: null,
                         status: "inactive",

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -1,8 +1,5 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
-import {
-  getConnectionDisplayTitle,
-  getGroupDisplayTitle,
-} from "@/shared/utils/group-connections";
+import { getConnectionDisplayTitle } from "@/shared/utils/group-connections";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { recordToEnvVars } from "@/web/components/env-vars-editor";
@@ -428,9 +425,7 @@ function ConnectionInspectorViewWithConnection({
         <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbPage>
-            {siblings.length > 1
-              ? getGroupDisplayTitle(siblings)
-              : getConnectionDisplayTitle(siblings[0] ?? connection)}
+            {getConnectionDisplayTitle(siblings[0] ?? connection)}
           </BreadcrumbPage>
         </BreadcrumbItem>
       </BreadcrumbList>
@@ -563,11 +558,7 @@ function ConnectionInspectorViewWithConnection({
         <div className="flex flex-col h-full overflow-hidden">
           <ConnectionDetailHeader
             connection={connection}
-            displayTitle={
-              siblings.length > 1
-                ? getGroupDisplayTitle(siblings)
-                : getConnectionDisplayTitle(siblings[0] ?? connection)
-            }
+            displayTitle={getConnectionDisplayTitle(siblings[0] ?? connection)}
           />
           <div className="flex-1 overflow-auto @container">
             <div className="grid grid-cols-1 @3xl:grid-cols-2 gap-5 p-6">
@@ -585,10 +576,7 @@ function ConnectionInspectorViewWithConnection({
                     setIsAddingInstance(true);
                     try {
                       const base = siblings[0] ?? connection;
-                      const baseName =
-                        siblings.length > 1
-                          ? getGroupDisplayTitle(siblings)
-                          : getConnectionDisplayTitle(base);
+                      const baseName = getConnectionDisplayTitle(base);
                       const nextNumber = siblings.length + 1;
                       const newTitle = `${baseName} (${nextNumber})`;
                       const newId = generatePrefixedId("conn");

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -1,4 +1,5 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { getConnectionDisplayTitle } from "@/shared/utils/group-connections";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { recordToEnvVars } from "@/web/components/env-vars-editor";
@@ -424,12 +425,7 @@ function ConnectionInspectorViewWithConnection({
         <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbPage>
-            {(() => {
-              const first = siblings[0] ?? connection;
-              return first.app_name
-                ? first.title.replace(/\s*\(\d+\)\s*$/, "")
-                : first.title;
-            })()}
+            {getConnectionDisplayTitle(siblings[0] ?? connection)}
           </BreadcrumbPage>
         </BreadcrumbItem>
       </BreadcrumbList>
@@ -562,12 +558,7 @@ function ConnectionInspectorViewWithConnection({
         <div className="flex flex-col h-full overflow-hidden">
           <ConnectionDetailHeader
             connection={connection}
-            displayTitle={(() => {
-              const first = siblings[0] ?? connection;
-              return first.app_name
-                ? first.title.replace(/\s*\(\d+\)\s*$/, "")
-                : first.title;
-            })()}
+            displayTitle={getConnectionDisplayTitle(siblings[0] ?? connection)}
           />
           <div className="flex-1 overflow-auto @container">
             <div className="grid grid-cols-1 @3xl:grid-cols-2 gap-5 p-6">
@@ -585,7 +576,7 @@ function ConnectionInspectorViewWithConnection({
                     setIsAddingInstance(true);
                     try {
                       const base = siblings[0] ?? connection;
-                      const baseName = base.title.replace(/\s*\(\d+\)\s*$/, "");
+                      const baseName = getConnectionDisplayTitle(base);
                       const nextNumber = siblings.length + 1;
                       const newTitle = `${baseName} (${nextNumber})`;
                       const newId = generatePrefixedId("conn");

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -1,5 +1,8 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
-import { getConnectionDisplayTitle } from "@/shared/utils/group-connections";
+import {
+  getConnectionDisplayTitle,
+  getGroupDisplayTitle,
+} from "@/shared/utils/group-connections";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { recordToEnvVars } from "@/web/components/env-vars-editor";
@@ -425,7 +428,9 @@ function ConnectionInspectorViewWithConnection({
         <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbPage>
-            {getConnectionDisplayTitle(siblings[0] ?? connection)}
+            {siblings.length > 1
+              ? getGroupDisplayTitle(siblings)
+              : getConnectionDisplayTitle(siblings[0] ?? connection)}
           </BreadcrumbPage>
         </BreadcrumbItem>
       </BreadcrumbList>
@@ -558,7 +563,11 @@ function ConnectionInspectorViewWithConnection({
         <div className="flex flex-col h-full overflow-hidden">
           <ConnectionDetailHeader
             connection={connection}
-            displayTitle={getConnectionDisplayTitle(siblings[0] ?? connection)}
+            displayTitle={
+              siblings.length > 1
+                ? getGroupDisplayTitle(siblings)
+                : getConnectionDisplayTitle(siblings[0] ?? connection)
+            }
           />
           <div className="flex-1 overflow-auto @container">
             <div className="grid grid-cols-1 @3xl:grid-cols-2 gap-5 p-6">
@@ -576,10 +585,10 @@ function ConnectionInspectorViewWithConnection({
                     setIsAddingInstance(true);
                     try {
                       const base = siblings[0] ?? connection;
-                      const baseName = getConnectionDisplayTitle(base).replace(
-                        /\s*\(\d+\)\s*$/,
-                        "",
-                      );
+                      const baseName =
+                        siblings.length > 1
+                          ? getGroupDisplayTitle(siblings)
+                          : getConnectionDisplayTitle(base);
                       const nextNumber = siblings.length + 1;
                       const newTitle = `${baseName} (${nextNumber})`;
                       const newId = generatePrefixedId("conn");

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -576,7 +576,10 @@ function ConnectionInspectorViewWithConnection({
                     setIsAddingInstance(true);
                     try {
                       const base = siblings[0] ?? connection;
-                      const baseName = getConnectionDisplayTitle(base);
+                      const baseName = getConnectionDisplayTitle(base).replace(
+                        /\s*\(\d+\)\s*$/,
+                        "",
+                      );
                       const nextNumber = siblings.length + 1;
                       const newTitle = `${baseName} (${nextNumber})`;
                       const newId = generatePrefixedId("conn");

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -136,6 +136,7 @@ import {
 
 import {
   groupConnections,
+  getConnectionDisplayTitle,
   type ConnectionGroup,
 } from "@/shared/utils/group-connections";
 
@@ -552,6 +553,9 @@ function CatalogItemCard({
   const icon =
     item.server?.icons?.[0]?.src ||
     getGitHubAvatarUrl(item.server?.repository) ||
+    item.icon ||
+    item.image ||
+    item.logo ||
     null;
   const appInstances = allConnections.filter(
     (c) => c.connection_type !== "VIRTUAL" && c.app_name === appName,
@@ -1054,7 +1058,10 @@ function ConnectionResults({
                 return (
                   <ConnectionCard
                     key={connection.id}
-                    connection={connection}
+                    connection={{
+                      ...connection,
+                      title: getConnectionDisplayTitle(connection),
+                    }}
                     fallbackIcon={<Container />}
                     onClick={() =>
                       selectionMode

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -113,6 +113,7 @@ import type {
 } from "@/tools/connection/schema";
 import { EnvVarsEditor } from "@/web/components/env-vars-editor";
 import {
+  buildRegistryTitleMap,
   extractConnectionData,
   getRegistryItemAppName,
 } from "@/web/utils/extract-connection-data";
@@ -699,8 +700,6 @@ function ConnectionResults({
     return true;
   });
 
-  const grouped = groupConnections(filteredConnections);
-
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -720,6 +719,8 @@ function ConnectionResults({
     listState.searchTerm,
   );
   const registryItems = mergedDiscovery.items;
+  const registryTitles = buildRegistryTitleMap(registryItems);
+  const grouped = groupConnections(filteredConnections, registryTitles);
 
   const catalogSentinelRef = useInfiniteScroll(
     mergedDiscovery.loadMore,
@@ -1060,7 +1061,10 @@ function ConnectionResults({
                     key={connection.id}
                     connection={{
                       ...connection,
-                      title: getConnectionDisplayTitle(connection),
+                      title:
+                        (connection.app_name &&
+                          registryTitles.get(connection.app_name)) ||
+                        getConnectionDisplayTitle(connection),
                     }}
                     fallbackIcon={<Container />}
                     onClick={() =>

--- a/apps/mesh/src/web/utils/extract-connection-data.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.ts
@@ -26,6 +26,34 @@ export function getRegistryItemAppName(
 }
 
 /**
+ * Build a map from app_name → display title from a list of registry items.
+ * Used so connected cards can show the same title as the store catalog.
+ */
+export function buildRegistryTitleMap(
+  items: Pick<RegistryItem, "_meta" | "server" | "title" | "name" | "id">[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const item of items) {
+    const appName = getRegistryItemAppName(item);
+    if (!appName || map.has(appName)) continue;
+    const meshMeta = item._meta?.["mcp.mesh"] as
+      | Record<string, string>
+      | undefined;
+    const title =
+      meshMeta?.friendlyName ||
+      meshMeta?.friendly_name ||
+      item.server?.title ||
+      item.title ||
+      item.server?.name ||
+      item.name ||
+      item.id ||
+      "";
+    if (title) map.set(appName, title);
+  }
+  return map;
+}
+
+/**
  * Get a display name for a remote endpoint
  * Uses the hostname (without common suffixes) as the display name
  * Example: "https://graphql.mcp.cloudflare.com/mcp" -> "graphql.mcp.cloudflare.com"

--- a/apps/mesh/src/web/utils/extract-connection-data.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.ts
@@ -232,6 +232,7 @@ export function extractConnectionData(
     configuration_scopes: configScopes ?? null,
     metadata: {
       source: "store",
+      displayName: baseName,
       registry_item_id: item.id,
       verified: meshMeta?.verified ?? false,
       scopeName: meshMeta?.scopeName ?? null,

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -1,4 +1,7 @@
-import { groupConnections } from "@/shared/utils/group-connections";
+import {
+  groupConnections,
+  getConnectionDisplayTitle,
+} from "@/shared/utils/group-connections";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { CollectionTabs } from "@/web/components/collections/collection-tabs.tsx";
 import { CreateConnectionDialog } from "@/web/components/connections/create-connection-dialog.tsx";
@@ -296,6 +299,9 @@ function AddConnectionDialogContent({
     const icon =
       item.server?.icons?.[0]?.src ||
       getGitHubAvatarUrl(item.server?.repository) ||
+      item.icon ||
+      item.image ||
+      item.logo ||
       null;
 
     return (
@@ -373,7 +379,7 @@ function AddConnectionDialogContent({
             const c = item.connection;
             return renderConnectedApp(
               c.id,
-              c.title,
+              getConnectionDisplayTitle(c),
               c.icon,
               c.description ?? null,
               [c],
@@ -471,7 +477,7 @@ export function AddConnectionDialog({
   const handleCloneAndAdd = async (base: ConnectionEntity) => {
     setConnectingItemId(base.app_name ?? base.id);
     try {
-      const baseName = base.title.replace(/\s*\(\d+\)\s*$/, "");
+      const baseName = getConnectionDisplayTitle(base);
       const newTitle = `${baseName} (${Date.now().toString(36).slice(-4)})`;
 
       const created = await connectionActions.create.mutateAsync({

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -17,6 +17,7 @@ import {
 import { KEYS } from "@/web/lib/query-keys";
 import { authClient } from "@/web/lib/auth-client";
 import {
+  buildRegistryTitleMap,
   extractConnectionData,
   getRegistryItemAppName,
 } from "@/web/utils/extract-connection-data";
@@ -179,7 +180,6 @@ function AddConnectionDialogContent({
     connectionsData?.pages.flatMap(
       (p: CollectionListOutput<ConnectionEntity>) => p?.items ?? [],
     ) ?? [];
-  const grouped = groupConnections(allConnections);
 
   // Build set of connected app names to deduplicate catalog items
   const connectedAppNames = new Set(
@@ -192,6 +192,9 @@ function AddConnectionDialogContent({
     enabledRegistries,
     deferredSearch,
   );
+
+  const registryTitles = buildRegistryTitleMap(mergedDiscovery.items);
+  const grouped = groupConnections(allConnections, registryTitles);
 
   const catalogSentinelRef = useInfiniteScroll(
     mergedDiscovery.loadMore,
@@ -379,7 +382,8 @@ function AddConnectionDialogContent({
             const c = item.connection;
             return renderConnectedApp(
               c.id,
-              getConnectionDisplayTitle(c),
+              (c.app_name && registryTitles.get(c.app_name)) ||
+                getConnectionDisplayTitle(c),
               c.icon,
               c.description ?? null,
               [c],

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -494,6 +494,7 @@ export function AddConnectionDialog({
         app_name: base.app_name ?? null,
         app_id: base.app_id ?? null,
         connection_headers: base.connection_headers ?? null,
+        metadata: base.metadata ?? null,
       });
       const id = created.id;
 

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1202,6 +1202,7 @@ function VirtualMcpDetailViewWithData({
         app_name: base.app_name ?? null,
         app_id: base.app_id ?? null,
         connection_headers: base.connection_headers ?? null,
+        metadata: base.metadata ?? null,
       });
 
       // Handle OAuth if needed

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1,4 +1,5 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
+import { getConnectionDisplayTitle } from "@/shared/utils/group-connections";
 import type { VirtualMCPEntity } from "@/tools/virtual/schema";
 import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import { useChatTask } from "@/web/components/chat/context";
@@ -1185,7 +1186,7 @@ function VirtualMcpDetailViewWithData({
       };
       if (!base) return;
 
-      const baseName = base.title.replace(/\s*\(.*?\)\s*$/, "");
+      const baseName = getConnectionDisplayTitle(base);
       const newId = generatePrefixedId("conn");
       // Temporary title — will be updated with email suffix after OAuth if available
       const tempTitle = `${baseName} (${Date.now().toString(36).slice(-4)})`;


### PR DESCRIPTION
## What is this contribution about?

Connection cards, group headers, detail page headers, and breadcrumbs were deriving the display name from the first instance's mutable `title` field. When a user renamed an instance (e.g. "Google Gmail" → "Google Gmail adsfadsfa"), that renamed name would propagate everywhere — catalog cards, group titles, and the detail header.

The fix introduces `getConnectionDisplayTitle()` which derives the canonical name from the stable `app_name` slug (`"google-gmail"` → `"Google Gmail"`) for registry-installed connections. Custom connections (no `app_name`) continue using their user-set title. Instance-specific names still appear where they belong: the instances panel, the settings sheet, and the binding selector.

Also adds icon fallbacks (`item.icon`, `item.image`, `item.logo`) for non-store registry items in the connections catalog and add-connection dialog.

## Screenshots/Demonstration

Before: renaming an instance to "Google Gmail adsfadsfa" caused that name to show in the catalog card and detail header.
After: catalog cards and headers always show "Google Gmail" (from `app_name`); instance names only appear in the instances list.

## How to Test

1. Install a registry connection (e.g. Google Gmail)
2. Rename the instance to something custom via the settings sheet
3. Go back to the Connections catalog — card should still show "Google Gmail"
4. Click through to the detail page — header and breadcrumb should show "Google Gmail"
5. The instances panel should show the custom name you set

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses registry catalog titles and a stored `metadata.displayName` for connection display names, stripping auto-generated suffixes so cards, group headers, detail headers, and breadcrumbs stay stable and correctly cased. The home connections dialog now marks existing apps as Added, closes on Add, and only mounts/fetches when opened.

- **Bug Fixes**
  - Connected cards/groups: use `buildRegistryTitleMap` (`app_name` → catalog title); fallback to `getConnectionDisplayTitle` (checks `metadata.displayName`, then strips 1–6 char parenthesized suffixes).
  - Persist canonical title in `metadata.displayName` at install; use it for headers/breadcrumbs; clone/add flows copy it.
  - Prevent stacked suffixes when creating/cloning by stripping before appending.
  - Add icon fallbacks in catalog and add-connection dialog (`item.icon`, `item.image`, `item.logo`).
  - Home connections dialog: loads org connections to mark Added, closes after Add, only mounts when the banner/dialog is visible.

<sup>Written for commit 0de74e82ae51c795814b5762e6d0d3598feb6d52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

