### PR TITLE
fix(mesh): show pinned view labels with proper case in tab bar

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -89,6 +89,7 @@ import { VirtualMcpFormSchema, type VirtualMcpFormData } from "./types";
 import { VirtualMCPShareModal } from "./virtual-mcp-share-modal";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { FIXED_SYSTEM_TABS } from "@/web/layouts/main-panel-tabs/tab-id";
+import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
 
 type DialogState = {
   shareDialogOpen: boolean;
@@ -787,7 +788,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
         {
           connectionId,
           toolName,
-          label: toolName.replace(/_/g, " "),
+          label: toTitleCase(toolName),
           icon: null,
         },
       ];
@@ -1012,7 +1013,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
                                   value={
                                     pinned && pinnedView
                                       ? pinnedView.label
-                                      : tool.name.replace(/_/g, " ")
+                                      : toTitleCase(tool.name)
                                   }
                                   onChange={(e) =>
                                     handleLabelChange(
@@ -1022,7 +1023,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
                                     )
                                   }
                                   onBlur={handleLabelBlur}
-                                  className="h-7 text-sm w-40 capitalize"
+                                  className="h-7 text-sm w-40"
                                   disabled={!pinned || isSaving}
                                   readOnly={!pinned}
                                 />


### PR DESCRIPTION
## Summary
- The Pinned views label input in agent settings used the CSS `capitalize` class, which visually title-cases the displayed string without modifying the stored value. The default label was being generated as `toolName.replace(/_/g, " ")` (e.g. `"slide maker"`), so the input *looked* like "Slide Maker" while the saved data was lowercase.
- The top-bar tab renders the raw `pv.label`, so it showed the lowercase value — settings and the top bar disagreed.
- Default new pin labels through the existing `toTitleCase` helper (so `slide_maker` → `Slide Maker`) and drop the misleading `capitalize` CSS so the input is WYSIWYG.
- Existing pins keep whatever label is already stored; users can re-edit the input to update them.

## Test plan
- [ ] In agent settings → Layout → Pinned views, toggle a tool on for the first time. The input should show its name in Title Case (e.g. "Slide Maker"), and the same string should appear in the top-bar tab.
- [ ] Type a custom label (e.g. all lowercase, or all caps). After blur, the input keeps your exact casing and the top bar matches.
- [ ] Pre-existing pins with lowercase labels still render with their stored value (no surprise rename); editing the field saves whatever you type.
- [ ] `bun run --cwd=apps/mesh check` and `bun run fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned view labels now show the same casing in settings and in the top-bar tabs. New labels default to proper Title Case and the input is WYSIWYG.

- **Bug Fixes**
  - Default new pin labels with `toTitleCase(tool.name)` (e.g., `slide_maker` → "Slide Maker").
  - Removed the `capitalize` CSS class so the input shows the actual stored value.
  - Existing pins keep their saved labels; users can edit to change casing.

<sup>Written for commit 0e9fc648a6d033f215e76c94cc8402948fc192f3. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3209?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

