### PR TITLE
feat(decopilot): add take_screenshot and scrape_url with cross-provider image support

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/constants.ts
@@ -1,0 +1,4 @@
+export const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
+
+/** Results above this threshold are offloaded to blob storage. */
+export const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -21,6 +21,8 @@ import { userAskTool } from "./user-ask";
 import { proposePlanTool } from "./propose-plan";
 import { createGenerateImageTool } from "./generate-image";
 import { createWebSearchTool } from "./web-search";
+import { createTakeScreenshotTool, type PendingImage } from "./take-screenshot";
+import { createScrapeUrlTool } from "./scrape-url";
 import type { ModelsConfig } from "../types";
 import type { MeshProvider } from "@/ai-providers/types";
 
@@ -40,12 +42,21 @@ export interface BuiltinToolParams {
   toolOutputMap: Map<string, string>;
   passthroughClient: VirtualClient;
   /**
+   * Images captured by take_screenshot, queued for injection as user
+   * messages by prepareStep in stream-core.ts. This approach works
+   * across all providers (including OpenRouter) since images in tool
+   * result messages aren't universally supported.
+   */
+  pendingImages: PendingImage[];
+  /**
    * When set, VM file tools replace the QuickJS sandbox tool. Provisioning
    * already happened in `VM_START` — tools read the handle directly from
    * the vmMap entry.
    */
   activeVm?: ActiveVm | null;
 }
+
+export type { PendingImage };
 
 /**
  * Full tool set type — always includes propose_plan so that ChatMessage
@@ -66,6 +77,7 @@ async function buildAllTools(
     toolApprovalLevel = "auto",
     isPlanMode = false,
     toolOutputMap,
+    pendingImages,
     passthroughClient,
     activeVm,
   } = params;
@@ -152,6 +164,18 @@ async function buildAllTools(
       toolOutputMap,
     });
   }
+  // take_screenshot and scrape_url require Browserless API token
+  if (process.env.BROWSERLESS_TOKEN) {
+    tools.take_screenshot = createTakeScreenshotTool(writer, {
+      ctx,
+      toolOutputMap,
+      pendingImages,
+    });
+    tools.scrape_url = createScrapeUrlTool(writer, {
+      ctx,
+      toolOutputMap,
+    });
+  }
   return tools as {
     user_ask: typeof userAskTool;
     propose_plan: typeof proposePlanTool;
@@ -163,6 +187,8 @@ async function buildAllTools(
     read_prompt: ReturnType<typeof createReadPromptTool>;
     generate_image: ReturnType<typeof createGenerateImageTool>;
     web_search: ReturnType<typeof createWebSearchTool>;
+    take_screenshot: ReturnType<typeof createTakeScreenshotTool>;
+    scrape_url: ReturnType<typeof createScrapeUrlTool>;
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -23,6 +23,7 @@ import { createGenerateImageTool } from "./generate-image";
 import { createWebSearchTool } from "./web-search";
 import { createTakeScreenshotTool, type PendingImage } from "./take-screenshot";
 import { createScrapeUrlTool } from "./scrape-url";
+import { createInspectPageTool } from "./inspect-page";
 import type { ModelsConfig } from "../types";
 import type { MeshProvider } from "@/ai-providers/types";
 
@@ -175,6 +176,10 @@ async function buildAllTools(
       ctx,
       toolOutputMap,
     });
+    tools.inspect_page = createInspectPageTool(writer, {
+      ctx,
+      toolOutputMap,
+    });
   }
   return tools as {
     user_ask: typeof userAskTool;
@@ -189,6 +194,7 @@ async function buildAllTools(
     web_search: ReturnType<typeof createWebSearchTool>;
     take_screenshot: ReturnType<typeof createTakeScreenshotTool>;
     scrape_url: ReturnType<typeof createScrapeUrlTool>;
+    inspect_page: ReturnType<typeof createInspectPageTool>;
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/inspect-page.ts
@@ -142,7 +142,21 @@ export function createInspectPageTool(
           };
         }
 
-        const result = await response.json();
+        let result: {
+          consoleLogs?: { type: string; text: string }[];
+          errors?: string[];
+          evaluateResult?: unknown;
+        };
+        try {
+          result = await response.json();
+        } catch {
+          const text = await response.text().catch(() => "");
+          return {
+            success: false,
+            error: `Browserless returned non-JSON response: ${text.slice(0, 200)}`,
+            url: input.url,
+          };
+        }
         const resultJson = JSON.stringify(result, null, 2);
 
         // Always store in toolOutputMap for read_tool_output access

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/inspect-page.ts
@@ -1,0 +1,198 @@
+/**
+ * inspect_page Built-in Tool
+ *
+ * Server-side tool that navigates to a URL using Browserless v2 Function API,
+ * collects console logs and JS errors during page load, and optionally
+ * evaluates a JavaScript expression in the page context.
+ *
+ * Requires the BROWSERLESS_TOKEN env var.
+ *
+ * Small results are returned inline. Large results (> 8k tokens) are
+ * offloaded to blob storage and a preview + mesh-storage: URI is returned.
+ * The model can re-access the full content via read_tool_output or
+ * read_resource.
+ */
+
+import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
+import { z } from "zod";
+import type { MeshContext } from "@/core/mesh-context";
+import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
+import { toMeshStorageUri } from "../mesh-storage-uri";
+
+const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
+
+/** Results above this threshold are offloaded to blob storage. */
+const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+
+const InspectPageInputSchema = z.object({
+  url: z.string().url().describe("The URL of the web page to inspect."),
+  evaluate: z
+    .string()
+    .optional()
+    .describe(
+      "Optional JavaScript expression to evaluate in the page context after load. " +
+        "Examples: 'window.dataLayer', 'document.querySelectorAll(\"script\").length', " +
+        "'performance.getEntriesByType(\"resource\").map(e => ({name: e.name, duration: e.duration}))'",
+    ),
+  waitUntil: z
+    .enum(["load", "domcontentloaded", "networkidle0", "networkidle2"])
+    .optional()
+    .describe(
+      "When to consider navigation complete. Defaults to 'networkidle2'.",
+    ),
+});
+
+export type InspectPageInput = z.infer<typeof InspectPageInputSchema>;
+
+/**
+ * Build the Puppeteer function code string sent to Browserless /function API.
+ * The function collects console logs, JS errors, navigates, and optionally
+ * evaluates a JS expression.
+ */
+function buildFunctionCode(
+  url: string,
+  options: { evaluate?: string; waitUntil?: string },
+): string {
+  const waitUntil = options.waitUntil ?? "networkidle2";
+  const evaluateExpr = options.evaluate
+    ? JSON.stringify(options.evaluate)
+    : "null";
+
+  return `
+    export default async function ({ page }) {
+      const consoleLogs = [];
+      const errors = [];
+
+      page.on("console", (msg) => {
+        consoleLogs.push({ type: msg.type(), text: msg.text() });
+      });
+
+      page.on("pageerror", (err) => {
+        errors.push(err.message || String(err));
+      });
+
+      await page.goto(${JSON.stringify(url)}, {
+        waitUntil: ${JSON.stringify(waitUntil)},
+        timeout: 30000,
+      });
+
+      let evaluateResult = null;
+      const expr = ${evaluateExpr};
+      if (expr) {
+        try {
+          evaluateResult = await page.evaluate(expr);
+        } catch (e) {
+          evaluateResult = { error: e.message || String(e) };
+        }
+      }
+
+      return { consoleLogs, errors, evaluateResult };
+    }
+  `;
+}
+
+export function createInspectPageTool(
+  writer: UIMessageStreamWriter,
+  params: {
+    ctx: MeshContext;
+    toolOutputMap: Map<string, string>;
+  },
+) {
+  const { ctx, toolOutputMap } = params;
+
+  return tool({
+    description:
+      "Inspect a web page's client-side runtime state. " +
+      "Navigates to a URL and collects browser console logs, JavaScript errors, " +
+      "and optionally evaluates a JS expression (e.g. window.dataLayer, document.title). " +
+      "Use this for debugging client-side issues, checking analytics setup, or inspecting runtime state. " +
+      "For very large results the output may be truncated — use read_tool_output to access the full content.",
+    inputSchema: zodSchema(InspectPageInputSchema),
+    execute: async (input, options) => {
+      const startTime = performance.now();
+      try {
+        const token = process.env.BROWSERLESS_TOKEN;
+        if (!token) {
+          return {
+            success: false,
+            error: "BROWSERLESS_TOKEN is not configured.",
+          };
+        }
+
+        const code = buildFunctionCode(input.url, {
+          evaluate: input.evaluate,
+          waitUntil: input.waitUntil,
+        });
+
+        const response = await fetch(
+          `${BROWSERLESS_BASE_URL}/function?token=${encodeURIComponent(token)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/javascript" },
+            body: code,
+          },
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "Unknown error");
+          return {
+            success: false,
+            error: `Browserless function call failed (${response.status}): ${errorText}`,
+            url: input.url,
+          };
+        }
+
+        const result = await response.json();
+        const resultJson = JSON.stringify(result, null, 2);
+
+        // Always store in toolOutputMap for read_tool_output access
+        toolOutputMap.set(options.toolCallId, resultJson);
+
+        const tokenCount = estimateJsonTokens(resultJson);
+
+        // Large results → blob storage with preview
+        if (tokenCount > LARGE_RESULT_TOKEN_THRESHOLD && ctx.objectStorage) {
+          const key = `inspect-pages/${crypto.randomUUID()}.json`;
+          const bytes = new TextEncoder().encode(resultJson);
+          try {
+            await ctx.objectStorage.put(key, bytes, {
+              contentType: "application/json",
+            });
+            const preview = createOutputPreview(resultJson);
+            return {
+              success: true,
+              uri: toMeshStorageUri(key),
+              preview,
+              url: input.url,
+              tokenCount,
+              consoleLogCount: result.consoleLogs?.length ?? 0,
+              errorCount: result.errors?.length ?? 0,
+              hasEvaluateResult: result.evaluateResult != null,
+            };
+          } catch (err) {
+            console.error(
+              "[inspect-page] Failed to upload to storage, returning inline",
+              err,
+            );
+          }
+        }
+
+        return {
+          success: true,
+          consoleLogs: result.consoleLogs,
+          errors: result.errors,
+          evaluateResult: result.evaluateResult,
+          url: input.url,
+          tokenCount,
+        };
+      } finally {
+        const latencyMs = performance.now() - startTime;
+        writer.write({
+          type: "data-tool-metadata",
+          id: options.toolCallId,
+          data: { latencyMs },
+        });
+      }
+    },
+  });
+}

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/inspect-page.ts
@@ -18,11 +18,10 @@ import { z } from "zod";
 import type { MeshContext } from "@/core/mesh-context";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toMeshStorageUri } from "../mesh-storage-uri";
-
-const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
-
-/** Results above this threshold are offloaded to blob storage. */
-const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+import {
+  BROWSERLESS_BASE_URL,
+  LARGE_RESULT_TOKEN_THRESHOLD,
+} from "./constants";
 
 const InspectPageInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to inspect."),

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/registration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/registration.test.ts
@@ -15,6 +15,7 @@ const mockParams: BuiltinToolParams = {
     thinking: { id: "model_test" },
   } as never,
   toolOutputMap: new Map(),
+  pendingImages: [],
   passthroughClient: {
     listTools: () => Promise.resolve({ tools: [] }),
     callTool: () => Promise.resolve({ content: [] }),

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/scrape-url.ts
@@ -15,11 +15,10 @@ import { z } from "zod";
 import type { MeshContext } from "@/core/mesh-context";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toMeshStorageUri } from "../mesh-storage-uri";
-
-const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
-
-/** Results above this threshold are offloaded to blob storage. */
-const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+import {
+  BROWSERLESS_BASE_URL,
+  LARGE_RESULT_TOKEN_THRESHOLD,
+} from "./constants";
 
 const ScrapeUrlInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to scrape."),

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/scrape-url.ts
@@ -1,0 +1,124 @@
+/**
+ * scrape_url Built-in Tool
+ *
+ * Server-side tool that fetches the rendered HTML content of a web page
+ * using Browserless v2 cloud API. Requires the BROWSERLESS_TOKEN env var.
+ *
+ * Small results are returned inline. Large results (> 8k tokens) are
+ * offloaded to blob storage and a preview + mesh-storage: URI is returned.
+ * The model can re-access the full content via read_tool_output or
+ * read_resource.
+ */
+
+import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
+import { z } from "zod";
+import type { MeshContext } from "@/core/mesh-context";
+import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
+import { toMeshStorageUri } from "../mesh-storage-uri";
+
+const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
+
+/** Results above this threshold are offloaded to blob storage. */
+const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+
+const ScrapeUrlInputSchema = z.object({
+  url: z.string().url().describe("The URL of the web page to scrape."),
+});
+
+export type ScrapeUrlInput = z.infer<typeof ScrapeUrlInputSchema>;
+
+export function createScrapeUrlTool(
+  writer: UIMessageStreamWriter,
+  params: {
+    ctx: MeshContext;
+    toolOutputMap: Map<string, string>;
+  },
+) {
+  const { ctx, toolOutputMap } = params;
+
+  return tool({
+    description:
+      "Scrape the rendered HTML content of a web page. " +
+      "Use this when you need to read the content, structure, or data from a website. " +
+      "Returns the full HTML of the page after JavaScript has been executed. " +
+      "For very large pages the result may be truncated — use read_tool_output to access the full content.",
+    inputSchema: zodSchema(ScrapeUrlInputSchema),
+    execute: async (input, options) => {
+      const startTime = performance.now();
+      try {
+        const token = process.env.BROWSERLESS_TOKEN;
+        if (!token) {
+          return {
+            success: false,
+            error: "BROWSERLESS_TOKEN is not configured.",
+          };
+        }
+
+        const response = await fetch(
+          `${BROWSERLESS_BASE_URL}/content?token=${encodeURIComponent(token)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              url: input.url,
+            }),
+          },
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "Unknown error");
+          return {
+            success: false,
+            error: `Browserless content fetch failed (${response.status}): ${errorText}`,
+            url: input.url,
+          };
+        }
+
+        const htmlText = await response.text();
+
+        // Always store in toolOutputMap for read_tool_output access
+        toolOutputMap.set(options.toolCallId, htmlText);
+
+        const tokenCount = estimateJsonTokens(htmlText);
+
+        // Large results → blob storage with preview
+        if (tokenCount > LARGE_RESULT_TOKEN_THRESHOLD && ctx.objectStorage) {
+          const key = `scraped-pages/${crypto.randomUUID()}.html`;
+          const bytes = new TextEncoder().encode(htmlText);
+          try {
+            await ctx.objectStorage.put(key, bytes, {
+              contentType: "text/html",
+            });
+            const preview = createOutputPreview(htmlText);
+            return {
+              success: true,
+              uri: toMeshStorageUri(key),
+              preview,
+              url: input.url,
+              tokenCount,
+            };
+          } catch (err) {
+            console.error(
+              "[scrape-url] Failed to upload to storage, returning inline",
+              err,
+            );
+          }
+        }
+
+        return {
+          success: true,
+          content: htmlText,
+          url: input.url,
+          tokenCount,
+        };
+      } finally {
+        const latencyMs = performance.now() - startTime;
+        writer.write({
+          type: "data-tool-metadata",
+          id: options.toolCallId,
+          data: { latencyMs },
+        });
+      }
+    },
+  });
+}

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/take-screenshot.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/take-screenshot.ts
@@ -1,0 +1,181 @@
+/**
+ * take_screenshot Built-in Tool
+ *
+ * Server-side tool that captures a JPEG screenshot of a web page using
+ * Browserless v2 cloud API. Requires the BROWSERLESS_TOKEN env var.
+ *
+ * The screenshot is uploaded to object storage and injected into the
+ * conversation as a user message via `pendingImages` + `prepareStep`,
+ * bypassing provider-specific limitations with images in tool results.
+ */
+
+import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
+import { z } from "zod";
+import type { MeshContext } from "@/core/mesh-context";
+import { toMeshStorageUri } from "../mesh-storage-uri";
+import { generatePresignedGetUrl } from "../file-materializer";
+
+const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
+
+/**
+ * Default viewport for screenshots. 1280x800 gives a reasonable desktop
+ * view while staying well under the 1568px optimal limit for Claude's
+ * vision processing.
+ */
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
+
+/** JPEG quality for screenshots (0-100). Lower = smaller payload. */
+const JPEG_QUALITY = 80;
+
+const TakeScreenshotInputSchema = z.object({
+  url: z.string().url().describe("The URL of the web page to screenshot."),
+  fullPage: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, captures the full scrollable page instead of just the viewport. Defaults to false.",
+    ),
+});
+
+export type TakeScreenshotInput = z.infer<typeof TakeScreenshotInputSchema>;
+
+/**
+ * Pending image entry. Stored by `execute`, consumed by `prepareStep`
+ * in stream-core.ts which injects it as a user message content part.
+ */
+export interface PendingImage {
+  url: string;
+  mediaType: string;
+  pageUrl: string;
+}
+
+export function createTakeScreenshotTool(
+  writer: UIMessageStreamWriter,
+  params: {
+    ctx: MeshContext;
+    toolOutputMap: Map<string, string>;
+    pendingImages: PendingImage[];
+  },
+) {
+  const { ctx, toolOutputMap, pendingImages } = params;
+
+  return tool({
+    description:
+      "Take a screenshot of a web page. " +
+      "Use this when you need to visually see a website, check its layout, " +
+      "verify a deployment, or inspect a page's appearance. " +
+      "The screenshot is displayed automatically by the UI — do NOT include image URLs or markdown images in your response.",
+    inputSchema: zodSchema(TakeScreenshotInputSchema),
+    execute: async (input, options) => {
+      const startTime = performance.now();
+      try {
+        const token = process.env.BROWSERLESS_TOKEN;
+        if (!token) {
+          return {
+            success: false as const,
+            error: "BROWSERLESS_TOKEN is not configured.",
+          };
+        }
+
+        // Use JPEG with quality to keep payload small for the LLM.
+        // Set a viewport so the screenshot dimensions are predictable.
+        const response = await fetch(
+          `${BROWSERLESS_BASE_URL}/screenshot?token=${encodeURIComponent(token)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              url: input.url,
+              options: {
+                fullPage: input.fullPage ?? false,
+                type: "jpeg",
+                quality: JPEG_QUALITY,
+              },
+              viewport: DEFAULT_VIEWPORT,
+            }),
+          },
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "Unknown error");
+          return {
+            success: false as const,
+            error: `Browserless screenshot failed (${response.status}): ${errorText}`,
+            url: input.url,
+          };
+        }
+
+        const imgBytes = new Uint8Array(await response.arrayBuffer());
+        const mediaType = "image/jpeg";
+        const key = `screenshots/${crypto.randomUUID()}.jpg`;
+
+        // Upload to object storage — needed for UI rendering.
+        // Also generates a presigned URL or data URI for injecting
+        // the image into the conversation via prepareStep.
+        let uri = `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
+        let imageUrl: string | null = null;
+
+        if (ctx.objectStorage) {
+          try {
+            await ctx.objectStorage.put(key, imgBytes, {
+              contentType: mediaType,
+            });
+            uri = toMeshStorageUri(key);
+            imageUrl = await generatePresignedGetUrl(key, ctx);
+          } catch (err) {
+            console.error(
+              "[take-screenshot] Failed to upload, using data: URI fallback",
+              err,
+            );
+          }
+        }
+
+        // Fallback: use the data URI directly if no presigned URL
+        if (!imageUrl) {
+          imageUrl = `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
+        }
+
+        // Queue the image for injection as a user message in prepareStep.
+        // This bypasses provider limitations with images in tool results.
+        pendingImages.push({
+          url: imageUrl,
+          mediaType,
+          pageUrl: input.url,
+        });
+
+        toolOutputMap.set(
+          options.toolCallId,
+          `Screenshot of ${input.url} stored at ${uri}`,
+        );
+
+        return {
+          success: true as const,
+          image: { uri, mediaType },
+          url: input.url,
+        };
+      } finally {
+        const latencyMs = performance.now() - startTime;
+        writer.write({
+          type: "data-tool-metadata",
+          id: options.toolCallId,
+          data: { latencyMs },
+        });
+      }
+    },
+    // Return text-only result for the tool message. The actual image
+    // is injected as a user message by prepareStep in stream-core.ts,
+    // which is universally supported by all providers (including OpenRouter).
+    toModelOutput({ output }) {
+      if (!output.success) {
+        return {
+          type: "text",
+          value: output.error ?? "Screenshot failed",
+        };
+      }
+      return {
+        type: "text",
+        value: `Screenshot of ${output.url} captured successfully. The image is attached below.`,
+      };
+    },
+  });
+}

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/take-screenshot.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/take-screenshot.ts
@@ -14,8 +14,7 @@ import { z } from "zod";
 import type { MeshContext } from "@/core/mesh-context";
 import { toMeshStorageUri } from "../mesh-storage-uri";
 import { generatePresignedGetUrl } from "../file-materializer";
-
-const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
+import { BROWSERLESS_BASE_URL } from "./constants";
 
 /**
  * Default viewport for screenshots. 1280x800 gives a reasonable desktop

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/user-ask.e2e.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/user-ask.e2e.test.ts
@@ -27,6 +27,7 @@ const mockParams: BuiltinToolParams = {
     thinking: { id: "model_test" },
   } as never,
   toolOutputMap: new Map(),
+  pendingImages: [],
   passthroughClient: {
     listTools: () => Promise.resolve({ tools: [] }),
     callTool: () => Promise.resolve({ content: [] }),

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/web-search.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/web-search.ts
@@ -23,9 +23,7 @@ import { sanitizeProviderMetadata } from "@decocms/mesh-sdk";
 import type { ModelInfo } from "../types";
 import { createOutputPreview } from "./read-tool-output";
 import { toMeshStorageUri } from "../mesh-storage-uri";
-
-/** Results above this threshold are offloaded to blob storage. */
-const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 
 const WebSearchInputSchema = z.object({
   query: z

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -22,7 +22,7 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
-import { getBuiltInTools } from "./built-in-tools";
+import { getBuiltInTools, type PendingImage } from "./built-in-tools";
 import { createEnableToolsTool } from "./built-in-tools/enable-tools";
 import {
   buildBasePlatformPrompt,
@@ -383,6 +383,7 @@ async function streamCoreInner(
     }
 
     const toolOutputMap = new Map<string, string>();
+    const pendingImages: PendingImage[] = [];
     const organization = ctx.organization!;
     let titleHandle: ReturnType<typeof genTitle> | null = null;
 
@@ -459,6 +460,7 @@ async function streamCoreInner(
                 toolApprovalLevel: input.toolApprovalLevel,
                 isPlanMode: modeConfig.isPlanMode,
                 toolOutputMap,
+                pendingImages,
                 passthroughClient,
                 activeVm,
               },
@@ -724,9 +726,54 @@ async function streamCoreInner(
                         : null;
                     let stepIndex = 0;
 
-                    return () => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    return (stepArgs: any) => {
+                      const stepMessages = stepArgs.messages;
                       const isFirstStep = stepIndex === 0;
                       stepIndex++;
+
+                      // Inject pending screenshot images as a user message.
+                      // Images in tool result messages aren't supported by all
+                      // providers (e.g. OpenRouter), so we append them as user
+                      // content which is universally supported.
+                      // biome-ignore lint: complex AI SDK generic types
+                      let injectedMessages: any;
+                      if (pendingImages.length > 0) {
+                        const imageParts = pendingImages.splice(
+                          0,
+                          pendingImages.length,
+                        );
+                        const content: unknown[] = [];
+                        for (const img of imageParts) {
+                          content.push({
+                            type: "text",
+                            text: `[Screenshot of ${img.pageUrl}]`,
+                          });
+                          if (img.url.startsWith("data:")) {
+                            // data URI → send as inline image
+                            const match = img.url.match(
+                              /^data:([^;]+);base64,(.+)$/s,
+                            );
+                            if (match) {
+                              content.push({
+                                type: "image",
+                                image: match[2],
+                                mimeType: match[1],
+                              });
+                            }
+                          } else {
+                            // Presigned URL → send as image URL
+                            content.push({
+                              type: "image",
+                              image: new URL(img.url),
+                            });
+                          }
+                        }
+                        injectedMessages = [
+                          ...stepMessages,
+                          { role: "user", content },
+                        ];
+                      }
 
                       let activeToolNames = [
                         ...builtInToolNames,
@@ -758,6 +805,9 @@ async function streamCoreInner(
 
                       return {
                         activeTools: activeToolNames as (keyof typeof tools)[],
+                        ...(injectedMessages && {
+                          messages: injectedMessages,
+                        }),
                         ...(forcedToolName && {
                           toolChoice: {
                             type: "tool" as const,

--- a/apps/mesh/src/cli/build-child-env.ts
+++ b/apps/mesh/src/cli/build-child-env.ts
@@ -80,6 +80,9 @@ export function buildChildEnv(
     MESH_SANDBOX_RUNNER: process.env.MESH_SANDBOX_RUNNER,
     FREESTYLE_API_KEY: process.env.FREESTYLE_API_KEY,
 
+    // Browserless
+    BROWSERLESS_TOKEN: process.env.BROWSERLESS_TOKEN,
+
     // TLS: propagate custom CA certificates (e.g. RDS CA bundles)
     NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,
 


### PR DESCRIPTION
## Summary
- Adds `take_screenshot` and `scrape_url` built-in tools for the decopilot agent (requires `BROWSERLESS_TOKEN`)
- Screenshots are injected as **user messages** via `prepareStep` instead of tool result content parts, fixing compatibility with OpenRouter and other providers that don't support images in tool results
- `scrape_url` fetches rendered HTML via Browserless with large result offloading to blob storage

## Test plan
- [ ] Verify `take_screenshot` works with OpenRouter provider — model should be able to see and describe the screenshot
- [ ] Verify `take_screenshot` works with Anthropic provider directly
- [ ] Verify `scrape_url` returns HTML content and offloads large pages to blob storage
- [ ] Verify tools only appear when `BROWSERLESS_TOKEN` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `take_screenshot`, `scrape_url`, and `inspect_page` built-in tools to `decopilot`, injecting screenshots as user messages for cross‑provider image support. Requires `BROWSERLESS_TOKEN` (propagated by the CLI); large outputs offload to blob storage with `mesh-storage:` URIs and presigned URL or `data:` fallbacks, and improves `inspect_page` error handling.

- **New Features**
  - `take_screenshot`: Captures JPEG via Browserless, uploads to storage, and queues images for user-message injection in `prepareStep` (presigned URL or `data:` URI).
  - `scrape_url`: Fetches rendered HTML; large pages are stored with a preview and `mesh-storage:` URI.
  - `inspect_page`: Uses Browserless Function API to collect console logs, JS errors, and optionally evaluate JS; large results offload to storage. Tools are enabled only when `BROWSERLESS_TOKEN` is set and include latency metadata.

- **Refactors**
  - Extracted shared `BROWSERLESS_BASE_URL` and `LARGE_RESULT_TOKEN_THRESHOLD` into `constants.ts` and updated `web_search` to use them.

<sup>Written for commit 1a9068ea44eb96b46934e9a1e9dcb5e6f2b28fe8. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

