### PR TITLE
fix(sandbox): inline daemon bundle into server build to survive publish

### DIFF
--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -405,7 +405,26 @@ async function copyQuickjsWasm() {
   console.log(`✅ QuickJS WASM copied to ${wasmDest}`);
 }
 
+// runner.ts inlines packages/sandbox/daemon/dist/daemon.js via a text-import
+// attribute. bun build needs that file present on disk to embed it into the
+// server bundle, so produce it before bundling. Idempotent — `bun build`
+// just rewrites the same outfile.
+async function buildSandboxDaemon() {
+  console.log("🔨 Building sandbox daemon bundle...");
+  const sandboxRoot = join(WORKSPACE_ROOT, "packages/sandbox");
+  await $`bun run build`.cwd(sandboxRoot).quiet();
+  const daemonBundle = join(sandboxRoot, "daemon/dist/daemon.js");
+  if (!existsSync(daemonBundle)) {
+    console.error(`❌ Sandbox daemon bundle missing at ${daemonBundle}`);
+    process.exit(1);
+  }
+  console.log(`✅ Sandbox daemon bundle ready at ${daemonBundle}`);
+}
+
 async function main() {
+  // Build sandbox daemon bundle so runner.ts's text-import has a file to embed.
+  await buildSandboxDaemon();
+
   // Prune node_modules to only include required dependencies for both scripts
   const packagesToExternalize = await pruneNodeModules();
 

--- a/apps/mesh/src/web/layouts/tasks-panel/mcp-avatar.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/mcp-avatar.tsx
@@ -12,7 +12,7 @@ export function McpAvatar({
   showAutomationBadge,
 }: {
   virtualMcpId: string | null | undefined;
-  size?: "sm" | "md";
+  size?: "xs" | "sm" | "md";
   showAutomationBadge?: boolean;
 }) {
   return (
@@ -39,7 +39,7 @@ function McpAvatarInner({
   size,
 }: {
   virtualMcpId: string;
-  size: "sm" | "md";
+  size: "xs" | "sm" | "md";
 }) {
   const entity = useVirtualMCP(virtualMcpId);
   if (!entity) return <AgentAvatar icon={null} name="?" size={size} />;

--- a/packages/sandbox/server/runner/freestyle/runner.ts
+++ b/packages/sandbox/server/runner/freestyle/runner.ts
@@ -13,8 +13,6 @@
  */
 
 import { randomBytes, randomUUID } from "node:crypto";
-import fs from "node:fs";
-import { fileURLToPath } from "node:url";
 import { VmBun } from "@freestyle-sh/with-bun";
 import { VmDeno } from "@freestyle-sh/with-deno";
 import { VmNodeJs } from "@freestyle-sh/with-nodejs";
@@ -32,15 +30,17 @@ import {
   type SandboxRunner,
   type Workload,
 } from "../types";
-
-/**
- * Unified daemon bundle. Read once at module load; subsequent VM creates
- * reuse the cached string. bun build produces this at package build time.
- */
-const DAEMON_BUNDLE_PATH = fileURLToPath(
-  new URL("../../../daemon/dist/daemon.js", import.meta.url),
-);
-const DAEMON_BUNDLE_CONTENT = fs.readFileSync(DAEMON_BUNDLE_PATH, "utf-8");
+// Inlined as a string at build time. Path lookup via import.meta.url breaks
+// once the server is bundled into apps/mesh/dist/server/server.js because
+// `../../../` then resolves outside the published package. The text-import
+// attribute makes bun build embed the daemon bytes directly into server.js,
+// so no asset has to ship alongside the bundle.
+// @ts-expect-error - Bun-specific text loader attribute; TS resolves the
+// underlying .js file and doesn't model `with { type: "text" }`.
+import _daemonBundle from "../../../daemon/dist/daemon.js" with {
+  type: "text",
+};
+const DAEMON_BUNDLE_CONTENT: string = _daemonBundle;
 
 const RUNNER_KIND = "freestyle" as const;
 const LOG_LABEL = "FreestyleSandboxRunner";


### PR DESCRIPTION
## What is this contribution about?

Fixes `Error: ENOENT: no such file or directory, open '/app/apps/mesh/node_modules/daemon/dist/daemon.js'` hit by published `decocms` Docker images.

`packages/sandbox/server/runner/freestyle/runner.ts` was reading the daemon bundle at module load via `fs.readFileSync(new URL("../../../daemon/dist/daemon.js", import.meta.url))`. That relative path is correct for the source tree, but once `@decocms/sandbox` is bundled inline into `apps/mesh/dist/server/server.js` and installed via `bun add decocms`, `../../../` resolves to `node_modules/` — outside the published package — so the read fails. Switched to a `with { type: "text" }` import so `bun build` embeds the daemon bytes directly into `server.js`. `bundle-server-script.ts` now also runs `bun run --cwd packages/sandbox build` before server bundling so the file exists on disk for `bun build` to inline, mirroring the existing QuickJS WASM safety-net pattern.

## How to Test

1. `bun run --cwd=apps/mesh build:server`
2. Confirm `apps/mesh/dist/server/server.js` contains the daemon source signature (e.g. `grep -c "daemon/entry.ts" apps/mesh/dist/server/server.js` → ≥ 1).
3. `npm pack` in `apps/mesh`, install the tarball into a fresh `oven/bun:1-slim` container under `/app/apps/mesh`, run the deco CLI, and confirm there is no ENOENT for `node_modules/daemon/dist/daemon.js` — the path no longer needs to exist because the daemon is inlined.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlines the sandbox daemon into the server bundle to fix ENOENT errors in published `decocms` images and installs. Also fixes a tasks UI type error by allowing `xs` size in `McpAvatar`.

- **Bug Fixes**
  - In `@decocms/sandbox` runner, replace file read with `import ... with { type: "text" }` so `bun build` embeds `packages/sandbox/daemon/dist/daemon.js` directly.
  - In `apps/mesh` bundler script, build the sandbox daemon before bundling and verify it exists (mirrors the QuickJS WASM step).
  - In tasks panel, allow `size="xs"` in `McpAvatar` to match usage and `AgentAvatar` support.

<sup>Written for commit 00bf56f8e1a0878792c5aa8699dd2b3e0c86de06. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

