### PR TITLE
fix(mesh): validate redirect_uri in oauth-proxy to prevent OAuth hijacking

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -672,7 +672,10 @@ export async function createApp(options: CreateAppOptions = {}) {
       const redirectUri = targetUrl.searchParams.get("redirect_uri");
       if (!redirectUri) {
         return c.json(
-          { error: "invalid_request", error_description: "redirect_uri is required" },
+          {
+            error: "invalid_request",
+            error_description: "redirect_uri is required",
+          },
           400,
         );
       }
@@ -685,13 +688,19 @@ export async function createApp(options: CreateAppOptions = {}) {
           redirectHost.endsWith(".studio.decocms.com");
         if (!allowed) {
           return c.json(
-            { error: "invalid_request", error_description: "redirect_uri is not allowed" },
+            {
+              error: "invalid_request",
+              error_description: "redirect_uri is not allowed",
+            },
             400,
           );
         }
       } catch {
         return c.json(
-          { error: "invalid_request", error_description: "redirect_uri is malformed" },
+          {
+            error: "invalid_request",
+            error_description: "redirect_uri is malformed",
+          },
           400,
         );
       }

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -668,17 +668,13 @@ export async function createApp(options: CreateAppOptions = {}) {
     // 2. Cookies are set on the correct domain
     // 3. The user can interact with the consent screen
     if (endpoint === "authorize") {
-      // Validate redirect_uri to prevent OAuth hijacking — only allow our own origins
+      // Validate redirect_uri to prevent OAuth hijacking — only allow our own origin
       const redirectUri = targetUrl.searchParams.get("redirect_uri");
       if (redirectUri) {
+        const allowedOrigin = getSettings().baseUrl ?? reqUrl.origin;
         try {
-          const redirectHost = new URL(redirectUri).hostname;
-          const allowed =
-            redirectHost === "localhost" ||
-            redirectHost === "127.0.0.1" ||
-            redirectHost === "studio.decocms.com" ||
-            redirectHost.endsWith(".studio.decocms.com");
-          if (!allowed) {
+          const redirectOrigin = new URL(redirectUri).origin;
+          if (redirectOrigin !== new URL(allowedOrigin).origin) {
             return c.json(
               {
                 error: "invalid_request",

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -668,6 +668,34 @@ export async function createApp(options: CreateAppOptions = {}) {
     // 2. Cookies are set on the correct domain
     // 3. The user can interact with the consent screen
     if (endpoint === "authorize") {
+      // Validate redirect_uri to prevent OAuth hijacking — only allow our own origins
+      const redirectUri = targetUrl.searchParams.get("redirect_uri");
+      if (!redirectUri) {
+        return c.json(
+          { error: "invalid_request", error_description: "redirect_uri is required" },
+          400,
+        );
+      }
+      try {
+        const redirectHost = new URL(redirectUri).hostname;
+        const allowed =
+          redirectHost === "localhost" ||
+          redirectHost === "127.0.0.1" ||
+          redirectHost === "studio.decocms.com" ||
+          redirectHost.endsWith(".studio.decocms.com");
+        if (!allowed) {
+          return c.json(
+            { error: "invalid_request", error_description: "redirect_uri is not allowed" },
+            400,
+          );
+        }
+      } catch {
+        return c.json(
+          { error: "invalid_request", error_description: "redirect_uri is malformed" },
+          400,
+        );
+      }
+
       // IMPORTANT: Rewrite the 'resource' parameter to point to the origin MCP endpoint
       // Some auth servers (like Supabase) validate that the resource is their actual endpoint,
       // not our proxy. We keep the proxy URL for redirect_uri since that's where we handle the callback.

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -668,7 +668,9 @@ export async function createApp(options: CreateAppOptions = {}) {
     // 2. Cookies are set on the correct domain
     // 3. The user can interact with the consent screen
     if (endpoint === "authorize") {
-      // Validate redirect_uri to prevent OAuth hijacking — only allow our own origin
+      // Validate redirect_uri to prevent OAuth hijacking — only allow our own origin.
+      // Use .get() to grab the first value, then .set() to canonicalize to exactly
+      // one redirect_uri param, preventing parser-differential bypasses via duplicates.
       const redirectUri = targetUrl.searchParams.get("redirect_uri");
       if (redirectUri) {
         const allowedOrigin = getSettings().baseUrl ?? reqUrl.origin;
@@ -692,6 +694,8 @@ export async function createApp(options: CreateAppOptions = {}) {
             400,
           );
         }
+        // Collapse any duplicate redirect_uri params to the single validated value
+        targetUrl.searchParams.set("redirect_uri", redirectUri);
       }
 
       // IMPORTANT: Rewrite the 'resource' parameter to point to the origin MCP endpoint

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -670,39 +670,32 @@ export async function createApp(options: CreateAppOptions = {}) {
     if (endpoint === "authorize") {
       // Validate redirect_uri to prevent OAuth hijacking — only allow our own origins
       const redirectUri = targetUrl.searchParams.get("redirect_uri");
-      if (!redirectUri) {
-        return c.json(
-          {
-            error: "invalid_request",
-            error_description: "redirect_uri is required",
-          },
-          400,
-        );
-      }
-      try {
-        const redirectHost = new URL(redirectUri).hostname;
-        const allowed =
-          redirectHost === "localhost" ||
-          redirectHost === "127.0.0.1" ||
-          redirectHost === "studio.decocms.com" ||
-          redirectHost.endsWith(".studio.decocms.com");
-        if (!allowed) {
+      if (redirectUri) {
+        try {
+          const redirectHost = new URL(redirectUri).hostname;
+          const allowed =
+            redirectHost === "localhost" ||
+            redirectHost === "127.0.0.1" ||
+            redirectHost === "studio.decocms.com" ||
+            redirectHost.endsWith(".studio.decocms.com");
+          if (!allowed) {
+            return c.json(
+              {
+                error: "invalid_request",
+                error_description: "redirect_uri is not allowed",
+              },
+              400,
+            );
+          }
+        } catch {
           return c.json(
             {
               error: "invalid_request",
-              error_description: "redirect_uri is not allowed",
+              error_description: "redirect_uri is malformed",
             },
             400,
           );
         }
-      } catch {
-        return c.json(
-          {
-            error: "invalid_request",
-            error_description: "redirect_uri is malformed",
-          },
-          400,
-        );
       }
 
       // IMPORTANT: Rewrite the 'resource' parameter to point to the origin MCP endpoint


### PR DESCRIPTION
The oauth-proxy authorize endpoint was forwarding any redirect_uri to the upstream auth server without validation. An attacker could supply a malicious redirect_uri (e.g. https://evil.com) and steal authorization codes after consent.

Now the proxy requires redirect_uri and rejects any host that is not studio.decocms.com (or subdomains) or localhost/127.0.0.1.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the oauth-proxy authorize endpoint by validating redirect_uri (optional per RFC 6749) to prevent OAuth hijacking. If present, its origin must match getSettings().baseUrl (or the request origin); invalid values return 400 invalid_request and duplicate redirect_uri params are collapsed to a single validated value.

<sup>Written for commit 21c0be58d2d4c8bdba57aa70eed8ea57b9a4c75b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

