### PR TITLE
fix(virtual-mcp): relocate Connect share button next to URL field

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1442,39 +1442,6 @@ Define step-by-step how the agent should handle requests.
                       Test Agent
                     </Button>
                     <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        dispatch({
-                          type: "SET_SHARE_DIALOG_OPEN",
-                          payload: true,
-                        })
-                      }
-                    >
-                      <span className="flex items-center -space-x-1.5 mr-0.5">
-                        {/* Cursor — behind */}
-                        <span className="inline-flex items-center justify-center size-4 rounded-full bg-black ring-1 ring-white/20 shrink-0">
-                          <img
-                            src="/logos/cursor.svg"
-                            alt="Cursor"
-                            className="size-2.5 brightness-0 invert"
-                          />
-                        </span>
-                        {/* Claude — on top */}
-                        <span
-                          className="relative z-10 inline-flex items-center justify-center size-4 rounded-full ring-1 ring-background shrink-0"
-                          style={{ backgroundColor: "#D97757" }}
-                        >
-                          <img
-                            src="/logos/Claude Code.svg"
-                            alt="Claude"
-                            className="size-2.5 brightness-0 invert"
-                          />
-                        </span>
-                      </span>
-                      Connect
-                    </Button>
-                    <Button
                       variant="ghost"
                       size="icon"
                       className="text-muted-foreground hover:text-destructive"
@@ -1579,6 +1546,40 @@ Define step-by-step how the agent should handle requests.
                       )}
                     />
                   </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0"
+                    onClick={() =>
+                      dispatch({
+                        type: "SET_SHARE_DIALOG_OPEN",
+                        payload: true,
+                      })
+                    }
+                  >
+                    <span className="flex items-center -space-x-1.5 mr-0.5">
+                      {/* Cursor — behind */}
+                      <span className="inline-flex items-center justify-center size-4 rounded-full bg-black ring-1 ring-white/20 shrink-0">
+                        <img
+                          src="/logos/cursor.svg"
+                          alt="Cursor"
+                          className="size-2.5 brightness-0 invert"
+                        />
+                      </span>
+                      {/* Claude — on top */}
+                      <span
+                        className="relative z-10 inline-flex items-center justify-center size-4 rounded-full ring-1 ring-background shrink-0"
+                        style={{ backgroundColor: "#D97757" }}
+                      >
+                        <img
+                          src="/logos/Claude Code.svg"
+                          alt="Claude"
+                          className="size-2.5 brightness-0 invert"
+                        />
+                      </span>
+                    </span>
+                    Connect
+                  </Button>
                 </div>
 
                 {!hasGithubRepo && (


### PR DESCRIPTION
## What is this contribution about?
Moves the "Connect" share button on the virtual MCP view out of the top action row and places it next to the URL field, improving the affordance between the shareable URL and the action that opens the share dialog.

## How to Test
1. Run `bun run dev` and open a virtual MCP (agent) view
2. Verify the Connect button (with Cursor + Claude avatars) now appears next to the URL field instead of the top-right action cluster
3. Click it and confirm the share dialog still opens

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relocated the "Connect" share button to sit next to the URL field in the virtual MCP (agent) view, improving the link between the shareable URL and the action. Functionality is unchanged: clicking still opens the share dialog.

<sup>Written for commit 154143529115b7f76e3614d535307f6757eae14b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

