### PR TITLE
fix(monitoring): add ClickHouse pre-aggregation rollup to prevent OOM

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -860,8 +860,10 @@ export async function createMeshContextFactory(
     : (orgId: string) =>
         `read_ndjson('${logsBasePath}/${orgId}/**/*.ndjson', auto_detect=true)`;
 
+  const useMetricsRollup = process.env.USE_METRICS_ROLLUP !== "false";
   const metricSourceFactory = isClickHouse
-    ? (_orgId: string) => "monitoring_metrics"
+    ? (_orgId: string) =>
+        useMetricsRollup ? "monitoring_metrics_rollup_1m" : "monitoring_metrics"
     : (orgId: string) =>
         `read_ndjson('${metricsBasePath}/${orgId}/**/*.ndjson', auto_detect=true)`;
 

--- a/apps/mesh/src/monitoring/clickhouse-schema.ts
+++ b/apps/mesh/src/monitoring/clickhouse-schema.ts
@@ -1,0 +1,89 @@
+/**
+ * ClickHouse DDL management for monitoring rollup tables.
+ *
+ * Creates the pre-aggregated rollup table and materialized view that
+ * eliminate per-query full-table scans on monitoring_metrics.
+ *
+ * Uses its own @clickhouse/client instance with client.command() for DDL,
+ * keeping the QueryEngine interface read-only.
+ */
+
+const ROLLUP_TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS monitoring_metrics_rollup_1m (
+  bucket DateTime,
+  organization_id String,
+  connection_id String,
+  tool_name String,
+  name String,
+  status String,
+  value SimpleAggregateFunction(sum, Float64),
+  hist_count SimpleAggregateFunction(sum, Float64),
+  hist_sum SimpleAggregateFunction(sum, Float64),
+  hist_min SimpleAggregateFunction(min, Float64),
+  hist_max SimpleAggregateFunction(max, Float64),
+  hist_bucket_counts AggregateFunction(sumForEach, Array(Float64)),
+  hist_boundaries SimpleAggregateFunction(any, Array(Float64))
+) ENGINE = AggregatingMergeTree()
+PARTITION BY toYYYYMM(bucket)
+ORDER BY (organization_id, name, bucket, connection_id, tool_name, status)
+TTL bucket + INTERVAL 90 DAY
+`;
+
+const MATERIALIZED_VIEW_DDL = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS monitoring_metrics_rollup_1m_mv
+TO monitoring_metrics_rollup_1m
+AS SELECT
+  toStartOfMinute(timestamp) AS bucket,
+  organization_id,
+  connection_id,
+  tool_name,
+  name,
+  status,
+  sum(value) AS value,
+  sum(hist_count) AS hist_count,
+  sum(hist_sum) AS hist_sum,
+  min(hist_min) AS hist_min,
+  max(hist_max) AS hist_max,
+  sumForEachState(
+    JSONExtract(hist_bucket_counts, 'Array(Float64)')
+  ) AS hist_bucket_counts,
+  any(
+    JSONExtract(hist_boundaries, 'Array(Float64)')
+  ) AS hist_boundaries
+FROM monitoring_metrics
+GROUP BY organization_id, name, bucket, connection_id, tool_name, status
+`;
+
+/**
+ * Run ClickHouse DDL to create the rollup table and materialized view.
+ *
+ * Logs errors but does not throw — queries detect the rollup table's
+ * existence at query time and fall back to the raw table automatically.
+ */
+export async function ensureClickHouseRollup(
+  clickhouseUrl: string,
+): Promise<void> {
+  try {
+    const { createClient } = await import("@clickhouse/client");
+    const client = createClient({ url: clickhouseUrl });
+
+    try {
+      await client.command({ query: ROLLUP_TABLE_DDL });
+      console.log(
+        "[clickhouse-schema] monitoring_metrics_rollup_1m table ready",
+      );
+
+      await client.command({ query: MATERIALIZED_VIEW_DDL });
+      console.log(
+        "[clickhouse-schema] monitoring_metrics_rollup_1m_mv view ready",
+      );
+    } finally {
+      await client.close();
+    }
+  } catch (err) {
+    console.error(
+      "[clickhouse-schema] Failed to create rollup DDL (queries will fall back to raw table):",
+      err,
+    );
+  }
+}

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -94,8 +94,12 @@ export class ClickHouseClientEngine implements QueryEngine {
       clickhouse_settings: {
         max_memory_usage: this.maxMemoryUsage,
         max_execution_time: this.maxExecutionTime,
-        max_bytes_before_external_group_by: this.maxMemoryUsage,
-        max_bytes_before_external_sort: this.maxMemoryUsage,
+        max_bytes_before_external_group_by: String(
+          Math.floor(Number(this.maxMemoryUsage) / 2),
+        ),
+        max_bytes_before_external_sort: String(
+          Math.floor(Number(this.maxMemoryUsage) / 2),
+        ),
       },
     });
     return await result.json<Record<string, unknown>>();

--- a/apps/mesh/src/settings/pipeline.ts
+++ b/apps/mesh/src/settings/pipeline.ts
@@ -55,6 +55,14 @@ export async function buildSettings(flags: CliFlags): Promise<BuildResult> {
     await migrateToLatest({ keepOpen: true, database, skipBetterAuth: true });
   }
 
+  // 4b. ClickHouse rollup DDL (non-blocking — queries fall back to raw table)
+  if (config.settings.clickhouseUrl) {
+    const { ensureClickHouseRollup } = await import(
+      "../monitoring/clickhouse-schema"
+    );
+    await ensureClickHouseRollup(config.settings.clickhouseUrl);
+  }
+
   // 5. Assemble and freeze
   const settings: Settings = {
     ...config.settings,

--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -711,58 +711,69 @@ export class SqlMonitoringStorage implements MonitoringStorage {
       timeseries: [],
     };
 
-    try {
-      if (!params.organizationId) {
-        throw new Error("organizationId is required");
-      }
+    if (!params.organizationId) {
+      return emptyResult;
+    }
 
-      const metricSource = this.metricSourceFactory(params.organizationId);
-      // For ClickHouse rollup table, use "bucket" column; otherwise "timestamp"
-      const isRollup =
-        this.dialect === "clickhouse" &&
-        metricSource === "monitoring_metrics_rollup_1m";
-      const tsCol = isRollup ? "bucket" : "timestamp";
-      const bucketExpr = intervalToSQL(params.interval, this.dialect, tsCol);
+    const metricSource = this.metricSourceFactory(params.organizationId);
+    const isRollup =
+      this.dialect === "clickhouse" &&
+      metricSource === "monitoring_metrics_rollup_1m";
 
-      const where: string[] = [
-        `organization_id = '${esc(params.organizationId)}'`,
-      ];
+    // Try rollup table first; if it fails (e.g. table doesn't exist),
+    // fall back to the raw monitoring_metrics table.
+    const sources = isRollup
+      ? [metricSource, "monitoring_metrics"]
+      : [metricSource];
 
-      applyStartDateBound(where, params.startDate, this.dialect, tsCol);
-      if (params.endDate) {
-        where.push(tsLte(params.endDate, this.dialect, tsCol));
-      }
-      if (params.filters?.toolNames?.length) {
-        const names = params.filters.toolNames
-          .slice(0, 100)
-          .map((n) => `'${esc(n)}'`)
-          .join(",");
-        where.push(`tool_name IN (${names})`);
-      }
-      if (params.filters?.connectionIds?.length) {
-        const ids = params.filters.connectionIds
-          .slice(0, 100)
-          .map((id) => `'${esc(id)}'`)
-          .join(",");
-        where.push(`connection_id IN (${ids})`);
-      }
-      if (params.filters?.excludeConnectionIds?.length) {
-        const ids = params.filters.excludeConnectionIds
-          .slice(0, 100)
-          .map((id) => `'${esc(id)}'`)
-          .join(",");
-        where.push(`connection_id NOT IN (${ids})`);
-      }
-      // NOTE: status is intentionally NOT added to the WHERE clause here.
-      // The errors and errorRate aggregations use sumIf/SUM FILTER (WHERE ...),
-      // which would always return 0 if WHERE already filters to status = 'success'
-      // (and conversely, errorRate would always be 100% when filtering to 'error').
+    for (const source of sources) {
+      try {
+        const usingRollup =
+          this.dialect === "clickhouse" &&
+          source === "monitoring_metrics_rollup_1m";
+        // For ClickHouse rollup table, use "bucket" column; otherwise "timestamp"
+        const tsCol = usingRollup ? "bucket" : "timestamp";
+        const bucketExpr = intervalToSQL(params.interval, this.dialect, tsCol);
 
-      const whereClause = where.join(" AND ");
+        const where: string[] = [
+          `organization_id = '${esc(params.organizationId)}'`,
+        ];
 
-      let sql: string;
-      if (this.dialect === "duckdb") {
-        sql = `SELECT
+        applyStartDateBound(where, params.startDate, this.dialect, tsCol);
+        if (params.endDate) {
+          where.push(tsLte(params.endDate, this.dialect, tsCol));
+        }
+        if (params.filters?.toolNames?.length) {
+          const names = params.filters.toolNames
+            .slice(0, 100)
+            .map((n) => `'${esc(n)}'`)
+            .join(",");
+          where.push(`tool_name IN (${names})`);
+        }
+        if (params.filters?.connectionIds?.length) {
+          const ids = params.filters.connectionIds
+            .slice(0, 100)
+            .map((id) => `'${esc(id)}'`)
+            .join(",");
+          where.push(`connection_id IN (${ids})`);
+        }
+        if (params.filters?.excludeConnectionIds?.length) {
+          const ids = params.filters.excludeConnectionIds
+            .slice(0, 100)
+            .map((id) => `'${esc(id)}'`)
+            .join(",");
+          where.push(`connection_id NOT IN (${ids})`);
+        }
+        // NOTE: status is intentionally NOT added to the WHERE clause here.
+        // The errors and errorRate aggregations use sumIf/SUM FILTER (WHERE ...),
+        // which would always return 0 if WHERE already filters to status = 'success'
+        // (and conversely, errorRate would always be 100% when filtering to 'error').
+
+        const whereClause = where.join(" AND ");
+
+        let sql: string;
+        if (this.dialect === "duckdb") {
+          sql = `SELECT
   ${bucketExpr} AS bucket,
   SUM(value) FILTER (WHERE name = 'tool.execution.count') AS calls,
   SUM(value) FILTER (WHERE name = 'tool.execution.count' AND status = 'error') AS errors,
@@ -770,12 +781,12 @@ export class SqlMonitoringStorage implements MonitoringStorage {
   SUM(hist_count) FILTER (WHERE name = 'tool.execution.duration') AS total_hist_count,
   LIST(hist_boundaries) FILTER (WHERE name = 'tool.execution.duration') AS boundaries_arr,
   LIST(hist_bucket_counts) FILTER (WHERE name = 'tool.execution.duration') AS bucket_counts_arr
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause}
 GROUP BY bucket
 ORDER BY bucket ASC`;
-      } else if (isRollup) {
-        sql = `SELECT
+        } else if (usingRollup) {
+          sql = `SELECT
   ${bucketExpr} AS bucket,
   sumIf(value, name = 'tool.execution.count') AS calls,
   sumIf(value, name = 'tool.execution.count' AND status = 'error') AS errors,
@@ -783,12 +794,12 @@ ORDER BY bucket ASC`;
   sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count,
   anyIf(hist_boundaries, name = 'tool.execution.duration') AS boundaries_arr,
   sumForEachMergeIf(hist_bucket_counts, name = 'tool.execution.duration') AS bucket_counts_arr
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause}
 GROUP BY bucket
 ORDER BY bucket ASC`;
-      } else {
-        sql = `SELECT
+        } else {
+          sql = `SELECT
   ${bucketExpr} AS bucket,
   sumIf(value, name = 'tool.execution.count') AS calls,
   sumIf(value, name = 'tool.execution.count' AND status = 'error') AS errors,
@@ -796,47 +807,152 @@ ORDER BY bucket ASC`;
   sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count,
   anyIf(JSONExtract(hist_boundaries, 'Array(Float64)'), name = 'tool.execution.duration') AS boundaries_arr,
   sumForEachIf(JSONExtract(hist_bucket_counts, 'Array(Float64)'), name = 'tool.execution.duration') AS bucket_counts_arr
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause}
 GROUP BY bucket
 ORDER BY bucket ASC`;
-      }
+        }
 
-      const rows = await this.metricEngine.query(sql);
+        const rows = await this.metricEngine.query(sql);
 
-      let breakdownSql: string;
-      if (this.dialect === "duckdb") {
-        breakdownSql = `SELECT
+        let breakdownSql: string;
+        if (this.dialect === "duckdb") {
+          breakdownSql = `SELECT
   connection_id,
   SUM(value) FILTER (WHERE name = 'tool.execution.count') AS calls,
   SUM(value) FILTER (WHERE name = 'tool.execution.count' AND status = 'error') AS errors,
   SUM(hist_sum) FILTER (WHERE name = 'tool.execution.duration') AS total_hist_sum,
   SUM(hist_count) FILTER (WHERE name = 'tool.execution.duration') AS total_hist_count
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause} AND connection_id != ''
 GROUP BY connection_id
 ORDER BY calls DESC
 LIMIT 1000`;
-      } else {
-        breakdownSql = `SELECT
+        } else {
+          breakdownSql = `SELECT
   connection_id,
   sumIf(value, name = 'tool.execution.count') AS calls,
   sumIf(value, name = 'tool.execution.count' AND status = 'error') AS errors,
   sumIf(hist_sum, name = 'tool.execution.duration') AS total_hist_sum,
   sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause} AND connection_id != ''
 GROUP BY connection_id
 ORDER BY calls DESC
 LIMIT 1000`;
-      }
+        }
 
-      const connectionBreakdownRows =
-        await this.metricEngine.query(breakdownSql);
+        const connectionBreakdownRows =
+          await this.metricEngine.query(breakdownSql);
 
-      if (rows.length === 0) {
+        if (rows.length === 0) {
+          return {
+            ...emptyResult,
+            connectionBreakdown: connectionBreakdownRows.map((row) => {
+              const calls = Number(row.calls ?? 0);
+              const errors = Number(row.errors ?? 0);
+              const totalHistSum = Number(row.total_hist_sum ?? 0);
+              const totalHistCount = Number(row.total_hist_count ?? 0);
+
+              return {
+                connectionId: String(row.connection_id ?? ""),
+                calls,
+                errors,
+                errorRate: calls > 0 ? (errors / calls) * 100 : 0,
+                avgDurationMs:
+                  totalHistCount > 0 ? totalHistSum / totalHistCount : 0,
+              };
+            }),
+          };
+        }
+
+        // Accumulate totals across all buckets
+        let totalCalls = 0;
+        let totalErrors = 0;
+        let totalHistSum = 0;
+        let totalHistCount = 0;
+        const allBoundaries: number[][] = [];
+        const allBucketCounts: number[][] = [];
+
+        const timeseries = rows.map((row) => {
+          const calls = Number(row.calls ?? 0);
+          const errors = Number(row.errors ?? 0);
+          const histSum = Number(row.total_hist_sum ?? 0);
+          const histCount = Number(row.total_hist_count ?? 0);
+          const avg = histCount > 0 ? histSum / histCount : 0;
+          const errorRate = calls > 0 ? errors / calls : 0;
+
+          totalCalls += calls;
+          totalErrors += errors;
+          totalHistSum += histSum;
+          totalHistCount += histCount;
+
+          // Parse and merge histogram data for percentile computation
+          let mergedBounds: number[];
+          let mergedCounts: number[];
+
+          if (this.dialect === "clickhouse") {
+            // ClickHouse: already merged via anyIf/sumForEachIf
+            mergedBounds = parseSingleArray(row.boundaries_arr);
+            mergedCounts = parseSingleArray(row.bucket_counts_arr);
+          } else {
+            // DuckDB: merge in JS
+            const boundariesArr = parseGroupedArrays(row.boundaries_arr);
+            const bucketCountsArr = parseGroupedArrays(row.bucket_counts_arr);
+            const merged = mergeHistogramBuckets(
+              boundariesArr,
+              bucketCountsArr,
+            );
+            mergedBounds = merged.boundaries;
+            mergedCounts = merged.counts;
+          }
+
+          // Accumulate for global percentiles
+          if (mergedBounds.length > 0) {
+            allBoundaries.push(mergedBounds);
+            allBucketCounts.push(mergedCounts);
+          }
+
+          const p50 = computePercentileFromHistogramBuckets(
+            mergedBounds,
+            mergedCounts,
+            0.5,
+          );
+          const p95 = computePercentileFromHistogramBuckets(
+            mergedBounds,
+            mergedCounts,
+            0.95,
+          );
+
+          return {
+            timestamp: toISOBucket(row.bucket),
+            calls,
+            errors,
+            errorRate,
+            avg,
+            p50,
+            p95,
+          };
+        });
+
+        // Global percentiles from merged histogram data
+        const { boundaries: globalBounds, counts: globalCounts } =
+          mergeHistogramBuckets(allBoundaries, allBucketCounts);
+
         return {
-          ...emptyResult,
+          totalCalls,
+          totalErrors,
+          avgDurationMs: totalHistCount > 0 ? totalHistSum / totalHistCount : 0,
+          p50DurationMs: computePercentileFromHistogramBuckets(
+            globalBounds,
+            globalCounts,
+            0.5,
+          ),
+          p95DurationMs: computePercentileFromHistogramBuckets(
+            globalBounds,
+            globalCounts,
+            0.95,
+          ),
           connectionBreakdown: connectionBreakdownRows.map((row) => {
             const calls = Number(row.calls ?? 0);
             const errors = Number(row.errors ?? 0);
@@ -852,114 +968,22 @@ LIMIT 1000`;
                 totalHistCount > 0 ? totalHistSum / totalHistCount : 0,
             };
           }),
+          timeseries,
         };
+      } catch (err) {
+        if (source !== sources[sources.length - 1]) {
+          console.warn(
+            `queryMetricTimeseries: rollup table query failed, falling back to raw table:`,
+            err,
+          );
+          continue;
+        }
+        console.error("queryMetricTimeseries failed:", err);
+        return emptyResult;
       }
-
-      // Accumulate totals across all buckets
-      let totalCalls = 0;
-      let totalErrors = 0;
-      let totalHistSum = 0;
-      let totalHistCount = 0;
-      const allBoundaries: number[][] = [];
-      const allBucketCounts: number[][] = [];
-
-      const timeseries = rows.map((row) => {
-        const calls = Number(row.calls ?? 0);
-        const errors = Number(row.errors ?? 0);
-        const histSum = Number(row.total_hist_sum ?? 0);
-        const histCount = Number(row.total_hist_count ?? 0);
-        const avg = histCount > 0 ? histSum / histCount : 0;
-        const errorRate = calls > 0 ? errors / calls : 0;
-
-        totalCalls += calls;
-        totalErrors += errors;
-        totalHistSum += histSum;
-        totalHistCount += histCount;
-
-        // Parse and merge histogram data for percentile computation
-        let mergedBounds: number[];
-        let mergedCounts: number[];
-
-        if (this.dialect === "clickhouse") {
-          // ClickHouse: already merged via anyIf/sumForEachIf
-          mergedBounds = parseSingleArray(row.boundaries_arr);
-          mergedCounts = parseSingleArray(row.bucket_counts_arr);
-        } else {
-          // DuckDB: merge in JS
-          const boundariesArr = parseGroupedArrays(row.boundaries_arr);
-          const bucketCountsArr = parseGroupedArrays(row.bucket_counts_arr);
-          const merged = mergeHistogramBuckets(boundariesArr, bucketCountsArr);
-          mergedBounds = merged.boundaries;
-          mergedCounts = merged.counts;
-        }
-
-        // Accumulate for global percentiles
-        if (mergedBounds.length > 0) {
-          allBoundaries.push(mergedBounds);
-          allBucketCounts.push(mergedCounts);
-        }
-
-        const p50 = computePercentileFromHistogramBuckets(
-          mergedBounds,
-          mergedCounts,
-          0.5,
-        );
-        const p95 = computePercentileFromHistogramBuckets(
-          mergedBounds,
-          mergedCounts,
-          0.95,
-        );
-
-        return {
-          timestamp: toISOBucket(row.bucket),
-          calls,
-          errors,
-          errorRate,
-          avg,
-          p50,
-          p95,
-        };
-      });
-
-      // Global percentiles from merged histogram data
-      const { boundaries: globalBounds, counts: globalCounts } =
-        mergeHistogramBuckets(allBoundaries, allBucketCounts);
-
-      return {
-        totalCalls,
-        totalErrors,
-        avgDurationMs: totalHistCount > 0 ? totalHistSum / totalHistCount : 0,
-        p50DurationMs: computePercentileFromHistogramBuckets(
-          globalBounds,
-          globalCounts,
-          0.5,
-        ),
-        p95DurationMs: computePercentileFromHistogramBuckets(
-          globalBounds,
-          globalCounts,
-          0.95,
-        ),
-        connectionBreakdown: connectionBreakdownRows.map((row) => {
-          const calls = Number(row.calls ?? 0);
-          const errors = Number(row.errors ?? 0);
-          const totalHistSum = Number(row.total_hist_sum ?? 0);
-          const totalHistCount = Number(row.total_hist_count ?? 0);
-
-          return {
-            connectionId: String(row.connection_id ?? ""),
-            calls,
-            errors,
-            errorRate: calls > 0 ? (errors / calls) * 100 : 0,
-            avgDurationMs:
-              totalHistCount > 0 ? totalHistSum / totalHistCount : 0,
-          };
-        }),
-        timeseries,
-      };
-    } catch (err) {
-      console.error("queryMetricTimeseries failed:", err);
-      return emptyResult;
     }
+
+    return emptyResult;
   }
 
   async queryMetricTopToolsTimeseries(params: {
@@ -994,56 +1018,67 @@ LIMIT 1000`;
       timeseries: [],
     };
 
-    try {
-      if (!params.organizationId) {
-        throw new Error("organizationId is required");
-      }
+    if (!params.organizationId) {
+      return emptyResult;
+    }
 
-      const metricSource = this.metricSourceFactory(params.organizationId);
-      const isRollup =
-        this.dialect === "clickhouse" &&
-        metricSource === "monitoring_metrics_rollup_1m";
-      const tsCol = isRollup ? "bucket" : "timestamp";
-      const bucketExpr = intervalToSQL(params.interval, this.dialect, tsCol);
-      const where: string[] = [
-        `organization_id = '${esc(params.organizationId)}'`,
-      ];
+    const metricSource = this.metricSourceFactory(params.organizationId);
+    const isRollup =
+      this.dialect === "clickhouse" &&
+      metricSource === "monitoring_metrics_rollup_1m";
 
-      applyStartDateBound(where, params.startDate, this.dialect, tsCol);
-      if (params.endDate) {
-        where.push(tsLte(params.endDate, this.dialect, tsCol));
-      }
-      if (params.filters?.toolNames?.length) {
-        const names = params.filters.toolNames
-          .slice(0, 100)
-          .map((n) => `'${esc(n)}'`)
-          .join(",");
-        where.push(`tool_name IN (${names})`);
-      }
-      if (params.filters?.connectionIds?.length) {
-        const ids = params.filters.connectionIds
-          .slice(0, 100)
-          .map((id) => `'${esc(id)}'`)
-          .join(",");
-        where.push(`connection_id IN (${ids})`);
-      }
-      if (params.filters?.excludeConnectionIds?.length) {
-        const ids = params.filters.excludeConnectionIds
-          .slice(0, 100)
-          .map((id) => `'${esc(id)}'`)
-          .join(",");
-        where.push(`connection_id NOT IN (${ids})`);
-      }
-      // NOTE: status is intentionally NOT added to the WHERE clause here.
-      // The errors aggregation uses SUM FILTER (WHERE ...)/sumIf(... AND status = 'error'),
-      // which would always return 0 if WHERE already filters to status = 'success'.
+    // Try rollup table first; if it fails (e.g. table doesn't exist),
+    // fall back to the raw monitoring_metrics table.
+    const sources = isRollup
+      ? [metricSource, "monitoring_metrics"]
+      : [metricSource];
 
-      const whereClause = where.join(" AND ");
-      const topN = Math.min(Math.max(1, Math.floor(params.topN ?? 10)), 20);
+    for (const source of sources) {
+      try {
+        const usingRollup =
+          this.dialect === "clickhouse" &&
+          source === "monitoring_metrics_rollup_1m";
+        const tsCol = usingRollup ? "bucket" : "timestamp";
+        const bucketExpr = intervalToSQL(params.interval, this.dialect, tsCol);
+        const where: string[] = [
+          `organization_id = '${esc(params.organizationId)}'`,
+        ];
 
-      let topToolsSql: string;
-      if (this.dialect === "duckdb") {
-        topToolsSql = `SELECT
+        applyStartDateBound(where, params.startDate, this.dialect, tsCol);
+        if (params.endDate) {
+          where.push(tsLte(params.endDate, this.dialect, tsCol));
+        }
+        if (params.filters?.toolNames?.length) {
+          const names = params.filters.toolNames
+            .slice(0, 100)
+            .map((n) => `'${esc(n)}'`)
+            .join(",");
+          where.push(`tool_name IN (${names})`);
+        }
+        if (params.filters?.connectionIds?.length) {
+          const ids = params.filters.connectionIds
+            .slice(0, 100)
+            .map((id) => `'${esc(id)}'`)
+            .join(",");
+          where.push(`connection_id IN (${ids})`);
+        }
+        if (params.filters?.excludeConnectionIds?.length) {
+          const ids = params.filters.excludeConnectionIds
+            .slice(0, 100)
+            .map((id) => `'${esc(id)}'`)
+            .join(",");
+          where.push(`connection_id NOT IN (${ids})`);
+        }
+        // NOTE: status is intentionally NOT added to the WHERE clause here.
+        // The errors aggregation uses SUM FILTER (WHERE ...)/sumIf(... AND status = 'error'),
+        // which would always return 0 if WHERE already filters to status = 'success'.
+
+        const whereClause = where.join(" AND ");
+        const topN = Math.min(Math.max(1, Math.floor(params.topN ?? 10)), 20);
+
+        let topToolsSql: string;
+        if (this.dialect === "duckdb") {
+          topToolsSql = `SELECT
   tool_name,
   argMax(connection_id, connection_calls) AS connection_id,
   sum(connection_calls) AS calls
@@ -1052,15 +1087,15 @@ FROM (
     tool_name,
     connection_id,
     SUM(value) FILTER (WHERE name = 'tool.execution.count') AS connection_calls
-  FROM ${metricSource}
+  FROM ${source}
   WHERE ${whereClause} AND tool_name != ''
   GROUP BY tool_name, connection_id
 )
 GROUP BY tool_name
 ORDER BY calls DESC
 LIMIT ${topN}`;
-      } else {
-        topToolsSql = `SELECT
+        } else {
+          topToolsSql = `SELECT
   tool_name,
   argMax(connection_id, connection_calls) AS connection_id,
   sum(connection_calls) AS calls
@@ -1069,31 +1104,31 @@ FROM (
     tool_name,
     connection_id,
     sumIf(value, name = 'tool.execution.count') AS connection_calls
-  FROM ${metricSource}
+  FROM ${source}
   WHERE ${whereClause} AND tool_name != ''
   GROUP BY tool_name, connection_id
 )
 GROUP BY tool_name
 ORDER BY calls DESC
 LIMIT ${topN}`;
-      }
+        }
 
-      const topToolRows = await this.metricEngine.query(topToolsSql);
+        const topToolRows = await this.metricEngine.query(topToolsSql);
 
-      if (topToolRows.length === 0) {
-        return emptyResult;
-      }
+        if (topToolRows.length === 0) {
+          return emptyResult;
+        }
 
-      const topToolNames = topToolRows
-        .map((row) => String(row.tool_name ?? ""))
-        .filter(Boolean);
-      const toolNamesSql = topToolNames
-        .map((name) => `'${esc(name)}'`)
-        .join(",");
+        const topToolNames = topToolRows
+          .map((row) => String(row.tool_name ?? ""))
+          .filter(Boolean);
+        const toolNamesSql = topToolNames
+          .map((name) => `'${esc(name)}'`)
+          .join(",");
 
-      let timeseriesSql: string;
-      if (this.dialect === "duckdb") {
-        timeseriesSql = `SELECT
+        let timeseriesSql: string;
+        if (this.dialect === "duckdb") {
+          timeseriesSql = `SELECT
   ${bucketExpr} AS bucket,
   tool_name,
   SUM(value) FILTER (WHERE name = 'tool.execution.count') AS calls,
@@ -1102,12 +1137,12 @@ LIMIT ${topN}`;
   SUM(hist_count) FILTER (WHERE name = 'tool.execution.duration') AS total_hist_count,
   LIST(hist_boundaries) FILTER (WHERE name = 'tool.execution.duration') AS boundaries_arr,
   LIST(hist_bucket_counts) FILTER (WHERE name = 'tool.execution.duration') AS bucket_counts_arr
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
 GROUP BY bucket, tool_name
 ORDER BY bucket ASC, tool_name ASC`;
-      } else if (isRollup) {
-        timeseriesSql = `SELECT
+        } else if (usingRollup) {
+          timeseriesSql = `SELECT
   ${bucketExpr} AS bucket,
   tool_name,
   sumIf(value, name = 'tool.execution.count') AS calls,
@@ -1116,12 +1151,12 @@ ORDER BY bucket ASC, tool_name ASC`;
   sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count,
   anyIf(hist_boundaries, name = 'tool.execution.duration') AS boundaries_arr,
   sumForEachMergeIf(hist_bucket_counts, name = 'tool.execution.duration') AS bucket_counts_arr
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
 GROUP BY bucket, tool_name
 ORDER BY bucket ASC, tool_name ASC`;
-      } else {
-        timeseriesSql = `SELECT
+        } else {
+          timeseriesSql = `SELECT
   ${bucketExpr} AS bucket,
   tool_name,
   sumIf(value, name = 'tool.execution.count') AS calls,
@@ -1130,61 +1165,71 @@ ORDER BY bucket ASC, tool_name ASC`;
   sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count,
   anyIf(JSONExtract(hist_boundaries, 'Array(Float64)'), name = 'tool.execution.duration') AS boundaries_arr,
   sumForEachIf(JSONExtract(hist_bucket_counts, 'Array(Float64)'), name = 'tool.execution.duration') AS bucket_counts_arr
-FROM ${metricSource}
+FROM ${source}
 WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
 GROUP BY bucket, tool_name
 ORDER BY bucket ASC, tool_name ASC`;
-      }
+        }
 
-      const rows = await this.metricEngine.query(timeseriesSql);
+        const rows = await this.metricEngine.query(timeseriesSql);
 
-      return {
-        topTools: topToolRows.map((row) => ({
-          toolName: String(row.tool_name ?? ""),
-          connectionId:
-            row.connection_id != null ? String(row.connection_id) : null,
-          calls: Number(row.calls ?? 0),
-        })),
-        timeseries: rows.map((row) => {
-          const calls = Number(row.calls ?? 0);
-          const errors = Number(row.errors ?? 0);
-          const histSum = Number(row.total_hist_sum ?? 0);
-          const histCount = Number(row.total_hist_count ?? 0);
-          let boundaries: number[];
-          let counts: number[];
-
-          if (this.dialect === "clickhouse") {
-            boundaries = parseSingleArray(row.boundaries_arr);
-            counts = parseSingleArray(row.bucket_counts_arr);
-          } else {
-            const boundariesArr = parseGroupedArrays(row.boundaries_arr);
-            const bucketCountsArr = parseGroupedArrays(row.bucket_counts_arr);
-            const merged = mergeHistogramBuckets(
-              boundariesArr,
-              bucketCountsArr,
-            );
-            boundaries = merged.boundaries;
-            counts = merged.counts;
-          }
-
-          return {
-            timestamp: toISOBucket(row.bucket),
+        return {
+          topTools: topToolRows.map((row) => ({
             toolName: String(row.tool_name ?? ""),
-            calls,
-            errors,
-            avg: histCount > 0 ? histSum / histCount : 0,
-            p95: computePercentileFromHistogramBuckets(
-              boundaries,
-              counts,
-              0.95,
-            ),
-          };
-        }),
-      };
-    } catch (err) {
-      console.error("queryMetricTopToolsTimeseries failed:", err);
-      return emptyResult;
+            connectionId:
+              row.connection_id != null ? String(row.connection_id) : null,
+            calls: Number(row.calls ?? 0),
+          })),
+          timeseries: rows.map((row) => {
+            const calls = Number(row.calls ?? 0);
+            const errors = Number(row.errors ?? 0);
+            const histSum = Number(row.total_hist_sum ?? 0);
+            const histCount = Number(row.total_hist_count ?? 0);
+            let boundaries: number[];
+            let counts: number[];
+
+            if (this.dialect === "clickhouse") {
+              boundaries = parseSingleArray(row.boundaries_arr);
+              counts = parseSingleArray(row.bucket_counts_arr);
+            } else {
+              const boundariesArr = parseGroupedArrays(row.boundaries_arr);
+              const bucketCountsArr = parseGroupedArrays(row.bucket_counts_arr);
+              const merged = mergeHistogramBuckets(
+                boundariesArr,
+                bucketCountsArr,
+              );
+              boundaries = merged.boundaries;
+              counts = merged.counts;
+            }
+
+            return {
+              timestamp: toISOBucket(row.bucket),
+              toolName: String(row.tool_name ?? ""),
+              calls,
+              errors,
+              avg: histCount > 0 ? histSum / histCount : 0,
+              p95: computePercentileFromHistogramBuckets(
+                boundaries,
+                counts,
+                0.95,
+              ),
+            };
+          }),
+        };
+      } catch (err) {
+        if (source !== sources[sources.length - 1]) {
+          console.warn(
+            `queryMetricTopToolsTimeseries: rollup table query failed, falling back to raw table:`,
+            err,
+          );
+          continue;
+        }
+        console.error("queryMetricTopToolsTimeseries failed:", err);
+        return emptyResult;
+      }
     }
+
+    return emptyResult;
   }
 }
 

--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -115,7 +115,11 @@ function parseInterval(interval: string): { amount: number; unit: string } {
   return { amount, unit };
 }
 
-function intervalToSQL(interval: string, dialect: SqlDialect): string {
+function intervalToSQL(
+  interval: string,
+  dialect: SqlDialect,
+  column: string = "timestamp",
+): string {
   const { amount, unit } = parseInterval(interval);
   const unitMap: Record<string, string> = {
     m: "MINUTE",
@@ -124,9 +128,9 @@ function intervalToSQL(interval: string, dialect: SqlDialect): string {
   };
   const sqlUnit = unitMap[unit];
   if (dialect === "duckdb") {
-    return `time_bucket(INTERVAL '${amount} ${sqlUnit}', CAST(timestamp AS TIMESTAMP))`;
+    return `time_bucket(INTERVAL '${amount} ${sqlUnit}', CAST(${column} AS TIMESTAMP))`;
   }
-  return `toStartOfInterval(timestamp, INTERVAL ${amount} ${sqlUnit})`;
+  return `toStartOfInterval(${column}, INTERVAL ${amount} ${sqlUnit})`;
 }
 
 // ---------------------------------------------------------------------------
@@ -333,18 +337,32 @@ function buildCommonFilterClauses(
   return clauses;
 }
 
-function tsGte(date: Date, dialect: SqlDialect): string {
+function tsGte(
+  date: Date,
+  dialect: SqlDialect,
+  column: string = "timestamp",
+): string {
   if (dialect === "duckdb") {
-    return `CAST(timestamp AS TIMESTAMP) >= TIMESTAMP '${date.toISOString()}'`;
+    return `CAST(${column} AS TIMESTAMP) >= TIMESTAMP '${date.toISOString()}'`;
   }
-  return `timestamp >= parseDateTime64BestEffort('${date.toISOString()}', 9)`;
+  if (column === "bucket") {
+    return `${column} >= parseDateTimeBestEffort('${date.toISOString()}')`;
+  }
+  return `${column} >= parseDateTime64BestEffort('${date.toISOString()}', 9)`;
 }
 
-function tsLte(date: Date, dialect: SqlDialect): string {
+function tsLte(
+  date: Date,
+  dialect: SqlDialect,
+  column: string = "timestamp",
+): string {
   if (dialect === "duckdb") {
-    return `CAST(timestamp AS TIMESTAMP) <= TIMESTAMP '${date.toISOString()}'`;
+    return `CAST(${column} AS TIMESTAMP) <= TIMESTAMP '${date.toISOString()}'`;
   }
-  return `timestamp <= parseDateTime64BestEffort('${date.toISOString()}', 9)`;
+  if (column === "bucket") {
+    return `${column} <= parseDateTimeBestEffort('${date.toISOString()}')`;
+  }
+  return `${column} <= parseDateTime64BestEffort('${date.toISOString()}', 9)`;
 }
 
 /**
@@ -358,11 +376,14 @@ function applyStartDateBound(
   where: string[],
   startDate: Date | undefined,
   dialect: SqlDialect,
+  column: string = "timestamp",
 ): void {
   if (startDate) {
-    where.push(tsGte(startDate, dialect));
+    where.push(tsGte(startDate, dialect, column));
   } else if (dialect === "clickhouse") {
-    where.push(tsGte(new Date(Date.now() - DEFAULT_LOOKBACK_MS), dialect));
+    where.push(
+      tsGte(new Date(Date.now() - DEFAULT_LOOKBACK_MS), dialect, column),
+    );
   }
 }
 
@@ -696,15 +717,20 @@ export class SqlMonitoringStorage implements MonitoringStorage {
       }
 
       const metricSource = this.metricSourceFactory(params.organizationId);
-      const bucketExpr = intervalToSQL(params.interval, this.dialect);
+      // For ClickHouse rollup table, use "bucket" column; otherwise "timestamp"
+      const isRollup =
+        this.dialect === "clickhouse" &&
+        metricSource === "monitoring_metrics_rollup_1m";
+      const tsCol = isRollup ? "bucket" : "timestamp";
+      const bucketExpr = intervalToSQL(params.interval, this.dialect, tsCol);
 
       const where: string[] = [
         `organization_id = '${esc(params.organizationId)}'`,
       ];
 
-      applyStartDateBound(where, params.startDate, this.dialect);
+      applyStartDateBound(where, params.startDate, this.dialect, tsCol);
       if (params.endDate) {
-        where.push(tsLte(params.endDate, this.dialect));
+        where.push(tsLte(params.endDate, this.dialect, tsCol));
       }
       if (params.filters?.toolNames?.length) {
         const names = params.filters.toolNames
@@ -744,6 +770,19 @@ export class SqlMonitoringStorage implements MonitoringStorage {
   SUM(hist_count) FILTER (WHERE name = 'tool.execution.duration') AS total_hist_count,
   LIST(hist_boundaries) FILTER (WHERE name = 'tool.execution.duration') AS boundaries_arr,
   LIST(hist_bucket_counts) FILTER (WHERE name = 'tool.execution.duration') AS bucket_counts_arr
+FROM ${metricSource}
+WHERE ${whereClause}
+GROUP BY bucket
+ORDER BY bucket ASC`;
+      } else if (isRollup) {
+        sql = `SELECT
+  ${bucketExpr} AS bucket,
+  sumIf(value, name = 'tool.execution.count') AS calls,
+  sumIf(value, name = 'tool.execution.count' AND status = 'error') AS errors,
+  sumIf(hist_sum, name = 'tool.execution.duration') AS total_hist_sum,
+  sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count,
+  anyIf(hist_boundaries, name = 'tool.execution.duration') AS boundaries_arr,
+  sumForEachMergeIf(hist_bucket_counts, name = 'tool.execution.duration') AS bucket_counts_arr
 FROM ${metricSource}
 WHERE ${whereClause}
 GROUP BY bucket
@@ -961,14 +1000,18 @@ LIMIT 1000`;
       }
 
       const metricSource = this.metricSourceFactory(params.organizationId);
-      const bucketExpr = intervalToSQL(params.interval, this.dialect);
+      const isRollup =
+        this.dialect === "clickhouse" &&
+        metricSource === "monitoring_metrics_rollup_1m";
+      const tsCol = isRollup ? "bucket" : "timestamp";
+      const bucketExpr = intervalToSQL(params.interval, this.dialect, tsCol);
       const where: string[] = [
         `organization_id = '${esc(params.organizationId)}'`,
       ];
 
-      applyStartDateBound(where, params.startDate, this.dialect);
+      applyStartDateBound(where, params.startDate, this.dialect, tsCol);
       if (params.endDate) {
-        where.push(tsLte(params.endDate, this.dialect));
+        where.push(tsLte(params.endDate, this.dialect, tsCol));
       }
       if (params.filters?.toolNames?.length) {
         const names = params.filters.toolNames
@@ -1059,6 +1102,20 @@ LIMIT ${topN}`;
   SUM(hist_count) FILTER (WHERE name = 'tool.execution.duration') AS total_hist_count,
   LIST(hist_boundaries) FILTER (WHERE name = 'tool.execution.duration') AS boundaries_arr,
   LIST(hist_bucket_counts) FILTER (WHERE name = 'tool.execution.duration') AS bucket_counts_arr
+FROM ${metricSource}
+WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
+GROUP BY bucket, tool_name
+ORDER BY bucket ASC, tool_name ASC`;
+      } else if (isRollup) {
+        timeseriesSql = `SELECT
+  ${bucketExpr} AS bucket,
+  tool_name,
+  sumIf(value, name = 'tool.execution.count') AS calls,
+  sumIf(value, name = 'tool.execution.count' AND status = 'error') AS errors,
+  sumIf(hist_sum, name = 'tool.execution.duration') AS total_hist_sum,
+  sumIf(hist_count, name = 'tool.execution.duration') AS total_hist_count,
+  anyIf(hist_boundaries, name = 'tool.execution.duration') AS boundaries_arr,
+  sumForEachMergeIf(hist_bucket_counts, name = 'tool.execution.duration') AS bucket_counts_arr
 FROM ${metricSource}
 WHERE ${whereClause} AND tool_name IN (${toolNamesSql})
 GROUP BY bucket, tool_name


### PR DESCRIPTION
## What is this contribution about?

Fixes ClickHouse OOM errors (error code 241, MEMORY_LIMIT_EXCEEDED) on the monitoring dashboard by adding pre-aggregation via a 1-minute rollup table and materialized view. Instead of re-aggregating millions of raw `monitoring_metrics` rows on every dashboard page load, queries now read from a pre-aggregated `AggregatingMergeTree` table that the MV populates at insert time.

Also fixes `max_bytes_before_external_group_by` to 50% of `max_memory_usage` (was incorrectly set to 100%), per ClickHouse docs.

**Key changes:**
- **`clickhouse-schema.ts`** (new): Idempotent DDL for rollup table + materialized view, run at startup
- **`pipeline.ts`**: Calls DDL alongside Kysely migrations (logs errors but doesn't block startup)
- **`monitoring-sql.ts`**: Rollup queries use `sumForEachMergeIf` for histogram buckets and `bucket` (DateTime) column instead of `timestamp` (DateTime64); falls back to raw-table syntax when not on rollup
- **`context-factory.ts`**: Metric queries point to rollup table; `USE_METRICS_ROLLUP=false` env var for instant rollback
- **`query-engine.ts`**: Fix `max_bytes_before_external_group_by` to half of `max_memory_usage`

## How to Test

1. Deploy to a staging environment with `CLICKHOUSE_URL` set
2. Verify startup logs show `monitoring_metrics_rollup_1m table ready` and `monitoring_metrics_rollup_1m_mv view ready`
3. Generate some tool executions, then check the monitoring dashboard loads without OOM errors
4. Verify `USE_METRICS_ROLLUP=false` falls back to raw table queries

## Migration Notes

- The rollup table and materialized view are created automatically on startup — no manual DDL needed
- Only **new** data is captured by the MV; historical data backfill is deferred to a follow-up
- Set `USE_METRICS_ROLLUP=false` to revert to raw-table queries without redeploying

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-aggregates monitoring metrics in ClickHouse with a 1‑minute rollup to stop dashboard OOM (error 241). Dashboard queries now read from the rollup by default, with automatic fallback to the raw table and safer memory limits.

- **Bug Fixes**
  - Create `monitoring_metrics_rollup_1m` and `monitoring_metrics_rollup_1m_mv` via idempotent DDL at startup (non-blocking) using `@clickhouse/client`.
  - Route metric queries to the rollup using the `bucket` column and `sumForEachMergeIf` for histograms; auto‑fallback to raw `monitoring_metrics` if the rollup is missing or DDL hasn’t run.
  - Set `max_bytes_before_external_group_by` and `max_bytes_before_external_sort` to 50% of `max_memory_usage`.
  - Add `USE_METRICS_ROLLUP=false` to switch back to raw-table queries.

- **Migration**
  - No manual DDL required; tables/views are created on boot.
  - Only new data is captured by the rollup; historical backfill will come later.

<sup>Written for commit 5a39936df4e1d7b09ccc852a28d1835c4ae963ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

