### PR TITLE
feat(sidebar): add connections button with browse-mode dialog

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -741,10 +741,9 @@ export function ChatInput({
       </div>
 
       <AddConnectionDialog
+        mode="browse"
         open={connectionsOpen}
         onOpenChange={setConnectionsOpen}
-        addedConnectionIds={new Set()}
-        onAdd={() => {}}
         defaultTab="all"
       />
     </>

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -16,14 +16,6 @@ import {
   isConnectionAuthenticated,
 } from "@/web/lib/mcp-oauth";
 import { KEYS } from "@/web/lib/query-keys";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@deco/ui/components/breadcrumb.tsx";
 import { ConnectionInstancesPanel } from "./connection-instances-panel.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -58,7 +50,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { Loading01, Trash01 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -411,31 +403,6 @@ function ConnectionInspectorViewWithConnection({
     }
   };
 
-  const breadcrumb = (
-    <Breadcrumb>
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link to="/$org/settings/connections" params={{ org }}>
-              Connections
-            </Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>
-            {(() => {
-              const first = siblings[0] ?? connection;
-              return first.app_name
-                ? first.title.replace(/\s*\(\d+\)\s*$/, "")
-                : first.title;
-            })()}
-          </BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
-  );
-
   return (
     <>
       <DeleteConnectionDialogs {...deleteConnection} />
@@ -558,7 +525,7 @@ function ConnectionInspectorViewWithConnection({
       </Sheet>
 
       {/* Main page */}
-      <ViewLayout breadcrumb={breadcrumb}>
+      <ViewLayout>
         <div className="flex flex-col h-full overflow-hidden">
           <ConnectionDetailHeader
             connection={connection}

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -525,7 +525,7 @@ function ConnectionInspectorViewWithConnection({
       </Sheet>
 
       {/* Main page */}
-      <ViewLayout>
+      <ViewLayout hideHeader>
         <div className="flex flex-col h-full overflow-hidden">
           <ConnectionDetailHeader
             connection={connection}

--- a/apps/mesh/src/web/components/details/layout.tsx
+++ b/apps/mesh/src/web/components/details/layout.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/web/components/page";
+import { cn } from "@deco/ui/lib/utils.ts";
 import {
   createContext,
   type ReactNode,
@@ -97,7 +98,7 @@ export function ViewLayout({
     <ViewLayoutContext value={slots}>
       <Page>
         {/* Header */}
-        <Page.Header className={hideHeader ? "hidden" : undefined}>
+        <Page.Header className={cn(hideHeader && "hidden")}>
           <Page.Header.Left>
             {breadcrumb}
             <div ref={leftRef} className="flex items-center gap-2 min-w-0" />

--- a/apps/mesh/src/web/components/details/layout.tsx
+++ b/apps/mesh/src/web/components/details/layout.tsx
@@ -91,28 +91,30 @@ export function ViewLayout({ children, breadcrumb }: ViewLayoutProps) {
   return (
     <ViewLayoutContext value={slots}>
       <Page>
-        {/* Header */}
-        <Page.Header>
-          <Page.Header.Left>
-            {breadcrumb}
-            <div ref={leftRef} className="flex items-center gap-2 min-w-0" />
-          </Page.Header.Left>
+        {/* Header — only rendered when breadcrumb is provided */}
+        {breadcrumb && (
+          <Page.Header>
+            <Page.Header.Left>
+              {breadcrumb}
+              <div ref={leftRef} className="flex items-center gap-2 min-w-0" />
+            </Page.Header.Left>
 
-          {/* Tabs and Actions */}
-          <Page.Header.Right>
-            {/* Tabs Slot */}
-            <div
-              ref={tabsRef}
-              className="flex items-center gap-2 overflow-x-auto min-w-0"
-            />
+            {/* Tabs and Actions */}
+            <Page.Header.Right>
+              {/* Tabs Slot */}
+              <div
+                ref={tabsRef}
+                className="flex items-center gap-2 overflow-x-auto min-w-0"
+              />
 
-            {/* Actions Slot */}
-            <div
-              ref={actionsRef}
-              className="flex items-center gap-2 shrink-0"
-            />
-          </Page.Header.Right>
-        </Page.Header>
+              {/* Actions Slot */}
+              <div
+                ref={actionsRef}
+                className="flex items-center gap-2 shrink-0"
+              />
+            </Page.Header.Right>
+          </Page.Header>
+        )}
 
         {/* Main Content */}
         <Page.Content>{children}</Page.Content>

--- a/apps/mesh/src/web/components/details/layout.tsx
+++ b/apps/mesh/src/web/components/details/layout.tsx
@@ -40,9 +40,14 @@ export const ViewActions = HeaderRight;
 interface ViewLayoutProps {
   children: ReactNode;
   breadcrumb?: ReactNode;
+  hideHeader?: boolean;
 }
 
-export function ViewLayout({ children, breadcrumb }: ViewLayoutProps) {
+export function ViewLayout({
+  children,
+  breadcrumb,
+  hideHeader,
+}: ViewLayoutProps) {
   const [slots, setSlots] = useState<{
     leftEl: HTMLDivElement | null;
     tabsEl: HTMLDivElement | null;
@@ -91,30 +96,28 @@ export function ViewLayout({ children, breadcrumb }: ViewLayoutProps) {
   return (
     <ViewLayoutContext value={slots}>
       <Page>
-        {/* Header — only rendered when breadcrumb is provided */}
-        {breadcrumb && (
-          <Page.Header>
-            <Page.Header.Left>
-              {breadcrumb}
-              <div ref={leftRef} className="flex items-center gap-2 min-w-0" />
-            </Page.Header.Left>
+        {/* Header */}
+        <Page.Header className={hideHeader ? "hidden" : undefined}>
+          <Page.Header.Left>
+            {breadcrumb}
+            <div ref={leftRef} className="flex items-center gap-2 min-w-0" />
+          </Page.Header.Left>
 
-            {/* Tabs and Actions */}
-            <Page.Header.Right>
-              {/* Tabs Slot */}
-              <div
-                ref={tabsRef}
-                className="flex items-center gap-2 overflow-x-auto min-w-0"
-              />
+          {/* Tabs and Actions */}
+          <Page.Header.Right>
+            {/* Tabs Slot */}
+            <div
+              ref={tabsRef}
+              className="flex items-center gap-2 overflow-x-auto min-w-0"
+            />
 
-              {/* Actions Slot */}
-              <div
-                ref={actionsRef}
-                className="flex items-center gap-2 shrink-0"
-              />
-            </Page.Header.Right>
-          </Page.Header>
-        )}
+            {/* Actions Slot */}
+            <div
+              ref={actionsRef}
+              className="flex items-center gap-2 shrink-0"
+            />
+          </Page.Header.Right>
+        </Page.Header>
 
         {/* Main Content */}
         <Page.Content>{children}</Page.Content>

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -12,7 +12,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@deco/ui/components/sidebar.tsx";
-import { Check, Coins01, Inbox01, Settings02, XClose } from "@untitledui/icons";
+import {
+  Check,
+  Coins01,
+  ZapSquare,
+  Inbox01,
+  Settings02,
+  XClose,
+} from "@untitledui/icons";
 import { AuthUIContext } from "@daveyplate/better-auth-ui";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Component, Suspense, useContext, useState } from "react";
@@ -27,6 +34,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
 import { useNavigate } from "@tanstack/react-router";
+import { ConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 
 interface Invitation {
   id: string;
@@ -217,6 +225,31 @@ function CreditChipConditional() {
   return <CreditChip />;
 }
 
+function ConnectionsButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            tooltip="Connections"
+            onClick={() => setOpen(true)}
+          >
+            <ZapSquare size={24} />
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+      <ConnectionDialog
+        mode="browse"
+        open={open}
+        onOpenChange={setOpen}
+        defaultTab="all"
+      />
+    </>
+  );
+}
+
 function InboxButton() {
   const pendingInvitations = usePendingInvitations();
 
@@ -297,6 +330,7 @@ export function SidebarInboxFooter() {
           <CreditChipConditional />
         </Suspense>
       </SilentErrorBoundary>
+      <ConnectionsButton />
       <InboxButton />
       <SettingsButton />
       <SidebarMenu>

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -34,7 +34,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
 import { useNavigate } from "@tanstack/react-router";
-import { ConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
+import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 
 interface Invitation {
   id: string;
@@ -240,7 +240,7 @@ function ConnectionsButton() {
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>
-      <ConnectionDialog
+      <AddConnectionDialog
         mode="browse"
         open={open}
         onOpenChange={setOpen}

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -27,7 +27,7 @@ import {
   Building02,
   ChevronLeft,
   ChevronRight,
-  Container,
+  ZapSquare,
   CpuChip01,
   Loading01,
   Lock01,
@@ -76,7 +76,7 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
         {
           key: "connections",
           label: "Connections",
-          icon: <Container size={14} />,
+          icon: <ZapSquare size={14} />,
           to: "/$org/settings/connections",
         },
         {

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -1,3 +1,4 @@
+import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import { groupConnections } from "@/shared/utils/group-connections";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { CollectionTabs } from "@/web/components/collections/collection-tabs.tsx";
@@ -41,6 +42,7 @@ import {
   useQueryClient,
   useSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Check,
   CheckVerified02,
@@ -55,13 +57,24 @@ import { toast } from "sonner";
 // Types
 // ---------------------------------------------------------------------------
 
-interface AddConnectionDialogProps {
+type ConnectionDialogMode = "add" | "browse";
+
+type ConnectionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  addedConnectionIds: Set<string>;
-  onAdd: (connectionId: string) => void;
   defaultTab?: "all" | "connected";
-}
+} & (
+  | {
+      mode?: "add";
+      addedConnectionIds: Set<string>;
+      onAdd: (connectionId: string) => void;
+    }
+  | {
+      mode: "browse";
+      addedConnectionIds?: undefined;
+      onAdd?: undefined;
+    }
+);
 
 // ---------------------------------------------------------------------------
 // Dialog content (needs Suspense boundary above it)
@@ -69,7 +82,8 @@ interface AddConnectionDialogProps {
 
 type ConnectionTab = "all" | "connected";
 
-function AddConnectionDialogContent({
+function ConnectionDialogContent({
+  mode = "add",
   addedConnectionIds,
   onAdd,
   onCloneAndAdd,
@@ -77,8 +91,10 @@ function AddConnectionDialogContent({
   connectingItemId,
   search,
   onCreateConnection,
+  onBrowseNavigate,
   defaultTab = "connected",
 }: {
+  mode?: ConnectionDialogMode;
   addedConnectionIds: Set<string>;
   onAdd: (connectionId: string) => void;
   onCloneAndAdd: (base: ConnectionEntity) => void;
@@ -86,6 +102,7 @@ function AddConnectionDialogContent({
   connectingItemId: string | null;
   search: string;
   onCreateConnection: () => void;
+  onBrowseNavigate?: (slug: string) => void;
   defaultTab?: "all" | "connected";
 }) {
   const { org } = useProjectContext();
@@ -229,7 +246,7 @@ function AddConnectionDialogContent({
   const hasAddedInstance = (connections: ConnectionEntity[]) =>
     connections.some((c) => addedConnectionIds.has(c.id));
 
-  // Render a connected app card — has instances, "Add" adds first instance
+  // Render a connected app card
   const renderConnectedApp = (
     key: string,
     title: string,
@@ -242,6 +259,31 @@ function AddConnectionDialogContent({
       (c) => !addedConnectionIds.has(c.id),
     );
     const firstInstance = connections[0]!;
+
+    if (mode === "browse") {
+      const slug = getConnectionSlug(firstInstance);
+      return (
+        <ConnectionCard
+          key={key}
+          connection={{
+            title,
+            icon,
+            description:
+              connections.length > 1
+                ? `${connections.length} instances`
+                : (description ?? undefined),
+          }}
+          fallbackIcon={<Container />}
+          headerActionsAlwaysVisible
+          headerActions={
+            <Badge variant="secondary" className="text-xs gap-1 font-normal">
+              <Check size={11} /> Connected
+            </Badge>
+          }
+          onClick={() => onBrowseNavigate?.(slug)}
+        />
+      );
+    }
 
     return (
       <ConnectionCard
@@ -278,7 +320,7 @@ function AddConnectionDialogContent({
     );
   };
 
-  // Render a catalog item card — no instances yet, "Add" creates + adds
+  // Render a catalog item card — no instances yet
   const renderCatalogItem = (item: RegistryItem) => {
     const meshMeta = item._meta?.["mcp.mesh"] as
       | Record<string, string>
@@ -317,6 +359,8 @@ function AddConnectionDialogContent({
           >
             {connectingItemId === item.id ? (
               <Loading01 size={14} className="animate-spin" />
+            ) : mode === "browse" ? (
+              "Connect"
             ) : (
               "Add"
             )}
@@ -452,13 +496,20 @@ function AddConnectionDialogContent({
 // Main Dialog
 // ---------------------------------------------------------------------------
 
-export function AddConnectionDialog({
+export function ConnectionDialog({
   open,
   onOpenChange,
-  addedConnectionIds,
-  onAdd,
   defaultTab,
-}: AddConnectionDialogProps) {
+  ...rest
+}: ConnectionDialogProps) {
+  const mode: ConnectionDialogMode = rest.mode ?? "add";
+  const addedConnectionIds =
+    "addedConnectionIds" in rest
+      ? (rest.addedConnectionIds ?? new Set<string>())
+      : new Set<string>();
+  const onAdd =
+    "onAdd" in rest && rest.onAdd ? rest.onAdd : (_id: string) => {};
+
   const [connectingItemId, setConnectingItemId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
@@ -466,6 +517,15 @@ export function AddConnectionDialog({
   const { data: session } = authClient.useSession();
   const connectionActions = useConnectionActions();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const handleBrowseNavigate = (slug: string) => {
+    onOpenChange(false);
+    navigate({
+      to: "/$org/settings/connections/$appSlug",
+      params: { org: org.slug, appSlug: slug },
+    });
+  };
 
   // For connected apps: clone existing connection + add to agent
   const handleCloneAndAdd = async (base: ConnectionEntity) => {
@@ -661,7 +721,7 @@ export function AddConnectionDialog({
       <DialogContent className="sm:max-w-5xl h-[85vh] max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden w-[95vw]">
         <DialogHeader className="px-6 pt-5 pb-0 shrink-0">
           <DialogTitle className="text-base font-semibold">
-            Add Connection
+            {mode === "browse" ? "Connections" : "Add Connection"}
           </DialogTitle>
         </DialogHeader>
 
@@ -683,7 +743,8 @@ export function AddConnectionDialog({
             </div>
           }
         >
-          <AddConnectionDialogContent
+          <ConnectionDialogContent
+            mode={mode}
             addedConnectionIds={addedConnectionIds}
             onAdd={onAdd}
             onCloneAndAdd={handleCloneAndAdd}
@@ -691,6 +752,7 @@ export function AddConnectionDialog({
             connectingItemId={connectingItemId}
             search={search}
             onCreateConnection={() => setCreateOpen(true)}
+            onBrowseNavigate={handleBrowseNavigate}
             defaultTab={defaultTab}
           />
         </Suspense>
@@ -774,3 +836,6 @@ export function AddConnectionDialog({
     </Dialog>
   );
 }
+
+/** @deprecated Use `ConnectionDialog` instead */
+export const AddConnectionDialog = ConnectionDialog;

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -496,7 +496,7 @@ function ConnectionDialogContent({
 // Main Dialog
 // ---------------------------------------------------------------------------
 
-export function ConnectionDialog({
+export function AddConnectionDialog({
   open,
   onOpenChange,
   defaultTab,
@@ -836,6 +836,3 @@ export function ConnectionDialog({
     </Dialog>
   );
 }
-
-/** @deprecated Use `ConnectionDialog` instead */
-export const AddConnectionDialog = ConnectionDialog;


### PR DESCRIPTION
## What is this contribution about?
Adds a connections shortcut (ZapSquare icon) to the sidebar footer, above Inbox, that opens a browse-mode connection dialog. Refactors `AddConnectionDialog` into `ConnectionDialog` with two modes:
- **"add"** (agent context): existing behavior with "Add" buttons for adding connections to an agent
- **"browse"** (sidebar/home): shows "Connected" badges, clicking a card navigates to its detail page, catalog items show "Connect" instead of "Add"

Also updates the connections icon from `Container` to `ZapSquare` across settings sidebar, removes the breadcrumb bar from the connection detail page, and hides the `ViewLayout` header entirely when no breadcrumb is provided.

## Screenshots/Demonstration
> N/A — UI change, test locally

## How to Test
1. Open the sidebar — a new ZapSquare icon should appear above Inbox
2. Click it — a "Connections" dialog opens showing connected apps and catalog
3. Click a connected app card — dialog closes and navigates to its detail page
4. Catalog items show "Connect" button; "Custom Connection" button is present
5. Open the home chat input connections banner — same browse-mode dialog
6. Open an agent's connection dialog — still shows "Add" buttons (add mode)
7. Navigate to Settings > Connections — icon should be ZapSquare
8. Open a connection detail — no breadcrumb bar at the top

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes — `AddConnectionDialog` re-exported as alias

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Connections shortcut (ZapSquare) in the sidebar that opens a browse‑mode dialog for quick access to connection details. Refactors `AddConnectionDialog` to support add/browse modes and fixes header rendering so views without breadcrumbs keep their tabs/actions.

- New Features
  - Added ZapSquare button above Inbox to open browse‑mode dialog; updated Settings > Connections icon to ZapSquare.
  - Browse mode shows a “Connected” badge and navigates to detail on click; catalog items show “Connect”. Also used by the home chat input banner.

- Bug Fixes
  - `ViewLayout` now always renders the header and hides it via a `hideHeader` prop, fixing broken `ViewTabs`/`ViewActions` portals when no breadcrumb is present.
  - Used `cn()` for conditional header className and removed the duplicate `ConnectionDialog` export/alias.

<sup>Written for commit 5bbfec0efc9e3c522f55596bebfee4a72ee5d4ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

