### PR TITLE
fix(monitoring): truncate output/input at 64KB to prevent ClickHouse OOM

### DIFF
--- a/apps/mesh/src/monitoring/emit.test.ts
+++ b/apps/mesh/src/monitoring/emit.test.ts
@@ -136,7 +136,7 @@ describe("emitMonitoringLog", () => {
     expect(emittedRecords[1]!.severityText).toBe("ERROR");
   });
 
-  it("should truncate output exceeding 64KB", { timeout: 15_000 }, () => {
+  it("should truncate output exceeding 64KB", () => {
     const largeOutput = { data: "x".repeat(70_000) };
     emitMonitoringLog(makeParams({ result: largeOutput }));
 
@@ -145,7 +145,7 @@ describe("emitMonitoringLog", () => {
     const output = attrs[MONITORING_LOG_ATTR.OUTPUT] as string;
     expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(65_536);
     expect(output).toContain("... [TRUNCATED]");
-  });
+  }, 15_000);
 
   it("should truncate input exceeding 64KB", () => {
     const largeInput = { query: "y".repeat(70_000) };
@@ -156,7 +156,7 @@ describe("emitMonitoringLog", () => {
     const input = attrs[MONITORING_LOG_ATTR.INPUT] as string;
     expect(Buffer.byteLength(input, "utf8")).toBeLessThanOrEqual(65_536);
     expect(input).toContain("... [TRUNCATED]");
-  });
+  }, 15_000);
 
   it("should not truncate output under 64KB", () => {
     const smallOutput = { data: "hello" };

--- a/apps/mesh/src/monitoring/emit.test.ts
+++ b/apps/mesh/src/monitoring/emit.test.ts
@@ -136,7 +136,7 @@ describe("emitMonitoringLog", () => {
     expect(emittedRecords[1]!.severityText).toBe("ERROR");
   });
 
-  it("should truncate output exceeding 64KB", () => {
+  it("should truncate output exceeding 64KB", { timeout: 15_000 }, () => {
     const largeOutput = { data: "x".repeat(70_000) };
     emitMonitoringLog(makeParams({ result: largeOutput }));
 

--- a/apps/mesh/src/monitoring/emit.test.ts
+++ b/apps/mesh/src/monitoring/emit.test.ts
@@ -135,4 +135,37 @@ describe("emitMonitoringLog", () => {
     expect(emittedRecords[0]!.severityText).toBe("INFO");
     expect(emittedRecords[1]!.severityText).toBe("ERROR");
   });
+
+  it("should truncate output exceeding 64KB", () => {
+    const largeOutput = { data: "x".repeat(70_000) };
+    emitMonitoringLog(makeParams({ result: largeOutput }));
+
+    expect(emittedRecords.length).toBe(1);
+    const attrs = emittedRecords[0]!.attributes!;
+    const output = attrs[MONITORING_LOG_ATTR.OUTPUT] as string;
+    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(65_536);
+    expect(output).toContain("... [TRUNCATED]");
+  });
+
+  it("should truncate input exceeding 64KB", () => {
+    const largeInput = { query: "y".repeat(70_000) };
+    emitMonitoringLog(makeParams({ toolArguments: largeInput }));
+
+    expect(emittedRecords.length).toBe(1);
+    const attrs = emittedRecords[0]!.attributes!;
+    const input = attrs[MONITORING_LOG_ATTR.INPUT] as string;
+    expect(Buffer.byteLength(input, "utf8")).toBeLessThanOrEqual(65_536);
+    expect(input).toContain("... [TRUNCATED]");
+  });
+
+  it("should not truncate output under 64KB", () => {
+    const smallOutput = { data: "hello" };
+    emitMonitoringLog(makeParams({ result: smallOutput }));
+
+    expect(emittedRecords.length).toBe(1);
+    const attrs = emittedRecords[0]!.attributes!;
+    const output = attrs[MONITORING_LOG_ATTR.OUTPUT] as string;
+    expect(output).not.toContain("[TRUNCATED]");
+    expect(JSON.parse(output)).toEqual({ data: "hello" });
+  });
 });

--- a/apps/mesh/src/monitoring/emit.ts
+++ b/apps/mesh/src/monitoring/emit.ts
@@ -17,6 +17,7 @@ import type { Context } from "@opentelemetry/api";
 import { SeverityNumber, logs } from "@opentelemetry/api-logs";
 import { RegexRedactor } from "./redactor";
 import { MONITORING_LOG_ATTR, MONITORING_LOG_TYPE_VALUE } from "./schema";
+import { truncateString } from "./truncate-string";
 
 const redactor = new RegexRedactor();
 
@@ -70,8 +71,12 @@ export function emitMonitoringLog(
         [MONITORING_LOG_ATTR.CONNECTION_ID]: params.connectionId,
         [MONITORING_LOG_ATTR.CONNECTION_TITLE]: "",
         [MONITORING_LOG_ATTR.TOOL_NAME]: params.toolName,
-        [MONITORING_LOG_ATTR.INPUT]: JSON.stringify(redactedInput),
-        [MONITORING_LOG_ATTR.OUTPUT]: JSON.stringify(redactedOutput),
+        [MONITORING_LOG_ATTR.INPUT]: truncateString(
+          JSON.stringify(redactedInput),
+        ),
+        [MONITORING_LOG_ATTR.OUTPUT]: truncateString(
+          JSON.stringify(redactedOutput),
+        ),
         [MONITORING_LOG_ATTR.IS_ERROR]: params.isError,
         [MONITORING_LOG_ATTR.ERROR_MESSAGE]: redactedErrorMessage,
         [MONITORING_LOG_ATTR.DURATION_MS]: params.duration,

--- a/apps/mesh/src/monitoring/truncate-string.test.ts
+++ b/apps/mesh/src/monitoring/truncate-string.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test";
+import { truncateString } from "./truncate-string";
+
+describe("truncateString", () => {
+  it("should return short strings unchanged", () => {
+    const s = JSON.stringify({ hello: "world" });
+    expect(truncateString(s, 1024)).toBe(s);
+  });
+
+  it("should truncate strings exceeding maxBytes", () => {
+    const s = "x".repeat(200);
+    const result = truncateString(s, 100);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(100);
+    expect(result).toContain("... [TRUNCATED]");
+  });
+
+  it("should handle exact boundary without truncation", () => {
+    const s = JSON.stringify({ a: 1 });
+    const len = Buffer.byteLength(s, "utf8");
+    expect(truncateString(s, len)).toBe(s);
+  });
+
+  it("should handle empty string", () => {
+    expect(truncateString("", 100)).toBe("");
+  });
+
+  it("should not split multi-byte UTF-8 characters", () => {
+    // Each emoji is 4 bytes in UTF-8
+    const s = "\u{1F600}".repeat(50); // 200 bytes
+    const result = truncateString(s, 100);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(100);
+    // Verify no partial character by re-encoding
+    expect(Buffer.from(result, "utf8").toString("utf8")).toBe(result);
+  });
+
+  it("should use default maxBytes of 64KB", () => {
+    const s = "x".repeat(100_000);
+    const result = truncateString(s);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(65_536);
+    expect(result).toContain("... [TRUNCATED]");
+  });
+
+  it("should use most of the budget (not wastefully small)", () => {
+    const s = "x".repeat(200);
+    const result = truncateString(s, 100);
+    // Should use at least 50% of budget
+    expect(Buffer.byteLength(result, "utf8")).toBeGreaterThan(50);
+  });
+});

--- a/apps/mesh/src/monitoring/truncate-string.ts
+++ b/apps/mesh/src/monitoring/truncate-string.ts
@@ -1,0 +1,45 @@
+const TRUNCATION_MARKER = "... [TRUNCATED]";
+const MARKER_BYTES = Buffer.byteLength(TRUNCATION_MARKER, "utf8");
+
+/**
+ * Truncate a string to fit within maxBytes (UTF-8).
+ *
+ * If the string exceeds maxBytes, it is cut at a safe character
+ * boundary and a truncation marker is appended.
+ *
+ * The result is NOT valid JSON — it's a raw truncated string with
+ * a human-readable marker. This is fine because the ClickHouse
+ * `output` column is a plain String, not a JSON column.
+ *
+ * @param value - The string to truncate
+ * @param maxBytes - Maximum byte length (default: 64 KB)
+ */
+export function truncateString(value: string, maxBytes = 65_536): string {
+  // Fast path: for ASCII-only strings (common case), string length equals byte length.
+  // For mixed content, check actual byte length only if string length exceeds budget.
+  if (
+    value.length <= maxBytes &&
+    Buffer.byteLength(value, "utf8") <= maxBytes
+  ) {
+    return value;
+  }
+
+  const budget = maxBytes - MARKER_BYTES;
+  if (budget <= 0) {
+    return TRUNCATION_MARKER.slice(0, maxBytes);
+  }
+
+  // Walk characters to find the safe cut point.
+  // This avoids splitting multi-byte UTF-8 characters.
+  let bytes = 0;
+  let cutIndex = 0;
+  for (const char of value) {
+    const charBytes =
+      char.charCodeAt(0) <= 0x7f ? 1 : Buffer.byteLength(char, "utf8");
+    if (bytes + charBytes > budget) break;
+    bytes += charBytes;
+    cutIndex += char.length; // surrogate pairs have length 2
+  }
+
+  return value.slice(0, cutIndex) + TRUNCATION_MARKER;
+}

--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -174,7 +174,7 @@ function safeJsonParse(val: unknown): Record<string, unknown> {
   } catch {
     // Truncated JSON strings (from truncateString) are not valid JSON.
     // Wrap the raw string so the UI can still display it.
-    return { _raw: str };
+    return { _decocms_truncated: str };
   }
 }
 

--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -168,10 +168,13 @@ function jsonExtractFloat(
 function safeJsonParse(val: unknown): Record<string, unknown> {
   if (val === null || val === undefined) return {};
   if (typeof val === "object") return val as Record<string, unknown>;
+  const str = String(val);
   try {
-    return JSON.parse(String(val));
+    return JSON.parse(str);
   } catch {
-    return {};
+    // Truncated JSON strings (from truncateString) are not valid JSON.
+    // Wrap the raw string so the UI can still display it.
+    return { _raw: str };
   }
 }
 

--- a/apps/mesh/src/web/components/details/workflow/components/monaco-editor.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/monaco-editor.tsx
@@ -61,7 +61,7 @@ class MonacoErrorBoundary extends Component<
   override render() {
     if (this.state.hasError) {
       return (
-        <div className="flex items-center justify-center h-full w-full bg-[#1e1e1e] text-gray-400">
+        <div className="flex items-center justify-center h-full w-full bg-white dark:bg-[#1e1e1e] text-gray-400">
           <Spinner size="sm" />
         </div>
       );
@@ -146,7 +146,6 @@ const EDITOR_BASE_OPTIONS: EditorProps["options"] = {
     verticalScrollbarSize: 8,
     horizontalScrollbarSize: 8,
   },
-  theme: "light",
 };
 
 const LoadingPlaceholder = (
@@ -287,6 +286,11 @@ const InternalMonacoEditor = memo(function InternalMonacoEditor({
         key={editorKey}
         height={height}
         language={language}
+        theme={
+          document.documentElement.classList.contains("dark")
+            ? "vs-dark"
+            : "light"
+        }
         value={code}
         path={filePath}
         onChange={onChange}

--- a/apps/mesh/src/web/components/monitoring/types.tsx
+++ b/apps/mesh/src/web/components/monitoring/types.tsx
@@ -304,6 +304,15 @@ function truncateJsonForDisplay(
     return { content: "null", isTruncated: false, originalSize: 4 };
   }
 
+  // Server-side truncated output: render the raw truncated string directly
+  if (typeof data._decocms_truncated === "string") {
+    return {
+      content: data._decocms_truncated,
+      isTruncated: true,
+      originalSize: data._decocms_truncated.length,
+    };
+  }
+
   const fullJson = JSON.stringify(data, null, 2);
   const originalSize = fullJson.length;
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -169,6 +169,12 @@ otel:
   protocol: "http/protobuf"  # http/protobuf | grpc
   service: ""                # OTEL_SERVICE_NAME
   endpoint: ""               # Remote OTLP endpoint (direct export, bypasses collector)
+  # When otel.endpoint is set, the app sends directly to this endpoint
+  # and headers are passed as OTEL_EXPORTER_OTLP_HEADERS.
+  # When otel.endpoint is empty and otel.collector.enabled is true,
+  # the app sends to the in-cluster collector which handles forwarding.
+  # In that case, configure the remote endpoint in the collector config
+  # (opentelemetry-collector.config.exporters) instead.
   headers: {}                # OTEL_EXPORTER_OTLP_HEADERS (key=value format)
   # headers:
   #   authorization: "Bearer your-token"


### PR DESCRIPTION
## What is this contribution about?

ClickPipes ingestion from S3 into ClickHouse Cloud has been failing with OOM errors (Error 241, 7.2 GiB limit) since April 12. The root cause: the `output` field in monitoring logs averages 1.37 MB per row (max 121 MB), which overwhelms ClickHouse when batch-ingesting NDJSON files.

This PR adds a `truncateString` utility that caps `input` and `output` fields at 64 KB in `emitMonitoringLog()`, appending a `... [TRUNCATED]` marker. It also clarifies the Helm values documentation for OTel collector relay vs direct export configuration.

## How to Test

1. Run `bun test apps/mesh/src/monitoring/` — all 80 tests pass
2. Verify truncation: the new tests in `emit.test.ts` confirm fields >64KB are truncated and fields <64KB are unchanged
3. After deploy, monitor `monitoring_logs_clickpipes_error` in ClickHouse for OOM errors — they should stop

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncates monitoring log input/output at 64KB to stop ClickHouse OOMs during ClickPipes S3 ingestion. Preserves and displays truncated content in the monitoring UI.

- **Bug Fixes**
  - `truncateString` caps `input`/`output` at 65,536 bytes with "... [TRUNCATED]"; UTF‑8 safe.
  - Truncation runs after redaction in `emitMonitoringLog()`; `safeJsonParse()` wraps as `{ _decocms_truncated: str }`; UI renders it; tests added and timeouts fixed.
  - Clarified `deploy/helm/values.yaml` for `otel.endpoint` vs collector relay and headers.
  - Monaco editor now follows app dark/light mode.

<sup>Written for commit f3f19ffb1ff900d7f8fc3e4864ecd3a3e348cf23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

