### PR TITLE
fix(mesh): forward POSTHOG_KEY/POSTHOG_HOST to worker subprocesses

### DIFF
--- a/apps/mesh/src/cli/build-child-env.ts
+++ b/apps/mesh/src/cli/build-child-env.ts
@@ -83,6 +83,10 @@ export function buildChildEnv(
     // Browserless
     BROWSERLESS_TOKEN: process.env.BROWSERLESS_TOKEN,
 
+    // PostHog analytics (server-side capture + exposed to UI via /api/config)
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+
     // TLS: propagate custom CA certificates (e.g. RDS CA bundles)
     NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,
 


### PR DESCRIPTION
## What is this contribution about?

`/api/config` was intermittently returning `posthog: null` in production. Root cause: when the server runs with `--num-threads N`, `buildChildEnv` (apps/mesh/src/cli/build-child-env.ts) explicitly allowlists which env vars get forwarded to worker subprocesses, and `POSTHOG_KEY` / `POSTHOG_HOST` weren't on the list — so ~75% of requests (load-balanced via SO_REUSEPORT to workers) saw `process.env.POSTHOG_KEY` as undefined and `buildPosthogConfig()` returned `null`. Server-side PostHog capture from workers was also silently disabled. This adds both vars to the allowlist.

## How to Test
1. Deploy and hit `GET /api/config` ~10 times against a pod running with `--num-threads > 1`.
2. Every response should include `posthog: { key, host }` (previously ~75% returned `null`).
3. Verify worker processes can also send server-side PostHog events.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward `POSTHOG_KEY` and `POSTHOG_HOST` to worker subprocesses so `/api/config` consistently returns PostHog config and server-side capture works with `--num-threads`.

- **Bug Fixes**
  - Workers were missing PostHog env vars due to `buildChildEnv` allowlist.
  - Added both vars to the allowlist in `apps/mesh/src/cli/build-child-env.ts`.
  - Fixes intermittent `posthog: null` responses and restores worker capture.

<sup>Written for commit f46f7c117a5e09d358705966eff02a68362b4cb5. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3207">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

