### PR TITLE
feat(chat): experimental caveman mode 🪨

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -75,6 +75,7 @@ import { useLocalStorage } from "../../hooks/use-local-storage";
 import { chatModeForTransportRef } from "../../lib/chat-mode-sync";
 import { LOCALSTORAGE_KEYS } from "../../lib/localstorage-keys";
 import { useSimpleMode } from "../../hooks/use-organization-settings";
+import { CAVEMAN_SYSTEM_PROMPT } from "../../lib/caveman-mode";
 
 // ============================================================================
 // Context Types
@@ -253,6 +254,8 @@ interface TaskProviderInternals {
   contextPrompt: string;
   preferences: {
     toolApprovalLevel?: import("../../hooks/use-preferences").ToolApprovalLevel;
+    experimental_caveman?: boolean;
+    caveman_active?: boolean;
   };
   taskManager: {
     updateMessagesCache: (taskId: string, messages: ChatMessage[]) => void;
@@ -896,7 +899,11 @@ export function ActiveTaskProvider({
             .map(([source, text]) => `### App Context: ${source}\n${text}`)
             .join("\n\n")
         : "";
-    const system = [contextPrompt, appContextSection]
+    const cavemanPrompt =
+      preferences.experimental_caveman && preferences.caveman_active
+        ? CAVEMAN_SYSTEM_PROMPT
+        : "";
+    const system = [contextPrompt, appContextSection, cavemanPrompt]
       .filter(Boolean)
       .join("\n\n");
 

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -52,6 +52,10 @@ import {
 import { isTiptapDocEmpty } from "./tiptap/utils";
 import { ToolsPopover } from "./tools-popover";
 import { SessionStats } from "./usage-stats";
+import {
+  useCavemanFeatureEnabled,
+  useCavemanToggle,
+} from "@/web/lib/caveman-mode.ts";
 import { authClient } from "@/web/lib/auth-client.ts";
 import { track } from "@/web/lib/posthog-client";
 import { useSound } from "@/web/hooks/use-sound.ts";
@@ -279,6 +283,8 @@ export function ChatInput({
   const { org } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const playSwitchSound = useSound(question004Sound);
+  const cavemanFeatureEnabled = useCavemanFeatureEnabled();
+  const [cavemanActive, setCavemanActive] = useCavemanToggle();
   const [connectionsOpen, setConnectionsOpen] = useState(false);
   const { unsupportedFile, onUnsupportedFile, clearUnsupportedFile } =
     useUnsupportedFileDialog();
@@ -608,6 +614,43 @@ export function ChatInput({
                             size={14}
                             className="shrink-0 hidden group-hover:block"
                           />
+                        </button>
+                      )}
+                      {cavemanFeatureEnabled && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const next = !cavemanActive;
+                            track("caveman_mode_toggled", { enabled: next });
+                            setCavemanActive(next);
+                          }}
+                          aria-label={
+                            cavemanActive
+                              ? "Disable caveman mode"
+                              : "Enable caveman mode"
+                          }
+                          title={
+                            cavemanActive
+                              ? "Disable caveman mode"
+                              : "Enable caveman mode"
+                          }
+                          className={cn(
+                            "flex items-center gap-1.5 h-8 rounded-lg transition-colors whitespace-nowrap group",
+                            cavemanActive
+                              ? "px-2.5 text-sm font-medium text-[#8B6F47] dark:text-[#C19A6B] hover:bg-[#8B6F47]/10 animate-in fade-in duration-200"
+                              : "size-8 justify-center text-muted-foreground/60 hover:text-foreground hover:bg-muted",
+                          )}
+                        >
+                          <span className="text-[14px] leading-none">🪨</span>
+                          {cavemanActive && (
+                            <>
+                              Caveman
+                              <X
+                                size={14}
+                                className="shrink-0 hidden group-hover:block"
+                              />
+                            </>
+                          )}
                         </button>
                       )}
                       {contextWindow && lastTotalTokens > 0 && (

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -7,17 +7,26 @@ import { Activity } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { UsageStats as UsageStatsType } from "@/web/lib/usage-utils.ts";
 import { formatDuration } from "@/web/lib/format-time.ts";
+import {
+  CAVEMAN_RING_COLORS,
+  cavemanLabel,
+  useCavemanMode,
+} from "@/web/lib/caveman-mode.ts";
 
 const RING_SIZE = 16;
 const RING_STROKE = 2.5;
 const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
+const CAVEMAN_TOOLTIP_CLASSES = "bg-[#3A322B] text-[#E8DDC9] border-[#5C4A38]";
+const CAVEMAN_TOOLTIP_LABEL = "opacity-70";
+
 interface UsageStatsProps {
   usage: UsageStatsType | null | undefined;
 }
 
 export function MessageUsageStats({ usage }: UsageStatsProps) {
+  const caveman = useCavemanMode();
   if (!usage) return null;
   const { totalTokens, inputTokens, outputTokens, cost } = usage;
   if (!totalTokens && !inputTokens && !outputTokens) return null;
@@ -32,20 +41,39 @@ export function MessageUsageStats({ usage }: UsageStatsProps) {
           </span>
         </span>
       </TooltipTrigger>
-      <TooltipContent side="top" className="font-mono text-[11px]">
-        <p className="text-muted text-[10px] mb-1">tokens</p>
+      <TooltipContent
+        side="top"
+        className={cn(
+          "font-mono text-[11px]",
+          caveman && CAVEMAN_TOOLTIP_CLASSES,
+        )}
+      >
+        <p
+          className={cn(
+            "text-[10px] mb-1",
+            caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted",
+          )}
+        >
+          {cavemanLabel("tokens", caveman)}
+        </p>
         <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
-          <span className="text-muted">in</span>
+          <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+            {cavemanLabel("in", caveman)}
+          </span>
           <span className="text-right tabular-nums">
             {inputTokens.toLocaleString()}
           </span>
-          <span className="text-muted">out</span>
+          <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+            {cavemanLabel("out", caveman)}
+          </span>
           <span className="text-right tabular-nums">
             {(outputTokens - (usage.reasoningTokens ?? 0)).toLocaleString()}
           </span>
           {cost > 0 && (
             <>
-              <span className="text-muted">cost</span>
+              <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+                {cavemanLabel("cost", caveman)}
+              </span>
               <span className="text-right tabular-nums">
                 ${cost.toFixed(4)}
               </span>
@@ -63,6 +91,7 @@ interface MessageStatsBarProps {
 }
 
 export function MessageStatsBar({ usage, duration }: MessageStatsBarProps) {
+  const caveman = useCavemanMode();
   const hasDuration = duration != null && duration > 0;
   const hasCost = usage != null && (usage.cost ?? 0) > 0;
   const hasTokens = usage != null && (usage.totalTokens ?? 0) > 0;
@@ -80,8 +109,21 @@ export function MessageStatsBar({ usage, duration }: MessageStatsBarProps) {
               {durationLabel}
             </span>
           </TooltipTrigger>
-          <TooltipContent side="top" className="font-mono text-[11px]">
-            <p className="opacity-60 text-[10px] mb-1">thinking</p>
+          <TooltipContent
+            side="top"
+            className={cn(
+              "font-mono text-[11px]",
+              caveman && CAVEMAN_TOOLTIP_CLASSES,
+            )}
+          >
+            <p
+              className={cn(
+                "text-[10px] mb-1",
+                caveman ? CAVEMAN_TOOLTIP_LABEL : "opacity-60",
+              )}
+            >
+              {cavemanLabel("thinking", caveman)}
+            </p>
             <span className="tabular-nums">
               {formatDuration(duration! / 1000)}
             </span>
@@ -105,14 +147,31 @@ export function MessageStatsBar({ usage, duration }: MessageStatsBarProps) {
                 : `${usage!.totalTokens.toLocaleString()} tok`}
             </span>
           </TooltipTrigger>
-          <TooltipContent side="top" className="font-mono text-[11px]">
-            <p className="opacity-60 text-[10px] mb-1">tokens</p>
+          <TooltipContent
+            side="top"
+            className={cn(
+              "font-mono text-[11px]",
+              caveman && CAVEMAN_TOOLTIP_CLASSES,
+            )}
+          >
+            <p
+              className={cn(
+                "text-[10px] mb-1",
+                caveman ? CAVEMAN_TOOLTIP_LABEL : "opacity-60",
+              )}
+            >
+              {cavemanLabel("tokens", caveman)}
+            </p>
             <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
-              <span className="opacity-60">in</span>
+              <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "opacity-60"}>
+                {cavemanLabel("in", caveman)}
+              </span>
               <span className="text-right tabular-nums">
                 {(usage!.inputTokens ?? 0).toLocaleString()}
               </span>
-              <span className="opacity-60">out</span>
+              <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "opacity-60"}>
+                {cavemanLabel("out", caveman)}
+              </span>
               <span className="text-right tabular-nums">
                 {(
                   (usage!.outputTokens ?? 0) - (usage?.reasoningTokens ?? 0)
@@ -120,7 +179,11 @@ export function MessageStatsBar({ usage, duration }: MessageStatsBarProps) {
               </span>
               {(usage?.reasoningTokens ?? 0) > 0 && (
                 <>
-                  <span className="opacity-60">think</span>
+                  <span
+                    className={caveman ? CAVEMAN_TOOLTIP_LABEL : "opacity-60"}
+                  >
+                    {cavemanLabel("think", caveman)}
+                  </span>
                   <span className="text-right tabular-nums">
                     {usage!.reasoningTokens!.toLocaleString()}
                   </span>
@@ -147,11 +210,19 @@ export function SessionStats({
   contextWindow,
   onOpenContextPanel,
 }: SessionStatsProps) {
+  const caveman = useCavemanMode();
   const pct = Math.min((totalTokens / contextWindow) * 100, 100);
   const offset = RING_CIRCUMFERENCE - (pct / 100) * RING_CIRCUMFERENCE;
   const cost = usage?.cost ?? 0;
   const inputTokens = usage?.inputTokens ?? 0;
   const outputTokens = usage?.outputTokens ?? 0;
+
+  const cavemanFillColor =
+    pct > 90
+      ? CAVEMAN_RING_COLORS.danger
+      : pct > 70
+        ? CAVEMAN_RING_COLORS.warn
+        : CAVEMAN_RING_COLORS.default;
 
   return (
     <Tooltip>
@@ -160,7 +231,10 @@ export function SessionStats({
           type="button"
           onClick={onOpenContextPanel}
           className={cn(
-            "flex items-center gap-1.5 text-muted-foreground hover:text-foreground h-6 px-1 shrink-0",
+            "flex items-center gap-1.5 h-6 px-1 shrink-0",
+            caveman
+              ? "text-[#8B6F47] hover:text-[#6B3410]"
+              : "text-muted-foreground hover:text-foreground",
             onOpenContextPanel ? "cursor-pointer" : "cursor-default",
           )}
         >
@@ -170,53 +244,71 @@ export function SessionStats({
               cy={RING_SIZE / 2}
               r={RING_RADIUS}
               fill="none"
-              stroke="currentColor"
+              stroke={caveman ? CAVEMAN_RING_COLORS.track : "currentColor"}
               strokeWidth={RING_STROKE}
-              className="opacity-15"
+              className={caveman ? "opacity-35" : "opacity-15"}
             />
             <circle
               cx={RING_SIZE / 2}
               cy={RING_SIZE / 2}
               r={RING_RADIUS}
               fill="none"
-              stroke="currentColor"
+              stroke={caveman ? cavemanFillColor : "currentColor"}
               strokeWidth={RING_STROKE}
               strokeDasharray={RING_CIRCUMFERENCE}
               strokeDashoffset={offset}
-              strokeLinecap="round"
+              strokeLinecap={caveman ? "butt" : "round"}
               className={cn(
-                pct > 90
-                  ? "text-destructive"
-                  : pct > 70
-                    ? "text-warning"
-                    : "text-muted-foreground",
+                !caveman &&
+                  (pct > 90
+                    ? "text-destructive"
+                    : pct > 70
+                      ? "text-warning"
+                      : "text-muted-foreground"),
               )}
             />
           </svg>
           <span className="text-[11px] font-mono tabular-nums">
+            {caveman ? "🪨 " : ""}
             {pct.toFixed(0)}%{cost > 0 ? ` · $${cost.toFixed(2)}` : ""}
           </span>
         </button>
       </TooltipTrigger>
-      <TooltipContent side="top" className="font-mono text-[11px]">
+      <TooltipContent
+        side="top"
+        className={cn(
+          "font-mono text-[11px]",
+          caveman && CAVEMAN_TOOLTIP_CLASSES,
+        )}
+      >
         <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
-          <span className="text-muted">context</span>
+          <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+            {cavemanLabel("context", caveman)}
+          </span>
           <span className="text-right tabular-nums">{pct.toFixed(1)}%</span>
-          <span className="text-muted">tokens</span>
+          <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+            {cavemanLabel("tokens", caveman)}
+          </span>
           <span className="text-right tabular-nums">
             {totalTokens.toLocaleString()}
           </span>
           {cost > 0 && (
             <>
-              <span className="text-muted">cost</span>
+              <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+                {cavemanLabel("cost", caveman)}
+              </span>
               <span className="text-right tabular-nums">
                 ${cost.toFixed(4)}
               </span>
-              <span className="text-muted">in</span>
+              <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+                {cavemanLabel("in", caveman)}
+              </span>
               <span className="text-right tabular-nums">
                 {inputTokens.toLocaleString()}
               </span>
-              <span className="text-muted">out</span>
+              <span className={caveman ? CAVEMAN_TOOLTIP_LABEL : "text-muted"}>
+                {cavemanLabel("out", caveman)}
+              </span>
               <span className="text-right tabular-nums">
                 {outputTokens.toLocaleString()}
               </span>

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -9,6 +9,8 @@ interface Preferences {
   enableSounds: boolean;
   theme: ThemeMode;
   experimental_vibecode: boolean;
+  experimental_caveman: boolean;
+  caveman_active: boolean;
 }
 
 const DEFAULT_PREFERENCES: Preferences = {
@@ -17,6 +19,8 @@ const DEFAULT_PREFERENCES: Preferences = {
   enableSounds: false,
   theme: "system",
   experimental_vibecode: false,
+  experimental_caveman: false,
+  caveman_active: false,
 };
 
 const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];

--- a/apps/mesh/src/web/lib/caveman-mode.ts
+++ b/apps/mesh/src/web/lib/caveman-mode.ts
@@ -1,0 +1,64 @@
+import { usePreferences } from "@/web/hooks/use-preferences.ts";
+
+export const CAVEMAN_SYSTEM_PROMPT = `<caveman-mode>
+You are caveman. Talk like caveman. Why use many token when few token do trick.
+
+Rules:
+- Drop articles (a, an, the).
+- Drop pleasantries, greetings, sign-offs, hedges, and filler ("just", "actually", "I think").
+- Short, blunt sentences. Lower-case unless proper noun or code.
+- Simple words. Tech terms okay when needed (function, type, error). Caveman still smart.
+- Sprinkle 🪨 emoji occasionally. Not every line.
+- Stay technically accurate and complete. Caveman talk short, not lazy.
+- Keep code blocks and file paths exact. Do not caveman-ify identifiers.
+- No "Sure!", no "Of course!", no "Let me know if...".
+</caveman-mode>`;
+
+export const CAVEMAN_LABELS: Record<string, string> = {
+  context: "rock full",
+  tokens: "words",
+  cost: "shiny",
+  in: "ear",
+  out: "mouth",
+  think: "ponder",
+  thinking: "ponder",
+};
+
+export const CAVEMAN_RING_COLORS = {
+  track: "#A29B92",
+  default: "#8B6F47",
+  warn: "#B8722C",
+  danger: "#6B3410",
+} as const;
+
+export function cavemanLabel(label: string, enabled: boolean): string {
+  if (!enabled) return label;
+  return CAVEMAN_LABELS[label] ?? label;
+}
+
+/**
+ * Whether the caveman skin is currently applied. Requires both the
+ * experimental feature flag (settings) and the in-chat toggle.
+ */
+export function useCavemanMode(): boolean {
+  const [preferences] = usePreferences();
+  return preferences.experimental_caveman && preferences.caveman_active;
+}
+
+/**
+ * Whether the experimental feature is enabled in settings.
+ * Used to decide whether to render the in-chat toggle.
+ */
+export function useCavemanFeatureEnabled(): boolean {
+  const [preferences] = usePreferences();
+  return preferences.experimental_caveman;
+}
+
+export function useCavemanToggle(): [boolean, (next: boolean) => void] {
+  const [preferences, setPreferences] = usePreferences();
+  const active = preferences.experimental_caveman && preferences.caveman_active;
+  const setActive = (next: boolean) => {
+    setPreferences((prev) => ({ ...prev, caveman_active: next }));
+  };
+  return [active, setActive];
+}

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -354,6 +354,33 @@ function ExperimentalSection() {
             />
           }
         />
+        <PreferenceRow
+          label="Caveman mode"
+          description="Adds a 🪨 toggle to the chat input. Activate to re-skin the context window and cost tooltip with stone-age vibes."
+          onClick={() => {
+            track("preferences_experimental_caveman_toggled", {
+              enabled: !preferences.experimental_caveman,
+            });
+            setPreferences((prev) => ({
+              ...prev,
+              experimental_caveman: !prev.experimental_caveman,
+            }));
+          }}
+          control={
+            <Switch
+              checked={preferences.experimental_caveman}
+              onCheckedChange={(checked) => {
+                track("preferences_experimental_caveman_toggled", {
+                  enabled: checked,
+                });
+                setPreferences((prev) => ({
+                  ...prev,
+                  experimental_caveman: checked,
+                }));
+              }}
+            />
+          }
+        />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

Adds an opt-in **caveman mode** to the chat — a fun, experimental easter egg inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman). When activated, the model responds in terse caveman-speak ("why use many token when few token do trick") and the context-window ring + cost tooltips re-skin themselves with a stone-and-clay palette.

Two-tier toggle:
1. **Settings → Profile & Preferences → Experimental → Caveman mode** — gates the feature (off by default).
2. **🪨 button in the chat input footer** — only appears when the experimental flag is on; click to activate the skin and inject the caveman system prompt for the next message.

## What changes when active

- A `<caveman-mode>` system prompt is appended to the chat's `system` string, instructing the model to drop articles/filler, stay technically accurate, sprinkle 🪨, and skip greetings/sign-offs.
- The context-window ring (`SessionStats`) turns clay-brown / warm-clay / burnt-umber by fill tier, with a butt linecap and a 🪨 prefix on the percentage.
- The session, per-message, and thinking tooltips switch to a dark-stone background with parchment text. Labels swap: `context`→`rock full`, `tokens`→`words`, `cost`→`shiny`, `in`/`out`→`ear`/`mouth`, `think`/`thinking`→`ponder`. Numbers stay numeric.

Two preference keys (`experimental_caveman` and `caveman_active`) live in `usePreferences()` and follow the existing `experimental_vibecode` pattern. No backend, migration, or new dependency.

## Files

- `apps/mesh/src/web/lib/caveman-mode.ts` *(new)* — `CAVEMAN_SYSTEM_PROMPT`, `CAVEMAN_LABELS`, `CAVEMAN_RING_COLORS`, `useCavemanMode`, `useCavemanFeatureEnabled`, `useCavemanToggle`.
- `apps/mesh/src/web/hooks/use-preferences.ts` — adds `experimental_caveman` and `caveman_active`.
- `apps/mesh/src/web/views/settings/profile-preferences.tsx` — Switch row in `ExperimentalSection` + tracking event.
- `apps/mesh/src/web/components/chat/input.tsx` — 🪨 toggle button in the left actions, gated on the experimental flag.
- `apps/mesh/src/web/components/chat/usage-stats.tsx` — `SessionStats` / `MessageUsageStats` / `MessageStatsBar` branch on `useCavemanMode()`.
- `apps/mesh/src/web/components/chat/chat-context.tsx` — appends `CAVEMAN_SYSTEM_PROMPT` to the system string in `sendMessageInternal` when both flags are on.

## Test plan

- [ ] Toggle off (default): chat looks/behaves identically to main.
- [ ] Enable **Settings → Experimental → Caveman mode**, return to chat: 🪨 button appears in the input footer next to Tools.
- [ ] Click 🪨: button expands to a clay-colored "Caveman" pill (matches Plan/Image/Web mode pill styling).
- [ ] Send a message: response comes back in caveman-speak; cost/tokens tooltip shows `rock full`, `words`, `shiny`, `ear`, `mouth`, `ponder`.
- [ ] After the assistant replies: ring indicator shows clay-brown stroke + 🪨 % label.
- [ ] Click X on the pill (or click the pill again): toggle deactivates; subsequent messages return to normal.
- [ ] Disable the experimental flag in Settings: 🪨 button disappears even if `caveman_active` was on; messages stop carrying the caveman prompt.

`bun run fmt` ✅. `bun run check` clean for files in this PR (the only error — `task-row.tsx` avatar `"xs"`, from commit 61a4d81c7 — is pre-existing on main and untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in caveman mode for chat. A Settings flag unlocks a 🪨 button that injects a caveman system prompt and re-skins usage stats with a stone-and-clay look.

- **New Features**
  - Settings: adds `experimental_caveman` (flag) and `caveman_active` (per-chat toggle) in preferences; off by default.
  - Chat: shows a 🪨 button in the input footer when the flag is on; toggling applies/removes caveman mode.
  - Prompt: when both flags are true, appends `CAVEMAN_SYSTEM_PROMPT` to the `system` string for outgoing messages.
  - UI: `SessionStats`, `MessageUsageStats`, and `MessageStatsBar` get a stone palette, butt linecap, and caveman labels (`context`→`rock full`, `tokens`→`words`, `cost`→`shiny`, `in`/`out`→`ear`/`mouth`, `think(ing)`→`ponder`); numbers unchanged.

<sup>Written for commit 04d9f93c8d448de716b062387cc0f4e3a1b340e6. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

