### PR TITLE
refactor(mcp-apps): rename workspaceId to orgId in host context

### DIFF
--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -39,7 +39,7 @@ function useResourceHtml(data: ReadResourceData | undefined): string | null {
 
 interface MCPAppRendererProps {
   resourceURI: string;
-  workspaceId?: string;
+  orgId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -61,7 +61,7 @@ interface MCPAppRendererProps {
 
 export function MCPAppRenderer({
   resourceURI: uri,
-  workspaceId,
+  orgId,
   toolInfo,
   toolInput,
   toolResult,
@@ -82,7 +82,7 @@ export function MCPAppRenderer({
     displayMode,
     minHeight,
     maxHeight,
-    workspaceId,
+    orgId,
     toolInfo,
     toolInput,
     toolResult,

--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -60,7 +60,7 @@ function buildHostContext(
   displayMode: McpUiDisplayMode,
   toolInfo?: McpUiHostContext["toolInfo"],
   maxHeight?: number,
-  workspaceId?: string,
+  orgId?: string,
 ): McpUiHostContext {
   return {
     theme: getDocumentTheme(),
@@ -74,7 +74,7 @@ function buildHostContext(
     ...(maxHeight != null && {
       containerDimensions: { maxHeight },
     }),
-    ...(workspaceId != null && { workspaceId }),
+    ...(orgId != null && { orgId }),
   };
 }
 
@@ -129,7 +129,7 @@ interface BridgeStoreConfig {
   displayMode: McpUiDisplayMode;
   minHeight: number;
   maxHeight: number;
-  workspaceId?: string;
+  orgId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -197,9 +197,9 @@ class BridgeStore {
   /** Rebuild and push full host context to the bridge (e.g. on theme change). */
   private pushHostContext() {
     if (!this.bridge || this.disposed) return;
-    const { displayMode, maxHeight, toolInfo, workspaceId } = this.config;
+    const { displayMode, maxHeight, toolInfo, orgId } = this.config;
     this.bridge.setHostContext(
-      buildHostContext(displayMode, toolInfo, maxHeight, workspaceId),
+      buildHostContext(displayMode, toolInfo, maxHeight, orgId),
     );
   }
 
@@ -264,13 +264,12 @@ class BridgeStore {
     };
 
     try {
-      const { client, displayMode, maxHeight, toolInfo, workspaceId } =
-        this.config;
+      const { client, displayMode, maxHeight, toolInfo, orgId } = this.config;
       const hostContext = buildHostContext(
         displayMode,
         toolInfo,
         maxHeight,
-        workspaceId,
+        orgId,
       );
 
       // Pass the MCP client directly — AppBridge auto-wires oncalltool,
@@ -425,7 +424,7 @@ interface UseAppBridgeOptions {
   displayMode: McpUiDisplayMode;
   minHeight: number;
   maxHeight: number;
-  workspaceId?: string;
+  orgId?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -467,7 +467,7 @@ function MCPAppRenderer({
     <div className="mt-2 border border-border/75 rounded-lg overflow-hidden p-3">
       <MCPAppIframeRenderer
         resourceURI={uiResourceUri}
-        workspaceId={orgId}
+        orgId={orgId}
         toolInfo={{ tool: toolDef }}
         toolInput={normalizeToolInput(toolInput)}
         toolResult={normalizeToolResult(toolResult)}

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -28,7 +28,7 @@ function AppRenderer({
   resourceURI,
   tool,
   connectionId,
-  workspaceId,
+  orgId,
 }: {
   client: ReturnType<typeof useMCPClient>;
   resourceURI: string;
@@ -39,7 +39,7 @@ function AppRenderer({
     _meta?: Record<string, unknown>;
   };
   connectionId: string;
-  workspaceId?: string;
+  orgId?: string;
 }) {
   const { sendMessage } = useChatBridge();
   const { setAppContext, clearAppContext } = useChatPrefs();
@@ -72,7 +72,7 @@ function AppRenderer({
   return (
     <MCPAppRenderer
       resourceURI={resourceURI}
-      workspaceId={workspaceId}
+      orgId={orgId}
       toolInfo={{ tool: strippedTool }}
       toolInput={EMPTY_TOOL_INPUT}
       toolResult={toolResult}
@@ -121,7 +121,7 @@ export function AppViewContent({
       resourceURI={resourceURI}
       tool={tool}
       connectionId={connectionId}
-      workspaceId={org.id}
+      orgId={org.id}
     />
   );
 }


### PR DESCRIPTION
## What is this contribution about?
Renames `workspaceId` to `orgId` across the MCP app bridge layer to align with the codebase convention. Follows up on #3130.

## How to Test
1. Open a project with an MCP app that uses host context
2. Verify `orgId` is present in the host context received by the app
3. Confirm no regressions in app loading (inline chat + fullscreen panel)

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the MCP host context field from workspaceId to orgId across the bridge and renderers to match our org-wide naming. Behavior is unchanged; apps now receive orgId in the host context.

- **Refactors**
  - `buildHostContext` now emits `orgId` instead of `workspaceId`.
  - Renamed props/options to `orgId` in `MCPAppRenderer`, `use-app-bridge`, and project app view.
  - Updated chat tool-call renderer to pass `orgId`.

<sup>Written for commit 4f1b4a25787ea7360cc0987393057061bc2d4e41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

