### PR TITLE
fix(auth): identify users in posthog on signup and session create

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -40,6 +40,7 @@ import { createEmailSender, findEmailProvider } from "./email-providers";
 import { emailButton, emailParagraph, emailTemplate } from "./email-template";
 import { createMagicLinkConfig } from "./magic-link";
 import { seedOrgDb } from "./org";
+import { identifyAuthenticatedUser } from "./posthog-identify";
 import { ADMIN_ROLES } from "./roles";
 import { createSSOConfig } from "./sso";
 
@@ -434,6 +435,16 @@ export const auth = betterAuth({
     user: {
       create: {
         after: async (user) => {
+          // Tag the PostHog person record with email/name BEFORE the
+          // user_signed_up capture so that event lands on a person record
+          // that already has $set: { email } applied.
+          identifyAuthenticatedUser({
+            id: user.id,
+            email: user.email,
+            name: user.name ?? null,
+            emailVerified: !!user.emailVerified,
+          });
+
           // Top-of-funnel signup event. Fires once per new user account,
           // before any org is created. Use this (not organization_created)
           // to measure raw signup volume.

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -558,6 +558,31 @@ export const auth = betterAuth({
         },
       },
     },
+    session: {
+      create: {
+        // Re-identify on every successful login (email/password, OTP,
+        // magic link, SSO). PostHog merges person properties server-side,
+        // so this is idempotent and provides automatic backfill for
+        // existing users whose person records were created before
+        // posthog.identify was wired into the auth flow.
+        after: async (session) => {
+          const row = await getDb()
+            .db.selectFrom("user")
+            .select(["id", "email", "name", "emailVerified"])
+            .where("id", "=", session.userId)
+            .executeTakeFirst();
+
+          if (!row) return;
+
+          identifyAuthenticatedUser({
+            id: row.id,
+            email: row.email,
+            name: row.name ?? null,
+            emailVerified: !!row.emailVerified,
+          });
+        },
+      },
+    },
   },
 });
 

--- a/apps/mesh/src/auth/posthog-identify.test.ts
+++ b/apps/mesh/src/auth/posthog-identify.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { buildIdentifyPayload } from "./posthog-identify";
+
+describe("buildIdentifyPayload", () => {
+  const now = new Date("2026-04-28T12:00:00.000Z");
+
+  it("sets email, name, and email_verified via $set", () => {
+    const payload = buildIdentifyPayload(
+      {
+        id: "user_123",
+        email: "alice@acme.com",
+        name: "Alice",
+        emailVerified: true,
+      },
+      now,
+    );
+
+    expect(payload.distinctId).toBe("user_123");
+    expect(payload.properties.$set).toEqual({
+      email: "alice@acme.com",
+      name: "Alice",
+      email_verified: true,
+    });
+  });
+
+  it("sets first_seen_at and signup_email_domain via $set_once", () => {
+    const payload = buildIdentifyPayload(
+      {
+        id: "user_123",
+        email: "alice@acme.com",
+        name: "Alice",
+        emailVerified: true,
+      },
+      now,
+    );
+
+    expect(payload.properties.$set_once).toEqual({
+      first_seen_at: "2026-04-28T12:00:00.000Z",
+      signup_email_domain: "acme.com",
+    });
+  });
+
+  it("forwards email_verified: false unchanged", () => {
+    const payload = buildIdentifyPayload(
+      {
+        id: "user_456",
+        email: "bob@example.com",
+        name: "Bob",
+        emailVerified: false,
+      },
+      now,
+    );
+
+    expect(payload.properties.$set.email_verified).toBe(false);
+  });
+
+  it("normalizes the email domain to lowercase", () => {
+    const payload = buildIdentifyPayload(
+      {
+        id: "user_789",
+        email: "CHARLIE@WIDGETS.IO",
+        name: null,
+        emailVerified: true,
+      },
+      now,
+    );
+
+    expect(payload.properties.$set_once.signup_email_domain).toBe("widgets.io");
+  });
+
+  it("sets name to null when user has no name", () => {
+    const payload = buildIdentifyPayload(
+      {
+        id: "user_789",
+        email: "charlie@widgets.io",
+        name: null,
+        emailVerified: true,
+      },
+      now,
+    );
+
+    expect(payload.properties.$set.name).toBeNull();
+  });
+
+  it("sets signup_email_domain to null when email has no @ separator", () => {
+    const payload = buildIdentifyPayload(
+      {
+        id: "user_999",
+        email: "malformed-email",
+        name: "Dave",
+        emailVerified: false,
+      },
+      now,
+    );
+
+    expect(payload.properties.$set_once.signup_email_domain).toBeNull();
+  });
+});

--- a/apps/mesh/src/auth/posthog-identify.ts
+++ b/apps/mesh/src/auth/posthog-identify.ts
@@ -1,0 +1,58 @@
+/**
+ * Builds the PostHog `identify` payload tagging the person record with
+ * email/name/email_verified ($set, last-write-wins) and first-seen
+ * metadata ($set_once, written only on the first identify per user).
+ *
+ * Pure for testability — all inputs are explicit. The impure wrapper
+ * `identifyAuthenticatedUser` below calls `posthog.identify` with the
+ * payload.
+ */
+
+import { posthog } from "@/posthog";
+
+export interface IdentifiableUser {
+  id: string;
+  email: string;
+  name: string | null;
+  emailVerified: boolean;
+}
+
+export interface PostHogIdentifyPayload {
+  distinctId: string;
+  properties: {
+    $set: {
+      email: string;
+      name: string | null;
+      email_verified: boolean;
+    };
+    $set_once: {
+      first_seen_at: string;
+      signup_email_domain: string | null;
+    };
+  };
+}
+
+export function buildIdentifyPayload(
+  user: IdentifiableUser,
+  now: Date,
+): PostHogIdentifyPayload {
+  const domain = user.email.split("@")[1]?.toLowerCase() ?? null;
+  return {
+    distinctId: user.id,
+    properties: {
+      $set: {
+        email: user.email,
+        name: user.name,
+        email_verified: user.emailVerified,
+      },
+      $set_once: {
+        first_seen_at: now.toISOString(),
+        signup_email_domain: domain,
+      },
+    },
+  };
+}
+
+export function identifyAuthenticatedUser(user: IdentifiableUser): void {
+  posthog.identify(buildIdentifyPayload(user, new Date()));
+}


### PR DESCRIPTION
## Summary

Fixes patchy email coverage on `tool_called` events by tagging the PostHog person record on every Better Auth signup and login.

- New helper `apps/mesh/src/auth/posthog-identify.ts` builds the identify payload (`\$set: { email, name, email_verified }` + `\$set_once: { first_seen_at, signup_email_domain }`).
- `user.create.after` now calls `posthog.identify` before the existing `user_signed_up` capture, so brand-new signups land on a person record that already has email applied.
- New `session.create.after` hook re-identifies on every successful login (email/password, OTP, magic link, SSO). Idempotent — provides automatic backfill for existing users whose person records were created before identify was wired in.

PostHog joins events to persons at query time, so once an existing user signs in after this rolls out, their historical `tool_called` events render with email attached retroactively.

**Out of scope (deferred):** API key auth, OAuth 2.1 access-token validation, instant email-change correction.

## Test plan

- [x] Unit tests for the payload builder (`bun test apps/mesh/src/auth/posthog-identify.test.ts`) — 6 passing
- [x] Full auth test suite (`bun test apps/mesh/src/auth/`) — 31 passing
- [x] Type check (`bun run check`) — clean
- [x] Format (`bun run fmt`) — clean
- [ ] Staging: sign in as an existing user with no email on their PostHog person and confirm the record now shows email within ~30s
- [ ] Staging: open a historical `tool_called` event for that user and confirm it now displays email (proves retroactive query-time join)
- [ ] Staging: sign up a brand-new user and confirm `user_signed_up` lands on a person with email already set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Identify users in PostHog on signup and every login to fix missing emails on `tool_called` events. New and existing users now have email/name on their PostHog person, and historical events show email after the next login.

- Bug Fixes
  - Added `apps/mesh/src/auth/posthog-identify.ts` with `buildIdentifyPayload` and `identifyAuthenticatedUser` (`$set: email, name, email_verified`; `$set_once: first_seen_at, signup_email_domain`).
  - Call `identifyAuthenticatedUser` in `user.create.after` before capturing `user_signed_up`.
  - Re-identify in `session.create.after` for all login flows; idempotent backfill for older accounts.

<sup>Written for commit 0264526ac1efc72fa47d60838abad22d84797266. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3212?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

