### PR TITLE
feat(virtual-mcp): auto-adopt MCP server prompt as agent instructions

### DIFF
--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -128,6 +128,39 @@ export async function handleVirtualMcpRequest(
       "passthrough",
     );
 
+    // Resolve instructions: prefer metadata.instructions, then auto-fetch from
+    // connected MCP prompts. This allows MCP servers to declare their own system
+    // prompt via a named prompt resource — no manual copy-paste into the studio.
+    let instructions: string | undefined =
+      typeof virtualMcp.metadata?.instructions === "string"
+        ? virtualMcp.metadata.instructions
+        : undefined;
+    if (!instructions) {
+      try {
+        const promptsResult = await client.listPrompts().catch(() => ({ prompts: [] }));
+        if (promptsResult.prompts.length > 0) {
+          // Prefer a prompt whose name matches the agent title, otherwise use first
+          const agentSlug = (virtualMcp.title ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+          const matchingPrompt =
+            promptsResult.prompts.find(
+              (p) => p.name.toLowerCase().replace(/[^a-z0-9]/g, "") === agentSlug,
+            ) ?? promptsResult.prompts[0];
+          if (matchingPrompt) {
+            const promptResult = await client.getPrompt({ name: matchingPrompt.name }).catch(() => null);
+            if (promptResult) {
+              const text = promptResult.messages
+                .filter((m) => m.content.type === "text")
+                .map((m) => (m.content as { type: "text"; text: string }).text)
+                .join("\n\n");
+              if (text) instructions = text;
+            }
+          }
+        }
+      } catch {
+        // Non-fatal — fall through with no instructions
+      }
+    }
+
     // Build ImplementationSchema-compatible server info
     const serverInfo = {
       name: virtualMcp.id ?? "Decopilot",
@@ -140,10 +173,7 @@ export async function handleVirtualMcpRequest(
     // Create server from client using the bridge
     const server = createServerFromClient(client, serverInfo, {
       capabilities: { tools: {}, resources: {}, prompts: {} },
-      instructions:
-        typeof virtualMcp.metadata?.instructions === "string"
-          ? virtualMcp.metadata.instructions
-          : undefined,
+      instructions,
       toolCallTimeoutMs: MCP_TOOL_CALL_TIMEOUT_MS,
     });
 


### PR DESCRIPTION
## Summary

- When a virtual MCP agent has no `metadata.instructions` set, the server now automatically resolves the system prompt from the connected MCP server's named prompts
- Resolution order: (1) `metadata.instructions` if explicitly set, (2) prompt matching agent title slug, (3) first available prompt, (4) `undefined`
- All existing behavior preserved — `metadata.instructions` always wins

## Motivation

MCP servers should own their system prompt in code (e.g. `prompt.md`). Previously, there was no bridge between a server's declared prompt and the studio's `metadata.instructions` field — requiring manual copy-paste that was never done. This change closes that gap automatically.

## Test plan

- [ ] Agent with `metadata.instructions` set → still uses it, no change
- [ ] Agent with no `metadata.instructions`, connected MCP has a prompt named `"ceo"` (matches title "CEO Agent") → uses that prompt as instructions
- [ ] Agent with no `metadata.instructions`, connected MCP has prompts but none match → uses first available
- [ ] Agent with no `metadata.instructions`, connected MCP has no prompts → falls through gracefully, `undefined`
- [ ] Connected MCP listPrompts throws → caught, falls through gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically uses the connected MCP server’s named prompt as the agent’s system instructions when a virtual MCP agent has no `metadata.instructions`. This removes manual copy-paste and keeps agents aligned with server `prompt.md`.

- **New Features**
  - Resolution order: `metadata.instructions` > prompt matching agent title slug (lowercased, alphanumeric) > first available prompt > undefined.
  - Handles errors and empty prompts gracefully; falls back to no instructions.
  - Passes the resolved `instructions` to `createServerFromClient`; existing behavior unchanged.

<sup>Written for commit f447f7b0ff21c8d852bdd2a754f6b18c75e27ff2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

