### PR TITLE
fix(chat): warning color for tool errors, chevron-only collapsed section header

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -336,7 +336,8 @@ function CollapsedSection({
 
   return (
     <ToolCallShell
-      icon={<Tool02 className="size-4" />}
+      icon={null}
+      alwaysChevron
       title={
         <CollapsedSectionTitle toolCalls={toolCalls} messages={messages} />
       }

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
@@ -39,6 +39,8 @@ export interface ToolCallShellProps {
   trailing?: ReactNode;
   /** When true, renders the icon in destructive color regardless of state */
   iconDestructive?: boolean;
+  /** When true, always shows the chevron in the icon slot (skips the icon/hover morph) */
+  alwaysChevron?: boolean;
   /** Custom expandable content — when provided, replaces detail string rendering */
   children?: ReactNode;
 }
@@ -56,6 +58,7 @@ export function ToolCallShell({
   variant = "default",
   trailing,
   iconDestructive,
+  alwaysChevron,
   children,
 }: ToolCallShellProps) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -88,40 +91,53 @@ export function ToolCallShell({
         )}
         aria-disabled={!isExpandable}
       >
-        {/* Icon slot: tool icon by default, morphs into chevron on hover/expand */}
+        {/* Icon slot: chevron only (alwaysChevron), or tool icon that morphs into chevron on hover/expand */}
         <div className="relative shrink-0 size-4 flex items-center justify-center">
-          {/* Tool icon — hidden on hover (expandable) or when expanded */}
-          <div
-            className={cn(
-              "absolute inset-0 flex items-center justify-center [&>svg]:size-4 transition-opacity duration-150",
-              iconDestructive || isError
-                ? "[&>svg]:text-destructive/70"
-                : "[&>svg]:text-muted-foreground/75",
-              isExpandable &&
-                (effectiveOpen
-                  ? "opacity-0"
-                  : "[@media(hover:hover)]:group-hover/tool:opacity-0"),
-            )}
-          >
-            {icon}
-          </div>
-          {/* Chevron — appears on hover or when expanded */}
-          {isExpandable && (
-            <div
+          {alwaysChevron ? (
+            <ChevronRight
               className={cn(
-                "absolute inset-0 flex items-center justify-center transition-opacity duration-150",
-                effectiveOpen
-                  ? "opacity-100"
-                  : "opacity-0 [@media(hover:hover)]:group-hover/tool:opacity-100",
+                "size-4 text-foreground/60 transition-transform duration-200 ease-in-out",
+                effectiveOpen && "rotate-90",
               )}
-            >
-              <ChevronRight
+            />
+          ) : (
+            <>
+              {/* Tool icon — hidden on hover (expandable) or when expanded */}
+              <div
                 className={cn(
-                  "size-4 text-foreground/60 transition-transform duration-200 ease-in-out",
-                  effectiveOpen && "rotate-90",
+                  "absolute inset-0 flex items-center justify-center [&>svg]:size-4 transition-opacity duration-150",
+                  iconDestructive
+                    ? "[&>svg]:text-destructive/70"
+                    : isError
+                      ? "[&>svg]:text-warning/70"
+                      : "[&>svg]:text-muted-foreground/75",
+                  isExpandable &&
+                    (effectiveOpen
+                      ? "opacity-0"
+                      : "[@media(hover:hover)]:group-hover/tool:opacity-0"),
                 )}
-              />
-            </div>
+              >
+                {icon}
+              </div>
+              {/* Chevron — appears on hover or when expanded */}
+              {isExpandable && (
+                <div
+                  className={cn(
+                    "absolute inset-0 flex items-center justify-center transition-opacity duration-150",
+                    effectiveOpen
+                      ? "opacity-100"
+                      : "opacity-0 [@media(hover:hover)]:group-hover/tool:opacity-100",
+                  )}
+                >
+                  <ChevronRight
+                    className={cn(
+                      "size-4 text-foreground/60 transition-transform duration-200 ease-in-out",
+                      effectiveOpen && "rotate-90",
+                    )}
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
 
@@ -129,7 +145,7 @@ export function ToolCallShell({
         <span
           className={cn(
             "shrink-0 text-[14px] font-normal",
-            isError ? "text-destructive/70" : "text-foreground",
+            isError ? "text-warning/80" : "text-foreground",
           )}
         >
           {title}


### PR DESCRIPTION
## What is this contribution about?

Two small UX improvements for tool calls in the chat UI:

1. **Warning color instead of red for tool call errors** — LLM tool failures are non-destructive (the agent can retry and recover), so red was misleading. Replaced `text-destructive` with `text-warning` (yellow/amber) on both the icon and label in `ToolCallShell`.

2. **Always-chevron in the collapsed section header** — The collapsed tool calls summary row (`CollapsedSection`) was showing a tool icon in the icon slot that morphed into a chevron on hover, while also showing another tool icon inside the title label — two icons. Added an `alwaysChevron` prop to `ToolCallShell` and used it on `CollapsedSection` to show only the chevron (no duplicate icon).

## Screenshots/Demonstration

> See attached screenshot in the PR thread — before: two tool icons + red error color. After: single chevron + yellow warning color.

## How to Test

1. Trigger a tool call that results in an error — it should appear yellow/amber instead of red.
2. Trigger enough tool calls to collapse (≥ threshold) — the collapsed section header should show a chevron on the left, not a tool icon.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch tool call error styling from red to warning yellow and make the collapsed tool-calls header show a persistent chevron instead of a tool icon. This clarifies that tool failures are non-destructive and removes the duplicate icon in the summary row.

<sup>Written for commit d1cb7cdfb47e2af16f95bef6962d787cb57cbc92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

