### PR TITLE
feat(mesh): pass tool args to app view

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -32,10 +32,11 @@ export function MainPanelContent({
   taskId: string;
   virtualMcpId: string;
 }) {
-  const { activeTab, layoutTabs, automationTabParsed } = useMainPanelTabs({
-    virtualMcpId,
-    taskId,
-  });
+  const { activeTab, layoutTabs, expandedTools, automationTabParsed } =
+    useMainPanelTabs({
+      virtualMcpId,
+      taskId,
+    });
 
   if (isLegacySettingsTab(activeTab)) {
     return <SettingsTab virtualMcpId={virtualMcpId} />;
@@ -58,6 +59,11 @@ export function MainPanelContent({
 
   const pinnedView = parsePinnedViewTabId(activeTab);
   if (pinnedView) {
+    const expandedTool = expandedTools.find(
+      (t) =>
+        t.appId === pinnedView.connectionId &&
+        t.toolName === pinnedView.toolName,
+    );
     return (
       <Suspense
         fallback={
@@ -73,6 +79,7 @@ export function MainPanelContent({
           key={activeTab}
           connectionId={pinnedView.connectionId}
           toolName={pinnedView.toolName}
+          args={expandedTool?.args}
         />
       </Suspense>
     );
@@ -95,6 +102,7 @@ export function MainPanelContent({
           key={activeTab}
           connectionId={agentTab.view.appId}
           toolName={agentTab.id}
+          args={agentTab.view.args}
         />
       </Suspense>
     );

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -28,6 +28,7 @@ function AppRenderer({
   tool,
   connectionId,
   orgId,
+  args,
 }: {
   client: ReturnType<typeof useMCPClient>;
   resourceURI: string;
@@ -39,6 +40,7 @@ function AppRenderer({
   };
   connectionId: string;
   orgId?: string;
+  args?: Record<string, unknown>;
 }) {
   const { sendMessage } = useChatBridge();
   const { setAppContext, clearAppContext } = useChatPrefs();
@@ -54,10 +56,11 @@ function AppRenderer({
     }
     return "fullscreen";
   };
+  const toolInput = args ?? EMPTY_TOOL_INPUT;
   const { data: toolResult } = useMCPToolCall({
     client,
     toolName: tool.name,
-    toolArguments: EMPTY_TOOL_INPUT,
+    toolArguments: toolInput,
   });
 
   const clientId = getGatewayClientId(tool._meta);
@@ -83,7 +86,7 @@ function AppRenderer({
       resourceURI={resourceURI}
       orgId={orgId}
       toolInfo={{ tool: strippedTool }}
-      toolInput={EMPTY_TOOL_INPUT}
+      toolInput={toolInput}
       toolResult={toolResult}
       displayMode="fullscreen"
       minHeight={MCP_APP_DISPLAY_MODES.fullscreen.minHeight}
@@ -101,9 +104,11 @@ function AppRenderer({
 export function AppViewContent({
   connectionId,
   toolName,
+  args,
 }: {
   connectionId: string;
   toolName: string;
+  args?: Record<string, unknown>;
 }) {
   const { org } = useProjectContext();
   const client = useMCPClient({ connectionId, orgId: org.id });
@@ -132,6 +137,7 @@ export function AppViewContent({
       tool={tool}
       connectionId={connectionId}
       orgId={org.id}
+      args={args}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Propagate `args` from `expandedTools` and agent tab views to `AppViewContent` and `AppRenderer`
- Pinned views and agent tabs now render with the correct tool arguments instead of always using empty input
- Affects `MainPanelContent` (tab layout) and `AppViewContent` / `AppRenderer` (app rendering)

## Test plan
- [ ] Open a pinned view that has tool args — verify the app renders with those args
- [ ] Open an agent tab with args — verify the tool call uses the correct arguments
- [ ] Confirm views without args still default to empty input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass tool arguments from expanded tools and agent tabs into the app view so pinned views and agent tabs render with the correct input. MCP tool calls now use provided args instead of defaulting to empty.

- **Bug Fixes**
  - Propagate `args` from `expandedTools` and agent tab views to `AppViewContent` and `AppRenderer`.
  - Match pinned views to their expanded tool and supply its args.
  - Fallback to empty input when no args are provided.

<sup>Written for commit 23c10625da80e45f0ef3c949bf128a491b975c52. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3214?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

