### PR TITLE
fix(web): remount tool app view when switching between tool tabs

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -74,6 +74,7 @@ export function MainPanelContent({
         }
       >
         <AppViewContent
+          key={activeTab}
           connectionId={pinnedView.connectionId}
           toolName={pinnedView.toolName}
         />
@@ -95,6 +96,7 @@ export function MainPanelContent({
         }
       >
         <AppViewContent
+          key={activeTab}
           connectionId={agentTab.view.appId}
           toolName={agentTab.id}
         />


### PR DESCRIPTION
## Summary
- Two consecutive tool tabs both render `AppViewContent`, so React was reconciling the same component instance — the `useAppBridge` `BridgeStore` (kept in a ref) and the iframe were reused, relying on `attach()` teardown to reset state correctly.
- Adding `key={activeTab}` to both `AppViewContent` call sites in `main-panel-tabs/index.tsx` (pinned view + agent-declared layout tab) forces a full remount on tab switch: fresh `BridgeStore`, fresh iframe, fresh MCP client subscriptions.
- `activeTab` already equals `app:${connectionId}:${toolName}` for pinned views, so it doubles as the stable identity key without any additional computation.

## Test plan
- [ ] Open two tool UIs from the same connection in consecutive tabs; switch between them and confirm each renders its own iframe from scratch
- [ ] Open two tool UIs from different connections and confirm switching remounts (no bridge state leaks)
- [ ] Switch between an agent-declared layout tab and a pinned tool tab and confirm both remount correctly
- [ ] Confirm non-tool tabs (instructions, connections, layout, env, preview, automations) still switch without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force remount of the tool app view when switching between tool tabs by keying `AppViewContent` with `activeTab`. Prevents iframe and bridge state reuse so each tab gets a fresh `BridgeStore`, iframe, and MCP subscriptions.

<sup>Written for commit ba57ea21fad8af3981d4718e7142f6f82957b7d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

