### PR TITLE
fix(ai-providers): clear simple-mode slots when key is deleted

### DIFF
--- a/apps/mesh/src/tools/ai-providers/key-delete.ts
+++ b/apps/mesh/src/tools/ai-providers/key-delete.ts
@@ -2,6 +2,38 @@ import z from "zod";
 import { posthog } from "../../posthog";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import type {
+  SimpleModeConfig,
+  SimpleModeModelSlot,
+} from "../../storage/types";
+
+const clearSlotIfMatches = (
+  slot: SimpleModeModelSlot | null,
+  keyId: string,
+): SimpleModeModelSlot | null => (slot && slot.keyId === keyId ? null : slot);
+
+const clearSlotsForKey = (
+  config: SimpleModeConfig,
+  keyId: string,
+): { config: SimpleModeConfig; changed: boolean } => {
+  const next: SimpleModeConfig = {
+    enabled: config.enabled,
+    chat: {
+      fast: clearSlotIfMatches(config.chat.fast, keyId),
+      smart: clearSlotIfMatches(config.chat.smart, keyId),
+      thinking: clearSlotIfMatches(config.chat.thinking, keyId),
+    },
+    image: clearSlotIfMatches(config.image, keyId),
+    webResearch: clearSlotIfMatches(config.webResearch, keyId),
+  };
+  const changed =
+    next.chat.fast !== config.chat.fast ||
+    next.chat.smart !== config.chat.smart ||
+    next.chat.thinking !== config.chat.thinking ||
+    next.image !== config.image ||
+    next.webResearch !== config.webResearch;
+  return { config: next, changed };
+};
 
 export const AI_PROVIDER_KEY_DELETE = defineTool({
   name: "AI_PROVIDER_KEY_DELETE",
@@ -18,6 +50,19 @@ export const AI_PROVIDER_KEY_DELETE = defineTool({
     await ctx.access.check();
 
     await ctx.storage.aiProviderKeys.delete(input.keyId, org.id);
+
+    const settings = await ctx.storage.organizationSettings.get(org.id);
+    if (settings?.simple_mode) {
+      const { config, changed } = clearSlotsForKey(
+        settings.simple_mode,
+        input.keyId,
+      );
+      if (changed) {
+        await ctx.storage.organizationSettings.upsert(org.id, {
+          simple_mode: config,
+        });
+      }
+    }
 
     posthog.capture({
       distinctId: ctx.auth.user!.id,


### PR DESCRIPTION
## What is this contribution about?
Deleting an AI provider key left dangling references in `SimpleModeConfig` slots (`chat.fast`/`smart`/`thinking`, `image`, `webResearch`). Once simple mode tried to resolve a slot whose `keyId` no longer existed, `findModel()` returned `null`, `selectedModel` stayed null, and the org chat input silently disabled itself with no error. The `AI_PROVIDER_KEY_DELETE` tool now scans the org's simple-mode config after deletion and nullifies any slot pointing at the removed key, only writing back when something actually changed.

## How to Test
1. Configure a provider key and set it as a Simple Mode chat slot (fast/smart/thinking).
2. Delete that provider key via the AI Providers UI.
3. Re-enable Simple Mode (or reload the chat).
4. Expected: the chat input is **not** stuck disabled — the affected slot is now empty and the user can pick a new model. Before this fix, the input would be silently disabled because the slot still pointed at the deleted key.

## Migration Notes
None. Existing rows with stale slots will be cleaned up the next time the corresponding key is deleted; pre-existing dangling references are not auto-healed by this PR.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where deleting an AI provider key left dangling Simple Mode slots that silently disabled the org chat input. The delete tool now clears any slot pointing to the removed key and only writes settings if something changed.

- **Bug Fixes**
  - On `AI_PROVIDER_KEY_DELETE`, scan org Simple Mode config and nullify `chat.fast`, `chat.smart`, `chat.thinking`, `image`, and `webResearch` slots that reference the deleted key.
  - Prevents disabled input by leaving affected slots empty so users can pick a new model.

<sup>Written for commit be3f5d8ef171d0eb4aa2dc518b2dbff76b426d87. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

