### PR TITLE
feat(runtime): allow tools to return raw MCP content directly

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -957,6 +957,25 @@ export const createMCPServer = <
             ctx,
           );
 
+          if (
+            result != null &&
+            typeof result === "object" &&
+            "content" in result &&
+            Array.isArray(result.content) &&
+            result.content.every(
+              (item: unknown) =>
+                item != null &&
+                typeof item === "object" &&
+                "type" in item &&
+                typeof (item as Record<string, unknown>).type === "string",
+            )
+          ) {
+            return result as {
+              structuredContent?: Record<string, unknown>;
+              content: Array<{ type: string; [key: string]: unknown }>;
+            };
+          }
+
           return {
             structuredContent: result as Record<string, unknown>,
             content: [

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -8,6 +8,7 @@ import {
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport as HttpServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import type {
+  CallToolResult,
   GetPromptResult,
   Implementation,
   ToolAnnotations,
@@ -970,10 +971,7 @@ export const createMCPServer = <
                 typeof (item as Record<string, unknown>).type === "string",
             )
           ) {
-            return result as {
-              structuredContent?: Record<string, unknown>;
-              content: Array<{ type: string; [key: string]: unknown }>;
-            };
+            return result as CallToolResult;
           }
 
           return {


### PR DESCRIPTION
## What is this contribution about?
Tools created with `createTool` previously had their return values automatically wrapped into `{ structuredContent, content: [{ type: "text", text: JSON.stringify(result) }] }`. This change allows tools to return raw MCP content directly (e.g., `{ content: [{ type: "image", ... }] }`) by detecting when the result already has a valid MCP `content` array. This enables returning images, embedded resources, and other MCP content types without the forced JSON text wrapping.

## How to Test
1. Create a tool that returns `{ content: [{ type: "text", text: "hello" }] }` directly
2. Verify it passes through as-is without double-wrapping
3. Create a tool that returns a plain object like `{ foo: "bar" }` 
4. Verify it still gets auto-wrapped as before

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow tools created with `createTool` to return raw MCP `content` directly, bypassing JSON wrapping when a valid array is provided. Also bumps `@decocms/runtime` to `1.5.0`.

- **New Features**
  - Passes through results with a valid `content` array unchanged (including images and embedded resources).
  - Keeps auto-wrapping for plain objects into `{ structuredContent, content: [{ type: "text", text: JSON.stringify(result) }] }`.

- **Bug Fixes**
  - Uses `CallToolResult` for passthrough to ensure correct typing.

<sup>Written for commit ae8bae99a5dec912c2b1f87fe6615514e8c587fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

