### PR TITLE
fix(deco-sites): avoid duplicate profile insert on service account creation

### DIFF
--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -236,12 +236,19 @@ async function getOrCreateTeamServiceAccount(
     email,
   );
 
-  // 2. Create profile
-  await supabasePost<{ id: number }>(supabaseUrl, serviceKey, "profiles", {
-    user_id: authUserId,
-    email,
-    name: `Mesh Service Account (team ${teamId})`,
-  });
+  // 2. Create profile (skip if a DB trigger already created one)
+  const autoProfile = await supabaseGet<{ user_id: string }>(
+    supabaseUrl,
+    serviceKey,
+    `profiles?user_id=eq.${encodeURIComponent(authUserId)}&select=user_id&limit=1`,
+  );
+  if (!autoProfile[0]) {
+    await supabasePost<{ id: number }>(supabaseUrl, serviceKey, "profiles", {
+      user_id: authUserId,
+      email,
+      name: `Mesh Service Account (team ${teamId})`,
+    });
+  }
 
   // 3. Create team membership (admin: true)
   const member = await supabasePost<{ id: number }>(


### PR DESCRIPTION
## Summary
- Supabase has a DB trigger that auto-creates a `profiles` row when a new auth user is created
- `getOrCreateTeamServiceAccount` was unconditionally inserting a profile after creating the auth user, hitting a `409` unique constraint violation (`profiles_user_id_key`) on the first call
- Now checks if the profile already exists before attempting to insert, making the first call succeed

## Test plan
- [ ] Call `POST /api/deco-sites/connection` for a site whose team has no service account yet — should succeed on the first attempt
- [ ] Call it again for another site in the same team — should reuse the existing service account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate profile creation for team service accounts by checking for an existing `profiles` row before inserting. This removes the 409 unique constraint error and makes the first request succeed.

- **Bug Fixes**
  - In `getOrCreateTeamServiceAccount`, query `profiles` by `user_id` and only insert if missing (accounts for Supabase trigger-created rows).
  - `POST /api/deco-sites/connection` succeeds on first use and reuses the same service account for the team on later calls.

<sup>Written for commit ac89f641736b05f23f085973d19e2f9aa7550c9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

