### PR TITLE
fix(ui): correct GitHub repo link in account popover

### DIFF
--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -539,9 +539,9 @@ export function AccountPopover() {
     },
     {
       key: "github",
-      label: "decocms/mesh",
+      label: "decocms/studio",
       icon: <GitHubIcon className="w-4 h-4" />,
-      href: "https://github.com/decocms/mesh",
+      href: "https://github.com/decocms/studio",
       external: true,
     },
     {


### PR DESCRIPTION
## Summary
- Fixes the GitHub link in the account popover from `decocms/mesh` to `decocms/studio`

## Test plan
- [ ] Open account popover and verify the GitHub link label reads "decocms/studio"
- [ ] Click the link and verify it navigates to the correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub repo link in the account popover to point to `decocms/studio` instead of `decocms/mesh`. This ensures users land on the correct repository.

<sup>Written for commit ecbe0cb09b216bdd654d3203342a556294157d4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

