### PR TITLE
feat(home): replace self-healing banner with tile, rename Site Editor

### DIFF
--- a/apps/mesh/src/monitoring/query-engine.test.ts
+++ b/apps/mesh/src/monitoring/query-engine.test.ts
@@ -95,10 +95,17 @@ describe("createMonitoringEngine", () => {
     },
   );
 
-  it("should use DEFAULT_LOGS_DIR when no basePath", async () => {
-    const { source } = await createMonitoringEngine({});
-    expect(source).toContain("deco/logs");
-  });
+  it.skipIf(!duckdbAvailable)(
+    "should use DEFAULT_LOGS_DIR when no basePath",
+    async () => {
+      const { engine, source } = await createMonitoringEngine({});
+      try {
+        expect(source).toContain("deco/logs");
+      } finally {
+        await engine.destroy?.();
+      }
+    },
+  );
 
   it("should create ClickHouseClientEngine when clickhouseUrl is set", async () => {
     const { engine, source } = await createMonitoringEngine({

--- a/apps/mesh/src/monitoring/query-engine.ts
+++ b/apps/mesh/src/monitoring/query-engine.ts
@@ -29,7 +29,9 @@ export class DuckDBEngine implements QueryEngine {
   constructor() {
     this.connectionPromise = import("@duckdb/node-api").then(
       async ({ DuckDBInstance }) => {
-        const instance = await DuckDBInstance.create();
+        const { cpus } = await import("node:os");
+        const threads = String(Math.max(1, cpus().length));
+        const instance = await DuckDBInstance.create("", { threads });
         return instance.connect();
       },
     );

--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -342,6 +342,7 @@ export function AgentAvatar({
     return (
       <AgentAvatarImage
         url={parsed.url}
+        color={parsed.color}
         name={name}
         size={size}
         className={className}
@@ -377,19 +378,26 @@ export function AgentAvatar({
 // Image sub-component (handles load errors)
 // ---------------------------------------------------------------------------
 
+const URL_COLOR_BG: Record<string, string> = {
+  "brand-green": "bg-[var(--brand-green-light)]",
+};
+
 function AgentAvatarImage({
   url,
+  color,
   name,
   size = "md",
   className,
 }: {
   url: string;
+  color?: string;
   name: string;
   size?: AgentAvatarSize;
   className?: string;
 }) {
   const [errored, setErrored] = useState(false);
   const sizeConfig = SIZES[size];
+  const bgClass = color ? (URL_COLOR_BG[color] ?? "") : "";
 
   if (errored) {
     const { IconComp: FallbackIcon, color: fallbackColor } =
@@ -420,6 +428,7 @@ function AgentAvatarImage({
       className={cn(
         sizeConfig.container,
         sizeConfig.radius,
+        bgClass,
         "shrink-0 overflow-hidden",
         className,
       )}
@@ -431,7 +440,10 @@ function AgentAvatarImage({
       <img
         src={url}
         alt={name}
-        className="h-full w-full object-cover"
+        className={cn(
+          "h-full w-full",
+          bgClass ? "object-contain p-3" : "object-cover",
+        )}
         onError={() => setErrored(true)}
       />
     </div>

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -31,10 +31,8 @@ import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnost
 import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-modal.tsx";
 import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
 import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-healing-repo-flow.tsx";
-import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
-import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { Suspense, useState } from "react";
 import { track } from "@/web/lib/posthog-client";
 
@@ -188,7 +186,6 @@ function AgentsListContent() {
   const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
   const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
   const [selfHealingOpen, setSelfHealingOpen] = useState(false);
-  const [preferences] = usePreferences();
   const navigateToAgent = useNavigateToAgent();
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
@@ -202,6 +199,9 @@ function AgentsListContent() {
   )!;
   const aiResearchAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "ai-research",
+  )!;
+  const selfHealingStorefrontAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "self-healing-storefront",
   )!;
 
   const recentIds = readRecentAgentIds(locator);
@@ -255,28 +255,6 @@ function AgentsListContent() {
 
   return (
     <>
-      {preferences.experimental_vibecode && (
-        <div className="w-full flex justify-center mb-4">
-          <button
-            type="button"
-            onClick={() => setSelfHealingOpen(true)}
-            className="w-full max-w-[560px] flex items-center gap-3 rounded-xl border border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent px-4 py-3 text-left transition-colors hover:border-primary/50 hover:from-primary/15 cursor-pointer group"
-          >
-            <div className="size-10 rounded-lg bg-primary/15 flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <GitHubIcon className="size-5 text-primary" />
-            </div>
-            <div className="flex flex-col min-w-0 flex-1">
-              <span className="text-sm font-medium text-foreground leading-tight">
-                Set up self-healing repo
-              </span>
-              <span className="text-xs text-muted-foreground line-clamp-2">
-                Connect GitHub and add specialist monitors that open issues
-                automatically.
-              </span>
-            </div>
-          </button>
-        </div>
-      )}
       <div className="w-full max-md:overflow-x-auto max-md:[scrollbar-width:none] max-md:[&::-webkit-scrollbar]:hidden">
         <div className="flex flex-wrap justify-center gap-1.5 max-md:flex-nowrap max-md:justify-start md:max-h-52 md:overflow-hidden">
           <AgentPreview
@@ -285,6 +263,16 @@ function AgentsListContent() {
             onSpecialClick={() => setImportDecoOpen(true)}
             tracking={{
               template_id: siteEditorAgent.id,
+              tile_kind: "template",
+              action: "open_modal",
+            }}
+          />
+          <AgentPreview
+            key={selfHealingStorefrontAgent.id}
+            agent={selfHealingStorefrontAgent}
+            onSpecialClick={() => setSelfHealingOpen(true)}
+            tracking={{
+              template_id: selfHealingStorefrontAgent.id,
               tile_kind: "template",
               action: "open_modal",
             }}

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -33,6 +33,7 @@ import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recrui
 import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-healing-repo-flow.tsx";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { Suspense, useState } from "react";
 import { track } from "@/web/lib/posthog-client";
 
@@ -186,6 +187,7 @@ function AgentsListContent() {
   const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
   const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
   const [selfHealingOpen, setSelfHealingOpen] = useState(false);
+  const [preferences] = usePreferences();
   const navigateToAgent = useNavigateToAgent();
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
@@ -267,16 +269,18 @@ function AgentsListContent() {
               action: "open_modal",
             }}
           />
-          <AgentPreview
-            key={selfHealingStorefrontAgent.id}
-            agent={selfHealingStorefrontAgent}
-            onSpecialClick={() => setSelfHealingOpen(true)}
-            tracking={{
-              template_id: selfHealingStorefrontAgent.id,
-              tile_kind: "template",
-              action: "open_modal",
-            }}
-          />
+          {preferences.experimental_vibecode && (
+            <AgentPreview
+              key={selfHealingStorefrontAgent.id}
+              agent={selfHealingStorefrontAgent}
+              onSpecialClick={() => setSelfHealingOpen(true)}
+              tracking={{
+                template_id: selfHealingStorefrontAgent.id,
+                tile_kind: "template",
+                action: "open_modal",
+              }}
+            />
+          )}
           <AgentPreview
             key={siteDiagnosticsAgent.id}
             agent={existingDiagnostics ?? siteDiagnosticsAgent}

--- a/apps/mesh/src/web/components/integration-icon.tsx
+++ b/apps/mesh/src/web/components/integration-icon.tsx
@@ -57,8 +57,8 @@ export function IntegrationIcon({
   className,
   fallbackIcon,
 }: IntegrationIconProps) {
-  // Delegate icon:// URLs to AgentAvatar for colored-icon rendering
-  if (icon?.startsWith("icon://")) {
+  // Delegate icon:// and URL-with-color to AgentAvatar for colored rendering
+  if (icon?.startsWith("icon://") || icon?.includes("#agentcolor=")) {
     return (
       <AgentAvatar
         icon={icon}

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -373,7 +373,10 @@ function PinAgentPopoverContent({
   const filteredTemplates = WELL_KNOWN_AGENT_TEMPLATES.filter(
     (t) =>
       (!search || t.title.toLowerCase().includes(lowerSearch)) &&
-      !(t.id === "studio-pack" && studioPackInstalled),
+      !(t.id === "studio-pack" && studioPackInstalled) &&
+      !(
+        t.id === "self-healing-storefront" && !preferences.experimental_vibecode
+      ),
   );
 
   // Find existing recruited Site Diagnostics agent

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -412,7 +412,9 @@ function PinAgentPopoverContent({
   const handleTemplateClick = (templateId: string) => {
     onClose();
     setSearch("");
-    if (templateId === "site-editor") {
+    if (templateId === "self-healing-storefront") {
+      onOpenSelfHealing();
+    } else if (templateId === "site-editor") {
       onOpenImportDeco();
     } else if (templateId === "site-diagnostics") {
       if (existingDiagnostics) {
@@ -444,31 +446,6 @@ function PinAgentPopoverContent({
 
       {/* Scrollable content */}
       <div className="overflow-y-auto flex-1 min-h-0 px-3 pb-3">
-        {/* Self-healing repo — featured */}
-        {preferences.experimental_vibecode && (
-          <button
-            type="button"
-            onClick={() => {
-              onOpenSelfHealing();
-              onClose();
-            }}
-            className="mt-3 w-full flex items-center gap-3 rounded-xl border border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent px-3 py-3 text-left transition-colors hover:border-primary/50 hover:from-primary/15 cursor-pointer group"
-          >
-            <div className="w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <GitHubIcon className="size-5 text-primary" />
-            </div>
-            <div className="flex flex-col min-w-0 flex-1">
-              <span className="text-sm font-medium text-foreground leading-tight">
-                Set up self-healing repo
-              </span>
-              <span className="text-xs text-muted-foreground line-clamp-2">
-                Connect GitHub and add specialist monitors that open issues
-                automatically.
-              </span>
-            </div>
-          </button>
-        )}
-
         {/* Agents section */}
         <div className="px-1 pt-3 pb-2">
           <span className="text-xs font-medium text-muted-foreground">
@@ -492,27 +469,6 @@ function PinAgentPopoverContent({
             </div>
             <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
               Create new
-            </span>
-          </button>
-
-          <button
-            type="button"
-            onClick={() => {
-              track("agent_import_clicked", { source: "deco_cx" });
-              onOpenImportDeco();
-              onClose();
-            }}
-            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group"
-          >
-            <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <img
-                src="/logos/deco%20logo.svg"
-                alt="deco.cx"
-                className="size-5"
-              />
-            </div>
-            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-              Import deco.cx
             </span>
           </button>
 

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -310,9 +310,15 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
   {
     id: "site-editor",
     appId: "deco/site-editor",
-    title: "Site Editor",
-    icon: "icon://Globe01?color=violet",
+    title: "deco Site Editor",
+    icon: "/logos/deco%20logo.svg#agentcolor=brand-green",
     type: "registry-agent" as const,
+  },
+  {
+    id: "self-healing-storefront",
+    title: "Self-healing Storefront",
+    icon: "icon://Zap?color=amber",
+    type: "builtin-agent" as const,
   },
   {
     id: "site-diagnostics",


### PR DESCRIPTION
## What is this contribution about?

Replaces the experimental "Set up self-healing repo" full-width banner (gated behind `experimental_vibecode`) on the home page and inside the `+` popover with proper first-class agent tiles. Renames "Site Editor" to "deco Site Editor" with the deco logo and brand-green background, and removes the redundant "Import deco.cx" shortcut button from the `+` popover (the import flow is still reachable via the deco Site Editor template tile).

## Screenshots/Demonstration

> UI changes — see tile grid on home page and agent templates section of `+` popover.

## How to Test

1. Open the home page — confirm no self-healing banner; confirm "deco Site Editor" tile shows deco logo with green bg and "Self-healing Storefront" tile appears next to it
2. Click "Self-healing Storefront" — should open the GitHub repo picker flow
3. Click "deco Site Editor" — should open the Import deco.cx dialog
4. Open the `+` popover — confirm no banner, no "Import deco.cx" shortcut button; "Self-healing Storefront" appears in the Agent templates grid

## Migration Notes

No migrations required.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the self-healing banner with a first-class “Self-healing Storefront” tile on Home and in the + popover, gated behind `experimental_vibecode`. Renamed “Site Editor” to “deco Site Editor” with a branded icon, removed the “Import deco.cx” shortcut, and fixed DuckDB thread handling in CI.

- **New Features**
  - Added “Self-healing Storefront” template tile that opens the GitHub repo picker flow; visible only when `experimental_vibecode` is enabled.
  - Renamed “Site Editor” → “deco Site Editor” and switched to `/logos/deco%20logo.svg#agentcolor=brand-green`.
  - Extended `AgentAvatar` to support `#agentcolor=` on image URLs; `IntegrationIcon` now delegates icon URLs with `#agentcolor=` or `icon://` to it.
  - Updated the + popover: clicking “Self-healing Storefront” opens the flow; removed the banner and the “Import deco.cx” shortcut.

- **Bug Fixes**
  - Ensure DuckDB uses at least 1 thread in CI; gated the DEFAULT_LOGS_DIR test behind availability and cleaned up the engine to avoid leaked rejections.

<sup>Written for commit 20f26c849f2b0b255918ada7041cefc38f1b2ab5. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

