### PR TITLE
feat(mcp-apps): implement ui/request-display-mode host handler

### DIFF
--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -57,6 +57,9 @@ interface MCPAppRendererProps {
     params: McpUiUpdateModelContextRequest["params"],
   ) => void;
   onTeardown?: () => void;
+  onRequestDisplayMode?: (
+    mode: McpUiDisplayMode,
+  ) => McpUiDisplayMode | Promise<McpUiDisplayMode>;
   className?: string;
 }
 
@@ -77,6 +80,7 @@ export function MCPAppRenderer({
   onMessage,
   onUpdateModelContext,
   onTeardown,
+  onRequestDisplayMode,
   className,
 }: MCPAppRendererProps) {
   const { data } = useMCPReadResource({ client, uri, staleTime: 30_000 });
@@ -106,6 +110,7 @@ export function MCPAppRenderer({
     onMessage,
     onUpdateModelContext,
     onTeardown,
+    onRequestDisplayMode,
   });
 
   if (!html) return null;

--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -138,6 +138,9 @@ interface BridgeStoreConfig {
     params: McpUiUpdateModelContextRequest["params"],
   ) => void;
   onTeardown?: () => void;
+  onRequestDisplayMode?: (
+    mode: McpUiDisplayMode,
+  ) => McpUiDisplayMode | Promise<McpUiDisplayMode>;
 }
 
 class BridgeStore {
@@ -186,6 +189,9 @@ class BridgeStore {
 
     if (!this.bridge || this.disposed) return;
 
+    if (config.displayMode !== prev.displayMode) {
+      this.pushHostContext();
+    }
     if (config.toolInput !== prev.toolInput && config.toolInput != null) {
       this.bridge.sendToolInput({ arguments: config.toolInput });
     }
@@ -338,6 +344,13 @@ class BridgeStore {
       );
     };
 
+    bridge.onrequestdisplaymode = async ({ mode }) => {
+      const actualMode = this.config.onRequestDisplayMode
+        ? await this.config.onRequestDisplayMode(mode)
+        : this.config.displayMode;
+      return { mode: actualMode };
+    };
+
     bridge.ondownloadfile = async ({ contents }) => {
       for (const item of contents) {
         if (item.type === "resource") {
@@ -433,6 +446,9 @@ interface UseAppBridgeOptions {
     params: McpUiUpdateModelContextRequest["params"],
   ) => void;
   onTeardown?: () => void;
+  onRequestDisplayMode?: (
+    mode: McpUiDisplayMode,
+  ) => McpUiDisplayMode | Promise<McpUiDisplayMode>;
 }
 
 interface UseAppBridgeReturn {

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -28,6 +28,7 @@ import { stripMcpServerPrefix } from "@/web/lib/tool-namespace";
 import { useToolDefinitionLookup } from "@/web/hooks/use-tool-definition-lookup";
 import { toTitleCase } from "./utils.tsx";
 import type {
+  McpUiDisplayMode,
   McpUiMessageRequest,
   McpUiUpdateModelContextRequest,
 } from "@modelcontextprotocol/ext-apps";
@@ -244,6 +245,16 @@ export function GenericToolCallPart({
     });
   };
 
+  const handleRequestDisplayMode = (
+    mode: McpUiDisplayMode,
+  ): McpUiDisplayMode => {
+    if (mode === "fullscreen" && canOpenInPanel) {
+      handleOpenInPanel();
+      return "fullscreen";
+    }
+    return "inline";
+  };
+
   const handleAppMessage = (params: McpUiMessageRequest["params"]) => {
     const doc = contentBlocksToTiptapDoc(params.content);
     if (doc.content.length > 0) {
@@ -384,6 +395,9 @@ export function GenericToolCallPart({
                     ? () => chatPrefs.clearAppContext(sourceId)
                     : undefined
                 }
+                onRequestDisplayMode={
+                  canOpenInPanel ? handleRequestDisplayMode : undefined
+                }
               />
             </Suspense>
           </ErrorBoundary>
@@ -406,6 +420,9 @@ interface MCPAppRendererProps {
     params: McpUiUpdateModelContextRequest["params"],
   ) => void;
   onTeardown?: () => void;
+  onRequestDisplayMode?: (
+    mode: McpUiDisplayMode,
+  ) => McpUiDisplayMode | Promise<McpUiDisplayMode>;
 }
 
 /**
@@ -492,6 +509,7 @@ function MCPAppRenderer({
   onMessage,
   onUpdateModelContext,
   onTeardown,
+  onRequestDisplayMode,
 }: MCPAppRendererProps) {
   const client = useMCPClient({ connectionId, orgId });
 
@@ -513,6 +531,7 @@ function MCPAppRenderer({
         onMessage={onMessage}
         onUpdateModelContext={onUpdateModelContext}
         onTeardown={onTeardown}
+        onRequestDisplayMode={onRequestDisplayMode}
       />
     </div>
   );

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -9,7 +9,10 @@ import {
   useMCPToolsList,
   useMCPToolCall,
 } from "@decocms/mesh-sdk";
-import type { McpUiMessageRequest } from "@modelcontextprotocol/ext-apps";
+import type {
+  McpUiDisplayMode,
+  McpUiMessageRequest,
+} from "@modelcontextprotocol/ext-apps";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { contentBlocksToTiptapDoc } from "@/mcp-apps/content-blocks.ts";
 import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";
@@ -39,8 +42,18 @@ function AppRenderer({
 }) {
   const { sendMessage } = useChatBridge();
   const { setAppContext, clearAppContext } = useChatPrefs();
-  const { setChatOpen } = usePanelActions();
+  const { setChatOpen, openTab } = usePanelActions();
   const sourceId = `${connectionId}:${tool.name}`;
+
+  const handleRequestDisplayMode = (
+    mode: McpUiDisplayMode,
+  ): McpUiDisplayMode => {
+    if (mode === "inline") {
+      openTab("0");
+      return "inline";
+    }
+    return "fullscreen";
+  };
   const { data: toolResult } = useMCPToolCall({
     client,
     toolName: tool.name,
@@ -79,6 +92,7 @@ function AppRenderer({
       onMessage={handleAppMessage}
       onUpdateModelContext={(params) => setAppContext(sourceId, params)}
       onTeardown={() => clearAppContext(sourceId)}
+      onRequestDisplayMode={handleRequestDisplayMode}
       className="h-full"
     />
   );


### PR DESCRIPTION
## What is this contribution about?

Implements the MCP `ui/request-display-mode` host handler so apps can programmatically promote themselves from the inline chat embed to the fullscreen right-side panel (and back). Previously `bridge.onrequestdisplaymode` was never registered, causing `app.requestDisplayMode({ mode: "fullscreen" })` to silently return the unchanged current mode. This unblocks the Cogna slide-builder use case where the panel should auto-open when the AI generates slides.

## How to Test

1. Open a project with an MCP app that calls `await app.requestDisplayMode({ mode: "fullscreen" })` on load or on a user action (e.g. the slide builder)
2. Trigger the action — the right-side panel should open automatically, same as clicking "Open in panel"
3. From the panel view, call `await app.requestDisplayMode({ mode: "inline" })` — the panel should close
4. Verify `hostContext.availableDisplayModes` contains `["inline", "fullscreen"]` and `hostContext.displayMode` matches the iframe's actual context

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the MCP `ui/request-display-mode` host handler so apps can switch between inline and fullscreen. Apps can now auto-open the right-side panel and return to inline as needed.

- **New Features**
  - Register `bridge.onrequestdisplaymode` and return the resolved mode.
  - Add `onRequestDisplayMode` in `MCPAppRenderer` and `useAppBridge`, and handle it in chat tool calls and the project app view to open/close the right panel.
  - Push host context when `displayMode` changes so `hostContext.displayMode` and `availableDisplayModes` stay accurate per iframe.

<sup>Written for commit 49f750948cc0067bba9f9260e10602028d1e4fb4. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

