### PR TITLE
feat(mcp-apps): add workspaceId to MCP host context

### DIFF
--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -39,6 +39,7 @@ function useResourceHtml(data: ReadResourceData | undefined): string | null {
 
 interface MCPAppRendererProps {
   resourceURI: string;
+  workspaceId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -60,6 +61,7 @@ interface MCPAppRendererProps {
 
 export function MCPAppRenderer({
   resourceURI: uri,
+  workspaceId,
   toolInfo,
   toolInput,
   toolResult,
@@ -80,6 +82,7 @@ export function MCPAppRenderer({
     displayMode,
     minHeight,
     maxHeight,
+    workspaceId,
     toolInfo,
     toolInput,
     toolResult,

--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -60,6 +60,7 @@ function buildHostContext(
   displayMode: McpUiDisplayMode,
   toolInfo?: McpUiHostContext["toolInfo"],
   maxHeight?: number,
+  workspaceId?: string,
 ): McpUiHostContext {
   return {
     theme: getDocumentTheme(),
@@ -73,6 +74,7 @@ function buildHostContext(
     ...(maxHeight != null && {
       containerDimensions: { maxHeight },
     }),
+    ...(workspaceId != null && { workspaceId }),
   };
 }
 
@@ -127,6 +129,7 @@ interface BridgeStoreConfig {
   displayMode: McpUiDisplayMode;
   minHeight: number;
   maxHeight: number;
+  workspaceId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -194,9 +197,9 @@ class BridgeStore {
   /** Rebuild and push full host context to the bridge (e.g. on theme change). */
   private pushHostContext() {
     if (!this.bridge || this.disposed) return;
-    const { displayMode, maxHeight, toolInfo } = this.config;
+    const { displayMode, maxHeight, toolInfo, workspaceId } = this.config;
     this.bridge.setHostContext(
-      buildHostContext(displayMode, toolInfo, maxHeight),
+      buildHostContext(displayMode, toolInfo, maxHeight, workspaceId),
     );
   }
 
@@ -261,8 +264,14 @@ class BridgeStore {
     };
 
     try {
-      const { client, displayMode, maxHeight, toolInfo } = this.config;
-      const hostContext = buildHostContext(displayMode, toolInfo, maxHeight);
+      const { client, displayMode, maxHeight, toolInfo, workspaceId } =
+        this.config;
+      const hostContext = buildHostContext(
+        displayMode,
+        toolInfo,
+        maxHeight,
+        workspaceId,
+      );
 
       // Pass the MCP client directly — AppBridge auto-wires oncalltool,
       // onreadresource, onlistresources, etc. via the client's capabilities.
@@ -416,6 +425,7 @@ interface UseAppBridgeOptions {
   displayMode: McpUiDisplayMode;
   minHeight: number;
   maxHeight: number;
+  workspaceId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -467,6 +467,7 @@ function MCPAppRenderer({
     <div className="mt-2 border border-border/75 rounded-lg overflow-hidden p-3">
       <MCPAppIframeRenderer
         resourceURI={uiResourceUri}
+        workspaceId={orgId}
         toolInfo={{ tool: toolDef }}
         toolInput={normalizeToolInput(toolInput)}
         toolResult={normalizeToolResult(toolResult)}

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -28,6 +28,7 @@ function AppRenderer({
   resourceURI,
   tool,
   connectionId,
+  workspaceId,
 }: {
   client: ReturnType<typeof useMCPClient>;
   resourceURI: string;
@@ -38,6 +39,7 @@ function AppRenderer({
     _meta?: Record<string, unknown>;
   };
   connectionId: string;
+  workspaceId?: string;
 }) {
   const { sendMessage } = useChatBridge();
   const { setAppContext, clearAppContext } = useChatPrefs();
@@ -70,6 +72,7 @@ function AppRenderer({
   return (
     <MCPAppRenderer
       resourceURI={resourceURI}
+      workspaceId={workspaceId}
       toolInfo={{ tool: strippedTool }}
       toolInput={EMPTY_TOOL_INPUT}
       toolResult={toolResult}
@@ -118,6 +121,7 @@ export function AppViewContent({
       resourceURI={resourceURI}
       tool={tool}
       connectionId={connectionId}
+      workspaceId={org.id}
     />
   );
 }


### PR DESCRIPTION
## What is this contribution about?
Threads the organization ID (`org.id` from `useProjectContext()`) into the MCP AppBridge host context as `workspaceId`. This allows MCP apps running in iframes to resolve `mesh-storage://` URIs by knowing which workspace they belong to.

Changes span four files: `buildHostContext` gains a `workspaceId` parameter, the bridge store config and hook options carry it through, `MCPAppRenderer` accepts and forwards it, and both call sites (inline chat renderer in `generic.tsx` and fullscreen panel in `project-app-view.tsx`) pass `org.id`.

## How to Test
1. Open a project with an MCP app that uses `mesh-storage://` URIs
2. Trigger the tool inline in chat — verify the app loads and can resolve storage URIs
3. Open the same app in the fullscreen panel — verify it also resolves storage URIs
4. Confirm no regressions in theme switching or tool input/result forwarding

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `workspaceId` to the MCP AppBridge host context so MCP apps can resolve `mesh-storage://` URIs. Uses `org.id` from `useProjectContext()` in both inline chat and the fullscreen app view.

- **New Features**
  - Added optional `workspaceId` to `buildHostContext`, bridge store config/flow, and `MCPAppRenderer`.
  - Passed `org.id` to the inline tool renderer and the project app view, forwarding it into the iframe host context.
  - Host context now includes `workspaceId` on init and when re-pushed (e.g., theme changes).

<sup>Written for commit 042dba6663fd03169055011c0e55d6bfda2aafc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

