### PR TITLE
fix(chat): show file upload when model supports file capability

### DIFF
--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -954,7 +954,7 @@ export function modelSupportsFiles(
 ): boolean {
   return (
     selectedModel?.capabilities?.includes("vision") === true ||
-    selectedModel?.capabilities?.includes("image") === true
+    selectedModel?.capabilities?.includes("file") === true
   );
 }
 


### PR DESCRIPTION
## What is this contribution about?
The chat composer's file-upload button was hidden whenever the selected model — including the simpler-tier model in Simple Mode — had `file` as its only file-input capability. The check in `modelSupportsFiles` was matching `image` (the image-**output** / image-generation capability) instead of `file` (the file-**input** capability), so models whose capabilities are e.g. `["text", "file"]` lost the upload UI even though they accept files. Swapped the bogus `image` check for `file`.

## How to Test
1. Configure Simple Mode with a chat tier model whose capabilities include `file` but not `vision` (e.g. a document-input model).
2. Open the chat and confirm the paperclip / file upload button is visible in the composer.
3. Switch to a vision-capable model — upload still appears. Switch to a text-only model — upload hides.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat composer so the file upload button shows when the selected model supports file input. Updated modelSupportsFiles to check the 'file' capability instead of 'image', so models with ['text', 'file'] are handled correctly.

<sup>Written for commit 935c089263fa4b79da483aa94a9351e0e07f0c0b. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

