### PR TITLE
fix(ui): improve connection card settings affordance and icon consistency

### DIFF
--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -28,7 +28,7 @@ import {
   Monitor01,
   Moon01,
   Plus,
-  Settings01,
+  Settings02,
   Shield01,
   Sun,
   Users03,
@@ -515,7 +515,7 @@ export function AccountPopover() {
     {
       key: "preferences",
       label: "Preferences",
-      icon: <Settings01 size={16} />,
+      icon: <Settings02 size={16} />,
       onClick: () => {
         navigate({
           to: "/$org/settings/profile",

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -34,7 +34,7 @@ import {
   Key01,
   RefreshCcw01,
   SearchMd,
-  Settings01,
+  Settings02,
   Stars01,
   Tool01,
 } from "@untitledui/icons";
@@ -1179,7 +1179,7 @@ function ModelSelectorInner({
               onClick={() => startTransition(() => setManaging(true))}
               className="flex items-center gap-2 flex-1 px-4 py-2.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent cursor-pointer"
             >
-              <Settings01 className="size-3.5 shrink-0" />
+              <Settings02 className="size-3.5 shrink-0" />
               Manage models
             </button>
             <div className="w-px bg-border shrink-0" />

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -11,7 +11,7 @@ import { Page } from "@/web/components/page";
 import { getIconComponent, parseIconString } from "../agent-icon";
 
 import { usePanelActions } from "@/web/layouts/shell-layout";
-import { Edit05, LayoutLeft, Loading01, Settings01 } from "@untitledui/icons";
+import { Edit05, LayoutLeft, Loading01, Settings02 } from "@untitledui/icons";
 import { useVirtualMCPActions, useVirtualMCP } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { Suspense, useEffect, useRef, useState, useTransition } from "react";
@@ -320,7 +320,7 @@ function TasksPanelContent({
               isSettingsActive && "bg-accent text-foreground",
             )}
           >
-            <Settings01 size={16} className="shrink-0" />
+            <Settings02 size={16} className="shrink-0" />
             <span className="text-foreground">Settings</span>
           </button>
         )}

--- a/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
@@ -3,7 +3,7 @@ import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
-import { Loading01, Plus, Settings01, Trash01 } from "@untitledui/icons";
+import { Loading01, Plus, Settings02, Trash01 } from "@untitledui/icons";
 import { Suspense } from "react";
 
 interface ConnectionInstancesPanelProps {
@@ -72,7 +72,7 @@ function InstanceItem({
           onClick={() => onConfigure(instance)}
           title="Configure"
         >
-          <Settings01 size={13} />
+          <Settings02 size={13} />
         </Button>
         <Button
           variant="ghost"
@@ -114,7 +114,7 @@ function InstanceItemFallback({
           onClick={() => onConfigure(instance)}
           title="Configure"
         >
-          <Settings01 size={13} />
+          <Settings02 size={13} />
         </Button>
       </div>
     </div>

--- a/apps/mesh/src/web/components/project-card.tsx
+++ b/apps/mesh/src/web/components/project-card.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { DotsVertical, Settings01, Trash01 } from "@untitledui/icons";
+import { DotsVertical, Settings02, Trash01 } from "@untitledui/icons";
 import { formatDistanceToNow } from "date-fns";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
@@ -58,7 +58,7 @@ export function ProjectCard({ project, onDeleteClick }: ProjectCardProps) {
                       params={{ org: org.slug, virtualMcpId: project.id }}
                       search={{ main: "settings" }}
                     >
-                      <Settings01 size={16} />
+                      <Settings02 size={16} />
                       Settings
                     </Link>
                   </DropdownMenuItem>

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -39,7 +39,7 @@ import {
 } from "@deco/ui/components/drawer.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { CollectionSearch } from "@deco/ui/components/collection-search.tsx";
-import { Plus, Settings01, X } from "@untitledui/icons";
+import { Plus, Settings02, X } from "@untitledui/icons";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -164,7 +164,7 @@ function AgentListItem({
               });
             }}
           >
-            <Settings01 size={14} />
+            <Settings02 size={14} />
             Settings
           </ContextMenuItem>
           <ContextMenuSeparator />

--- a/apps/mesh/src/web/components/sidebar/footer/inbox-mobile.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox-mobile.tsx
@@ -6,7 +6,7 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@deco/ui/components/sidebar.tsx";
-import { Settings01 } from "@untitledui/icons";
+import { Settings02 } from "@untitledui/icons";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 
@@ -29,7 +29,7 @@ export function SidebarInboxFooterMobile() {
               setOpenMobile(false);
             }}
           >
-            <Settings01 />
+            <Settings02 />
           </SidebarMenuButton>
         </SidebarMenuItem>
         <SidebarMenuItem>

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -12,7 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@deco/ui/components/sidebar.tsx";
-import { Check, Coins01, Inbox01, Settings01, XClose } from "@untitledui/icons";
+import { Check, Coins01, Inbox01, Settings02, XClose } from "@untitledui/icons";
 import { AuthUIContext } from "@daveyplate/better-auth-ui";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Component, Suspense, useContext, useState } from "react";
@@ -282,7 +282,7 @@ function SettingsButton() {
             })
           }
         >
-          <Settings01 size={24} />
+          <Settings02 size={24} />
         </SidebarMenuButton>
       </SidebarMenuItem>
     </SidebarMenu>

--- a/apps/mesh/src/web/layouts/plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/plugin-layout.tsx
@@ -28,7 +28,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { authClient } from "@/web/lib/auth-client";
 import { Outlet, useParams, Link } from "@tanstack/react-router";
-import { Loading01, Settings01 } from "@untitledui/icons";
+import { Loading01, Settings02 } from "@untitledui/icons";
 import type { ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
@@ -204,7 +204,7 @@ export function PluginLayout({
       <PluginContextProvider value={emptyContext}>
         <div className="h-full flex flex-col items-center justify-center gap-4 p-8">
           <div className="flex flex-col items-center gap-2 text-center max-w-md">
-            <Settings01 size={48} className="text-muted-foreground mb-2" />
+            <Settings02 size={48} className="text-muted-foreground mb-2" />
             <h2 className="text-lg font-semibold">Plugin Not Configured</h2>
             <p className="text-sm text-muted-foreground">
               This plugin requires a connection to be configured. Go to project

--- a/apps/mesh/src/web/views/registry/registry-layout.tsx
+++ b/apps/mesh/src/web/views/registry/registry-layout.tsx
@@ -4,7 +4,7 @@ import {
   ArrowNarrowLeft,
   CheckCircle,
   Container,
-  Settings01,
+  Settings02,
   Tool02,
 } from "@untitledui/icons";
 import { PLUGIN_ID } from "@/tools/registry/shared";
@@ -101,7 +101,7 @@ export default function RegistryLayout({ onBack }: { onBack?: () => void }) {
         ]
       : []),
     { id: "qa", label: "QA", icon: Tool02, tab: "qa" },
-    { id: "settings", label: "Settings", icon: Settings01, tab: "settings" },
+    { id: "settings", label: "Settings", icon: Settings02, tab: "settings" },
   ];
 
   return (

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -62,10 +62,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
-  ChevronRight,
+  Settings02,
+  Settings04,
   Play,
   Plus,
-  Settings01,
   Stars01,
   Trash01,
   XClose,
@@ -379,7 +379,14 @@ function ConnectionItemWithAuth({
             Authorize
           </Button>
         ) : (
-          <ChevronRight size={16} className="text-muted-foreground shrink-0" />
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <span className="inline-flex items-center justify-center rounded-md h-7 w-7 hover:bg-accent text-muted-foreground shrink-0 transition-colors">
+                <Settings02 size={16} />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Connection settings</TooltipContent>
+          </Tooltip>
         )}
       </Link>
 
@@ -406,7 +413,7 @@ function ConnectionItemWithAuth({
                 onClick={onOpenSettings}
                 aria-label="Configure resources"
               >
-                <Settings01 size={13} />
+                <Settings04 size={13} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">Configure resources</TooltipContent>


### PR DESCRIPTION
## What is this contribution about?

Two UX improvements to the connection card in the agent settings view:

1. **Clearer settings affordance**: replaced the ambiguous `ChevronRight` arrow on the connection card body with a `Settings02` icon wrapped in a tooltip ("Connection settings"), making it obvious that clicking navigates to the connection's settings page.
2. **Disambiguated resource config icon**: the footer gear icon (previously `Settings01`) now uses `Settings04` so it's visually distinct from the settings navigation icon, reducing confusion between "go to settings" and "configure resources".
3. **Global icon rename**: all `Settings01` usages across the web UI have been renamed to `Settings02` for consistency.

## Screenshots/Demonstration

> Before: connection card showed `›` on the body and `⚙` (Settings01) on both the body link and the footer resource button — causing confusion about which one opened settings.
> After: body shows `Settings02` with tooltip "Connection settings", footer resource button shows `Settings04`.

## How to Test

1. Navigate to an agent's settings view (click the settings button in the sidebar or task panel)
2. Observe the connection cards — the right side of the card body now shows a settings icon instead of a chevron
3. Hover over it — a tooltip "Connection settings" should appear with its own hover highlight
4. Click the card body → navigates to the connection detail/settings page
5. In the card footer, the resource config button now uses a different icon (Settings04) — visually distinct from the settings icon

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the connection card’s settings action obvious and standardize settings icons across the web UI. This removes confusion between navigating to connection settings and configuring resources.

- **UI Improvements**
  - Replaced the body chevron with a `Settings02` icon and tooltip (“Connection settings”) on connection cards; click navigates to the connection’s settings page.
  - Updated the resource configuration button to use `Settings04` so it’s visually distinct from the settings navigation icon.

- **Refactors**
  - Renamed all `Settings01` usages to `Settings02` across the web UI for icon consistency.

<sup>Written for commit d03900493f8372b8b3bf0ea60fb2400af1378642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

