### PR TITLE
feat(ai): add auto-provisioning support for API keys

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/deco-ai-gateway.ts
+++ b/apps/mesh/src/ai-providers/adapters/deco-ai-gateway.ts
@@ -1,4 +1,4 @@
-import type { OAuthPkceResult, ProviderAdapter } from "../types";
+import type { ProviderAdapter } from "../types";
 import { openrouterAdapter } from "./openrouter";
 import { getSettings } from "../../settings";
 
@@ -14,58 +14,21 @@ export const decoAiGatewayAdapter: ProviderAdapter = {
     logo: "/logos/deco logo.svg",
   },
 
-  supportedMethods: ["oauth-pkce", "api-key"],
-
-  getOAuthUrl({
-    callbackUrl,
-    codeChallenge,
-    codeChallengeMethod,
-    organizationId,
-  }: {
-    callbackUrl: string;
-    codeChallenge: string;
-    codeChallengeMethod: "S256";
-    organizationId: string;
-  }) {
-    const params = new URLSearchParams({
-      redirect_uri: callbackUrl,
-      code_challenge: codeChallenge,
-      code_challenge_method: codeChallengeMethod,
-      organization_id: organizationId,
-    });
-    return `${getBase()}/oauth/authorize?${params}`;
-  },
-
-  async exchangeOAuthCode({ code, codeVerifier }): Promise<OAuthPkceResult> {
-    const res = await fetch(`${getBase()}/oauth/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        code,
-        code_verifier: codeVerifier,
-        grant_type: "authorization_code",
-      }),
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!res.ok) {
-      throw new Error(`Deco AI Gateway OAuth exchange failed: ${res.status}`);
-    }
-    const data = await res.json();
-    return { apiKey: data.key };
-  },
+  supportedMethods: ["api-key"],
 
   async getTopUpUrl(
-    apiKey: string,
+    meshJwt: string,
+    orgId: string,
     amountCents: number,
     currency: "usd" | "brl" = "usd",
   ) {
-    const res = await fetch(`${getBase()}/api/credits/topup`, {
+    const res = await fetch(`${getBase()}/api/credits/checkout`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${meshJwt}`,
       },
-      body: JSON.stringify({ amountCents, currency }),
+      body: JSON.stringify({ teamId: orgId, amountCents, currency }),
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {

--- a/apps/mesh/src/ai-providers/types.ts
+++ b/apps/mesh/src/ai-providers/types.ts
@@ -66,7 +66,8 @@ export interface ProviderAdapter {
 
   // Only defined for providers that support credit top-ups
   getTopUpUrl?(
-    apiKey: string,
+    meshJwt: string,
+    orgId: string,
     amountCents: number,
     currency?: "usd" | "brl",
   ): Promise<string>;

--- a/apps/mesh/src/tools/ai-providers/index.ts
+++ b/apps/mesh/src/tools/ai-providers/index.ts
@@ -6,6 +6,7 @@ export { AI_PROVIDER_KEY_DELETE } from "./key-delete";
 export { AI_PROVIDER_KEY_LIST } from "./key-list";
 export { AI_PROVIDER_OAUTH_URL } from "./oauth-url";
 export { AI_PROVIDER_OAUTH_EXCHANGE } from "./oauth-exchange";
+export { AI_PROVIDER_PROVISION_KEY } from "./provision-key";
 export { AI_PROVIDER_TOPUP_URL } from "./topup-url";
 export { AI_PROVIDER_CREDITS } from "./credits";
 export { AI_PROVIDER_CLI_ACTIVATE } from "./cli-activate";

--- a/apps/mesh/src/tools/ai-providers/list.ts
+++ b/apps/mesh/src/tools/ai-providers/list.ts
@@ -24,6 +24,7 @@ export const AI_PROVIDERS_LIST = defineTool({
         ),
         supportsTopUp: z.boolean().optional(),
         supportsCredits: z.boolean().optional(),
+        supportsProvision: z.boolean().optional(),
       }),
     ),
   }),
@@ -40,6 +41,7 @@ export const AI_PROVIDERS_LIST = defineTool({
         supportedMethods: adapter.supportedMethods,
         supportsTopUp: !!adapter.getTopUpUrl,
         supportsCredits: !!adapter.getCreditsBalance,
+        supportsProvision: !!adapter.provisionKey,
       }));
     return { providers };
   },

--- a/apps/mesh/src/tools/ai-providers/provision-key.ts
+++ b/apps/mesh/src/tools/ai-providers/provision-key.ts
@@ -8,25 +8,16 @@ import {
 import { PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import { mintGatewayJwt } from "../../auth/jwt";
+import { providerKeyOutputSchema } from "./key-create";
 
-export const AI_PROVIDER_TOPUP_URL = defineTool({
-  name: "AI_PROVIDER_TOPUP_URL",
+export const AI_PROVIDER_PROVISION_KEY = defineTool({
+  name: "AI_PROVIDER_PROVISION_KEY",
   description:
-    "Get a checkout URL to top up credits for a provider that supports it (e.g. Deco AI Gateway)",
+    "Auto-provision an API key for a provider that supports server-to-server key creation (e.g. Deco AI Gateway).",
   inputSchema: z.object({
     providerId: z.enum(PROVIDER_IDS),
-    amountCents: z
-      .number()
-      .int()
-      .positive()
-      .describe("Amount in cents (e.g. 1000 = $10.00)"),
-    currency: z.enum(["usd", "brl"]).default("usd"),
   }),
-  outputSchema: z.object({
-    url: z
-      .string()
-      .describe("Checkout URL — open in browser to complete payment"),
-  }),
+  outputSchema: providerKeyOutputSchema,
   handler: async (input, ctx) => {
     requireAuth(ctx);
     const org = requireOrganization(ctx);
@@ -39,21 +30,28 @@ export const AI_PROVIDER_TOPUP_URL = defineTool({
     if (!adapter) {
       throw new Error(`Unknown provider: ${input.providerId}`);
     }
-    if (!adapter.getTopUpUrl) {
+    if (!adapter.provisionKey) {
       throw new Error(
-        `Provider ${input.providerId} does not support credit top-ups`,
+        `Provider ${input.providerId} does not support key provisioning`,
       );
     }
 
     const meshJwt = await mintGatewayJwt(userId);
+    const apiKey = await adapter.provisionKey(meshJwt, org.id);
 
-    const url = await adapter.getTopUpUrl(
-      meshJwt,
-      org.id,
-      input.amountCents,
-      input.currency,
-    );
+    const key = await ctx.storage.aiProviderKeys.upsert({
+      providerId: input.providerId,
+      label: "Auto-provisioned",
+      apiKey,
+      organizationId: org.id,
+      createdBy: userId,
+    });
 
-    return { url };
+    return {
+      id: key.id,
+      providerId: key.providerId,
+      label: key.label,
+      createdAt: key.createdAt,
+    };
   },
 });

--- a/apps/mesh/src/tools/guides/ai-providers.ts
+++ b/apps/mesh/src/tools/guides/ai-providers.ts
@@ -13,14 +13,15 @@ Read docs://ai-providers.md for provider types, authentication options, and cred
 Recommended tool order:
 1. Use AI_PROVIDERS_LIST to inspect available providers.
 2. If the user has not chosen a provider or auth method, use user_ask.
-3. For API-key providers, use AI_PROVIDER_KEY_CREATE.
-4. For OAuth providers, use AI_PROVIDER_OAUTH_URL and complete the exchange flow with AI_PROVIDER_OAUTH_EXCHANGE.
-5. Use AI_PROVIDER_KEY_LIST or AI_PROVIDERS_ACTIVE to confirm configuration.
-6. If relevant, use AI_PROVIDERS_LIST_MODELS and AI_PROVIDER_CREDITS for model availability and balance checks.
+3. For providers that support auto-provisioning (supportsProvision=true), use AI_PROVIDER_PROVISION_KEY.
+4. For API-key providers, use AI_PROVIDER_KEY_CREATE.
+5. For OAuth providers, use AI_PROVIDER_OAUTH_URL and complete the exchange flow with AI_PROVIDER_OAUTH_EXCHANGE.
+6. Use AI_PROVIDER_KEY_LIST or AI_PROVIDERS_ACTIVE to confirm configuration.
+7. If relevant, use AI_PROVIDERS_LIST_MODELS and AI_PROVIDER_CREDITS for model availability and balance checks.
 
 Checks:
 - Match the provider to the user's model or routing needs.
-- Use the correct auth flow: API key or OAuth.
+- Use the correct auth flow: auto-provision, API key, or OAuth.
 - Confirm the provider becomes active or otherwise available after setup.
 - Surface low-credit or no-credit states when they may block usage.
 `,
@@ -55,6 +56,10 @@ AI providers supply the models and credentials Decopilot and agents use for gene
 - The most common setup.
 - Use a provider-issued secret key.
 - Confirm whether the workspace should store one shared credential or replace an existing one.
+
+### Auto-provisioning
+- Some providers (e.g. Deco AI Gateway) support server-to-server key provisioning.
+- Use AI_PROVIDER_PROVISION_KEY — no user interaction required beyond a single click.
 
 ### OAuth
 - Some providers use a browser authorization flow.

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -140,6 +140,7 @@ const CORE_TOOLS = [
   AiProvidersTools.AI_PROVIDER_KEY_LIST,
   AiProvidersTools.AI_PROVIDER_OAUTH_URL,
   AiProvidersTools.AI_PROVIDER_OAUTH_EXCHANGE,
+  AiProvidersTools.AI_PROVIDER_PROVISION_KEY,
   AiProvidersTools.AI_PROVIDER_TOPUP_URL,
   AiProvidersTools.AI_PROVIDER_CREDITS,
   AiProvidersTools.AI_PROVIDER_CLI_ACTIVATE,

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -131,6 +131,7 @@ const ALL_TOOL_NAMES = [
   "AI_PROVIDER_KEY_DELETE",
   "AI_PROVIDER_OAUTH_URL",
   "AI_PROVIDER_OAUTH_EXCHANGE",
+  "AI_PROVIDER_PROVISION_KEY",
   "AI_PROVIDER_TOPUP_URL",
   "AI_PROVIDER_CREDITS",
   "AI_PROVIDER_CLI_ACTIVATE",
@@ -639,6 +640,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     category: "AI Providers",
   },
   {
+    name: "AI_PROVIDER_PROVISION_KEY",
+    description: "Auto-provision API key for a provider",
+    category: "AI Providers",
+  },
+  {
     name: "AI_PROVIDER_TOPUP_URL",
     description: "Get checkout URL to top up provider credits",
     category: "AI Providers",
@@ -938,6 +944,7 @@ const TOOL_LABELS: Record<ToolName, string> = {
   AI_PROVIDER_KEY_DELETE: "Delete provider key",
   AI_PROVIDER_OAUTH_URL: "Get OAuth URL",
   AI_PROVIDER_OAUTH_EXCHANGE: "Connect via OAuth",
+  AI_PROVIDER_PROVISION_KEY: "Auto-provision key",
   AI_PROVIDER_TOPUP_URL: "Get top-up checkout URL",
   AI_PROVIDER_CREDITS: "Get credit balance",
   AI_PROVIDER_CLI_ACTIVATE: "Activate Claude Code CLI",

--- a/apps/mesh/src/web/components/chat/credits-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/credits-empty-state.tsx
@@ -85,12 +85,10 @@ export function CreditsEmptyState() {
 
   const { mutate: topUp, isPending } = useMutation({
     mutationFn: async (amountCents: number) => {
-      if (!decoKeyId) throw new Error("No Deco key found");
       const result = (await client.callTool({
         name: "AI_PROVIDER_TOPUP_URL",
         arguments: {
           providerId: "deco",
-          keyId: decoKeyId,
           amountCents,
           currency,
         },

--- a/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
+++ b/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
@@ -80,12 +80,10 @@ export function CreditsExhaustedBanner({
 
   const { mutate: topUp, isPending } = useMutation({
     mutationFn: async (amountCents: number) => {
-      if (!decoKeyId) throw new Error("No Deco key found");
       const result = (await client.callTool({
         name: "AI_PROVIDER_TOPUP_URL",
         arguments: {
           providerId: "deco",
-          keyId: decoKeyId,
           amountCents,
           currency,
         },

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -401,6 +401,7 @@ export type AiProvider = {
   supportedMethods: ("api-key" | "oauth-pkce" | "cli-activate")[];
   supportsTopUp?: boolean;
   supportsCredits?: boolean;
+  supportsProvision?: boolean;
 };
 
 function ProviderCard({
@@ -510,6 +511,30 @@ function ProviderCard({
     onError: (err) => toast.error(err.message),
   });
 
+  const { mutate: provisionKey, isPending: isProvisioning } = useMutation({
+    mutationFn: async () => {
+      const result = (await client.callTool({
+        name: "AI_PROVIDER_PROVISION_KEY",
+        arguments: { providerId: provider.id },
+      })) as {
+        isError?: boolean;
+        content?: { text?: string }[];
+      };
+      if (result?.isError) {
+        const msg = result.content?.[0]?.text ?? "Key provisioning failed";
+        throw new Error(msg);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });
+      queryClient.invalidateQueries({ queryKey: KEYS.aiProviders(org.id) });
+      toast.success(`${provider.name} connected successfully`);
+    },
+    onError: (err) => {
+      toast.error(`Failed to connect ${provider.name}: ${err.message}`);
+    },
+  });
+
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
     if (!isOAuthPending || !oauthStateToken) return;
@@ -546,16 +571,20 @@ function ProviderCard({
     };
   }, [isOAuthPending, oauthStateToken, exchangeOAuth]);
 
+  const supportsProvision = !!provider.supportsProvision;
   const supportsOAuth = provider.supportedMethods.includes("oauth-pkce");
   const supportsApiKey = provider.supportedMethods.includes("api-key");
 
   const handleCardClick = () => {
-    if (isConnectFormOpen || isOAuthPending || isActivating) return;
+    if (isConnectFormOpen || isOAuthPending || isActivating || isProvisioning)
+      return;
     if (isCliActivate) {
       if (!isActive) activateCli();
       return;
     }
-    if (supportsOAuth) {
+    if (supportsProvision) {
+      provisionKey();
+    } else if (supportsOAuth) {
       handleConnectOAuth();
     } else if (supportsApiKey) {
       setIsConnectFormOpen(true);
@@ -599,8 +628,9 @@ function ProviderCard({
           isActive && "border-primary/20",
           !isOAuthPending &&
             !isActivating &&
+            !isProvisioning &&
             "cursor-pointer hover:bg-muted/30",
-          (isOAuthPending || isActivating) && "cursor-wait",
+          (isOAuthPending || isActivating || isProvisioning) && "cursor-wait",
         )}
         onClick={handleCardClick}
       >
@@ -627,9 +657,11 @@ function ProviderCard({
               <p className="text-sm text-muted-foreground line-clamp-1">
                 {isActivating
                   ? "Checking CLI..."
-                  : isOAuthPending
-                    ? "Authorizing..."
-                    : provider.description}
+                  : isProvisioning
+                    ? "Connecting..."
+                    : isOAuthPending
+                      ? "Authorizing..."
+                      : provider.description}
               </p>
             </div>
           </div>
@@ -778,7 +810,6 @@ function QuickTopUp({ keyId }: { keyId: string }) {
         name: "AI_PROVIDER_TOPUP_URL",
         arguments: {
           providerId: "deco",
-          keyId,
           amountCents,
           currency,
         },

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -796,7 +796,7 @@ const TOP_UP_PRESETS = {
   brl: [50, 100, 500],
 } as const;
 
-function QuickTopUp({ keyId }: { keyId: string }) {
+function QuickTopUp() {
   const { org } = useProjectContext();
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -1083,7 +1083,7 @@ function DecoCreditsHero() {
           <p className="text-xs font-medium text-muted-foreground mb-2.5">
             Add credits
           </p>
-          <QuickTopUp keyId={decoKey.id} />
+          <QuickTopUp />
         </div>
       </div>
     </div>

--- a/packages/mesh-sdk/src/types/ai-providers.ts
+++ b/packages/mesh-sdk/src/types/ai-providers.ts
@@ -69,4 +69,5 @@ export interface AiProviderInfo {
   supportedMethods: ("api-key" | "oauth-pkce" | "cli-activate")[];
   supportsTopUp?: boolean;
   supportsCredits?: boolean;
+  supportsProvision?: boolean;
 }


### PR DESCRIPTION
- Updated the ProviderAdapter interface to include support for auto-provisioning with a new method.
- Implemented AI_PROVIDER_PROVISION_KEY tool for seamless API key provisioning for compatible providers.
- Enhanced the AI_PROVIDER_TOPUP_URL tool to utilize JWT for authorization instead of API keys.
- Updated UI components to reflect changes in provisioning capabilities and improve user experience.
- Adjusted related tools and metadata to incorporate new provisioning functionality.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds auto-provisioning for provider API keys and switches credit top-ups to JWT auth. This enables one-click provider setup and removes the need to expose API keys during checkout.

- **New Features**
  - Added `AI_PROVIDER_PROVISION_KEY` for server-side key creation; adapters can implement `provisionKey(meshJwt, orgId)`.
  - Updated `AI_PROVIDER_TOPUP_URL` to use a Mesh-minted JWT and `orgId` instead of a provider API key.
  - Exposed `supportsProvision` in `AI_PROVIDERS_LIST` and SDK types to surface one-click setup in the UI.
  - UI: Provider cards trigger auto-provision when supported; top-up flows no longer require a stored key; simplified `QuickTopUp` (removed `keyId` prop).
  - Guides: Tool order updated to prefer auto-provision when available.

- **Migration**
  - `ProviderAdapter.getTopUpUrl` signature changed to `(meshJwt, orgId, amountCents, currency?)`.
  - To opt into auto-provisioning, implement `provisionKey(meshJwt, orgId)` in your adapter.
  - Deco Gateway adapter no longer supports `oauth-pkce`; it now uses API key with auto-provision.

<sup>Written for commit ab437625d288bf4aa6d9a4ffda89ce8d6f354ad3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

