### PR TITLE
feat(deco-flights): flight research MCP agent

### DIFF
--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -29,6 +29,7 @@ import { ChevronRight, Plus, Users03 } from "@untitledui/icons";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
+import { DecoFlightsRecruitModal } from "@/web/components/home/deco-flights-recruit-modal.tsx";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { Suspense, useState } from "react";
@@ -159,6 +160,7 @@ function AgentsListContent() {
   const [importDecoOpen, setImportDecoOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
+  const [decoFlightsModalOpen, setDecoFlightsModalOpen] = useState(false);
   const navigateToAgent = useNavigateToAgent();
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
@@ -169,6 +171,9 @@ function AgentsListContent() {
   )!;
   const leanCanvasAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "lean-canvas",
+  )!;
+  const decoFlightsAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "deco-flights",
   )!;
 
   const recentIds = readRecentAgentIds(locator);
@@ -209,6 +214,15 @@ function AgentsListContent() {
         a.title === leanCanvasAgent.title),
   );
 
+  // Check if Deco Flights agent already exists
+  const existingDecoFlights = virtualMcps.find(
+    (a): a is typeof a & { id: string } =>
+      a.id !== null &&
+      ((a as { metadata?: { type?: string } }).metadata?.type ===
+        decoFlightsAgent.id ||
+        a.title === decoFlightsAgent.title),
+  );
+
   const hasAgents = agents.length > 0;
 
   return (
@@ -238,11 +252,21 @@ function AgentsListContent() {
                 : () => setLeanCanvasModalOpen(true)
             }
           />
+          <AgentPreview
+            key={decoFlightsAgent.id}
+            agent={existingDecoFlights ?? decoFlightsAgent}
+            onSpecialClick={
+              existingDecoFlights
+                ? () => navigateToAgent(existingDecoFlights.id)
+                : () => setDecoFlightsModalOpen(true)
+            }
+          />
           {agents
             .filter(
               (a) =>
                 a.id !== existingDiagnostics?.id &&
-                a.id !== existingLeanCanvas?.id,
+                a.id !== existingLeanCanvas?.id &&
+                a.id !== existingDecoFlights?.id,
             )
             .map((agent) => (
               <AgentPreview
@@ -271,6 +295,12 @@ function AgentsListContent() {
         open={leanCanvasModalOpen}
         onOpenChange={setLeanCanvasModalOpen}
         existingAgent={existingLeanCanvas}
+      />
+
+      <DecoFlightsRecruitModal
+        open={decoFlightsModalOpen}
+        onOpenChange={setDecoFlightsModalOpen}
+        existingAgent={existingDecoFlights}
       />
     </>
   );

--- a/apps/mesh/src/web/components/home/deco-flights-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/deco-flights-recruit-modal.tsx
@@ -1,0 +1,287 @@
+/**
+ * Deco Flights Recruitment Modal
+ *
+ * Shown when the user clicks the Flights template on the home page.
+ * Creates an HTTP connection to the local deco-flights MCP + virtual MCP,
+ * then navigates to the agent view.
+ */
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@deco/ui/components/drawer.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import {
+  SELF_MCP_ALIAS_ID,
+  WELL_KNOWN_AGENT_TEMPLATES,
+  WellKnownOrgMCPId,
+  useConnectionActions,
+  useMCPClient,
+  useMCPToolCallMutation,
+  useProjectContext,
+  useVirtualMCPActions,
+} from "@decocms/mesh-sdk";
+import type { CollectionListOutput } from "@decocms/bindings/collections";
+import type { ConnectionEntity } from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+
+const DECO_FLIGHTS_MCP_URL = "http://localhost:4747/mcp";
+
+const AGENT_INSTRUCTIONS = `You are a flight research assistant powered by Deco Flights. Help users plan trips by searching for the best flights across flexible date ranges.
+
+## Workflow
+1. Ask the user where they want to go, when, how long, and any preferences
+2. Use TRIP_CREATE to save the trip with all gathered details
+3. Review the search plan and confirm with the user
+4. Use TRIP_EXECUTE to run all searches
+5. Use TRIP_GET to display the ranked results
+
+## Tips
+- Confirm destination IATA codes (e.g., LAX for Los Angeles, SFO for San Francisco)
+- Ask about stops, layover limits, airline preferences, budget
+- Suggest wider date ranges for more options
+- Use TRIP_LIST to show all saved trips`;
+
+interface DecoFlightsRecruitModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingAgent?: { id: string } | null;
+}
+
+const CAPABILITIES = [
+  "Search flights across flexible date ranges via Google Flights",
+  "Save trip research plans with preferences and constraints",
+  "Automated multi-search execution across date combinations",
+  "Score and rank results by price, stops, layovers, and preferences",
+  "Interactive trip planner UI with sortable results table",
+  "Persistent local storage — come back to review results anytime",
+];
+
+function RecruitContent({
+  onRecruit,
+  isRecruiting,
+}: {
+  onRecruit: () => void;
+  isRecruiting: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Add a Flights agent that helps you research and compare flights.
+        Describe your trip and it searches across date ranges, scores results,
+        and presents the best options.
+      </p>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">Capabilities</p>
+        <ul className="space-y-1.5">
+          {CAPABILITIES.map((cap) => (
+            <li
+              key={cap}
+              className="text-sm text-muted-foreground flex items-start gap-2"
+            >
+              <span className="text-sky-500 mt-0.5 shrink-0">+</span>
+              {cap}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="rounded-lg border border-sky-200 bg-sky-50 p-3">
+        <p className="text-xs text-sky-800">
+          Start the flights server with{" "}
+          <code className="bg-sky-100 px-1 rounded">
+            bun run --cwd packages/deco-flights dev
+          </code>
+        </p>
+      </div>
+
+      <Button
+        onClick={onRecruit}
+        disabled={isRecruiting}
+        className="w-full cursor-pointer"
+      >
+        {isRecruiting ? "Setting up..." : "Add Flights Agent"}
+      </Button>
+    </div>
+  );
+}
+
+export function DecoFlightsRecruitModal({
+  open,
+  onOpenChange,
+  existingAgent,
+}: DecoFlightsRecruitModalProps) {
+  const isMobile = useIsMobile();
+  const { org } = useProjectContext();
+  const navigateToAgent = useNavigateToAgent();
+  const connectionActions = useConnectionActions();
+  const virtualMcpActions = useVirtualMCPActions();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+  const connectionQuery = useMCPToolCallMutation({ client });
+  const [isRecruiting, setIsRecruiting] = useState(false);
+
+  const template = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "deco-flights",
+  )!;
+
+  const headerIcon = (
+    <IntegrationIcon icon={template.icon} name={template.title} size="sm" />
+  );
+
+  const handleRecruit = async () => {
+    if (existingAgent) {
+      onOpenChange(false);
+      navigateToAgent(existingAgent.id);
+      return;
+    }
+
+    setIsRecruiting(true);
+    try {
+      // 1. Find or create the HTTP connection to the local flights MCP
+      const existingConnectionResult = await connectionQuery.mutateAsync({
+        name: "COLLECTION_CONNECTIONS_LIST",
+        arguments: {
+          where: {
+            field: ["app_id"],
+            operator: "eq",
+            value: "deco-flights",
+          },
+          limit: 1,
+          offset: 0,
+        },
+      });
+
+      let connectionId: string;
+      const existingConnections = (
+        existingConnectionResult as {
+          structuredContent?: CollectionListOutput<ConnectionEntity>;
+        }
+      )?.structuredContent?.items;
+
+      const matchingConnection = existingConnections?.find(
+        (c) => c.app_id === "deco-flights",
+      );
+
+      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
+
+      if (matchingConnection) {
+        connectionId = matchingConnection.id;
+      } else {
+        const connection = await connectionActions.create.mutateAsync({
+          title: template.title,
+          description: "Flight research assistant powered by Google Flights",
+          icon: template.icon,
+          connection_type: "HTTP",
+          connection_url: DECO_FLIGHTS_MCP_URL,
+          app_name: "deco-flights",
+          app_id: "deco-flights",
+          metadata: {
+            type: "deco-flights",
+            source: "local",
+          },
+        });
+        connectionId = connection.id;
+      }
+
+      // 2. Create a virtual MCP (agent) with the connection + self MCP attached
+      const virtualMcp = await virtualMcpActions.create.mutateAsync({
+        title: template.title,
+        description: "Flight research assistant powered by Google Flights",
+        icon: template.icon,
+        status: "active",
+        connections: [
+          {
+            connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+          {
+            connection_id: selfConnectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+        metadata: {
+          type: "deco-flights",
+          instructions: AGENT_INSTRUCTIONS,
+          ui: {
+            pinnedViews: [
+              {
+                connectionId,
+                toolName: "TRIP_LIST",
+                label: "My Trips",
+                icon: null,
+              },
+            ],
+            layout: {
+              defaultMainView: {
+                type: "ext-apps",
+                id: connectionId,
+                toolName: "TRIP_LIST",
+              },
+              chatDefaultOpen: true,
+            },
+          },
+        },
+      });
+
+      // 3. Navigate to the new agent
+      onOpenChange(false);
+      navigateToAgent(virtualMcp.id!);
+    } catch (error) {
+      console.error("Failed to create Flights agent:", error);
+    } finally {
+      setIsRecruiting(false);
+    }
+  };
+
+  const title = `Add ${template.title}`;
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="h-[70dvh]">
+        <DrawerHeader className="px-4 pt-4 pb-4 shrink-0">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DrawerTitle className="text-xl font-semibold">{title}</DrawerTitle>
+          </div>
+        </DrawerHeader>
+        <div className="flex flex-col flex-1 min-h-0 px-4 pb-8">
+          <RecruitContent
+            onRecruit={handleRecruit}
+            isRecruiting={isRecruiting}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] p-8">
+        <DialogHeader className="mb-4">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DialogTitle className="text-xl font-semibold">{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+        <RecruitContent onRecruit={handleRecruit} isRecruiting={isRecruiting} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/routes/agents-list.tsx
+++ b/apps/mesh/src/web/routes/agents-list.tsx
@@ -17,6 +17,7 @@ import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.t
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
+import { DecoFlightsRecruitModal } from "@/web/components/home/deco-flights-recruit-modal.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -56,6 +57,7 @@ export default function AgentsListPage() {
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
   const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
+  const [decoFlightsModalOpen, setDecoFlightsModalOpen] = useState(false);
 
   const lowerSearch = search.toLowerCase();
 
@@ -91,6 +93,12 @@ export default function AgentsListPage() {
       (a as { metadata?: { type?: string } }).metadata?.type === "lean-canvas",
   );
 
+  // Find existing recruited Deco Flights agent
+  const existingDecoFlights = agents.find(
+    (a) =>
+      (a as { metadata?: { type?: string } }).metadata?.type === "deco-flights",
+  );
+
   const handleTemplateClick = (templateId: string) => {
     if (templateId === "site-editor") {
       setImportDecoOpen(true);
@@ -105,6 +113,12 @@ export default function AgentsListPage() {
         navigateToAgent(existingLeanCanvas.id);
       } else {
         setLeanCanvasModalOpen(true);
+      }
+    } else if (templateId === "deco-flights") {
+      if (existingDecoFlights) {
+        navigateToAgent(existingDecoFlights.id);
+      } else {
+        setDecoFlightsModalOpen(true);
       }
     } else if (templateId === "studio-pack") {
       setStudioPackModalOpen(true);
@@ -275,6 +289,11 @@ export default function AgentsListPage() {
         open={leanCanvasModalOpen}
         onOpenChange={setLeanCanvasModalOpen}
         existingAgent={existingLeanCanvas}
+      />
+      <DecoFlightsRecruitModal
+        open={decoFlightsModalOpen}
+        onOpenChange={setDecoFlightsModalOpen}
+        existingAgent={existingDecoFlights}
       />
       <StudioPackRecruitModal
         open={studioPackModalOpen}

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.261.0",
+      "version": "2.266.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -209,6 +209,20 @@
         "create-deco": "./index.js",
       },
     },
+    "packages/deco-flights": {
+      "name": "@decocms/deco-flights",
+      "version": "0.1.0",
+      "dependencies": {
+        "@decocms/runtime": "workspace:*",
+        "@modelcontextprotocol/sdk": "1.27.1",
+        "fast-flights-ts": "4.1.0",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.9.3",
+      },
+    },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
       "version": "1.0.2",
@@ -269,7 +283,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
         "@cloudflare/workers-types": "^4.20250617.0",
@@ -646,6 +660,8 @@
 
     "@decocms/bindings": ["@decocms/bindings@workspace:packages/bindings"],
 
+    "@decocms/deco-flights": ["@decocms/deco-flights@workspace:packages/deco-flights"],
+
     "@decocms/docs": ["@decocms/docs@workspace:apps/docs"],
 
     "@decocms/mcp-utils": ["@decocms/mcp-utils@workspace:packages/mcp-utils"],
@@ -854,6 +870,8 @@
 
     "@instantdb/version": ["@instantdb/version@0.22.158", "", {}, "sha512-RkO73PcZbYdczZMUGfwM5u0OPCG2Bzs1e/cI9adAPmh/1tSvEpJDCU4j0R9JQnHAoMGJ/XNrGT2DqHfkfBV8Cw=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.31.0", "", {}, "sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw=="],
@@ -901,6 +919,10 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@npmcli/agent": ["@npmcli/agent@2.2.2", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^10.0.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og=="],
+
+    "@npmcli/fs": ["@npmcli/fs@3.1.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg=="],
 
     "@oclif/core": ["@oclif/core@4.9.0", "", { "dependencies": { "ansi-escapes": "^4.3.2", "ansis": "^3.17.0", "clean-stack": "^3.0.1", "cli-spinners": "^2.9.2", "debug": "^4.4.3", "ejs": "^3.1.10", "get-package-type": "^0.1.0", "indent-string": "^4.0.0", "is-wsl": "^2.2.0", "lilconfig": "^3.1.3", "minimatch": "^10.2.4", "semver": "^7.7.3", "string-width": "^4.2.3", "supports-color": "^8", "tinyglobby": "^0.2.14", "widest-line": "^3.1.0", "wordwrap": "^1.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-k/ntRgDcUprTT+aaNoF+whk3cY3f9fRD2lkF6ul7JeCUg2MaMXVXZXfbRhJCfsiX51X8/5Pqo0LGdO9SLYXNHg=="],
 
@@ -1089,6 +1111,8 @@
     "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.6.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "asn1js": "^3.0.6", "tslib": "^2.8.1" } }, "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ=="],
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
@@ -1700,6 +1724,8 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
     "ai": ["ai@6.0.116", "", { "dependencies": { "@ai-sdk/gateway": "3.0.66", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA=="],
 
     "ai-sdk-provider-claude-code": ["ai-sdk-provider-claude-code@3.4.4", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@ai-sdk/provider-utils": "^4.0.1", "@anthropic-ai/claude-agent-sdk": "^0.2.63" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-iHcup5SHh4Tul1RIi9J+bnpngen8WX66yC3lsz1YlbtwAmRhUEzZUuGKzmFGIN8Pmx9uQrerGfLJdbFxIxKkyw=="],
@@ -1723,6 +1749,10 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "aproba": ["aproba@2.1.0", "", {}, "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew=="],
+
+    "are-we-there-yet": ["are-we-there-yet@4.0.2", "", {}, "sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -1792,6 +1822,8 @@
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "cacache": ["cacache@18.0.4", "", { "dependencies": { "@npmcli/fs": "^3.1.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^10.0.1", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^4.0.0", "ssri": "^10.0.0", "tar": "^6.1.11", "unique-filename": "^3.0.0" } }, "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
@@ -1846,6 +1878,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
+
     "colorjs.io": ["colorjs.io@0.5.2", "", {}, "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw=="],
 
     "comlink": ["comlink@4.4.2", "", {}, "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="],
@@ -1863,6 +1897,8 @@
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -1944,6 +1980,8 @@
 
     "degit": ["degit@2.8.4", "", { "bin": { "degit": "degit" } }, "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng=="],
 
+    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
@@ -1978,13 +2016,15 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
-    "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dotenv-expand": ["dotenv-expand@11.0.7", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA=="],
 
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -2006,11 +2046,17 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.20.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "env-paths": ["env-paths@2.2.0", "", {}, "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -2058,6 +2104,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
@@ -2067,6 +2115,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
+
+    "fast-flights-ts": ["fast-flights-ts@4.1.0", "", { "optionalDependencies": { "node-libcurl": "^4.0.0" } }, "sha512-E5MkU5blEYaEtSQPFCOCQfyAoiWT6Ths/MXMY1TS9qkAkC1reZYFyNioFyudtA+sJD2aNeIEC8RMYwe5WAz66Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -2102,6 +2152,8 @@
 
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
@@ -2114,11 +2166,15 @@
 
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
+    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gauge": ["gauge@5.0.2", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.3", "console-control-strings": "^1.1.0", "has-unicode": "^2.0.1", "signal-exit": "^4.0.1", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.5" } }, "sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -2157,6 +2213,8 @@
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -2206,6 +2264,8 @@
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
@@ -2219,6 +2279,8 @@
     "import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -2266,6 +2328,8 @@
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
+    "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
@@ -2283,6 +2347,8 @@
     "isbot": ["isbot@5.1.36", "", {}, "sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
@@ -2385,6 +2451,10 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
+
+    "make-fetch-happen": ["make-fetch-happen@13.0.1", "", { "dependencies": { "@npmcli/agent": "^2.0.0", "cacache": "^18.0.0", "http-cache-semantics": "^4.1.1", "is-lambda": "^1.0.1", "minipass": "^7.0.2", "minipass-fetch": "^3.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "proc-log": "^4.2.0", "promise-retry": "^2.0.1", "ssri": "^10.0.0" } }, "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
@@ -2530,7 +2600,19 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "minipass-fetch": ["minipass-fetch@3.0.5", "", { "dependencies": { "minipass": "^7.0.3", "minipass-sized": "^1.0.3", "minizlib": "^2.1.2" }, "optionalDependencies": { "encoding": "^0.1.13" } }, "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
+    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
+
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "mlly": ["mlly@1.8.1", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ=="],
 
@@ -2545,6 +2627,8 @@
     "mutative": ["mutative@1.3.0", "", {}, "sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nan": ["nan@github:JCMais/nan#0ec2eca", {}, "JCMais-nan-0ec2eca", "sha512-AuR6UeuiQhmNK2Zx2nggKGrWAohYBhqMqQd8lZeOTfh2ZatkmYITHTFQlblSLaUJ+c5jPvj4iq+XzRrCczGAGQ=="],
 
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
@@ -2568,7 +2652,11 @@
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
+    "node-gyp": ["node-gyp@10.2.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^10.3.10", "graceful-fs": "^4.2.6", "make-fetch-happen": "^13.0.0", "nopt": "^7.0.0", "proc-log": "^4.1.0", "semver": "^7.3.5", "tar": "^6.2.1", "which": "^4.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-sp3FonBAaFe4aYTcFdZUn2NYkbP7xroPGYvQmP4Nl5PxamznItBnNCgjrVTKrEfQynInMsJvZrdmqUnysCJ8rw=="],
+
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-libcurl": ["node-libcurl@4.1.0", "", { "dependencies": { "@mapbox/node-pre-gyp": "1.0.11", "env-paths": "2.2.0", "nan": "github:JCMais/nan#fix/electron-failures", "node-gyp": "10.2.0", "npmlog": "7.0.1", "rimraf": "5.0.5", "tslib": "2.6.2" } }, "sha512-cwJ4pEqFmzUivMl0CtS2yYjBmZJ3/63Fl1WJCGzw45jXTCL04Ygbqvl+I5blMZm4ZOQChbATmQ6H4lxAnlIU+g=="],
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
@@ -2579,6 +2667,8 @@
     "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npmlog": ["npmlog@7.0.1", "", { "dependencies": { "are-we-there-yet": "^4.0.0", "console-control-strings": "^1.1.0", "gauge": "^5.0.0", "set-blocking": "^2.0.0" } }, "sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
@@ -2608,9 +2698,13 @@
 
     "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
+    "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
+
     "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
@@ -2693,6 +2787,10 @@
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+
+    "proc-log": ["proc-log@4.2.0", "", {}, "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA=="],
+
+    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -2800,6 +2898,8 @@
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recharts": ["recharts@2.15.1", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q=="],
@@ -2876,7 +2976,11 @@
 
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@5.0.5", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
@@ -2889,6 +2993,8 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -2952,6 +3058,8 @@
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
@@ -2986,7 +3094,13 @@
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
@@ -3000,6 +3114,8 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "ssri": ["ssri@10.0.6", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ=="],
+
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
@@ -3008,9 +3124,15 @@
 
     "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
@@ -3132,6 +3254,10 @@
 
     "unifont": ["unifont@0.7.4", "", { "dependencies": { "css-tree": "^3.1.0", "ofetch": "^1.5.1", "ohash": "^2.0.11" } }, "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg=="],
 
+    "unique-filename": ["unique-filename@3.0.0", "", { "dependencies": { "unique-slug": "^4.0.0" } }, "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g=="],
+
+    "unique-slug": ["unique-slug@4.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ=="],
+
     "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
@@ -3208,6 +3334,8 @@
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 
+    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
+
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
@@ -3219,6 +3347,8 @@
     "wrangler": ["wrangler@4.73.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.15.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260312.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260312.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260312.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-VJXsqKDFCp6OtFEHXITSOR5kh95JOknwPY8m7RyQuWJQguSybJy43m4vhoCSt42prutTef7eeuw7L4V4xiynGw=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -3300,6 +3430,8 @@
 
     "@daveyplate/better-auth-ui/@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
+    "@decocms/deco-flights/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "@decocms/runtime/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@grpc/proto-loader/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
@@ -3309,6 +3441,12 @@
     "@instantdb/core/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@instantdb/react/eventsource": ["eventsource@4.1.0", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@oclif/core/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -3560,6 +3698,10 @@
 
     "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "aggregate-error/clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
+
+    "aggregate-error/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3581,6 +3723,14 @@
     "boxen/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "boxen/widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
+
+    "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "cacache/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -3612,11 +3762,23 @@
 
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "freestyle-sandboxes/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "gauge/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "git-diff/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -3648,6 +3810,10 @@
 
     "kysely-pglite/jiti": ["jiti@2.0.0-beta.3", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-pmfRbVRs/7khFrSAYnSiJ8C0D5GvzkE4Ey2pAvUcJsw1ly/p+7ut27jbJrjY79BpAJQJ4gXYFtK6d1Aub+9baQ=="],
 
+    "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -3656,7 +3822,27 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "minipass-fetch/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
     "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
+    "node-gyp/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "node-gyp/nopt": ["nopt@7.2.1", "", { "dependencies": { "abbrev": "^2.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w=="],
+
+    "node-gyp/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
+    "node-gyp/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@1.0.11", "", { "dependencies": { "detect-libc": "^2.0.0", "https-proxy-agent": "^5.0.0", "make-dir": "^3.1.0", "node-fetch": "^2.6.7", "nopt": "^5.0.0", "npmlog": "^5.0.1", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.11" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ=="],
+
+    "node-libcurl/tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
 
     "p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -3672,6 +3858,8 @@
 
     "refractor/prismjs": ["prismjs@1.27.0", "", {}, "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="],
 
+    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "samlify/camelcase": ["camelcase@9.0.0", "", {}, "sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw=="],
@@ -3681,6 +3869,14 @@
     "shelljs/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -3692,7 +3888,15 @@
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
+    "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "xml-crypto/xpath": ["xpath@0.0.33", "", {}, "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="],
 
@@ -3714,7 +3918,11 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@decocms/deco-flights/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
     "@decocms/runtime/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@oclif/core/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
@@ -3828,6 +4036,20 @@
 
     "astro/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
+    "cacache/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "cacache/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "cacache/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "cacache/tar/fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
+
+    "cacache/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "cacache/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "cacache/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
@@ -3851,6 +4073,14 @@
     "freestyle-sandboxes/yargs/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "freestyle-sandboxes/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "gauge/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "gauge/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "git-diff/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
@@ -3876,9 +4106,63 @@
 
     "mesh-plugin-workflows/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "minipass-fetch/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-fetch/minizlib/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "minipass-sized/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "node-gyp/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "node-gyp/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "node-gyp/nopt/abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
+
+    "node-gyp/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "node-gyp/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "node-gyp/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "node-gyp/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "node-gyp/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/nopt": ["nopt@5.0.0", "", { "dependencies": { "abbrev": "1" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog": ["npmlog@5.0.1", "", { "dependencies": { "are-we-there-yet": "^2.0.0", "console-control-strings": "^1.1.0", "gauge": "^3.0.0", "set-blocking": "^2.0.0" } }, "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
+    "rimraf/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "shelljs/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "wide-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wide-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "wide-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -4004,6 +4288,12 @@
 
     "astro/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "cacache/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "cacache/tar/fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "cacache/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "git-diff/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
@@ -4014,12 +4304,66 @@
 
     "mdast-util-mdx-jsx/parse-entities/is-alphanumerical/is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
+    "node-gyp/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "node-gyp/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "node-gyp/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/nopt/abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/are-we-there-yet": ["are-we-there-yet@2.0.0", "", { "dependencies": { "delegates": "^1.0.0", "readable-stream": "^3.6.0" } }, "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/gauge": ["gauge@3.0.2", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.2", "console-control-strings": "^1.0.0", "has-unicode": "^2.0.1", "object-assign": "^4.1.1", "signal-exit": "^3.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.2" } }, "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/tar/minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/tar/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "shelljs/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "cacache/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "git-diff/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
+    "node-gyp/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/tar/minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "shelljs/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/gauge/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/gauge/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/npmlog/gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "node-libcurl/@mapbox/node-pre-gyp/rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/packages/deco-flights/package.json
+++ b/packages/deco-flights/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@decocms/deco-flights",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Flight research MCP agent for Deco Studio",
+  "scripts": {
+    "dev": "bun run --hot server/index.ts",
+    "start": "bun run server/index.ts",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@decocms/runtime": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.27.1",
+    "fast-flights-ts": "4.1.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.9.3"
+  },
+  "exports": {
+    ".": "./server/index.ts"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/packages/deco-flights/server/index.ts
+++ b/packages/deco-flights/server/index.ts
@@ -1,0 +1,208 @@
+import { withRuntime } from "@decocms/runtime";
+import { createPublicPrompt, createPublicResource } from "@decocms/runtime";
+import { FLIGHT_SEARCH } from "./tools/flight-search.ts";
+import { TRIP_CREATE } from "./tools/trip-create.ts";
+import { TRIP_LIST } from "./tools/trip-list.ts";
+import { TRIP_GET } from "./tools/trip-get.ts";
+import { TRIP_UPDATE } from "./tools/trip-update.ts";
+import { TRIP_DELETE } from "./tools/trip-delete.ts";
+import { TRIP_EXECUTE } from "./tools/trip-execute.ts";
+import { TRIP_STOP } from "./tools/trip-stop.ts";
+import { TRIP_ADD_SEARCHES } from "./tools/trip-add-searches.ts";
+import { AGENT_INSTRUCTIONS } from "./lib/agent-instructions.ts";
+import { renderSearchResults } from "./ui/search-results.ts";
+import { renderTripCard } from "./ui/trip-card.ts";
+import { renderTripsDashboard } from "./ui/trips-dashboard.ts";
+import { renderTripPlanner } from "./ui/trip-planner.ts";
+import { loadTrip, listFullTrips } from "./lib/storage.ts";
+import { isWorkerRunning } from "./lib/worker.ts";
+
+const RESOURCE_MIME = "text/html;profile=mcp-app";
+const port = Number(process.env.PORT) || 4747;
+const API_ORIGIN = `http://localhost:${port}`;
+
+// CSP override to allow the UI iframes to fetch from our REST API
+const resourceCsp = {
+  connectDomains: [API_ORIGIN],
+};
+
+const flightAssistantPrompt = createPublicPrompt({
+  name: "flight-assistant",
+  title: "Flight Assistant",
+  description:
+    "Instructions for the flight research workflow — how to help users plan trips, create searches, and present results.",
+  execute: () => ({
+    messages: [
+      {
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: AGENT_INSTRUCTIONS,
+        },
+      },
+    ],
+  }),
+});
+
+const searchResultsResource = createPublicResource({
+  uri: "ui://deco-flights/search-results",
+  name: "Flight Search Results",
+  description: "Inline UI showing flight search results",
+  mimeType: RESOURCE_MIME,
+  read: () => ({
+    uri: "ui://deco-flights/search-results",
+    mimeType: RESOURCE_MIME,
+    text: renderSearchResults(),
+    _meta: { ui: { csp: resourceCsp } },
+  }),
+});
+
+const tripCardResource = createPublicResource({
+  uri: "ui://deco-flights/trip-card",
+  name: "Trip Card",
+  description: "Inline UI showing a trip summary card",
+  mimeType: RESOURCE_MIME,
+  read: () => ({
+    uri: "ui://deco-flights/trip-card",
+    mimeType: RESOURCE_MIME,
+    text: renderTripCard(),
+    _meta: { ui: { csp: resourceCsp } },
+  }),
+});
+
+const tripsDashboardResource = createPublicResource({
+  uri: "ui://deco-flights/trips-dashboard",
+  name: "Trips Dashboard",
+  description: "Fullscreen UI showing all saved trips with drill-down",
+  mimeType: RESOURCE_MIME,
+  read: () => ({
+    uri: "ui://deco-flights/trips-dashboard",
+    mimeType: RESOURCE_MIME,
+    text: renderTripsDashboard(),
+    _meta: { ui: { csp: resourceCsp } },
+  }),
+});
+
+const tripPlannerResource = createPublicResource({
+  uri: "ui://deco-flights/trip-planner",
+  name: "Trip Planner",
+  description:
+    "Fullscreen UI showing trip details, preferences, and ranked results",
+  mimeType: RESOURCE_MIME,
+  read: () => ({
+    uri: "ui://deco-flights/trip-planner",
+    mimeType: RESOURCE_MIME,
+    text: renderTripPlanner(),
+    _meta: { ui: { csp: resourceCsp } },
+  }),
+});
+
+const mcpServer = withRuntime({
+  serverInfo: {
+    name: "deco-flights",
+    version: "0.1.0",
+    instructions: AGENT_INSTRUCTIONS,
+  },
+  tools: [
+    FLIGHT_SEARCH,
+    TRIP_CREATE,
+    TRIP_LIST,
+    TRIP_GET,
+    TRIP_UPDATE,
+    TRIP_DELETE,
+    TRIP_EXECUTE,
+    TRIP_STOP,
+    TRIP_ADD_SEARCHES,
+  ],
+  prompts: [flightAssistantPrompt],
+  resources: [
+    searchResultsResource,
+    tripCardResource,
+    tripsDashboardResource,
+    tripPlannerResource,
+  ],
+  cors: {
+    origin: "*",
+  },
+});
+
+// REST API handler for direct fetch from UI iframes
+function handleApi(req: Request): Response | null {
+  const url = new URL(req.url);
+
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+      },
+    });
+  }
+
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+  };
+
+  // GET /api/trips — list all trips (trimmed)
+  if (url.pathname === "/api/trips" && req.method === "GET") {
+    return (async () => {
+      const trips = await listFullTrips();
+      const trimmed = trips.map((t) => ({
+        ...t,
+        results: (t.results ?? []).slice(0, 20),
+        _totalResults: t.results?.length ?? 0,
+        workerRunning: isWorkerRunning(t.id),
+      }));
+      return new Response(JSON.stringify({ trips: trimmed }), {
+        headers: corsHeaders,
+      });
+    })() as unknown as Response;
+  }
+
+  // GET /api/trips/:id — get single trip (trimmed)
+  const tripMatch = url.pathname.match(/^\/api\/trips\/([^/]+)$/);
+  if (tripMatch && req.method === "GET") {
+    return (async () => {
+      const trip = await loadTrip(tripMatch[1]);
+      if (!trip) {
+        return new Response(JSON.stringify({ error: "Not found" }), {
+          status: 404,
+          headers: corsHeaders,
+        });
+      }
+      const trimmed = {
+        ...trip,
+        results: (trip.results ?? []).slice(0, 20),
+        _totalResults: trip.results?.length ?? 0,
+      };
+      return new Response(
+        JSON.stringify({
+          trip: trimmed,
+          workerRunning: isWorkerRunning(trip.id),
+        }),
+        { headers: corsHeaders },
+      );
+    })() as unknown as Response;
+  }
+
+  return null;
+}
+
+export default {
+  fetch: async (req: Request, env?: unknown, ctx?: unknown) => {
+    // Try REST API first
+    const apiResponse = handleApi(req);
+    if (apiResponse) return apiResponse;
+    // Fall through to MCP handler
+    return (mcpServer.fetch as Function)(req, env, ctx);
+  },
+  port,
+};
+
+console.log(
+  `[deco-flights] MCP server running on http://localhost:${port}/mcp`,
+);
+console.log(`[deco-flights] REST API at http://localhost:${port}/api/trips`);

--- a/packages/deco-flights/server/lib/agent-instructions.ts
+++ b/packages/deco-flights/server/lib/agent-instructions.ts
@@ -1,0 +1,54 @@
+export const AGENT_INSTRUCTIONS = `You are a flight research assistant powered by Deco Flights. You help users plan trips by searching for the best flights.
+
+## CRITICAL RULES
+
+1. **MAX 10 SEARCHES PER TRIP.** The system hard-caps at 10. Keep date ranges tight.
+2. **ALWAYS set currency in preferences.** Default to USD. Ask the user if unclear.
+   Example: \`preferences: { currency: "USD", maxStops: 1 }\`
+3. **Narrow date ranges.** Don't pass a 2-week departure window. Pick 3-4 specific dates.
+
+## Search Strategy — Tiered, Fast
+
+### Tier 1 — Quick Scan (5-8 searches)
+- Pick 3-4 departure dates spread across the user's desired range
+- Use ONE return length (midpoint of their min/max)
+- This gives fast results in under 30 seconds
+
+### Tier 2 — Drill Down (use TRIP_ADD_SEARCHES on the SAME trip)
+- Look at Tier 1: which dates were cheapest?
+- Use TRIP_ADD_SEARCHES to add +/- 1-2 day variations around the best finds
+- Try different return lengths or routes
+- All results accumulate in one place — no need for separate trips
+
+### Tier 3 — Refine
+- User says "now try without COPA" → update preferences with avoidAirlines, add new searches
+- User says "what about flying back from LAX?" → add open-jaw searches with returnFrom
+- Use FLIGHT_SEARCH for quick one-off comparisons
+
+### Example
+User: "Flights GIG to SFO, May 21 to June 7, 7-9 days, business"
+
+GOOD: Create trip with departures [May 22, May 26, May 30, Jun 3], return length 8 days → 4 searches
+BAD: Create trip with earliestDeparture May 21, latestDeparture Jun 7 → 50+ combinations
+
+Then Tier 2: "Best price on May 26. Let me add May 25 and May 27."
+→ TRIP_ADD_SEARCHES with 2 new searches on the same trip. Results merge in.
+
+## Workflow
+
+1. **Understand the trip**: Ask where, when, how long, preferences, currency
+2. **Create a focused trip**: Tight dates, 5-8 searches max, always set currency
+3. **Execute**: Use TRIP_EXECUTE — results show live in the dashboard
+4. **Present results**: Share the best finds
+5. **Drill down if asked**: Create a second focused trip around the sweet spot
+
+## Tips
+
+- Confirm IATA codes (LAX, SFO, JFK, GIG, etc.)
+- For open-jaw (fly into LAX, return from SFO): use returnOrigins field
+- Use preferredAirlines with IATA codes (DL, AA, UA, LA) to filter at Google level
+- avoidAirlines filters results after fetch
+- Use TRIP_LIST to show all saved trips
+- Use TRIP_STOP to cancel running research
+- Each search task has a "GF↗" link to open that exact search on Google Flights
+`;

--- a/packages/deco-flights/server/lib/planner.ts
+++ b/packages/deco-flights/server/lib/planner.ts
@@ -1,0 +1,97 @@
+import type { Trip, SearchPlan, SearchSpec } from "./types.ts";
+
+const MAX_SEARCHES = 10;
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function dateRange(start: string, end: string): string[] {
+  const dates: string[] = [];
+  let current = start;
+  while (current <= end) {
+    dates.push(current);
+    current = addDays(current, 1);
+  }
+  return dates;
+}
+
+export function generateSearchPlan(trip: Trip): SearchPlan {
+  const searches: SearchSpec[] = [];
+  const departureDates = dateRange(
+    trip.earliestDeparture,
+    trip.latestDeparture,
+  );
+
+  const hasOpenJaw = trip.returnOrigins && trip.returnOrigins.length > 0;
+
+  interface RoutePair {
+    to: string;
+    returnFrom?: string;
+  }
+
+  const routePairs: RoutePair[] = [];
+
+  if (hasOpenJaw) {
+    for (const dest of trip.destinations) {
+      for (const retOrigin of trip.returnOrigins!) {
+        if (dest !== retOrigin)
+          routePairs.push({ to: dest, returnFrom: retOrigin });
+      }
+    }
+    for (const dest of trip.destinations) {
+      routePairs.push({ to: dest });
+    }
+  } else {
+    for (const dest of trip.destinations) {
+      routePairs.push({ to: dest });
+    }
+  }
+
+  for (const departDate of departureDates) {
+    const minReturn = addDays(departDate, trip.tripLengthDays.min);
+    const maxReturn = addDays(departDate, trip.tripLengthDays.max);
+    const effectiveLatestReturn =
+      maxReturn < trip.latestReturn ? maxReturn : trip.latestReturn;
+
+    if (minReturn > effectiveLatestReturn) continue;
+
+    const returnDates = dateRange(minReturn, effectiveLatestReturn);
+
+    for (const returnDate of returnDates) {
+      for (const route of routePairs) {
+        searches.push({
+          from: trip.origin,
+          to: route.to,
+          departDate,
+          returnDate,
+          returnFrom: route.returnFrom,
+        });
+      }
+    }
+  }
+
+  const totalCombinations = searches.length;
+  const capped = totalCombinations > MAX_SEARCHES;
+
+  if (capped) {
+    const step = Math.ceil(totalCombinations / MAX_SEARCHES);
+    const sampled: SearchSpec[] = [];
+    for (
+      let i = 0;
+      i < totalCombinations && sampled.length < MAX_SEARCHES;
+      i += step
+    ) {
+      sampled.push(searches[i]);
+    }
+    return { searches: sampled, totalCombinations, capped };
+  }
+
+  return { searches, totalCombinations, capped };
+}
+
+export function specKey(s: SearchSpec): string {
+  return `${s.from}-${s.to}-${s.departDate}-${s.returnDate}-${s.returnFrom || ""}`;
+}

--- a/packages/deco-flights/server/lib/scorer.ts
+++ b/packages/deco-flights/server/lib/scorer.ts
@@ -1,0 +1,134 @@
+import type {
+  FlightResult,
+  ScoredFlightResult,
+  TripPreferences,
+} from "./types.ts";
+
+const WEIGHTS = {
+  price: 0.4,
+  stops: 0.25,
+  layover: 0.15,
+  preferredAirports: 0.1,
+  totalTime: 0.1,
+};
+
+function maxLayoverMinutes(result: FlightResult): number {
+  let maxGap = 0;
+  for (let i = 1; i < result.flights.length; i++) {
+    const prevArrival = new Date(result.flights[i - 1].arrival.time).getTime();
+    const nextDepart = new Date(result.flights[i].departure.time).getTime();
+    const gap = (nextDepart - prevArrival) / (1000 * 60);
+    if (gap > maxGap) maxGap = gap;
+  }
+  return maxGap;
+}
+
+function normalize(value: number, min: number, max: number): number {
+  if (max === min) return 0.5;
+  return 1 - (value - min) / (max - min);
+}
+
+export function scoreResults(
+  results: FlightResult[],
+  prefs: TripPreferences,
+): ScoredFlightResult[] {
+  // Apply hard filters
+  let filtered = results;
+
+  if (prefs.maxStops !== undefined) {
+    filtered = filtered.filter((r) => r.stops <= prefs.maxStops!);
+  }
+
+  if (prefs.maxLayoverHours !== undefined) {
+    const maxMinutes = prefs.maxLayoverHours * 60;
+    filtered = filtered.filter((r) => maxLayoverMinutes(r) <= maxMinutes);
+  }
+
+  if (prefs.maxPrice !== undefined) {
+    filtered = filtered.filter((r) => r.price <= prefs.maxPrice!);
+  }
+
+  if (prefs.avoidAirlines?.length) {
+    const avoid = new Set(prefs.avoidAirlines.map((a) => a.toLowerCase()));
+    filtered = filtered.filter(
+      (r) => !r.flights.some((f) => avoid.has(f.airline.toLowerCase())),
+    );
+  }
+
+  if (filtered.length === 0) {
+    // Relax numeric filters but always respect avoidAirlines
+    let fallback = results;
+    if (prefs.avoidAirlines?.length) {
+      const avoid = new Set(prefs.avoidAirlines.map((a) => a.toLowerCase()));
+      fallback = fallback.filter(
+        (r) => !r.flights.some((f) => avoid.has(f.airline.toLowerCase())),
+      );
+    }
+    return fallback
+      .slice(0, 20)
+      .map((r, i) => ({ ...r, score: 0, rank: i + 1 }));
+  }
+
+  // Compute ranges for normalization
+  const prices = filtered.map((r) => r.price);
+  const stops = filtered.map((r) => r.stops);
+  const layovers = filtered.map((r) => maxLayoverMinutes(r));
+  const durations = filtered.map((r) => r.totalDurationMinutes);
+
+  const minPrice = Math.min(...prices);
+  const maxPrice = Math.max(...prices);
+  const minStops = Math.min(...stops);
+  const maxStops = Math.max(...stops);
+  const minLayover = Math.min(...layovers);
+  const maxLayover = Math.max(...layovers);
+  const minDuration = Math.min(...durations);
+  const maxDuration = Math.max(...durations);
+
+  const preferredSet = new Set(
+    prefs.preferredAirports?.map((a) => a.toUpperCase()) ?? [],
+  );
+  const preferredAirlineSet = new Set(
+    prefs.preferredAirlines?.map((a) => a.toLowerCase()) ?? [],
+  );
+
+  const scored: ScoredFlightResult[] = filtered.map((r) => {
+    let score = 0;
+
+    // Price score (lower is better)
+    score += WEIGHTS.price * normalize(r.price, minPrice, maxPrice);
+
+    // Stops score (fewer is better)
+    score += WEIGHTS.stops * normalize(r.stops, minStops, maxStops);
+
+    // Layover score (shorter is better)
+    score +=
+      WEIGHTS.layover * normalize(maxLayoverMinutes(r), minLayover, maxLayover);
+
+    // Preferred airports bonus
+    const hasPreferred = r.flights.some(
+      (f) =>
+        preferredSet.has(f.departure.airport.toUpperCase()) ||
+        preferredSet.has(f.arrival.airport.toUpperCase()),
+    );
+    const hasPreferredAirline = r.flights.some((f) =>
+      preferredAirlineSet.has(f.airline.toLowerCase()),
+    );
+    score +=
+      WEIGHTS.preferredAirports *
+      ((hasPreferred ? 0.5 : 0) + (hasPreferredAirline ? 0.5 : 0));
+
+    // Total travel time (shorter is better)
+    score +=
+      WEIGHTS.totalTime *
+      normalize(r.totalDurationMinutes, minDuration, maxDuration);
+
+    return { ...r, score: Math.round(score * 1000) / 1000, rank: 0 };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  scored.forEach((r, i) => {
+    r.rank = i + 1;
+  });
+
+  return scored;
+}

--- a/packages/deco-flights/server/lib/scraper.ts
+++ b/packages/deco-flights/server/lib/scraper.ts
@@ -1,0 +1,140 @@
+import {
+  createQuery,
+  getFlights,
+  Passengers,
+  CaptchaError,
+  HttpError,
+  TimeoutError,
+  ParseError,
+  type FlightQueryInput,
+  type SeatType,
+} from "fast-flights-ts";
+import type { FlightResult, SearchSpec } from "./types.ts";
+
+export interface SearchOptions {
+  from: string;
+  to: string;
+  date: string;
+  returnDate?: string;
+  returnFrom?: string;
+  passengers?: number;
+  seatClass?: string;
+  maxStops?: number;
+  airlines?: string[];
+  currency?: string;
+}
+
+export interface SearchResponse {
+  results: FlightResult[];
+  googleFlightsUrl: string;
+  error?: string;
+}
+
+function formatDt(dt: {
+  date: readonly [number, number, number];
+  time: readonly [number, number];
+}): string {
+  const [y, m, d] = dt.date;
+  const [h, min] = dt.time;
+  return `${y}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}T${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
+}
+
+export async function searchFlights(
+  opts: SearchOptions,
+  searchSpec: SearchSpec,
+  signal?: AbortSignal,
+): Promise<SearchResponse> {
+  try {
+    const flights: FlightQueryInput[] = [
+      {
+        date: opts.date,
+        from_airport: opts.from,
+        to_airport: opts.to,
+        max_stops: opts.maxStops,
+        airlines: opts.airlines,
+      },
+    ];
+
+    const returnOrigin = opts.returnFrom || opts.to;
+    const isOpenJaw = opts.returnDate && returnOrigin !== opts.to;
+
+    if (opts.returnDate) {
+      flights.push({
+        date: opts.returnDate,
+        from_airport: returnOrigin,
+        to_airport: opts.from,
+        max_stops: opts.maxStops,
+        airlines: opts.airlines,
+      });
+    }
+
+    const tripType = isOpenJaw
+      ? "multi-city"
+      : opts.returnDate
+        ? "round-trip"
+        : "one-way";
+
+    const query = createQuery({
+      flights,
+      seat: (opts.seatClass as SeatType) || "economy",
+      trip: tripType,
+      passengers: new Passengers({ adults: opts.passengers || 1 }),
+      currency: opts.currency || "USD",
+      language: "en-US",
+    });
+
+    const googleFlightsUrl = query.url();
+
+    const rawResults = await getFlights(query, {
+      timeout: isOpenJaw ? 45000 : 25000,
+      maxRetries: 1,
+      retryDelay: 2000,
+      signal,
+    });
+
+    const results: FlightResult[] = rawResults.map((r) => ({
+      price: r.price,
+      currency: opts.currency || "USD",
+      flights: r.flights.map((leg) => ({
+        airline: r.airlines[0] || "Unknown",
+        flightNumber: "",
+        departure: {
+          airport: leg.from_airport.code,
+          time: formatDt(leg.departure),
+        },
+        arrival: {
+          airport: leg.to_airport.code,
+          time: formatDt(leg.arrival),
+        },
+        durationMinutes: leg.duration,
+        aircraft: leg.plane_type,
+      })),
+      totalDurationMinutes: r.flights.reduce((s, l) => s + l.duration, 0),
+      stops: Math.max(0, r.flights.length - 1),
+      emissions: r.carbon
+        ? { typical: r.carbon.typical_on_route, actual: r.carbon.emission }
+        : undefined,
+      searchSpec,
+    }));
+
+    return { results, googleFlightsUrl };
+  } catch (err) {
+    const fallbackUrl = `https://www.google.com/travel/flights?q=${encodeURIComponent(`flights from ${opts.from} to ${opts.to} on ${opts.date}`)}`;
+    const errResponse = (msg: string) => ({
+      results: [] as FlightResult[],
+      googleFlightsUrl: fallbackUrl,
+      error: msg,
+    });
+
+    if (err instanceof CaptchaError)
+      return errResponse("Google CAPTCHA — rate limited. Wait and retry.");
+    if (err instanceof HttpError)
+      return errResponse(`HTTP ${err.status} from Google Flights`);
+    if (err instanceof TimeoutError) return errResponse("Search timed out");
+    if (err instanceof ParseError)
+      return errResponse(`Parse error: ${err.message}`);
+    return errResponse(
+      `Search error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/packages/deco-flights/server/lib/storage.ts
+++ b/packages/deco-flights/server/lib/storage.ts
@@ -1,0 +1,96 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { Trip, TripSummary } from "./types.ts";
+
+const TRIPS_DIR = join(homedir(), ".deco", "flights", "trips");
+
+async function ensureDir(dir: string): Promise<void> {
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(dir, { recursive: true });
+}
+
+function tripPath(id: string): string {
+  return join(TRIPS_DIR, `${id}.json`);
+}
+
+export async function saveTrip(trip: Trip): Promise<void> {
+  await ensureDir(TRIPS_DIR);
+  await Bun.write(tripPath(trip.id), JSON.stringify(trip, null, 2));
+}
+
+export async function loadTrip(id: string): Promise<Trip | null> {
+  const file = Bun.file(tripPath(id));
+  if (!(await file.exists())) return null;
+  return file.json() as Promise<Trip>;
+}
+
+export async function listTrips(statusFilter?: string): Promise<TripSummary[]> {
+  await ensureDir(TRIPS_DIR);
+  const { readdir } = await import("node:fs/promises");
+  const files = await readdir(TRIPS_DIR);
+  const summaries: TripSummary[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const trip = (await Bun.file(join(TRIPS_DIR, file)).json()) as Trip;
+    if (
+      statusFilter &&
+      statusFilter !== "all" &&
+      trip.status !== statusFilter
+    ) {
+      continue;
+    }
+    const bestPrice = trip.results?.length
+      ? Math.min(...trip.results.map((r) => r.price))
+      : undefined;
+    summaries.push({
+      id: trip.id,
+      name: trip.name,
+      status: trip.status,
+      origin: trip.origin,
+      destinations: trip.destinations,
+      earliestDeparture: trip.earliestDeparture,
+      latestReturn: trip.latestReturn,
+      resultCount: trip.results?.length ?? 0,
+      bestPrice,
+    });
+  }
+
+  return summaries.sort((a, b) =>
+    b.earliestDeparture.localeCompare(a.earliestDeparture),
+  );
+}
+
+export async function listFullTrips(statusFilter?: string): Promise<Trip[]> {
+  await ensureDir(TRIPS_DIR);
+  const { readdir } = await import("node:fs/promises");
+  const files = await readdir(TRIPS_DIR);
+  const trips: Trip[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const trip = (await Bun.file(join(TRIPS_DIR, file)).json()) as Trip;
+    if (
+      statusFilter &&
+      statusFilter !== "all" &&
+      trip.status !== statusFilter
+    ) {
+      continue;
+    }
+    trips.push(trip);
+  }
+
+  return trips.sort((a, b) =>
+    b.earliestDeparture.localeCompare(a.earliestDeparture),
+  );
+}
+
+export async function deleteTrip(id: string): Promise<boolean> {
+  const { unlink } = await import("node:fs/promises");
+  try {
+    await unlink(tripPath(id));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/deco-flights/server/lib/types.ts
+++ b/packages/deco-flights/server/lib/types.ts
@@ -1,0 +1,103 @@
+export interface TripPreferences {
+  maxStops?: number;
+  maxLayoverHours?: number;
+  preferredAirports?: string[];
+  avoidAirlines?: string[];
+  preferredAirlines?: string[];
+  maxPrice?: number;
+  currency?: string;
+}
+
+export interface TripLengthDays {
+  min: number;
+  max: number;
+}
+
+export type TripStatus = "draft" | "researching" | "complete";
+
+export type SearchTaskStatus = "pending" | "running" | "done" | "error";
+
+export interface SearchTask {
+  id: number;
+  spec: SearchSpec;
+  status: SearchTaskStatus;
+  resultCount: number;
+  googleFlightsUrl?: string;
+  tier?: number;
+  error?: string;
+  durationMs?: number;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface Trip {
+  id: string;
+  name: string;
+  status: TripStatus;
+  origin: string;
+  destinations: string[];
+  returnOrigins?: string[];
+  earliestDeparture: string;
+  latestDeparture: string;
+  earliestReturn: string;
+  latestReturn: string;
+  tripLengthDays: TripLengthDays;
+  passengers: number;
+  seatClass: string;
+  preferences: TripPreferences;
+  searchPlan?: SearchPlan;
+  searchTasks?: SearchTask[];
+  results?: ScoredFlightResult[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SearchSpec {
+  from: string;
+  to: string;
+  departDate: string;
+  returnDate: string;
+  returnFrom?: string;
+}
+
+export interface SearchPlan {
+  searches: SearchSpec[];
+  totalCombinations: number;
+  capped: boolean;
+}
+
+export interface FlightLeg {
+  airline: string;
+  flightNumber: string;
+  departure: { airport: string; time: string };
+  arrival: { airport: string; time: string };
+  durationMinutes: number;
+  aircraft: string;
+}
+
+export interface FlightResult {
+  price: number;
+  currency: string;
+  flights: FlightLeg[];
+  totalDurationMinutes: number;
+  stops: number;
+  emissions?: { typical: number; actual: number };
+  searchSpec: SearchSpec;
+}
+
+export interface ScoredFlightResult extends FlightResult {
+  score: number;
+  rank: number;
+}
+
+export interface TripSummary {
+  id: string;
+  name: string;
+  status: TripStatus;
+  origin: string;
+  destinations: string[];
+  earliestDeparture: string;
+  latestReturn: string;
+  resultCount: number;
+  bestPrice?: number;
+}

--- a/packages/deco-flights/server/lib/worker.ts
+++ b/packages/deco-flights/server/lib/worker.ts
@@ -1,0 +1,179 @@
+import { loadTrip, saveTrip } from "./storage.ts";
+import { generateSearchPlan } from "./planner.ts";
+import { searchFlights } from "./scraper.ts";
+import { scoreResults } from "./scorer.ts";
+import type { FlightResult, SearchTask, Trip } from "./types.ts";
+
+const CONCURRENCY = 3;
+const DELAY_BETWEEN_WAVES_MS = 1000;
+
+const activeWorkers = new Map<
+  string,
+  { stop: () => void; abort: AbortController }
+>();
+
+export function isWorkerRunning(tripId: string): boolean {
+  return activeWorkers.has(tripId);
+}
+
+export function stopWorker(tripId: string): boolean {
+  const worker = activeWorkers.get(tripId);
+  if (worker) {
+    worker.stop();
+    worker.abort.abort();
+    return true;
+  }
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function startWorker(tripId: string): void {
+  if (activeWorkers.has(tripId)) return;
+
+  let stopped = false;
+  const abort = new AbortController();
+  const handle = {
+    stop: () => {
+      stopped = true;
+    },
+    abort,
+  };
+  activeWorkers.set(tripId, handle);
+
+  runWorker(tripId, () => stopped, abort.signal).finally(() => {
+    activeWorkers.delete(tripId);
+  });
+}
+
+async function executeTask(
+  task: SearchTask,
+  trip: Trip,
+  signal: AbortSignal,
+): Promise<FlightResult[]> {
+  task.status = "running";
+  task.startedAt = new Date().toISOString();
+  task.error = undefined;
+
+  const startTime = Date.now();
+
+  try {
+    const response = await searchFlights(
+      {
+        from: task.spec.from,
+        to: task.spec.to,
+        date: task.spec.departDate,
+        returnDate: task.spec.returnDate,
+        returnFrom: task.spec.returnFrom,
+        passengers: trip.passengers,
+        seatClass: trip.seatClass,
+        maxStops: trip.preferences.maxStops,
+        airlines: trip.preferences.preferredAirlines,
+        currency: trip.preferences.currency || "USD",
+      },
+      task.spec,
+      signal,
+    );
+
+    task.durationMs = Date.now() - startTime;
+    task.finishedAt = new Date().toISOString();
+    task.googleFlightsUrl = response.googleFlightsUrl;
+
+    if (response.results.length > 0) {
+      task.status = "done";
+      task.resultCount = response.results.length;
+      return response.results;
+    } else if (response.error) {
+      task.status = "error";
+      task.error = response.error;
+    } else {
+      task.status = "done";
+      task.resultCount = 0;
+    }
+  } catch (err) {
+    task.durationMs = Date.now() - startTime;
+    task.finishedAt = new Date().toISOString();
+    task.status = "error";
+    task.error = err instanceof Error ? err.message : "Unknown error";
+  }
+  return [];
+}
+
+async function runWorker(
+  tripId: string,
+  isStopped: () => boolean,
+  signal: AbortSignal,
+): Promise<void> {
+  const trip = await loadTrip(tripId);
+  if (!trip) return;
+
+  if (!trip.searchPlan) {
+    trip.searchPlan = generateSearchPlan(trip);
+  }
+
+  if (!trip.searchTasks) {
+    trip.searchTasks = trip.searchPlan.searches.map((spec, i) => ({
+      id: i,
+      spec,
+      status: "pending" as const,
+      resultCount: 0,
+    }));
+  }
+
+  for (const t of trip.searchTasks) {
+    if (t.status === "running") {
+      t.status = "pending";
+      t.error = undefined;
+      t.startedAt = undefined;
+    }
+  }
+
+  trip.status = "researching";
+  await saveTrip(trip);
+
+  const allResults: FlightResult[] = [...(trip.results ?? [])];
+
+  // Run searches in parallel waves of CONCURRENCY
+  while (!isStopped()) {
+    const pending = trip.searchTasks.filter(
+      (t) => t.status === "pending" || t.status === "error",
+    );
+    if (pending.length === 0) break;
+
+    const wave = pending.slice(0, CONCURRENCY);
+    await saveTrip(trip); // save "running" states
+
+    const waveResults = await Promise.all(
+      wave.map((task) => executeTask(task, trip, signal)),
+    );
+
+    for (const results of waveResults) {
+      allResults.push(...results);
+    }
+
+    // Score and persist after each wave
+    trip.results = scoreResults(allResults, trip.preferences);
+    trip.updatedAt = new Date().toISOString();
+    await saveTrip(trip);
+
+    if (!isStopped() && pending.length > CONCURRENCY) {
+      await sleep(DELAY_BETWEEN_WAVES_MS);
+    }
+  }
+
+  for (const t of trip.searchTasks ?? []) {
+    if (t.status === "running") {
+      t.status = "pending";
+      t.startedAt = undefined;
+    }
+  }
+
+  const remaining = (trip.searchTasks ?? []).filter(
+    (t) => t.status === "pending",
+  ).length;
+  trip.status = remaining > 0 ? "draft" : "complete";
+  trip.updatedAt = new Date().toISOString();
+  await saveTrip(trip);
+}

--- a/packages/deco-flights/server/tools/flight-search.ts
+++ b/packages/deco-flights/server/tools/flight-search.ts
@@ -1,0 +1,85 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { searchFlights } from "../lib/scraper.ts";
+
+export const FLIGHT_SEARCH = createTool({
+  id: "FLIGHT_SEARCH",
+  description:
+    "Search for flights between two airports on a specific date. Returns flight options with prices, airlines, stops, and durations.",
+  annotations: {
+    title: "Search Flights",
+    readOnlyHint: true,
+  },
+  _meta: {
+    ui: { resourceUri: "ui://deco-flights/search-results" },
+  },
+  inputSchema: z.object({
+    from: z.string().describe("Departure airport IATA code (e.g., SFO)"),
+    to: z.string().describe("Arrival airport IATA code (e.g., LAX)"),
+    date: z.string().describe("Departure date in YYYY-MM-DD format"),
+    returnDate: z
+      .string()
+      .optional()
+      .describe("Return date in YYYY-MM-DD format (for round trips)"),
+    returnFrom: z
+      .string()
+      .optional()
+      .describe(
+        "Return departure airport if different from arrival (open-jaw). E.g., fly into LAX, return from SFO.",
+      ),
+    passengers: z
+      .number()
+      .optional()
+      .default(1)
+      .describe("Number of adult passengers"),
+    seatClass: z
+      .enum(["economy", "premium-economy", "business", "first"])
+      .optional()
+      .default("economy")
+      .describe("Seat class"),
+    maxStops: z
+      .number()
+      .optional()
+      .describe("Maximum number of stops (0 for nonstop)"),
+    airlines: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Only show flights from these airlines (IATA codes, e.g. ['DL', 'AA', 'UA'])",
+      ),
+    currency: z.string().optional().default("USD").describe("Currency code"),
+  }),
+  execute: async ({ context }) => {
+    const returnFrom = context.returnFrom?.toUpperCase();
+    const searchSpec = {
+      from: context.from.toUpperCase(),
+      to: context.to.toUpperCase(),
+      departDate: context.date,
+      returnDate: context.returnDate ?? context.date,
+      returnFrom,
+    };
+
+    const response = await searchFlights(
+      {
+        from: searchSpec.from,
+        to: searchSpec.to,
+        date: context.date,
+        returnDate: context.returnDate,
+        returnFrom,
+        passengers: context.passengers,
+        seatClass: context.seatClass,
+        maxStops: context.maxStops,
+        airlines: context.airlines,
+        currency: context.currency,
+      },
+      searchSpec,
+    );
+
+    return {
+      results: response.results,
+      resultCount: response.results.length,
+      googleFlightsUrl: response.googleFlightsUrl,
+      error: response.error,
+    };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-add-searches.ts
+++ b/packages/deco-flights/server/tools/trip-add-searches.ts
@@ -1,0 +1,103 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadTrip, saveTrip } from "../lib/storage.ts";
+import { specKey } from "../lib/planner.ts";
+import { startWorker, isWorkerRunning } from "../lib/worker.ts";
+import type { SearchTask } from "../lib/types.ts";
+
+export const TRIP_ADD_SEARCHES = createTool({
+  id: "TRIP_ADD_SEARCHES",
+  description:
+    "Add more searches to an existing trip and start executing them. Use this to drill down around good dates, try different routes, or refine results. Duplicates are skipped.",
+  annotations: {
+    title: "Add Searches to Trip",
+  },
+  inputSchema: z.object({
+    tripId: z.string().describe("The trip ID to add searches to"),
+    searches: z
+      .array(
+        z.object({
+          from: z.string().describe("Departure airport IATA code"),
+          to: z.string().describe("Arrival airport IATA code"),
+          departDate: z.string().describe("Departure date YYYY-MM-DD"),
+          returnDate: z.string().describe("Return date YYYY-MM-DD"),
+          returnFrom: z
+            .string()
+            .optional()
+            .describe("Return from different airport (open-jaw)"),
+        }),
+      )
+      .describe("New searches to add"),
+    execute: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe("Start executing immediately (default true)"),
+  }),
+  execute: async ({ context }) => {
+    const trip = await loadTrip(context.tripId);
+    if (!trip) {
+      throw new Error(`Trip not found: ${context.tripId}`);
+    }
+
+    if (!trip.searchTasks) trip.searchTasks = [];
+
+    // Build set of existing spec keys for dedup
+    const existing = new Set(trip.searchTasks.map((t) => specKey(t.spec)));
+
+    const startId = trip.searchTasks.length;
+    let added = 0;
+    let skipped = 0;
+
+    for (const s of context.searches) {
+      const spec = {
+        from: s.from.toUpperCase(),
+        to: s.to.toUpperCase(),
+        departDate: s.departDate,
+        returnDate: s.returnDate,
+        returnFrom: s.returnFrom?.toUpperCase(),
+      };
+
+      const key = specKey(spec);
+      if (existing.has(key)) {
+        skipped++;
+        continue;
+      }
+      existing.add(key);
+
+      const task: SearchTask = {
+        id: startId + added,
+        spec,
+        status: "pending",
+        resultCount: 0,
+      };
+      trip.searchTasks.push(task);
+      added++;
+    }
+
+    // Update search plan to reflect new total
+    if (trip.searchPlan) {
+      trip.searchPlan.searches = trip.searchTasks.map((t) => t.spec);
+      trip.searchPlan.totalCombinations = trip.searchTasks.length;
+    }
+
+    trip.updatedAt = new Date().toISOString();
+    await saveTrip(trip);
+
+    // Start worker if requested and not already running
+    if (context.execute && added > 0 && !isWorkerRunning(context.tripId)) {
+      startWorker(context.tripId);
+    }
+
+    return {
+      added,
+      skipped,
+      totalSearches: trip.searchTasks.length,
+      workerRunning: isWorkerRunning(context.tripId),
+      message:
+        added > 0
+          ? `Added ${added} searches${skipped ? ` (${skipped} duplicates skipped)` : ""}. ${context.execute ? "Research started." : "Ready to execute."}`
+          : `All ${skipped} searches already exist in this trip.`,
+    };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-create.ts
+++ b/packages/deco-flights/server/tools/trip-create.ts
@@ -1,0 +1,97 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { saveTrip } from "../lib/storage.ts";
+import { generateSearchPlan } from "../lib/planner.ts";
+import type { Trip } from "../lib/types.ts";
+
+export const TRIP_CREATE = createTool({
+  id: "TRIP_CREATE",
+  description:
+    "Create a new trip research plan. Specify destinations, date ranges, trip length, and preferences. The system generates a search plan covering all valid date combinations.",
+  annotations: {
+    title: "Create Trip",
+  },
+  _meta: {
+    ui: { resourceUri: "ui://deco-flights/trip-card" },
+  },
+  inputSchema: z.object({
+    name: z.string().describe('Trip name (e.g., "Trip to California")'),
+    origin: z.string().describe("Departure airport IATA code"),
+    destinations: z
+      .array(z.string())
+      .describe("Destination airport IATA codes"),
+    returnOrigins: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Return departure airports for open-jaw itineraries (e.g., fly into LAX, return from SFO). Omit for standard round-trips.",
+      ),
+    earliestDeparture: z
+      .string()
+      .describe("Earliest acceptable departure date (YYYY-MM-DD)"),
+    latestDeparture: z
+      .string()
+      .describe("Latest acceptable departure date (YYYY-MM-DD)"),
+    earliestReturn: z
+      .string()
+      .describe("Earliest acceptable return date (YYYY-MM-DD)"),
+    latestReturn: z
+      .string()
+      .describe("Latest acceptable return date (YYYY-MM-DD)"),
+    tripLengthDays: z.object({
+      min: z.number().describe("Minimum trip length in days"),
+      max: z.number().describe("Maximum trip length in days"),
+    }),
+    passengers: z.number().optional().default(1),
+    seatClass: z
+      .enum(["economy", "premium-economy", "business", "first"])
+      .optional()
+      .default("economy"),
+    preferences: z
+      .object({
+        maxStops: z.number().optional(),
+        maxLayoverHours: z.number().optional(),
+        preferredAirports: z.array(z.string()).optional(),
+        avoidAirlines: z.array(z.string()).optional(),
+        preferredAirlines: z.array(z.string()).optional(),
+        maxPrice: z.number().optional(),
+        currency: z
+          .string()
+          .optional()
+          .describe("Currency code for prices (default USD)"),
+      })
+      .optional()
+      .default({}),
+  }),
+  execute: async ({ context }) => {
+    const id = crypto.randomUUID().slice(0, 8);
+    const now = new Date().toISOString();
+
+    const trip: Trip = {
+      id,
+      name: context.name,
+      status: "draft",
+      origin: context.origin.toUpperCase(),
+      destinations: context.destinations.map((d) => d.toUpperCase()),
+      returnOrigins: context.returnOrigins?.map((d) => d.toUpperCase()),
+      earliestDeparture: context.earliestDeparture,
+      latestDeparture: context.latestDeparture,
+      earliestReturn: context.earliestReturn,
+      latestReturn: context.latestReturn,
+      tripLengthDays: context.tripLengthDays,
+      passengers: context.passengers,
+      seatClass: context.seatClass,
+      preferences: context.preferences,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    trip.searchPlan = generateSearchPlan(trip);
+    await saveTrip(trip);
+
+    return {
+      trip,
+      message: `Trip "${trip.name}" created with ${trip.searchPlan.searches.length} planned searches${trip.searchPlan.capped ? ` (capped from ${trip.searchPlan.totalCombinations} total combinations)` : ""}.`,
+    };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-delete.ts
+++ b/packages/deco-flights/server/tools/trip-delete.ts
@@ -1,0 +1,22 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { deleteTrip } from "../lib/storage.ts";
+
+export const TRIP_DELETE = createTool({
+  id: "TRIP_DELETE",
+  description: "Delete a saved trip and its results.",
+  annotations: {
+    title: "Delete Trip",
+    destructiveHint: true,
+  },
+  inputSchema: z.object({
+    tripId: z.string().describe("The trip ID to delete"),
+  }),
+  execute: async ({ context }) => {
+    const deleted = await deleteTrip(context.tripId);
+    if (!deleted) {
+      throw new Error(`Trip not found: ${context.tripId}`);
+    }
+    return { success: true };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-execute.ts
+++ b/packages/deco-flights/server/tools/trip-execute.ts
@@ -1,0 +1,57 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadTrip } from "../lib/storage.ts";
+import { isWorkerRunning, startWorker } from "../lib/worker.ts";
+
+export const TRIP_EXECUTE = createTool({
+  id: "TRIP_EXECUTE",
+  description:
+    "Start flight research for a trip. Launches a background worker that runs ALL searches automatically. " +
+    "Returns immediately with the trip data and a live UI dashboard. Use TRIP_STOP to cancel.",
+  annotations: {
+    title: "Execute Trip Research",
+  },
+  _meta: {
+    ui: { resourceUri: "ui://deco-flights/trip-planner" },
+  },
+  inputSchema: z.object({
+    tripId: z.string().describe("The trip ID to research"),
+  }),
+  execute: async ({ context }) => {
+    const trip = await loadTrip(context.tripId);
+    if (!trip) {
+      throw new Error(`Trip not found: ${context.tripId}`);
+    }
+
+    const alreadyRunning = isWorkerRunning(context.tripId);
+
+    if (!alreadyRunning) {
+      startWorker(context.tripId);
+    }
+
+    // Re-read trip after worker may have initialized tasks
+    const freshTrip = (await loadTrip(context.tripId)) ?? trip;
+
+    const tasks = freshTrip.searchTasks ?? [];
+    const done = tasks.filter(
+      (t) => t.status === "done" || t.status === "error",
+    ).length;
+    const totalSearches =
+      tasks.length || freshTrip.searchPlan?.searches.length || 0;
+
+    const trimmedTrip = {
+      ...freshTrip,
+      results: (freshTrip.results ?? []).slice(0, 20),
+      _totalResults: freshTrip.results?.length ?? 0,
+    };
+
+    return {
+      trip: trimmedTrip,
+      workerRunning: true,
+      started: !alreadyRunning,
+      message: alreadyRunning
+        ? `Research running (${done}/${totalSearches} done). Dashboard is live.`
+        : `Research started! ${totalSearches} searches running in background.`,
+    };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-get.ts
+++ b/packages/deco-flights/server/tools/trip-get.ts
@@ -1,0 +1,40 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadTrip } from "../lib/storage.ts";
+import { isWorkerRunning } from "../lib/worker.ts";
+
+export const TRIP_GET = createTool({
+  id: "TRIP_GET",
+  description:
+    "Get trip details including search tasks progress and top results. " +
+    "Returns at most 20 results to keep response size manageable.",
+  annotations: {
+    title: "Get Trip",
+    readOnlyHint: true,
+  },
+  _meta: {
+    ui: { resourceUri: "ui://deco-flights/trip-planner" },
+  },
+  inputSchema: z.object({
+    tripId: z.string().describe("The trip ID"),
+  }),
+  execute: async ({ context }) => {
+    const trip = await loadTrip(context.tripId);
+    if (!trip) {
+      throw new Error(`Trip not found: ${context.tripId}`);
+    }
+
+    // Return a trimmed trip: full searchTasks but capped results
+    const totalResults = trip.results?.length ?? 0;
+    const trimmedTrip = {
+      ...trip,
+      results: (trip.results ?? []).slice(0, 20),
+      _totalResults: totalResults,
+    };
+
+    return {
+      trip: trimmedTrip,
+      workerRunning: isWorkerRunning(context.tripId),
+    };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-list.ts
+++ b/packages/deco-flights/server/tools/trip-list.ts
@@ -1,0 +1,34 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { listFullTrips } from "../lib/storage.ts";
+import { isWorkerRunning } from "../lib/worker.ts";
+
+export const TRIP_LIST = createTool({
+  id: "TRIP_LIST",
+  description:
+    "List all saved trips with search tasks and top results (capped at 10 per trip).",
+  annotations: {
+    title: "List Trips",
+    readOnlyHint: true,
+  },
+  _meta: {
+    ui: { resourceUri: "ui://deco-flights/trips-dashboard" },
+  },
+  inputSchema: z.object({
+    status: z
+      .enum(["draft", "researching", "complete", "all"])
+      .optional()
+      .default("all")
+      .describe("Filter by trip status"),
+  }),
+  execute: async ({ context }) => {
+    const trips = await listFullTrips(context.status);
+    const trimmed = trips.map((t) => ({
+      ...t,
+      results: (t.results ?? []).slice(0, 20),
+      _totalResults: t.results?.length ?? 0,
+      workerRunning: isWorkerRunning(t.id),
+    }));
+    return { trips: trimmed, totalCount: trips.length };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-stop.ts
+++ b/packages/deco-flights/server/tools/trip-stop.ts
@@ -1,0 +1,53 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadTrip, saveTrip } from "../lib/storage.ts";
+import { stopWorker } from "../lib/worker.ts";
+
+export const TRIP_STOP = createTool({
+  id: "TRIP_STOP",
+  description:
+    "Stop an in-progress trip research. The background worker will finish its current search then stop. All results found so far are kept.",
+  annotations: {
+    title: "Stop Research",
+  },
+  inputSchema: z.object({
+    tripId: z.string().describe("The trip ID to stop researching"),
+  }),
+  execute: async ({ context }) => {
+    const trip = await loadTrip(context.tripId);
+    if (!trip) {
+      throw new Error(`Trip not found: ${context.tripId}`);
+    }
+
+    const wasRunning = stopWorker(context.tripId);
+
+    // Reset running tasks
+    for (const task of trip.searchTasks ?? []) {
+      if (task.status === "running") {
+        task.status = "pending";
+        task.startedAt = undefined;
+        task.error = undefined;
+      }
+    }
+
+    trip.status = "draft";
+    trip.updatedAt = new Date().toISOString();
+    await saveTrip(trip);
+
+    const done = (trip.searchTasks ?? []).filter(
+      (t) => t.status === "done",
+    ).length;
+    const pending = (trip.searchTasks ?? []).filter(
+      (t) => t.status === "pending",
+    ).length;
+
+    return {
+      success: true,
+      wasRunning,
+      resultsKept: trip.results?.length ?? 0,
+      done,
+      pending,
+      message: `Stopped "${trip.name}". ${trip.results?.length ?? 0} results kept, ${done} searches done, ${pending} remaining.`,
+    };
+  },
+});

--- a/packages/deco-flights/server/tools/trip-update.ts
+++ b/packages/deco-flights/server/tools/trip-update.ts
@@ -1,0 +1,97 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadTrip, saveTrip } from "../lib/storage.ts";
+import { generateSearchPlan } from "../lib/planner.ts";
+
+export const TRIP_UPDATE = createTool({
+  id: "TRIP_UPDATE",
+  description:
+    "Update a trip's configuration or preferences. Regenerates the search plan if date/destination fields change.",
+  annotations: {
+    title: "Update Trip",
+  },
+  inputSchema: z.object({
+    tripId: z.string().describe("The trip ID to update"),
+    name: z.string().optional(),
+    origin: z.string().optional(),
+    destinations: z.array(z.string()).optional(),
+    earliestDeparture: z.string().optional(),
+    latestDeparture: z.string().optional(),
+    earliestReturn: z.string().optional(),
+    latestReturn: z.string().optional(),
+    tripLengthDays: z
+      .object({
+        min: z.number(),
+        max: z.number(),
+      })
+      .optional(),
+    passengers: z.number().optional(),
+    seatClass: z
+      .enum(["economy", "premium-economy", "business", "first"])
+      .optional(),
+    preferences: z
+      .object({
+        maxStops: z.number().optional(),
+        maxLayoverHours: z.number().optional(),
+        preferredAirports: z.array(z.string()).optional(),
+        avoidAirlines: z.array(z.string()).optional(),
+        preferredAirlines: z.array(z.string()).optional(),
+        maxPrice: z.number().optional(),
+        currency: z
+          .string()
+          .optional()
+          .describe("Currency code (e.g. USD, BRL, EUR)"),
+      })
+      .optional(),
+  }),
+  execute: async ({ context }) => {
+    const trip = await loadTrip(context.tripId);
+    if (!trip) {
+      throw new Error(`Trip not found: ${context.tripId}`);
+    }
+
+    const { tripId: _, ...updates } = context;
+    let planChanged = false;
+
+    for (const [key, value] of Object.entries(updates)) {
+      if (value !== undefined) {
+        (trip as unknown as Record<string, unknown>)[key] =
+          key === "origin"
+            ? (value as string).toUpperCase()
+            : key === "destinations"
+              ? (value as string[]).map((d) => d.toUpperCase())
+              : value;
+
+        if (
+          [
+            "origin",
+            "destinations",
+            "earliestDeparture",
+            "latestDeparture",
+            "earliestReturn",
+            "latestReturn",
+            "tripLengthDays",
+          ].includes(key)
+        ) {
+          planChanged = true;
+        }
+      }
+    }
+
+    if (planChanged) {
+      trip.searchPlan = generateSearchPlan(trip);
+      trip.results = undefined;
+      trip.status = "draft";
+    }
+
+    trip.updatedAt = new Date().toISOString();
+    await saveTrip(trip);
+
+    return {
+      trip,
+      message: planChanged
+        ? `Trip updated. New search plan: ${trip.searchPlan!.searches.length} searches.`
+        : "Trip preferences updated.",
+    };
+  },
+});

--- a/packages/deco-flights/server/ui/search-results.ts
+++ b/packages/deco-flights/server/ui/search-results.ts
@@ -1,0 +1,99 @@
+import { SHARED_STYLES, APPBRIDGE_SCRIPT } from "./shared-styles.ts";
+
+export function renderSearchResults(): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>${SHARED_STYLES}
+  .flight-card {
+    border: 1px solid var(--color-border-primary, #e2e8f0);
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .flight-card:last-child { margin-bottom: 0; }
+  .route { display: flex; align-items: center; gap: 8px; }
+  .time { font-weight: 600; font-size: 15px; }
+  .airport { font-size: 12px; color: var(--color-text-secondary, #64748b); }
+  .stops-info { font-size: 12px; color: var(--color-text-secondary, #64748b); text-align: center; }
+  .stops-line { width: 60px; height: 1px; background: #cbd5e1; margin: 2px auto; position: relative; }
+  .stops-dot { width: 6px; height: 6px; border-radius: 50%; background: #94a3b8; position: absolute; top: -2.5px; }
+  .price-tag { font-size: 18px; font-weight: 700; color: #16a34a; text-align: right; }
+  .duration { font-size: 12px; color: var(--color-text-secondary, #64748b); }
+</style></head><body>
+<div id="root">
+  <div class="empty-state">
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 12h5l3-9 4 18 3-9h5"/></svg>
+    <p class="muted text-sm">Waiting for search results...</p>
+  </div>
+</div>
+${APPBRIDGE_SCRIPT}
+<script>
+function formatTime(t) {
+  if (!t) return '--:--';
+  const d = new Date(t);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+function formatDuration(mins) {
+  if (!mins) return '';
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? h + 'h ' + (m > 0 ? m + 'm' : '') : m + 'm';
+}
+function stopsLabel(n) {
+  if (n === 0) return 'Nonstop';
+  return n + ' stop' + (n > 1 ? 's' : '');
+}
+
+function onToolResult(result) {
+  const data = result?.structuredContent || result;
+  if (!data) return;
+  const results = data.results || [];
+  const error = data.error;
+  const fallbackUrl = data.fallbackUrl;
+  const root = document.getElementById('root');
+
+  if (results.length === 0) {
+    root.innerHTML = '<div class="empty-state">' +
+      '<p class="text-sm muted">' + (error || 'No flights found.') + '</p>' +
+      (fallbackUrl ? '<a href="' + fallbackUrl + '" target="_blank" style="margin-top:8px;color:#2563eb;font-size:13px;">Search on Google Flights ↗</a>' : '') +
+      '</div>';
+    resizeHeight(120);
+    return;
+  }
+
+  const top = results.slice(0, 3);
+  let html = '<div style="margin-bottom:8px"><span class="font-semibold text-sm">' + results.length + ' flights found</span></div>';
+
+  top.forEach(function(r) {
+    const legs = r.flights || [];
+    const first = legs[0] || {};
+    const last = legs[legs.length - 1] || {};
+    html += '<div class="flight-card">' +
+      '<div>' +
+        '<div class="route">' +
+          '<div><div class="time">' + formatTime(first.departure?.time) + '</div><div class="airport">' + (first.departure?.airport || '') + '</div></div>' +
+          '<div class="stops-info">' +
+            '<div>' + formatDuration(r.totalDurationMinutes) + '</div>' +
+            '<div class="stops-line">' + (r.stops > 0 ? '<div class="stops-dot" style="left:50%"></div>' : '') + '</div>' +
+            '<div>' + stopsLabel(r.stops) + '</div>' +
+          '</div>' +
+          '<div><div class="time">' + formatTime(last.arrival?.time) + '</div><div class="airport">' + (last.arrival?.airport || '') + '</div></div>' +
+        '</div>' +
+        '<div class="text-xs muted mt-2">' + (first.airline || '') + '</div>' +
+      '</div>' +
+      '<div class="price-tag">$' + (r.price || 0) + '</div>' +
+    '</div>';
+  });
+
+  if (results.length > 3) {
+    html += '<div style="text-align:center;margin-top:8px">' +
+      '<button class="btn-ghost text-xs" onclick="sendMessage(\\'Show all ' + results.length + ' flight results\\')">View all ' + results.length + ' results</button>' +
+    '</div>';
+  }
+  root.innerHTML = html;
+  resizeHeight(Math.min(root.scrollHeight + 32, 400));
+}
+</script></body></html>`;
+}

--- a/packages/deco-flights/server/ui/shared-styles.ts
+++ b/packages/deco-flights/server/ui/shared-styles.ts
@@ -1,0 +1,228 @@
+export const SHARED_STYLES = `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+    background: var(--color-background-primary, #ffffff);
+    color: var(--color-text-primary, #0f172a);
+    line-height: 1.5;
+    padding: 16px;
+  }
+  .muted { color: var(--color-text-secondary, #64748b); }
+  .small { font-size: 12px; }
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .badge-draft { background: #f1f5f9; color: #475569; }
+  .badge-researching { background: #dbeafe; color: #1d4ed8; }
+  .badge-complete { background: #dcfce7; color: #16a34a; }
+  .card {
+    border: 1px solid var(--color-border-primary, #e2e8f0);
+    border-radius: var(--border-radius-md, 8px);
+    padding: 12px 16px;
+    background: var(--color-background-primary, #ffffff);
+  }
+  .card:hover { background: var(--color-background-secondary, #f8fafc); }
+  .grid { display: grid; gap: 12px; }
+  .flex { display: flex; align-items: center; }
+  .gap-2 { gap: 8px; }
+  .gap-3 { gap: 12px; }
+  .gap-4 { gap: 16px; }
+  .justify-between { justify-content: space-between; }
+  .font-medium { font-weight: 500; }
+  .font-semibold { font-weight: 600; }
+  .text-lg { font-size: 18px; }
+  .text-sm { font-size: 14px; }
+  .text-xs { font-size: 12px; }
+  .text-2xl { font-size: 24px; }
+  .price { color: #16a34a; font-weight: 700; }
+  .price-high { color: #dc2626; }
+  .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .w-full { width: 100%; }
+  .mt-2 { margin-top: 8px; }
+  .mt-4 { margin-top: 16px; }
+  .mb-2 { margin-bottom: 8px; }
+  .mb-4 { margin-bottom: 16px; }
+  .p-3 { padding: 12px; }
+  .p-4 { padding: 16px; }
+  .rounded { border-radius: var(--border-radius-md, 8px); }
+  .border { border: 1px solid var(--color-border-primary, #e2e8f0); }
+  .bg-muted { background: var(--color-background-secondary, #f8fafc); }
+  button {
+    cursor: pointer;
+    border: none;
+    border-radius: var(--border-radius-md, 6px);
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: inherit;
+    transition: all 0.15s;
+  }
+  .btn-primary {
+    background: #0f172a;
+    color: white;
+  }
+  .btn-primary:hover { background: #1e293b; }
+  .btn-ghost {
+    background: transparent;
+    color: var(--color-text-secondary, #64748b);
+  }
+  .btn-ghost:hover { background: var(--color-background-secondary, #f1f5f9); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+  th {
+    text-align: left;
+    padding: 8px 12px;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary, #64748b);
+    border-bottom: 2px solid var(--color-border-primary, #e2e8f0);
+  }
+  td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--color-border-primary, #e2e8f0);
+    vertical-align: middle;
+  }
+  tr:hover td { background: var(--color-background-secondary, #f8fafc); }
+  .arrow { color: var(--color-text-secondary, #94a3b8); margin: 0 4px; }
+  .rank-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .rank-1 { background: #fef3c7; color: #92400e; }
+  .rank-2 { background: #e2e8f0; color: #475569; }
+  .rank-3 { background: #fed7aa; color: #9a3412; }
+  .rank-other { background: #f1f5f9; color: #64748b; }
+  .score-bar {
+    height: 4px;
+    border-radius: 2px;
+    background: #e2e8f0;
+    overflow: hidden;
+  }
+  .score-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: #16a34a;
+    transition: width 0.3s;
+  }
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 24px;
+    text-align: center;
+  }
+  .empty-state svg { margin-bottom: 16px; opacity: 0.4; }
+`;
+
+export const APPBRIDGE_SCRIPT = `
+<script>
+  // Minimal MCP App SDK — iframe sends ui/initialize to host, then listens for data
+  var toolResult = null;
+  var toolInput = null;
+  var _rpcId = 1;
+  var _pendingRequests = {};
+  var _hostContext = null;
+
+  window.addEventListener('message', function(event) {
+    var msg = event.data;
+    if (!msg || typeof msg !== 'object' || msg.jsonrpc !== '2.0') return;
+
+    // JSON-RPC Request from host (has method + id) — respond to it
+    if (msg.method && msg.id !== undefined) {
+      // Host asks us to teardown
+      if (msg.method === 'ui/resource-teardown') {
+        window.parent.postMessage({ jsonrpc: '2.0', id: msg.id, result: {} }, '*');
+        return;
+      }
+      // Host calls a tool on us (we don't provide tools, just ack)
+      window.parent.postMessage({ jsonrpc: '2.0', id: msg.id, result: {} }, '*');
+      return;
+    }
+
+    // JSON-RPC Notification from host (has method, no id)
+    if (msg.method && msg.id === undefined) {
+      if (msg.method === 'ui/notifications/tool-input') {
+        toolInput = msg.params?.arguments || msg.params;
+        if (typeof onToolInput === 'function') onToolInput(toolInput);
+      }
+      if (msg.method === 'ui/notifications/tool-result') {
+        toolResult = msg.params;
+        if (typeof onToolResult === 'function') onToolResult(toolResult);
+      }
+      if (msg.method === 'ui/notifications/host-context-changed') {
+        _hostContext = Object.assign(_hostContext || {}, msg.params);
+      }
+      return;
+    }
+
+    // JSON-RPC Response to our request (has result or error, no method)
+    if (msg.id !== undefined && !msg.method) {
+      var cb = _pendingRequests[msg.id];
+      if (cb) { delete _pendingRequests[msg.id]; cb(msg); }
+    }
+  });
+
+  // Send a JSON-RPC request to host
+  function rpcRequest(method, params, callback) {
+    var id = _rpcId++;
+    if (callback) _pendingRequests[id] = callback;
+    window.parent.postMessage({ jsonrpc: '2.0', method: method, params: params, id: id }, '*');
+  }
+
+  // Send a JSON-RPC notification to host (no id = no response expected)
+  function rpcNotify(method, params) {
+    window.parent.postMessage({ jsonrpc: '2.0', method: method, params: params }, '*');
+  }
+
+  // Initiate handshake: App sends ui/initialize, host responds with context
+  rpcRequest('ui/initialize', {
+    appInfo: { name: 'deco-flights-ui', version: '0.1.0' },
+    appCapabilities: {},
+    protocolVersion: '2026-01-26'
+  }, function(resp) {
+    if (resp.result) {
+      _hostContext = resp.result.hostContext;
+    }
+    // Tell host we're ready — this triggers tool-input and tool-result delivery
+    rpcNotify('ui/notifications/initialized', {});
+  });
+
+  // Call a server tool via the host proxy
+  function callServerTool(name, args, callback) {
+    rpcRequest('tools/call', { name: name, arguments: args || {} }, function(resp) {
+      if (callback) callback(resp.result || resp.error);
+    });
+  }
+
+  // Send a message to chat
+  function sendMessage(text) {
+    rpcRequest('ui/message', {
+      role: 'user',
+      content: [{ type: 'text', text: text }]
+    });
+  }
+
+  // Request height change
+  function resizeHeight(h) {
+    rpcNotify('ui/notifications/size-changed', { height: h, width: document.documentElement.scrollWidth });
+  }
+</script>
+`;

--- a/packages/deco-flights/server/ui/trip-card.ts
+++ b/packages/deco-flights/server/ui/trip-card.ts
@@ -1,0 +1,102 @@
+import { SHARED_STYLES, APPBRIDGE_SCRIPT } from "./shared-styles.ts";
+
+export function renderTripCard(): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>${SHARED_STYLES}
+  .trip-header { display: flex; align-items: flex-start; justify-content: space-between; }
+  .trip-name { font-size: 16px; font-weight: 600; }
+  .route-display {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 8px;
+    font-size: 14px;
+  }
+  .airport-code {
+    font-weight: 600;
+    background: var(--color-background-secondary, #f1f5f9);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 13px;
+    font-family: var(--font-mono, monospace);
+  }
+  .date-range { margin-top: 8px; font-size: 13px; }
+  .stats { display: flex; gap: 16px; margin-top: 12px; }
+  .stat { text-align: center; }
+  .stat-value { font-size: 18px; font-weight: 700; }
+  .stat-label { font-size: 11px; color: var(--color-text-secondary, #64748b); text-transform: uppercase; }
+  .prefs-list { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 4px; }
+  .pref-tag {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: #f1f5f9;
+    color: #475569;
+  }
+</style></head><body>
+<div id="root">
+  <div class="empty-state">
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 7l6 6-6 6"/><path d="M21 7l-6 6 6 6"/></svg>
+    <p class="muted text-sm">Loading trip...</p>
+  </div>
+</div>
+${APPBRIDGE_SCRIPT}
+<script>
+function formatDate(d) {
+  if (!d) return '';
+  return new Date(d + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function onToolResult(result) {
+  const data = result?.structuredContent || result;
+  const trip = data?.trip || data;
+  if (!trip || !trip.name) return;
+  const root = document.getElementById('root');
+
+  const statusClass = 'badge badge-' + trip.status;
+  const dests = (trip.destinations || []).join(', ');
+  const resultCount = (trip.results || []).length;
+  const bestPrice = resultCount > 0
+    ? Math.min(...trip.results.map(function(r) { return r.price; }))
+    : null;
+
+  let prefsHtml = '';
+  const p = trip.preferences || {};
+  if (p.maxStops !== undefined) prefsHtml += '<span class="pref-tag">Max ' + p.maxStops + ' stop' + (p.maxStops !== 1 ? 's' : '') + '</span>';
+  if (p.maxLayoverHours) prefsHtml += '<span class="pref-tag">Layover &lt;' + p.maxLayoverHours + 'h</span>';
+  if (p.maxPrice) prefsHtml += '<span class="pref-tag">Budget $' + p.maxPrice + '</span>';
+  if (p.preferredAirports?.length) prefsHtml += '<span class="pref-tag">Prefer: ' + p.preferredAirports.join(', ') + '</span>';
+
+  let html = '<div class="trip-header">' +
+    '<div class="trip-name">' + trip.name + '</div>' +
+    '<span class="' + statusClass + '">' + trip.status + '</span>' +
+  '</div>' +
+  '<div class="route-display">' +
+    '<span class="airport-code">' + trip.origin + '</span>' +
+    '<span class="arrow">→</span>' +
+    '<span class="airport-code">' + dests + '</span>' +
+  '</div>' +
+  '<div class="date-range muted">' +
+    formatDate(trip.earliestDeparture) + ' – ' + formatDate(trip.latestReturn) +
+    ' · ' + trip.tripLengthDays.min + '–' + trip.tripLengthDays.max + ' days' +
+  '</div>';
+
+  if (prefsHtml) {
+    html += '<div class="prefs-list">' + prefsHtml + '</div>';
+  }
+
+  if (trip.status === 'complete' && resultCount > 0) {
+    html += '<div class="stats">' +
+      '<div class="stat"><div class="stat-value price">$' + bestPrice + '</div><div class="stat-label">Best Price</div></div>' +
+      '<div class="stat"><div class="stat-value">' + resultCount + '</div><div class="stat-label">Options</div></div>' +
+      '<div class="stat"><div class="stat-value">' + (trip.searchPlan?.searches?.length || 0) + '</div><div class="stat-label">Searches</div></div>' +
+    '</div>';
+  } else if (trip.searchPlan) {
+    html += '<div class="mt-2 text-sm muted">' + trip.searchPlan.searches.length + ' searches planned</div>';
+  }
+
+  root.innerHTML = html;
+  resizeHeight(Math.min(root.scrollHeight + 32, 280));
+}
+</script></body></html>`;
+}

--- a/packages/deco-flights/server/ui/trip-planner.ts
+++ b/packages/deco-flights/server/ui/trip-planner.ts
@@ -1,0 +1,243 @@
+import { SHARED_STYLES, APPBRIDGE_SCRIPT } from "./shared-styles.ts";
+
+const API_BASE = `http://localhost:${Number(process.env.PORT) || 4747}`;
+
+export function renderTripPlanner(): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>${SHARED_STYLES}
+  .planner { max-width: 1000px; margin: 0 auto; }
+  .trip-banner {
+    background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%);
+    color: white;
+    border-radius: 12px;
+    padding: 20px 24px;
+    margin-bottom: 16px;
+  }
+  .trip-banner h1 { font-size: 22px; font-weight: 700; margin-bottom: 4px; }
+  .trip-banner .route { font-size: 16px; opacity: 0.85; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .trip-banner .code { font-family: var(--font-mono, monospace); font-weight: 600; background: rgba(255,255,255,0.15); padding: 2px 8px; border-radius: 4px; }
+  .trip-banner .meta { margin-top: 8px; font-size: 13px; opacity: 0.7; display: flex; gap: 16px; flex-wrap: wrap; }
+  .tasks-section { margin-bottom: 20px; }
+  .tasks-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+  .tasks-progress { display: flex; align-items: center; gap: 8px; }
+  .progress-bar { height: 6px; background: #e2e8f0; border-radius: 3px; overflow: hidden; min-width: 120px; }
+  .progress-fill { height: 100%; border-radius: 3px; transition: width 0.3s; }
+  .progress-fill.active { background: linear-gradient(90deg, #3b82f6, #60a5fa); animation: shimmer 1.5s infinite; }
+  .progress-fill.done { background: #16a34a; }
+  @keyframes shimmer { 0%,100% { opacity: 1; } 50% { opacity: 0.7; } }
+  .tasks-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 6px; }
+  .task-item { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 6px; font-size: 12px; border: 1px solid var(--color-border-primary, #e2e8f0); }
+  .task-item.pending { opacity: 0.35; }
+  .task-item.running { border-color: #3b82f6; background: #eff6ff; }
+  .task-item.done { border-color: #86efac; background: #f0fdf4; }
+  .task-item.error { border-color: #fca5a5; background: #fef2f2; }
+  .task-route { font-weight: 500; white-space: nowrap; }
+  .task-date { color: var(--color-text-secondary, #64748b); white-space: nowrap; }
+  .task-meta { margin-left: auto; font-size: 11px; color: var(--color-text-secondary, #64748b); white-space: nowrap; }
+  .spinner-sm { width: 14px; height: 14px; border: 2px solid #93c5fd; border-top-color: #2563eb; border-radius: 50%; animation: spin 0.8s linear infinite; display: inline-block; flex-shrink: 0; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .top-picks { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; margin-bottom: 20px; }
+  .pick-card { border: 2px solid var(--color-border-primary, #e2e8f0); border-radius: 10px; padding: 14px 16px; }
+  .pick-card.rank-1 { border-color: #f59e0b; background: #fffbeb; }
+  .pick-card.rank-2 { border-color: #94a3b8; background: #f8fafc; }
+  .pick-card.rank-3 { border-color: #f97316; background: #fff7ed; }
+  .pick-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px; }
+  .pick-price { font-size: 22px; font-weight: 700; color: #16a34a; }
+  .pick-route { font-size: 13px; margin-bottom: 4px; }
+  .pick-details { font-size: 12px; color: var(--color-text-secondary, #64748b); }
+  .pick-score { display: flex; align-items: center; gap: 6px; margin-top: 6px; }
+  .section-title { font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--color-text-secondary, #64748b); margin-bottom: 12px; margin-top: 4px; }
+  .results-table-wrap { border: 1px solid var(--color-border-primary, #e2e8f0); border-radius: 10px; overflow: hidden; }
+  .sort-btn { background: none; border: none; cursor: pointer; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--color-text-secondary, #64748b); padding: 0; }
+  .sort-btn:hover, .sort-btn.active { color: var(--color-text-primary, #0f172a); }
+  .prefs-grid { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+  .pref-chip { padding: 4px 10px; border-radius: 6px; font-size: 12px; background: #f1f5f9; color: #475569; }
+  .live-badge { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: #16a34a; }
+  .live-dot { width: 6px; height: 6px; border-radius: 50%; background: #16a34a; animation: pulse 1.5s infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+</style></head><body>
+<div id="root" class="planner">
+  <div class="empty-state">
+    <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3.5 5.5L5 7l2.5-2.5"/><path d="M3.5 11.5L5 13l2.5-2.5"/><path d="M3.5 17.5L5 19l2.5-2.5"/><path d="M11 6h9"/><path d="M11 12h9"/><path d="M11 18h9"/></svg>
+    <p class="muted">Loading trip details...</p>
+  </div>
+</div>
+${APPBRIDGE_SCRIPT}
+<script>
+var sortField = 'rank', sortAsc = true, tripData = null, workerRunning = false, _pollTimer = null;
+
+function fmt(t) { if (!t) return '--:--'; var d = new Date(t); return d.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit',hour12:false}); }
+function fmtD(d) { if (!d) return ''; return new Date(d+'T00:00:00').toLocaleDateString('en-US',{month:'short',day:'numeric'}); }
+function fmtDur(m) { if (!m) return ''; var h=Math.floor(m/60),r=m%60; return h>0?h+'h'+(r>0?' '+r+'m':''):r+'m'; }
+function stops(n) { return n===0?'Nonstop':n+' stop'+(n>1?'s':''); }
+
+function taskIcon(s) {
+  if (s==='running') return '<div class="spinner-sm"></div>';
+  if (s==='done') return '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#16a34a" stroke-width="2"><path d="M3 8l3.5 3.5L13 5"/></svg>';
+  if (s==='error') return '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#dc2626" stroke-width="2"><path d="M4 4l8 8M12 4l-8 8"/></svg>';
+  return '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#94a3b8" stroke-width="2"><circle cx="8" cy="8" r="5"/></svg>';
+}
+
+function renderTasks(trip) {
+  var tasks = trip.searchTasks || [];
+  if (!tasks.length) return '';
+  var dn = tasks.filter(function(t){return t.status==='done';}).length;
+  var er = tasks.filter(function(t){return t.status==='error';}).length;
+  var rn = tasks.filter(function(t){return t.status==='running';}).length;
+  var tot = tasks.length;
+  var pct = Math.round(((dn+er)/tot)*100);
+  var isActive = workerRunning || rn > 0;
+
+  var h = '<div class="tasks-section">';
+  h += '<div class="tasks-header">';
+  h += '<div style="display:flex;align-items:center;gap:8px"><span class="section-title" style="margin:0">Search Tasks</span>';
+  if (isActive) h += '<span class="live-badge"><span class="live-dot"></span>LIVE</span>';
+  h += '</div>';
+  h += '<div class="tasks-progress"><span class="text-xs muted">' + dn + '/' + tot + (er?' · '+er+' err':'') + '</span>';
+  h += '<div class="progress-bar" style="width:140px"><div class="progress-fill '+(isActive?'active':'done')+'" style="width:'+pct+'%"></div></div></div></div>';
+
+  // Show running first, then done (recent), then pending
+  var sorted = tasks.slice().sort(function(a,b) {
+    var ord = {running:0,error:1,done:2,pending:3};
+    return (ord[a.status]||3) - (ord[b.status]||3);
+  });
+
+  h += '<div class="tasks-grid">';
+  sorted.forEach(function(t) {
+    var ms = t.durationMs ? (t.durationMs/1000).toFixed(1)+'s' : '';
+    h += '<div class="task-item '+t.status+'">';
+    h += taskIcon(t.status);
+    h += '<span class="task-route">'+t.spec.from+'→'+t.spec.to+'</span>';
+    h += '<span class="task-date">'+fmtD(t.spec.departDate)+'</span>';
+    h += '<span class="task-meta">';
+    if (t.status==='done') h += t.resultCount+' results';
+    else if (t.status==='error') h += '<span style="color:#dc2626">err</span>';
+    else if (t.status==='running') h += 'searching…';
+    if (ms) h += ' · '+ms;
+    h += '</span></div>';
+  });
+  h += '</div></div>';
+  return h;
+}
+
+function getCurrency(trip){var r=(trip.results||[])[0];return(r&&r.currency)?r.currency:'USD';}
+function fmtPrice(amount,cur){
+  try{return new Intl.NumberFormat(undefined,{style:'currency',currency:cur||'USD',maximumFractionDigits:0}).format(amount);}
+  catch(e){return cur+' '+amount;}
+}
+
+function render() {
+  var trip = tripData;
+  if (!trip) return;
+  var root = document.getElementById('root');
+  var results = trip.results || [];
+
+  var h = '<div class="trip-banner"><h1>'+trip.name+'</h1>';
+  h += '<div class="route"><span class="code">'+trip.origin+'</span><span style="opacity:0.5">→</span><span class="code">'+trip.destinations.join(', ')+'</span>';
+  h += '<span class="badge badge-'+trip.status+'" style="margin-left:12px">'+trip.status+'</span></div>';
+  h += '<div class="meta"><span>'+fmtD(trip.earliestDeparture)+' – '+fmtD(trip.latestReturn)+'</span>';
+  h += '<span>'+trip.tripLengthDays.min+'–'+trip.tripLengthDays.max+' days</span>';
+  h += '<span>'+trip.passengers+' pax · '+trip.seatClass+'</span>';
+  if (results.length) { var bp=Math.min.apply(null,results.map(function(r){return r.price;})); var cur=getCurrency(trip); h+='<span style="color:#4ade80;font-weight:700">Best: '+fmtPrice(bp,cur)+'</span>'; }
+  h += '</div></div>';
+
+  var p = trip.preferences || {};
+  var prefs = [];
+  if (p.maxStops!==undefined) prefs.push('Max '+p.maxStops+' stops');
+  if (p.maxLayoverHours) prefs.push('Layover <'+p.maxLayoverHours+'h');
+  if (p.maxPrice) prefs.push('Budget $'+p.maxPrice);
+  if (p.preferredAirports&&p.preferredAirports.length) prefs.push('Prefer: '+p.preferredAirports.join(', '));
+  if (prefs.length) { h+='<div class="prefs-grid">'; prefs.forEach(function(pr){h+='<div class="pref-chip">'+pr+'</div>';}); h+='</div>'; }
+
+  h += renderTasks(trip);
+
+  if (results.length === 0 && trip.status === 'draft') {
+    h += '<div class="card p-4" style="text-align:center"><p class="font-semibold">'+(trip.searchPlan?trip.searchPlan.searches.length:0)+' searches planned</p>';
+    h += '<button class="btn-primary mt-4" onclick="sendMessage(\\'Execute research for trip '+trip.id+'\\')">Execute Research</button></div>';
+    root.innerHTML = h; return;
+  }
+  if (!results.length) { root.innerHTML = h; return; }
+
+  var top3 = results.slice(0,3);
+  h += '<div class="section-title">Top Picks</div><div class="top-picks">';
+  top3.forEach(function(r,i) {
+    var legs=r.flights||[], f=legs[0]||{}, l=legs[legs.length-1]||{};
+    h += '<div class="pick-card rank-'+(i+1)+'">';
+    h += '<div class="pick-header"><div class="rank-badge rank-'+(i<3?i+1:'other')+'">#'+r.rank+'</div><div class="pick-price">'+fmtPrice(r.price,r.currency)+'</div></div>';
+    h += '<div class="pick-route"><strong>'+fmt(f.departure?.time)+'</strong> '+(f.departure?.airport||'')+' → <strong>'+fmt(l.arrival?.time)+'</strong> '+(l.arrival?.airport||'')+'</div>';
+    h += '<div class="pick-details">'+fmtDur(r.totalDurationMinutes)+' · '+stops(r.stops)+' · '+(f.airline||'')+' · '+fmtD(r.searchSpec?.departDate)+'–'+fmtD(r.searchSpec?.returnDate)+'</div>';
+    h += '<div class="pick-score"><div class="score-bar" style="flex:1"><div class="score-fill" style="width:'+Math.round(r.score*100)+'%"></div></div><span class="text-xs muted">'+Math.round(r.score*100)+'%</span></div>';
+    h += '</div>';
+  });
+  h += '</div>';
+
+  var sorted = results.slice().sort(function(a,b) {
+    var va,vb;
+    if (sortField==='price'){va=a.price;vb=b.price;}
+    else if (sortField==='duration'){va=a.totalDurationMinutes;vb=b.totalDurationMinutes;}
+    else if (sortField==='stops'){va=a.stops;vb=b.stops;}
+    else {va=a.rank;vb=b.rank;}
+    return sortAsc?(va-vb):(vb-va);
+  });
+
+  h += '<div class="section-title">All Results ('+results.length+')</div>';
+  h += '<div class="results-table-wrap"><table><thead><tr>';
+  h += '<th style="width:36px">#</th><th>Date</th><th>Route</th><th>Times</th>';
+  h += '<th><button class="sort-btn'+(sortField==='duration'?' active':'')+'" onclick="setSort(\\'duration\\')">Dur ↕</button></th>';
+  h += '<th><button class="sort-btn'+(sortField==='stops'?' active':'')+'" onclick="setSort(\\'stops\\')">Stops ↕</button></th>';
+  h += '<th><button class="sort-btn'+(sortField==='price'?' active':'')+'" onclick="setSort(\\'price\\')">Price ↕</button></th>';
+  h += '<th style="width:50px">Score</th></tr></thead><tbody>';
+
+  sorted.slice(0,50).forEach(function(r) {
+    var legs=r.flights||[], f=legs[0]||{}, l=legs[legs.length-1]||{};
+    h += '<tr><td><span class="rank-badge rank-'+(r.rank<=3?r.rank:'other')+'">'+r.rank+'</span></td>';
+    h += '<td class="text-sm">'+fmtD(r.searchSpec?.departDate)+'<br><span class="muted">'+fmtD(r.searchSpec?.returnDate)+'</span></td>';
+    h += '<td class="text-sm font-medium">'+(f.departure?.airport||'')+' → '+(l.arrival?.airport||'')+'</td>';
+    h += '<td class="text-sm">'+fmt(f.departure?.time)+' – '+fmt(l.arrival?.time)+'</td>';
+    h += '<td class="text-sm">'+fmtDur(r.totalDurationMinutes)+'</td>';
+    h += '<td class="text-sm">'+stops(r.stops)+'</td>';
+    h += '<td class="font-semibold price">'+fmtPrice(r.price,r.currency)+'</td>';
+    h += '<td><div class="score-bar"><div class="score-fill" style="width:'+Math.round(r.score*100)+'%"></div></div></td></tr>';
+  });
+  h += '</tbody></table></div>';
+  root.innerHTML = h;
+}
+
+function setSort(f) { if (sortField===f) sortAsc=!sortAsc; else { sortField=f; sortAsc=true; } render(); }
+
+var API_BASE = '${API_BASE}';
+
+function startPolling() {
+  if (_pollTimer) return;
+  _pollTimer = setInterval(function() {
+    if (!tripData || !tripData.id) return;
+    fetch(API_BASE + '/api/trips/' + tripData.id).then(function(r){return r.json();}).then(function(data) {
+      if (data && data.trip) {
+        tripData = data.trip;
+        workerRunning = !!data.workerRunning;
+        render();
+        if (!workerRunning && tripData.status !== 'researching') {
+          clearInterval(_pollTimer);
+          _pollTimer = null;
+        }
+      }
+    }).catch(function(){});
+  }, 2000);
+}
+
+function onToolResult(result) {
+  var data = result?.structuredContent || result;
+  if (data?.trip) {
+    tripData = data.trip;
+    workerRunning = !!data.workerRunning;
+  } else if (data?.started !== undefined) {
+    // TRIP_EXECUTE response — just start polling
+    workerRunning = true;
+  }
+  render();
+  if (workerRunning || (tripData && tripData.status === 'researching')) {
+    startPolling();
+  }
+}
+</script></body></html>`;
+}

--- a/packages/deco-flights/server/ui/trips-dashboard.ts
+++ b/packages/deco-flights/server/ui/trips-dashboard.ts
@@ -1,0 +1,354 @@
+import { SHARED_STYLES, APPBRIDGE_SCRIPT } from "./shared-styles.ts";
+
+const API_BASE = `http://localhost:${Number(process.env.PORT) || 4747}`;
+
+export function renderTripsDashboard(): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>${SHARED_STYLES}
+  .app { max-width: 1000px; margin: 0 auto; }
+  .header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+  .header h1 { font-size: 20px; font-weight: 700; }
+  .back-btn { display: inline-flex; align-items: center; gap: 4px; font-size: 13px; color: var(--color-text-secondary, #64748b); cursor: pointer; background: none; border: none; padding: 4px 8px; border-radius: 6px; font-family: inherit; }
+  .back-btn:hover { background: var(--color-background-secondary, #f1f5f9); color: var(--color-text-primary, #0f172a); }
+  .filters { display: flex; gap: 4px; margin-bottom: 16px; }
+  .filter-btn { padding: 4px 12px; border-radius: 6px; font-size: 12px; font-weight: 500; background: transparent; color: var(--color-text-secondary, #64748b); border: 1px solid transparent; font-family: inherit; cursor: pointer; }
+  .filter-btn:hover { background: var(--color-background-secondary, #f1f5f9); }
+  .filter-btn.active { background: var(--color-background-primary, #fff); border-color: var(--color-border-primary, #e2e8f0); color: var(--color-text-primary, #0f172a); font-weight: 600; }
+  .trips-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+  .trip-item { border: 1px solid var(--color-border-primary, #e2e8f0); border-radius: 10px; padding: 16px; cursor: pointer; transition: all 0.15s; }
+  .trip-item:hover { border-color: #94a3b8; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+  .trip-title { font-weight: 600; font-size: 15px; margin-bottom: 4px; }
+  .trip-route { font-size: 13px; color: var(--color-text-secondary, #64748b); }
+  .trip-meta { display: flex; align-items: center; gap: 8px; margin-top: 8px; font-size: 12px; }
+  .trip-price { font-weight: 700; color: #16a34a; font-size: 15px; }
+  .count-badge { background: var(--color-background-secondary, #f1f5f9); padding: 0 6px; border-radius: 4px; font-size: 11px; font-weight: 600; }
+  .trip-banner { background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 100%); color: white; border-radius: 12px; padding: 20px 24px; margin-bottom: 16px; }
+  .trip-banner h1 { font-size: 22px; font-weight: 700; margin-bottom: 4px; }
+  .trip-banner .route { font-size: 16px; opacity: 0.85; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .trip-banner .code { font-family: var(--font-mono, monospace); font-weight: 600; background: rgba(255,255,255,0.15); padding: 2px 8px; border-radius: 4px; }
+  .trip-banner .meta { margin-top: 8px; font-size: 13px; opacity: 0.7; display: flex; gap: 16px; flex-wrap: wrap; }
+  .tasks-section { margin-bottom: 20px; }
+  .tasks-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+  .progress-bar { height: 6px; background: #e2e8f0; border-radius: 3px; overflow: hidden; min-width: 120px; }
+  .progress-fill { height: 100%; border-radius: 3px; transition: width 0.3s; }
+  .progress-fill.active { background: linear-gradient(90deg, #3b82f6, #60a5fa); animation: shimmer 1.5s infinite; }
+  .progress-fill.done { background: #16a34a; }
+  @keyframes shimmer { 0%,100%{opacity:1} 50%{opacity:0.7} }
+  .tasks-grid { display: flex; flex-direction: column; gap: 4px; }
+  .task-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; border-radius: 6px; font-size: 13px; border: 1px solid var(--color-border-primary, #e2e8f0); }
+  .task-item.pending { opacity: 0.35; }
+  .task-item.running { border-color: #3b82f6; background: #eff6ff; }
+  .task-item.done { border-color: #86efac; background: #f0fdf4; }
+  .task-item.error { border-color: #fca5a5; background: #fef2f2; }
+  .task-route { font-weight: 500; white-space: nowrap; }
+  .task-date { color: var(--color-text-secondary, #64748b); white-space: nowrap; }
+  .task-meta { margin-left: auto; font-size: 11px; color: var(--color-text-secondary, #64748b); white-space: nowrap; }
+  .spinner-sm { width: 14px; height: 14px; border: 2px solid #93c5fd; border-top-color: #2563eb; border-radius: 50%; animation: spin 0.8s linear infinite; display: inline-block; flex-shrink: 0; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .top-picks { display: flex; flex-direction: column; gap: 8px; margin-bottom: 20px; }
+  .pick-card { border: 2px solid var(--color-border-primary, #e2e8f0); border-radius: 10px; padding: 14px 16px; display: flex; align-items: center; gap: 16px; }
+  .pick-card.rank-1 { border-color: #f59e0b; background: #fffbeb; }
+  .pick-card.rank-2 { border-color: #94a3b8; background: #f8fafc; }
+  .pick-card.rank-3 { border-color: #f97316; background: #fff7ed; }
+  .pick-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px; }
+  .pick-price { font-size: 22px; font-weight: 700; color: #16a34a; }
+  .pick-route { font-size: 13px; margin-bottom: 4px; }
+  .pick-details { font-size: 12px; color: var(--color-text-secondary, #64748b); }
+  .pick-score { display: flex; align-items: center; gap: 6px; margin-top: 6px; }
+  .section-title { font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--color-text-secondary, #64748b); margin-bottom: 12px; margin-top: 4px; }
+  .results-table-wrap { border: 1px solid var(--color-border-primary, #e2e8f0); border-radius: 10px; overflow: hidden; overflow-x: auto; }
+  .sort-btn { background: none; border: none; cursor: pointer; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--color-text-secondary, #64748b); padding: 0; font-family: inherit; }
+  .sort-btn:hover, .sort-btn.active { color: var(--color-text-primary, #0f172a); }
+  .prefs-grid { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+  .pref-chip { padding: 4px 10px; border-radius: 6px; font-size: 12px; background: #f1f5f9; color: #475569; }
+  .live-badge { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; color: #16a34a; }
+  .live-dot { width: 6px; height: 6px; border-radius: 50%; background: #16a34a; animation: pulse 1.5s infinite; }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.3} }
+  .action-bar { display: flex; gap: 8px; margin-bottom: 16px; }
+</style></head><body>
+<div id="root" class="app">
+  <div class="empty-state">
+    <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    <p class="muted">Loading trips...</p>
+  </div>
+</div>
+${APPBRIDGE_SCRIPT}
+<script>
+var currentView = 'list';
+var allTrips = []; // full Trip objects with workerRunning flag
+var currentFilter = 'all';
+var detailTripId = null;
+var sortField = 'price', sortAsc = true;
+var _pollTimer = null;
+
+function fmt(t){if(!t)return'--:--';var d=new Date(t);return d.toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',hour12:false});}
+function fmtD(d){if(!d)return'';return new Date(d+'T00:00:00').toLocaleDateString('en-US',{month:'short',day:'numeric'});}
+function fmtDur(m){if(!m)return'';var h=Math.floor(m/60),r=m%60;return h>0?h+'h'+(r>0?' '+r+'m':''):r+'m';}
+function nStops(n){return n===0?'Nonstop':n+' stop'+(n>1?'s':'');}
+function getCurrency(trip){var r=(trip.results||[])[0];return(r&&r.currency)?r.currency:'USD';}
+function copyUrl(url){navigator.clipboard.writeText(url).then(function(){}).catch(function(){window.prompt('Copy this URL:',url);});}
+function fmtPrice(amount,cur){
+  try{return new Intl.NumberFormat(undefined,{style:'currency',currency:cur||'USD',maximumFractionDigits:0}).format(amount);}
+  catch(e){return cur+' '+amount;}
+}
+function taskIcon(s){
+  if(s==='running')return'<div class="spinner-sm"></div>';
+  if(s==='done')return'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#16a34a" stroke-width="2"><path d="M3 8l3.5 3.5L13 5"/></svg>';
+  if(s==='error')return'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#dc2626" stroke-width="2"><path d="M4 4l8 8M12 4l-8 8"/></svg>';
+  return'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#94a3b8" stroke-width="2"><circle cx="8" cy="8" r="5"/></svg>';
+}
+function getTrip(id){return allTrips.find(function(t){return t.id===id;});}
+
+// ===== LIST VIEW — table layout, sorted by creation date ===
+function renderList() {
+  var filtered = currentFilter==='all'?allTrips:allTrips.filter(function(t){return t.status===currentFilter;});
+  // Sort by creation date, newest first
+  filtered.sort(function(a,b){return(b.createdAt||'').localeCompare(a.createdAt||'');});
+  var root = document.getElementById('root');
+  var counts = {all:allTrips.length,draft:0,researching:0,complete:0};
+  allTrips.forEach(function(t){counts[t.status]=(counts[t.status]||0)+1;});
+
+  var h = '<div class="header"><h1>My Trips</h1><button class="btn-primary" onclick="sendMessage(\\'Create a new trip\\')">+ New Trip</button></div>';
+  h += '<div class="filters">';
+  ['all','draft','researching','complete'].forEach(function(f){
+    h+='<button class="filter-btn'+(currentFilter===f?' active':'')+'" onclick="setFilter(\\''+f+'\\')">'+f.charAt(0).toUpperCase()+f.slice(1)+' <span class="count-badge">'+counts[f]+'</span></button>';
+  });
+  h += '</div>';
+
+  if (!filtered.length) {
+    h += '<div class="empty-state"><p class="muted text-sm">'+(allTrips.length?'No trips match this filter.':'No trips yet.')+'</p>';
+    if(!allTrips.length)h+='<button class="btn-primary mt-4" onclick="sendMessage(\\'Plan a trip\\')">Plan a Trip</button>';
+    h+='</div>';
+  } else {
+    h += '<div class="results-table-wrap"><table><thead><tr>';
+    h += '<th>Name</th><th>Route</th><th>Dates</th><th>Class</th><th>Status</th><th>Best Price</th><th>Results</th><th>Created</th>';
+    h += '</tr></thead><tbody>';
+    filtered.forEach(function(t){
+      var bestPrice=(t.results&&t.results.length)?Math.min.apply(null,t.results.map(function(r){return r.price;})):null;
+      var resultCount=(t.results||[]).length;
+      var totalResults=t._totalResults||resultCount;
+      var isLive=t.workerRunning||t.status==='researching';
+      var tasks=t.searchTasks||[];
+      var dn=tasks.filter(function(x){return x.status==='done';}).length;
+      var created=t.createdAt?new Date(t.createdAt).toLocaleDateString('en-US',{month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'}):'';
+
+      h+='<tr style="cursor:pointer" onclick="openTrip(\\''+t.id+'\\')">';
+      h+='<td class="font-medium">'+t.name+'</td>';
+      h+='<td class="text-sm">'+t.origin+' → '+t.destinations.join(', ')+(t.returnOrigins&&t.returnOrigins.length?' <span class="muted">ret '+t.returnOrigins.join(', ')+'</span>':'')+'</td>';
+      h+='<td class="text-sm">'+fmtD(t.earliestDeparture)+' – '+fmtD(t.latestReturn)+'</td>';
+      h+='<td class="text-sm">'+t.seatClass+'</td>';
+      h+='<td>';
+      if(isLive)h+='<span class="live-badge"><span class="live-dot"></span>'+dn+'/'+tasks.length+'</span>';
+      else h+='<span class="badge badge-'+t.status+'">'+t.status+'</span>';
+      h+='</td>';
+      h+='<td class="font-semibold">'+(bestPrice?fmtPrice(bestPrice,getCurrency(t)):'–')+'</td>';
+      h+='<td class="text-sm">'+(totalResults||'–')+'</td>';
+      h+='<td class="text-sm muted">'+created+'</td>';
+      h+='</tr>';
+    });
+    h += '</tbody></table></div>';
+  }
+  root.innerHTML = h;
+}
+
+var API_BASE = '${API_BASE}';
+
+function setFilter(f){currentFilter=f;renderList();}
+function openTrip(id){currentView='detail';detailTripId=id;renderDetail();startPoll();}
+function goBack(){currentView='list';detailTripId=null;stopPoll();refreshList();}
+
+// ===== DETAIL VIEW — ONE UNIFIED LIST =====
+function renderDetail() {
+  var trip=getTrip(detailTripId);
+  if(!trip){goBack();return;}
+  var root=document.getElementById('root');
+  var results=trip.results||[];
+  var tasks=trip.searchTasks||[];
+  var isLive=trip.workerRunning||trip.status==='researching';
+  var cur=getCurrency(trip);
+
+  // Progress stats
+  var dn=tasks.filter(function(t){return t.status==='done';}).length;
+  var er=tasks.filter(function(t){return t.status==='error';}).length;
+  var rn=tasks.filter(function(t){return t.status==='running';}).length;
+  var tot=tasks.length, pct=tot?Math.round(((dn+er)/tot)*100):0;
+
+  var h='<button class="back-btn" onclick="goBack()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg> Back</button>';
+
+  // Banner
+  h+='<div class="trip-banner"><h1>'+trip.name+'</h1>';
+  h+='<div class="route"><span class="code">'+trip.origin+'</span><span style="opacity:0.5">→</span><span class="code">'+trip.destinations.join(', ')+'</span>';
+  h+='<span class="badge badge-'+trip.status+'" style="margin-left:12px">'+trip.status+'</span></div>';
+  h+='<div class="meta"><span>'+fmtD(trip.earliestDeparture)+' – '+fmtD(trip.latestReturn)+'</span>';
+  h+='<span>'+trip.tripLengthDays.min+'–'+trip.tripLengthDays.max+' days</span>';
+  h+='<span>'+trip.passengers+' pax · '+trip.seatClass+'</span>';
+  if(results.length){var bp=Math.min.apply(null,results.map(function(r){return r.price;}));h+='<span style="color:#4ade80;font-weight:700">Best: '+fmtPrice(bp,cur)+'</span>';}
+  if(tot)h+='<span>'+dn+'/'+tot+' searches</span>';
+  h+='</div></div>';
+
+  // Action bar + progress
+  h+='<div style="display:flex;align-items:center;gap:12px;margin-bottom:16px">';
+  var hasPending=tasks.some(function(t){return t.status==='pending'||t.status==='error';});
+  if(!isLive&&hasPending)h+='<button class="btn-primary" onclick="sendMessage(\\'Execute research for trip '+trip.id+'\\')">▶ Resume Research</button>';
+  else if(!isLive&&!hasPending&&tot===0&&trip.searchPlan)h+='<button class="btn-primary" onclick="sendMessage(\\'Execute research for trip '+trip.id+'\\')">▶ Start Research</button>';
+  if(isLive)h+='<button class="btn-ghost" style="color:#dc2626" onclick="sendMessage(\\'Stop research for trip '+trip.id+'\\')">■ Stop</button>';
+  if(tot){
+    if(isLive)h+='<span class="live-badge"><span class="live-dot"></span>LIVE</span>';
+    h+='<div class="progress-bar" style="flex:1;max-width:200px"><div class="progress-fill '+(isLive?'active':'done')+'" style="width:'+pct+'%"></div></div>';
+    h+='<span class="text-xs muted">'+dn+'/'+tot+(er?' · '+er+' err':'')+'</span>';
+  }
+  h+='</div>';
+
+  // Prefs
+  var p=trip.preferences||{},prefs=[];
+  if(p.maxStops!==undefined)prefs.push('Max '+p.maxStops+' stops');
+  if(p.maxLayoverHours)prefs.push('Layover <'+p.maxLayoverHours+'h');
+  if(p.maxPrice)prefs.push('Budget '+fmtPrice(p.maxPrice,cur));
+  if(p.preferredAirports&&p.preferredAirports.length)prefs.push('Prefer: '+p.preferredAirports.join(', '));
+  if(p.preferredAirlines&&p.preferredAirlines.length)prefs.push('Airlines: '+p.preferredAirlines.join(', '));
+  if(p.avoidAirlines&&p.avoidAirlines.length)prefs.push('Avoid: '+p.avoidAirlines.join(', '));
+  if(p.currency)prefs.push('Currency: '+p.currency);
+  if(prefs.length){h+='<div class="prefs-grid">';prefs.forEach(function(pr){h+='<div class="pref-chip">'+pr+'</div>';});h+='</div>';}
+
+  // === ONE TABLE: results + pending tasks, top 3 highlighted, sorted by price ===
+  if(results.length>0||tasks.length>0){
+    var sorted=results.slice().sort(function(a,b){
+      var va,vb;
+      if(sortField==='price'){va=a.price;vb=b.price;}
+      else if(sortField==='duration'){va=a.totalDurationMinutes;vb=b.totalDurationMinutes;}
+      else if(sortField==='stops'){va=a.stops;vb=b.stops;}
+      else if(sortField==='date'){va=a.searchSpec?.departDate||'';vb=b.searchSpec?.departDate||'';}
+      else{va=a.price;vb=b.price;} // default = price
+      if(va<vb)return sortAsc?-1:1;
+      if(va>vb)return sortAsc?1:-1;
+      return 0;
+    });
+    // Mark top 3 in sorted order
+    var top3Ids={};
+    sorted.slice(0,3).forEach(function(r,i){top3Ids[r.rank]=i+1;});
+
+    // Pending/running/error tasks not in results
+    var doneKeys={};
+    results.forEach(function(r){if(r.searchSpec)doneKeys[r.searchSpec.departDate+r.searchSpec.to+r.searchSpec.returnDate]=true;});
+    var activeTasks=tasks.filter(function(t){return t.status==='running'||t.status==='error';});
+    var pendingTasks=tasks.filter(function(t){return t.status==='pending';});
+
+    var totalLabel=trip._totalResults&&trip._totalResults>results.length?trip._totalResults+' total, showing '+results.length:''+results.length;
+    h+='<div class="section-title">Results ('+totalLabel+')'+(pendingTasks.length?' · '+pendingTasks.length+' pending':'')+(activeTasks.length?' · '+activeTasks.length+' active':'')+'</div>';
+    h+='<div class="results-table-wrap"><table><thead><tr>';
+    h+='<th style="width:30px"></th>';
+    h+='<th><button class="sort-btn'+(sortField==='price'?' active':'')+'" onclick="setSort(\\'price\\')">Price ↕</button></th>';
+    h+='<th><button class="sort-btn'+(sortField==='date'?' active':'')+'" onclick="setSort(\\'date\\')">Date ↕</button></th>';
+    h+='<th>Route</th><th>Airlines</th><th>Times</th>';
+    h+='<th><button class="sort-btn'+(sortField==='duration'?' active':'')+'" onclick="setSort(\\'duration\\')">Dur ↕</button></th>';
+    h+='<th><button class="sort-btn'+(sortField==='stops'?' active':'')+'" onclick="setSort(\\'stops\\')">Stops ↕</button></th>';
+    h+='<th style="width:40px"></th>';
+    h+='</tr></thead><tbody>';
+
+    // Render running/error tasks at top
+    function renderTaskRow(t){
+      var cls=t.status==='running'?'style="background:#eff6ff"':t.status==='error'?'style="background:#fef2f2"':'style="opacity:0.35"';
+      h+='<tr '+cls+'>';
+      h+='<td>'+taskIcon(t.status)+'</td>';
+      h+='<td class="text-sm muted">'+(t.status==='running'?'searching…':t.status==='error'?'<span style="color:#dc2626">error</span>':'pending')+'</td>';
+      h+='<td class="text-sm">'+fmtD(t.spec.departDate)+' – '+fmtD(t.spec.returnDate)+'</td>';
+      h+='<td class="text-sm">'+t.spec.from+' → '+t.spec.to+(t.spec.returnFrom?' ret '+t.spec.returnFrom:'')+'</td>';
+      h+='<td colspan="4" class="text-sm muted">'+(t.status==='error'?(t.error||'').slice(0,40):'')+'</td>';
+      h+='<td>'+(t.googleFlightsUrl?'<button class="btn-ghost" style="padding:1px 4px;font-size:10px;color:#2563eb" onclick="event.stopPropagation();copyUrl(\\''+t.googleFlightsUrl+'\\')">GF↗</button>':'')+'</td>';
+      h+='</tr>';
+    }
+    activeTasks.forEach(renderTaskRow);
+
+    // Render results
+    sorted.slice(0,50).forEach(function(r,idx){
+      var legs=r.flights||[],f=legs[0]||{},l=legs[legs.length-1]||{};
+      var allAir=[]; legs.forEach(function(lg){if(allAir.indexOf(lg.airline)===-1)allAir.push(lg.airline);});
+      var gfUrl2='';
+      tasks.forEach(function(t2){if(t2.spec.departDate===r.searchSpec?.departDate&&t2.spec.to===r.searchSpec?.to&&t2.spec.returnDate===r.searchSpec?.returnDate&&t2.googleFlightsUrl)gfUrl2=t2.googleFlightsUrl;});
+      var isTop=top3Ids[r.rank]!==undefined;
+      var topN=top3Ids[r.rank];
+      var rowStyle=isTop?'style="background:'+(topN===1?'#fffbeb;border-left:3px solid #f59e0b':topN===2?'#f8fafc;border-left:3px solid #94a3b8':'#fff7ed;border-left:3px solid #f97316')+'"':'';
+      h+='<tr '+rowStyle+'>';
+      h+='<td>'+(isTop?'<span class="rank-badge rank-'+topN+'">'+topN+'</span>':'')+'</td>';
+      h+='<td class="font-semibold'+(isTop?' text-lg':'')+'">'+fmtPrice(r.price,r.currency)+'</td>';
+      h+='<td class="text-sm">'+fmtD(r.searchSpec?.departDate)+' – '+fmtD(r.searchSpec?.returnDate)+'</td>';
+      h+='<td class="text-sm font-medium">'+(f.departure?.airport||'')+' → '+(l.arrival?.airport||'')+(r.searchSpec?.returnFrom?' <span class="muted">ret '+r.searchSpec.returnFrom+'</span>':'')+'</td>';
+      h+='<td class="text-sm">'+allAir.join(', ')+'</td>';
+      h+='<td class="text-sm">'+fmt(f.departure?.time)+' – '+fmt(l.arrival?.time)+'</td>';
+      h+='<td class="text-sm">'+fmtDur(r.totalDurationMinutes)+'</td>';
+      h+='<td class="text-sm">'+nStops(r.stops)+'</td>';
+      h+='<td>'+(gfUrl2?'<button class="btn-ghost" style="padding:1px 4px;font-size:10px;color:#2563eb" onclick="event.stopPropagation();copyUrl(\\''+gfUrl2+'\\')">GF↗</button>':'')+'</td>';
+      h+='</tr>';
+    });
+    // Pending tasks at the bottom
+    pendingTasks.forEach(renderTaskRow);
+
+    h+='</tbody></table></div>';
+  } else if(trip.searchPlan) {
+    h+='<div class="card p-4" style="text-align:center"><p class="font-semibold">'+trip.searchPlan.searches.length+' searches planned</p></div>';
+  }
+
+  root.innerHTML=h;
+}
+
+function setSort(f){if(sortField===f)sortAsc=!sortAsc;else{sortField=f;sortAsc=true;}renderDetail();}
+
+// ===== POLLING via direct REST fetch =====
+function refreshList() {
+  fetch(API_BASE + '/api/trips').then(function(r){return r.json();}).then(function(data){
+    if(data&&data.trips){allTrips=data.trips;if(currentView==='list')renderList();else renderDetail();}
+  }).catch(function(){});
+}
+function refreshTrip(id) {
+  fetch(API_BASE + '/api/trips/' + id).then(function(r){return r.json();}).then(function(data){
+    if(data&&data.trip){
+      var t=data.trip;t.workerRunning=!!data.workerRunning;
+      var idx=allTrips.findIndex(function(x){return x.id===t.id;});
+      if(idx>=0)allTrips[idx]=t;else allTrips.unshift(t);
+      if(currentView==='detail'&&detailTripId===t.id)renderDetail();
+    }
+  }).catch(function(){});
+}
+function startPoll() {
+  if(_pollTimer)return;
+  _pollTimer=setInterval(function(){
+    if(currentView==='detail'&&detailTripId){
+      refreshTrip(detailTripId);
+    } else {
+      refreshList();
+    }
+    var anyLive=allTrips.some(function(t){return t.workerRunning||t.status==='researching';});
+    if(!anyLive)stopPoll();
+  }, 2000);
+}
+function stopPoll(){if(_pollTimer){clearInterval(_pollTimer);_pollTimer=null;}}
+
+// ===== ENTRY =====
+function onToolResult(result) {
+  var data = result?.structuredContent || result;
+  // TRIP_LIST response — array of full trips
+  if (data?.trips) {
+    allTrips = data.trips;
+    if(currentView==='list')renderList();
+    else renderDetail();
+    var anyLive=allTrips.some(function(t){return t.workerRunning||t.status==='researching';});
+    if(anyLive)startPoll();
+    return;
+  }
+  // TRIP_GET / TRIP_EXECUTE response — single trip, merge into list
+  if (data?.trip) {
+    var t=data.trip;
+    t.workerRunning=!!data.workerRunning;
+    var idx=allTrips.findIndex(function(x){return x.id===t.id;});
+    if(idx>=0)allTrips[idx]=t;else allTrips.unshift(t);
+    currentView='detail';
+    detailTripId=t.id;
+    renderDetail();
+    if(t.workerRunning||t.status==='researching')startPoll();
+    return;
+  }
+  // No data from tool result — fetch from REST API directly
+  refreshList();
+}
+</script></body></html>`;
+}

--- a/packages/deco-flights/tsconfig.json
+++ b/packages/deco-flights/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -288,6 +288,12 @@ export const StudioPackAgentId = {
 /**
  * Check if a connection or virtual MCP ID is a Studio Pack agent.
  */
+export function isDecoFlights(id: string | null | undefined): string | null {
+  if (!id) return null;
+  const match = id.match(/^deco-flights_(.+)$/);
+  return match?.[1] ?? null;
+}
+
 export function isStudioPackAgent(id: string | null | undefined): boolean {
   if (!id) return false;
   return (
@@ -332,6 +338,12 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
     title: "Studio Pack",
     icon: "icon://Package?color=blue",
     type: "pack" as const,
+  },
+  {
+    id: "deco-flights",
+    title: "Flights",
+    icon: "icon://Compass03?color=sky",
+    type: "registry-agent" as const,
   },
 ] as const;
 


### PR DESCRIPTION
<img width="2468" height="1367" alt="CleanShot 2026-04-12 at 23 17 41" src="https://github.com/user-attachments/assets/5c6dfa9f-924a-4c30-9452-78faa948e018" />

<img width="2468" height="1367" alt="CleanShot 2026-04-12 at 23 16 50" src="https://github.com/user-attachments/assets/7b6512ff-52a4-4339-a63f-c1fff325b2a6" />


## Summary

- New `packages/deco-flights/` standalone MCP server for flight research via Google Flights
- Uses `fast-flights-ts@4.1.0` (TypeScript port of fast-flights) for scraping
- 9 MCP tools: search, trip CRUD, background execution, add searches, stop
- MCP-app UIs with live dashboard, sortable results table, Google Flights links
- Background worker with 3x parallel search execution and real-time progress
- REST API (`/api/trips`) for iframe polling (bypasses AppBridge limitations)
- Recruit modal on home screen ("Flights" agent template)
- Tiered search strategy via agent instructions (small focused trips, drill down with TRIP_ADD_SEARCHES)
- Open-jaw/multi-city, airline filtering, weighted scoring, currency support

## Test plan

- [ ] `bun run --cwd packages/deco-flights dev` starts server on :4747
- [ ] Install Flights agent from home screen
- [ ] Create a trip via chat, execute research, verify live progress in dashboard
- [ ] Verify Google Flights links work (copy to clipboard)
- [ ] Test TRIP_ADD_SEARCHES for drill-down workflow
- [ ] Test TRIP_STOP cancellation
- [ ] Verify currency displays correctly (USD default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@decocms/deco-flights`, a standalone MCP agent for flight research powered by Google Flights, plus a home-screen Flights template and live dashboards. It runs parallel searches and delivers live updates with deep links to Google Flights.

- **New Features**
  - 9 MCP tools: `FLIGHT_SEARCH`, `TRIP_CREATE/GET/LIST/UPDATE/DELETE`, `TRIP_EXECUTE/STOP`, `TRIP_ADD_SEARCHES`
  - Background worker with 3 concurrent searches, live progress, and cancel support
  - MCP-app UIs: trips dashboard, trip planner, and sortable search results with Google Flights links; REST `/api/trips` for polling
  - Tiered search strategy, open‑jaw/multi‑city, airline include/exclude filters, weighted scoring, and currency support
  - Home “Flights” template and recruit modal; added to `WELL_KNOWN_AGENT_TEMPLATES`

- **Migration**
  - Start the server: `bun run --cwd packages/deco-flights dev` (port 4747)
  - From Home, open the Flights template to install the agent, create a trip, and run research
  - Trip data persists at `~/.deco/flights/trips/`

<sup>Written for commit 2c8c6cfa6aff4aa81b375618c2ceb8c43f2b3d73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



