### PR TITLE
fix(brand): handle hyphen separator in page title extraction

### DIFF
--- a/apps/mesh/src/auth/extract-brand.ts
+++ b/apps/mesh/src/auth/extract-brand.ts
@@ -67,7 +67,7 @@ export async function extractBrandFromDomain(
   // title (e.g. "Visual CMS for Your Storefront | Deco" → "Deco"),
   // then ogSiteName, then the fallback.
   const titleParts = (metadata.title as string)
-    ?.split(/[|–—]/)
+    ?.split(/[|–—]|\s+-\s+/)
     .map((s) => s.trim())
     .filter(Boolean);
   const shortestPart = titleParts


### PR DESCRIPTION
## What is this contribution about?

The brand name extraction logic splits page titles on separators (`|`, `–`, `—`) to find the short brand name. However, many websites use a spaced hyphen (` - `) as their title separator — e.g. "deco.cx - AI-Powered E-commerce Builder". This wasn't handled, causing the full title to be used as the org/brand name.

Adds `\s+-\s+` to the split regex so spaced hyphens are recognized as separators. Hyphens inside words (e.g. "AI-Powered") are unaffected since they lack surrounding spaces.

## How to Test

1. Trigger brand extraction for a domain whose page title uses ` - ` as separator (e.g. deco.cx)
2. Verify the extracted brand name is the short segment (e.g. "deco.cx"), not the full title

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix brand name extraction by recognizing spaced hyphen separators in page titles. Titles like "deco.cx - AI-Powered E-commerce Builder" now correctly yield "deco.cx" instead of the full title.

<sup>Written for commit 5aee111d8c8778f5507bf46fe8452ed8cdee38de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

