### PR TITLE
fix(ui): remove unwanted shadows and fix select height

### DIFF
--- a/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
@@ -128,7 +128,7 @@ export function ConnectionFields({
               <div className="flex items-stretch rounded-lg border border-border overflow-hidden">
                 <Select value={field.value} onValueChange={field.onChange}>
                   <FormControl>
-                    <SelectTrigger className="h-10 w-auto min-w-[90px] border-0 rounded-none bg-muted/50 focus:ring-0 focus:ring-offset-0">
+                    <SelectTrigger className="h-full! w-auto min-w-[90px] border-0 rounded-none bg-muted/50 focus:ring-0 focus:ring-offset-0">
                       <Globe02 className="w-4 h-4 text-muted-foreground shrink-0" />
                       <SelectValue />
                     </SelectTrigger>

--- a/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
@@ -298,7 +298,7 @@ export function OverviewTabContent({
   const [latencyMetric, setLatencyMetric] = useState<"avg" | "p95">("avg");
 
   return (
-    <div className="flex flex-col gap-4 px-4 md:px-10 pt-0 pb-6 max-w-[1200px] mx-auto w-full overflow-auto">
+    <div className="flex flex-col gap-4 px-4 md:px-10 pt-2 pb-6 max-w-[1200px] mx-auto w-full overflow-auto">
       {/* Row 1: Tool Calls — full width */}
       <MonitoringMetricCard
         title="Tool Calls"

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -478,6 +478,7 @@ export function SettingsTab({
               {...form.register("name")}
               placeholder="Automation name"
               className="border border-transparent shadow-none px-0 text-lg font-medium h-auto focus-visible:ring-0 focus-visible:border-border bg-transparent flex-1"
+              style={{ boxShadow: "none" }}
             />
             {onDelete && (
               <Button

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1489,6 +1489,7 @@ Define step-by-step how the agent should handle requests.
                     onBlur={field.onBlur}
                     placeholder="Define how this agent should behave, what tone to use, any constraints or guidelines..."
                     className="min-h-[300px] flex-1 resize-none text-[15px] placeholder:text-muted-foreground/40 leading-relaxed border-0 rounded-none shadow-none px-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-0 bg-transparent"
+                    style={{ boxShadow: "none" }}
                   />
                 )}
               />


### PR DESCRIPTION
## What is this contribution about?

Fixes several small UI issues introduced after `card-shadow` was added to the shared `Textarea` and `Input` components. Views that intentionally rendered these components without a shadow were now showing an unwanted box shadow. Also fixes the `SelectTrigger` in the connection sidebar not stretching to the correct height inside its flex container, and adds a small top padding to the monitoring overview page.

## Screenshots/Demonstration

> Changes affect the agent instructions textarea, automation name input, connection settings protocol select, and monitoring overview spacing.

## How to Test

1. Open an agent's Instructions tab — textarea should have no box shadow
2. Open an automation detail — name input should have no box shadow
3. Open a connection's settings drawer — HTTP/SSE/Websocket select should match the height of the URL input next to it
4. Open the Monitoring > Overview page — content should have slight top padding

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unwanted input shadows introduced by the shared `card-shadow`, restores intended styles, and fixes select height to improve visual consistency. Also adds a small top padding to Monitoring Overview.

- **Bug Fixes**
  - Remove shadow on agent instructions `Textarea` and automation name `Input` via inline `box-shadow: none`.
  - Make connection sidebar protocol `SelectTrigger` match container height with `h-full!`.
  - Add `pt-2` to Monitoring > Overview container for proper top spacing.

<sup>Written for commit 413e3babc07bd2ed2b2a26db66b4c59b49c69390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

