### PR TITLE
refactor(runner): rename and enhance runner kind resolution logic

### DIFF
--- a/apps/mesh/src/cli/sandbox-image.ts
+++ b/apps/mesh/src/cli/sandbox-image.ts
@@ -15,17 +15,11 @@ export async function kickoffSandboxImageBuild(opts: {
   if (process.env.NODE_ENV === "production") return;
   if (process.env.MESH_SANDBOX_IMAGE) return;
 
-  const { resolveRunnerKindFromEnv, ensureSandboxImage } = await import(
+  const { tryResolveRunnerKindFromEnv, ensureSandboxImage } = await import(
     "mesh-plugin-user-sandbox/runner"
   );
 
-  let kind: "docker" | "freestyle";
-  try {
-    kind = resolveRunnerKindFromEnv();
-  } catch {
-    return;
-  }
-  if (kind !== "docker") return;
+  if (tryResolveRunnerKindFromEnv() !== "docker") return;
 
   const log = opts.noTui
     ? (line: string) => console.log(`[sandbox-image] ${line}`)

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -81,10 +81,10 @@ let ingressServers: import("node:net").Server[] = [];
 // Docker-only boot/dev wiring. Both hooks (boot sweep + local ingress) are
 // intimate with Docker-specific primitives (labels, host-port mappings);
 // other runners manage their own VM/ingress lifecycle.
-const { resolveRunnerKindFromEnv } = await import(
+const { tryResolveRunnerKindFromEnv } = await import(
   "mesh-plugin-user-sandbox/runner"
 );
-if (resolveRunnerKindFromEnv() === "docker") {
+if (tryResolveRunnerKindFromEnv() === "docker") {
   const { sweepDockerOrphansOnBoot, startLocalSandboxIngress } = await import(
     "mesh-plugin-user-sandbox/runner"
   );

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -10,6 +10,7 @@ import type { MeshContext } from "@/core/mesh-context";
 import {
   DockerSandboxRunner,
   resolveRunnerKindFromEnv,
+  tryResolveRunnerKindFromEnv,
   type RunnerKind,
   type SandboxRunner,
 } from "mesh-plugin-user-sandbox/runner";
@@ -60,12 +61,8 @@ export async function getRunnerByKind(
  * Returns null if env is unresolved.
  */
 export function getSharedRunnerIfInit(): SandboxRunner | null {
-  let kind: RunnerKind;
-  try {
-    kind = resolveRunnerKindFromEnv();
-  } catch {
-    return null;
-  }
+  const kind = tryResolveRunnerKindFromEnv();
+  if (!kind) return null;
   return runners[kind] ?? null;
 }
 

--- a/packages/mesh-plugin-user-sandbox/server/runner/index.ts
+++ b/packages/mesh-plugin-user-sandbox/server/runner/index.ts
@@ -85,10 +85,10 @@ function isDockerInstalled(): boolean {
  * Rules:
  *   1. `MESH_SANDBOX_RUNNER=docker|freestyle` — honored.
  *   2. No explicit value, `FREESTYLE_API_KEY` set — pick freestyle.
- *   3. Production w/o explicit value and no freestyle key — throw.
- *   4. Dev w/o explicit value — docker if CLI present, else throw.
+ *   3. Production w/o explicit value and no freestyle key — null.
+ *   4. Dev w/o explicit value — docker if CLI present, else null.
  */
-export function resolveRunnerKindFromEnv(): RunnerKind {
+export function tryResolveRunnerKindFromEnv(): RunnerKind | null {
   const raw = process.env.MESH_SANDBOX_RUNNER;
   if (raw === "docker" || raw === "freestyle") return raw;
   if (raw && raw.length > 0) {
@@ -97,13 +97,20 @@ export function resolveRunnerKindFromEnv(): RunnerKind {
     );
   }
   if (process.env.FREESTYLE_API_KEY) return "freestyle";
+  if (process.env.NODE_ENV === "production") return null;
+  return isDockerInstalled() ? "docker" : null;
+}
+
+/** Strict variant: throws with remediation hints when no runner is resolvable. */
+export function resolveRunnerKindFromEnv(): RunnerKind {
+  const kind = tryResolveRunnerKindFromEnv();
+  if (kind) return kind;
   if (process.env.NODE_ENV === "production") {
     throw new Error(
       `MESH_SANDBOX_RUNNER must be set explicitly in production — ` +
         `choose "docker" or "freestyle" (or set FREESTYLE_API_KEY).`,
     );
   }
-  if (isDockerInstalled()) return "docker";
   throw new Error(
     `No sandbox runner available: Docker CLI not found on PATH. ` +
       `Install Docker for local dev, or set MESH_SANDBOX_RUNNER explicitly.`,


### PR DESCRIPTION
- Updated the function name from `resolveRunnerKindFromEnv` to `tryResolveRunnerKindFromEnv` to better reflect its behavior of returning null for unresolved environments.
- Simplified the logic for determining the runner kind in various files, ensuring consistent handling across the application.
- Improved error handling and streamlined the integration of runner kind checks in the CLI and sandbox lifecycle management.
- Enhanced documentation to clarify the new behavior and usage of the runner kind resolution functions.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed and improved sandbox runner resolution by introducing a non-throwing `tryResolveRunnerKindFromEnv()` and updating call sites to use it for optional Docker paths. Startup is now more forgiving when no runner is configured, while keeping a strict `resolveRunnerKindFromEnv()` for required flows.

- **Refactors**
  - Added `tryResolveRunnerKindFromEnv(): RunnerKind | null` in `mesh-plugin-user-sandbox/runner`; returns `"freestyle"` if `FREESTYLE_API_KEY`, returns `"docker"` in dev if Docker CLI is present, else `null`.
  - Kept `resolveRunnerKindFromEnv()` as strict; throws with guidance when no runner can be resolved.
  - Updated `apps/mesh` boot, CLI image build, and sandbox lifecycle to gate Docker logic with `tryResolveRunnerKindFromEnv() === "docker"` and simplify null checks.

- **Migration**
  - Replace non-critical uses of `resolveRunnerKindFromEnv()` with `tryResolveRunnerKindFromEnv()` and handle `null`.
  - In production, set `MESH_SANDBOX_RUNNER` or `FREESTYLE_API_KEY` if you require strict resolution.

<sup>Written for commit fc44f220242d7da11dffa5d340319f4c60aa231e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

