### PR TITLE
feat(ai-providers): omit deprecated models from listings

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/google.ts
+++ b/apps/mesh/src/ai-providers/adapters/google.ts
@@ -15,6 +15,8 @@ interface GoogleModel {
   description: string;
   topP: number;
   topK: number;
+  /** Lifecycle stage returned by the API (e.g. "ACTIVE", "DEPRECATED"). */
+  lifecycleState?: string;
 }
 
 export const googleAdapter: ProviderAdapter = {
@@ -42,19 +44,21 @@ export const googleAdapter: ProviderAdapter = {
           throw new Error(`Google listModels failed: ${res.status}`);
         }
         const data: { models: GoogleModel[] } = await res.json();
-        return data.models.map((m: GoogleModel) => ({
-          modelId: m.name.replace("models/", ""),
-          providerId: "google",
-          title: m.displayName,
-          description: m.description,
-          logo: null,
-          capabilities: [],
-          limits: {
-            contextWindow: m.inputTokenLimit,
-            maxOutputTokens: m.outputTokenLimit,
-          },
-          costs: null,
-        }));
+        return data.models
+          .filter((m: GoogleModel) => m.lifecycleState !== "DEPRECATED")
+          .map((m: GoogleModel) => ({
+            modelId: m.name.replace("models/", ""),
+            providerId: "google",
+            title: m.displayName,
+            description: m.description,
+            logo: null,
+            capabilities: [],
+            limits: {
+              contextWindow: m.inputTokenLimit,
+              maxOutputTokens: m.outputTokenLimit,
+            },
+            costs: null,
+          }));
       },
     };
   },

--- a/apps/mesh/src/ai-providers/factory.ts
+++ b/apps/mesh/src/ai-providers/factory.ts
@@ -144,9 +144,10 @@ export class AIProviderFactory {
     const provider = adapter.create(apiKey);
     const rawModels = await provider.listModels();
 
-    // Providers occasionally return duplicate modelIds — keep first occurrence
+    // Drop deprecated and duplicate models
     const seen = new Set<string>();
     let models = rawModels.filter((m) => {
+      if (m.deprecated) return false;
       if (seen.has(m.modelId)) return false;
       seen.add(m.modelId);
       return true;

--- a/apps/mesh/src/ai-providers/types.ts
+++ b/apps/mesh/src/ai-providers/types.ts
@@ -19,6 +19,8 @@ export interface ModelInfo {
   capabilities: ModelCapability[];
   limits?: { contextWindow: number; maxOutputTokens: number | null } | null;
   costs: { input: number; output: number } | null;
+  /** When true the upstream provider has flagged this model as deprecated. */
+  deprecated?: boolean;
 }
 
 export interface TokenCounter {

--- a/packages/mesh-sdk/src/types/ai-providers.ts
+++ b/packages/mesh-sdk/src/types/ai-providers.ts
@@ -47,6 +47,8 @@ export interface AiProviderModel {
   capabilities: ModelCapability[];
   limits: AiProviderModelLimits | null;
   costs: AiProviderModelCosts | null;
+  /** When true the upstream provider has flagged this model as deprecated. */
+  deprecated?: boolean;
   /** Client-side only — the credential key ID used to fetch this model. */
   keyId?: string;
 }


### PR DESCRIPTION
## What is this contribution about?
Filters out deprecated models from AI provider listings. Google's Gemini API returns a `lifecycleState` field on each model — models marked `"DEPRECATED"` are now excluded from results. A factory-level filter also drops any model with `deprecated=true`, so future adapters that surface deprecation metadata will benefit automatically.

Other providers (Anthropic, OpenRouter, OpenAI-compatible) don't currently expose deprecation fields in their model list APIs, so no changes were needed there.

## Screenshots/Demonstration
N/A — backend-only change.

## How to Test
1. Connect a Google Gemini API key
2. List models via the AI providers tool or UI
3. Verify that deprecated Gemini models (e.g. old `gemini-1.0-*` variants) no longer appear

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide deprecated models from AI provider listings. Google Gemini models with lifecycleState "DEPRECATED" are filtered out, and a generic factory filter removes any model flagged as deprecated.

- New Features
  - Google adapter excludes models with `lifecycleState === "DEPRECATED"`.
  - Factory drops models with `deprecated === true` and de-duplicates by `modelId`.
  - Added optional `deprecated` flag to `ModelInfo` and `AiProviderModel` so providers can surface deprecation.

<sup>Written for commit 57dcbc4a2fc2afd8b1cd5672a2a7a53b09676861. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

