### PR TITLE
feat(templates): add Lean Canvas agent template

### DIFF
--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -28,6 +28,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { ChevronRight, Plus, Users03 } from "@untitledui/icons";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
+import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { Suspense, useState } from "react";
@@ -157,6 +158,7 @@ function AgentsListContent() {
   const { locator } = useProjectContext();
   const [siteEditorModalOpen, setSiteEditorModalOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
+  const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
   const navigateToAgent = useNavigateToAgent();
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
@@ -164,6 +166,9 @@ function AgentsListContent() {
   )!;
   const siteDiagnosticsAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "site-diagnostics",
+  )!;
+  const leanCanvasAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "lean-canvas",
   )!;
 
   const recentIds = readRecentAgentIds(locator);
@@ -195,6 +200,15 @@ function AgentsListContent() {
         a.title === siteDiagnosticsAgent.title),
   );
 
+  // Check if Lean Canvas agent already exists
+  const existingLeanCanvas = virtualMcps.find(
+    (a): a is typeof a & { id: string } =>
+      a.id !== null &&
+      ((a as { metadata?: { type?: string } }).metadata?.type ===
+        leanCanvasAgent.id ||
+        a.title === leanCanvasAgent.title),
+  );
+
   const hasAgents = agents.length > 0;
 
   return (
@@ -215,8 +229,21 @@ function AgentsListContent() {
                 : () => setDiagnosticsModalOpen(true)
             }
           />
+          <AgentPreview
+            key={leanCanvasAgent.id}
+            agent={existingLeanCanvas ?? leanCanvasAgent}
+            onSpecialClick={
+              existingLeanCanvas
+                ? () => navigateToAgent(existingLeanCanvas.id)
+                : () => setLeanCanvasModalOpen(true)
+            }
+          />
           {agents
-            .filter((a) => a.id !== existingDiagnostics?.id)
+            .filter(
+              (a) =>
+                a.id !== existingDiagnostics?.id &&
+                a.id !== existingLeanCanvas?.id,
+            )
             .map((agent) => (
               <AgentPreview
                 key={agent.id ?? "default"}
@@ -238,6 +265,12 @@ function AgentsListContent() {
         open={diagnosticsModalOpen}
         onOpenChange={setDiagnosticsModalOpen}
         existingAgent={existingDiagnostics}
+      />
+
+      <LeanCanvasRecruitModal
+        open={leanCanvasModalOpen}
+        onOpenChange={setLeanCanvasModalOpen}
+        existingAgent={existingLeanCanvas}
       />
     </>
   );

--- a/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
@@ -25,6 +25,7 @@ import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   SELF_MCP_ALIAS_ID,
   WELL_KNOWN_AGENT_TEMPLATES,
+  WellKnownOrgMCPId,
   useConnectionActions,
   useMCPClient,
   useMCPToolCallMutation,
@@ -173,7 +174,8 @@ export function LeanCanvasRecruitModal({
         connectionId = connection.id;
       }
 
-      // 2. Create a virtual MCP (agent) with the connection attached
+      // 2. Create a virtual MCP (agent) with the connection + self MCP attached
+      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
       const virtualMcp = await virtualMcpActions.create.mutateAsync({
         title: template.title,
         description: "Lean Canvas business model builder",
@@ -182,6 +184,12 @@ export function LeanCanvasRecruitModal({
         connections: [
           {
             connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+          {
+            connection_id: selfConnectionId,
             selected_tools: null,
             selected_resources: null,
             selected_prompts: null,

--- a/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
@@ -154,6 +154,8 @@ export function LeanCanvasRecruitModal({
         (c) => c.app_id === "lean-canvas",
       );
 
+      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
+
       if (matchingConnection) {
         connectionId = matchingConnection.id;
       } else {
@@ -165,6 +167,13 @@ export function LeanCanvasRecruitModal({
           connection_url: LEAN_CANVAS_MCP_URL,
           app_name: "lean-canvas",
           app_id: "lean-canvas",
+          configuration_state: {
+            OBJECT_STORAGE: {
+              __type: "@deco/object-storage",
+              value: selfConnectionId,
+            },
+          },
+          configuration_scopes: ["OBJECT_STORAGE::*"],
           metadata: {
             type: "lean-canvas",
             source: "store",
@@ -175,7 +184,6 @@ export function LeanCanvasRecruitModal({
       }
 
       // 2. Create a virtual MCP (agent) with the connection + self MCP attached
-      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
       const virtualMcp = await virtualMcpActions.create.mutateAsync({
         title: template.title,
         description: "Lean Canvas business model builder",

--- a/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
@@ -1,0 +1,256 @@
+/**
+ * Lean Canvas Recruitment Modal
+ *
+ * Shown when the user clicks the Lean Canvas template on the home page.
+ * Creates an HTTP connection to the external Lean Canvas MCP + virtual MCP,
+ * then navigates to the agent view.
+ */
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@deco/ui/components/drawer.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import {
+  SELF_MCP_ALIAS_ID,
+  WELL_KNOWN_AGENT_TEMPLATES,
+  useConnectionActions,
+  useMCPClient,
+  useMCPToolCallMutation,
+  useProjectContext,
+  useVirtualMCPActions,
+} from "@decocms/mesh-sdk";
+import type { CollectionListOutput } from "@decocms/bindings/collections";
+import type { ConnectionEntity } from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+
+const LEAN_CANVAS_MCP_URL = "https://sites-lean-canva.decocache.com/api/mcp";
+
+interface LeanCanvasRecruitModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingAgent?: { id: string } | null;
+}
+
+const CAPABILITIES = [
+  "Build and update Lean Canvas business models visually",
+  "Interactive grid UI with all 9 canvas sections",
+  "Iterative updates — add information as you discover it",
+  "Covers: Problem, Solution, Key Metrics, Unique Value Proposition",
+  "Covers: Channels, Customer Segments, Cost Structure, Revenue Streams",
+  "Unfair Advantage analysis",
+];
+
+function RecruitContent({
+  onRecruit,
+  isRecruiting,
+}: {
+  onRecruit: () => void;
+  isRecruiting: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Add a Lean Canvas agent that helps you build and iterate on your
+        business model. Describe your idea and it produces a visual, structured
+        canvas.
+      </p>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">Capabilities</p>
+        <ul className="space-y-1.5">
+          {CAPABILITIES.map((cap) => (
+            <li
+              key={cap}
+              className="text-sm text-muted-foreground flex items-start gap-2"
+            >
+              <span className="text-emerald-500 mt-0.5 shrink-0">+</span>
+              {cap}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Button
+        onClick={onRecruit}
+        disabled={isRecruiting}
+        className="w-full cursor-pointer"
+      >
+        {isRecruiting ? "Setting up..." : "Add Lean Canvas"}
+      </Button>
+    </div>
+  );
+}
+
+export function LeanCanvasRecruitModal({
+  open,
+  onOpenChange,
+  existingAgent,
+}: LeanCanvasRecruitModalProps) {
+  const isMobile = useIsMobile();
+  const { org } = useProjectContext();
+  const navigateToAgent = useNavigateToAgent();
+  const connectionActions = useConnectionActions();
+  const virtualMcpActions = useVirtualMCPActions();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+  const connectionQuery = useMCPToolCallMutation({ client });
+  const [isRecruiting, setIsRecruiting] = useState(false);
+
+  const template = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "lean-canvas",
+  )!;
+
+  const headerIcon = (
+    <IntegrationIcon icon={template.icon} name={template.title} size="sm" />
+  );
+
+  const handleRecruit = async () => {
+    // If agent already exists, just navigate to it
+    if (existingAgent) {
+      onOpenChange(false);
+      navigateToAgent(existingAgent.id);
+      return;
+    }
+
+    setIsRecruiting(true);
+    try {
+      // 1. Find or create the HTTP connection to the external Lean Canvas MCP
+      const existingConnectionResult = await connectionQuery.mutateAsync({
+        name: "COLLECTION_CONNECTIONS_LIST",
+        arguments: {
+          where: {
+            field: ["app_id"],
+            operator: "eq",
+            value: "lean-canvas",
+          },
+          limit: 1,
+          offset: 0,
+        },
+      });
+
+      let connectionId: string;
+      const existingConnections = (
+        existingConnectionResult as {
+          structuredContent?: CollectionListOutput<ConnectionEntity>;
+        }
+      )?.structuredContent?.items;
+
+      const matchingConnection = existingConnections?.find(
+        (c) => c.app_id === "lean-canvas",
+      );
+
+      if (matchingConnection) {
+        connectionId = matchingConnection.id;
+      } else {
+        const connection = await connectionActions.create.mutateAsync({
+          title: template.title,
+          description: "Lean Canvas business model builder",
+          icon: template.icon,
+          connection_type: "HTTP",
+          connection_url: LEAN_CANVAS_MCP_URL,
+          app_name: "lean-canvas",
+          app_id: "lean-canvas",
+          metadata: {
+            type: "lean-canvas",
+            source: "store",
+            verified: true,
+          },
+        });
+        connectionId = connection.id;
+      }
+
+      // 2. Create a virtual MCP (agent) with the connection attached
+      const virtualMcp = await virtualMcpActions.create.mutateAsync({
+        title: template.title,
+        description: "Lean Canvas business model builder",
+        icon: template.icon,
+        status: "active",
+        connections: [
+          {
+            connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+        metadata: {
+          type: "lean-canvas",
+          instructions: null,
+          ui: {
+            pinnedViews: [
+              {
+                connectionId,
+                toolName: "lean_canvas",
+                label: "lean_canvas",
+                icon: null,
+              },
+            ],
+            layout: {
+              defaultMainView: {
+                type: "ext-apps",
+                id: connectionId,
+                toolName: "lean_canvas",
+              },
+              chatDefaultOpen: false,
+            },
+          },
+        },
+      });
+
+      // 3. Navigate to the new agent
+      onOpenChange(false);
+      navigateToAgent(virtualMcp.id!);
+    } catch (error) {
+      console.error("Failed to create Lean Canvas agent:", error);
+    } finally {
+      setIsRecruiting(false);
+    }
+  };
+
+  const title = `Add ${template.title}`;
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="h-[70dvh]">
+        <DrawerHeader className="px-4 pt-4 pb-4 shrink-0">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DrawerTitle className="text-xl font-semibold">{title}</DrawerTitle>
+          </div>
+        </DrawerHeader>
+        <div className="flex flex-col flex-1 min-h-0 px-4 pb-8">
+          <RecruitContent
+            onRecruit={handleRecruit}
+            isRecruiting={isRecruiting}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] p-8">
+        <DialogHeader className="mb-4">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DialogTitle className="text-xl font-semibold">{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+        <RecruitContent onRecruit={handleRecruit} isRecruiting={isRecruiting} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
@@ -173,7 +173,6 @@ export function LeanCanvasRecruitModal({
               value: selfConnectionId,
             },
           },
-          configuration_scopes: ["OBJECT_STORAGE::*"],
           metadata: {
             type: "lean-canvas",
             source: "store",

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -64,6 +64,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
+import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
 import { useAgentBadges } from "@/web/hooks/use-agent-badges";
 
 function AgentListItem({
@@ -292,11 +293,13 @@ function PinAgentPopoverContent({
   onClose,
   onOpenSiteEditorModal,
   onOpenDiagnosticsModal,
+  onOpenLeanCanvasModal,
   onOpenStudioPackModal,
 }: {
   onClose: () => void;
   onOpenSiteEditorModal: () => void;
   onOpenDiagnosticsModal: () => void;
+  onOpenLeanCanvasModal: () => void;
   onOpenStudioPackModal: () => void;
 }) {
   const [search, setSearch] = useState("");
@@ -335,6 +338,18 @@ function PinAgentPopoverContent({
       )
     : undefined;
 
+  // Find existing recruited Lean Canvas agent
+  const leanCanvasTemplate = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "lean-canvas",
+  );
+  const existingLeanCanvas = leanCanvasTemplate
+    ? allAgents.find(
+        (a) =>
+          (a as { metadata?: { type?: string } }).metadata?.type ===
+          leanCanvasTemplate.id,
+      )
+    : undefined;
+
   const handleSelect = (agent: VirtualMCPEntity) => {
     if (!isPinned(agent.id)) {
       pin(agent.id);
@@ -354,6 +369,12 @@ function PinAgentPopoverContent({
         navigateToAgent(existingDiagnostics.id);
       } else {
         onOpenDiagnosticsModal();
+      }
+    } else if (templateId === "lean-canvas") {
+      if (existingLeanCanvas) {
+        navigateToAgent(existingLeanCanvas.id);
+      } else {
+        onOpenLeanCanvasModal();
       }
     } else if (templateId === "studio-pack") {
       onOpenStudioPackModal();
@@ -466,6 +487,7 @@ function PinAgentPopover() {
   const [open, setOpen] = useState(false);
   const [siteEditorModalOpen, setSiteEditorModalOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
+  const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
   const isMobile = useIsMobile();
   const { setOpenMobile } = useSidebar();
@@ -487,6 +509,7 @@ function PinAgentPopover() {
         onClose={handleClose}
         onOpenSiteEditorModal={() => setSiteEditorModalOpen(true)}
         onOpenDiagnosticsModal={() => setDiagnosticsModalOpen(true)}
+        onOpenLeanCanvasModal={() => setLeanCanvasModalOpen(true)}
         onOpenStudioPackModal={() => setStudioPackModalOpen(true)}
       />
     </Suspense>
@@ -540,6 +563,10 @@ function PinAgentPopover() {
       <SiteDiagnosticsRecruitModal
         open={diagnosticsModalOpen}
         onOpenChange={setDiagnosticsModalOpen}
+      />
+      <LeanCanvasRecruitModal
+        open={leanCanvasModalOpen}
+        onOpenChange={setLeanCanvasModalOpen}
       />
       <StudioPackRecruitModal
         open={studioPackModalOpen}

--- a/apps/mesh/src/web/routes/agents-list.tsx
+++ b/apps/mesh/src/web/routes/agents-list.tsx
@@ -15,6 +15,7 @@ import { AgentAvatar } from "@/web/components/agent-icon";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
+import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -47,6 +48,7 @@ export default function AgentsListPage() {
   const [siteEditorModalOpen, setSiteEditorModalOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
+  const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
 
   const lowerSearch = search.toLowerCase();
 
@@ -76,6 +78,12 @@ export default function AgentsListPage() {
       "site-diagnostics",
   );
 
+  // Find existing recruited Lean Canvas agent
+  const existingLeanCanvas = agents.find(
+    (a) =>
+      (a as { metadata?: { type?: string } }).metadata?.type === "lean-canvas",
+  );
+
   const handleTemplateClick = (templateId: string) => {
     if (templateId === "site-editor") {
       setSiteEditorModalOpen(true);
@@ -84,6 +92,12 @@ export default function AgentsListPage() {
         navigateToAgent(existingDiagnostics.id);
       } else {
         setDiagnosticsModalOpen(true);
+      }
+    } else if (templateId === "lean-canvas") {
+      if (existingLeanCanvas) {
+        navigateToAgent(existingLeanCanvas.id);
+      } else {
+        setLeanCanvasModalOpen(true);
       }
     } else if (templateId === "studio-pack") {
       setStudioPackModalOpen(true);
@@ -230,6 +244,11 @@ export default function AgentsListPage() {
       <SiteDiagnosticsRecruitModal
         open={diagnosticsModalOpen}
         onOpenChange={setDiagnosticsModalOpen}
+      />
+      <LeanCanvasRecruitModal
+        open={leanCanvasModalOpen}
+        onOpenChange={setLeanCanvasModalOpen}
+        existingAgent={existingLeanCanvas}
       />
       <StudioPackRecruitModal
         open={studioPackModalOpen}

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -322,6 +322,12 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
     type: "registry-agent" as const,
   },
   {
+    id: "lean-canvas",
+    title: "Lean Canvas",
+    icon: "icon://FileCheck02?color=green",
+    type: "registry-agent" as const,
+  },
+  {
     id: "studio-pack",
     title: "Studio Pack",
     icon: "icon://Package?color=blue",


### PR DESCRIPTION
## What is this contribution about?

Adds a new "Lean Canvas" agent template to the template gallery, alongside Site Diagnostics and Site Editor. When a user clicks the template, it creates an HTTP connection to the external Lean Canvas MCP server (`https://sites-lean-canva.decocache.com/api/mcp`) and sets up a virtual agent with the `lean_canvas` tool pinned as the default view. If the agent already exists, it navigates directly to it.

## Screenshots/Demonstration

> UI changes are in the template grid — the new "Lean Canvas" card appears in the agents list page, home page, and sidebar agent picker.

## How to Test

1. Start the dev server with `bun run dev`
2. Navigate to the Agents page or Home page
3. Verify the "Lean Canvas" template card appears in the templates grid
4. Click the template — the recruit modal should open with capabilities listed
5. Click "Add Lean Canvas" — it should create the connection + agent and navigate to the agent view
6. Click the template again — it should navigate directly to the existing agent

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Lean Canvas agent template that connects to the external Lean Canvas MCP and the org’s self MCP, then creates a virtual agent with the `lean_canvas` tool as the default view. Object Storage is preconfigured via the self MCP; scopes are auto-populated by the backend.

- **New Features**
  - Added Lean Canvas template to the Home, Agents page, and sidebar picker with a recruit modal.
  - On first use, creates an HTTP connection to the Lean Canvas MCP (https://sites-lean-canva.decocache.com/api/mcp) with app_id/type `lean-canvas`, and preconfigures `OBJECT_STORAGE` to the org’s self MCP.
  - Creates a virtual agent with a pinned `lean_canvas` view and sets it as the default main view.
  - Detects existing Lean Canvas agents and navigates directly to avoid duplicates in lists and the pin popover.

- **Bug Fixes**
  - Removed `configuration_scopes` from the connection create payload so the backend keeps registry-provided scopes.

<sup>Written for commit 284888070eec9d16892a69e6ffe2fc85a435bac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

