### PR TITLE
Feat/research

### DIFF
--- a/apps/mesh/src/ai-providers/coding-agents/claude-code/index.ts
+++ b/apps/mesh/src/ai-providers/coding-agents/claude-code/index.ts
@@ -18,6 +18,8 @@ export function createClaudeCodeModel(
       }
     >;
     toolApprovalLevel?: ToolApprovalLevel;
+    /** Chat mode plan — same tool restrictions as readonly for headless CLI */
+    isPlanMode?: boolean;
     resume?: string;
   },
 ) {
@@ -37,31 +39,21 @@ export function createClaudeCodeModel(
     cwd: process.cwd(),
   };
 
-  switch (options?.toolApprovalLevel) {
-    case "plan":
-      settings.permissionMode = "bypassPermissions";
-      settings.disallowedTools = [
-        ...HEADLESS_DISALLOWED_TOOLS,
-        "Write",
-        "Edit",
-        "Bash",
-        "NotebookEdit",
-      ];
-      break;
-    case "readonly":
-      settings.permissionMode = "bypassPermissions";
-      settings.disallowedTools = [
-        ...HEADLESS_DISALLOWED_TOOLS,
-        "Write",
-        "Edit",
-        "Bash",
-        "NotebookEdit",
-      ];
-      break;
-    default:
-      settings.permissionMode = "bypassPermissions";
-      settings.disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
-      break;
+  const restrictWrites =
+    options?.isPlanMode || options?.toolApprovalLevel === "readonly";
+
+  if (restrictWrites) {
+    settings.permissionMode = "bypassPermissions";
+    settings.disallowedTools = [
+      ...HEADLESS_DISALLOWED_TOOLS,
+      "Write",
+      "Edit",
+      "Bash",
+      "NotebookEdit",
+    ];
+  } else {
+    settings.permissionMode = "bypassPermissions";
+    settings.disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
   }
 
   if (options?.resume) {

--- a/apps/mesh/src/ai-providers/coding-agents/codex/index.ts
+++ b/apps/mesh/src/ai-providers/coding-agents/codex/index.ts
@@ -21,6 +21,8 @@ export function createCodexModel(
       }
     >;
     toolApprovalLevel?: ToolApprovalLevel;
+    /** Chat mode plan — stricter approval policy */
+    isPlanMode?: boolean;
   },
 ) {
   const mcpServers = options?.mcpServers
@@ -37,14 +39,10 @@ export function createCodexModel(
     : undefined;
 
   let approvalPolicy: "never" | "on-failure";
-  switch (options?.toolApprovalLevel) {
-    case "plan":
-    case "readonly":
-      approvalPolicy = "on-failure";
-      break;
-    default:
-      approvalPolicy = "never";
-      break;
+  if (options?.isPlanMode || options?.toolApprovalLevel === "readonly") {
+    approvalPolicy = "on-failure";
+  } else {
+    approvalPolicy = "never";
   }
 
   const provider = createCodexAppServer({

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1113,6 +1113,7 @@ export async function createApp(options: CreateAppOptions = {}) {
         agent: config.agent,
         temperature: config.temperature,
         toolApprovalLevel: config.toolApprovalLevel,
+        mode: config.mode,
         organizationId: thread.organization_id,
         userId: thread.created_by,
         taskId: thread.id,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/enable-tools.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/enable-tools.ts
@@ -7,7 +7,6 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import type { ToolApprovalLevel } from "../helpers";
 
 const enableToolsInputSchema = z.object({
   tools: z
@@ -26,7 +25,7 @@ export function createEnableToolsTool(
   enabledTools: Set<string>,
   availableToolNames: Set<string>,
   options?: {
-    toolApprovalLevel?: ToolApprovalLevel;
+    isPlanMode?: boolean;
     toolAnnotations?: Map<string, { readOnlyHint?: boolean }>;
   },
 ) {
@@ -51,7 +50,7 @@ export function createEnableToolsTool(
         }
 
         // In plan mode, block non-read-only tools
-        if (options?.toolApprovalLevel === "plan") {
+        if (options?.isPlanMode) {
           const annotations = options.toolAnnotations?.get(name);
           if (annotations?.readOnlyHint !== true) {
             blocked.push(name);

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/generate-image.ts
@@ -20,6 +20,7 @@ import type { MeshProvider } from "@/ai-providers/types";
 import type { MeshContext } from "@/core/mesh-context";
 import { getSettings } from "@/settings";
 import type { ModelInfo } from "../types";
+import { toMeshStorageUri, parseMeshStorageKey } from "../mesh-storage-uri";
 
 const GenerateImageInputSchema = z.object({
   prompt: z
@@ -34,7 +35,7 @@ const GenerateImageInputSchema = z.object({
         uri: z
           .string()
           .describe(
-            "URI of the reference image (e.g. mesh-storage:generated-images/uuid.png).",
+            "URI of the reference image (e.g. mesh-storage://generated-images/uuid.png).",
           ),
       }),
     )
@@ -71,10 +72,10 @@ async function fetchImageBytes(
   url: string,
   ctx: MeshContext,
 ): Promise<Uint8Array> {
-  // mesh-storage:{key} — read directly from object storage
-  if (url.startsWith("mesh-storage:")) {
-    const key = url.slice("mesh-storage:".length);
-    return readFromObjectStorage(key, ctx);
+  // mesh-storage://{key} — read directly from object storage
+  const meshKey = parseMeshStorageKey(url);
+  if (meshKey !== null) {
+    return readFromObjectStorage(meshKey, ctx);
   }
 
   // Our own /api/:org/files/:key URL — extract key and read directly
@@ -222,7 +223,7 @@ export function createGenerateImageTool(
                 await ctx.objectStorage.put(key, bytes, {
                   contentType: mediaType,
                 });
-                return { uri: `mesh-storage:${key}`, mediaType };
+                return { uri: toMeshStorageUri(key), mediaType };
               } catch (err) {
                 console.error(
                   "[generate-image] Failed to upload, falling back to data: URI",

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -18,6 +18,7 @@ import { createSubtaskTool } from "./subtask";
 import { userAskTool } from "./user-ask";
 import { proposePlanTool } from "./propose-plan";
 import { createGenerateImageTool } from "./generate-image";
+import { createWebSearchTool } from "./web-search";
 import type { ModelsConfig } from "../types";
 import type { MeshProvider } from "@/ai-providers/types";
 
@@ -75,6 +76,7 @@ function buildAllTools(
     read_resource: createReadResourceTool({
       passthroughClient,
       toolOutputMap,
+      ctx,
     }),
     read_prompt: createReadPromptTool({
       passthroughClient,
@@ -111,6 +113,15 @@ function buildAllTools(
       ctx,
     });
   }
+  // web_search requires a provider and a deep-research model
+  if (provider && models.deepResearch) {
+    tools.web_search = createWebSearchTool(writer, {
+      provider,
+      deepResearchModelInfo: models.deepResearch,
+      ctx,
+      toolOutputMap,
+    });
+  }
   return tools as {
     user_ask: typeof userAskTool;
     propose_plan: typeof proposePlanTool;
@@ -122,6 +133,7 @@ function buildAllTools(
     read_prompt: ReturnType<typeof createReadPromptTool>;
     open_in_agent: ReturnType<typeof createOpenInAgentTool>;
     generate_image: ReturnType<typeof createGenerateImageTool>;
+    web_search: ReturnType<typeof createWebSearchTool>;
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -29,6 +29,8 @@ export interface BuiltinToolParams {
   models: ModelsConfig;
   userId: string;
   toolApprovalLevel?: ToolApprovalLevel;
+  /** When true (chat mode `plan`), include `propose_plan` and plan-style approvals */
+  isPlanMode?: boolean;
   toolOutputMap: Map<string, string>;
   passthroughClient: VirtualClient;
 }
@@ -36,7 +38,7 @@ export interface BuiltinToolParams {
 /**
  * Full tool set type — always includes propose_plan so that ChatMessage
  * (derived via ReturnType) can render historical plan parts regardless
- * of the current toolApprovalLevel.
+ * of the current chat mode.
  */
 export type BuiltInToolSet = ReturnType<typeof buildAllTools>;
 
@@ -51,9 +53,11 @@ function buildAllTools(
     models,
     userId,
     toolApprovalLevel = "auto",
+    isPlanMode = false,
     toolOutputMap,
     passthroughClient,
   } = params;
+  const approvalOpts = { isPlanMode };
   const tools: Record<string, unknown> = {
     user_ask: userAskTool,
     propose_plan: proposePlanTool,
@@ -61,7 +65,8 @@ function buildAllTools(
       writer,
       {
         organization,
-        needsApproval: toolNeedsApproval(toolApprovalLevel, true) !== false,
+        needsApproval:
+          toolNeedsApproval(toolApprovalLevel, true, approvalOpts) !== false,
       },
       ctx,
     ),
@@ -71,7 +76,8 @@ function buildAllTools(
     sandbox: createSandboxTool({
       passthroughClient,
       toolOutputMap,
-      needsApproval: toolNeedsApproval(toolApprovalLevel, false) !== false,
+      needsApproval:
+        toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false,
     }),
     read_resource: createReadResourceTool({
       passthroughClient,
@@ -87,7 +93,8 @@ function buildAllTools(
       {
         organization,
         userId,
-        needsApproval: toolNeedsApproval(toolApprovalLevel, false) !== false,
+        needsApproval:
+          toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false,
       },
       ctx,
     ),
@@ -100,7 +107,8 @@ function buildAllTools(
         provider,
         organization,
         models,
-        needsApproval: toolNeedsApproval(toolApprovalLevel, false) !== false,
+        needsApproval:
+          toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false,
       },
       ctx,
     );
@@ -139,7 +147,7 @@ function buildAllTools(
 
 /**
  * Get built-in tools as a ToolSet.
- * propose_plan is only included when toolApprovalLevel is "plan".
+ * propose_plan is only included when chat mode is `plan`.
  */
 export function getBuiltInTools(
   writer: UIMessageStreamWriter,
@@ -147,9 +155,8 @@ export function getBuiltInTools(
   ctx: MeshContext,
 ) {
   const tools = buildAllTools(writer, params, ctx);
-  const { toolApprovalLevel = "auto" } = params;
 
-  if (toolApprovalLevel !== "plan") {
+  if (!params.isPlanMode) {
     const { propose_plan: _, ...rest } = tools;
     return rest;
   }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/resources.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/resources.ts
@@ -7,8 +7,7 @@ import {
   createOutputPreview,
   estimateJsonTokens,
 } from "./read-tool-output";
-
-const MESH_STORAGE_PREFIX = "mesh-storage:";
+import { parseMeshStorageKey } from "../mesh-storage-uri";
 
 export interface ResourceToolParams {
   readonly passthroughClient: VirtualClient;
@@ -21,22 +20,20 @@ export function createReadResourceTool(params: ResourceToolParams) {
   return tool({
     description:
       "Read a resource by its URI. Returns the content of the resource. " +
-      "Resource URIs (docs://...) are provided in prompt content. " +
-      "Also supports mesh-storage: URIs from web_search results.",
+      "Resource URIs (docs://...) are provided in prompt content. ",
     inputSchema: zodSchema(
       z.object({
         uri: z
           .string()
           .min(1)
-          .describe(
-            "The URI of the resource to read (e.g. docs://store.md, mesh-storage:web-search/…).",
-          ),
+          .describe("The URI of the resource to read (e.g. docs://store.md)."),
       }),
     ),
     execute: async ({ uri }) => {
-      // Resolve mesh-storage: URIs from object storage (e.g. web_search blobs)
-      if (uri.startsWith(MESH_STORAGE_PREFIX)) {
-        const key = uri.slice(MESH_STORAGE_PREFIX.length);
+      // Resolve mesh-storage:// URIs from object storage (e.g. web_search blobs)
+      const meshKey = parseMeshStorageKey(uri);
+      if (meshKey !== null) {
+        const key = meshKey;
         if (!ctx.objectStorage) {
           return { result: "Object storage is not configured." };
         }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/resources.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/resources.ts
@@ -1,32 +1,74 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { VirtualClient } from "./sandbox";
+import type { MeshContext } from "@/core/mesh-context";
 import {
   MAX_RESULT_TOKENS,
   createOutputPreview,
   estimateJsonTokens,
 } from "./read-tool-output";
 
+const MESH_STORAGE_PREFIX = "mesh-storage:";
+
 export interface ResourceToolParams {
   readonly passthroughClient: VirtualClient;
   readonly toolOutputMap: Map<string, string>;
+  readonly ctx: MeshContext;
 }
 
 export function createReadResourceTool(params: ResourceToolParams) {
-  const { passthroughClient, toolOutputMap } = params;
+  const { passthroughClient, toolOutputMap, ctx } = params;
   return tool({
     description:
       "Read a resource by its URI. Returns the content of the resource. " +
-      "Resource URIs (docs://...) are provided in prompt content.",
+      "Resource URIs (docs://...) are provided in prompt content. " +
+      "Also supports mesh-storage: URIs from web_search results.",
     inputSchema: zodSchema(
       z.object({
         uri: z
           .string()
           .min(1)
-          .describe("The URI of the resource to read (e.g. docs://store.md)."),
+          .describe(
+            "The URI of the resource to read (e.g. docs://store.md, mesh-storage:web-search/…).",
+          ),
       }),
     ),
     execute: async ({ uri }) => {
+      // Resolve mesh-storage: URIs from object storage (e.g. web_search blobs)
+      if (uri.startsWith(MESH_STORAGE_PREFIX)) {
+        const key = uri.slice(MESH_STORAGE_PREFIX.length);
+        if (!ctx.objectStorage) {
+          return { result: "Object storage is not configured." };
+        }
+        try {
+          const data = await ctx.objectStorage.get(key);
+          if ("error" in data) {
+            return {
+              result: `Resource too large to inline (${data.size} bytes). Presigned URL: ${data.presignedUrl}`,
+            };
+          }
+          const text = data.content;
+          const tokens = estimateJsonTokens(text);
+          if (tokens > MAX_RESULT_TOKENS) {
+            const toolCallId = `resource_${Date.now()}`;
+            toolOutputMap.set(toolCallId, text);
+            const preview = createOutputPreview(text);
+            return {
+              result: `Resource content too large (${tokens} tokens). Use read_tool_output with tool_call_id "${toolCallId}" to extract specific data.\n\nPreview:\n${preview}`,
+            };
+          }
+          return {
+            contents: [
+              { uri, mimeType: data.contentType || "text/markdown", text },
+            ],
+          };
+        } catch (err) {
+          return {
+            result: `Failed to read resource: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      }
+
       const result = await passthroughClient.readResource({ uri });
       const contents = result.contents;
 

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/web-search.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/web-search.ts
@@ -22,6 +22,7 @@ import type { MeshContext } from "@/core/mesh-context";
 import { sanitizeProviderMetadata } from "@decocms/mesh-sdk";
 import type { ModelInfo } from "../types";
 import { createOutputPreview } from "./read-tool-output";
+import { toMeshStorageUri } from "../mesh-storage-uri";
 
 /** Results above this threshold are offloaded to blob storage. */
 const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
@@ -138,7 +139,7 @@ export function createWebSearchTool(
         };
 
         // Large results → blob storage, compact tool result with URI.
-        // The model can re-access it later via read_resource("mesh-storage:…").
+        // The model can re-access it later via read_resource("mesh-storage://…").
         if (outputTokens > LARGE_RESULT_TOKEN_THRESHOLD && ctx.objectStorage) {
           const key = `web-search/${crypto.randomUUID()}.md`;
           const bytes = new TextEncoder().encode(fullText);
@@ -149,7 +150,7 @@ export function createWebSearchTool(
             const preview = createOutputPreview(fullText);
             return {
               success: true as const,
-              uri: `mesh-storage:${key}`,
+              uri: toMeshStorageUri(key),
               preview,
               query: input.query,
               model: deepResearchModelInfo.id,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/web-search.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/web-search.ts
@@ -1,0 +1,186 @@
+/**
+ * web_search Built-in Tool
+ *
+ * Server-side tool that performs web research using deep research models
+ * (e.g. Perplexity Sonar) through OpenRouter. Calls streamText with the
+ * provider's languageModel — OpenRouter handles the routing to the
+ * underlying research model.
+ *
+ * Text chunks are streamed to the UI via data parts so the user sees
+ * the research in real time.
+ *
+ * Small results are returned inline in the tool result (stays in thread).
+ * Large results (> 8k output tokens) are stored in blob storage and the
+ * tool result contains only a preview + mesh-storage: URI. The model can
+ * re-access the full content in later turns via read_resource(uri).
+ */
+
+import { tool, zodSchema, streamText, type UIMessageStreamWriter } from "ai";
+import { z } from "zod";
+import type { MeshProvider } from "@/ai-providers/types";
+import type { MeshContext } from "@/core/mesh-context";
+import { sanitizeProviderMetadata } from "@decocms/mesh-sdk";
+import type { ModelInfo } from "../types";
+import { createOutputPreview } from "./read-tool-output";
+
+/** Results above this threshold are offloaded to blob storage. */
+const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+
+const WebSearchInputSchema = z.object({
+  query: z
+    .string()
+    .max(10_000)
+    .describe(
+      "The research query. Be specific about what information you need. " +
+        "The research model will search the web and synthesize a comprehensive answer.",
+    ),
+});
+
+export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
+
+export function createWebSearchTool(
+  writer: UIMessageStreamWriter,
+  params: {
+    provider: MeshProvider;
+    deepResearchModelInfo: ModelInfo;
+    ctx: MeshContext;
+    toolOutputMap: Map<string, string>;
+  },
+) {
+  const { provider, deepResearchModelInfo, ctx, toolOutputMap } = params;
+
+  return tool({
+    description:
+      "Search the web and synthesize a comprehensive research report. " +
+      "Use this when the user needs up-to-date information from the internet, " +
+      "in-depth research on a topic, fact-checking, or when the answer requires " +
+      "knowledge beyond your training data.",
+    inputSchema: zodSchema(WebSearchInputSchema),
+    execute: async (input, options) => {
+      const startTime = performance.now();
+      try {
+        const model = provider.aiSdk.languageModel(deepResearchModelInfo.id);
+
+        const result = streamText({
+          model,
+          prompt: input.query,
+          abortSignal: options.abortSignal,
+        });
+
+        // Accumulate text while streaming to the UI.
+        // The AI SDK replaces data parts with the same id on each write,
+        // so we send the full accumulated text (not just the delta).
+        // Throttled to limit wire overhead.
+        let fullText = "";
+        let lastSendTime = 0;
+        const THROTTLE_MS = 50;
+
+        for await (const chunk of result.textStream) {
+          fullText += chunk;
+          const now = Date.now();
+          if (now - lastSendTime >= THROTTLE_MS) {
+            lastSendTime = now;
+            (writer as any).write({
+              type: "data-web-search",
+              id: options.toolCallId,
+              data: { text: fullText },
+            });
+          }
+        }
+        // Final flush to ensure all text is sent
+        (writer as any).write({
+          type: "data-web-search",
+          id: options.toolCallId,
+          data: { text: fullText },
+        });
+
+        const [usage, sources, providerMetadata] = await Promise.all([
+          result.usage,
+          result.sources,
+          result.providerMetadata,
+        ]);
+        const inputTokens = usage.inputTokens ?? 0;
+        const outputTokens = usage.outputTokens ?? 0;
+        const safeProviderMeta = sanitizeProviderMetadata(
+          providerMetadata as Record<string, unknown> | undefined,
+        );
+
+        // Normalize sources into a simple { url, title } array for the UI.
+        const citations: Array<{ url: string; title?: string }> = [];
+        if (sources && Array.isArray(sources)) {
+          for (const s of sources) {
+            if (
+              s &&
+              typeof s === "object" &&
+              "sourceType" in s &&
+              s.sourceType === "url" &&
+              "url" in s &&
+              typeof s.url === "string"
+            ) {
+              citations.push({
+                url: s.url,
+                title:
+                  "title" in s && typeof s.title === "string"
+                    ? s.title
+                    : undefined,
+              });
+            }
+          }
+        }
+
+        // Always store in toolOutputMap for read_tool_output within this loop.
+        toolOutputMap.set(options.toolCallId, fullText);
+
+        const usageMeta = {
+          inputTokens,
+          outputTokens,
+          providerMetadata: safeProviderMeta,
+        };
+
+        // Large results → blob storage, compact tool result with URI.
+        // The model can re-access it later via read_resource("mesh-storage:…").
+        if (outputTokens > LARGE_RESULT_TOKEN_THRESHOLD && ctx.objectStorage) {
+          const key = `web-search/${crypto.randomUUID()}.md`;
+          const bytes = new TextEncoder().encode(fullText);
+          try {
+            await ctx.objectStorage.put(key, bytes, {
+              contentType: "text/markdown",
+            });
+            const preview = createOutputPreview(fullText);
+            return {
+              success: true as const,
+              uri: `mesh-storage:${key}`,
+              preview,
+              query: input.query,
+              model: deepResearchModelInfo.id,
+              usage: usageMeta,
+              ...(citations.length > 0 && { citations }),
+            };
+          } catch (err) {
+            console.error(
+              "[web-search] Failed to upload to storage, returning inline",
+              err,
+            );
+          }
+        }
+
+        // Small result — return content inline so it stays in thread history.
+        return {
+          success: true as const,
+          content: fullText,
+          query: input.query,
+          model: deepResearchModelInfo.id,
+          usage: usageMeta,
+          ...(citations.length > 0 && { citations }),
+        };
+      } finally {
+        const latencyMs = performance.now() - startTime;
+        writer.write({
+          type: "data-tool-metadata",
+          id: options.toolCallId,
+          data: { latencyMs },
+        });
+      }
+    },
+  });
+}

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -20,24 +20,11 @@
 
 import type { MeshContext } from "@/core/mesh-context";
 import type { ChatMessage } from "./types";
-
-// ============================================================================
-// Stable URI scheme
-// ============================================================================
-
-/** Prefix for stable storage references stored in the DB. */
-const MESH_STORAGE_SCHEME = "mesh-storage:";
-
-/** Wrap a storage key in the stable URI scheme. */
-function toMeshStorageUrl(key: string): string {
-  return `${MESH_STORAGE_SCHEME}${key}`;
-}
-
-/** Extract the storage key from a mesh-storage: URI, or return null. */
-function parseMeshStorageKey(url: string): string | null {
-  if (!url.startsWith(MESH_STORAGE_SCHEME)) return null;
-  return url.slice(MESH_STORAGE_SCHEME.length);
-}
+import {
+  toMeshStorageUri,
+  parseMeshStorageKey,
+  meshStorageRegex,
+} from "./mesh-storage-uri";
 
 /** Build the stable redirect URL the UI / tools use to access a file. */
 function toFileRedirectUrl(
@@ -201,7 +188,7 @@ export async function uploadFileParts(
 
       return {
         dataUrl: part.url,
-        meshStorageUrl: toMeshStorageUrl(uploadedKey),
+        meshStorageUrl: toMeshStorageUri(uploadedKey),
         redirectUrl: toFileRedirectUrl(ctx.baseUrl, orgId, uploadedKey),
         filename,
       };
@@ -370,7 +357,7 @@ export async function resolveArgsStorageRefs(
 
 function collectMeshStorageKeys(value: unknown, out: Set<string>): void {
   if (typeof value === "string") {
-    for (const match of value.matchAll(/mesh-storage:([^\s"'<>[\]]+)/g)) {
+    for (const match of value.matchAll(meshStorageRegex())) {
       out.add(match[1]!);
     }
   } else if (Array.isArray(value)) {
@@ -388,8 +375,8 @@ function substituteValues(
 ): unknown {
   if (typeof value === "string") {
     return value.replace(
-      /mesh-storage:([^\s"'<>[\]]+)/g,
-      (_, key: string) => keyToPresigned.get(key) ?? `mesh-storage:${key}`,
+      meshStorageRegex(),
+      (_, key: string) => keyToPresigned.get(key) ?? toMeshStorageUri(key),
     );
   }
   if (Array.isArray(value)) {

--- a/apps/mesh/src/api/routes/decopilot/helpers.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.test.ts
@@ -345,19 +345,23 @@ describe("toolNeedsApproval", () => {
     });
   });
 
-  describe('approval level: "plan"', () => {
-    const level: ToolApprovalLevel = "plan";
+  describe("plan mode (isPlanMode)", () => {
+    const level: ToolApprovalLevel = "auto";
 
     test("returns false when readOnlyHint is true (read-only allowed)", () => {
-      expect(toolNeedsApproval(level, true)).toBe(false);
+      expect(toolNeedsApproval(level, true, { isPlanMode: true })).toBe(false);
     });
 
     test('returns "hard-block" when readOnlyHint is false', () => {
-      expect(toolNeedsApproval(level, false)).toBe("hard-block");
+      expect(toolNeedsApproval(level, false, { isPlanMode: true })).toBe(
+        "hard-block",
+      );
     });
 
     test('returns "hard-block" when readOnlyHint is undefined', () => {
-      expect(toolNeedsApproval(level, undefined)).toBe("hard-block");
+      expect(toolNeedsApproval(level, undefined, { isPlanMode: true })).toBe(
+        "hard-block",
+      );
     });
   });
 

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -30,25 +30,26 @@ import {
 /**
  * Tool approval levels determine which tools require user approval before executing
  */
-export type ToolApprovalLevel = "auto" | "readonly" | "plan";
+export type ToolApprovalLevel = "auto" | "readonly";
 
 /**
  * Determine if a tool needs approval based on approval level and readOnlyHint
  *
  * @param level - The approval level setting
  * @param readOnlyHint - Optional hint from MCP tool annotations
+ * @param options.isPlanMode - When true (chat `mode: "plan"`), non-read-only tools are hard-blocked
  * @returns true if the tool requires approval, false if auto-approved
  */
 export function toolNeedsApproval(
   level: ToolApprovalLevel,
   readOnlyHint?: boolean,
+  options?: { isPlanMode?: boolean },
 ): boolean | "hard-block" {
-  if (level === "auto") return false;
-  if (level === "plan") {
-    // Hard block: non-read-only tools cannot run at all in plan mode
+  if (options?.isPlanMode) {
     if (readOnlyHint === true) return false;
     return "hard-block";
   }
+  if (level === "auto") return false;
   // "readonly": auto-approve only if explicitly marked readOnly
   return readOnlyHint !== true;
 }
@@ -137,7 +138,11 @@ export async function toolsFromMCP(
   toolOutputMap: Map<string, string>,
   writer?: UIMessageStreamWriter,
   toolApprovalLevel: ToolApprovalLevel = "auto",
-  options?: { disableOutputTruncation?: boolean; ctx?: MeshContext },
+  options?: {
+    disableOutputTruncation?: boolean;
+    ctx?: MeshContext;
+    isPlanMode?: boolean;
+  },
 ): Promise<{ tools: ToolSet; nameMap: Map<string, string> }> {
   const truncate = !options?.disableOutputTruncation;
   const meshCtx = options?.ctx;
@@ -157,8 +162,9 @@ export async function toolsFromMCP(
         inputSchema: jsonSchema(inputSchema as JSONSchema7),
         outputSchema: undefined,
         needsApproval:
-          toolNeedsApproval(toolApprovalLevel, annotations?.readOnlyHint) !==
-          false,
+          toolNeedsApproval(toolApprovalLevel, annotations?.readOnlyHint, {
+            isPlanMode: options?.isPlanMode,
+          }) !== false,
         execute: async (input, callOptions) => {
           const startTime = performance.now();
           try {

--- a/apps/mesh/src/api/routes/decopilot/mesh-storage-uri.ts
+++ b/apps/mesh/src/api/routes/decopilot/mesh-storage-uri.ts
@@ -6,7 +6,7 @@
  */
 
 /** URI scheme prefix for stable object-storage references. */
-export const MESH_STORAGE_SCHEME = "mesh-storage://";
+const MESH_STORAGE_SCHEME = "mesh-storage://";
 
 /** Wrap a storage key in the stable URI scheme. */
 export function toMeshStorageUri(key: string): string {

--- a/apps/mesh/src/api/routes/decopilot/mesh-storage-uri.ts
+++ b/apps/mesh/src/api/routes/decopilot/mesh-storage-uri.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared utilities for the `mesh-storage://` URI scheme.
+ *
+ * All code that produces or consumes mesh-storage URIs should import from here
+ * so the scheme string stays in one place and the parse/build logic is consistent.
+ */
+
+/** URI scheme prefix for stable object-storage references. */
+export const MESH_STORAGE_SCHEME = "mesh-storage://";
+
+/** Wrap a storage key in the stable URI scheme. */
+export function toMeshStorageUri(key: string): string {
+  return `${MESH_STORAGE_SCHEME}${key}`;
+}
+
+/**
+ * Extract the storage key from a `mesh-storage://` URI.
+ * Returns null for any other URI scheme.
+ */
+export function parseMeshStorageKey(uri: string): string | null {
+  if (!uri.startsWith(MESH_STORAGE_SCHEME)) return null;
+  return uri.slice(MESH_STORAGE_SCHEME.length);
+}
+
+/**
+ * Returns a fresh RegExp that matches `mesh-storage://` URIs and captures the key.
+ * Group 1 = storage key.
+ *
+ * A factory is used (rather than a shared instance) because RegExp with the `g`
+ * flag is stateful — callers using matchAll() or replace() need their own copy.
+ */
+export function meshStorageRegex(): RegExp {
+  return /mesh-storage:\/\/([^\s"'<>[\]]+)/g;
+}

--- a/apps/mesh/src/api/routes/decopilot/mode-config.ts
+++ b/apps/mesh/src/api/routes/decopilot/mode-config.ts
@@ -1,0 +1,88 @@
+/**
+ * Decopilot chat mode — orthogonal to tool approval level.
+ * Maps mode to system prompts and first-step tool forcing.
+ */
+
+export const CHAT_MODES = [
+  "default",
+  "plan",
+  "web-search",
+  "gen-image",
+] as const;
+
+export type ChatMode = (typeof CHAT_MODES)[number];
+
+export interface ResolvedModeConfig {
+  /** When true, use plan-mode hard-block + propose_plan + enable_tools gating */
+  isPlanMode: boolean;
+  /** First step only — forces this tool name when present in the tool set */
+  forcedFirstStepTool: "web_search" | "generate_image" | null;
+  /** Injected when mode is plan */
+  planPrompt: string | null;
+  /**
+   * When mode is web-search and web_search is registered — behavior hint for the model.
+   * Omitted for other modes even if the tool exists.
+   */
+  webSearchInstructionPrompt: string | null;
+}
+
+function buildPlanPrompt(isCliAgent: boolean): string {
+  return (
+    "<plan-mode>\n" +
+    "You are in plan mode.\n\n" +
+    (isCliAgent
+      ? ""
+      : "CRITICAL: your final output MUST be a single call to `propose_plan`. " +
+        "Do NOT write the plan as chat text — call the tool instead. " +
+        "Describing the plan in chat without calling `propose_plan` is an error.\n\n") +
+    "Your goal: produce a plan so complete that a fresh thread, with no memory of " +
+    "this conversation, can execute it without asking follow-up questions.\n\n" +
+    "Clarifications: if the request is ambiguous, you may call `user_ask` AT MOST ONCE " +
+    "with a single, focused question. Do not ask multiple questions in sequence. " +
+    "If you can make a reasonable assumption, do so and note it in the plan instead of asking.\n\n" +
+    "Plan quality bar: include concrete details, ordered steps, risks, trade-offs, " +
+    "and alternatives you considered. Write for a reader with no prior context.\n" +
+    "</plan-mode>"
+  );
+}
+
+const WEB_SEARCH_INSTRUCTION_PROMPT =
+  "<web-search>\n" +
+  "The web_search tool streams its research result directly to the user in real time. " +
+  "After a search completes, do NOT repeat, summarize, or restate the research content — " +
+  "the user can already see it. Simply confirm the search succeeded and highlight key " +
+  "takeaways in one or two sentences. Only elaborate if the user explicitly asks.\n\n" +
+  "For large results, the tool result contains a `uri` (mesh-storage:…) instead of " +
+  "inline content. To re-access the full research in a later turn, call " +
+  "`read_resource` with that URI.\n" +
+  "</web-search>";
+
+/**
+ * Resolve active prompt fragments and tool forcing from chat mode.
+ */
+export function resolveModeConfig(
+  mode: ChatMode,
+  options: { isCliAgent: boolean },
+): ResolvedModeConfig {
+  const isPlanMode = mode === "plan";
+
+  const forcedFirstStepTool =
+    mode === "web-search"
+      ? "web_search"
+      : mode === "gen-image"
+        ? "generate_image"
+        : null;
+
+  const planPrompt =
+    mode === "plan" ? buildPlanPrompt(options.isCliAgent) : null;
+
+  const webSearchInstructionPrompt =
+    mode === "web-search" ? WEB_SEARCH_INSTRUCTION_PROMPT : null;
+
+  return {
+    isPlanMode,
+    forcedFirstStepTool,
+    planPrompt,
+    webSearchInstructionPrompt,
+  };
+}

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -155,6 +155,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         thread_id,
         toolApprovalLevel,
         forceImageGeneration,
+        forceWebSearch,
       } = await validateRequest(c);
 
       const userId = ctx.auth?.user?.id;
@@ -202,6 +203,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           taskId: resolvedThreadId,
           windowSize,
           forceImageGeneration,
+          forceWebSearch,
         },
         ctx,
         { runRegistry, streamBuffer, cancelBroadcast },
@@ -250,6 +252,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         thread_id,
         toolApprovalLevel,
         forceImageGeneration,
+        forceWebSearch,
       } = await validateRequest(c);
 
       const userId = ctx.auth?.user?.id;
@@ -297,6 +300,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           taskId: resolvedThreadId,
           windowSize,
           forceImageGeneration,
+          forceWebSearch,
         },
         ctx,
         { runRegistry, streamBuffer, cancelBroadcast },

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -154,8 +154,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         memory: memoryConfig,
         thread_id,
         toolApprovalLevel,
-        forceImageGeneration,
-        forceWebSearch,
+        mode,
       } = await validateRequest(c);
 
       const userId = ctx.auth?.user?.id;
@@ -198,12 +197,11 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           agent,
           temperature,
           toolApprovalLevel,
+          mode,
           organizationId: organization.id,
           userId,
           taskId: resolvedThreadId,
           windowSize,
-          forceImageGeneration,
-          forceWebSearch,
         },
         ctx,
         { runRegistry, streamBuffer, cancelBroadcast },
@@ -251,8 +249,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         memory: memoryConfig,
         thread_id,
         toolApprovalLevel,
-        forceImageGeneration,
-        forceWebSearch,
+        mode,
       } = await validateRequest(c);
 
       const userId = ctx.auth?.user?.id;
@@ -295,12 +292,11 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           agent,
           temperature,
           toolApprovalLevel,
+          mode,
           organizationId: organization.id,
           userId,
           taskId: resolvedThreadId,
           windowSize,
-          forceImageGeneration,
-          forceWebSearch,
         },
         ctx,
         { runRegistry, streamBuffer, cancelBroadcast },
@@ -485,6 +481,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
           agent: config.agent,
           temperature: config.temperature,
           toolApprovalLevel: config.toolApprovalLevel,
+          mode: config.mode,
           organizationId: organization.id,
           userId,
           taskId,

--- a/apps/mesh/src/api/routes/decopilot/run-config.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-config.test.ts
@@ -10,6 +10,7 @@ describe("PersistedRunConfigSchema", () => {
     agent: { id: "agent_456" },
     temperature: 0.7,
     toolApprovalLevel: "auto" as const,
+    mode: "default" as const,
     windowSize: 50,
   };
 
@@ -17,7 +18,22 @@ describe("PersistedRunConfigSchema", () => {
     const json = JSON.stringify(validConfig);
     const parsed = PersistedRunConfigSchema.safeParse(JSON.parse(json));
     expect(parsed.success).toBe(true);
-    if (parsed.success) expect(parsed.data).toEqual(validConfig);
+    if (parsed.success) expect(parsed.data).toMatchObject(validConfig);
+  });
+
+  it("maps legacy toolApprovalLevel plan to mode plan and readonly", () => {
+    const legacy = {
+      models: validConfig.models,
+      agent: validConfig.agent,
+      temperature: validConfig.temperature,
+      toolApprovalLevel: "plan" as const,
+    };
+    const parsed = PersistedRunConfigSchema.safeParse(legacy);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.mode).toBe("plan");
+      expect(parsed.data.toolApprovalLevel).toBe("readonly");
+    }
   });
 
   it("rejects missing required fields", () => {

--- a/apps/mesh/src/api/routes/decopilot/run-config.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-config.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import type { ChatMode } from "./mode-config";
+
 /**
  * Persisted run configuration schema.
  *
@@ -30,7 +32,8 @@ const PersistedModelInfoSchema = z.object({
   provider: z.string().nullish(),
 });
 
-export const PersistedRunConfigSchema = z.object({
+/** Raw DB shape may include legacy `toolApprovalLevel: "plan"`. */
+const PersistedRunConfigRawSchema = z.object({
   models: z.object({
     credentialId: z.string(),
     thinking: PersistedModelInfoSchema,
@@ -41,12 +44,39 @@ export const PersistedRunConfigSchema = z.object({
   }),
   agent: z.object({ id: z.string() }),
   temperature: z.number(),
-  toolApprovalLevel: z.enum(["auto", "readonly", "plan"]),
+  toolApprovalLevel: z.enum(["auto", "readonly", "plan"]).optional(),
+  mode: z.enum(["default", "plan", "web-search", "gen-image"]).optional(),
   windowSize: z.number().optional(),
   triggerId: z.string().optional(),
 });
 
-export type PersistedRunConfig = z.infer<typeof PersistedRunConfigSchema>;
+export const PersistedRunConfigSchema = PersistedRunConfigRawSchema.transform(
+  (raw) => {
+    let mode: ChatMode = raw.mode ?? "default";
+    let toolApprovalLevel: "auto" | "readonly" = "auto";
+
+    if (raw.toolApprovalLevel === "plan") {
+      mode = "plan";
+      toolApprovalLevel = "readonly";
+    } else if (raw.toolApprovalLevel === "readonly") {
+      toolApprovalLevel = "readonly";
+    } else if (raw.toolApprovalLevel === "auto") {
+      toolApprovalLevel = "auto";
+    }
+
+    return {
+      models: raw.models,
+      agent: raw.agent,
+      temperature: raw.temperature,
+      toolApprovalLevel,
+      mode,
+      windowSize: raw.windowSize,
+      triggerId: raw.triggerId,
+    };
+  },
+);
+
+export type PersistedRunConfig = z.output<typeof PersistedRunConfigSchema>;
 
 type PersistedModelInfo = z.infer<typeof PersistedModelInfoSchema>;
 

--- a/apps/mesh/src/api/routes/decopilot/run-config.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-config.ts
@@ -37,6 +37,7 @@ export const PersistedRunConfigSchema = z.object({
     coding: PersistedModelInfoSchema.optional(),
     fast: PersistedModelInfoSchema.optional(),
     image: PersistedModelInfoSchema.optional(),
+    deepResearch: PersistedModelInfoSchema.optional(),
   }),
   agent: z.object({ id: z.string() }),
   temperature: z.number(),
@@ -69,5 +70,8 @@ export function toModelsConfig(models: PersistedRunConfig["models"]) {
     ...(models.coding && { coding: toModelInfo(models.coding) }),
     ...(models.fast && { fast: toModelInfo(models.fast) }),
     ...(models.image && { image: toModelInfo(models.image) }),
+    ...(models.deepResearch && {
+      deepResearch: toModelInfo(models.deepResearch),
+    }),
   };
 }

--- a/apps/mesh/src/api/routes/decopilot/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/schemas.ts
@@ -67,28 +67,47 @@ const ModelsSchema = z
     coding: ModelInfoSchema.optional().describe("Good coding model"),
     fast: ModelInfoSchema.optional().describe("Cheap model for simple tasks"),
     image: ModelInfoSchema.optional().describe("Image generation model"),
+    deepResearch: ModelInfoSchema.optional().describe(
+      "Deep research model (e.g. Perplexity Sonar) for web_search tool",
+    ),
   })
   .loose();
 
-export const StreamRequestSchema = z.object({
-  messages: z
-    .array(UIMessageSchema)
-    .min(1)
-    .refine((msgs) => msgs.filter((m) => m.role !== "system").length === 1, {
-      message: "Expected exactly one non-system message",
-    }),
-  memory: MemoryConfigSchema.optional(),
-  models: ModelsSchema.optional(),
-  agent: z
-    .object({
-      id: z.string(),
-    })
-    .loose(),
-  stream: z.boolean().optional(),
-  temperature: z.number().default(0.5),
-  thread_id: z.string().optional(),
-  toolApprovalLevel: z.enum(["auto", "readonly", "plan"]).default("auto"),
-  forceImageGeneration: z.boolean().optional(),
-});
+export const StreamRequestSchema = z
+  .object({
+    messages: z
+      .array(UIMessageSchema)
+      .min(1)
+      .refine((msgs) => msgs.filter((m) => m.role !== "system").length === 1, {
+        message: "Expected exactly one non-system message",
+      }),
+    memory: MemoryConfigSchema.optional(),
+    models: ModelsSchema.optional(),
+    agent: z
+      .object({
+        id: z.string(),
+      })
+      .loose(),
+    stream: z.boolean().optional(),
+    temperature: z.number().default(0.5),
+    thread_id: z.string().optional(),
+    toolApprovalLevel: z.enum(["auto", "readonly", "plan"]).default("auto"),
+    forceImageGeneration: z.boolean().optional(),
+    forceWebSearch: z.boolean().optional(),
+  })
+  .refine(
+    (data) => {
+      const modes = [
+        data.toolApprovalLevel === "plan",
+        !!data.forceImageGeneration,
+        !!data.forceWebSearch,
+      ].filter(Boolean).length;
+      return modes <= 1;
+    },
+    {
+      message:
+        "Only one of plan mode, forceImageGeneration, or forceWebSearch can be active at a time",
+    },
+  );
 
 export type StreamRequest = z.infer<typeof StreamRequestSchema>;

--- a/apps/mesh/src/api/routes/decopilot/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/schemas.ts
@@ -73,41 +73,27 @@ const ModelsSchema = z
   })
   .loose();
 
-export const StreamRequestSchema = z
-  .object({
-    messages: z
-      .array(UIMessageSchema)
-      .min(1)
-      .refine((msgs) => msgs.filter((m) => m.role !== "system").length === 1, {
-        message: "Expected exactly one non-system message",
-      }),
-    memory: MemoryConfigSchema.optional(),
-    models: ModelsSchema.optional(),
-    agent: z
-      .object({
-        id: z.string(),
-      })
-      .loose(),
-    stream: z.boolean().optional(),
-    temperature: z.number().default(0.5),
-    thread_id: z.string().optional(),
-    toolApprovalLevel: z.enum(["auto", "readonly", "plan"]).default("auto"),
-    forceImageGeneration: z.boolean().optional(),
-    forceWebSearch: z.boolean().optional(),
-  })
-  .refine(
-    (data) => {
-      const modes = [
-        data.toolApprovalLevel === "plan",
-        !!data.forceImageGeneration,
-        !!data.forceWebSearch,
-      ].filter(Boolean).length;
-      return modes <= 1;
-    },
-    {
-      message:
-        "Only one of plan mode, forceImageGeneration, or forceWebSearch can be active at a time",
-    },
-  );
+export const StreamRequestSchema = z.object({
+  messages: z
+    .array(UIMessageSchema)
+    .min(1)
+    .refine((msgs) => msgs.filter((m) => m.role !== "system").length === 1, {
+      message: "Expected exactly one non-system message",
+    }),
+  memory: MemoryConfigSchema.optional(),
+  models: ModelsSchema.optional(),
+  agent: z
+    .object({
+      id: z.string(),
+    })
+    .loose(),
+  stream: z.boolean().optional(),
+  temperature: z.number().default(0.5),
+  thread_id: z.string().optional(),
+  toolApprovalLevel: z.enum(["auto", "readonly"]).default("auto"),
+  mode: z
+    .enum(["default", "plan", "web-search", "gen-image"])
+    .default("default"),
+});
 
 export type StreamRequest = z.infer<typeof StreamRequestSchema>;

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -98,6 +98,8 @@ export interface StreamCoreInput {
   isResume?: boolean;
   /** When true, forces generate_image as the required tool for this request */
   forceImageGeneration?: boolean;
+  /** When true, forces web_search as the required tool for this request */
+  forceWebSearch?: boolean;
 }
 
 export interface StreamCoreDeps {
@@ -490,9 +492,24 @@ async function streamCoreInner(
               "</plan-mode>"
             : null;
 
+        // web_search behavior hint — only when the tool is registered
+        const webSearchPrompt =
+          "web_search" in tools
+            ? "<web-search>\n" +
+              "The web_search tool streams its research result directly to the user in real time. " +
+              "After a search completes, do NOT repeat, summarize, or restate the research content — " +
+              "the user can already see it. Simply confirm the search succeeded and highlight key " +
+              "takeaways in one or two sentences. Only elaborate if the user explicitly asks.\n\n" +
+              "For large results, the tool result contains a `uri` (mesh-storage:…) instead of " +
+              "inline content. To re-access the full research in a later turn, call " +
+              "`read_resource` with that URI.\n" +
+              "</web-search>"
+            : null;
+
         const systemPrompts = [
           basePrompt,
           planModePrompt,
+          webSearchPrompt,
           toolCatalog,
           promptCatalog,
           agentPrompt,
@@ -678,6 +695,8 @@ async function streamCoreInner(
                     // model choose freely on subsequent steps.
                     const shouldForceImage =
                       input.forceImageGeneration && "generate_image" in tools;
+                    const shouldForceWebSearch =
+                      input.forceWebSearch && "web_search" in tools;
                     let stepIndex = 0;
 
                     return () => {
@@ -707,15 +726,22 @@ async function streamCoreInner(
                         });
                       }
 
+                      // Determine forced tool (image takes precedence if both set)
+                      const forcedToolName =
+                        shouldForceImage && isFirstStep
+                          ? "generate_image"
+                          : shouldForceWebSearch && isFirstStep
+                            ? "web_search"
+                            : null;
+
                       return {
                         activeTools: activeToolNames as (keyof typeof tools)[],
-                        ...(shouldForceImage &&
-                          isFirstStep && {
-                            toolChoice: {
-                              type: "tool" as const,
-                              toolName: "generate_image" as never,
-                            },
-                          }),
+                        ...(forcedToolName && {
+                          toolChoice: {
+                            type: "tool" as const,
+                            toolName: forcedToolName as never,
+                          },
+                        }),
                       };
                     };
                   })(),

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -33,6 +33,9 @@ import { loadAndMergeMessages, processConversation } from "./conversation";
 import { uploadFileParts, resolveStorageRefs } from "./file-materializer";
 import { isToolVisibleToModel, toolsFromMCP } from "./helpers";
 import type { ToolApprovalLevel } from "./helpers";
+import { type ChatMode, resolveModeConfig } from "./mode-config";
+
+export type { ChatMode } from "./mode-config";
 import { createMemory } from "./memory";
 import { ensureModelCompatibility } from "./model-compat";
 import {
@@ -89,6 +92,8 @@ export interface StreamCoreInput {
   agent: AgentConfig;
   temperature: number;
   toolApprovalLevel: ToolApprovalLevel;
+  /** Chat mode — plan, forced web search / image, or default */
+  mode: ChatMode;
   organizationId: string;
   userId: string;
   taskId?: string;
@@ -96,10 +101,6 @@ export interface StreamCoreInput {
   windowSize?: number;
   abortSignal?: AbortSignal;
   isResume?: boolean;
-  /** When true, forces generate_image as the required tool for this request */
-  forceImageGeneration?: boolean;
-  /** When true, forces web_search as the required tool for this request */
-  forceWebSearch?: boolean;
 }
 
 export interface StreamCoreDeps {
@@ -264,6 +265,7 @@ async function streamCoreInner(
           agent: input.agent,
           temperature: input.temperature,
           toolApprovalLevel: input.toolApprovalLevel,
+          mode: input.mode,
           windowSize: input.windowSize,
           triggerId: input.triggerId,
         },
@@ -378,6 +380,8 @@ async function streamCoreInner(
     const uiStream = createUIMessageStream({
       originalMessages: allMessages,
       execute: async ({ writer }) => {
+        const modeConfig = resolveModeConfig(input.mode, { isCliAgent });
+
         const passthroughClient = await createVirtualClientFrom(
           virtualMcp,
           ctx,
@@ -403,7 +407,7 @@ async function streamCoreInner(
                 toolOutputMap,
                 writer,
                 input.toolApprovalLevel,
-                { ctx },
+                { ctx, isPlanMode: modeConfig.isPlanMode },
               );
 
         const builtInTools = isCliAgent
@@ -416,6 +420,7 @@ async function streamCoreInner(
                 models: input.models,
                 userId: input.userId,
                 toolApprovalLevel: input.toolApprovalLevel,
+                isPlanMode: modeConfig.isPlanMode,
                 toolOutputMap,
                 passthroughClient,
               },
@@ -434,7 +439,7 @@ async function streamCoreInner(
         // Uses the same nameMap from toolsFromMCP so collision-suffixed names
         // match the keys in passthroughTools.
         const toolAnnotations = new Map<string, { readOnlyHint?: boolean }>();
-        if (input.toolApprovalLevel === "plan" && !isCliAgent) {
+        if (modeConfig.isPlanMode && !isCliAgent) {
           const { tools: toolList } = await passthroughClient.listTools();
           for (const t of toolList) {
             const safeName = passthroughNameMap.get(t.name);
@@ -455,7 +460,7 @@ async function streamCoreInner(
                 enabledTools,
                 passthroughToolNames,
                 {
-                  toolApprovalLevel: input.toolApprovalLevel,
+                  isPlanMode: modeConfig.isPlanMode,
                   toolAnnotations,
                 },
               ),
@@ -475,35 +480,11 @@ async function streamCoreInner(
           ? buildDecopilotAgentPrompt()
           : serverInstructions;
 
-        // Plan mode system prompt injection
-        const planModePrompt =
-          input.toolApprovalLevel === "plan"
-            ? "<plan-mode>\n" +
-              "You are in plan mode. The user is planning something — your job is to " +
-              "deeply understand the problem and produce a plan so complete that a fresh " +
-              "thread, with no memory of this conversation, can execute it.\n\n" +
-              "Explore thoroughly before planning. When requirements are ambiguous, ask via " +
-              "`user_ask` — one good question beats three wrong assumptions.\n\n" +
-              "Write the plan for a reader with no prior context. Include concrete details, " +
-              "ordered steps, risks, trade-offs, and alternatives you considered.\n\n" +
-              (isCliAgent
-                ? "When your plan is complete, provide it directly in chat as a comprehensive markdown plan.\n"
-                : "When your plan is complete, you MUST call `propose_plan`. This is the only way to submit a plan — do not describe it in chat.\n") +
-              "</plan-mode>"
-            : null;
+        const planModePrompt = modeConfig.planPrompt;
 
-        // web_search behavior hint — only when the tool is registered
         const webSearchPrompt =
-          "web_search" in tools
-            ? "<web-search>\n" +
-              "The web_search tool streams its research result directly to the user in real time. " +
-              "After a search completes, do NOT repeat, summarize, or restate the research content — " +
-              "the user can already see it. Simply confirm the search succeeded and highlight key " +
-              "takeaways in one or two sentences. Only elaborate if the user explicitly asks.\n\n" +
-              "For large results, the tool result contains a `uri` (mesh-storage:…) instead of " +
-              "inline content. To re-access the full research in a later turn, call " +
-              "`read_resource` with that URI.\n" +
-              "</web-search>"
+          modeConfig.webSearchInstructionPrompt && "web_search" in tools
+            ? modeConfig.webSearchInstructionPrompt
             : null;
 
         const systemPrompts = [
@@ -621,6 +602,7 @@ async function streamCoreInner(
                 },
               },
               toolApprovalLevel: input.toolApprovalLevel,
+              isPlanMode: modeConfig.isPlanMode,
               resume: resumeSessionId,
             },
           );
@@ -652,6 +634,7 @@ async function streamCoreInner(
                 },
               },
               toolApprovalLevel: input.toolApprovalLevel,
+              isPlanMode: modeConfig.isPlanMode,
             },
           );
           languageModel = codexResult.model;
@@ -691,12 +674,11 @@ async function streamCoreInner(
               ? {}
               : {
                   prepareStep: (() => {
-                    // Force generate_image only on the first step, then let the
-                    // model choose freely on subsequent steps.
-                    const shouldForceImage =
-                      input.forceImageGeneration && "generate_image" in tools;
-                    const shouldForceWebSearch =
-                      input.forceWebSearch && "web_search" in tools;
+                    const forcedFirstStepToolName =
+                      modeConfig.forcedFirstStepTool &&
+                      modeConfig.forcedFirstStepTool in tools
+                        ? modeConfig.forcedFirstStepTool
+                        : null;
                     let stepIndex = 0;
 
                     return () => {
@@ -711,7 +693,7 @@ async function streamCoreInner(
 
                       // Layer 2: In plan mode, filter out any non-read-only tools that
                       // somehow got enabled (safety net for Layer 1 in enable_tools)
-                      if (input.toolApprovalLevel === "plan") {
+                      if (modeConfig.isPlanMode) {
                         activeToolNames = activeToolNames.filter((name) => {
                           // Built-in tools and enable_tools are always allowed
                           if (
@@ -726,13 +708,10 @@ async function streamCoreInner(
                         });
                       }
 
-                      // Determine forced tool (image takes precedence if both set)
                       const forcedToolName =
-                        shouldForceImage && isFirstStep
-                          ? "generate_image"
-                          : shouldForceWebSearch && isFirstStep
-                            ? "web_search"
-                            : null;
+                        forcedFirstStepToolName && isFirstStep
+                          ? forcedFirstStepToolName
+                          : null;
 
                       return {
                         activeTools: activeToolNames as (keyof typeof tools)[],

--- a/apps/mesh/src/api/routes/decopilot/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/types.ts
@@ -43,6 +43,9 @@ export type ChatMessage = UIMessage<
       images: Array<{ base64: string; mediaType: string }>;
       prompt: string;
     };
+    "web-search": {
+      delta: string;
+    };
   },
   {
     [K in keyof BuiltInToolSet]: InferUITool<BuiltInToolSet[K]>;
@@ -72,6 +75,7 @@ export interface ModelsConfig {
   coding?: ModelInfo;
   fast?: ModelInfo;
   image?: ModelInfo;
+  deepResearch?: ModelInfo;
 }
 
 // ============================================================================

--- a/apps/mesh/src/automations/build-stream-request.test.ts
+++ b/apps/mesh/src/automations/build-stream-request.test.ts
@@ -100,6 +100,11 @@ describe("buildStreamRequest", () => {
     expect(result.toolApprovalLevel).toBe("auto");
   });
 
+  it("always sets mode to default", () => {
+    const result = buildStreamRequest(makeAutomation(), null, "thrd_1");
+    expect(result.mode).toBe("default");
+  });
+
   it("extracts agent id from stored JSON", () => {
     const automation = makeAutomation({
       agent: JSON.stringify({

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -33,6 +33,7 @@ export function buildStreamRequest(
     })(),
     temperature: automation.temperature ?? 0.5,
     toolApprovalLevel: "auto",
+    mode: "default",
     organizationId: automation.organization_id,
     userId: automation.created_by,
     triggerId: triggerId ?? undefined,

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -126,9 +126,15 @@ export interface ChatPrefsContextValue {
   /** Selected image generation model (null = no image models available) */
   imageModel: AiProviderModel | null;
   setImageModel: (model: AiProviderModel | null) => void;
+  /** Selected deep research model (null = no deep research models available) */
+  deepResearchModel: AiProviderModel | null;
+  setDeepResearchModel: (model: AiProviderModel | null) => void;
   /** When true, forces generate_image tool on the next request (one-shot) */
   forceImageGeneration: boolean;
   setForceImageGeneration: (force: boolean) => void;
+  /** When true, forces web_search tool on the next request (one-shot) */
+  forceWebSearch: boolean;
+  setForceWebSearch: (force: boolean) => void;
   appContexts: Record<string, string>;
   setAppContext: (sourceId: string, params: SetAppContextParams) => void;
   clearAppContext: (sourceId: string) => void;
@@ -232,8 +238,17 @@ export function ChatContextProvider({
       null,
     );
 
+  // Deep research model selection (localStorage-backed).
+  const [storedDeepResearchModel, setStoredDeepResearchModel] =
+    useLocalStorage<AiProviderModel | null>(
+      LOCALSTORAGE_KEYS.chatSelectedDeepResearchModel(locator),
+      null,
+    );
+
   // Force image generation — one-shot flag, resets after send
   const [forceImageGeneration, setForceImageGeneration] = useState(false);
+  // Force web search — one-shot flag, resets after send
+  const [forceWebSearch, setForceWebSearch] = useState(false);
 
   // AI provider keys and models
   const keys = useAiProviderKeys();
@@ -268,6 +283,25 @@ export function ChatContextProvider({
     (storedModelIsAvailable ? storedImageModel : null) ??
     imageModels[0] ??
     null;
+
+  // Deep research model auto-detection + user override.
+  // Validates stored selection against current credential's models.
+  const deepResearchModels = allKeyModels.filter((m) => {
+    const n = m.modelId.toLowerCase().replace(/[^a-z0-9]/g, "");
+    return n.includes("sonar") || n.includes("deepresearch");
+  });
+  const storedDeepResearchIsAvailable =
+    storedDeepResearchModel &&
+    deepResearchModels.some(
+      (m) => m.modelId === storedDeepResearchModel.modelId,
+    );
+  const defaultDeepResearchModel =
+    deepResearchModels.find((m) => m.modelId === "perplexity/sonar") ??
+    deepResearchModels[0] ??
+    null;
+  const resolvedDeepResearchModel: AiProviderModel | null =
+    (storedDeepResearchIsAvailable ? storedDeepResearchModel : null) ??
+    defaultDeepResearchModel;
 
   // Task management (scoped by URL virtualMcpId — task list doesn't change on override)
   const taskManager = useTaskManager(virtualMcpId);
@@ -472,8 +506,14 @@ export function ChatContextProvider({
     setImageModel: (model: AiProviderModel | null) => {
       setStoredImageModel(model);
     },
+    deepResearchModel: resolvedDeepResearchModel,
+    setDeepResearchModel: (model: AiProviderModel | null) => {
+      setStoredDeepResearchModel(model);
+    },
     forceImageGeneration,
     setForceImageGeneration,
+    forceWebSearch,
+    setForceWebSearch,
     appContexts,
     setAppContext,
     clearAppContext,
@@ -524,8 +564,11 @@ export function ActiveTaskProvider({
   const {
     selectedModel,
     imageModel,
+    deepResearchModel,
     forceImageGeneration,
     setForceImageGeneration,
+    forceWebSearch,
+    setForceWebSearch,
     appContexts,
     setTiptapDoc,
     setModel,
@@ -675,9 +718,11 @@ export function ActiveTaskProvider({
       .filter(Boolean)
       .join("\n\n");
 
-    // Capture and reset one-shot forceImageGeneration before the async send
+    // Capture and reset one-shot force flags before the async send
     const shouldForceImage = forceImageGeneration && !!imageModel;
     if (forceImageGeneration) setForceImageGeneration(false);
+    const shouldForceWebSearch = forceWebSearch && !!deepResearchModel;
+    if (forceWebSearch) setForceWebSearch(false);
 
     const metadata: Metadata = {
       ...messageMetadata,
@@ -689,8 +734,12 @@ export function ActiveTaskProvider({
         ...(imageModel && {
           image: toMetadataModelInfo(imageModel),
         }),
+        ...(deepResearchModel && {
+          deepResearch: toMetadataModelInfo(deepResearchModel),
+        }),
       },
       ...(shouldForceImage && { forceImageGeneration: true }),
+      ...(shouldForceWebSearch && { forceWebSearch: true }),
     };
 
     const userMessage: ChatMessage = {

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -44,7 +44,6 @@ import { useContext as useContextHook } from "../../hooks/use-context";
 import {
   usePreferences,
   readToolApprovalLevel,
-  type ToolApprovalLevel,
 } from "../../hooks/use-preferences";
 import { useInvalidateCollectionsOnToolCall } from "../../hooks/use-invalidate-collections-on-tool-call";
 import { useTaskReadState } from "../../hooks/use-task-read-state";
@@ -57,7 +56,7 @@ import { useTaskManager, type TaskOwnerFilter } from "./task";
 import { useTaskMessages } from "./task/use-task-manager";
 import { derivePartsFromTiptapDoc } from "./derive-parts";
 import type { VirtualMCPInfo } from "./select-virtual-mcp";
-import type { ChatMessage, Metadata } from "./types";
+import type { ChatMessage, ChatMode, Metadata } from "./types";
 import type { Task } from "./task/types";
 import type {
   FinishPayload,
@@ -65,6 +64,7 @@ import type {
   SetAppContextParams,
 } from "./store/types";
 import { useLocalStorage } from "../../hooks/use-local-storage";
+import { chatModeForTransportRef } from "../../lib/chat-mode-sync";
 import { LOCALSTORAGE_KEYS } from "../../lib/localstorage-keys";
 
 // ============================================================================
@@ -129,12 +129,9 @@ export interface ChatPrefsContextValue {
   /** Selected deep research model (null = no deep research models available) */
   deepResearchModel: AiProviderModel | null;
   setDeepResearchModel: (model: AiProviderModel | null) => void;
-  /** When true, forces generate_image tool on the next request (one-shot) */
-  forceImageGeneration: boolean;
-  setForceImageGeneration: (force: boolean) => void;
-  /** When true, forces web_search tool on the next request (one-shot) */
-  forceWebSearch: boolean;
-  setForceWebSearch: (force: boolean) => void;
+  /** Chat mode for the next send — plan, web-search, gen-image, or default */
+  chatMode: ChatMode;
+  setChatMode: (mode: ChatMode) => void;
   appContexts: Record<string, string>;
   setAppContext: (sourceId: string, params: SetAppContextParams) => void;
   clearAppContext: (sourceId: string) => void;
@@ -175,7 +172,7 @@ interface TaskProviderInternals {
   user: { image?: string | null; name?: string } | null;
   contextPrompt: string;
   preferences: {
-    toolApprovalLevel?: ToolApprovalLevel;
+    toolApprovalLevel?: import("../../hooks/use-preferences").ToolApprovalLevel;
   };
   taskManager: {
     updateMessagesCache: (taskId: string, messages: ChatMessage[]) => void;
@@ -245,10 +242,8 @@ export function ChatContextProvider({
       null,
     );
 
-  // Force image generation — one-shot flag, resets after send
-  const [forceImageGeneration, setForceImageGeneration] = useState(false);
-  // Force web search — one-shot flag, resets after send
-  const [forceWebSearch, setForceWebSearch] = useState(false);
+  const [chatMode, setChatMode] = useState<ChatMode>("default");
+  chatModeForTransportRef.current = chatMode;
 
   // AI provider keys and models
   const keys = useAiProviderKeys();
@@ -406,6 +401,9 @@ export function ChatContextProvider({
             messages: allMessages,
             ...mergedMetadata,
             toolApprovalLevel: readToolApprovalLevel(),
+            // mode comes from mergedMetadata (set in sendMessageInternal before
+            // the mode state is reset). Reading from a ref here races with the
+            // React state flush that resets chatMode to "default".
           },
         };
       },
@@ -510,10 +508,8 @@ export function ChatContextProvider({
     setDeepResearchModel: (model: AiProviderModel | null) => {
       setStoredDeepResearchModel(model);
     },
-    forceImageGeneration,
-    setForceImageGeneration,
-    forceWebSearch,
-    setForceWebSearch,
+    chatMode,
+    setChatMode,
     appContexts,
     setAppContext,
     clearAppContext,
@@ -565,10 +561,8 @@ export function ActiveTaskProvider({
     selectedModel,
     imageModel,
     deepResearchModel,
-    forceImageGeneration,
-    setForceImageGeneration,
-    forceWebSearch,
-    setForceWebSearch,
+    chatMode,
+    setChatMode,
     appContexts,
     setTiptapDoc,
     setModel,
@@ -718,11 +712,18 @@ export function ActiveTaskProvider({
       .filter(Boolean)
       .join("\n\n");
 
-    // Capture and reset one-shot force flags before the async send
-    const shouldForceImage = forceImageGeneration && !!imageModel;
-    if (forceImageGeneration) setForceImageGeneration(false);
-    const shouldForceWebSearch = forceWebSearch && !!deepResearchModel;
-    if (forceWebSearch) setForceWebSearch(false);
+    let modeToSend: ChatMode = chatMode;
+    if (modeToSend === "gen-image" && !imageModel) {
+      modeToSend = "default";
+    }
+    if (modeToSend === "web-search" && !deepResearchModel) {
+      modeToSend = "default";
+    }
+    // One-shot modes (web-search, gen-image) reset after send.
+    // Plan mode is persistent — the user must explicitly disable it.
+    if (modeToSend !== "plan") {
+      setChatMode("default");
+    }
 
     const metadata: Metadata = {
       ...messageMetadata,
@@ -738,8 +739,7 @@ export function ActiveTaskProvider({
           deepResearch: toMetadataModelInfo(deepResearchModel),
         }),
       },
-      ...(shouldForceImage && { forceImageGeneration: true }),
-      ...(shouldForceWebSearch && { forceWebSearch: true }),
+      mode: modeToSend,
     };
 
     const userMessage: ChatMessage = {

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -20,6 +20,7 @@ import {
   Check,
   ChevronDown,
   Edit01,
+  Globe02,
   Image01,
   Lock01,
   Microphone01,
@@ -323,6 +324,9 @@ export function ChatInput({
     imageModel,
     forceImageGeneration,
     setForceImageGeneration,
+    deepResearchModel,
+    forceWebSearch,
+    setForceWebSearch,
   } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
@@ -406,6 +410,11 @@ export function ChatInput({
         e.preventDefault();
         if (e.shiftKey) {
           const isPlan = preferences.toolApprovalLevel === "plan";
+          if (!isPlan) {
+            // Mutual exclusion: disable forced modes when entering plan mode
+            if (forceImageGeneration) setForceImageGeneration(false);
+            if (forceWebSearch) setForceWebSearch(false);
+          }
           setPreferences({
             ...preferences,
             toolApprovalLevel: isPlan ? "auto" : "plan",
@@ -669,6 +678,30 @@ export function ChatInput({
                                     .slice(1)
                                     .join(": ")
                                 : imageModel.title}
+                            </span>
+                            <X
+                              size={14}
+                              className="shrink-0 hidden group-hover:block"
+                            />
+                          </button>
+                        )}
+                        {forceWebSearch && deepResearchModel && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              playSwitchSound();
+                              setForceWebSearch(false);
+                            }}
+                            className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200"
+                          >
+                            <Globe02 size={14} className="shrink-0" />
+                            <span className="max-w-[120px] truncate">
+                              {deepResearchModel.title.includes(": ")
+                                ? deepResearchModel.title
+                                    .split(": ")
+                                    .slice(1)
+                                    .join(": ")
+                                : deepResearchModel.title}
                             </span>
                             <X
                               size={14}

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -35,7 +35,6 @@ import type { FormEvent } from "react";
 import { useEffect, useRef, useState, type MouseEvent } from "react";
 import type { Metadata } from "./types.ts";
 import { useChatStream, useChatTask, useChatPrefs } from "./context";
-import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { ChatHighlight } from "./highlight";
 import { ModelSelector } from "./select-model";
 import {
@@ -322,11 +321,9 @@ export function ChatInput({
     isModelsLoading,
     tiptapDocRef,
     imageModel,
-    forceImageGeneration,
-    setForceImageGeneration,
     deepResearchModel,
-    forceWebSearch,
-    setForceWebSearch,
+    chatMode,
+    setChatMode,
   } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
@@ -399,8 +396,7 @@ export function ChatInput({
 
   const tiptapRef = useRef<TiptapInputHandle | null>(null);
 
-  const [preferences, setPreferences] = usePreferences();
-  const isPlanMode = preferences.toolApprovalLevel === "plan";
+  const isPlanMode = chatMode === "plan";
 
   // Focus chat input on Cmd+L, toggle plan mode on Cmd+Shift+L
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
@@ -409,23 +405,14 @@ export function ChatInput({
       if (isModKey(e) && e.code === "KeyL") {
         e.preventDefault();
         if (e.shiftKey) {
-          const isPlan = preferences.toolApprovalLevel === "plan";
-          if (!isPlan) {
-            // Mutual exclusion: disable forced modes when entering plan mode
-            if (forceImageGeneration) setForceImageGeneration(false);
-            if (forceWebSearch) setForceWebSearch(false);
-          }
-          setPreferences({
-            ...preferences,
-            toolApprovalLevel: isPlan ? "auto" : "plan",
-          });
+          setChatMode(chatMode === "plan" ? "default" : "plan");
         }
         tiptapRef.current?.focus();
       }
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [preferences, setPreferences]);
+  }, [chatMode, setChatMode]);
 
   const usage = calculateUsageStats(messages);
 
@@ -646,10 +633,7 @@ export function ChatInput({
                             type="button"
                             onClick={() => {
                               playSwitchSound();
-                              setPreferences({
-                                ...preferences,
-                                toolApprovalLevel: "auto",
-                              });
+                              setChatMode("default");
                             }}
                             className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                           >
@@ -661,12 +645,12 @@ export function ChatInput({
                             />
                           </button>
                         )}
-                        {forceImageGeneration && imageModel && (
+                        {chatMode === "gen-image" && imageModel && (
                           <button
                             type="button"
                             onClick={() => {
                               playSwitchSound();
-                              setForceImageGeneration(false);
+                              setChatMode("default");
                             }}
                             className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                           >
@@ -685,12 +669,12 @@ export function ChatInput({
                             />
                           </button>
                         )}
-                        {forceWebSearch && deepResearchModel && (
+                        {chatMode === "web-search" && deepResearchModel && (
                           <button
                             type="button"
                             onClick={() => {
                               playSwitchSound();
-                              setForceWebSearch(false);
+                              setChatMode("default");
                             }}
                             className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                           >

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -15,6 +15,7 @@ import { MessageTextPart } from "./parts/text-part.tsx";
 import {
   GenericToolCallPart,
   GenerateImagePart,
+  WebSearchPart,
   OpenInAgentPart,
   ProposePlanPart,
   SubtaskPart,
@@ -492,6 +493,14 @@ function MessagePart({
           latency={getMeta(part.toolCallId)?.latencySeconds}
         />
       );
+    case "tool-web_search":
+      return (
+        <WebSearchPart
+          part={part}
+          latency={getMeta(part.toolCallId)?.latencySeconds}
+          streamingText={dataParts.webSearchStreaming.get(part.toolCallId)}
+        />
+      );
     case "tool-subtask":
       return (
         <SubtaskPart
@@ -529,6 +538,7 @@ function MessagePart({
     case "data-tool-metadata":
     case "data-tool-subtask-metadata":
     case "data-generate-image":
+    case "data-web-search":
       return null;
     default: {
       const fallback = part as ToolUIPart;

--- a/apps/mesh/src/web/components/chat/message/pair.tsx
+++ b/apps/mesh/src/web/components/chat/message/pair.tsx
@@ -26,14 +26,18 @@ export interface MessagePair {
 export function useMessagePairs(messages: ChatMessage[]): MessagePair[] {
   const pairs: MessagePair[] = [];
 
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i];
+  // Filter out system messages (e.g. infrastructure restart notices) so they
+  // don't break user/assistant pairing.
+  const filtered = messages.filter((m) => m.role !== "system");
+
+  for (let i = 0; i < filtered.length; i++) {
+    const message = filtered[i];
 
     if (!message) continue;
 
     if (message.role === "user") {
       // Look ahead for the next message
-      const nextMessage = messages[i + 1];
+      const nextMessage = filtered[i + 1];
 
       if (nextMessage && nextMessage.role === "assistant") {
         // Pair with the following assistant message

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
@@ -83,6 +83,7 @@ export function ToolCallShell({
     <Collapsible
       open={effectiveOpen}
       onOpenChange={forceOpen ? undefined : setIsExpanded}
+      className="min-w-0"
     >
       <CollapsibleTrigger
         disabled={!isExpandable}

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -13,14 +13,11 @@ import { getEffectiveState } from "./utils.tsx";
 import { ImageLightbox } from "../../../image-lightbox.tsx";
 import type { UsageStats } from "@/web/lib/usage-utils.ts";
 import { formatDuration } from "@/web/lib/format-time.ts";
-
-const MESH_STORAGE_PREFIX = "mesh-storage:";
+import { parseMeshStorageKey } from "@/api/routes/decopilot/mesh-storage-uri";
 
 function resolveImageSrc(uri: string, orgId: string): string {
-  if (uri.startsWith(MESH_STORAGE_PREFIX)) {
-    const key = uri.slice(MESH_STORAGE_PREFIX.length);
-    return `/api/${orgId}/files/${key}`;
-  }
+  const key = parseMeshStorageKey(uri);
+  if (key !== null) return `/api/${orgId}/files/${key}`;
   // data: URIs or any other URL — use as-is
   return uri;
 }
@@ -62,9 +59,10 @@ function extractUsage(
 
 function ReferenceImageChip({ uri, orgId }: { uri: string; orgId: string }) {
   const src = resolveImageSrc(uri, orgId);
-  const label = uri.startsWith(MESH_STORAGE_PREFIX)
-    ? uri.slice(uri.lastIndexOf("/") + 1)
-    : "reference";
+  const label =
+    parseMeshStorageKey(uri) !== null
+      ? uri.slice(uri.lastIndexOf("/") + 1)
+      : "reference";
 
   return (
     <Tooltip>

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
@@ -1,5 +1,6 @@
 export { GenericToolCallPart } from "./generic.tsx";
 export { GenerateImagePart } from "./generate-image.tsx";
+export { WebSearchPart } from "./web-search.tsx";
 export { OpenInAgentPart } from "./open-in-agent.tsx";
 export { UserAskPart } from "./user-ask.tsx";
 export { SubtaskPart } from "./subtask.tsx";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
@@ -16,14 +16,11 @@ import {
   type UsageData,
   getCostFromUsage,
 } from "@decocms/mesh-sdk";
-
-const MESH_STORAGE_PREFIX = "mesh-storage:";
+import { parseMeshStorageKey } from "@/api/routes/decopilot/mesh-storage-uri";
 
 function resolveStorageUri(uri: string, orgId: string): string {
-  if (uri.startsWith(MESH_STORAGE_PREFIX)) {
-    const key = uri.slice(MESH_STORAGE_PREFIX.length);
-    return `/api/${orgId}/files/${key}`;
-  }
+  const key = parseMeshStorageKey(uri);
+  if (key !== null) return `/api/${orgId}/files/${key}`;
   return uri;
 }
 

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Globe02, LinkExternal01 } from "@untitledui/icons";
+import type { ToolUIPart } from "ai";
+import { useOrg } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys.ts";
+import { ToolCallShell } from "./common.tsx";
+import { getEffectiveState } from "./utils.tsx";
+import { MemoizedMarkdown } from "../../../markdown.tsx";
+import { formatDuration } from "@/web/lib/format-time.ts";
+import {
+  type UsageStats,
+  type UsageData,
+  getCostFromUsage,
+} from "@decocms/mesh-sdk";
+
+const MESH_STORAGE_PREFIX = "mesh-storage:";
+
+function resolveStorageUri(uri: string, orgId: string): string {
+  if (uri.startsWith(MESH_STORAGE_PREFIX)) {
+    const key = uri.slice(MESH_STORAGE_PREFIX.length);
+    return `/api/${orgId}/files/${key}`;
+  }
+  return uri;
+}
+
+interface Citation {
+  url: string;
+  title?: string;
+}
+
+interface WebSearchResult {
+  success?: boolean;
+  content?: string;
+  uri?: string;
+  query?: string;
+  model?: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    providerMetadata?: Record<string, unknown>;
+  };
+  citations?: Citation[];
+}
+
+function extractUsage(result: WebSearchResult | undefined): UsageStats | null {
+  if (!result?.usage) return null;
+  const inputTokens = result.usage.inputTokens ?? 0;
+  const outputTokens = result.usage.outputTokens ?? 0;
+  const totalTokens = inputTokens + outputTokens;
+  if (!totalTokens) return null;
+  const usageData: UsageData = {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    providerMetadata: result.usage.providerMetadata,
+  };
+  return {
+    inputTokens,
+    outputTokens,
+    reasoningTokens: 0,
+    totalTokens,
+    cost: getCostFromUsage(usageData),
+  };
+}
+
+interface WebSearchPartProps {
+  part: ToolUIPart;
+  /** Latency in seconds from data-tool-metadata part */
+  latency?: number;
+  /** Accumulated streaming text from data-web-search parts */
+  streamingText?: string;
+}
+
+/** Extract a short display hostname from a URL. */
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/** Get a favicon URL for a given site. */
+function getFaviconUrl(url: string): string {
+  try {
+    const origin = new URL(url).origin;
+    return `${origin}/favicon.ico`;
+  } catch {
+    return "";
+  }
+}
+
+function SourceChip({
+  citation,
+  index,
+}: {
+  citation: Citation;
+  index: number;
+}) {
+  const hostname = getHostname(citation.url);
+  const faviconUrl = getFaviconUrl(citation.url);
+  const label = citation.title || hostname;
+
+  return (
+    <a
+      href={citation.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group/src inline-flex items-center gap-1.5 rounded-md border border-border/50 bg-muted/30 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/60 hover:border-border hover:text-foreground"
+    >
+      <img
+        src={faviconUrl}
+        alt=""
+        className="size-3.5 rounded-sm shrink-0"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.display = "none";
+        }}
+      />
+      <span className="truncate max-w-[180px]">{label}</span>
+      <span className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0">
+        [{index + 1}]
+      </span>
+      <LinkExternal01
+        size={10}
+        className="shrink-0 opacity-0 group-hover/src:opacity-100 transition-opacity"
+      />
+    </a>
+  );
+}
+
+/** Replace `[N]` citation refs in text with markdown links to the source URL. */
+function linkifyCitations(text: string, citations: Citation[]): string {
+  return text.replace(/\[(\d+)\]/g, (match, numStr) => {
+    const index = parseInt(numStr, 10) - 1;
+    const citation = citations[index];
+    if (!citation) return match;
+    return `[\\[${numStr}\\]](${citation.url})`;
+  });
+}
+
+const MAX_VISIBLE_SOURCES = 5;
+
+function SourcesList({ citations }: { citations: Citation[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasOverflow = citations.length > MAX_VISIBLE_SOURCES;
+  const visible = expanded
+    ? citations
+    : citations.slice(0, MAX_VISIBLE_SOURCES);
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {visible.map((c, i) => (
+        <SourceChip key={c.url} citation={c} index={i} />
+      ))}
+      {hasOverflow && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="inline-flex items-center rounded-md border border-border/50 bg-muted/30 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/60 hover:border-border hover:text-foreground"
+        >
+          {expanded
+            ? "show less"
+            : `+${citations.length - MAX_VISIBLE_SOURCES} more`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function WebSearchPart({
+  part,
+  latency,
+  streamingText,
+}: WebSearchPartProps) {
+  const org = useOrg();
+  const state = getEffectiveState(part.state);
+  const input = part.input as { query?: string } | undefined;
+  const result = part.output as WebSearchResult | undefined;
+
+  // Resolve blob-stored content for large results
+  const blobUrl = result?.uri
+    ? resolveStorageUri(result.uri, org.id)
+    : undefined;
+
+  const { data: blobContent } = useQuery({
+    queryKey: KEYS.webSearchBlob(blobUrl ?? ""),
+    queryFn: async () => {
+      const res = await fetch(blobUrl!);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+      return res.text();
+    },
+    enabled: !!blobUrl,
+    staleTime: Infinity,
+  });
+
+  const isLoading = state === "loading";
+  const isDone = state !== "loading" && state !== "error";
+  const citations = result?.citations;
+  const usage = extractUsage(result);
+
+  // Display priority: inline content > fetched blob > streaming text
+  const rawContent = result?.content ?? blobContent ?? streamingText;
+  const displayContent =
+    rawContent && citations?.length
+      ? linkifyCitations(rawContent, citations)
+      : rawContent;
+
+  const latencyLabel =
+    latency != null && latency > 0 ? (
+      <span className="text-[11px] font-mono tabular-nums text-muted-foreground/60">
+        {formatDuration(latency)}
+      </span>
+    ) : null;
+
+  if (state === "error") {
+    return (
+      <ToolCallShell
+        icon={<Globe02 size={14} />}
+        title="Web search"
+        summary="Failed"
+        state="error"
+        usage={usage}
+        trailing={latencyLabel}
+      />
+    );
+  }
+
+  return (
+    <ToolCallShell
+      icon={
+        <Globe02
+          size={14}
+          className={cn(isLoading ? "animate-pulse" : "text-blue-500")}
+        />
+      }
+      title={isLoading ? "Researching..." : "Web search"}
+      summary={
+        isDone
+          ? (result?.model ?? input?.query?.slice(0, 60))
+          : input?.query
+            ? `"${input.query.slice(0, 80)}"`
+            : undefined
+      }
+      state={isLoading ? "loading" : "idle"}
+      usage={usage}
+      trailing={latencyLabel}
+      defaultOpen
+    >
+      <div className="pl-6 pb-3 flex flex-col gap-1 min-w-0">
+        {input?.query && (
+          <p className="text-xs text-muted-foreground/70 whitespace-pre-wrap wrap-break-word">
+            {input.query}
+          </p>
+        )}
+
+        {/* Research content */}
+        {displayContent ? (
+          <div className="max-h-96 overflow-y-auto overflow-x-hidden rounded-lg border border-border/40 bg-muted/20 px-4 py-3 min-w-0">
+            <div className="prose prose-sm prose-neutral dark:prose-invert max-w-none text-[13px] leading-relaxed break-words">
+              <MemoizedMarkdown id={part.toolCallId} text={displayContent} />
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border/40 bg-muted/20 px-4 py-3">
+            <div className="space-y-2 animate-pulse">
+              <div className="h-3 rounded bg-muted-foreground/10 w-3/4" />
+              <div className="h-3 rounded bg-muted-foreground/10 w-1/2" />
+            </div>
+          </div>
+        )}
+
+        {/* Sources — rendered after content so they don't shift text when they appear */}
+        {citations && citations.length > 0 && (
+          <SourcesList citations={citations} />
+        )}
+      </div>
+    </ToolCallShell>
+  );
+}

--- a/apps/mesh/src/web/components/chat/message/use-filter-parts.ts
+++ b/apps/mesh/src/web/components/chat/message/use-filter-parts.ts
@@ -25,6 +25,8 @@ export interface ToolSubtaskMetadata {
 export interface DataParts {
   toolMetadata: Map<string, ToolMetadata>;
   toolSubtaskMetadata: Map<string, ToolSubtaskMetadata>;
+  /** Accumulated streaming text from data-web-search parts, keyed by toolCallId */
+  webSearchStreaming: Map<string, string>;
 }
 
 export interface ReasoningGroup {
@@ -47,6 +49,7 @@ export function useFilterParts(message: ChatMessage | null) {
   const reasoningIndices = new Set<number>();
   const toolMetadata = new Map<string, ToolMetadata>();
   const toolSubtaskMetadata = new Map<string, ToolSubtaskMetadata>();
+  const webSearchStreaming = new Map<string, string>();
 
   if (message) {
     let currentGroup: ReasoningGroup | null = null;
@@ -101,6 +104,14 @@ export function useFilterParts(message: ChatMessage | null) {
           (p as { id: string }).id,
           (p as { data: ToolSubtaskMetadata }).data,
         );
+        continue;
+      }
+
+      if (p.type === "data-web-search" && "id" in p && "data" in p) {
+        const id = (p as { id: string }).id;
+        const data = (p as { data: { text?: string } }).data;
+        webSearchStreaming.set(id, data.text ?? "");
+        continue;
       }
     }
   }
@@ -157,6 +168,6 @@ export function useFilterParts(message: ChatMessage | null) {
   return {
     reasoningGroups,
     renderOrder,
-    dataParts: { toolMetadata, toolSubtaskMetadata },
+    dataParts: { toolMetadata, toolSubtaskMetadata, webSearchStreaming },
   };
 }

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -42,7 +42,6 @@ import {
 } from "./dialog-prompt-arguments.tsx";
 import { insertMention } from "./tiptap/mention";
 import { KEYS } from "@/web/lib/query-keys";
-import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { useSound } from "@/web/hooks/use-sound.ts";
 import { switch005Sound } from "@deco/ui/lib/switch-005.ts";
 import { useChatPrefs } from "./context";
@@ -87,8 +86,6 @@ export function ToolsPopover({
   isAgentContext = false,
 }: ToolsPopoverProps) {
   const [open, setOpen] = useState(false);
-  const [preferences, setPreferences] = usePreferences();
-  const isPlanMode = preferences.toolApprovalLevel === "plan";
   const playSwitchSound = useSound(switch005Sound);
   const { org } = useProjectContext();
   const { editor } = useCurrentEditor();
@@ -115,11 +112,10 @@ export function ToolsPopover({
     setImageModel,
     deepResearchModel,
     setDeepResearchModel,
-    forceImageGeneration,
-    setForceImageGeneration,
-    forceWebSearch,
-    setForceWebSearch,
+    chatMode,
+    setChatMode,
   } = useChatPrefs();
+  const isPlanMode = chatMode === "plan";
 
   // Fetch models for submenus (only when a submenu is hovered/open)
   const [imageSubOpen, setImageSubOpen] = useState(false);
@@ -137,16 +133,7 @@ export function ToolsPopover({
 
   const handleTogglePlanMode = () => {
     playSwitchSound();
-    const turningOn = !isPlanMode;
-    if (turningOn) {
-      // Mutual exclusion: disable the other forced modes
-      if (forceImageGeneration) setForceImageGeneration(false);
-      if (forceWebSearch) setForceWebSearch(false);
-    }
-    setPreferences({
-      ...preferences,
-      toolApprovalLevel: isPlanMode ? "auto" : "plan",
-    });
+    setChatMode(isPlanMode ? "default" : "plan");
     setOpen(false);
   };
 
@@ -209,34 +196,18 @@ export function ToolsPopover({
 
   const handleForceImageGeneration = () => {
     playSwitchSound();
-    const turningOn = !forceImageGeneration;
-    if (turningOn) {
-      // Mutual exclusion: disable the other forced modes
-      if (forceWebSearch) setForceWebSearch(false);
-      if (isPlanMode) {
-        setPreferences({ ...preferences, toolApprovalLevel: "auto" });
-      }
-    }
-    setForceImageGeneration(turningOn);
+    setChatMode(chatMode === "gen-image" ? "default" : "gen-image");
     setOpen(false);
   };
 
   const handleForceWebSearch = () => {
     playSwitchSound();
-    const turningOn = !forceWebSearch;
-    if (turningOn) {
-      // Mutual exclusion: disable the other forced modes
-      if (forceImageGeneration) setForceImageGeneration(false);
-      if (isPlanMode) {
-        setPreferences({ ...preferences, toolApprovalLevel: "auto" });
-      }
-    }
-    setForceWebSearch(turningOn);
+    setChatMode(chatMode === "web-search" ? "default" : "web-search");
     setOpen(false);
   };
 
-  const isImageActive = forceImageGeneration;
-  const isWebSearchActive = forceWebSearch;
+  const isImageActive = chatMode === "gen-image";
+  const isWebSearchActive = chatMode === "web-search";
 
   return (
     <>

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -28,6 +28,7 @@ import {
   BookOpen01,
   Check,
   ChevronDown,
+  Globe02,
   Image01,
   Link01,
   Loading01,
@@ -107,26 +108,41 @@ export function ToolsPopover({
 
   const [activePrompt, setActivePrompt] = useState<Prompt | null>(null);
 
-  // Image model state from chat prefs
+  // Image & deep research model state from chat prefs
   const {
     credentialId,
     imageModel,
     setImageModel,
+    deepResearchModel,
+    setDeepResearchModel,
     forceImageGeneration,
     setForceImageGeneration,
+    forceWebSearch,
+    setForceWebSearch,
   } = useChatPrefs();
 
-  // Fetch models for the image submenu (only when submenu is hovered/open)
+  // Fetch models for submenus (only when a submenu is hovered/open)
   const [imageSubOpen, setImageSubOpen] = useState(false);
+  const [searchSubOpen, setSearchSubOpen] = useState(false);
   const { models: allModels, isLoading: isModelsLoading } = useAiProviderModels(
-    imageSubOpen ? (credentialId ?? undefined) : undefined,
+    imageSubOpen || searchSubOpen ? (credentialId ?? undefined) : undefined,
   );
   const imageModels = allModels.filter((m) =>
     m.capabilities?.includes("image"),
   );
+  const deepResearchModels = allModels.filter((m) => {
+    const n = m.modelId.toLowerCase().replace(/[^a-z0-9]/g, "");
+    return n.includes("sonar") || n.includes("deepresearch");
+  });
 
   const handleTogglePlanMode = () => {
     playSwitchSound();
+    const turningOn = !isPlanMode;
+    if (turningOn) {
+      // Mutual exclusion: disable the other forced modes
+      if (forceImageGeneration) setForceImageGeneration(false);
+      if (forceWebSearch) setForceWebSearch(false);
+    }
     setPreferences({
       ...preferences,
       toolApprovalLevel: isPlanMode ? "auto" : "plan",
@@ -185,13 +201,42 @@ export function ToolsPopover({
     setOpen(false);
   };
 
+  const handleSearchModelSelect = (model: AiProviderModel) => {
+    playSwitchSound();
+    setDeepResearchModel(model);
+    setOpen(false);
+  };
+
   const handleForceImageGeneration = () => {
     playSwitchSound();
-    setForceImageGeneration(!forceImageGeneration);
+    const turningOn = !forceImageGeneration;
+    if (turningOn) {
+      // Mutual exclusion: disable the other forced modes
+      if (forceWebSearch) setForceWebSearch(false);
+      if (isPlanMode) {
+        setPreferences({ ...preferences, toolApprovalLevel: "auto" });
+      }
+    }
+    setForceImageGeneration(turningOn);
+    setOpen(false);
+  };
+
+  const handleForceWebSearch = () => {
+    playSwitchSound();
+    const turningOn = !forceWebSearch;
+    if (turningOn) {
+      // Mutual exclusion: disable the other forced modes
+      if (forceImageGeneration) setForceImageGeneration(false);
+      if (isPlanMode) {
+        setPreferences({ ...preferences, toolApprovalLevel: "auto" });
+      }
+    }
+    setForceWebSearch(turningOn);
     setOpen(false);
   };
 
   const isImageActive = forceImageGeneration;
+  const isWebSearchActive = forceWebSearch;
 
   return (
     <>
@@ -293,6 +338,80 @@ export function ToolsPopover({
               )}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+
+          {/* Web search: split row — left toggles force mode, right opens model picker */}
+          {deepResearchModel && (
+            <DropdownMenuSub
+              open={searchSubOpen}
+              onOpenChange={setSearchSubOpen}
+            >
+              <div className="flex items-center rounded-lg">
+                <DropdownMenuItem
+                  onClick={handleForceWebSearch}
+                  className={cn(
+                    "flex-1 rounded-r-none pr-1",
+                    isWebSearchActive && "text-blue-600 dark:text-blue-400",
+                  )}
+                >
+                  <Globe02
+                    size={16}
+                    className={cn(isWebSearchActive && "text-blue-500")}
+                  />
+                  <span className="flex-1">Web search</span>
+                  {isWebSearchActive && (
+                    <span className="text-xs text-blue-500 font-medium">
+                      On
+                    </span>
+                  )}
+                </DropdownMenuItem>
+                <DropdownMenuPrimitive.SubTrigger
+                  className={cn(
+                    "flex items-center justify-center rounded-r-lg rounded-l-none px-1.5 py-1.5 text-muted-foreground outline-hidden select-none",
+                    "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+                    "data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+                  )}
+                >
+                  <ChevronDown size={14} />
+                </DropdownMenuPrimitive.SubTrigger>
+              </div>
+              <DropdownMenuSubContent className="w-80 max-h-72 overflow-y-auto p-1.5">
+                {isModelsLoading ? (
+                  <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+                    <Loading01 size={14} className="animate-spin" />
+                    Loading models…
+                  </div>
+                ) : (
+                  deepResearchModels.map((model) => {
+                    const isSelected =
+                      deepResearchModel?.modelId === model.modelId;
+                    const logo = getProviderLogo(model);
+                    const displayName = model.title.includes(": ")
+                      ? model.title.split(": ").slice(1).join(": ")
+                      : model.title;
+                    return (
+                      <DropdownMenuItem
+                        key={model.modelId}
+                        onClick={() => handleSearchModelSelect(model)}
+                        className="flex items-center gap-2"
+                      >
+                        <img
+                          src={logo}
+                          alt=""
+                          className="size-4 shrink-0 rounded-sm dark:bg-white dark:p-px"
+                        />
+                        <span className="flex-1 text-sm truncate">
+                          {displayName}
+                        </span>
+                        {isSelected && (
+                          <Check size={14} className="text-blue-500 shrink-0" />
+                        )}
+                      </DropdownMenuItem>
+                    );
+                  })
+                )}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
 
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="gap-2">

--- a/apps/mesh/src/web/components/chat/types.ts
+++ b/apps/mesh/src/web/components/chat/types.ts
@@ -72,6 +72,7 @@ export interface Metadata {
     coding?: MetadataModelInfo;
     fast?: MetadataModelInfo;
     image?: MetadataModelInfo;
+    deepResearch?: MetadataModelInfo;
   };
   agent?: ChatAgentConfig;
   user?: ChatUserConfig;
@@ -88,6 +89,8 @@ export interface Metadata {
   toolApprovalLevel?: ToolApprovalLevel;
   /** When true, forces the generate_image tool for the next request */
   forceImageGeneration?: boolean;
+  /** When true, forces the web_search tool for the next request */
+  forceWebSearch?: boolean;
   usage?: {
     inputTokens?: number;
     outputTokens?: number;

--- a/apps/mesh/src/web/components/chat/types.ts
+++ b/apps/mesh/src/web/components/chat/types.ts
@@ -2,7 +2,10 @@ import type { ChatMessage } from "@/api/routes/decopilot/types";
 export type { ChatMessage };
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { JSONContent } from "@tiptap/core";
+import type { ChatMode } from "@/api/routes/decopilot/mode-config";
 import type { ToolApprovalLevel } from "@/web/hooks/use-preferences";
+
+export type { ChatMode };
 
 // ============================================================================
 // Chat Config Types
@@ -85,11 +88,13 @@ export interface Metadata {
   tiptapDoc?: TiptapDoc;
   /** Agent mentions in this message — used to render delegation cards */
   agentMentions?: Array<{ agentId: string; title: string; taskId?: string }>;
-  /** Tool approval level at send time — used for visual treatment (e.g., purple border for plan mode) */
+  /** Tool approval level at send time */
   toolApprovalLevel?: ToolApprovalLevel;
-  /** When true, forces the generate_image tool for the next request */
+  /** Decopilot chat mode — plan, forced tools, or default (matches stream schema `mode`) */
+  mode?: ChatMode;
+  /** @deprecated Old one-shot flags — prefer `mode` */
   forceImageGeneration?: boolean;
-  /** When true, forces the web_search tool for the next request */
+  /** @deprecated Old one-shot flags — prefer `mode` */
   forceWebSearch?: boolean;
   usage?: {
     inputTokens?: number;

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -28,7 +28,7 @@ export function MessageUsageStats({ usage }: UsageStatsProps) {
         <span className="inline-flex items-center text-muted-foreground [@media(hover:hover)]:hover:text-foreground pl-1 h-6 gap-1 whitespace-nowrap shrink-0 cursor-default">
           <Activity size={12} />
           <span className="text-sm font-mono tabular-nums">
-            {totalTokens.toLocaleString()}
+            {cost > 0 ? `$${cost.toFixed(4)}` : totalTokens.toLocaleString()}
           </span>
         </span>
       </TooltipTrigger>

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "./use-local-storage.ts";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys.ts";
 
-export type ToolApprovalLevel = "auto" | "readonly" | "plan";
+export type ToolApprovalLevel = "auto" | "readonly";
 export type ThemeMode = "light" | "dark" | "system";
 interface Preferences {
   toolApprovalLevel: ToolApprovalLevel;
@@ -17,11 +17,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
 };
 
-const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = [
-  "auto",
-  "readonly",
-  "plan",
-];
+const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];
 
 const VALID_THEME_MODES: ThemeMode[] = ["light", "dark", "system"];
 

--- a/apps/mesh/src/web/lib/chat-mode-sync.ts
+++ b/apps/mesh/src/web/lib/chat-mode-sync.ts
@@ -1,0 +1,8 @@
+import type { ChatMode } from "@/api/routes/decopilot/mode-config";
+
+/**
+ * Ref updated every render so the transport can read the current chat mode
+ * without React state access. Not used for sends — the mode is passed through
+ * message metadata instead (see sendMessageInternal in chat-context.tsx).
+ */
+export const chatModeForTransportRef = { current: "default" as ChatMode };

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -18,6 +18,8 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:selectedKeyId:${locator}`,
   chatSelectedImageModel: (locator: ProjectLocator) =>
     `mesh:chat:selectedImageModel:${locator}`,
+  chatSelectedDeepResearchModel: (locator: ProjectLocator) =>
+    `mesh:chat:selectedDeepResearchModel:${locator}`,
   assistantChatActiveTask: (locator: ProjectLocator) =>
     `mesh:assistant-chat:active-task:${locator}`,
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -319,4 +319,7 @@ export const KEYS = {
 
   // Deco sites (scoped by user email)
   decoSites: (email: string | undefined) => ["deco-sites", email] as const,
+
+  // Web search blob content (fetched from object storage)
+  webSearchBlob: (url: string) => ["web-search-blob", url] as const,
 } as const;

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -297,6 +297,7 @@ export function SettingsTab({
     setModel,
     credentialId: chatCredentialId,
     selectedModel: chatModel,
+    setChatMode,
   } = useChatPrefs();
   const [preferences, setPreferences] = usePreferences();
   const initialTiptapDoc =
@@ -321,7 +322,7 @@ export function SettingsTab({
       .join("\n");
     if (!instructionsText.trim()) return;
 
-    setPreferences({ ...preferences, toolApprovalLevel: "plan" });
+    setChatMode("plan");
 
     createTaskWithMessage({
       virtualMcpId: getDecopilotId(org.id),

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -276,7 +276,6 @@ function PreferencesSection() {
                   {{
                     readonly: "Ask before edit",
                     auto: "Auto approve",
-                    plan: "Plan mode",
                   }[preferences.toolApprovalLevel] ?? "Ask before edit"}
                 </span>
               </SelectTrigger>

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1,13 +1,12 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import type { VirtualMCPEntity } from "@/tools/virtual/schema";
 import { getUIResourceUri } from "@/mcp-apps/types.ts";
-import { useChatTask } from "@/web/components/chat/context";
+import { useChatPrefs, useChatTask } from "@/web/components/chat/context";
 import { CollectionTabs } from "@/web/components/collections/collection-tabs.tsx";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
-import { usePreferences } from "@/web/hooks/use-preferences";
 import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
 import {
   authenticateMcp,
@@ -1062,15 +1061,15 @@ function VirtualMcpDetailViewWithData({
   });
 
   // Chat hooks
-  const [preferences, setPreferences] = usePreferences();
   const { createTaskWithMessage } = useChatTask();
+  const { setChatMode } = useChatPrefs();
   const { createNewTask } = usePanelActions();
 
   const handleImprovePrompt = () => {
     const currentInstructions = form.getValues("metadata.instructions");
     if (!currentInstructions?.trim()) return;
 
-    setPreferences({ ...preferences, toolApprovalLevel: "plan" });
+    setChatMode("plan");
 
     createTaskWithMessage({
       virtualMcpId: getDecopilotId(org.id),

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -161,7 +161,10 @@ export const AgentOf = () =>
     thinking: AgentModelInfoSchema.optional(),
     coding: AgentModelInfoSchema.optional(),
     fast: AgentModelInfoSchema.optional(),
-    toolApprovalLevel: z.enum(["auto", "readonly", "plan"]).default("auto"),
+    toolApprovalLevel: z.enum(["auto", "readonly"]).default("auto"),
+    mode: z
+      .enum(["default", "plan", "web-search", "gen-image"])
+      .default("default"),
     temperature: z.number().default(0.5),
   });
 

--- a/packages/runtime/src/decopilot.ts
+++ b/packages/runtime/src/decopilot.ts
@@ -31,7 +31,9 @@ export interface AgentBindingConfig {
   thinking?: AgentModelInfo;
   coding?: AgentModelInfo;
   fast?: AgentModelInfo;
-  toolApprovalLevel?: "auto" | "readonly" | "plan";
+  toolApprovalLevel?: "auto" | "readonly";
+  /** Decopilot stream mode — default, plan, web-search, gen-image */
+  mode?: "default" | "plan" | "web-search" | "gen-image";
   temperature?: number;
 }
 
@@ -45,7 +47,9 @@ export interface AgentStreamParams {
   thinking?: AgentModelInfo;
   coding?: AgentModelInfo;
   fast?: AgentModelInfo;
-  toolApprovalLevel?: "auto" | "readonly" | "plan";
+  toolApprovalLevel?: "auto" | "readonly";
+  /** Decopilot stream mode — default, plan, web-search, gen-image */
+  mode?: "default" | "plan" | "web-search" | "gen-image";
   temperature?: number;
   memory?: { windowSize: number; thread_id: string };
   thread_id?: string;
@@ -126,6 +130,7 @@ export async function streamAgent(
     agent: { id: agentId },
     temperature: params.temperature ?? config.temperature,
     toolApprovalLevel: params.toolApprovalLevel ?? config.toolApprovalLevel,
+    mode: params.mode ?? config.mode ?? "default",
     ...(params.memory ? { memory: params.memory } : {}),
     ...(params.thread_id ? { thread_id: params.thread_id } : {}),
   };
@@ -188,6 +193,7 @@ export function createDecopilotClient(options: DecopilotClientOptions) {
         coding: request.coding,
         fast: request.fast,
         toolApprovalLevel: request.toolApprovalLevel,
+        mode: request.mode,
         temperature: request.temperature,
       };
       return streamAgent(streamUrl, token, config, request, opts);


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce Decopilot chat modes (`default`, `plan`, `web-search`, `gen-image`) and a streaming `web_search` tool. Standardizes object storage links to `mesh-storage://`, streams live research with citations, latency, and cost, and fixes chat message pairing by ignoring system messages.

- **New Features**
  - Added `mode` to all streams and runtime APIs. Plan mode hard‑blocks non‑read‑only tools and injects a planning prompt.
  - First-step tool forcing for modes: `web-search` → `web_search`, `gen-image` → `generate_image`.
  - New server tool `web_search` (deep research via provider). Streams text to the UI, includes citations, and offloads large results to object storage as `mesh-storage://` URIs.
  - UI: mode toggles in the composer, per‑mode model pickers (image, deep research), and a Web Search part with live updates, sources, latency, and $ cost.
  - Models config supports `deepResearch`; tool approval and coding agents (`claude-code`, `codex`) respect plan-mode read‑only behavior.

- **Migration**
  - Replace `forceImageGeneration` with `mode`; default is `default`.
  - `toolApprovalLevel` now accepts `auto` or `readonly` only. Legacy `"plan"` auto‑maps to `mode: "plan"` + `toolApprovalLevel: "readonly"`.
  - Provide a deep‑research model in `models.deepResearch` to enable `web_search`.
  - Adopt the `mesh-storage://` scheme. Update any old `mesh-storage:` references; `read_resource` and image tools now resolve `mesh-storage://` URIs. Configure object storage for large research outputs.
  - Update runtime bindings and any client calls to include `mode`.

<sup>Written for commit ac70b35b919bd612a28e9a2062aeac51065591a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

