### PR TITLE
Feat/easy to use ai

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/deco-ai-gateway.ts
+++ b/apps/mesh/src/ai-providers/adapters/deco-ai-gateway.ts
@@ -90,6 +90,23 @@ export const decoAiGatewayAdapter: ProviderAdapter = {
     return { balanceCents: data.balance_cents };
   },
 
+  async provisionKey(meshJwt: string, organizationId: string) {
+    const res = await fetch(`${getBase()}/api/keys/provision`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${meshJwt}`,
+      },
+      body: JSON.stringify({ organization_id: organizationId }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      throw new Error(`Deco AI Gateway key provisioning failed: ${res.status}`);
+    }
+    const data = (await res.json()) as { key: string };
+    return data.key;
+  },
+
   create(apiKey) {
     const base = openrouterAdapter.create(apiKey);
     return { ...base, info: this.info };

--- a/apps/mesh/src/ai-providers/adapters/deco-ai-gateway.ts
+++ b/apps/mesh/src/ai-providers/adapters/deco-ai-gateway.ts
@@ -91,10 +91,16 @@ export const decoAiGatewayAdapter: ProviderAdapter = {
   },
 
   async provisionKey(meshJwt: string, organizationId: string) {
+    const studioProvisionSecretKey =
+      getSettings().studioProvisionSecretKey ?? "";
+    if (!studioProvisionSecretKey) {
+      throw new Error("STUDIO_PROVISION_SECRET_KEY is not set");
+    }
     const res = await fetch(`${getBase()}/api/keys/provision`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "X-Provision-Key": studioProvisionSecretKey,
         Authorization: `Bearer ${meshJwt}`,
       },
       body: JSON.stringify({ organization_id: organizationId }),

--- a/apps/mesh/src/ai-providers/types.ts
+++ b/apps/mesh/src/ai-providers/types.ts
@@ -77,6 +77,12 @@ export interface ProviderAdapter {
     meshJwt: string,
     organizationId: string,
   ): Promise<{ balanceCents: number }>;
+
+  /**
+   * Server-to-server key provisioning (e.g. on org creation).
+   * meshJwt is a gateway-compatible JWT minted by mintGatewayJwt(userId).
+   */
+  provisionKey?(meshJwt: string, organizationId: string): Promise<string>;
 }
 
 export interface OpenRouterAPIModel {

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -3,9 +3,11 @@ import {
   getWellKnownRegistryConnection,
   getWellKnownSelfConnection,
 } from "@decocms/mesh-sdk";
+import { decoAiGatewayAdapter } from "@/ai-providers/adapters/deco-ai-gateway";
 import { getBaseUrl } from "@/core/server-constants";
 import { getDb } from "@/database";
 import { CredentialVault } from "@/encryption/credential-vault";
+import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ConnectionStorage } from "@/storage/connection";
 import { Permission } from "@/storage/types";
 import { VirtualMCPStorage } from "@/storage/virtual";
@@ -18,6 +20,7 @@ import { installStudioPack } from "@/tools/virtual/studio-pack";
 import { z } from "zod";
 import { getSettings } from "../settings";
 import { auth } from "./index";
+import { mintGatewayJwt } from "./jwt";
 
 interface MCPCreationSpec {
   data: ConnectionCreateData;
@@ -88,7 +91,8 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
 export async function seedOrgDb(organizationId: string, createdBy: string) {
   try {
     const database = getDb();
-    const vault = new CredentialVault(getSettings().encryptionKey);
+    const settings = getSettings();
+    const vault = new CredentialVault(settings.encryptionKey);
     const connectionStorage = new ConnectionStorage(database.db, vault);
     const defaultOrgMcps = getDefaultOrgMcps(organizationId);
 
@@ -151,6 +155,29 @@ export async function seedOrgDb(organizationId: string, createdBy: string) {
       await installStudioPack(organizationId, createdBy, virtualMcpStorage);
     } catch (err) {
       console.error("Failed to install studio pack agents:", err);
+    }
+
+    if (settings.aiGatewayEnabled && decoAiGatewayAdapter.provisionKey) {
+      try {
+        const meshJwt = await mintGatewayJwt(createdBy);
+        const apiKey = await decoAiGatewayAdapter.provisionKey(
+          meshJwt,
+          organizationId,
+        );
+        const aiProviderKeyStorage = new AIProviderKeyStorage(
+          database.db,
+          vault,
+        );
+        await aiProviderKeyStorage.upsert({
+          providerId: "deco",
+          label: "Auto-provisioned",
+          apiKey,
+          organizationId,
+          createdBy,
+        });
+      } catch (err) {
+        console.error("Failed to auto-provision Deco AI Gateway key:", err);
+      }
     }
   } catch (err) {
     console.error("Error creating default MCP connections:", err);

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -110,6 +110,9 @@ export function resolveConfig(
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,
     decoSupabaseServiceKey: envVars.DECO_SUPABASE_SERVICE_KEY,
     firecrawlApiKey: envVars.FIRECRAWL_API_KEY,
+
+    // Studio Provision Secret Key
+    studioProvisionSecretKey: envVars.STUDIO_PROVISION_SECRET_KEY,
   };
 
   return {

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -24,6 +24,7 @@ export interface Settings {
   localMode: boolean;
   allowLocalProd: boolean;
   disableRateLimit: boolean;
+  studioProvisionSecretKey: string | undefined; // Secret key to call the Deco AI Gateway API to provision keys
 
   // Observability
   clickhouseUrl: string | undefined;


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically provisions and stores a Deco Gateway API key for new organizations via a secure server-to-server call. Adds `provisionKey` to the `deco` provider and uses `STUDIO_PROVISION_SECRET_KEY` for authorization.

- **New Features**
  - Added `provisionKey(meshJwt, organizationId)` to `decoAiGatewayAdapter` to call `/api/keys/provision` with `X-Provision-Key`.
  - Auto-provision on org creation (`seedOrgDb`) when `aiGatewayEnabled`: mints a gateway JWT, provisions the key, and saves it to `AIProviderKeyStorage` as “Auto-provisioned”.
  - Added `studioProvisionSecretKey` to settings; includes validation and error handling for missing/failed provisioning.

- **Migration**
  - Set `STUDIO_PROVISION_SECRET_KEY` in the environment.
  - Enable `aiGatewayEnabled` to activate auto-provisioning for new orgs.

<sup>Written for commit f0d141b500853cb7bf58f0365cfa1ac28671d955. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

