### PR TITLE
fix(monitoring): fix period selector popover flickering

### DIFF
--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -117,7 +117,7 @@ function FiltersPopover({
 }: FiltersPopoverProps) {
   const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
   const [propertyFilterMode, setPropertyFilterMode] = useState<"raw" | "form">(
-    "raw",
+    "form",
   );
 
   const [localTool, setLocalTool] = useState(tool);

--- a/packages/ui/src/components/time-range-picker.tsx
+++ b/packages/ui/src/components/time-range-picker.tsx
@@ -45,7 +45,6 @@ export function TimeRangePicker({
   const [validationError, setValidationError] = React.useState<string | null>(
     null,
   );
-
   // Sync local state when prop changes (action during render)
   const prevValueRef = React.useRef({ from: value.from, to: value.to });
   if (
@@ -58,8 +57,11 @@ export function TimeRangePicker({
   }
 
   const handleQuickRangeSelect = (range: QuickRange) => {
-    onChange({ from: range.from, to: range.to });
+    prevValueRef.current = { from: range.from, to: range.to };
+    setLocalFrom(range.from);
+    setLocalTo(range.to);
     setOpen(false);
+    onChange({ from: range.from, to: range.to });
   };
 
   const handleApply = () => {
@@ -109,7 +111,16 @@ export function TimeRangePicker({
           <ChevronDown className="size-4 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[540px] p-0" align="end" sideOffset={4}>
+      <PopoverContent
+        className="w-[540px] p-0"
+        align="end"
+        sideOffset={4}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        // Instant exit animation prevents the popover from "blinking" when a
+        // re-render (triggered by route navigation) restarts the CSS exit
+        // animation while the portal is still in the DOM.
+        style={!open ? { animationDuration: "0s" } : undefined}
+      >
         <div className="flex">
           {/* Left: Absolute time range */}
           <div className="flex-1 p-4 border-r">


### PR DESCRIPTION
## Summary
- Fix the TimeRangePicker popover "blinking" (close → reopen → close) when selecting a quick range. Root cause: Radix's `onCloseAutoFocus` was returning focus to the trigger during route re-render, and the CSS exit animation was restarting when `navigate()` triggered a re-render while the portal was still in the DOM.
- Default the property filter mode to "form" view instead of "raw text".

## Test plan
- [ ] Open monitoring tab → click the period selector → select a quick range → popover should close cleanly without flickering
- [ ] Verify "Apply time range" button still works
- [ ] Verify Escape key and click-outside still close the popover
- [ ] Open Filters → verify Property Filters defaults to form view instead of raw text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Monitoring period selector popover flicker when choosing a quick range, and defaults Property Filters to "form" view for a better first-run experience.

- **Bug Fixes**
  - Block focus return on close by preventing `onCloseAutoFocus` in `PopoverContent`.
  - Update local range state and close the popover before calling `onChange` when a quick range is selected.
  - Use an instant exit animation on close (`animationDuration: "0s"`) to avoid the CSS exit animation restarting during route navigation.

<sup>Written for commit 0fb1d58cfb66f9db2fdb84c0ad098e2ba4d13065. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3189?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

