### PR TITLE
fix(tasks): hide empty threads from task panel until first message

### DIFF
--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -57,6 +57,7 @@ export interface ThreadStoragePort {
       agentId?: string;
       includeArchived?: boolean;
       hasTrigger?: boolean;
+      hasMessages?: boolean;
     },
   ): Promise<{ threads: Thread[]; total: number }>;
   listByTriggerIds(

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -84,6 +84,7 @@ export class OrgScopedThreadStorage {
       agentId?: string;
       includeArchived?: boolean;
       hasTrigger?: boolean;
+      hasMessages?: boolean;
     },
   ): Promise<{ threads: Thread[]; total: number }> {
     return this.inner.list(this.requireOrg(), createdBy, options);
@@ -288,6 +289,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       agentId?: string;
       includeArchived?: boolean;
       hasTrigger?: boolean;
+      hasMessages?: boolean;
     },
   ): Promise<{ threads: Thread[]; total: number }> {
     const archived = options?.includeArchived === true;
@@ -309,6 +311,29 @@ export class SqlThreadStorage implements ThreadStoragePort {
       query = query.where("trigger_id", "is not", null);
     } else if (options?.hasTrigger === false) {
       query = query.where("trigger_id", "is", null);
+    }
+    if (options?.hasMessages === true) {
+      query = query.where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom("thread_messages")
+            .select("thread_messages.id")
+            .whereRef("thread_messages.thread_id", "=", "threads.id")
+            .limit(1),
+        ),
+      );
+    } else if (options?.hasMessages === false) {
+      query = query.where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom("thread_messages")
+              .select("thread_messages.id")
+              .whereRef("thread_messages.thread_id", "=", "threads.id")
+              .limit(1),
+          ),
+        ),
+      );
     }
     if (options?.startDate) {
       // updated_at is stored as ISO text — string comparison is correct for ISO dates
@@ -348,6 +373,29 @@ export class SqlThreadStorage implements ThreadStoragePort {
       countQuery = countQuery.where("trigger_id", "is not", null);
     } else if (options?.hasTrigger === false) {
       countQuery = countQuery.where("trigger_id", "is", null);
+    }
+    if (options?.hasMessages === true) {
+      countQuery = countQuery.where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom("thread_messages")
+            .select("thread_messages.id")
+            .whereRef("thread_messages.thread_id", "=", "threads.id")
+            .limit(1),
+        ),
+      );
+    } else if (options?.hasMessages === false) {
+      countQuery = countQuery.where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom("thread_messages")
+              .select("thread_messages.id")
+              .whereRef("thread_messages.thread_id", "=", "threads.id")
+              .limit(1),
+          ),
+        ),
+      );
     }
     if (options?.startDate) {
       countQuery = countQuery.where(

--- a/apps/mesh/src/tools/thread/list.ts
+++ b/apps/mesh/src/tools/thread/list.ts
@@ -25,6 +25,8 @@ const ThreadListInputSchema = CollectionListInputSchema.extend({
       hidden: z.boolean().optional(),
       /** Filter by presence of a trigger_id (automation-owned) */
       has_trigger: z.boolean().optional(),
+      /** Filter by presence of at least one message in the thread */
+      has_messages: z.boolean().optional(),
     })
     .optional(),
   startDate: z
@@ -107,6 +109,7 @@ export const COLLECTION_THREADS_LIST = defineTool({
           agentId: input.agentId,
           includeArchived: input.where?.hidden,
           hasTrigger: input.where?.has_trigger,
+          hasMessages: input.where?.has_messages,
         });
 
     const hasMore = offset + limit < total;

--- a/apps/mesh/src/web/components/chat/task/use-task-manager.ts
+++ b/apps/mesh/src/web/components/chat/task/use-task-manager.ts
@@ -36,6 +36,7 @@ export interface UseTasksParams {
   userId?: string;
   virtualMcpId?: string;
   hasTrigger?: boolean;
+  hasMessages?: boolean;
 }
 
 // ============================================================================
@@ -56,6 +57,7 @@ export function useTasks(params: UseTasksParams) {
       virtualMcpId: params.virtualMcpId,
       userId: params.owner === "me" ? (params.userId ?? null) : null,
       hasTrigger: params.hasTrigger ?? null,
+      hasMessages: params.hasMessages ?? null,
     }),
     queryFn: async () => {
       if (!client) {
@@ -69,6 +71,8 @@ export function useTasks(params: UseTasksParams) {
       if (params.owner === "automation") where.has_trigger = true;
       if (params.hasTrigger !== undefined)
         where.has_trigger = params.hasTrigger;
+      if (params.hasMessages !== undefined)
+        where.has_messages = params.hasMessages;
 
       const input = {
         limit: TASK_CONSTANTS.TASKS_PAGE_SIZE,

--- a/apps/mesh/src/web/layouts/tasks-panel/index.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/index.tsx
@@ -34,6 +34,7 @@ function TasksPanelContent() {
     owner: "me",
     status: "open",
     hasTrigger: false,
+    hasMessages: true,
   });
   const { tasks: automationTasks } = useTasks({
     owner: "all",

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -24,6 +24,7 @@ export const KEYS = {
       virtualMcpId?: string;
       userId?: string | null;
       hasTrigger?: boolean | null;
+      hasMessages?: boolean | null;
     },
   ) =>
     [
@@ -34,6 +35,7 @@ export const KEYS = {
       filters.virtualMcpId ?? null,
       filters.userId ?? null,
       filters.hasTrigger ?? null,
+      filters.hasMessages ?? null,
     ] as const,
   // Prefix for broad invalidation of all task queries for a locator
   tasksPrefix: (locator: string) => ["tasks", locator] as const,


### PR DESCRIPTION
## What is this contribution about?

Every time a user clicked home or an agent, `useNavigateToAgent` generated a fresh UUID and `useEnsureTask` eagerly created the thread on 404, causing multiple "New chat" entries to accumulate in the task panel. The fix adds a `has_messages` filter (backed by a `WHERE EXISTS` subquery on `thread_messages`) through the full stack — storage port, SQL implementation, tool schema, query cache key, and `useTasks` hook — and applies `hasMessages: true` to the task panel's user-tasks query. Threads are still created eagerly on navigation (preserving sandbox pre-warm behavior), but only appear in the panel once they have actual content.

## Screenshots/Demonstration

> No UI screenshot needed — the fix removes the unintended "New chat" entries; existing tasks with messages are unaffected.

## How to Test

1. Open the app and note the current task panel entries.
2. Click "Home" and then click a different agent several times.
3. Confirm no new "New chat" entries appear in the task panel.
4. Send a message in a chat and confirm the task now appears in the panel.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide empty “New chat” threads from the tasks panel by filtering to only show threads with messages. Eager thread creation on navigation is preserved; tasks appear after the first message.

- **Bug Fixes**
  - Added a messages filter end-to-end: storage port option, SQL WHERE EXISTS on `thread_messages`, and matching count query.
  - Extended the thread list tool schema with `has_messages` and forwarded it to storage.
  - Included `hasMessages` in the query key and `useTasks`, sending `has_messages` to the tool.
  - Set `hasMessages: true` for the user tasks query in the tasks panel.

<sup>Written for commit 73d6747b02a5627624b8d7af01f69746017c144e. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3217?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

