### PR TITLE
fix(sidebar): open recruit modal for ai-image / ai-research templates

### DIFF
--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -76,6 +76,8 @@ import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-hea
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
+import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-modal.tsx";
+import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
 import { useTaskActions } from "@/web/hooks/use-tasks";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
 
@@ -342,6 +344,8 @@ function PinAgentPopoverContent({
   onOpenDiagnosticsModal,
   onOpenLeanCanvasModal,
   onOpenStudioPackModal,
+  onOpenAiImageModal,
+  onOpenAiResearchModal,
 }: {
   onClose: () => void;
   onOpenImportDeco: () => void;
@@ -350,6 +354,8 @@ function PinAgentPopoverContent({
   onOpenDiagnosticsModal: () => void;
   onOpenLeanCanvasModal: () => void;
   onOpenStudioPackModal: () => void;
+  onOpenAiImageModal: () => void;
+  onOpenAiResearchModal: () => void;
 }) {
   const [search, setSearch] = useState("");
   const allAgents = useVirtualMCPs();
@@ -403,6 +409,32 @@ function PinAgentPopoverContent({
       )
     : undefined;
 
+  const aiImageTemplate = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "ai-image",
+  );
+  const existingAiImage = aiImageTemplate
+    ? allAgents.find(
+        (a): a is typeof a & { id: string } =>
+          a.id !== null &&
+          ((a as { metadata?: { type?: string } }).metadata?.type ===
+            aiImageTemplate.id ||
+            a.title === aiImageTemplate.title),
+      )
+    : undefined;
+
+  const aiResearchTemplate = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "ai-research",
+  );
+  const existingAiResearch = aiResearchTemplate
+    ? allAgents.find(
+        (a): a is typeof a & { id: string } =>
+          a.id !== null &&
+          ((a as { metadata?: { type?: string } }).metadata?.type ===
+            aiResearchTemplate.id ||
+            a.title === aiResearchTemplate.title),
+      )
+    : undefined;
+
   const handleSelect = (agent: VirtualMCPEntity) => {
     if (!isPinned(agent.id)) {
       pin(agent.id);
@@ -430,6 +462,18 @@ function PinAgentPopoverContent({
         navigateToAgent(existingLeanCanvas.id);
       } else {
         onOpenLeanCanvasModal();
+      }
+    } else if (templateId === "ai-image") {
+      if (existingAiImage) {
+        navigateToAgent(existingAiImage.id);
+      } else {
+        onOpenAiImageModal();
+      }
+    } else if (templateId === "ai-research") {
+      if (existingAiResearch) {
+        navigateToAgent(existingAiResearch.id);
+      } else {
+        onOpenAiResearchModal();
       }
     } else if (templateId === "studio-pack") {
       onOpenStudioPackModal();
@@ -572,6 +616,8 @@ function PinAgentPopover() {
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
+  const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
+  const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
   const isMobile = useIsMobile();
   const { setOpenMobile } = useSidebar();
 
@@ -602,6 +648,8 @@ function PinAgentPopover() {
         onOpenDiagnosticsModal={() => setDiagnosticsModalOpen(true)}
         onOpenLeanCanvasModal={() => setLeanCanvasModalOpen(true)}
         onOpenStudioPackModal={() => setStudioPackModalOpen(true)}
+        onOpenAiImageModal={() => setAiImageModalOpen(true)}
+        onOpenAiResearchModal={() => setAiResearchModalOpen(true)}
       />
     </Suspense>
   );
@@ -681,6 +729,14 @@ function PinAgentPopover() {
       <StudioPackRecruitModal
         open={studioPackModalOpen}
         onOpenChange={setStudioPackModalOpen}
+      />
+      <AiImageRecruitModal
+        open={aiImageModalOpen}
+        onOpenChange={setAiImageModalOpen}
+      />
+      <AiResearchRecruitModal
+        open={aiResearchModalOpen}
+        onOpenChange={setAiResearchModalOpen}
       />
     </>
   );

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -414,11 +414,9 @@ function PinAgentPopoverContent({
   );
   const existingAiImage = aiImageTemplate
     ? allAgents.find(
-        (a): a is typeof a & { id: string } =>
-          a.id !== null &&
-          ((a as { metadata?: { type?: string } }).metadata?.type ===
-            aiImageTemplate.id ||
-            a.title === aiImageTemplate.title),
+        (a) =>
+          (a as { metadata?: { type?: string } }).metadata?.type ===
+          aiImageTemplate.id,
       )
     : undefined;
 
@@ -427,11 +425,9 @@ function PinAgentPopoverContent({
   );
   const existingAiResearch = aiResearchTemplate
     ? allAgents.find(
-        (a): a is typeof a & { id: string } =>
-          a.id !== null &&
-          ((a as { metadata?: { type?: string } }).metadata?.type ===
-            aiResearchTemplate.id ||
-            a.title === aiResearchTemplate.title),
+        (a) =>
+          (a as { metadata?: { type?: string } }).metadata?.type ===
+          aiResearchTemplate.id,
       )
     : undefined;
 


### PR DESCRIPTION
## What is this contribution about?

Clicking the **Image Creator** or **Web Researcher** templates in the sidebar "+" popover threw `Failed to create item: Error: Virtual MCP not found: ai-research` (and the equivalent for `ai-image`). The popover's `handleTemplateClick` only had branches for the older templates and fell through to `navigateToNewTask(templateId)`, which tried to start a thread using the template id as a vMCP id. This wires `ai-image` and `ai-research` to their existing recruit modals (already used on the home view), so first click opens the dialog and subsequent clicks navigate to the recruited agent.

## Screenshots/Demonstration

Before: error toast `Virtual MCP not found: ai-research`. After: the recruit modal opens.

## How to Test

1. Open the sidebar "+" popover.
2. Click **Image Creator** — the AI Image recruit modal opens (no error toast).
3. Click **Web Researcher** — the AI Research recruit modal opens.
4. Recruit one, reopen the popover, click the same template — it now navigates to the existing agent.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar “+” popover for Image Creator and Web Researcher by opening their recruit modals instead of failing with “Virtual MCP not found.” After recruiting, subsequent clicks navigate to the existing agent.

- **Bug Fixes**
  - Add branches for `ai-image` and `ai-research` in the template click handler to open recruit modals or navigate if already recruited.
  - Detect existing agents by `metadata.type` only (removed title fallback) to avoid matching unrelated agents.
  - Import and render `AiImageRecruitModal` and `AiResearchRecruitModal`; add open state and wiring in the popover.

<sup>Written for commit d237505b3c7013a5b0e7536eccce0d4b51b7df06. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3210?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

