### PR TITLE
fix(oauth): only delete cached token on definitive invalid_grant

### DIFF
--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -167,12 +167,20 @@ export async function buildRequestHeaders(
 
           accessToken = refreshResult.accessToken;
         } else {
-          // Refresh failed - token is invalid
-          // Delete the cached token so user gets prompted to re-auth
-          await tokenStorage.delete(connectionId);
-          console.error(
-            `[Proxy] Token refresh failed for ${connectionId}: ${refreshResult.error}`,
-          );
+          // Only delete on a definitive `400 invalid_grant`. Transient
+          // failures (5xx, network, non-spec status codes) leave the cached
+          // row intact so the next request retries instead of forcing a
+          // manual reconnect.
+          if (refreshResult.permanent === true) {
+            await tokenStorage.delete(connectionId);
+          }
+          console.error("[Proxy] token refresh failed", {
+            connectionId,
+            status: refreshResult.status,
+            errorCode: refreshResult.errorCode,
+            permanent: refreshResult.permanent === true,
+            deleted: refreshResult.permanent === true,
+          });
         }
       } else {
         // Token expired but no refresh capability - delete it

--- a/apps/mesh/src/oauth/refresh-access-token.test.ts
+++ b/apps/mesh/src/oauth/refresh-access-token.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { refreshAccessToken } from "./refresh-access-token";
+import type { DownstreamToken } from "../storage/types";
+
+const baseToken: DownstreamToken = {
+  id: "dtok_test",
+  connectionId: "conn_test",
+  accessToken: "stale",
+  refreshToken: "rt",
+  scope: "repo",
+  expiresAt: new Date(Date.now() - 1000),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  clientId: "cid",
+  clientSecret: null,
+  tokenEndpoint: "https://example.com/token",
+};
+
+const originalFetch = globalThis.fetch;
+
+const installFetch = (responder: () => Response | Promise<Response>): void => {
+  globalThis.fetch = (async () =>
+    await responder()) as unknown as typeof globalThis.fetch;
+};
+
+describe("refreshAccessToken", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("flags 400 invalid_grant as permanent so callers can delete the token", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description: "refresh token revoked",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(true);
+    expect(result.error).toContain("revoked");
+  });
+
+  it("flags other 4xx errors as transient (could be config issue, retry-worthy)", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_request",
+            error_description: "missing parameter",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+  });
+
+  it("flags 5xx as transient — the OAuth server is broken, the token might still be valid", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: "server_error",
+            error_description: "Failed to process token request",
+          }),
+          { status: 500, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+  });
+
+  it("flags network errors as transient", async () => {
+    installFetch(() => {
+      throw new Error("network down");
+    });
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+  });
+
+  it("flags missing prerequisites as transient (config bug, not a bad refresh_token)", async () => {
+    const noRefreshToken = { ...baseToken, refreshToken: null };
+    const result = await refreshAccessToken(noRefreshToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+  });
+
+  it("does not flag success results as permanent", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(true);
+    expect(result.permanent).toBeUndefined();
+    expect(result.accessToken).toBe("new");
+  });
+});

--- a/apps/mesh/src/oauth/refresh-access-token.ts
+++ b/apps/mesh/src/oauth/refresh-access-token.ts
@@ -12,26 +12,50 @@ import type { DownstreamToken } from "../storage/types";
 
 export interface TokenRefreshResult {
   success: boolean;
+  /**
+   * `true` only when the OAuth server told us the refresh_token itself is
+   * permanently invalid (RFC 6749 §5.2: `400 invalid_grant`). Callers use
+   * this to decide whether to delete the cached token: deleting on transient
+   * failures (5xx, network blips, non-spec status codes) silently logs users
+   * out and forces a manual reconnect, so we only delete when we're certain.
+   */
+  permanent?: boolean;
   accessToken?: string;
   refreshToken?: string;
   expiresIn?: number;
   scope?: string;
   error?: string;
+  /** HTTP status of the OAuth response, when there was one. */
+  status?: number;
+  /** OAuth error code from the response body, when present. */
+  errorCode?: string;
 }
 
 export async function refreshAccessToken(
   token: DownstreamToken,
 ): Promise<TokenRefreshResult> {
   if (!token.refreshToken) {
-    return { success: false, error: "No refresh token available" };
+    return {
+      success: false,
+      permanent: false,
+      error: "No refresh token available",
+    };
   }
 
   if (!token.tokenEndpoint) {
-    return { success: false, error: "No token endpoint available" };
+    return {
+      success: false,
+      permanent: false,
+      error: "No token endpoint available",
+    };
   }
 
   if (!token.clientId) {
-    return { success: false, error: "No client ID available" };
+    return {
+      success: false,
+      permanent: false,
+      error: "No client ID available",
+    };
   }
 
   try {
@@ -60,26 +84,41 @@ export async function refreshAccessToken(
 
     if (!response.ok) {
       const errorBody = await response.text();
-      console.error(
-        `[TokenRefresh] Failed to refresh token: ${response.status}`,
-        errorBody,
-      );
-
+      let errorCode: string | undefined;
+      let errorDescription: string | undefined;
       try {
         const errorJson = JSON.parse(errorBody);
-        return {
-          success: false,
-          error:
-            errorJson.error_description ||
-            errorJson.error ||
-            `Token refresh failed: ${response.status}`,
-        };
+        errorCode = errorJson.error;
+        errorDescription = errorJson.error_description;
       } catch {
-        return {
-          success: false,
-          error: `Token refresh failed: ${response.status}`,
-        };
+        // body wasn't JSON — fall through with undefined codes
       }
+
+      // Only `400 invalid_grant` means the refresh_token is permanently dead.
+      // Everything else (5xx, network blips, non-spec status codes) is treated
+      // as transient — the cached token should not be deleted.
+      const permanent =
+        response.status === 400 && errorCode === "invalid_grant";
+
+      console.error("[TokenRefresh] refresh failed", {
+        connectionId: token.connectionId,
+        tokenEndpoint: token.tokenEndpoint,
+        status: response.status,
+        errorCode,
+        errorDescription,
+        permanent,
+      });
+
+      return {
+        success: false,
+        permanent,
+        status: response.status,
+        errorCode,
+        error:
+          errorDescription ||
+          errorCode ||
+          `Token refresh failed: ${response.status}`,
+      };
     }
 
     const data = (await response.json()) as {
@@ -98,9 +137,14 @@ export async function refreshAccessToken(
       scope: data.scope,
     };
   } catch (error) {
-    console.error("[TokenRefresh] Error refreshing token:", error);
+    console.error("[TokenRefresh] network/parse error", {
+      connectionId: token.connectionId,
+      tokenEndpoint: token.tokenEndpoint,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return {
       success: false,
+      permanent: false,
       error: error instanceof Error ? error.message : "Token refresh failed",
     };
   }

--- a/apps/mesh/src/oauth/token-refresh.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.test.ts
@@ -1,0 +1,147 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  mock,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import {
+  createTestDatabase,
+  closeTestDatabase,
+  type TestDatabase,
+} from "../database/test-db";
+import {
+  createTestSchema,
+  seedCommonTestFixtures,
+} from "../storage/test-helpers";
+import { CredentialVault } from "../encryption/credential-vault";
+import { DownstreamTokenStorage } from "../storage/downstream-token";
+import { ConnectionStorage } from "../storage/connection";
+import type { TokenRefreshResult } from "./refresh-access-token";
+
+const mockRefreshAccessToken =
+  vi.fn<(...args: unknown[]) => Promise<TokenRefreshResult>>();
+mock.module("./refresh-access-token", () => ({
+  refreshAccessToken: mockRefreshAccessToken,
+}));
+
+const { refreshAndStore } = await import("./token-refresh");
+
+describe("refreshAndStore", () => {
+  let database: TestDatabase;
+  let vault: CredentialVault;
+  let tokenStorage: DownstreamTokenStorage;
+  const connectionId = "conn_refresh_test";
+
+  beforeAll(async () => {
+    database = await createTestDatabase();
+    await createTestSchema(database.db);
+    await seedCommonTestFixtures(database.db);
+    vault = new CredentialVault(CredentialVault.generateKey());
+    tokenStorage = new DownstreamTokenStorage(database.db, vault);
+
+    const connectionStorage = new ConnectionStorage(database.db, vault);
+    await connectionStorage.create({
+      id: connectionId,
+      organization_id: "org_123",
+      created_by: "user_1",
+      title: "GitHub",
+      connection_type: "HTTP",
+      connection_url: "https://mcp.example.com/github",
+      connection_token: null,
+      tools: null,
+    });
+  });
+
+  afterAll(async () => {
+    await closeTestDatabase(database);
+  });
+
+  beforeEach(async () => {
+    mockRefreshAccessToken.mockReset();
+    await tokenStorage.delete(connectionId);
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "stale",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 1000),
+      clientId: "cid",
+      clientSecret: null,
+      tokenEndpoint: "https://example.com/token",
+    });
+  });
+
+  it("preserves the cached token on transient (5xx) failures", async () => {
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 500,
+      errorCode: "server_error",
+      error: "Failed to process token request",
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    expect(token).not.toBeNull();
+    const result = await refreshAndStore(token!, tokenStorage);
+
+    expect(result).toBeNull();
+    const after = await tokenStorage.get(connectionId);
+    expect(after).not.toBeNull();
+    expect(after?.refreshToken).toBe("rt");
+  });
+
+  it("deletes the cached token on permanent (400 invalid_grant) failure", async () => {
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: true,
+      status: 400,
+      errorCode: "invalid_grant",
+      error: "refresh token revoked",
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    expect(token).not.toBeNull();
+    const result = await refreshAndStore(token!, tokenStorage);
+
+    expect(result).toBeNull();
+    expect(await tokenStorage.get(connectionId)).toBeNull();
+  });
+
+  it("preserves the cached token when refresh result lacks the permanent flag (defensive: legacy callers)", async () => {
+    // Older code paths or unmocked-in-prod callers might forget to set
+    // `permanent`. Default behavior must be "preserve" so we don't
+    // regress to the old delete-on-anything bug.
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      error: "something broke",
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    const result = await refreshAndStore(token!, tokenStorage);
+
+    expect(result).toBeNull();
+    expect(await tokenStorage.get(connectionId)).not.toBeNull();
+  });
+
+  it("stores the refreshed token on success", async () => {
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh",
+      refreshToken: "rt2",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    const result = await refreshAndStore(token!, tokenStorage);
+
+    expect(result).toBe("fresh");
+    const after = await tokenStorage.get(connectionId);
+    expect(after?.accessToken).toBe("fresh");
+    expect(after?.refreshToken).toBe("rt2");
+  });
+});

--- a/apps/mesh/src/oauth/token-refresh.ts
+++ b/apps/mesh/src/oauth/token-refresh.ts
@@ -33,7 +33,14 @@ export async function refreshAndStore(
 ): Promise<string | null> {
   const result = await refreshAccessToken(token);
   if (!result.success || !result.accessToken) {
-    await tokenStorage.delete(token.connectionId);
+    // Only delete the cached row when the OAuth server told us the
+    // refresh_token is permanently invalid (RFC 6749: 400 invalid_grant).
+    // Transient failures (5xx, network, parse errors, non-spec status codes)
+    // must not nuke the user's auth — that turns every blip in the upstream
+    // OAuth server into a forced manual reconnect.
+    if (result.permanent === true) {
+      await tokenStorage.delete(token.connectionId);
+    }
     return null;
   }
   await tokenStorage.upsert({

--- a/apps/mesh/src/tools/github/list-user-orgs.test.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.test.ts
@@ -275,7 +275,7 @@ describe("GITHUB_LIST_USER_ORGS", () => {
     expect(persisted?.refreshToken).toBe("rt2");
   });
 
-  it("deletes the cached token and throws when proactive refresh fails", async () => {
+  it("deletes the cached token and throws when proactive refresh fails permanently (invalid_grant)", async () => {
     await tokenStorage.upsert({
       connectionId,
       accessToken: "stale-token",
@@ -289,7 +289,10 @@ describe("GITHUB_LIST_USER_ORGS", () => {
 
     mockRefreshAccessToken.mockResolvedValueOnce({
       success: false,
-      error: "invalid_grant",
+      permanent: true,
+      status: 400,
+      errorCode: "invalid_grant",
+      error: "refresh token revoked",
     });
 
     installHandler();
@@ -299,6 +302,40 @@ describe("GITHUB_LIST_USER_ORGS", () => {
     ).rejects.toThrow(/reconnect/i);
 
     expect(await tokenStorage.get(connectionId)).toBeNull();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("preserves the cached token and throws when proactive refresh fails transiently (5xx)", async () => {
+    // The whole point of the fix: a 500 from the OAuth server must not
+    // wipe the user's auth — the refresh_token might still be valid.
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "stale-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 500,
+      errorCode: "server_error",
+      error: "Failed to process token request",
+    });
+
+    installHandler();
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/reconnect/i);
+
+    const persisted = await tokenStorage.get(connectionId);
+    expect(persisted).not.toBeNull();
+    expect(persisted?.refreshToken).toBe("rt");
     expect(fetchCalls).toHaveLength(0);
   });
 
@@ -352,7 +389,11 @@ describe("GITHUB_LIST_USER_ORGS", () => {
     expect(persisted?.accessToken).toBe("fresh-token");
   });
 
-  it("deletes the token and throws reconnect error when retry after 401 still fails", async () => {
+  it("throws reconnect error without deleting the row when retry after 401 still 401s", async () => {
+    // The refresh succeeded, so the refresh_token is fine. Even if GitHub
+    // keeps returning 401 with the new access_token, deleting the cached
+    // row would lose the (still-valid) refresh_token. Throw the reconnect
+    // error so the user re-OAuths, which will overwrite the row anyway.
     await tokenStorage.upsert({
       connectionId,
       accessToken: "seemingly-valid-token",
@@ -382,10 +423,12 @@ describe("GITHUB_LIST_USER_ORGS", () => {
     ).rejects.toThrow(/reconnect/i);
 
     expect(fetchCalls).toHaveLength(2);
-    expect(await tokenStorage.get(connectionId)).toBeNull();
+    const persisted = await tokenStorage.get(connectionId);
+    expect(persisted).not.toBeNull();
+    expect(persisted?.accessToken).toBe("fresh-token");
   });
 
-  it("deletes the token and throws when reactive refresh itself fails", async () => {
+  it("deletes the token and throws when reactive refresh fails permanently", async () => {
     await tokenStorage.upsert({
       connectionId,
       accessToken: "seemingly-valid-token",
@@ -399,7 +442,10 @@ describe("GITHUB_LIST_USER_ORGS", () => {
 
     mockRefreshAccessToken.mockResolvedValueOnce({
       success: false,
-      error: "invalid_grant",
+      permanent: true,
+      status: 400,
+      errorCode: "invalid_grant",
+      error: "refresh token revoked",
     });
 
     installHandler(() => github401());
@@ -410,6 +456,41 @@ describe("GITHUB_LIST_USER_ORGS", () => {
 
     expect(fetchCalls).toHaveLength(1);
     expect(await tokenStorage.get(connectionId)).toBeNull();
+  });
+
+  it("preserves the cached token when reactive refresh fails transiently", async () => {
+    // GitHub returned 401 (current access_token is bad), but the OAuth
+    // server's refresh endpoint returned a 5xx. The refresh_token may still
+    // be valid — keep it so the next request can try to refresh again.
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "seemingly-valid-token",
+      refreshToken: "rt",
+      scope: "repo",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      clientId: "cid",
+      clientSecret: "csecret",
+      tokenEndpoint: "https://github.com/login/oauth/access_token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: false,
+      status: 500,
+      errorCode: "server_error",
+      error: "Failed to process token request",
+    });
+
+    installHandler(() => github401());
+
+    await expect(
+      GITHUB_LIST_USER_ORGS.execute({ connectionId }, ctx),
+    ).rejects.toThrow(/reconnect/i);
+
+    expect(fetchCalls).toHaveLength(1);
+    const persisted = await tokenStorage.get(connectionId);
+    expect(persisted).not.toBeNull();
+    expect(persisted?.refreshToken).toBe("rt");
   });
 
   it("throws a clear error when no GitHub token is stored", async () => {

--- a/apps/mesh/src/tools/github/list-user-orgs.ts
+++ b/apps/mesh/src/tools/github/list-user-orgs.ts
@@ -93,10 +93,12 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       // expired before our clock said so). Try one refresh + retry before
       // giving up. Applies to any page — a token can be invalidated
       // between pages of a long installations listing.
+      // Deletion of the cached row is delegated to `refreshAndStore`, which
+      // only deletes on a definitive `400 invalid_grant`. Transient OAuth
+      // failures leave the row intact so a later request can recover.
       if (res.status === 401) {
         const current = await tokenStorage.get(input.connectionId);
         if (!current || !canRefresh(current)) {
-          await tokenStorage.delete(input.connectionId);
           throw new Error(RECONNECT_ERROR);
         }
         const refreshed = await refreshAndStore(current, tokenStorage);
@@ -106,7 +108,6 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
         accessToken = refreshed;
         res = await fetchPage(accessToken);
         if (res.status === 401) {
-          await tokenStorage.delete(input.connectionId);
           throw new Error(RECONNECT_ERROR);
         }
       }

--- a/apps/mesh/src/tools/vm/start.test.ts
+++ b/apps/mesh/src/tools/vm/start.test.ts
@@ -584,7 +584,10 @@ describe("VM_START", () => {
     }));
     mockRefreshAccessToken.mockImplementation(async () => ({
       success: false,
-      error: "invalid_grant",
+      permanent: true,
+      status: 400,
+      errorCode: "invalid_grant",
+      error: "refresh token revoked",
     }));
 
     const virtualMcp = makeVirtualMcp("org_1", BASE_METADATA);

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from "./bindings.ts";
 import { type CORSOptions, handlePreflight, withCORS } from "./cors.ts";
 import { createOAuthHandlers } from "./oauth.ts";
+export { OAuthInvalidGrantError } from "./oauth.ts";
 import { State } from "./state.ts";
 import {
   createMCPServer,

--- a/packages/runtime/src/oauth.test.ts
+++ b/packages/runtime/src/oauth.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "bun:test";
+import { createOAuthHandlers, OAuthInvalidGrantError } from "./oauth.ts";
+import type { OAuthConfig } from "./tools.ts";
+
+const baseConfig = (
+  refreshToken?: OAuthConfig["refreshToken"],
+): OAuthConfig => ({
+  mode: "PKCE",
+  authorizationServer: "https://upstream.example.com",
+  authorizationUrl: () => "https://upstream.example.com/authorize",
+  exchangeCode: async () => ({
+    access_token: "at",
+    token_type: "Bearer",
+  }),
+  refreshToken,
+});
+
+const buildTokenRequest = (body: Record<string, string>) =>
+  new Request("https://mcp.example.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+
+describe("OAuth /token refresh handler", () => {
+  it("returns 400 invalid_grant when refreshToken throws OAuthInvalidGrantError", async () => {
+    const handlers = createOAuthHandlers(
+      baseConfig(async () => {
+        throw new OAuthInvalidGrantError(
+          "invalid_grant",
+          "refresh token revoked",
+        );
+      }),
+    );
+
+    const response = await handlers.handleToken(
+      buildTokenRequest({
+        grant_type: "refresh_token",
+        refresh_token: "rt",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: string;
+      error_description?: string;
+    };
+    expect(body.error).toBe("invalid_grant");
+    expect(body.error_description).toBe("refresh token revoked");
+  });
+
+  it("returns 500 server_error when refreshToken throws a generic error", async () => {
+    const handlers = createOAuthHandlers(
+      baseConfig(async () => {
+        throw new Error("upstream is down");
+      }),
+    );
+
+    const response = await handlers.handleToken(
+      buildTokenRequest({
+        grant_type: "refresh_token",
+        refresh_token: "rt",
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("server_error");
+  });
+
+  it("forwards the new token on success", async () => {
+    const handlers = createOAuthHandlers(
+      baseConfig(async () => ({
+        access_token: "fresh",
+        token_type: "Bearer",
+        refresh_token: "rt2",
+        expires_in: 3600,
+      })),
+    );
+
+    const response = await handlers.handleToken(
+      buildTokenRequest({
+        grant_type: "refresh_token",
+        refresh_token: "rt",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      access_token: string;
+      refresh_token?: string;
+    };
+    expect(body.access_token).toBe("fresh");
+    expect(body.refresh_token).toBe("rt2");
+  });
+});

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -1,6 +1,29 @@
 import type { OAuthClient, OAuthConfig, OAuthParams } from "./tools.ts";
 
 /**
+ * Thrown by `OAuthConfig.refreshToken` (or `exchangeCode`) implementations
+ * when the upstream OAuth provider says the grant itself is permanently
+ * invalid — e.g. GitHub returns `400 invalid_grant` because the user
+ * revoked the app or the refresh_token was rotated out from under us.
+ *
+ * The `/token` handler maps this to an RFC-6749-compliant
+ * `400 {"error":"invalid_grant",...}` response, so callers can tell apart
+ * "the user needs to reconnect" from a transient upstream 5xx (which the
+ * outer catch maps to a 500). Throwing a plain `Error` from `refreshToken`
+ * will be treated as transient and surface as 500.
+ */
+export class OAuthInvalidGrantError extends Error {
+  readonly error: string;
+  readonly errorDescription?: string;
+  constructor(error = "invalid_grant", errorDescription?: string) {
+    super(errorDescription ?? error);
+    this.name = "OAuthInvalidGrantError";
+    this.error = error;
+    this.errorDescription = errorDescription;
+  }
+}
+
+/**
  * Generate a cryptographically secure random token
  */
 function generateRandomToken(length = 32): string {
@@ -338,8 +361,30 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
           );
         }
 
-        // Call the external provider to refresh the token
-        const newTokenResponse = await oauth.refreshToken(refresh_token);
+        // Call the external provider to refresh the token. We catch
+        // `OAuthInvalidGrantError` here (not in the outer catch) so we can
+        // map it to a spec-compliant 400 instead of letting all errors fall
+        // through to a generic 500. Any other thrown error is treated as
+        // transient and surfaces from the outer catch as 500.
+        let newTokenResponse: Awaited<
+          ReturnType<NonNullable<OAuthConfig["refreshToken"]>>
+        >;
+        try {
+          newTokenResponse = await oauth.refreshToken(refresh_token);
+        } catch (err) {
+          if (err instanceof OAuthInvalidGrantError) {
+            return Response.json(
+              {
+                error: err.error,
+                ...(err.errorDescription
+                  ? { error_description: err.errorDescription }
+                  : {}),
+              },
+              { status: 400 },
+            );
+          }
+          throw err;
+        }
 
         const tokenResponse: Record<string, unknown> = {
           access_token: newTokenResponse.access_token,

--- a/packages/sandbox/server/runner/docker/runner.test.ts
+++ b/packages/sandbox/server/runner/docker/runner.test.ts
@@ -404,7 +404,14 @@ describe("DockerSandboxRunner.ensure() — in-process dedupe", () => {
     });
     installFetch(() => healthOkResponse());
 
-    const runner = new DockerSandboxRunner({ exec });
+    // Pass a non-default image so `ensureSandboxImage` short-circuits — otherwise
+    // the runner spawns a real `docker build` (not honoring the injected exec)
+    // and the test times out on the cold cache. Matches the pattern used by the
+    // tests above.
+    const runner = new DockerSandboxRunner({
+      image: "test-image:latest",
+      exec,
+    });
 
     const [a, b] = await Promise.all([runner.ensure(ID), runner.ensure(ID)]);
     expect(a.handle).toBe(b.handle);
@@ -456,7 +463,10 @@ describe("DockerSandboxRunner.ensure() — env contract for unified daemon", () 
     const { exec, calls } = makeExec(defaultResponder);
     installFetch(() => healthOkResponse());
 
-    const runner = new DockerSandboxRunner({ exec });
+    const runner = new DockerSandboxRunner({
+      image: "test-image:latest",
+      exec,
+    });
     await runner.ensure(ID, {
       repo: {
         cloneUrl: "https://x-access-token:TOKEN@github.com/o/r.git",
@@ -515,7 +525,10 @@ describe("DockerSandboxRunner.ensure() — env contract for unified daemon", () 
     const { exec, calls } = makeExec(defaultResponder);
     installFetch(() => healthOkResponse());
 
-    const runner = new DockerSandboxRunner({ exec });
+    const runner = new DockerSandboxRunner({
+      image: "test-image:latest",
+      exec,
+    });
     await runner.ensure(ID);
 
     const runCall = calls.find((c) => c.args[0] === "run")!;
@@ -608,7 +621,11 @@ describe("DockerSandboxRunner.delete()", () => {
         : new Response("", { status: 204 }),
     );
 
-    const runner = new DockerSandboxRunner({ exec, stateStore: store });
+    const runner = new DockerSandboxRunner({
+      image: "test-image:latest",
+      exec,
+      stateStore: store,
+    });
     const sb = await runner.ensure(ID);
 
     // Clear fetch calls so we only see what delete() triggers.
@@ -657,6 +674,7 @@ describe("DockerSandboxRunner — sanity: preview URL & port resolvers", () => {
     installFetch(() => healthOkResponse());
 
     const runner = new DockerSandboxRunner({
+      image: "test-image:latest",
       exec,
       previewUrlPattern: "https://preview.example.com/{handle}",
     });


### PR DESCRIPTION
## Summary

GitHub MCP connections kept losing their tokens in production — users had to manually reconnect every few hours. Root cause: a transient 5xx from the OAuth server (or any non-spec error code) was unconditionally deleting the cached token row, even when the refresh_token was probably still valid.

This PR fixes both ends:

- **Mesh client**: `TokenRefreshResult` gains a `permanent` flag, set to `true` only on a spec-compliant `400 invalid_grant`. `refreshAndStore` (and the equivalent block in `headers.ts`) now only calls `tokenStorage.delete` when `permanent === true`. Transient failures (5xx, network blips, non-spec status codes) leave the row intact so the next request can recover.
- **Runtime (`@decocms/runtime` 1.5.0 → 1.6.0)**: new exported `OAuthInvalidGrantError`. The `/token` handler wraps `oauth.refreshToken(...)` in its own try/catch and maps that error to `400 invalid_grant`. Other thrown errors still surface as `500 server_error`. This lets downstream MCP Workers (e.g. `github-mcp.decocms.com`) faithfully propagate "user revoked the refresh_token" as 400, while keeping real server errors as 500.
- **Logging**: refresh failures now log a structured object (`connectionId`, `status`, `errorCode`, `permanent`, `deleted`) instead of a single opaque string — should be much easier to triage in Loki once pod stdout shipping is fixed.

### Investigation notes (for context)

Direct test of the production OAuth endpoint confirmed it returns `500 server_error` even for invalid credentials, instead of the spec-compliant `400 invalid_grant`. Combined with the mesh client deleting on any non-2xx, this turned every transient blip into a forced reconnect. Survey across 18 GitHub MCP connections in prod showed 5 (28%) had lost their token rows entirely; one (gimenes org) was reproduced and confirmed deleted.

### Follow-up needed (separate repo)

The `github-mcp` Worker repo needs a small companion change: its `oauth.refreshToken` implementation must throw `OAuthInvalidGrantError` (imported from `@decocms/runtime` 1.6.0) when GitHub returns `400 invalid_grant`. Without that, the runtime can't tell a real revocation apart from a 5xx, and the mesh client will (correctly, but suboptimally) preserve all rows including dead ones.

## Test plan

- [x] `bun run check` — clean across all workspaces
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run fmt:check` — clean
- [x] New unit tests: `apps/mesh/src/oauth/refresh-access-token.test.ts` (6 tests), `apps/mesh/src/oauth/token-refresh.test.ts` (4 tests), `packages/runtime/src/oauth.test.ts` (3 tests)
- [x] Updated existing tests: `list-user-orgs.test.ts` (split into permanent vs transient cases, +2 new tests), `vm/start.test.ts` (mock fixture updated)
- [x] All 38 tests across the touched files pass
- [ ] Smoke-test in staging: reconnect the gimenes GitHub connection, force a transient OAuth-server 5xx, confirm the cached row survives and a subsequent retry succeeds
- [ ] Ship companion change to `github-mcp` repo so revocations propagate as 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes token refresh so we only delete a cached token on a definitive 400 invalid_grant, preventing unnecessary reconnects after transient OAuth errors and stabilizing GitHub MCP connections.

- **Bug Fixes**
  - Mesh client and callers (outbound headers, GitHub tool): add a `permanent` flag to refresh results and only delete the cached token when `permanent === true`; transient failures (5xx, network, non-spec responses) keep the row. Logs now include `connectionId`, `status`, `errorCode`, `permanent`, and `deleted`.
  - Runtime (`@decocms/runtime` 1.6.0): export `OAuthInvalidGrantError` and map it to a spec-compliant `400 invalid_grant` in the `/token` handler; other errors return `500 server_error`.
  - Tests: pin a test Docker image in `DockerSandboxRunner` tests to skip real `docker build` and deflake CI.

- **Migration**
  - Update MCP Workers (e.g. `github-mcp`) to throw `OAuthInvalidGrantError` when the upstream returns `400 invalid_grant`, and bump to `@decocms/runtime@1.6.0`.

<sup>Written for commit a53e88f9e7e5895e2865c10648e3cade9a1a29ea. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

