### PR TITLE
feat(sandbox): static skills mount, v1 pptx reading, polymorphic view tool

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -35,8 +35,8 @@ import { createReadPromptTool } from "./prompts";
 import { createReadResourceTool } from "./resources";
 import { createSandboxTool, type VirtualClient } from "./sandbox";
 import { createVmTools } from "./vm-tools";
-import { getRunnerByKind } from "@/sandbox/lifecycle";
-import type { RunnerKind } from "@decocms/sandbox/runner";
+import { getSharedRunner } from "@/sandbox/lifecycle";
+import { ensureVmForBranch } from "@/tools/vm/start";
 import { createSubtaskTool } from "./subtask";
 import { userAskTool } from "./user-ask";
 import { proposePlanTool } from "./propose-plan";
@@ -48,9 +48,15 @@ import { createInspectPageTool } from "./inspect-page";
 import type { ModelsConfig } from "../types";
 import type { MeshProvider } from "@/ai-providers/types";
 
-export type ActiveVm = {
-  runnerKind: RunnerKind;
-  vmId: string;
+/**
+ * Identifies the (virtual MCP, branch, user) tuple that the built-in VM
+ * tools should bind to. Provisioning is lazy — the VM is only ensured on
+ * the first VM-tool invocation.
+ */
+export type VmContext = {
+  virtualMcpId: string;
+  branch: string;
+  userId: string;
 };
 
 export interface BuiltinToolParams {
@@ -71,11 +77,12 @@ export interface BuiltinToolParams {
    */
   pendingImages: PendingImage[];
   /**
-   * When set, VM file tools replace the QuickJS sandbox tool. Provisioning
-   * already happened in `VM_START` — tools read the handle directly from
-   * the vmMap entry.
+   * When set, the six VM file tools (view/write/edit/grep/glob/bash) are
+   * registered with a memoized lazy provisioner: the first tool call
+   * triggers `ensureVmForBranch`, subsequent calls reuse the same handle.
+   * When null, no VM-backed code execution tool is included.
    */
-  activeVm?: ActiveVm | null;
+  vmContext?: VmContext | null;
 }
 
 export type { PendingImage };
@@ -101,7 +108,7 @@ async function buildAllTools(
     toolOutputMap,
     pendingImages,
     passthroughClient,
-    activeVm,
+    vmContext,
   } = params;
   const approvalOpts = { isPlanMode };
   const tools: Record<string, unknown> = {
@@ -129,31 +136,42 @@ async function buildAllTools(
       toolOutputMap,
     }),
   };
-  // VM file tools — same six LLM-visible tools across runners (schemas in
-  // vm-tools/schemas.ts). Dispatch resolves through `getRunnerByKind` so
-  // the entry's recorded runnerKind drives the routing, regardless of the
-  // current MESH_SANDBOX_RUNNER env value. When no entry exists, fall back
-  // to the QuickJS `sandbox` tool — VM_START must run first for file tools.
+  // VM file tools — six LLM-visible tools (read/write/edit/grep/glob/bash)
+  // always registered when a vmContext is provided. The handle is resolved
+  // lazily on the first tool invocation: `ensureVmForBranch` either reuses
+  // the existing vmMap entry (fast path) or provisions a new sandbox via
+  // the env-selected runner. The promise is memoized on the closure so
+  // parallel first calls (e.g. the model emitting bash + read in one step)
+  // share a single provisioning round-trip.
   const vmNeedsApproval =
     toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false;
-  if (activeVm) {
-    const runner = await getRunnerByKind(ctx, activeVm.runnerKind);
-    const { vmId } = activeVm;
+  if (vmContext) {
+    const runner = await getSharedRunner(ctx);
+    let cached: Promise<string> | null = null;
+    const ensureHandle = () => {
+      if (!cached) {
+        cached = ensureVmForBranch(
+          { virtualMcpId: vmContext.virtualMcpId, branch: vmContext.branch },
+          ctx,
+        ).then((entry) => entry.vmId);
+        // Reset on failure so the next tool call retries instead of
+        // permanently caching a rejected promise.
+        cached.catch(() => {
+          cached = null;
+        });
+      }
+      return cached;
+    };
     Object.assign(
       tools,
       createVmTools({
         runner,
-        ensureHandle: () => Promise.resolve(vmId),
+        ensureHandle,
         toolOutputMap,
         needsApproval: vmNeedsApproval,
+        pendingImages,
       }),
     );
-  } else {
-    tools.sandbox = createSandboxTool({
-      passthroughClient,
-      toolOutputMap,
-      needsApproval: vmNeedsApproval,
-    });
   }
   // subtask requires a provider (LLM calls) — skip when provider is null (Claude Code)
   if (provider) {

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -77,7 +77,7 @@ export interface BuiltinToolParams {
    */
   pendingImages: PendingImage[];
   /**
-   * When set, the six VM file tools (view/write/edit/grep/glob/bash) are
+   * When set, the six VM file tools (read/write/edit/grep/glob/bash) are
    * registered with a memoized lazy provisioner: the first tool call
    * triggers `ensureVmForBranch`, subsequent calls reuse the same handle.
    * When null, no VM-backed code execution tool is included.

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/take-screenshot.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/take-screenshot.ts
@@ -41,11 +41,17 @@ export type TakeScreenshotInput = z.infer<typeof TakeScreenshotInputSchema>;
 /**
  * Pending image entry. Stored by `execute`, consumed by `prepareStep`
  * in stream-core.ts which injects it as a user message content part.
+ *
+ * One of `pageUrl` or `label` should be set; `label` takes precedence
+ * when present. Screenshots use `pageUrl` (preserving the legacy
+ * `[Screenshot of <url>]` framing); other sources (e.g. `view` loading
+ * a sandbox image) set `label` directly.
  */
 export interface PendingImage {
   url: string;
   mediaType: string;
-  pageUrl: string;
+  pageUrl?: string;
+  label?: string;
 }
 
 export function createTakeScreenshotTool(

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -1,7 +1,7 @@
 /**
  * VM File Tools — runner-agnostic.
  *
- * Registers the six LLM-visible tools (view/write/edit/grep/glob/bash) on
+ * Registers the six LLM-visible tools (read/write/edit/grep/glob/bash) on
  * top of any `SandboxRunner.proxyDaemonRequest`. All runners speak the
  * unified `/_decopilot_vm/*` surface with base64-wrapped JSON bodies
  * (Cloudflare WAF bypass; harmless 33% overhead on non-CF paths).
@@ -19,9 +19,9 @@ import {
   GREP_DESCRIPTION,
   GlobInputSchema,
   GrepInputSchema,
+  READ_DESCRIPTION,
+  ReadInputSchema,
   TOOL_APPROVAL,
-  VIEW_DESCRIPTION,
-  ViewInputSchema,
   WRITE_DESCRIPTION,
   WriteInputSchema,
 } from "./schemas";
@@ -97,12 +97,12 @@ export function createVmTools(params: VmToolsParams) {
     return daemonRequest(runner, handle, path, input);
   };
 
-  const view = tool({
-    needsApproval: approvalFor(TOOL_APPROVAL.view),
-    description: VIEW_DESCRIPTION,
-    inputSchema: zodSchema(ViewInputSchema),
+  const read = tool({
+    needsApproval: approvalFor(TOOL_APPROVAL.read),
+    description: READ_DESCRIPTION,
+    inputSchema: zodSchema(ReadInputSchema),
     execute: async (input) => {
-      const result = (await call("/_decopilot_vm/view", input)) as
+      const result = (await call("/_decopilot_vm/read", input)) as
         | { kind: "text"; content: string; lineCount: number }
         | {
             kind: "image";
@@ -175,5 +175,5 @@ export function createVmTools(params: VmToolsParams) {
     },
   });
 
-  return { view, write, edit, grep, glob, bash };
+  return { read, write, edit, grep, glob, bash };
 }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -1,7 +1,7 @@
 /**
  * VM File Tools — runner-agnostic.
  *
- * Registers the six LLM-visible tools (read/write/edit/grep/glob/bash) on
+ * Registers the six LLM-visible tools (view/write/edit/grep/glob/bash) on
  * top of any `SandboxRunner.proxyDaemonRequest`. All runners speak the
  * unified `/_decopilot_vm/*` surface with base64-wrapped JSON bodies
  * (Cloudflare WAF bypass; harmless 33% overhead on non-CF paths).
@@ -19,9 +19,9 @@ import {
   GREP_DESCRIPTION,
   GlobInputSchema,
   GrepInputSchema,
-  READ_DESCRIPTION,
-  ReadInputSchema,
   TOOL_APPROVAL,
+  VIEW_DESCRIPTION,
+  ViewInputSchema,
   WRITE_DESCRIPTION,
   WriteInputSchema,
 } from "./schemas";
@@ -89,19 +89,44 @@ async function daemonRequest(
 }
 
 export function createVmTools(params: VmToolsParams) {
-  const { runner, ensureHandle, toolOutputMap, needsApproval } = params;
+  const { runner, ensureHandle, toolOutputMap, needsApproval, pendingImages } =
+    params;
   const approvalFor = (mutating: boolean) => (mutating ? needsApproval : false);
   const call = async (path: string, input: Record<string, unknown>) => {
     const handle = await ensureHandle();
     return daemonRequest(runner, handle, path, input);
   };
 
-  const read = tool({
-    needsApproval: approvalFor(TOOL_APPROVAL.read),
-    description: READ_DESCRIPTION,
-    inputSchema: zodSchema(ReadInputSchema),
+  const view = tool({
+    needsApproval: approvalFor(TOOL_APPROVAL.view),
+    description: VIEW_DESCRIPTION,
+    inputSchema: zodSchema(ViewInputSchema),
     execute: async (input) => {
-      const result = await call("/_decopilot_vm/read", input);
+      const result = (await call("/_decopilot_vm/view", input)) as
+        | { kind: "text"; content: string; lineCount: number }
+        | {
+            kind: "image";
+            mediaType: string;
+            base64: string;
+            size: number;
+          };
+      if (result.kind === "image") {
+        // Queue the image for injection as a user message in prepareStep.
+        // Tool result is text-only — providers don't all carry images in
+        // tool result messages, but everyone supports them in user content.
+        pendingImages.push({
+          url: `data:${result.mediaType};base64,${result.base64}`,
+          mediaType: result.mediaType,
+          label: `[Image at ${input.path}]`,
+        });
+        return {
+          kind: "image" as const,
+          path: input.path,
+          mediaType: result.mediaType,
+          size: result.size,
+          message: "Image attached below.",
+        };
+      }
       return maybeTruncate(result, toolOutputMap);
     },
   });
@@ -150,5 +175,5 @@ export function createVmTools(params: VmToolsParams) {
     },
   });
 
-  return { read, write, edit, grep, glob, bash };
+  return { view, write, edit, grep, glob, bash };
 }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 
-export const ViewInputSchema = z.object({
+export const ReadInputSchema = z.object({
   path: z
     .string()
     .describe(
@@ -79,18 +79,18 @@ export const BashInputSchema = z.object({
     .describe("Timeout in milliseconds (default 30000, max 120000)"),
 });
 
-export type ViewInput = z.infer<typeof ViewInputSchema>;
+export type ReadInput = z.infer<typeof ReadInputSchema>;
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 export type EditInput = z.infer<typeof EditInputSchema>;
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 export type GlobInput = z.infer<typeof GlobInputSchema>;
 export type BashInput = z.infer<typeof BashInputSchema>;
 
-export const VIEW_DESCRIPTION =
-  "View a file. For text files, returns content with line numbers (use offset " +
+export const READ_DESCRIPTION =
+  "Read a file. For text files, returns content with line numbers (use offset " +
   "and limit for large files). For images (jpeg, png, gif, webp), the image " +
   "is injected into the next turn as a vision input — do NOT describe what " +
-  "you 'expect' to see, just call view and look at the next message. Other " +
+  "you 'expect' to see, just call read and look at the next message. Other " +
   "binary formats are not supported; use a format-specific skill " +
   "(e.g. pptx-extract for .pptx).";
 
@@ -114,9 +114,9 @@ export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
   "Working directory is the project root. Timeout default 30s, max 2min.";
 
-// view/grep/glob are non-mutating; write/edit/bash mutate.
+// read/grep/glob are non-mutating; write/edit/bash mutate.
 export const TOOL_APPROVAL = {
-  view: false,
+  read: false,
   write: true,
   edit: true,
   grep: false,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -5,15 +5,22 @@
 
 import { z } from "zod";
 
-export const ReadInputSchema = z.object({
+export const ViewInputSchema = z.object({
   path: z
     .string()
-    .describe("File path relative to project root (e.g. 'src/index.ts')"),
+    .describe(
+      "File path. Relative paths resolve against the project root (e.g. " +
+        "'src/index.ts'); absolute paths are accepted for files outside the " +
+        "project (e.g. '/home/sandbox/deck.thumbnail.jpg').",
+    ),
   offset: z
     .number()
     .optional()
-    .describe("Starting line number (1-based, default 1)"),
-  limit: z.number().optional().describe("Max lines to return (default 2000)"),
+    .describe("Starting line number for text files (1-based, default 1)"),
+  limit: z
+    .number()
+    .optional()
+    .describe("Max lines to return for text files (default 2000)"),
 });
 
 export const WriteInputSchema = z.object({
@@ -72,16 +79,20 @@ export const BashInputSchema = z.object({
     .describe("Timeout in milliseconds (default 30000, max 120000)"),
 });
 
-export type ReadInput = z.infer<typeof ReadInputSchema>;
+export type ViewInput = z.infer<typeof ViewInputSchema>;
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 export type EditInput = z.infer<typeof EditInputSchema>;
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 export type GlobInput = z.infer<typeof GlobInputSchema>;
 export type BashInput = z.infer<typeof BashInputSchema>;
 
-export const READ_DESCRIPTION =
-  "Read a file from the VM's project directory. Returns content with line numbers. " +
-  "Use offset and limit for large files.";
+export const VIEW_DESCRIPTION =
+  "View a file. For text files, returns content with line numbers (use offset " +
+  "and limit for large files). For images (jpeg, png, gif, webp), the image " +
+  "is injected into the next turn as a vision input — do NOT describe what " +
+  "you 'expect' to see, just call view and look at the next message. Other " +
+  "binary formats are not supported; use a format-specific skill " +
+  "(e.g. pptx-extract for .pptx).";
 
 export const WRITE_DESCRIPTION =
   "Write content to a file in the VM's project directory. " +
@@ -103,9 +114,9 @@ export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
   "Working directory is the project root. Timeout default 30s, max 2min.";
 
-// read/grep/glob are non-mutating; write/edit/bash mutate.
+// view/grep/glob are non-mutating; write/edit/bash mutate.
 export const TOOL_APPROVAL = {
-  read: false,
+  view: false,
   write: true,
   edit: true,
   grep: false,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/types.ts
@@ -12,7 +12,7 @@ export interface VmToolsParams {
   readonly needsApproval: boolean;
   /**
    * Shared queue for vision inputs that should be injected into the next
-   * model turn. The `view` tool pushes here when it loads an image; the
+   * model turn. The `read` tool pushes here when it loads an image; the
    * queue is flushed by `prepareStep` in stream-core.ts.
    */
   readonly pendingImages: PendingImage[];

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/types.ts
@@ -1,4 +1,5 @@
 import type { SandboxRunner } from "@decocms/sandbox/runner";
+import type { PendingImage } from "../take-screenshot";
 
 export interface VmToolsParams {
   readonly runner: SandboxRunner;
@@ -9,4 +10,10 @@ export interface VmToolsParams {
   readonly ensureHandle: () => Promise<string>;
   readonly toolOutputMap: Map<string, string>;
   readonly needsApproval: boolean;
+  /**
+   * Shared queue for vision inputs that should be injected into the next
+   * model turn. The `view` tool pushes here when it loads an image; the
+   * queue is flushed by `prepareStep` in stream-core.ts.
+   */
+  readonly pendingImages: PendingImage[];
 }

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -466,32 +466,19 @@ async function streamCoreInner(
                 { ctx, isPlanMode: modeConfig.isPlanMode },
               );
 
-        // Resolve active VM for (user, branch). Per-entry `runnerKind` drives
-        // transport dispatch inside `getBuiltInTools`.
+        // VM file tools bind to (virtualMcpId, branch, userId). The VM is
+        // provisioned lazily on the first tool call inside getBuiltInTools.
+        // Threads without a branch (no explicit VM_START flow) still get a
+        // VM — keyed by a synthetic `thread:<taskId>` slot so every thread
+        // has its own sandbox.
         const vmMetadata = virtualMcp.metadata as {
-          vmMap?: Record<
-            string,
-            Record<
-              string,
-              {
-                vmId: string;
-                previewUrl: string;
-                runnerKind?: "docker" | "freestyle";
-              }
-            >
-          >;
           githubRepo?: GithubRepo | null;
         };
-        const activeVmEntry =
-          input.branch && input.userId
-            ? vmMetadata?.vmMap?.[input.userId]?.[input.branch]
-            : undefined;
-        const activeVm = activeVmEntry
+        const vmContext = input.userId
           ? {
-              runnerKind: (activeVmEntry.runnerKind ?? "freestyle") as
-                | "docker"
-                | "freestyle",
-              vmId: activeVmEntry.vmId,
+              virtualMcpId: input.agent.id,
+              branch: input.branch ?? `thread:${mem.thread.id}`,
+              userId: input.userId,
             }
           : null;
 
@@ -508,7 +495,7 @@ async function streamCoreInner(
                 toolOutputMap,
                 pendingImages,
                 passthroughClient,
-                activeVm,
+                vmContext,
               },
               ctx,
             );
@@ -793,7 +780,11 @@ async function streamCoreInner(
                         for (const img of imageParts) {
                           content.push({
                             type: "text",
-                            text: `[Screenshot of ${img.pageUrl}]`,
+                            text:
+                              img.label ??
+                              (img.pageUrl
+                                ? `[Screenshot of ${img.pageUrl}]`
+                                : "[Image]"),
                           });
                           if (img.url.startsWith("data:")) {
                             // data URI → send as inline image

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -468,16 +468,28 @@ async function streamCoreInner(
 
         // VM file tools bind to (virtualMcpId, branch, userId). The VM is
         // provisioned lazily on the first tool call inside getBuiltInTools.
-        // Threads without a branch (no explicit VM_START flow) still get a
-        // VM — keyed by a synthetic `thread:<taskId>` slot so every thread
-        // has its own sandbox.
+        //
+        // Two keying regimes:
+        // - GitHub-linked agents (githubRepo set) need per-branch isolation
+        //   so PR/branch workflows don't trample each other. Falls back to a
+        //   `thread:<taskId>` synthetic branch when no explicit branch is
+        //   supplied yet.
+        // - Ephemeral agents (no githubRepo) share one VM per (user, agent)
+        //   across threads. The skills work is mostly read-heavy and
+        //   sharing a sandbox cuts the VM count linearly with thread count.
+        //   Tradeoff: concurrent threads share /app, /home/sandbox, /tmp —
+        //   parallel writes to overlapping filenames can race. Fine for
+        //   reads and scoped outputs; revisit if it bites.
         const vmMetadata = virtualMcp.metadata as {
           githubRepo?: GithubRepo | null;
         };
+        const isEphemeralAgent = !vmMetadata.githubRepo;
         const vmContext = input.userId
           ? {
               virtualMcpId: input.agent.id,
-              branch: input.branch ?? `thread:${mem.thread.id}`,
+              branch: isEphemeralAgent
+                ? "ephemeral"
+                : (input.branch ?? `thread:${mem.thread.id}`),
               userId: input.userId,
             }
           : null;

--- a/apps/mesh/src/tools/vm/start.ts
+++ b/apps/mesh/src/tools/vm/start.ts
@@ -18,8 +18,14 @@ import {
   type Workload,
 } from "@decocms/sandbox/runner";
 import { defineTool } from "../../core/define-tool";
-import type { MeshContext } from "../../core/mesh-context";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+  type MeshContext,
+} from "../../core/mesh-context";
 import { requireVmEntry, resolveRuntimeConfig } from "./helpers";
+import { readVmMap, resolveVm } from "./vm-map";
 import { buildCloneInfo } from "../../shared/github-clone-info";
 import { detectRepoRuntime } from "../../shared/github-runtime-detect";
 import { generateBranchName } from "../../shared/branch-name";
@@ -28,12 +34,14 @@ import { getRunnerByKind, getSharedRunner } from "../../sandbox/lifecycle";
 import { setVmMapEntry } from "./vm-map";
 import type { VirtualMCPUpdateData } from "../virtual/schema";
 
+type GithubRepo = {
+  owner: string;
+  name: string;
+  connectionId?: string;
+};
+
 type GithubRepoMeta = {
-  githubRepo?: {
-    owner: string;
-    name: string;
-    connectionId?: string;
-  } | null;
+  githubRepo?: GithubRepo | null;
 };
 
 export const VM_START = defineTool({
@@ -81,16 +89,8 @@ export const VM_START = defineTool({
     if (!githubRepo) {
       throw new Error("No GitHub repo connected");
     }
-    if (!githubRepo.connectionId) {
-      throw new Error("GitHub connection id missing on virtual MCP metadata");
-    }
 
     const runnerKind = resolveRunnerKindFromEnv();
-
-    // Runner env flipped since the existing entry was written. We don't
-    // preserve the old VM — tear it down under its original runner and let
-    // the provisioning below spin a fresh one. The boot overlay covers the
-    // transition; `isNewVm` fires naturally because the handle changes.
     await reapStaleRunner(ctx, existing, runnerKind);
 
     const { entry, isNewVm } = await provisionSandbox({
@@ -111,6 +111,61 @@ export const VM_START = defineTool({
     };
   },
 });
+
+/**
+ * Lazy provisioner for the always-on VM tools path. Mirrors VM_START's
+ * flow but: (a) tolerates a missing GitHub repo (boots blank under Docker),
+ * and (b) takes a fast path when the existing vmMap entry already matches
+ * the current runner kind — avoiding a full `runner.ensure` round-trip on
+ * every fresh stream when the VM is already registered.
+ */
+export async function ensureVmForBranch(
+  input: { virtualMcpId: string; branch: string },
+  ctx: MeshContext,
+): Promise<VmMapEntry> {
+  // Inline auth + lookup; the standard `requireVmEntry` runs
+  // `ctx.access.check()`, which expects resource scoping that the
+  // streaming turn doesn't carry. Storage writes below still go through
+  // the per-port authorization hooks.
+  requireAuth(ctx);
+  const organization = requireOrganization(ctx);
+  const userId = getUserId(ctx);
+  if (!userId) throw new Error("User ID required");
+
+  const virtualMcp = await ctx.storage.virtualMcps.findById(input.virtualMcpId);
+  if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+    throw new Error("Virtual MCP not found");
+  }
+  const metadata = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
+  const existing: VmMapEntry | null = resolveVm(
+    readVmMap(metadata),
+    userId,
+    input.branch,
+  );
+
+  const runnerKind = resolveRunnerKindFromEnv();
+
+  // Fast path: vmMap already has an entry under the current runner. Trust
+  // it; matches the prior `activeVm` behavior in built-in-tools.
+  if (existing && (existing.runnerKind ?? "freestyle") === runnerKind) {
+    return existing;
+  }
+
+  await reapStaleRunner(ctx, existing, runnerKind);
+
+  const githubRepo = (metadata as GithubRepoMeta).githubRepo ?? null;
+  const { entry } = await provisionSandbox({
+    ctx,
+    userId,
+    orgId: organization.id,
+    virtualMcpId: input.virtualMcpId,
+    branch: input.branch,
+    metadata,
+    githubRepo,
+    existing,
+  });
+  return entry;
+}
 
 async function reapStaleRunner(
   ctx: MeshContext,
@@ -146,7 +201,7 @@ type StartParams = {
   virtualMcpId: string;
   branch: string;
   metadata: Record<string, unknown>;
-  githubRepo: { owner: string; name: string; connectionId?: string };
+  githubRepo: GithubRepo | null;
   existing: VmMapEntry | null;
 };
 
@@ -164,42 +219,69 @@ async function provisionSandbox(
     existing,
   } = params;
 
-  let { runtime, packageManager, port } = resolveRuntimeConfig(metadata);
-  const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
-    githubRepo.connectionId!,
-    githubRepo.owner,
-    githubRepo.name,
-    ctx.db,
-    ctx.vault,
-  );
+  if (githubRepo && !githubRepo.connectionId) {
+    throw new Error("GitHub connection id missing on virtual MCP metadata");
+  }
 
-  // Lockfile probe only when metadata has no PM. Used to be client-side in
-  // the repo picker, but that introduced a race — VM_START fired from the
-  // auto-start paths before `runtime` landed in metadata, and the daemon
-  // got baked clone-only (no install, no dev server, UI stuck on setup).
-  // Running it here piggybacks on the same request so the baked workload
-  // always matches the detected PM; the result is persisted so subsequent
-  // starts skip the probe.
-  if (!packageManager) {
-    const detected = await detectRepoRuntime(
+  let { runtime, packageManager, port } = resolveRuntimeConfig(metadata);
+
+  // Skip clone + lockfile probe entirely when no repo is connected — the
+  // sandbox boots blank (Docker only; freestyle requires a baked clone).
+  let repoOpts:
+    | {
+        cloneUrl: string;
+        userName: string;
+        userEmail: string;
+        branch: string;
+        displayName: string;
+      }
+    | undefined;
+
+  if (githubRepo) {
+    const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
       githubRepo.connectionId!,
       githubRepo.owner,
       githubRepo.name,
       ctx.db,
       ctx.vault,
     );
-    if (detected) {
-      packageManager = detected.packageManager;
-      runtime = PACKAGE_MANAGER_CONFIG[detected.packageManager].runtime;
-      port = detected.devPort ?? port;
-      await persistDetectedRuntime(
-        ctx,
-        virtualMcpId,
-        userId,
-        detected.packageManager,
-        detected.devPort,
+
+    // Lockfile probe only when metadata has no PM. Used to be client-side in
+    // the repo picker, but that introduced a race — VM_START fired from the
+    // auto-start paths before `runtime` landed in metadata, and the daemon
+    // got baked clone-only (no install, no dev server, UI stuck on setup).
+    // Running it here piggybacks on the same request so the baked workload
+    // always matches the detected PM; the result is persisted so subsequent
+    // starts skip the probe.
+    if (!packageManager) {
+      const detected = await detectRepoRuntime(
+        githubRepo.connectionId!,
+        githubRepo.owner,
+        githubRepo.name,
+        ctx.db,
+        ctx.vault,
       );
+      if (detected) {
+        packageManager = detected.packageManager;
+        runtime = PACKAGE_MANAGER_CONFIG[detected.packageManager].runtime;
+        port = detected.devPort ?? port;
+        await persistDetectedRuntime(
+          ctx,
+          virtualMcpId,
+          userId,
+          detected.packageManager,
+          detected.devPort,
+        );
+      }
     }
+
+    repoOpts = {
+      cloneUrl,
+      userName: gitUserName,
+      userEmail: gitUserEmail,
+      branch,
+      displayName: `${githubRepo.owner}/${githubRepo.name}`,
+    };
   }
 
   // Missing workload = clone-only. Freestyle treats it as "node, no install,
@@ -222,13 +304,7 @@ async function provisionSandbox(
   const sandbox = await runner.ensure(
     { userId, projectRef },
     {
-      repo: {
-        cloneUrl,
-        userName: gitUserName,
-        userEmail: gitUserEmail,
-        branch,
-        displayName: `${githubRepo.owner}/${githubRepo.name}`,
-      },
+      repo: repoOpts,
       workload,
     },
   );

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -90,7 +90,9 @@ export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
   const images = result?.images;
   const usage = extractUsage(result);
   const modelLabel = result?.model;
-  const refImages = input?.referenceImages?.filter((r) => r.uri ?? r.url);
+  const refImages = Array.isArray(input?.referenceImages)
+    ? input.referenceImages.filter((r) => r.uri ?? r.url)
+    : undefined;
   const latencyLabel =
     latency != null && latency > 0 ? (
       <span className="text-[11px] font-mono tabular-nums text-muted-foreground/60">

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -5,7 +5,7 @@ import { Broadcaster } from "./events/broadcast";
 import { ProcessManager } from "./process/run-process";
 import { SetupOrchestrator } from "./setup/orchestrator";
 import {
-  makeReadHandler,
+  makeViewHandler,
   makeWriteHandler,
   makeEditHandler,
   makeGrepHandler,
@@ -65,7 +65,7 @@ broadcaster.broadcastEvent = (event: string, data: unknown) => {
   origEvent(event, data);
 };
 
-const readH = makeReadHandler({ appRoot: config.appRoot, dropPrivileges });
+const viewH = makeViewHandler({ appRoot: config.appRoot, dropPrivileges });
 const writeH = makeWriteHandler({ appRoot: config.appRoot, dropPrivileges });
 const editH = makeEditHandler({ appRoot: config.appRoot, dropPrivileges });
 const grepH = makeGrepHandler({ appRoot: config.appRoot, dropPrivileges });
@@ -107,7 +107,10 @@ Bun.serve({
       return scriptsHandler();
 
     if (req.method === "POST") {
-      if (p === "/_decopilot_vm/read") return readH(req);
+      // /view is the canonical endpoint; /read kept as alias for one
+      // release cycle so mid-upgrade sandboxes don't 404.
+      if (p === "/_decopilot_vm/view" || p === "/_decopilot_vm/read")
+        return viewH(req);
       if (p === "/_decopilot_vm/write") return writeH(req);
       if (p === "/_decopilot_vm/edit") return editH(req);
       if (p === "/_decopilot_vm/grep") return grepH(req);

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -5,7 +5,7 @@ import { Broadcaster } from "./events/broadcast";
 import { ProcessManager } from "./process/run-process";
 import { SetupOrchestrator } from "./setup/orchestrator";
 import {
-  makeViewHandler,
+  makeReadHandler,
   makeWriteHandler,
   makeEditHandler,
   makeGrepHandler,
@@ -65,7 +65,7 @@ broadcaster.broadcastEvent = (event: string, data: unknown) => {
   origEvent(event, data);
 };
 
-const viewH = makeViewHandler({ appRoot: config.appRoot, dropPrivileges });
+const readH = makeReadHandler({ appRoot: config.appRoot, dropPrivileges });
 const writeH = makeWriteHandler({ appRoot: config.appRoot, dropPrivileges });
 const editH = makeEditHandler({ appRoot: config.appRoot, dropPrivileges });
 const grepH = makeGrepHandler({ appRoot: config.appRoot, dropPrivileges });
@@ -107,10 +107,7 @@ Bun.serve({
       return scriptsHandler();
 
     if (req.method === "POST") {
-      // /view is the canonical endpoint; /read kept as alias for one
-      // release cycle so mid-upgrade sandboxes don't 404.
-      if (p === "/_decopilot_vm/view" || p === "/_decopilot_vm/read")
-        return viewH(req);
+      if (p === "/_decopilot_vm/read") return readH(req);
       if (p === "/_decopilot_vm/write") return writeH(req);
       if (p === "/_decopilot_vm/edit") return editH(req);
       if (p === "/_decopilot_vm/grep") return grepH(req);

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import {
-  makeReadHandler,
+  makeViewHandler,
   makeWriteHandler,
   makeEditHandler,
   makeGrepHandler,
@@ -30,27 +30,73 @@ describe("fs handlers", () => {
     rmSync(appRoot, { recursive: true, force: true });
   });
 
-  it("read: returns numbered content", async () => {
+  it("view: returns numbered content for text", async () => {
     writeFileSync(join(appRoot, "a.txt"), "one\ntwo\nthree\n");
-    const h = makeReadHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/read", { path: "a.txt" }));
-    const body = (await res.json()) as { content: string; lineCount: number };
+    const h = makeViewHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/view", { path: "a.txt" }));
+    const body = (await res.json()) as {
+      kind: string;
+      content: string;
+      lineCount: number;
+    };
+    expect(body.kind).toBe("text");
     expect(body.content).toContain("1\tone");
     expect(body.content).toContain("3\tthree");
     expect(body.lineCount).toBeGreaterThanOrEqual(3);
   });
 
-  it("read: rejects binary files (null byte)", async () => {
+  it("view: returns base64 + mediaType for jpeg", async () => {
+    // Minimal JPEG: SOI + EOI markers, enough to pass the magic-byte sniff.
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xff, 0xd9]);
+    writeFileSync(join(appRoot, "img.jpg"), jpeg);
+    const h = makeViewHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/view", { path: "img.jpg" }));
+    const body = (await res.json()) as {
+      kind: string;
+      mediaType: string;
+      base64: string;
+      size: number;
+    };
+    expect(body.kind).toBe("image");
+    expect(body.mediaType).toBe("image/jpeg");
+    expect(body.size).toBe(jpeg.length);
+    expect(Buffer.from(body.base64, "base64")).toEqual(jpeg);
+  });
+
+  it("view: returns base64 + mediaType for png", async () => {
+    const png = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
+    ]);
+    writeFileSync(join(appRoot, "img.png"), png);
+    const h = makeViewHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/view", { path: "img.png" }));
+    const body = (await res.json()) as { kind: string; mediaType: string };
+    expect(body.kind).toBe("image");
+    expect(body.mediaType).toBe("image/png");
+  });
+
+  it("view: rejects non-image binary files", async () => {
     writeFileSync(join(appRoot, "bin"), Buffer.from([0, 1, 2, 3]));
-    const h = makeReadHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/read", { path: "bin" }));
+    const h = makeViewHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/view", { path: "bin" }));
     expect(res.status).toBe(400);
   });
 
-  it("read: rejects path escape", async () => {
-    const h = makeReadHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/read", { path: "../etc/passwd" }));
+  it("view: rejects relative path escape", async () => {
+    const h = makeViewHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/view", { path: "../etc/passwd" }));
     expect(res.status).toBe(400);
+  });
+
+  it("view: accepts absolute paths", async () => {
+    writeFileSync(join(appRoot, "abs.txt"), "hello");
+    const h = makeViewHandler({ appRoot });
+    const res = await h(
+      post("/_decopilot_vm/view", { path: join(appRoot, "abs.txt") }),
+    );
+    const body = (await res.json()) as { kind: string; content: string };
+    expect(body.kind).toBe("text");
+    expect(body.content).toContain("hello");
   });
 
   it("write: creates file and returns byte count", async () => {

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import {
-  makeViewHandler,
+  makeReadHandler,
   makeWriteHandler,
   makeEditHandler,
   makeGrepHandler,
@@ -30,10 +30,10 @@ describe("fs handlers", () => {
     rmSync(appRoot, { recursive: true, force: true });
   });
 
-  it("view: returns numbered content for text", async () => {
+  it("read: returns numbered content for text", async () => {
     writeFileSync(join(appRoot, "a.txt"), "one\ntwo\nthree\n");
-    const h = makeViewHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/view", { path: "a.txt" }));
+    const h = makeReadHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/read", { path: "a.txt" }));
     const body = (await res.json()) as {
       kind: string;
       content: string;
@@ -45,12 +45,12 @@ describe("fs handlers", () => {
     expect(body.lineCount).toBeGreaterThanOrEqual(3);
   });
 
-  it("view: returns base64 + mediaType for jpeg", async () => {
+  it("read: returns base64 + mediaType for jpeg", async () => {
     // Minimal JPEG: SOI + EOI markers, enough to pass the magic-byte sniff.
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xff, 0xd9]);
     writeFileSync(join(appRoot, "img.jpg"), jpeg);
-    const h = makeViewHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/view", { path: "img.jpg" }));
+    const h = makeReadHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/read", { path: "img.jpg" }));
     const body = (await res.json()) as {
       kind: string;
       mediaType: string;
@@ -63,36 +63,36 @@ describe("fs handlers", () => {
     expect(Buffer.from(body.base64, "base64")).toEqual(jpeg);
   });
 
-  it("view: returns base64 + mediaType for png", async () => {
+  it("read: returns base64 + mediaType for png", async () => {
     const png = Buffer.from([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00,
     ]);
     writeFileSync(join(appRoot, "img.png"), png);
-    const h = makeViewHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/view", { path: "img.png" }));
+    const h = makeReadHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/read", { path: "img.png" }));
     const body = (await res.json()) as { kind: string; mediaType: string };
     expect(body.kind).toBe("image");
     expect(body.mediaType).toBe("image/png");
   });
 
-  it("view: rejects non-image binary files", async () => {
+  it("read: rejects non-image binary files", async () => {
     writeFileSync(join(appRoot, "bin"), Buffer.from([0, 1, 2, 3]));
-    const h = makeViewHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/view", { path: "bin" }));
+    const h = makeReadHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/read", { path: "bin" }));
     expect(res.status).toBe(400);
   });
 
-  it("view: rejects relative path escape", async () => {
-    const h = makeViewHandler({ appRoot });
-    const res = await h(post("/_decopilot_vm/view", { path: "../etc/passwd" }));
+  it("read: rejects relative path escape", async () => {
+    const h = makeReadHandler({ appRoot });
+    const res = await h(post("/_decopilot_vm/read", { path: "../etc/passwd" }));
     expect(res.status).toBe(400);
   });
 
-  it("view: accepts absolute paths", async () => {
+  it("read: accepts absolute paths", async () => {
     writeFileSync(join(appRoot, "abs.txt"), "hello");
-    const h = makeViewHandler({ appRoot });
+    const h = makeReadHandler({ appRoot });
     const res = await h(
-      post("/_decopilot_vm/view", { path: join(appRoot, "abs.txt") }),
+      post("/_decopilot_vm/read", { path: join(appRoot, "abs.txt") }),
     );
     const body = (await res.json()) as { kind: string; content: string };
     expect(body.kind).toBe("text");

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -75,12 +75,12 @@ function sniffImageMediaType(probe: Buffer): string | null {
  * permissions already gate what the sandbox user can read. Relative paths
  * are resolved against `appRoot` for the project-relative UX.
  */
-function resolveViewPath(appRoot: string, userPath: string): string | null {
+function resolveReadPath(appRoot: string, userPath: string): string | null {
   if (path.isAbsolute(userPath)) return userPath;
   return safePath(appRoot, userPath);
 }
 
-export function makeViewHandler(deps: FsDeps) {
+export function makeReadHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
     let body: { path?: string; offset?: number; limit?: number };
     try {
@@ -88,7 +88,7 @@ export function makeViewHandler(deps: FsDeps) {
     } catch (e) {
       return jsonResponse({ error: (e as Error).message }, 400);
     }
-    const filePath = resolveViewPath(deps.appRoot, body.path ?? "");
+    const filePath = resolveReadPath(deps.appRoot, body.path ?? "");
     if (!filePath)
       return jsonResponse({ error: "Path escapes project root" }, 400);
 
@@ -147,9 +147,6 @@ export function makeViewHandler(deps: FsDeps) {
     });
   };
 }
-
-/** @deprecated Use makeViewHandler. Kept as alias during one release cycle. */
-export const makeReadHandler = makeViewHandler;
 
 export function makeWriteHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -20,7 +20,67 @@ function spawnOpts(
     : { ...extra };
 }
 
-export function makeReadHandler(deps: FsDeps) {
+/** Cap on bytes returned for image responses. ~5MB matches Anthropic's
+ * vision input ceiling and keeps tool result payloads bounded. */
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/** Magic-byte sniffer for the image types Claude vision accepts.
+ * Returns null for everything else; we don't try to be clever about
+ * arbitrary binary formats. */
+function sniffImageMediaType(probe: Buffer): string | null {
+  if (
+    probe.length >= 3 &&
+    probe[0] === 0xff &&
+    probe[1] === 0xd8 &&
+    probe[2] === 0xff
+  )
+    return "image/jpeg";
+  if (
+    probe.length >= 8 &&
+    probe[0] === 0x89 &&
+    probe[1] === 0x50 &&
+    probe[2] === 0x4e &&
+    probe[3] === 0x47 &&
+    probe[4] === 0x0d &&
+    probe[5] === 0x0a &&
+    probe[6] === 0x1a &&
+    probe[7] === 0x0a
+  )
+    return "image/png";
+  if (
+    probe.length >= 6 &&
+    probe[0] === 0x47 &&
+    probe[1] === 0x49 &&
+    probe[2] === 0x46 &&
+    probe[3] === 0x38
+  )
+    return "image/gif";
+  if (
+    probe.length >= 12 &&
+    probe[0] === 0x52 &&
+    probe[1] === 0x49 &&
+    probe[2] === 0x46 &&
+    probe[3] === 0x46 &&
+    probe[8] === 0x57 &&
+    probe[9] === 0x45 &&
+    probe[10] === 0x42 &&
+    probe[11] === 0x50
+  )
+    return "image/webp";
+  return null;
+}
+
+/**
+ * Resolves a user-supplied path. Absolute paths pass through as-is — OS
+ * permissions already gate what the sandbox user can read. Relative paths
+ * are resolved against `appRoot` for the project-relative UX.
+ */
+function resolveViewPath(appRoot: string, userPath: string): string | null {
+  if (path.isAbsolute(userPath)) return userPath;
+  return safePath(appRoot, userPath);
+}
+
+export function makeViewHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
     let body: { path?: string; offset?: number; limit?: number };
     try {
@@ -28,8 +88,9 @@ export function makeReadHandler(deps: FsDeps) {
     } catch (e) {
       return jsonResponse({ error: (e as Error).message }, 400);
     }
-    const filePath = safePath(deps.appRoot, body.path ?? "");
-    if (!filePath) return jsonResponse({ error: "Path escapes /app" }, 400);
+    const filePath = resolveViewPath(deps.appRoot, body.path ?? "");
+    if (!filePath)
+      return jsonResponse({ error: "Path escapes project root" }, 400);
 
     let stat: fs.Stats;
     try {
@@ -44,8 +105,34 @@ export function makeReadHandler(deps: FsDeps) {
     const probe = Buffer.alloc(Math.min(8192, stat.size));
     fs.readSync(fd, probe, 0, probe.length, 0);
     fs.closeSync(fd);
+
+    const imageMediaType = sniffImageMediaType(probe);
+    if (imageMediaType) {
+      if (stat.size > MAX_IMAGE_BYTES) {
+        return jsonResponse(
+          {
+            error: `Image too large (${stat.size} bytes; cap is ${MAX_IMAGE_BYTES})`,
+          },
+          400,
+        );
+      }
+      const bytes = fs.readFileSync(filePath);
+      return jsonResponse({
+        kind: "image",
+        mediaType: imageMediaType,
+        size: stat.size,
+        base64: bytes.toString("base64"),
+      });
+    }
+
     if (probe.includes(0))
-      return jsonResponse({ error: "File appears to be binary" }, 400);
+      return jsonResponse(
+        {
+          error:
+            "File appears to be binary and is not a supported image format (jpeg/png/gif/webp).",
+        },
+        400,
+      );
 
     const raw = fs.readFileSync(filePath, "utf-8");
     const lines = raw.split("\n");
@@ -53,9 +140,16 @@ export function makeReadHandler(deps: FsDeps) {
     const limit = body.limit ?? 2000;
     const slice = lines.slice(offset - 1, offset - 1 + limit);
     const numbered = slice.map((l, i) => `${offset + i}\t${l}`).join("\n");
-    return jsonResponse({ content: numbered, lineCount: lines.length });
+    return jsonResponse({
+      kind: "text",
+      content: numbered,
+      lineCount: lines.length,
+    });
   };
 }
+
+/** @deprecated Use makeViewHandler. Kept as alias during one release cycle. */
+export const makeReadHandler = makeViewHandler;
 
 export function makeWriteHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -8,7 +8,8 @@ ARG DENO_VERSION=v1.46.3
 # `embedded-postgres` refuse to init without it.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-       bash ca-certificates curl git gnupg locales python3 ripgrep unzip \
+       bash ca-certificates curl git gnupg locales python3 python3-pip \
+       ripgrep unzip \
   && sed -i 's/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
   && locale-gen \
   && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
@@ -20,6 +21,25 @@ RUN apt-get update \
   && corepack enable \
   && corepack prepare yarn@stable --activate \
   && corepack prepare pnpm@latest --activate
+
+# Office tooling used by /mnt/skills/public/* document skills:
+# - LibreOffice headless for pptx/xlsx/docx → PDF conversion (rasterization,
+#   formula recalc, accept-tracked-changes).
+# - Poppler suite for PDF inspection and page-image extraction (pdftoppm,
+#   pdfinfo, pdftotext, pdfimages, pdfdetach, pdffonts).
+# - dbus + a generated /etc/machine-id so soffice doesn't warn on every call.
+# - DejaVu + Liberation fonts so soffice renders text instead of fallback
+#   tofu glyphs.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       libreoffice-impress poppler-utils dbus \
+       fonts-dejavu-core fonts-liberation \
+  && rm -rf /var/lib/apt/lists/* \
+  && dbus-uuidgen > /etc/machine-id
+
+# Python libraries used by /mnt/skills/public/* helper scripts.
+RUN pip3 install --break-system-packages --no-cache-dir \
+      python-pptx python-docx openpyxl pypdf Pillow
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
@@ -33,6 +53,13 @@ RUN userdel --remove bun \
 
 WORKDIR /app
 COPY --chown=sandbox:sandbox daemon/dist/daemon.js /opt/sandbox-daemon/daemon.js
+COPY --chown=sandbox:sandbox image/skills /mnt/skills/public
+
+# Expose skill helper scripts as bare commands. Wrappers in skills/_bin/
+# are tiny shell shims; symlinking them into /usr/local/bin lets the model
+# run e.g. `pptx-thumbnail deck.pptx` instead of typing the full python path.
+RUN chmod +x /mnt/skills/public/_bin/* \
+  && ln -s /mnt/skills/public/_bin/* /usr/local/bin/
 
 ENV IS_SANDBOX=1
 USER sandbox

--- a/packages/sandbox/image/skills-features.md
+++ b/packages/sandbox/image/skills-features.md
@@ -1,0 +1,317 @@
+# Skills features checklist
+
+Tracking sheet for the static skills shipped at `/mnt/skills/public/` inside
+the sandbox image. The full feature surface below is the long-term target
+(inspired by Anthropic's claude.ai sandbox design); items marked **v1** are
+the prioritized reading-focused milestone.
+
+Status legend:
+- `- [x]` shipped
+- `- [ ]` not yet shipped
+- **v1** = part of the first reading-focused milestone (must-ship)
+- _no v1 marker_ = later milestone (creation, XML round-trip editing,
+  tracked changes, form filling, etc.)
+
+System-level dependency callouts use the `> deps:` admonition so we can plan
+the image-size impact ahead of time.
+
+---
+
+## docx
+
+### Reading & extraction
+- [x] **v1** Plain-text dump of a document (paragraph order preserved, basic markdown)
+- [ ] **v1** Tracked-changes-aware extraction (show insertions/deletions vs. accept them)
+- [ ] **v1** Raw XML access by unpacking the `.docx` zip into a directory
+- [ ] **v1** Page-by-page rasterization to images (via PDF intermediate) for visual inspection
+- [ ] Programmatically accept all tracked changes to produce a clean copy
+- [ ] **v1** Convert legacy `.doc` to `.docx` first (LibreOffice headless conversion)
+
+### Creating new documents (from scratch)
+- [ ] Set page size and margins explicitly (US Letter vs A4, portrait/landscape)
+- [ ] Custom paragraph styles, including overriding built-in heading styles (Heading 1, 2, …)
+- [ ] Fonts, sizes, weights, colors at run level
+- [ ] Bulleted and numbered lists via real numbering definitions (not unicode bullets)
+- [ ] Multi-level lists with continuation vs. restart behavior
+- [ ] Tables with: column widths, cell widths, borders, shading, padding, vertical alignment
+- [ ] Hyperlinks (external) and internal cross-references with bookmarks
+- [ ] Headers and footers, including different first-page or odd/even
+- [ ] Page numbers and total page count fields
+- [ ] Page breaks and section breaks
+- [ ] Multi-column layouts
+- [ ] Tab stops with leaders (useful for two-column footers, TOC dot leaders)
+- [ ] Footnotes and endnotes
+- [ ] Embedded images with explicit sizing
+- [ ] Auto-generated table of contents (driven by heading outline levels)
+- [ ] File validation pass after generation
+
+### Editing existing documents (XML round-trip)
+- [ ] Unpack → edit XML → repack workflow with auto-repair on pack
+- [ ] Pretty-printing on unpack so XML is human-editable
+- [ ] Smart-quote preservation across the round-trip
+- [ ] Find-and-replace at the run/text level
+- [ ] Inserting and replacing inline images (requires updating media folder + relationships + content types + document XML in lockstep)
+
+### Tracked changes & comments
+- [ ] Insert tracked insertions (`<w:ins>`) with author and timestamp
+- [ ] Insert tracked deletions (`<w:del>` + `<w:delText>`) with author and timestamp
+- [ ] Reject another author's insertion (nested deletion inside their insertion)
+- [ ] Restore another author's deletion (sibling insertion)
+- [ ] Delete entire paragraphs/list items cleanly (mark paragraph mark as deleted)
+- [ ] Add comments anchored to a text range
+- [ ] Add threaded replies to existing comments
+- [ ] Custom comment author names
+
+> **deps:** `python-docx` (Python), `pandoc`, LibreOffice headless, Poppler (`pdftoppm`)
+
+---
+
+## pptx
+
+### Reading & inspection
+- [x] **v1** Per-slide text extraction with `## Slide N` section headers
+- [ ] **v1** Visual thumbnail grid of all slides as a single composite image (overview at a glance)
+- [ ] **v1** Per-slide full-resolution rasterization (via PDF intermediate)
+- [ ] **v1** Raw XML unpack of the `.pptx` zip
+
+> **Important for v1:** the thumbnail-grid script is a load-bearing
+> capability for this milestone. Implementation path: LibreOffice headless
+> renders `.pptx` → PDF, `pdftoppm` rasterizes pages → Pillow composes a
+> grid image at a fixed cell size (e.g. 4 columns × N rows). The script
+> should print the path to the resulting image so the model can read it
+> back as a multimodal attachment.
+
+### Creating from scratch (no template)
+- [ ] Slide creation with arbitrary layouts using `pptxgenjs` (Node) or `python-pptx`
+- [ ] Text boxes with full typography (font family, size, weight, color, alignment, line spacing)
+- [ ] Shapes (rectangles, circles, lines, arrows) with fill, stroke, opacity
+- [ ] Native charts (bar, line, pie, etc.)
+- [ ] Tables
+- [ ] Images (embedded, sized, positioned)
+- [ ] Slide masters and per-slide layouts
+- [ ] Speaker notes
+- [ ] Color palettes / theming
+
+### Editing an existing template (XML round-trip)
+- [ ] Unpack → manipulate slides → edit content → clean → pack
+- [ ] Duplicate a slide (with all the side-effect updates: notes refs, content types, relationship IDs)
+- [ ] Add a slide from a layout
+- [ ] Delete a slide (remove from `<p:sldIdLst>`, then clean up orphans)
+- [ ] Reorder slides
+- [ ] Clean up orphaned media and relationships
+- [ ] Edit slide content text via direct XML edits
+- [ ] Preserve smart quotes across the round-trip
+- [ ] Preserve formatting (`<a:rPr>` runs) when changing text
+- [ ] Bold inline labels, headers, titles
+- [ ] Use proper bullet formatting (inherit from layout, or set `<a:buChar>` / `<a:buAutoNum>`)
+
+### Quality & visual QA loop
+- [ ] Check for leftover placeholder text (lorem ipsum, "XXXX", "[insert]")
+- [ ] Convert deck → PDF → JPGs → visually inspect for overflow, overlap, low contrast, misalignment, missing margins
+- [ ] Iterate on fixes once, then stop (avoid infinite polishing loops)
+
+### Encoded design system (for the eventual creation skill)
+- [ ] Color palette suggestions tied to topic (don't default to blue)
+- [ ] Typography pairings (header font + body font)
+- [ ] Layout variety (don't repeat the same layout across slides)
+- [ ] Spacing rules (0.5" min margins, 0.3–0.5" between blocks)
+- [ ] Anti-patterns to avoid (accent lines under titles, full-width colored bars, cream backgrounds, text-only slides, overflow)
+
+> **deps:** `python-pptx` (Python), Pillow, LibreOffice headless, Poppler (`pdftoppm`)
+
+---
+
+## xlsx
+
+### Reading & analysis
+- [x] **v1** Quick text dump of all sheets (tab-separated rows under sheet headers)
+- [ ] **v1** Same dump for `.xlsm` (just override the format)
+- [ ] **v1** Pandas-based analysis (`read_excel`, `head`, `info`, `describe`, multi-sheet load)
+- [x] **v1** Read-only mode for very large files
+- [x] **v1** Read calculated values (vs. formulas) via `data_only=True`
+
+### Creating new files
+- [ ] New workbook with multiple sheets (openpyxl)
+- [ ] Cell values, ranges, append rows
+- [ ] Excel formulas as strings (`=SUM(...)`, `=AVERAGE(...)`, etc.)
+- [ ] Cross-sheet references (`Sheet1!A1`)
+- [ ] Cell formatting: font (family, size, bold, color), fill (background color), alignment, number formats
+- [ ] Column widths and row heights
+- [ ] Merged cells
+- [ ] Conditional formatting
+- [ ] Charts (bar, line, pie, scatter) bound to data ranges
+- [ ] Named ranges
+- [ ] Cell comments / notes
+- [ ] Data validation (dropdowns, restricted input)
+- [ ] Freeze panes, hidden rows/columns
+
+### Editing existing files
+- [ ] Load + modify while preserving formulas and formatting (openpyxl, not pandas)
+- [ ] Insert/delete rows and columns
+- [ ] Add new sheets
+- [ ] Iterate all sheets by name
+- [ ] Watch out: opening with `data_only=True` and saving destroys formulas
+
+### Formula recalculation pipeline
+- [ ] After any openpyxl write, formulas exist as strings but have no cached values
+- [ ] Recalculate by opening in LibreOffice headless and triggering a recalc-and-save
+- [ ] Scan all cells afterward for `#REF!`, `#DIV/0!`, `#VALUE!`, `#N/A`, `#NAME?`
+- [ ] Return structured error report (count + locations) so you can fix and re-run
+
+### Standards/conventions encoded in SKILL.md (for the eventual creation skill)
+- [ ] Financial-model color coding (blue=input, black=formula, green=cross-sheet link, red=external link, yellow=key assumption)
+- [ ] Number formats: years as text, currency `$#,##0`, zeros as `-`, parens for negatives, `0.0x` for multiples
+- [ ] Always reference assumption cells, never hardcode values inside formulas
+- [ ] Document hardcoded inputs with source citations
+- [ ] Use formulas, not Python-computed-and-pasted values, so the model stays live
+
+> **deps:** `openpyxl`, `pandas` (Python), LibreOffice headless
+
+---
+
+## pdf (creation & manipulation)
+
+> Reading lives in the separate `pdf-reading` skill below. This skill is
+> entirely **later milestones** — none of it is in v1.
+
+### Creation
+- [ ] Low-level canvas drawing (text, lines, shapes at coordinates) via `reportlab` Canvas
+- [ ] High-level document flow (paragraphs, headings, page breaks, spacers) via `reportlab` Platypus
+- [ ] Page size and orientation control
+- [ ] Subscripts/superscripts via XML markup tags (NOT unicode characters — they render as black boxes in built-in fonts)
+- [ ] JavaScript alternative: `pdf-lib`
+
+### Merging & splitting
+- [ ] Concatenate multiple PDFs into one (`pypdf` or `qpdf --empty --pages`)
+- [ ] Split into one-file-per-page
+- [ ] Extract a page range into a new file (`qpdf input.pdf --pages . 1-5 -- out.pdf`)
+- [ ] `pdftk` equivalents if available
+
+### Page operations
+- [ ] Rotate pages (any multiple of 90°), single page or all
+- [ ] Reorder pages
+- [ ] Delete pages
+
+### Watermarking
+- [ ] Overlay a watermark PDF page onto every page of a target PDF (`merge_page`)
+
+### Image extraction
+- [ ] All embedded raster images via `pdfimages -j` (JPG) or `-png`
+- [ ] Specific page ranges
+- [ ] Original format preservation with `-all`
+
+### OCR (scanned PDFs)
+- [ ] Convert pages to images with `pdf2image`
+- [ ] Run `pytesseract` on each image to recover text
+
+### Encryption / decryption
+- [ ] Encrypt with user and owner passwords
+- [ ] Decrypt with `qpdf --password=... --decrypt`
+
+### Form filling
+- [ ] Detect whether a PDF has fillable fields
+- [ ] Extract field metadata (name, page, bounding box, type, options for checkboxes/radios/dropdowns)
+- [ ] Fill text fields, set checkbox states, choose radio option, pick dropdown value
+- [ ] Fall-back path for non-fillable PDFs: place text annotations at coordinates
+- [ ] Validate field IDs and values before writing
+
+### Metadata
+- [ ] Read/write title, author, subject, creator, producer
+
+> **deps:** `pypdf`, `reportlab`, `pdfplumber`, `pdf2image`, `pytesseract` (Python); `pypdfium2` for higher-fidelity rendering; `qpdf`, `pdftk`, Poppler suite (CLI); Tesseract binary
+
+---
+
+## pdf-reading
+
+> This skill does not yet exist in `/mnt/skills/public/` — it needs to be
+> split out from the current `pdf` skill. **Entirely v1.**
+
+### Diagnostic content inventory (run before anything else)
+- [ ] **v1** Page count, file size, version, metadata (`pdfinfo`)
+- [ ] **v1** Quick "is this text or scanned?" check (`pdftotext` first page sample)
+- [ ] **v1** List of embedded raster images with size/color/compression (`pdfimages -list`)
+- [ ] **v1** List of file attachments embedded in the PDF (`pdfdetach -list`)
+- [ ] **v1** Font report — embedded? custom encoding? (`pdffonts`) — diagnoses garbled extraction
+
+### Text extraction strategies
+- [x] **v1** Basic: `pypdf` page-by-page _(lives in `pdf/extract.py` today; needs reorganizing under `pdf-reading/`)_
+- [ ] **v1** Layout-preserving for multi-column: `pdftotext -layout`
+- [ ] **v1** Layout-aware with positioning data: `pdfplumber`
+- [ ] **v1** Page range selection (`-f` first, `-l` last)
+
+### Visual inspection
+- [ ] **v1** Rasterize a single page (or range) at chosen DPI with `pdftoppm`
+- [ ] **v1** Awareness of zero-padded filename behavior (depends on total page count)
+- [ ] **v1** Token-cost tradeoff between text extraction (~200–400 tok/page) and rasterized image (~1,600 tok/page) — encoded in `SKILL.md` prose
+
+### Strategy decision tree (the real value of this skill)
+- [ ] **v1** Text-heavy → text extraction primary, rasterize specific figures
+- [ ] **v1** Scanned → rasterize + OCR
+- [ ] **v1** Slide-deck PDFs → rasterize per-page on demand
+- [ ] **v1** Forms → extract field values programmatically
+- [ ] **v1** Data-heavy → `pdfplumber` for tables + rasterize for charts
+
+### Table extraction
+- [ ] **v1** `pdfplumber` `page.extract_tables()`
+- [ ] Convert to pandas DataFrame, combine across pages, export to xlsx _(later — write step)_
+
+### Embedded image extraction
+- [ ] **v1** All / specific page range / original-format flags via `pdfimages`
+- [ ] **v1** Programmatic alternative with PyMuPDF (`fitz`) including position data and color-space normalization
+- [ ] **v1** Gotcha awareness: vector charts (matplotlib/Excel) won't appear — must rasterize the whole page _(in `SKILL.md`)_
+- [ ] **v1** Gotcha awareness: tiny "empty" images are usually masks/decoration; filter by file size _(in `SKILL.md`)_
+
+### Attachment extraction
+- [ ] **v1** List, save-all, save-by-index via `pdfdetach`
+- [ ] **v1** Programmatic via `pypdf`'s `reader.attachments` (sanitize filenames!)
+- [ ] **v1** Awareness of two attachment mechanisms (page-level annotations vs. document-level EmbeddedFiles tree)
+
+### Form field reading (read-only — filling lives in the `pdf` skill)
+- [ ] **v1** Text-only fields via `get_form_text_fields()`
+- [ ] **v1** All field types (checkbox, radio, dropdown) via `get_fields()` with `/V` and `/FT` keys
+- [ ] Comprehensive metadata via `pdftk dump_data_fields`
+
+### Rare embedded media
+- [ ] Audio/video/3D — first check `pdfdetach`, fall back to PyMuPDF page annotations
+
+### Font diagnostics
+- [ ] **v1** Identify non-embedded fonts or Identity-H encodings without CIDToGID maps as the cause of garbled extraction → fall back to rasterization _(in `SKILL.md`)_
+
+### OCR (for scanned PDFs detected by the diagnostic step)
+- [ ] **v1** Convert pages to images with `pdf2image`
+- [ ] **v1** Run `pytesseract` on each image to recover text
+
+> **deps:** `pypdf`, `pdfplumber`, `pymupdf` / `fitz` (Python); Poppler suite (`pdfinfo`, `pdftotext`, `pdftoppm`, `pdfimages`, `pdfdetach`, `pdffonts`); `qpdf`; for OCR: `pytesseract` + `pdf2image` + Tesseract binary
+
+---
+
+## file-reading (router)
+
+- [x] **v1** Map extension → which sub-skill to invoke
+- [ ] **v1** Update routing table once `pdf-reading` is split out from `pdf`
+- [ ] **v1** Mention `file <path>` fallback for unknown formats
+
+---
+
+## v1 summary — what we're shipping in the reading milestone
+
+In rough sequence:
+
+1. **`pdf-reading`** — split from current `pdf/`, add `pdfinfo` diagnostic, layout-preserving extraction, rasterization, OCR fallback, table extraction, attachment extraction, form-field reading, and the strategy decision tree in `SKILL.md`.
+2. **`pptx`** thumbnail grid + per-slide rasterization + raw XML unpack. The grid is the headline capability.
+3. **`xlsx`** pandas-analysis script + `.xlsm` support.
+4. **`docx`** tracked-changes-aware extraction, raw XML unpack, page rasterization, legacy `.doc`→`.docx` conversion.
+5. **`file-reading`** routing table updated.
+6. **`SKILL.md` prose pass** — fold the pitfall lists from this doc (smart quotes, formula recalc, vector-chart pdfimages gap, font diagnostics, etc.) into the per-skill `SKILL.md` files. This is where the real model UX value lives.
+
+System dependencies that need to land in the Dockerfile for v1:
+
+- LibreOffice headless (`libreoffice-core`, `libreoffice-impress`, `libreoffice-calc`, `libreoffice-writer` — pick the minimum that covers what we need)
+- Poppler suite (`poppler-utils` Debian package: `pdfinfo`, `pdftotext`, `pdftoppm`, `pdfimages`, `pdfdetach`, `pdffonts`)
+- `qpdf`
+- Tesseract OCR (`tesseract-ocr` + at minimum `tesseract-ocr-eng`)
+- Pillow (Python; pulls in libjpeg/libpng via wheels — may already be present transitively)
+- `pdfplumber`, `pymupdf`, `pdf2image`, `pytesseract`, `pandas` (Python)
+
+Estimated image-size impact: roughly +1–1.5GB compressed (LibreOffice dominates at ~500MB; Tesseract + language data ~150MB; the rest is small). Acceptable for a sandbox image.

--- a/packages/sandbox/image/skills/_bin/pptx-extract
+++ b/packages/sandbox/image/skills/_bin/pptx-extract
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /mnt/skills/public/pptx/extract.py "$@"

--- a/packages/sandbox/image/skills/_bin/pptx-rasterize
+++ b/packages/sandbox/image/skills/_bin/pptx-rasterize
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /mnt/skills/public/pptx/rasterize.py "$@"

--- a/packages/sandbox/image/skills/_bin/pptx-thumbnail
+++ b/packages/sandbox/image/skills/_bin/pptx-thumbnail
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /mnt/skills/public/pptx/thumbnail.py "$@"

--- a/packages/sandbox/image/skills/_bin/pptx-unpack
+++ b/packages/sandbox/image/skills/_bin/pptx-unpack
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /mnt/skills/public/pptx/unpack.py "$@"

--- a/packages/sandbox/image/skills/docx/SKILL.md
+++ b/packages/sandbox/image/skills/docx/SKILL.md
@@ -1,0 +1,26 @@
+# docx — Word documents
+
+Use this skill to read or summarize `.docx` files.
+
+## Scripts
+
+### extract.py
+
+Print text content from a `.docx` as plain text. Paragraphs are separated by
+blank lines; tables are rendered with tab-separated cells.
+
+```
+python /mnt/skills/public/docx/extract.py <path-to-file.docx>
+```
+
+## Direct python-docx usage
+
+For headings, styles, tables, images, or editing, import `docx` directly. The
+library is preinstalled.
+
+```python
+from docx import Document
+doc = Document("/path/to/file.docx")
+for paragraph in doc.paragraphs:
+    ...
+```

--- a/packages/sandbox/image/skills/docx/extract.py
+++ b/packages/sandbox/image/skills/docx/extract.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Extract text from a Word (.docx) file."""
+
+import sys
+
+from docx import Document
+
+
+def main(path: str) -> int:
+    doc = Document(path)
+    for paragraph in doc.paragraphs:
+        if paragraph.text.strip():
+            print(paragraph.text)
+        else:
+            print()
+    for table in doc.tables:
+        print()
+        for row in table.rows:
+            print("\t".join(cell.text for cell in row.cells))
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: extract.py <file.docx>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/packages/sandbox/image/skills/file-reading/SKILL.md
+++ b/packages/sandbox/image/skills/file-reading/SKILL.md
@@ -1,0 +1,18 @@
+# file-reading — router by file type
+
+When asked to read or summarize a file, dispatch by extension to the
+appropriate skill under `/mnt/skills/public/`:
+
+| Extension     | Skill   | Script                                        |
+| ------------- | ------- | --------------------------------------------- |
+| `.pptx`       | `pptx`  | `python /mnt/skills/public/pptx/extract.py`   |
+| `.docx`       | `docx`  | `python /mnt/skills/public/docx/extract.py`   |
+| `.xlsx`       | `xlsx`  | `python /mnt/skills/public/xlsx/extract.py`   |
+| `.pdf`        | `pdf`   | `python /mnt/skills/public/pdf/extract.py`    |
+| `.txt`, `.md` | —       | `cat`                                         |
+| `.csv`        | —       | `cat` (or `column -t -s,` for alignment)      |
+| `.json`       | —       | `cat` (or `jq .` if structure matters)        |
+
+For extensions not listed, read the corresponding `SKILL.md` under
+`/mnt/skills/public/` if one exists, otherwise fall back to `file <path>` to
+identify the format and proceed manually.

--- a/packages/sandbox/image/skills/pdf/SKILL.md
+++ b/packages/sandbox/image/skills/pdf/SKILL.md
@@ -1,0 +1,29 @@
+# pdf — PDF documents
+
+Use this skill to read text from `.pdf` files.
+
+## Scripts
+
+### extract.py
+
+Print text content from a `.pdf`, page by page.
+
+```
+python /mnt/skills/public/pdf/extract.py <path-to-file.pdf>
+```
+
+Output is plain text with `--- page N ---` separators. PDFs that are pure
+scans (image-only, no embedded text layer) will produce empty pages — OCR is
+not performed.
+
+## Direct pypdf usage
+
+For metadata, structure, splitting, merging, or filling forms, import `pypdf`
+directly. The library is preinstalled.
+
+```python
+from pypdf import PdfReader
+reader = PdfReader("/path/to/file.pdf")
+for page in reader.pages:
+    text = page.extract_text()
+```

--- a/packages/sandbox/image/skills/pdf/extract.py
+++ b/packages/sandbox/image/skills/pdf/extract.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Extract text from a PDF file, page by page."""
+
+import sys
+
+from pypdf import PdfReader
+
+
+def main(path: str) -> int:
+    reader = PdfReader(path)
+    for index, page in enumerate(reader.pages, start=1):
+        print(f"--- page {index} ---")
+        text = page.extract_text() or ""
+        print(text.strip())
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: extract.py <file.pdf>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/packages/sandbox/image/skills/pptx/SKILL.md
+++ b/packages/sandbox/image/skills/pptx/SKILL.md
@@ -1,0 +1,76 @@
+# pptx — PowerPoint presentations
+
+Reading and inspection of `.pptx` files. Editing and creation are not yet
+supported.
+
+## Quick reference
+
+| Task                          | Command                                       |
+| ----------------------------- | --------------------------------------------- |
+| Plain-text dump               | `pptx-extract <file.pptx>`                    |
+| Plain-text + speaker notes    | `pptx-extract --notes <file.pptx>`            |
+| Visual overview (grid image)  | `pptx-thumbnail <file.pptx>`                  |
+| One slide at full resolution  | `pptx-rasterize --pages 3 <file.pptx>`        |
+| Several slides                | `pptx-rasterize --pages 1,3-5 <file.pptx>`    |
+| Raw XML inspection            | `pptx-unpack <file.pptx>`                     |
+
+Every command writes its output next to the input file and prints the
+output path(s) on stdout.
+
+## Reading text
+
+`pptx-extract` prints each slide as a `## Slide N` section followed by the
+visible text. Speaker notes are excluded by default; pass `--notes` to
+include them under a `### Notes` subsection per slide.
+
+## Visual overview
+
+`pptx-thumbnail` produces two artifacts:
+
+- A composite grid image at `<input-stem>.thumbnail.jpg` — 4-column grid
+  with a small slide-number overlay on each cell. Suitable for a single
+  multimodal read to get the shape of the deck.
+- A directory `<input-stem>.slides/` containing per-slide JPGs at the
+  same resolution. When a slide in the grid looks interesting, view
+  `slide-NNN.jpg` directly instead of re-running `pptx-thumbnail`.
+
+To actually see the rendered image, call the `view` tool on the path
+`pptx-thumbnail` printed:
+
+```
+view /home/sandbox/deck.thumbnail.jpg
+```
+
+The image is injected into the next turn as a vision input.
+
+## Per-slide rasterization
+
+`pptx-rasterize` renders specific slides at higher DPI (default 150) into
+`<input-stem>.rasterized/slide-NNN.jpg`. Use `--pages 3` for a single
+slide or `--pages 1,3-5` for a selection. Override DPI with `--dpi`.
+
+Pass the resulting path to the `view` tool to actually see the slide.
+
+## Raw XML
+
+`pptx-unpack` unzips the `.pptx` into `<input-stem>.unpacked/`. Useful
+locations inside:
+
+- `ppt/slides/slideN.xml` — slide content
+- `ppt/notesSlides/notesSlideN.xml` — speaker notes
+- `ppt/media/` — embedded images
+- `ppt/theme/` — color palette and font definitions
+
+## Direct python-pptx usage
+
+For programmatic access beyond what these scripts cover (table cell data,
+shape positions, layout metadata, etc.), import `pptx` directly. The
+library is preinstalled.
+
+```python
+from pptx import Presentation
+prs = Presentation("/path/to/file.pptx")
+for slide in prs.slides:
+    for shape in slide.shapes:
+        ...
+```

--- a/packages/sandbox/image/skills/pptx/SKILL.md
+++ b/packages/sandbox/image/skills/pptx/SKILL.md
@@ -31,14 +31,14 @@ include them under a `### Notes` subsection per slide.
   with a small slide-number overlay on each cell. Suitable for a single
   multimodal read to get the shape of the deck.
 - A directory `<input-stem>.slides/` containing per-slide JPGs at the
-  same resolution. When a slide in the grid looks interesting, view
+  same resolution. When a slide in the grid looks interesting, read
   `slide-NNN.jpg` directly instead of re-running `pptx-thumbnail`.
 
-To actually see the rendered image, call the `view` tool on the path
+To actually see the rendered image, call the `read` tool on the path
 `pptx-thumbnail` printed:
 
 ```
-view /home/sandbox/deck.thumbnail.jpg
+read /home/sandbox/deck.thumbnail.jpg
 ```
 
 The image is injected into the next turn as a vision input.
@@ -49,7 +49,7 @@ The image is injected into the next turn as a vision input.
 `<input-stem>.rasterized/slide-NNN.jpg`. Use `--pages 3` for a single
 slide or `--pages 1,3-5` for a selection. Override DPI with `--dpi`.
 
-Pass the resulting path to the `view` tool to actually see the slide.
+Pass the resulting path to the `read` tool to actually see the slide.
 
 ## Raw XML
 

--- a/packages/sandbox/image/skills/pptx/_office.py
+++ b/packages/sandbox/image/skills/pptx/_office.py
@@ -1,0 +1,61 @@
+"""Sandbox-safe LibreOffice headless wrapper.
+
+LibreOffice's defaults assume an interactive desktop session: a persistent
+user profile under ~/.config/libreoffice with lockfiles, recovery dialogs,
+first-start wizards, and dbus integration that depends on /etc/machine-id.
+None of that is friendly to a hardened, parallel-invocation sandbox.
+
+The `convert_to_pdf` helper here neutralises those by routing every soffice
+invocation through a fresh per-call user profile and suppressing the
+interactive cruft.
+"""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def convert_to_pdf(src: Path, out_dir: Path, *, timeout: float = 180.0) -> Path:
+    """Convert `src` to PDF inside `out_dir`. Returns the resulting PDF path."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="lo_profile_") as profile:
+        env = {
+            **os.environ,
+            "HOME": profile,
+            "SAL_USE_COMMON_ONE_INSTANCE": "1",
+            "LC_ALL": os.environ.get("LC_ALL", "en_US.UTF-8"),
+        }
+        cmd = [
+            "soffice",
+            "--headless",
+            "--norestore",
+            "--nofirststartwizard",
+            "--nolockcheck",
+            f"-env:UserInstallation=file://{profile}",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            str(out_dir),
+            str(src),
+        ]
+        result = subprocess.run(
+            cmd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"soffice failed (exit {result.returncode})\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    pdf_path = out_dir / (src.stem + ".pdf")
+    if not pdf_path.exists():
+        raise RuntimeError(
+            f"soffice succeeded but expected PDF not found at {pdf_path}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return pdf_path

--- a/packages/sandbox/image/skills/pptx/extract.py
+++ b/packages/sandbox/image/skills/pptx/extract.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Extract text from a PowerPoint (.pptx) file."""
+
+import argparse
+import sys
+
+from pptx import Presentation
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Extract text from a .pptx.")
+    parser.add_argument("input")
+    parser.add_argument(
+        "--notes",
+        action="store_true",
+        help="Include speaker notes under a ### Notes subsection per slide.",
+    )
+    args = parser.parse_args(argv)
+
+    prs = Presentation(args.input)
+    for index, slide in enumerate(prs.slides, start=1):
+        print(f"## Slide {index}")
+        print()
+        for shape in slide.shapes:
+            if not shape.has_text_frame:
+                continue
+            for paragraph in shape.text_frame.paragraphs:
+                text = "".join(run.text for run in paragraph.runs)
+                if text.strip():
+                    print(text)
+        if args.notes and slide.has_notes_slide:
+            notes = slide.notes_slide.notes_text_frame.text.strip()
+            if notes:
+                print()
+                print("### Notes")
+                print()
+                print(notes)
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packages/sandbox/image/skills/pptx/rasterize.py
+++ b/packages/sandbox/image/skills/pptx/rasterize.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Render specific .pptx slides at full resolution.
+
+Same soffice + pdftoppm pipeline as `thumbnail.py`, but at higher DPI and
+without the grid composition step. Useful when the model has already seen
+the thumbnail grid and wants one slide back at higher fidelity.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _office import convert_to_pdf  # noqa: E402
+
+
+def parse_pages(spec: str | None, total: int) -> list[int]:
+    if spec is None:
+        return list(range(1, total + 1))
+    pages: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if "-" in part:
+            a, b = part.split("-", 1)
+            pages.update(range(int(a), int(b) + 1))
+        else:
+            pages.add(int(part))
+    return sorted(p for p in pages if 1 <= p <= total)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Rasterise pptx slides.")
+    parser.add_argument("input", type=Path)
+    parser.add_argument(
+        "--pages",
+        default=None,
+        help='Selection like "3" or "1,3-5"; defaults to all slides.',
+    )
+    parser.add_argument("--dpi", type=int, default=150)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output directory (default: <input-stem>.rasterized)",
+    )
+    args = parser.parse_args(argv)
+
+    src = args.input.resolve()
+    if not src.exists():
+        print(f"input not found: {src}", file=sys.stderr)
+        return 2
+
+    out_dir = args.out or src.with_name(src.stem + ".rasterized")
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pdf = convert_to_pdf(src, tmp_path)
+        info = subprocess.run(
+            ["pdfinfo", str(pdf)], capture_output=True, text=True, check=True
+        )
+        total = 0
+        for line in info.stdout.splitlines():
+            if line.startswith("Pages:"):
+                total = int(line.split(":", 1)[1].strip())
+                break
+        if total == 0:
+            print("could not determine page count", file=sys.stderr)
+            return 1
+
+        pages = parse_pages(args.pages, total)
+        if not pages:
+            print("no pages to render", file=sys.stderr)
+            return 1
+
+        # Render one page at a time. pdftoppm zero-pads its output filename
+        # based on the *total* page count of the source PDF, so producing a
+        # sparse selection (e.g. 1,5,10) into a shared prefix is messy.
+        # Per-page invocations keep the output predictable and let us name
+        # the result deterministically as slide-NNN.jpg.
+        for page in pages:
+            prefix = tmp_path / f"page-{page}"
+            subprocess.run(
+                [
+                    "pdftoppm",
+                    "-jpeg",
+                    "-r",
+                    str(args.dpi),
+                    "-f",
+                    str(page),
+                    "-l",
+                    str(page),
+                    str(pdf),
+                    str(prefix),
+                ],
+                check=True,
+            )
+            matches = list(tmp_path.glob(f"{prefix.name}*.jpg"))
+            if not matches:
+                print(f"no output for page {page}", file=sys.stderr)
+                return 1
+            shutil.move(str(matches[0]), str(out_dir / f"slide-{page:03d}.jpg"))
+
+    print(out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packages/sandbox/image/skills/pptx/thumbnail.py
+++ b/packages/sandbox/image/skills/pptx/thumbnail.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Render a .pptx as a thumbnail-grid composite image plus per-slide JPGs.
+
+Pipeline: LibreOffice headless renders the deck to PDF, `pdftoppm` rasterises
+each page at 96 DPI, Pillow downscales and assembles a 4-column grid with a
+small slide-number overlay in the top-left of each cell. Per-slide JPGs are
+preserved in a sibling directory so the model can pull a single slide at full
+resolution after spotting it in the grid.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _office import convert_to_pdf  # noqa: E402
+
+GRID_COLS = 4
+THUMB_WIDTH = 320
+GAP = 12
+BG = (240, 240, 240)
+LABEL_BG = (255, 255, 255)
+LABEL_FG = (24, 24, 24)
+LABEL_FONT_PATH = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Render a pptx as a thumbnail grid.")
+    parser.add_argument("input", type=Path)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output composite image path (default: <input-stem>.thumbnail.jpg)",
+    )
+    args = parser.parse_args(argv)
+
+    src = args.input.resolve()
+    if not src.exists():
+        print(f"input not found: {src}", file=sys.stderr)
+        return 2
+
+    out_grid = args.out or src.with_name(src.stem + ".thumbnail.jpg")
+    out_slides_dir = src.with_name(src.stem + ".slides")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        pdf = convert_to_pdf(src, tmp_path)
+        prefix = tmp_path / "slide"
+        subprocess.run(
+            ["pdftoppm", "-jpeg", "-r", "96", str(pdf), str(prefix)],
+            check=True,
+        )
+        slides = sorted(tmp_path.glob("slide-*.jpg"))
+        if not slides:
+            print("no slides produced by pdftoppm", file=sys.stderr)
+            return 1
+
+        if out_slides_dir.exists():
+            shutil.rmtree(out_slides_dir)
+        out_slides_dir.mkdir(parents=True)
+        slide_paths: list[Path] = []
+        for i, src_jpg in enumerate(slides, start=1):
+            dst = out_slides_dir / f"slide-{i:03d}.jpg"
+            shutil.copy(src_jpg, dst)
+            slide_paths.append(dst)
+
+        thumbs = []
+        for jpg in slide_paths:
+            img = Image.open(jpg).convert("RGB")
+            ratio = THUMB_WIDTH / img.width
+            new_h = int(img.height * ratio)
+            thumbs.append(img.resize((THUMB_WIDTH, new_h), Image.LANCZOS))
+
+        thumb_h = thumbs[0].height
+        n = len(thumbs)
+        rows = (n + GRID_COLS - 1) // GRID_COLS
+        comp_w = GRID_COLS * THUMB_WIDTH + (GRID_COLS + 1) * GAP
+        comp_h = rows * thumb_h + (rows + 1) * GAP
+        comp = Image.new("RGB", (comp_w, comp_h), BG)
+
+        try:
+            font = ImageFont.truetype(LABEL_FONT_PATH, 18)
+        except OSError:
+            font = ImageFont.load_default()
+
+        for idx, thumb in enumerate(thumbs):
+            row, col = divmod(idx, GRID_COLS)
+            x = GAP + col * (THUMB_WIDTH + GAP)
+            y = GAP + row * (thumb_h + GAP)
+            comp.paste(thumb, (x, y))
+            label = str(idx + 1)
+            label_w = 14 + len(label) * 11
+            label_h = 26
+            label_box = Image.new("RGB", (label_w, label_h), LABEL_BG)
+            ImageDraw.Draw(label_box).text((6, 2), label, fill=LABEL_FG, font=font)
+            comp.paste(label_box, (x + 6, y + 6))
+
+        comp.save(out_grid, "JPEG", quality=85)
+
+    print(out_grid)
+    print(out_slides_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packages/sandbox/image/skills/pptx/unpack.py
+++ b/packages/sandbox/image/skills/pptx/unpack.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Unpack a .pptx archive's XML and media into a directory."""
+
+import argparse
+import shutil
+import sys
+import zipfile
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Unpack .pptx XML.")
+    parser.add_argument("input", type=Path)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output directory (default: <input-stem>.unpacked)",
+    )
+    args = parser.parse_args(argv)
+
+    src = args.input.resolve()
+    if not src.exists():
+        print(f"input not found: {src}", file=sys.stderr)
+        return 2
+
+    out_dir = args.out or src.with_name(src.stem + ".unpacked")
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    with zipfile.ZipFile(src) as zf:
+        zf.extractall(out_dir)
+
+    print(out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packages/sandbox/image/skills/xlsx/SKILL.md
+++ b/packages/sandbox/image/skills/xlsx/SKILL.md
@@ -1,0 +1,30 @@
+# xlsx — Excel spreadsheets
+
+Use this skill to read or summarize `.xlsx` files.
+
+## Scripts
+
+### extract.py
+
+Print sheet contents from an `.xlsx` as TSV. Each sheet is preceded by a
+`--- sheet "<name>" ---` header.
+
+```
+python /mnt/skills/public/xlsx/extract.py <path-to-file.xlsx>
+```
+
+Empty trailing rows and columns are trimmed. Cell values are stringified;
+formulas show their cached value, not the formula text.
+
+## Direct openpyxl usage
+
+For richer operations (formulas, formatting, charts, writing workbooks),
+import `openpyxl` directly. The library is preinstalled.
+
+```python
+from openpyxl import load_workbook
+wb = load_workbook("/path/to/file.xlsx", data_only=True)
+for sheet in wb.worksheets:
+    for row in sheet.iter_rows(values_only=True):
+        ...
+```

--- a/packages/sandbox/image/skills/xlsx/extract.py
+++ b/packages/sandbox/image/skills/xlsx/extract.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Extract sheet contents from an Excel (.xlsx) file as TSV."""
+
+import sys
+
+from openpyxl import load_workbook
+
+
+def main(path: str) -> int:
+    workbook = load_workbook(path, data_only=True, read_only=True)
+    for sheet in workbook.worksheets:
+        print(f'--- sheet "{sheet.title}" ---')
+        for row in sheet.iter_rows(values_only=True):
+            cells = ["" if value is None else str(value) for value in row]
+            while cells and cells[-1] == "":
+                cells.pop()
+            if cells:
+                print("\t".join(cells))
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: extract.py <file.xlsx>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/packages/sandbox/server/image-build.ts
+++ b/packages/sandbox/server/image-build.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { type Hash, createHash } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_IMAGE } from "../shared";
@@ -20,6 +20,8 @@ const IMAGE_DIR = resolve(fileURLToPath(import.meta.url), "../../image");
 const SANDBOX_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const DAEMON_BUNDLE = resolve(SANDBOX_ROOT, "daemon/dist/daemon.js");
 const DOCKERFILE = resolve(IMAGE_DIR, "Dockerfile");
+/** Static skills tree COPY'd into the image at /mnt/skills/public. */
+const SKILLS_DIR = resolve(IMAGE_DIR, "skills");
 
 /**
  * Label key embedding the content hash of (Dockerfile + daemon bundle) into
@@ -81,11 +83,35 @@ async function computeExpectedHash(): Promise<string> {
     throw err;
   }
   const dockerfile = await readFile(DOCKERFILE);
-  return createHash("sha256")
-    .update(daemon)
-    .update(dockerfile)
-    .digest("hex")
-    .slice(0, 16);
+  const hash = createHash("sha256").update(daemon).update(dockerfile);
+  await hashDirectory(hash, SKILLS_DIR);
+  return hash.digest("hex").slice(0, 16);
+}
+
+/**
+ * Fold a directory tree's contents into `hash` deterministically. Sorted by
+ * entry name at each level; file paths and bytes both contribute, so renames
+ * and content edits both bust the cache. Missing dir is treated as empty.
+ */
+async function hashDirectory(hash: Hash, dir: string): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      hash.update(`d:${entry.name}/`);
+      await hashDirectory(hash, full);
+    } else if (entry.isFile()) {
+      hash.update(`f:${entry.name}:`);
+      hash.update(await readFile(full));
+    }
+  }
 }
 
 async function readImageHash(


### PR DESCRIPTION
## What is this contribution about?

Lays the foundation for letting the model work with documents in the sandbox. Three things land together:

1. **Static skills mount.** `/mnt/skills/public/` is baked into the sandbox image with a `SKILL.md` + helper scripts per format (pptx fully fleshed out; docx/xlsx/pdf as text-extraction stubs; `file-reading` as a router). The image-build hash now includes the skills tree so editing a `SKILL.md` triggers a rebuild on the next sandbox start.
2. **v1 pptx reading skill.** `pptx-extract` (text, optional `--notes`), `pptx-thumbnail` (single composite grid image + per-slide JPGs), `pptx-rasterize` (per-slide @150dpi with `--pages 1,3-5` selectors), `pptx-unpack` (raw XML). Pipeline uses LibreOffice headless → pdftoppm → Pillow. Bare commands wired via `/usr/local/bin` symlinks.
3. **Polymorphic `view` tool.** Renames the vm-tool `read` → `view` and makes it polymorphic: text returns numbered content like before; supported images (jpeg/png/gif/webp via magic-byte sniff) return base64 bytes that get queued in `pendingImages` and injected as a vision input on the next turn (same plumbing `take_screenshot` uses). 5MB cap; absolute paths now allowed since OS perms gate them.

Also includes a refactor of VM tool registration to lazy provisioning (`vmContext` + `ensureHandle` instead of the old `VM_START`-gated `activeVm`), generalisation of `PendingImage` to support non-screenshot labels, and a defensive `Array.isArray` guard in `generate-image.tsx` to stop the UI from crashing when the model passes `referenceImages` as something other than an array.

## How to Test

1. Restart `bun run dev` so the daemon bundle rebuilds and `ensureSandboxImage` picks up the new hash.
2. From a chat with a sandbox attached, drop a `.pptx` somewhere reachable (e.g. temporarily add `COPY image/sample.pptx /home/sandbox/sample.pptx` to the Dockerfile and place a sample at `packages/sandbox/image/sample.pptx`).
3. Have the model run `pptx-extract /home/sandbox/sample.pptx` — confirm `## Slide N` text output.
4. Have the model run `pptx-thumbnail /home/sandbox/sample.pptx`, then `view /home/sandbox/sample.thumbnail.jpg` — confirm the model can describe what it visually sees in the deck.
5. Bonus: `pptx-rasterize --pages 4 /home/sandbox/sample.pptx` then `view` the resulting JPG.
6. Run `bun test packages/sandbox/daemon/routes/fs.test.ts` — 12 pass (4 new tests for image handling and absolute paths).

## Migration Notes

- The vm-tool `read` is gone from the model's toolset; `view` replaces it (covers all text-reading use cases plus images). The daemon endpoint `/_decopilot_vm/read` is kept as an alias for one release cycle so mid-upgrade running sandboxes don't 404.
- Image rebuild on first start adds ~5–10 minutes for the LibreOffice install (~500MB). Subsequent rebuilds touching only daemon/skills are quick because the apt layer is cached.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (daemon fs tests pass; mesh + sandbox `tsc --noEmit` clean)
- [x] Documentation is updated (SKILL.md per skill + skills-features.md checklist)
- [x] No breaking changes for end users (daemon `/read` alias preserves backward compat for one cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds document skills to the sandbox and v1 PPTX reading. Also makes the VM `read` tool polymorphic (text + images), provisions the VM lazily, and reuses one VM per (user, agent) for ephemeral agents.

- **New Features**
  - Static skills baked into the image at `/mnt/skills/public/` with `SKILL.md` + helper scripts; image build hash now includes the skills tree. `_bin` scripts are symlinked into `/usr/local/bin`. Docker image adds LibreOffice, `poppler-utils`, fonts, `dbus`, and Python libs (`python-pptx`, `python-docx`, `openpyxl`, `pypdf`, `Pillow`).
  - v1 PPTX tools: `pptx-extract` (text, `--notes`), `pptx-thumbnail` (grid + per-slide JPGs), `pptx-rasterize` (`--pages`, `--dpi`), `pptx-unpack`. Pipeline: LibreOffice → `pdftoppm` → Pillow. Commands exposed via `/usr/local/bin`.
  - Polymorphic `read` tool: text returns numbered lines; images (jpeg/png/gif/webp, ≤5MB) are queued and injected as a vision input on the next turn with a label. Absolute paths allowed. Canonical daemon route remains `/_decopilot_vm/read`. Tests cover image handling and absolute paths.
  - Lazy VM provisioning: `ensureVmForBranch` binds tools to `(virtualMcpId, branch, user)` and memoizes the handle. GitHub-linked agents keep per-branch isolation (fallback `thread:<id>`); agents without a repo share a single `branch: "ephemeral"` VM per (user, agent). QuickJS `sandbox` fallback is not registered when no VM context is provided. Minor UI guard for non-array `referenceImages`.

- **Migration**
  - Keep using `read`. No breaking changes.
  - The image now installs LibreOffice, Poppler, fonts, and Python libs. First rebuild after upgrade may take ~5–10 minutes; later rebuilds are cached.

<sup>Written for commit 4a41a1fb227e5e8b66b200bac123784f8cf2ee98. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3211?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

