### PR TITLE
fix(chat): warning color for MCP isError tool responses

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -234,10 +234,23 @@ export function GenericToolCallPart({
   const isStaleApproval =
     part.state === "approval-requested" && isLastMessage === false;
   const isCancelled = part.state === "output-denied" || isStaleApproval;
+
+  // MCP tools can return isError:true inside a successful output-available response
+  const isOutputError =
+    part.state === "output-available" &&
+    typeof part.output === "object" &&
+    part.output != null &&
+    "isError" in (part.output as object) &&
+    (part.output as Record<string, unknown>).isError === true;
+
   // Approval-requested parts render as idle inline (approval UI is in the highlight above input)
   const rawState = getEffectiveState(part.state);
   const effectiveState =
-    isStaleApproval || rawState === "approval" ? "idle" : rawState;
+    isStaleApproval || rawState === "approval"
+      ? "idle"
+      : isOutputError
+        ? "error"
+        : rawState;
 
   // Error text (used in summary and detail)
   const errorText =
@@ -245,7 +258,9 @@ export function GenericToolCallPart({
 
   const summary = isStaleApproval
     ? "Cancelled"
-    : getSummary(part.state, part.output, errorText);
+    : isOutputError
+      ? "Failed"
+      : getSummary(part.state, part.output, errorText);
 
   // Build expanded content
   let detail = "";

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -70,7 +70,7 @@
   --destructive-foreground: oklch(0.97 0.01 17);
   --success: oklch(0.6 0.17 149);
   --success-foreground: oklch(0.98 0.02 156);
-  --warning: oklch(0.75 0.15 70);
+  --warning: oklch(0.62 0.17 70);
   --warning-foreground: oklch(0.99 0.02 95);
 
   --sidebar: oklch(0.975 0.006 80);


### PR DESCRIPTION
## What is this contribution about?

Two small fixes to make error states more visible:

1. **MCP `isError` response detection** — When a tool returns `isError: true` inside a successful `output-available` response (MCP protocol in-band error), the UI now correctly renders the tool call row in warning/error color instead of the default gray. Previously only transport-level `output-error` states were styled as errors.

2. **Darker warning token in light mode** — The `--warning` CSS token in light mode was `oklch(0.75)`, too pale against a white background. Darkened to `oklch(0.62 0.17 70)`, matching the contrast level of `destructive` and `success`.

## Screenshots/Demonstration

Before: error tool responses rendered in gray, indistinguishable from successful calls.
After: they render with warning color on both the icon and title label.

## How to Test

1. Trigger any MCP tool that returns `{ isError: true, content: [...] }` (e.g. a Zod validation error from a mesh tool)
2. Verify the tool call row title and icon appear in amber/warning color
3. Verify the summary line reads "Failed"
4. Switch to light mode and confirm warning-colored elements are clearly legible

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render MCP tool calls with in-band errors as failures and improve warning color contrast in light mode.

- **Bug Fixes**
  - Detect `isError: true` in successful MCP `output-available` responses and mark the tool call as error (shows "Failed" with warning-colored title/icon).
  - Darken the light-mode `--warning` token for better legibility.

<sup>Written for commit 8e45f944480931ae851aaa2d252b8d403a6f53d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

