### PR TITLE
feat(ui): publish @decocms/ui as an npm package

### DIFF
--- a/.github/workflows/publish-ui-npm.yaml
+++ b/.github/workflows/publish-ui-npm.yaml
@@ -1,0 +1,80 @@
+name: Publish @decocms/ui
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/ui/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check if version changed
+        id: version-check
+        run: |
+          CURRENT_VERSION=$(node -e "console.log(require('./package.json').version)")
+
+          if npm view @decocms/ui@$CURRENT_VERSION version >/dev/null 2>&1; then
+            echo "version-changed=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Version $CURRENT_VERSION already published, skipping publish"
+          else
+            echo "version-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Version $CURRENT_VERSION not found in npm, will publish"
+          fi
+
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            echo "npm-tag=next" >> $GITHUB_OUTPUT
+            echo "📦 Prerelease version detected, will publish with tag 'next'"
+          else
+            echo "npm-tag=latest" >> $GITHUB_OUTPUT
+            echo "📦 Stable version detected, will publish with tag 'latest'"
+          fi
+        working-directory: packages/ui
+
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/ui
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "ui-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/ui v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/ui package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/ui
+          \`\`\`"

--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -1,4 +1,4 @@
-@import "@deco/ui/styles/global.css";
+@import "@decocms/ui/styles/global.css";
 @import "@daveyplate/better-auth-ui/css";
 
 @layer base {

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -75,7 +75,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.80",
     "@better-auth/sso": "1.4.1",
     "@daveyplate/better-auth-ui": "^3.2.7",
-    "@deco/ui": "workspace:*",
+    "@decocms/ui": "workspace:*",
     "@decocms/better-auth": "1.5.17",
     "@decocms/bindings": "workspace:*",
     "@decocms/mcp-utils": "workspace:*",

--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useMCPReadResource } from "@decocms/mesh-sdk";
 import type {
   McpUiDisplayMode,

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -4,21 +4,21 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+} from "@decocms/ui/components/drawer.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   Check,
   Copy01,
@@ -36,11 +36,11 @@ import {
   VolumeX,
 } from "@untitledui/icons";
 import { GitHubIcon } from "@daveyplate/better-auth-ui";
-import { SidebarMenuButton } from "@deco/ui/components/sidebar.tsx";
+import { SidebarMenuButton } from "@decocms/ui/components/sidebar.tsx";
 import { authClient } from "@/web/lib/auth-client";
 import { CreateOrganizationDialog } from "@/web/components/create-organization-dialog";
 import { usePreferences, type ThemeMode } from "@/web/hooks/use-preferences.ts";
-import { toast } from "@deco/ui/components/sonner.js";
+import { toast } from "@decocms/ui/components/sonner.js";
 
 function getOrgColorStyle(name: string): {
   backgroundColor: string;

--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -10,7 +10,7 @@
  *   - null → deterministic fallback
  */
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import * as AllIcons from "@untitledui/icons";
 import { useState, type ComponentType, type SVGProps } from "react";
 

--- a/apps/mesh/src/web/components/automations/add-starter-popover.tsx
+++ b/apps/mesh/src/web/components/automations/add-starter-popover.tsx
@@ -5,7 +5,7 @@
 
 import { useAutomationTriggerAdd } from "@/web/hooks/use-automations";
 import { SCHEDULE_UNITS } from "@/web/lib/cron-utils.ts";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,7 +14,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import { Clock, Plus, Zap } from "@untitledui/icons";
 import { useState } from "react";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/components/automations/trigger-card.tsx
+++ b/apps/mesh/src/web/components/automations/trigger-card.tsx
@@ -24,8 +24,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Clock, Edit01, Loading01, XClose, Zap } from "@untitledui/icons";
 import { useState } from "react";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/components/chat/connections-banner.tsx
+++ b/apps/mesh/src/web/components/chat/connections-banner.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ChevronRight } from "@untitledui/icons";
 
 const FEATURED_ICONS = [

--- a/apps/mesh/src/web/components/chat/context-panel.tsx
+++ b/apps/mesh/src/web/components/chat/context-panel.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   AlertCircle,
   CheckCircle,

--- a/apps/mesh/src/web/components/chat/credits-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/credits-empty-state.tsx
@@ -9,20 +9,20 @@
 
 import { useState } from "react";
 import { Coins04, ArrowRight } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   ToggleGroup,
   ToggleGroupItem,
-} from "@deco/ui/components/toggle-group.tsx";
+} from "@decocms/ui/components/toggle-group.tsx";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
-} from "@deco/ui/components/dialog.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/dialog.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {

--- a/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
+++ b/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
@@ -8,20 +8,20 @@
 
 import { useState } from "react";
 import { Check } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   ToggleGroup,
   ToggleGroupItem,
-} from "@deco/ui/components/toggle-group.tsx";
+} from "@decocms/ui/components/toggle-group.tsx";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
-} from "@deco/ui/components/dialog.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/dialog.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {

--- a/apps/mesh/src/web/components/chat/credits-eyebrow.tsx
+++ b/apps/mesh/src/web/components/chat/credits-eyebrow.tsx
@@ -7,7 +7,7 @@
  */
 
 import { Coins04, AlertCircle } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useNavigate } from "@tanstack/react-router";
 import { useProjectContext } from "@decocms/mesh-sdk";
 

--- a/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
+++ b/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
@@ -2,14 +2,14 @@ import {
   displayToolName,
   getGatewayClientId,
 } from "@decocms/mcp-utils/aggregate";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Form,
   FormControl,
@@ -17,9 +17,9 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { useId } from "react";

--- a/apps/mesh/src/web/components/chat/highlight/approval.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/approval.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
+} from "@decocms/ui/components/select.tsx";
 import { ShieldTick } from "@untitledui/icons";
 import { useState } from "react";
 import {

--- a/apps/mesh/src/web/components/chat/highlight/card.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/card.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ArrowLeft, ArrowRight } from "@untitledui/icons";
 
 // ============================================================================

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { AlertCircle, AlertTriangle, X } from "@untitledui/icons";
 import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { useChatStream, useChatTask } from "../context";

--- a/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Check } from "@untitledui/icons";
 import { HighlightCard } from "./card";
 import { MessageTextPart } from "../message/parts/text-part.tsx";

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
@@ -1,13 +1,13 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Form,
   FormControl,
   FormField,
   FormItem,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Tabs, TabsContent } from "@deco/ui/components/tabs.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/form.tsx";
+import { Tabs, TabsContent } from "@decocms/ui/components/tabs.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Edit02, MessageQuestionCircle } from "@untitledui/icons";
 import { useEffect, useRef, useState } from "react";

--- a/apps/mesh/src/web/components/chat/ice-breakers.tsx
+++ b/apps/mesh/src/web/components/chat/ice-breakers.tsx
@@ -3,28 +3,28 @@ import {
   getGatewayClientId,
   stripToolNamespace,
 } from "@decocms/mcp-utils/aggregate";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
+} from "@decocms/ui/components/drawer.tsx";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   getPrompt,
   getWellKnownDecopilotVirtualMCP,

--- a/apps/mesh/src/web/components/chat/image-lightbox.tsx
+++ b/apps/mesh/src/web/components/chat/image-lightbox.tsx
@@ -5,8 +5,8 @@ import {
   DialogPortal,
   DialogOverlay,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import { cn } from "@deco/ui/lib/utils.js";
+} from "@decocms/ui/components/dialog.tsx";
+import { cn } from "@decocms/ui/lib/utils.js";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Download01, ZoomIn, ZoomOut } from "@untitledui/icons";
 import { useRef, useState } from "react";

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { PropsWithChildren } from "react";
 import {
   ChatContextProvider,

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -1,13 +1,13 @@
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import { calculateUsageStats } from "@/web/lib/usage-utils.ts";
 import { getAgentWrapperColor } from "@/web/components/agent-icon";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/popover.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   getWellKnownDecopilotVirtualMCP,
   isDecopilot,
@@ -30,7 +30,7 @@ import {
   X,
   XCircle,
 } from "@untitledui/icons";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import type { FormEvent } from "react";
 import { useEffect, useRef, useState, type MouseEvent } from "react";
 import type { Metadata } from "./types.ts";
@@ -55,7 +55,7 @@ import { ToolsPopover } from "./tools-popover";
 import { SessionStats } from "./usage-stats";
 import { authClient } from "@/web/lib/auth-client.ts";
 import { useSound } from "@/web/hooks/use-sound.ts";
-import { question004Sound } from "@deco/ui/lib/question-004.ts";
+import { question004Sound } from "@decocms/ui/lib/question-004.ts";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { ConnectionsBanner } from "./connections-banner";
 import { useVoiceInput } from "@/web/hooks/use-voice-input.ts";

--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -5,8 +5,8 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { Button } from "@deco/ui/components/button.tsx";
-import { markdownComponents as sharedMarkdownComponents } from "@deco/ui/components/markdown.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { markdownComponents as sharedMarkdownComponents } from "@decocms/ui/components/markdown.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import { ImageLightbox } from "./image-lightbox.tsx";
 // @ts-ignore - correct

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Lightbulb01,
   MessageTextSquare01,

--- a/apps/mesh/src/web/components/chat/message/pair.tsx
+++ b/apps/mesh/src/web/components/chat/message/pair.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useRef } from "react";
 import type { ChatMessage, ChatStatus } from "../types.ts";
 import { MessageAssistant } from "./assistant.tsx";

--- a/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/text-part.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from "react";
-import { useCopy } from "@deco/ui/hooks/use-copy.ts";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { useCopy } from "@decocms/ui/hooks/use-copy.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { MemoizedMarkdown } from "../../markdown.tsx";
 import { Check, Copy01 } from "@untitledui/icons";
 import type { TextUIPart } from "ai";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx
@@ -2,15 +2,15 @@
 
 import type { ReactNode } from "react";
 import { useRef, useState } from "react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ChevronRight, Check, Copy01 } from "@untitledui/icons";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from "@deco/ui/components/collapsible.tsx";
-import { useAutoScroll } from "@deco/ui/hooks/use-auto-scroll.ts";
-import { useCopy } from "@deco/ui/hooks/use-copy.ts";
+} from "@decocms/ui/components/collapsible.tsx";
+import { useAutoScroll } from "@decocms/ui/hooks/use-auto-scroll.ts";
+import { useCopy } from "@decocms/ui/hooks/use-copy.ts";
 import { MessageUsageStats } from "../../../usage-stats.tsx";
 import type { UsageStats as UsageStatsType } from "@/web/lib/usage-utils.ts";
 

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -4,7 +4,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { Image01 } from "@untitledui/icons";
 import type { ToolUIPart } from "ai";
 import { useOrg } from "@decocms/mesh-sdk";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -7,12 +7,12 @@ import {
   useOptionalChatStream,
   useOptionalChatPrefs,
 } from "@/web/components/chat/context.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 
 import type { ToolDefinition } from "@decocms/mesh-sdk";
 import { useMCPClient, useProjectContext } from "@decocms/mesh-sdk";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/open-in-agent.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/open-in-agent.tsx
@@ -3,8 +3,8 @@
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { useOrg, useVirtualMCP, type ToolDefinition } from "@decocms/mesh-sdk";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ArrowRight, Users03 } from "@untitledui/icons";
 import { useRef } from "react";
 import { getEffectiveState } from "./utils.tsx";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/user-ask.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/user-ask.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { MessageQuestionCircle } from "@untitledui/icons";
 import type { UserAskToolPart } from "../../../types.ts";
 import { getToolPartErrorText } from "../utils.ts";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Globe02, LinkExternal01 } from "@untitledui/icons";
 import type { ToolUIPart } from "ai";
 import { useOrg } from "@decocms/mesh-sdk";

--- a/apps/mesh/src/web/components/chat/message/smart-auto-scroll.tsx
+++ b/apps/mesh/src/web/components/chat/message/smart-auto-scroll.tsx
@@ -1,4 +1,4 @@
-import { useAutoScroll } from "@deco/ui/hooks/use-auto-scroll.ts";
+import { useAutoScroll } from "@decocms/ui/hooks/use-auto-scroll.ts";
 
 /**
  * Smart auto-scroll sentinel component that handles auto-scrolling when visible.

--- a/apps/mesh/src/web/components/chat/message/user.tsx
+++ b/apps/mesh/src/web/components/chat/message/user.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { type UIMessage } from "ai";

--- a/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { Zap } from "@untitledui/icons";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ProviderCardGrid } from "@/web/views/settings/org-ai-providers";
 import {
   SELF_MCP_ALIAS_ID,

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -1,28 +1,28 @@
-import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Dialog,
   DialogContent,
   DialogTitle,
   DialogTrigger,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerTitle,
   DrawerTrigger,
-} from "@deco/ui/components/drawer.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   AlertTriangle,
   AlignLeft,

--- a/apps/mesh/src/web/components/chat/select-virtual-mcp.tsx
+++ b/apps/mesh/src/web/components/chat/select-virtual-mcp.tsx
@@ -1,18 +1,18 @@
 import { AgentAvatar } from "@/web/components/agent-icon";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { isDecopilot, type VirtualMCPEntity } from "@decocms/mesh-sdk";
 import { useVirtualMCPs } from "@decocms/mesh-sdk";
 import { Check, Loading01, SearchMd, Users03 } from "@untitledui/icons";
@@ -24,7 +24,7 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { useCreateVirtualMCP } from "../../hooks/use-create-virtual-mcp";
 
 export interface VirtualMCPInfo

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -3,8 +3,8 @@ import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.t
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,

--- a/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-tasks.tsx
@@ -25,13 +25,13 @@ import { isMac } from "@/web/lib/keyboard-shortcuts";
 import { ErrorBoundary } from "../error-boundary";
 import { Chat } from "./index";
 import { OwnerFilter, TaskListContent } from "./tasks-panel";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { IconPicker } from "@/web/components/icon-picker.tsx";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import { useActiveGithubRepo } from "@/web/hooks/use-active-github-repo";

--- a/apps/mesh/src/web/components/chat/skeleton.tsx
+++ b/apps/mesh/src/web/components/chat/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 export function DecoChatSkeleton({ className }: { className?: string }) {
   return (

--- a/apps/mesh/src/web/components/chat/tasks-panel.tsx
+++ b/apps/mesh/src/web/components/chat/tasks-panel.tsx
@@ -23,8 +23,8 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Loading01, Plus, RefreshCcw01 } from "@untitledui/icons";
 import { useRef, useState } from "react";
 import { User as UserIcon, Users as UsersIcon } from "lucide-react";
@@ -35,7 +35,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.js";
+} from "@decocms/ui/components/dropdown-menu.js";
 import type { TaskOwnerFilter } from "./task";
 import {
   useAutomationsList,
@@ -53,10 +53,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
 import { Archive, Trash01 } from "@untitledui/icons";
 import { useSound } from "@/web/hooks/use-sound.ts";
-import { question004Sound } from "@deco/ui/lib/question-004.ts";
+import { question004Sound } from "@decocms/ui/lib/question-004.ts";
 
 // ────────────────────────────────────────
 

--- a/apps/mesh/src/web/components/chat/tiptap/file/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/node.tsx
@@ -2,8 +2,8 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { JSONContent, Node } from "@tiptap/core";
 import {
   NodeViewWrapper,

--- a/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
@@ -1,9 +1,9 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { useCurrentEditor, type Editor } from "@tiptap/react";
 import { useEffect, useRef, type ChangeEvent } from "react";

--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import Placeholder from "@tiptap/extension-placeholder";
 import type { EditorView } from "@tiptap/pm/view";
 import {

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -1,5 +1,5 @@
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { JSONContent, Node } from "@tiptap/core";
 import {
   NodeViewWrapper,

--- a/apps/mesh/src/web/components/chat/tiptap/mention/suggestion.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/suggestion.tsx
@@ -5,8 +5,8 @@ import {
   getGatewayClientId,
 } from "@decocms/mcp-utils/aggregate";
 import { AgentAvatar } from "@/web/components/agent-icon";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   autoUpdate,
   flip,

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -9,7 +9,7 @@ import {
   useMCPClient,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,9 +18,9 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentEditor } from "@tiptap/react";
@@ -43,7 +43,7 @@ import {
 import { insertMention } from "./tiptap/mention";
 import { KEYS } from "@/web/lib/query-keys";
 import { useSound } from "@/web/hooks/use-sound.ts";
-import { switch005Sound } from "@deco/ui/lib/switch-005.ts";
+import { switch005Sound } from "@decocms/ui/lib/switch-005.ts";
 import { useChatPrefs } from "./context";
 import {
   useAiProviderModels,

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -2,9 +2,9 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { Activity } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { UsageStats as UsageStatsType } from "@/web/lib/usage-utils.ts";
 import { formatDuration } from "@/web/lib/format-time.ts";
 

--- a/apps/mesh/src/web/components/collections/collection-card.tsx
+++ b/apps/mesh/src/web/components/collections/collection-card.tsx
@@ -1,5 +1,5 @@
 import type { JsonSchema } from "@/web/utils/constants";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import type { BaseCollectionEntity } from "@decocms/bindings/collections";
 import { IntegrationIcon } from "../integration-icon.tsx";
 import {
@@ -7,8 +7,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { DotsVertical, Eye, Edit01, Copy01, Trash01 } from "@untitledui/icons";
 
 interface CollectionCardProps<T extends BaseCollectionEntity> {

--- a/apps/mesh/src/web/components/collections/collection-display-button.tsx
+++ b/apps/mesh/src/web/components/collections/collection-display-button.tsx
@@ -1,10 +1,10 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   Sliders01,
   List,
@@ -18,10 +18,10 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { ViewModeToggle } from "@deco/ui/components/view-mode-toggle.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { ViewModeToggle } from "@decocms/ui/components/view-mode-toggle.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 export interface FilterGroup {
   label: string;

--- a/apps/mesh/src/web/components/collections/collection-search.tsx
+++ b/apps/mesh/src/web/components/collections/collection-search.tsx
@@ -1,5 +1,5 @@
 import { SearchMd, Loading01 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface CollectionSearchProps {
   value: string;

--- a/apps/mesh/src/web/components/collections/collection-table.tsx
+++ b/apps/mesh/src/web/components/collections/collection-table.tsx
@@ -5,8 +5,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@deco/ui/components/table.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/table.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { ReactNode } from "react";
 import { ArrowUp, ArrowDown } from "@untitledui/icons";
 

--- a/apps/mesh/src/web/components/collections/collection-tabs.tsx
+++ b/apps/mesh/src/web/components/collections/collection-tabs.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Badge } from "@deco/ui/components/badge.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
 
 export interface CollectionTab {
   id: string;

--- a/apps/mesh/src/web/components/collections/collections-list.tsx
+++ b/apps/mesh/src/web/components/collections/collections-list.tsx
@@ -4,14 +4,14 @@ import { CollectionTableWrapper } from "./collection-table-wrapper.tsx";
 import { CollectionDisplayButton } from "./collection-display-button.tsx";
 import type { CollectionsListProps } from "./types";
 import type { TableColumn } from "./collection-table.tsx";
-import { EmptyState } from "@deco/ui/components/empty-state.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { EmptyState } from "@decocms/ui/components/empty-state.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   DotsVertical,
   Eye,

--- a/apps/mesh/src/web/components/collections/types.ts
+++ b/apps/mesh/src/web/components/collections/types.ts
@@ -1,6 +1,6 @@
 import type { BaseCollectionEntity } from "@decocms/bindings/collections";
 import type { ReactNode } from "react";
-import type { Filter } from "@deco/ui/components/filter-bar.tsx";
+import type { Filter } from "@decocms/ui/components/filter-bar.tsx";
 import type { TableColumn } from "./collection-table.tsx";
 import type { JsonSchema } from "@/web/utils/constants";
 

--- a/apps/mesh/src/web/components/connections/connection-card.tsx
+++ b/apps/mesh/src/web/components/connections/connection-card.tsx
@@ -1,5 +1,5 @@
-import { Card } from "@deco/ui/components/card.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { ReactNode } from "react";
 import { IntegrationIcon } from "../integration-icon.tsx";
 

--- a/apps/mesh/src/web/components/connections/create-connection-dialog.tsx
+++ b/apps/mesh/src/web/components/connections/create-connection-dialog.tsx
@@ -3,7 +3,7 @@ import { useEnabledRegistries } from "@/web/hooks/use-enabled-registries";
 import { useMergedStoreDiscovery } from "@/web/hooks/use-merged-store-discovery";
 import { authClient } from "@/web/lib/auth-client";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Dialog,
   DialogContent,
@@ -11,7 +11,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerClose,
@@ -20,8 +20,8 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   Form,
   FormControl,
@@ -29,16 +29,16 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import { useConnectionActions, useProjectContext } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/apps/mesh/src/web/components/create-agent-dropdown.tsx
+++ b/apps/mesh/src/web/components/create-agent-dropdown.tsx
@@ -1,7 +1,7 @@
 import {
   DropdownMenuContent,
   DropdownMenuItem,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import { Users03 } from "@untitledui/icons";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { usePreferences } from "@/web/hooks/use-preferences.ts";

--- a/apps/mesh/src/web/components/create-organization-dialog.tsx
+++ b/apps/mesh/src/web/components/create-organization-dialog.tsx
@@ -7,8 +7,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Form,
   FormControl,
@@ -17,9 +17,9 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";

--- a/apps/mesh/src/web/components/delete-connection-dialogs.tsx
+++ b/apps/mesh/src/web/components/delete-connection-dialogs.tsx
@@ -7,7 +7,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
 import type { DeleteConnectionState } from "@/web/hooks/use-delete-connection";
 
 export function DeleteConnectionDialogs({

--- a/apps/mesh/src/web/components/details/connection/collection-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/collection-tab.tsx
@@ -20,8 +20,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import type { BaseCollectionEntity } from "@decocms/bindings/collections";
 import {
   useCollectionActions,

--- a/apps/mesh/src/web/components/details/connection/connection-activity.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-activity.tsx
@@ -7,9 +7,9 @@ import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
-} from "@deco/ui/components/chart.tsx";
+} from "@decocms/ui/components/chart.tsx";
 import { KEYS } from "@/web/lib/query-keys.ts";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,

--- a/apps/mesh/src/web/components/details/connection/connection-capabilities.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-capabilities.tsx
@@ -3,7 +3,7 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
-} from "@deco/ui/components/tabs.tsx";
+} from "@decocms/ui/components/tabs.tsx";
 import { useConnection } from "@decocms/mesh-sdk";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import { BookOpen01, Columns01, ChevronRight, Tool01 } from "@untitledui/icons";

--- a/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
@@ -1,7 +1,7 @@
 import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
 import { Loading01, Plus, Settings02, Trash01 } from "@untitledui/icons";
 import { Suspense } from "react";

--- a/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
@@ -2,13 +2,13 @@ import type { ConnectionEntity } from "@/tools/connection/schema";
 import { parseVirtualUrl } from "@/tools/connection/schema";
 import { EnvVarsEditor } from "@/web/components/env-vars-editor";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
-import { Badge } from "@deco/ui/components/badge.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   FormControl,
   FormDescription,
@@ -16,15 +16,15 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
+} from "@decocms/ui/components/select.tsx";
 import {
   CheckCircle,
   ChevronDown,

--- a/apps/mesh/src/web/components/details/connection/connection-ui-tab.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-ui-tab.tsx
@@ -3,7 +3,7 @@ import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ToolAnnotationBadges, type Tool } from "@/web/components/tools";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import {
   useConnection,
   useMCPClient,

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -10,21 +10,21 @@ import { connectionImplementsBinding } from "@/web/hooks/use-binding";
 import { MCP_BINDING } from "@decocms/bindings/mcp";
 import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
 import { useMembers } from "@/web/hooks/use-members";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   authenticateMcp,
   isConnectionAuthenticated,
 } from "@/web/lib/mcp-oauth";
 import { KEYS } from "@/web/lib/query-keys";
 import { ConnectionInstancesPanel } from "./connection-instances-panel.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
-} from "@deco/ui/components/sheet.tsx";
+} from "@decocms/ui/components/sheet.tsx";
 import {
   Form,
   FormControl,
@@ -32,8 +32,8 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   isStdioParameters,
   useConnectionActions,

--- a/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/index.tsx
@@ -6,7 +6,7 @@ import {
   useProjectContext,
   type ConnectionEntity,
 } from "@decocms/mesh-sdk";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Key01, File06, Loading01 } from "@untitledui/icons";
 import { Suspense } from "react";
 import { useWatch, type useForm } from "react-hook-form";

--- a/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
+++ b/apps/mesh/src/web/components/details/connection/settings-tab/mcp-configuration-form.tsx
@@ -6,15 +6,15 @@ import {
 import { resolveBindingType } from "@/web/hooks/use-binding";
 import { useInstallFromRegistry } from "@/web/hooks/use-install-from-registry";
 import { Loading01, Plus } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import RjsfForm from "@rjsf/shadcn";
 import type { FieldTemplateProps, ObjectFieldTemplateProps } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";

--- a/apps/mesh/src/web/components/details/layout.tsx
+++ b/apps/mesh/src/web/components/details/layout.tsx
@@ -1,5 +1,5 @@
 import { Page } from "@/web/components/page";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   createContext,
   type ReactNode,

--- a/apps/mesh/src/web/components/details/prompt/index.tsx
+++ b/apps/mesh/src/web/components/details/prompt/index.tsx
@@ -11,9 +11,9 @@ import {
   FormControl,
   FormField,
   FormItem,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import { PromptSchema } from "@decocms/bindings/prompt";
 import { Suspense } from "react";
 import { useForm, type UseFormReturn } from "react-hook-form";

--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -4,23 +4,23 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-} from "@deco/ui/components/alert.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+} from "@decocms/ui/components/alert.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { Loading01 } from "@untitledui/icons";
 import { Link, useSearch } from "@tanstack/react-router";
 import {
@@ -30,7 +30,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-} from "@deco/ui/components/breadcrumb.tsx";
+} from "@decocms/ui/components/breadcrumb.tsx";
 import {
   AlertCircle,
   Box,

--- a/apps/mesh/src/web/components/details/workflow/components/executions-list.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/executions-list.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@deco/ui/components/button.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   X,
   Check,

--- a/apps/mesh/src/web/components/details/workflow/components/input-schema-panel.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/input-schema-panel.tsx
@@ -1,13 +1,13 @@
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useWorkflow, useWorkflowActions } from "../stores/workflow";

--- a/apps/mesh/src/web/components/details/workflow/components/monaco-editor.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/monaco-editor.tsx
@@ -5,7 +5,7 @@ import Editor, {
   type EditorProps,
 } from "@monaco-editor/react";
 import type { Plugin } from "prettier";
-import { Spinner } from "@deco/ui/components/spinner.js";
+import { Spinner } from "@decocms/ui/components/spinner.js";
 import { getReturnType } from "./monaco";
 
 // ============================================

--- a/apps/mesh/src/web/components/details/workflow/components/step-detail-panel.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/step-detail-panel.tsx
@@ -3,11 +3,11 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from "@deco/ui/components/accordion.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { ScrollArea, ScrollBar } from "@deco/ui/components/scroll-area.tsx";
-import { toast } from "@deco/ui/components/sonner.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/accordion.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { ScrollArea, ScrollBar } from "@decocms/ui/components/scroll-area.tsx";
+import { toast } from "@decocms/ui/components/sonner.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Check, CornerDownRight, Repeat03, XClose } from "@untitledui/icons";
 import {
   Box,

--- a/apps/mesh/src/web/components/details/workflow/components/tool-selection/rjsf/rjsf-templates.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/tool-selection/rjsf/rjsf-templates.tsx
@@ -4,7 +4,7 @@ import type {
   ArrayFieldTemplateProps,
   TemplatesType,
 } from "@rjsf/utils";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Type,
   Hash,
@@ -14,7 +14,7 @@ import {
   X,
   FileText,
 } from "lucide-react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function getTypeIcon(type: string | string[] | undefined) {
   const typeStr = Array.isArray(type) ? type[0] : (type ?? "unknown");

--- a/apps/mesh/src/web/components/details/workflow/components/tool-selection/rjsf/rjsf-widgets.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/tool-selection/rjsf/rjsf-widgets.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { WidgetProps, RegistryWidgetsType } from "@rjsf/utils";
 import { MentionInput } from "@/web/components/tiptap-mentions-input";
 import { useMentions } from "./rjsf-context";

--- a/apps/mesh/src/web/components/details/workflow/components/tool-sidebar.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/tool-sidebar.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import type { JsonSchema } from "@/web/utils/constants";
 import { usePrioritizedList } from "../hooks";
@@ -14,7 +14,7 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
 
 interface ToolSidebarProps {
   className?: string;

--- a/apps/mesh/src/web/components/details/workflow/components/virtual-mcp-select.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/virtual-mcp-select.tsx
@@ -10,8 +10,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface VirtualMCPSelectProps {
   selectedVirtualMcpId: string | null | undefined;

--- a/apps/mesh/src/web/components/details/workflow/components/workflow-editor-header.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/workflow-editor-header.tsx
@@ -1,8 +1,8 @@
 import { VirtualMCPSelect } from "./virtual-mcp-select";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
-import { ViewModeToggle } from "@deco/ui/components/view-mode-toggle.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
+import { ViewModeToggle } from "@decocms/ui/components/view-mode-toggle.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   ClockFastForward,
   Code02,
@@ -18,7 +18,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import {
   usePollingWorkflowExecution,
   useWorkflowCancel,

--- a/apps/mesh/src/web/components/details/workflow/components/workflow-input-dialog.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/workflow-input-dialog.tsx
@@ -6,9 +6,9 @@ import {
   DialogTitle,
   DialogFooter,
   DialogDescription,
-} from "@deco/ui/components/dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Spinner } from "@deco/ui/components/spinner.tsx";
+} from "@decocms/ui/components/dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Spinner } from "@decocms/ui/components/spinner.tsx";
 import { Play } from "@untitledui/icons";
 import { ToolInput } from "./tool-selection/components/tool-input";
 import type { JsonSchema } from "@/web/utils/constants";

--- a/apps/mesh/src/web/components/details/workflow/components/workflow-step-card.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/workflow-step-card.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   AlertOctagon,
   Calendar,
@@ -18,7 +18,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import { Copy, Trash2 } from "lucide-react";
 import type { StepExecutionStatus } from "../hooks/derived/use-step-execution-status";
 import {

--- a/apps/mesh/src/web/components/details/workflow/components/workflow-steps-canvas.tsx
+++ b/apps/mesh/src/web/components/details/workflow/components/workflow-steps-canvas.tsx
@@ -1,13 +1,13 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import { Database01, Plus, Tool01 } from "@untitledui/icons";
 import { Code } from "lucide-react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   WORKFLOW_INPUT_VIEW,
   useCurrentStepName,

--- a/apps/mesh/src/web/components/details/workflow/index.tsx
+++ b/apps/mesh/src/web/components/details/workflow/index.tsx
@@ -16,8 +16,8 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/web/components/resizable";
-import { Badge } from "@deco/ui/components/badge.js";
-import { Button } from "@deco/ui/components/button.js";
+import { Badge } from "@decocms/ui/components/badge.js";
+import { Button } from "@decocms/ui/components/button.js";
 import {
   AlertOctagon,
   AlertTriangle,
@@ -42,7 +42,7 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 
-import { EmptyState } from "@deco/ui/components/empty-state.js";
+import { EmptyState } from "@decocms/ui/components/empty-state.js";
 import { usePollingWorkflowExecution } from "./hooks";
 import { useWorkflowSSE } from "./hooks/use-workflow-sse";
 import { InputSchemaPanel } from "./components/input-schema-panel";

--- a/apps/mesh/src/web/components/empty-state.tsx
+++ b/apps/mesh/src/web/components/empty-state.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface EmptyStateProps {
   image?: ReactNode;

--- a/apps/mesh/src/web/components/env-vars-editor.tsx
+++ b/apps/mesh/src/web/components/env-vars-editor.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import { Plus, Trash01 } from "@untitledui/icons";
 
 /**

--- a/apps/mesh/src/web/components/error-boundary.tsx
+++ b/apps/mesh/src/web/components/error-boundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { AlertTriangle, RefreshCw01 } from "@untitledui/icons";
 
 const CHUNK_RELOAD_KEY = "__mesh_chunk_reload_ts";

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -3,8 +3,8 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import { SearchInput } from "@deco/ui/components/search-input.tsx";
+} from "@decocms/ui/components/dialog.tsx";
+import { SearchInput } from "@decocms/ui/components/search-input.tsx";
 import { Suspense, useDeferredValue, useState } from "react";
 import {
   useMutation,

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -6,8 +6,8 @@
  */
 
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   isDecopilot,
   WELL_KNOWN_AGENT_TEMPLATES,

--- a/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/lean-canvas-recruit-modal.tsx
@@ -12,15 +12,15 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   SELF_MCP_ALIAS_ID,

--- a/apps/mesh/src/web/components/home/site-diagnostics-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/site-diagnostics-recruit-modal.tsx
@@ -15,15 +15,15 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   SELF_MCP_ALIAS_ID,

--- a/apps/mesh/src/web/components/home/studio-pack-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/studio-pack-recruit-modal.tsx
@@ -12,15 +12,15 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   WellKnownOrgMCPId,

--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -5,15 +5,15 @@
  * or remove the current icon. Stores the selection as an icon:// URL string.
  */
 
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
-import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/popover.tsx";
+import { ScrollArea } from "@decocms/ui/components/scroll-area.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Edit05, SearchMd, Shuffle01, Upload01 } from "@untitledui/icons";
 import { useRef, useState } from "react";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -13,9 +13,9 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ArrowLeft } from "@untitledui/icons";
 import { authClient } from "@/web/lib/auth-client";
 import { generatePrefixedId } from "@/shared/utils/generate-id";

--- a/apps/mesh/src/web/components/integration-icon.tsx
+++ b/apps/mesh/src/web/components/integration-icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Container } from "@untitledui/icons";
 import { useState, type ReactNode } from "react";
 import { AgentAvatar, type AgentAvatarSize } from "./agent-icon";

--- a/apps/mesh/src/web/components/invite-member-dialog.tsx
+++ b/apps/mesh/src/web/components/invite-member-dialog.tsx
@@ -10,8 +10,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@deco/ui/components/dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+} from "@decocms/ui/components/dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Form,
   FormControl,
@@ -19,15 +19,15 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
+} from "@decocms/ui/components/form.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import { authClient } from "@/web/lib/auth-client";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";

--- a/apps/mesh/src/web/components/keyboard-shortcuts-dialog.tsx
+++ b/apps/mesh/src/web/components/keyboard-shortcuts-dialog.tsx
@@ -3,7 +3,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import { SHORTCUT_GROUPS } from "@/web/lib/keyboard-shortcuts";
 
 export function KeyboardShortcutsDialog({

--- a/apps/mesh/src/web/components/logo-upload.tsx
+++ b/apps/mesh/src/web/components/logo-upload.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Upload01, X } from "@untitledui/icons";
 import { useRef } from "react";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/components/manage-roles-dialog.tsx
+++ b/apps/mesh/src/web/components/manage-roles-dialog.tsx
@@ -18,10 +18,10 @@ import {
   useAiProviderKeys,
   useSuspenseAiProviderModels,
 } from "@/web/hooks/collections/use-ai-providers";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -31,18 +31,18 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
 import {
   Dialog,
   DialogContent,
   DialogTrigger,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   Plus,
   Lock01,
@@ -51,15 +51,15 @@ import {
   Loading01,
   X,
 } from "@untitledui/icons";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Suspense, useDeferredValue, useState } from "react";

--- a/apps/mesh/src/web/components/monitoring/log-row.tsx
+++ b/apps/mesh/src/web/components/monitoring/log-row.tsx
@@ -5,11 +5,11 @@
  */
 
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { Container } from "@untitledui/icons";
 import type { EnrichedMonitoringLog } from "./types.tsx";
-import { TableCell, TableRow } from "@deco/ui/components/table.tsx";
+import { TableCell, TableRow } from "@decocms/ui/components/table.tsx";
 
 // ============================================================================
 // Types

--- a/apps/mesh/src/web/components/monitoring/monitoring-stats-row.tsx
+++ b/apps/mesh/src/web/components/monitoring/monitoring-stats-row.tsx
@@ -5,8 +5,8 @@
  * Used by both the Monitoring page and the Home page.
  */
 
-import { ChartContainer, ChartTooltip } from "@deco/ui/components/chart.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { ChartContainer, ChartTooltip } from "@decocms/ui/components/chart.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Area,
   AreaChart,

--- a/apps/mesh/src/web/components/monitoring/types.tsx
+++ b/apps/mesh/src/web/components/monitoring/types.tsx
@@ -5,18 +5,18 @@
  */
 
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import {
   Download01,
   Check,

--- a/apps/mesh/src/web/components/page/index.tsx
+++ b/apps/mesh/src/web/components/page/index.tsx
@@ -1,5 +1,5 @@
-import { SidebarTrigger } from "@deco/ui/components/sidebar.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { SidebarTrigger } from "@decocms/ui/components/sidebar.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { PropsWithChildren, ReactElement, ReactNode } from "react";
 import { Children, createContext, isValidElement, useContext } from "react";
 

--- a/apps/mesh/src/web/components/plugin-not-enabled-empty-state.tsx
+++ b/apps/mesh/src/web/components/plugin-not-enabled-empty-state.tsx
@@ -6,7 +6,7 @@
  * the plugin without leaving the page.
  */
 
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { EmptyState } from "@/web/components/empty-state";
 import { useEnablePlugin } from "@/web/hooks/use-enable-plugin";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/components/project-card.tsx
+++ b/apps/mesh/src/web/components/project-card.tsx
@@ -5,14 +5,14 @@ import { useProjectContext } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 
 interface ProjectCardProps {
   project: VirtualMCPEntity;

--- a/apps/mesh/src/web/components/resizable.tsx
+++ b/apps/mesh/src/web/components/resizable.tsx
@@ -8,7 +8,7 @@ export type {
   ImperativePanelGroupHandle,
 } from "react-resizable-panels";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function ResizablePanelGroup({
   className,

--- a/apps/mesh/src/web/components/save-actions.tsx
+++ b/apps/mesh/src/web/components/save-actions.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { FlipBackward, Loading01, Save01 } from "@untitledui/icons";
 
 interface SaveActionsProps {

--- a/apps/mesh/src/web/components/settings/domain-settings.tsx
+++ b/apps/mesh/src/web/components/settings/domain-settings.tsx
@@ -6,16 +6,16 @@ import {
   useMCPClient,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@deco/ui/components/card.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
+} from "@decocms/ui/components/card.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 

--- a/apps/mesh/src/web/components/settings/organization-form.tsx
+++ b/apps/mesh/src/web/components/settings/organization-form.tsx
@@ -1,16 +1,16 @@
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Card,
   CardContent,
   CardFooter,
   CardHeader,
   CardTitle,
-} from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+} from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";

--- a/apps/mesh/src/web/components/settings/project-plugins-form.tsx
+++ b/apps/mesh/src/web/components/settings/project-plugins-form.tsx
@@ -6,7 +6,7 @@ import {
   SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
-import { Switch } from "@deco/ui/components/switch.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import { toast } from "sonner";
 import { Container } from "@untitledui/icons";
 import { sourcePlugins } from "@/web/plugins";

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -26,20 +26,20 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from "@deco/ui/components/sidebar.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+} from "@decocms/ui/components/sidebar.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import { CollectionSearch } from "@deco/ui/components/collection-search.tsx";
+} from "@decocms/ui/components/drawer.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
+import { CollectionSearch } from "@decocms/ui/components/collection-search.tsx";
 import { FolderPlus, Plus, Settings02, X } from "@untitledui/icons";
 import {
   ContextMenu,
@@ -47,7 +47,7 @@ import {
   ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
-} from "@deco/ui/components/context-menu.tsx";
+} from "@decocms/ui/components/context-menu.tsx";
 import {
   isDecopilot,
   isStudioPackAgent,
@@ -64,8 +64,8 @@ import { AgentAvatar } from "@/web/components/agent-icon";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/dropdown-menu.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { GitHubRepoPicker } from "@/web/components/github-repo-picker.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";

--- a/apps/mesh/src/web/components/sidebar/footer/inbox-mobile.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox-mobile.tsx
@@ -5,7 +5,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from "@deco/ui/components/sidebar.tsx";
+} from "@decocms/ui/components/sidebar.tsx";
 import { Settings02 } from "@untitledui/icons";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -1,17 +1,17 @@
 import { authClient } from "@/web/lib/auth-client";
 import { AccountPopover } from "@/web/components/account-popover";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   SidebarFooter,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-} from "@deco/ui/components/sidebar.tsx";
+} from "@decocms/ui/components/sidebar.tsx";
 import {
   Check,
   Coins04,
@@ -21,7 +21,7 @@ import {
   XClose,
 } from "@untitledui/icons";
 import { AuthUIContext } from "@daveyplate/better-auth-ui";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Component, Suspense, useContext, useState } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation-mobile.tsx
@@ -8,8 +8,8 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarSeparator,
-} from "@deco/ui/components/sidebar.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/sidebar.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { type ReactNode, Suspense } from "react";
 import { SidebarCollapsibleGroup } from "./sidebar-group";
 import type { NavigationSidebarItem, SidebarSection } from "./types";

--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -9,9 +9,9 @@ import {
   SidebarMenuItem,
   SidebarSeparator,
   useSidebar,
-} from "@deco/ui/components/sidebar.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/sidebar.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Suspense, type ReactNode } from "react";
 import type { NavigationSidebarItem, SidebarSection } from "./types";
 import { SidebarCollapsibleGroup } from "./sidebar-group";

--- a/apps/mesh/src/web/components/sidebar/sidebar-group.tsx
+++ b/apps/mesh/src/web/components/sidebar/sidebar-group.tsx
@@ -2,7 +2,7 @@ import {
   SidebarGroup as SidebarGroupUI,
   SidebarGroupContent,
   SidebarMenu,
-} from "@deco/ui/components/sidebar.tsx";
+} from "@decocms/ui/components/sidebar.tsx";
 import type { PropsWithChildren } from "react";
 
 interface SidebarCollapsibleGroupProps extends PropsWithChildren {

--- a/apps/mesh/src/web/components/simple-icon-picker.tsx
+++ b/apps/mesh/src/web/components/simple-icon-picker.tsx
@@ -6,14 +6,14 @@
  * Stores the selection as "icon://<Name>" (no color).
  */
 
-import { Input } from "@deco/ui/components/input.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
-import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/popover.tsx";
+import { ScrollArea } from "@decocms/ui/components/scroll-area.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { LayoutLeft, SearchMd } from "@untitledui/icons";
 import { useState } from "react";
 import {

--- a/apps/mesh/src/web/components/sso-required-screen.tsx
+++ b/apps/mesh/src/web/components/sso-required-screen.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Lock01 } from "@untitledui/icons";
 
 export interface SsoRequiredScreenProps {

--- a/apps/mesh/src/web/components/tag-multi-select.tsx
+++ b/apps/mesh/src/web/components/tag-multi-select.tsx
@@ -9,10 +9,10 @@
  */
 
 import { useState } from "react";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
 import {
   Command,
   CommandEmpty,
@@ -21,12 +21,12 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
-} from "@deco/ui/components/command.tsx";
+} from "@decocms/ui/components/command.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import { ChevronDown, Plus, XClose, Loading01 } from "@untitledui/icons";
 import {
   useTags,

--- a/apps/mesh/src/web/components/tiptap-mentions-input.tsx
+++ b/apps/mesh/src/web/components/tiptap-mentions-input.tsx
@@ -9,14 +9,14 @@ import {
 } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Mention from "@tiptap/extension-mention";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { createStore } from "zustand";
 import { useStore } from "zustand";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
-} from "@deco/ui/components/hover-card.tsx";
+} from "@decocms/ui/components/hover-card.tsx";
 import { createContext, useContext } from "react";
 import { useResolvedRefs } from "./details/workflow/components/tool-selector";
 

--- a/apps/mesh/src/web/components/tool-set-selector.tsx
+++ b/apps/mesh/src/web/components/tool-set-selector.tsx
@@ -1,10 +1,10 @@
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { useInfiniteScroll } from "@/web/hooks/use-infinite-scroll";
 import { KEYS } from "@/web/lib/query-keys";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { ArrowLeft, Loading01 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { CollectionListOutput } from "@decocms/bindings/collections";
 import {
   type ConnectionEntity,

--- a/apps/mesh/src/web/components/tools/tools-list.tsx
+++ b/apps/mesh/src/web/components/tools/tools-list.tsx
@@ -1,10 +1,10 @@
-import { Badge } from "@deco/ui/components/badge.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import type { ToolDefinition } from "@decocms/mesh-sdk";
 import {

--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
 import { authClient } from "@/web/lib/auth-client";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface UnifiedAuthFormProps {
   /**

--- a/apps/mesh/src/web/components/user/user.tsx
+++ b/apps/mesh/src/web/components/user/user.tsx
@@ -5,8 +5,8 @@
  * Handles loading and error states gracefully.
  */
 
-import { Avatar, type AvatarProps } from "@deco/ui/components/avatar.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Avatar, type AvatarProps } from "@decocms/ui/components/avatar.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useUserById } from "../../hooks/use-user-by-id";
 
 export interface UserProps {

--- a/apps/mesh/src/web/components/vm/env/env.tsx
+++ b/apps/mesh/src/web/components/vm/env/env.tsx
@@ -17,29 +17,29 @@ import {
   MessageChatCircle,
   LinkExternal01,
 } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useChatBridge } from "@/web/components/chat/context";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { VmErrorState } from "../vm-error-state";

--- a/apps/mesh/src/web/components/vm/env/terminal.tsx
+++ b/apps/mesh/src/web/components/vm/env/terminal.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from "react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -9,16 +9,16 @@ import {
   RefreshCw01,
   Server01,
 } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   ViewModeToggle,
   type ViewModeOption,
-} from "@deco/ui/components/view-mode-toggle.tsx";
+} from "@decocms/ui/components/view-mode-toggle.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import {
   VISUAL_EDITOR_SCRIPT,
   VisualEditorPayloadSchema,

--- a/apps/mesh/src/web/components/vm/vm-error-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-error-state.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { toast } from "sonner";
 
 interface VmErrorStateProps {

--- a/apps/mesh/src/web/components/vm/vm-suspended-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-suspended-state.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Server01 } from "@untitledui/icons";
 
 interface VmSuspendedStateProps {

--- a/apps/mesh/src/web/hooks/use-list-state.ts
+++ b/apps/mesh/src/web/hooks/use-list-state.ts
@@ -1,7 +1,7 @@
-import type { Filter } from "@deco/ui/components/filter-bar.tsx";
-import { usePersistedFilters } from "@deco/ui/hooks/use-persisted-filters.ts";
-import { useSortable } from "@deco/ui/hooks/use-sortable.ts";
-import { useViewMode } from "@deco/ui/hooks/use-view-mode.ts";
+import type { Filter } from "@decocms/ui/components/filter-bar.tsx";
+import { usePersistedFilters } from "@decocms/ui/hooks/use-persisted-filters.ts";
+import { useSortable } from "@decocms/ui/hooks/use-sortable.ts";
+import { useViewMode } from "@decocms/ui/hooks/use-view-mode.ts";
 import type { BaseCollectionEntity } from "@decocms/bindings/collections";
 import { useDeferredValue, useState } from "react";
 

--- a/apps/mesh/src/web/hooks/use-sound.ts
+++ b/apps/mesh/src/web/hooks/use-sound.ts
@@ -1,5 +1,5 @@
-import type { SoundAsset } from "@deco/ui/lib/sound-types.ts";
-import { playSound } from "@deco/ui/lib/sound-engine.ts";
+import type { SoundAsset } from "@decocms/ui/lib/sound-types.ts";
+import { playSound } from "@decocms/ui/lib/sound-engine.ts";
 import { usePreferences } from "./use-preferences";
 
 /**

--- a/apps/mesh/src/web/hooks/use-status-sounds.ts
+++ b/apps/mesh/src/web/hooks/use-status-sounds.ts
@@ -1,5 +1,5 @@
-import { playSound } from "@deco/ui/lib/sound-engine.ts";
-import { question004Sound } from "@deco/ui/lib/question-004.ts";
+import { playSound } from "@decocms/ui/lib/sound-engine.ts";
+import { question004Sound } from "@decocms/ui/lib/question-004.ts";
 import { useDecopilotEvents } from "./use-decopilot-events";
 import { usePreferences } from "./use-preferences";
 

--- a/apps/mesh/src/web/layouts/agent-shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout.tsx
@@ -27,7 +27,11 @@ import {
   SidebarProvider,
   useSidebar,
 } from "@decocms/ui/components/sidebar.tsx";
-import { Sheet, SheetContent, SheetTitle } from "@decocms/ui/components/sheet.tsx";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@decocms/ui/components/sheet.tsx";
 import {
   Tooltip,
   TooltipContent,

--- a/apps/mesh/src/web/layouts/agent-shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout.tsx
@@ -26,15 +26,15 @@ import {
   SidebarLayout,
   SidebarProvider,
   useSidebar,
-} from "@deco/ui/components/sidebar.tsx";
-import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
+} from "@decocms/ui/components/sidebar.tsx";
+import { Sheet, SheetContent, SheetTitle } from "@decocms/ui/components/sheet.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.js";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.js";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   AlertCircle,
   Browser,
@@ -63,7 +63,7 @@ import {
 } from "@tanstack/react-router";
 import { PropsWithChildren, Suspense, useTransition } from "react";
 import { useStatusSounds } from "../hooks/use-status-sounds";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { EmptyState } from "@/web/components/empty-state";
 import {
   computeDefaultSizes,

--- a/apps/mesh/src/web/layouts/plugin-layout.tsx
+++ b/apps/mesh/src/web/layouts/plugin-layout.tsx
@@ -32,7 +32,7 @@ import { Loading01, Settings02 } from "@untitledui/icons";
 import type { ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { Page } from "@/web/components/page";
 
 interface PluginLayoutProps {

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -4,7 +4,7 @@ import {
   useRouterState,
   useParams,
 } from "@tanstack/react-router";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Sidebar,
   SidebarContent,
@@ -17,8 +17,8 @@ import {
   SidebarMenuItem,
   SidebarProvider,
   useSidebar,
-} from "@deco/ui/components/sidebar.tsx";
-import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
+} from "@decocms/ui/components/sidebar.tsx";
+import { Sheet, SheetContent, SheetTitle } from "@decocms/ui/components/sheet.tsx";
 import { PageContentClassNameProvider } from "@/web/components/page";
 import {
   ArrowNarrowLeft,
@@ -38,7 +38,7 @@ import {
   Zap,
 } from "@untitledui/icons";
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { Suspense } from "react";
 import { pluginSettingsSidebarItems } from "@/web/index";
 import { useStatusSounds } from "../hooks/use-status-sounds";

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -18,7 +18,11 @@ import {
   SidebarProvider,
   useSidebar,
 } from "@decocms/ui/components/sidebar.tsx";
-import { Sheet, SheetContent, SheetTitle } from "@decocms/ui/components/sheet.tsx";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@decocms/ui/components/sheet.tsx";
 import { PageContentClassNameProvider } from "@/web/components/page";
 import {
   ArrowNarrowLeft,

--- a/apps/mesh/src/web/routes/agent-home.tsx
+++ b/apps/mesh/src/web/routes/agent-home.tsx
@@ -3,7 +3,7 @@ import { AutomationInlineDetail } from "@/web/views/automations/automations-tab"
 import { PreviewContent } from "@/web/components/vm/preview/preview";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { EmptyState } from "@/web/components/empty-state";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import { MessageChatCircle } from "@untitledui/icons";
 import { lazy } from "react";
 import {

--- a/apps/mesh/src/web/routes/agents-list.tsx
+++ b/apps/mesh/src/web/routes/agents-list.tsx
@@ -26,14 +26,14 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { SearchInput } from "@deco/ui/components/search-input.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { SearchInput } from "@decocms/ui/components/search-input.tsx";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import { FolderClosed, Plus } from "@untitledui/icons";
 import { toast } from "sonner";
 import { GitHubRepoPicker } from "@/web/components/github-repo-picker.tsx";

--- a/apps/mesh/src/web/routes/onboarding.tsx
+++ b/apps/mesh/src/web/routes/onboarding.tsx
@@ -1,10 +1,10 @@
 import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Building02,
   CheckCircle,

--- a/apps/mesh/src/web/routes/orgs/collection-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/collection-detail.tsx
@@ -8,7 +8,7 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 
-import { EmptyState } from "@deco/ui/components/empty-state.tsx";
+import { EmptyState } from "@decocms/ui/components/empty-state.tsx";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -16,7 +16,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-} from "@deco/ui/components/breadcrumb.tsx";
+} from "@decocms/ui/components/breadcrumb.tsx";
 import { Loading01, Container } from "@untitledui/icons";
 import { Link, useParams, useRouter } from "@tanstack/react-router";
 import { Suspense, type ComponentType } from "react";

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -1,6 +1,6 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
-import { SearchInput } from "@deco/ui/components/search-input.tsx";
+import { SearchInput } from "@decocms/ui/components/search-input.tsx";
 import { CollectionTabs } from "@/web/components/collections/collection-tabs.tsx";
 import { ConnectionCard } from "@/web/components/connections/connection-card.tsx";
 import { EmptyState } from "@/web/components/empty-state.tsx";
@@ -29,9 +29,9 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
 import {
   Dialog,
   DialogContent,
@@ -39,7 +39,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerClose,
@@ -48,14 +48,14 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   Form,
   FormControl,
@@ -63,17 +63,17 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "@deco/ui/components/form.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+} from "@decocms/ui/components/form.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   SELF_MCP_ALIAS_ID,
   useConnectionActions,

--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -1,5 +1,5 @@
 import { CollectionDisplayButton } from "@/web/components/collections/collection-display-button.tsx";
-import { SearchInput } from "@deco/ui/components/search-input.tsx";
+import { SearchInput } from "@decocms/ui/components/search-input.tsx";
 import { Page } from "@/web/components/page";
 import { CollectionTableWrapper } from "@/web/components/collections/collection-table-wrapper.tsx";
 import { ManageRolesDialog } from "@/web/components/manage-roles-dialog";
@@ -20,7 +20,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -30,11 +30,11 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import type { TableColumn } from "@/web/components/collections/collection-table.tsx";
 import {
   DropdownMenu,
@@ -45,7 +45,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   DotsVertical,
   SwitchHorizontal01,
@@ -61,8 +61,8 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";

--- a/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
@@ -7,20 +7,20 @@ import type { useConnections, useVirtualMCPs } from "@decocms/mesh-sdk";
 import { useMCPClient } from "@decocms/mesh-sdk";
 import type { useProjectContext } from "@decocms/mesh-sdk";
 import { useQuery, useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
-} from "@deco/ui/components/sheet.tsx";
+} from "@decocms/ui/components/sheet.tsx";
 import {
   Table,
   TableBody,
   TableHead,
   TableHeader,
   TableRow,
-} from "@deco/ui/components/table.tsx";
+} from "@decocms/ui/components/table.tsx";
 import { ChevronUp, ChevronDown } from "@untitledui/icons";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { LogRow } from "@/web/components/monitoring/log-row.tsx";

--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -4,7 +4,7 @@
  * Tab switcher + shared state. Delegates to overview, audit, and threads tabs.
  */
 
-import { SearchInput } from "@deco/ui/components/search-input.tsx";
+import { SearchInput } from "@decocms/ui/components/search-input.tsx";
 import { Page } from "@/web/components/page";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
@@ -29,43 +29,43 @@ import {
   useProjectContext,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { FilterLines, Container } from "@untitledui/icons";
-import { Input } from "@deco/ui/components/input.tsx";
-import { MultiSelect } from "@deco/ui/components/multi-select.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { MultiSelect } from "@decocms/ui/components/multi-select.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
+} from "@decocms/ui/components/select.tsx";
 import {
   TimeRangePicker,
   type TimeRange as TimeRangeValue,
-} from "@deco/ui/components/time-range-picker.tsx";
-import { expressionToDate } from "@deco/ui/lib/time-expressions.ts";
+} from "@decocms/ui/components/time-range-picker.tsx";
+import { expressionToDate } from "@decocms/ui/lib/time-expressions.ts";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Suspense, useRef, useState } from "react";
 import { Plus, Trash01, Code01, Grid01 } from "@untitledui/icons";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { CollectionTabs } from "@/web/components/collections/collection-tabs.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 
 import { OverviewTabContent, OverviewTabSkeleton } from "./overview.tsx";
 import { AuditTabContent, MonitoringLogsTable } from "./audit.tsx";

--- a/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
@@ -7,15 +7,15 @@ import { useState } from "react";
 import type { useConnections } from "@decocms/mesh-sdk";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/select.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Container } from "@untitledui/icons";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
@@ -9,28 +9,28 @@ import {
   useInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Badge } from "@deco/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
 import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
-} from "@deco/ui/components/sheet.tsx";
+} from "@decocms/ui/components/sheet.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { MultiSelect } from "@deco/ui/components/multi-select.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { MultiSelect } from "@decocms/ui/components/multi-select.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   Table,
   TableBody,
@@ -38,8 +38,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@deco/ui/components/table.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+} from "@decocms/ui/components/table.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   ChevronUp,
   ChevronDown,

--- a/apps/mesh/src/web/routes/reset-password.tsx
+++ b/apps/mesh/src/web/routes/reset-password.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { authClient } from "@/web/lib/auth-client";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 
 export default function ResetPasswordRoute() {
   const { token, error: tokenError } = useSearch({ from: "/reset-password" });

--- a/apps/mesh/src/web/views/automations/agent-automations.tsx
+++ b/apps/mesh/src/web/views/automations/agent-automations.tsx
@@ -6,7 +6,7 @@ import {
   BreadcrumbItem,
   BreadcrumbList,
   BreadcrumbPage,
-} from "@deco/ui/components/breadcrumb.tsx";
+} from "@decocms/ui/components/breadcrumb.tsx";
 import { Loading01 } from "@untitledui/icons";
 import { useMatch, useSearch } from "@tanstack/react-router";
 import { Suspense } from "react";

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -19,14 +19,14 @@ import {
 } from "@/web/hooks/use-automations";
 import { useChatTask, useChatPrefs } from "@/web/components/chat/context";
 import { usePreferences } from "@/web/hooks/use-preferences";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import {
   getDecopilotId,
   useConnections,
@@ -80,7 +80,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
+} from "@decocms/ui/components/select.tsx";
 
 // ============================================================================
 // Event Trigger Form

--- a/apps/mesh/src/web/views/automations/automations-tab.tsx
+++ b/apps/mesh/src/web/views/automations/automations-tab.tsx
@@ -22,15 +22,15 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   DotsVertical,
   Eye,

--- a/apps/mesh/src/web/views/registry/broken-mcp-list.tsx
+++ b/apps/mesh/src/web/views/registry/broken-mcp-list.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import type { MonitorResult } from "@/web/lib/registry/types";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 export function BrokenMCPList({ results }: { results: MonitorResult[] }) {
   if (results.length === 0) {

--- a/apps/mesh/src/web/views/registry/cron-schedule-selector.tsx
+++ b/apps/mesh/src/web/views/registry/cron-schedule-selector.tsx
@@ -1,5 +1,5 @@
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 
 type CronFrequency = "daily" | "weekly" | "biweekly" | "monthly" | "custom";
 

--- a/apps/mesh/src/web/views/registry/csv-import-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/csv-import-dialog.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Dialog,
   DialogContent,
@@ -8,7 +8,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Table,
   TableBody,
@@ -16,7 +16,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@deco/ui/components/table.tsx";
+} from "@decocms/ui/components/table.tsx";
 import {
   AlertCircle,
   CheckCircle,

--- a/apps/mesh/src/web/views/registry/delete-confirm-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/delete-confirm-dialog.tsx
@@ -7,7 +7,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
 
 interface DeleteConfirmDialogProps {
   open: boolean;

--- a/apps/mesh/src/web/views/registry/image-upload.tsx
+++ b/apps/mesh/src/web/views/registry/image-upload.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import {
   ImagePlus,
   RefreshCcw01,
@@ -9,7 +9,7 @@ import {
   Link01,
   Loading01,
 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface ImageUploadProps {
   value: string;

--- a/apps/mesh/src/web/views/registry/monitor-configuration.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-configuration.tsx
@@ -1,15 +1,15 @@
 import { useRef, useState } from "react";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 import { MessageQuestionCircle } from "@untitledui/icons";
 import {
   useMonitorScheduleCancel,

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -1,16 +1,16 @@
 import { useState } from "react";
 import { authenticateMcp, isConnectionAuthenticated } from "@decocms/mesh-sdk";
 import { useQuery } from "@tanstack/react-query";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import { toast } from "sonner";
 import {
   useSyncMonitorConnections,
@@ -20,7 +20,7 @@ import {
   useUpdateMonitorConnectionAuth,
 } from "@/web/hooks/registry/use-monitor";
 import { KEYS } from "@/web/lib/registry/query-keys";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { useRegistryMutations } from "@/web/hooks/registry/use-registry";
 import type {
   MonitorConnectionAuthStatus,

--- a/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
@@ -8,10 +8,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import {
   useRegistryMonitorConfig,
   useMonitorResults,
@@ -26,7 +26,7 @@ import type {
   MonitorResult,
   MonitorToolResult,
 } from "@/web/lib/registry/types";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   collapseLatestToolResults,
   formatMonitorDuration,

--- a/apps/mesh/src/web/views/registry/monitor-run-detail.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-run-detail.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   useMonitorResults,
   useMonitorRun,

--- a/apps/mesh/src/web/views/registry/monitor-run-history.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-run-history.tsx
@@ -1,8 +1,8 @@
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import { useMonitorRuns } from "@/web/hooks/registry/use-monitor";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   formatMonitorDuration,
   monitorStatusBadgeClass,

--- a/apps/mesh/src/web/views/registry/registry-item-card.tsx
+++ b/apps/mesh/src/web/views/registry/registry-item-card.tsx
@@ -1,12 +1,12 @@
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   CheckVerified02,
   DotsVertical,

--- a/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Dialog,
   DialogContent,
@@ -8,19 +8,19 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+} from "@decocms/ui/components/dialog.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
 import {
   AlertCircle,
   ArrowLeft,

--- a/apps/mesh/src/web/views/registry/registry-items-page.tsx
+++ b/apps/mesh/src/web/views/registry/registry-items-page.tsx
@@ -1,8 +1,8 @@
 import { useDeferredValue, useRef, useState } from "react";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
 import {
   Table,
   TableBody,
@@ -19,12 +19,12 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@deco/ui/components/table.tsx";
+} from "@decocms/ui/components/table.tsx";
 import {
   ToggleGroup,
   ToggleGroupItem,
-} from "@deco/ui/components/toggle-group.tsx";
-import { useViewMode } from "@deco/ui/hooks/use-view-mode.ts";
+} from "@decocms/ui/components/toggle-group.tsx";
+import { useViewMode } from "@decocms/ui/hooks/use-view-mode.ts";
 import { toast } from "sonner";
 import {
   DotsVertical,

--- a/apps/mesh/src/web/views/registry/registry-layout.tsx
+++ b/apps/mesh/src/web/views/registry/registry-layout.tsx
@@ -1,5 +1,5 @@
 import { useState, type ComponentType } from "react";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   ArrowNarrowLeft,
   CheckCircle,

--- a/apps/mesh/src/web/views/registry/registry-monitor-page.tsx
+++ b/apps/mesh/src/web/views/registry/registry-monitor-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { BrokenMCPList } from "./broken-mcp-list";
 import { MonitorConfiguration } from "./monitor-configuration";
 import { MonitorConnectionsPanel } from "./monitor-connections-panel";

--- a/apps/mesh/src/web/views/registry/registry-requests-page.tsx
+++ b/apps/mesh/src/web/views/registry/registry-requests-page.tsx
@@ -8,11 +8,11 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
 import {
   Dialog,
   DialogContent,
@@ -20,8 +20,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+} from "@decocms/ui/components/dialog.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import {
   Table,
   TableBody,
@@ -29,8 +29,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@deco/ui/components/table.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+} from "@decocms/ui/components/table.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   CheckCircle,
   Eye,

--- a/apps/mesh/src/web/views/registry/registry-settings-page.tsx
+++ b/apps/mesh/src/web/views/registry/registry-settings-page.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,10 +13,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { useCopy } from "@deco/ui/hooks/use-copy.ts";
-import { Label } from "@deco/ui/components/label.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { useCopy } from "@decocms/ui/hooks/use-copy.ts";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
   Check,
   Copy01,

--- a/apps/mesh/src/web/views/registry/tools-editor.tsx
+++ b/apps/mesh/src/web/views/registry/tools-editor.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
 import {
   Loading01,
   RefreshCcw01,

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -14,15 +14,15 @@ import {
   RefreshCw01,
 } from "@untitledui/icons";
 import { Page } from "@/web/components/page";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   ToggleGroup,
   ToggleGroupItem,
-} from "@deco/ui/components/toggle-group.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+} from "@decocms/ui/components/toggle-group.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   Dialog,
   DialogContent,
@@ -30,7 +30,7 @@ import {
   DialogTitle,
   DialogDescription,
   DialogFooter,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,7 +40,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
 import {
   useAiProviders,
   useAiProviderKeys,
@@ -52,7 +52,7 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 
 function ErrorFallback({ error }: { error: Error }) {

--- a/apps/mesh/src/web/views/settings/org-brand-context.tsx
+++ b/apps/mesh/src/web/views/settings/org-brand-context.tsx
@@ -18,10 +18,10 @@ import {
   Globe02,
   Zap,
 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import { toast } from "sonner";
 import { Page } from "@/web/components/page";
 import { KEYS } from "@/web/lib/query-keys";

--- a/apps/mesh/src/web/views/settings/org-sso.tsx
+++ b/apps/mesh/src/web/views/settings/org-sso.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { Page } from "@/web/components/page";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   useOrgSsoConfig,

--- a/apps/mesh/src/web/views/settings/org-store.tsx
+++ b/apps/mesh/src/web/views/settings/org-store.tsx
@@ -3,17 +3,17 @@ import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { AlertCircle, ChevronRight, Plus, Trash01 } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card } from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
+} from "@decocms/ui/components/popover.tsx";
 import {
   useProjectContext,
   WellKnownOrgMCPId,

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -1,27 +1,27 @@
 import { useState } from "react";
 import { Page } from "@/web/components/page";
-import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import {
   Card,
   CardContent,
   CardFooter,
   CardHeader,
   CardTitle,
-} from "@deco/ui/components/card.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
+} from "@decocms/ui/components/card.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
-} from "@deco/ui/components/select.tsx";
+} from "@decocms/ui/components/select.tsx";
 import {
   ToggleGroup,
   ToggleGroupItem,
-} from "@deco/ui/components/toggle-group.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+} from "@decocms/ui/components/toggle-group.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import { Moon01, Monitor01, Play, Sun } from "@untitledui/icons";
 import { authClient } from "@/web/lib/auth-client";
 import {
@@ -29,9 +29,9 @@ import {
   type ThemeMode,
   type ToolApprovalLevel,
 } from "@/web/hooks/use-preferences.ts";
-import { playSound } from "@deco/ui/lib/sound-engine.ts";
-import { question004Sound } from "@deco/ui/lib/question-004.ts";
-import { toast } from "@deco/ui/components/sonner.js";
+import { playSound } from "@decocms/ui/lib/sound-engine.ts";
+import { question004Sound } from "@decocms/ui/lib/question-004.ts";
+import { toast } from "@decocms/ui/components/sonner.js";
 
 function PreferenceRow({
   label,

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -21,15 +21,15 @@ import {
 import { getGitHubAvatarUrl } from "@/web/utils/github";
 import { useEnabledRegistries } from "@/web/hooks/use-enabled-registries";
 import { useMergedStoreDiscovery } from "@/web/hooks/use-merged-store-discovery";
-import { Badge } from "@deco/ui/components/badge.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/dialog.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   type ConnectionEntity,
   SELF_MCP_ALIAS_ID,

--- a/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
@@ -3,14 +3,14 @@ import { ToolAnnotationBadges } from "@/web/components/tools";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Checkbox } from "@decocms/ui/components/checkbox.tsx";
 import {
   Dialog,
   DialogContent,
   DialogFooter,
-} from "@deco/ui/components/dialog.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/dialog.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   useConnection,
   useMCPClient,

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -25,26 +25,26 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@deco/ui/components/alert-dialog.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Card, CardContent, CardHeader } from "@deco/ui/components/card.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { Label } from "@deco/ui/components/label.tsx";
+} from "@decocms/ui/components/alert-dialog.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card, CardContent, CardHeader } from "@decocms/ui/components/card.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { Switch } from "@deco/ui/components/switch.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
+} from "@decocms/ui/components/select.tsx";
+import { Switch } from "@decocms/ui/components/switch.tsx";
+import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/tooltip.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   type ConnectionEntity,
   getDecopilotId,

--- a/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -1,17 +1,17 @@
 import { slugify } from "@/shared/utils/slugify";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import {
   Drawer,
   DrawerContent,
   DrawerTitle,
-} from "@deco/ui/components/drawer.tsx";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+} from "@decocms/ui/components/drawer.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,
@@ -19,7 +19,7 @@ import {
 } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk";
 import { Check, Copy01, Key01, Loading01 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 

--- a/apps/ui-playground/index.html
+++ b/apps/ui-playground/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@decocms/ui playground</title>
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("playground:theme") || "system";
+          var dark =
+            t === "dark" ||
+            (t === "system" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (dark) document.documentElement.classList.add("dark");
+        } catch (e) {}
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/ui-playground/package.json
+++ b/apps/ui-playground/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@decocms/ui-playground",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4100",
+    "build": "vite build",
+    "preview": "vite preview --port 4100",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@decocms/ui": "workspace:*",
+    "next-themes": "^0.4.6",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.17",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^5.1.0",
+    "tailwindcss": "^4.1.17",
+    "typescript": "^5.9.3",
+    "vite": "^7.2.1"
+  }
+}

--- a/apps/ui-playground/src/App.tsx
+++ b/apps/ui-playground/src/App.tsx
@@ -1,0 +1,234 @@
+import { useState } from "react";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@decocms/ui/components/card.tsx";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Label } from "@decocms/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@decocms/ui/components/select.tsx";
+
+type Theme = "light" | "dark" | "system";
+
+const THEME_KEY = "playground:theme";
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  const resolved =
+    theme === "system"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light"
+      : theme;
+  root.classList.toggle("dark", resolved === "dark");
+}
+
+function useTheme(): [Theme, (t: Theme) => void] {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    return (localStorage.getItem(THEME_KEY) as Theme) || "system";
+  });
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    localStorage.setItem(THEME_KEY, t);
+    applyTheme(t);
+  };
+  return [theme, setTheme];
+}
+
+const COLOR_TOKENS = [
+  "background",
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "border",
+  "input",
+  "ring",
+  "destructive",
+  "destructive-foreground",
+  "success",
+  "success-foreground",
+  "warning",
+  "warning-foreground",
+  "brand",
+  "brand-foreground",
+] as const;
+
+const RADIUS_TOKENS = [
+  "none",
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+  "4xl",
+  "full",
+] as const;
+
+export function App() {
+  const [theme, setTheme] = useTheme();
+
+  return (
+    <div className="mx-auto max-w-5xl p-8 space-y-8">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">@decocms/ui playground</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Local validation surface for the design system. Ephemeral — use to
+            catch issues before publishing.
+          </p>
+        </div>
+        <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
+          <SelectTrigger className="w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="light">Light</SelectItem>
+            <SelectItem value="dark">Dark</SelectItem>
+            <SelectItem value="system">System</SelectItem>
+          </SelectContent>
+        </Select>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Color tokens</CardTitle>
+          <CardDescription>Semantic tokens from global.css.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+            {COLOR_TOKENS.map((t) => (
+              <div key={t} className="space-y-1">
+                <div
+                  className="h-12 rounded-md border border-border"
+                  style={{ background: `var(--${t})` }}
+                />
+                <div className="text-xs font-mono text-muted-foreground">
+                  --{t}
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Radius scale</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-3">
+            {RADIUS_TOKENS.map((r) => (
+              <div key={r} className="text-center space-y-1">
+                <div
+                  className="h-16 w-16 bg-accent border border-border"
+                  style={{ borderRadius: `var(--radius-${r})` }}
+                />
+                <div className="text-xs font-mono text-muted-foreground">
+                  {r}
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Typography</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="font-sans">
+            Sans (Inter var) — The quick brown fox jumps over the lazy dog.
+          </p>
+          <p className="font-serif">
+            Serif — The quick brown fox jumps over the lazy dog.
+          </p>
+          <p className="font-mono">
+            Mono (CommitMono) — The quick brown fox jumps over the lazy dog.
+          </p>
+          <div className="flex gap-3 pt-2">
+            {[300, 400, 500, 600, 650].map((w) => (
+              <span key={w} style={{ fontWeight: w }}>
+                {w}
+              </span>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Buttons</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          <Button>Default</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="destructive">Destructive</Button>
+          <Button variant="link">Link</Button>
+          <Button disabled>Disabled</Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Badges</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          <Badge>Default</Badge>
+          <Badge variant="secondary">Secondary</Badge>
+          <Badge variant="outline">Outline</Badge>
+          <Badge variant="destructive">Destructive</Badge>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Form primitives</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 max-w-md">
+          <div className="space-y-1.5">
+            <Label htmlFor="p-email">Email</Label>
+            <Input id="p-email" type="email" placeholder="hi@example.com" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="p-err">Invalid state</Label>
+            <Input id="p-err" aria-invalid placeholder="try focusing me" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="p-disabled">Disabled</Label>
+            <Input id="p-disabled" disabled placeholder="disabled" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <footer className="text-xs text-muted-foreground pt-4 pb-8">
+        Active theme: <code className="font-mono">{theme}</code>. Validate:
+        tokens render, fonts load, components interactive, dark mode flips.
+      </footer>
+    </div>
+  );
+}

--- a/apps/ui-playground/src/main.tsx
+++ b/apps/ui-playground/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/ui-playground/src/styles.css
+++ b/apps/ui-playground/src/styles.css
@@ -1,0 +1,7 @@
+@import "@decocms/ui/styles/global.css";
+
+@layer base {
+  body {
+    @apply bg-background text-foreground min-h-screen;
+  }
+}

--- a/apps/ui-playground/tsconfig.json
+++ b/apps/ui-playground/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "."
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/ui-playground/vite.config.ts
+++ b/apps/ui-playground/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: { port: 4100 },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.261.0",
+      "version": "2.266.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -94,12 +94,12 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.80",
         "@better-auth/sso": "1.4.1",
         "@daveyplate/better-auth-ui": "^3.2.7",
-        "@deco/ui": "workspace:*",
         "@decocms/better-auth": "1.5.17",
         "@decocms/bindings": "workspace:*",
         "@decocms/mcp-utils": "workspace:*",
         "@decocms/mesh-sdk": "workspace:*",
         "@decocms/runtime": "workspace:*",
+        "@decocms/ui": "workspace:*",
         "@decocms/vite-plugin": "workspace:*",
         "@electric-sql/pglite": "^0.3.15",
         "@floating-ui/react": "^0.27.16",
@@ -187,6 +187,25 @@
         "@duckdb/node-api": "^1.5.0-r.1",
       },
     },
+    "apps/ui-playground": {
+      "name": "@decocms/ui-playground",
+      "version": "0.0.0",
+      "dependencies": {
+        "@decocms/ui": "workspace:*",
+        "next-themes": "^0.4.6",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.17",
+        "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.0.4",
+        "@vitejs/plugin-react": "^5.1.0",
+        "tailwindcss": "^4.1.17",
+        "typescript": "^5.9.3",
+        "vite": "^7.2.1",
+      },
+    },
     "packages/bindings": {
       "name": "@decocms/bindings",
       "version": "1.4.1",
@@ -269,7 +288,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
         "@cloudflare/workers-types": "^4.20250617.0",
@@ -309,8 +328,8 @@
       },
     },
     "packages/ui": {
-      "name": "@deco/ui",
-      "version": "1.0.0",
+      "name": "@decocms/ui",
+      "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -346,10 +365,7 @@
         "date-fns": "^3.0.0",
         "embla-carousel-react": "^8.5.2",
         "input-otp": "^1.4.2",
-        "next-themes": "^0.4.6",
-        "react": "^19.2.0",
         "react-day-picker": "^8.10.1",
-        "react-dom": "^19.2.0",
         "react-hook-form": "^7.55.0",
         "react-markdown": "^10.1.0",
         "recharts": "2.15.1",
@@ -363,6 +379,15 @@
       "devDependencies": {
         "tailwindcss": "^4.1.1",
       },
+      "peerDependencies": {
+        "next-themes": ">=0.4.0",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0",
+        "tailwindcss": ">=4.0.0",
+      },
+      "optionalPeers": [
+        "next-themes",
+      ],
     },
     "packages/vite-plugin-deco": {
       "name": "@decocms/vite-plugin",
@@ -638,8 +663,6 @@
 
     "@daveyplate/better-auth-ui": ["@daveyplate/better-auth-ui@3.3.15", "", { "dependencies": { "@better-fetch/fetch": "^1.1.21", "@hcaptcha/react-hcaptcha": "^1.17.1", "@noble/hashes": "^2.0.1", "@react-email/components": "^1.0.1", "@wojtekmaj/react-recaptcha-v3": "^0.1.4", "react-google-recaptcha": "^3.1.0", "react-qr-code": "^2.0.18", "ua-parser-js": "^2.0.7", "vaul": "^1.1.2" }, "peerDependencies": { "@better-auth/passkey": ">=1.4.6", "@captchafox/react": "^1.10.0", "@daveyplate/better-auth-tanstack": "^1.3.6", "@hookform/resolvers": ">=5.2.0", "@instantdb/react": ">=0.18.0", "@marsidev/react-turnstile": ">=1.1.0", "@radix-ui/react-avatar": ">=1.1.0", "@radix-ui/react-checkbox": ">=1.1.0", "@radix-ui/react-context": ">=1.1.0", "@radix-ui/react-dialog": ">=1.1.0", "@radix-ui/react-dropdown-menu": ">=2.1.0", "@radix-ui/react-label": ">=2.1.0", "@radix-ui/react-primitive": ">=2.0.0", "@radix-ui/react-select": ">=2.2.0", "@radix-ui/react-separator": ">=1.1.0", "@radix-ui/react-slot": ">=1.1.0", "@radix-ui/react-tabs": ">=1.1.0", "@radix-ui/react-tooltip": ">=1.2.0", "@radix-ui/react-use-callback-ref": ">=1.1.0", "@radix-ui/react-use-layout-effect": ">=1.1.0", "@tanstack/react-query": ">=5.66.0", "@triplit/client": ">=1.0.0", "@triplit/react": ">=1.0.0", "better-auth": "^1.4.6", "class-variance-authority": ">=0.7.0", "clsx": ">=2.1.0", "input-otp": ">=1.4.0", "lucide-react": ">=0.469.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-hook-form": ">=7.55.0", "sonner": ">=1.7.0", "tailwind-merge": ">=2.6.0", "tailwindcss": ">=3.0.0", "zod": ">=3.0.0" } }, "sha512-vvsQ70EJha+WTBKjLbw4U/ycRjL0IgKHZ3RphZAONGnR/2BfdfVn8CEfrrsydmkYKMB8HGxtoMiU7/uu3qD72g=="],
 
-    "@deco/ui": ["@deco/ui@workspace:packages/ui"],
-
     "@decocms/benchmark": ["@decocms/benchmark@workspace:apps/benchmark"],
 
     "@decocms/better-auth": ["@decocms/better-auth@1.5.17", "", { "dependencies": { "@better-auth/core": "1.4.6-beta.3", "@better-auth/telemetry": "1.4.6-beta.3", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.5", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "ms": "4.0.0-nightly.202508271359", "nanostores": "^1.0.1", "zod": "^4.1.12" }, "peerDependencies": { "@lynx-js/react": "*", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@sveltejs/kit", "@tanstack/react-start", "next", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-7AiNXIX51oYMUeNSPNLHDcr/uvQEs+acAfoD2g41Rv+u9DKbOZy6Vh869yAcUNNqzRMWmF4RqvRK3woVUzM5ww=="],
@@ -655,6 +678,10 @@
     "@decocms/runtime": ["@decocms/runtime@workspace:packages/runtime"],
 
     "@decocms/typegen": ["@decocms/typegen@workspace:packages/typegen"],
+
+    "@decocms/ui": ["@decocms/ui@workspace:packages/ui"],
+
+    "@decocms/ui-playground": ["@decocms/ui-playground@workspace:apps/ui-playground"],
 
     "@decocms/vite-plugin": ["@decocms/vite-plugin@workspace:packages/vite-plugin-deco"],
 

--- a/packages/mesh-sdk/src/hooks/use-collections.ts
+++ b/packages/mesh-sdk/src/hooks/use-collections.ts
@@ -38,7 +38,7 @@ export type CollectionEntity = Omit<BaseCollectionEntity, "id"> & {
 };
 
 /**
- * Filter definition for collection queries (matches @deco/ui Filter shape)
+ * Filter definition for collection queries (matches @decocms/ui Filter shape)
  */
 export interface CollectionFilter {
   /** Field to filter on (must match an entity property) */

--- a/packages/mesh-sdk/src/hooks/use-connection.ts
+++ b/packages/mesh-sdk/src/hooks/use-connection.ts
@@ -18,7 +18,7 @@ import { useMCPClient } from "./use-mcp-client";
 import { SELF_MCP_ALIAS_ID } from "../lib/constants";
 
 /**
- * Filter definition for connections (matches @deco/ui Filter shape)
+ * Filter definition for connections (matches @decocms/ui Filter shape)
  */
 export type ConnectionFilter = CollectionFilter;
 

--- a/packages/mesh-sdk/src/hooks/use-virtual-mcp.ts
+++ b/packages/mesh-sdk/src/hooks/use-virtual-mcp.ts
@@ -18,7 +18,7 @@ import { useMCPClient } from "./use-mcp-client";
 import { SELF_MCP_ALIAS_ID } from "../lib/constants";
 
 /**
- * Filter definition for virtual MCPs (matches @deco/ui Filter shape)
+ * Filter definition for virtual MCPs (matches @decocms/ui Filter shape)
  */
 export type VirtualMCPFilter = CollectionFilter;
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,168 @@
+# @decocms/ui
+
+The Deco design system. Shadcn-based React 19 components, semantic color tokens, Tailwind v4 theme, self-hosted typography.
+
+Single source of truth for UI across all Deco products. Update once here, every product gets the change on its next release.
+
+## Install
+
+```bash
+bun add @decocms/ui
+# or: npm install @decocms/ui / pnpm add @decocms/ui
+```
+
+### Peer dependencies
+
+You need these in your app:
+
+- `react >= 19`, `react-dom >= 19`
+- `tailwindcss >= 4`
+- `next-themes >= 0.4` (optional — only if you use the theme provider)
+
+## Setup
+
+### 1. Import the theme
+
+In your app's global CSS (e.g. `index.css`):
+
+```css
+@import "@decocms/ui/styles/global.css";
+```
+
+This brings: font-face declarations (Inter var, CommitMono), all design tokens (colors, radius, spacing, motion, shadows), light + dark variants, and base element styles.
+
+### 2. Tell Tailwind to scan the components
+
+Tailwind v4 does not scan `node_modules` by default. Add this to your global CSS so utility classes used inside `@decocms/ui` get emitted:
+
+```css
+@source "../../node_modules/@decocms/ui/src/**/*.{ts,tsx}";
+```
+
+Adjust the relative path to match where your CSS file lives.
+
+### 3. Use components
+
+```tsx
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card, CardContent, CardHeader, CardTitle } from "@decocms/ui/components/card.tsx";
+
+export function Example() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Hello</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Button>Click me</Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+> **Note:** import paths include the `.tsx` extension. The package ships raw source files, so your `tsconfig.json` needs `"allowImportingTsExtensions": true` and `"moduleResolution": "bundler"` (or "NodeNext"). See "Known limitations" below.
+
+## Exports
+
+```
+@decocms/ui/components/*    React components (71 total)
+@decocms/ui/hooks/*         React hooks
+@decocms/ui/lib/*           Utilities (cn, etc.)
+@decocms/ui/providers/*     Theme provider
+@decocms/ui/styles/*        global.css
+@decocms/ui/assets/*        Fonts
+```
+
+## Customization
+
+The design system ships with semantic tokens. Customize by overriding CSS variables in your app, **before** the `@import`:
+
+```css
+:root {
+  --radius: 0.5rem;        /* bump all radius tokens */
+  --spacing: 0.3rem;       /* bump the whole spacing scale */
+  --brand: #ff00aa;        /* override brand color */
+  --primary: oklch(0.3 0.2 300); /* override primary */
+}
+
+@import "@decocms/ui/styles/global.css";
+```
+
+Most product-level visual variation should happen here. If you find yourself forking components, consider whether a token is missing.
+
+### Semantic color tokens
+
+| Token              | Purpose                          |
+| ------------------ | -------------------------------- |
+| `background` / `foreground` | Page canvas + text       |
+| `card`             | Elevated surfaces                |
+| `popover`          | Floating surfaces                |
+| `primary`          | Primary action color             |
+| `secondary`        | Secondary action color           |
+| `muted`            | Low-emphasis surfaces            |
+| `accent`           | Hover / selection surfaces       |
+| `destructive`      | Errors, destructive actions      |
+| `success` / `warning` | Status colors                 |
+| `border` / `input` / `ring` | Form primitives          |
+| `brand`            | Marketing / identity surfaces    |
+| `sidebar-*`        | Sidebar-specific variants        |
+| `chart-1..5`       | Chart series colors              |
+
+All have dark-mode variants. All paired with a `*-foreground` text color.
+
+## Releasing a new version
+
+The package is published automatically on push to `main` when anything under `packages/ui/**` changes. The publish workflow checks if the `version` in `packages/ui/package.json` already exists on npm; if it does, it skips. If not, it publishes.
+
+To release:
+
+1. Bump `packages/ui/package.json` version (`0.1.0` → `0.1.1` patch, `0.2.0` minor, etc.).
+2. Merge to `main`.
+3. The workflow (`.github/workflows/publish-ui-npm.yaml`) publishes and creates a GitHub release.
+
+For prereleases, use a hyphenated version (`0.2.0-rc.1`). It will publish under the `next` tag instead of `latest`.
+
+### One-time setup required
+
+An `NPM_TOKEN` secret must be configured in repo settings for the publish workflow to authenticate with npm.
+
+## Local validation
+
+Before publishing a breaking change, validate the package works as a real consumer would:
+
+```bash
+# 1. Pack the package
+cd packages/ui
+bun pack
+
+# 2. Install the tarball into the playground
+cd ../../apps/ui-playground
+bun add file:../../packages/ui/decocms-ui-$VERSION.tgz
+
+# 3. Run the playground
+bun run dev
+```
+
+The playground (`apps/ui-playground`) is a minimal Vite app that imports only from `@decocms/ui`. Good for catching: missing files in the tarball, broken relative paths (fonts!), Tailwind not scanning, dark mode not flipping.
+
+## Contributing
+
+Components live in `packages/ui/src/components/`. Follow the house rules:
+
+- Use **semantic tokens only** (`bg-primary`, `text-destructive`) — not raw Tailwind palette (`bg-red-500`). Palette colors are reserved for intentional identity surfaces (avatar colors, role badges).
+- Never hardcode hex or rgb in components. If a value isn't in `global.css`, add it there first.
+- Use `class-variance-authority` for variant APIs.
+- Keep component files single-file and readable — this package ships raw source, not bundled output.
+- React 19 / React Compiler — do not use `useEffect`, `useMemo`, `useCallback`, or `memo`. The compiler handles memoization.
+
+## Known limitations
+
+- **Raw source, no compiled output.** The package ships `.tsx` files directly; there is no build step. Consumers must use a bundler that understands TS/JSX (Vite, Next.js, etc.) and a tsconfig with `allowImportingTsExtensions` + bundler/NodeNext resolution. A future version may add a build step with proper `.d.ts` emission to allow extension-free imports.
+- **Tailwind v4 required.** The theme relies on v4-only features (`@theme inline`, `oklch()` color space). Not compatible with Tailwind v3.
+- **React 19 required.** Uses React 19 features; older React versions are not supported.
+- **No tree-shakeable barrel.** Every component must be imported by its own subpath (no `@decocms/ui` root export). This is intentional — keeps bundle size predictable.
+
+## License
+
+MIT.

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -11,10 +11,10 @@
     "prefix": ""
   },
   "aliases": {
-    "ui": "@deco/ui/components",
-    "components": "@deco/ui/components",
-    "utils": "@deco/ui/lib/utils.ts",
-    "lib": "@deco/ui/lib",
-    "hooks": "@deco/ui/hooks"
+    "ui": "@decocms/ui/components",
+    "components": "@decocms/ui/components",
+    "utils": "@decocms/ui/lib/utils.ts",
+    "lib": "@decocms/ui/lib",
+    "hooks": "@decocms/ui/hooks"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "@deco/ui",
-  "private": true,
-  "version": "1.0.0",
+  "name": "@decocms/ui",
+  "version": "0.1.0",
+  "description": "Deco CMS design system — shadcn-based React 19 components, tokens, and Tailwind v4 theme.",
   "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "bun test"
+  },
   "exports": {
     "./components/*": "./src/components/*",
     "./hooks/*": "./src/hooks/*",
@@ -11,6 +15,11 @@
     "./assets/*": "./src/assets/*",
     "./providers/*": "./src/providers/*"
   },
+  "files": [
+    "src",
+    "components.json",
+    "README.md"
+  ],
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
@@ -46,10 +55,7 @@
     "date-fns": "^3.0.0",
     "embla-carousel-react": "^8.5.2",
     "input-otp": "^1.4.2",
-    "next-themes": "^0.4.6",
-    "react": "^19.2.0",
     "react-day-picker": "^8.10.1",
-    "react-dom": "^19.2.0",
     "react-hook-form": "^7.55.0",
     "react-markdown": "^10.1.0",
     "recharts": "2.15.1",
@@ -60,8 +66,38 @@
     "vaul": "^1.1.2",
     "zod": "^4.0.0"
   },
-  "packageManager": "npm@10.5.0",
+  "peerDependencies": {
+    "next-themes": ">=0.4.0",
+    "react": ">=19.0.0",
+    "react-dom": ">=19.0.0",
+    "tailwindcss": ">=4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next-themes": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "tailwindcss": "^4.1.1"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "keywords": [
+    "design-system",
+    "react",
+    "shadcn",
+    "tailwind",
+    "radix",
+    "deco"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/decocms/studio.git",
+    "directory": "packages/ui"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronRight } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Accordion({
   ...props

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -3,8 +3,8 @@
 import type * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "@deco/ui/lib/utils.ts";
-import { buttonVariants } from "@deco/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { buttonVariants } from "@decocms/ui/components/button.tsx";
 
 function AlertDialog({
   ...props

--- a/packages/ui/src/components/alert.tsx
+++ b/packages/ui/src/components/alert.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm flex items-start gap-3 [&>svg]:size-4 [&>svg]:flex-shrink-0 [&>svg]:mt-0.5 [&>svg]:text-current",

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -2,7 +2,7 @@ import type * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/20 focus-visible:ring-[2px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",

--- a/packages/ui/src/components/breadcrumb.tsx
+++ b/packages/ui/src/components/breadcrumb.tsx
@@ -2,7 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { ChevronRight, DotsHorizontal } from "@untitledui/icons";
 import type * as React from "react";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
   return (

--- a/packages/ui/src/components/button-group.tsx
+++ b/packages/ui/src/components/button-group.tsx
@@ -1,7 +1,7 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Separator } from "./separator";
 
 const buttonGroupVariants = cva(

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -2,7 +2,7 @@ import type * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/20 focus-visible:ring-[2px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -4,8 +4,8 @@ import type * as React from "react";
 import { ChevronLeft, ChevronRight } from "@untitledui/icons";
 import { DayPicker } from "react-day-picker";
 
-import { cn } from "@deco/ui/lib/utils.ts";
-import { buttonVariants } from "@deco/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { buttonVariants } from "@decocms/ui/components/button.tsx";
 
 function Calendar({
   className,

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/ui/src/components/carousel.tsx
+++ b/packages/ui/src/components/carousel.tsx
@@ -7,8 +7,8 @@ import useEmblaCarousel, {
 } from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;

--- a/packages/ui/src/components/chart.tsx
+++ b/packages/ui/src/components/chart.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import * as RechartsPrimitive from "recharts";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { Check } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Checkbox({
   className,

--- a/packages/ui/src/components/collection-search.tsx
+++ b/packages/ui/src/components/collection-search.tsx
@@ -1,5 +1,5 @@
 import { SearchMd, Loading01 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface CollectionSearchProps {
   value: string;

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -3,7 +3,7 @@
 import { Check, ChevronSelectorVertical } from "@untitledui/icons";
 import { ReactNode, useState } from "react";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Button } from "./button.tsx";
 import {
   Command,

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -3,14 +3,14 @@
 import type * as React from "react";
 import { Command as CommandPrimitive } from "cmdk";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+} from "@decocms/ui/components/dialog.tsx";
 import { SearchMd } from "@untitledui/icons";
 
 function Command({

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import { Check, ChevronRight, Circle } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function ContextMenu({
   ...props

--- a/packages/ui/src/components/datetime-input.tsx
+++ b/packages/ui/src/components/datetime-input.tsx
@@ -1,20 +1,20 @@
 "use client";
 
 import * as React from "react";
-import { Calendar } from "@deco/ui/components/calendar.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { Calendar } from "@decocms/ui/components/calendar.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/popover.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Calendar as CalendarIcon } from "@untitledui/icons";
 import {
   expressionToDate,
   isTimeExpression,
-} from "@deco/ui/lib/time-expressions.ts";
+} from "@decocms/ui/lib/time-expressions.ts";
 
 export interface DateTimeInputProps {
   value: string;

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Dialog({
   ...props

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Drawer({
   ...props

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function DropdownMenu({
   ...props

--- a/packages/ui/src/components/email-tags-input.tsx
+++ b/packages/ui/src/components/email-tags-input.tsx
@@ -14,7 +14,7 @@ import {
 import { z } from "zod";
 import { Badge } from "./badge.tsx";
 import { Button } from "./button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { X } from "@untitledui/icons";
 
 // Email validation schema

--- a/packages/ui/src/components/empty-state.tsx
+++ b/packages/ui/src/components/empty-state.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, ReactNode } from "react";
 
-import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 export function EmptyState({
   icon,

--- a/packages/ui/src/components/filter-bar.tsx
+++ b/packages/ui/src/components/filter-bar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable ban-memoization/ban-memoization */
 import { useMemo, useState, type ReactNode } from "react";
 
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Command,
   CommandEmpty,
@@ -9,15 +9,15 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-} from "@deco/ui/components/command.tsx";
+} from "@decocms/ui/components/command.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+} from "@decocms/ui/components/dropdown-menu.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import { ArrowLeft, X, Plus } from "@untitledui/icons";
 
 export type FilterOperator =

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Label } from "@deco/ui/components/label.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Label } from "@decocms/ui/components/label.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function HoverCard({
   ...props

--- a/packages/ui/src/components/input-otp.tsx
+++ b/packages/ui/src/components/input-otp.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { OTPInput, OTPInputContext } from "input-otp";
 import { Minus } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function InputOTP({
   className,

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Label({
   className,

--- a/packages/ui/src/components/menubar.tsx
+++ b/packages/ui/src/components/menubar.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as MenubarPrimitive from "@radix-ui/react-menubar";
 import { Check, ChevronRight, Circle } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Menubar({
   className,

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -3,7 +3,7 @@ import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDown } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function NavigationMenu({
   className,

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -1,8 +1,8 @@
 import type * as React from "react";
 import { ChevronLeft, ChevronRight, DotsHorizontal } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
-import { type Button, buttonVariants } from "@deco/ui/components/button.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { type Button, buttonVariants } from "@decocms/ui/components/button.tsx";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (

--- a/packages/ui/src/components/password-input.tsx
+++ b/packages/ui/src/components/password-input.tsx
@@ -1,8 +1,8 @@
 /* oxlint-disable no-explicit-any */
 import { useState } from "react";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Eye, EyeOff, Check, Copy01 } from "@untitledui/icons";
 
 interface PasswordInputProps {

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Popover({
   ...props

--- a/packages/ui/src/components/progress.tsx
+++ b/packages/ui/src/components/progress.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Progress({
   className,

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { Circle } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function RadioGroup({
   className,

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function ScrollArea({
   className,

--- a/packages/ui/src/components/search-input.tsx
+++ b/packages/ui/src/components/search-input.tsx
@@ -1,5 +1,5 @@
 import { SearchMd, Loading01 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface SearchInputProps {
   value: string;

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Select({
   ...props

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Separator({
   className,

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { X } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -6,24 +6,24 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { LayoutLeft } from "@untitledui/icons";
 
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import { cn } from "@deco/ui/lib/utils.ts";
-import { Button } from "@deco/ui/components/button.tsx";
-import { Input } from "@deco/ui/components/input.tsx";
+import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Input } from "@decocms/ui/components/input.tsx";
 import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
-} from "@deco/ui/components/sheet.tsx";
-import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+} from "@decocms/ui/components/sheet.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 
 const SIDEBAR_WIDTH = "15rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Slider({
   className,

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 const variants = cva("animate-spin", {
   variants: {

--- a/packages/ui/src/components/step-indicator.tsx
+++ b/packages/ui/src/components/step-indicator.tsx
@@ -1,6 +1,6 @@
 import { Check } from "@untitledui/icons";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 interface Step {
   id: string;

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as SwitchPrimitive from "@radix-ui/react-switch";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Switch({
   className,

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from "react";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 type TabsVariant = "pill" | "underline" | "canvas";
 

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -1,6 +1,6 @@
 import type * as React from "react";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/packages/ui/src/components/time-range-picker.tsx
+++ b/packages/ui/src/components/time-range-picker.tsx
@@ -1,22 +1,22 @@
 "use client";
 
 import * as React from "react";
-import { Button } from "@deco/ui/components/button.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
-import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
+} from "@decocms/ui/components/popover.tsx";
+import { ScrollArea } from "@decocms/ui/components/scroll-area.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import { Clock, ChevronDown } from "@untitledui/icons";
-import { DateTimeInput } from "@deco/ui/components/datetime-input.tsx";
+import { DateTimeInput } from "@decocms/ui/components/datetime-input.tsx";
 import {
   QUICK_RANGES,
   expressionToDate,
   getTimeRangeDisplayText,
   type QuickRange,
-} from "@deco/ui/lib/time-expressions.ts";
+} from "@decocms/ui/lib/time-expressions.ts";
 
 export interface TimeRange {
   from: string;

--- a/packages/ui/src/components/toggle-group.tsx
+++ b/packages/ui/src/components/toggle-group.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import type { VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
-import { toggleVariants } from "@deco/ui/components/toggle.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { toggleVariants } from "@decocms/ui/components/toggle.tsx";
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants>

--- a/packages/ui/src/components/toggle.tsx
+++ b/packages/ui/src/components/toggle.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/20 focus-visible:ring-[2px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -3,7 +3,7 @@
 import type * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 
 function TooltipProvider({
   delayDuration = 0,

--- a/packages/ui/src/components/view-mode-toggle.tsx
+++ b/packages/ui/src/components/view-mode-toggle.tsx
@@ -1,11 +1,11 @@
-import { cn } from "@deco/ui/lib/utils.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+} from "@decocms/ui/components/tooltip.tsx";
 
 export interface ViewModeOption<T extends string = string> {
   value: T;

--- a/packages/ui/src/hooks/use-persisted-filters.ts
+++ b/packages/ui/src/hooks/use-persisted-filters.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import type { Filter } from "@deco/ui/components/filter-bar.tsx";
+import type { Filter } from "@decocms/ui/components/filter-bar.tsx";
 
 export function usePersistedFilters(
   key: string,

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -28,7 +28,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-/* Explicitly scan @deco/ui components for Tailwind classes */
+/* Explicitly scan @decocms/ui components for Tailwind classes */
 @source "../components/**/*.tsx";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Summary

Prepares the design system (`packages/ui`) for distribution via npm so sibling repos can consume it as `@decocms/ui` instead of depending on this monorepo. Nothing is actually published by this PR — publishing happens only when version bumps land on `main` after review.

Three concerns, three commits:

1. **`refactor(ui): rename @deco/ui → @decocms/ui`** — mechanical scope rename across 238 files so the package aligns with `@decocms/runtime`, `@decocms/mesh-sdk`, etc. No behavior change.
2. **`feat(ui): prepare @decocms/ui for npm publishing`** — restructures `packages/ui/package.json` to match the proven `@decocms/mesh-sdk` publishing pattern (publishConfig, files, peerDeps, repository, license), adds a README covering install/setup/tokens/release, and adds `.github/workflows/publish-ui-npm.yaml` mirroring the existing `publish-runtime-npm.yaml`.
3. **`feat(ui-playground): add local validation app`** — minimal Vite + React 19 app at `apps/ui-playground` that imports only from `@decocms/ui`. Surfaces tokens, typography, and key components in light/dark mode. Used to validate `bun pack` output before publishing.

## What only a reviewer can do

This PR is self-contained except for **one secret**: the publish workflow needs an `NPM_TOKEN` with write access to the `@decocms` scope. Add it under repo settings → secrets → actions once this is merged. Without it, the workflow fails gracefully (nothing publishes, nothing breaks).

## Verification

- `bun install` clean, `bun.lock` updated (scope rename only).
- `bun run --cwd apps/mesh check` → passes.
- `bun run --cwd apps/ui-playground check` → passes.
- `bun run fmt` applied.

## Known issue flagged in README

`@decocms/ui` currently exports **raw .tsx source** via wildcard (`"./components/*": "./src/components/*"`), so consumers must import with explicit `.tsx` extensions and enable `allowImportingTsExtensions` in their tsconfig. This works fine for the existing workspace apps (they already do this) and for bundler-based consumers (Vite, Next.js), but it will surprise external consumers expecting extension-less imports.

Proper fix (future PR): add a build step that emits `.js` + `.d.ts`, or add explicit extensions to the wildcard (breaking — requires all internal imports to drop `.tsx`). Not in scope here; flagged in the README under "Known limitations".

## Release flow after merge

1. Reviewer adds `NPM_TOKEN` secret (one-time).
2. Tag the first version by bumping `packages/ui/package.json` from `0.1.0` to (say) `0.1.0-rc.1` and merging — that publishes to npm under the `next` tag, letting you validate without affecting any real `latest` consumer.
3. When confident, bump to `0.1.0` and merge → publishes as `latest`.
4. Sibling repos add `"@decocms/ui": "^0.1.0"` and migrate off workspace deps.

## Test plan

- [ ] CI passes.
- [ ] Reviewer verifies workflow matches the `publish-runtime-npm` pattern.
- [ ] Reviewer decides if the `apps/ui-playground` app should stay (useful for validation) or be dropped (ephemeral, could be gitignored).
- [ ] After merge: add `NPM_TOKEN` secret, bump to `0.1.0-rc.1`, confirm package appears on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the design system for npm distribution under `@decocms/ui`, replaces all `@deco/ui` imports, and adds an automated publish workflow. Includes a small `apps/ui-playground` app to validate the package before releases.

- **New Features**
  - Added `.github/workflows/publish-ui-npm.yaml` to publish `@decocms/ui` on version bumps with `next` or `latest` tags; requires `NPM_TOKEN`.
  - Updated `packages/ui/package.json` for publishing (`publishConfig`, `files`, peer deps) and bumped to `0.1.0`; added README.
  - Added `apps/ui-playground` (Vite + React 19) for local validation of tokens, typography, and core components.

- **Migration**
  - Replace `@deco/ui` imports with `@decocms/ui` (including CSS like `@decocms/ui/styles/global.css`).
  - Ensure peer deps are provided by consumers: `react`, `react-dom`, `tailwindcss`, `next-themes`.
  - Package currently exports `.tsx` sources; use explicit `.tsx` imports and enable `allowImportingTsExtensions` in `tsconfig` until `.js` + `.d.ts` builds are added.

<sup>Written for commit 6ab4797f47d1792835185a54951fee086484c504. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

