### PR TITLE
fix(oauth): allow localhost redirect_uri in oauth-proxy validation

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -675,8 +675,16 @@ export async function createApp(options: CreateAppOptions = {}) {
       if (redirectUri) {
         const allowedOrigin = getSettings().baseUrl ?? reqUrl.origin;
         try {
-          const redirectOrigin = new URL(redirectUri).origin;
-          if (redirectOrigin !== new URL(allowedOrigin).origin) {
+          const redirectUrl = new URL(redirectUri);
+          const allowedOriginObj = new URL(allowedOrigin);
+
+          // Check if redirect_uri origin matches the allowed origin
+          const isAllowed =
+            redirectUrl.origin === allowedOriginObj.origin ||
+            // Allow localhost for development
+            redirectUrl.hostname === "localhost";
+
+          if (!isAllowed) {
             return c.json(
               {
                 error: "invalid_request",


### PR DESCRIPTION
## What is this contribution about?

The redirect_uri validation added in #3110 rejected localhost origins, breaking GitHub OAuth in development. This fix allows `localhost` as a valid redirect_uri hostname (using exact hostname match to prevent bypasses like `localhost.evil.com`) while keeping the security validation for production origins.

Found via `git bisect` — commit 22b5ef7df introduced the regression.

## How to Test

1. Run `bun run dev`
2. Try connecting a GitHub app via OAuth
3. The redirect_uri should be accepted and OAuth flow should complete successfully

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth redirect_uri validation to accept localhost in development, restoring the GitHub OAuth flow. Keeps strict origin matching for production.

- **Bug Fixes**
  - Allow `localhost` as a redirect_uri via exact hostname match in the oauth-proxy.
  - Maintain strict origin equality for non-localhost redirects to keep production secure.

<sup>Written for commit f6fcb2c56d09d7e8bb282641e42fe394ad8eb94d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

