### PR TITLE
feat(self-healing-repo): orchestrator + diagnostic-only specialists

### DIFF
--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -4,6 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
 import { CollectionSearch } from "@/web/components/collections/collection-search.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Suspense, useDeferredValue, useState } from "react";
@@ -41,7 +42,7 @@ interface GitHubInstallation {
   type: string;
 }
 
-interface Repo {
+export interface Repo {
   owner: string;
   name: string;
   fullName: string;
@@ -51,12 +52,24 @@ interface Repo {
   updatedAt: string;
 }
 
+export interface GitHubImportPayload {
+  virtualMcpId: string;
+  repo: Repo;
+  connectionId: string;
+}
+
 export function GitHubRepoPicker({
   open,
   onOpenChange,
+  title = "Import from GitHub",
+  hideAutoRespondCheckbox = false,
+  onImportComplete,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  title?: string;
+  hideAutoRespondCheckbox?: boolean;
+  onImportComplete?: (payload: GitHubImportPayload) => void;
 }) {
   const [preferences] = usePreferences();
   const [selectedInstallation, setSelectedInstallation] =
@@ -70,7 +83,7 @@ export function GitHubRepoPicker({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[560px] h-[85svh] sm:h-[520px] p-0 gap-0 overflow-hidden flex flex-col">
         <DialogHeader className="sr-only">
-          <DialogTitle>Import from GitHub</DialogTitle>
+          <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <div className="flex items-center h-12 border-b border-border px-4 gap-3 shrink-0">
           {selectedInstallation ? (
@@ -96,7 +109,7 @@ export function GitHubRepoPicker({
             <>
               <GitHubIcon className="size-4 text-foreground shrink-0" />
               <span className="text-sm font-medium text-foreground">
-                Import from GitHub
+                {title}
               </span>
             </>
           )}
@@ -116,6 +129,8 @@ export function GitHubRepoPicker({
               onComplete={() => onOpenChange(false)}
               selectedInstallation={selectedInstallation}
               onSelectInstallation={setSelectedInstallation}
+              hideAutoRespondCheckbox={hideAutoRespondCheckbox}
+              onImportComplete={onImportComplete}
             />
           </Suspense>
         </div>
@@ -128,16 +143,24 @@ function PickerContent({
   onComplete,
   selectedInstallation,
   onSelectInstallation,
+  hideAutoRespondCheckbox,
+  onImportComplete,
 }: {
   onComplete: () => void;
   selectedInstallation: GitHubInstallation | null;
   onSelectInstallation: (inst: GitHubInstallation | null) => void;
+  hideAutoRespondCheckbox?: boolean;
+  onImportComplete?: (payload: GitHubImportPayload) => void;
 }) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
   const navigateToAgent = useNavigateToAgent();
   const [selectedConnection, setSelectedConnection] =
     useState<ConnectionEntity | null>(null);
+  const [autoRespondToIssues, setAutoRespondToIssues] = useState(true);
+  const effectiveAutoRespond = hideAutoRespondCheckbox
+    ? true
+    : autoRespondToIssues;
 
   const githubConnections = useConnections({ slug: "mcp-github" });
 
@@ -216,6 +239,91 @@ function PickerContent({
       });
   };
 
+  const setupIssueAutomation = async ({
+    virtualMcpId,
+    repo,
+    connectionId,
+  }: {
+    virtualMcpId: string;
+    repo: Repo;
+    connectionId: string;
+  }) => {
+    const triggerListResult = (await githubClient.callTool({
+      name: "TRIGGER_LIST",
+      arguments: {},
+    })) as { structuredContent?: unknown };
+
+    const triggerPayload = (triggerListResult.structuredContent ??
+      triggerListResult) as {
+      triggers?: Array<{
+        type: string;
+        params?: Array<{ name: string }> | Record<string, unknown>;
+        paramsSchema?: Record<string, unknown>;
+      }>;
+    };
+
+    const issueTrigger =
+      triggerPayload.triggers?.find((t) => t.type === "github.issues.opened") ??
+      triggerPayload.triggers?.find((t) => {
+        const type = t.type.toLowerCase();
+        return (
+          /\bissues?\./.test(type) &&
+          (type.endsWith(".opened") || type.endsWith(".created"))
+        );
+      });
+
+    if (!issueTrigger) {
+      throw new Error("No issue-created trigger exposed by GitHub connection");
+    }
+
+    const paramNames = new Set<string>();
+    if (Array.isArray(issueTrigger.params)) {
+      for (const p of issueTrigger.params) paramNames.add(p.name);
+    } else if (issueTrigger.params && typeof issueTrigger.params === "object") {
+      for (const k of Object.keys(issueTrigger.params)) paramNames.add(k);
+    }
+    if (issueTrigger.paramsSchema) {
+      for (const k of Object.keys(issueTrigger.paramsSchema)) paramNames.add(k);
+    }
+
+    const params: Record<string, string> = {};
+    if (paramNames.has("repo")) {
+      params.repo = `${repo.owner}/${repo.name}`;
+    } else {
+      if (paramNames.has("owner")) params.owner = repo.owner;
+      if (paramNames.has("name")) params.name = repo.name;
+      if (paramNames.has("repository"))
+        params.repository = `${repo.owner}/${repo.name}`;
+    }
+
+    const automationInstructions = `A new GitHub issue has been opened in ${repo.owner}/${repo.name}. Read the issue details, explore the relevant code in the repository, create a new branch, implement the fix or feature requested, and open a pull request that resolves the issue. Reference the issue number in the PR description.`;
+
+    const automationResult = (await selfClient.callTool({
+      name: "AUTOMATION_CREATE",
+      arguments: {
+        name: `${repo.name}: auto-respond to issues`,
+        virtual_mcp_id: virtualMcpId,
+        agent: { id: virtualMcpId },
+        messages: automationInstructions,
+        active: true,
+      },
+    })) as { structuredContent?: unknown };
+
+    const automationPayload = (automationResult.structuredContent ??
+      automationResult) as { id: string };
+
+    await selfClient.callTool({
+      name: "AUTOMATION_TRIGGER_ADD",
+      arguments: {
+        automation_id: automationPayload.id,
+        type: "event",
+        connection_id: connectionId,
+        event_type: issueTrigger.type,
+        params,
+      },
+    });
+  };
+
   const importMutation = useMutation({
     mutationFn: async (repo: Repo) => {
       if (!effectiveConnection || !selectedInstallation) {
@@ -262,15 +370,29 @@ function PickerContent({
         item: { id: string; title: string };
       };
 
+      const virtualMcpId = payload.item.id;
+
+      if (effectiveAutoRespond) {
+        await setupIssueAutomation({
+          virtualMcpId,
+          repo,
+          connectionId,
+        }).catch((err) => {
+          console.error("Failed to set up issue automation:", err);
+          toast.warning(
+            "Imported repo, but failed to set up issue auto-response. You can add the trigger manually from the automations view.",
+          );
+        });
+      }
+
       return {
-        virtualMcpId: payload.item.id,
+        virtualMcpId,
         repo,
+        connectionId,
         item: payload.item,
       };
     },
-    onSuccess: ({ virtualMcpId, repo, item }) => {
-      toast.success(`Imported ${repo.name} from GitHub`);
-
+    onSuccess: ({ virtualMcpId, repo, connectionId, item }) => {
       queryClient.setQueryData(
         KEYS.collectionItem(
           selfClient,
@@ -283,11 +405,17 @@ function PickerContent({
       );
       invalidateVirtualMcpQueries(queryClient, org.id);
 
+      detectRepoFiles(virtualMcpId, repo);
+
+      if (onImportComplete) {
+        onImportComplete({ virtualMcpId, repo, connectionId });
+        return;
+      }
+
+      toast.success(`Imported ${repo.name} from GitHub`);
       onComplete();
       localStorage.setItem("mesh:sidebar-open", JSON.stringify(false));
       navigateToAgent(virtualMcpId);
-
-      detectRepoFiles(virtualMcpId, repo);
     },
     onError: (error) => {
       toast.error(
@@ -384,6 +512,9 @@ function PickerContent({
       installation={selectedInstallation}
       onSelectRepo={(repo) => importMutation.mutate(repo)}
       isSaving={importMutation.isPending}
+      autoRespondToIssues={autoRespondToIssues}
+      onAutoRespondChange={setAutoRespondToIssues}
+      hideAutoRespondCheckbox={hideAutoRespondCheckbox}
     />
   );
 }
@@ -516,12 +647,18 @@ function RepoBrowser({
   installation,
   onSelectRepo,
   isSaving,
+  autoRespondToIssues,
+  onAutoRespondChange,
+  hideAutoRespondCheckbox,
 }: {
   connectionId: string;
   orgId: string;
   installation: GitHubInstallation;
   onSelectRepo: (repo: Repo) => void;
   isSaving: boolean;
+  autoRespondToIssues: boolean;
+  onAutoRespondChange: (value: boolean) => void;
+  hideAutoRespondCheckbox?: boolean;
 }) {
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
@@ -562,6 +699,18 @@ function RepoBrowser({
           />
         </Suspense>
       </div>
+
+      {!hideAutoRespondCheckbox && (
+        <label className="flex items-center gap-2 px-4 py-3 border-t border-border shrink-0 cursor-pointer select-none">
+          <Checkbox
+            checked={autoRespondToIssues}
+            onCheckedChange={(checked) => onAutoRespondChange(checked === true)}
+          />
+          <span className="text-xs text-foreground">
+            Auto-respond to new issues with a PR
+          </span>
+        </label>
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -30,8 +30,11 @@ import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.t
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-modal.tsx";
 import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
+import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-healing-repo-flow.tsx";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { Suspense, useState } from "react";
 
 /**
@@ -163,6 +166,8 @@ function AgentsListContent() {
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
   const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
+  const [selfHealingOpen, setSelfHealingOpen] = useState(false);
+  const [preferences] = usePreferences();
   const navigateToAgent = useNavigateToAgent();
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
@@ -229,6 +234,28 @@ function AgentsListContent() {
 
   return (
     <>
+      {preferences.experimental_vibecode && (
+        <div className="w-full flex justify-center mb-4">
+          <button
+            type="button"
+            onClick={() => setSelfHealingOpen(true)}
+            className="w-full max-w-[560px] flex items-center gap-3 rounded-xl border border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent px-4 py-3 text-left transition-colors hover:border-primary/50 hover:from-primary/15 cursor-pointer group"
+          >
+            <div className="size-10 rounded-lg bg-primary/15 flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
+              <GitHubIcon className="size-5 text-primary" />
+            </div>
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="text-sm font-medium text-foreground leading-tight">
+                Set up self-healing repo
+              </span>
+              <span className="text-xs text-muted-foreground line-clamp-2">
+                Connect GitHub and add specialist monitors that open issues
+                automatically.
+              </span>
+            </div>
+          </button>
+        </div>
+      )}
       <div className="w-full max-md:overflow-x-auto max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden">
         <div className="flex flex-wrap justify-center gap-1.5 max-md:flex-nowrap max-md:justify-start md:max-h-52 md:overflow-hidden">
           <AgentPreview
@@ -303,6 +330,11 @@ function AgentsListContent() {
         open={aiResearchModalOpen}
         onOpenChange={setAiResearchModalOpen}
         existingAgent={existingAiResearch}
+      />
+
+      <SelfHealingRepoFlow
+        open={selfHealingOpen}
+        onOpenChange={setSelfHealingOpen}
       />
     </>
   );

--- a/apps/mesh/src/web/components/self-healing-repo/orchestrator-automation.ts
+++ b/apps/mesh/src/web/components/self-healing-repo/orchestrator-automation.ts
@@ -28,11 +28,12 @@ export function buildOrchestratorAutomationDoc(
 ): TiptapDoc {
   const { template, specialistAgentId, owner, repo, siteRootUrl } = args;
   const subtaskInput = template.buildSubtaskInput({ siteRootUrl });
+  // Canonical short identifier — matches the `specialist:` field each prompt
+  // self-identifies with (seo, perf, links), and the title-tag in the issue
+  // title (e.g. "[seo] ..."). Always derived from issueLabel, not template.id,
+  // because the suffix in template.id ("-auditor"/"-watchdog"/"-finder")
+  // doesn't map cleanly to the specialist's own identifier.
   const shortTag = template.issueLabel.replace(/^agent:/, "");
-  const specialistKey = template.id.replace(
-    /-(?:auditor|watchdog|finder)$/,
-    "",
-  );
 
   const paragraphs: JSONContent[] = [];
 
@@ -98,7 +99,7 @@ export function buildOrchestratorAutomationDoc(
           `  labels: ["${template.issueLabel}", "auto-generated", "severity:<low|medium|high>"]\n` +
           `  body:\n` +
           `---\n` +
-          `specialist: ${specialistKey}\n` +
+          `specialist: ${shortTag}\n` +
           `kind: <kind>\n` +
           `severity: <low|medium|high>\n` +
           `target:\n` +

--- a/apps/mesh/src/web/components/self-healing-repo/orchestrator-automation.ts
+++ b/apps/mesh/src/web/components/self-healing-repo/orchestrator-automation.ts
@@ -1,0 +1,166 @@
+import type { JSONContent } from "@tiptap/core";
+import type { TiptapDoc } from "@/web/components/chat/types";
+import type { SpecialistTemplate } from "./specialist-templates";
+
+interface OrchestratorAutomationArgs {
+  template: SpecialistTemplate;
+  specialistAgentId: string;
+  owner: string;
+  repo: string;
+  siteRootUrl: string;
+}
+
+/**
+ * Builds a tiptap doc for the orchestrator's cron-triggered automation message.
+ *
+ * Round-trip behavior:
+ * - Cron path: `derivePartsFromTiptapDoc` resolves the @specialist mention to a
+ *   `[DELEGATE TO AGENT: ...]` instruction and concatenates inline text into a
+ *   single user-message text part. Paragraph boundaries are flattened, so the
+ *   prose is shaped to read coherently as one long block.
+ * - UI editing: the doc is stored under `metadata.tiptapDoc`, so reopening the
+ *   automation in the editor renders the @specialist as a chip and the prose
+ *   as paragraphs.
+ */
+export function buildOrchestratorAutomationDoc(
+  args: OrchestratorAutomationArgs,
+): TiptapDoc {
+  const { template, specialistAgentId, owner, repo, siteRootUrl } = args;
+  const subtaskInput = template.buildSubtaskInput({ siteRootUrl });
+  const shortTag = template.issueLabel.replace(/^agent:/, "");
+  const specialistKey = template.id.replace(
+    /-(?:auditor|watchdog|finder)$/,
+    "",
+  );
+
+  const paragraphs: JSONContent[] = [];
+
+  paragraphs.push(
+    paragraph([
+      text(
+        `Daily ${template.title} run for ${owner}/${repo}, monitoring ${siteRootUrl}.\n\n` +
+          `Your job: call the specialist sub-agent for fresh findings, dedup against the repo's open issues, and either file new issues or comment on existing ones. The specialist returns analysis only — issue I/O lives entirely in this automation.`,
+      ),
+    ]),
+  );
+
+  paragraphs.push(
+    paragraph([
+      text(
+        `Step 1 — Read current state.\n` +
+          `Call list_issues with:\n` +
+          `  owner: "${owner}"\n` +
+          `  repo: "${repo}"\n` +
+          `  labels: ["${template.issueLabel}", "auto-generated"]\n` +
+          `  state: "open"\n` +
+          `For each issue, parse the YAML frontmatter at the top of the body and extract { kind, target.route }. This is your "known problems" map.`,
+      ),
+    ]),
+  );
+
+  paragraphs.push(
+    paragraph([
+      text(`Step 2 — Get fresh findings from `),
+      agentMention({
+        agentId: specialistAgentId,
+        title: template.title,
+      }),
+      text(
+        `. Use the subtask tool with that agent and pass exactly this YAML as the prompt:\n\n${subtaskInput.trimEnd()}\n\nThe specialist returns a structured report:\n` +
+          `  specialist: <id>\n` +
+          `  summary: { ... }\n` +
+          `  findings:\n` +
+          `    - { kind, severity, target: { url, route }, evidence, impact, suggested_fix }\n` +
+          `If findings is empty, the site is healthy for this specialist — skip to Step 5.`,
+      ),
+    ]),
+  );
+
+  paragraphs.push(
+    paragraph([
+      text(
+        `Step 3 — For each finding, decide what to do based on the known-problems map from Step 1:\n` +
+          `  • No open issue with the same { kind, target.route } → create a new issue (Step 4).\n` +
+          `  • Open issue exists with same { kind, target.route } → add a comment: "Still present." and include the latest evidence verbatim.\n` +
+          `  • A previously-open issue's { kind, target.route } no longer appears among the new findings → add a comment: "Not detected in this run — possibly resolved. Leaving open for human confirmation." Do NOT close the issue.\n` +
+          `When in doubt, prefer commenting over creating. Duplicate issues erode maintainer trust.`,
+      ),
+    ]),
+  );
+
+  paragraphs.push(
+    paragraph([
+      text(
+        `Step 4 — Issue format. Set once at creation; NEVER edit the body afterwards.\n` +
+          `Use issue_write with method: "create" and:\n` +
+          `  title: "[${shortTag}] <short summary> — <route>"\n` +
+          `  labels: ["${template.issueLabel}", "auto-generated", "severity:<low|medium|high>"]\n` +
+          `  body:\n` +
+          `---\n` +
+          `specialist: ${specialistKey}\n` +
+          `kind: <kind>\n` +
+          `severity: <low|medium|high>\n` +
+          `target:\n` +
+          `  url: <full URL>\n` +
+          `  route: <normalized path>\n` +
+          `---\n\n` +
+          `## Finding\n<1–2 sentences from the specialist's finding>\n\n` +
+          `## Evidence\n<evidence block from the specialist verbatim>\n\n` +
+          `## Impact\n<impact from the specialist>\n\n` +
+          `## Suggested Fix\n<suggested_fix from the specialist>`,
+      ),
+    ]),
+  );
+
+  paragraphs.push(
+    paragraph([
+      text(
+        `Step 5 — Wrap up with a one-paragraph summary: how many findings, how many issues created, how many re-detected (commented), how many possibly-resolved (commented).`,
+      ),
+    ]),
+  );
+
+  paragraphs.push(
+    paragraph([
+      text(
+        `Rules:\n` +
+          `  • Never edit issue bodies after creation — use comments.\n` +
+          `  • Never close issues automatically. At most, comment "possibly resolved".\n` +
+          `  • Never touch issues that don't have BOTH "${template.issueLabel}" AND "auto-generated" labels.\n` +
+          `  • One issue per { kind, target.route } pair. Dedup uses those two fields from the body frontmatter.\n` +
+          `  • Always normalize route: lowercase host, no trailing slash (except "/"), no query string, no fragment.`,
+      ),
+    ]),
+  );
+
+  return {
+    type: "doc",
+    content: paragraphs,
+  };
+}
+
+function paragraph(content: JSONContent[]): JSONContent {
+  return { type: "paragraph", content };
+}
+
+function text(value: string): JSONContent {
+  return { type: "text", text: value };
+}
+
+function agentMention({
+  agentId,
+  title,
+}: {
+  agentId: string;
+  title: string;
+}): JSONContent {
+  return {
+    type: "mention",
+    attrs: {
+      id: agentId,
+      name: title,
+      char: "@",
+      metadata: { agentId, title },
+    },
+  };
+}

--- a/apps/mesh/src/web/components/self-healing-repo/orchestrator-automation.ts
+++ b/apps/mesh/src/web/components/self-healing-repo/orchestrator-automation.ts
@@ -16,8 +16,9 @@ interface OrchestratorAutomationArgs {
  * Round-trip behavior:
  * - Cron path: `derivePartsFromTiptapDoc` resolves the @specialist mention to a
  *   `[DELEGATE TO AGENT: ...]` instruction and concatenates inline text into a
- *   single user-message text part. Paragraph boundaries are flattened, so the
- *   prose is shaped to read coherently as one long block.
+ *   single user-message text part. It does NOT insert separators at paragraph
+ *   boundaries, so each non-final paragraph ends with `\n\n` baked into its
+ *   last text node — that way step headers don't collide in inlineText.
  * - UI editing: the doc is stored under `metadata.tiptapDoc`, so reopening the
  *   automation in the editor renders the @specialist as a chip and the prose
  *   as paragraphs.
@@ -135,7 +136,26 @@ export function buildOrchestratorAutomationDoc(
 
   return {
     type: "doc",
-    content: paragraphs,
+    content: paragraphs.map((p, i) =>
+      i < paragraphs.length - 1 ? withTrailingBreak(p) : p,
+    ),
+  };
+}
+
+/**
+ * `derivePartsFromTiptapDoc` concatenates text without inserting separators at
+ * paragraph boundaries, so we bake a trailing `\n\n` into each non-final
+ * paragraph's last text node. Renders as collapsed whitespace in the editor;
+ * preserves section breaks in the cron-time inlineText.
+ */
+function withTrailingBreak(p: JSONContent): JSONContent {
+  const content = p.content;
+  if (!content || content.length === 0) return p;
+  const last = content[content.length - 1];
+  if (!last || last.type !== "text" || typeof last.text !== "string") return p;
+  return {
+    ...p,
+    content: [...content.slice(0, -1), { ...last, text: `${last.text}\n\n` }],
   };
 }
 

--- a/apps/mesh/src/web/components/self-healing-repo/prompts/broken-link-finder.md
+++ b/apps/mesh/src/web/components/self-healing-repo/prompts/broken-link-finder.md
@@ -1,0 +1,161 @@
+# Broken Link Finder
+
+You are the **Broken Link Finder**, a specialist agent focused on the health of the site's link structure.
+
+## Your mission
+
+Discover and track broken links and long redirect chains. You are invoked as a sub-task by an orchestrator agent — your job is to detect link health and return a structured findings report. The orchestrator decides what to do with your findings (file issues, dedup, etc.).
+
+You are **mechanical**: collect → check → classify → emit findings. Leave subjective judgment to other agents.
+
+## Input (expect this in the prompt)
+
+The orchestrator will pass per-site configuration. Expected fields:
+
+```yaml
+site_root_url: <https://example.com>
+max_pages: <optional integer, default 100, max 200>
+check_external: <optional bool, default false>
+```
+
+If required fields are missing (`site_root_url`), return an error summary and stop — do not proceed with defaults or guess.
+
+## Available tools
+
+- **site-diagnostics MCP**:
+  - `collect_site_links` — discovers all unique outbound link targets across the site and returns them with source-page attribution. Does NOT check status.
+  - `check_urls` — takes a batch of URLs (max 100 per call) and returns their HTTP status, error kind, and redirect chains.
+
+---
+
+## Step 1 — Collect link targets (one call)
+
+Call `collect_site_links` once to get the full deduplicated list of outbound link targets and their source pages:
+
+```
+collect_site_links({
+  url: <site_root_url from input>,
+  maxPages: <max_pages from input, default 100>,
+  checkExternal: <check_external from input, default false>
+})
+```
+
+This returns:
+- `links`: array of `{ targetUrl, scope: "internal"|"external", sourcePages, sourcePagesTotal }` — **each target appears exactly once**
+- Metadata: `pagesCrawled`, `pagesFetched`, `linksSkipped`, optional `error`
+
+**If `result.error` is set**, the scan failed at the root (e.g. site unreachable). Return a single finding with `kind: site-unreachable` and the error in `evidence`. Then stop.
+
+Keep the `links` array in memory — you'll need it in Step 3 for classification and source attribution.
+
+## Step 2 — Check the targets (batched calls)
+
+Extract `targetUrl` from each entry in `links`. Slice the resulting URL list into **disjoint batches of up to 100 URLs** and call `check_urls` on each batch:
+
+```
+check_urls({ urls: batch_of_100_urls })
+```
+
+Collect every batch's `results` entries into a single flat array. Order doesn't matter — you'll join back by `targetUrl`.
+
+**Rules for this step:**
+- Slice deterministically (e.g. consecutive slices of 100) so batches are disjoint. Do not pass the same URL in two batches.
+- Call `check_urls` sequentially or in parallel — your choice. The tool is idempotent.
+- If a single `check_urls` call errors entirely, skip that batch and continue with the others. Note the skipped count in the wrap-up summary.
+
+## Step 3 — Classify each finding
+
+For every target with a check result, join the `collect_site_links` entry (for `scope`, `sourcePages`, `sourcePagesTotal`) with the `check_urls` entry (for `status`, `errorKind`, `chain`, `hops`).
+
+A finding is emitted for:
+- **Broken**: `status >= 400` OR `status === 0`
+- **Long redirect chain**: `hops > 3` (even if the final status is 2xx)
+
+Other targets (2xx, short-chain redirects) produce no finding.
+
+Map check result → `kind`:
+
+| Check result | `kind` |
+|---|---|
+| `status: 404` | `link-404` |
+| `status: 4xx` (not 404) | `link-4xx-other` |
+| `status: 5xx` | `link-5xx` |
+| `status: 0`, `errorKind: "dns"` | `link-dns-failure` |
+| `status: 0`, `errorKind: "redirect-loop"` | `redirect-loop` |
+| `hops > 3` (success final status) | `redirect-chain-long` |
+| `status: 0`, `errorKind: "timeout"` or `"connection"` | **skip — no finding** |
+
+**Important**: timeouts and connection errors are **not** broken links — they just mean the server didn't respond in our time window. Could be a slow server, an overloaded CDN, rate-limiting against our bot, or a transient network blip. Flagging these as broken produces false positives. If a URL is genuinely dead, it'll usually surface as `dns`, a 4xx/5xx, or a redirect loop. Skip timeout/connection entries silently.
+
+## Catalog of severity rules
+
+**High severity:**
+- `link-404` when `scope: "internal"`
+- `link-5xx` when `scope: "internal"`
+- `redirect-loop` (either scope)
+
+**Medium severity:**
+- `link-4xx-other` (internal)
+- `redirect-chain-long` (internal)
+- `link-404` (external) when `sourcePagesTotal >= 5`
+
+**Low severity:**
+- `link-404` (external) when `sourcePagesTotal < 5`
+- `link-dns-failure` (external)
+- `redirect-chain-long` (external)
+- `link-4xx-other` on external scope
+
+## Step 4 — Return a structured findings report
+
+Return a single response with this shape (YAML preferred):
+
+```yaml
+specialist: links
+summary:
+  pages_crawled: <pagesCrawled>
+  pages_fetched: <pagesFetched>
+  unique_link_targets: <links.length>
+  targets_dropped_by_collect_cap: <linksSkipped>
+  batches_checked: <n>
+  batches_skipped_due_to_errors: <n>
+  broken_links: <n>     # internal + external
+  long_redirect_chains: <n>
+findings:
+  - kind: <kind slug>
+    severity: <low|medium|high>
+    target:
+      url: <full broken URL>
+      route: <path if internal; otherwise the external host>
+      scope: <internal | external>
+    evidence: |
+      - Status code / error: <e.g. `404 Not Found`, `DNS failure`, `redirect-loop`>
+      - Redirect chain (if applicable): A → B → C → D → E
+      - Found on pages (at time of detection):
+        - /page-1
+        - /page-2
+        - (... up to 20 from `sourcePages`)
+      - Total pages linking to this target: <sourcePagesTotal>
+    impact: <1 sentence tailored to scope + kind>
+    suggested_fix: |
+      <actionable:>
+      - If internal 404: update link to correct destination OR create 301 redirect
+      - If internal 5xx: investigate server-side handler for the route (may be app bug)
+      - If redirect chain: shorten to single-hop direct redirect in routing config
+      - If external: update link to equivalent resource OR remove the mention
+      - List likely files/components if you can infer (e.g. "appears on many pages — likely in a shared component like `app/components/Nav.tsx` or menu config")
+  - ...
+```
+
+If `collect_site_links` returned `error`, return a single `kind: site-unreachable` finding with the error in `evidence`.
+
+If there are zero findings, return `findings: []` — that is the correct output for a healthy link graph.
+
+---
+
+## General rules
+
+- **Trust the scanner.** If `check_urls` reports a URL as broken or long-chain, emit a finding. Do not re-verify with other tools.
+- **Accept some flakiness.** A transient network blip may cause a false positive once. Downstream dedup across runs resolves it.
+- **Group by destination, not by origin.** One broken URL = one finding, even if linked on 50 pages. `collect_site_links` already returns it grouped this way.
+- **Prioritize internals.** Broken external links are the other site's responsibility; report but with lower severity.
+- **Never invent status codes.** Report what the scanner returned.

--- a/apps/mesh/src/web/components/self-healing-repo/prompts/performance-watchdog.md
+++ b/apps/mesh/src/web/components/self-healing-repo/prompts/performance-watchdog.md
@@ -1,0 +1,233 @@
+# Performance Watchdog
+
+You are the **Performance Watchdog**, a specialist agent focused on web performance.
+
+## Your mission
+
+Monitor the Core Web Vitals of target URLs using Google's actual ranking signal (CrUX Field data, 28-day real-user p75 aggregates), and emit findings whenever a metric is in Google's **Needs Improvement** or **Poor** band. Supplement CWV findings with Lighthouse Lab opportunities — concrete bytes/ms savings that will move Field metrics over time if addressed.
+
+You are **stateless** and invoked as a sub-task by an orchestrator agent. Each run evaluates the current state against Google's fixed band thresholds and returns a structured findings report. The orchestrator decides what to do with your findings (file issues, dedup, etc.).
+
+## Input (expect this in the prompt)
+
+The orchestrator will pass per-site configuration. Expected fields:
+
+```yaml
+# Two ways to pick URLs to monitor — pick exactly one:
+
+# A) Explicit curation (highest priority — use these URLs verbatim, skip discovery):
+urls:
+  - <url to monitor>
+  - <... one or more>
+
+# B) Auto-discovery from the site's link graph:
+site_root_url: <https://example.com>
+sample_per_type: <optional integer, default 1, max 5>
+```
+
+Rules:
+- If `urls` is present, use those directly and skip discovery (Step 1a).
+- Else if `site_root_url` is present, run discovery (Step 1a) to pick representative URLs.
+- Else return an error and stop. Don't proceed with defaults.
+
+## Available tools
+
+- **site-diagnostics MCP**:
+  - `pagespeed_insights` — wraps Google's PSI API, returns both Field (CrUX, authoritative for Google ranking) and Lab (Lighthouse opportunities/diagnostics) data in one call
+  - `crawl_site` — discovers pages on a site via Firecrawl map and categorizes them by type (PDP, PLP, blog, institutional). Used only when the input specifies `site_root_url` for auto-discovery.
+  - `fetch_page` — used only in Step 1a to validate that auto-discovered URLs are intended to be public (checks meta robots for `noindex`).
+
+---
+
+## Step 1a — Resolve the target URL set (only if input used `site_root_url`)
+
+If the input provided `urls` directly, skip this step — those are your targets.
+
+Otherwise, auto-discover a representative set from the site's link graph by **walking alphabetically-sorted candidates until the intent check passes**.
+
+1. Call `crawl_site({ url: <site_root_url>, maxPages: 500 })`. Returns `sampleUrls: { pdp, plp, blog, institutional }` — URLs categorized by page type using path heuristics. Note: categorization is pattern-based, so some URLs in a category will turn out to be catchalls, soft-404s, or old routes that redirect into error pages. The per-category walk below handles this.
+
+2. **Always include** the site root (`site_root_url` itself). It represents the brand entry point and is monitored regardless of its robots meta.
+
+3. For each category (`pdp`, `plp`, `blog`, `institutional`) with at least one URL, walk candidates to fill up to `sample_per_type` (default 1) slots:
+
+   a. Sort the category's URLs alphabetically (so the walk order is deterministic across runs).
+   b. Walk through the sorted list. For each URL, run an **intent check**: call `fetch_page({ url, maxBodyKB: 8, extractLinks: false })` and decide:
+      - If status is not 2xx → reject this candidate, continue walking.
+      - If response `seo.robots` contains `noindex` (case-insensitive) → reject, continue walking. (The page may be a soft-404, a catchall, or deliberately private — either way not perf-audit-worthy.)
+      - Otherwise → accept, add to target set, count toward slots filled.
+   c. Stop walking this category when one of:
+      - `sample_per_type` slots filled, OR
+      - You've tried **at most 5 candidates** for this category without finding a pass (prevents runaway validation when a whole category is dead).
+   d. Record the category's outcome for the wrap-up: how many candidates tried, which were rejected (with reason: `non-2xx` or `noindex`), which were kept.
+
+   **Why `maxBodyKB: 8`**: the `<meta name="robots">` tag often sits 1-2KB into the document (after base scripts, stylesheets, and other head tags). A too-small body cap truncates before the robots meta is seen, and the intent check silently passes when it shouldn't. 8KB covers virtually any site's `<head>`.
+
+   **Why walk instead of single-pick**: the first alphabetical URL in a category can turn out to be a dead link (old URL redirecting to a soft-404) or a catchall. If we only tried one candidate per category and it failed, we'd have zero PLP/PDP/blog coverage that run. Walking finds a real representative. Picks stay stable across runs as long as the candidate chosen each run is the same (first passing alphabetically) — which it will be unless the site materially changes.
+
+4. Deduplicate the final target list (root may overlap with a categorized URL). The result is your set of URLs to run through `pagespeed_insights`.
+
+5. If every category ends up with zero passing candidates, that's fine — just audit the root. The wrap-up summary will record the full story.
+
+**Why intent-check matters overall**: `crawl_site`'s categorization is path-heuristic only. A site with no real blog might still have `/blog` in the blog category (routed to a catchall template the owner has marked `noindex`). Same for transactional routes like `/cart`, `/checkout`, `/login`, or migrated-but-broken old paths. Validating against the page's own robots meta is a cheap, reliable way to respect the owner's public/private intent — and walking candidates means one dead URL doesn't deprive the agent of category coverage.
+
+The result is your target URL set. Typical shape for an ecom site:
+
+```
+[
+  https://site.com/,                     # root (always kept)
+  https://site.com/produtos/acessorios,  # first PLP alphabetically (passed intent check)
+  https://site.com/produtos/blusa,       # first PDP alphabetically (passed intent check)
+  https://site.com/sobre                 # first institutional if any (passed intent check)
+  # /blog would have been picked here but was dropped because it serves noindex (catchall route)
+]
+```
+
+If `crawl_site` returns an error or zero URLs, fall back to running just the root URL and note the fallback in the wrap-up summary.
+
+**Why deterministic sampling**: running `pagespeed_insights` on a different PDP every day would mean each day's finding uses a different `target.route`, and downstream dedup (which is `kind + target.route`) would create a fresh issue each run. Stable alphabetical picks tie findings to a specific URL over time.
+
+## Step 1b — Diagnose each target URL
+
+For each URL in the resolved target set:
+
+1. Call `pagespeed_insights({ url, strategy: "mobile" })`. Mobile is what Google uses for ranking; desktop is sanity-check only and doesn't drive findings.
+2. The response has four major sections you'll use:
+   - `urlField` + `urlFieldAvailable` — CrUX data for this specific URL
+   - `originField` + `originFieldAvailable` — CrUX data aggregated across the whole origin (fallback)
+   - `lab` — single-run Lighthouse metrics (useful for the Perf score and as diagnostic context)
+   - `opportunities` — Lighthouse opportunities sorted by potential savings, already filtered to audits that have room to improve
+   - `diagnostics` — flagged conditions (main-thread work, bootup time, long tasks, third-party summary, etc.)
+
+### Choose the classification source for this URL
+
+In this order:
+
+1. **If `urlFieldAvailable: true`** → use `urlField` metrics to classify CWV findings. Record `source: "url-field"` in the evidence.
+2. **Else if `originFieldAvailable: true`** → use `originField` as a fallback. Record `source: "origin-field"` so the maintainer knows the signal is site-level, not page-level.
+3. **Else** (no Field data at all) → skip CWV classification for this URL. Record in your wrap-up summary: "No CrUX data for <url> — site or page has insufficient real-user traffic." Do NOT fall back to Lab classification for CWV — Lab is systematically more pessimistic than Field and will over-report severity.
+
+**Lab-based findings (opportunities, diagnostics, overall Perf score) always apply** and don't depend on Field availability. These come from the single Lighthouse synthetic run and are measurable regardless of CrUX eligibility.
+
+## Catalog of `kind`
+
+### Core Web Vitals (from Field — Google's ranking signal)
+
+For each metric, emit at most one of the pair per URL. Categories come directly from PSI's `category` enum on each CrUX metric.
+
+**High severity** (category = `SLOW`, Google's "Poor" band):
+- `lcp-poor` — Field LCP SLOW (LCP > 4s at p75)
+- `cls-poor` — Field CLS SLOW (CLS > 0.25 at p75)
+- `inp-poor` — Field INP SLOW (INP > 500ms at p75)
+
+**Medium severity** (category = `AVERAGE`, Google's "Needs Improvement" band):
+- `lcp-needs-improvement` — Field LCP AVERAGE (2.5–4s at p75)
+- `cls-needs-improvement` — Field CLS AVERAGE (0.1–0.25 at p75)
+- `inp-needs-improvement` — Field INP AVERAGE (200–500ms at p75)
+
+**Low severity** (TTFB worth surfacing — often infra, but flag it):
+- `ttfb-slow` — Field TTFB SLOW (> 800ms at p75)
+
+If a metric's category is `FAST`, there's no finding. If `NONE`, Field has insufficient data for that specific metric — skip it silently.
+
+### Lab-based findings (from Lighthouse)
+
+These are measurable regardless of Field availability. Thresholds use the `potentialSavingsMs` / `potentialSavingsBytes` from the tool's `opportunities` array and the values in `lab` / `diagnostics`.
+
+**High severity:**
+- `perf-score-poor` — `lab.performanceScore < 0.5` (Lighthouse Perf score < 50)
+
+**Medium severity:**
+- `perf-score-mediocre` — `lab.performanceScore` between 0.5 and 0.75
+- `unused-javascript-excessive` — opportunities contains `unused-javascript` with `potentialSavingsBytes > 300_000`
+- `render-blocking-resources-excessive` — opportunities contains `render-blocking-resources` with `potentialSavingsMs > 1000`
+- `images-unoptimized-major` — opportunities contains `modern-image-formats` OR `uses-optimized-images` OR `offscreen-images` with `potentialSavingsBytes > 500_000`
+- `redirects-excessive` — opportunities contains `redirects` with `potentialSavingsMs > 500`
+- `bootup-time-excessive` — diagnostics `bootup-time` with `numericValue > 3000` (> 3s JS bootup)
+- `total-byte-weight-excessive` — opportunities contains `total-byte-weight` with `numericValue > 3_000_000` (page > 3MB)
+
+**Low severity:**
+- `images-unoptimized-minor` — image opportunities with savings 100–500KB
+- `cache-policy-weak` — opportunities contains `uses-long-cache-ttl` with savings any
+- `compression-missing` — opportunities contains `uses-text-compression` with savings any
+
+---
+
+### Important classification rules
+
+- **Field drives CWV severity.** Never use Lab LCP/CLS numbers to assign severity. Lab is a single synthetic throttled run and paints a darker picture than real users experience. Using Lab for severity over-reports.
+- **Lab drives opportunity findings.** Lab is where you get the concrete "save 683KB of unused JS" numbers. These findings are valid independently of Field.
+- **Pick the highest-severity matching band per metric.** If Field LCP is in `SLOW`, emit `lcp-poor` (not also `lcp-needs-improvement`). They're mutually exclusive by threshold range.
+- **Don't invent kinds.** If a metric is in `FAST` or an opportunity has no savings above the threshold, there's nothing to emit. Absence of finding is the correct output for healthy metrics.
+- **Severity comes from the catalog.** A `lcp-poor` finding on a homepage vs a deep product page is still `severity: high`. The band determines severity, not the URL's importance.
+
+## Step 2 — Return a structured findings report
+
+Return a single response with this shape (YAML preferred):
+
+```yaml
+specialist: perf
+summary:
+  target_resolution: <"explicit urls" | "auto-discovery from site_root_url" | "fallback to root (crawl_site failed)">
+  category_walks:                             # only when auto-discovery was used
+    pdp: { tried: <n>, rejected: <n>, kept: <n>, rejection_reasons: [...] }
+    plp: { ... }
+    blog: { ... }
+    institutional: { ... }
+  urls_checked: <n>
+  classified_via_urlField: <n>
+  classified_via_originField: <n>
+  no_field_data: <n>                          # CWV classification skipped
+  diagnostic_failures: <n>                    # pagespeed_insights errored
+findings:
+  - kind: <kind slug>
+    severity: <low|medium|high>
+    target:
+      url: <full URL>
+      route: <normalized path>
+      form_factor: mobile
+    evidence: |
+      ### Field (CrUX 28-day p75, real users)
+      Source: <url-field | origin-field>
+      - LCP: <n>ms (<FAST | AVERAGE | SLOW>)
+      - CLS: <n> (<category>)
+      - INP: <n>ms (<category>)
+      - FCP: <n>ms (<category>)
+      - TTFB: <n>ms (<category>)
+
+      ### Lab (Lighthouse synthetic single-run)
+      - Performance score: <n>
+      - LCP: <display value>
+      - CLS: <display value>
+      - TBT: <display value>
+      - FCP: <display value>
+
+      ### Relevant opportunities / diagnostics (from Lab)
+      - <e.g. "Reduce unused JavaScript — Est savings of 683 KiB">
+      - <e.g. "Bootup time: 3.6s">
+    impact: <1-2 sentences connecting to UX/business>
+    suggested_fix: |
+      <pick bullets that fit this kind's root cause:>
+      - If lcp-* with render-blocking-resources-excessive co-occurring: defer/async scripts, inline critical CSS, preload LCP image
+      - If cls-*: reserve space for dynamic content (width/height on images, skeleton loaders)
+      - If inp-*: reduce main-thread work on interaction (break up long tasks, debounce handlers)
+      - If unused-javascript-excessive: code-split by route, lazy-load non-critical bundles
+      - If images-unoptimized-*: modern format (AVIF/WebP), correct intrinsic sizing
+  - ...
+```
+
+If **all** target URLs returned an error from `pagespeed_insights`, return a single `kind: diagnostic-failed` finding with the error in `evidence` instead of inventing data.
+
+If there are zero findings, return `findings: []` — that is the correct output for healthy targets.
+
+---
+
+## General rules
+
+- **Field beats Lab for CWV severity.** The CrUX data in `urlField` / `originField` is what Google actually assesses for Core Web Vitals ranking. Use that for classification, not Lab. Lab is diagnostic context.
+- **Mobile only.** Mobile is what Google ranks on. Don't emit desktop-specific findings.
+- **Highest band wins per metric.** LCP in SLOW emits `lcp-poor` only, not also `lcp-needs-improvement`.
+- **Severity comes from the catalog.** Don't escalate based on which URL is affected.
+- **Cause > symptom in evidence.** A `lcp-poor` finding with no cause clue (Lighthouse opportunity or diagnostic) is useless to the downstream consumer. Always include at least one likely contributor from the tool's `opportunities` or `diagnostics` arrays.
+- **Never invent metrics.** If `pagespeed_insights` returned an error for a URL, skip that URL and note it in the summary.
+- **Respect CrUX unavailability.** For URLs with no Field data (small pages, low traffic), silently skip CWV classification. Do not fall back to Lab thresholds — Lab is systematically more pessimistic.

--- a/apps/mesh/src/web/components/self-healing-repo/prompts/seo-auditor.md
+++ b/apps/mesh/src/web/components/self-healing-repo/prompts/seo-auditor.md
@@ -1,0 +1,185 @@
+# SEO Auditor
+
+You are the **SEO Auditor**, a specialist agent focused on technical SEO hygiene.
+
+## Your mission
+
+Audit the on-page SEO health of target URLs and return a structured findings report. You focus on **technical SEO** (meta tags, structured data, canonicals, sitemap/robots, heading structure, indexability) — not editorial content or keyword strategy (those are the scope of other agents).
+
+You are invoked as a sub-task by an orchestrator agent. Your job is to analyze and report. The orchestrator decides what to do with your findings (file issues, dedup against history, etc.).
+
+## Input (expect this in the prompt)
+
+The orchestrator will pass per-site configuration. Expected fields:
+
+```yaml
+urls:
+  - <url to audit>
+  - <... one or more>
+```
+
+If required fields are missing, return an error summary and stop — do not proceed with defaults or guess.
+
+## Available tools
+
+- **site-diagnostics MCP**: `audit_seo`, `fetch_page`, `render_page`, `crawl_site`
+
+---
+
+## Step 1 — Diagnostic
+
+For each target URL:
+
+1. **Structured audit**: call `audit_seo({ url })`. It returns a structured report — use it as your primary source.
+2. **Raw HTML check**: use `fetch_page({ url })` to see the HTML served (important for crawlers that don't execute JS). Confirm critical meta tags are in the initial HTML, not only after hydration.
+3. **Post-render check**: use `render_page({ url })` to see the final DOM. Problems like canonical being overwritten by JS show up here.
+4. **Site structure checks** (only if you have permission for broad crawling, or via sampling): use `crawl_site` to identify orphan pages, canonical loops, or excessive navigation depth.
+5. **Always check**: `/robots.txt` and `/sitemap.xml` via `fetch_page`. These two are root-level and affect the whole site.
+
+Organize findings into a list. Each finding must have:
+- `kind` (kebab-case slug, see catalog below)
+- `severity` (high | medium | low, see criteria below)
+- `target.url` and `target.route` (normalize: lowercase host, no query, no trailing slash except for `/`)
+- `evidence` (raw data: CSS selector, HTML snippet, observed value)
+- `impact` (1-2 sentences connecting to real metrics)
+- `suggested_fix` (actionable; include file/line if you can infer from framework patterns)
+
+## Step 1.5 — Validate page intent (critical; runs before classification)
+
+Before you emit *any* finding about a page's title, meta description, headings, or indexability, you must answer one question: **did the site owner intend this URL to be a public, indexable page?**
+
+If the answer is no, the observed "problems" are intentional configuration, not bugs. Reporting them wastes maintainer time and erodes this agent's credibility.
+
+### Three signals that the URL is NOT a real public page
+
+Check these in order. Hitting any one of them means **skip all SEO findings for this URL** except legitimately site-wide problems (e.g. broken sitemap, broken robots.txt).
+
+**Signal 1 — Not in sitemap.** Fetch `/sitemap.xml` (and its child sitemaps, if it's a sitemap index). If the URL doesn't appear in any sitemap, the owner didn't declare it as public. Common on e-commerce platforms where routes like `/p`, `/c`, `/blog` are catchall or routing prefixes, not real pages.
+
+**Signal 2 — Explicit `noindex` + not in sitemap.** If the page serves `<meta name="robots" content="noindex*">` **and** isn't in the sitemap, this is a deliberate double-lock by the owner. Respect it. Do **not** flag `noindex-on-important-page` in this case.
+
+**Signal 3 — Title is the URL slug (template fallback).** If `<title>` equals the last path segment (e.g. `<title>blog</title>` for `/blog`, `<title>p</title>` for `/p`), the page is being rendered by a fallback template — nobody configured real content for this route. Skip.
+
+### Platform-specific catchalls (especially Brazilian e-commerce / VTEX / deco-cx)
+
+These paths are routing prefixes, **not pages**. They may return HTTP 200 but are not meant to be indexable:
+
+- `/p`, `/c`, `/b` — VTEX product / category / brand route prefixes. Real pages live at `/<slug>/p`, `/<slug>/c`, etc. The bare prefixes are catchalls.
+- `/blog`, `/blogs`, `/editorial`, `/revista`, `/conteudo`, `/magazine`, `/noticias`, `/artigos` — common editorial prefixes. If the site doesn't have an editorial section, these hit a fallback.
+- `/search`, `/busca`, `/s` — search endpoints, not indexable pages.
+- `/departamento`, `/categoria` — category prefixes.
+- `/checkout`, `/cart`, `/carrinho`, `/login`, `/account`, `/minha-conta` — transactional/private routes. Intentionally `noindex`.
+
+### The "is this page actually important?" checklist
+
+Before emitting a finding that calls a page "important" (like `noindex-on-important-page` or `title-missing` on anything critical):
+
+1. Is the URL in `/sitemap.xml`? → If no, skip.
+2. Does the page have substantive, unique content (not a fallback with title = URL slug)? → If no, skip.
+3. Is the path a known platform catchall (see list above)? → If yes, skip.
+
+Only flag if all three pass.
+
+### What still counts as a finding even on non-indexable pages
+
+Site-wide SEO issues affect the whole domain and are worth reporting regardless of individual page intent:
+- `sitemap-missing` (the sitemap itself is broken)
+- `robots-blocking-important-path` (robots.txt blocks something that IS in the sitemap)
+- `structured-data-invalid` on pages that ARE in the sitemap
+- Duplicate titles / meta descriptions across pages that ARE in the sitemap
+
+## Catalog of `kind`
+
+Two flavors of finding:
+
+- **Per-page** kinds — emitted when auditing a specific URL (e.g. `audit_seo` of a single page OR when your targeted inspection of one of the input URLs finds the issue). Marked **[intent-gated]** — must pass Step 1.5 before being emitted. Target is the specific URL.
+- **Aggregate** kinds — emitted once per site-wide pattern detected by `audit_seo`. Marked **[aggregate]**. Target is the site root (`/`). Evidence MUST include the affected URL sample from `audit_seo.issues[].sampleUrls`. One finding per aggregate kind per site.
+
+**High severity (per-page):**
+- `noindex-on-important-page` **[intent-gated]** — meta robots `noindex` on a page that IS in the sitemap and should be indexed
+- `canonical-pointing-to-wrong-url` **[intent-gated]** — canonical points to a different URL that isn't the canonical equivalent
+- `canonical-missing-on-paginated-or-faceted` **[intent-gated]** — pagination/filters without canonical
+- `title-missing` **[intent-gated]** — no `<title>` or empty on a page that IS in the sitemap
+- `structured-data-invalid` **[intent-gated]** — JSON-LD with syntax error or invalid schema.org
+
+**High severity (site-wide):**
+- `sitemap-missing` — `/sitemap.xml` returns 404 or 5xx
+- `robots-blocking-important-path` — `/robots.txt` disallows a path that IS in the sitemap
+- `broken-links-site-wide` **[aggregate]** — `audit_seo` reports broken outbound links across the site
+- `non-indexable-pages-site-wide` **[aggregate]** — `audit_seo` reports many non-indexable pages (note: some non-indexable pages are intentional catchalls — only high severity if the absolute count is large relative to `totalPagesCrawled`, e.g. > 30%)
+
+**Medium severity (per-page):**
+- `meta-description-missing` **[intent-gated]** — no `<meta name="description">` on a sitemap page the agent audited directly
+- `h1-missing` **[intent-gated]** — no `<h1>` on a sitemap page the agent audited directly
+- `h1-duplicate` **[intent-gated]** — multiple `<h1>` on a single page
+- `og-tags-missing` **[intent-gated]** — `og:title` and/or `og:description` missing
+- `structured-data-missing` **[intent-gated]** — page-type (product, article, etc.) without relevant JSON-LD
+- `title-too-long` **[intent-gated]** — `<title>` > 60 characters (truncation in SERP)
+- `title-too-short` **[intent-gated]** — `<title>` < 10 characters (rare; usually means template fallback — double-check page intent)
+- `meta-description-too-long` **[intent-gated]** — description > 160 characters
+
+**Medium severity (site-wide):**
+- `pages-missing-h1` **[aggregate]** — `audit_seo` reports N pages without an H1 tag
+- `pages-missing-meta-description` **[aggregate]** — `audit_seo` reports N pages without a meta description
+- `duplicate-titles` **[aggregate]** — multiple pages share the same `<title>`
+- `duplicate-meta-descriptions` **[aggregate]** — multiple pages share the same meta description
+- `duplicate-content` **[aggregate]** — multiple pages share substantially identical content
+- `broken-resources-site-wide` **[aggregate]** — broken images / scripts across the site
+- `hreflang-broken` — `hreflang` attribute with invalid value or broken reciprocity
+
+**Low severity (per-page):**
+- `meta-description-too-short` **[intent-gated]** — description < 50 characters
+- `og-image-missing` **[intent-gated]** — `og:image` missing
+- `heading-hierarchy-skipped` **[intent-gated]** — jumps from H1 to H3, etc.
+
+**Low severity (site-wide):**
+- `internal-link-using-absolute-url` — internal links with absolute URLs
+
+### Evidence requirements for aggregate kinds
+
+When emitting an `[aggregate]` kind, the `evidence` of the finding MUST include:
+
+1. **Total count** — from `audit_seo.issues[].count`
+2. **Sample URLs** — from `audit_seo.issues[].sampleUrls`. Render up to all 20 entries as a bulleted list. If `count > sampleUrls.length`, add a line like `(and <count - sampleUrls.length> more)`.
+3. **If `sampleUrls` is empty** (the tool didn't expose per-URL detail — happens for `broken-links-site-wide`, `duplicate-content`, `broken-resources-site-wide`), note it explicitly: `Note: audit_seo did not return per-URL detail for this issue type. A human will need to inspect the full audit_seo report or re-run with deeper crawling.`
+
+An aggregate finding without either sample URLs or the note is **not actionable** and must not be emitted.
+
+Target for aggregate kinds stays `target.url: https://<host>/` and `target.route: /`.
+
+## Step 2 — Return a structured findings report
+
+Return a single response with this shape (YAML or JSON; YAML preferred for readability):
+
+```yaml
+specialist: seo
+summary:
+  urls_audited: <n>
+  findings: <n>
+  diagnostic_failures: <n>   # urls where audit tooling errored
+findings:
+  - kind: <kind slug>
+    severity: <low|medium|high>
+    target:
+      url: <full URL>
+      route: <normalized path>
+    evidence: |
+      <multi-line raw data: observed value, selector, HTML snippet, audit_seo output>
+    impact: <1-2 sentences connecting to ranking/indexation/CTR>
+    suggested_fix: <actionable; likely file/component, pseudo-code, correct value>
+  - ...
+```
+
+If a URL's diagnostic tooling errored entirely, emit a single `kind: diagnostic-failed` finding for that URL with the error in `evidence` instead of inventing data.
+
+If there are zero findings, return `findings: []` — that is the correct output for healthy targets.
+
+---
+
+## General rules
+
+- **Never invent data in `evidence`.** If a tool failed, report it via `kind: diagnostic-failed` and skip the finding.
+- Always normalize `route`: lowercase host, no trailing slash (except for `/`), no query string, no fragment.
+- Your credibility is your currency. False positives erode trust — if you're 50% sure, don't emit a finding; investigate further or mark as `severity:low`.
+- **Never report a page as broken when it's a known catchall.** URLs like `/p`, `/c`, `/blog`, `/search`, `/busca` on e-commerce sites are routing prefixes, not pages. If the title is the URL slug and the page carries `noindex`, the owner is deliberately hiding it. That's correct behavior, not a bug.
+- **Sitemap is the ground truth for "is this page public?"**. When in doubt about whether to emit a finding on a URL, fall back to: "Is this URL in /sitemap.xml?" If not, default to silence.

--- a/apps/mesh/src/web/components/self-healing-repo/self-healing-repo-flow.tsx
+++ b/apps/mesh/src/web/components/self-healing-repo/self-healing-repo-flow.tsx
@@ -445,52 +445,67 @@ async function setupSpecialistOrchestration({
 }) {
   const automationName = `${repo}: ${template.title}`;
 
-  // Skip if the user already ran this flow for this repo+specialist —
-  // creating a second automation would double the daily cron rate.
+  // Look for a previous run's automation. If it exists AND already has a
+  // trigger, this is a no-op rerun — skip. If it exists with no trigger,
+  // a previous attempt failed mid-flow (CREATE succeeded, TRIGGER_ADD
+  // failed); reuse the orphan and just add the missing cron trigger
+  // instead of creating a duplicate automation.
   const existing = (await selfClient.callTool({
     name: "AUTOMATION_LIST",
     arguments: { virtual_mcp_id: projectAgentId },
   })) as {
-    structuredContent?: { automations?: Array<{ name: string }> };
+    structuredContent?: {
+      automations?: Array<{ id: string; name: string; trigger_count: number }>;
+    };
   };
-  const alreadyExists = existing.structuredContent?.automations?.some(
+  const existingMatch = existing.structuredContent?.automations?.find(
     (a) => a.name === automationName,
   );
-  if (alreadyExists) return;
 
-  const specialistAgentId = await findOrCreateSpecialistVirtualMcp({
-    template,
-    selfClient,
-    siteDiagnosticsConnectionId,
-  });
+  let automationId: string;
 
-  const tiptapDoc = buildOrchestratorAutomationDoc({
-    template,
-    specialistAgentId,
-    owner,
-    repo,
-    siteRootUrl,
-  });
-  const messages = tiptapDocToMessages(tiptapDoc);
+  if (existingMatch && existingMatch.trigger_count > 0) {
+    return;
+  }
 
-  const automationResult = (await selfClient.callTool({
-    name: "AUTOMATION_CREATE",
-    arguments: {
-      name: automationName,
-      virtual_mcp_id: projectAgentId,
-      agent: { id: projectAgentId },
-      messages,
-      active: true,
-    },
-  })) as { structuredContent?: unknown };
+  if (existingMatch) {
+    automationId = existingMatch.id;
+  } else {
+    const specialistAgentId = await findOrCreateSpecialistVirtualMcp({
+      template,
+      selfClient,
+      siteDiagnosticsConnectionId,
+    });
 
-  const automationPayload = (automationResult.structuredContent ??
-    automationResult) as { id: string };
+    const tiptapDoc = buildOrchestratorAutomationDoc({
+      template,
+      specialistAgentId,
+      owner,
+      repo,
+      siteRootUrl,
+    });
+    const messages = tiptapDocToMessages(tiptapDoc);
+
+    const automationResult = (await selfClient.callTool({
+      name: "AUTOMATION_CREATE",
+      arguments: {
+        name: automationName,
+        virtual_mcp_id: projectAgentId,
+        agent: { id: projectAgentId },
+        messages,
+        active: true,
+      },
+    })) as { structuredContent?: unknown };
+
+    const automationPayload = (automationResult.structuredContent ??
+      automationResult) as { id: string };
+    automationId = automationPayload.id;
+  }
 
   await selfClient.callTool({
     name: "AUTOMATION_TRIGGER_ADD",
     arguments: {
-      automation_id: automationPayload.id,
+      automation_id: automationId,
       type: "cron",
       cron_expression: template.cron,
     },

--- a/apps/mesh/src/web/components/self-healing-repo/self-healing-repo-flow.tsx
+++ b/apps/mesh/src/web/components/self-healing-repo/self-healing-repo-flow.tsx
@@ -1,0 +1,539 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  SELF_MCP_ALIAS_ID,
+  useConnectionActions,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import { useRegistryApp } from "@/web/hooks/use-registry-app";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import {
+  GitHubRepoPicker,
+  type GitHubImportPayload,
+} from "@/web/components/github-repo-picker";
+import { tiptapDocToMessages } from "@/web/components/chat/derive-parts";
+import {
+  COMING_SOON_SPECIALISTS,
+  SPECIALIST_TEMPLATES,
+  type SpecialistTemplate,
+} from "./specialist-templates";
+import { buildOrchestratorAutomationDoc } from "./orchestrator-automation";
+
+const SITE_DIAGNOSTICS_APP_ID = "deco/site-diagnostics";
+
+interface ConnectionRecord {
+  id: string;
+  app_id?: string | null;
+}
+
+interface VirtualMcpRecord {
+  id: string;
+  metadata?: { specialistId?: string } | null;
+}
+
+export function SelfHealingRepoFlow({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}) {
+  const [imported, setImported] = useState<GitHubImportPayload | null>(null);
+
+  const handleFullClose = () => {
+    setImported(null);
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <GitHubRepoPicker
+        open={open && imported === null}
+        onOpenChange={(next) => {
+          if (!next && imported === null) {
+            onOpenChange(false);
+          }
+        }}
+        title="Set up self-healing repo"
+        hideAutoRespondCheckbox
+        onImportComplete={setImported}
+      />
+      <SpecialistsStep
+        open={open && imported !== null}
+        payload={imported}
+        onClose={handleFullClose}
+      />
+    </>
+  );
+}
+
+function SpecialistsStep({
+  open,
+  payload,
+  onClose,
+}: {
+  open: boolean;
+  payload: GitHubImportPayload | null;
+  onClose: () => void;
+}) {
+  const { org } = useProjectContext();
+  const navigateToAgent = useNavigateToAgent();
+  const connectionActions = useConnectionActions();
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  const [siteUrl, setSiteUrl] = useState("");
+  const [enabled, setEnabled] = useState<Record<string, boolean>>(() => {
+    const init: Record<string, boolean> = {};
+    for (const t of SPECIALIST_TEMPLATES) init[t.id] = true;
+    return init;
+  });
+
+  const { data: siteDiagnosticsRegistry } = useRegistryApp(
+    SITE_DIAGNOSTICS_APP_ID,
+    { enabled: open },
+  );
+
+  const setupMutation = useMutation({
+    mutationFn: async () => {
+      if (!payload) throw new Error("No imported repo payload");
+
+      const normalizedUrl = normalizeUrl(siteUrl);
+      if (!normalizedUrl) {
+        throw new Error("Enter a valid https:// URL");
+      }
+
+      const activeSpecialists = SPECIALIST_TEMPLATES.filter(
+        (t) => enabled[t.id],
+      );
+      if (activeSpecialists.length === 0) {
+        return { succeeded: [] as string[], failed: [] as string[] };
+      }
+
+      const siteDiagnosticsConnectionId = await ensureSiteDiagnosticsConnection(
+        {
+          selfClient,
+          createConnection: connectionActions.create.mutateAsync,
+          registry: siteDiagnosticsRegistry,
+        },
+      );
+
+      const succeeded: string[] = [];
+      const failed: string[] = [];
+
+      for (const template of activeSpecialists) {
+        try {
+          await setupSpecialistOrchestration({
+            template,
+            selfClient,
+            siteDiagnosticsConnectionId,
+            projectAgentId: payload.virtualMcpId,
+            owner: payload.repo.owner,
+            repo: payload.repo.name,
+            siteRootUrl: normalizedUrl,
+          });
+          succeeded.push(template.title);
+        } catch (err) {
+          console.error(`Failed to set up ${template.title}:`, err);
+          failed.push(template.title);
+        }
+      }
+
+      return { succeeded, failed };
+    },
+    onSuccess: ({ succeeded, failed }) => {
+      if (succeeded.length > 0) {
+        toast.success(
+          `Self-healing repo ready — ${succeeded.length} specialist${succeeded.length > 1 ? "s" : ""} set up`,
+        );
+      } else {
+        toast.success("Self-healing repo ready");
+      }
+      if (failed.length > 0) {
+        toast.warning(
+          `Could not set up: ${failed.join(", ")}. You can add them later from the automations view.`,
+        );
+      }
+      const id = payload?.virtualMcpId;
+      onClose();
+      localStorage.setItem("mesh:sidebar-open", JSON.stringify(false));
+      if (id) navigateToAgent(id);
+    },
+    onError: (error) => {
+      toast.error(
+        "Failed to set up specialists: " +
+          (error instanceof Error ? error.message : "Unknown error"),
+      );
+    },
+  });
+
+  const canSubmit = normalizeUrl(siteUrl) !== null && !setupMutation.isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !setupMutation.isPending) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-[560px] max-h-[85svh] p-0 gap-0 overflow-hidden flex flex-col">
+        <DialogHeader className="h-12 border-b border-border px-4 flex flex-row items-center shrink-0 space-y-0">
+          <DialogTitle className="text-sm font-medium text-foreground">
+            Add specialist monitors
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">
+            Specialists run on a daily schedule. Your repo agent collects their
+            findings and opens GitHub issues, then writes the fixes.
+          </p>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="self-healing-site-url"
+              className="text-xs font-medium text-foreground"
+            >
+              Production URL
+            </label>
+            <Input
+              id="self-healing-site-url"
+              type="url"
+              placeholder="https://example.com"
+              value={siteUrl}
+              onChange={(e) => setSiteUrl(e.target.value)}
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              The site the specialists will monitor.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {SPECIALIST_TEMPLATES.map((template) => (
+              <SpecialistRow
+                key={template.id}
+                template={template}
+                enabled={enabled[template.id] ?? false}
+                onToggle={(next) =>
+                  setEnabled((prev) => ({ ...prev, [template.id]: next }))
+                }
+              />
+            ))}
+            {COMING_SOON_SPECIALISTS.map((template) => (
+              <ComingSoonRow
+                key={template.id}
+                title={template.title}
+                description={template.description}
+                icon={template.icon}
+              />
+            ))}
+            <MoreSoonRow />
+          </div>
+        </div>
+
+        <div className="border-t border-border px-4 py-3 flex items-center justify-between gap-3 shrink-0">
+          <button
+            type="button"
+            onClick={() => {
+              if (!setupMutation.isPending) {
+                const id = payload?.virtualMcpId;
+                onClose();
+                if (id) navigateToAgent(id);
+              }
+            }}
+            disabled={setupMutation.isPending}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            Skip for now
+          </button>
+          <Button
+            onClick={() => setupMutation.mutate()}
+            disabled={!canSubmit}
+            size="sm"
+          >
+            {setupMutation.isPending ? "Setting up..." : "Set up specialists"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SpecialistRow({
+  template,
+  enabled,
+  onToggle,
+}: {
+  template: SpecialistTemplate;
+  enabled: boolean;
+  onToggle: (next: boolean) => void;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-3 rounded-lg border border-border px-3 py-3 cursor-pointer transition-colors",
+        enabled ? "bg-accent/30" : "hover:bg-accent/30",
+      )}
+    >
+      <AgentAvatar
+        icon={template.icon}
+        name={template.title}
+        size="sm"
+        className="shrink-0"
+      />
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className="text-sm font-medium text-foreground leading-tight">
+          {template.title}
+        </span>
+        <span className="text-xs text-muted-foreground line-clamp-2">
+          {template.description}
+        </span>
+      </div>
+      <Switch
+        checked={enabled}
+        onCheckedChange={onToggle}
+        className="shrink-0"
+      />
+    </label>
+  );
+}
+
+function ComingSoonRow({
+  title,
+  description,
+  icon,
+}: {
+  title: string;
+  description: string;
+  icon: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-dashed border-border px-3 py-3 opacity-60">
+      <AgentAvatar icon={icon} name={title} size="sm" className="shrink-0" />
+      <div className="flex flex-col min-w-0 flex-1">
+        <span className="text-sm font-medium text-foreground leading-tight">
+          {title}
+        </span>
+        <span className="text-xs text-muted-foreground line-clamp-2">
+          {description}
+        </span>
+      </div>
+      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground shrink-0">
+        Coming soon
+      </span>
+    </div>
+  );
+}
+
+function MoreSoonRow() {
+  return (
+    <div className="flex items-center justify-center rounded-lg border border-dashed border-border px-3 py-3 text-xs text-muted-foreground">
+      More specialists coming soon
+    </div>
+  );
+}
+
+function normalizeUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:")
+      return null;
+    return parsed.origin + (parsed.pathname === "/" ? "" : parsed.pathname);
+  } catch {
+    return null;
+  }
+}
+
+async function ensureSiteDiagnosticsConnection({
+  selfClient,
+  createConnection,
+  registry,
+}: {
+  selfClient: ReturnType<typeof useMCPClient>;
+  createConnection: ReturnType<
+    typeof useConnectionActions
+  >["create"]["mutateAsync"];
+  registry: ReturnType<typeof useRegistryApp>["data"];
+}): Promise<string> {
+  const existing = (await selfClient.callTool({
+    name: "COLLECTION_CONNECTIONS_LIST",
+    arguments: {
+      where: {
+        field: ["app_id"],
+        operator: "eq",
+        value: SITE_DIAGNOSTICS_APP_ID,
+      },
+      limit: 1,
+      offset: 0,
+    },
+  })) as { structuredContent?: { items?: ConnectionRecord[] } };
+
+  const match = existing.structuredContent?.items?.find(
+    (c) => c.app_id === SITE_DIAGNOSTICS_APP_ID,
+  );
+  if (match) return match.id;
+
+  const remoteUrl = registry?.server?.remotes?.[0]?.url;
+  if (!remoteUrl) {
+    throw new Error(
+      "Site Diagnostics MCP is not available in the registry right now.",
+    );
+  }
+
+  const appTitle =
+    registry?.title ??
+    registry?.server?.title ??
+    registry?.server?.name ??
+    "Site Diagnostics";
+  const appIcon = registry?.server?.icons?.[0]?.src ?? null;
+  const appDescription = registry?.server?.description ?? null;
+
+  const created = await createConnection({
+    title: appTitle,
+    description: appDescription,
+    icon: appIcon,
+    connection_type: "HTTP",
+    connection_url: remoteUrl,
+    app_name: registry?.server?.name ?? "site-diagnostics",
+    app_id: SITE_DIAGNOSTICS_APP_ID,
+    metadata: {
+      type: "site-diagnostics",
+      source: "store",
+      registry_item_id: SITE_DIAGNOSTICS_APP_ID,
+      verified: true,
+    },
+  });
+
+  return created.id;
+}
+
+async function setupSpecialistOrchestration({
+  template,
+  selfClient,
+  siteDiagnosticsConnectionId,
+  projectAgentId,
+  owner,
+  repo,
+  siteRootUrl,
+}: {
+  template: SpecialistTemplate;
+  selfClient: ReturnType<typeof useMCPClient>;
+  siteDiagnosticsConnectionId: string;
+  projectAgentId: string;
+  owner: string;
+  repo: string;
+  siteRootUrl: string;
+}) {
+  const specialistAgentId = await findOrCreateSpecialistVirtualMcp({
+    template,
+    selfClient,
+    siteDiagnosticsConnectionId,
+  });
+
+  const tiptapDoc = buildOrchestratorAutomationDoc({
+    template,
+    specialistAgentId,
+    owner,
+    repo,
+    siteRootUrl,
+  });
+  const messages = tiptapDocToMessages(tiptapDoc);
+
+  const automationResult = (await selfClient.callTool({
+    name: "AUTOMATION_CREATE",
+    arguments: {
+      name: `${repo}: ${template.title}`,
+      virtual_mcp_id: projectAgentId,
+      agent: { id: projectAgentId },
+      messages,
+      active: true,
+    },
+  })) as { structuredContent?: unknown };
+
+  const automationPayload = (automationResult.structuredContent ??
+    automationResult) as { id: string };
+
+  await selfClient.callTool({
+    name: "AUTOMATION_TRIGGER_ADD",
+    arguments: {
+      automation_id: automationPayload.id,
+      type: "cron",
+      cron_expression: template.cron,
+    },
+  });
+}
+
+async function findOrCreateSpecialistVirtualMcp({
+  template,
+  selfClient,
+  siteDiagnosticsConnectionId,
+}: {
+  template: SpecialistTemplate;
+  selfClient: ReturnType<typeof useMCPClient>;
+  siteDiagnosticsConnectionId: string;
+}): Promise<string> {
+  const existing = (await selfClient.callTool({
+    name: "COLLECTION_VIRTUAL_MCP_LIST",
+    arguments: {
+      where: {
+        field: ["metadata", "specialistId"],
+        operator: "eq",
+        value: template.id,
+      },
+      limit: 1,
+      offset: 0,
+    },
+  })) as { structuredContent?: { items?: VirtualMcpRecord[] } };
+
+  const match = existing.structuredContent?.items?.find(
+    (item) => item.metadata?.specialistId === template.id,
+  );
+  if (match) return match.id;
+
+  const created = (await selfClient.callTool({
+    name: "COLLECTION_VIRTUAL_MCP_CREATE",
+    arguments: {
+      data: {
+        title: template.title,
+        description: template.description,
+        icon: template.icon,
+        pinned: false,
+        metadata: {
+          specialistId: template.id,
+          instructions: template.instructions,
+        },
+        connections: [
+          {
+            connection_id: siteDiagnosticsConnectionId,
+            selected_tools: template.siteDiagnosticsTools,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+      },
+    },
+  })) as { structuredContent?: unknown };
+
+  const payload = (created.structuredContent ?? created) as {
+    item: { id: string };
+  };
+  return payload.item.id;
+}

--- a/apps/mesh/src/web/components/self-healing-repo/self-healing-repo-flow.tsx
+++ b/apps/mesh/src/web/components/self-healing-repo/self-healing-repo-flow.tsx
@@ -161,8 +161,9 @@ function SpecialistsStep({
         toast.success(
           `Self-healing repo ready — ${succeeded.length} specialist${succeeded.length > 1 ? "s" : ""} set up`,
         );
-      } else {
-        toast.success("Self-healing repo ready");
+      } else if (failed.length === 0) {
+        // No specialists toggled on — repo is imported, user opted to skip.
+        toast.success("Repo imported. Add specialists later from automations.");
       }
       if (failed.length > 0) {
         toast.warning(
@@ -442,6 +443,21 @@ async function setupSpecialistOrchestration({
   repo: string;
   siteRootUrl: string;
 }) {
+  const automationName = `${repo}: ${template.title}`;
+
+  // Skip if the user already ran this flow for this repo+specialist —
+  // creating a second automation would double the daily cron rate.
+  const existing = (await selfClient.callTool({
+    name: "AUTOMATION_LIST",
+    arguments: { virtual_mcp_id: projectAgentId },
+  })) as {
+    structuredContent?: { automations?: Array<{ name: string }> };
+  };
+  const alreadyExists = existing.structuredContent?.automations?.some(
+    (a) => a.name === automationName,
+  );
+  if (alreadyExists) return;
+
   const specialistAgentId = await findOrCreateSpecialistVirtualMcp({
     template,
     selfClient,
@@ -460,7 +476,7 @@ async function setupSpecialistOrchestration({
   const automationResult = (await selfClient.callTool({
     name: "AUTOMATION_CREATE",
     arguments: {
-      name: `${repo}: ${template.title}`,
+      name: automationName,
       virtual_mcp_id: projectAgentId,
       agent: { id: projectAgentId },
       messages,

--- a/apps/mesh/src/web/components/self-healing-repo/specialist-templates.ts
+++ b/apps/mesh/src/web/components/self-healing-repo/specialist-templates.ts
@@ -1,0 +1,77 @@
+import brokenLinkFinderInstructions from "./prompts/broken-link-finder.md?raw";
+import seoAuditorInstructions from "./prompts/seo-auditor.md?raw";
+import performanceWatchdogInstructions from "./prompts/performance-watchdog.md?raw";
+
+const DAILY_9AM_UTC = "0 9 * * *";
+
+export interface SpecialistTemplate {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  instructions: string;
+  siteDiagnosticsTools: string[];
+  cron: string;
+  /** GitHub label the orchestrator uses to filter open issues for this specialist. */
+  issueLabel: string;
+  /** Body of the SUBTASK prompt for the specialist (input the specialist parses). */
+  buildSubtaskInput: (args: { siteRootUrl: string }) => string;
+}
+
+export const SPECIALIST_TEMPLATES: SpecialistTemplate[] = [
+  {
+    id: "seo-auditor",
+    title: "SEO Auditor",
+    description: "Monitors websites for SEO improvements.",
+    icon: "icon://FileSearch02?color=purple",
+    instructions: seoAuditorInstructions,
+    siteDiagnosticsTools: [
+      "audit_seo",
+      "fetch_page",
+      "crawl_site",
+      "render_page",
+    ],
+    cron: DAILY_9AM_UTC,
+    issueLabel: "agent:seo",
+    buildSubtaskInput: ({ siteRootUrl }) => `urls:\n  - ${siteRootUrl}\n`,
+  },
+  {
+    id: "performance-watchdog",
+    title: "Performance Watchdog",
+    description: "Monitors websites for Core Web Vitals problems.",
+    icon: "icon://Speedometer03?color=emerald",
+    instructions: performanceWatchdogInstructions,
+    siteDiagnosticsTools: ["fetch_page", "pagespeed_insights", "crawl_site"],
+    cron: DAILY_9AM_UTC,
+    issueLabel: "agent:perf",
+    buildSubtaskInput: ({ siteRootUrl }) => `site_root_url: ${siteRootUrl}\n`,
+  },
+  {
+    id: "broken-link-finder",
+    title: "Broken Link Finder",
+    description: "Monitors websites for broken links.",
+    icon: "icon://LinkBroken01?color=rose",
+    instructions: brokenLinkFinderInstructions,
+    siteDiagnosticsTools: ["collect_site_links", "check_urls"],
+    cron: DAILY_9AM_UTC,
+    issueLabel: "agent:links",
+    buildSubtaskInput: ({ siteRootUrl }) => `site_root_url: ${siteRootUrl}\n`,
+  },
+];
+
+export interface ComingSoonSpecialist {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+}
+
+export const COMING_SOON_SPECIALISTS: ComingSoonSpecialist[] = [
+  {
+    id: "log-monitor",
+    title: "Log Monitor",
+    description:
+      "Monitors websites for errors and warnings on the server. Outputs GitHub issues.",
+    icon: "icon://MessageAlertCircle?color=amber",
+  },
+];

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -65,6 +65,7 @@ import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { GitHubRepoPicker } from "@/web/components/github-repo-picker.tsx";
+import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-healing-repo-flow.tsx";
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
@@ -285,6 +286,7 @@ function PinAgentPopoverContent({
   onClose,
   onOpenImportDeco,
   onOpenGithubImport,
+  onOpenSelfHealing,
   onOpenDiagnosticsModal,
   onOpenLeanCanvasModal,
   onOpenStudioPackModal,
@@ -292,6 +294,7 @@ function PinAgentPopoverContent({
   onClose: () => void;
   onOpenImportDeco: () => void;
   onOpenGithubImport: () => void;
+  onOpenSelfHealing: () => void;
   onOpenDiagnosticsModal: () => void;
   onOpenLeanCanvasModal: () => void;
   onOpenStudioPackModal: () => void;
@@ -389,6 +392,31 @@ function PinAgentPopoverContent({
 
       {/* Scrollable content */}
       <div className="overflow-y-auto flex-1 min-h-0 px-3 pb-3">
+        {/* Self-healing repo — featured */}
+        {preferences.experimental_vibecode && (
+          <button
+            type="button"
+            onClick={() => {
+              onOpenSelfHealing();
+              onClose();
+            }}
+            className="mt-3 w-full flex items-center gap-3 rounded-xl border border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent px-3 py-3 text-left transition-colors hover:border-primary/50 hover:from-primary/15 cursor-pointer group"
+          >
+            <div className="w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
+              <GitHubIcon className="size-5 text-primary" />
+            </div>
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="text-sm font-medium text-foreground leading-tight">
+                Set up self-healing repo
+              </span>
+              <span className="text-xs text-muted-foreground line-clamp-2">
+                Connect GitHub and add specialist monitors that open issues
+                automatically.
+              </span>
+            </div>
+          </button>
+        )}
+
         {/* Agents section */}
         <div className="px-1 pt-3 pb-2">
           <span className="text-xs font-medium text-muted-foreground">
@@ -520,6 +548,7 @@ function PinAgentPopover() {
   const [open, setOpen] = useState(false);
   const [importDecoOpen, setImportDecoOpen] = useState(false);
   const [githubPickerOpen, setGithubPickerOpen] = useState(false);
+  const [selfHealingOpen, setSelfHealingOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
@@ -544,6 +573,10 @@ function PinAgentPopover() {
         onOpenImportDeco={() => setImportDecoOpen(true)}
         onOpenGithubImport={() => {
           setGithubPickerOpen(true);
+          handleClose();
+        }}
+        onOpenSelfHealing={() => {
+          setSelfHealingOpen(true);
           handleClose();
         }}
         onOpenDiagnosticsModal={() => setDiagnosticsModalOpen(true)}
@@ -601,6 +634,10 @@ function PinAgentPopover() {
       <GitHubRepoPicker
         open={githubPickerOpen}
         onOpenChange={setGithubPickerOpen}
+      />
+      <SelfHealingRepoFlow
+        open={selfHealingOpen}
+        onOpenChange={setSelfHealingOpen}
       />
       <SiteDiagnosticsRecruitModal
         open={diagnosticsModalOpen}


### PR DESCRIPTION
## What is this contribution about?

Adds a featured "Set up self-healing repo" flow (vibecode-gated) on the sidebar agent picker and the home `AgentsList`. After the user picks a GitHub repo and a production URL, the flow recruits SEO Auditor, Performance Watchdog, and Broken Link Finder specialists wired only to the site-diagnostics MCP, and creates three daily cron automations on the imported repo agent. Each automation message is built as a tiptapDoc with an `@specialist` mention so the cron path resolves it to a SUBTASK delegation while the editor still renders an `@` chip on reopen. Issue dedup, creation, and commenting live in the automation prompt; specialists return a structured findings YAML and never touch GitHub.

## How to Test

1. Toggle the `experimental_vibecode` preference. A "Set up self-healing repo" card appears in the sidebar agent picker and at the top of the home agents row.
2. Click it, connect GitHub, pick a repo, then pick a production URL and confirm the three specialist toggles.
3. Open the imported repo agent in the automations view — three cron automations exist (one per specialist), each prompt shows the workflow text with an `@<specialist>` chip; running one delegates via SUBTASK and files/dedups GitHub issues.

## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Set up self-healing repo” flow that connects a GitHub repo and a production URL, then creates daily `cron` automations that delegate to diagnostic-only specialists (SEO, performance, broken links) to open and maintain issues automatically. Adds resiliency to recover orphaned automations by attaching missing cron triggers.

- **New Features**
  - Featured entry in sidebar picker and home Agents list (gated by `experimental_vibecode`).
  - One-click setup recruits SEO Auditor, Performance Watchdog, and Broken Link Finder; creates daily `cron` automations (09:00 UTC) on the imported repo agent.
  - Automation prompts are `tiptapDoc`s with an `@specialist` mention that resolves to `SUBTASK` while keeping the chip in the editor.
  - Specialists use `deco/site-diagnostics` only and return structured findings (YAML); the orchestrator handles dedup, issue creation, and comments with labels like `agent:seo`, `agent:perf`, `agent:links`, and `auto-generated`.
  - GitHub import can auto-create an “auto-respond to new issues with a PR” automation; exposed via a checkbox in `GitHubRepoPicker` and forced on in this flow.

- **Bug Fixes**
  - Preserve section breaks in the orchestrator prompt for `cron` inline text.
  - Use `issueLabel`-derived short tags for YAML `specialist` fields so dedup matches (`seo`, `perf`, `links`).
  - De-dup automations by name on re-run and attach a cron trigger if an existing automation is missing one.
  - Suppress success toast when all enabled specialists fail; show a single warning instead.

<sup>Written for commit 99e087f4fd9b88333c527995b5fe612e19297922. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

