### PR TITLE
fix(ui): normalize icon sizes to 16px

### DIFF
--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -407,7 +407,7 @@ function PinAgentPopoverContent({
             className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <div className="w-12 h-12 rounded-xl border-2 border-dashed border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <Plus size={18} className="text-muted-foreground" />
+              <Plus size={16} className="text-muted-foreground" />
             </div>
             <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
               Create new

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -51,7 +51,7 @@ export function TasksSection({
 
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="px-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground">
+      <div className="px-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">
           <DropdownMenu>
@@ -64,7 +64,7 @@ export function TasksSection({
                   filter !== "all" && "text-foreground",
                 )}
               >
-                <FilterLines size={14} />
+                <FilterLines size={16} />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -87,7 +87,7 @@ export function TasksSection({
               aria-label={`New ${title.toLowerCase()}`}
               className="flex size-8 items-center justify-center rounded-md hover:bg-muted hover:text-foreground"
             >
-              <Edit05 size={14} />
+              <Edit05 size={16} />
             </button>
           )}
         </div>


### PR DESCRIPTION
## What is this contribution about?
Normalizes icon sizes to 16px across the task panel and sidebar for visual consistency. Previously, task panel icons (filter, new task) were 14px, the sidebar agent popover plus icon was 18px, and header toggle icons were already 16px.

## Screenshots/Demonstration
> UI-only change — icon sizes in task panel header buttons and agent popover are now consistent with the rest of the shell.

## How to Test
1. Open the tasks panel and check the filter and new task icons in the section header
2. Open the agent pin popover and check the "Create new" plus icon
3. Expected: all shell icons render at a consistent 16px

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize all shell icon sizes to 16px in the tasks panel and sidebar for consistent visuals and cleaner alignment.

- **Bug Fixes**
  - Tasks panel: set filter and new task icons to 16px; added a small bottom margin to the header for alignment.
  - Sidebar agent popover: set the plus icon to 16px.

<sup>Written for commit 8fa93a2dac31b14006d1121792ea41084728b2f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

