### PR TITLE
feat(pages): add site pages editor with schema viewer and live preview

### DIFF
--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -11,7 +11,13 @@ import { Page } from "@/web/components/page";
 import { getIconComponent, parseIconString } from "../agent-icon";
 
 import { usePanelActions } from "@/web/layouts/shell-layout";
-import { Edit05, LayoutLeft, Loading01, Settings02 } from "@untitledui/icons";
+import {
+  Edit05,
+  File06,
+  LayoutLeft,
+  Loading01,
+  Settings02,
+} from "@untitledui/icons";
 import { useVirtualMCPActions, useVirtualMCP } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { Suspense, useEffect, useRef, useState, useTransition } from "react";
@@ -28,6 +34,10 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { IconPicker } from "@/web/components/icon-picker.tsx";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import {
+  PageSectionsSidebar,
+  getDecoConnectionId,
+} from "@/web/views/pages/index";
 
 // ────────────────────────────────────────
 // Shared nav item style — used by New session and view buttons
@@ -117,10 +127,14 @@ function ProjectViewsSection({ project }: { project: VirtualMCPEntity }) {
       icon: string | null;
     }> | null) ?? [];
 
-  if (pinnedViews.length === 0) return null;
+  // Deco projects have a file_explorer pinned view
+  const isDecoProject = pinnedViews.some((v) => v.toolName === "file_explorer");
+
+  if (pinnedViews.length === 0 && !isDecoProject) return null;
 
   // Determine which pinned view is currently active
   const currentMain = virtualMcpCtx?.mainView;
+  const isPagesActive = currentMain?.type === "pages";
   const isExtAppActive = (view: { connectionId: string; toolName: string }) =>
     currentMain?.type === "ext-apps" &&
     currentMain.id === view.connectionId &&
@@ -128,6 +142,21 @@ function ProjectViewsSection({ project }: { project: VirtualMCPEntity }) {
 
   return (
     <>
+      {isDecoProject && (
+        <button
+          type="button"
+          onClick={() =>
+            isPagesActive ? openMainView("default") : openMainView("pages")
+          }
+          className={cn(
+            navItemClass,
+            isPagesActive && "bg-accent text-foreground",
+          )}
+        >
+          <File06 size={16} className="shrink-0 text-muted-foreground" />
+          <span className="truncate text-foreground">Pages</span>
+        </button>
+      )}
       {pinnedViews.map((view) => (
         <button
           key={`${view.connectionId}-${view.toolName}`}
@@ -272,6 +301,49 @@ function TasksPanelContent({
   const virtualMcpId = virtualMcpIdProp ?? null;
 
   const virtualMcp = useVirtualMCP(virtualMcpId);
+
+  // When a page is selected, take over the sidebar with sections panel
+  const mainView = virtualMcpCtx?.mainView;
+  const pageKey =
+    mainView?.type === "pages"
+      ? (mainView as { type: "pages"; pageKey?: string }).pageKey
+      : undefined;
+
+  const decoConnectionId = getDecoConnectionId(virtualMcp ?? null);
+
+  if (pageKey && decoConnectionId) {
+    return (
+      <ErrorBoundary
+        fallback={
+          <div className="flex items-center justify-center h-32">
+            <p className="text-xs text-muted-foreground">
+              Failed to load sections.
+            </p>
+          </div>
+        }
+      >
+        <Suspense
+          fallback={
+            <div className="flex flex-col h-full">
+              <div className="shrink-0 flex items-center gap-2 px-3 h-11 border-b border-border/50">
+                <Skeleton className="h-4 w-20" />
+              </div>
+              <div className="flex flex-col gap-2 p-3">
+                {[1, 2, 3, 4].map((i) => (
+                  <Skeleton key={i} className="h-10 w-full rounded-md" />
+                ))}
+              </div>
+            </div>
+          }
+        >
+          <PageSectionsSidebar
+            connectionId={decoConnectionId}
+            pageKey={pageKey}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    );
+  }
 
   const handleNewTask = () => {
     startTransition(() => {

--- a/apps/mesh/src/web/layouts/agent-shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout.tsx
@@ -73,13 +73,19 @@ import {
 // Types & Context
 // ---------------------------------------------------------------------------
 
-export type MainViewType = "chat" | "settings" | "automation" | "ext-apps";
+export type MainViewType =
+  | "chat"
+  | "settings"
+  | "automation"
+  | "ext-apps"
+  | "pages";
 
 export type MainView =
   | { type: "chat" }
   | { type: "settings" }
   | { type: "automation"; id: string }
   | { type: "ext-apps"; id: string; toolName?: string; [key: string]: unknown }
+  | { type: "pages"; pageKey?: string }
   | null;
 
 export interface InsetContextValue {
@@ -409,6 +415,8 @@ function AgentInsetProvider() {
     mainView = id
       ? { type: "ext-apps", id, toolName: search.toolName }
       : { type: "settings" };
+  } else if (search.main === "pages") {
+    mainView = { type: "pages", pageKey: search.id };
   } else {
     mainView = null;
   }

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -162,8 +162,16 @@ export function usePanelActions() {
         main: view,
         mainOpen: 1,
       };
-      if (opts?.id) next.id = opts.id;
-      if (opts?.toolName) next.toolName = opts.toolName;
+      if (opts?.id) {
+        next.id = opts.id;
+      } else {
+        delete next.id;
+      }
+      if (opts?.toolName) {
+        next.toolName = opts.toolName;
+      } else {
+        delete next.toolName;
+      }
       return next;
     });
   };

--- a/apps/mesh/src/web/lib/schema-resolver.ts
+++ b/apps/mesh/src/web/lib/schema-resolver.ts
@@ -238,6 +238,29 @@ export class SchemaResolver {
   }
 
   /**
+   * Resolve a section with decofile fallback for saved blocks.
+   *
+   * When a section's __resolveType is a saved block name (e.g. "Footer"),
+   * it won't exist in definitions. This method looks it up in the decofile
+   * to find the actual component resolveType.
+   */
+  resolveSectionWithDecofile(
+    resolveType: string,
+    decofile: Record<string, Record<string, unknown>> | null,
+  ): FieldDescriptor | null {
+    const direct = this.resolveSection(resolveType);
+    if (direct) return direct;
+
+    if (!decofile) return null;
+
+    const savedBlock = decofile[resolveType];
+    if (!savedBlock?.__resolveType) return null;
+
+    const realResolveType = savedBlock.__resolveType as string;
+    return this.resolveSection(realResolveType);
+  }
+
+  /**
    * Look up a raw definition by key (escape hatch).
    */
   getDefinition(key: string): JSONSchemaNode | undefined {
@@ -463,4 +486,65 @@ export class SchemaResolver {
       variants,
     };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Section unwrapping helpers
+// ---------------------------------------------------------------------------
+
+const LAZY_SUFFIX = "Rendering/Lazy.tsx";
+const SINGLE_DEFERRED_SUFFIX = "Rendering/SingleDeferred.tsx";
+
+export interface UnwrappedSection {
+  resolveType: string;
+  isLazy: boolean;
+}
+
+/**
+ * Unwrap a section's data to find the real resolveType, handling:
+ * - Lazy/SingleDeferred wrappers (unwrap to inner `section.__resolveType`)
+ * - Saved blocks (look up in decofile to find the real component path)
+ */
+export function unwrapSection(
+  sectionData: { __resolveType: string; [k: string]: unknown },
+  decofile: Record<string, Record<string, unknown>> | null,
+): UnwrappedSection {
+  const rt = sectionData.__resolveType;
+
+  const isLazy =
+    rt.endsWith(LAZY_SUFFIX) || rt.endsWith(SINGLE_DEFERRED_SUFFIX);
+
+  if (isLazy) {
+    const inner = sectionData.section as
+      | { __resolveType: string; [k: string]: unknown }
+      | undefined;
+
+    if (!inner?.__resolveType) {
+      return { resolveType: rt, isLazy: true };
+    }
+
+    const innerResolved = resolveBlockName(inner.__resolveType, decofile);
+    return { resolveType: innerResolved, isLazy: true };
+  }
+
+  return { resolveType: resolveBlockName(rt, decofile), isLazy: false };
+}
+
+/**
+ * If a resolveType looks like a saved block name (no "/" in it),
+ * look it up in the decofile to get the actual component path.
+ */
+function resolveBlockName(
+  resolveType: string,
+  decofile: Record<string, Record<string, unknown>> | null,
+): string {
+  if (resolveType.includes("/")) return resolveType;
+  if (!decofile) return resolveType;
+
+  const block = decofile[resolveType];
+  if (block?.__resolveType && typeof block.__resolveType === "string") {
+    return block.__resolveType as string;
+  }
+
+  return resolveType;
 }

--- a/apps/mesh/src/web/lib/schema-resolver.ts
+++ b/apps/mesh/src/web/lib/schema-resolver.ts
@@ -1,0 +1,466 @@
+/**
+ * SchemaResolver — Layer 1 of the Studio Forms system.
+ *
+ * Consumes the raw `_meta` JSON from a deco site and resolves JSON Schema
+ * definitions into flat, renderable FieldDescriptor trees. Handles $ref chains,
+ * allOf merging, anyOf unions, and deco-specific extensions like `format` and
+ * `titleBy`.
+ *
+ * Only supports the JSON Schema subset emitted by deco's TS→JSON Schema
+ * compiler — not arbitrary JSON Schema.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type FieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "object"
+  | "array"
+  | "union"
+  | "unknown";
+
+export interface FieldDescriptor {
+  key: string;
+  type: FieldType;
+  nullable: boolean;
+  title: string;
+  description?: string;
+  format?: string;
+  required: boolean;
+  enumValues?: string[];
+  defaultValue?: unknown;
+  properties?: FieldDescriptor[];
+  itemDescriptor?: FieldDescriptor;
+  titleBy?: string;
+  variants?: VariantDescriptor[];
+}
+
+export interface VariantDescriptor {
+  resolveType: string;
+  title: string;
+  schema: FieldDescriptor;
+}
+
+export interface SectionInfo {
+  resolveType: string;
+  title: string;
+  namespace: string;
+}
+
+export interface SiteMeta {
+  major?: number;
+  version?: string;
+  namespace?: string;
+  site?: string;
+  manifest?: {
+    blocks?: Record<
+      string,
+      Record<string, { $ref?: string; namespace?: string }>
+    >;
+  };
+  schema?: {
+    definitions?: Record<string, JSONSchemaNode>;
+    root?: Record<
+      string,
+      { title?: string; anyOf?: Array<{ $ref?: string; [k: string]: unknown }> }
+    >;
+  };
+}
+
+export interface JSONSchemaNode {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  format?: string;
+  properties?: Record<string, JSONSchemaNode>;
+  required?: string[];
+  items?: JSONSchemaNode;
+  $ref?: string;
+  allOf?: JSONSchemaNode[];
+  anyOf?: JSONSchemaNode[];
+  oneOf?: JSONSchemaNode[];
+  enum?: unknown[];
+  default?: unknown;
+  titleBy?: string;
+  additionalProperties?: boolean | JSONSchemaNode;
+  not?: JSONSchemaNode;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REF_PREFIX = "#/definitions/";
+const MAX_DEPTH = 10;
+
+function extractRefKey(ref: string): string | null {
+  if (ref.startsWith(REF_PREFIX)) {
+    return ref.slice(REF_PREFIX.length);
+  }
+  return null;
+}
+
+function humanizeKey(key: string): string {
+  return key
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]/g, " ")
+    .replace(/^\w/, (c) => c.toUpperCase());
+}
+
+function parseType(schemaType: string | string[] | undefined): {
+  type: FieldType;
+  nullable: boolean;
+} {
+  if (!schemaType) return { type: "unknown", nullable: false };
+
+  if (Array.isArray(schemaType)) {
+    const filtered = schemaType.filter((t) => t !== "null");
+    const nullable = schemaType.includes("null");
+    const primary = filtered[0] ?? "unknown";
+    return { type: mapPrimitive(primary), nullable };
+  }
+
+  return { type: mapPrimitive(schemaType), nullable: false };
+}
+
+function mapPrimitive(t: string): FieldType {
+  switch (t) {
+    case "string":
+      return "string";
+    case "number":
+    case "integer":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "object":
+      return "object";
+    case "array":
+      return "array";
+    default:
+      return "unknown";
+  }
+}
+
+function formatSectionTitle(resolveType: string): string {
+  const parts = resolveType.split("/");
+  const fileName = parts[parts.length - 1] ?? resolveType;
+  return fileName.replace(/\.tsx?$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// SchemaResolver
+// ---------------------------------------------------------------------------
+
+type RootSchema = Record<
+  string,
+  { title?: string; anyOf?: Array<{ $ref?: string; [k: string]: unknown }> }
+>;
+
+export class SchemaResolver {
+  private definitions: Record<string, JSONSchemaNode>;
+  private manifest: SiteMeta["manifest"];
+  private root: RootSchema;
+  private resolvedCache = new Map<string, FieldDescriptor>();
+
+  constructor(meta: SiteMeta) {
+    this.definitions = meta.schema?.definitions ?? {};
+    this.manifest = meta.manifest;
+    this.root = (meta.schema?.root ?? {}) as RootSchema;
+  }
+
+  /**
+   * List available sections from schema.root.sections.anyOf.
+   */
+  listSections(): SectionInfo[] {
+    const sectionsRoot = this.root?.sections;
+    if (!sectionsRoot?.anyOf) return [];
+
+    const manifestSections = this.manifest?.blocks?.sections ?? {};
+
+    return sectionsRoot.anyOf
+      .map((entry) => {
+        const refKey = entry.$ref ? extractRefKey(entry.$ref) : null;
+        if (!refKey || refKey === "Resolvable") return null;
+
+        const def = this.definitions[refKey];
+        const resolveType = def?.properties?.__resolveType?.enum?.[0] as
+          | string
+          | undefined;
+        if (!resolveType) return null;
+
+        const namespace = manifestSections[resolveType]?.namespace ?? "unknown";
+
+        return {
+          resolveType,
+          title: formatSectionTitle(resolveType),
+          namespace,
+        };
+      })
+      .filter((s): s is SectionInfo => s !== null);
+  }
+
+  /**
+   * Resolve the full field descriptor tree for a section by its __resolveType.
+   */
+  resolveSection(resolveType: string): FieldDescriptor | null {
+    const cached = this.resolvedCache.get(resolveType);
+    if (cached) return cached;
+
+    const key = btoa(resolveType);
+    const wrapperSchema = this.definitions[key];
+    if (!wrapperSchema) return null;
+
+    const merged = this.mergeAllOf(wrapperSchema, new Set(), 0);
+    if (!merged) return null;
+
+    const descriptor = this.schemaToDescriptor(
+      resolveType,
+      merged,
+      merged.required ?? [],
+      new Set(),
+      0,
+    );
+
+    // Remove the __resolveType field from properties — it's internal
+    if (descriptor.properties) {
+      descriptor.properties = descriptor.properties.filter(
+        (p) => p.key !== "__resolveType",
+      );
+    }
+
+    this.resolvedCache.set(resolveType, descriptor);
+    return descriptor;
+  }
+
+  /**
+   * Look up a raw definition by key (escape hatch).
+   */
+  getDefinition(key: string): JSONSchemaNode | undefined {
+    return this.definitions[key];
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal resolution
+  // -------------------------------------------------------------------------
+
+  private resolveRef(
+    schema: JSONSchemaNode,
+    visited: Set<string>,
+    depth: number,
+  ): JSONSchemaNode | null {
+    if (depth > MAX_DEPTH) return null;
+
+    if (schema.$ref) {
+      const refKey = extractRefKey(schema.$ref);
+      if (!refKey || visited.has(refKey)) return null;
+
+      const resolved = this.definitions[refKey];
+      if (!resolved) return null;
+
+      visited.add(refKey);
+      return this.resolveRef(resolved, visited, depth + 1);
+    }
+
+    return schema;
+  }
+
+  private mergeAllOf(
+    schema: JSONSchemaNode,
+    visited: Set<string>,
+    depth: number,
+  ): JSONSchemaNode | null {
+    if (depth > MAX_DEPTH) return null;
+
+    let resolved = this.resolveRef(schema, new Set(visited), depth);
+    if (!resolved) return null;
+
+    if (!resolved.allOf?.length) return resolved;
+
+    // Merge all allOf entries into a single schema
+    const merged: JSONSchemaNode = {
+      type: resolved.type ?? "object",
+      title: resolved.title,
+      description: resolved.description,
+      properties: { ...(resolved.properties ?? {}) },
+      required: [...(resolved.required ?? [])],
+    };
+
+    for (const subSchema of resolved.allOf) {
+      const sub = subSchema.$ref
+        ? this.resolveRef(subSchema, new Set(visited), depth + 1)
+        : subSchema;
+      if (!sub) continue;
+
+      const expanded = this.mergeAllOf(sub, visited, depth + 1);
+      if (!expanded) continue;
+
+      if (expanded.properties) {
+        merged.properties = { ...merged.properties, ...expanded.properties };
+      }
+      if (expanded.required) {
+        merged.required = [
+          ...new Set([...(merged.required ?? []), ...expanded.required]),
+        ];
+      }
+    }
+
+    return merged;
+  }
+
+  private schemaToDescriptor(
+    key: string,
+    schema: JSONSchemaNode,
+    parentRequired: string[],
+    visited: Set<string>,
+    depth: number,
+  ): FieldDescriptor {
+    if (depth > MAX_DEPTH) {
+      return {
+        key,
+        type: "unknown",
+        nullable: false,
+        title: humanizeKey(key),
+        required: false,
+      };
+    }
+
+    // Resolve $ref first
+    let resolved = schema;
+    if (schema.$ref) {
+      const refKey = extractRefKey(schema.$ref);
+      if (refKey && !visited.has(refKey)) {
+        visited.add(refKey);
+        const def = this.definitions[refKey];
+        if (def) {
+          resolved = def;
+        }
+      }
+    }
+
+    // Merge allOf if present
+    if (resolved.allOf?.length) {
+      const merged = this.mergeAllOf(resolved, new Set(visited), depth);
+      if (merged) resolved = merged;
+    }
+
+    // Handle anyOf → union type
+    if (resolved.anyOf?.length) {
+      return this.buildUnionDescriptor(
+        key,
+        resolved,
+        parentRequired,
+        visited,
+        depth,
+      );
+    }
+
+    const { type, nullable } = parseType(resolved.type);
+    const isRequired = parentRequired.includes(key);
+
+    const base: FieldDescriptor = {
+      key,
+      type,
+      nullable,
+      title: resolved.title ?? humanizeKey(key),
+      description: resolved.description,
+      format: resolved.format,
+      required: isRequired,
+      enumValues: resolved.enum?.map(String),
+      defaultValue: resolved.default,
+      titleBy: resolved.titleBy,
+    };
+
+    if (type === "object" && resolved.properties) {
+      base.properties = Object.entries(resolved.properties).map(
+        ([propKey, propSchema]) =>
+          this.schemaToDescriptor(
+            propKey,
+            propSchema,
+            resolved.required ?? [],
+            new Set(visited),
+            depth + 1,
+          ),
+      );
+    }
+
+    if (type === "array" && resolved.items) {
+      base.itemDescriptor = this.schemaToDescriptor(
+        "item",
+        resolved.items,
+        [],
+        new Set(visited),
+        depth + 1,
+      );
+    }
+
+    return base;
+  }
+
+  private buildUnionDescriptor(
+    key: string,
+    schema: JSONSchemaNode,
+    parentRequired: string[],
+    visited: Set<string>,
+    depth: number,
+  ): FieldDescriptor {
+    const variants: VariantDescriptor[] = [];
+
+    for (const option of schema.anyOf ?? []) {
+      const refKey = option.$ref ? extractRefKey(option.$ref) : null;
+
+      // Skip the Resolvable option for now
+      if (refKey === "Resolvable") continue;
+
+      let optionSchema = option;
+      if (refKey && this.definitions[refKey]) {
+        optionSchema = this.definitions[refKey];
+      }
+
+      // Merge allOf in the variant
+      const merged = this.mergeAllOf(optionSchema, new Set(visited), depth + 1);
+      if (!merged) continue;
+
+      const resolveType =
+        (merged.properties?.__resolveType?.enum?.[0] as string) ??
+        merged.title ??
+        refKey ??
+        "unknown";
+
+      const variantDescriptor = this.schemaToDescriptor(
+        resolveType,
+        merged,
+        [],
+        new Set(visited),
+        depth + 1,
+      );
+
+      // Remove __resolveType from variant properties
+      if (variantDescriptor.properties) {
+        variantDescriptor.properties = variantDescriptor.properties.filter(
+          (p) => p.key !== "__resolveType",
+        );
+      }
+
+      variants.push({
+        resolveType,
+        title: formatSectionTitle(resolveType),
+        schema: variantDescriptor,
+      });
+    }
+
+    return {
+      key,
+      type: "union",
+      nullable: false,
+      title: schema.title ?? humanizeKey(key),
+      description: schema.description,
+      required: parentRequired.includes(key),
+      variants,
+    };
+  }
+}

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -19,6 +19,8 @@ const ProjectAppViewContent = lazy(() =>
   })),
 );
 
+const PagesView = lazy(() => import("@/web/views/pages"));
+
 /**
  * Resolve the effective main view: if the URL specifies one, use it;
  * otherwise fall back to the entity's layout config, then to settings.
@@ -51,6 +53,8 @@ function useResolvedMainView(): MainView & {} {
         : { type: "chat" };
     case "settings":
       return { type: "settings" };
+    case "pages":
+      return { type: "pages" };
     default:
       return { type: "chat" };
   }
@@ -115,6 +119,10 @@ function AgentHomeContent() {
     );
   }
 
+  if (resolved.type === "pages") {
+    return <PagesView pageKey={resolved.pageKey} />;
+  }
+
   // settings
   return (
     <VirtualMcpDetailView key={virtualMcpId} virtualMcpId={virtualMcpId} />
@@ -132,6 +140,8 @@ function mainViewKey(view: MainView): string {
       return `automation:${view.id}`;
     case "ext-apps":
       return `ext-apps:${view.id}:${view.toolName ?? ""}`;
+    case "pages":
+      return `pages:${view.pageKey ?? "list"}`;
   }
 }
 

--- a/apps/mesh/src/web/views/pages/index.tsx
+++ b/apps/mesh/src/web/views/pages/index.tsx
@@ -14,6 +14,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
   SchemaResolver,
+  unwrapSection,
   type FieldDescriptor,
   type SiteMeta,
 } from "@/web/lib/schema-resolver";
@@ -26,9 +27,11 @@ import {
   RefreshCw01,
   SearchLg,
 } from "@untitledui/icons";
+import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
 import { useRef, useState } from "react";
 
 // ---------------------------------------------------------------------------
@@ -433,7 +436,8 @@ export function PageSectionsPanel({
             {sections.map((section, idx) => (
               <SectionSchemaCard
                 key={`${section.__resolveType}-${idx}`}
-                resolveType={section.__resolveType}
+                sectionData={section}
+                decofile={decofile}
                 resolver={resolver}
                 index={idx}
               />
@@ -559,16 +563,20 @@ function PagePreviewView({
 // ---------------------------------------------------------------------------
 
 function SectionSchemaCard({
-  resolveType,
+  sectionData,
+  decofile,
   resolver,
   index,
 }: {
-  resolveType: string;
+  sectionData: { __resolveType: string; [k: string]: unknown };
+  decofile: Decofile | null;
   resolver: SchemaResolver;
   index: number;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const descriptor = resolver.resolveSection(resolveType);
+
+  const { resolveType, isLazy } = unwrapSection(sectionData, decofile);
+  const descriptor = resolver.resolveSectionWithDecofile(resolveType, decofile);
 
   const sectionName =
     resolveType
@@ -592,15 +600,17 @@ function SectionSchemaCard({
           #{index + 1}
         </span>
         <span className="text-sm font-medium truncate">{sectionName}</span>
-        <span className="text-xs text-muted-foreground truncate ml-auto">
-          {resolveType}
-        </span>
+        {isLazy && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+            Async
+          </Badge>
+        )}
       </button>
 
       {expanded && (
         <div className="mt-3 ml-8 border-l border-border/50 pl-4">
           {descriptor ? (
-            <FieldDescriptorTree descriptor={descriptor} depth={0} />
+            <ReadonlyFieldRenderer descriptor={descriptor} depth={0} />
           ) : (
             <p className="text-xs text-muted-foreground italic">
               Schema not found for this section.
@@ -613,20 +623,131 @@ function SectionSchemaCard({
 }
 
 // ---------------------------------------------------------------------------
-// Field Descriptor Tree (read-only display)
+// Readonly Field Renderer — renders actual form inputs from FieldDescriptors
 // ---------------------------------------------------------------------------
 
-const TYPE_COLORS: Record<string, string> = {
-  string: "text-green-600 dark:text-green-400",
-  number: "text-blue-600 dark:text-blue-400",
-  boolean: "text-amber-600 dark:text-amber-400",
-  object: "text-purple-600 dark:text-purple-400",
-  array: "text-cyan-600 dark:text-cyan-400",
-  union: "text-pink-600 dark:text-pink-400",
-  unknown: "text-muted-foreground",
-};
+function humanizeKey(key: string): string {
+  return key
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
-function FieldDescriptorTree({
+function FieldLabel({ descriptor }: { descriptor: FieldDescriptor }) {
+  const label = descriptor.title || humanizeKey(descriptor.key);
+  return (
+    <div className="flex items-center gap-1.5 mb-1">
+      <Label className="text-xs font-medium">{label}</Label>
+      {!descriptor.required && (
+        <span className="text-[10px] text-muted-foreground">(optional)</span>
+      )}
+    </div>
+  );
+}
+
+function FieldDescription({ text }: { text?: string }) {
+  if (!text) return null;
+  return <p className="text-[11px] text-muted-foreground mt-0.5">{text}</p>;
+}
+
+function ReadonlyFieldRenderer({
+  descriptor,
+  depth,
+}: {
+  descriptor: FieldDescriptor;
+  depth: number;
+}) {
+  switch (descriptor.type) {
+    case "string":
+      return <StringField descriptor={descriptor} />;
+    case "number":
+      return <NumberField descriptor={descriptor} />;
+    case "boolean":
+      return <BooleanField descriptor={descriptor} />;
+    case "object":
+      return <ObjectField descriptor={descriptor} depth={depth} />;
+    case "array":
+      return <ArrayField descriptor={descriptor} depth={depth} />;
+    case "union":
+      return <UnionField descriptor={descriptor} depth={depth} />;
+    default:
+      return (
+        <div className="py-1.5">
+          <FieldLabel descriptor={descriptor} />
+          <Input readOnly className="h-8 text-xs bg-muted/30" placeholder="—" />
+        </div>
+      );
+  }
+}
+
+function StringField({ descriptor }: { descriptor: FieldDescriptor }) {
+  if (descriptor.enumValues && descriptor.enumValues.length > 0) {
+    return (
+      <div className="py-1.5">
+        <FieldLabel descriptor={descriptor} />
+        <div className="flex flex-wrap gap-1">
+          {descriptor.enumValues.map((val) => (
+            <Badge key={val} variant="outline" className="text-[10px]">
+              {val}
+            </Badge>
+          ))}
+        </div>
+        <FieldDescription text={descriptor.description} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-1.5">
+      <FieldLabel descriptor={descriptor} />
+      <Input
+        readOnly
+        className="h-8 text-xs bg-muted/30"
+        placeholder={descriptor.format ? `(${descriptor.format})` : "—"}
+      />
+      {descriptor.format && (
+        <span className="text-[10px] text-muted-foreground mt-0.5 block">
+          Format: {descriptor.format}
+        </span>
+      )}
+      <FieldDescription text={descriptor.description} />
+    </div>
+  );
+}
+
+function NumberField({ descriptor }: { descriptor: FieldDescriptor }) {
+  return (
+    <div className="py-1.5">
+      <FieldLabel descriptor={descriptor} />
+      <Input
+        readOnly
+        type="number"
+        className="h-8 text-xs bg-muted/30"
+        placeholder="—"
+      />
+      <FieldDescription text={descriptor.description} />
+    </div>
+  );
+}
+
+function BooleanField({ descriptor }: { descriptor: FieldDescriptor }) {
+  const label = descriptor.title || humanizeKey(descriptor.key);
+  return (
+    <div className="py-1.5 flex items-center justify-between gap-2">
+      <div className="flex-1 min-w-0">
+        <Label className="text-xs font-medium">{label}</Label>
+        {descriptor.description && (
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            {descriptor.description}
+          </p>
+        )}
+      </div>
+      <Switch disabled checked={false} className="shrink-0" />
+    </div>
+  );
+}
+
+function ObjectField({
   descriptor,
   depth,
 }: {
@@ -634,91 +755,152 @@ function FieldDescriptorTree({
   depth: number;
 }) {
   const [expanded, setExpanded] = useState(depth < 1);
-  const hasChildren =
-    (descriptor.properties && descriptor.properties.length > 0) ||
-    descriptor.itemDescriptor ||
-    (descriptor.variants && descriptor.variants.length > 0);
+  const props = descriptor.properties ?? [];
 
-  const typeLabel =
-    descriptor.type === "array" && descriptor.itemDescriptor
-      ? `${descriptor.itemDescriptor.type}[]`
-      : descriptor.type;
+  if (props.length === 0) {
+    return (
+      <div className="py-1.5">
+        <FieldLabel descriptor={descriptor} />
+        <p className="text-[11px] text-muted-foreground italic">Empty object</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="text-xs">
+    <div className="py-1.5">
       <button
         type="button"
-        onClick={() => hasChildren && setExpanded(!expanded)}
-        className={cn(
-          "flex items-center gap-1.5 py-0.5 w-full text-left",
-          hasChildren && "cursor-pointer hover:bg-accent/30 rounded -mx-1 px-1",
-          !hasChildren && "cursor-default",
-        )}
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-1.5 text-left"
       >
-        {hasChildren ? (
-          expanded ? (
-            <ChevronDown size={12} className="text-muted-foreground shrink-0" />
-          ) : (
-            <ChevronRight
-              size={12}
-              className="text-muted-foreground shrink-0"
-            />
-          )
+        {expanded ? (
+          <ChevronDown size={12} className="text-muted-foreground shrink-0" />
         ) : (
-          <span className="w-3 shrink-0" />
+          <ChevronRight size={12} className="text-muted-foreground shrink-0" />
         )}
-        <span className="font-mono font-medium">{descriptor.key}</span>
-        <span className={cn("font-mono", TYPE_COLORS[descriptor.type])}>
-          {typeLabel}
+        <Label className="text-xs font-medium cursor-pointer">
+          {descriptor.title || humanizeKey(descriptor.key)}
+        </Label>
+        <span className="text-[10px] text-muted-foreground">
+          {props.length} {props.length === 1 ? "field" : "fields"}
         </span>
-        {descriptor.nullable && (
-          <span className="text-muted-foreground">| null</span>
-        )}
-        {descriptor.required && (
-          <span className="text-red-500 dark:text-red-400">*</span>
-        )}
-        {descriptor.format && (
-          <span className="text-muted-foreground bg-muted px-1 rounded">
-            {descriptor.format}
-          </span>
-        )}
-        {descriptor.enumValues && (
-          <span className="text-muted-foreground">
-            [{descriptor.enumValues.join(" | ")}]
-          </span>
-        )}
       </button>
-
-      {expanded && hasChildren && (
-        <div className="ml-4 border-l border-border/30 pl-2 mt-0.5">
-          {descriptor.properties?.map((prop) => (
-            <FieldDescriptorTree
+      {expanded && (
+        <div className="ml-3 mt-1 border-l border-border/40 pl-3 space-y-0.5">
+          {props.map((prop) => (
+            <ReadonlyFieldRenderer
               key={prop.key}
               descriptor={prop}
               depth={depth + 1}
             />
           ))}
-          {descriptor.itemDescriptor && (
-            <FieldDescriptorTree
-              descriptor={descriptor.itemDescriptor}
-              depth={depth + 1}
-            />
-          )}
-          {descriptor.variants?.map((variant) => (
-            <div key={variant.resolveType} className="mt-1">
-              <span className="text-muted-foreground font-mono text-[10px]">
-                variant: {variant.title}
-              </span>
-              <div className="ml-2">
-                <FieldDescriptorTree
-                  descriptor={variant.schema}
-                  depth={depth + 1}
-                />
-              </div>
-            </div>
-          ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function ArrayField({
+  descriptor,
+  depth,
+}: {
+  descriptor: FieldDescriptor;
+  depth: number;
+}) {
+  const [expanded, setExpanded] = useState(depth < 1);
+  const itemDescriptor = descriptor.itemDescriptor;
+
+  return (
+    <div className="py-1.5">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-1.5 text-left"
+      >
+        {expanded ? (
+          <ChevronDown size={12} className="text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight size={12} className="text-muted-foreground shrink-0" />
+        )}
+        <Label className="text-xs font-medium cursor-pointer">
+          {descriptor.title || humanizeKey(descriptor.key)}
+        </Label>
+        <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+          {itemDescriptor?.type ?? "item"}[]
+        </Badge>
+      </button>
+      {expanded && itemDescriptor && (
+        <div className="ml-3 mt-1 border-l border-border/40 pl-3">
+          <ReadonlyFieldRenderer
+            descriptor={itemDescriptor}
+            depth={depth + 1}
+          />
+        </div>
+      )}
+      <FieldDescription text={descriptor.description} />
+    </div>
+  );
+}
+
+function UnionField({
+  descriptor,
+  depth,
+}: {
+  descriptor: FieldDescriptor;
+  depth: number;
+}) {
+  const [expanded, setExpanded] = useState(depth < 1);
+  const variants = descriptor.variants ?? [];
+
+  return (
+    <div className="py-1.5">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-1.5 text-left"
+      >
+        {expanded ? (
+          <ChevronDown size={12} className="text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight size={12} className="text-muted-foreground shrink-0" />
+        )}
+        <Label className="text-xs font-medium cursor-pointer">
+          {descriptor.title || humanizeKey(descriptor.key)}
+        </Label>
+        <span className="text-[10px] text-muted-foreground">
+          {variants.length} {variants.length === 1 ? "variant" : "variants"}
+        </span>
+      </button>
+      {expanded && variants.length > 0 && (
+        <div className="ml-3 mt-1 space-y-2">
+          {variants.map((variant) => {
+            const variantName =
+              variant.title ||
+              variant.resolveType
+                .split("/")
+                .pop()
+                ?.replace(/\.tsx?$/, "") ||
+              variant.resolveType;
+            return (
+              <div
+                key={variant.resolveType}
+                className="border border-border/40 rounded-md p-2"
+              >
+                <Badge variant="outline" className="text-[10px] mb-1.5">
+                  {variantName}
+                </Badge>
+                <div className="pl-1 space-y-0.5">
+                  <ReadonlyFieldRenderer
+                    descriptor={variant.schema}
+                    depth={depth + 1}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <FieldDescription text={descriptor.description} />
     </div>
   );
 }

--- a/apps/mesh/src/web/views/pages/index.tsx
+++ b/apps/mesh/src/web/views/pages/index.tsx
@@ -1,0 +1,724 @@
+import { Suspense } from "react";
+import { Page } from "@/web/components/page";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import { usePanelActions } from "@/web/layouts/shell-layout";
+import {
+  useProjectContext,
+  useMCPClient,
+  useMCPToolCall,
+  useVirtualMCP,
+} from "@decocms/mesh-sdk";
+import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  SchemaResolver,
+  type FieldDescriptor,
+  type SiteMeta,
+} from "@/web/lib/schema-resolver";
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  File06,
+  LinkExternal01,
+  RefreshCw01,
+  SearchLg,
+} from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function getDecoConnectionId(
+  entity: VirtualMCPEntity | null,
+): string | null {
+  if (!entity) return null;
+  const pinnedViews = (
+    entity.metadata?.ui as Record<string, unknown> | null | undefined
+  )?.pinnedViews as
+    | Array<{ connectionId: string; toolName: string }>
+    | null
+    | undefined;
+  return (
+    pinnedViews?.find((v) => v.toolName === "file_explorer")?.connectionId ??
+    null
+  );
+}
+
+function extractStructured<T>(result: CallToolResult): T | null {
+  if (result.isError) return null;
+  if (result.structuredContent) return result.structuredContent as T;
+  const textBlock = result.content?.find(
+    (b): b is { type: "text"; text: string } => b.type === "text",
+  );
+  if (textBlock?.text) {
+    try {
+      return JSON.parse(textBlock.text) as T;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function consistentHash(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FileExplorerResult {
+  site: string;
+  userEnv: string;
+  userEnvUrl: string | null;
+  productionUrl: string;
+}
+
+type Decofile = Record<string, Record<string, unknown>>;
+
+interface PageInfo {
+  key: string;
+  name: string;
+  path: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared data hooks — single source of truth for _meta and decofile
+// ---------------------------------------------------------------------------
+
+function buildEnvUrl(site: string, userEnv: string, userEnvUrl: string | null) {
+  return (
+    userEnvUrl ||
+    `https://sites-${site}--${consistentHash(userEnv)}.decocdn.com`
+  );
+}
+
+const DECOFILE_STALE = 60_000;
+const META_STALE = 5 * 60 * 1000;
+
+function useDecofile(envUrl: string) {
+  return useSuspenseQuery<Decofile | null>({
+    queryKey: ["decofile", envUrl],
+    queryFn: async () => {
+      const res = await fetch(`${envUrl}/.decofile`);
+      if (!res.ok) return null;
+      return res.json();
+    },
+    staleTime: DECOFILE_STALE,
+    retry: 1,
+  });
+}
+
+function useSiteMeta(envUrl: string) {
+  return useSuspenseQuery<SiteMeta>({
+    queryKey: ["site-meta", envUrl],
+    queryFn: async () => {
+      const res = await fetch(`${envUrl}/live/_meta`);
+      if (!res.ok) throw new Error(`Failed to fetch _meta (${res.status})`);
+      return res.json();
+    },
+    staleTime: META_STALE,
+    retry: 1,
+  });
+}
+
+/**
+ * Derive pages list from the decofile — same logic as get_pages MCP tool
+ * but done client-side, no round-trip needed.
+ */
+function derivePagesFromDecofile(decofile: Decofile | null): PageInfo[] {
+  if (!decofile) return [];
+  return Object.entries(decofile)
+    .filter(([, block]) => {
+      if (!block?.path) return false;
+      const rt = (block.__resolveType as string) ?? "";
+      return rt.split("/").includes("pages");
+    })
+    .map(([id, block]) => ({
+      key: id,
+      name: String(block.name ?? id),
+      path: String(block.path ?? "/"),
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+// ---------------------------------------------------------------------------
+// PagesView (entry point)
+// ---------------------------------------------------------------------------
+
+export default function PagesView({ pageKey }: { pageKey?: string }) {
+  const { virtualMcpId } = useInsetContext()!;
+  const entity = useVirtualMCP(virtualMcpId);
+  const connectionId = getDecoConnectionId(entity);
+
+  if (!connectionId) {
+    return (
+      <Page>
+        <Page.Content>
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-muted-foreground">
+              No deco.cx connection found for this project.
+            </p>
+          </div>
+        </Page.Content>
+      </Page>
+    );
+  }
+
+  return (
+    <ErrorBoundary>
+      <Suspense
+        fallback={
+          <Page>
+            <Page.Content>
+              <div className="flex items-center justify-center h-full">
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <div className="size-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  <span className="text-sm">Loading pages...</span>
+                </div>
+              </div>
+            </Page.Content>
+          </Page>
+        }
+      >
+        <PagesViewInner connectionId={connectionId} pageKey={pageKey} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inner — bootstraps env, fetches decofile once, then branches
+// ---------------------------------------------------------------------------
+
+function PagesViewInner({
+  connectionId,
+  pageKey,
+}: {
+  connectionId: string;
+  pageKey?: string;
+}) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({ connectionId, orgId: org.id });
+
+  const { data: envResult } = useMCPToolCall({
+    client,
+    toolName: "file_explorer",
+    toolArguments: {},
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const env = extractStructured<FileExplorerResult>(envResult);
+  if (!env?.userEnv) {
+    return (
+      <Page>
+        <Page.Content>
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-muted-foreground">
+              Could not initialize sandbox environment.
+            </p>
+          </div>
+        </Page.Content>
+      </Page>
+    );
+  }
+
+  const envUrl = buildEnvUrl(env.site, env.userEnv, env.userEnvUrl);
+
+  if (pageKey) {
+    return (
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center h-full">
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <div className="size-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm">Loading preview...</span>
+            </div>
+          </div>
+        }
+      >
+        <PagePreviewView envUrl={envUrl} pageKey={pageKey} />
+      </Suspense>
+    );
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <Page>
+          <Page.Content>
+            <div className="flex items-center justify-center h-full">
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <div className="size-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                <span className="text-sm">Loading pages...</span>
+              </div>
+            </div>
+          </Page.Content>
+        </Page>
+      }
+    >
+      <PagesListView envUrl={envUrl} />
+    </Suspense>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pages List — derives page list from the decofile (no MCP call)
+// ---------------------------------------------------------------------------
+
+function PagesListView({ envUrl }: { envUrl: string }) {
+  const { openMainView } = usePanelActions();
+  const [search, setSearch] = useState("");
+
+  const { data: decofile } = useDecofile(envUrl);
+  const allPages = derivePagesFromDecofile(decofile);
+
+  const query = search.trim().toLowerCase();
+  const pages = query
+    ? allPages.filter(
+        (p) =>
+          p.name.toLowerCase().includes(query) ||
+          p.path.toLowerCase().includes(query),
+      )
+    : allPages;
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Left>
+          <File06 size={16} className="text-muted-foreground shrink-0" />
+          <span className="text-sm font-medium truncate">Pages</span>
+          <span className="text-xs text-muted-foreground">
+            {allPages.length} {allPages.length === 1 ? "page" : "pages"}
+          </span>
+        </Page.Header.Left>
+      </Page.Header>
+      <Page.Content>
+        {allPages.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-muted-foreground">
+              No pages found in this environment.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col h-full">
+            <div className="px-4 py-2 border-b border-border/50">
+              <div className="relative">
+                <SearchLg
+                  size={14}
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+                />
+                <Input
+                  placeholder="Search pages..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-8 h-8 text-sm"
+                />
+              </div>
+            </div>
+            {pages.length === 0 ? (
+              <div className="flex items-center justify-center flex-1 py-12">
+                <p className="text-sm text-muted-foreground">
+                  No pages matching &quot;{search}&quot;
+                </p>
+              </div>
+            ) : (
+              <div className="divide-y divide-border/50 overflow-auto flex-1">
+                {pages.map((page) => (
+                  <button
+                    key={page.key}
+                    type="button"
+                    onClick={() => openMainView("pages", { id: page.key })}
+                    className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-accent/50 transition-colors"
+                  >
+                    <File06
+                      size={14}
+                      className="text-muted-foreground shrink-0"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">
+                        {page.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {page.path}
+                      </div>
+                    </div>
+                    <ChevronRight
+                      size={14}
+                      className="text-muted-foreground shrink-0"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </Page.Content>
+    </Page>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PageSectionsPanel — rendered inside the thick sidebar
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders sections list for a page. Used by PageSectionsSidebar.
+ * Fetches _meta + decofile via shared hooks (cached, no duplication).
+ */
+export function PageSectionsPanel({
+  envUrl,
+  pageKey,
+}: {
+  envUrl: string;
+  pageKey: string;
+}) {
+  const { openMainView } = usePanelActions();
+
+  const { data: meta } = useSiteMeta(envUrl);
+  const { data: decofile } = useDecofile(envUrl);
+
+  const resolver = meta ? new SchemaResolver(meta) : null;
+  const pageContent = decofile?.[pageKey] ?? null;
+  const pageName =
+    (pageContent?.name as string) ?? (pageContent?.title as string) ?? pageKey;
+
+  const sections = (pageContent?.sections ?? []) as Array<{
+    __resolveType: string;
+    [k: string]: unknown;
+  }>;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="shrink-0 flex items-center gap-1.5 px-3 h-11 border-b border-border/50">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => openMainView("pages")}
+          className="gap-1.5 -ml-1"
+        >
+          <ArrowLeft size={14} />
+          Pages
+        </Button>
+        <span className="text-muted-foreground text-xs">/</span>
+        <span className="text-sm font-medium truncate">{pageName}</span>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {!resolver ? (
+          <div className="flex items-center justify-center h-32">
+            <p className="text-xs text-muted-foreground">
+              Could not load site schema.
+            </p>
+          </div>
+        ) : sections.length === 0 ? (
+          <div className="flex items-center justify-center h-32">
+            <p className="text-xs text-muted-foreground">No sections found.</p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border/50">
+            {sections.map((section, idx) => (
+              <SectionSchemaCard
+                key={`${section.__resolveType}-${idx}`}
+                resolveType={section.__resolveType}
+                resolver={resolver}
+                index={idx}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PageSectionsSidebar — bootstraps env then renders sections panel
+// ---------------------------------------------------------------------------
+
+export function PageSectionsSidebar({
+  connectionId,
+  pageKey,
+}: {
+  connectionId: string;
+  pageKey: string;
+}) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({ connectionId, orgId: org.id });
+
+  const { data: envResult } = useMCPToolCall({
+    client,
+    toolName: "file_explorer",
+    toolArguments: {},
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const env = extractStructured<FileExplorerResult>(envResult);
+  if (!env?.userEnv) {
+    return (
+      <div className="flex items-center justify-center h-32">
+        <p className="text-xs text-muted-foreground">
+          Initializing environment...
+        </p>
+      </div>
+    );
+  }
+
+  const envUrl = buildEnvUrl(env.site, env.userEnv, env.userEnvUrl);
+
+  return <PageSectionsPanel envUrl={envUrl} pageKey={pageKey} />;
+}
+
+// ---------------------------------------------------------------------------
+// PagePreviewView — iframe + URL bar (main content area)
+// ---------------------------------------------------------------------------
+
+function PagePreviewView({
+  envUrl,
+  pageKey,
+}: {
+  envUrl: string;
+  pageKey: string;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const { data: decofile } = useDecofile(envUrl);
+  const initialPath = (decofile?.[pageKey]?.path as string) ?? "/";
+
+  const [previewPath, setPreviewPath] = useState(initialPath);
+  const [pathInput, setPathInput] = useState(initialPath);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const previewSrc = `${envUrl}${previewPath}`;
+
+  const handlePathSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const normalized = pathInput.startsWith("/") ? pathInput : `/${pathInput}`;
+    setPreviewPath(normalized);
+  };
+
+  return (
+    <div className="flex flex-col h-full w-full overflow-hidden">
+      <div className="shrink-0 flex items-center gap-2 px-3 h-11 border-b border-border/50">
+        <form onSubmit={handlePathSubmit} className="flex-1 min-w-0">
+          <div className="flex h-8 items-center gap-1.5 rounded-lg border bg-muted/30 px-1">
+            <Input
+              value={pathInput}
+              onChange={(e) => setPathInput(e.target.value)}
+              placeholder="/"
+              className="h-7 min-w-0 flex-1 border-0 bg-transparent px-1.5 shadow-none focus-visible:ring-0 text-sm"
+            />
+          </div>
+        </form>
+        <button
+          type="button"
+          onClick={() => window.open(previewSrc, "_blank")}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Open in new tab"
+        >
+          <LinkExternal01 size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setRefreshKey((k) => k + 1)}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Refresh preview"
+        >
+          <RefreshCw01 size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 bg-muted/20">
+        <iframe
+          key={`${previewSrc}-${refreshKey}`}
+          ref={iframeRef}
+          src={previewSrc}
+          title={`Preview of ${previewPath}`}
+          className="h-full w-full border-0"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section Schema Card
+// ---------------------------------------------------------------------------
+
+function SectionSchemaCard({
+  resolveType,
+  resolver,
+  index,
+}: {
+  resolveType: string;
+  resolver: SchemaResolver;
+  index: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const descriptor = resolver.resolveSection(resolveType);
+
+  const sectionName =
+    resolveType
+      .split("/")
+      .pop()
+      ?.replace(/\.tsx?$/, "") ?? resolveType;
+
+  return (
+    <div className="px-4 py-3">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 text-left"
+      >
+        {expanded ? (
+          <ChevronDown size={14} className="text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight size={14} className="text-muted-foreground shrink-0" />
+        )}
+        <span className="text-xs font-mono text-muted-foreground w-6 shrink-0">
+          #{index + 1}
+        </span>
+        <span className="text-sm font-medium truncate">{sectionName}</span>
+        <span className="text-xs text-muted-foreground truncate ml-auto">
+          {resolveType}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-3 ml-8 border-l border-border/50 pl-4">
+          {descriptor ? (
+            <FieldDescriptorTree descriptor={descriptor} depth={0} />
+          ) : (
+            <p className="text-xs text-muted-foreground italic">
+              Schema not found for this section.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field Descriptor Tree (read-only display)
+// ---------------------------------------------------------------------------
+
+const TYPE_COLORS: Record<string, string> = {
+  string: "text-green-600 dark:text-green-400",
+  number: "text-blue-600 dark:text-blue-400",
+  boolean: "text-amber-600 dark:text-amber-400",
+  object: "text-purple-600 dark:text-purple-400",
+  array: "text-cyan-600 dark:text-cyan-400",
+  union: "text-pink-600 dark:text-pink-400",
+  unknown: "text-muted-foreground",
+};
+
+function FieldDescriptorTree({
+  descriptor,
+  depth,
+}: {
+  descriptor: FieldDescriptor;
+  depth: number;
+}) {
+  const [expanded, setExpanded] = useState(depth < 1);
+  const hasChildren =
+    (descriptor.properties && descriptor.properties.length > 0) ||
+    descriptor.itemDescriptor ||
+    (descriptor.variants && descriptor.variants.length > 0);
+
+  const typeLabel =
+    descriptor.type === "array" && descriptor.itemDescriptor
+      ? `${descriptor.itemDescriptor.type}[]`
+      : descriptor.type;
+
+  return (
+    <div className="text-xs">
+      <button
+        type="button"
+        onClick={() => hasChildren && setExpanded(!expanded)}
+        className={cn(
+          "flex items-center gap-1.5 py-0.5 w-full text-left",
+          hasChildren && "cursor-pointer hover:bg-accent/30 rounded -mx-1 px-1",
+          !hasChildren && "cursor-default",
+        )}
+      >
+        {hasChildren ? (
+          expanded ? (
+            <ChevronDown size={12} className="text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight
+              size={12}
+              className="text-muted-foreground shrink-0"
+            />
+          )
+        ) : (
+          <span className="w-3 shrink-0" />
+        )}
+        <span className="font-mono font-medium">{descriptor.key}</span>
+        <span className={cn("font-mono", TYPE_COLORS[descriptor.type])}>
+          {typeLabel}
+        </span>
+        {descriptor.nullable && (
+          <span className="text-muted-foreground">| null</span>
+        )}
+        {descriptor.required && (
+          <span className="text-red-500 dark:text-red-400">*</span>
+        )}
+        {descriptor.format && (
+          <span className="text-muted-foreground bg-muted px-1 rounded">
+            {descriptor.format}
+          </span>
+        )}
+        {descriptor.enumValues && (
+          <span className="text-muted-foreground">
+            [{descriptor.enumValues.join(" | ")}]
+          </span>
+        )}
+      </button>
+
+      {expanded && hasChildren && (
+        <div className="ml-4 border-l border-border/30 pl-2 mt-0.5">
+          {descriptor.properties?.map((prop) => (
+            <FieldDescriptorTree
+              key={prop.key}
+              descriptor={prop}
+              depth={depth + 1}
+            />
+          ))}
+          {descriptor.itemDescriptor && (
+            <FieldDescriptorTree
+              descriptor={descriptor.itemDescriptor}
+              depth={depth + 1}
+            />
+          )}
+          {descriptor.variants?.map((variant) => (
+            <div key={variant.resolveType} className="mt-1">
+              <span className="text-muted-foreground font-mono text-[10px]">
+                variant: {variant.title}
+              </span>
+              <div className="ml-2">
+                <FieldDescriptorTree
+                  descriptor={variant.schema}
+                  depth={depth + 1}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/views/pages/index.tsx
+++ b/apps/mesh/src/web/views/pages/index.tsx
@@ -22,6 +22,7 @@ import {
   ArrowLeft,
   ChevronDown,
   ChevronRight,
+  CursorClick01,
   File06,
   LinkExternal01,
   RefreshCw01,
@@ -32,7 +33,8 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
-import { useRef, useState } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { forwardRef, useEffect, useRef, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -78,6 +80,78 @@ function consistentHash(input: string): string {
   }
   return Math.abs(hash).toString(36);
 }
+
+// ---------------------------------------------------------------------------
+// Inspect mode — scripts injected into the preview iframe
+// ---------------------------------------------------------------------------
+
+const SECTION_CLICK_EVENT = "studio:section-click";
+
+const INSPECT_ENABLE_SCRIPT = `(function() {
+  document.querySelectorAll('[data-studio-inspect]').forEach(function(el) { el.remove(); });
+  document.querySelectorAll('[data-studio-section-idx]').forEach(function(el) {
+    el.removeAttribute('data-studio-section-idx');
+  });
+
+  var style = document.createElement('style');
+  style.setAttribute('data-studio-inspect', 'true');
+  style.textContent = [
+    '[data-studio-section-idx] { position: relative !important; }',
+    '[data-studio-overlay] {',
+    '  position: absolute; inset: 0; z-index: 9999;',
+    '  pointer-events: none; transition: all 0.15s ease;',
+    '  border: 2px solid transparent;',
+    '}',
+    '[data-studio-section-idx]:hover > [data-studio-overlay] {',
+    '  background: rgba(59,130,246,0.08);',
+    '  border-color: rgba(59,130,246,0.6);',
+    '  pointer-events: auto; cursor: pointer;',
+    '}',
+    '[data-studio-label] {',
+    '  position: absolute; top: 4px; left: 4px;',
+    '  background: rgba(59,130,246,0.9); color: #fff;',
+    '  font: 500 11px/1 system-ui, sans-serif;',
+    '  padding: 3px 8px; border-radius: 4px;',
+    '  opacity: 0; transition: opacity 0.15s; z-index: 10000;',
+    '}',
+    '[data-studio-section-idx]:hover [data-studio-label] { opacity: 1; }',
+  ].join('\\n');
+  document.head.appendChild(style);
+
+  var sel = 'section[data-manifest-key]';
+  var sections = document.querySelectorAll(sel);
+  if (!sections.length) sections = document.querySelectorAll('body > section, body > div > section, body > main > section');
+
+  sections.forEach(function(section, index) {
+    section.setAttribute('data-studio-section-idx', index);
+    var manifestKey = section.getAttribute('data-manifest-key') || '';
+
+    var overlay = document.createElement('div');
+    overlay.setAttribute('data-studio-inspect', 'true');
+    overlay.setAttribute('data-studio-overlay', '');
+
+    var label = document.createElement('div');
+    label.setAttribute('data-studio-label', '');
+    var short = manifestKey.split('/').pop() || ('Section');
+    short = short.replace(/\\.tsx?$/, '');
+    label.textContent = short;
+    overlay.appendChild(label);
+
+    overlay.addEventListener('click', function(e) {
+      e.stopPropagation(); e.preventDefault();
+      parent.postMessage({ type: 'studio::section-click', manifestKey: manifestKey }, '*');
+    });
+
+    section.appendChild(overlay);
+  });
+})();`;
+
+const INSPECT_DISABLE_SCRIPT = `(function() {
+  document.querySelectorAll('[data-studio-inspect]').forEach(function(el) { el.remove(); });
+  document.querySelectorAll('[data-studio-section-idx]').forEach(function(el) {
+    el.removeAttribute('data-studio-section-idx');
+  });
+})();`;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -390,6 +464,8 @@ export function PageSectionsPanel({
   pageKey: string;
 }) {
   const { openMainView } = usePanelActions();
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+  const sectionRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
   const { data: meta } = useSiteMeta(envUrl);
   const { data: decofile } = useDecofile(envUrl);
@@ -403,6 +479,36 @@ export function PageSectionsPanel({
     __resolveType: string;
     [k: string]: unknown;
   }>;
+
+  // Build a mapping from resolveType -> sidebar index for inspect matching.
+  // The DOM's data-manifest-key is the component path (e.g. "site/sections/Hero.tsx"),
+  // which matches our unwrapped resolveType.
+  const resolveTypeToIndex = new Map<string, number>();
+  for (let i = 0; i < sections.length; i++) {
+    const sec = sections[i];
+    if (!sec) continue;
+    const { resolveType } = unwrapSection(sec, decofile);
+    resolveTypeToIndex.set(resolveType, i);
+  }
+
+  // Listen for inspect clicks from the preview iframe
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect — custom event listener for cross-component communication
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { manifestKey } = (e as CustomEvent<{ manifestKey: string }>)
+        .detail;
+      const idx = resolveTypeToIndex.get(manifestKey);
+      if (idx == null) return;
+      setExpandedIndex(idx);
+      requestAnimationFrame(() => {
+        sectionRefs.current
+          .get(idx)
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    };
+    window.addEventListener(SECTION_CLICK_EVENT, handler);
+    return () => window.removeEventListener(SECTION_CLICK_EVENT, handler);
+  });
 
   return (
     <div className="flex flex-col h-full">
@@ -440,6 +546,14 @@ export function PageSectionsPanel({
                 decofile={decofile}
                 resolver={resolver}
                 index={idx}
+                expanded={expandedIndex === idx}
+                onToggle={() =>
+                  setExpandedIndex(expandedIndex === idx ? null : idx)
+                }
+                ref={(el) => {
+                  if (el) sectionRefs.current.set(idx, el);
+                  else sectionRefs.current.delete(idx);
+                }}
               />
             ))}
           </div>
@@ -490,6 +604,14 @@ export function PageSectionsSidebar({
 // PagePreviewView — iframe + URL bar (main content area)
 // ---------------------------------------------------------------------------
 
+function sendToIframe(iframe: HTMLIFrameElement | null, script: string) {
+  if (!iframe?.contentWindow) return;
+  iframe.contentWindow.postMessage(
+    { type: "editor::inject", args: { script } },
+    "*",
+  );
+}
+
 function PagePreviewView({
   envUrl,
   pageKey,
@@ -505,6 +627,7 @@ function PagePreviewView({
   const [previewPath, setPreviewPath] = useState(initialPath);
   const [pathInput, setPathInput] = useState(initialPath);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [inspectMode, setInspectMode] = useState(false);
 
   const previewSrc = `${envUrl}${previewPath}`;
 
@@ -513,6 +636,36 @@ function PagePreviewView({
     const normalized = pathInput.startsWith("/") ? pathInput : `/${pathInput}`;
     setPreviewPath(normalized);
   };
+
+  const toggleInspect = () => {
+    const next = !inspectMode;
+    setInspectMode(next);
+    sendToIframe(
+      iframeRef.current,
+      next ? INSPECT_ENABLE_SCRIPT : INSPECT_DISABLE_SCRIPT,
+    );
+  };
+
+  // Re-inject inspect overlays after iframe navigates or refreshes
+  const handleIframeLoad = () => {
+    if (inspectMode) {
+      sendToIframe(iframeRef.current, INSPECT_ENABLE_SCRIPT);
+    }
+  };
+
+  // Listen for section-click messages from the iframe and relay as a custom event
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect — window message listener for cross-origin iframe communication
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type !== "studio::section-click") return;
+      const manifestKey = e.data.manifestKey as string;
+      window.dispatchEvent(
+        new CustomEvent(SECTION_CLICK_EVENT, { detail: { manifestKey } }),
+      );
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
 
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
@@ -527,6 +680,19 @@ function PagePreviewView({
             />
           </div>
         </form>
+        <button
+          type="button"
+          onClick={toggleInspect}
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors",
+            inspectMode
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
+          )}
+          title={inspectMode ? "Disable inspect mode" : "Inspect sections"}
+        >
+          <CursorClick01 size={14} />
+        </button>
         <button
           type="button"
           onClick={() => window.open(previewSrc, "_blank")}
@@ -550,6 +716,7 @@ function PagePreviewView({
           key={`${previewSrc}-${refreshKey}`}
           ref={iframeRef}
           src={previewSrc}
+          onLoad={handleIframeLoad}
           title={`Preview of ${previewPath}`}
           className="h-full w-full border-0"
         />
@@ -562,19 +729,20 @@ function PagePreviewView({
 // Section Schema Card
 // ---------------------------------------------------------------------------
 
-function SectionSchemaCard({
-  sectionData,
-  decofile,
-  resolver,
-  index,
-}: {
-  sectionData: { __resolveType: string; [k: string]: unknown };
-  decofile: Decofile | null;
-  resolver: SchemaResolver;
-  index: number;
-}) {
-  const [expanded, setExpanded] = useState(false);
-
+const SectionSchemaCard = forwardRef<
+  HTMLDivElement,
+  {
+    sectionData: { __resolveType: string; [k: string]: unknown };
+    decofile: Decofile | null;
+    resolver: SchemaResolver;
+    index: number;
+    expanded: boolean;
+    onToggle: () => void;
+  }
+>(function SectionSchemaCard(
+  { sectionData, decofile, resolver, index, expanded, onToggle },
+  ref,
+) {
   const { resolveType, isLazy } = unwrapSection(sectionData, decofile);
   const descriptor = resolver.resolveSectionWithDecofile(resolveType, decofile);
 
@@ -585,10 +753,10 @@ function SectionSchemaCard({
       ?.replace(/\.tsx?$/, "") ?? resolveType;
 
   return (
-    <div className="px-4 py-3">
+    <div ref={ref} className="px-4 py-3">
       <button
         type="button"
-        onClick={() => setExpanded(!expanded)}
+        onClick={onToggle}
         className="w-full flex items-center gap-2 text-left"
       >
         {expanded ? (
@@ -620,7 +788,7 @@ function SectionSchemaCard({
       )}
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // Readonly Field Renderer — renders actual form inputs from FieldDescriptors


### PR DESCRIPTION
Introduce a Pages view for deco sites with:
- Pages list derived client-side from .decofile (no MCP round-trip)
- Section schema viewer in the thick sidebar (SchemaResolver parses _meta)
- Live iframe preview with editable URL bar in the main content area
- Shared data hooks (useDecofile, useSiteMeta) with React Query caching
- Search/filter on the pages list
- Fix openMainView to properly clear id/toolName on navigation

Made-with: Cursor

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Pages editor for deco sites with a schema viewer, live preview, and an inspect mode that links clicks in the preview to the correct section in the sidebar. Resolves saved blocks and lazy sections, and renders readonly form fields.

- **New Features**
  - New "Pages" view wired into navigation; lists pages from `.decofile` with search/filter (no MCP round-trip).
  - Schema viewer in the thick sidebar using a new `SchemaResolver` that resolves `$ref`, `allOf`, `anyOf`, saved blocks, and unwraps `Lazy`/`SingleDeferred` (shows an "Async" badge).
  - Readonly form rendering for section schemas using `@deco/ui` (string, number, boolean, enum, object, array, union).
  - Live preview iframe with editable URL bar, refresh, open-in-new-tab, and Inspect mode that injects hover overlays and expands the matching section on click (ignores layout header/footer).
  - Sidebar integration: deco projects get a "Pages" entry; when a page is open, the sidebar switches to the Sections panel.
  - Shared hooks (`useDecofile`, `useSiteMeta`) with `@tanstack/react-query` caching; integrates with `@decocms/mesh-sdk`, `@deco/ui`, and `@untitledui/icons`.

- **Bug Fixes**
  - `openMainView` now clears `id`/`toolName` when switching views to prevent stale params.

<sup>Written for commit cfd57896eeb121b9440070030067400e91316106. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

