### PR TITLE
fix(build): copy QuickJS WASM alongside bundled server scripts

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -382,6 +382,29 @@ async function copyRootReadme() {
   }
 }
 
+// QuickJS's emscripten loader resolves `new URL("emscripten-module.wasm",
+// import.meta.url)` — on Linux bun in production this can resolve relative
+// to the bundle output (dist/server/) rather than the externalized package,
+// causing ENOENT. Copy the WASM alongside the bundles as a safety net so the
+// file exists at whichever location bun looks.
+async function copyQuickjsWasm() {
+  console.log("📄 Copying QuickJS WASM...");
+
+  const wasmSource = join(
+    OUTPUT_DIR,
+    "node_modules/@jitl/quickjs-wasmfile-release-sync/dist/emscripten-module.wasm",
+  );
+  const wasmDest = join(OUTPUT_DIR, "emscripten-module.wasm");
+
+  if (!existsSync(wasmSource)) {
+    console.warn(`⚠️  QuickJS WASM not found at ${wasmSource}, skipping...`);
+    return;
+  }
+
+  await cp(wasmSource, wasmDest);
+  console.log(`✅ QuickJS WASM copied to ${wasmDest}`);
+}
+
 async function main() {
   // Prune node_modules to only include required dependencies for both scripts
   const packagesToExternalize = await pruneNodeModules();
@@ -394,11 +417,15 @@ async function main() {
   // Copy root README.md to dist folder
   await copyRootReadme();
 
+  // Copy QuickJS WASM alongside bundles as a safety net for path resolution
+  await copyQuickjsWasm();
+
   console.log("\n🎉 Build completed successfully!");
   console.log(`📦 Output directory: ${OUTPUT_DIR}`);
   console.log(`   - migrate.js`);
   console.log(`   - server.js`);
   console.log(`   - cli.js`);
+  console.log(`   - emscripten-module.wasm`);
   console.log(`   - node_modules/`);
   console.log(`   - ../README.md`);
 }


### PR DESCRIPTION
## What is this contribution about?

Fixes `ENOENT: no such file or directory, open '/app/apps/mesh/node_modules/decocms/dist/server/emscripten-module.wasm'` encountered when running the `decocms` npm package inside the Linux Docker image.

The `@jitl/quickjs-wasmfile-release-sync` package is already externalized and copied to `dist/server/node_modules/@jitl/.../dist/emscripten-module.wasm` (and the published npm tarball contains it). However, in the Linux bun runtime, `new URL("emscripten-module.wasm", import.meta.url)` inside the emscripten loader resolves relative to the bundle output (`dist/server/`) rather than the externalized package — same pattern as the earlier PGlite WASM fix.

As a safety net, the build now copies the WASM to `dist/server/emscripten-module.wasm` alongside `server.js`/`cli.js` so the file exists at whichever path bun resolves. The nested copy under `node_modules/` is preserved.

## How to Test

1. `bun run --cwd=apps/mesh build:server`
2. Confirm `apps/mesh/dist/server/emscripten-module.wasm` exists (~518 KB)
3. Confirm `apps/mesh/dist/server/node_modules/@jitl/quickjs-wasmfile-release-sync/dist/emscripten-module.wasm` still exists
4. After next release, running the Docker image should no longer throw the ENOENT error when a QuickJS-using code path is exercised.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copies the QuickJS `emscripten-module.wasm` to `dist/server/` during build to prevent ENOENT in Linux Docker when bun resolves the loader URL relative to the bundle. The nested copy under `node_modules/` is kept.

- **Bug Fixes**
  - Add build step to copy `@jitl/quickjs-wasmfile-release-sync`’s WASM to `dist/server/` as a safety net.
  - Output now includes `emscripten-module.wasm` next to `server.js` and `cli.js`.

<sup>Written for commit 3d0a043b55a2842de5883ad69f836cd73e0234d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

