### PR TITLE
fix(chat): add PDF capability to vision-capable Anthropic models

### DIFF
--- a/apps/mesh/src/ai-providers/factory.ts
+++ b/apps/mesh/src/ai-providers/factory.ts
@@ -91,6 +91,27 @@ function candidateIds(modelId: string): string[] {
   return [...new Set([modelId, dashed, withoutDate, dashedWithoutDate])];
 }
 
+// Anthropic's document blocks support PDFs on all vision-capable Claude models.
+// This covers both direct Anthropic keys (providerId="anthropic") and models
+// routed through OpenRouter/deco (modelId starts with "anthropic/").
+function isAnthropicModel(m: ModelInfo): boolean {
+  return m.providerId === "anthropic" || m.modelId.startsWith("anthropic/");
+}
+
+function applyAnthropicPdfCapability(
+  caps: ModelCapability[],
+  m: ModelInfo,
+): ModelCapability[] {
+  if (
+    isAnthropicModel(m) &&
+    caps.includes("vision") &&
+    !caps.includes("file")
+  ) {
+    return [...caps, "file"] as ModelCapability[];
+  }
+  return caps;
+}
+
 function enrich(
   models: ModelInfo[],
   index: Map<string, Partial<ModelInfo>>,
@@ -98,15 +119,17 @@ function enrich(
   return models.map((m) => {
     const candidates = candidateIds(m.modelId);
     const meta = candidates.map((id) => index.get(id)).find(Boolean);
+    const rawCaps: ModelCapability[] = m.capabilities.length
+      ? m.capabilities
+      : (meta?.capabilities ?? []);
+    const caps = applyAnthropicPdfCapability(rawCaps, m);
     if (!meta) {
-      return m;
+      return caps === rawCaps ? m : { ...m, capabilities: caps };
     }
     return {
       ...m,
       description: m.description ?? meta.description ?? null,
-      capabilities: m.capabilities.length
-        ? m.capabilities
-        : (meta.capabilities ?? []),
+      capabilities: caps,
       limits: m.limits ?? meta.limits ?? null,
       costs: m.costs ?? meta.costs ?? null,
     };
@@ -161,6 +184,12 @@ export class AIProviderFactory {
     if (providerId !== "openrouter") {
       const index = await getOpenRouterIndex(this.cache);
       models = enrich(models, index);
+    } else {
+      // OpenRouter path skips enrich() — still apply provider-specific fixes.
+      models = models.map((m) => ({
+        ...m,
+        capabilities: applyAnthropicPdfCapability(m.capabilities, m),
+      }));
     }
 
     const result = models.map((m) => ({ ...m, providerId }));

--- a/apps/mesh/src/api/routes/decopilot/model-compat.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-compat.ts
@@ -19,9 +19,10 @@ export function ensureModelCompatibility(
   models: ModelsConfig,
   messages: MessageWithParts[],
 ): void {
-  const modelHasVision = models.thinking.capabilities?.vision ?? false;
+  const caps = models.thinking.capabilities;
+  const modelSupportsFiles = (caps?.vision ?? false) || (caps?.file ?? false);
 
-  if (!modelHasVision) {
+  if (!modelSupportsFiles) {
     const hasFiles = messages.some((message) =>
       message.parts?.some((part) => part.type === "file"),
     );

--- a/apps/mesh/src/api/routes/decopilot/run-config.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-config.ts
@@ -19,6 +19,7 @@ const PersistedModelInfoSchema = z.object({
       text: z.boolean().optional(),
       tools: z.boolean().optional(),
       reasoning: z.boolean().optional(),
+      file: z.boolean().optional(),
     })
     .passthrough()
     .optional(),

--- a/apps/mesh/src/api/routes/decopilot/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/types.ts
@@ -64,6 +64,7 @@ export interface ModelInfo {
     text?: boolean;
     tools?: boolean;
     reasoning?: boolean;
+    file?: boolean;
   };
   provider?: string | null;
   limits?: { contextWindow?: number; maxOutputTokens?: number };

--- a/apps/mesh/src/web/components/chat/types.ts
+++ b/apps/mesh/src/web/components/chat/types.ts
@@ -62,6 +62,7 @@ export interface MetadataModelInfo {
     text?: boolean;
     tools?: boolean;
     reasoning?: boolean;
+    file?: boolean;
   };
   limits?: { contextWindow?: number; maxOutputTokens?: number };
 }

--- a/apps/mesh/src/web/lib/metadata-model-info.ts
+++ b/apps/mesh/src/web/lib/metadata-model-info.ts
@@ -10,6 +10,7 @@ export function toMetadataModelInfo(model: AiProviderModel): MetadataModelInfo {
             caps.includes("vision") || caps.includes("image") || undefined,
           text: caps.includes("text") || undefined,
           reasoning: caps.includes("reasoning") || undefined,
+          file: caps.includes("file") || undefined,
         }
       : undefined;
   return {


### PR DESCRIPTION
## What is this contribution about?

Anthropic document blocks support PDFs on all vision-capable Claude models, but OpenRouter does not always report `file` in `input_modalities` for them. This caused PDF uploads to be blocked in the UI for models like `claude-opus-4-7` even though the model can read them natively.

The fix adds the `file` capability to any Anthropic model (direct key, deco, or OpenRouter) that already has `vision`, covering all three provider paths. The `file` flag is also propagated through `MetadataModelInfo`, the persisted run-config schema, and the server-side `model-compat` check so the entire stack stays consistent.

## Screenshots/Demonstration

N/A — the fix makes the PDF upload option appear in the file picker when claude-opus-4-7 (and other vision-capable Claude models) is selected.

## How to Test

1. Open a chat and select claude-opus-4-7 (via Deco or Anthropic key)
2. Click the file upload button — PDF should now appear as an accepted type
3. Upload a PDF and verify the model reads it correctly

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable PDF uploads for vision-capable Anthropic Claude models by auto-adding the `file` capability when `vision` is present, including via OpenRouter/deco. This fixes the UI blocking PDFs (e.g., `claude-opus-4-7`) and keeps server/client checks consistent.

- **Bug Fixes**
  - Add `file` capability to Anthropic models with `vision` across direct key, deco, and OpenRouter paths.
  - Apply fix in the OpenRouter path even when `enrich()` is skipped.
  - Update compat check to allow files when `vision` or `file` is set.
  - Propagate `file` through persisted run-config, shared types, and metadata mapping so the UI shows PDF as an accepted type.

<sup>Written for commit 62cad5e982826531b2679972f2b7aec40b764cd2. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3190?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

