### PR TITLE
feat(cli): add environment variables for sandbox runner and freestyle…

### DIFF
--- a/apps/mesh/src/cli/build-child-env.ts
+++ b/apps/mesh/src/cli/build-child-env.ts
@@ -76,6 +76,10 @@ export function buildChildEnv(
     DECO_SUPABASE_SERVICE_KEY: settings.decoSupabaseServiceKey,
     FIRECRAWL_API_KEY: settings.firecrawlApiKey,
 
+    // Sandbox runner: read from env by resolveRunnerKindFromEnv() in workers
+    MESH_SANDBOX_RUNNER: process.env.MESH_SANDBOX_RUNNER,
+    FREESTYLE_API_KEY: process.env.FREESTYLE_API_KEY,
+
     // TLS: propagate custom CA certificates (e.g. RDS CA bundles)
     NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,
 


### PR DESCRIPTION
… API key

- Introduced `MESH_SANDBOX_RUNNER` to read the sandbox runner type from the environment.
- Added `FREESTYLE_API_KEY` to allow configuration of the freestyle API key from the environment settings.
- Enhanced the buildChildEnv function to support these new environment variables, improving flexibility for sandbox execution.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for `MESH_SANDBOX_RUNNER` and `FREESTYLE_API_KEY` in the CLI by passing them through `buildChildEnv`, enabling sandbox runner selection and Freestyle API config via environment variables. Workers can now read the runner type and API key from the environment without code changes.

<sup>Written for commit 7d2b8d2a0e52583d25818e8cc050ea35d38b9f5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

