### PR TITLE
fix(tasks): shrink agent avatar to 24px in task row

### DIFF
--- a/apps/mesh/src/web/layouts/tasks-panel/task-row.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/task-row.tsx
@@ -49,7 +49,7 @@ export function TaskRow({
     >
       <McpAvatar
         virtualMcpId={task.virtual_mcp_id}
-        size="sm"
+        size="xs"
         showAutomationBadge={showAutomationBadge}
       />
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
## What is this contribution about?
Changes the agent avatar size in the tasks panel from `sm` (32px) to `xs` (24px) for a more compact task row.

## Screenshots/Demonstration
Visual change only — avatar in task rows is now 24×24px instead of 32×32px.

## How to Test
1. Open the tasks panel
2. Verify agent avatars are smaller (24px)

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks the agent avatar in task rows from 32px (`sm`) to 24px (`xs`) to tighten spacing in the tasks panel. Visual-only change with no functional impact.

<sup>Written for commit 191cdbec7843d7e01f44c5eff6305b2fd99ccdba. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

