### PR TITLE
fix(deco-sites): generate connId server-side and ensure member row idempotency

### DIFF
--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -13,6 +13,7 @@
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 import { getUserId } from "../../core/mesh-context";
+import { generatePrefixedId } from "../../shared/utils/generate-id";
 import { fetchToolsFromMCP } from "../../tools/connection/fetch-tools";
 
 type Variables = { meshContext: MeshContext };
@@ -190,7 +191,6 @@ async function getOrCreateTeamServiceAccount(
 ): Promise<string> {
   const email = serviceAccountEmail(teamId);
 
-  // Check if profile already exists for this service account.
   const existingProfile = await supabaseGet<{ user_id: string }>(
     supabaseUrl,
     serviceKey,
@@ -198,12 +198,30 @@ async function getOrCreateTeamServiceAccount(
   );
 
   if (existingProfile[0]?.user_id) {
-    // Service account exists — return its API key.
-    return getOrCreateDecoApiKey(
+    const authUserId = existingProfile[0].user_id;
+
+    // Ensure the member row exists for this team (may be missing if a previous
+    // run created the profile but failed before reaching step 3).
+    const existingMember = await supabaseGet<{ id: number }>(
       supabaseUrl,
       serviceKey,
-      existingProfile[0].user_id,
+      `members?user_id=eq.${encodeURIComponent(authUserId)}&team_id=eq.${teamId}&select=id&limit=1`,
     );
+
+    if (!existingMember[0]?.id) {
+      const member = await supabasePost<{ id: number }>(
+        supabaseUrl,
+        serviceKey,
+        "members",
+        { user_id: authUserId, team_id: teamId, admin: true },
+      );
+      await supabasePost<{ id: number }>(supabaseUrl, serviceKey, "member_roles", {
+        member_id: member.id,
+        role_id: 1,
+      });
+    }
+
+    return getOrCreateDecoApiKey(supabaseUrl, serviceKey, authUserId);
   }
 
   // 1. Create Supabase Auth user
@@ -365,17 +383,19 @@ app.post("/connection", async (c) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  let body: { siteName: string; connId: string; orgId: string };
+  let body: { siteName: string; orgId: string };
   try {
     body = await c.req.json();
   } catch {
     return c.json({ error: "Invalid request body" }, 400);
   }
 
-  const { siteName, connId, orgId } = body;
-  if (!siteName || !connId || !orgId) {
-    return c.json({ error: "siteName, connId, and orgId are required" }, 400);
+  const { siteName, orgId } = body;
+  if (!siteName || !orgId) {
+    return c.json({ error: "siteName and orgId are required" }, 400);
   }
+
+  const connId = generatePrefixedId("conn");
 
   // Validate siteName is a safe DNS subdomain label to prevent SSRF.
   if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/.test(siteName)) {

--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -215,10 +215,15 @@ async function getOrCreateTeamServiceAccount(
         "members",
         { user_id: authUserId, team_id: teamId, admin: true },
       );
-      await supabasePost<{ id: number }>(supabaseUrl, serviceKey, "member_roles", {
-        member_id: member.id,
-        role_id: 1,
-      });
+      await supabasePost<{ id: number }>(
+        supabaseUrl,
+        serviceKey,
+        "member_roles",
+        {
+          member_id: member.id,
+          role_id: 1,
+        },
+      );
     }
 
     return getOrCreateDecoApiKey(supabaseUrl, serviceKey, authUserId);

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -18,7 +18,6 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ArrowLeft } from "@untitledui/icons";
 import { authClient } from "@/web/lib/auth-client";
-import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { KEYS } from "@/web/lib/query-keys";
 import { generateSlug } from "@/web/lib/slug";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
@@ -112,11 +111,10 @@ export function ImportFromDecoDialog({
     mutationFn: async (siteName: string) => {
       // 1. Create the connection server-side so the deco.cx API key never
       //    reaches the browser — the backend fetches and encrypts it directly.
-      const connId = generatePrefixedId("conn");
       const connRes = await fetch("/api/deco-sites/connection", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ siteName, connId, orgId: org.id }),
+        body: JSON.stringify({ siteName, orgId: org.id }),
       });
       const connBody = (await connRes.json().catch(() => ({}))) as {
         connId?: string;
@@ -127,6 +125,11 @@ export function ImportFromDecoDialog({
         throw new Error(
           connBody.error ?? `Failed to create connection (${connRes.status})`,
         );
+      }
+
+      const connId = connBody.connId;
+      if (!connId) {
+        throw new Error("Server did not return a connection ID");
       }
 
       const projectIcon = connBody.icon ?? null;
@@ -170,6 +173,18 @@ export function ImportFromDecoDialog({
                     label: "Monitor",
                     icon: null,
                   },
+                  {
+                    connectionId: connId,
+                    toolName: "list_pull_requests",
+                    label: "Pull Requests",
+                    icon: null,
+                  },
+                  {
+                    connectionId: connId,
+                    toolName: "list_releases",
+                    label: "Releases",
+                    icon: null,
+                  }
                 ],
                 layout: {
                   defaultMainView: {

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -184,7 +184,7 @@ export function ImportFromDecoDialog({
                     toolName: "list_releases",
                     label: "Releases",
                     icon: null,
-                  }
+                  },
                 ],
                 layout: {
                   defaultMainView: {


### PR DESCRIPTION
## Summary

- **Security fix**: `connId` was being generated on the client and sent in the request body, allowing any authenticated user to supply an arbitrary UUID as the connection primary key. The backend now generates `connId` server-side via `generatePrefixedId("conn")` and returns it in the response — the client uses whatever the server hands back.
- **Bug fix**: `getOrCreateTeamServiceAccount` was returning early (with just the API key) when a profile already existed, skipping the `members` and `member_roles` creation steps. The function now checks for a missing member row and creates it on the fly, making the whole flow idempotent.

## Test plan

- [ ] Import a deco.cx site — connection is created successfully, `connId` in the response matches the one used by the MCP tool call
- [ ] Trigger the import for a team whose profile exists but is missing a `members` row — membership is created automatically
- [ ] Confirm the request body no longer accepts/uses a client-supplied `connId`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate connection IDs on the server and make team service account creation idempotent to close a security gap and stabilize deco site imports. The client no longer sends `connId`; it uses the ID returned by the API.

- **Bug Fixes**
  - Generate `connId` on the server via `generatePrefixedId("conn")`; ignore client-supplied IDs and require only `siteName` and `orgId`.
  - Ensure `getOrCreateTeamServiceAccount` creates missing `members` and `member_roles` rows when a profile exists, making the flow idempotent.

- **New Features**
  - Add “Pull Requests” and “Releases” to the default main view for new deco site imports.

<sup>Written for commit 7d4e097411aa7b5dbd26601942be3ace2fcf5698. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

