### PR TITLE
fix(registry): pass tool instances directly to withRuntime

### DIFF
--- a/apps/mesh/src/api/routes/registry/public-mcp-server.ts
+++ b/apps/mesh/src/api/routes/registry/public-mcp-server.ts
@@ -152,7 +152,7 @@ export function publicMCPServerRoutes(
     // Create MCP server with public tools
     const tools = createPublicMCPTools(storage, org.id);
     const mcpServer = withRuntime({
-      tools: () => tools,
+      tools,
     });
 
     // Rewrite the request URL to remove the /org/:orgSlug/registry prefix

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -197,7 +197,7 @@ function useWindowFileDrop(
       window.removeEventListener("dragover", onDragOver);
       window.removeEventListener("drop", onDrop);
     };
-  }, [editor, selectedModel]);
+  }, [editor, selectedModel, onUnsupportedFile]);
 
   return isDraggingOver;
 }

--- a/apps/mesh/src/web/components/vm/vm-booting-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-booting-state.tsx
@@ -53,6 +53,7 @@ function getPhaseIndex(
 /** Strip ANSI color + cursor escape sequences from terminal output. */
 function stripAnsi(str: string): string {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes use control chars
+  // oxlint-disable-next-line no-control-regex
   return str.replace(/\u001b\[[0-9;?]*[a-zA-Z]/g, "");
 }
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -39,7 +39,7 @@ const greetTool = createTool({
 
 // Create the MCP server
 export default withRuntime({
-  tools: [() => greetTool],
+  tools: [greetTool],
 });
 ```
 
@@ -154,21 +154,11 @@ const getUserDataTool = createPrivateTool({
 
 ### Registering Tools
 
-Tools can be registered in multiple ways:
+Pass an array of tool instances created with `createTool()` / `createPrivateTool()`:
 
 ```typescript
 export default withRuntime({
-  // Option 1: Array of tool factories
-  tools: [
-    () => greetTool,
-    () => calculateTool,
-    (env) => createDynamicTool(env),
-  ],
-  
-  // Option 2: Single function returning array
-  tools: async (env) => {
-    return [greetTool, calculateTool];
-  },
+  tools: [greetTool, calculateTool],
 });
 ```
 
@@ -358,10 +348,10 @@ export default withRuntime({
   },
   
   tools: [
-    (env) => createTool({
+    createTool({
       id: "query",
       inputSchema: z.object({ sql: z.string() }),
-      execute: async ({ runtimeContext }) => {
+      execute: async ({ context, runtimeContext }) => {
         // Access resolved bindings from state
         const { database } = runtimeContext.env.MESH_REQUEST_CONTEXT.state;
         return database.QUERY({ sql: context.sql });
@@ -451,7 +441,7 @@ const channelTools = impl(WellKnownBindings.Channel, [
 ]);
 
 export default withRuntime({
-  tools: [() => channelTools].flat(),
+  tools: channelTools,
 });
 ```
 
@@ -648,16 +638,9 @@ const statusResource = createResource({
 
 // Export the MCP server
 export default withRuntime({
-  tools: [
-    () => echoTool,
-    () => getProfileTool,
-  ],
-  prompts: [
-    () => analyzePrompt,
-  ],
-  resources: [
-    () => statusResource,
-  ],
+  tools: [echoTool, getProfileTool],
+  prompts: [analyzePrompt],
+  resources: [statusResource],
   cors: {
     origin: "*",
     credentials: true,

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -156,7 +156,7 @@ class TriggerStateManager {
  *
  * // In withRuntime:
  * export default withRuntime({
- *   tools: [() => triggers.tools()],
+ *   tools: triggers.tools(),
  * });
  *
  * // In webhook handler:

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { loadConfig } from "./config";
-import { MAX_SSE_CLIENTS, REPLAY_BYTES } from "./constants";
+import { REPLAY_BYTES } from "./constants";
 import { Broadcaster } from "./events/broadcast";
 import { ProcessManager } from "./process/run-process";
 import { SetupOrchestrator } from "./setup/orchestrator";


### PR DESCRIPTION
## Summary

- The public registry MCP server (`apps/mesh/src/api/routes/registry/public-mcp-server.ts`) passed `tools: () => tools` to `withRuntime`. The runtime emits `[runtime] Passing factory functions to tools/prompts/resources is deprecated...` whenever `options.tools` is a function (`packages/runtime/src/tools.ts:880`). Since `withRuntime` is invoked per-request inside the route handler, each request to `/org/:orgSlug/registry/*` produced a fresh warning in production logs.
- Fix: pass the `tools` array of `createTool()` instances directly. Each instance has an `id`, satisfying `isInstance()` (`tools.ts:841`) and taking the non-deprecated branch.
- Doc cleanup: updated `packages/runtime/README.md` (Quick Start, Registering Tools, Configuration State, Bindings, Complete Example) and the `triggers.ts` JSDoc so users aren't taught the deprecated `tools: [() => x]` factory pattern.

## Test plan

- [x] `bun run fmt` clean
- [x] `bun run --cwd apps/mesh tsc --noEmit` clean
- [x] Verified there are no other production callers of `withRuntime` / `createMCPServer` that pass factories (only this one path in `apps/mesh/src/`)
- [ ] Manually hit `/org/:orgSlug/registry/mcp` in dev and confirm no `[runtime] Passing factory functions...` warning is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops per-request runtime deprecation logs by passing tool instances directly to `withRuntime` in the public registry MCP server. Updates `packages/runtime` docs/JSDoc to remove the factory pattern and align examples with `tools: [instance]`.

- **Bug Fixes**
  - `apps/mesh/src/api/routes/registry/public-mcp-server.ts`: pass `tools` array directly instead of `tools: () => tools`, preventing repeated `[runtime] Passing factory functions...` logs.
  - Clear oxlint warnings: add missing `onUnsupportedFile` dep in `apps/mesh/src/web/components/chat/input.tsx`, silence ANSI regex rule in `apps/mesh/src/web/components/vm/vm-booting-state.tsx`, and remove unused import in `packages/sandbox/daemon/entry.ts`.

<sup>Written for commit 9f7fd8b7524f55482c8179164d0b9e5fa3f75bb0. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3200?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

