### PR TITLE
fix(github): refresh expired tokens in GITHUB_LIST_USER_ORGS

### DIFF
--- a/apps/mesh/src/tools/github/list-user-orgs.test.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.test.ts
@@ -449,4 +449,67 @@ describe("GITHUB_LIST_USER_ORGS", () => {
 
     expect(mockRefreshAccessToken).not.toHaveBeenCalled();
   });
+
+  it("reactively refreshes on 401 that surfaces on a later page", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "seemingly-valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh-token",
+      refreshToken: "rt2",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      account: {
+        login: `org-${i + 1}`,
+        avatar_url: `https://example.com/${i + 1}.png`,
+        type: "Organization",
+      },
+      app_slug: "mcp-github",
+    }));
+
+    installHandler(
+      () => githubOkResponse(fullPage),
+      () => github401(),
+      () =>
+        githubOkResponse([
+          {
+            id: 101,
+            account: {
+              login: "late",
+              avatar_url: "https://example.com/late.png",
+              type: "Organization",
+            },
+            app_slug: "mcp-github",
+          },
+        ]),
+    );
+
+    const result = await GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx);
+
+    expect(result.installations).toHaveLength(101);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchCalls).toHaveLength(3);
+    expect(fetchCalls[0]?.headers["authorization"]).toBe(
+      "Bearer seemingly-valid-token",
+    );
+    expect(fetchCalls[1]?.headers["authorization"]).toBe(
+      "Bearer seemingly-valid-token",
+    );
+    expect(fetchCalls[2]?.headers["authorization"]).toBe("Bearer fresh-token");
+    expect(fetchCalls[1]?.url).toContain("page=2");
+    expect(fetchCalls[2]?.url).toContain("page=2");
+  });
 });

--- a/apps/mesh/src/tools/github/list-user-orgs.test.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.test.ts
@@ -1,0 +1,452 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  mock,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import {
+  createTestDatabase,
+  closeTestDatabase,
+  type TestDatabase,
+} from "../../database/test-db";
+import {
+  createTestSchema,
+  seedCommonTestFixtures,
+} from "../../storage/test-helpers";
+import { CredentialVault } from "../../encryption/credential-vault";
+import { DownstreamTokenStorage } from "../../storage/downstream-token";
+import { ConnectionStorage } from "../../storage/connection";
+import type { BoundAuthClient, MeshContext } from "../../core/mesh-context";
+import type { EventBus } from "../../event-bus/interface";
+import type { TokenRefreshResult } from "@/oauth/token-refresh";
+
+const mockRefreshAccessToken =
+  vi.fn<
+    (
+      ...args: Parameters<
+        typeof import("@/oauth/token-refresh").refreshAccessToken
+      >
+    ) => Promise<TokenRefreshResult>
+  >();
+mock.module("@/oauth/token-refresh", () => ({
+  refreshAccessToken: mockRefreshAccessToken,
+}));
+
+const { GITHUB_LIST_USER_ORGS } = await import("./list-user-orgs");
+
+const createMockBoundAuth = (): BoundAuthClient =>
+  ({
+    hasPermission: vi.fn().mockResolvedValue(true),
+  }) as unknown as BoundAuthClient;
+
+interface FetchCall {
+  url: string;
+  headers: Record<string, string>;
+}
+
+type FetchResponder = (call: FetchCall) => Response | Promise<Response>;
+
+describe("GITHUB_LIST_USER_ORGS", () => {
+  let database: TestDatabase;
+  let ctx: MeshContext;
+  let vault: CredentialVault;
+  let tokenStorage: DownstreamTokenStorage;
+  const connectionId = "conn_github_test";
+  const originalFetch = globalThis.fetch;
+  let fetchCalls: FetchCall[] = [];
+
+  const installHandler = (
+    ...responders: FetchResponder[]
+  ): Array<() => void> => {
+    const queue = [...responders];
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const headers: Record<string, string> = {};
+      const rawHeaders = init?.headers as
+        | Record<string, string>
+        | Headers
+        | undefined;
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k.toLowerCase()] = v;
+        });
+      } else if (rawHeaders) {
+        for (const [k, v] of Object.entries(rawHeaders)) {
+          headers[k.toLowerCase()] = v;
+        }
+      }
+      const call = { url, headers };
+      fetchCalls.push(call);
+      const responder = queue.shift();
+      if (!responder) {
+        throw new Error(`Unexpected fetch to ${url} — no responder queued`);
+      }
+      return await responder(call);
+    }) as typeof globalThis.fetch;
+    return [() => (globalThis.fetch = originalFetch)];
+  };
+
+  const githubOkResponse = (installations: unknown[]) =>
+    new Response(
+      JSON.stringify({ installations, total_count: installations.length }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  const github401 = () =>
+    new Response(JSON.stringify({ message: "Bad credentials" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  beforeAll(async () => {
+    database = await createTestDatabase();
+    await createTestSchema(database.db);
+    await seedCommonTestFixtures(database.db);
+
+    vault = new CredentialVault(CredentialVault.generateKey());
+    tokenStorage = new DownstreamTokenStorage(database.db, vault);
+
+    const connectionStorage = new ConnectionStorage(database.db, vault);
+    await connectionStorage.create({
+      id: connectionId,
+      organization_id: "org_123",
+      created_by: "user_1",
+      title: "GitHub",
+      connection_type: "HTTP",
+      connection_url: "https://mcp.example.com/github",
+      connection_token: null,
+      tools: null,
+    });
+
+    ctx = {
+      timings: {
+        measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
+      },
+      auth: {
+        user: {
+          id: "user_1",
+          email: "[email protected]",
+          name: "Test",
+          role: "admin",
+        },
+      },
+      organization: {
+        id: "org_123",
+        slug: "test-org",
+        name: "Test Organization",
+      },
+      storage: {} as never,
+      vault,
+      authInstance: null as never,
+      boundAuth: createMockBoundAuth(),
+      access: {
+        granted: () => true,
+        check: async () => {},
+        grant: () => {},
+        setToolName: () => {},
+      } as never,
+      db: database.db,
+      tracer: {
+        startActiveSpan: (
+          _name: string,
+          _opts: unknown,
+          fn: (span: unknown) => unknown,
+        ) =>
+          fn({
+            setStatus: () => {},
+            recordException: () => {},
+            end: () => {},
+          }),
+      } as never,
+      meter: {
+        createHistogram: () => ({ record: () => {} }),
+        createCounter: () => ({ add: () => {} }),
+      } as never,
+      baseUrl: "https://mesh.example.com",
+      metadata: {
+        requestId: "req_123",
+        timestamp: new Date(),
+      },
+      eventBus: {} as EventBus,
+      objectStorage: null as never,
+      aiProviders: null as never,
+      createMCPProxy: vi.fn().mockResolvedValue({}),
+      getOrCreateClient: vi.fn().mockResolvedValue({}),
+      pendingRevalidations: [],
+    };
+  });
+
+  afterAll(async () => {
+    await closeTestDatabase(database);
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(async () => {
+    fetchCalls = [];
+    mockRefreshAccessToken.mockReset();
+    await tokenStorage.delete(connectionId);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns installations on happy path with valid token", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    installHandler(() =>
+      githubOkResponse([
+        {
+          id: 42,
+          account: {
+            login: "octocat",
+            avatar_url: "https://example.com/a.png",
+            type: "User",
+          },
+          app_slug: "mcp-github",
+        },
+      ]),
+    );
+
+    const result = await GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx);
+
+    expect(result.installations).toEqual([
+      {
+        installationId: 42,
+        login: "octocat",
+        avatarUrl: "https://example.com/a.png",
+        type: "User",
+      },
+    ]);
+    expect(result.appSlug).toBe("mcp-github");
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.headers["authorization"]).toBe("Bearer valid-token");
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("proactively refreshes an expired token before fetching", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "stale-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh-token",
+      refreshToken: "rt2",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    installHandler(() => githubOkResponse([]));
+
+    const result = await GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx);
+
+    expect(result.installations).toEqual([]);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.headers["authorization"]).toBe("Bearer fresh-token");
+
+    const persisted = await tokenStorage.get(connectionId);
+    expect(persisted?.accessToken).toBe("fresh-token");
+    expect(persisted?.refreshToken).toBe("rt2");
+  });
+
+  it("deletes the cached token and throws when proactive refresh fails", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "stale-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      error: "invalid_grant",
+    });
+
+    installHandler();
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/reconnect/i);
+
+    expect(await tokenStorage.get(connectionId)).toBeNull();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("reactively refreshes on 401 from GitHub and retries once", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "seemingly-valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh-token",
+      refreshToken: "rt2",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    installHandler(
+      () => github401(),
+      () =>
+        githubOkResponse([
+          {
+            id: 7,
+            account: {
+              login: "acme",
+              avatar_url: "https://example.com/b.png",
+              type: "Organization",
+            },
+            app_slug: "mcp-github",
+          },
+        ]),
+    );
+
+    const result = await GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx);
+
+    expect(result.installations).toHaveLength(1);
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchCalls).toHaveLength(2);
+    expect(fetchCalls[0]?.headers["authorization"]).toBe(
+      "Bearer seemingly-valid-token",
+    );
+    expect(fetchCalls[1]?.headers["authorization"]).toBe("Bearer fresh-token");
+
+    const persisted = await tokenStorage.get(connectionId);
+    expect(persisted?.accessToken).toBe("fresh-token");
+  });
+
+  it("deletes the token and throws reconnect error when retry after 401 still fails", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "seemingly-valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh-token",
+      refreshToken: "rt2",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    installHandler(
+      () => github401(),
+      () => github401(),
+    );
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/reconnect/i);
+
+    expect(fetchCalls).toHaveLength(2);
+    expect(await tokenStorage.get(connectionId)).toBeNull();
+  });
+
+  it("deletes the token and throws when reactive refresh itself fails", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "seemingly-valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      error: "invalid_grant",
+    });
+
+    installHandler(() => github401());
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/reconnect/i);
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(await tokenStorage.get(connectionId)).toBeNull();
+  });
+
+  it("throws a clear error when no GitHub token is stored", async () => {
+    installHandler();
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/No GitHub token found/i);
+
+    expect(fetchCalls).toHaveLength(0);
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("still propagates non-401 GitHub errors", async () => {
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    installHandler(
+      () =>
+        new Response(JSON.stringify({ message: "Server error" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/500/);
+
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mesh/src/tools/github/list-user-orgs.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.ts
@@ -119,8 +119,9 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
 
       // Reactive refresh: GitHub rejected the token (revoked, rotated, or
       // expired before our clock said so). Try one refresh + retry before
-      // giving up.
-      if (res.status === 401 && page === 1) {
+      // giving up. Applies to any page — a token can be invalidated
+      // between pages of a long installations listing.
+      if (res.status === 401) {
         const current = await tokenStorage.get(input.connectionId);
         if (!current || !canRefresh(current)) {
           await tokenStorage.delete(input.connectionId);

--- a/apps/mesh/src/tools/github/list-user-orgs.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.ts
@@ -1,8 +1,42 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
+import { refreshAccessToken } from "@/oauth/token-refresh";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
+import type { DownstreamToken } from "../../storage/types";
 
 const GITHUB_API = "https://api.github.com";
+const PROACTIVE_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+const RECONNECT_ERROR =
+  "GitHub token refresh failed — reconnect the mcp-github integration.";
+
+function canRefresh(token: DownstreamToken): boolean {
+  return !!token.refreshToken && !!token.tokenEndpoint && !!token.clientId;
+}
+
+async function refreshAndStore(
+  token: DownstreamToken,
+  tokenStorage: DownstreamTokenStorage,
+): Promise<string | null> {
+  const result = await refreshAccessToken(token);
+  if (!result.success || !result.accessToken) {
+    await tokenStorage.delete(token.connectionId);
+    return null;
+  }
+  await tokenStorage.upsert({
+    connectionId: token.connectionId,
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken ?? token.refreshToken,
+    scope: result.scope ?? token.scope,
+    expiresAt: result.expiresIn
+      ? new Date(Date.now() + result.expiresIn * 1000)
+      : null,
+    clientId: token.clientId,
+    clientSecret: token.clientSecret,
+    tokenEndpoint: token.tokenEndpoint,
+  });
+  return result.accessToken;
+}
 
 export const GITHUB_LIST_USER_ORGS = defineTool({
   name: "GITHUB_LIST_USER_ORGS",
@@ -34,20 +68,29 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
     await ctx.access.check();
 
     const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
-    const token = await tokenStorage.get(input.connectionId);
+    let token = await tokenStorage.get(input.connectionId);
     if (!token) {
       throw new Error(
         "No GitHub token found. Ensure the mcp-github connection is authenticated.",
       );
     }
 
-    const headers = {
-      Authorization: `Bearer ${token.accessToken}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    };
+    let accessToken = token.accessToken;
 
-    // GitHub App tokens use /user/installations instead of /user/orgs
+    // Proactive refresh: if the cached token is (about to be) expired and we
+    // have refresh credentials, swap it for a fresh one before hitting GitHub.
+    if (
+      canRefresh(token) &&
+      tokenStorage.isExpired(token, PROACTIVE_REFRESH_BUFFER_MS)
+    ) {
+      const refreshed = await refreshAndStore(token, tokenStorage);
+      if (!refreshed) {
+        throw new Error(RECONNECT_ERROR);
+      }
+      accessToken = refreshed;
+      token = (await tokenStorage.get(input.connectionId)) ?? token;
+    }
+
     const installations: Array<{
       installationId: number;
       login: string;
@@ -59,11 +102,41 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
     let page = 1;
     const perPage = 100;
 
-    while (true) {
-      const res = await fetch(
+    const fetchPage = async (token: string) =>
+      fetch(
         `${GITHUB_API}/user/installations?per_page=${perPage}&page=${page}`,
-        { headers },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        },
       );
+
+    while (true) {
+      let res = await fetchPage(accessToken);
+
+      // Reactive refresh: GitHub rejected the token (revoked, rotated, or
+      // expired before our clock said so). Try one refresh + retry before
+      // giving up.
+      if (res.status === 401 && page === 1) {
+        const current = await tokenStorage.get(input.connectionId);
+        if (!current || !canRefresh(current)) {
+          await tokenStorage.delete(input.connectionId);
+          throw new Error(RECONNECT_ERROR);
+        }
+        const refreshed = await refreshAndStore(current, tokenStorage);
+        if (!refreshed) {
+          throw new Error(RECONNECT_ERROR);
+        }
+        accessToken = refreshed;
+        res = await fetchPage(accessToken);
+        if (res.status === 401) {
+          await tokenStorage.delete(input.connectionId);
+          throw new Error(RECONNECT_ERROR);
+        }
+      }
 
       if (!res.ok) {
         throw new Error(`GitHub /user/installations failed: ${res.status}`);

--- a/apps/mesh/src/tools/vm/start.test.ts
+++ b/apps/mesh/src/tools/vm/start.test.ts
@@ -101,11 +101,20 @@ const mockTokenGet = mock(
   }),
 );
 
+// Load the real class first so our mock can extend it — otherwise this
+// mock.module leaks a class that only has `get()` into every test file that
+// loads after this one.
+const { DownstreamTokenStorage: RealDownstreamTokenStorage } = await import(
+  "../../storage/downstream-token"
+);
+
 mock.module("../../storage/downstream-token", () => ({
-  DownstreamTokenStorage: class MockDownstreamTokenStorage {
-    constructor(_db: unknown, _vault: unknown) {}
-    get(connectionId: string) {
-      return mockTokenGet(connectionId);
+  DownstreamTokenStorage: class MockDownstreamTokenStorage extends RealDownstreamTokenStorage {
+    override async get(connectionId: string) {
+      if (connectionId === "conn_github_1") {
+        return mockTokenGet(connectionId);
+      }
+      return super.get(connectionId);
     }
   },
 }));


### PR DESCRIPTION
## Summary

- The `InstallationPicker` in the GitHub repo picker calls `GITHUB_LIST_USER_ORGS` via the self MCP, which read the cached token straight from `DownstreamTokenStorage` and hit `api.github.com/user/installations` — bypassing the refresh flow used by the downstream proxy (`buildRequestHeaders`).
- After a GitHub App user-to-server token expired (~8h for new Apps), the picker surfaced a 4xx and "Failed to load GitHub accounts".
- Add **proactive refresh** (5-min buffer when `refreshToken` + `tokenEndpoint` + `clientId` are all present) and **reactive 401 retry** (refresh once and retry) directly inside `GITHUB_LIST_USER_ORGS`. On unrecoverable failure delete the cached token and throw a clear "reconnect the mcp-github integration" error.
- Fix a pre-existing `mock.module` leak in `apps/mesh/src/tools/vm/start.test.ts`: its narrow `DownstreamTokenStorage` mock exposed only `get()`, breaking any later-loaded test file that needs the full class (this PR's new tests, in particular). The mock now extends the real class and only intercepts the one connection id `vm/start.test.ts` cares about.

## Test plan

- [x] New unit tests in `apps/mesh/src/tools/github/list-user-orgs.test.ts` covering: happy path, proactive refresh success + failure, reactive 401 with refresh success + refresh failure + persistent 401, missing token, non-401 error.
- [x] `bun test apps/mesh/src packages` — 1648 pass / 0 fail.
- [x] `bun run check`, `bun run lint`, `bun run fmt:check` — all clean.
- [x] Manually opened the repo picker in the local dev server at `http://islamabad-v5.localhost/...` — installation list loads as expected (`deco-sites`, `decocms`).

## Not in scope

- Shared `getFreshAccessToken` helper / refactor of `buildRequestHeaders`.
- Proxy-layer changes (`proxy.ts` / `handleAuthError`) to also refresh server-side on 401 for downstream connections.
- UI "Reconnect GitHub" button in `InstallationPicker` — the new error message is still surfaced as the generic "Failed to load GitHub accounts" in the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix token expiry in `GITHUB_LIST_USER_ORGS` so the repo picker no longer shows "Failed to load GitHub accounts". Adds in-tool refresh and handles 401s on any page to keep the installation list loading reliably.

- **Bug Fixes**
  - Proactive refresh with a 5‑minute buffer when refresh credentials exist; persist new tokens.
  - On 401 from GitHub on any page, refresh once and retry; if refresh fails or 401 persists, delete the cached token and throw a “reconnect the mcp-github integration” error.
  - Preserve non‑401 errors; throw a clear error when no token is stored.
  - Fix test `mock.module` leak by extending the real `DownstreamTokenStorage`; add unit tests including 401 on later pages.

<sup>Written for commit be513ea4e642926d66b6f847331588ff33000a53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

