### PR TITLE
feat(ai-providers): swap OpenRouter Claude opus 4.6 for 4.7

### DIFF
--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -93,8 +93,7 @@ const TIER_PATTERNS: Array<{ tier: TierId; prefixes: string[] }> = [
     tier: "smarter",
     prefixes: [
       "claude-code:opus",
-      "anthropic/claude-4.6-opus",
-      "anthropic/claude-opus-4.6",
+      "anthropic/claude-opus-4.7",
       "anthropic/claude-sonnet-4.6",
       "anthropic/claude-4.6-sonnet",
       "openai/gpt-5.3-codex",
@@ -206,8 +205,7 @@ const SHORTLIST_KEY_PREFIX = "mesh:model-shortlist:";
 
 const DEFAULT_SHORTLIST = new Set([
   // Smarter
-  "anthropic/claude-4.6-opus-20260205",
-  "anthropic/claude-opus-4.6",
+  "anthropic/claude-opus-4.7",
   "anthropic/claude-sonnet-4.6",
   "anthropic/claude-4.6-sonnet",
   "anthropic/claude-sonnet-4.6:extended",

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -11,8 +11,7 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
     anthropic: ["claude-sonnet-4-6", "claude-sonnet", "claude"],
     openrouter: [
-      "anthropic/claude-opus-4.6",
-      "anthropic/claude-4.6-opus",
+      "anthropic/claude-opus-4.7",
       "anthropic/claude-sonnet-4-6",
       "anthropic/claude-sonnet",
       "anthropic/claude",


### PR DESCRIPTION
## What is this contribution about?
Updates the OpenRouter integration to feature Anthropic's newest opus model (`anthropic/claude-opus-4.7`) in place of the retired 4.6 opus IDs. Touches three spots: the SDK default-model preferences (`DEFAULT_MODEL_PREFERENCES.openrouter`), the chat model picker's smarter-tier classification prefixes, and the featured-model shortlist. Sonnet 4.6 entries are intentionally left alone.

## How to Test
1. Start the dev server (`bun run dev`) with an OpenRouter API key configured.
2. Open the chat model picker — the featured shortlist should show `claude-opus-4.7` (not 4.6) under "Smarter".
3. With no explicitly chosen model, the default selection for an OpenRouter key should resolve to opus 4.7 if available.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches OpenRouter to use `anthropic/claude-opus-4.7` instead of the retired 4.6 opus IDs. Updates `DEFAULT_MODEL_PREFERENCES.openrouter`, smarter-tier classification prefixes in the chat model picker, and the featured shortlist; Sonnet 4.6 entries stay as-is.

<sup>Written for commit b41fc2cf017cfaa4e2c2f15a1e68ca09569328ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

