### PR TITLE
fix: update runner rules for sandbox execution

### DIFF
--- a/packages/mesh-plugin-user-sandbox/server/runner/index.ts
+++ b/packages/mesh-plugin-user-sandbox/server/runner/index.ts
@@ -84,9 +84,9 @@ function isDockerInstalled(): boolean {
 /**
  * Rules:
  *   1. `MESH_SANDBOX_RUNNER=docker|freestyle` — honored.
- *   2. Production w/o explicit value — throw (no silent picks in prod).
- *   3. Dev w/o explicit value — docker if CLI present, else throw.
- * Freestyle is never picked implicitly (optional dep, dynamically imported).
+ *   2. No explicit value, `FREESTYLE_API_KEY` set — pick freestyle.
+ *   3. Production w/o explicit value and no freestyle key — throw.
+ *   4. Dev w/o explicit value — docker if CLI present, else throw.
  */
 export function resolveRunnerKindFromEnv(): RunnerKind {
   const raw = process.env.MESH_SANDBOX_RUNNER;
@@ -96,10 +96,11 @@ export function resolveRunnerKindFromEnv(): RunnerKind {
       `Unknown MESH_SANDBOX_RUNNER="${raw}" — expected "docker" or "freestyle".`,
     );
   }
+  if (process.env.FREESTYLE_API_KEY) return "freestyle";
   if (process.env.NODE_ENV === "production") {
     throw new Error(
       `MESH_SANDBOX_RUNNER must be set explicitly in production — ` +
-        `choose "docker" or "freestyle".`,
+        `choose "docker" or "freestyle" (or set FREESTYLE_API_KEY).`,
     );
   }
   if (isDockerInstalled()) return "docker";


### PR DESCRIPTION
- Modified the rules for determining the runner kind based on environment variables.
- Introduced a new condition to select the freestyle runner if the `FREESTYLE_API_KEY` is set without an explicit runner value.
- Adjusted error messages for clarity regarding production and development environments.
- Ensured that the logic for selecting the Docker runner remains intact when applicable.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update sandbox runner selection to choose the freestyle runner when `FREESTYLE_API_KEY` is set, and clarify prod/dev error handling. Honors explicit `MESH_SANDBOX_RUNNER` and keeps the dev docker fallback.

- **Bug Fixes**
  - Default to `freestyle` when `FREESTYLE_API_KEY` is set and `MESH_SANDBOX_RUNNER` is unset.
  - In production without an explicit runner or freestyle key, throw with a clear message.
  - In development without an explicit runner, use `docker` only if the CLI is installed; otherwise throw.

<sup>Written for commit 3b6736e2a7767399614375330b70267ae0ca0f94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

