### PR TITLE
feat(onboarding): guard route for users who already have orgs

### DIFF
--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -154,6 +154,12 @@ const homeRoute = createRoute({
 const onboardingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/onboarding",
+  beforeLoad: async () => {
+    const { data: orgs } = await authClient.organization.list();
+    if (orgs && orgs.length > 0) {
+      throw redirect({ to: "/" });
+    }
+  },
   component: lazyRouteComponent(() => import("./routes/onboarding.tsx")),
 });
 


### PR DESCRIPTION
## What is this contribution about?

The `/onboarding` route was accessible even for users who already belong to organizations. This adds a `beforeLoad` guard that checks `authClient.organization.list()` and redirects users with existing orgs back to `/`, which then routes them to their active org. This mirrors the inverse guard on the home route that sends org-less users to `/onboarding`.

## How to Test

1. Log in as a user who already has an organization
2. Navigate directly to `/onboarding`
3. You should be redirected to your org home instead of seeing the onboarding flow

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `beforeLoad` guard to `/onboarding` that checks `authClient.organization.list()` and redirects users with existing orgs to `/` (then to their active org). This mirrors the home route guard that sends org-less users to onboarding.

<sup>Written for commit afed5373fd282f981d680766dff4b6abc7751671. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

