### PR TITLE
fix(decopilot): inject current date into base system prompt

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -17,9 +17,14 @@ export const SUBAGENT_EXCLUDED_TOOLS = ["user_ask", "subtask"];
  * Covers: platform concepts, tool usage, default workflow, safety, output style.
  */
 export function buildBasePlatformPrompt(): string {
+  const now = new Date();
+  const currentDate = now.toISOString().split("T")[0];
+
   return `<platform>
 You are an AI agent running on Deco CMS — a control plane for connecting
 AI agents to external services via the Model Context Protocol (MCP).
+
+Current date: ${currentDate}
 
 Building blocks:
 - **Connections** — tool providers that connect to external services


### PR DESCRIPTION
## Summary
- Injects the current date (`YYYY-MM-DD`) into the shared base platform prompt via `Date.now()`
- Fixes tools occasionally using the wrong year due to lack of temporal context in the system prompt

## Test plan
- [ ] Verify the system prompt includes `Current date: YYYY-MM-DD` in a new chat session
- [ ] Confirm date-sensitive tool calls (e.g. web search, scheduling) use the correct year

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject the current date (YYYY-MM-DD) into the Decopilot base system prompt to give tools temporal context and stop wrong-year usage.

- **Bug Fixes**
  - Add “Current date: YYYY-MM-DD” to the shared base prompt using `toISOString()` from `Date`.
  - Improves accuracy for date-sensitive tools (e.g., web search, scheduling).

<sup>Written for commit 32aa77005393bac7c307d3e4fb27ec8e7ab12988. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

