### PR TITLE
fix(chat): create thread lazily on first message instead of page load

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -29,11 +29,20 @@ import {
   type UIMessage,
 } from "ai";
 import {
+  SELF_MCP_ALIAS_ID,
   selectDefaultModel,
+  useMCPClient,
   useProjectContext,
   useVirtualMCP,
 } from "@decocms/mesh-sdk";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { KEYS } from "../../lib/query-keys";
+import {
+  clearIntendedTaskMeta,
+  getIntendedTaskMeta,
+  setIntendedTaskMeta,
+} from "../../lib/intended-task-meta";
 
 import {
   useAiProviderKeys,
@@ -59,7 +68,6 @@ import { toMetadataModelInfo } from "../../lib/metadata-model-info";
 
 import { useChatNavigation } from "./hooks/use-chat-navigation";
 import { useStreamManager } from "./hooks/use-stream-manager";
-import { useTaskActions } from "../../hooks/use-tasks";
 import { useTaskManager, type TaskOwnerFilter } from "./task";
 import { useTaskMessages } from "./task/use-task-manager";
 import { derivePartsFromTiptapDoc } from "./derive-parts";
@@ -260,6 +268,16 @@ interface TaskProviderInternals {
   };
   rawNavigateToTask: (taskId: string) => void;
   bridgeRef: React.RefObject<ChatBridgeValue>;
+  /**
+   * Lazily create the thread row on the server. Called by sendMessage right
+   * before the first send when no row exists yet (the user navigated to this
+   * task id but hasn't engaged with it). Idempotent on the server.
+   */
+  ensureTaskExists: (
+    taskId: string,
+    virtualMcpId: string,
+    branch: string | null,
+  ) => Promise<void>;
 }
 
 // ============================================================================
@@ -293,6 +311,83 @@ export function ChatContextProvider({
   const { org, locator } = useProjectContext();
   const { data: session } = authClient.useSession();
   const user = session?.user ?? null;
+  const queryClient = useQueryClient();
+  const ensureClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
+
+  // Branches picked for threads that don't yet have a server row. When the
+  // user opens the branch picker on a freshly navigated empty chat, the choice
+  // lives here until sendMessage creates the row with this branch baked in.
+  const [pendingBranches, setPendingBranches] = useState<
+    Record<string, string>
+  >({});
+
+  // Silent create mutation — same payload as taskActions.create but with no
+  // success toast and a focused cache invalidation. Used by sendMessage to
+  // turn a lazily navigated task id into a real row right before the first
+  // user message goes through. Server INSERT … ON CONFLICT DO NOTHING makes
+  // this idempotent across tabs and StrictMode double-effects.
+  const ensureCreate = useMutation<
+    Task,
+    Error,
+    { taskId: string; virtualMcpId: string; branch: string | null }
+  >({
+    mutationFn: async ({ taskId, virtualMcpId: vmcpId, branch }) => {
+      const result = await ensureClient.callTool({
+        name: "COLLECTION_THREADS_CREATE",
+        arguments: {
+          data: {
+            id: taskId,
+            virtual_mcp_id: vmcpId,
+            ...(branch ? { branch } : {}),
+          },
+        },
+      });
+      if ((result as { isError?: boolean }).isError) {
+        const content = (result as { content?: unknown }).content;
+        const msg =
+          Array.isArray(content) && content[0] && typeof content[0] === "object"
+            ? ((content[0] as { text?: string }).text ?? "Create failed")
+            : "Create failed";
+        throw new Error(msg);
+      }
+      const payload = (result as { structuredContent?: unknown })
+        .structuredContent as { item: Task };
+      return payload.item;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        predicate: (q) =>
+          q.queryKey[1] === org.id &&
+          q.queryKey[3] === "collection" &&
+          q.queryKey[4] === "THREADS",
+      });
+      queryClient.invalidateQueries({ queryKey: KEYS.tasksPrefix(locator) });
+      queryClient.invalidateQueries({
+        queryKey: KEYS.ensureTask(org.id, vars.taskId),
+      });
+      // The branch is now persisted on the row; drop the local override and
+      // the cross-tree intent so subsequent reads come from the canonical
+      // task list.
+      setPendingBranches((prev) => {
+        if (!(vars.taskId in prev)) return prev;
+        const next = { ...prev };
+        delete next[vars.taskId];
+        return next;
+      });
+      clearIntendedTaskMeta(vars.taskId);
+    },
+  });
+
+  const ensureTaskExists = async (
+    taskId: string,
+    vmcpId: string,
+    branch: string | null,
+  ): Promise<void> => {
+    await ensureCreate.mutateAsync({ taskId, virtualMcpId: vmcpId, branch });
+  };
 
   // URL state
   const {
@@ -556,35 +651,39 @@ export function ChatContextProvider({
   };
 
   const activeTask = tasks.find((t) => t.id === effectiveTaskId);
-  const currentBranch = activeTask?.branch ?? null;
+  // Branch resolution for the active task, in priority order:
+  //   1. The persisted thread row (canonical once the row exists).
+  //   2. A pending in-context override the user picked before sending.
+  //   3. The cross-tree "intended" branch carried from a "+ New chat" entry
+  //      point that navigated here without creating a row.
+  const intendedBranchForActive = effectiveTaskId
+    ? (pendingBranches[effectiveTaskId] ??
+      getIntendedTaskMeta(effectiveTaskId)?.branch ??
+      null)
+    : null;
+  const currentBranch = activeTask?.branch ?? intendedBranchForActive ?? null;
+  // Branch is locked once the row persists it — the picker can still move
+  // freely on a not-yet-created thread.
   const isBranchLocked = !!activeTask?.branch;
 
-  // Create task — calls COLLECTION_THREADS_CREATE up-front with the active
-  // task's branch so the new thread lands on the same warm sandbox. The
-  // route loader's useEnsureTask will see the row already exists on its
-  // GET and skip the create-on-404 fallback.
-  const taskActions = useTaskActions();
+  // Create task — lazy. Just navigate to a fresh id; the row only lands in
+  // the database once the user actually sends a message (sendMessage's
+  // ensureTaskExists path). This keeps the task list clean of phantom rows
+  // from page-load redirects and idle "+ New" clicks.
   const createTask = (): string => {
     const newId = crypto.randomUUID();
-    void taskActions.create
-      .mutateAsync({
-        id: newId,
-        virtual_mcp_id: virtualMcpId,
-        ...(currentBranch ? { branch: currentBranch } : {}),
-      } as Partial<Task>)
-      .then(() => navigateToTask(newId))
-      .catch(() => {
-        // create error toast already fired by useCollectionActions; navigate
-        // anyway so the user's not stranded — the route loader's ensure
-        // fallback will retry.
-        navigateToTask(newId);
-      });
+    if (currentBranch) {
+      setIntendedTaskMeta(newId, { branch: currentBranch });
+    }
+    navigateToTask(newId);
     return newId;
   };
 
-  // Create task + queue a pending message. Propagates currentBranch only
-  // when the new task is on the same vMCP (different vMCPs have their own
-  // vmMap, so carrying a branch across them would land on a cold sandbox).
+  // Create task + queue a pending message — also lazy. Carries currentBranch
+  // only when the new task targets the same vMCP (different vMCPs maintain
+  // their own vmMap, so a foreign branch would land on a cold sandbox). The
+  // pending message triggers sendMessage in the new context, which lazily
+  // creates the row with the carried branch.
   const createTaskWithMessage = (params: {
     message: SendMessageParams;
     virtualMcpId?: string;
@@ -592,22 +691,12 @@ export function ChatContextProvider({
     const newId = crypto.randomUUID();
     const targetVmcp = params.virtualMcpId ?? virtualMcpId;
     const carryBranch = targetVmcp === virtualMcpId ? currentBranch : null;
-    void taskActions.create
-      .mutateAsync({
-        id: newId,
-        virtual_mcp_id: targetVmcp,
-        ...(carryBranch ? { branch: carryBranch } : {}),
-      } as Partial<Task>)
-      .then(() =>
-        navigateToTask(newId, {
-          virtualMcpId: params.virtualMcpId,
-        }),
-      )
-      .catch(() => {
-        navigateToTask(newId, {
-          virtualMcpId: params.virtualMcpId,
-        });
-      });
+    if (carryBranch) {
+      setIntendedTaskMeta(newId, { branch: carryBranch });
+    }
+    navigateToTask(newId, {
+      virtualMcpId: params.virtualMcpId,
+    });
     setPendingMessage({
       taskId: newId,
       message: params.message,
@@ -643,8 +732,24 @@ export function ChatContextProvider({
     currentBranch,
     isBranchLocked,
     setCurrentTaskBranch: (branch: string | null) => {
-      if (effectiveTaskId) {
+      if (!effectiveTaskId) return;
+      // Once the row exists, persist on the server (existing behavior).
+      // Otherwise stash the choice locally so sendMessage can create the row
+      // with the picked branch baked in.
+      if (activeTask) {
         taskManager.setTaskBranch(effectiveTaskId, branch);
+        return;
+      }
+      setPendingBranches((prev) => {
+        const next = { ...prev };
+        if (branch) next[effectiveTaskId] = branch;
+        else delete next[effectiveTaskId];
+        return next;
+      });
+      if (branch) {
+        setIntendedTaskMeta(effectiveTaskId, { branch });
+      } else {
+        clearIntendedTaskMeta(effectiveTaskId);
       }
     },
     ownerFilter: taskManager.ownerFilter,
@@ -705,6 +810,7 @@ export function ChatContextProvider({
     },
     rawNavigateToTask,
     bridgeRef,
+    ensureTaskExists,
   };
 
   return (
@@ -770,6 +876,7 @@ export function ActiveTaskProvider({
     taskManager,
     rawNavigateToTask,
     bridgeRef,
+    ensureTaskExists,
   } = internals;
 
   const { org } = useProjectContext();
@@ -868,6 +975,26 @@ export function ActiveTaskProvider({
     // Capture at send time (frozen in closure)
     const capturedTaskId = taskId;
     const capturedVirtualMcpId = virtualMcpId;
+
+    // Lazy thread creation — the row only exists once the user actually
+    // engages with this URL. The server stream endpoint requires the row, so
+    // create it here before the first send. Subsequent sends short-circuit
+    // (the row appears in `tasks` after the cache invalidation in onSuccess).
+    if (capturedTaskId && !tasks.some((t) => t.id === capturedTaskId)) {
+      try {
+        await ensureTaskExists(
+          capturedTaskId,
+          capturedVirtualMcpId,
+          currentBranch,
+        );
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to create chat";
+        toast.error(msg);
+        console.error("[chat] ensureTaskExists failed:", err);
+        return;
+      }
+    }
 
     if (params.model) setModel(params.model);
 

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -76,7 +76,7 @@ import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-hea
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
-import { useTaskActions } from "@/web/hooks/use-tasks";
+import { setIntendedTaskMeta } from "@/web/lib/intended-task-meta";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
 
 /**
@@ -89,7 +89,6 @@ import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
 function useNavigateToNewTaskWithBranchCarry(orgSlug: string) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const taskActions = useTaskActions();
   const { locator } = useProjectContext();
   const params = useParams({ strict: false }) as { taskId?: string };
   const search = useSearch({ strict: false }) as { virtualmcpid?: string };
@@ -100,15 +99,8 @@ function useNavigateToNewTaskWithBranchCarry(orgSlug: string) {
       clickedVirtualMcpId === search.virtualmcpid
         ? readCachedTaskBranch(queryClient, locator, params.taskId ?? "")
         : null;
-    try {
-      await taskActions.create.mutateAsync({
-        id: taskId,
-        virtual_mcp_id: clickedVirtualMcpId,
-        ...(carryBranch ? { branch: carryBranch } : {}),
-      });
-    } catch {
-      // Toast already fired; navigate anyway so the route loader's
-      // ensure-fallback can retry.
+    if (carryBranch) {
+      setIntendedTaskMeta(taskId, { branch: carryBranch });
     }
     navigate({
       to: "/$org/$taskId",

--- a/apps/mesh/src/web/hooks/use-ensure-task.ts
+++ b/apps/mesh/src/web/hooks/use-ensure-task.ts
@@ -1,15 +1,15 @@
 /**
- * useEnsureTask — read a task; on 404, create it with the given id and vMCP.
+ * useEnsureTask — read a task by id; report whether the row exists yet.
+ *
+ * Threads are created lazily on the first user message (see chat-context's
+ * sendMessage path), so a missing row is the expected state for a freshly
+ * navigated `/$org/$taskId` URL. Returning `task: null` lets the chat render
+ * an empty conversation without a phantom row appearing in the task list.
  *
  * Returns a discriminated union so the consumer can render the right UI:
- *   - { status: "loading" }   — initial GET in flight
- *   - { status: "creating" }  — create mutation in flight (after a 404)
- *   - { status: "ready", task: Task } — resolved
- *   - { status: "error", error: Error } — non-404 failure
- *
- * Race safety: the create mutation is server-side idempotent (`INSERT … ON
- * CONFLICT DO NOTHING RETURNING *`). Two tabs hitting the same URL both end
- * up with the same row.
+ *   - { status: "loading" }                  — initial GET in flight
+ *   - { status: "ready", task: Task | null } — row exists, or doesn't yet
+ *   - { status: "error", error: Error }      — non-recoverable failure
  */
 
 import {
@@ -17,24 +17,21 @@ import {
   useMCPClient,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { useEffect } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "../lib/query-keys";
 import type { Task } from "./use-tasks";
 
 type State =
   | { status: "loading" }
-  | { status: "creating" }
-  | { status: "ready"; task: Task }
+  | { status: "ready"; task: Task | null }
   | { status: "error"; error: Error };
 
-export function useEnsureTask(id: string, virtualMcpId: string): State {
-  const { org, locator } = useProjectContext();
+export function useEnsureTask(id: string): State {
+  const { org } = useProjectContext();
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
   });
-  const queryClient = useQueryClient();
 
   const query = useQuery<Task | null>({
     queryKey: KEYS.ensureTask(org.id, id),
@@ -44,79 +41,17 @@ export function useEnsureTask(id: string, virtualMcpId: string): State {
         arguments: { id },
       });
       const payload = (result as { structuredContent?: unknown })
-        .structuredContent as { item?: Task } | undefined;
+        .structuredContent as { item?: Task | null } | undefined;
       return payload?.item ?? null;
     },
     retry: false,
     refetchOnWindowFocus: false,
   });
 
-  // Private mutation owned by this hook so we can suppress the toast and
-  // shared-cache invalidation that `useTaskActions().create` does. Effects
-  // re-run on (id, query.isSuccess, query.data) changes; React 19 Strict
-  // Mode dev may double-fire on first mount, but the server's `INSERT … ON
-  // CONFLICT DO NOTHING` makes this silent (no duplicate row, no toast).
-  const ensureCreate = useMutation<Task, Error, string>({
-    mutationFn: async (taskId) => {
-      const result = await client.callTool({
-        name: "COLLECTION_THREADS_CREATE",
-        arguments: {
-          data: { id: taskId, virtual_mcp_id: virtualMcpId },
-        },
-      });
-      if ((result as { isError?: boolean }).isError) {
-        const content = (result as { content?: unknown }).content;
-        const msg =
-          Array.isArray(content) && content[0] && typeof content[0] === "object"
-            ? ((content[0] as { text?: string }).text ?? "Create failed")
-            : "Create failed";
-        throw new Error(msg);
-      }
-      const payload = (result as { structuredContent?: unknown })
-        .structuredContent as { item: Task };
-      return payload.item;
-    },
-    onSuccess: () => {
-      // Refresh the canonical THREADS collection cache and the legacy
-      // KEYS.tasksPrefix list (read by chat-context's tasks.find), then
-      // refetch the ensure query so the consumer transitions from
-      // "creating" to "ready" without an extra round-trip.
-      queryClient.invalidateQueries({
-        predicate: (q) =>
-          q.queryKey[1] === org.id &&
-          q.queryKey[3] === "collection" &&
-          q.queryKey[4] === "THREADS",
-      });
-      queryClient.invalidateQueries({
-        queryKey: KEYS.tasksPrefix(locator),
-      });
-      void query.refetch();
-    },
-  });
-
-  // Fires the create mutation when GET resolves to a missing thread.
-  // Dependency array re-fires after `id` changes; the variables/isPending
-  // checks dedupe within a single id. React 19 Strict Mode dev double-mount
-  // is silent because the server's INSERT … ON CONFLICT DO NOTHING handles
-  // the duplicate request and the private mutation has no toast.
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect
-  useEffect(() => {
-    if (!query.isSuccess || query.data) return;
-    if (ensureCreate.isPending) return;
-    if (ensureCreate.variables === id) return;
-    ensureCreate.mutate(id);
-  }, [id, query.isSuccess, query.data, ensureCreate]);
-
   if (query.isLoading) return { status: "loading" };
   if (query.isError) return { status: "error", error: query.error as Error };
-  if (query.isSuccess && query.data) {
-    return { status: "ready", task: query.data };
-  }
-  if (ensureCreate.isPending || (query.isSuccess && !query.data)) {
-    return { status: "creating" };
-  }
-  if (ensureCreate.isError) {
-    return { status: "error", error: ensureCreate.error };
+  if (query.isSuccess) {
+    return { status: "ready", task: query.data ?? null };
   }
   return { status: "loading" };
 }

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -18,7 +18,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { resolveDefaultTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
-import { useTaskActions } from "@/web/hooks/use-tasks";
+import { setIntendedTaskMeta } from "@/web/lib/intended-task-meta";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -144,7 +144,6 @@ export function useChatMainPanelState(
     taskId?: string;
   };
   const queryClient = useQueryClient();
-  const taskActions = useTaskActions();
   const { locator } = useProjectContext();
 
   const { virtualMcpId, orgSlug, isAgentRoute } = routeCtx;
@@ -211,20 +210,15 @@ export function useChatMainPanelState(
     navigateSearch({ chat: 1 }, { replace: true });
   };
 
-  // Carry the active task's branch into the new thread so it lands on the
-  // same warm sandbox. Server picks from vmMap when no branch is provided.
+  // Lazy "+ New chat" — navigate without creating the row. Carry the source
+  // task's branch via the intended-task-meta store so the chat-context's
+  // sendMessage path can create the thread on the first user message with
+  // the same warm sandbox.
   const createNewTask = async () => {
     const newTaskId = crypto.randomUUID();
     const branch = readCachedTaskBranch(queryClient, locator, taskId);
-    try {
-      await taskActions.create.mutateAsync({
-        id: newTaskId,
-        virtual_mcp_id: virtualMcpId,
-        ...(branch ? { branch } : {}),
-      });
-    } catch {
-      // Toast already fired by useCollectionActions; navigate anyway so the
-      // route loader's ensure-fallback can retry.
+    if (branch) {
+      setIntendedTaskMeta(newTaskId, { branch });
     }
     navigate({
       to: routeBase,

--- a/apps/mesh/src/web/hooks/use-tasks.ts
+++ b/apps/mesh/src/web/hooks/use-tasks.ts
@@ -1,56 +1,13 @@
 /**
- * Task (thread) hooks — mirror the useConnection/useConnections/useConnectionActions
- * pattern. Backed by COLLECTION_THREADS_* tools.
+ * Task (thread) hooks — backed by COLLECTION_THREADS_* tools.
+ *
+ * The actions wrapper has been retired now that thread creation is owned
+ * exclusively by the lazy path in chat-context's sendMessage. Re-exports
+ * useEnsureTask for callers that just want to look up a task by id.
  */
 
-import {
-  SELF_MCP_ALIAS_ID,
-  useCollectionActions,
-  useMCPClient,
-  useProjectContext,
-} from "@decocms/mesh-sdk";
-import { useQueryClient } from "@tanstack/react-query";
-import { KEYS } from "@/web/lib/query-keys";
 import type { ThreadEntity } from "@/tools/thread/schema";
 
 export type Task = ThreadEntity;
-
-/**
- * Mutation hooks. `create.mutateAsync({ id?, virtual_mcp_id, branch?, title?, description? })`.
- * `update.mutateAsync({ id, data })`.
- *
- * The `create.onSuccess` from useCollectionActions only invalidates the
- * canonical collection cache. Tasks have a parallel legacy task list at
- * KEYS.tasksPrefix(locator) that chat-context reads from for the branch
- * picker; we wrap the create mutation here so every caller refreshes both
- * caches consistently.
- */
-export function useTaskActions() {
-  const { org, locator } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-  });
-  const queryClient = useQueryClient();
-  const actions = useCollectionActions<Task>(org.id, "THREADS", client);
-
-  const originalCreate = actions.create;
-  const wrappedMutateAsync: typeof originalCreate.mutateAsync = async (
-    data,
-    options,
-  ) => {
-    const result = await originalCreate.mutateAsync(data, options);
-    queryClient.invalidateQueries({ queryKey: KEYS.tasksPrefix(locator) });
-    return result;
-  };
-
-  return {
-    ...actions,
-    create: {
-      ...originalCreate,
-      mutateAsync: wrappedMutateAsync,
-    },
-  };
-}
 
 export { useEnsureTask } from "./use-ensure-task";

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -253,11 +253,11 @@ function AgentInsetProvider() {
   const isDecopilot = virtualMcpId === getDecopilotId(org.id);
   const isAgentRoute = !isDecopilot;
 
-  // Ensure the thread row exists for this URL before rendering the chat. On
-  // 404 the hook fires COLLECTION_THREADS_CREATE (idempotent) and surfaces a
-  // "Creating task…" state until the row is persisted. Without this the
-  // chat renders with branch=null because the thread never existed.
-  const ensureState = useEnsureTask(params.taskId ?? "", virtualMcpId);
+  // Look up the thread row for this URL, but don't create it. Threads are
+  // created lazily on the first user message so empty page-load navigations
+  // (the home-page redirect, "+ New chat" buttons) don't flood the task list.
+  // The chat renders fine without a row — sendMessage handles creation.
+  const ensureState = useEnsureTask(params.taskId ?? "");
 
   // Fetch entity (Suspense-based — resolved before render)
   const entity = useVirtualMCP(virtualMcpId);
@@ -302,13 +302,13 @@ function AgentInsetProvider() {
     entity,
   };
 
-  if (ensureState.status === "creating" || ensureState.status === "loading") {
+  if (ensureState.status === "loading") {
     return (
       <InsetContext value={insetContextValue}>
         <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
           <div className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground">
             <Loading01 className="size-4 animate-spin mr-2" />
-            Creating task…
+            Loading task…
           </div>
         </div>
       </InsetContext>

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -12,11 +12,10 @@ import {
   useMatch,
   useNavigate,
   useParams,
-  useSearch,
 } from "@tanstack/react-router";
 import { KEYS } from "../lib/query-keys";
 import { readCachedTaskBranch } from "../lib/read-cached-task-branch";
-import { useTaskActions } from "../hooks/use-tasks";
+import { setIntendedTaskMeta } from "../lib/intended-task-meta";
 import { useOrganizationSettingsSuspense } from "../hooks/use-organization-settings";
 import { useOrgSsoStatus } from "../hooks/use-org-sso";
 import { SsoRequiredScreen } from "../components/sso-required-screen";
@@ -65,14 +64,12 @@ function ShellProjectProvider({
 export function usePanelActions() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const taskActions = useTaskActions();
   const { locator } = useProjectContext();
 
   const params = useParams({ strict: false }) as {
     org?: string;
     taskId?: string;
   };
-  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
   const orgSlug = params.org ?? "";
   const currentTaskId = params.taskId ?? "";
 
@@ -115,23 +112,15 @@ export function usePanelActions() {
       false,
     );
 
-  // Create a new task carrying the current task's branch (if any) so the
-  // new thread lands on the same warm sandbox. Server picks from vmMap when
-  // no branch is provided. Awaiting the create avoids the route loader's
-  // create-on-404 fallback firing without a branch hint.
+  // Lazy "+ New chat" — navigates to a fresh id without creating a row.
+  // The chat-context's sendMessage path creates the thread on the first user
+  // message, picking up the carried branch from the intended-task-meta store
+  // so the new thread lands on the same warm sandbox.
   const createNewTask = async () => {
     const newId = crypto.randomUUID();
     const branch = readCachedTaskBranch(queryClient, locator, currentTaskId);
-    const targetVmcp = search.virtualmcpid;
-    try {
-      await taskActions.create.mutateAsync({
-        id: newId,
-        ...(targetVmcp ? { virtual_mcp_id: targetVmcp } : {}),
-        ...(branch ? { branch } : {}),
-      });
-    } catch {
-      // Toast already fired by useCollectionActions; navigate anyway so the
-      // route loader's ensure-fallback can retry.
+    if (branch) {
+      setIntendedTaskMeta(newId, { branch });
     }
     setTaskId(newId);
   };

--- a/apps/mesh/src/web/lib/intended-task-meta.ts
+++ b/apps/mesh/src/web/lib/intended-task-meta.ts
@@ -1,0 +1,41 @@
+/**
+ * Intended task meta — module-level Map keyed by taskId, holding metadata
+ * (currently the carried branch) for not-yet-created threads.
+ *
+ * Threads are created lazily on the first user message so empty page-load
+ * navigations don't flood the task list. When a "+ New chat" entry point
+ * outside the chat context (panel/toolbar) navigates to a fresh task id, it
+ * stashes the source task's branch here so the eventual lazy create lands on
+ * the same warm sandbox.
+ *
+ * Cleared by sendMessage's create path on success and on lazy-create failure.
+ */
+
+interface IntendedTaskMeta {
+  branch: string | null;
+}
+
+const STORE = new Map<string, IntendedTaskMeta>();
+
+export function setIntendedTaskMeta(
+  taskId: string,
+  meta: IntendedTaskMeta,
+): void {
+  if (!taskId) return;
+  if (!meta.branch) {
+    STORE.delete(taskId);
+    return;
+  }
+  STORE.set(taskId, meta);
+}
+
+export function getIntendedTaskMeta(
+  taskId: string,
+): IntendedTaskMeta | undefined {
+  if (!taskId) return undefined;
+  return STORE.get(taskId);
+}
+
+export function clearIntendedTaskMeta(taskId: string): void {
+  STORE.delete(taskId);
+}


### PR DESCRIPTION
## What is this contribution about?

Every navigation to the home page (`/$org`) — and every click of "+ New chat" in the panel/sidebar/toolbar — was eagerly inserting a thread row, flooding the task list with empty conversations the user never engaged with. After this change, threads only persist when the user actually sends their first message: `useEnsureTask` just reads, and `sendMessage` lazily creates the row through a silent `ensureTaskExists` mutation. Warm-sandbox branch carry-over is preserved via a new module-level intent store (`intended-task-meta.ts`) for cross-tree entry points and an in-context override map for the branch picker on not-yet-created threads. The PostHog `chat_started` event still fires from the same `COLLECTION_THREADS_CREATE` tool call, just at first-send time instead of page-load time.

## How to Test

1. Visit `/$org` — the URL should redirect to `/$org/$randomId` and the task list should NOT show a new entry.
2. Type a message and send it — the thread should now appear in the task list with the user's message.
3. Click "+ New chat" while in an existing chat with a branch — navigate but stay out of the task list until you send.
4. Confirm in PostHog that `chat_started` fires once on first send (with `created_via: \"tool\"`).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`bun run check`, `bun run lint`, `bun test apps/mesh/src/web/...`, `bun run --cwd=apps/mesh build:client`)
- [x] No breaking changes (server thread API unchanged; idempotent INSERT covers any race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create chat threads lazily on the first user message instead of on page load or “+ New chat”, preventing empty threads from cluttering the task list while preserving warm-sandbox branch carry-over. PostHog `chat_started` still fires on first send via the same backend tool.

- **New Features**
  - Lazy thread creation: `sendMessage` calls `COLLECTION_THREADS_CREATE` only on first send.
  - Read-only `useEnsureTask`: now returns `Task | null` without creating rows.
  - Branch carry-over maintained via a module-level `intended-task-meta` store and an in-context override for not-yet-created threads.
  - UX tweak: loading copy changed to “Loading task…” while fetching.
  - Server path remains idempotent; cache is selectively invalidated on creation.

- **Refactors**
  - Removed eager creates from home redirect, sidebar, toolbar, and layout “+ New chat” flows; they now navigate only and set intended branch when present.
  - Centralized creation logic in chat-context with a silent `ensureTaskExists` mutation.
  - Simplified `use-ensure-task` signature to `(id)` and eliminated the “creating” state.
  - Retired `useTaskActions().create` usage for threads; legacy task-list cache invalidations are handled in chat-context.

<sup>Written for commit a2b55c8c8dd87db3d3a5465f53c7bae6d5bbc402. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

