### PR TITLE
feat(home): add Image Creator and Web Researcher agent templates

### DIFF
--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -28,7 +28,8 @@ import { useNavigate } from "@tanstack/react-router";
 import { ChevronRight, Plus, Users03 } from "@untitledui/icons";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
-import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
+import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-modal.tsx";
+import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { Suspense, useState } from "react";
@@ -160,7 +161,8 @@ function AgentsListContent() {
   const { locator } = useProjectContext();
   const [importDecoOpen, setImportDecoOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
-  const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
+  const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
+  const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
   const navigateToAgent = useNavigateToAgent();
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
@@ -169,8 +171,11 @@ function AgentsListContent() {
   const siteDiagnosticsAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "site-diagnostics",
   )!;
-  const leanCanvasAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
-    (t) => t.id === "lean-canvas",
+  const aiImageAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "ai-image",
+  )!;
+  const aiResearchAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "ai-research",
   )!;
 
   const recentIds = readRecentAgentIds(locator);
@@ -202,13 +207,22 @@ function AgentsListContent() {
         a.title === siteDiagnosticsAgent.title),
   );
 
-  // Check if Lean Canvas agent already exists
-  const existingLeanCanvas = virtualMcps.find(
+  // Check if AI Image agent already exists
+  const existingAiImage = virtualMcps.find(
     (a): a is typeof a & { id: string } =>
       a.id !== null &&
       ((a as { metadata?: { type?: string } }).metadata?.type ===
-        leanCanvasAgent.id ||
-        a.title === leanCanvasAgent.title),
+        aiImageAgent.id ||
+        a.title === aiImageAgent.title),
+  );
+
+  // Check if AI Research agent already exists
+  const existingAiResearch = virtualMcps.find(
+    (a): a is typeof a & { id: string } =>
+      a.id !== null &&
+      ((a as { metadata?: { type?: string } }).metadata?.type ===
+        aiResearchAgent.id ||
+        a.title === aiResearchAgent.title),
   );
 
   const hasAgents = agents.length > 0;
@@ -232,19 +246,29 @@ function AgentsListContent() {
             }
           />
           <AgentPreview
-            key={leanCanvasAgent.id}
-            agent={existingLeanCanvas ?? leanCanvasAgent}
+            key={aiImageAgent.id}
+            agent={existingAiImage ?? aiImageAgent}
             onSpecialClick={
-              existingLeanCanvas
-                ? () => navigateToAgent(existingLeanCanvas.id)
-                : () => setLeanCanvasModalOpen(true)
+              existingAiImage
+                ? () => navigateToAgent(existingAiImage.id)
+                : () => setAiImageModalOpen(true)
+            }
+          />
+          <AgentPreview
+            key={aiResearchAgent.id}
+            agent={existingAiResearch ?? aiResearchAgent}
+            onSpecialClick={
+              existingAiResearch
+                ? () => navigateToAgent(existingAiResearch.id)
+                : () => setAiResearchModalOpen(true)
             }
           />
           {agents
             .filter(
               (a) =>
                 a.id !== existingDiagnostics?.id &&
-                a.id !== existingLeanCanvas?.id,
+                a.id !== existingAiImage?.id &&
+                a.id !== existingAiResearch?.id,
             )
             .map((agent) => (
               <AgentPreview
@@ -269,10 +293,16 @@ function AgentsListContent() {
         existingAgent={existingDiagnostics}
       />
 
-      <LeanCanvasRecruitModal
-        open={leanCanvasModalOpen}
-        onOpenChange={setLeanCanvasModalOpen}
-        existingAgent={existingLeanCanvas}
+      <AiImageRecruitModal
+        open={aiImageModalOpen}
+        onOpenChange={setAiImageModalOpen}
+        existingAgent={existingAiImage}
+      />
+
+      <AiResearchRecruitModal
+        open={aiResearchModalOpen}
+        onOpenChange={setAiResearchModalOpen}
+        existingAgent={existingAiResearch}
       />
     </>
   );

--- a/apps/mesh/src/web/components/home/ai-image-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/ai-image-recruit-modal.tsx
@@ -16,8 +16,6 @@ import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   WELL_KNOWN_AGENT_TEMPLATES,
-  WellKnownOrgMCPId,
-  useProjectContext,
   useVirtualMCPActions,
 } from "@decocms/mesh-sdk";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
@@ -328,7 +326,6 @@ export function AiImageRecruitModal({
   existingAgent,
 }: AiImageRecruitModalProps) {
   const isMobile = useIsMobile();
-  const { org } = useProjectContext();
   const navigateToAgent = useNavigateToAgent();
   const virtualMcpActions = useVirtualMCPActions();
   const [isRecruiting, setIsRecruiting] = useState(false);
@@ -348,22 +345,13 @@ export function AiImageRecruitModal({
 
     setIsRecruiting(true);
     try {
-      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
-
       const virtualMcp = await virtualMcpActions.create.mutateAsync({
         title: template.title,
         description:
           "AI image prompt engineering and visual ideation assistant",
         icon: template.icon,
         status: "active",
-        connections: [
-          {
-            connection_id: selfConnectionId,
-            selected_tools: null,
-            selected_resources: null,
-            selected_prompts: null,
-          },
-        ],
+        connections: [],
         metadata: {
           type: "ai-image",
           instructions: AI_IMAGE_SYSTEM_PROMPT,

--- a/apps/mesh/src/web/components/home/ai-image-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/ai-image-recruit-modal.tsx
@@ -1,0 +1,414 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@deco/ui/components/drawer.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import {
+  WELL_KNOWN_AGENT_TEMPLATES,
+  WellKnownOrgMCPId,
+  useProjectContext,
+  useVirtualMCPActions,
+} from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+
+const AI_IMAGE_SYSTEM_PROMPT = `You are an image generator agent. Every request of the user is somewhat related to creating, editing or varying an image. You have access to image generation tools
+
+These guidelines define how prompts should be structured, specified, and iterated to produce high-quality, controlled image outputs across different use cases.
+
+VERY IMPORTANT: The user might not have any image model connected. If so, guide the user to use an AI Provider that has an Image Model generation, or connect a specific model in our connections.
+
+---
+
+1. Core Structure
+
+Always structure prompts in this order:
+
+1. Scene or backdrop
+2. Primary subject
+3. Key visual details
+4. Constraints and invariants
+5. Intended output use or polish level
+
+For complex requests, prefer short labeled lines instead of one dense paragraph.
+
+Example structure:
+
+\`\`\`
+Scene:
+Subject:
+Details:
+Constraints:
+Output intent:
+\`\`\`
+
+2. Specificity Policy
+
+When the user prompt is already detailed:
+* Normalize it into a clean, well-structured specification.
+* Do not add new creative elements.
+* Do not expand the narrative beyond what is requested.
+
+When the user prompt is vague:
+You may add:
+* Composition guidance
+* Lighting clarity
+* Material realism
+* Practical layout support
+* Neutral environmental context
+
+Do not add:
+* Extra characters or props
+* Brand identities or slogans
+* Unrequested story elements
+* Arbitrary left/right positioning unless layout requires it
+
+---
+
+3. Composition and Framing
+
+Specify composition only when it improves the result.
+
+You may define:
+* Camera distance (close-up, medium, wide shot)
+* Perspective (top-down, eye-level, low angle)
+* Framing (centered, rule of thirds)
+* Depth of field
+* Negative space (if needed for UI or text)
+
+Avoid unnecessary spatial instructions unless they materially improve clarity.
+
+---
+
+4. Visual Fidelity and Style
+
+If photorealistic:
+* Use real-world photography language (lens, lighting, texture, shadows)
+* Avoid over-polished or artificial styling unless requested
+
+If stylized:
+* Clearly define medium (3D render, oil painting, watercolor, vector, clay)
+* Specify surface finish (matte, glossy, rough, metallic)
+* Define rendering approach (flat, cinematic, painterly)
+
+Do not mix realism and stylization unless explicitly requested.
+
+---
+
+5. Constraints and Invariants
+
+Explicitly state what must remain unchanged.
+
+For edits:
+* "Change only X"
+* "Keep Y unchanged"
+* Repeat critical constraints in every iteration to prevent drift
+
+Examples:
+* Keep background unchanged
+* Preserve identity (face, pose, expression)
+* Maintain exact layout and spacing
+* Do not alter proportions
+
+---
+
+6. Text Inside Images
+
+When including text in the image:
+
+* Put exact text in quotes or ALL CAPS
+* Require verbatim rendering
+* Specify typography (font style, weight, size, color)
+* Define placement
+* State: "No extra characters"
+
+If spelling accuracy is critical, clarify it explicitly.
+
+---
+
+7. Working With Reference Images
+
+If images are provided:
+
+Label each clearly:
+* Image 1: base image (edit target)
+* Image 2: style reference
+* Image 3: composition reference
+
+Clarify intent:
+* Generation with reference
+* Direct edit
+* Compositing
+* Style transfer
+
+For compositing:
+* Specify what moves where
+* Match lighting, perspective, and scale
+* Preserve original framing unless stated otherwise
+
+Never assume a reference image is meant to be modified.
+
+---
+
+8. Iteration Strategy
+
+* Start with a clean base prompt.
+* Make small, single-variable adjustments.
+* Re-state key constraints in every revision.
+* Avoid rewriting the entire prompt when refining.
+
+---
+
+9. Use-Case Guidance
+
+Photorealistic Image
+* Describe the scene as a real moment
+* Specify natural lighting behavior
+* Emphasize material realism and texture
+
+Product Mockup
+* Clear silhouette
+* Accurate materials and surface finish
+* Legible labels
+* Controlled background
+* If text is included: verbatim, no distortion
+
+UI Mockup
+* Define fidelity level first (wireframe or production-ready)
+* Focus on layout, hierarchy, spacing
+* Avoid cinematic or fantasy language
+
+Infographic or Diagram
+* Define audience
+* Specify layout flow
+* Label sections explicitly
+* Require exact text rendering
+
+Logo or Brand Mark
+* Simple and scalable
+* Strong silhouette
+* Balanced negative space
+* No decorative clutter unless requested
+
+Illustration or Story Scene
+* Define concrete actions
+* Keep scene readable
+* Avoid unnecessary subplots
+
+Historical Scene
+* Specify date and location
+* Constrain clothing, architecture, and props to the correct era
+* Avoid modern artifacts
+
+---
+
+10. Editing Modes
+
+Identity Preservation
+* Lock face, body, pose, hair, and expression
+* Change only specified elements
+* Match original lighting and shadows
+
+Precise Object Edit
+* Clearly define what is removed or replaced
+* Preserve surrounding texture and lighting
+* Do not alter unrelated elements
+
+Lighting or Weather Change
+* Modify only environmental conditions
+* Keep geometry, framing, and identity unchanged
+
+Background Extraction
+* Clean cutout
+* Sharp silhouette
+* No halos
+* Preserve original object proportions
+
+Style Transfer
+* Specify what stylistic traits must transfer
+* Specify what must remain unchanged
+* Add "no extra elements" to prevent drift
+
+Sketch to Render
+* Preserve layout and proportions
+* Enhance materials and lighting
+* Do not add new objects
+
+11. Output Intent
+
+Include the intended purpose to guide polish level:
+
+Examples:
+* Advertising creative
+* Website hero image
+* App store screenshot
+* Social media post
+* Print poster
+* Packaging mockup
+
+This helps define finish quality and realism level.
+
+## 12. General Quality Rules
+
+* Avoid ambiguity.
+* Avoid unnecessary adjectives.
+* Avoid conflicting style instructions.
+* Prefer clarity over poetic language.
+* Keep prompts structured, not verbose.
+* Add detail only when it improves control.
+* Prevent drift by restating critical constraints`;
+
+interface AiImageRecruitModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingAgent?: { id: string } | null;
+}
+
+const CAPABILITIES = [
+  "Turn ideas into detailed, ready-to-use image generation prompts",
+  "Offer multiple artistic directions for every concept",
+  "Refine prompts iteratively based on your feedback",
+  "Advise on style, lighting, composition, and color palette",
+  "Support any use case: product shots, illustrations, concept art, and more",
+];
+
+function RecruitContent({
+  onRecruit,
+  isRecruiting,
+}: {
+  onRecruit: () => void;
+  isRecruiting: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Add an Image Creator agent that turns your ideas into precise, evocative
+        prompts for any AI image generation tool.
+      </p>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">Capabilities</p>
+        <ul className="space-y-1.5">
+          {CAPABILITIES.map((cap) => (
+            <li
+              key={cap}
+              className="text-sm text-muted-foreground flex items-start gap-2"
+            >
+              <span className="text-rose-500 mt-0.5 shrink-0">+</span>
+              {cap}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Button
+        onClick={onRecruit}
+        disabled={isRecruiting}
+        className="w-full cursor-pointer"
+      >
+        {isRecruiting ? "Setting up..." : "Add Image Creator"}
+      </Button>
+    </div>
+  );
+}
+
+export function AiImageRecruitModal({
+  open,
+  onOpenChange,
+  existingAgent,
+}: AiImageRecruitModalProps) {
+  const isMobile = useIsMobile();
+  const { org } = useProjectContext();
+  const navigateToAgent = useNavigateToAgent();
+  const virtualMcpActions = useVirtualMCPActions();
+  const [isRecruiting, setIsRecruiting] = useState(false);
+
+  const template = WELL_KNOWN_AGENT_TEMPLATES.find((t) => t.id === "ai-image")!;
+
+  const headerIcon = (
+    <IntegrationIcon icon={template.icon} name={template.title} size="sm" />
+  );
+
+  const handleRecruit = async () => {
+    if (existingAgent) {
+      onOpenChange(false);
+      navigateToAgent(existingAgent.id);
+      return;
+    }
+
+    setIsRecruiting(true);
+    try {
+      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
+
+      const virtualMcp = await virtualMcpActions.create.mutateAsync({
+        title: template.title,
+        description:
+          "AI image prompt engineering and visual ideation assistant",
+        icon: template.icon,
+        status: "active",
+        connections: [
+          {
+            connection_id: selfConnectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+        metadata: {
+          type: "ai-image",
+          instructions: AI_IMAGE_SYSTEM_PROMPT,
+        },
+      });
+
+      onOpenChange(false);
+      navigateToAgent(virtualMcp.id!);
+    } catch (error) {
+      console.error("Failed to create Image Creator agent:", error);
+    } finally {
+      setIsRecruiting(false);
+    }
+  };
+
+  const title = `Add ${template.title}`;
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="h-[70dvh]">
+        <DrawerHeader className="px-4 pt-4 pb-4 shrink-0">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DrawerTitle className="text-xl font-semibold">{title}</DrawerTitle>
+          </div>
+        </DrawerHeader>
+        <div className="flex flex-col flex-1 min-h-0 px-4 pb-8">
+          <RecruitContent
+            onRecruit={handleRecruit}
+            isRecruiting={isRecruiting}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] p-8">
+        <DialogHeader className="mb-4">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DialogTitle className="text-xl font-semibold">{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+        <RecruitContent onRecruit={handleRecruit} isRecruiting={isRecruiting} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/home/ai-research-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/ai-research-recruit-modal.tsx
@@ -16,8 +16,6 @@ import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   WELL_KNOWN_AGENT_TEMPLATES,
-  WellKnownOrgMCPId,
-  useProjectContext,
   useVirtualMCPActions,
 } from "@decocms/mesh-sdk";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
@@ -95,7 +93,6 @@ export function AiResearchRecruitModal({
   existingAgent,
 }: AiResearchRecruitModalProps) {
   const isMobile = useIsMobile();
-  const { org } = useProjectContext();
   const navigateToAgent = useNavigateToAgent();
   const virtualMcpActions = useVirtualMCPActions();
   const [isRecruiting, setIsRecruiting] = useState(false);
@@ -117,21 +114,12 @@ export function AiResearchRecruitModal({
 
     setIsRecruiting(true);
     try {
-      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
-
       const virtualMcp = await virtualMcpActions.create.mutateAsync({
         title: template.title,
         description: "Systematic research and information synthesis assistant",
         icon: template.icon,
         status: "active",
-        connections: [
-          {
-            connection_id: selfConnectionId,
-            selected_tools: null,
-            selected_resources: null,
-            selected_prompts: null,
-          },
-        ],
+        connections: [],
         metadata: {
           type: "ai-research",
           instructions: AI_RESEARCH_SYSTEM_PROMPT,

--- a/apps/mesh/src/web/components/home/ai-research-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/ai-research-recruit-modal.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@deco/ui/components/drawer.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import {
+  WELL_KNOWN_AGENT_TEMPLATES,
+  WellKnownOrgMCPId,
+  useProjectContext,
+  useVirtualMCPActions,
+} from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+
+const AI_RESEARCH_SYSTEM_PROMPT = `You are a systematic research assistant. You have access to web search tools and user's prompts will have somewhat relation to searching the web. Help users conduct thorough, well-structured research on any topic.
+
+VERY IMPORTANT: The user might not have any web research model connected. If so, guide the user to use an AI Provider that has an Web Search generation, or connect a specific model in our connections.
+
+When given a research question or topic:
+- Break it down into key sub-questions and define the scope
+- Gather and synthesize information from multiple angles
+- Distinguish clearly between established facts, expert consensus, and contested claims
+- Identify sources, patterns, gaps, and contradictions
+- Deliver findings as clear, structured summaries with actionable insights
+
+Approach every request with rigor and intellectual honesty. Always surface what is uncertain or debated, not just what is known.`;
+
+interface AiResearchRecruitModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingAgent?: { id: string } | null;
+}
+
+const CAPABILITIES = [
+  "Break any topic into key sub-questions and define scope",
+  "Synthesize information from multiple angles and sources",
+  "Distinguish facts, expert consensus, and contested claims",
+  "Identify gaps, contradictions, and emerging patterns",
+  "Deliver structured summaries with actionable insights",
+];
+
+function RecruitContent({
+  onRecruit,
+  isRecruiting,
+}: {
+  onRecruit: () => void;
+  isRecruiting: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Add a Web Researcher agent that conducts thorough, rigorous research on
+        any topic and delivers structured, actionable insights.
+      </p>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">Capabilities</p>
+        <ul className="space-y-1.5">
+          {CAPABILITIES.map((cap) => (
+            <li
+              key={cap}
+              className="text-sm text-muted-foreground flex items-start gap-2"
+            >
+              <span className="text-amber-500 mt-0.5 shrink-0">+</span>
+              {cap}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Button
+        onClick={onRecruit}
+        disabled={isRecruiting}
+        className="w-full cursor-pointer"
+      >
+        {isRecruiting ? "Setting up..." : "Add Web Researcher"}
+      </Button>
+    </div>
+  );
+}
+
+export function AiResearchRecruitModal({
+  open,
+  onOpenChange,
+  existingAgent,
+}: AiResearchRecruitModalProps) {
+  const isMobile = useIsMobile();
+  const { org } = useProjectContext();
+  const navigateToAgent = useNavigateToAgent();
+  const virtualMcpActions = useVirtualMCPActions();
+  const [isRecruiting, setIsRecruiting] = useState(false);
+
+  const template = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "ai-research",
+  )!;
+
+  const headerIcon = (
+    <IntegrationIcon icon={template.icon} name={template.title} size="sm" />
+  );
+
+  const handleRecruit = async () => {
+    if (existingAgent) {
+      onOpenChange(false);
+      navigateToAgent(existingAgent.id);
+      return;
+    }
+
+    setIsRecruiting(true);
+    try {
+      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
+
+      const virtualMcp = await virtualMcpActions.create.mutateAsync({
+        title: template.title,
+        description: "Systematic research and information synthesis assistant",
+        icon: template.icon,
+        status: "active",
+        connections: [
+          {
+            connection_id: selfConnectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+        metadata: {
+          type: "ai-research",
+          instructions: AI_RESEARCH_SYSTEM_PROMPT,
+        },
+      });
+
+      onOpenChange(false);
+      navigateToAgent(virtualMcp.id!);
+    } catch (error) {
+      console.error("Failed to create Researcher agent:", error);
+    } finally {
+      setIsRecruiting(false);
+    }
+  };
+
+  const title = `Add ${template.title}`;
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="h-[70dvh]">
+        <DrawerHeader className="px-4 pt-4 pb-4 shrink-0">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DrawerTitle className="text-xl font-semibold">{title}</DrawerTitle>
+          </div>
+        </DrawerHeader>
+        <div className="flex flex-col flex-1 min-h-0 px-4 pb-8">
+          <RecruitContent
+            onRecruit={handleRecruit}
+            isRecruiting={isRecruiting}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] p-8">
+        <DialogHeader className="mb-4">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DialogTitle className="text-xl font-semibold">{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+        <RecruitContent onRecruit={handleRecruit} isRecruiting={isRecruiting} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -342,7 +342,7 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
   {
     id: "ai-research",
     title: "Web Researcher",
-    icon: "icon://SearchMd?color=amber",
+    icon: "icon://SearchMd?color=green",
     type: "builtin-agent" as const,
   },
 ] as const;

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -333,6 +333,18 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
     icon: "icon://Package?color=blue",
     type: "pack" as const,
   },
+  {
+    id: "ai-image",
+    title: "Image Creator",
+    icon: "icon://Image01?color=rose",
+    type: "builtin-agent" as const,
+  },
+  {
+    id: "ai-research",
+    title: "Web Researcher",
+    icon: "icon://SearchMd?color=amber",
+    type: "builtin-agent" as const,
+  },
 ] as const;
 
 export type WellKnownAgentTemplate =


### PR DESCRIPTION
## What is this contribution about?

Adds two new built-in agent templates to the home page quick-access list:

- **Image Creator** — a structured prompt engineering agent with detailed guidelines covering scene/subject composition, visual fidelity, constraints, editing modes, and iteration strategy. Guides users to connect an image generation model if none is configured.
- **Web Researcher** — a systematic research agent aware of web search tools, helping users break down questions, synthesize sources, and surface uncertainty. Guides users to connect a web search provider if none is configured.

Lean Canvas is removed from the home list (it remains available as a template in Settings → Agents).

## Screenshots/Demonstration

> UI-only change — two new agent icons appear on the home page between Site Diagnostics and the Create Agent button. Clicking each opens a capabilities modal with a one-click "Add" action.

## How to Test

1. Open the home page (chat view)
2. Verify **Image Creator** and **Web Researcher** appear in the agents row
3. Click each — confirm the capabilities modal opens and "Add" creates the agent with the correct system prompt
4. Confirm Lean Canvas is no longer shown on home (still accessible via Settings → Agents)

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Image Creator and Web Researcher templates to the home agents row with recruit modals and one‑click Add; remove Lean Canvas from home (still in Settings → Agents). Also sets the Web Researcher icon to green and creates both agents without pre‑connected Deco CMS.

- **New Features**
  - Image Creator: structured prompt engineering for image generation; guides users to connect an image model if none is configured.
  - Web Researcher: systematic, web‑aware research; guides users to connect a web search provider.
  - Home UI: both templates appear in the agents row; click opens a capabilities modal with one‑click Add or navigates to an existing agent.
  - SDK constants: added `ai-image` and `ai-research` to `WELL_KNOWN_AGENT_TEMPLATES`.

- **Bug Fixes**
  - Web Researcher icon color set to green.
  - Removed default Deco CMS connection; both agents start with `connections: []`.

<sup>Written for commit a08e065ff2cc1482e3b86c2f87a204d09806aa5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

