### PR TITLE
fix(mesh): drop legacy options from agent layout main view dropdown

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -611,8 +611,15 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   const serverDefaultMainKey = (() => {
     if (!serverDefaultMain || serverDefaultMain.type === "chat") return "chat";
-    // Legacy: "settings" used to be its own tab; map onto Layout.
-    if (serverDefaultMain.type === "settings") return "layout";
+    // Legacy: instructions/connections/layout were separate tabs that have
+    // since been unified into the Settings tab.
+    if (
+      serverDefaultMain.type === "instructions" ||
+      serverDefaultMain.type === "connections" ||
+      serverDefaultMain.type === "layout"
+    ) {
+      return "settings";
+    }
     if (fixedTabTypeSet.has(serverDefaultMain.type)) {
       return serverDefaultMain.type;
     }
@@ -846,9 +853,8 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
   // matching the gating in main-panel-tabs/index.tsx.
   const defaultMainOptions: { value: string; label: string }[] = [
     { value: "chat", label: "Chat" },
-    { value: "instructions", label: "Instructions" },
-    { value: "connections", label: "Connections" },
-    { value: "layout", label: "Layout" },
+    { value: "settings", label: "Settings" },
+    { value: "automations", label: "Automations" },
   ];
   if (hasGithubRepo) {
     defaultMainOptions.push({ value: "env", label: "Terminal" });


### PR DESCRIPTION
## Summary
- The agent settings → Layout → **Main view** dropdown was still listing **Instructions**, **Connections**, and **Layout** — leftovers from the old UI where these were separate top-level views. They now all live inside **Settings**, so the options were stale and (because they're not in `FIXED_SYSTEM_TABS`) silently saved as `null`.
- Replaced those three with **Settings** and **Automations**. The dropdown now shows: Chat, Settings, Automations, Terminal/Preview (when an active GitHub repo is linked), plus each pinned view. Non-pinned views are intentionally excluded.
- Updated `serverDefaultMainKey` so any agent whose stored `defaultMainView.type` is `instructions`, `connections`, or `layout` resolves to `settings` in the dropdown (instead of dangling on a no-longer-listed value). Removed the obsolete inverse `settings → layout` mapping.

## Test plan
- [ ] Open an agent's Settings → Layout. Confirm the Main view dropdown lists only: Chat, Settings, Automations, and any pinned views.
- [ ] On a GitHub-linked agent, confirm Terminal and Preview also appear.
- [ ] Pin/unpin a view in the Pinned views list and confirm it appears/disappears in the dropdown.
- [ ] Open an agent that previously had Instructions/Connections/Layout selected as the default main view and confirm the dropdown now shows Settings.
- [ ] `bun run --cwd=apps/mesh check` and `bun run fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed legacy options from the agent Settings → Layout → Main view dropdown and added the current views. Old saved values now resolve to Settings, preventing null defaults.

- **Bug Fixes**
  - Replaced "Instructions," "Connections," and "Layout" with "Settings" and "Automations" in the Main view dropdown.
  - Kept "Terminal" and "Preview" gated behind an active GitHub repo; only pinned views appear.
  - Mapped stored defaults of type `instructions`, `connections`, or `layout` to `settings` and removed the old `settings → layout` mapping.

<sup>Written for commit a8bde113aa906317498cba38d1844abc9417a17e. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

