### PR TITLE
fix(settings): prevent crash on connections page without ChatContextProvider

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/prompts.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/prompts.ts
@@ -79,8 +79,7 @@ export function createReadPromptTool(params: PromptToolParams) {
           arguments: args ?? {},
         });
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         return { error: `Failed to read prompt "${name}": ${message}` };
       }
       const messages = result.messages;

--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -63,7 +63,10 @@ import {
 import { contentBlocksToTiptapDoc } from "@/mcp-apps/content-blocks.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { ToolAnnotationBadges } from "@/web/components/tools/tools-list.tsx";
-import { useChatBridge, useChatPrefs } from "@/web/components/chat/context.tsx";
+import {
+  useChatBridge,
+  useOptionalChatPrefs,
+} from "@/web/components/chat/context.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { MonacoCodeEditor } from "./workflow/components/monaco-editor";
 
@@ -200,7 +203,7 @@ function ToolDetailsAuthenticated({
   const { org } = useProjectContext();
   const connection = useConnection(connectionId);
   const { sendMessage } = useChatBridge();
-  const { setAppContext, clearAppContext } = useChatPrefs();
+  const chatPrefs = useOptionalChatPrefs();
   const { setChatOpen } = usePanelActions();
   const sourceId = `${connectionId}:${toolName}`;
 
@@ -654,8 +657,10 @@ function ToolDetailsAuthenticated({
               maxHeight={MCP_APP_DISPLAY_MODES.view.maxHeight}
               client={client}
               onMessage={handleAppMessage}
-              onUpdateModelContext={(params) => setAppContext(sourceId, params)}
-              onTeardown={() => clearAppContext(sourceId)}
+              onUpdateModelContext={(params) =>
+                chatPrefs?.setAppContext(sourceId, params)
+              }
+              onTeardown={() => chatPrefs?.clearAppContext(sourceId)}
               className="h-full"
             />
           </Suspense>


### PR DESCRIPTION
## What is this contribution about?
The Settings > Connections page crashes with "useChatPrefs must be used within ChatContextProvider" because `ToolDetailsView` calls `useChatPrefs()` which throws when no `ChatContextProvider` exists in the component tree — and the settings layout doesn't wrap one (only the agent shell layout does).

Switches to `useOptionalChatPrefs()` (already available) so the hook returns `null` instead of throwing, and guards call sites with optional chaining. Chat-related features in tool details become no-ops when outside the chat context.

## Screenshots/Demonstration
Before: navigating to Settings > Connections shows "Something went wrong — useChatPrefs must be used within ChatContextProvider".
After: page renders normally.

## How to Test
1. Navigate to Settings > Connections
2. Click on any connection, then open a tool detail
3. Page should render without crashing

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash on Settings > Connections tool details when no `ChatContextProvider` is present. The page now renders, and chat-specific behavior is disabled outside chat.

- **Bug Fixes**
  - Switched to `useOptionalChatPrefs()` in `tool.tsx` to avoid throwing outside chat context.
  - Guarded `setAppContext` and `clearAppContext` calls with optional chaining.
  - Minor cleanup in `prompts.ts` to simplify error message formatting (no behavior change).

<sup>Written for commit 038c4c2f28ff8e993f18cd07dc4d19dc4a15d4e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

