### PR TITLE
feat(decopilot): add first-class image generation with lightbox viewer

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
@@ -1,0 +1,241 @@
+/**
+ * generate_image Built-in Tool
+ *
+ * Server-side tool that generates images using the selected image model.
+ * Uses AI SDK generateImage() with the provider's imageModel().
+ *
+ * Generated images are uploaded to object storage and their stable URLs
+ * are returned in the tool result. The model can pass these URLs back as
+ * referenceImages in follow-up calls. The frontend reads the URLs from
+ * the tool result to render the images.
+ *
+ * Supports reference images via URL: the AI passes image URLs from the
+ * conversation (uploaded files, previously generated images) and the tool
+ * fetches the bytes before calling the image model.
+ */
+
+import { tool, zodSchema, generateImage, type UIMessageStreamWriter } from "ai";
+import { z } from "zod";
+import type { MeshProvider } from "@/ai-providers/types";
+import type { MeshContext } from "@/core/mesh-context";
+import type { ModelInfo } from "../types";
+
+const GenerateImageInputSchema = z.object({
+  prompt: z
+    .string()
+    .max(10000)
+    .describe(
+      "Detailed description of the image to generate. Be specific about style, composition, colors, and subject matter.",
+    ),
+  referenceImages: z
+    .array(
+      z.object({
+        uri: z
+          .string()
+          .describe(
+            "URI of the reference image (e.g. mesh-storage:generated-images/uuid.png).",
+          ),
+      }),
+    )
+    .optional()
+    .describe(
+      "Reference images to use as input for image-to-image generation. " +
+        "Pass the URI of any image from the conversation (uploaded files, previously generated images, etc.) " +
+        "when the user wants to modify, transform, or use an existing image as a starting point.",
+    ),
+  aspectRatio: z
+    .enum(["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"])
+    .optional()
+    .describe("Aspect ratio for the generated image. Defaults to 1:1."),
+  n: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .optional()
+    .describe("Number of images to generate. Defaults to 1."),
+});
+
+export type GenerateImageInput = z.infer<typeof GenerateImageInputSchema>;
+
+/** Pattern to extract the storage key from our own files endpoint URL. */
+const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/(.+)$/;
+
+/**
+ * Resolve an image URL to raw bytes.
+ * Handles mesh-storage: URIs, our own /api/:org/files/ URLs,
+ * data: URIs, and external HTTP(S) URLs.
+ */
+async function fetchImageBytes(
+  url: string,
+  ctx: MeshContext,
+): Promise<Uint8Array> {
+  // mesh-storage:{key} — read directly from object storage
+  if (url.startsWith("mesh-storage:")) {
+    const key = url.slice("mesh-storage:".length);
+    return readFromObjectStorage(key, ctx);
+  }
+
+  // Our own /api/:org/files/:key URL — extract key and read directly
+  // instead of round-tripping through HTTP (which would lack auth cookies).
+  const filesMatch = url.match(FILES_URL_PATTERN);
+  if (filesMatch) {
+    return readFromObjectStorage(filesMatch[1]!, ctx);
+  }
+
+  // data: URI — decode inline
+  if (url.startsWith("data:")) {
+    const match = url.match(/^data:[^;]+;base64,(.+)$/s);
+    if (!match) throw new Error("Invalid data: URI");
+    return Buffer.from(match[1]!, "base64");
+  }
+
+  // External HTTP(S) URL — fetch
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch image from ${url}: ${res.status}`);
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+async function readFromObjectStorage(
+  key: string,
+  ctx: MeshContext,
+): Promise<Uint8Array> {
+  if (!ctx.objectStorage) {
+    throw new Error("Object storage not available");
+  }
+  const result = await ctx.objectStorage.get(key);
+  if ("content" in result && typeof result.content === "string") {
+    if (result.encoding === "base64") {
+      return Buffer.from(result.content, "base64");
+    }
+    return new TextEncoder().encode(result.content);
+  }
+  throw new Error(`Failed to read from object storage: ${key}`);
+}
+
+export function createGenerateImageTool(
+  writer: UIMessageStreamWriter,
+  params: {
+    provider: MeshProvider;
+    imageModelInfo: ModelInfo;
+    ctx: MeshContext;
+  },
+) {
+  const { provider, imageModelInfo, ctx } = params;
+
+  return tool({
+    description:
+      "Generate an image from a text description, optionally using reference images. " +
+      "Use this when the user asks you to create, generate, draw, or design an image. " +
+      "If the user has attached images and wants to modify or use them as a reference, " +
+      "pass them as referenceImages. " +
+      "The image is displayed automatically by the UI — do NOT include image URLs or markdown images in your response.",
+    inputSchema: zodSchema(GenerateImageInputSchema),
+    execute: async (input, options) => {
+      const startTime = performance.now();
+      try {
+        const imageModel = provider.aiSdk.imageModel(imageModelInfo.id);
+
+        // Build the prompt: text-only or text + reference images
+        const hasRefs =
+          input.referenceImages && input.referenceImages.length > 0;
+
+        let refImageBytes: Uint8Array[] = [];
+        if (hasRefs) {
+          console.log(
+            "[generate-image] referenceImages input:",
+            JSON.stringify(input.referenceImages),
+          );
+          refImageBytes = await Promise.all(
+            input.referenceImages!.map((ref) => {
+              // Accept both `uri` (current schema) and `url` (legacy threads)
+              const raw = ref.uri ?? (ref as unknown as { url?: string }).url;
+              console.log("[generate-image] resolving ref:", { raw, ref });
+              if (!raw) throw new Error("Reference image missing uri");
+              return fetchImageBytes(raw, ctx);
+            }),
+          );
+          console.log(
+            "[generate-image] fetched",
+            refImageBytes.length,
+            "reference images, sizes:",
+            refImageBytes.map((b) => b.byteLength),
+          );
+        }
+
+        const prompt = hasRefs
+          ? { text: input.prompt, images: refImageBytes }
+          : input.prompt;
+
+        const result = await generateImage({
+          model: imageModel,
+          prompt,
+          n: input.n ?? 1,
+          ...(input.aspectRatio && { aspectRatio: input.aspectRatio }),
+        });
+
+        console.log("[generate-image] result:", JSON.stringify(result));
+
+        console.log("[generate-image] usage:", result.usage);
+        console.log(
+          "[generate-image] providerMetadata:",
+          JSON.stringify(result.providerMetadata),
+        );
+
+        // Upload images to object storage, return stable mesh-storage: URIs.
+        // The model sees only URIs (lightweight, opaque); the frontend resolves
+        // them to fetchable URLs for rendering.
+        const images = await Promise.all(
+          result.images.map(async (img) => {
+            const mediaType = img.mediaType ?? "image/png";
+            const ext = mediaType.split("/")[1] ?? "png";
+            const key = `generated-images/${crypto.randomUUID()}.${ext}`;
+
+            if (ctx.objectStorage) {
+              try {
+                const bytes = Uint8Array.from(atob(img.base64), (c) =>
+                  c.charCodeAt(0),
+                );
+                await ctx.objectStorage.put(key, bytes, {
+                  contentType: mediaType,
+                });
+                return { uri: `mesh-storage:${key}`, mediaType };
+              } catch (err) {
+                console.error(
+                  "[generate-image] Failed to upload, falling back to data: URI",
+                  err,
+                );
+              }
+            }
+            // Fallback: inline data: URI (no object storage configured)
+            return {
+              uri: `data:${mediaType};base64,${img.base64}`,
+              mediaType,
+            };
+          }),
+        );
+
+        return {
+          success: true,
+          images,
+          prompt: input.prompt,
+          model: imageModelInfo.id,
+          usage: {
+            inputTokens: result.usage.inputTokens ?? 0,
+            outputTokens: result.usage.outputTokens ?? 0,
+          },
+          usedReferenceImages: hasRefs ? input.referenceImages!.length : 0,
+        };
+      } finally {
+        const latencyMs = performance.now() - startTime;
+        writer.write({
+          type: "data-tool-metadata",
+          id: options.toolCallId,
+          data: { latencyMs },
+        });
+      }
+    },
+  });
+}

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
@@ -110,6 +110,7 @@ const PRIVATE_HOST_PATTERNS = [
   /^\[::1\]$/, // IPv6 loopback
   /^\[fd/, // IPv6 unique local
   /^\[fe80:/, // IPv6 link-local
+  /^\[::ffff:/i, // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1)
   /^localhost$/i,
 ];
 

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
@@ -144,24 +144,13 @@ export function createGenerateImageTool(
 
         let refImageBytes: Uint8Array[] = [];
         if (hasRefs) {
-          console.log(
-            "[generate-image] referenceImages input:",
-            JSON.stringify(input.referenceImages),
-          );
           refImageBytes = await Promise.all(
             input.referenceImages!.map((ref) => {
               // Accept both `uri` (current schema) and `url` (legacy threads)
               const raw = ref.uri ?? (ref as unknown as { url?: string }).url;
-              console.log("[generate-image] resolving ref:", { raw, ref });
               if (!raw) throw new Error("Reference image missing uri");
               return fetchImageBytes(raw, ctx);
             }),
-          );
-          console.log(
-            "[generate-image] fetched",
-            refImageBytes.length,
-            "reference images, sizes:",
-            refImageBytes.map((b) => b.byteLength),
           );
         }
 
@@ -175,14 +164,6 @@ export function createGenerateImageTool(
           n: input.n ?? 1,
           ...(input.aspectRatio && { aspectRatio: input.aspectRatio }),
         });
-
-        console.log("[generate-image] result:", JSON.stringify(result));
-
-        console.log("[generate-image] usage:", result.usage);
-        console.log(
-          "[generate-image] providerMetadata:",
-          JSON.stringify(result.providerMetadata),
-        );
 
         // Upload images to object storage, return stable mesh-storage: URIs.
         // The model sees only URIs (lightweight, opaque); the frontend resolves

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
@@ -18,6 +18,7 @@ import { tool, zodSchema, generateImage, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { MeshProvider } from "@/ai-providers/types";
 import type { MeshContext } from "@/core/mesh-context";
+import { getSettings } from "@/settings";
 import type { ModelInfo } from "../types";
 
 const GenerateImageInputSchema = z.object({
@@ -59,7 +60,7 @@ const GenerateImageInputSchema = z.object({
 export type GenerateImageInput = z.infer<typeof GenerateImageInputSchema>;
 
 /** Pattern to extract the storage key from our own files endpoint URL. */
-const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/(.+)$/;
+const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 
 /**
  * Resolve an image URL to raw bytes.
@@ -90,12 +91,50 @@ async function fetchImageBytes(
     return Buffer.from(match[1]!, "base64");
   }
 
-  // External HTTP(S) URL — fetch
+  // External HTTP(S) URL — validate before fetching to prevent SSRF
+  validateExternalUrl(url);
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch image from ${url}: ${res.status}`);
   }
   return new Uint8Array(await res.arrayBuffer());
+}
+
+const PRIVATE_HOST_PATTERNS = [
+  /^127\./, // loopback
+  /^10\./, // 10.0.0.0/8
+  /^172\.(1[6-9]|2\d|3[01])\./, // 172.16.0.0/12
+  /^192\.168\./, // 192.168.0.0/16
+  /^169\.254\./, // link-local (cloud metadata)
+  /^0\./, // 0.0.0.0/8
+  /^\[::1\]$/, // IPv6 loopback
+  /^\[fd/, // IPv6 unique local
+  /^\[fe80:/, // IPv6 link-local
+  /^localhost$/i,
+];
+
+function validateExternalUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid image URL");
+  }
+
+  const allowHttp = getSettings().nodeEnv !== "production";
+  if (
+    parsed.protocol !== "https:" &&
+    !(allowHttp && parsed.protocol === "http:")
+  ) {
+    throw new Error("Image URL must use HTTPS");
+  }
+
+  const host = parsed.hostname;
+  for (const pattern of PRIVATE_HOST_PATTERNS) {
+    if (pattern.test(host)) {
+      throw new Error("Image URL must not point to a private network address");
+    }
+  }
 }
 
 async function readFromObjectStorage(

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -17,6 +17,7 @@ import { createOpenInAgentTool } from "./open-in-agent";
 import { createSubtaskTool } from "./subtask";
 import { userAskTool } from "./user-ask";
 import { proposePlanTool } from "./propose-plan";
+import { createGenerateImageTool } from "./generate-image";
 import type { ModelsConfig } from "../types";
 import type { MeshProvider } from "@/ai-providers/types";
 
@@ -102,6 +103,14 @@ function buildAllTools(
       ctx,
     );
   }
+  // generate_image requires a provider and an image model selection
+  if (provider && models.image) {
+    tools.generate_image = createGenerateImageTool(writer, {
+      provider,
+      imageModelInfo: models.image,
+      ctx,
+    });
+  }
   return tools as {
     user_ask: typeof userAskTool;
     propose_plan: typeof proposePlanTool;
@@ -112,6 +121,7 @@ function buildAllTools(
     read_resource: ReturnType<typeof createReadResourceTool>;
     read_prompt: ReturnType<typeof createReadPromptTool>;
     open_in_agent: ReturnType<typeof createOpenInAgentTool>;
+    generate_image: ReturnType<typeof createGenerateImageTool>;
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -154,6 +154,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         memory: memoryConfig,
         thread_id,
         toolApprovalLevel,
+        forceImageGeneration,
       } = await validateRequest(c);
 
       const userId = ctx.auth?.user?.id;
@@ -200,6 +201,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           userId,
           taskId: resolvedThreadId,
           windowSize,
+          forceImageGeneration,
         },
         ctx,
         { runRegistry, streamBuffer, cancelBroadcast },
@@ -247,6 +249,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         memory: memoryConfig,
         thread_id,
         toolApprovalLevel,
+        forceImageGeneration,
       } = await validateRequest(c);
 
       const userId = ctx.auth?.user?.id;
@@ -293,6 +296,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           userId,
           taskId: resolvedThreadId,
           windowSize,
+          forceImageGeneration,
         },
         ctx,
         { runRegistry, streamBuffer, cancelBroadcast },

--- a/apps/mesh/src/api/routes/decopilot/run-config.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-config.ts
@@ -36,6 +36,7 @@ export const PersistedRunConfigSchema = z.object({
     thinking: PersistedModelInfoSchema,
     coding: PersistedModelInfoSchema.optional(),
     fast: PersistedModelInfoSchema.optional(),
+    image: PersistedModelInfoSchema.optional(),
   }),
   agent: z.object({ id: z.string() }),
   temperature: z.number(),
@@ -67,5 +68,6 @@ export function toModelsConfig(models: PersistedRunConfig["models"]) {
     thinking: toModelInfo(models.thinking),
     ...(models.coding && { coding: toModelInfo(models.coding) }),
     ...(models.fast && { fast: toModelInfo(models.fast) }),
+    ...(models.image && { image: toModelInfo(models.image) }),
   };
 }

--- a/apps/mesh/src/api/routes/decopilot/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/schemas.ts
@@ -66,6 +66,7 @@ const ModelsSchema = z
     ),
     coding: ModelInfoSchema.optional().describe("Good coding model"),
     fast: ModelInfoSchema.optional().describe("Cheap model for simple tasks"),
+    image: ModelInfoSchema.optional().describe("Image generation model"),
   })
   .loose();
 
@@ -87,6 +88,7 @@ export const StreamRequestSchema = z.object({
   temperature: z.number().default(0.5),
   thread_id: z.string().optional(),
   toolApprovalLevel: z.enum(["auto", "readonly", "plan"]).default("auto"),
+  forceImageGeneration: z.boolean().optional(),
 });
 
 export type StreamRequest = z.infer<typeof StreamRequestSchema>;

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -96,6 +96,8 @@ export interface StreamCoreInput {
   windowSize?: number;
   abortSignal?: AbortSignal;
   isResume?: boolean;
+  /** When true, forces generate_image as the required tool for this request */
+  forceImageGeneration?: boolean;
 }
 
 export interface StreamCoreDeps {
@@ -369,6 +371,7 @@ async function streamCoreInner(
 
     const toolOutputMap = new Map<string, string>();
     const organization = ctx.organization!;
+    let titleHandle: ReturnType<typeof genTitle> | null = null;
 
     const uiStream = createUIMessageStream({
       originalMessages: allMessages,
@@ -487,9 +490,24 @@ async function streamCoreInner(
               "</plan-mode>"
             : null;
 
+        // Image generation system prompt injection
+        const imageGenPrompt = input.models.image
+          ? "<image-generation>\n" +
+            "You have image generation enabled. When the user asks you to create, generate, draw, " +
+            "design, or illustrate an image, use the `generate_image` tool.\n\n" +
+            "Write detailed, descriptive prompts for the image model. Include style, composition, " +
+            "colors, lighting, and subject matter details to get the best results.\n\n" +
+            "IMPORTANT: After calling `generate_image`, the image is automatically displayed to the user " +
+            "by the UI. Do NOT include the image URL, data URI, or any markdown image syntax in your " +
+            "text response. Just describe what was generated in plain text.\n\n" +
+            `Image model: ${input.models.image.title ?? input.models.image.id}\n` +
+            "</image-generation>"
+          : null;
+
         const systemPrompts = [
           basePrompt,
           planModePrompt,
+          imageGenPrompt,
           toolCatalog,
           promptCatalog,
           agentPrompt,
@@ -515,14 +533,15 @@ async function streamCoreInner(
           mem.thread.title === DEFAULT_THREAD_TITLE && !isCliAgent;
         if (shouldGenerateTitle) {
           const titleInput = JSON.stringify(processedMessages[0]?.content);
-          const titleOp = genTitle({
+          titleHandle = genTitle({
             abortSignal: registrySignal,
             model: createLanguageModel(
               provider!,
               input.models.fast ?? input.models.thinking,
             ),
             userMessage: titleInput,
-          })
+          });
+          const titleOp = titleHandle.promise
             .then(async (title) => {
               if (!title) return;
 
@@ -669,34 +688,52 @@ async function streamCoreInner(
             ...(isCliAgent
               ? {}
               : {
-                  prepareStep: () => {
-                    let activeToolNames = [
-                      ...builtInToolNames,
-                      "enable_tools",
-                      ...enabledTools,
-                    ];
+                  prepareStep: (() => {
+                    // Force generate_image only on the first step, then let the
+                    // model choose freely on subsequent steps.
+                    const shouldForceImage =
+                      input.forceImageGeneration && "generate_image" in tools;
+                    let stepIndex = 0;
 
-                    // Layer 2: In plan mode, filter out any non-read-only tools that
-                    // somehow got enabled (safety net for Layer 1 in enable_tools)
-                    if (input.toolApprovalLevel === "plan") {
-                      activeToolNames = activeToolNames.filter((name) => {
-                        // Built-in tools and enable_tools are always allowed
-                        if (
-                          builtInToolNames.includes(name) ||
-                          name === "enable_tools"
-                        ) {
-                          return true;
-                        }
-                        // Only allow passthrough tools with readOnlyHint
-                        const annotations = toolAnnotations.get(name);
-                        return annotations?.readOnlyHint === true;
-                      });
-                    }
+                    return () => {
+                      const isFirstStep = stepIndex === 0;
+                      stepIndex++;
 
-                    return {
-                      activeTools: activeToolNames as (keyof typeof tools)[],
+                      let activeToolNames = [
+                        ...builtInToolNames,
+                        "enable_tools",
+                        ...enabledTools,
+                      ];
+
+                      // Layer 2: In plan mode, filter out any non-read-only tools that
+                      // somehow got enabled (safety net for Layer 1 in enable_tools)
+                      if (input.toolApprovalLevel === "plan") {
+                        activeToolNames = activeToolNames.filter((name) => {
+                          // Built-in tools and enable_tools are always allowed
+                          if (
+                            builtInToolNames.includes(name) ||
+                            name === "enable_tools"
+                          ) {
+                            return true;
+                          }
+                          // Only allow passthrough tools with readOnlyHint
+                          const annotations = toolAnnotations.get(name);
+                          return annotations?.readOnlyHint === true;
+                        });
+                      }
+
+                      return {
+                        activeTools: activeToolNames as (keyof typeof tools)[],
+                        ...(shouldForceImage &&
+                          isFirstStep && {
+                            toolChoice: {
+                              type: "tool" as const,
+                              toolName: "generate_image" as never,
+                            },
+                          }),
+                      };
                     };
-                  },
+                  })(),
                   temperature: input.temperature,
                   maxOutputTokens,
                   stopWhen: stepCountIs(PARENT_STEP_LIMIT),
@@ -928,6 +965,9 @@ async function streamCoreInner(
         streamFinished = true;
         closeClients?.();
 
+        // Stream done — start grace period for title generation
+        titleHandle?.finish();
+
         await Promise.allSettled(pendingOps);
         await saveMessagesToThread(responseMessage);
 
@@ -974,6 +1014,7 @@ async function streamCoreInner(
       onError: (error) => {
         streamFinished = true;
         closeClients?.();
+        titleHandle?.finish();
         if (registrySignal.aborted) {
           return sanitizeStreamError(error);
         }

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -490,24 +490,9 @@ async function streamCoreInner(
               "</plan-mode>"
             : null;
 
-        // Image generation system prompt injection
-        const imageGenPrompt = input.models.image
-          ? "<image-generation>\n" +
-            "You have image generation enabled. When the user asks you to create, generate, draw, " +
-            "design, or illustrate an image, use the `generate_image` tool.\n\n" +
-            "Write detailed, descriptive prompts for the image model. Include style, composition, " +
-            "colors, lighting, and subject matter details to get the best results.\n\n" +
-            "IMPORTANT: After calling `generate_image`, the image is automatically displayed to the user " +
-            "by the UI. Do NOT include the image URL, data URI, or any markdown image syntax in your " +
-            "text response. Just describe what was generated in plain text.\n\n" +
-            `Image model: ${input.models.image.title ?? input.models.image.id}\n` +
-            "</image-generation>"
-          : null;
-
         const systemPrompts = [
           basePrompt,
           planModePrompt,
-          imageGenPrompt,
           toolCatalog,
           promptCatalog,
           agentPrompt,

--- a/apps/mesh/src/api/routes/decopilot/title-generator.ts
+++ b/apps/mesh/src/api/routes/decopilot/title-generator.ts
@@ -11,74 +11,97 @@ import { TITLE_GENERATOR_PROMPT } from "./constants";
 
 /**
  * Generate a short title for the conversation in the background.
+ *
+ * Title generation lives as long as the parent stream. When the stream
+ * finishes, the caller should call `finish()` — this starts a short grace
+ * period so the title LLM can still complete, but won't block teardown
+ * indefinitely.
  */
-const TITLE_TIMEOUT_MS = 2500;
+const POST_STREAM_GRACE_MS = 10_000;
 
-export async function genTitle(config: {
+export function genTitle(config: {
   abortSignal: AbortSignal;
   model: LanguageModelV3;
   userMessage: string;
-}): Promise<string | null> {
+}): { promise: Promise<string | null>; finish: () => void } {
   const { abortSignal, model, userMessage } = config;
 
-  // Create a local abort controller for title generation only
   const titleAbortController = new AbortController();
 
   // Abort title generation if parent stream is aborted
   const onParentAbort = () => titleAbortController.abort();
   abortSignal.addEventListener("abort", onParentAbort, { once: true });
 
-  // Abort title generation after timeout (doesn't affect parent stream)
-  const timeoutId = setTimeout(() => {
-    titleAbortController.abort();
-  }, TITLE_TIMEOUT_MS);
+  let graceTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
-  try {
-    const result = await generateText({
-      model,
-      system: TITLE_GENERATOR_PROMPT,
-      messages: [{ role: "user", content: userMessage }],
-      maxOutputTokens: 60,
-      temperature: 0.2,
-      abortSignal: titleAbortController.signal,
-    });
+  // Called when the main LLM stream finishes — gives the title a grace
+  // period to complete, then aborts so onFinish doesn't hang.
+  const finish = () => {
+    graceTimeoutId = setTimeout(() => {
+      titleAbortController.abort();
+    }, POST_STREAM_GRACE_MS);
+  };
 
-    // Try JSON parse first (preferred format), fall back to raw text
-    const rawTitle = result.text.trim();
-    let title: string;
-
+  const promise = (async (): Promise<string | null> => {
     try {
-      const parsed = JSON.parse(rawTitle);
-      title = typeof parsed.title === "string" ? parsed.title : rawTitle;
-    } catch {
-      // Fallback: extract first line and clean up formatting
-      const firstLine = rawTitle.split("\n")[0] ?? rawTitle;
-      title = firstLine;
-    }
+      const result = await generateText({
+        model,
+        system: TITLE_GENERATOR_PROMPT,
+        messages: [{ role: "user", content: userMessage }],
+        maxOutputTokens: 60,
+        temperature: 0.2,
+        abortSignal: titleAbortController.signal,
+      });
 
-    title = title
-      .replace(/^["']|["']$/g, "") // Remove quotes
-      .replace(/^(Title:|title:)\s*/i, "") // Remove "Title:" prefix
-      .replace(/[.!?]$/, "") // Remove trailing punctuation
-      .slice(0, 60) // Max 60 chars
-      .trim();
+      // Strip markdown code fences if present, then try JSON parse
+      const cleaned = result.text
+        .trim()
+        .replace(/^```(?:json)?\s*\n?/i, "")
+        .replace(/\n?```\s*$/, "")
+        .trim();
 
-    return title;
-  } catch (error) {
-    const err = error as Error;
-    if (err.name === "AbortError") {
-      console.warn(
-        "[decopilot:title] Title generation aborted (timeout or parent abort)",
-      );
-    } else {
-      console.error(
-        "[decopilot:title] ❌ Failed to generate title:",
-        err.message,
-      );
+      let title: string;
+
+      try {
+        const parsed = JSON.parse(cleaned);
+        title = typeof parsed.title === "string" ? parsed.title : cleaned;
+      } catch {
+        // Fallback: extract first line and clean up formatting
+        const firstLine = cleaned.split("\n")[0] ?? cleaned;
+        title = firstLine;
+      }
+
+      title = title
+        .replace(/^["']|["']$/g, "") // Remove quotes
+        .replace(/^(Title:|title:)\s*/i, "") // Remove "Title:" prefix
+        .replace(/^```.*$/gm, "") // Remove any remaining fence lines
+        .replace(/[{}[\]]/g, "") // Remove JSON braces/brackets
+        .replace(/[.!?]$/, "") // Remove trailing punctuation
+        .slice(0, 60) // Max 60 chars
+        .trim();
+
+      // If cleanup left nothing useful, don't set a broken title
+      if (!title || /^[\s"':{}[\],]+$/.test(title)) return null;
+
+      return title;
+    } catch (error) {
+      const err = error as Error;
+      if (err.name === "AbortError") {
+        console.warn(
+          "[decopilot:title] Title generation aborted (timeout or parent abort)",
+        );
+      } else {
+        console.error(
+          "[decopilot:title] ❌ Failed to generate title:",
+          err.message,
+        );
+      }
+      return null;
+    } finally {
+      clearTimeout(graceTimeoutId);
+      abortSignal.removeEventListener("abort", onParentAbort);
     }
-    return null;
-  } finally {
-    clearTimeout(timeoutId);
-    abortSignal.removeEventListener("abort", onParentAbort);
-  }
+  })();
+
+  return { promise, finish };
 }

--- a/apps/mesh/src/api/routes/decopilot/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/types.ts
@@ -38,6 +38,11 @@ export type ChatMessage = UIMessage<
     "thread-title": {
       title: string;
     };
+    "generate-image": {
+      toolCallId: string;
+      images: Array<{ base64: string; mediaType: string }>;
+      prompt: string;
+    };
   },
   {
     [K in keyof BuiltInToolSet]: InferUITool<BuiltInToolSet[K]>;
@@ -66,6 +71,7 @@ export interface ModelsConfig {
   thinking: ModelInfo;
   coding?: ModelInfo;
   fast?: ModelInfo;
+  image?: ModelInfo;
 }
 
 // ============================================================================

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -10,12 +10,16 @@
  * This endpoint is the stable public URL stored in chat history as
  * the text annotation for uploaded files. Clients (UI <img> tags,
  * MCP tools) can use it instead of presigned URLs and it always works.
+ *
+ * Requires an authenticated session (MeshContext) — the org ID in the
+ * URL is only used to extract the file key, not to bypass auth.
  */
 
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { MeshContext } from "@/core/mesh-context";
 import { generatePresignedGetUrl } from "./decopilot/file-materializer";
+import { isDevMode } from "@/tools/connection/dev-assets";
 
 type Variables = { meshContext: MeshContext };
 
@@ -23,6 +27,7 @@ const app = new Hono<{ Variables: Variables }>();
 
 app.get("/:org/files/*", async (c) => {
   const ctx = c.get("meshContext");
+
   const orgId = ctx.organization?.id;
 
   if (!orgId) {
@@ -30,7 +35,8 @@ app.get("/:org/files/*", async (c) => {
   }
 
   // Extract the file key from the wildcard segment
-  const key = c.req.path.replace(/^\/[^/]+\/files\//, "");
+  // Full path is /api/:org/files/:key — strip everything up to and including /files/
+  const key = c.req.path.replace(/^.*\/files\//, "");
 
   if (!key) {
     throw new HTTPException(400, { message: "Missing file key" });
@@ -40,6 +46,23 @@ app.get("/:org/files/*", async (c) => {
 
   if (!presignedUrl) {
     throw new HTTPException(503, { message: "Object storage not configured" });
+  }
+
+  // In dev mode, DevObjectStorage returns data: URIs which browsers can't
+  // follow as 302 redirects. Serve the bytes inline instead.
+  if (presignedUrl.startsWith("data:") && isDevMode()) {
+    const match = presignedUrl.match(/^data:([^;]+);base64,(.+)$/s);
+    if (!match) {
+      throw new HTTPException(500, {
+        message: "Invalid data URL from storage",
+      });
+    }
+    const [, contentType, base64] = match;
+    const bytes = Buffer.from(base64!, "base64");
+    return c.body(bytes, 200, {
+      "Content-Type": contentType!,
+      "Cache-Control": "private, max-age=86400",
+    });
   }
 
   return c.redirect(presignedUrl, 302);

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -87,6 +87,8 @@ export function shouldSkipMeshContext(path: string): boolean {
     path.startsWith(PATH_PREFIXES.API_AUTH) ||
     path === "/api/trigger-callback" ||
     isSystemPath(path) ||
-    isStaticFilePath(path)
+    // Static file extension check only applies to non-API paths (e.g. Vite assets).
+    // API paths like /api/:org/files/image.jpeg still need MeshContext for auth.
+    (!isApiPath(path) && isStaticFilePath(path))
   );
 }

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -256,11 +256,18 @@ export function ChatContextProvider({
 
   // Image model auto-detection: always resolve to an available model.
   // The image tool is enabled whenever an image model exists.
+  // Validate stored selection against current credential's models to avoid
+  // sending a stale model when the user switches keys.
   const imageModels = allKeyModels.filter((m) =>
     m.capabilities?.includes("image"),
   );
+  const storedModelIsAvailable =
+    storedImageModel &&
+    imageModels.some((m) => m.modelId === storedImageModel.modelId);
   const resolvedImageModel: AiProviderModel | null =
-    storedImageModel ?? imageModels[0] ?? null;
+    (storedModelIsAvailable ? storedImageModel : null) ??
+    imageModels[0] ??
+    null;
 
   // Task management (scoped by URL virtualMcpId — task list doesn't change on override)
   const taskManager = useTaskManager(virtualMcpId);

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -123,6 +123,12 @@ export interface ChatPrefsContextValue {
   allModelsConnections: ReturnType<typeof useAiProviderKeys>;
   isModelsLoading: boolean;
   selectedVirtualMcp: VirtualMCPInfo | null;
+  /** Selected image generation model (null = no image models available) */
+  imageModel: AiProviderModel | null;
+  setImageModel: (model: AiProviderModel | null) => void;
+  /** When true, forces generate_image tool on the next request (one-shot) */
+  forceImageGeneration: boolean;
+  setForceImageGeneration: (force: boolean) => void;
   appContexts: Record<string, string>;
   setAppContext: (sourceId: string, params: SetAppContextParams) => void;
   clearAppContext: (sourceId: string) => void;
@@ -218,26 +224,43 @@ export function ChatContextProvider({
     string | null
   >(LOCALSTORAGE_KEYS.chatSelectedKeyId(locator), null);
 
+  // Image model selection (localStorage-backed).
+  // null = auto-detect from available models, model = user-chosen model.
+  const [storedImageModel, setStoredImageModel] =
+    useLocalStorage<AiProviderModel | null>(
+      LOCALSTORAGE_KEYS.chatSelectedImageModel(locator),
+      null,
+    );
+
+  // Force image generation — one-shot flag, resets after send
+  const [forceImageGeneration, setForceImageGeneration] = useState(false);
+
   // AI provider keys and models
   const keys = useAiProviderKeys();
   const effectiveKeyId = keys.some((k) => k.id === storedCredentialId)
     ? storedCredentialId
     : (keys[0]?.id ?? null);
-  // Only fetch models when no stored model — once the user picks one, skip the fetch
-  const needsDefault = !storedModel;
-  const { models: defaultKeyModels, isLoading: isModelsQueryLoading } =
-    useAiProviderModels(
-      needsDefault ? (effectiveKeyId ?? undefined) : undefined,
-    );
+  // Always fetch models — React Query (staleTime 60s) caches across consumers.
+  // Needed for both default model selection and image model auto-detection.
+  const { models: allKeyModels, isLoading: isModelsQueryLoading } =
+    useAiProviderModels(effectiveKeyId ?? undefined);
   const effectiveProviderId =
     keys.find((k) => k.id === effectiveKeyId)?.providerId ?? "anthropic";
   const defaultModel = selectDefaultModel(
-    defaultKeyModels,
+    allKeyModels,
     effectiveProviderId,
     effectiveKeyId ?? undefined,
   );
   const selectedModel = storedModel ?? defaultModel;
-  const isModelsLoading = needsDefault && isModelsQueryLoading;
+  const isModelsLoading = !storedModel && isModelsQueryLoading;
+
+  // Image model auto-detection: always resolve to an available model.
+  // The image tool is enabled whenever an image model exists.
+  const imageModels = allKeyModels.filter((m) =>
+    m.capabilities?.includes("image"),
+  );
+  const resolvedImageModel: AiProviderModel | null =
+    storedImageModel ?? imageModels[0] ?? null;
 
   // Task management (scoped by URL virtualMcpId — task list doesn't change on override)
   const taskManager = useTaskManager(virtualMcpId);
@@ -438,6 +461,12 @@ export function ChatContextProvider({
     allModelsConnections: keys,
     isModelsLoading,
     selectedVirtualMcp,
+    imageModel: resolvedImageModel,
+    setImageModel: (model: AiProviderModel | null) => {
+      setStoredImageModel(model);
+    },
+    forceImageGeneration,
+    setForceImageGeneration,
     appContexts,
     setAppContext,
     clearAppContext,
@@ -485,7 +514,15 @@ export function ActiveTaskProvider({
 }: PropsWithChildren<{ taskId: string }>) {
   const { virtualMcpId, tasks, pendingMessage, clearPendingMessage } =
     useChatTask();
-  const { selectedModel, appContexts, setTiptapDoc, setModel } = useChatPrefs();
+  const {
+    selectedModel,
+    imageModel,
+    forceImageGeneration,
+    setForceImageGeneration,
+    appContexts,
+    setTiptapDoc,
+    setModel,
+  } = useChatPrefs();
   const internals = useContext(TaskInternalsCtx);
   if (!internals) {
     throw new Error(
@@ -631,6 +668,10 @@ export function ActiveTaskProvider({
       .filter(Boolean)
       .join("\n\n");
 
+    // Capture and reset one-shot forceImageGeneration before the async send
+    const shouldForceImage = forceImageGeneration && !!imageModel;
+    if (forceImageGeneration) setForceImageGeneration(false);
+
     const metadata: Metadata = {
       ...messageMetadata,
       system,
@@ -638,7 +679,11 @@ export function ActiveTaskProvider({
         credentialId: model.keyId ?? effectiveKeyId ?? "",
         thinking: toMetadataModelInfo(model),
         fast: toMetadataModelInfo(model),
+        ...(imageModel && {
+          image: toMetadataModelInfo(imageModel),
+        }),
       },
+      ...(shouldForceImage && { forceImageGeneration: true }),
     };
 
     const userMessage: ChatMessage = {

--- a/apps/mesh/src/web/components/chat/image-lightbox.tsx
+++ b/apps/mesh/src/web/components/chat/image-lightbox.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Download01, ZoomIn, ZoomOut } from "@untitledui/icons";
+import { useRef, useState } from "react";
+
+interface ImageLightboxProps {
+  src: string;
+  alt?: string;
+  children: React.ReactNode;
+}
+
+const ZOOM_STEP = 0.25;
+const ZOOM_MIN = 1;
+const ZOOM_MAX = 3;
+
+/**
+ * Clamp pan so the image edge never goes past the container edge.
+ * maxPan = (scaledSize - containerSize) / 2  (in screen pixels).
+ * When zoom=1, maxPan=0 so no panning is possible.
+ */
+function clampPan(
+  rawX: number,
+  rawY: number,
+  currentZoom: number,
+  imgEl: HTMLImageElement | null,
+): { x: number; y: number } {
+  if (!imgEl || currentZoom <= ZOOM_MIN) return { x: 0, y: 0 };
+  const w = imgEl.offsetWidth;
+  const h = imgEl.offsetHeight;
+  const maxX = ((currentZoom - 1) * w) / 2;
+  const maxY = ((currentZoom - 1) * h) / 2;
+  return {
+    x: Math.max(-maxX, Math.min(maxX, rawX)),
+    y: Math.max(-maxY, Math.min(maxY, rawY)),
+  };
+}
+
+export function ImageLightbox({
+  src,
+  alt = "Image",
+  children,
+}: ImageLightboxProps) {
+  const [open, setOpen] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const imgRef = useRef<HTMLImageElement>(null);
+  const dragRef = useRef<{
+    active: boolean;
+    startX: number;
+    startY: number;
+    startPanX: number;
+    startPanY: number;
+  } | null>(null);
+
+  const handleDownload = () => {
+    const a = document.createElement("a");
+    a.href = src;
+    a.download = alt.replace(/[^a-zA-Z0-9-_ ]/g, "") || "image";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  const handleOpen = () => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+    setOpen(true);
+  };
+
+  const zoomTo = (newZoom: number) => {
+    const clamped = Math.min(Math.max(newZoom, ZOOM_MIN), ZOOM_MAX);
+    if (clamped === ZOOM_MIN) {
+      setPan({ x: 0, y: 0 });
+    } else {
+      // Re-clamp existing pan for the new zoom level
+      setPan((prev) => clampPan(prev.x, prev.y, clamped, imgRef.current));
+    }
+    setZoom(clamped);
+  };
+
+  const zoomInFn = () => zoomTo(zoom + ZOOM_STEP);
+  const zoomOutFn = () => zoomTo(zoom - ZOOM_STEP);
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (zoom <= ZOOM_MIN) return;
+    e.preventDefault();
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = {
+      active: true,
+      startX: e.clientX,
+      startY: e.clientY,
+      startPanX: pan.x,
+      startPanY: pan.y,
+    };
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag?.active) return;
+    const rawX = drag.startPanX + (e.clientX - drag.startX);
+    const rawY = drag.startPanY + (e.clientY - drag.startY);
+    setPan(clampPan(rawX, rawY, zoom, imgRef.current));
+  };
+
+  const handlePointerUp = () => {
+    if (dragRef.current) {
+      dragRef.current.active = false;
+    }
+  };
+
+  const isZoomed = zoom > ZOOM_MIN;
+
+  const btnClass =
+    "flex items-center justify-center size-8 rounded-lg bg-black/60 text-white hover:bg-black/80 backdrop-blur-sm transition-colors";
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <button
+        type="button"
+        className="cursor-zoom-in text-left"
+        onClick={handleOpen}
+      >
+        {children}
+      </button>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          className="fixed inset-0 z-50 flex items-center justify-center p-8 focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200"
+          onClick={() => setOpen(false)}
+        >
+          <DialogTitle className="sr-only">{alt}</DialogTitle>
+          <div
+            className="relative overflow-hidden rounded-lg shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img
+              ref={imgRef}
+              src={src}
+              alt={alt}
+              className="max-w-[min(800px,85vw)] max-h-[80vh] object-contain select-none"
+              style={{
+                transform: `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`,
+                transition: dragRef.current?.active
+                  ? "none"
+                  : "transform 200ms ease-out",
+                cursor: isZoomed ? "grab" : "default",
+              }}
+              draggable={false}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerUp}
+            />
+
+            {/* Bottom-left: zoom controls */}
+            <div className="absolute bottom-3 left-3 flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={zoomOutFn}
+                disabled={zoom <= ZOOM_MIN}
+                className={btnClass}
+                aria-label="Zoom out"
+              >
+                <ZoomOut size={16} />
+              </button>
+              <button
+                type="button"
+                onClick={zoomInFn}
+                disabled={zoom >= ZOOM_MAX}
+                className={btnClass}
+                aria-label="Zoom in"
+              >
+                <ZoomIn size={16} />
+              </button>
+            </div>
+
+            {/* Bottom-right: download */}
+            <button
+              type="button"
+              onClick={handleDownload}
+              className={cn("absolute bottom-3 right-3", btnClass)}
+              aria-label="Download image"
+            >
+              <Download01 size={16} />
+            </button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -20,6 +20,7 @@ import {
   Check,
   ChevronDown,
   Edit01,
+  Image01,
   Lock01,
   Microphone01,
   Plus,
@@ -314,8 +315,15 @@ export function ChatInput({
   const { messages, isStreaming, isRunInProgress, sendMessage, stop } =
     useChatStream();
   const { taskId, tasks } = useChatTask();
-  const { selectedModel, selectedVirtualMcp, isModelsLoading, tiptapDocRef } =
-    useChatPrefs();
+  const {
+    selectedModel,
+    selectedVirtualMcp,
+    isModelsLoading,
+    tiptapDocRef,
+    imageModel,
+    forceImageGeneration,
+    setForceImageGeneration,
+  } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
@@ -638,6 +646,30 @@ export function ChatInput({
                           >
                             <BookOpen01 size={14} className="shrink-0" />
                             Plan mode
+                            <X
+                              size={14}
+                              className="shrink-0 hidden group-hover:block"
+                            />
+                          </button>
+                        )}
+                        {forceImageGeneration && imageModel && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              playSwitchSound();
+                              setForceImageGeneration(false);
+                            }}
+                            className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200"
+                          >
+                            <Image01 size={14} className="shrink-0" />
+                            <span className="max-w-[120px] truncate">
+                              {imageModel.title.includes(": ")
+                                ? imageModel.title
+                                    .split(": ")
+                                    .slice(1)
+                                    .join(": ")
+                                : imageModel.title}
+                            </span>
                             <X
                               size={14}
                               className="shrink-0 hidden group-hover:block"

--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -8,6 +8,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { Button } from "@deco/ui/components/button.tsx";
 import { markdownComponents as sharedMarkdownComponents } from "@deco/ui/components/markdown.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
+import { ImageLightbox } from "./image-lightbox.tsx";
 // @ts-ignore - correct
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/index.js";
 
@@ -130,12 +131,26 @@ function Table(props: React.HTMLAttributes<HTMLTableElement>) {
 const remarkPluginsMemo = [remarkGfm];
 const rehypePluginsMemo = [rehypeRaw];
 
-// Extend shared markdown components with chat-specific overrides (table with CSV copy)
+// Extend shared markdown components with chat-specific overrides (table with CSV copy, image lightbox)
 const markdownComponents = {
   ...sharedMarkdownComponents,
   table: (props: React.HTMLAttributes<HTMLTableElement>) => (
     <Table {...props} />
   ),
+  img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    const { src, alt, ...rest } = props;
+    if (!src) return <img {...props} />;
+    return (
+      <ImageLightbox src={src} alt={alt ?? "Image"}>
+        <img
+          {...rest}
+          src={src}
+          alt={alt}
+          className="max-w-full rounded-lg border border-border hover:border-foreground/20 transition-colors"
+        />
+      </ImageLightbox>
+    );
+  },
 } as typeof sharedMarkdownComponents;
 
 const MemoizedMarkdownBlock = memo(

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -14,6 +14,7 @@ import { MessageStatsBar } from "../usage-stats.tsx";
 import { MessageTextPart } from "./parts/text-part.tsx";
 import {
   GenericToolCallPart,
+  GenerateImagePart,
   OpenInAgentPart,
   ProposePlanPart,
   SubtaskPart,
@@ -484,6 +485,13 @@ function MessagePart({
       );
     case "tool-propose_plan":
       return <ProposePlanPart part={part} />;
+    case "tool-generate_image":
+      return (
+        <GenerateImagePart
+          part={part}
+          latency={getMeta(part.toolCallId)?.latencySeconds}
+        />
+      );
     case "tool-subtask":
       return (
         <SubtaskPart
@@ -520,6 +528,7 @@ function MessagePart({
       return null;
     case "data-tool-metadata":
     case "data-tool-subtask-metadata":
+    case "data-generate-image":
       return null;
     default: {
       const fallback = part as ToolUIPart;

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
@@ -41,6 +41,8 @@ export interface ToolCallShellProps {
   iconDestructive?: boolean;
   /** When true, always shows the chevron in the icon slot (skips the icon/hover morph) */
   alwaysChevron?: boolean;
+  /** When true, the collapsible starts expanded (user can still close it) */
+  defaultOpen?: boolean;
   /** Custom expandable content — when provided, replaces detail string rendering */
   children?: ReactNode;
 }
@@ -59,9 +61,10 @@ export function ToolCallShell({
   trailing,
   iconDestructive,
   alwaysChevron,
+  defaultOpen,
   children,
 }: ToolCallShellProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(defaultOpen ?? false);
   const { handleCopy, copied } = useCopy();
   const isLoading = state === "loading";
   const isError = state === "error";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { Image01 } from "@untitledui/icons";
+import type { ToolUIPart } from "ai";
+import { useOrg } from "@decocms/mesh-sdk";
+import { ToolCallShell } from "./common.tsx";
+import { getEffectiveState } from "./utils.tsx";
+import { ImageLightbox } from "../../../image-lightbox.tsx";
+import type { UsageStats } from "@/web/lib/usage-utils.ts";
+import { formatDuration } from "@/web/lib/format-time.ts";
+
+const MESH_STORAGE_PREFIX = "mesh-storage:";
+
+function resolveImageSrc(uri: string, orgId: string): string {
+  if (uri.startsWith(MESH_STORAGE_PREFIX)) {
+    const key = uri.slice(MESH_STORAGE_PREFIX.length);
+    return `/api/${orgId}/files/${key}`;
+  }
+  // data: URIs or any other URL — use as-is
+  return uri;
+}
+
+interface GenerateImageResult {
+  success?: boolean;
+  images?: Array<{ uri?: string; url?: string; mediaType: string }>;
+  model?: string;
+  usage?: { inputTokens?: number; outputTokens?: number };
+}
+
+interface GenerateImageInput {
+  prompt?: string;
+  referenceImages?: Array<{ uri?: string; url?: string }>;
+}
+
+interface GenerateImagePartProps {
+  part: ToolUIPart;
+  /** Latency in seconds from data-tool-metadata part */
+  latency?: number;
+}
+
+function extractUsage(
+  result: GenerateImageResult | undefined,
+): UsageStats | null {
+  if (!result?.usage) return null;
+  const inputTokens = result.usage.inputTokens ?? 0;
+  const outputTokens = result.usage.outputTokens ?? 0;
+  const totalTokens = inputTokens + outputTokens;
+  if (!totalTokens) return null;
+  return {
+    inputTokens,
+    outputTokens,
+    reasoningTokens: 0,
+    totalTokens,
+    cost: 0,
+  };
+}
+
+function ReferenceImageChip({ uri, orgId }: { uri: string; orgId: string }) {
+  const src = resolveImageSrc(uri, orgId);
+  const label = uri.startsWith(MESH_STORAGE_PREFIX)
+    ? uri.slice(uri.lastIndexOf("/") + 1)
+    : "reference";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-1 px-1 py-0.5 rounded bg-muted text-muted-foreground text-xs cursor-default select-none">
+          {label}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-sm p-1.5">
+        <img
+          src={src}
+          alt={label}
+          className="max-w-full max-h-64 object-contain rounded"
+        />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
+  const org = useOrg();
+  const state = getEffectiveState(part.state);
+  const input = part.input as GenerateImageInput | undefined;
+  const result = part.output as GenerateImageResult | undefined;
+  const images = result?.images;
+  const usage = extractUsage(result);
+  const modelLabel = result?.model;
+  const refImages = input?.referenceImages?.filter((r) => r.uri ?? r.url);
+  const latencyLabel =
+    latency != null && latency > 0 ? (
+      <span className="text-[11px] font-mono tabular-nums text-muted-foreground/60">
+        {formatDuration(latency)}
+      </span>
+    ) : null;
+
+  if (state === "loading") {
+    return (
+      <ToolCallShell
+        icon={<Image01 size={14} />}
+        title="Generating image"
+        summary={input?.prompt ? `"${input.prompt.slice(0, 80)}…"` : undefined}
+        state="loading"
+      />
+    );
+  }
+
+  if (state === "error" || !images || images.length === 0) {
+    return (
+      <ToolCallShell
+        icon={<Image01 size={14} />}
+        title="Image generation"
+        summary={state === "error" ? "Failed" : "No images generated"}
+        state={state === "error" ? "error" : "idle"}
+        usage={usage}
+        trailing={latencyLabel}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ToolCallShell
+        icon={<Image01 size={14} className="text-pink-500" />}
+        title="Generated image"
+        summary={modelLabel}
+        state="idle"
+        usage={usage}
+        trailing={latencyLabel}
+      >
+        <div className="flex flex-col gap-1 pb-2 pl-6">
+          {input?.prompt && (
+            <p className="text-xs text-muted-foreground/70 whitespace-pre-wrap wrap-break-word">
+              {input.prompt}
+            </p>
+          )}
+          {refImages && refImages.length > 0 && (
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <span className="text-[11px] text-muted-foreground/50">
+                references:
+              </span>
+              {refImages.map((ref, i) => {
+                const raw = (ref.uri ?? ref.url)!;
+                return <ReferenceImageChip key={i} uri={raw} orgId={org.id} />;
+              })}
+            </div>
+          )}
+        </div>
+      </ToolCallShell>
+      <div className="flex flex-wrap gap-2">
+        {images.map((img, i) => {
+          const raw = img.uri ?? img.url;
+          if (!raw) return null;
+          const src = resolveImageSrc(raw, org.id);
+          return (
+            <ImageLightbox
+              key={i}
+              src={src}
+              alt={input?.prompt ?? "Generated image"}
+            >
+              <img
+                src={src}
+                alt={input?.prompt ?? "Generated image"}
+                className="max-w-sm max-h-80 object-contain rounded-lg border border-border hover:border-foreground/20 transition-colors"
+              />
+            </ImageLightbox>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
@@ -1,4 +1,5 @@
 export { GenericToolCallPart } from "./generic.tsx";
+export { GenerateImagePart } from "./generate-image.tsx";
 export { OpenInAgentPart } from "./open-in-agent.tsx";
 export { UserAskPart } from "./user-ask.tsx";
 export { SubtaskPart } from "./subtask.tsx";

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -19,12 +19,15 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentEditor } from "@tiptap/react";
 import {
   BookOpen01,
+  Check,
+  ChevronDown,
   Image01,
   Link01,
   Loading01,
@@ -41,6 +44,12 @@ import { KEYS } from "@/web/lib/query-keys";
 import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { useSound } from "@/web/hooks/use-sound.ts";
 import { switch005Sound } from "@deco/ui/lib/switch-005.ts";
+import { useChatPrefs } from "./context";
+import {
+  useAiProviderModels,
+  type AiProviderModel,
+} from "@/web/hooks/collections/use-ai-providers";
+import { getProviderLogo } from "@/web/utils/ai-providers-logos";
 
 const FEATURED_CONNECTION_ICONS = [
   { src: "/connections/gmail.png", name: "Gmail" },
@@ -98,6 +107,24 @@ export function ToolsPopover({
 
   const [activePrompt, setActivePrompt] = useState<Prompt | null>(null);
 
+  // Image model state from chat prefs
+  const {
+    credentialId,
+    imageModel,
+    setImageModel,
+    forceImageGeneration,
+    setForceImageGeneration,
+  } = useChatPrefs();
+
+  // Fetch models for the image submenu (only when submenu is hovered/open)
+  const [imageSubOpen, setImageSubOpen] = useState(false);
+  const { models: allModels, isLoading: isModelsLoading } = useAiProviderModels(
+    imageSubOpen ? (credentialId ?? undefined) : undefined,
+  );
+  const imageModels = allModels.filter((m) =>
+    m.capabilities?.includes("image"),
+  );
+
   const handleTogglePlanMode = () => {
     playSwitchSound();
     setPreferences({
@@ -152,6 +179,20 @@ export function ToolsPopover({
     setActivePrompt(null);
   };
 
+  const handleImageModelSelect = (model: AiProviderModel) => {
+    playSwitchSound();
+    setImageModel(model);
+    setOpen(false);
+  };
+
+  const handleForceImageGeneration = () => {
+    playSwitchSound();
+    setForceImageGeneration(!forceImageGeneration);
+    setOpen(false);
+  };
+
+  const isImageActive = forceImageGeneration;
+
   return (
     <>
       <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -182,11 +223,76 @@ export function ToolsPopover({
             )}
           </DropdownMenuItem>
 
-          <DropdownMenuItem disabled>
-            <Image01 size={16} />
-            <span className="flex-1">Create Image</span>
-            <span className="text-xs">Soon</span>
-          </DropdownMenuItem>
+          {/* Image mode: split row — left toggles mode, right opens model picker */}
+          <DropdownMenuSub open={imageSubOpen} onOpenChange={setImageSubOpen}>
+            <div className="flex items-center rounded-lg">
+              <DropdownMenuItem
+                onClick={handleForceImageGeneration}
+                disabled={!imageModel}
+                className={cn(
+                  "flex-1 rounded-r-none pr-1",
+                  isImageActive && "text-pink-600 dark:text-pink-400",
+                )}
+              >
+                <Image01
+                  size={16}
+                  className={cn(isImageActive && "text-pink-500")}
+                />
+                <span className="flex-1">Image mode</span>
+                {isImageActive && (
+                  <span className="text-xs text-pink-500 font-medium">On</span>
+                )}
+              </DropdownMenuItem>
+              <DropdownMenuPrimitive.SubTrigger
+                className={cn(
+                  "flex items-center justify-center rounded-r-lg rounded-l-none px-1.5 py-1.5 text-muted-foreground outline-hidden select-none",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+                  "data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+                )}
+              >
+                <ChevronDown size={14} />
+              </DropdownMenuPrimitive.SubTrigger>
+            </div>
+            <DropdownMenuSubContent className="w-80 max-h-72 overflow-y-auto p-1.5">
+              {isModelsLoading ? (
+                <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+                  <Loading01 size={14} className="animate-spin" />
+                  Loading models…
+                </div>
+              ) : imageModels.length === 0 ? (
+                <div className="px-2 py-3 text-sm text-muted-foreground">
+                  No image models available
+                </div>
+              ) : (
+                imageModels.map((model) => {
+                  const isSelected = imageModel?.modelId === model.modelId;
+                  const logo = getProviderLogo(model);
+                  const displayName = model.title.includes(": ")
+                    ? model.title.split(": ").slice(1).join(": ")
+                    : model.title;
+                  return (
+                    <DropdownMenuItem
+                      key={model.modelId}
+                      onClick={() => handleImageModelSelect(model)}
+                      className="flex items-center gap-2"
+                    >
+                      <img
+                        src={logo}
+                        alt=""
+                        className="size-4 shrink-0 rounded-sm dark:bg-white dark:p-px"
+                      />
+                      <span className="flex-1 text-sm truncate">
+                        {displayName}
+                      </span>
+                      {isSelected && (
+                        <Check size={14} className="text-pink-500 shrink-0" />
+                      )}
+                    </DropdownMenuItem>
+                  );
+                })
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
 
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="gap-2">

--- a/apps/mesh/src/web/components/chat/types.ts
+++ b/apps/mesh/src/web/components/chat/types.ts
@@ -71,6 +71,7 @@ export interface Metadata {
     thinking: MetadataModelInfo;
     coding?: MetadataModelInfo;
     fast?: MetadataModelInfo;
+    image?: MetadataModelInfo;
   };
   agent?: ChatAgentConfig;
   user?: ChatUserConfig;
@@ -85,6 +86,8 @@ export interface Metadata {
   agentMentions?: Array<{ agentId: string; title: string; taskId?: string }>;
   /** Tool approval level at send time — used for visual treatment (e.g., purple border for plan mode) */
   toolApprovalLevel?: ToolApprovalLevel;
+  /** When true, forces the generate_image tool for the next request */
+  forceImageGeneration?: boolean;
   usage?: {
     inputTokens?: number;
     outputTokens?: number;

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -3,7 +3,6 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@deco/ui/components/tooltip.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
 import { Activity } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { UsageStats as UsageStatsType } from "@/web/lib/usage-utils.ts";
@@ -26,16 +25,12 @@ export function MessageUsageStats({ usage }: UsageStatsProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-muted-foreground hover:text-foreground pl-1! h-6 gap-1 whitespace-nowrap shrink-0"
-        >
+        <span className="inline-flex items-center text-muted-foreground [@media(hover:hover)]:hover:text-foreground pl-1 h-6 gap-1 whitespace-nowrap shrink-0 cursor-default">
           <Activity size={12} />
           <span className="text-sm font-mono tabular-nums">
             {totalTokens.toLocaleString()}
           </span>
-        </Button>
+        </span>
       </TooltipTrigger>
       <TooltipContent side="top" className="font-mono text-[11px]">
         <p className="text-muted text-[10px] mb-1">tokens</p>

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -16,6 +16,8 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:selectedMode:${locator}`,
   chatSelectedKeyId: (locator: ProjectLocator) =>
     `mesh:chat:selectedKeyId:${locator}`,
+  chatSelectedImageModel: (locator: ProjectLocator) =>
+    `mesh:chat:selectedImageModel:${locator}`,
   assistantChatActiveTask: (locator: ProjectLocator) =>
     `mesh:assistant-chat:active-task:${locator}`,
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,


### PR DESCRIPTION
## What is this contribution about?

Adds image generation as a first-class feature in the chat. Users can select an image model (e.g. FLUX, Nano Banana) from the **Tools → Create Image** submenu — models are fetched from the active AI provider and filtered by `image` capability. The selected model appears as a removable pink pill badge in the input area (same UX pattern as plan mode).

When active, the AI gets a `generate_image` built-in tool it can call naturally during conversation. The tool supports text-to-image and image-to-image (reference images from user attachments). Image data is streamed via a separate data part to avoid blowing up the context window.

Also adds a shared **ImageLightbox** component used by both generated images and markdown-rendered images. Click any image to open a modal with zoom (clamped pan so edges never overflow), and download controls.

**Backend changes:**
- New `generate_image` built-in tool using AI SDK `generateImage()` with provider's `imageModel()`
- Image data streamed as `data-generate-image` data part (not in tool result sent to model)
- `image` field added to `ModelsConfig`, schemas, run-config persistence
- System prompt injection when image model is active

**Frontend changes:**
- Tools menu: "Create Image" submenu with provider logos and clean model names
- Removable pill badge for active image model
- `GenerateImagePart` renderer for inline image display
- `ImageLightbox` component: zoom in/out, clamped pan/drag, download button
- Markdown `img` tags wrapped in lightbox automatically

## Screenshots/Demonstration

> UI screenshots to be added

## How to Test

1. Start dev server with `bun run dev`
2. Connect an OpenRouter API key (or any provider with image models)
3. Open the **Tools** menu in chat input → click **Create Image**
4. Select an image model (e.g. "Nano Banana 2") — a pink pill badge appears
5. Type "generate an image of a banana in pajamas" and send
6. Verify: image appears inline under "Generated image" header, single image, no token overflow on next message
7. Click the generated image → lightbox opens with zoom/pan/download controls
8. Zoom in → drag to pan (edges clamped) → zoom out resets to center
9. Remove the pill badge (click X) → image generation is deactivated

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class image generation to chat with a toggleable Image mode and a lightbox viewer. Images are created via a new `generate_image` tool, saved to object storage, and resolved via `/api/:org/files/*` without bloating context.

- **New Features**
  - Tools → Image mode: toggle on/off and pick a provider image model; active model shows as a removable pink pill in the input.
  - Built-in `generate_image` tool using `generateImage()` + provider `imageModel()`; supports text-to-image, reference images from attachments or previous outputs, aspect ratio, and multi-image (`n`); uploads images and returns `mesh-storage:` URIs (fallback to data URIs).
  - UI resolves image URIs via `/api/:org/files/:key` and renders them with a shared lightbox (zoom with clamped pan and download); markdown images are also wrapped.
  - Models config includes optional `image` and a `forceImageGeneration` flag that forces `generate_image` on the first step; title generation runs with a post-stream grace period.

- **Bug Fixes**
  - Hardened image/file handling: external image URLs must be HTTPS and cannot target private networks; now also blocks IPv4‑mapped IPv6 (e.g., `::ffff:127.0.0.1`); file key extraction is more robust; `/api/:org/files/*` serves presigned URLs with auth and serves bytes inline in dev.
  - More reliable image model selection in chat context to avoid stale choices when switching provider keys; token counter UI simplified.

<sup>Written for commit 65c6930509ffc0a0b539511c092e410fe7e78b66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

