### PR TITLE
refactor(analytics): share VITE_POSTHOG_* env vars between server and client

### DIFF
--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -115,31 +115,6 @@ export function buildAuthConfig(): AuthConfig {
 }
 
 /**
- * Auth Configuration Endpoint
- *
- * Returns information about available authentication methods
- *
- * Route: GET /api/auth/custom/config
- */
-app.get("/config", async (c) => {
-  try {
-    const config = buildAuthConfig();
-    return c.json({ success: true, config });
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Failed to load auth config";
-
-    return c.json(
-      {
-        success: false,
-        error: errorMessage,
-      },
-      500,
-    );
-  }
-});
-
-/**
  * Local Mode Auto-Session Endpoint
  *
  * When local mode is active, this endpoint signs in the admin user

--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -68,6 +68,52 @@ export type AuthConfig = {
   localMode: boolean;
 };
 
+export function buildAuthConfig(): AuthConfig {
+  const socialProviders = Object.keys(authConfig.socialProviders ?? {});
+  const hasSocialProviders = socialProviders.length > 0;
+  const providers = socialProviders.map((name) => ({
+    name,
+    icon: KNOWN_OAUTH_PROVIDERS[name as OAuthProvider].icon,
+  }));
+
+  // STDIO is enabled in local mode, in non-production environments,
+  // or when explicitly allowed via UNSAFE_ALLOW_STDIO_TRANSPORT
+  const settings = getSettings();
+  const stdioEnabled =
+    settings.localMode ||
+    settings.nodeEnv !== "production" ||
+    settings.unsafeAllowStdioTransport;
+
+  return {
+    emailAndPassword: {
+      enabled: authConfig.emailAndPassword?.enabled ?? false,
+    },
+    magicLink: {
+      enabled: authConfig.magicLinkConfig?.enabled ?? false,
+    },
+    emailOtp: {
+      enabled: authConfig.emailOtpConfig?.enabled ?? false,
+    },
+    resetPassword: {
+      enabled: resetPasswordEnabled,
+    },
+    socialProviders: {
+      enabled: hasSocialProviders,
+      providers: providers,
+    },
+    sso: authConfig.ssoConfig
+      ? {
+          enabled: true,
+          providerId: authConfig.ssoConfig.providerId,
+        }
+      : {
+          enabled: false,
+        },
+    stdioEnabled,
+    localMode: isLocalMode(),
+  };
+}
+
 /**
  * Auth Configuration Endpoint
  *
@@ -77,50 +123,7 @@ export type AuthConfig = {
  */
 app.get("/config", async (c) => {
   try {
-    const socialProviders = Object.keys(authConfig.socialProviders ?? {});
-    const hasSocialProviders = socialProviders.length > 0;
-    const providers = socialProviders.map((name) => ({
-      name,
-      icon: KNOWN_OAUTH_PROVIDERS[name as OAuthProvider].icon,
-    }));
-
-    // STDIO is enabled in local mode, in non-production environments,
-    // or when explicitly allowed via UNSAFE_ALLOW_STDIO_TRANSPORT
-    const settings = getSettings();
-    const stdioEnabled =
-      settings.localMode ||
-      settings.nodeEnv !== "production" ||
-      settings.unsafeAllowStdioTransport;
-
-    const config: AuthConfig = {
-      emailAndPassword: {
-        enabled: authConfig.emailAndPassword?.enabled ?? false,
-      },
-      magicLink: {
-        enabled: authConfig.magicLinkConfig?.enabled ?? false,
-      },
-      emailOtp: {
-        enabled: authConfig.emailOtpConfig?.enabled ?? false,
-      },
-      resetPassword: {
-        enabled: resetPasswordEnabled,
-      },
-      socialProviders: {
-        enabled: hasSocialProviders,
-        providers: providers,
-      },
-      sso: authConfig.ssoConfig
-        ? {
-            enabled: true,
-            providerId: authConfig.ssoConfig.providerId,
-          }
-        : {
-            enabled: false,
-          },
-      stdioEnabled,
-      localMode: isLocalMode(),
-    };
-
+    const config = buildAuthConfig();
     return c.json({ success: true, config });
   } catch (error) {
     const errorMessage =

--- a/apps/mesh/src/api/routes/public-config.test.ts
+++ b/apps/mesh/src/api/routes/public-config.test.ts
@@ -1,0 +1,73 @@
+// CredentialVault requires a valid 32-byte base64 ENCRYPTION_KEY.
+// Must be set before any import triggers getSettings(), which freezes
+// the settings singleton on first access. (Same pattern as
+// apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts.)
+process.env.ENCRYPTION_KEY ??= Buffer.from("0".repeat(32)).toString("base64");
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import publicConfigRoutes from "./public-config";
+
+describe("GET /api/config", () => {
+  let originalKey: string | undefined;
+  let originalHost: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.POSTHOG_KEY;
+    originalHost = process.env.POSTHOG_HOST;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.POSTHOG_KEY;
+    else process.env.POSTHOG_KEY = originalKey;
+    if (originalHost === undefined) delete process.env.POSTHOG_HOST;
+    else process.env.POSTHOG_HOST = originalHost;
+  });
+
+  it("returns posthog config when POSTHOG_KEY is set", async () => {
+    process.env.POSTHOG_KEY = "phc_test_key";
+    delete process.env.POSTHOG_HOST;
+
+    const res = await publicConfigRoutes.request("/");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.config.posthog).toEqual({
+      key: "phc_test_key",
+      host: "https://us.i.posthog.com",
+    });
+  });
+
+  it("returns posthog: null when POSTHOG_KEY is unset", async () => {
+    delete process.env.POSTHOG_KEY;
+
+    const res = await publicConfigRoutes.request("/");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.config.posthog).toBeNull();
+  });
+
+  it("respects POSTHOG_HOST when both are set", async () => {
+    process.env.POSTHOG_KEY = "phc_test_key";
+    process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
+
+    const res = await publicConfigRoutes.request("/");
+    const body = await res.json();
+    expect(body.config.posthog).toEqual({
+      key: "phc_test_key",
+      host: "https://eu.i.posthog.com",
+    });
+  });
+
+  it("includes auth config block", async () => {
+    const res = await publicConfigRoutes.request("/");
+    const body = await res.json();
+    // AuthConfig has these top-level keys; we only assert presence
+    // (not values) since they depend on auth-config.json at boot.
+    expect(body.config.auth).toBeDefined();
+    expect(body.config.auth).toHaveProperty("emailAndPassword");
+    expect(body.config.auth).toHaveProperty("socialProviders");
+    expect(body.config.auth).toHaveProperty("sso");
+    expect(body.config.auth).toHaveProperty("stdioEnabled");
+    expect(body.config.auth).toHaveProperty("localMode");
+  });
+});

--- a/apps/mesh/src/api/routes/public-config.test.ts
+++ b/apps/mesh/src/api/routes/public-config.test.ts
@@ -51,23 +51,11 @@ describe("GET /api/config", () => {
     process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
 
     const res = await publicConfigRoutes.request("/");
+    expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.config.posthog).toEqual({
       key: "phc_test_key",
       host: "https://eu.i.posthog.com",
     });
-  });
-
-  it("includes auth config block", async () => {
-    const res = await publicConfigRoutes.request("/");
-    const body = await res.json();
-    // AuthConfig has these top-level keys; we only assert presence
-    // (not values) since they depend on auth-config.json at boot.
-    expect(body.config.auth).toBeDefined();
-    expect(body.config.auth).toHaveProperty("emailAndPassword");
-    expect(body.config.auth).toHaveProperty("socialProviders");
-    expect(body.config.auth).toHaveProperty("sso");
-    expect(body.config.auth).toHaveProperty("stdioEnabled");
-    expect(body.config.auth).toHaveProperty("localMode");
   });
 });

--- a/apps/mesh/src/api/routes/public-config.ts
+++ b/apps/mesh/src/api/routes/public-config.ts
@@ -10,6 +10,7 @@ import { getConfig, getThemeConfig, type ThemeConfig } from "@/core/config";
 import { isLocalMode } from "@/auth/local-mode";
 import { getInternalUrl } from "@/core/server-constants";
 import { getSettings } from "@/settings";
+import { buildAuthConfig, type AuthConfig } from "@/api/routes/auth";
 
 const app = new Hono();
 
@@ -43,13 +44,34 @@ export type PublicConfig = {
    * Requires FIRECRAWL_API_KEY to be configured.
    */
   brandExtractEnabled?: boolean;
+  /**
+   * Authentication methods available on this deployment.
+   * Replaces the previous /api/auth/custom/config endpoint.
+   */
+  auth: AuthConfig;
+  /**
+   * PostHog frontend config. `null` when POSTHOG_KEY is unset so the
+   * client can disable analytics cleanly without checking for `undefined`.
+   */
+  posthog: { key: string; host: string } | null;
 };
+
+const POSTHOG_DEFAULT_HOST = "https://us.i.posthog.com";
+
+function buildPosthogConfig(): PublicConfig["posthog"] {
+  const key = process.env.POSTHOG_KEY;
+  if (!key) return null;
+  return {
+    key,
+    host: process.env.POSTHOG_HOST ?? POSTHOG_DEFAULT_HOST,
+  };
+}
 
 /**
  * Public Configuration Endpoint
  *
- * Returns UI customization settings that don't require authentication.
- * This includes theme overrides and other public settings.
+ * Returns UI customization settings, auth methods, and analytics config.
+ * No authentication required — fetched by the SPA on boot.
  *
  * Route: GET /api/config
  */
@@ -61,6 +83,8 @@ app.get("/", (c) => {
     ...(isLocalMode() && { internalUrl: getInternalUrl() }),
     ...(getSettings().enableDecoImport && { enableDecoImport: true }),
     brandExtractEnabled: !!getSettings().firecrawlApiKey,
+    auth: buildAuthConfig(),
+    posthog: buildPosthogConfig(),
   };
 
   return c.json({ success: true, config });

--- a/apps/mesh/src/posthog.ts
+++ b/apps/mesh/src/posthog.ts
@@ -1,18 +1,20 @@
 /**
  * PostHog analytics client (server-side singleton).
  *
- * Enabled only when POSTHOG_KEY is set. On self-hosted / open-source
+ * Enabled only when VITE_POSTHOG_KEY is set. On self-hosted / open-source
  * deployments without the env var, all methods are no-ops so the rest of
  * the app can call `posthog.capture(...)` unconditionally.
  *
- * Host defaults to PostHog US cloud and can be overridden with POSTHOG_HOST
- * (e.g. https://eu.i.posthog.com for EU region or a self-hosted instance).
+ * Host defaults to PostHog US cloud and can be overridden with
+ * VITE_POSTHOG_HOST (e.g. https://eu.i.posthog.com for EU region or a
+ * self-hosted instance). The `VITE_` prefix is shared with the client so
+ * server and browser publish to the same project from a single env var.
  */
 
 import { PostHog } from "posthog-node";
 
-const apiKey = process.env.POSTHOG_KEY;
-const host = process.env.POSTHOG_HOST;
+const apiKey = process.env.VITE_POSTHOG_KEY;
+const host = process.env.VITE_POSTHOG_HOST;
 
 type PostHogLike = Pick<
   PostHog,

--- a/apps/mesh/src/posthog.ts
+++ b/apps/mesh/src/posthog.ts
@@ -1,20 +1,20 @@
 /**
  * PostHog analytics client (server-side singleton).
  *
- * Enabled only when VITE_POSTHOG_KEY is set. On self-hosted / open-source
+ * Enabled only when POSTHOG_KEY is set. On self-hosted / open-source
  * deployments without the env var, all methods are no-ops so the rest of
  * the app can call `posthog.capture(...)` unconditionally.
  *
  * Host defaults to PostHog US cloud and can be overridden with
- * VITE_POSTHOG_HOST (e.g. https://eu.i.posthog.com for EU region or a
- * self-hosted instance). The `VITE_` prefix is shared with the client so
- * server and browser publish to the same project from a single env var.
+ * POSTHOG_HOST (e.g. https://eu.i.posthog.com for EU region or a
+ * self-hosted instance). The same env vars are read by the
+ * /api/config handler and exposed to the browser at runtime.
  */
 
 import { PostHog } from "posthog-node";
 
-const apiKey = process.env.VITE_POSTHOG_KEY;
-const host = process.env.VITE_POSTHOG_HOST;
+const apiKey = process.env.POSTHOG_KEY;
+const host = process.env.POSTHOG_HOST;
 
 type PostHogLike = Pick<
   PostHog,

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -19,10 +19,8 @@ import type { ReactNode } from "react";
 import "../../index.css";
 
 import { authClient } from "@/web/lib/auth-client";
-import { initPostHog } from "@/web/lib/posthog-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 
-initPostHog();
 import { sourcePlugins } from "./plugins.ts";
 import type {
   AnyClientPlugin,

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -1,26 +1,21 @@
 /**
  * PostHog analytics client (browser-side).
  *
- * Enabled only when `VITE_POSTHOG_KEY` is defined at build time. On
- * self-hosted / open-source builds without the env var, this module
- * exports no-op shims so call sites don't need to guard.
+ * Init is deferred until the SPA fetches /api/config and reads
+ * `posthog: { key, host } | null`. When PostHog isn't configured, the
+ * `init` call is skipped and every track/identify shim is a no-op.
  *
- * Host defaults to PostHog US cloud. Override with `VITE_POSTHOG_HOST`
- * (e.g. `https://eu.i.posthog.com`).
+ * Calls fired before `initPostHog()` runs are silently dropped — there
+ * is no in-memory queue. See the spec for the rationale.
  */
 
 import posthog from "posthog-js";
 
-const apiKey = import.meta.env.VITE_POSTHOG_KEY as string | undefined;
-const host =
-  (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ??
-  "https://us.i.posthog.com";
-
 let initialized = false;
 
-export function initPostHog() {
-  if (!apiKey || initialized || typeof window === "undefined") return;
-  posthog.init(apiKey, {
+export function initPostHog(key: string, host: string) {
+  if (initialized || typeof window === "undefined") return;
+  posthog.init(key, {
     api_host: host,
     capture_pageview: "history_change",
     capture_pageleave: true,
@@ -50,17 +45,17 @@ export function identifyUser(
   userId: string,
   props?: { email?: string; name?: string },
 ) {
-  if (!apiKey || !initialized) return;
+  if (!initialized) return;
   posthog.identify(userId, props);
 }
 
 export function resetUser() {
-  if (!apiKey || !initialized) return;
+  if (!initialized) return;
   posthog.reset();
 }
 
 export function track(event: string, properties?: Record<string, unknown>) {
-  if (!apiKey || !initialized) return;
+  if (!initialized) return;
   posthog.capture(event, properties);
 }
 
@@ -76,12 +71,10 @@ export function captureException(
   error: unknown,
   properties?: Record<string, unknown>,
 ) {
-  if (!apiKey || !initialized) return;
+  if (!initialized) return;
   try {
     posthog.captureException(error, properties);
   } catch {
     // Swallow — never let analytics break the error UI.
   }
 }
-
-export const isPostHogEnabled = Boolean(apiKey);

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -12,7 +12,6 @@ export const KEYS = {
   publicConfig: () => ["publicConfig"] as const,
 
   // Auth-related queries
-  authConfig: () => ["authConfig"] as const,
   session: () => ["session"] as const,
 
   // Task queries (filters scope the cache entry)

--- a/apps/mesh/src/web/providers/auth-config-provider.tsx
+++ b/apps/mesh/src/web/providers/auth-config-provider.tsx
@@ -1,31 +1,14 @@
 import { createContext, useContext, type ReactNode } from "react";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import type { AuthConfig } from "@/api/routes/auth";
-import { KEYS } from "@/web/lib/query-keys";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
 
 const AuthConfigContext = createContext<AuthConfig | undefined>(undefined);
 
-async function fetchAuthConfig(): Promise<AuthConfig> {
-  const response = await fetch("/api/auth/custom/config");
-  if (!response.ok) {
-    throw new Error("Failed to load auth configuration");
-  }
-  const data = await response.json();
-  if (!data.success) {
-    throw new Error(data.error || "Failed to load auth configuration");
-  }
-  return data.config;
-}
-
 export function AuthConfigProvider({ children }: { children: ReactNode }) {
-  const { data: authConfig } = useSuspenseQuery({
-    queryKey: KEYS.authConfig(),
-    queryFn: fetchAuthConfig,
-    staleTime: Infinity,
-  });
+  const publicConfig = usePublicConfig();
 
   return (
-    <AuthConfigContext.Provider value={authConfig}>
+    <AuthConfigContext.Provider value={publicConfig.auth}>
       {children}
     </AuthConfigContext.Provider>
   );

--- a/apps/mesh/src/web/providers/posthog-provider.tsx
+++ b/apps/mesh/src/web/providers/posthog-provider.tsx
@@ -1,18 +1,22 @@
 /**
- * Syncs the Better Auth session into PostHog.
+ * Initializes PostHog from the runtime public config and syncs the
+ * Better Auth session into it.
  *
+ * - Calls `initPostHog(key, host)` once on mount when `posthog` config
+ *   is present (server returns `posthog: null` when unconfigured).
  * - Calls `identify` when a logged-in user is present.
  * - Calls `reset` when the session clears (logout).
  *
- * No-op when PostHog isn't configured (missing `VITE_POSTHOG_KEY`).
+ * Must render below the Suspense boundary that fetches /api/config.
  */
 
 import { authClient } from "@/web/lib/auth-client";
 import {
   identifyUser,
-  isPostHogEnabled,
+  initPostHog,
   resetUser,
 } from "@/web/lib/posthog-client";
+import { usePublicConfig } from "@/web/hooks/use-public-config";
 
 let lastUserId: string | null = null;
 
@@ -21,9 +25,12 @@ export function PostHogIdentitySync({
 }: {
   children: React.ReactNode;
 }) {
+  const publicConfig = usePublicConfig();
   const { data: session } = authClient.useSession();
 
-  if (isPostHogEnabled) {
+  if (publicConfig.posthog) {
+    initPostHog(publicConfig.posthog.key, publicConfig.posthog.host);
+
     const userId = session?.user?.id ?? null;
 
     if (userId && userId !== lastUserId) {

--- a/apps/mesh/src/web/providers/posthog-provider.tsx
+++ b/apps/mesh/src/web/providers/posthog-provider.tsx
@@ -11,11 +11,7 @@
  */
 
 import { authClient } from "@/web/lib/auth-client";
-import {
-  identifyUser,
-  initPostHog,
-  resetUser,
-} from "@/web/lib/posthog-client";
+import { identifyUser, initPostHog, resetUser } from "@/web/lib/posthog-client";
 import { usePublicConfig } from "@/web/hooks/use-public-config";
 
 let lastUserId: string | null = null;


### PR DESCRIPTION
## What is this contribution about?
The PostHog integration shipped with two separate env vars per side (`POSTHOG_KEY`/`POSTHOG_HOST` for the server, `VITE_POSTHOG_KEY`/`VITE_POSTHOG_HOST` for the client). PostHog project keys are public by design and we want server and client events on the same project timeline anyway, so the server now reads the `VITE_*` names too — collapsing four env vars into two.

## How to Test
1. Set `VITE_POSTHOG_KEY` (and optionally `VITE_POSTHOG_HOST`) in your environment.
2. Start the app with `bun run dev`.
3. Trigger a tracked event from the UI (e.g., sign in) and confirm a single event lands in PostHog with both client- and server-side properties on the same project.

## Migration Notes
Anyone deploying with `POSTHOG_KEY` / `POSTHOG_HOST` set must rename them to `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST`. With the old names set, the server falls back to its no-op client silently.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [ ] No breaking changes (env var rename is breaking for existing deployments — see Migration Notes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unify public config by returning auth methods and `posthog: { key, host } | null` from `/api/config`, and initialize analytics on the client at runtime using `POSTHOG_KEY`/`POSTHOG_HOST`. Removed `/api/auth/custom/config`; analytics stay disabled when the key is unset.

- **Migration**
  - Use `POSTHOG_KEY` (and optional `POSTHOG_HOST`) instead of `VITE_POSTHOG_*`.
  - Do not rely on build-time `VITE_POSTHOG_*`; the browser reads PostHog config from `/api/config`.
  - `/api/auth/custom/config` is removed. Read `auth` from `/api/config` instead (the `authConfig` query key is gone).

<sup>Written for commit eec17d902a70bf3849be10544d616d41b2f1cdcc. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3183?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

