### PR TITLE
feat(tasks-panel): add member filter to task area

### DIFF
--- a/apps/mesh/src/web/layouts/tasks-panel/index.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/index.tsx
@@ -23,10 +23,13 @@ import { useTasksAutoRefresh } from "@/web/hooks/use-tasks-auto-refresh";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { KEYS } from "@/web/lib/query-keys";
 import { toast } from "sonner";
+import { authClient } from "@/web/lib/auth-client";
 import { TasksSection } from "./tasks-section";
 
 function TasksPanelContent() {
   useTasksAutoRefresh();
+  const { data: session } = authClient.useSession();
+  const currentUserId = session?.user?.id;
   const { tasks: myTasks } = useTasks({
     owner: "me",
     status: "open",
@@ -87,6 +90,7 @@ function TasksPanelContent() {
         onArchive={handleArchive}
         onNew={createNewTask}
         showNewButton
+        currentUserId={currentUserId}
       />
     </div>
   );

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -65,7 +65,7 @@ export function TasksSection({
 
   return (
     <div className="flex flex-col gap-0.5 mt-1">
-      <div className="px-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
+      <div className="pl-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">
           <DropdownMenu>

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -16,7 +16,7 @@ type MemberFilter = "all" | "mine";
 
 const FILTER_LABELS: Record<FilterOption, string> = {
   all: "All tasks",
-  manual: "Manual",
+  manual: "Chats",
   automation: "Automation",
 };
 

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -65,7 +65,7 @@ export function TasksSection({
 
   return (
     <div className="flex flex-col gap-0.5 mt-1">
-      <div className="pl-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
+      <div className="pl-2 pr-1 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">
           <DropdownMenu>

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Edit05, FilterLines } from "@untitledui/icons";
+import { Edit05, FilterLines, User01 } from "@untitledui/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,11 +12,17 @@ import type { Task } from "@/web/components/chat/task/types";
 import { TaskRow } from "./task-row";
 
 type FilterOption = "all" | "manual" | "automation";
+type MemberFilter = "all" | "mine";
 
 const FILTER_LABELS: Record<FilterOption, string> = {
   all: "All tasks",
   manual: "Manual",
   automation: "Automation",
+};
+
+const MEMBER_FILTER_LABELS: Record<MemberFilter, string> = {
+  all: "All members",
+  mine: "Mine only",
 };
 
 export function TasksSection({
@@ -29,6 +35,7 @@ export function TasksSection({
   showNewButton,
   showAutomationBadge,
   emptyLabel,
+  currentUserId,
 }: {
   title: string;
   tasks: Task[];
@@ -39,21 +46,56 @@ export function TasksSection({
   showNewButton?: boolean;
   showAutomationBadge?: boolean;
   emptyLabel?: string;
+  currentUserId?: string;
 }) {
   const [filter, setFilter] = useState<FilterOption>("all");
+  const [memberFilter, setMemberFilter] = useState<MemberFilter>("all");
+
+  const memberFiltered =
+    memberFilter === "mine" && currentUserId
+      ? tasks.filter((t) => t.created_by === currentUserId)
+      : tasks;
 
   const visibleTasks =
     filter === "automation"
-      ? tasks.filter((t) => t.fromAutomation)
+      ? memberFiltered.filter((t) => t.fromAutomation)
       : filter === "manual"
-        ? tasks.filter((t) => !t.fromAutomation)
-        : tasks;
+        ? memberFiltered.filter((t) => !t.fromAutomation)
+        : memberFiltered;
 
   return (
     <div className="flex flex-col gap-0.5">
       <div className="px-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Filter by member"
+                className={cn(
+                  "flex size-8 items-center justify-center rounded-md hover:bg-muted hover:text-foreground",
+                  memberFilter !== "all" && "text-foreground",
+                )}
+              >
+                <User01 size={16} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuRadioGroup
+                value={memberFilter}
+                onValueChange={(v) => setMemberFilter(v as MemberFilter)}
+              >
+                {(Object.keys(MEMBER_FILTER_LABELS) as MemberFilter[]).map(
+                  (opt) => (
+                    <DropdownMenuRadioItem key={opt} value={opt}>
+                      {MEMBER_FILTER_LABELS[opt]}
+                    </DropdownMenuRadioItem>
+                  ),
+                )}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -65,7 +65,7 @@ export function TasksSection({
 
   return (
     <div className="flex flex-col gap-0.5 mt-1">
-      <div className="pl-2 pr-1 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
+      <div className="pl-2 pr-1.5 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">
           <DropdownMenu>

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -64,7 +64,7 @@ export function TasksSection({
         : memberFiltered;
 
   return (
-    <div className="flex flex-col gap-0.5">
+    <div className="flex flex-col gap-0.5 mt-1">
       <div className="px-2 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Edit05, FilterLines, User01 } from "@untitledui/icons";
+import { Edit05, FilterLines, User02, Users03 } from "@untitledui/icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,7 +49,7 @@ export function TasksSection({
   currentUserId?: string;
 }) {
   const [filter, setFilter] = useState<FilterOption>("all");
-  const [memberFilter, setMemberFilter] = useState<MemberFilter>("all");
+  const [memberFilter, setMemberFilter] = useState<MemberFilter>("mine");
 
   const memberFiltered =
     memberFilter === "mine" && currentUserId
@@ -73,12 +73,13 @@ export function TasksSection({
               <button
                 type="button"
                 aria-label="Filter by member"
-                className={cn(
-                  "flex size-8 items-center justify-center rounded-md hover:bg-muted hover:text-foreground",
-                  memberFilter !== "all" && "text-foreground",
-                )}
+                className="flex size-8 items-center justify-center rounded-md hover:bg-muted hover:text-foreground"
               >
-                <User01 size={16} />
+                {memberFilter === "mine" ? (
+                  <User02 size={16} />
+                ) : (
+                  <Users03 size={16} />
+                )}
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -103,7 +104,7 @@ export function TasksSection({
                 aria-label="Filter tasks"
                 className={cn(
                   "flex size-8 items-center justify-center rounded-md hover:bg-muted hover:text-foreground",
-                  filter !== "all" && "text-foreground",
+                  filter !== "all" && "text-purple-500",
                 )}
               >
                 <FilterLines size={16} />


### PR DESCRIPTION
## What is this contribution about?

Adds a second filter to the tasks panel sidebar so users can scope the task list to "All members" or "Mine only". The new user-icon button composes with the existing automation/manual type filter — both filters apply independently. Current user ID is read from the auth session and passed down to `TasksSection`, which filters `created_by` client-side.

## Screenshots/Demonstration

> Two filter buttons now appear in the Tasks section header: a user icon (member scope) and the existing filter-lines icon (task type).

## How to Test

1. Open the tasks panel with multiple members having open tasks.
2. Click the user icon button — select "Mine only".
3. Verify only tasks created by the logged-in user are shown.
4. Switch the type filter (automation/manual) — both filters should compose correctly.
5. Switch member filter back to "All members" — full list returns.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a member filter to the tasks panel that composes with the type filter. Renamed the “Manual” label to “Chats” and refined header spacing.

- **New Features**
  - User-icon filter in the Tasks header; defaults to “Mine only” and filters by `created_by` using the current user from `authClient.useSession()`.
  - UI polish: swap `User02` (mine) and `Users03` (all), remove member button highlight, and use purple for the active type filter.

- **Bug Fixes**
  - Adjust tasks header spacing: add `mt-1` and set right padding to `pr-1.5` for better alignment.

<sup>Written for commit 72c8705cadbd79ce6e463b724c93b45334f39f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

