### PR TITLE
fix(prompts): derive display title from prompt name when title is absent

### DIFF
--- a/apps/mesh/src/auth/jwt.test.ts
+++ b/apps/mesh/src/auth/jwt.test.ts
@@ -343,14 +343,14 @@ describe("Token Expiration", () => {
     };
 
     // Issue token with very short expiration
-    const token = await issueMeshToken(payload, "1s");
+    const token = await issueMeshToken(payload, "2s");
 
     // Token should be valid immediately
     const validResult = await verifyMeshToken(token);
     expect(validResult).toBeDefined();
 
-    // Wait for token to expire
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // Wait for token to expire (3s gives ample buffer on loaded CI runners)
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     // Token should now be invalid
     const expiredResult = await verifyMeshToken(token);

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -116,7 +116,7 @@ export function displayToolName(
 function titleFromName(name: string): string {
   return name
     .split(/[-_]/)
-    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
     .join(" ");
 }
 

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -109,6 +109,17 @@ export function displayToolName(
     .toLowerCase();
 }
 
+/**
+ * Convert a kebab/snake-case prompt name to a human-readable Title Case string.
+ * e.g. "writing-prompts" → "Writing Prompts"
+ */
+function titleFromName(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
 export interface GatewayClientOptions {
   clientInfo?: Implementation;
   capabilities?: ClientCapabilities;
@@ -495,6 +506,7 @@ export class GatewayClient extends Client {
         prompts.push({
           ...prompt,
           name: this.namespace(clientKey, prompt.name),
+          title: prompt.title ?? titleFromName(prompt.name),
           _meta: {
             ...(prompt._meta ?? {}),
             gatewayClientId: clientKey,


### PR DESCRIPTION
## What is this contribution about?

Prompts registered via the legacy `server.prompt()` API don't include a `title` field. This caused the UI fallback (`displayToolName`) to render the raw namespaced slug — producing garbled output like _"H0jwredec58c9… Self Writing Prompts"_ instead of _"Writing Prompts"_.

`aggregatePrompts()` in `gateway-client.ts` now populates `title` with a human-readable Title Case string derived from the original (pre-namespace) prompt name when the upstream prompt has no `title` set (e.g. `"writing-prompts"` → `"Writing Prompts"`). Both `tools-popover.tsx` and `ice-breakers.tsx` already check `prompt.title` first, so they will immediately pick up the clean title.

## Screenshots/Demonstration

Before: `H0jwredec58c9deafwgviubptt3gneyw Self Writing Prompts`
After: `Writing Prompts`

## How to Test

1. Open a chat with a virtual MCP that registers prompts via the old `server.prompt()` API (guide prompts).
2. Open the Tools popover → Prompts submenu, or observe the icebreaker pills.
3. Expected: prompt names display as clean Title Case (e.g. "Writing Prompts", "Agents Create") with no leading hash/slug.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives a readable Title Case `title` from the prompt `name` when missing to fix garbled labels from legacy `server.prompt()` prompts. `aggregatePrompts()` now sets `title` so Tools and icebreaker pills show clean names; also fixes TS2532 in `titleFromName` and stabilizes the JWT expiry test.

<sup>Written for commit d268f753f5edfc7b983362a5cc16969b638632ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

