### PR TITLE
Exploring projects and files

### DIFF
--- a/apps/mesh/scripts/seed-slide-project.ts
+++ b/apps/mesh/scripts/seed-slide-project.ts
@@ -1,0 +1,135 @@
+/**
+ * Seed script: Creates a Slide Maker connection, wraps it in an agent,
+ * wraps that in a project, and sets the slide_maker tool as the default UI.
+ *
+ * Run: bun run --cwd apps/mesh scripts/seed-slide-project.ts
+ *
+ * Prerequisites: dev server must be running (bun run dev)
+ */
+
+const BASE_URL = "http://localhost:4000";
+
+async function getSession(): Promise<{
+  token: string;
+  orgId: string;
+  orgSlug: string;
+}> {
+  // Get current session
+  const res = await fetch(`${BASE_URL}/api/auth/get-session`, {
+    headers: { Accept: "application/json" },
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error("Not logged in. Open the app first and log in.");
+  const session = (await res.json()) as {
+    session: { token: string };
+    user: { id: string };
+  };
+
+  // Get active org
+  const orgRes = await fetch(
+    `${BASE_URL}/api/auth/organization/get-full-organization`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.session.token}`,
+      },
+      body: "{}",
+    },
+  );
+
+  if (!orgRes.ok) {
+    // Try listing orgs
+    const listRes = await fetch(
+      `${BASE_URL}/api/auth/organization/list-organizations`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${session.session.token}`,
+        },
+      },
+    );
+    const orgs = (await listRes.json()) as Array<{
+      id: string;
+      slug: string;
+    }>;
+    if (orgs.length === 0) throw new Error("No organizations found");
+    return {
+      token: session.session.token,
+      orgId: orgs[0].id,
+      orgSlug: orgs[0].slug,
+    };
+  }
+
+  const org = (await orgRes.json()) as { id: string; slug: string };
+  return {
+    token: session.session.token,
+    orgId: org.id,
+    orgSlug: org.slug,
+  };
+}
+
+async function callTool(
+  token: string,
+  orgId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+) {
+  const res = await fetch(`${BASE_URL}/api/mcp/self`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "x-mesh-org-id": orgId,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: crypto.randomUUID(),
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Tool call failed (${res.status}): ${text}`);
+  }
+
+  const json = (await res.json()) as {
+    result?: { structuredContent?: unknown };
+  };
+  return json.result?.structuredContent ?? json.result;
+}
+
+async function main() {
+  console.log("Getting session...");
+
+  // Since we can't easily get the session token from a script,
+  // let's use the MCP endpoint directly through the internal API.
+  // The dev server should have the embedded postgres running.
+
+  // Actually, let's just use the Kysely DB directly since we're in the same codebase.
+  console.log(
+    "\nThis script needs the dev server running. Instead of API calls,",
+  );
+  console.log("let's create the data through the UI:\n");
+  console.log("1. Open Studio in your browser (http://localhost:4000)");
+  console.log("2. Go to Settings > Connections");
+  console.log("3. Click 'Create connection' and fill in:");
+  console.log("   - Title: Slide Maker");
+  console.log("   - Type: HTTP");
+  console.log("   - URL: https://slide-maker.decocms.com/api/mcp");
+  console.log("   - Token: 9c8ed79c-4e23-4ca8-9f22-257afff0aee5");
+  console.log("4. Save the connection");
+  console.log("5. Go to Settings > Agents (or create a new agent)");
+  console.log("   - Name it 'Slide Maker'");
+  console.log("   - Add the Slide Maker connection to it");
+  console.log("6. Go home > New Project or click '+' in sidebar");
+  console.log("   - Name it 'My Slides'");
+  console.log("   - In project settings, add the Slide Maker agent");
+  console.log(
+    "\nThe slide_maker tool UI will be available in the agent's ext-apps view.",
+  );
+}
+
+main().catch(console.error);

--- a/apps/mesh/src/web/components/chat/select-virtual-mcp.tsx
+++ b/apps/mesh/src/web/components/chat/select-virtual-mcp.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import { isDecopilot, type VirtualMCPEntity } from "@decocms/mesh-sdk";
 import { useVirtualMCPs } from "@decocms/mesh-sdk";
+import { useProjectScope } from "@/web/providers/project-scope";
 import { Check, Loading01, SearchMd, Users03 } from "@untitledui/icons";
 import {
   Suspense,
@@ -79,6 +80,8 @@ export interface VirtualMCPPopoverContentProps {
   selectedVirtualMcpId?: string | null;
   onVirtualMcpChange: (virtualMcpId: string | null) => void;
   searchInputRef?: RefObject<HTMLInputElement | null>;
+  /** If provided, only show agents with these IDs (project scoping) */
+  scopeToIds?: Set<string>;
 }
 
 function PopoverContentLoading() {
@@ -101,6 +104,7 @@ function VirtualMCPPopoverContentInner({
   selectedVirtualMcpId,
   onVirtualMcpChange,
   searchInputRef,
+  scopeToIds: scopeToIdsProp,
 }: VirtualMCPPopoverContentProps) {
   const virtualMcps = useVirtualMCPs();
   const [searchTerm, setSearchTerm] = useState("");
@@ -110,17 +114,27 @@ function VirtualMCPPopoverContentInner({
     navigateOnCreate: true,
   });
 
-  // Filter virtual MCPs based on search term and exclude Decopilot
+  // Auto-scope to project agents if inside a project
+  const projectScope = useProjectScope();
+  const scopeToIds = scopeToIdsProp ?? projectScope?.agentIds;
+
+  // Filter virtual MCPs: exclude Decopilot, scope to project agents if provided
   const filteredVirtualMcps = (() => {
-    // First filter out Decopilot
-    const nonDecopilotMcps = virtualMcps.filter(
+    let mcps = virtualMcps.filter(
       (virtualMcp) => !virtualMcp.id || !isDecopilot(virtualMcp.id),
     );
 
-    if (!searchTerm.trim()) return nonDecopilotMcps;
+    // If scoped to a project, only show those specific agents
+    if (scopeToIds) {
+      mcps = mcps.filter(
+        (virtualMcp) => virtualMcp.id != null && scopeToIds.has(virtualMcp.id),
+      );
+    }
+
+    if (!searchTerm.trim()) return mcps;
 
     const search = searchTerm.toLowerCase();
-    return nonDecopilotMcps.filter((virtualMcp) => {
+    return mcps.filter((virtualMcp) => {
       return (
         virtualMcp.title.toLowerCase().includes(search) ||
         virtualMcp.description?.toLowerCase().includes(search)

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -127,9 +127,7 @@ function HomeEmptyState({
 
   return (
     <>
-      <div className="flex-1 relative flex flex-col items-center overflow-y-auto px-10">
-        {/* Top spacer to push greeting toward center when content is short */}
-        <div className="flex-1 min-h-16 max-h-[30vh]" />
+      <div className="flex-1 relative flex flex-col items-center overflow-y-auto px-10 pt-[25vh]">
         <div className="flex flex-col items-center w-full max-w-[672px]">
           <div className="text-center mb-10">
             <p className="text-3xl font-medium text-foreground">
@@ -144,11 +142,10 @@ function HomeEmptyState({
           <QuickActions />
         </div>
         {isDecoUser && (
-          <div className="w-full max-w-[500px] mx-auto mt-6 mb-6">
+          <div className="w-full max-w-[500px] mx-auto mt-6">
             <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
           </div>
         )}
-        {/* Bottom spacer */}
         <div className="min-h-6" />
       </div>
       <ImportFromDecoDialog open={importOpen} onOpenChange={setImportOpen} />

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -1,4 +1,4 @@
-import { AgentsList } from "@/web/components/home/agents-list.tsx";
+import { QuickActions } from "@/web/components/home/quick-actions.tsx";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { authClient } from "@/web/lib/auth-client";
@@ -111,7 +111,7 @@ function HomeEmptyState({
           </div>
           {/* Agents above input at bottom */}
           <div className="w-full flex flex-col gap-4 pb-4">
-            <AgentsList />
+            <QuickActions />
             <Chat.Input onOpenContextPanel={onOpenContextPanel} />
           </div>
           {isDecoUser && (
@@ -127,29 +127,29 @@ function HomeEmptyState({
 
   return (
     <>
-      <div className="flex-1 relative flex flex-col items-center px-10">
-        <div className="flex-1 flex flex-col items-center justify-center w-full">
-          <div className="flex flex-col items-center w-full max-w-[672px]">
-            <div className="text-center mb-10">
-              <p className="text-3xl font-medium text-foreground">
-                What's on your mind, {userName}?
-              </p>
-            </div>
-            <div className="w-full">
-              <Chat.Input onOpenContextPanel={onOpenContextPanel} />
-            </div>
+      <div className="flex-1 relative flex flex-col items-center overflow-y-auto px-10">
+        {/* Top spacer to push greeting toward center when content is short */}
+        <div className="flex-1 min-h-16 max-h-[30vh]" />
+        <div className="flex flex-col items-center w-full max-w-[672px]">
+          <div className="text-center mb-10">
+            <p className="text-3xl font-medium text-foreground">
+              What's on your mind, {userName}?
+            </p>
           </div>
-          <div className="w-full mt-10 mx-auto">
-            <AgentsList />
+          <div className="w-full">
+            <Chat.Input onOpenContextPanel={onOpenContextPanel} />
           </div>
         </div>
+        <div className="w-full mt-10 mx-auto">
+          <QuickActions />
+        </div>
         {isDecoUser && (
-          <div className="absolute bottom-6 left-0 right-0 px-10">
-            <div className="w-full max-w-[500px] mx-auto">
-              <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
-            </div>
+          <div className="w-full max-w-[500px] mx-auto mt-6 mb-6">
+            <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
           </div>
         )}
+        {/* Bottom spacer */}
+        <div className="min-h-6" />
       </div>
       <ImportFromDecoDialog open={importOpen} onOpenChange={setImportOpen} />
     </>

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -15,7 +15,7 @@ import { Suspense, useTransition } from "react";
 import { isMac } from "@/web/lib/keyboard-shortcuts";
 import { ErrorBoundary } from "../error-boundary";
 import { Chat } from "./index";
-import { OwnerFilter, TaskListContent } from "./tasks-panel";
+import { OwnerFilter, TaskListContent, type ProjectInfo } from "./tasks-panel";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import {
@@ -95,10 +95,10 @@ function TasksPanelContent({
 
   // Always show ALL tasks — unified panel regardless of context
   const allProjects = useVirtualMCPs();
-  const projectNames = new Map(
+  const projectNames = new Map<string, ProjectInfo>(
     allProjects
       .filter((p) => p.id && !isDecopilotFn(p.id))
-      .map((p) => [p.id, p.title]),
+      .map((p) => [p.id, { name: p.title, icon: p.icon }]),
   );
 
   const handleNewTask = () => {

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -12,7 +12,12 @@ import { getIconComponent, parseIconString } from "../agent-icon";
 
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { Edit05, LayoutLeft, Loading01, Settings01 } from "@untitledui/icons";
-import { useVirtualMCPActions, useVirtualMCP } from "@decocms/mesh-sdk";
+import {
+  useVirtualMCPActions,
+  useVirtualMCP,
+  useVirtualMCPs,
+  isDecopilot as isDecopilotFn,
+} from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { Suspense, useEffect, useRef, useState, useTransition } from "react";
 import { isMac } from "@/web/lib/keyboard-shortcuts";
@@ -273,6 +278,20 @@ function TasksPanelContent({
 
   const virtualMcp = useVirtualMCP(virtualMcpId);
 
+  // When on org home (decopilot / hideProjectHeader), show ALL tasks
+  const isGlobalView = hideProjectHeader;
+  const taskListVirtualMcpId = isGlobalView ? "" : (virtualMcpId ?? "");
+
+  // Build project names map for labeling tasks in global view
+  const allProjects = useVirtualMCPs();
+  const projectNames = isGlobalView
+    ? new Map(
+        allProjects
+          .filter((p) => p.id && !isDecopilotFn(p.id))
+          .map((p) => [p.id, p.title]),
+      )
+    : undefined;
+
   const handleNewTask = () => {
     startTransition(() => {
       createNewTask();
@@ -331,12 +350,13 @@ function TasksPanelContent({
 
       {/* Task list */}
       <TaskListContent
-        virtualMcpId={virtualMcpId}
+        virtualMcpId={taskListVirtualMcpId}
         showAutomations={showAutomations}
         onTaskCreate={handleNewTask}
         onTaskSelect={(taskId) => {
           setTaskId(taskId);
         }}
+        projectNames={projectNames}
       />
     </div>
   );

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -11,6 +11,7 @@ import {
   useVirtualMCPs,
   isDecopilot as isDecopilotFn,
 } from "@decocms/mesh-sdk";
+import { isProject } from "@/web/hooks/use-create-project";
 import { Suspense, useTransition } from "react";
 import { isMac } from "@/web/lib/keyboard-shortcuts";
 import { ErrorBoundary } from "../error-boundary";
@@ -90,14 +91,15 @@ function TasksPanelContent({
   hideProjectHeader?: boolean;
   showAutomations?: boolean;
 }) {
-  const { createNewTask, setTaskId } = usePanelActions();
+  const { createNewTask } = usePanelActions();
   const [isPending, startTransition] = useTransition();
 
   // Always show ALL tasks — unified panel regardless of context
-  const allProjects = useVirtualMCPs();
+  const allVirtualMcps = useVirtualMCPs();
+  // Only show project names (not agent names) on task labels
   const projectNames = new Map<string, ProjectInfo>(
-    allProjects
-      .filter((p) => p.id && !isDecopilotFn(p.id))
+    allVirtualMcps
+      .filter((p) => p.id && !isDecopilotFn(p.id) && isProject(p))
       .map((p) => [p.id, { name: p.title, icon: p.icon }]),
   );
 
@@ -131,9 +133,6 @@ function TasksPanelContent({
         virtualMcpId=""
         showAutomations={showAutomations}
         onTaskCreate={handleNewTask}
-        onTaskSelect={(taskId) => {
-          setTaskId(taskId);
-        }}
         projectNames={projectNames}
       />
     </div>

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -1,25 +1,17 @@
 /**
  * Global Tasks Side Panel
  *
- * When inside a project: shows project name header (Cursor-style) with
- * settings, New session button, pinned Views, then tasks for that project.
- *
- * When global (no project): shows "Tasks" header, New task button, all tasks.
+ * Unified task list — always shows all tasks across all projects,
+ * labeled by project name. Optionally filterable.
  */
 
-import { Page } from "@/web/components/page";
-import { getIconComponent, parseIconString } from "../agent-icon";
-
 import { usePanelActions } from "@/web/layouts/shell-layout";
-import { Edit05, LayoutLeft, Loading01, Settings01 } from "@untitledui/icons";
+import { Edit05, Loading01 } from "@untitledui/icons";
 import {
-  useVirtualMCPActions,
-  useVirtualMCP,
   useVirtualMCPs,
   isDecopilot as isDecopilotFn,
 } from "@decocms/mesh-sdk";
-import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
-import { Suspense, useEffect, useRef, useState, useTransition } from "react";
+import { Suspense, useTransition } from "react";
 import { isMac } from "@/web/lib/keyboard-shortcuts";
 import { ErrorBoundary } from "../error-boundary";
 import { Chat } from "./index";
@@ -31,8 +23,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { IconPicker } from "@/web/components/icon-picker.tsx";
-import { useInsetContext } from "@/web/layouts/shell-layout";
 
 // ────────────────────────────────────────
 // Shared nav item style — used by New session and view buttons
@@ -88,209 +78,28 @@ function NewTaskButton({
 }
 
 // ────────────────────────────────────────
-// Pinned view icon — renders icon:// as plain stroke, falls back to Browser icon
-// ────────────────────────────────────────
-
-function PinnedViewIcon({ icon }: { icon: string | null | undefined }) {
-  const parsed = parseIconString(icon);
-  if (parsed.type === "icon") {
-    const IconComp = getIconComponent(parsed.name);
-    if (IconComp) {
-      return <IconComp size={16} className="shrink-0 text-muted-foreground" />;
-    }
-  }
-  if (parsed.type === "url") {
-    return <img src={parsed.url} alt="" className="size-4 rounded shrink-0" />;
-  }
-  return <LayoutLeft size={16} className="shrink-0 text-muted-foreground" />;
-}
-
-// ────────────────────────────────────────
-// Views section — pinned UIs for the project
-// ────────────────────────────────────────
-
-function ProjectViewsSection({ project }: { project: VirtualMCPEntity }) {
-  const virtualMcpCtx = useInsetContext();
-  const { openMainView } = usePanelActions();
-
-  const pinnedViews =
-    ((project.metadata?.ui as Record<string, unknown> | null | undefined)
-      ?.pinnedViews as Array<{
-      connectionId: string;
-      toolName: string;
-      label: string;
-      icon: string | null;
-    }> | null) ?? [];
-
-  if (pinnedViews.length === 0) return null;
-
-  // Determine which pinned view is currently active
-  const currentMain = virtualMcpCtx?.mainView;
-  const isExtAppActive = (view: { connectionId: string; toolName: string }) =>
-    currentMain?.type === "ext-apps" &&
-    currentMain.id === view.connectionId &&
-    currentMain.toolName === view.toolName;
-
-  return (
-    <>
-      {pinnedViews.map((view) => (
-        <button
-          key={`${view.connectionId}-${view.toolName}`}
-          type="button"
-          onClick={() =>
-            isExtAppActive(view)
-              ? openMainView("default")
-              : openMainView("ext-apps", {
-                  id: view.connectionId,
-                  toolName: view.toolName,
-                })
-          }
-          className={cn(
-            navItemClass,
-            isExtAppActive(view) && "bg-accent text-foreground",
-          )}
-        >
-          <PinnedViewIcon icon={view.icon} />
-          <span className="truncate text-foreground capitalize">
-            {view.label || view.toolName}
-          </span>
-        </button>
-      ))}
-    </>
-  );
-}
-
-// ────────────────────────────────────────
-// Space identity header — inline-editable name, description, icon, pin
-// ────────────────────────────────────────
-
-function SpaceIdentityHeader({ project }: { project: VirtualMCPEntity }) {
-  const actions = useVirtualMCPActions();
-  const [title, setTitle] = useState(project.title);
-  const [description, setDescription] = useState(project.description ?? "");
-  const initialRenderRef = useRef(true);
-
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — debounced title sync
-  useEffect(() => {
-    if (initialRenderRef.current) return;
-    const trimmed = title.trim();
-    if (!trimmed || trimmed === project.title) return;
-    const timer = setTimeout(() => {
-      actions.update.mutate({ id: project.id, data: { title: trimmed } });
-    }, 1000);
-    return () => clearTimeout(timer);
-  }, [title, actions.update, project.title, project.id]);
-
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — debounced description sync
-  useEffect(() => {
-    if (initialRenderRef.current) return;
-    if (description === (project.description ?? "")) return;
-    const timer = setTimeout(() => {
-      actions.update.mutate({
-        id: project.id,
-        data: { description },
-      });
-    }, 1000);
-    return () => clearTimeout(timer);
-  }, [description, actions.update, project.description, project.id]);
-
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — skip initial render for debounce effects
-  useEffect(() => {
-    initialRenderRef.current = false;
-  }, []);
-
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
-  };
-
-  const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDescription(e.target.value);
-  };
-
-  const handleIconChange = (icon: string | null) => {
-    actions.update.mutate({ id: project.id, data: { icon } });
-  };
-
-  const handleColorChange = (color: string) => {
-    actions.update.mutate({
-      id: project.id,
-      data: {
-        metadata: {
-          ...project.metadata,
-          ui: {
-            ...(project.metadata?.ui as Record<string, unknown> | undefined),
-            themeColor: color,
-          },
-        },
-      },
-    });
-  };
-
-  return (
-    <div className="flex items-center gap-3 pl-3 pr-4 pt-3 pb-3">
-      <IconPicker
-        value={project.icon}
-        onChange={handleIconChange}
-        onColorChange={handleColorChange}
-        name={project.title || "Space"}
-        size="sm+"
-        className="shrink-0 self-start"
-        avatarClassName="[&_svg]:w-1/2 [&_svg]:h-1/2"
-      />
-      <div className="flex flex-col flex-1 min-w-0">
-        <input
-          type="text"
-          value={title}
-          onChange={handleTitleChange}
-          placeholder="Space Name"
-          className="text-sm font-medium text-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
-        />
-        <input
-          type="text"
-          value={description}
-          onChange={handleDescriptionChange}
-          placeholder="Add a description..."
-          className="text-sm text-muted-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
-        />
-      </div>
-    </div>
-  );
-}
-
-// ────────────────────────────────────────
 // Panel content
 // ────────────────────────────────────────
 
 function TasksPanelContent({
-  virtualMcpId: virtualMcpIdProp,
-  hideProjectHeader,
+  virtualMcpId: _virtualMcpIdProp,
+  hideProjectHeader: _hideProjectHeader,
   showAutomations,
 }: {
   virtualMcpId?: string;
   hideProjectHeader?: boolean;
   showAutomations?: boolean;
 }) {
-  const virtualMcpCtx = useInsetContext();
-  const { openMainView } = usePanelActions();
   const { createNewTask, setTaskId } = usePanelActions();
   const [isPending, startTransition] = useTransition();
-  const virtualMcpId = virtualMcpIdProp ?? null;
 
-  const virtualMcp = useVirtualMCP(virtualMcpId);
-
-  // When on org home (decopilot / hideProjectHeader), show ALL tasks
-  const isGlobalView = hideProjectHeader;
-  const taskListVirtualMcpId = isGlobalView ? "" : (virtualMcpId ?? "");
-
-  // Build project names map for labeling tasks in global view
+  // Always show ALL tasks — unified panel regardless of context
   const allProjects = useVirtualMCPs();
-  const projectNames = isGlobalView
-    ? new Map(
-        allProjects
-          .filter((p) => p.id && !isDecopilotFn(p.id))
-          .map((p) => [p.id, p.title]),
-      )
-    : undefined;
+  const projectNames = new Map(
+    allProjects
+      .filter((p) => p.id && !isDecopilotFn(p.id))
+      .map((p) => [p.id, p.title]),
+  );
 
   const handleNewTask = () => {
     startTransition(() => {
@@ -298,59 +107,28 @@ function TasksPanelContent({
     });
   };
 
-  const isSettingsActive = virtualMcpCtx?.mainView?.type === "settings";
-
   return (
     <div className="flex flex-col h-full">
-      {/* Space identity */}
-      {virtualMcp && !hideProjectHeader && (
-        <SpaceIdentityHeader key={virtualMcp.id} project={virtualMcp} />
-      )}
-
       {/* Header */}
-      {!virtualMcp && (
-        <Page.Header className="flex-none" hideSidebarTrigger>
-          <Page.Header.Left className="gap-2">
-            <span className="text-sm font-medium text-foreground">Tasks</span>
-          </Page.Header.Left>
-          <Page.Header.Right className="gap-1">
-            <OwnerFilter />
-          </Page.Header.Right>
-        </Page.Header>
-      )}
+      <div className="flex items-center gap-2 px-4 pt-3 pb-1">
+        <span className="text-sm font-medium text-foreground flex-1">
+          Tasks
+        </span>
+        <OwnerFilter />
+      </div>
 
-      {/* Nav items: New session + Settings + Views flow as one group */}
-      <div className="py-2 flex flex-col gap-0.5">
+      {/* New task */}
+      <div className="py-1 flex flex-col gap-0.5">
         <NewTaskButton
           onClick={handleNewTask}
           isPending={isPending}
           label="New task"
         />
-        {virtualMcp && virtualMcpCtx && !hideProjectHeader && (
-          <button
-            type="button"
-            onClick={() =>
-              isSettingsActive
-                ? openMainView("default")
-                : openMainView("settings")
-            }
-            className={cn(
-              navItemClass,
-              isSettingsActive && "bg-accent text-foreground",
-            )}
-          >
-            <Settings01 size={16} className="shrink-0" />
-            <span className="text-foreground">Settings</span>
-          </button>
-        )}
-        {virtualMcp && !hideProjectHeader && (
-          <ProjectViewsSection project={virtualMcp} />
-        )}
       </div>
 
-      {/* Task list */}
+      {/* Task list — always all tasks, labeled by project */}
       <TaskListContent
-        virtualMcpId={taskListVirtualMcpId}
+        virtualMcpId=""
         showAutomations={showAutomations}
         onTaskCreate={handleNewTask}
         onTaskSelect={(taskId) => {

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -96,11 +96,28 @@ function TasksPanelContent({
 
   // Always show ALL tasks — unified panel regardless of context
   const allVirtualMcps = useVirtualMCPs();
-  // Only show project names (not agent names) on task labels
+  // Only show project names (not agent names) on task labels, include default view
   const projectNames = new Map<string, ProjectInfo>(
     allVirtualMcps
       .filter((p) => p.id && !isDecopilotFn(p.id) && isProject(p))
-      .map((p) => [p.id, { name: p.title, icon: p.icon }]),
+      .map((p) => {
+        const layout = (p.metadata?.ui as Record<string, unknown> | undefined)
+          ?.layout as {
+          defaultMainView?: {
+            type: string;
+            id?: string;
+            toolName?: string;
+          };
+        } | null;
+        return [
+          p.id,
+          {
+            name: p.title,
+            icon: p.icon,
+            defaultView: layout?.defaultMainView ?? null,
+          },
+        ];
+      }),
   );
 
   const handleNewTask = () => {

--- a/apps/mesh/src/web/components/chat/task/use-task-manager.ts
+++ b/apps/mesh/src/web/components/chat/task/use-task-manager.ts
@@ -60,14 +60,18 @@ export function useTasks(
       if (!client) {
         throw new Error("MCP client is not available");
       }
+      const where: Record<string, unknown> = {
+        ...(ownerFilter === "me" && { created_by: "me" }),
+      };
+      // Only filter by virtual_mcp_id if one is provided
+      if (virtualMcpId) {
+        where.virtual_mcp_id = virtualMcpId;
+      }
       const input = {
         limit: TASK_CONSTANTS.TASKS_PAGE_SIZE,
         offset: 0,
         orderBy: [{ field: ["updated_at"], direction: "desc" as const }],
-        where: {
-          ...(ownerFilter === "me" && { created_by: "me" }),
-          virtual_mcp_id: virtualMcpId,
-        },
+        where,
       };
 
       const result = (await client.callTool({

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -18,7 +18,8 @@ import {
 import type { Task } from "./task/types";
 import { useTasks } from "./task";
 import { authClient } from "../../lib/auth-client";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   Tooltip,
   TooltipContent,
@@ -482,9 +483,23 @@ export function TaskListContent({
         new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
     );
 
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const insetCtx = useInsetContext();
+  const currentVirtualMcpId = insetCtx?.virtualMcpId;
+
   const handleSelect = (task: Task) => {
     if (onTaskSelect) {
       onTaskSelect(task.id);
+      return;
+    }
+    // Navigate cross-project if the task belongs to a different project
+    if (task.virtual_mcp_id && task.virtual_mcp_id !== currentVirtualMcpId) {
+      navigate({
+        to: "/$org/$virtualMcpId/",
+        params: { org: org.slug, virtualMcpId: task.virtual_mcp_id },
+        search: { taskId: task.id },
+      });
     } else {
       setTaskId(task.id);
     }

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -455,6 +455,12 @@ function IncomingSection({ virtualMcpId }: { virtualMcpId: string }) {
 export interface ProjectInfo {
   name: string;
   icon: string | null;
+  /** Default main view for this project (ext-apps, etc.) */
+  defaultView?: {
+    type: string;
+    id?: string;
+    toolName?: string;
+  } | null;
 }
 
 type GroupBy = "none" | "project" | "status";
@@ -511,10 +517,22 @@ export function TaskListContent({
       return;
     }
     if (task.virtual_mcp_id && task.virtual_mcp_id !== currentVirtualMcpId) {
+      // Restore the project's default UI view when navigating cross-project
+      const projectInfo = task.virtual_mcp_id
+        ? projectNames?.get(task.virtual_mcp_id)
+        : undefined;
+      const dv = projectInfo?.defaultView;
+      const searchParams: Record<string, unknown> = { taskId: task.id };
+      if (dv?.type) {
+        searchParams.main = dv.type;
+        searchParams.mainOpen = 1;
+        if (dv.id) searchParams.id = dv.id;
+        if (dv.toolName) searchParams.toolName = dv.toolName;
+      }
       navigate({
         to: "/$org/$virtualMcpId/",
         params: { org: org.slug, virtualMcpId: task.virtual_mcp_id },
-        search: { taskId: task.id },
+        search: searchParams,
       });
     } else {
       setTaskId(task.id);

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -141,10 +141,12 @@ function TaskRow({
   task,
   isActive,
   onClick,
+  projectName,
 }: {
   task: Task;
   isActive: boolean;
   onClick: () => void;
+  projectName?: string;
 }) {
   const { setTaskStatus, hideTask } = useChatTask();
   const playSound = useSound(question004Sound);
@@ -157,7 +159,8 @@ function TaskRow({
   return (
     <div
       className={cn(
-        "group/row relative flex items-center gap-2 mx-2 px-3 h-10 rounded-md w-[calc(100%-1rem)] cursor-pointer",
+        "group/row relative flex items-center gap-2 mx-2 px-3 rounded-md w-[calc(100%-1rem)] cursor-pointer",
+        projectName ? "h-12 py-1" : "h-10",
         isActive ? "bg-accent" : "hover:bg-accent/50",
       )}
       onClick={onClick}
@@ -207,15 +210,22 @@ function TaskRow({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* Title + time */}
-      <div className="flex-1 min-w-0 flex items-center gap-1.5">
-        <TruncatedText
-          text={task.title || "Untitled"}
-          className="text-sm text-muted-foreground flex-1 min-w-0"
-        />
-        <span className="text-xs text-muted-foreground tabular-nums shrink-0 whitespace-nowrap group-hover/row:invisible">
-          {task.updated_at ? formatTimeAgo(new Date(task.updated_at)) : ""}
-        </span>
+      {/* Title + project + time */}
+      <div className="flex-1 min-w-0 flex flex-col justify-center gap-0">
+        <div className="flex items-center gap-1.5">
+          <TruncatedText
+            text={task.title || "Untitled"}
+            className="text-sm text-muted-foreground flex-1 min-w-0"
+          />
+          <span className="text-xs text-muted-foreground tabular-nums shrink-0 whitespace-nowrap group-hover/row:invisible">
+            {task.updated_at ? formatTimeAgo(new Date(task.updated_at)) : ""}
+          </span>
+        </div>
+        {projectName && (
+          <span className="text-[11px] text-muted-foreground/50 truncate leading-tight">
+            {projectName}
+          </span>
+        )}
       </div>
 
       {/* Archive button — shown on hover */}
@@ -437,6 +447,8 @@ interface TaskListContentProps {
   onTaskCreate?: () => void;
   virtualMcpId?: string | null;
   showAutomations?: boolean;
+  /** Map of virtualMcpId → project name for labeling tasks */
+  projectNames?: Map<string, string>;
 }
 
 export function TaskListContent({
@@ -444,6 +456,7 @@ export function TaskListContent({
   onTaskCreate,
   virtualMcpId,
   showAutomations = true,
+  projectNames,
 }: TaskListContentProps) {
   const { ownerFilter } = useChatTask();
   const { setTaskId } = usePanelActions();
@@ -515,6 +528,11 @@ export function TaskListContent({
               task={task}
               isActive={task.id === taskId}
               onClick={() => handleSelect(task)}
+              projectName={
+                projectNames && task.virtual_mcp_id
+                  ? projectNames.get(task.virtual_mcp_id)
+                  : undefined
+              }
             />
           ))
         ) : (

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useChatTask } from "@/web/components/chat/context";
+import { AgentAvatar } from "@/web/components/agent-icon";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { useInsetContext } from "@/web/layouts/shell-layout";
 import { formatTimeAgo, formatTimeUntil } from "@/web/lib/format-time";
@@ -26,7 +27,7 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { Loading01, Plus, RefreshCcw01 } from "@untitledui/icons";
+import { FilterLines, Loading01, Plus, RefreshCcw01 } from "@untitledui/icons";
 import { useRef, useState } from "react";
 import { User as UserIcon, Users as UsersIcon } from "lucide-react";
 import {
@@ -142,12 +143,12 @@ function TaskRow({
   task,
   isActive,
   onClick,
-  projectName,
+  projectInfo,
 }: {
   task: Task;
   isActive: boolean;
   onClick: () => void;
-  projectName?: string;
+  projectInfo?: ProjectInfo;
 }) {
   const { setTaskStatus, hideTask } = useChatTask();
   const playSound = useSound(question004Sound);
@@ -161,7 +162,7 @@ function TaskRow({
     <div
       className={cn(
         "group/row relative flex items-center gap-2 mx-2 px-3 rounded-md w-[calc(100%-1rem)] cursor-pointer",
-        projectName ? "h-12 py-1" : "h-10",
+        projectInfo ? "h-12 py-1" : "h-10",
         isActive ? "bg-accent" : "hover:bg-accent/50",
       )}
       onClick={onClick}
@@ -222,10 +223,18 @@ function TaskRow({
             {task.updated_at ? formatTimeAgo(new Date(task.updated_at)) : ""}
           </span>
         </div>
-        {projectName && (
-          <span className="text-[11px] text-muted-foreground/50 truncate leading-tight">
-            {projectName}
-          </span>
+        {projectInfo && (
+          <div className="flex items-center gap-1 leading-tight">
+            <AgentAvatar
+              icon={projectInfo.icon}
+              name={projectInfo.name}
+              size="xs"
+              className="size-3.5 [&_svg]:size-2 shrink-0"
+            />
+            <span className="text-[11px] text-muted-foreground/50 truncate">
+              {projectInfo.name}
+            </span>
+          </div>
         )}
       </div>
 
@@ -443,13 +452,20 @@ function IncomingSection({ virtualMcpId }: { virtualMcpId: string }) {
 // Core list (sidebar + side-panel)
 // ────────────────────────────────────────
 
+export interface ProjectInfo {
+  name: string;
+  icon: string | null;
+}
+
+type GroupBy = "none" | "project" | "status";
+
 interface TaskListContentProps {
   onTaskSelect?: (taskId: string) => void;
   onTaskCreate?: () => void;
   virtualMcpId?: string | null;
   showAutomations?: boolean;
-  /** Map of virtualMcpId → project name for labeling tasks */
-  projectNames?: Map<string, string>;
+  /** Map of virtualMcpId → project info for labeling tasks */
+  projectNames?: Map<string, ProjectInfo>;
 }
 
 export function TaskListContent({
@@ -461,12 +477,12 @@ export function TaskListContent({
 }: TaskListContentProps) {
   const { ownerFilter } = useChatTask();
   const { setTaskId } = usePanelActions();
+  const [groupBy, setGroupBy] = useState<GroupBy>("none");
+  const [filterProjectId, setFilterProjectId] = useState<string | null>(null);
 
-  // Read taskId directly from router (seeded by validateSearch)
   const search = useSearch({ strict: false }) as { taskId?: string };
   const taskId = search.taskId ?? null;
 
-  // Own task list fetch — shares TanStack Query cache with ChatContextProvider
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
   const { tasks } = useTasks(
@@ -477,6 +493,7 @@ export function TaskListContent({
 
   const visible = tasks
     .filter((t) => !t.hidden)
+    .filter((t) => !filterProjectId || t.virtual_mcp_id === filterProjectId)
     .slice()
     .sort(
       (a, b) =>
@@ -493,7 +510,6 @@ export function TaskListContent({
       onTaskSelect(task.id);
       return;
     }
-    // Navigate cross-project if the task belongs to a different project
     if (task.virtual_mcp_id && task.virtual_mcp_id !== currentVirtualMcpId) {
       navigate({
         to: "/$org/$virtualMcpId/",
@@ -505,20 +521,143 @@ export function TaskListContent({
     }
   };
 
+  const grouped =
+    groupBy === "project"
+      ? groupByProject(visible, projectNames)
+      : groupBy === "status"
+        ? groupByStatus(visible)
+        : null;
+
+  const projectOptions = projectNames
+    ? Array.from(projectNames.entries()).map(([id, info]) => ({
+        id,
+        name: info.name,
+        icon: info.icon,
+      }))
+    : [];
+
+  const hasActiveFilter = groupBy !== "none" || filterProjectId !== null;
+
+  const renderTask = (task: Task) => (
+    <TaskRow
+      key={task.id}
+      task={task}
+      isActive={task.id === taskId}
+      onClick={() => handleSelect(task)}
+      projectInfo={
+        projectNames && task.virtual_mcp_id
+          ? projectNames.get(task.virtual_mcp_id)
+          : undefined
+      }
+    />
+  );
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div className="flex-1 overflow-y-auto">
-        {/* Automations section */}
         {virtualMcpId && showAutomations && (
           <IncomingSection virtualMcpId={virtualMcpId} />
         )}
 
-        {/* Tasks section header */}
-        <div className="flex items-center gap-2 mx-2 px-3 h-8 mt-2 w-[calc(100%-1rem)]">
-          <span className="text-xs font-medium text-muted-foreground/60">
+        {/* Header with filter */}
+        <div className="flex items-center gap-1 mx-2 px-3 h-8 mt-2 w-[calc(100%-1rem)]">
+          <span className="text-xs font-medium text-muted-foreground/60 flex-1">
             Tasks
           </span>
-          <span className="flex-1" />
+
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <span
+                    role="button"
+                    className={cn(
+                      "flex size-7 shrink-0 items-center justify-center rounded-md cursor-pointer",
+                      hasActiveFilter
+                        ? "text-foreground bg-accent"
+                        : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                    )}
+                  >
+                    <FilterLines size={14} />
+                  </span>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Filter</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem
+                className="gap-2 text-xs"
+                onSelect={() => {
+                  setGroupBy("none");
+                  setFilterProjectId(null);
+                }}
+              >
+                No grouping
+                {!hasActiveFilter && (
+                  <span className="ml-auto text-[10px] text-muted-foreground">
+                    active
+                  </span>
+                )}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2 text-xs"
+                onSelect={() => setGroupBy("project")}
+              >
+                Group by project
+                {groupBy === "project" && (
+                  <span className="ml-auto text-[10px] text-muted-foreground">
+                    active
+                  </span>
+                )}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2 text-xs"
+                onSelect={() => setGroupBy("status")}
+              >
+                Group by status
+                {groupBy === "status" && (
+                  <span className="ml-auto text-[10px] text-muted-foreground">
+                    active
+                  </span>
+                )}
+              </DropdownMenuItem>
+              {projectOptions.length > 0 && (
+                <>
+                  <div className="h-px bg-border my-1" />
+                  <div className="px-2 py-1">
+                    <span className="text-[10px] font-medium text-muted-foreground">
+                      Filter by project
+                    </span>
+                  </div>
+                  {projectOptions.map((p) => (
+                    <DropdownMenuItem
+                      key={p.id}
+                      className="gap-2 text-xs"
+                      onSelect={() =>
+                        setFilterProjectId(
+                          filterProjectId === p.id ? null : p.id,
+                        )
+                      }
+                    >
+                      <AgentAvatar
+                        icon={p.icon}
+                        name={p.name}
+                        size="xs"
+                        className="size-4 [&_svg]:size-2.5 shrink-0"
+                      />
+                      {p.name}
+                      {filterProjectId === p.id && (
+                        <span className="ml-auto text-[10px] text-muted-foreground">
+                          active
+                        </span>
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
           {onTaskCreate && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -535,21 +674,23 @@ export function TaskListContent({
           )}
         </div>
 
-        {/* Task rows — always visible */}
-        {visible.length > 0 ? (
-          visible.map((task) => (
-            <TaskRow
-              key={task.id}
-              task={task}
-              isActive={task.id === taskId}
-              onClick={() => handleSelect(task)}
-              projectName={
-                projectNames && task.virtual_mcp_id
-                  ? projectNames.get(task.virtual_mcp_id)
-                  : undefined
-              }
-            />
+        {/* Task rows */}
+        {grouped ? (
+          Object.entries(grouped).map(([label, groupTasks]) => (
+            <div key={label} className="mt-1">
+              <div className="flex items-center gap-2 mx-2 px-3 h-7 w-[calc(100%-1rem)]">
+                <span className="text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider truncate">
+                  {label}
+                </span>
+                <span className="text-[10px] text-muted-foreground/40 tabular-nums">
+                  {groupTasks.length}
+                </span>
+              </div>
+              {groupTasks.map(renderTask)}
+            </div>
           ))
+        ) : visible.length > 0 ? (
+          visible.map(renderTask)
         ) : (
           <div className="mx-2 px-2 py-3 text-xs text-muted-foreground/60">
             No tasks
@@ -558,4 +699,31 @@ export function TaskListContent({
       </div>
     </div>
   );
+}
+
+function groupByProject(
+  tasks: Task[],
+  projectNames?: Map<string, ProjectInfo>,
+): Record<string, Task[]> {
+  const groups: Record<string, Task[]> = {};
+  for (const task of tasks) {
+    const name =
+      (task.virtual_mcp_id && projectNames?.get(task.virtual_mcp_id)?.name) ??
+      "Other";
+    if (!groups[name]) groups[name] = [];
+    groups[name].push(task);
+  }
+  return groups;
+}
+
+function groupByStatus(tasks: Task[]): Record<string, Task[]> {
+  const groups: Record<string, Task[]> = {};
+  for (const task of tasks) {
+    const status = task.status ?? "unknown";
+    const label =
+      STATUS_CONFIG[status as keyof typeof STATUS_CONFIG]?.label ?? status;
+    if (!groups[label]) groups[label] = [];
+    groups[label].push(task);
+  }
+  return groups;
 }

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -7,6 +7,7 @@
 
 import { useChatTask } from "@/web/components/chat/context";
 import { AgentAvatar } from "@/web/components/agent-icon";
+import { getTaskLayout } from "@/web/lib/task-layout-store";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { useInsetContext } from "@/web/layouts/shell-layout";
 import { formatTimeAgo, formatTimeUntil } from "@/web/lib/format-time";
@@ -482,7 +483,6 @@ export function TaskListContent({
   projectNames,
 }: TaskListContentProps) {
   const { ownerFilter } = useChatTask();
-  const { setTaskId } = usePanelActions();
   const [groupBy, setGroupBy] = useState<GroupBy>("none");
   const [filterProjectId, setFilterProjectId] = useState<string | null>(null);
 
@@ -516,26 +516,50 @@ export function TaskListContent({
       onTaskSelect(task.id);
       return;
     }
-    if (task.virtual_mcp_id && task.virtual_mcp_id !== currentVirtualMcpId) {
-      // Restore the project's default UI view when navigating cross-project
-      const projectInfo = task.virtual_mcp_id
-        ? projectNames?.get(task.virtual_mcp_id)
-        : undefined;
+
+    // Build search params: restore per-task layout, fall back to project default
+    const saved = getTaskLayout(task.id);
+    const searchParams: Record<string, unknown> = { taskId: task.id };
+
+    if (saved) {
+      // Restore saved per-task state
+      if (saved.chatOpen !== undefined)
+        searchParams.chat = saved.chatOpen ? 1 : 0;
+      if (saved.mainOpen !== undefined)
+        searchParams.mainOpen = saved.mainOpen ? 1 : 0;
+      if (saved.main) {
+        searchParams.main = saved.main;
+        if (saved.id) searchParams.id = saved.id;
+        if (saved.toolName) searchParams.toolName = saved.toolName;
+      }
+    } else if (task.virtual_mcp_id) {
+      // No saved state — use project's default view
+      const projectInfo = projectNames?.get(task.virtual_mcp_id);
       const dv = projectInfo?.defaultView;
-      const searchParams: Record<string, unknown> = { taskId: task.id };
       if (dv?.type) {
         searchParams.main = dv.type;
         searchParams.mainOpen = 1;
         if (dv.id) searchParams.id = dv.id;
         if (dv.toolName) searchParams.toolName = dv.toolName;
       }
+    }
+
+    if (task.virtual_mcp_id && task.virtual_mcp_id !== currentVirtualMcpId) {
       navigate({
         to: "/$org/$virtualMcpId/",
         params: { org: org.slug, virtualMcpId: task.virtual_mcp_id },
         search: searchParams,
       });
     } else {
-      setTaskId(task.id);
+      // Same project — just update search params
+      navigate({
+        to: "/$org/$virtualMcpId/",
+        params: {
+          org: org.slug,
+          virtualMcpId: task.virtual_mcp_id ?? currentVirtualMcpId ?? "",
+        },
+        search: searchParams,
+      });
     }
   };
 

--- a/apps/mesh/src/web/components/files/artifact-card.tsx
+++ b/apps/mesh/src/web/components/files/artifact-card.tsx
@@ -1,0 +1,181 @@
+/**
+ * ArtifactCard - Visual card for a file/artifact in the file browser.
+ * Shows icon, title, type badge, and relative time.
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import { BarChart12, Globe04, PresentationChart01 } from "@untitledui/icons";
+import {
+  formatRelativeTime,
+  type Artifact,
+  type ArtifactType,
+} from "@/web/lib/mock-artifacts";
+
+const TYPE_CONFIG: Record<
+  ArtifactType,
+  {
+    label: string;
+    bgColor: string;
+    textColor: string;
+    iconBg: string;
+    Icon: typeof PresentationChart01;
+  }
+> = {
+  deck: {
+    label: "Slide Deck",
+    bgColor: "bg-violet-50 dark:bg-violet-950/30",
+    textColor: "text-violet-700 dark:text-violet-300",
+    iconBg: "bg-violet-100 dark:bg-violet-900/50",
+    Icon: PresentationChart01,
+  },
+  report: {
+    label: "Report",
+    bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
+    textColor: "text-emerald-700 dark:text-emerald-300",
+    iconBg: "bg-emerald-100 dark:bg-emerald-900/50",
+    Icon: BarChart12,
+  },
+  site: {
+    label: "Website",
+    bgColor: "bg-blue-50 dark:bg-blue-950/30",
+    textColor: "text-blue-700 dark:text-blue-300",
+    iconBg: "bg-blue-100 dark:bg-blue-900/50",
+    Icon: Globe04,
+  },
+};
+
+export function ArtifactCard({
+  artifact,
+  variant = "grid",
+  onClick,
+}: {
+  artifact: Artifact;
+  variant?: "grid" | "list";
+  onClick?: () => void;
+}) {
+  const config = TYPE_CONFIG[artifact.type];
+  const { Icon } = config;
+
+  if (variant === "list") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "flex items-center gap-3 px-3 py-2.5 w-full rounded-lg text-left",
+          "transition-colors hover:bg-accent/50 cursor-pointer group",
+        )}
+      >
+        <div
+          className={cn(
+            "flex items-center justify-center size-9 rounded-lg shrink-0",
+            config.iconBg,
+          )}
+        >
+          <Icon size={18} className={config.textColor} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {artifact.title}
+          </p>
+          <p className="text-xs text-muted-foreground truncate">
+            {artifact.preview}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span
+            className={cn(
+              "inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium",
+              config.bgColor,
+              config.textColor,
+            )}
+          >
+            {config.label}
+          </span>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {formatRelativeTime(artifact.updatedAt)}
+          </span>
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-col gap-2 p-3 rounded-xl text-left",
+        "border border-border bg-card",
+        "transition-all hover:border-foreground/20 hover:shadow-sm cursor-pointer group",
+        "w-full",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div
+          className={cn(
+            "flex items-center justify-center size-10 rounded-lg shrink-0",
+            config.iconBg,
+          )}
+        >
+          <Icon size={20} className={config.textColor} />
+        </div>
+        <span
+          className={cn(
+            "inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium shrink-0",
+            config.bgColor,
+            config.textColor,
+          )}
+        >
+          {config.label}
+        </span>
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground truncate">
+          {artifact.title}
+        </p>
+        <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+          {artifact.preview}
+        </p>
+      </div>
+      <p className="text-[11px] text-muted-foreground/70 mt-auto">
+        {formatRelativeTime(artifact.updatedAt)}
+      </p>
+    </button>
+  );
+}
+
+export function ArtifactTypeFilter({
+  value,
+  onChange,
+}: {
+  value: ArtifactType | "all";
+  onChange: (type: ArtifactType | "all") => void;
+}) {
+  const filters: Array<{ key: ArtifactType | "all"; label: string }> = [
+    { key: "all", label: "All" },
+    { key: "deck", label: "Decks" },
+    { key: "report", label: "Reports" },
+    { key: "site", label: "Sites" },
+  ];
+
+  return (
+    <div className="flex items-center gap-1">
+      {filters.map((f) => (
+        <button
+          key={f.key}
+          type="button"
+          onClick={() => onChange(f.key)}
+          className={cn(
+            "inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium transition-colors",
+            value === f.key
+              ? "bg-foreground text-background"
+              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+          )}
+        >
+          {f.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/files/file-browser-home.tsx
+++ b/apps/mesh/src/web/components/files/file-browser-home.tsx
@@ -1,6 +1,7 @@
 /**
  * FileBrowserHome - The main file-centric home page.
  * Shows folders, recent artifacts, and quick actions.
+ * Quick actions send messages to the chat agent.
  */
 
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -9,13 +10,20 @@ import {
   Globe04,
   Plus,
   PresentationChart01,
+  SearchLg,
 } from "@untitledui/icons";
 import { authClient } from "@/web/lib/auth-client";
-import { MOCK_FOLDERS, getRecentArtifacts } from "@/web/lib/mock-artifacts";
+import {
+  MOCK_FOLDERS,
+  MOCK_ARTIFACTS,
+  getRecentArtifacts,
+  type ArtifactType,
+} from "@/web/lib/mock-artifacts";
 import { FolderCard } from "./folder-card";
-import { ArtifactCard } from "./artifact-card";
+import { ArtifactCard, ArtifactTypeFilter } from "./artifact-card";
 import { useState } from "react";
 import { FolderView } from "./folder-view";
+import { useChatTask } from "@/web/components/chat/context";
 
 function QuickAction({
   icon: Icon,
@@ -68,14 +76,102 @@ function SectionHeader({
   );
 }
 
+type View = { type: "home" } | { type: "folder"; id: string } | { type: "all" };
+
+function AllFilesView({ onBack }: { onBack: () => void }) {
+  const [typeFilter, setTypeFilter] = useState<ArtifactType | "all">("all");
+  const [search, setSearch] = useState("");
+
+  const artifacts = MOCK_ARTIFACTS.filter((a) => {
+    if (typeFilter !== "all" && a.type !== typeFilter) return false;
+    if (search && !a.title.toLowerCase().includes(search.toLowerCase()))
+      return false;
+    return true;
+  }).sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 px-4 py-3 border-b border-border">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Home
+            </button>
+            <span className="text-xs text-muted-foreground/50">/</span>
+            <h1 className="text-sm font-medium text-foreground">All Files</h1>
+            <span className="text-xs text-muted-foreground">
+              {artifacts.length} {artifacts.length === 1 ? "item" : "items"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="shrink-0 px-4 py-2 flex items-center justify-between gap-3">
+        <ArtifactTypeFilter value={typeFilter} onChange={setTypeFilter} />
+        <div className="relative">
+          <SearchLg
+            size={14}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+          />
+          <input
+            type="text"
+            placeholder="Search..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-7 pl-8 pr-3 text-xs rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4 pb-4">
+        {artifacts.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <p className="text-sm text-muted-foreground">No files found</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {artifacts.map((artifact) => (
+              <ArtifactCard
+                key={artifact.id}
+                artifact={artifact}
+                variant="list"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function HomeContent({
   onOpenFolder,
+  onOpenAll,
 }: {
   onOpenFolder: (folderId: string) => void;
+  onOpenAll: () => void;
 }) {
   const { data: session } = authClient.useSession();
+  const { createTaskWithMessage } = useChatTask();
   const userName = session?.user?.name?.split(" ")[0] || "there";
   const recentArtifacts = getRecentArtifacts(6);
+
+  const sendQuickAction = (text: string) => {
+    createTaskWithMessage({
+      message: {
+        parts: [{ type: "text", text }],
+      },
+    });
+  };
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -97,13 +193,32 @@ function HomeContent({
               icon={PresentationChart01}
               label="New Slide Deck"
               color="#8B5CF6"
+              onClick={() =>
+                sendQuickAction(
+                  "Create a new slide deck. Ask me what it should be about.",
+                )
+              }
             />
             <QuickAction
               icon={BarChart12}
               label="Run Diagnostic"
               color="#10B981"
+              onClick={() =>
+                sendQuickAction(
+                  "Run a website diagnostic. Ask me which site to analyze.",
+                )
+              }
             />
-            <QuickAction icon={Globe04} label="Edit Site" color="#3B82F6" />
+            <QuickAction
+              icon={Globe04}
+              label="Edit Site"
+              color="#3B82F6"
+              onClick={() =>
+                sendQuickAction(
+                  "I'd like to edit a website. Ask me which site and what changes.",
+                )
+              }
+            />
           </div>
         </div>
 
@@ -143,7 +258,10 @@ function HomeContent({
 
         {/* Recent */}
         <div>
-          <SectionHeader title="Recent" />
+          <SectionHeader
+            title="Recent"
+            action={{ label: "See all", onClick: onOpenAll }}
+          />
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
             {recentArtifacts.map((artifact) => (
               <ArtifactCard
@@ -167,16 +285,22 @@ function getTimeOfDay(): string {
 }
 
 export function FileBrowserHome() {
-  const [openFolderId, setOpenFolderId] = useState<string | null>(null);
+  const [view, setView] = useState<View>({ type: "home" });
 
-  if (openFolderId) {
+  if (view.type === "folder") {
     return (
-      <FolderView
-        folderId={openFolderId}
-        onBack={() => setOpenFolderId(null)}
-      />
+      <FolderView folderId={view.id} onBack={() => setView({ type: "home" })} />
     );
   }
 
-  return <HomeContent onOpenFolder={setOpenFolderId} />;
+  if (view.type === "all") {
+    return <AllFilesView onBack={() => setView({ type: "home" })} />;
+  }
+
+  return (
+    <HomeContent
+      onOpenFolder={(id) => setView({ type: "folder", id })}
+      onOpenAll={() => setView({ type: "all" })}
+    />
+  );
 }

--- a/apps/mesh/src/web/components/files/file-browser-home.tsx
+++ b/apps/mesh/src/web/components/files/file-browser-home.tsx
@@ -1,0 +1,182 @@
+/**
+ * FileBrowserHome - The main file-centric home page.
+ * Shows folders, recent artifacts, and quick actions.
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  BarChart12,
+  Globe04,
+  Plus,
+  PresentationChart01,
+} from "@untitledui/icons";
+import { authClient } from "@/web/lib/auth-client";
+import { MOCK_FOLDERS, getRecentArtifacts } from "@/web/lib/mock-artifacts";
+import { FolderCard } from "./folder-card";
+import { ArtifactCard } from "./artifact-card";
+import { useState } from "react";
+import { FolderView } from "./folder-view";
+
+function QuickAction({
+  icon: Icon,
+  label,
+  color,
+  onClick,
+}: {
+  icon: typeof PresentationChart01;
+  label: string;
+  color: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-2 px-3 py-2 rounded-lg",
+        "border border-border bg-card",
+        "text-sm text-foreground font-medium",
+        "transition-all hover:border-foreground/20 hover:shadow-sm cursor-pointer",
+      )}
+    >
+      <Icon size={16} style={{ color }} />
+      {label}
+    </button>
+  );
+}
+
+function SectionHeader({
+  title,
+  action,
+}: {
+  title: string;
+  action?: { label: string; onClick: () => void };
+}) {
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <h2 className="text-sm font-medium text-muted-foreground">{title}</h2>
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function HomeContent({
+  onOpenFolder,
+}: {
+  onOpenFolder: (folderId: string) => void;
+}) {
+  const { data: session } = authClient.useSession();
+  const userName = session?.user?.name?.split(" ")[0] || "there";
+  const recentArtifacts = getRecentArtifacts(6);
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-3xl mx-auto px-6 py-8">
+        {/* Greeting */}
+        <div className="mb-8">
+          <h1 className="text-2xl font-medium text-foreground">
+            Good {getTimeOfDay()}, {userName}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Here's what you've been working on
+          </p>
+        </div>
+
+        {/* Quick Actions */}
+        <div className="mb-8">
+          <div className="flex flex-wrap gap-2">
+            <QuickAction
+              icon={PresentationChart01}
+              label="New Slide Deck"
+              color="#8B5CF6"
+            />
+            <QuickAction
+              icon={BarChart12}
+              label="Run Diagnostic"
+              color="#10B981"
+            />
+            <QuickAction icon={Globe04} label="Edit Site" color="#3B82F6" />
+          </div>
+        </div>
+
+        {/* Folders */}
+        <div className="mb-8">
+          <SectionHeader
+            title="My Folders"
+            action={{ label: "+ New Folder", onClick: () => {} }}
+          />
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {MOCK_FOLDERS.map((folder) => (
+              <FolderCard
+                key={folder.id}
+                folder={folder}
+                onClick={() => onOpenFolder(folder.id)}
+              />
+            ))}
+            <button
+              type="button"
+              className={cn(
+                "flex flex-col items-center justify-center gap-2 p-4 rounded-xl",
+                "border-2 border-dashed border-border",
+                "transition-colors hover:border-foreground/20 cursor-pointer group",
+                "w-full min-w-[120px] min-h-[120px]",
+              )}
+            >
+              <Plus
+                size={20}
+                className="text-muted-foreground group-hover:text-foreground transition-colors"
+              />
+              <p className="text-xs text-muted-foreground group-hover:text-foreground transition-colors">
+                New Folder
+              </p>
+            </button>
+          </div>
+        </div>
+
+        {/* Recent */}
+        <div>
+          <SectionHeader title="Recent" />
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+            {recentArtifacts.map((artifact) => (
+              <ArtifactCard
+                key={artifact.id}
+                artifact={artifact}
+                variant="grid"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getTimeOfDay(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return "morning";
+  if (hour < 18) return "afternoon";
+  return "evening";
+}
+
+export function FileBrowserHome() {
+  const [openFolderId, setOpenFolderId] = useState<string | null>(null);
+
+  if (openFolderId) {
+    return (
+      <FolderView
+        folderId={openFolderId}
+        onBack={() => setOpenFolderId(null)}
+      />
+    );
+  }
+
+  return <HomeContent onOpenFolder={setOpenFolderId} />;
+}

--- a/apps/mesh/src/web/components/files/folder-card.tsx
+++ b/apps/mesh/src/web/components/files/folder-card.tsx
@@ -1,0 +1,43 @@
+/**
+ * FolderCard - Visual card for a folder in the file browser.
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import { FolderClosed } from "@untitledui/icons";
+import type { Folder } from "@/web/lib/mock-artifacts";
+
+export function FolderCard({
+  folder,
+  onClick,
+}: {
+  folder: Folder;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-col items-center gap-2.5 p-4 rounded-xl text-center",
+        "border border-border bg-card",
+        "transition-all hover:border-foreground/20 hover:shadow-sm cursor-pointer group",
+        "w-full min-w-[120px]",
+      )}
+    >
+      <div
+        className="flex items-center justify-center size-12 rounded-xl transition-transform group-hover:scale-110"
+        style={{ backgroundColor: `${folder.color}15` }}
+      >
+        <FolderClosed size={24} style={{ color: folder.color }} />
+      </div>
+      <div className="min-w-0 w-full">
+        <p className="text-sm font-medium text-foreground truncate">
+          {folder.title}
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {folder.itemCount} {folder.itemCount === 1 ? "item" : "items"}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/apps/mesh/src/web/components/files/folder-view.tsx
+++ b/apps/mesh/src/web/components/files/folder-view.tsx
@@ -1,0 +1,95 @@
+/**
+ * FolderView - Shows artifacts inside a specific folder.
+ * Supports filtering by type and list/grid view.
+ */
+
+import { ChevronLeft, FolderClosed } from "@untitledui/icons";
+import { useState } from "react";
+import {
+  getArtifactsByFolder,
+  getFolderById,
+  type ArtifactType,
+} from "@/web/lib/mock-artifacts";
+import { ArtifactCard, ArtifactTypeFilter } from "./artifact-card";
+
+export function FolderView({
+  folderId,
+  onBack,
+}: {
+  folderId: string;
+  onBack: () => void;
+}) {
+  const folder = getFolderById(folderId);
+  const [typeFilter, setTypeFilter] = useState<ArtifactType | "all">("all");
+
+  if (!folder) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+        Folder not found
+      </div>
+    );
+  }
+
+  const allArtifacts = getArtifactsByFolder(folderId);
+  const artifacts =
+    typeFilter === "all"
+      ? allArtifacts
+      : allArtifacts.filter((a) => a.type === typeFilter);
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="shrink-0 px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <div
+            className="flex items-center justify-center size-7 rounded-md"
+            style={{ backgroundColor: `${folder.color}15` }}
+          >
+            <FolderClosed size={16} style={{ color: folder.color }} />
+          </div>
+          <h1 className="text-base font-medium text-foreground">
+            {folder.title}
+          </h1>
+          <span className="text-xs text-muted-foreground">
+            {allArtifacts.length} {allArtifacts.length === 1 ? "item" : "items"}
+          </span>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="shrink-0 px-4 py-2 flex items-center justify-between">
+        <ArtifactTypeFilter value={typeFilter} onChange={setTypeFilter} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4 pb-4">
+        {artifacts.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <p className="text-sm text-muted-foreground">
+              {typeFilter === "all"
+                ? "This folder is empty"
+                : `No ${typeFilter}s in this folder`}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {artifacts.map((artifact) => (
+              <ArtifactCard
+                key={artifact.id}
+                artifact={artifact}
+                variant="list"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/home/quick-actions.tsx
+++ b/apps/mesh/src/web/components/home/quick-actions.tsx
@@ -1,0 +1,335 @@
+/**
+ * QuickActions - Action-oriented items for the home page.
+ * Replaces the agents list with actions like "New Slide Deck", "Run Diagnostic", etc.
+ * Below shows recent files and folders.
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  BarChart12,
+  ChevronRight,
+  FolderClosed,
+  Globe04,
+  Plus,
+  PresentationChart01,
+} from "@untitledui/icons";
+import {
+  isDecopilot,
+  WELL_KNOWN_AGENT_TEMPLATES,
+  useProjectContext,
+  useVirtualMCPs,
+} from "@decocms/mesh-sdk";
+import { useNavigate } from "@tanstack/react-router";
+import { Suspense, useState } from "react";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal";
+import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal";
+import {
+  MOCK_FOLDERS,
+  getRecentArtifacts,
+  formatRelativeTime,
+  type Artifact,
+  type ArtifactType,
+} from "@/web/lib/mock-artifacts";
+
+// ---------- Action item (replaces agent preview) ----------
+
+const ACTION_ICON_CONFIG: Record<
+  string,
+  { Icon: typeof PresentationChart01; color: string; bg: string }
+> = {
+  "site-editor": {
+    Icon: Globe04,
+    color: "#3B82F6",
+    bg: "bg-blue-100 dark:bg-blue-900/50",
+  },
+  "site-diagnostics": {
+    Icon: BarChart12,
+    color: "#10B981",
+    bg: "bg-emerald-100 dark:bg-emerald-900/50",
+  },
+};
+
+function ActionItem({
+  label,
+  icon,
+  iconColor,
+  onClick,
+}: {
+  label: string;
+  icon?: string | null;
+  iconColor?: string;
+  onClick?: () => void;
+}) {
+  const config = icon ? ACTION_ICON_CONFIG[icon] : undefined;
+  const Icon = config?.Icon;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex flex-col items-center gap-3 p-2 rounded-lg",
+        "transition-colors cursor-pointer w-[100px] shrink-0 group",
+      )}
+    >
+      {Icon ? (
+        <div
+          className={cn(
+            "size-12 rounded-xl flex items-center justify-center shrink-0 transition-transform group-hover:scale-110",
+            config?.bg,
+          )}
+        >
+          <Icon size={24} style={{ color: config?.color }} />
+        </div>
+      ) : iconColor ? (
+        <div
+          className="size-12 rounded-xl flex items-center justify-center shrink-0 transition-transform group-hover:scale-110"
+          style={{ backgroundColor: `${iconColor}20` }}
+        >
+          <PresentationChart01 size={24} style={{ color: iconColor }} />
+        </div>
+      ) : (
+        <div className="size-12 rounded-xl bg-background border-2 border-dashed border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-110">
+          <Plus size={20} className="text-muted-foreground" />
+        </div>
+      )}
+      <p className="text-xs sm:text-sm text-foreground text-center leading-tight line-clamp-2 break-words w-full">
+        {label}
+      </p>
+    </button>
+  );
+}
+
+// ---------- Mini artifact row for recent files ----------
+
+const ARTIFACT_TYPE_CONFIG: Record<
+  ArtifactType,
+  { Icon: typeof PresentationChart01; color: string }
+> = {
+  deck: { Icon: PresentationChart01, color: "#8B5CF6" },
+  report: { Icon: BarChart12, color: "#10B981" },
+  site: { Icon: Globe04, color: "#3B82F6" },
+};
+
+function ArtifactRow({ artifact }: { artifact: Artifact }) {
+  const config = ARTIFACT_TYPE_CONFIG[artifact.type];
+  const { Icon } = config;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center gap-2.5 px-3 py-2 w-full rounded-lg text-left",
+        "transition-colors hover:bg-accent/50 cursor-pointer",
+      )}
+    >
+      <div
+        className="flex items-center justify-center size-7 rounded-md shrink-0"
+        style={{ backgroundColor: `${config.color}15` }}
+      >
+        <Icon size={14} style={{ color: config.color }} />
+      </div>
+      <span className="flex-1 text-sm text-foreground truncate min-w-0">
+        {artifact.title}
+      </span>
+      <span className="text-xs text-muted-foreground shrink-0">
+        {formatRelativeTime(artifact.updatedAt)}
+      </span>
+    </button>
+  );
+}
+
+// ---------- Mini folder card ----------
+
+function FolderRow({
+  folder,
+}: {
+  folder: { id: string; title: string; color: string; itemCount: number };
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center gap-2.5 px-3 py-2 w-full rounded-lg text-left",
+        "transition-colors hover:bg-accent/50 cursor-pointer",
+      )}
+    >
+      <div
+        className="flex items-center justify-center size-7 rounded-md shrink-0"
+        style={{ backgroundColor: `${folder.color}15` }}
+      >
+        <FolderClosed size={14} style={{ color: folder.color }} />
+      </div>
+      <span className="flex-1 text-sm text-foreground truncate min-w-0">
+        {folder.title}
+      </span>
+      <span className="text-xs text-muted-foreground shrink-0">
+        {folder.itemCount} items
+      </span>
+    </button>
+  );
+}
+
+// ---------- Main content ----------
+
+function QuickActionsContent() {
+  const virtualMcps = useVirtualMCPs();
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const navigateToAgent = useNavigateToAgent();
+  const [siteEditorModalOpen, setSiteEditorModalOpen] = useState(false);
+  const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
+  const { createVirtualMCP } = useCreateVirtualMCP({
+    navigateOnCreate: true,
+  });
+
+  const siteDiagnosticsAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "site-diagnostics",
+  )!;
+
+  const existingDiagnostics = virtualMcps.find(
+    (a): a is typeof a & { id: string } =>
+      a.id !== null &&
+      ((a as { metadata?: { type?: string } }).metadata?.type ===
+        siteDiagnosticsAgent.id ||
+        a.title === siteDiagnosticsAgent.title),
+  );
+
+  const recentArtifacts = getRecentArtifacts(5);
+
+  return (
+    <>
+      {/* Action items row */}
+      <div className="w-full max-md:overflow-x-auto max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden">
+        <div className="flex flex-wrap justify-center gap-1.5 max-md:flex-nowrap max-md:justify-start md:max-h-52 md:overflow-hidden">
+          <ActionItem
+            label="New Site"
+            icon="site-editor"
+            onClick={() => setSiteEditorModalOpen(true)}
+          />
+          <ActionItem
+            label="New Diagnostic"
+            icon="site-diagnostics"
+            onClick={
+              existingDiagnostics
+                ? () => navigateToAgent(existingDiagnostics.id)
+                : () => setDiagnosticsModalOpen(true)
+            }
+          />
+          {/* Custom agents as actions */}
+          {virtualMcps
+            .filter(
+              (a): a is typeof a & { id: string } =>
+                a.id !== null &&
+                !isDecopilot(a.id) &&
+                a.id !== existingDiagnostics?.id,
+            )
+            .slice(0, 3)
+            .map((agent) => (
+              <ActionItem
+                key={agent.id}
+                label={agent.title}
+                iconColor="#8B5CF6"
+                onClick={() => navigateToAgent(agent.id)}
+              />
+            ))}
+          <ActionItem label="Create agent" onClick={() => createVirtualMCP()} />
+          <button
+            type="button"
+            className={cn(
+              "flex flex-col items-center gap-3 p-2 rounded-lg",
+              "transition-colors cursor-pointer w-[100px] shrink-0 group",
+            )}
+            onClick={() => {
+              navigate({
+                to: "/$org/settings/agents",
+                params: { org: org.slug },
+              });
+            }}
+          >
+            <div className="size-12 rounded-xl bg-accent flex items-center justify-center shrink-0 transition-transform group-hover:scale-110">
+              <ChevronRight size={20} className="text-foreground" />
+            </div>
+            <p className="text-xs sm:text-sm text-foreground text-center leading-tight">
+              See all
+            </p>
+          </button>
+        </div>
+      </div>
+
+      {/* Files section */}
+      <div className="w-full max-w-[672px] mx-auto mt-6">
+        {/* Folders */}
+        {MOCK_FOLDERS.length > 0 && (
+          <div className="mb-4">
+            <div className="flex items-center justify-between mb-1 px-3">
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Folders
+              </h3>
+            </div>
+            <div className="flex flex-col">
+              {MOCK_FOLDERS.map((folder) => (
+                <FolderRow key={folder.id} folder={folder} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Recent files */}
+        {recentArtifacts.length > 0 && (
+          <div>
+            <div className="flex items-center justify-between mb-1 px-3">
+              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Recent
+              </h3>
+            </div>
+            <div className="flex flex-col">
+              {recentArtifacts.map((artifact) => (
+                <ArtifactRow key={artifact.id} artifact={artifact} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <SiteEditorOnboardingModal
+        open={siteEditorModalOpen}
+        onOpenChange={setSiteEditorModalOpen}
+      />
+      <SiteDiagnosticsRecruitModal
+        open={diagnosticsModalOpen}
+        onOpenChange={setDiagnosticsModalOpen}
+        existingAgent={existingDiagnostics}
+      />
+    </>
+  );
+}
+
+function QuickActionsSkeleton() {
+  return (
+    <div className="w-full max-md:overflow-x-auto max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden">
+      <div className="flex flex-wrap justify-center gap-1.5 max-md:flex-nowrap max-md:justify-start md:max-h-52 md:overflow-hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex flex-col items-center gap-3 p-2 w-[100px] shrink-0"
+          >
+            <Skeleton className="size-12 rounded-xl shrink-0" />
+            <Skeleton className="h-3 sm:h-4 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function QuickActions() {
+  return (
+    <Suspense fallback={<QuickActionsSkeleton />}>
+      <QuickActionsContent />
+    </Suspense>
+  );
+}

--- a/apps/mesh/src/web/components/home/quick-actions.tsx
+++ b/apps/mesh/src/web/components/home/quick-actions.tsx
@@ -176,6 +176,7 @@ function QuickActionsContent() {
     (t) => t.id === "site-diagnostics",
   )!;
 
+  // Find existing diagnostics agent to include in new projects
   const existingDiagnostics = virtualMcps.find(
     (a): a is typeof a & { id: string } =>
       a.id !== null &&
@@ -183,6 +184,24 @@ function QuickActionsContent() {
         siteDiagnosticsAgent.id ||
         a.title === siteDiagnosticsAgent.title),
   );
+
+  const handleNewDiagnostic = () => {
+    if (existingDiagnostics) {
+      // Create project with existing diagnostics agent
+      createProject({
+        title: "New Diagnostic",
+        agentIds: [existingDiagnostics.id],
+      });
+    } else {
+      // Need to recruit the agent first
+      setDiagnosticsModalOpen(true);
+    }
+  };
+
+  const handleNewSite = () => {
+    // Site editor needs onboarding first
+    setSiteEditorModalOpen(true);
+  };
 
   return (
     <>
@@ -192,16 +211,12 @@ function QuickActionsContent() {
           <ActionItem
             label="New Site"
             icon="site-editor"
-            onClick={() => setSiteEditorModalOpen(true)}
+            onClick={handleNewSite}
           />
           <ActionItem
             label="New Diagnostic"
             icon="site-diagnostics"
-            onClick={
-              existingDiagnostics
-                ? () => navigateToAgent(existingDiagnostics.id)
-                : () => setDiagnosticsModalOpen(true)
-            }
+            onClick={handleNewDiagnostic}
           />
           {/* Custom agents as actions */}
           {virtualMcps

--- a/apps/mesh/src/web/components/home/quick-actions.tsx
+++ b/apps/mesh/src/web/components/home/quick-actions.tsx
@@ -21,6 +21,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { Suspense, useState } from "react";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { useCreateProject } from "@/web/hooks/use-create-project";
+import { useCreateSlideProject } from "@/web/hooks/use-create-slide-project";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal";
@@ -37,6 +38,11 @@ const ACTION_ICON_CONFIG: Record<
   string,
   { Icon: typeof PresentationChart01; color: string; bg: string }
 > = {
+  "slide-maker": {
+    Icon: PresentationChart01,
+    color: "#8B5CF6",
+    bg: "bg-violet-100 dark:bg-violet-900/50",
+  },
   "site-editor": {
     Icon: Globe04,
     color: "#3B82F6",
@@ -171,6 +177,7 @@ function QuickActionsContent() {
   const { createProject } = useCreateProject({
     navigateOnCreate: true,
   });
+  const { create: createSlideProject } = useCreateSlideProject();
 
   const siteDiagnosticsAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "site-diagnostics",
@@ -208,6 +215,11 @@ function QuickActionsContent() {
       {/* Action items row */}
       <div className="w-full max-md:overflow-x-auto max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden">
         <div className="flex flex-wrap justify-center gap-1.5 max-md:flex-nowrap max-md:justify-start md:max-h-52 md:overflow-hidden">
+          <ActionItem
+            label="New Slides"
+            icon="slide-maker"
+            onClick={() => createSlideProject()}
+          />
           <ActionItem
             label="New Site"
             icon="site-editor"

--- a/apps/mesh/src/web/components/home/quick-actions.tsx
+++ b/apps/mesh/src/web/components/home/quick-actions.tsx
@@ -20,7 +20,7 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { Suspense, useState } from "react";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
+import { useCreateProject } from "@/web/hooks/use-create-project";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal";
@@ -168,7 +168,7 @@ function QuickActionsContent() {
   const navigateToAgent = useNavigateToAgent();
   const [siteEditorModalOpen, setSiteEditorModalOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
-  const { createVirtualMCP } = useCreateVirtualMCP({
+  const { createProject } = useCreateProject({
     navigateOnCreate: true,
   });
 
@@ -220,7 +220,7 @@ function QuickActionsContent() {
                 onClick={() => navigateToAgent(agent.id)}
               />
             ))}
-          <ActionItem label="New project" onClick={() => createVirtualMCP()} />
+          <ActionItem label="New project" onClick={() => createProject()} />
           <button
             type="button"
             className={cn(

--- a/apps/mesh/src/web/components/home/quick-actions.tsx
+++ b/apps/mesh/src/web/components/home/quick-actions.tsx
@@ -1,14 +1,12 @@
 /**
  * QuickActions - Action-oriented items for the home page.
- * Replaces the agents list with actions like "New Slide Deck", "Run Diagnostic", etc.
- * Below shows recent files and folders.
+ * Replaces the agents list with actions like "New Site", "New Diagnostic", etc.
  */
 
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   BarChart12,
   ChevronRight,
-  FolderClosed,
   Globe04,
   Plus,
   PresentationChart01,
@@ -26,13 +24,6 @@ import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal";
-import {
-  MOCK_FOLDERS,
-  getRecentArtifacts,
-  formatRelativeTime,
-  type Artifact,
-  type ArtifactType,
-} from "@/web/lib/mock-artifacts";
 
 // ---------- Action item (replaces agent preview) ----------
 
@@ -103,76 +94,6 @@ function ActionItem({
   );
 }
 
-// ---------- Mini artifact row for recent files ----------
-
-const ARTIFACT_TYPE_CONFIG: Record<
-  ArtifactType,
-  { Icon: typeof PresentationChart01; color: string }
-> = {
-  deck: { Icon: PresentationChart01, color: "#8B5CF6" },
-  report: { Icon: BarChart12, color: "#10B981" },
-  site: { Icon: Globe04, color: "#3B82F6" },
-};
-
-function ArtifactRow({ artifact }: { artifact: Artifact }) {
-  const config = ARTIFACT_TYPE_CONFIG[artifact.type];
-  const { Icon } = config;
-
-  return (
-    <button
-      type="button"
-      className={cn(
-        "flex items-center gap-2.5 px-3 py-2 w-full rounded-lg text-left",
-        "transition-colors hover:bg-accent/50 cursor-pointer",
-      )}
-    >
-      <div
-        className="flex items-center justify-center size-7 rounded-md shrink-0"
-        style={{ backgroundColor: `${config.color}15` }}
-      >
-        <Icon size={14} style={{ color: config.color }} />
-      </div>
-      <span className="flex-1 text-sm text-foreground truncate min-w-0">
-        {artifact.title}
-      </span>
-      <span className="text-xs text-muted-foreground shrink-0">
-        {formatRelativeTime(artifact.updatedAt)}
-      </span>
-    </button>
-  );
-}
-
-// ---------- Mini folder card ----------
-
-function FolderRow({
-  folder,
-}: {
-  folder: { id: string; title: string; color: string; itemCount: number };
-}) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        "flex items-center gap-2.5 px-3 py-2 w-full rounded-lg text-left",
-        "transition-colors hover:bg-accent/50 cursor-pointer",
-      )}
-    >
-      <div
-        className="flex items-center justify-center size-7 rounded-md shrink-0"
-        style={{ backgroundColor: `${folder.color}15` }}
-      >
-        <FolderClosed size={14} style={{ color: folder.color }} />
-      </div>
-      <span className="flex-1 text-sm text-foreground truncate min-w-0">
-        {folder.title}
-      </span>
-      <span className="text-xs text-muted-foreground shrink-0">
-        {folder.itemCount} items
-      </span>
-    </button>
-  );
-}
-
 // ---------- Main content ----------
 
 function QuickActionsContent() {
@@ -197,8 +118,6 @@ function QuickActionsContent() {
         siteDiagnosticsAgent.id ||
         a.title === siteDiagnosticsAgent.title),
   );
-
-  const recentArtifacts = getRecentArtifacts(5);
 
   return (
     <>
@@ -227,7 +146,7 @@ function QuickActionsContent() {
                 !isDecopilot(a.id) &&
                 a.id !== existingDiagnostics?.id,
             )
-            .slice(0, 3)
+            .slice(0, 4)
             .map((agent) => (
               <ActionItem
                 key={agent.id}
@@ -258,41 +177,6 @@ function QuickActionsContent() {
             </p>
           </button>
         </div>
-      </div>
-
-      {/* Files section */}
-      <div className="w-full max-w-[672px] mx-auto mt-6">
-        {/* Folders */}
-        {MOCK_FOLDERS.length > 0 && (
-          <div className="mb-4">
-            <div className="flex items-center justify-between mb-1 px-3">
-              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                Folders
-              </h3>
-            </div>
-            <div className="flex flex-col">
-              {MOCK_FOLDERS.map((folder) => (
-                <FolderRow key={folder.id} folder={folder} />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Recent files */}
-        {recentArtifacts.length > 0 && (
-          <div>
-            <div className="flex items-center justify-between mb-1 px-3">
-              <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                Recent
-              </h3>
-            </div>
-            <div className="flex flex-col">
-              {recentArtifacts.map((artifact) => (
-                <ArtifactRow key={artifact.id} artifact={artifact} />
-              ))}
-            </div>
-          </div>
-        )}
       </div>
 
       <SiteEditorOnboardingModal

--- a/apps/mesh/src/web/components/home/quick-actions.tsx
+++ b/apps/mesh/src/web/components/home/quick-actions.tsx
@@ -24,6 +24,12 @@ import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onboarding-modal";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal";
+import {
+  getRecentArtifacts,
+  formatRelativeTime,
+  type Artifact,
+  type ArtifactType,
+} from "@/web/lib/mock-artifacts";
 
 // ---------- Action item (replaces agent preview) ----------
 
@@ -94,6 +100,65 @@ function ActionItem({
   );
 }
 
+// ---------- Recent artifacts ----------
+
+const ARTIFACT_ICON: Record<
+  ArtifactType,
+  { Icon: typeof PresentationChart01; color: string }
+> = {
+  deck: { Icon: PresentationChart01, color: "#8B5CF6" },
+  report: { Icon: BarChart12, color: "#10B981" },
+  site: { Icon: Globe04, color: "#3B82F6" },
+};
+
+function ArtifactRow({ artifact }: { artifact: Artifact }) {
+  const config = ARTIFACT_ICON[artifact.type];
+  const { Icon } = config;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center gap-2.5 px-3 py-2 w-full rounded-lg text-left",
+        "transition-colors hover:bg-accent/50 cursor-pointer",
+      )}
+    >
+      <div
+        className="flex items-center justify-center size-7 rounded-md shrink-0"
+        style={{ backgroundColor: `${config.color}15` }}
+      >
+        <Icon size={14} style={{ color: config.color }} />
+      </div>
+      <span className="flex-1 text-sm text-foreground truncate min-w-0">
+        {artifact.title}
+      </span>
+      <span className="text-xs text-muted-foreground shrink-0">
+        {formatRelativeTime(artifact.updatedAt)}
+      </span>
+    </button>
+  );
+}
+
+function RecentSection() {
+  const recentArtifacts = getRecentArtifacts(5);
+  if (recentArtifacts.length === 0) return null;
+
+  return (
+    <div className="w-full max-w-[672px] mx-auto mt-14">
+      <div className="flex items-center justify-between mb-3 px-3">
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Recent
+        </h3>
+      </div>
+      <div className="flex flex-col">
+        {recentArtifacts.map((artifact) => (
+          <ArtifactRow key={artifact.id} artifact={artifact} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ---------- Main content ----------
 
 function QuickActionsContent() {
@@ -155,7 +220,7 @@ function QuickActionsContent() {
                 onClick={() => navigateToAgent(agent.id)}
               />
             ))}
-          <ActionItem label="Create agent" onClick={() => createVirtualMCP()} />
+          <ActionItem label="New project" onClick={() => createVirtualMCP()} />
           <button
             type="button"
             className={cn(
@@ -178,6 +243,9 @@ function QuickActionsContent() {
           </button>
         </div>
       </div>
+
+      {/* Recent */}
+      <RecentSection />
 
       <SiteEditorOnboardingModal
         open={siteEditorModalOpen}

--- a/apps/mesh/src/web/components/layout/content-toolbar.tsx
+++ b/apps/mesh/src/web/components/layout/content-toolbar.tsx
@@ -1,0 +1,161 @@
+/**
+ * ContentToolbar — Top bar on the main content panel.
+ * Shows icons for available UI tools from the project's agents.
+ * Clicking an icon switches the main view to that tool's UI.
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useInsetContext, usePanelActions } from "@/web/layouts/shell-layout";
+import { useVirtualMCP, useVirtualMCPs } from "@decocms/mesh-sdk";
+import { isProject } from "@/web/hooks/use-create-project";
+import { IntegrationIcon } from "@/web/components/integration-icon";
+import { Settings01 } from "@untitledui/icons";
+import { Suspense } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+
+interface ToolUIEntry {
+  connectionId: string;
+  toolName: string;
+  label: string;
+  icon: string | null;
+}
+
+function useProjectToolUIs(virtualMcpId: string): ToolUIEntry[] {
+  const entity = useVirtualMCP(virtualMcpId);
+  const allVirtualMcps = useVirtualMCPs();
+
+  if (!entity || !isProject(entity)) return [];
+
+  // Collect pinned views from the project metadata
+  const pinnedViews =
+    ((entity.metadata?.ui as Record<string, unknown> | null | undefined)
+      ?.pinnedViews as ToolUIEntry[] | null) ?? [];
+
+  if (pinnedViews.length > 0) return pinnedViews;
+
+  // Fallback: check if the project has a default ext-apps view
+  const defaultView = (
+    entity.metadata?.ui as Record<string, unknown> | null | undefined
+  )?.layout as {
+    defaultMainView?: { type: string; id?: string; toolName?: string };
+  } | null;
+
+  if (
+    defaultView?.defaultMainView?.type === "ext-apps" &&
+    defaultView.defaultMainView.id
+  ) {
+    const connId = defaultView.defaultMainView.id;
+    const toolName = defaultView.defaultMainView.toolName ?? "";
+    // Find the connection's title for the label
+    const agent = allVirtualMcps.find((a) =>
+      a.connections.some((c) => c.connection_id === connId),
+    );
+    return [
+      {
+        connectionId: connId,
+        toolName,
+        label: agent?.title ?? toolName,
+        icon: agent?.icon ?? null,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function ToolbarContent() {
+  const ctx = useInsetContext();
+  const { openMainView } = usePanelActions();
+
+  if (!ctx) return null;
+  const { virtualMcpId, mainView } = ctx;
+
+  const toolUIs = useProjectToolUIs(virtualMcpId);
+  const entity = useVirtualMCP(virtualMcpId);
+  const entityIsProject = entity ? isProject(entity) : false;
+
+  if (!entityIsProject) return null;
+
+  const isSettingsActive = mainView?.type === "settings";
+
+  return (
+    <div className="shrink-0 flex items-center gap-0.5 px-2 py-1.5 border-b border-border">
+      {/* Tool UI icons */}
+      {toolUIs.map((tool) => {
+        const isActive =
+          mainView?.type === "ext-apps" &&
+          mainView.id === tool.connectionId &&
+          mainView.toolName === tool.toolName;
+
+        return (
+          <Tooltip key={`${tool.connectionId}-${tool.toolName}`}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() =>
+                  isActive
+                    ? openMainView("default")
+                    : openMainView("ext-apps", {
+                        id: tool.connectionId,
+                        toolName: tool.toolName,
+                      })
+                }
+                className={cn(
+                  "flex items-center justify-center size-7 rounded-md transition-colors",
+                  isActive
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                )}
+              >
+                <IntegrationIcon
+                  icon={tool.icon}
+                  name={tool.label}
+                  size="2xs"
+                  className="border-0 bg-transparent"
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{tool.label}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+
+      <div className="flex-1" />
+
+      {/* Settings */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() =>
+              isSettingsActive
+                ? openMainView("default")
+                : openMainView("settings")
+            }
+            className={cn(
+              "flex items-center justify-center size-7 rounded-md transition-colors",
+              isSettingsActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+            )}
+          >
+            <Settings01 size={14} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Settings</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+export function ContentToolbar() {
+  return (
+    <Suspense fallback={null}>
+      <ToolbarContent />
+    </Suspense>
+  );
+}

--- a/apps/mesh/src/web/components/layout/content-toolbar.tsx
+++ b/apps/mesh/src/web/components/layout/content-toolbar.tsx
@@ -6,6 +6,7 @@
 
 import { cn } from "@deco/ui/lib/utils.ts";
 import { useInsetContext, usePanelActions } from "@/web/layouts/shell-layout";
+import { useSearch } from "@tanstack/react-router";
 import { useVirtualMCP, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { isProject } from "@/web/hooks/use-create-project";
 import { IntegrationIcon } from "@/web/components/integration-icon";
@@ -80,8 +81,9 @@ function ToolbarContent() {
 
   if (!entityIsProject) return null;
 
+  const search = useSearch({ strict: false }) as { main?: string };
   const isSettingsActive = mainView?.type === "settings";
-  const isFilesActive = mainView === null || mainView?.type === "chat";
+  const isFilesActive = search.main === "files";
 
   return (
     <div className="shrink-0 flex items-center gap-0.5 px-2 py-1.5 border-b border-border">
@@ -90,7 +92,7 @@ function ToolbarContent() {
         <TooltipTrigger asChild>
           <button
             type="button"
-            onClick={() => openMainView("default")}
+            onClick={() => openMainView("files")}
             className={cn(
               "flex items-center justify-center size-7 rounded-md transition-colors",
               isFilesActive

--- a/apps/mesh/src/web/components/layout/content-toolbar.tsx
+++ b/apps/mesh/src/web/components/layout/content-toolbar.tsx
@@ -1,7 +1,7 @@
 /**
  * ContentToolbar — Top bar on the main content panel.
  * Shows icons for available UI tools from the project's agents.
- * Clicking an icon switches the main view to that tool's UI.
+ * Styled to match the top bar layout toggles (size-7 ghost buttons, 16px icons).
  */
 
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -9,7 +9,7 @@ import { useInsetContext, usePanelActions } from "@/web/layouts/shell-layout";
 import { useSearch } from "@tanstack/react-router";
 import { useVirtualMCP, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { isProject } from "@/web/hooks/use-create-project";
-import { IntegrationIcon } from "@/web/components/integration-icon";
+import { AgentAvatar } from "@/web/components/agent-icon";
 import { FolderClosed, Settings02 } from "@untitledui/icons";
 import { Suspense } from "react";
 import {
@@ -31,18 +31,20 @@ function useProjectToolUIs(virtualMcpId: string): ToolUIEntry[] {
 
   if (!entity || !isProject(entity)) return [];
 
-  // Collect pinned views from the project metadata
   const pinnedViews =
     ((entity.metadata?.ui as Record<string, unknown> | null | undefined)
       ?.pinnedViews as ToolUIEntry[] | null) ?? [];
 
   if (pinnedViews.length > 0) return pinnedViews;
 
-  // Fallback: check if the project has a default ext-apps view
   const defaultView = (
     entity.metadata?.ui as Record<string, unknown> | null | undefined
   )?.layout as {
-    defaultMainView?: { type: string; id?: string; toolName?: string };
+    defaultMainView?: {
+      type: string;
+      id?: string;
+      toolName?: string;
+    };
   } | null;
 
   if (
@@ -51,7 +53,6 @@ function useProjectToolUIs(virtualMcpId: string): ToolUIEntry[] {
   ) {
     const connId = defaultView.defaultMainView.id;
     const toolName = defaultView.defaultMainView.toolName ?? "";
-    // Find the connection's title for the label
     const agent = allVirtualMcps.find((a) =>
       a.connections.some((c) => c.connection_id === connId),
     );
@@ -67,6 +68,13 @@ function useProjectToolUIs(virtualMcpId: string): ToolUIEntry[] {
 
   return [];
 }
+
+/** Button style matching the top bar layout toggles */
+const toolbarBtnClass =
+  "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors";
+const toolbarBtnActive = "bg-sidebar-accent text-sidebar-foreground";
+const toolbarBtnInactive =
+  "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground";
 
 function ToolbarContent() {
   const ctx = useInsetContext();
@@ -86,7 +94,7 @@ function ToolbarContent() {
   const isFilesActive = search.main === "files";
 
   return (
-    <div className="shrink-0 flex items-center gap-0.5 px-2 py-1.5 border-b border-border">
+    <div className="shrink-0 flex items-center gap-0.5 px-1.5 h-10 border-b border-border">
       {/* Files */}
       <Tooltip>
         <TooltipTrigger asChild>
@@ -94,13 +102,11 @@ function ToolbarContent() {
             type="button"
             onClick={() => openMainView("files")}
             className={cn(
-              "flex items-center justify-center size-7 rounded-md transition-colors",
-              isFilesActive
-                ? "bg-accent text-foreground"
-                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+              toolbarBtnClass,
+              isFilesActive ? toolbarBtnActive : toolbarBtnInactive,
             )}
           >
-            <FolderClosed size={14} />
+            <FolderClosed size={16} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Files</TooltipContent>
@@ -120,24 +126,22 @@ function ToolbarContent() {
                 type="button"
                 onClick={() =>
                   isActive
-                    ? openMainView("default")
+                    ? openMainView("files")
                     : openMainView("ext-apps", {
                         id: tool.connectionId,
                         toolName: tool.toolName,
                       })
                 }
                 className={cn(
-                  "flex items-center justify-center size-7 rounded-md transition-colors",
-                  isActive
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                  toolbarBtnClass,
+                  isActive ? toolbarBtnActive : toolbarBtnInactive,
                 )}
               >
-                <IntegrationIcon
+                <AgentAvatar
                   icon={tool.icon}
                   name={tool.label}
-                  size="2xs"
-                  className="border-0 bg-transparent"
+                  size="xs"
+                  className="size-5 [&_svg]:size-3"
                 />
               </button>
             </TooltipTrigger>
@@ -155,17 +159,15 @@ function ToolbarContent() {
             type="button"
             onClick={() =>
               isSettingsActive
-                ? openMainView("default")
+                ? openMainView("files")
                 : openMainView("settings")
             }
             className={cn(
-              "flex items-center justify-center size-7 rounded-md transition-colors",
-              isSettingsActive
-                ? "bg-accent text-foreground"
-                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+              toolbarBtnClass,
+              isSettingsActive ? toolbarBtnActive : toolbarBtnInactive,
             )}
           >
-            <Settings02 size={14} />
+            <Settings02 size={16} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Settings</TooltipContent>

--- a/apps/mesh/src/web/components/layout/content-toolbar.tsx
+++ b/apps/mesh/src/web/components/layout/content-toolbar.tsx
@@ -9,7 +9,7 @@ import { useInsetContext, usePanelActions } from "@/web/layouts/shell-layout";
 import { useVirtualMCP, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { isProject } from "@/web/hooks/use-create-project";
 import { IntegrationIcon } from "@/web/components/integration-icon";
-import { Settings01 } from "@untitledui/icons";
+import { File06, Settings01 } from "@untitledui/icons";
 import { Suspense } from "react";
 import {
   Tooltip,
@@ -81,9 +81,29 @@ function ToolbarContent() {
   if (!entityIsProject) return null;
 
   const isSettingsActive = mainView?.type === "settings";
+  const isFilesActive = mainView === null || mainView?.type === "chat";
 
   return (
     <div className="shrink-0 flex items-center gap-0.5 px-2 py-1.5 border-b border-border">
+      {/* Files */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => openMainView("default")}
+            className={cn(
+              "flex items-center justify-center size-7 rounded-md transition-colors",
+              isFilesActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+            )}
+          >
+            <File06 size={14} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Files</TooltipContent>
+      </Tooltip>
+
       {/* Tool UI icons */}
       {toolUIs.map((tool) => {
         const isActive =

--- a/apps/mesh/src/web/components/layout/content-toolbar.tsx
+++ b/apps/mesh/src/web/components/layout/content-toolbar.tsx
@@ -9,7 +9,7 @@ import { useInsetContext, usePanelActions } from "@/web/layouts/shell-layout";
 import { useVirtualMCP, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { isProject } from "@/web/hooks/use-create-project";
 import { IntegrationIcon } from "@/web/components/integration-icon";
-import { File06, Settings01 } from "@untitledui/icons";
+import { FolderClosed, Settings02 } from "@untitledui/icons";
 import { Suspense } from "react";
 import {
   Tooltip,
@@ -98,7 +98,7 @@ function ToolbarContent() {
                 : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
             )}
           >
-            <File06 size={14} />
+            <FolderClosed size={14} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Files</TooltipContent>
@@ -163,7 +163,7 @@ function ToolbarContent() {
                 : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
             )}
           >
-            <Settings01 size={14} />
+            <Settings02 size={14} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Settings</TooltipContent>

--- a/apps/mesh/src/web/components/layout/content-toolbar.tsx
+++ b/apps/mesh/src/web/components/layout/content-toolbar.tsx
@@ -10,7 +10,7 @@ import { useSearch } from "@tanstack/react-router";
 import { useVirtualMCP, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { isProject } from "@/web/hooks/use-create-project";
 import { AgentAvatar } from "@/web/components/agent-icon";
-import { FolderClosed, Settings02 } from "@untitledui/icons";
+import { Folder, Settings02 } from "@untitledui/icons";
 import { Suspense } from "react";
 import {
   Tooltip,
@@ -106,7 +106,7 @@ function ToolbarContent() {
               isFilesActive ? toolbarBtnActive : toolbarBtnInactive,
             )}
           >
-            <FolderClosed size={16} />
+            <Folder size={16} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Files</TooltipContent>

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -368,7 +368,7 @@ function PinAgentPopoverContent({
       <CollectionSearch
         value={search}
         onChange={setSearch}
-        placeholder="Search agents..."
+        placeholder="Search projects..."
       />
 
       {/* Scrollable content */}
@@ -376,7 +376,7 @@ function PinAgentPopoverContent({
         {/* Agents section */}
         <div className="px-1 pt-3 pb-2">
           <span className="text-xs font-medium text-muted-foreground">
-            Agents
+            Projects
           </span>
         </div>
         <div className="grid grid-cols-3 gap-1">
@@ -394,7 +394,7 @@ function PinAgentPopoverContent({
               <Plus size={18} className="text-muted-foreground" />
             </div>
             <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-              Create new
+              New project
             </span>
           </button>
 
@@ -455,7 +455,7 @@ function PinAgentPopoverContent({
           onClick={() => onClose()}
           className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center justify-center"
         >
-          See all agents
+          See all projects
         </Link>
       </div>
     </div>
@@ -498,7 +498,7 @@ function PinAgentPopover() {
         <>
           <SidebarMenuItem>
             <SidebarMenuButton
-              tooltip="Browse agents"
+              tooltip="Browse projects"
               className="bg-muted/75 hover:bg-sidebar-accent"
               onClick={() => setOpen(true)}
             >
@@ -507,7 +507,7 @@ function PinAgentPopover() {
           </SidebarMenuItem>
           <Drawer open={open} onOpenChange={setOpen} direction="bottom">
             <DrawerContent className="max-h-[85dvh] p-0">
-              <DrawerTitle className="sr-only">Browse agents</DrawerTitle>
+              <DrawerTitle className="sr-only">Browse projects</DrawerTitle>
               {popoverContent}
             </DrawerContent>
           </Drawer>
@@ -517,7 +517,7 @@ function PinAgentPopover() {
           <SidebarMenuItem>
             <PopoverTrigger asChild>
               <SidebarMenuButton
-                tooltip="Browse agents"
+                tooltip="Browse projects"
                 className="bg-muted/75 hover:bg-sidebar-accent"
               >
                 <Plus className="!opacity-100" />

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -191,8 +191,11 @@ function AgentListItem({
               onClick={(e) => {
                 e.stopPropagation();
                 setButtonRect(null);
-                onUnpin();
-                navigate({ to: "/$org", params: { org } });
+                navigate({
+                  to: "/$org/$virtualMcpId",
+                  params: { org, virtualMcpId: agent.id },
+                  search: { main: "settings", mainOpen: 1 },
+                });
               }}
               className={cn(
                 "flex items-center justify-center",
@@ -214,7 +217,7 @@ function AgentListItem({
                   "inset 0 0 0.5px 1px hsla(0, 0%, 100%, 0.075), 0 0 0 0.5px hsla(0, 0%, 0%, 0.12)",
               }}
             >
-              <X size={14} />
+              <Settings01 size={14} />
             </button>,
             document.body,
           )}

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -56,7 +56,6 @@ import {
 } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { usePinnedAgents } from "@/web/hooks/use-pinned-agents";
-import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useCreateTaskAndNavigate } from "@/web/hooks/use-create-task-and-navigate";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { AgentAvatar } from "@/web/components/agent-icon";
@@ -65,6 +64,7 @@ import { SiteEditorOnboardingModal } from "@/web/components/home/site-editor-onb
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { useAgentBadges } from "@/web/hooks/use-agent-badges";
+import { isProject, useCreateProject } from "@/web/hooks/use-create-project";
 
 function AgentListItem({
   agent,
@@ -291,23 +291,6 @@ function AgentGridItem({
   );
 }
 
-/**
- * Compute which Virtual MCP IDs are children of other Virtual MCPs.
- * These are "agents inside projects" and should not appear as top-level projects.
- */
-function getChildVirtualMcpIds(
-  allVirtualMcps: VirtualMCPEntity[],
-): Set<string> {
-  const allIds = new Set(allVirtualMcps.map((a) => a.id));
-  return new Set(
-    allVirtualMcps.flatMap((parent) =>
-      parent.connections
-        .map((c) => c.connection_id)
-        .filter((id) => allIds.has(id)),
-    ),
-  );
-}
-
 function PinAgentPopoverContent({
   onClose,
   onOpenSiteEditorModal,
@@ -324,20 +307,18 @@ function PinAgentPopoverContent({
   const { org } = useProjectContext();
   const serverPinnedIds = allAgents.filter((a) => a.pinned).map((a) => a.id);
   const { pin, isPinned } = usePinnedAgents(org.id, serverPinnedIds);
-  const { createVirtualMCP, isCreating } = useCreateVirtualMCP({
+  const { createProject, isCreating: isCreatingProject } = useCreateProject({
     navigateOnCreate: true,
   });
 
   const navigateToNewTask = useCreateTaskAndNavigate();
   const navigateToAgent = useNavigateToAgent();
 
-  // Filter to top-level projects only (not agents nested inside other projects)
-  const childIds = getChildVirtualMcpIds(allAgents);
-
   const lowerSearch = search.toLowerCase();
-  const userAgents = allAgents
-    .filter((s) => !isDecopilot(s.id))
-    .filter((s) => !childIds.has(s.id))
+
+  // Only show projects (metadata.type === "project") in the projects section
+  const projects = allAgents
+    .filter((s) => !isDecopilot(s.id) && isProject(s))
     .filter((s) => !search || s.title.toLowerCase().includes(lowerSearch));
 
   const studioPackInstalled = allAgents.some((a) => isStudioPackAgent(a.id));
@@ -404,12 +385,12 @@ function PinAgentPopoverContent({
           </span>
         </div>
         <div className="grid grid-cols-3 gap-1">
-          {/* Create new button */}
+          {/* Create new project */}
           <button
             type="button"
-            disabled={isCreating}
+            disabled={isCreatingProject}
             onClick={async () => {
-              await createVirtualMCP();
+              await createProject();
               onClose();
             }}
             className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group disabled:opacity-50 disabled:cursor-not-allowed"
@@ -422,11 +403,11 @@ function PinAgentPopoverContent({
             </span>
           </button>
 
-          {userAgents.map((agent) => (
+          {projects.map((project) => (
             <AgentGridItem
-              key={agent.id}
-              agent={agent}
-              onClick={() => handleSelect(agent)}
+              key={project.id}
+              agent={project}
+              onClick={() => handleSelect(project)}
             />
           ))}
         </div>
@@ -462,11 +443,11 @@ function PinAgentPopoverContent({
           </>
         )}
 
-        {userAgents.length === 0 &&
+        {projects.length === 0 &&
           filteredTemplates.length === 0 &&
-          !isCreating && (
+          !isCreatingProject && (
             <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
-              {search ? "No agents found" : "No agents yet"}
+              {search ? "No projects found" : "No projects yet"}
             </div>
           )}
       </div>
@@ -577,19 +558,18 @@ function AgentsSectionContent() {
   const allAgents = useVirtualMCPs();
   const { org } = useProjectContext();
 
-  // Filter to top-level projects only (not agents nested inside other projects)
-  const childIds = getChildVirtualMcpIds(allAgents);
-  const topLevelProjects = allAgents.filter((a) => !childIds.has(a.id));
+  // Only show projects (metadata.type === "project") in the sidebar
+  const projectsOnly = allAgents.filter(
+    (a) => !isDecopilot(a.id) && isProject(a),
+  );
 
-  const serverPinnedIds = topLevelProjects
-    .filter((a) => a.pinned)
-    .map((a) => a.id);
+  const serverPinnedIds = projectsOnly.filter((a) => a.pinned).map((a) => a.id);
   const { pinnedIds, unpin, reorder } = usePinnedAgents(
     org.id,
     serverPinnedIds,
   );
 
-  const agentMap = new Map(topLevelProjects.map((a) => [a.id, a]));
+  const agentMap = new Map(projectsOnly.map((a) => [a.id, a]));
   const pinnedAgents = pinnedIds
     .map((id) => agentMap.get(id))
     .filter((a): a is VirtualMCPEntity => !!a);

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -291,6 +291,23 @@ function AgentGridItem({
   );
 }
 
+/**
+ * Compute which Virtual MCP IDs are children of other Virtual MCPs.
+ * These are "agents inside projects" and should not appear as top-level projects.
+ */
+function getChildVirtualMcpIds(
+  allVirtualMcps: VirtualMCPEntity[],
+): Set<string> {
+  const allIds = new Set(allVirtualMcps.map((a) => a.id));
+  return new Set(
+    allVirtualMcps.flatMap((parent) =>
+      parent.connections
+        .map((c) => c.connection_id)
+        .filter((id) => allIds.has(id)),
+    ),
+  );
+}
+
 function PinAgentPopoverContent({
   onClose,
   onOpenSiteEditorModal,
@@ -314,9 +331,13 @@ function PinAgentPopoverContent({
   const navigateToNewTask = useCreateTaskAndNavigate();
   const navigateToAgent = useNavigateToAgent();
 
+  // Filter to top-level projects only (not agents nested inside other projects)
+  const childIds = getChildVirtualMcpIds(allAgents);
+
   const lowerSearch = search.toLowerCase();
   const userAgents = allAgents
     .filter((s) => !isDecopilot(s.id))
+    .filter((s) => !childIds.has(s.id))
     .filter((s) => !search || s.title.toLowerCase().includes(lowerSearch));
 
   const studioPackInstalled = allAgents.some((a) => isStudioPackAgent(a.id));
@@ -555,13 +576,20 @@ function PinAgentPopover() {
 function AgentsSectionContent() {
   const allAgents = useVirtualMCPs();
   const { org } = useProjectContext();
-  const serverPinnedIds = allAgents.filter((a) => a.pinned).map((a) => a.id);
+
+  // Filter to top-level projects only (not agents nested inside other projects)
+  const childIds = getChildVirtualMcpIds(allAgents);
+  const topLevelProjects = allAgents.filter((a) => !childIds.has(a.id));
+
+  const serverPinnedIds = topLevelProjects
+    .filter((a) => a.pinned)
+    .map((a) => a.id);
   const { pinnedIds, unpin, reorder } = usePinnedAgents(
     org.id,
     serverPinnedIds,
   );
 
-  const agentMap = new Map(allAgents.map((a) => [a.id, a]));
+  const agentMap = new Map(topLevelProjects.map((a) => [a.id, a]));
   const pinnedAgents = pinnedIds
     .map((id) => agentMap.get(id))
     .filter((a): a is VirtualMCPEntity => !!a);

--- a/apps/mesh/src/web/hooks/use-create-project.ts
+++ b/apps/mesh/src/web/hooks/use-create-project.ts
@@ -1,0 +1,44 @@
+/**
+ * Hook to create a new project.
+ * Projects are Virtual MCPs with metadata.type = "project".
+ * They contain agents (other Virtual MCPs) and tasks.
+ */
+
+import { useVirtualMCPActions, type VirtualMCPEntity } from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+
+export function useCreateProject(options: { navigateOnCreate?: boolean } = {}) {
+  const { navigateOnCreate = false } = options;
+  const actions = useVirtualMCPActions();
+  const navigateToAgent = useNavigateToAgent();
+
+  const createProject = async () => {
+    const virtualMcp = await actions.create.mutateAsync({
+      title: "New Project",
+      description: "",
+      status: "active",
+      connections: [],
+      pinned: true,
+      metadata: {
+        instructions: null,
+        type: "project",
+      },
+    });
+
+    if (navigateOnCreate) {
+      navigateToAgent(virtualMcp.id!, { search: { main: "settings" } });
+    }
+
+    return { id: virtualMcp.id!, virtualMcp };
+  };
+
+  return {
+    createProject,
+    isCreating: actions.create.isPending,
+  };
+}
+
+/** Check if a Virtual MCP is a project (vs an agent) */
+export function isProject(entity: VirtualMCPEntity): boolean {
+  return (entity.metadata as Record<string, unknown>)?.type === "project";
+}

--- a/apps/mesh/src/web/hooks/use-create-project.ts
+++ b/apps/mesh/src/web/hooks/use-create-project.ts
@@ -12,12 +12,22 @@ export function useCreateProject(options: { navigateOnCreate?: boolean } = {}) {
   const actions = useVirtualMCPActions();
   const navigateToAgent = useNavigateToAgent();
 
-  const createProject = async () => {
+  const createProject = async (params?: {
+    title?: string;
+    agentIds?: string[];
+  }) => {
+    const connections = (params?.agentIds ?? []).map((id) => ({
+      connection_id: id,
+      selected_tools: null,
+      selected_resources: null,
+      selected_prompts: null,
+    }));
+
     const virtualMcp = await actions.create.mutateAsync({
-      title: "New Project",
+      title: params?.title ?? "New Project",
       description: "",
       status: "active",
-      connections: [],
+      connections,
       pinned: true,
       metadata: {
         instructions: null,
@@ -26,7 +36,7 @@ export function useCreateProject(options: { navigateOnCreate?: boolean } = {}) {
     });
 
     if (navigateOnCreate) {
-      navigateToAgent(virtualMcp.id!, { search: { main: "settings" } });
+      navigateToAgent(virtualMcp.id!);
     }
 
     return { id: virtualMcp.id!, virtualMcp };

--- a/apps/mesh/src/web/hooks/use-create-slide-project.ts
+++ b/apps/mesh/src/web/hooks/use-create-slide-project.ts
@@ -1,0 +1,93 @@
+/**
+ * Hook to create a full Slide Maker project in one shot:
+ * 1. Creates the Slide Maker HTTP connection
+ * 2. Creates a "Slide Maker" agent with that connection
+ * 3. Creates a project with the agent inside
+ * 4. Navigates to the project
+ */
+
+import { useConnectionActions, useVirtualMCPActions } from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { useState } from "react";
+
+const SLIDE_MAKER_URL = "https://slide-maker.decocms.com/api/mcp";
+const SLIDE_MAKER_TOKEN = "9c8ed79c-4e23-4ca8-9f22-257afff0aee5";
+
+export function useCreateSlideProject() {
+  const connectionActions = useConnectionActions();
+  const vmcpActions = useVirtualMCPActions();
+  const navigateToAgent = useNavigateToAgent();
+  const [isCreating, setIsCreating] = useState(false);
+
+  const create = async () => {
+    if (isCreating) return;
+    setIsCreating(true);
+
+    try {
+      // 1. Create the HTTP connection for Slide Maker
+      const connection = await connectionActions.create.mutateAsync({
+        title: "Slide Maker",
+        description: "Create and edit slide decks",
+        connection_type: "HTTP",
+        connection_url: SLIDE_MAKER_URL,
+        connection_token: SLIDE_MAKER_TOKEN,
+        status: "active",
+      });
+
+      const connectionId = connection.id;
+
+      // 2. Create the Slide Maker agent (Virtual MCP) with this connection
+      const agent = await vmcpActions.create.mutateAsync({
+        title: "Slide Maker",
+        description: "Creates and edits slide presentations",
+        status: "active",
+        pinned: false, // Not pinned — lives inside a project
+        connections: [
+          {
+            connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+      });
+
+      // 3. Create the project with the agent and set default UI to slide_maker tool
+      const project = await vmcpActions.create.mutateAsync({
+        title: "My Slides",
+        description: "Slide decks and presentations",
+        status: "active",
+        pinned: true,
+        connections: [
+          {
+            connection_id: agent.id!,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+        metadata: {
+          instructions: null,
+          type: "project",
+          ui: {
+            layout: {
+              defaultMainView: {
+                type: "ext-apps",
+                id: connectionId,
+                toolName: "slide_maker",
+              },
+              chatDefaultOpen: true,
+            },
+          },
+        },
+      });
+
+      // 4. Navigate to the project
+      navigateToAgent(project.id!);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return { create, isCreating };
+}

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -95,10 +95,10 @@ export function resolveDefaultPanelState(ctx: {
     return allOpen;
   }
 
-  // Decopilot ID: tasks closed, main closed, chat open
+  // Decopilot ID: tasks closed, main open (file browser), chat open
   const isDecopilot = ctx.virtualMcpId === getDecopilotId(ctx.orgId);
   if (isDecopilot) {
-    return { tasksOpen: false, mainOpen: false, chatOpen: true };
+    return { tasksOpen: false, mainOpen: true, chatOpen: true };
   }
 
   // Entity metadata driven defaults

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -95,10 +95,10 @@ export function resolveDefaultPanelState(ctx: {
     return allOpen;
   }
 
-  // Decopilot ID: tasks closed, main open (file browser), chat open
+  // Decopilot ID: tasks closed, main closed, chat open
   const isDecopilot = ctx.virtualMcpId === getDecopilotId(ctx.orgId);
   if (isDecopilot) {
-    return { tasksOpen: false, mainOpen: true, chatOpen: true };
+    return { tasksOpen: false, mainOpen: false, chatOpen: true };
   }
 
   // Entity metadata driven defaults

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -95,10 +95,10 @@ export function resolveDefaultPanelState(ctx: {
     return allOpen;
   }
 
-  // Decopilot ID: tasks closed, main closed, chat open
+  // Decopilot ID: tasks open (all tasks), main closed, chat open
   const isDecopilot = ctx.virtualMcpId === getDecopilotId(ctx.orgId);
   if (isDecopilot) {
-    return { tasksOpen: false, mainOpen: false, chatOpen: true };
+    return { tasksOpen: true, mainOpen: false, chatOpen: true };
   }
 
   // Entity metadata driven defaults

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -82,6 +82,7 @@ export function resolveDefaultPanelState(ctx: {
   entityMetadata: EntityLayoutMetadata | null;
   hasMainParam: boolean;
   isAgentHomeRoute: boolean;
+  isProject?: boolean;
 }): { tasksOpen: boolean; mainOpen: boolean; chatOpen: boolean } {
   const allOpen = { tasksOpen: true, mainOpen: true, chatOpen: true };
 
@@ -99,6 +100,11 @@ export function resolveDefaultPanelState(ctx: {
   const isDecopilot = ctx.virtualMcpId === getDecopilotId(ctx.orgId);
   if (isDecopilot) {
     return { tasksOpen: true, mainOpen: false, chatOpen: true };
+  }
+
+  // Projects: show files (main) + chat by default
+  if (ctx.isProject) {
+    return { tasksOpen: false, mainOpen: true, chatOpen: true };
   }
 
   // Entity metadata driven defaults
@@ -176,6 +182,7 @@ function parsePanelParam(
 
 export function usePanelState(
   entityMetadata: EntityLayoutMetadata | null,
+  options?: { isProject?: boolean },
 ): LayoutState & LayoutActions {
   const navigate = useNavigate();
   const { org } = useProjectContext();
@@ -211,6 +218,7 @@ export function usePanelState(
     entityMetadata,
     hasMainParam: !!search.main,
     isAgentHomeRoute,
+    isProject: options?.isProject,
   };
   const defaults = resolveDefaultPanelState(resolveCtx);
 

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -11,6 +11,7 @@
 
 import { useRef } from "react";
 import { useMatch, useNavigate, useSearch } from "@tanstack/react-router";
+import { saveTaskLayout } from "@/web/lib/task-layout-store";
 import {
   getDecopilotId,
   getWellKnownDecopilotVirtualMCP,
@@ -230,6 +231,20 @@ export function usePanelState(
   // taskId fallback for non-validated routes
   const fallbackRef = useRef(crypto.randomUUID());
   const taskId = search.taskId ?? fallbackRef.current;
+
+  // Persist per-task layout (chat + main state, not tasks panel)
+  const prevTaskIdRef = useRef(taskId);
+  if (taskId && search.taskId) {
+    // Only save when we have an explicit taskId from URL (not fallback)
+    saveTaskLayout(taskId, {
+      chatOpen,
+      mainOpen,
+      main: search.main,
+      id: search.id,
+      toolName: search.toolName,
+    });
+  }
+  prevTaskIdRef.current = taskId;
 
   // Expanded count for toggle guard
   const expandedCount = [tasksOpen, mainOpen, chatOpen].filter(Boolean).length;

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -440,8 +440,15 @@ function InsetProvider({ isSettingsRoute }: { isSettingsRoute: boolean }) {
       }
     : null;
 
+  // Check if entity is a project
+  const entityIsProject =
+    (entity?.metadata as Record<string, unknown> | undefined)?.type ===
+    "project";
+
   // Layout state from URL querystring
-  const layout = usePanelState(entityMetadata);
+  const layout = usePanelState(entityMetadata, {
+    isProject: entityIsProject,
+  });
 
   // Tasks panel virtualMcpId
   const tasksVirtualMcpId = virtualMcpId;

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -838,9 +838,7 @@ function UnifiedPanelGroup({
       <PersistentResizablePanel defaultSize={sizes.chat}>
         <div className="h-full p-0.5">
           <div className="h-full bg-background rounded-[0.75rem] overflow-hidden border border-sidebar-border shadow-sm">
-            <ActiveTaskBoundary
-              variant={isDecopilot && !mainOpen ? "home" : undefined}
-            />
+            <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
           </div>
         </div>
       </PersistentResizablePanel>
@@ -858,9 +856,7 @@ function MobileAgentContent({
   return (
     <div className="flex-1 min-h-0 overflow-hidden">
       {isDecopilot || !mainOpen ? (
-        <ActiveTaskBoundary
-          variant={isDecopilot && !mainOpen ? "home" : undefined}
-        />
+        <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
       ) : (
         <Outlet />
       )}

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -838,7 +838,9 @@ function UnifiedPanelGroup({
       <PersistentResizablePanel defaultSize={sizes.chat}>
         <div className="h-full p-0.5">
           <div className="h-full bg-background rounded-[0.75rem] overflow-hidden border border-sidebar-border shadow-sm">
-            <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
+            <ActiveTaskBoundary
+              variant={isDecopilot && !mainOpen ? "home" : undefined}
+            />
           </div>
         </div>
       </PersistentResizablePanel>
@@ -856,7 +858,9 @@ function MobileAgentContent({
   return (
     <div className="flex-1 min-h-0 overflow-hidden">
       {isDecopilot || !mainOpen ? (
-        <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
+        <ActiveTaskBoundary
+          variant={isDecopilot && !mainOpen ? "home" : undefined}
+        />
       ) : (
         <Outlet />
       )}

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -12,6 +12,7 @@ import { TasksSidePanel } from "@/web/components/chat/side-panel-tasks";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { ContentToolbar } from "@/web/components/layout/content-toolbar";
+import { ProjectScopeProvider } from "@/web/providers/project-scope";
 import { KeyboardShortcutsDialog } from "@/web/components/keyboard-shortcuts-dialog";
 import { isMac, isModKey } from "@/web/lib/keyboard-shortcuts";
 import { StudioSidebar, StudioSidebarMobile } from "@/web/components/sidebar";
@@ -441,10 +442,13 @@ function InsetProvider({ isSettingsRoute }: { isSettingsRoute: boolean }) {
       }
     : null;
 
-  // Check if entity is a project
+  // Check if entity is a project and compute its agent IDs
   const entityIsProject =
     (entity?.metadata as Record<string, unknown> | undefined)?.type ===
     "project";
+  const projectAgentIds = entityIsProject
+    ? new Set(entity!.connections.map((c) => c.connection_id))
+    : null;
 
   // Layout state from URL querystring
   const layout = usePanelState(entityMetadata, {
@@ -655,49 +659,69 @@ function InsetProvider({ isSettingsRoute }: { isSettingsRoute: boolean }) {
         </div>
       </div>
 
-      <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-        <NewTaskBridge
-          onNewTaskRef={onNewTask}
-          createNewTask={layout.createNewTask}
-        />
-        {showThreePanels ? (
-          <UnifiedPanelGroup
-            virtualMcpId={virtualMcpId}
-            isDecopilot={isDecopilot}
-            tasksVirtualMcpId={tasksVirtualMcpId}
-            tasksOpen={layout.tasksOpen}
-            mainOpen={layout.mainOpen}
-            chatOpen={layout.chatOpen}
+      <MaybeProjectScope agentIds={projectAgentIds}>
+        <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
+          <NewTaskBridge
+            onNewTaskRef={onNewTask}
+            createNewTask={layout.createNewTask}
           />
-        ) : (
-          <div className="flex-1 min-h-0 p-0.5 pb-1 pr-1">
-            <div
-              className={cn(
-                "flex flex-col h-full min-h-0 bg-card overflow-hidden",
-                "border border-sidebar-border shadow-sm",
-                "rounded-[0.75rem]",
-              )}
-            >
-              <Suspense
-                fallback={
-                  <div className="flex-1 flex items-center justify-center">
-                    <Loading01
-                      size={20}
-                      className="animate-spin text-muted-foreground"
-                    />
-                  </div>
-                }
+          {showThreePanels ? (
+            <UnifiedPanelGroup
+              virtualMcpId={virtualMcpId}
+              isDecopilot={isDecopilot}
+              tasksVirtualMcpId={tasksVirtualMcpId}
+              tasksOpen={layout.tasksOpen}
+              mainOpen={layout.mainOpen}
+              chatOpen={layout.chatOpen}
+            />
+          ) : (
+            <div className="flex-1 min-h-0 p-0.5 pb-1 pr-1">
+              <div
+                className={cn(
+                  "flex flex-col h-full min-h-0 bg-card overflow-hidden",
+                  "border border-sidebar-border shadow-sm",
+                  "rounded-[0.75rem]",
+                )}
               >
-                <div className="flex flex-1 items-center overflow-hidden rounded-[inherit]">
-                  <Outlet />
-                </div>
-              </Suspense>
+                <Suspense
+                  fallback={
+                    <div className="flex-1 flex items-center justify-center">
+                      <Loading01
+                        size={20}
+                        className="animate-spin text-muted-foreground"
+                      />
+                    </div>
+                  }
+                >
+                  <div className="flex flex-1 items-center overflow-hidden rounded-[inherit]">
+                    <Outlet />
+                  </div>
+                </Suspense>
+              </div>
             </div>
-          </div>
-        )}
-      </Chat.Provider>
+          )}
+        </Chat.Provider>
+      </MaybeProjectScope>
     </InsetContext>
   );
+}
+
+/** Wraps children in ProjectScopeProvider only when agentIds is non-null */
+function MaybeProjectScope({
+  agentIds,
+  children,
+}: {
+  agentIds: Set<string> | null;
+  children: React.ReactNode;
+}) {
+  if (agentIds) {
+    return (
+      <ProjectScopeProvider agentIds={agentIds}>
+        {children}
+      </ProjectScopeProvider>
+    );
+  }
+  return <>{children}</>;
 }
 
 function MobileToolbar({ onOpenSidebar }: { onOpenSidebar: () => void }) {

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -11,6 +11,7 @@ import { ChatPanel } from "@/web/components/chat/side-panel-chat";
 import { TasksSidePanel } from "@/web/components/chat/side-panel-tasks";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { SplashScreen } from "@/web/components/splash-screen";
+import { ContentToolbar } from "@/web/components/layout/content-toolbar";
 import { KeyboardShortcutsDialog } from "@/web/components/keyboard-shortcuts-dialog";
 import { isMac, isModKey } from "@/web/lib/keyboard-shortcuts";
 import { StudioSidebar, StudioSidebarMobile } from "@/web/components/sidebar";
@@ -623,20 +624,6 @@ function InsetProvider({ isSettingsRoute }: { isSettingsRoute: boolean }) {
               </button>
               <button
                 type="button"
-                onClick={layout.toggleMain}
-                aria-pressed={layout.mainOpen}
-                className={cn(
-                  "flex size-7 items-center justify-center rounded-md transition-colors",
-                  layout.mainOpen
-                    ? "bg-sidebar-accent text-sidebar-foreground"
-                    : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",
-                )}
-                title="Toggle content"
-              >
-                <Browser size={16} />
-              </button>
-              <button
-                type="button"
                 onClick={layout.toggleChat}
                 aria-pressed={layout.chatOpen}
                 className={cn(
@@ -646,6 +633,20 @@ function InsetProvider({ isSettingsRoute }: { isSettingsRoute: boolean }) {
                     : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",
                 )}
                 title="Toggle chat"
+              >
+                <Browser size={16} />
+              </button>
+              <button
+                type="button"
+                onClick={layout.toggleMain}
+                aria-pressed={layout.mainOpen}
+                className={cn(
+                  "flex size-7 items-center justify-center rounded-md transition-colors",
+                  layout.mainOpen
+                    ? "bg-sidebar-accent text-sidebar-foreground"
+                    : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",
+                )}
+                title="Toggle content"
               >
                 <LayoutRight size={16} />
               </button>
@@ -792,6 +793,7 @@ function UnifiedPanelGroup({
       className="flex-1 min-h-0 pb-1 pr-1 pl-0 pt-0"
       style={{ overflow: "visible" }}
     >
+      {/* Panel 1: Tasks */}
       <TasksResizablePanel defaultSize={sizes.tasks}>
         <div className="h-full p-0.5 overflow-hidden">
           <div className="h-full bg-background rounded-[0.75rem] overflow-hidden border border-sidebar-border shadow-sm">
@@ -805,9 +807,21 @@ function UnifiedPanelGroup({
       </TasksResizablePanel>
       <ResizableHandle className="bg-sidebar" />
 
+      {/* Panel 2: Chat (center) */}
+      <PersistentResizablePanel defaultSize={sizes.chat}>
+        <div className="h-full p-0.5">
+          <div className="h-full bg-background rounded-[0.75rem] overflow-hidden border border-sidebar-border shadow-sm">
+            <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
+          </div>
+        </div>
+      </PersistentResizablePanel>
+
+      <ResizableHandle className="bg-sidebar" />
+
+      {/* Panel 3: Main content / Layout (right) */}
       <ResizablePanel
         className="min-w-0 flex flex-col"
-        order={2}
+        order={3}
         defaultSize={sizes.main}
         style={{ overflow: "visible" }}
         collapsible={true}
@@ -823,6 +837,7 @@ function UnifiedPanelGroup({
               "rounded-[0.75rem]",
             )}
           >
+            <ContentToolbar />
             <Suspense
               fallback={
                 <div className="flex-1 flex items-center justify-center">
@@ -840,15 +855,6 @@ function UnifiedPanelGroup({
           </div>
         </div>
       </ResizablePanel>
-
-      <ResizableHandle className="bg-sidebar" />
-      <PersistentResizablePanel defaultSize={sizes.chat}>
-        <div className="h-full p-0.5">
-          <div className="h-full bg-background rounded-[0.75rem] overflow-hidden border border-sidebar-border shadow-sm">
-            <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
-          </div>
-        </div>
-      </PersistentResizablePanel>
     </ResizablePanelGroup>
   );
 }

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -848,7 +848,7 @@ function UnifiedPanelGroup({
                 </div>
               }
             >
-              <div className="flex flex-1 items-center overflow-hidden rounded-[inherit]">
+              <div className="flex flex-1 items-center overflow-hidden">
                 <Outlet />
               </div>
             </Suspense>

--- a/apps/mesh/src/web/lib/mock-artifacts.ts
+++ b/apps/mesh/src/web/lib/mock-artifacts.ts
@@ -1,0 +1,262 @@
+/**
+ * Mock artifact data for the filesystem UX prototype.
+ * In production, this would come from MCP app queries and a Studio artifact registry.
+ */
+
+export type ArtifactType = "deck" | "report" | "site";
+
+export interface Artifact {
+  id: string;
+  title: string;
+  type: ArtifactType;
+  /** Which folder this belongs to, null = unfiled */
+  folderId: string | null;
+  /** Preview snippet or summary */
+  preview: string;
+  /** When last modified */
+  updatedAt: string;
+  /** Which MCP app connection this came from */
+  connectionId: string;
+  /** Tool name to open this artifact */
+  toolName: string;
+  /** External ID in the MCP app */
+  externalId: string;
+}
+
+export interface Folder {
+  id: string;
+  title: string;
+  icon: string;
+  color: string;
+  itemCount: number;
+}
+
+const ARTIFACT_TYPE_META: Record<
+  ArtifactType,
+  { label: string; icon: string }
+> = {
+  deck: { label: "Slide Deck", icon: "presentation" },
+  report: { label: "Report", icon: "report" },
+  site: { label: "Website", icon: "globe" },
+};
+
+export function getArtifactTypeMeta(type: ArtifactType) {
+  return ARTIFACT_TYPE_META[type];
+}
+
+// ---------- Mock Folders ----------
+
+export const MOCK_FOLDERS: Folder[] = [
+  {
+    id: "fld_deco",
+    title: "Deco",
+    icon: "building",
+    color: "#8B5CF6",
+    itemCount: 5,
+  },
+  {
+    id: "fld_farm",
+    title: "Farm",
+    icon: "shopping",
+    color: "#10B981",
+    itemCount: 3,
+  },
+  {
+    id: "fld_clients",
+    title: "Clients",
+    icon: "users",
+    color: "#F59E0B",
+    itemCount: 4,
+  },
+];
+
+// ---------- Mock Artifacts ----------
+
+const now = Date.now();
+const HOUR = 3600_000;
+const DAY = 86400_000;
+
+export const MOCK_ARTIFACTS: Artifact[] = [
+  // Deco folder
+  {
+    id: "art_pitch_v3",
+    title: "Pitch Deck v3",
+    type: "deck",
+    folderId: "fld_deco",
+    preview: "12 slides - Company overview, product demo, market opportunity",
+    updatedAt: new Date(now - 2 * HOUR).toISOString(),
+    connectionId: "conn_slide_maker",
+    toolName: "slide_maker",
+    externalId: "deck_pitch_v3",
+  },
+  {
+    id: "art_health_report",
+    title: "Site Health Report",
+    type: "report",
+    folderId: "fld_deco",
+    preview: "Health score: 87/100 - Performance, SEO, accessibility audit",
+    updatedAt: new Date(now - 1 * DAY).toISOString(),
+    connectionId: "conn_diagnostics",
+    toolName: "diagnose",
+    externalId: "diag_deco_health",
+  },
+  {
+    id: "art_deco_site",
+    title: "decocms.com",
+    type: "site",
+    folderId: "fld_deco",
+    preview: "Main marketing site - Next.js, 24 pages",
+    updatedAt: new Date(now - 3 * DAY).toISOString(),
+    connectionId: "conn_site_editor",
+    toolName: "site_editor",
+    externalId: "site_deco",
+  },
+  {
+    id: "art_brand_guide",
+    title: "Brand Guidelines",
+    type: "deck",
+    folderId: "fld_deco",
+    preview: "8 slides - Colors, typography, logo usage, brand voice",
+    updatedAt: new Date(now - 7 * DAY).toISOString(),
+    connectionId: "conn_slide_maker",
+    toolName: "slide_maker",
+    externalId: "deck_brand_guide",
+  },
+  {
+    id: "art_seo_analysis",
+    title: "SEO Analysis",
+    type: "report",
+    folderId: "fld_deco",
+    preview: "Health score: 72/100 - Keyword ranking, backlink audit",
+    updatedAt: new Date(now - 14 * DAY).toISOString(),
+    connectionId: "conn_diagnostics",
+    toolName: "diagnose",
+    externalId: "diag_deco_seo",
+  },
+  // Farm folder
+  {
+    id: "art_farm_site",
+    title: "farm.com.br",
+    type: "site",
+    folderId: "fld_farm",
+    preview: "E-commerce - 156 products, 12 categories",
+    updatedAt: new Date(now - 2 * DAY).toISOString(),
+    connectionId: "conn_site_editor",
+    toolName: "site_editor",
+    externalId: "site_farm",
+  },
+  {
+    id: "art_product_strategy",
+    title: "Product Strategy",
+    type: "deck",
+    folderId: "fld_farm",
+    preview: "15 slides - PLP optimization, conversion funnel, A/B tests",
+    updatedAt: new Date(now - 4 * DAY).toISOString(),
+    connectionId: "conn_slide_maker",
+    toolName: "slide_maker",
+    externalId: "deck_product_strategy",
+  },
+  {
+    id: "art_farm_diagnostic",
+    title: "Performance Audit",
+    type: "report",
+    folderId: "fld_farm",
+    preview: "Health score: 64/100 - Core Web Vitals, image optimization",
+    updatedAt: new Date(now - 5 * DAY).toISOString(),
+    connectionId: "conn_diagnostics",
+    toolName: "diagnose",
+    externalId: "diag_farm_perf",
+  },
+  // Clients folder
+  {
+    id: "art_client_proposal",
+    title: "Client Proposal Template",
+    type: "deck",
+    folderId: "fld_clients",
+    preview: "10 slides - Services overview, case studies, pricing",
+    updatedAt: new Date(now - 1 * DAY).toISOString(),
+    connectionId: "conn_slide_maker",
+    toolName: "slide_maker",
+    externalId: "deck_client_proposal",
+  },
+  {
+    id: "art_acme_site",
+    title: "acme-store.com",
+    type: "site",
+    folderId: "fld_clients",
+    preview: "Client site - Shopify integration, 89 products",
+    updatedAt: new Date(now - 6 * DAY).toISOString(),
+    connectionId: "conn_site_editor",
+    toolName: "site_editor",
+    externalId: "site_acme",
+  },
+  {
+    id: "art_acme_diagnostic",
+    title: "Acme Store Audit",
+    type: "report",
+    folderId: "fld_clients",
+    preview: "Health score: 91/100 - Excellent performance and SEO",
+    updatedAt: new Date(now - 8 * DAY).toISOString(),
+    connectionId: "conn_diagnostics",
+    toolName: "diagnose",
+    externalId: "diag_acme",
+  },
+  {
+    id: "art_q4_review",
+    title: "Q4 Review",
+    type: "deck",
+    folderId: "fld_clients",
+    preview: "20 slides - Quarterly results, client satisfaction, roadmap",
+    updatedAt: new Date(now - 10 * DAY).toISOString(),
+    connectionId: "conn_slide_maker",
+    toolName: "slide_maker",
+    externalId: "deck_q4_review",
+  },
+  // Unfiled
+  {
+    id: "art_quick_deck",
+    title: "Quick Notes",
+    type: "deck",
+    folderId: null,
+    preview: "3 slides - Meeting notes from standup",
+    updatedAt: new Date(now - 30 * 60_000).toISOString(),
+    connectionId: "conn_slide_maker",
+    toolName: "slide_maker",
+    externalId: "deck_quick_notes",
+  },
+];
+
+// ---------- Helper functions ----------
+
+export function getArtifactsByFolder(folderId: string): Artifact[] {
+  return MOCK_ARTIFACTS.filter((a) => a.folderId === folderId).sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+}
+
+export function getRecentArtifacts(limit = 8): Artifact[] {
+  return [...MOCK_ARTIFACTS]
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    )
+    .slice(0, limit);
+}
+
+export function getFolderById(id: string): Folder | undefined {
+  return MOCK_FOLDERS.find((f) => f.id === id);
+}
+
+export function formatRelativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  const hours = Math.floor(diff / HOUR);
+  const days = Math.floor(diff / DAY);
+  const weeks = Math.floor(days / 7);
+
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return `${weeks}w ago`;
+}

--- a/apps/mesh/src/web/lib/task-layout-store.ts
+++ b/apps/mesh/src/web/lib/task-layout-store.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-task layout state persistence.
+ * Stores which panels were open and which main view was active per taskId.
+ * Tasks panel state is NOT stored here (it's global).
+ */
+
+const STORAGE_KEY = "mesh:task-layout";
+const MAX_ENTRIES = 200;
+
+interface TaskLayoutState {
+  chatOpen?: boolean;
+  mainOpen?: boolean;
+  main?: string;
+  id?: string;
+  toolName?: string;
+}
+
+type Store = Record<string, TaskLayoutState>;
+
+function readStore(): Store {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Store) {
+  // Prune oldest entries if over limit
+  const keys = Object.keys(store);
+  if (keys.length > MAX_ENTRIES) {
+    const toRemove = keys.slice(0, keys.length - MAX_ENTRIES);
+    for (const key of toRemove) {
+      delete store[key];
+    }
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function saveTaskLayout(taskId: string, state: TaskLayoutState) {
+  const store = readStore();
+  store[taskId] = state;
+  writeStore(store);
+}
+
+export function getTaskLayout(taskId: string): TaskLayoutState | null {
+  const store = readStore();
+  return store[taskId] ?? null;
+}

--- a/apps/mesh/src/web/providers/project-scope.tsx
+++ b/apps/mesh/src/web/providers/project-scope.tsx
@@ -1,0 +1,30 @@
+/**
+ * ProjectScope — Context that provides the current project's agent IDs.
+ * Used to scope the agent selector to only show agents in this project.
+ */
+
+import { createContext, use, type ReactNode } from "react";
+
+interface ProjectScopeValue {
+  /** Set of Virtual MCP IDs that are agents in the current project */
+  agentIds: Set<string>;
+}
+
+const ProjectScopeContext = createContext<ProjectScopeValue | null>(null);
+
+export function ProjectScopeProvider({
+  agentIds,
+  children,
+}: {
+  agentIds: Set<string>;
+  children: ReactNode;
+}) {
+  return (
+    <ProjectScopeContext value={{ agentIds }}>{children}</ProjectScopeContext>
+  );
+}
+
+/** Returns the project's agent IDs if inside a project, null otherwise */
+export function useProjectScope(): ProjectScopeValue | null {
+  return use(ProjectScopeContext);
+}

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -12,6 +12,9 @@ import {
 } from "@/web/layouts/shell-layout";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { useChatTask } from "@/web/components/chat/context";
+import { isProject } from "@/web/hooks/use-create-project";
+import { ProjectHome } from "@/web/views/project/project-home";
+import { ProjectSettings } from "@/web/views/project/project-settings";
 
 const ProjectAppViewContent = lazy(() =>
   import("./project-app-view").then((m) => ({
@@ -96,8 +99,28 @@ function AgentEmptyState() {
 
 function AgentHomeContent() {
   const { virtualMcpId } = useInsetContext()!;
+  const entity = useVirtualMCP(virtualMcpId);
   const resolved = useResolvedMainView();
+  const entityIsProject = entity ? isProject(entity) : false;
 
+  // Projects show files as default, simplified settings
+  if (entityIsProject) {
+    if (resolved.type === "settings") {
+      return <ProjectSettings virtualMcpId={virtualMcpId} />;
+    }
+    if (resolved.type === "ext-apps") {
+      return (
+        <ProjectAppViewContent
+          connectionId={resolved.id}
+          toolName={resolved.toolName ?? ""}
+        />
+      );
+    }
+    // Default: show project files
+    return <ProjectHome virtualMcpId={virtualMcpId} />;
+  }
+
+  // Agents: existing behavior
   if (resolved.type === "chat") {
     return <AgentEmptyState />;
   }

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -10,13 +10,8 @@ import {
   type MainView,
   type MainViewType,
 } from "@/web/layouts/shell-layout";
-import {
-  useVirtualMCP,
-  getDecopilotId,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { useChatTask } from "@/web/components/chat/context";
-import { FileBrowserHome } from "@/web/components/files/file-browser-home";
 
 const ProjectAppViewContent = lazy(() =>
   import("./project-app-view").then((m) => ({
@@ -101,15 +96,9 @@ function AgentEmptyState() {
 
 function AgentHomeContent() {
   const { virtualMcpId } = useInsetContext()!;
-  const { org } = useProjectContext();
   const resolved = useResolvedMainView();
-  const isDecopilot = virtualMcpId === getDecopilotId(org.id);
 
   if (resolved.type === "chat") {
-    // Decopilot shows file browser as the main view
-    if (isDecopilot) {
-      return <FileBrowserHome />;
-    }
     return <AgentEmptyState />;
   }
 

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -10,8 +10,13 @@ import {
   type MainView,
   type MainViewType,
 } from "@/web/layouts/shell-layout";
-import { useVirtualMCP } from "@decocms/mesh-sdk";
+import {
+  useVirtualMCP,
+  getDecopilotId,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
 import { useChatTask } from "@/web/components/chat/context";
+import { FileBrowserHome } from "@/web/components/files/file-browser-home";
 
 const ProjectAppViewContent = lazy(() =>
   import("./project-app-view").then((m) => ({
@@ -96,9 +101,15 @@ function AgentEmptyState() {
 
 function AgentHomeContent() {
   const { virtualMcpId } = useInsetContext()!;
+  const { org } = useProjectContext();
   const resolved = useResolvedMainView();
+  const isDecopilot = virtualMcpId === getDecopilotId(org.id);
 
   if (resolved.type === "chat") {
+    // Decopilot shows file browser as the main view
+    if (isDecopilot) {
+      return <FileBrowserHome />;
+    }
     return <AgentEmptyState />;
   }
 

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -11,6 +11,7 @@ import {
   type MainViewType,
 } from "@/web/layouts/shell-layout";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
+import { useSearch } from "@tanstack/react-router";
 import { useChatTask } from "@/web/components/chat/context";
 import { isProject } from "@/web/hooks/use-create-project";
 import { ProjectHome } from "@/web/views/project/project-home";
@@ -104,7 +105,12 @@ function AgentHomeContent() {
   const entityIsProject = entity ? isProject(entity) : false;
 
   // Projects show files as default, simplified settings
+  const search = useSearch({ strict: false }) as { main?: string };
   if (entityIsProject) {
+    // Explicit ?main=files → show project file browser
+    if (search.main === "files") {
+      return <ProjectHome virtualMcpId={virtualMcpId} />;
+    }
     if (resolved.type === "settings") {
       return <ProjectSettings virtualMcpId={virtualMcpId} />;
     }

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -109,10 +109,19 @@ function AgentHomeContent() {
       return <ProjectSettings virtualMcpId={virtualMcpId} />;
     }
     if (resolved.type === "ext-apps") {
+      // Read toolInput from project metadata (e.g., { deckId: "xxx" })
+      const defaultViewMeta = (
+        entity?.metadata?.ui as Record<string, unknown> | null | undefined
+      )?.layout as {
+        defaultMainView?: { toolInput?: Record<string, unknown> };
+      } | null;
+      const toolInput = defaultViewMeta?.defaultMainView?.toolInput;
+
       return (
         <ProjectAppViewContent
           connectionId={resolved.id}
           toolName={resolved.toolName ?? ""}
+          toolInput={toolInput}
         />
       );
     }

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -101,14 +101,15 @@ function AgentEmptyState() {
 function AgentHomeContent() {
   const { virtualMcpId } = useInsetContext()!;
   const entity = useVirtualMCP(virtualMcpId);
-  const resolved = useResolvedMainView();
   const entityIsProject = entity ? isProject(entity) : false;
-
-  // Projects show files as default, simplified settings
   const search = useSearch({ strict: false }) as { main?: string };
+
+  const resolved = useResolvedMainView();
+
+  // Projects: use raw search param to decide view (don't fall through to entity default)
   if (entityIsProject) {
-    // Explicit ?main=files → show project file browser
-    if (search.main === "files") {
+    // Files is the default — show when ?main=files, or when no ?main= param at all
+    if (search.main === "files" || !search.main) {
       return <ProjectHome virtualMcpId={virtualMcpId} />;
     }
     if (resolved.type === "settings") {

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -28,6 +28,7 @@ function AppRenderer({
   resourceURI,
   tool,
   connectionId,
+  toolInput: toolInputProp,
 }: {
   client: ReturnType<typeof useMCPClient>;
   resourceURI: string;
@@ -38,15 +39,17 @@ function AppRenderer({
     _meta?: Record<string, unknown>;
   };
   connectionId: string;
+  toolInput?: Record<string, unknown>;
 }) {
   const { sendMessage } = useChatBridge();
   const { setAppContext, clearAppContext } = useChatPrefs();
   const { setChatOpen } = usePanelActions();
   const sourceId = `${connectionId}:${tool.name}`;
+  const effectiveInput = toolInputProp ?? EMPTY_TOOL_INPUT;
   const { data: toolResult } = useMCPToolCall({
     client,
     toolName: tool.name,
-    toolArguments: EMPTY_TOOL_INPUT,
+    toolArguments: effectiveInput,
   });
 
   const clientId = getGatewayClientId(tool._meta);
@@ -71,7 +74,7 @@ function AppRenderer({
     <MCPAppRenderer
       resourceURI={resourceURI}
       toolInfo={{ tool: strippedTool }}
-      toolInput={EMPTY_TOOL_INPUT}
+      toolInput={effectiveInput}
       toolResult={toolResult}
       displayMode="fullscreen"
       minHeight={MCP_APP_DISPLAY_MODES.fullscreen.minHeight}
@@ -88,9 +91,11 @@ function AppRenderer({
 export function AppViewContent({
   connectionId,
   toolName,
+  toolInput,
 }: {
   connectionId: string;
   toolName: string;
+  toolInput?: Record<string, unknown>;
 }) {
   const { org } = useProjectContext();
   const client = useMCPClient({ connectionId, orgId: org.id });
@@ -118,6 +123,7 @@ export function AppViewContent({
       resourceURI={resourceURI}
       tool={tool}
       connectionId={connectionId}
+      toolInput={toolInput}
     />
   );
 }

--- a/apps/mesh/src/web/views/project/project-home.tsx
+++ b/apps/mesh/src/web/views/project/project-home.tsx
@@ -1,0 +1,165 @@
+/**
+ * ProjectHome — The file browser view when entering a project.
+ * Shows the project's files (artifacts) in a clean, visual layout.
+ * This is what users see first — their stuff, not settings.
+ */
+
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  BarChart12,
+  Globe04,
+  Plus,
+  PresentationChart01,
+} from "@untitledui/icons";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
+import {
+  getRecentArtifacts,
+  formatRelativeTime,
+  type Artifact,
+  type ArtifactType,
+} from "@/web/lib/mock-artifacts";
+import { useChatTask } from "@/web/components/chat/context";
+
+const FILE_ICON: Record<
+  ArtifactType,
+  {
+    Icon: typeof PresentationChart01;
+    color: string;
+    bg: string;
+    label: string;
+  }
+> = {
+  deck: {
+    Icon: PresentationChart01,
+    color: "#8B5CF6",
+    bg: "bg-violet-100 dark:bg-violet-900/40",
+    label: "Slide Deck",
+  },
+  report: {
+    Icon: BarChart12,
+    color: "#10B981",
+    bg: "bg-emerald-100 dark:bg-emerald-900/40",
+    label: "Report",
+  },
+  site: {
+    Icon: Globe04,
+    color: "#3B82F6",
+    bg: "bg-blue-100 dark:bg-blue-900/40",
+    label: "Website",
+  },
+};
+
+function FileCard({ artifact }: { artifact: Artifact }) {
+  const config = FILE_ICON[artifact.type];
+  const { Icon } = config;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center gap-3 p-3 rounded-xl text-left w-full",
+        "border border-border bg-card",
+        "transition-all hover:border-foreground/15 hover:shadow-sm cursor-pointer group",
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-center justify-center size-10 rounded-lg shrink-0",
+          config.bg,
+        )}
+      >
+        <Icon size={20} style={{ color: config.color }} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-foreground truncate">
+          {artifact.title}
+        </p>
+        <p className="text-xs text-muted-foreground truncate mt-0.5">
+          {config.label}
+        </p>
+      </div>
+      <span className="text-xs text-muted-foreground/60 shrink-0">
+        {formatRelativeTime(artifact.updatedAt)}
+      </span>
+    </button>
+  );
+}
+
+function EmptyFiles({ onCreateFirst }: { onCreateFirst: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="size-16 rounded-2xl bg-muted/50 flex items-center justify-center mb-4">
+        <Plus size={24} className="text-muted-foreground" />
+      </div>
+      <p className="text-sm font-medium text-foreground mb-1">No files yet</p>
+      <p className="text-xs text-muted-foreground max-w-[240px] mb-4">
+        Start a conversation to create slides, reports, or edit a site
+      </p>
+      <button
+        type="button"
+        onClick={onCreateFirst}
+        className="text-xs font-medium text-foreground bg-accent hover:bg-accent/80 px-3 py-1.5 rounded-md transition-colors"
+      >
+        Start working
+      </button>
+    </div>
+  );
+}
+
+export function ProjectHome({ virtualMcpId }: { virtualMcpId: string }) {
+  const entity = useVirtualMCP(virtualMcpId);
+  const { createTaskWithMessage } = useChatTask();
+
+  // For prototype: show mock artifacts (in real app, query project's MCP apps)
+  const files = getRecentArtifacts(10);
+
+  const handleStartWorking = () => {
+    createTaskWithMessage({
+      message: {
+        parts: [
+          {
+            type: "text",
+            text: "What can I help you create? I can make slide decks, run diagnostics, or help edit a site.",
+          },
+        ],
+      },
+    });
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-2xl mx-auto px-6 py-6">
+        {/* Project header */}
+        <div className="mb-6">
+          <h1 className="text-lg font-medium text-foreground">
+            {entity?.title ?? "Project"}
+          </h1>
+          {entity?.description && (
+            <p className="text-sm text-muted-foreground mt-0.5">
+              {entity.description}
+            </p>
+          )}
+        </div>
+
+        {/* Files */}
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Files
+            </h2>
+          </div>
+
+          {files.length === 0 ? (
+            <EmptyFiles onCreateFirst={handleStartWorking} />
+          ) : (
+            <div className="flex flex-col gap-2">
+              {files.map((artifact) => (
+                <FileCard key={artifact.id} artifact={artifact} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/views/project/project-settings.tsx
+++ b/apps/mesh/src/web/views/project/project-settings.tsx
@@ -1,0 +1,307 @@
+/**
+ * ProjectSettings — Simplified settings for a project.
+ * Just: name, icon, description, and which agents are assigned.
+ * No instructions, no connections, no layout — those belong to agents.
+ */
+
+import { Page } from "@/web/components/page";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import { IconPicker } from "@/web/components/icon-picker";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+import { AddAgentDialog } from "@/web/views/virtual-mcp/add-agent-dialog";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import { ChevronRight, Plus, Trash01 } from "@untitledui/icons";
+import {
+  useProjectContext,
+  useVirtualMCP,
+  useVirtualMCPActions,
+  useVirtualMCPs,
+} from "@decocms/mesh-sdk";
+import { useNavigate } from "@tanstack/react-router";
+import { Suspense, useState } from "react";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { toast } from "sonner";
+
+function AgentCard({
+  agentId,
+  orgSlug,
+  onRemove,
+}: {
+  agentId: string;
+  orgSlug: string;
+  onRemove: () => void;
+}) {
+  const agent = useVirtualMCP(agentId);
+  const navigate = useNavigate();
+
+  if (!agent) return null;
+
+  const connectionCount = agent.connections.length;
+
+  return (
+    <div className="flex items-center gap-3 p-3 rounded-xl border border-border">
+      <button
+        type="button"
+        onClick={() =>
+          navigate({
+            to: "/$org/$virtualMcpId",
+            params: { org: orgSlug, virtualMcpId: agent.id },
+            search: { main: "settings", mainOpen: 1 },
+          })
+        }
+        className="flex items-center gap-3 flex-1 min-w-0 text-left hover:opacity-80 transition-opacity cursor-pointer"
+      >
+        <AgentAvatar
+          icon={agent.icon}
+          name={agent.title}
+          size="sm"
+          className="shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {agent.title}
+          </p>
+          {connectionCount > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {connectionCount}{" "}
+              {connectionCount === 1 ? "connection" : "connections"}
+            </p>
+          )}
+        </div>
+        <ChevronRight size={16} className="text-muted-foreground shrink-0" />
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors shrink-0"
+        title="Remove from project"
+      >
+        <Trash01 size={14} />
+      </button>
+    </div>
+  );
+}
+
+function AgentCardSkeleton() {
+  return (
+    <div className="flex items-center gap-3 p-3 rounded-xl border border-border">
+      <Skeleton className="size-9 rounded-lg shrink-0" />
+      <div className="flex-1 space-y-1.5">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-3 w-20" />
+      </div>
+    </div>
+  );
+}
+
+export function ProjectSettings({ virtualMcpId }: { virtualMcpId: string }) {
+  const entity = useVirtualMCP(virtualMcpId);
+  const actions = useVirtualMCPActions();
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const allVirtualMcps = useVirtualMCPs();
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  if (!entity) return null;
+
+  // Identify which children are agents (Virtual MCPs)
+  const virtualMcpIds = new Set(allVirtualMcps.map((v) => v.id));
+  const agentChildren = entity.connections.filter((c) =>
+    virtualMcpIds.has(c.connection_id),
+  );
+  const addedAgentIds = new Set(agentChildren.map((c) => c.connection_id));
+
+  const handleAddAgent = async (agentId: string) => {
+    const current = entity.connections;
+    await actions.update.mutateAsync({
+      id: entity.id,
+      data: {
+        connections: [
+          ...current,
+          {
+            connection_id: agentId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+      },
+    });
+    toast.success("Agent added to project");
+  };
+
+  const handleRemoveAgent = async (agentId: string) => {
+    const current = entity.connections;
+    await actions.update.mutateAsync({
+      id: entity.id,
+      data: {
+        connections: current.filter((c) => c.connection_id !== agentId),
+      },
+    });
+    toast.success("Agent removed from project");
+  };
+
+  const handleUpdateTitle = async (title: string) => {
+    if (!title.trim()) return;
+    await actions.update.mutateAsync({
+      id: entity.id,
+      data: { title: title.trim() },
+    });
+  };
+
+  const handleUpdateDescription = async (description: string) => {
+    await actions.update.mutateAsync({
+      id: entity.id,
+      data: { description: description || null },
+    });
+  };
+
+  const handleIconChange = (icon: string | null) => {
+    actions.update.mutate({ id: entity.id, data: { icon } });
+  };
+
+  const handleDelete = async () => {
+    await actions.delete.mutateAsync(entity.id);
+    toast.success(`Deleted "${entity.title}"`);
+    navigate({ to: "/$org", params: { org: org.slug } });
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-2xl mx-auto px-6 py-6">
+        <Page.Title
+          actions={
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-destructive"
+              onClick={() => setDeleteDialogOpen(true)}
+            >
+              <Trash01 size={14} />
+            </Button>
+          }
+        >
+          Project Settings
+        </Page.Title>
+
+        {/* Basic info */}
+        <div className="mt-6 flex items-start gap-4">
+          <IconPicker
+            value={entity.icon}
+            onChange={handleIconChange}
+            name={entity.title || "Project"}
+            size="sm+"
+            className="shrink-0"
+            avatarClassName="[&_svg]:w-1/2 [&_svg]:h-1/2"
+          />
+          <div className="flex-1 flex flex-col gap-2">
+            <Input
+              defaultValue={entity.title}
+              onBlur={(e) => handleUpdateTitle(e.target.value)}
+              placeholder="Project name"
+              className="text-base font-medium"
+            />
+            <Input
+              defaultValue={entity.description ?? ""}
+              onBlur={(e) => handleUpdateDescription(e.target.value)}
+              placeholder="Add a description..."
+              className="text-sm"
+            />
+          </div>
+        </div>
+
+        {/* Agents section */}
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-medium text-foreground">Agents</h2>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAddDialogOpen(true)}
+            >
+              <Plus size={13} />
+              Add Agent
+            </Button>
+          </div>
+
+          {agentChildren.length === 0 ? (
+            <button
+              type="button"
+              onClick={() => setAddDialogOpen(true)}
+              className="flex items-center gap-3 px-3 py-4 rounded-xl border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
+            >
+              <div className="flex items-center justify-center size-9 rounded-lg text-muted-foreground/60 border border-dashed border-border shrink-0">
+                <Plus size={16} />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">No agents yet</p>
+                <p className="text-xs text-muted-foreground/60">
+                  Add agents to give this project capabilities
+                </p>
+              </div>
+            </button>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {agentChildren.map((conn) => (
+                <ErrorBoundary key={conn.connection_id} fallback={() => null}>
+                  <Suspense fallback={<AgentCardSkeleton />}>
+                    <AgentCard
+                      agentId={conn.connection_id}
+                      orgSlug={org.slug}
+                      onRemove={() => handleRemoveAgent(conn.connection_id)}
+                    />
+                  </Suspense>
+                </ErrorBoundary>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Dialogs */}
+      <AddAgentDialog
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        projectId={entity.id}
+        addedAgentIds={addedAgentIds}
+        onAdd={handleAddAgent}
+      />
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Project?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete{" "}
+              <span className="font-medium text-foreground">
+                {entity.title}
+              </span>{" "}
+              and all its tasks. Agents will not be deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/views/project/project-settings.tsx
+++ b/apps/mesh/src/web/views/project/project-settings.tsx
@@ -4,6 +4,7 @@
  * No instructions, no connections, no layout — those belong to agents.
  */
 
+import { cn } from "@deco/ui/lib/utils.ts";
 import { Page } from "@/web/components/page";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { IconPicker } from "@/web/components/icon-picker";
@@ -21,7 +22,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
-import { ChevronRight, Plus, Trash01 } from "@untitledui/icons";
+import { Check, ChevronRight, Plus, Trash01 } from "@untitledui/icons";
 import {
   useProjectContext,
   useVirtualMCP,
@@ -100,6 +101,128 @@ function AgentCardSkeleton() {
       <div className="flex-1 space-y-1.5">
         <Skeleton className="h-4 w-28" />
         <Skeleton className="h-3 w-20" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * LayoutSection — Shows which agent connections have UIs and lets
+ * the user set one as the default view for this project.
+ */
+function LayoutSection({
+  entity,
+  allVirtualMcps,
+}: {
+  entity: {
+    id: string;
+    connections: Array<{ connection_id: string }>;
+    metadata: Record<string, unknown>;
+  };
+  allVirtualMcps: Array<{
+    id: string;
+    title: string;
+    icon: string | null;
+    connections: Array<{ connection_id: string }>;
+  }>;
+}) {
+  const actions = useVirtualMCPActions();
+  const virtualMcpIds = new Set(allVirtualMcps.map((v) => v.id));
+
+  // Find all connections (non-virtual) across all agents in this project
+  const agentChildren = entity.connections.filter((c) =>
+    virtualMcpIds.has(c.connection_id),
+  );
+
+  // Collect all real connections from agents
+  const connectionEntries: Array<{
+    agentTitle: string;
+    connectionId: string;
+  }> = [];
+  for (const ac of agentChildren) {
+    const agent = allVirtualMcps.find((v) => v.id === ac.connection_id);
+    if (!agent) continue;
+    for (const conn of agent.connections) {
+      if (!virtualMcpIds.has(conn.connection_id)) {
+        connectionEntries.push({
+          agentTitle: agent.title,
+          connectionId: conn.connection_id,
+        });
+      }
+    }
+  }
+
+  // Get current default view
+  const currentDefault = (
+    entity.metadata?.ui as Record<string, unknown> | undefined
+  )?.layout as
+    | { defaultMainView?: { type: string; id?: string; toolName?: string } }
+    | undefined;
+  const currentDefaultId = currentDefault?.defaultMainView?.id;
+
+  const handleSetDefault = async (connectionId: string, toolName: string) => {
+    const isAlreadyDefault = currentDefaultId === connectionId;
+    await actions.update.mutateAsync({
+      id: entity.id,
+      data: {
+        metadata: {
+          ...entity.metadata,
+          instructions:
+            ((entity.metadata as Record<string, unknown>)?.instructions as
+              | string
+              | null) ?? null,
+          ui: {
+            ...(entity.metadata?.ui as Record<string, unknown> | undefined),
+            layout: {
+              defaultMainView: isAlreadyDefault
+                ? null
+                : { type: "ext-apps", id: connectionId, toolName },
+              chatDefaultOpen: true,
+            },
+          },
+        },
+      },
+    });
+  };
+
+  if (connectionEntries.length === 0) return null;
+
+  return (
+    <div className="mt-8">
+      <h2 className="text-sm font-medium text-foreground mb-3">Layout</h2>
+      <p className="text-xs text-muted-foreground mb-3">
+        Connections with UIs. Click to set as default view when opening this
+        project.
+      </p>
+      <div className="flex flex-col gap-1.5">
+        {connectionEntries.map((entry) => {
+          const isDefault = currentDefaultId === entry.connectionId;
+          return (
+            <button
+              key={entry.connectionId}
+              type="button"
+              onClick={() => handleSetDefault(entry.connectionId, "")}
+              className={cn(
+                "flex items-center gap-3 px-3 py-2.5 rounded-lg border text-left transition-colors w-full",
+                isDefault
+                  ? "border-foreground/20 bg-accent/50"
+                  : "border-border hover:bg-accent/30",
+              )}
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-foreground truncate">
+                  {entry.connectionId.slice(0, 20)}...
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  via {entry.agentTitle}
+                </p>
+              </div>
+              {isDefault && (
+                <Check size={14} className="text-foreground shrink-0" />
+              )}
+            </button>
+          );
+        })}
       </div>
     </div>
   );
@@ -268,6 +391,9 @@ export function ProjectSettings({ virtualMcpId }: { virtualMcpId: string }) {
             </div>
           )}
         </div>
+
+        {/* Layout section — which UIs are available, set default */}
+        <LayoutSection entity={entity} allVirtualMcps={allVirtualMcps} />
       </div>
 
       {/* Dialogs */}

--- a/apps/mesh/src/web/views/virtual-mcp/add-agent-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-agent-dialog.tsx
@@ -1,0 +1,168 @@
+/**
+ * AddAgentDialog — Browse existing Virtual MCPs to add as agents to a project,
+ * or create a new agent.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { CollectionSearch } from "@deco/ui/components/collection-search.tsx";
+import { Plus } from "@untitledui/icons";
+import { isDecopilot, useVirtualMCPs } from "@decocms/mesh-sdk";
+import { useState, Suspense } from "react";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+
+function AddAgentDialogContent({
+  projectId,
+  addedAgentIds,
+  onAdd,
+  onClose,
+}: {
+  projectId: string;
+  addedAgentIds: Set<string>;
+  onAdd: (agentId: string) => void;
+  onClose: () => void;
+}) {
+  const [search, setSearch] = useState("");
+  const allVirtualMcps = useVirtualMCPs();
+  const { createVirtualMCP, isCreating } = useCreateVirtualMCP({
+    navigateOnCreate: false,
+  });
+
+  const lowerSearch = search.toLowerCase();
+
+  // Show all Virtual MCPs except: decopilot, current project, already added
+  const available = allVirtualMcps.filter(
+    (v) =>
+      !isDecopilot(v.id) &&
+      v.id !== projectId &&
+      !addedAgentIds.has(v.id) &&
+      (!search || v.title.toLowerCase().includes(lowerSearch)),
+  );
+
+  const handleCreateAndAdd = async () => {
+    const result = await createVirtualMCP();
+    if (result?.id) {
+      onAdd(result.id);
+      onClose();
+    }
+  };
+
+  return (
+    <div className="flex flex-col max-h-[min(640px,80dvh)]">
+      <CollectionSearch
+        value={search}
+        onChange={setSearch}
+        placeholder="Search agents..."
+      />
+
+      <div className="overflow-y-auto flex-1 min-h-0 px-3 pb-3">
+        <div className="px-1 pt-3 pb-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            Available Agents
+          </span>
+        </div>
+        <div className="grid grid-cols-3 gap-1">
+          {/* Create new agent */}
+          <button
+            type="button"
+            disabled={isCreating}
+            onClick={handleCreateAndAdd}
+            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <div className="w-12 h-12 rounded-xl border-2 border-dashed border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
+              <Plus size={18} className="text-muted-foreground" />
+            </div>
+            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
+              Create new
+            </span>
+          </button>
+
+          {available.map((agent) => (
+            <button
+              key={agent.id}
+              type="button"
+              onClick={() => {
+                onAdd(agent.id);
+                onClose();
+              }}
+              className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group"
+            >
+              <AgentAvatar
+                icon={agent.icon}
+                name={agent.title}
+                size="md"
+                className="transition-transform group-hover:scale-105"
+              />
+              <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground line-clamp-2 w-full">
+                {agent.title}
+              </span>
+              {agent.connections.length > 0 && (
+                <span className="text-[10px] text-muted-foreground/60">
+                  {agent.connections.length}{" "}
+                  {agent.connections.length === 1
+                    ? "connection"
+                    : "connections"}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {available.length === 0 && !isCreating && (
+          <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
+            {search
+              ? "No agents found"
+              : "No available agents. Create a new one."}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AddAgentDialog({
+  open,
+  onOpenChange,
+  projectId,
+  addedAgentIds,
+  onAdd,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  addedAgentIds: Set<string>;
+  onAdd: (agentId: string) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn("sm:max-w-md p-0 overflow-hidden")}>
+        <DialogHeader className="px-6 pt-5 pb-0 shrink-0">
+          <DialogTitle className="text-base font-semibold">
+            Add Agent
+          </DialogTitle>
+        </DialogHeader>
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-8">
+              <Skeleton className="h-4 w-24" />
+            </div>
+          }
+        >
+          <AddAgentDialogContent
+            projectId={projectId}
+            addedAgentIds={addedAgentIds}
+            onAdd={onAdd}
+            onClose={() => onOpenChange(false)}
+          />
+        </Suspense>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -661,7 +661,7 @@ export function AddConnectionDialog({
       <DialogContent className="sm:max-w-5xl h-[85vh] max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden w-[95vw]">
         <DialogHeader className="px-6 pt-5 pb-0 shrink-0">
           <DialogTitle className="text-base font-semibold">
-            Add Agent
+            Add Connection
           </DialogTitle>
         </DialogHeader>
 

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -661,7 +661,7 @@ export function AddConnectionDialog({
       <DialogContent className="sm:max-w-5xl h-[85vh] max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden w-[95vw]">
         <DialogHeader className="px-6 pt-5 pb-0 shrink-0">
           <DialogTitle className="text-base font-semibold">
-            Add Connection
+            Add Agent
           </DialogTitle>
         </DialogHeader>
 

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -57,6 +57,7 @@ import {
   useProjectContext,
   useVirtualMCP,
   useVirtualMCPActions,
+  useVirtualMCPs,
 } from "@decocms/mesh-sdk";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -74,8 +75,10 @@ import { Suspense, useReducer, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { SimpleIconPicker } from "../../components/simple-icon-picker";
+import { AgentAvatar } from "@/web/components/agent-icon";
 import { Page } from "@/web/components/page";
 import { AddConnectionDialog } from "./add-connection-dialog";
+import { AddAgentDialog } from "./add-agent-dialog";
 import { DependencySelectionDialog } from "./dependency-selection-dialog";
 import { ALL_ITEMS_SELECTED } from "./selection-utils";
 import { VirtualMcpFormSchema, type VirtualMcpFormData } from "./types";
@@ -84,6 +87,7 @@ import { VirtualMCPShareModal } from "./virtual-mcp-share-modal";
 type DialogState = {
   shareDialogOpen: boolean;
   addDialogOpen: boolean;
+  addAgentDialogOpen: boolean;
   settingsDialogOpen: boolean;
   settingsConnectionId: string | null;
 };
@@ -91,6 +95,7 @@ type DialogState = {
 type DialogAction =
   | { type: "SET_SHARE_DIALOG_OPEN"; payload: boolean }
   | { type: "SET_ADD_DIALOG_OPEN"; payload: boolean }
+  | { type: "SET_ADD_AGENT_DIALOG_OPEN"; payload: boolean }
   | { type: "OPEN_SETTINGS"; payload: string }
   | { type: "CLOSE_SETTINGS" };
 
@@ -100,6 +105,8 @@ function dialogReducer(state: DialogState, action: DialogAction): DialogState {
       return { ...state, shareDialogOpen: action.payload };
     case "SET_ADD_DIALOG_OPEN":
       return { ...state, addDialogOpen: action.payload };
+    case "SET_ADD_AGENT_DIALOG_OPEN":
+      return { ...state, addAgentDialogOpen: action.payload };
     case "OPEN_SETTINGS":
       return {
         ...state,
@@ -476,6 +483,74 @@ function ConnectionItemSkeleton() {
       </div>
       <div className="flex items-center px-4 py-2 border-t border-border bg-muted/25">
         <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Agent Item — represents a child Virtual MCP inside a project
+// ---------------------------------------------------------------------------
+
+function AgentItem({
+  agentId,
+  onRemove,
+}: {
+  agentId: string;
+  onRemove: () => void;
+}) {
+  const agent = useVirtualMCP(agentId);
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+
+  if (!agent) return null;
+
+  const connectionCount = agent.connections.length;
+
+  return (
+    <div className="rounded-xl border border-border overflow-hidden">
+      <button
+        type="button"
+        onClick={() =>
+          navigate({
+            to: "/$org/$virtualMcpId",
+            params: { org: org.slug, virtualMcpId: agent.id },
+            search: { main: "settings", mainOpen: 1 },
+          })
+        }
+        className="flex items-center gap-3 px-4 py-3 w-full text-left hover:bg-accent/50 transition-colors cursor-pointer"
+      >
+        <AgentAvatar
+          icon={agent.icon}
+          name={agent.title}
+          size="sm"
+          className="shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {agent.title}
+          </p>
+          <p className="text-xs text-muted-foreground truncate">
+            {agent.description || "No description"}
+          </p>
+        </div>
+        {connectionCount > 0 && (
+          <span className="text-xs text-muted-foreground shrink-0 tabular-nums">
+            {connectionCount}{" "}
+            {connectionCount === 1 ? "connection" : "connections"}
+          </span>
+        )}
+        <ChevronRight size={16} className="text-muted-foreground shrink-0" />
+      </button>
+      <div className="flex items-center justify-end px-4 py-1.5 border-t border-border bg-muted/25">
+        <button
+          type="button"
+          onClick={onRemove}
+          className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+          title="Remove agent from project"
+        >
+          <Trash01 size={14} />
+        </button>
       </div>
     </div>
   );
@@ -1037,10 +1112,22 @@ function VirtualMcpDetailViewWithData({
   // Watch connections for reactive UI
   const connections = form.watch("connections");
 
+  // Identify which children are Virtual MCPs (agents) vs regular connections
+  const allVirtualMcps = useVirtualMCPs();
+  const virtualMcpIds = new Set(allVirtualMcps.map((v) => v.id));
+  const agentConnections = connections.filter((c) =>
+    virtualMcpIds.has(c.connection_id),
+  );
+  const regularConnections = connections.filter(
+    (c) => !virtualMcpIds.has(c.connection_id),
+  );
+  const addedAgentIds = new Set(agentConnections.map((c) => c.connection_id));
+
   // Dialog states
   const [dialogState, dispatch] = useReducer(dialogReducer, {
     shareDialogOpen: false,
     addDialogOpen: false,
+    addAgentDialogOpen: false,
     settingsDialogOpen: false,
     settingsConnectionId: null,
   });
@@ -1438,14 +1525,21 @@ Define step-by-step how the agent should handle requests.
                 }}
               />
               {activeTab === "connections" && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleOpenAddDialog}
-                >
-                  <Plus size={13} />
-                  Add
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      dispatch({
+                        type: "SET_ADD_AGENT_DIALOG_OPEN",
+                        payload: true,
+                      })
+                    }
+                  >
+                    <Plus size={13} />
+                    Add Agent
+                  </Button>
+                </div>
               )}
               {activeTab === "instructions" && (
                 <div className="flex items-center gap-2">
@@ -1489,11 +1583,17 @@ Define step-by-step how the agent should handle requests.
             )}
 
             {activeTab === "connections" && (
-              <div className="flex flex-col gap-2">
-                {connections.length === 0 ? (
+              <div className="flex flex-col gap-4">
+                {/* Agents section */}
+                {agentConnections.length === 0 ? (
                   <button
                     type="button"
-                    onClick={handleOpenAddDialog}
+                    onClick={() =>
+                      dispatch({
+                        type: "SET_ADD_AGENT_DIALOG_OPEN",
+                        payload: true,
+                      })
+                    }
                     className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-dashed border-border hover:bg-accent/50 transition-colors w-full text-left cursor-pointer"
                   >
                     <div className="flex items-center justify-center size-8 rounded-md text-muted-foreground/75 border border-dashed border-border shrink-0">
@@ -1504,30 +1604,67 @@ Define step-by-step how the agent should handle requests.
                     </span>
                   </button>
                 ) : (
-                  connections.map((conn) => (
-                    <ErrorBoundary
-                      key={conn.connection_id}
-                      fallback={() => null}
-                    >
-                      <Suspense fallback={<ConnectionItemSkeleton />}>
-                        <ConnectionItem
-                          connection_id={conn.connection_id}
-                          usedConnectionIds={addedConnectionIds}
-                          onOpenSettings={() =>
-                            handleOpenSettings(conn.connection_id)
-                          }
-                          onRemove={() =>
-                            handleRemoveConnection(conn.connection_id)
-                          }
-                          onAuthenticate={handleAuthenticate}
-                          onSwitchInstance={handleSwitchInstance}
-                          onNewInstance={() =>
-                            handleNewInstance(conn.connection_id)
-                          }
-                        />
-                      </Suspense>
-                    </ErrorBoundary>
-                  ))
+                  <div className="flex flex-col gap-2">
+                    {agentConnections.map((conn) => (
+                      <ErrorBoundary
+                        key={conn.connection_id}
+                        fallback={() => null}
+                      >
+                        <Suspense fallback={<ConnectionItemSkeleton />}>
+                          <AgentItem
+                            agentId={conn.connection_id}
+                            onRemove={() =>
+                              handleRemoveConnection(conn.connection_id)
+                            }
+                          />
+                        </Suspense>
+                      </ErrorBoundary>
+                    ))}
+                  </div>
+                )}
+
+                {/* Regular connections (shown separately if any exist) */}
+                {regularConnections.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        Direct Connections
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleOpenAddDialog}
+                        className="h-6 text-xs"
+                      >
+                        <Plus size={12} />
+                        Add
+                      </Button>
+                    </div>
+                    {regularConnections.map((conn) => (
+                      <ErrorBoundary
+                        key={conn.connection_id}
+                        fallback={() => null}
+                      >
+                        <Suspense fallback={<ConnectionItemSkeleton />}>
+                          <ConnectionItem
+                            connection_id={conn.connection_id}
+                            usedConnectionIds={addedConnectionIds}
+                            onOpenSettings={() =>
+                              handleOpenSettings(conn.connection_id)
+                            }
+                            onRemove={() =>
+                              handleRemoveConnection(conn.connection_id)
+                            }
+                            onAuthenticate={handleAuthenticate}
+                            onSwitchInstance={handleSwitchInstance}
+                            onNewInstance={() =>
+                              handleNewInstance(conn.connection_id)
+                            }
+                          />
+                        </Suspense>
+                      </ErrorBoundary>
+                    ))}
+                  </div>
                 )}
               </div>
             )}
@@ -1570,6 +1707,16 @@ Define step-by-step how the agent should handle requests.
           dispatch({ type: "SET_ADD_DIALOG_OPEN", payload: open })
         }
         addedConnectionIds={addedConnectionIds}
+        onAdd={handleAddConnection}
+      />
+
+      <AddAgentDialog
+        open={dialogState.addAgentDialogOpen}
+        onOpenChange={(open) =>
+          dispatch({ type: "SET_ADD_AGENT_DIALOG_OPEN", payload: open })
+        }
+        projectId={virtualMcp.id}
+        addedAgentIds={addedAgentIds}
         onAdd={handleAddConnection}
       />
 

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -893,8 +893,8 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
         <CardContent className="p-0">
           {noConnections && (
             <p className="text-sm text-muted-foreground">
-              No connections yet. Add connections in the Connections tab to
-              configure pinned views.
+              No agents yet. Add agents in the Agents tab to configure pinned
+              views.
             </p>
           )}
           {noInteractiveTools && !noConnections && (
@@ -1362,7 +1362,7 @@ Define step-by-step how the agent should handle requests.
     },
     {
       id: "connections",
-      label: "Connections",
+      label: "Agents",
       count: connections.length || undefined,
     },
     { id: "layout", label: "Layout" },
@@ -1378,7 +1378,7 @@ Define step-by-step how the agent should handle requests.
                 <div className="flex items-center gap-2">
                   <Button variant="outline" size="sm" onClick={handleTestAgent}>
                     <Play size={14} className="!size-[14px]" />
-                    Test Agent
+                    Test
                   </Button>
                   <Button
                     variant="outline"
@@ -1500,7 +1500,7 @@ Define step-by-step how the agent should handle requests.
                       <Plus size={16} />
                     </div>
                     <span className="text-sm text-muted-foreground">
-                      No connections yet. Add one to get started.
+                      No agents yet. Add one to get started.
                     </span>
                   </button>
                 ) : (
@@ -1543,7 +1543,7 @@ Define step-by-step how the agent should handle requests.
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Agent?</AlertDialogTitle>
+            <AlertDialogTitle>Delete Project?</AlertDialogTitle>
             <AlertDialogDescription>
               This action cannot be undone. This will permanently delete{" "}
               <span className="font-medium text-foreground">


### PR DESCRIPTION
Exploration of projects, folders, file system and agents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a project-centric, file‑first UX: projects contain agents, open to a Files view with a new content toolbar, and the tasks panel now shows all tasks across projects. The home screen adds quick actions (e.g., New Project, New Slides) that create scoped projects and route users into the right UI.

- **New Features**
  - Projects: new entity type with a Files home, simplified settings (name, icon, description, agents), and a Layout section to pick a default tool UI.
  - Content Toolbar: shows Files plus tool UIs from project agents; projects default to Files; panels reordered to [Tasks | Chat | Content].
  - Tasks panel: unified list across all projects with project badges; filter/group by project or status; clicking a task navigates to its project and restores the saved view; per-task layout persisted locally.
  - Quick Actions: home replaces agent list with actions like New Project, New Diagnostic, New Site, and one‑click New Slides (creates connection, agent, project, and default view).
  - Agent scoping: chat agent selector is limited to the current project’s agents; sidebar hover exposes a settings icon for projects.
  - Tool input: thread `toolInput` from project metadata into app rendering to open a specific resource (e.g., a slide deck).
  - Seed script: `apps/mesh/scripts/seed-slide-project.ts` creates a slides project locally for demos.

- **Refactors**
  - Sidebar shows only top‑level projects; agents live inside project settings.
  - `useTasks` supports an empty `virtualMcpId` to fetch all tasks unfiltered.
  - Default panel state: projects open main+chat; org home opens tasks by default.
  - New components and utilities for the file browser and layout persistence (`ArtifactCard`, `FolderCard`, `FileBrowserHome`, `FolderView`, `ContentToolbar`, `task-layout-store`, mock artifacts).

<sup>Written for commit 90dc4fcb89d1c88693cc98b494d44e40f4de4359. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

