### PR TITLE
feat(ai): enhance Google model capability derivation

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/google.ts
+++ b/apps/mesh/src/ai-providers/adapters/google.ts
@@ -1,4 +1,5 @@
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { ModelCapability } from "@decocms/mesh-sdk";
 import type { MeshProvider, ProviderAdapter, ModelInfo } from "../types";
 
 interface GoogleModel {
@@ -17,6 +18,31 @@ interface GoogleModel {
   topK: number;
   /** Lifecycle stage returned by the API (e.g. "ACTIVE", "DEPRECATED"). */
   lifecycleState?: string;
+}
+
+/**
+ * Derive capabilities from the Google model metadata.
+ *
+ * Only tags dedicated image-generation models (Imagen, Gemini *-image variants).
+ * Multimodal language models (gemini-2.5-flash etc.) return [] so the
+ * OpenRouter enrichment in factory.ts fills in their full capability set
+ * (with the correct image→vision remapping for input modalities).
+ */
+function deriveCapabilities(m: GoogleModel): ModelCapability[] {
+  const id = m.name.replace("models/", "");
+
+  // Dedicated image generation models: Imagen family or Gemini image variants
+  if (/^imagen-/.test(id) || /-image/.test(id)) {
+    const caps: ModelCapability[] = ["image"];
+    // Gemini image models also support text in/out via generateContent
+    if (m.supportedGenerationMethods.includes("generateContent")) {
+      caps.push("text");
+    }
+    return caps;
+  }
+
+  // Everything else: let OpenRouter enrichment handle capabilities
+  return [];
 }
 
 export const googleAdapter: ProviderAdapter = {
@@ -52,7 +78,7 @@ export const googleAdapter: ProviderAdapter = {
             title: m.displayName,
             description: m.description,
             logo: null,
-            capabilities: [],
+            capabilities: deriveCapabilities(m),
             limits: {
               contextWindow: m.inputTokenLimit,
               maxOutputTokens: m.outputTokenLimit,

--- a/apps/mesh/src/ai-providers/factory.ts
+++ b/apps/mesh/src/ai-providers/factory.ts
@@ -22,7 +22,12 @@ function mapOpenRouterModel(m: OpenRouterAPIModel): ModelInfo {
     logo: null,
     capabilities: [
       ...new Set([
-        ...m.architecture.input_modalities,
+        // "image" in input_modalities means the model accepts image input (vision),
+        // not that it generates images. Remap to "vision" so we distinguish from
+        // "image" in output_modalities which means actual image generation.
+        ...m.architecture.input_modalities.map((mod) =>
+          mod === "image" ? "vision" : mod,
+        ),
         ...m.architecture.output_modalities,
         ...(canTools ? (["tools"] as const) : []),
         ...(canReasoning ? (["reasoning"] as const) : []),


### PR DESCRIPTION
- Updated the Google adapter to derive model capabilities based on metadata, specifically for image generation models.
- Remapped input modality "image" to "vision" in the factory to clarify distinctions between input and output modalities.
- Improved handling of capabilities for multimodal language models, allowing for better integration with OpenRouter enrichment.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives Google model capabilities from provider metadata to correctly tag image-generation models and let multimodal models rely on OpenRouter enrichment. Also remaps input modality "image" to "vision" to clearly separate input vs output modalities.

- **New Features**
  - Google adapter now derives capabilities; only Imagen/Gemini “-image” variants get the `image` capability, others defer to enrichment.
  - Factory remaps input `image` to `vision` to distinguish vision input from image-generation output (`@ai-sdk/google`, `@decocms/mesh-sdk`).

<sup>Written for commit a2a7daa9b6a51985a56585d1668b8e6c40e92909. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

