### PR TITLE
feat(chat): add voice input with real-time transcription

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -334,7 +334,8 @@ export function ChatInput({
   };
 
   const handleVoiceConfirm = () => {
-    voice.stopRecording();
+    const finalText = voice.stopRecording();
+    tiptapRef.current?.syncVoiceText(voiceBaselineDocRef.current, finalText);
     tiptapRef.current?.focus();
   };
 

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -20,6 +20,7 @@ import {
   ChevronDown,
   Edit01,
   Lock01,
+  Microphone01,
   Plus,
   Stop,
   Upload01,
@@ -55,6 +56,8 @@ import { useSound } from "@/web/hooks/use-sound.ts";
 import { question004Sound } from "@deco/ui/lib/question-004.ts";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { ConnectionsBanner } from "./connections-banner";
+import { useVoiceInput } from "@/web/hooks/use-voice-input.ts";
+import { VoiceInputOverlay } from "./voice-input";
 
 // ============================================================================
 // VirtualMCPBadge - Internal component for displaying selected virtual MCP
@@ -321,6 +324,24 @@ export function ChatInput({
   const playSwitchSound = useSound(question004Sound);
   const [connectionsOpen, setConnectionsOpen] = useState(false);
 
+  const voice = useVoiceInput();
+
+  const handleVoiceStart = async () => {
+    await voice.startRecording();
+  };
+
+  const handleVoiceConfirm = () => {
+    const text = voice.stopRecording();
+    if (text.trim()) {
+      tiptapRef.current?.appendText(text.trim());
+      setTimeout(() => tiptapRef.current?.focus(), 0);
+    }
+  };
+
+  const handleVoiceCancel = () => {
+    voice.cancelRecording();
+  };
+
   // Navigate to the agent route (like the sidebar does) instead of only
   // setting an ephemeral search-param override, so the thread list re-scopes.
   const handleAgentChange = (virtualMcpId: string | null) => {
@@ -537,104 +558,149 @@ export function ChatInput({
                 <FileDropZone selectedModel={selectedModel} />
 
                 <div className="group/input relative flex flex-col gap-2 flex-1">
-                  {/* Input Area with Tiptap */}
-                  <TiptapInput
-                    ref={tiptapRef}
-                    disabled={isStreaming || !selectedModel}
-                    virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
-                    showFileUploader={true}
-                    selectedModel={selectedModel}
-                  />
+                  {/* Voice recording overlay */}
+                  {voice.status === "recording" ? (
+                    <VoiceInputOverlay
+                      waveformData={voice.waveformData}
+                      transcript={voice.transcript}
+                      interimTranscript={voice.interimTranscript}
+                      onCancel={handleVoiceCancel}
+                      onConfirm={handleVoiceConfirm}
+                    />
+                  ) : (
+                    /* Input Area with Tiptap */
+                    <TiptapInput
+                      ref={tiptapRef}
+                      disabled={isStreaming || !selectedModel}
+                      virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
+                      showFileUploader={true}
+                      selectedModel={selectedModel}
+                    />
+                  )}
                 </div>
 
                 {/* Bottom Actions Row */}
                 <div className="flex items-center justify-between p-2.5 gap-1">
                   {/* Left Actions (+, Tools, active tool pills, stats) */}
                   <div className="flex items-center gap-1.5 min-w-0 shrink-0">
-                    <FileUploadButton
-                      selectedModel={selectedModel}
-                      isStreaming={isStreaming}
-                      icon={<Plus size={16} />}
-                    />
-                    <ToolsPopover
-                      disabled={isStreaming}
-                      onOpenConnections={() => setConnectionsOpen(true)}
-                      virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
-                      isAgentContext={hasAgentBadge}
-                    />
-                    {isPlanMode && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          playSwitchSound();
-                          setPreferences({
-                            ...preferences,
-                            toolApprovalLevel: "auto",
-                          });
-                        }}
-                        className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
-                      >
-                        <BookOpen01 size={14} className="shrink-0" />
-                        Plan mode
-                        <X
-                          size={14}
-                          className="shrink-0 hidden group-hover:block"
+                    {voice.status !== "recording" && (
+                      <>
+                        <FileUploadButton
+                          selectedModel={selectedModel}
+                          isStreaming={isStreaming}
+                          icon={<Plus size={16} />}
                         />
-                      </button>
-                    )}
-                    {contextWindow && lastTotalTokens > 0 && (
-                      <SessionStats
-                        usage={usage}
-                        totalTokens={lastTotalTokens}
-                        contextWindow={contextWindow}
-                        onOpenContextPanel={onOpenContextPanel}
-                      />
+                        <ToolsPopover
+                          disabled={isStreaming}
+                          onOpenConnections={() => setConnectionsOpen(true)}
+                          virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
+                          isAgentContext={hasAgentBadge}
+                        />
+                        {isPlanMode && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              playSwitchSound();
+                              setPreferences({
+                                ...preferences,
+                                toolApprovalLevel: "auto",
+                              });
+                            }}
+                            className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
+                          >
+                            <BookOpen01 size={14} className="shrink-0" />
+                            Plan mode
+                            <X
+                              size={14}
+                              className="shrink-0 hidden group-hover:block"
+                            />
+                          </button>
+                        )}
+                        {contextWindow && lastTotalTokens > 0 && (
+                          <SessionStats
+                            usage={usage}
+                            totalTokens={lastTotalTokens}
+                            contextWindow={contextWindow}
+                            onOpenContextPanel={onOpenContextPanel}
+                          />
+                        )}
+                      </>
                     )}
                   </div>
 
-                  {/* Right Actions (model, send) */}
+                  {/* Right Actions (mic, model, send) */}
                   <div className="flex items-center gap-1.5 min-w-0">
-                    <ModelSelector
-                      placeholder="Model"
-                      variant="borderless"
-                      className="h-8 text-sm py-2 min-w-0"
-                    />
+                    {voice.status !== "recording" && (
+                      <ModelSelector
+                        placeholder="Model"
+                        variant="borderless"
+                        className="h-8 text-sm py-2 min-w-0"
+                      />
+                    )}
 
-                    <Button
-                      type={showStopOrCancel ? "button" : "submit"}
-                      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                        if (showStopOrCancel) {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          if (isStreaming) stop();
-                          else stop();
+                    {/* Microphone button — only shown when not streaming and speech is supported */}
+                    {voice.isSupported &&
+                      !isStreaming &&
+                      !isRunInProgress &&
+                      voice.status !== "recording" && (
+                        <Button
+                          type="button"
+                          onClick={handleVoiceStart}
+                          variant="ghost"
+                          size="icon"
+                          className={cn(
+                            "size-8 rounded-lg transition-colors",
+                            voice.status === "permission-denied"
+                              ? "text-destructive hover:text-destructive hover:bg-destructive/10"
+                              : "text-muted-foreground hover:text-foreground",
+                          )}
+                          title={
+                            voice.status === "permission-denied"
+                              ? "Microphone access denied — click to try again"
+                              : "Voice input"
+                          }
+                        >
+                          <Microphone01 size={18} />
+                        </Button>
+                      )}
+
+                    {voice.status !== "recording" && (
+                      <Button
+                        type={showStopOrCancel ? "button" : "submit"}
+                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                          if (showStopOrCancel) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            if (isStreaming) stop();
+                            else stop();
+                          }
+                        }}
+                        variant={
+                          canSubmit || showStopOrCancel ? "default" : "ghost"
                         }
-                      }}
-                      variant={
-                        canSubmit || showStopOrCancel ? "default" : "ghost"
-                      }
-                      size="icon"
-                      disabled={!canSubmit && !showStopOrCancel}
-                      className={cn(
-                        "size-8 rounded-lg transition-all",
-                        !canSubmit &&
-                          !showStopOrCancel &&
-                          "bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground cursor-not-allowed",
-                      )}
-                      title={
-                        isStreaming
-                          ? "Stop generating"
-                          : isRunInProgress
-                            ? "Cancel run"
-                            : "Send message (Enter)"
-                      }
-                    >
-                      {showStopOrCancel ? (
-                        <Stop size={20} />
-                      ) : (
-                        <ArrowUp size={20} />
-                      )}
-                    </Button>
+                        size="icon"
+                        disabled={!canSubmit && !showStopOrCancel}
+                        className={cn(
+                          "size-8 rounded-lg transition-all",
+                          !canSubmit &&
+                            !showStopOrCancel &&
+                            "bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground cursor-not-allowed",
+                        )}
+                        title={
+                          isStreaming
+                            ? "Stop generating"
+                            : isRunInProgress
+                              ? "Cancel run"
+                              : "Send message (Enter)"
+                        }
+                      >
+                        {showStopOrCancel ? (
+                          <Stop size={20} />
+                        ) : (
+                          <ArrowUp size={20} />
+                        )}
+                      </Button>
+                    )}
                   </div>
                 </div>
               </form>

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -17,6 +17,7 @@ import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import {
   ArrowUp,
   BookOpen01,
+  Check,
   ChevronDown,
   Edit01,
   Lock01,
@@ -57,7 +58,7 @@ import { question004Sound } from "@deco/ui/lib/question-004.ts";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { ConnectionsBanner } from "./connections-banner";
 import { useVoiceInput } from "@/web/hooks/use-voice-input.ts";
-import { VoiceInputOverlay } from "./voice-input";
+import { VoiceWaveform } from "./voice-input";
 
 // ============================================================================
 // VirtualMCPBadge - Internal component for displaying selected virtual MCP
@@ -325,22 +326,33 @@ export function ChatInput({
   const [connectionsOpen, setConnectionsOpen] = useState(false);
 
   const voice = useVoiceInput();
+  const voiceBaselineDocRef = useRef<Metadata["tiptapDoc"]>(undefined);
 
   const handleVoiceStart = async () => {
+    voiceBaselineDocRef.current = tiptapDoc;
     await voice.startRecording();
   };
 
   const handleVoiceConfirm = () => {
-    const text = voice.stopRecording();
-    if (text.trim()) {
-      tiptapRef.current?.appendText(text.trim());
-      setTimeout(() => tiptapRef.current?.focus(), 0);
-    }
+    voice.stopRecording();
+    tiptapRef.current?.focus();
   };
 
   const handleVoiceCancel = () => {
     voice.cancelRecording();
+    tiptapRef.current?.restoreContent(voiceBaselineDocRef.current);
   };
+
+  // Sync live transcript into the editor while recording
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    if (voice.status !== "recording") return;
+    const voiceText = (
+      voice.transcript +
+      (voice.interimTranscript ? " " + voice.interimTranscript : "")
+    ).trim();
+    tiptapRef.current?.syncVoiceText(voiceBaselineDocRef.current, voiceText);
+  }, [voice.transcript, voice.interimTranscript, voice.status]);
 
   // Navigate to the agent route (like the sidebar does) instead of only
   // setting an ephemeral search-param override, so the thread list re-scopes.
@@ -558,33 +570,51 @@ export function ChatInput({
                 <FileDropZone selectedModel={selectedModel} />
 
                 <div className="group/input relative flex flex-col gap-2 flex-1">
-                  {/* Voice recording overlay */}
-                  {voice.status === "recording" ? (
-                    <VoiceInputOverlay
-                      waveformData={voice.waveformData}
-                      transcript={voice.transcript}
-                      interimTranscript={voice.interimTranscript}
-                      onCancel={handleVoiceCancel}
-                      onConfirm={handleVoiceConfirm}
-                    />
-                  ) : (
-                    /* Input Area with Tiptap */
-                    <TiptapInput
-                      ref={tiptapRef}
-                      disabled={isStreaming || !selectedModel}
-                      virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
-                      showFileUploader={true}
-                      selectedModel={selectedModel}
-                    />
-                  )}
+                  <TiptapInput
+                    ref={tiptapRef}
+                    disabled={
+                      isStreaming ||
+                      !selectedModel ||
+                      voice.status === "recording"
+                    }
+                    virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
+                    showFileUploader={true}
+                    selectedModel={selectedModel}
+                  />
                 </div>
 
                 {/* Bottom Actions Row */}
                 <div className="flex items-center justify-between p-2.5 gap-1">
-                  {/* Left Actions (+, Tools, active tool pills, stats) */}
-                  <div className="flex items-center gap-1.5 min-w-0 shrink-0">
-                    {voice.status !== "recording" && (
-                      <>
+                  {voice.status === "recording" ? (
+                    <>
+                      {/* Spacer */}
+                      <div className="flex-1" />
+
+                      {/* Waveform + Cancel + Confirm */}
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        <VoiceWaveform data={voice.waveformData.slice(0, 28)} />
+                        <button
+                          type="button"
+                          onClick={handleVoiceCancel}
+                          className="flex items-center justify-center size-8 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                          aria-label="Cancel recording"
+                        >
+                          <X size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleVoiceConfirm}
+                          className="flex items-center justify-center size-8 rounded-lg bg-foreground text-background hover:opacity-80 transition-opacity"
+                          aria-label="Use transcription"
+                        >
+                          <Check size={16} />
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      {/* Left Actions (+, Tools, active tool pills, stats) */}
+                      <div className="flex items-center gap-1.5 min-w-0 shrink-0">
                         <FileUploadButton
                           selectedModel={selectedModel}
                           isStreaming={isStreaming}
@@ -624,84 +654,79 @@ export function ChatInput({
                             onOpenContextPanel={onOpenContextPanel}
                           />
                         )}
-                      </>
-                    )}
-                  </div>
+                      </div>
 
-                  {/* Right Actions (mic, model, send) */}
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    {voice.status !== "recording" && (
-                      <ModelSelector
-                        placeholder="Model"
-                        variant="borderless"
-                        className="h-8 text-sm py-2 min-w-0"
-                      />
-                    )}
+                      {/* Right Actions (mic, model, send) */}
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <ModelSelector
+                          placeholder="Model"
+                          variant="borderless"
+                          className="h-8 text-sm py-2 min-w-0"
+                        />
 
-                    {/* Microphone button — only shown when not streaming and speech is supported */}
-                    {voice.isSupported &&
-                      !isStreaming &&
-                      !isRunInProgress &&
-                      voice.status !== "recording" && (
+                        {/* Microphone button — only shown when not streaming and speech is supported */}
+                        {voice.isSupported &&
+                          !isStreaming &&
+                          !isRunInProgress && (
+                            <Button
+                              type="button"
+                              onClick={handleVoiceStart}
+                              variant="ghost"
+                              size="icon"
+                              className={cn(
+                                "size-8 rounded-lg transition-colors",
+                                voice.status === "permission-denied"
+                                  ? "text-destructive hover:text-destructive hover:bg-destructive/10"
+                                  : "text-muted-foreground hover:text-foreground",
+                              )}
+                              title={
+                                voice.status === "permission-denied"
+                                  ? "Microphone access denied — click to try again"
+                                  : "Voice input"
+                              }
+                            >
+                              <Microphone01 size={18} />
+                            </Button>
+                          )}
+
                         <Button
-                          type="button"
-                          onClick={handleVoiceStart}
-                          variant="ghost"
+                          type={showStopOrCancel ? "button" : "submit"}
+                          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                            if (showStopOrCancel) {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              if (isStreaming) stop();
+                              else stop();
+                            }
+                          }}
+                          variant={
+                            canSubmit || showStopOrCancel ? "default" : "ghost"
+                          }
                           size="icon"
+                          disabled={!canSubmit && !showStopOrCancel}
                           className={cn(
-                            "size-8 rounded-lg transition-colors",
-                            voice.status === "permission-denied"
-                              ? "text-destructive hover:text-destructive hover:bg-destructive/10"
-                              : "text-muted-foreground hover:text-foreground",
+                            "size-8 rounded-lg transition-all",
+                            !canSubmit &&
+                              !showStopOrCancel &&
+                              "bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground cursor-not-allowed",
                           )}
                           title={
-                            voice.status === "permission-denied"
-                              ? "Microphone access denied — click to try again"
-                              : "Voice input"
+                            isStreaming
+                              ? "Stop generating"
+                              : isRunInProgress
+                                ? "Cancel run"
+                                : "Send message (Enter)"
                           }
                         >
-                          <Microphone01 size={18} />
+                          {showStopOrCancel ? (
+                            <Stop size={20} />
+                          ) : (
+                            <ArrowUp size={20} />
+                          )}
                         </Button>
-                      )}
-
-                    {voice.status !== "recording" && (
-                      <Button
-                        type={showStopOrCancel ? "button" : "submit"}
-                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                          if (showStopOrCancel) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (isStreaming) stop();
-                            else stop();
-                          }
-                        }}
-                        variant={
-                          canSubmit || showStopOrCancel ? "default" : "ghost"
-                        }
-                        size="icon"
-                        disabled={!canSubmit && !showStopOrCancel}
-                        className={cn(
-                          "size-8 rounded-lg transition-all",
-                          !canSubmit &&
-                            !showStopOrCancel &&
-                            "bg-muted text-muted-foreground hover:bg-muted hover:text-muted-foreground cursor-not-allowed",
-                        )}
-                        title={
-                          isStreaming
-                            ? "Stop generating"
-                            : isRunInProgress
-                              ? "Cancel run"
-                              : "Send message (Enter)"
-                        }
-                      >
-                        {showStopOrCancel ? (
-                          <Stop size={20} />
-                        ) : (
-                          <ArrowUp size={20} />
-                        )}
-                      </Button>
-                    )}
-                  </div>
+                      </div>
+                    </>
+                  )}
                 </div>
               </form>
             </TiptapProvider>

--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -41,6 +41,8 @@ export interface TiptapInputHandle {
   focus: () => void;
   clear: () => void;
   appendText: (text: string) => void;
+  syncVoiceText: (baseline: Metadata["tiptapDoc"], voiceText: string) => void;
+  restoreContent: (baseline: Metadata["tiptapDoc"]) => void;
 }
 
 interface TiptapProviderProps {
@@ -188,6 +190,18 @@ export function TiptapInput({
           editor.commands.insertContent(" ");
         }
         editor.commands.insertContent(text);
+      },
+      syncVoiceText: (baseline: Metadata["tiptapDoc"], voiceText: string) => {
+        if (!editor) return;
+        editor.commands.setContent(baseline || { type: "doc", content: [] });
+        if (voiceText) {
+          editor.commands.focus("end");
+          editor.commands.insertContent(voiceText);
+        }
+      },
+      restoreContent: (baseline: Metadata["tiptapDoc"]) => {
+        if (!editor) return;
+        editor.commands.setContent(baseline || { type: "doc", content: [] });
       },
     }),
     [editor],

--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -196,7 +196,10 @@ export function TiptapInput({
         editor.commands.setContent(baseline || { type: "doc", content: [] });
         if (voiceText) {
           editor.commands.focus("end");
-          editor.commands.insertContent(voiceText);
+          const hasBaseline = editor.state.doc.textContent.trim().length > 0;
+          editor.commands.insertContent(
+            hasBaseline ? " " + voiceText : voiceText,
+          );
         }
       },
       restoreContent: (baseline: Metadata["tiptapDoc"]) => {

--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -40,6 +40,7 @@ function buildExtensions(placeholderRef: React.RefObject<string | undefined>) {
 export interface TiptapInputHandle {
   focus: () => void;
   clear: () => void;
+  appendText: (text: string) => void;
 }
 
 interface TiptapProviderProps {
@@ -178,6 +179,15 @@ export function TiptapInput({
       },
       clear: () => {
         editor?.commands.clearContent(true);
+      },
+      appendText: (text: string) => {
+        if (!editor) return;
+        const isEmpty = editor.state.doc.textContent.trim() === "";
+        editor.commands.focus("end");
+        if (!isEmpty) {
+          editor.commands.insertContent(" ");
+        }
+        editor.commands.insertContent(text);
       },
     }),
     [editor],

--- a/apps/mesh/src/web/components/chat/voice-input.tsx
+++ b/apps/mesh/src/web/components/chat/voice-input.tsx
@@ -1,0 +1,100 @@
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Check, X } from "@untitledui/icons";
+
+// ============================================================================
+// VoiceWaveform - Animated waveform visualization
+// ============================================================================
+
+interface VoiceWaveformProps {
+  data: number[];
+}
+
+function VoiceWaveform({ data }: VoiceWaveformProps) {
+  return (
+    <div
+      className="flex items-center justify-center gap-[2px] flex-1 h-7 overflow-hidden"
+      aria-hidden="true"
+    >
+      {data.map((amp, i) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: static bars
+          key={i}
+          className="w-[2px] shrink-0 rounded-full bg-foreground/60 transition-[height] duration-75 ease-out"
+          style={{ height: `${Math.max(3, Math.round(amp * 28))}px` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// VoiceInputOverlay - Recording UI shown inside the chat form
+// ============================================================================
+
+export interface VoiceInputOverlayProps {
+  waveformData: number[];
+  transcript: string;
+  interimTranscript: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  className?: string;
+}
+
+export function VoiceInputOverlay({
+  waveformData,
+  transcript,
+  interimTranscript,
+  onCancel,
+  onConfirm,
+  className,
+}: VoiceInputOverlayProps) {
+  const displayText =
+    transcript + (interimTranscript ? " " + interimTranscript : "");
+  const hasText = displayText.trim().length > 0;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-2 w-full min-h-[52px]",
+        className,
+      )}
+    >
+      {/* Waveform or transcript text */}
+      <div className="flex items-center flex-1 min-w-0 overflow-hidden">
+        {hasText ? (
+          <p className="text-sm text-foreground/80 truncate leading-relaxed">
+            <span>{transcript}</span>
+            {interimTranscript && (
+              <span className="text-muted-foreground">
+                {" "}
+                {interimTranscript}
+              </span>
+            )}
+          </p>
+        ) : (
+          <VoiceWaveform data={waveformData} />
+        )}
+      </div>
+
+      {/* Cancel button */}
+      <button
+        type="button"
+        onClick={onCancel}
+        className="shrink-0 flex items-center justify-center size-7 rounded-full hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="Cancel recording"
+      >
+        <X size={15} />
+      </button>
+
+      {/* Confirm button */}
+      <button
+        type="button"
+        onClick={onConfirm}
+        className="shrink-0 flex items-center justify-center size-7 rounded-full bg-foreground text-background hover:opacity-80 transition-opacity"
+        aria-label="Use transcription"
+      >
+        <Check size={15} />
+      </button>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/chat/voice-input.tsx
+++ b/apps/mesh/src/web/components/chat/voice-input.tsx
@@ -9,18 +9,18 @@ interface VoiceWaveformProps {
   data: number[];
 }
 
-function VoiceWaveform({ data }: VoiceWaveformProps) {
+export function VoiceWaveform({ data }: VoiceWaveformProps) {
   return (
     <div
-      className="flex items-center justify-center gap-[2px] flex-1 h-7 overflow-hidden"
+      className="flex items-center justify-center gap-[2px] h-10 overflow-hidden"
       aria-hidden="true"
     >
       {data.map((amp, i) => (
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: static bars
           key={i}
-          className="w-[2px] shrink-0 rounded-full bg-foreground/60 transition-[height] duration-75 ease-out"
-          style={{ height: `${Math.max(3, Math.round(amp * 28))}px` }}
+          className="w-[2px] shrink-0 rounded-full bg-chart-2 transition-[height] duration-75 ease-out"
+          style={{ height: `${Math.max(4, Math.round(amp * 40))}px` }}
         />
       ))}
     </div>

--- a/apps/mesh/src/web/components/chat/voice-input.tsx
+++ b/apps/mesh/src/web/components/chat/voice-input.tsx
@@ -1,6 +1,3 @@
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Check, X } from "@untitledui/icons";
-
 // ============================================================================
 // VoiceWaveform - Animated waveform visualization
 // ============================================================================
@@ -23,78 +20,6 @@ export function VoiceWaveform({ data }: VoiceWaveformProps) {
           style={{ height: `${Math.max(4, Math.round(amp * 40))}px` }}
         />
       ))}
-    </div>
-  );
-}
-
-// ============================================================================
-// VoiceInputOverlay - Recording UI shown inside the chat form
-// ============================================================================
-
-export interface VoiceInputOverlayProps {
-  waveformData: number[];
-  transcript: string;
-  interimTranscript: string;
-  onCancel: () => void;
-  onConfirm: () => void;
-  className?: string;
-}
-
-export function VoiceInputOverlay({
-  waveformData,
-  transcript,
-  interimTranscript,
-  onCancel,
-  onConfirm,
-  className,
-}: VoiceInputOverlayProps) {
-  const displayText =
-    transcript + (interimTranscript ? " " + interimTranscript : "");
-  const hasText = displayText.trim().length > 0;
-
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-2 px-3 py-2 w-full min-h-[52px]",
-        className,
-      )}
-    >
-      {/* Waveform or transcript text */}
-      <div className="flex items-center flex-1 min-w-0 overflow-hidden">
-        {hasText ? (
-          <p className="text-sm text-foreground/80 truncate leading-relaxed">
-            <span>{transcript}</span>
-            {interimTranscript && (
-              <span className="text-muted-foreground">
-                {" "}
-                {interimTranscript}
-              </span>
-            )}
-          </p>
-        ) : (
-          <VoiceWaveform data={waveformData} />
-        )}
-      </div>
-
-      {/* Cancel button */}
-      <button
-        type="button"
-        onClick={onCancel}
-        className="shrink-0 flex items-center justify-center size-7 rounded-full hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-        aria-label="Cancel recording"
-      >
-        <X size={15} />
-      </button>
-
-      {/* Confirm button */}
-      <button
-        type="button"
-        onClick={onConfirm}
-        className="shrink-0 flex items-center justify-center size-7 rounded-full bg-foreground text-background hover:opacity-80 transition-opacity"
-        aria-label="Use transcription"
-      >
-        <Check size={15} />
-      </button>
     </div>
   );
 }

--- a/apps/mesh/src/web/globals.d.ts
+++ b/apps/mesh/src/web/globals.d.ts
@@ -4,3 +4,82 @@ declare module "*?raw" {
   const content: string;
   export default content;
 }
+
+// Web Speech API — not yet included in TypeScript's lib.dom.d.ts
+interface SpeechRecognitionEventMap {
+  result: SpeechRecognitionEvent;
+  end: Event;
+  error: SpeechRecognitionErrorEvent;
+  start: Event;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  grammars: SpeechGrammarList;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  abort(): void;
+  start(): void;
+  stop(): void;
+  onresult: ((ev: SpeechRecognitionEvent) => void) | null;
+  onend: ((ev: Event) => void) | null;
+  onerror: ((ev: SpeechRecognitionErrorEvent) => void) | null;
+  onstart: ((ev: Event) => void) | null;
+  addEventListener<K extends keyof SpeechRecognitionEventMap>(
+    type: K,
+    listener: (ev: SpeechRecognitionEventMap[K]) => void,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+}
+
+declare var SpeechRecognition: {
+  prototype: SpeechRecognition;
+  new (): SpeechRecognition;
+};
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+  readonly confidence: number;
+  readonly transcript: string;
+}
+
+interface SpeechGrammar {
+  src: string;
+  weight: number;
+}
+
+interface SpeechGrammarList {
+  readonly length: number;
+  addFromString(string: string, weight?: number): void;
+  addFromURI(src: string, weight?: number): void;
+  item(index: number): SpeechGrammar;
+  [index: number]: SpeechGrammar;
+}
+
+declare var SpeechGrammarList: {
+  prototype: SpeechGrammarList;
+  new (): SpeechGrammarList;
+};

--- a/apps/mesh/src/web/hooks/use-voice-input.ts
+++ b/apps/mesh/src/web/hooks/use-voice-input.ts
@@ -1,0 +1,198 @@
+import { useRef, useState } from "react";
+
+const WAVEFORM_BARS = 48;
+
+export interface UseVoiceInputReturn {
+  status: "idle" | "recording" | "unsupported" | "permission-denied";
+  transcript: string;
+  interimTranscript: string;
+  waveformData: number[];
+  isSupported: boolean;
+  startRecording: () => Promise<void>;
+  stopRecording: () => string;
+  cancelRecording: () => void;
+}
+
+export function useVoiceInput(): UseVoiceInputReturn {
+  const [status, setStatus] = useState<
+    "idle" | "recording" | "unsupported" | "permission-denied"
+  >("idle");
+  const [transcript, setTranscript] = useState("");
+  const [interimTranscript, setInterimTranscript] = useState("");
+  const [waveformData, setWaveformData] = useState<number[]>(() =>
+    Array(WAVEFORM_BARS).fill(0.05),
+  );
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const animFrameRef = useRef<number>(0);
+  const isRecordingRef = useRef(false);
+  const finalTranscriptRef = useRef("");
+  // Capture interim at stop time since state may be stale in the closure
+  const interimTranscriptRef = useRef("");
+
+  const isSupported =
+    typeof window !== "undefined" &&
+    !!(
+      (window as unknown as Record<string, unknown>).SpeechRecognition ||
+      (window as unknown as Record<string, unknown>).webkitSpeechRecognition
+    );
+
+  const stopVisualizer = () => {
+    if (animFrameRef.current) {
+      cancelAnimationFrame(animFrameRef.current);
+      animFrameRef.current = 0;
+    }
+    audioContextRef.current?.close().catch(() => {});
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    analyserRef.current = null;
+    audioContextRef.current = null;
+    streamRef.current = null;
+  };
+
+  const startVisualizerWithStream = (stream: MediaStream) => {
+    streamRef.current = stream;
+
+    const ctx = new AudioContext();
+    audioContextRef.current = ctx;
+
+    const source = ctx.createMediaStreamSource(stream);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 128;
+    analyser.smoothingTimeConstant = 0.8;
+    source.connect(analyser);
+    analyserRef.current = analyser;
+
+    const freqData = new Uint8Array(analyser.frequencyBinCount);
+
+    const tick = () => {
+      if (!analyserRef.current) return;
+      analyserRef.current.getByteFrequencyData(freqData);
+
+      const bars: number[] = [];
+      for (let i = 0; i < WAVEFORM_BARS; i++) {
+        const idx = Math.floor((i / WAVEFORM_BARS) * freqData.length);
+        bars.push(Math.max(0.04, freqData[idx] / 255));
+      }
+      setWaveformData(bars);
+      animFrameRef.current = requestAnimationFrame(tick);
+    };
+    tick();
+  };
+
+  const startRecording = async () => {
+    const SpeechRecognitionCtor =
+      (window as unknown as Record<string, unknown>).SpeechRecognition ||
+      (window as unknown as Record<string, unknown>).webkitSpeechRecognition;
+
+    if (!SpeechRecognitionCtor) {
+      setStatus("unsupported");
+      return;
+    }
+
+    // Request microphone permission first — this triggers the browser prompt
+    let stream: MediaStream | null = null;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      setStatus("permission-denied");
+      return;
+    }
+
+    setTranscript("");
+    setInterimTranscript("");
+    interimTranscriptRef.current = "";
+    finalTranscriptRef.current = "";
+    isRecordingRef.current = true;
+    setStatus("recording");
+
+    startVisualizerWithStream(stream);
+
+    const recognition = new (
+      SpeechRecognitionCtor as typeof SpeechRecognition
+    )();
+    recognitionRef.current = recognition;
+    recognition.interimResults = true;
+    recognition.continuous = true;
+    recognition.lang = navigator.language || "en-US";
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let interim = "";
+      let newFinal = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const text = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          newFinal += text;
+        } else {
+          interim += text;
+        }
+      }
+      if (newFinal) {
+        finalTranscriptRef.current += newFinal;
+        setTranscript(finalTranscriptRef.current);
+      }
+      interimTranscriptRef.current = interim;
+      setInterimTranscript(interim);
+    };
+
+    recognition.onend = () => {
+      if (isRecordingRef.current) {
+        try {
+          recognition.start();
+        } catch {
+          // Recognition may already be stopped
+        }
+      }
+    };
+
+    try {
+      recognition.start();
+    } catch {
+      setStatus("idle");
+    }
+  };
+
+  const stopRecording = (): string => {
+    isRecordingRef.current = false;
+    recognitionRef.current?.stop();
+    stopVisualizer();
+    setStatus("idle");
+    setWaveformData(Array(WAVEFORM_BARS).fill(0.05));
+    setInterimTranscript("");
+
+    const final = (
+      finalTranscriptRef.current +
+      (interimTranscriptRef.current ? " " + interimTranscriptRef.current : "")
+    ).trim();
+
+    setTranscript("");
+    finalTranscriptRef.current = "";
+    interimTranscriptRef.current = "";
+    return final;
+  };
+
+  const cancelRecording = () => {
+    isRecordingRef.current = false;
+    recognitionRef.current?.abort();
+    stopVisualizer();
+    setStatus("idle");
+    setTranscript("");
+    setInterimTranscript("");
+    setWaveformData(Array(WAVEFORM_BARS).fill(0.05));
+    finalTranscriptRef.current = "";
+    interimTranscriptRef.current = "";
+  };
+
+  return {
+    status,
+    transcript,
+    interimTranscript,
+    waveformData,
+    isSupported,
+    startRecording,
+    stopRecording,
+    cancelRecording,
+  };
+}

--- a/apps/mesh/src/web/hooks/use-voice-input.ts
+++ b/apps/mesh/src/web/hooks/use-voice-input.ts
@@ -74,7 +74,7 @@ export function useVoiceInput(): UseVoiceInputReturn {
       const bars: number[] = [];
       for (let i = 0; i < WAVEFORM_BARS; i++) {
         const idx = Math.floor((i / WAVEFORM_BARS) * freqData.length);
-        bars.push(Math.max(0.04, freqData[idx] / 255));
+        bars.push(Math.max(0.04, (freqData[idx] ?? 0) / 255));
       }
       setWaveformData(bars);
       animFrameRef.current = requestAnimationFrame(tick);
@@ -122,8 +122,9 @@ export function useVoiceInput(): UseVoiceInputReturn {
       let interim = "";
       let newFinal = "";
       for (let i = event.resultIndex; i < event.results.length; i++) {
-        const text = event.results[i][0].transcript;
-        if (event.results[i].isFinal) {
+        const result = event.results[i];
+        const text = result?.[0]?.transcript ?? "";
+        if (result?.isFinal) {
           newFinal += text;
         } else {
           interim += text;


### PR DESCRIPTION
## Summary

- Adds a microphone button to the chat input (only shown when the browser supports `SpeechRecognition`)
- Real-time speech-to-text using the browser-native Web Speech API — no backend changes required
- Live waveform visualizer driven by the Web Audio API (`AnalyserNode`) animates while listening
- Transcribed text is **appended** to any existing editor content (not replaced), so the user can mix typing and dictation freely
- Cancel (×) and confirm (✓) controls match the existing input style
- Proper microphone permission handling: `getUserMedia` is called upfront to trigger the browser prompt; if denied, the mic button turns red with a descriptive tooltip and clicking it re-prompts

## Test plan

- [ ] Click the mic button — browser should ask for microphone permission
- [ ] Deny permission — mic button should turn red with tooltip "Microphone access denied — click to try again"
- [ ] Grant permission — waveform overlay should appear and animate while speaking
- [ ] Speak — interim transcript (dimmed) should appear live, final transcript (solid) should accumulate
- [ ] Press ✓ — transcribed text should be inserted at the cursor / appended to existing text in the editor
- [ ] Press × — overlay should dismiss with no changes to the editor
- [ ] Type something first, then use voice — transcribed text should be appended after existing content
- [ ] Test on Firefox (Speech API unsupported) — mic button should not appear

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add voice input to chat with real-time transcription that types directly into the editor and shows a live waveform. During recording the editor locks; cancel restores previous text, confirm keeps the transcription.

- **New Features**
  - Mic button shows only when `SpeechRecognition` is available; hidden on unsupported browsers.
  - Transcript appears live in the editor while recording; input is disabled to prevent edits.
  - Bottom bar switches to waveform with ×/✓; cancel restores prior content, confirm keeps the text.
  - Permission flow via `getUserMedia`; denied state turns the mic red with a tooltip and allows retry.
  - New `use-voice-input` hook and `VoiceWaveform`; `TiptapInput` adds `appendText()`, `syncVoiceText()`, and `restoreContent()`.

- **Bug Fixes**
  - Added Web Speech API global types in `globals.d.ts` for `SpeechRecognition` and related interfaces to fix TypeScript builds and `noUncheckedIndexedAccess` issues.
  - Prevented losing last interim words on stop and ensured a space is added before appended voice text when baseline content exists.
  - Removed unused `VoiceInputOverlay` export.

<sup>Written for commit ec23fa4f0492de0035c4b73f54510c80653101ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

