### PR TITLE
fix(prompts): add explicit verb-first titles to all studio guide prompts

### DIFF
--- a/apps/mesh/src/auth/jwt.test.ts
+++ b/apps/mesh/src/auth/jwt.test.ts
@@ -343,14 +343,14 @@ describe("Token Expiration", () => {
     };
 
     // Issue token with very short expiration
-    const token = await issueMeshToken(payload, "1s");
+    const token = await issueMeshToken(payload, "2s");
 
     // Token should be valid immediately
     const validResult = await verifyMeshToken(token);
     expect(validResult).toBeDefined();
 
-    // Wait for token to expire
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    // Wait for token to expire (3s gives ample buffer on loaded CI runners)
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     // Token should now be invalid
     const expiredResult = await verifyMeshToken(token);

--- a/apps/mesh/src/tools/guides/agents.ts
+++ b/apps/mesh/src/tools/guides/agents.ts
@@ -3,6 +3,7 @@ import type { GuidePrompt, GuideResource } from "./index";
 export const prompts: GuidePrompt[] = [
   {
     name: "agents-create",
+    title: "Create Agents",
     description: "Build a new agent for a specific role or workflow.",
     text: `# Create agent
 
@@ -27,6 +28,7 @@ Checks:
   },
   {
     name: "agents-update",
+    title: "Update Agents",
     description:
       "Modify an existing agent's behavior, connections, or instructions.",
     text: `# Update agent
@@ -52,6 +54,7 @@ Checks:
   },
   {
     name: "writing-prompts",
+    title: "Improve Instructions",
     description: "Improve instructions for an agent or automation.",
     text: `# Writing instructions
 

--- a/apps/mesh/src/tools/guides/ai-providers.ts
+++ b/apps/mesh/src/tools/guides/ai-providers.ts
@@ -3,6 +3,7 @@ import type { GuidePrompt, GuideResource } from "./index";
 export const prompts: GuidePrompt[] = [
   {
     name: "ai-providers-setup",
+    title: "Set Up AI Provider",
     description: "Set up an AI provider so the workspace can use its models.",
     text: `# Set up AI provider
 

--- a/apps/mesh/src/tools/guides/automations.ts
+++ b/apps/mesh/src/tools/guides/automations.ts
@@ -3,6 +3,7 @@ import type { GuidePrompt, GuideResource } from "./index";
 export const prompts: GuidePrompt[] = [
   {
     name: "automations-create",
+    title: "Create Automations",
     description:
       "Set up a background workflow that runs on a schedule, event, or webhook.",
     text: `# Create automation
@@ -28,6 +29,7 @@ Checks:
   },
   {
     name: "automations-update",
+    title: "Update Automations",
     description: "Change an automation's triggers, agent, or configuration.",
     text: `# Update automation
 

--- a/apps/mesh/src/tools/guides/connections.ts
+++ b/apps/mesh/src/tools/guides/connections.ts
@@ -3,6 +3,7 @@ import type { GuidePrompt, GuideResource } from "./index";
 export const prompts: GuidePrompt[] = [
   {
     name: "connections-create",
+    title: "Create Connections",
     description: "Add a new MCP server connection to the workspace.",
     text: `# Create connection
 
@@ -27,6 +28,7 @@ Checks:
   },
   {
     name: "connections-update",
+    title: "Update Connections",
     description: "Change an existing connection's settings or credentials.",
     text: `# Update connection
 
@@ -50,6 +52,7 @@ Checks:
   },
   {
     name: "connections-troubleshoot",
+    title: "Troubleshoot Connections",
     description: "Fix a broken or unhealthy connection.",
     text: `# Troubleshoot connection
 

--- a/apps/mesh/src/tools/guides/index.ts
+++ b/apps/mesh/src/tools/guides/index.ts
@@ -8,6 +8,7 @@ import * as virtualTools from "./virtual-tools";
 
 export interface GuidePrompt {
   name: string;
+  title: string;
   description: string;
   text: string;
 }

--- a/apps/mesh/src/tools/guides/store.ts
+++ b/apps/mesh/src/tools/guides/store.ts
@@ -3,6 +3,7 @@ import type { GuidePrompt, GuideResource } from "./index";
 export const prompts: GuidePrompt[] = [
   {
     name: "store-search",
+    title: "Search Store",
     description: "Find MCP servers in the Deco Store or a registry.",
     text: `# Search store
 
@@ -30,6 +31,7 @@ Checks:
   },
   {
     name: "store-install",
+    title: "Install from Store",
     description: "Install an MCP server from a store or registry.",
     text: `# Install MCP server from store
 

--- a/apps/mesh/src/tools/guides/virtual-tools.ts
+++ b/apps/mesh/src/tools/guides/virtual-tools.ts
@@ -3,6 +3,7 @@ import type { GuidePrompt, GuideResource } from "./index";
 export const prompts: GuidePrompt[] = [
   {
     name: "virtual-tools-create",
+    title: "Create Virtual Tools",
     description: "Add a sandboxed JavaScript tool to an agent.",
     text: `# Create virtual tool
 
@@ -28,6 +29,7 @@ Checks:
   },
   {
     name: "virtual-tools-update",
+    title: "Update Virtual Tools",
     description: "Modify a virtual tool's code or schema safely.",
     text: `# Update virtual tool
 

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -274,14 +274,18 @@ export const managementMCP = async (ctx: MeshContext) => {
   // Register action prompts
   const prompts = getPrompts();
   for (const prompt of prompts) {
-    server.prompt(prompt.name, prompt.description, () => ({
-      messages: [
-        {
-          role: "user" as const,
-          content: { type: "text" as const, text: prompt.text },
-        },
-      ],
-    }));
+    server.registerPrompt(
+      prompt.name,
+      { title: prompt.title, description: prompt.description },
+      () => ({
+        messages: [
+          {
+            role: "user" as const,
+            content: { type: "text" as const, text: prompt.text },
+          },
+        ],
+      }),
+    );
   }
 
   // Register one prompt per brand context (e.g. /brand-acme-corp)

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -116,7 +116,7 @@ export function displayToolName(
 function titleFromName(name: string): string {
   return name
     .split(/[-_]/)
-    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
     .join(" ");
 }
 

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -109,6 +109,17 @@ export function displayToolName(
     .toLowerCase();
 }
 
+/**
+ * Convert a kebab/snake-case prompt name to a human-readable Title Case string.
+ * e.g. "writing-prompts" → "Writing Prompts"
+ */
+function titleFromName(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
 export interface GatewayClientOptions {
   clientInfo?: Implementation;
   capabilities?: ClientCapabilities;
@@ -495,6 +506,7 @@ export class GatewayClient extends Client {
         prompts.push({
           ...prompt,
           name: this.namespace(clientKey, prompt.name),
+          title: prompt.title ?? titleFromName(prompt.name),
           _meta: {
             ...(prompt._meta ?? {}),
             gatewayClientId: clientKey,


### PR DESCRIPTION
## What is this contribution about?

All guide prompts registered via the studio MCP now have explicit, verb-first titles (e.g. "Create Agents", "Update Connections", "Improve Instructions") instead of falling back to auto-derived names from the kebab-case slug.

The registration was also updated from the deprecated `server.prompt()` to `server.registerPrompt()` which accepts a `title` field in the config object, so the title is included in the MCP `listPrompts` response.

## Prompts updated

| Name | Title |
|---|---|
| `agents-create` | Create Agents |
| `agents-update` | Update Agents |
| `writing-prompts` | Improve Instructions |
| `connections-create` | Create Connections |
| `connections-update` | Update Connections |
| `connections-troubleshoot` | Troubleshoot Connections |
| `store-search` | Search Store |
| `store-install` | Install from Store |
| `automations-create` | Create Automations |
| `automations-update` | Update Automations |
| `ai-providers-setup` | Set Up AI Provider |
| `virtual-tools-create` | Create Virtual Tools |
| `virtual-tools-update` | Update Virtual Tools |

## How to Test

1. Open a chat and observe the icebreaker pills or Tools → Prompts submenu.
2. Expected: all guide prompts show clean verb-first titles.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear, verb-first titles to all Studio guide prompts and switches MCP prompt registration to `server.registerPrompt()` so titles render correctly in the UI. Also adds a safe fallback title for legacy prompts and stabilizes a flaky JWT expiry test.

- New Features
  - All guide prompts now include an explicit `title` (e.g. "Create Agents", "Update Connections").
  - Migrated from `server.prompt()` to `server.registerPrompt()` so titles are included in MCP `listPrompts` responses.
  - In `packages/mcp-utils`, derive a human-readable Title Case `title` from the prompt name when upstream prompts lack one.

- Bug Fixes
  - Stabilized JWT expiration test by increasing token lifetime and wait buffer.
  - Fixed TS error in `titleFromName` by using `charAt(0)` to satisfy strict indexing.

<sup>Written for commit dc3ffc13dbac2a6ef689f29891340ad2ed9c958a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

