### PR TITLE
fix(helm): s3-sync backlog cleanup + emptyDir cap

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: A Helm chart for deco Studio self-hosted deployment
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/templates/configmap-s3-sync.yaml
+++ b/deploy/helm/templates/configmap-s3-sync.yaml
@@ -81,7 +81,11 @@ data:
         "https://${S3_HOST}/${S3_KEY}")
 
       case "$HTTP_CODE" in
-        2*) echo "s3-sync: uploaded ${RELATIVE}" ; return 0 ;;
+        2*)
+          echo "s3-sync: uploaded ${RELATIVE}"
+          rm -f "$FILE"
+          return 0
+          ;;
         *)
           echo "s3-sync: upload failed ${RELATIVE} (HTTP ${HTTP_CODE})"
           return 1

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -138,7 +138,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.configMap.meshConfig.DATA_DIR | default "/app/data" }}
-              readOnly: true
             - name: s3-sync-script
               mountPath: /scripts
               readOnly: true
@@ -166,7 +165,8 @@ spec:
           {{- end }}
         {{- else }}
         - name: data
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.persistence.emptyDirSizeLimit | default "5Gi" }}
         {{- end }}
         {{- if .Values.s3Sync.enabled }}
         - name: s3-sync-script

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -166,7 +166,7 @@ spec:
         {{- else }}
         - name: data
           emptyDir:
-            sizeLimit: {{ .Values.persistence.emptyDirSizeLimit | default "5Gi" }}
+            sizeLimit: {{ .Values.persistence.emptyDirSizeLimit | default "10Gi" }}
         {{- end }}
         {{- if .Values.s3Sync.enabled }}
         - name: s3-sync-script

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -45,7 +45,7 @@ persistence:
   size: 10Gi
   claimName: ""  # Optional: Specify existing PVC name
   distributed: false  # Mark as true if storage offers ReadWriteMany
-  emptyDirSizeLimit: "5Gi"  # Cap for the emptyDir volume when persistence.enabled=false. Prevents a single pod from exhausting node ephemeral-storage.
+  emptyDirSizeLimit: "10Gi"  # Cap for the emptyDir volume when persistence.enabled=false. Prevents a single pod from exhausting node ephemeral-storage.
 
 autoscaling:
   enabled: false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -45,6 +45,7 @@ persistence:
   size: 10Gi
   claimName: ""  # Optional: Specify existing PVC name
   distributed: false  # Mark as true if storage offers ReadWriteMany
+  emptyDirSizeLimit: "5Gi"  # Cap for the emptyDir volume when persistence.enabled=false. Prevents a single pod from exhausting node ephemeral-storage.
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Summary

While debugging "missing metrics from the last 3 days" on the production cluster we found two failure modes that compounded into the outage. This PR addresses the two in-repo contributors; the third (ClickPipe resumed via UI) is outside the chart.

- **s3-sync sidecar never deleted local files after upload.** `scan_and_upload` walks every `.ndjson` file under `/app/data/{logs,traces,metrics}` on every 60s poll and on every container restart. Files were never removed after a successful upload, so each restart re-walks an unbounded backlog and keeps re-uploading everything already in S3. This amplified the node's ephemeral-storage pressure and slowed real-time ingestion.
- **`data` volume was `emptyDir: {}` with no `sizeLimit`.** A single pod could keep growing until the node's ephemeral-storage evict threshold (3.2 GB available) fired. When the pod was evicted, all buffered NDJSON on the `emptyDir` was lost before the sidecar could flush. We saw pod `deco-mcp-mesh-d99c549bf-v7b4n` Evicted on the production cluster for exactly this reason.

## Changes

- `deploy/helm/templates/configmap-s3-sync.yaml` — `rm -f "$FILE"` after HTTP 2xx upload. Failed uploads keep the file and retry on next poll.
- `deploy/helm/templates/deployment.yaml`:
  - s3-sync sidecar's `data` volumeMount no longer `readOnly: true` (`rm` needs rw).
  - `data` emptyDir now has `sizeLimit`, configurable via `persistence.emptyDirSizeLimit` (default `10Gi`).
- `deploy/helm/values.yaml` — new `persistence.emptyDirSizeLimit` setting documented.
- `deploy/helm/Chart.yaml` — version 0.6.1 → 0.6.2.

## Test plan

- [x] `helm template` renders cleanly with `persistence.enabled=false` and `s3Sync.enabled=true`; both container mounts are rw, sidecar script mount stays readOnly, volume has `sizeLimit: 10Gi`.
- [x] `bun run fmt:check` passes (no file changes in scope for Biome).
- [ ] Rollout to staging, confirm s3-sync logs show `uploaded X` immediately followed by the file no longer present in the next scan.
- [ ] Watch node ephemeral-storage pressure events — should not recur after this change.

## Related

- Live recovery: retried the Failed metrics ClickPipe (`decocms otel metrics`) via ClickHouse Cloud console; it is now Running and draining an 8.8M-message SQS backlog.
- Follow-up (not in this PR): the metrics ClickPipe's `Object storage concurrency` is still 2 — bump to 8 in the UI to accelerate backlog catch-up.
- Follow-up (not in this PR): consider a `kubernetes.io/hostname` topology spread constraint so replicas don't all land on the same node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop s3-sync from re-uploading the same NDJSON and cap pod ephemeral storage to prevent node evictions. The sidecar now deletes files after a successful upload and the `data` `emptyDir` has a configurable 10Gi limit.

- **Bug Fixes**
  - Delete local file after HTTP 2xx in s3-sync (`configmap-s3-sync.yaml`) to avoid infinite re-scans and storage growth.
  - Make the sidecar `data` mount writable and add `persistence.emptyDirSizeLimit` (default `10Gi`) to cap `emptyDir` when `persistence.enabled=false`.

- **Dependencies**
  - Bump Helm chart version to `0.6.2`.

<sup>Written for commit f6f4a81735a8f6ac100b8d5e4d6f15392f160681. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

