### PR TITLE
feat(sandbox): idle-reap housekeeper CronJob for sandbox-env chart

### DIFF
--- a/apps/mesh/src/cli/build-child-env.ts
+++ b/apps/mesh/src/cli/build-child-env.ts
@@ -78,26 +78,14 @@ export function buildChildEnv(
 
     // Sandbox runner: read from env by resolveRunnerKindFromEnv() in workers
     STUDIO_SANDBOX_RUNNER: process.env.STUDIO_SANDBOX_RUNNER,
-    // Per-env SandboxTemplate name override (sandbox-env Helm chart suffixes
-    // it with envName). Workers must inherit so claim creation hits the
-    // right template.
     STUDIO_SANDBOX_TEMPLATE_NAME: process.env.STUDIO_SANDBOX_TEMPLATE_NAME,
-    // Preview-URL templating + per-claim HTTPRoute parent. Mesh in workers
-    // creates SandboxClaims and mints HTTPRoutes; without these the runner
-    // silently falls back to in-process proxying / no preview URL.
+    STUDIO_ENV: process.env.STUDIO_ENV,
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN:
       process.env.STUDIO_SANDBOX_PREVIEW_URL_PATTERN,
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME:
       process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME,
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE:
       process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE,
-    // In-cluster K8s API discovery vars, set by Kubernetes when a service
-    // account is mounted. The agent-sandbox runner's `KubeConfig.loadFromDefault()`
-    // reads these from `process.env` to build the API URL — workers without
-    // them fall through to `https://undefined:undefined/...` and every claim
-    // creation throws a transport error. The primary thread inherits env
-    // naturally from PID 1 and works fine, which is why this surfaces as
-    // "sometimes weirdly works" (~1/N of requests succeed when N threads).
     KUBERNETES_SERVICE_HOST: process.env.KUBERNETES_SERVICE_HOST,
     KUBERNETES_SERVICE_PORT: process.env.KUBERNETES_SERVICE_PORT,
     FREESTYLE_API_KEY: process.env.FREESTYLE_API_KEY,

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -67,6 +67,21 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
+// Studio environment name. Stamped on every SandboxClaim, claimed Pod, and
+// per-claim HTTPRoute as `studio.decocms.com/env=<envName>` so the
+// sandbox-env chart's housekeeper can scope its sweep to a single env
+// instead of every studio claim in the namespace. Single-env installs that
+// don't run a per-env housekeeper can leave this unset; the label is then
+// omitted and behavior is unchanged.
+//
+// Format must be DNS-label-safe (validated in AgentSandboxRunner); the
+// chart enforces the same regex on its envName value so the two stay
+// compatible.
+function readEnvName(): string | undefined {
+  const raw = process.env.STUDIO_ENV;
+  return raw && raw.trim() !== "" ? raw : undefined;
+}
+
 // Per-claim HTTPRoute attaches to this Gateway. When NAME + NAMESPACE are
 // set alongside STUDIO_SANDBOX_PREVIEW_URL_PATTERN, mesh mints one
 // HTTPRoute per SandboxClaim so the wildcard Gateway can route directly
@@ -127,6 +142,7 @@ async function instantiate(
         stateStore,
         previewUrlPattern,
         sandboxTemplateName: readSandboxTemplateName(),
+        envName: readEnvName(),
         previewGateway: readPreviewGateway(),
         meter,
       });

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -67,16 +67,6 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
-// Studio environment name. Stamped on every SandboxClaim, claimed Pod, and
-// per-claim HTTPRoute as `studio.decocms.com/env=<envName>` so the
-// sandbox-env chart's housekeeper can scope its sweep to a single env
-// instead of every studio claim in the namespace. Single-env installs that
-// don't run a per-env housekeeper can leave this unset; the label is then
-// omitted and behavior is unchanged.
-//
-// Format must be DNS-label-safe (validated in AgentSandboxRunner); the
-// chart enforces the same regex on its envName value so the two stay
-// compatible.
 function readEnvName(): string | undefined {
   const raw = process.env.STUDIO_ENV;
   return raw && raw.trim() !== "" ? raw : undefined;

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,34 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-# 0.4.0: SandboxTemplate now passes `topologySpreadConstraints` from
-# values into the pod spec. Empty default preserves prior behaviour.
-# Use it to spread sandbox pods across AZs so a single-AZ spot reclaim
-# doesn't take half the pool out simultaneously — see values.yaml for
-# the recommended config.
-#
-# 0.3.0: mesh runner now Server-Side Applies `port: 9000` onto each
-# operator-created Service after the SandboxClaim becomes Ready, taking
-# ownership of `spec.ports[name=daemon]` under field manager
-# `mesh-sandbox-runner`. agent-sandbox v0.4.x ships Services with
-# `spec.ports: []` (the operator assumes direct pod-IP DNS), which makes
-# Istio's k8s service registry refuse to register an upstream cluster —
-# HTTPRoutes "Accept" but Envoy returns 500 with no body, surfacing as a
-# phantom CORS error in browsers. SSA (vs. plain PATCH) means a future
-# operator reconciler that tries to reset ports[] will hit a
-# managed-fields conflict rather than silently breaking routing. RBAC
-# gains `services: [get, patch]` in `agent-sandbox-system`. Upgraders
-# MUST bump mesh to the matching version; without the new RBAC the
-# runner fails to apply the Service and per-claim previews stop routing.
-#
-# 0.2.0: per-claim HTTPRoutes minted by mesh runner. The chart no longer
-# renders the cluster-wide HTTPRoute that backed the in-process preview
-# proxy; mesh now mints one HTTPRoute per SandboxClaim. RBAC gains
-# `httproutes` (gateway.networking.k8s.io) perms, and NetworkPolicy gains
-# an ingress rule from `previewGateway.namespace` to sandbox port 9000.
-# Upgraders MUST bump mesh to the matching version that creates per-claim
-# HTTPRoutes — otherwise preview URLs stop resolving.
-version: 0.4.0
+version: 0.5.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.1.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -65,7 +65,7 @@ Published as an OCI artifact at
 ```bash
 helm install sandbox-env-staging \
   oci://ghcr.io/decocms/studio/charts/sandbox-env \
-  --version 0.1.0 \
+  --version 0.5.0 \
   --namespace agent-sandbox-system \
   --set envName=staging \
   --set mesh.namespace=deco-studio-staging \
@@ -108,7 +108,7 @@ spec:
   source:
     repoURL: ghcr.io/decocms/studio/charts
     chart: sandbox-env
-    targetRevision: 0.1.0
+    targetRevision: 0.5.0
     helm:
       values: |
         envName: staging
@@ -139,7 +139,7 @@ values file:
 ```bash
 helm upgrade sandbox-env-staging \
   oci://ghcr.io/decocms/studio/charts/sandbox-env \
-  --version 0.2.0 \
+  --version 0.5.0 \
   --namespace agent-sandbox-system \
   --reset-then-reuse-values \
   --set housekeeper.enabled=true

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -127,6 +127,27 @@ spec:
 
 Repeat the `Application` per env, varying `metadata.name` and `envName`.
 
+### Upgrading an existing release to enable the housekeeper
+
+`helm upgrade --reuse-values` does NOT pull in defaults for newly-added
+values keys, so an upgrade that flips `housekeeper.enabled=true` on a
+release installed before the housekeeper landed will fail with
+`nil pointer evaluating interface {}.repository`. Use
+`--reset-then-reuse-values` (Helm 3.14+) instead, or re-pass the full
+values file:
+
+```bash
+helm upgrade sandbox-env-staging \
+  oci://ghcr.io/decocms/studio/charts/sandbox-env \
+  --version 0.2.0 \
+  --namespace agent-sandbox-system \
+  --reset-then-reuse-values \
+  --set housekeeper.enabled=true
+```
+
+ArgoCD users are unaffected — `Application.spec.source.helm.values` is a
+re-render from scratch, not a merge.
+
 ## Layout
 
 ```

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -28,6 +28,13 @@ installed (it ships the CRDs + controller).
   chart's `configMap.meshConfig`. Without that override the runner falls
   back to `studio-sandbox` (no suffix) and claim creation fails with
   `sandboxtemplate not found`.
+- The studio release must also set `STUDIO_ENV=<envName>` (same envName)
+  so mesh stamps `studio.decocms.com/env=<envName>` on every SandboxClaim,
+  pod, and HTTPRoute it creates. The housekeeper's default selectors
+  scope sweeps to that env label — without it the housekeeper matches
+  zero claims and reaps nothing. Single-env installs that don't enable
+  the housekeeper can leave `STUDIO_ENV` unset (the label is then
+  omitted and behavior is unchanged).
 
 ## Preview gateway auth model
 
@@ -75,6 +82,7 @@ this runner:
 configMap:
   meshConfig:
     STUDIO_SANDBOX_RUNNER: "agent-sandbox"
+    STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
     # Per-claim HTTPRoute attaches to this Gateway. Both required whenever

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -2,44 +2,34 @@
 # sandbox-housekeeper sweep — one CronJob run.
 #
 # Env (set by the CronJob spec):
-#   NS, TTL_MS, STUCK_TTL_MS, PROBE_TIMEOUT_SEC,
+#   NS, TTL_MS, PROBE_TIMEOUT_SEC,
 #   CLAIM_SELECTOR, POD_SELECTOR, RUN_ID.
 
 set -eu
 
 : "${NS:?must be set}"
 : "${TTL_MS:?must be set}"
-: "${STUCK_TTL_MS:?must be set}"
 : "${PROBE_TIMEOUT_SEC:?must be set}"
 : "${CLAIM_SELECTOR:?must be set}"
 : "${POD_SELECTOR:?must be set}"
 : "${RUN_ID:?must be set}"
 
-PROBE_FAIL_ANNOT="studio.decocms.com/probe-fail-since"
-PROBE_FAIL_DETAIL_ANNOT="studio.decocms.com/probe-fail-detail"
 DAEMON_PORT=9000
 IDLE_PATH="/_decopilot_vm/idle"
 
 now_iso()   { date -u +%Y-%m-%dT%H:%M:%SZ; }
 now_micro() { date -u +%Y-%m-%dT%H:%M:%S.000000Z; }
-now_secs()  { date -u +%s; }
 
 log() {
   printf '[%s] [housekeeper] run=%s %s\n' "$(now_iso)" "$RUN_ID" "$*"
 }
 
-# JSONPath escapes dots in keys with a backslash.
-jsonpath_for_annotation() {
-  printf '%s' "$1" | sed 's/\./\\./g'
-}
-
 # Best-effort — a misconfigured Event API shouldn't block the reap.
-# events.k8s.io/v1 is the current API; the legacy v1 Events API is
-# deprecated. `kubectl get events` and `kubectl describe sandboxclaim`
-# aggregate from both, so consumers see these unchanged.
 emit_event() {
   claim="$1"; reason="$2"; action="$3"; msg="$4"
   ts=$(now_micro)
+  # YAML single-quoted scalar: double any embedded single quotes.
+  safe_msg=$(printf '%s' "$msg" | sed "s/'/''/g")
   kubectl create -f - <<YAML >/dev/null 2>&1 || true
 apiVersion: events.k8s.io/v1
 kind: Event
@@ -50,7 +40,7 @@ eventTime: ${ts}
 type: Normal
 reason: ${reason}
 action: ${action}
-note: ${msg}
+note: '${safe_msg}'
 reportingController: sandbox-housekeeper
 reportingInstance: ${RUN_ID}
 regarding:
@@ -94,41 +84,6 @@ probe_daemon() {
   esac
 }
 
-# Echoes the failure-since marker as epoch seconds. Stored as a plain
-# integer (not ISO) so age math is bulletproof — no busybox `date -d`
-# parsing path that could silently fall back and reset the clock. Humans
-# can decode with `date -d @<epoch>`.
-#
-# Preserves the existing stamp on repeats so consecutive-failure age
-# accumulates across sweeps. If a previous-version sweep wrote an ISO
-# string, the non-numeric value is rewritten as a fresh failure (resets
-# the clock once during upgrade — conservative).
-mark_probe_failure() {
-  claim="$1"; detail="$2"
-  jp=$(jsonpath_for_annotation "$PROBE_FAIL_ANNOT")
-  existing=$(kubectl get sandboxclaim "$claim" -n "$NS" \
-    -o jsonpath="{.metadata.annotations.${jp}}" 2>/dev/null || true)
-  case "$existing" in
-    ''|*[!0-9]*)
-      secs=$(now_secs)
-      kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
-        "${PROBE_FAIL_ANNOT}=${secs}" \
-        "${PROBE_FAIL_DETAIL_ANNOT}=${detail}" >/dev/null 2>&1 || true
-      echo "$secs"
-      ;;
-    *)
-      echo "$existing"
-      ;;
-  esac
-}
-
-clear_probe_failure() {
-  claim="$1"
-  kubectl annotate sandboxclaim "$claim" -n "$NS" \
-    "${PROBE_FAIL_ANNOT}-" \
-    "${PROBE_FAIL_DETAIL_ANNOT}-" >/dev/null 2>&1 || true
-}
-
 # Shared prelude for both reap paths.
 mark_for_reap() {
   claim="$1"; reason="$2"; detail="$3"; action="$4"
@@ -146,7 +101,7 @@ mark_for_reap() {
 }
 
 # Graceful path: operator drains the pod via shutdownTime. Used for Idle
-# and StuckReady where the operator is still functional.
+# where the operator is still functional.
 request_shutdown() {
   claim="$1"; reason="$2"; detail="$3"
   log "shutdown claim=$claim reason=$reason detail=\"$detail\""
@@ -167,7 +122,7 @@ force_delete_claim() {
 }
 
 # === main ===
-log "starting (ttl=${TTL_MS}ms stuck_ttl=${STUCK_TTL_MS}ms probe_timeout=${PROBE_TIMEOUT_SEC}s)"
+log "starting (ttl=${TTL_MS}ms probe_timeout=${PROBE_TIMEOUT_SEC}s)"
 
 CLAIMS_FILE=$(mktemp)
 PODS_FILE=$(mktemp)
@@ -179,20 +134,18 @@ kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
   -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
   > "$CLAIMS_FILE" 2>/dev/null || true
 
-# Selector-mismatch detector: most common operator misconfiguration after
-# enabling the housekeeper is forgetting to set STUDIO_ENV on mesh, so the
-# scoped selector matches zero claims even though studio is happily creating
-# them. A silent `claims=0` heartbeat hides this — log loudly when the
-# unscoped query disagrees.
+# Selector-mismatch detector: silent `claims=0` hides a missing STUDIO_ENV
+# on mesh. Warn loudly and gate orphan GC off so we don't nuke routes whose
+# claims are present but unlabeled.
+selector_mismatch=0
 if ! [ -s "$CLAIMS_FILE" ]; then
   unscoped=$(kubectl get sandboxclaims -n "$NS" \
     -l "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox" \
     -o name 2>/dev/null | wc -l | tr -d ' ' || echo 0)
   if [ "${unscoped:-0}" -gt 0 ]; then
     log "WARN selector matched zero claims but ${unscoped} studio-managed claim(s) exist in ${NS} — verify STUDIO_ENV is set on the mesh deployment and matches the chart's envName (current selector: ${CLAIM_SELECTOR})"
+    selector_mismatch=1
   fi
-  log "heartbeat ok claims=0 reaped=0 skipped=0 orphan_routes=0"
-  exit 0
 fi
 
 kubectl get pods -n "$NS" -l "$POD_SELECTOR" \
@@ -231,20 +184,11 @@ while IFS='|' read -r CLAIM READY REASON; do
   RESULT=$(probe_daemon "$POD_IP")
   case "$RESULT" in
     __unreachable__|__not_found__|__server_error__|__bad_shape__)
-      detail="$RESULT"
-      since_secs=$(mark_probe_failure "$CLAIM" "$detail")
-      age_ms=$(( ($(now_secs) - since_secs) * 1000 ))
-      if [ "$age_ms" -ge "$STUCK_TTL_MS" ]; then
-        request_shutdown "$CLAIM" "StuckReady" "probe failing for ${age_ms}ms (last detail: $detail)"
-        reaped=$((reaped + 1))
-      else
-        log "skip claim=$CLAIM reason=probe-failed detail=$detail age_ms=$age_ms"
-        skipped=$((skipped + 1))
-      fi
+      log "skip claim=$CLAIM reason=probe-failed detail=$RESULT"
+      skipped=$((skipped + 1))
       ;;
     *)
       IDLE_MS="$RESULT"
-      clear_probe_failure "$CLAIM"
       if [ "$IDLE_MS" -lt "$TTL_MS" ]; then
         log "keep claim=$CLAIM idle_ms=$IDLE_MS remaining_ms=$((TTL_MS - IDLE_MS))"
         continue
@@ -255,8 +199,6 @@ while IFS='|' read -r CLAIM READY REASON; do
       RESULT2=$(probe_daemon "$POD_IP")
       case "$RESULT2" in
         __*)
-          # Conservative: next sweep picks it up via the probe-failure
-          # path with its own StuckReady escalation.
           log "abort-reap claim=$CLAIM reason=re-probe-failed first_idle_ms=$IDLE_MS detail=$RESULT2"
           skipped=$((skipped + 1))
           ;;
@@ -275,31 +217,27 @@ while IFS='|' read -r CLAIM READY REASON; do
 done < "$CLAIMS_FILE"
 
 # === orphan HTTPRoute GC ===
-# Routes whose backing claim is gone. Reachable when a runner stop() raced
-# with pod death and the per-claim HTTPRoute teardown didn't land — the
-# runner code path swallows the failure ("garbage-collection sweep will
-# clean it up") and this is that sweep. Reuses CLAIM_SELECTOR because mesh
-# stamps the same managed-by/name/env labels on routes (runner.ts).
-#
-# Limited to routes with a sandbox-handle label so a hand-managed route
-# accidentally tagged with managed-by=studio doesn't get nuked.
+# Catches routes whose runner stop() failed to delete. Skipped on selector
+# mismatch to avoid nuking routes whose claims are present but unlabeled.
 orphan_routes=0
-kubectl get httproutes -n "$NS" -l "$CLAIM_SELECTOR" \
-  -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.studio\.decocms\.com/sandbox-handle}{"\n"}{end}' \
-  > "$ROUTES_FILE" 2>/dev/null || true
+if [ "$selector_mismatch" -eq 0 ]; then
+  kubectl get httproutes -n "$NS" -l "$CLAIM_SELECTOR" \
+    -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.studio\.decocms\.com/sandbox-handle}{"\n"}{end}' \
+    > "$ROUTES_FILE" 2>/dev/null || true
 
-while IFS='|' read -r ROUTE_NAME ROUTE_HANDLE; do
-  [ -z "$ROUTE_NAME" ] && continue
-  [ -z "$ROUTE_HANDLE" ] && continue
-  # Live-claim membership test against col 1 of CLAIMS_FILE.
-  if awk -F'|' -v h="$ROUTE_HANDLE" '$1==h { exit 0 } END { exit 1 }' \
-       "$CLAIMS_FILE"; then
-    continue
-  fi
-  log "orphan-route-gc route=$ROUTE_NAME handle=$ROUTE_HANDLE"
-  kubectl delete httproute "$ROUTE_NAME" -n "$NS" \
-    --ignore-not-found >/dev/null 2>&1 || true
-  orphan_routes=$((orphan_routes + 1))
-done < "$ROUTES_FILE"
+  while IFS='|' read -r ROUTE_NAME ROUTE_HANDLE; do
+    [ -z "$ROUTE_NAME" ] && continue
+    [ -z "$ROUTE_HANDLE" ] && continue
+    # Live-claim membership test against col 1 of CLAIMS_FILE.
+    if awk -F'|' -v h="$ROUTE_HANDLE" '$1==h { exit 0 } END { exit 1 }' \
+         "$CLAIMS_FILE"; then
+      continue
+    fi
+    log "orphan-route-gc route=$ROUTE_NAME handle=$ROUTE_HANDLE"
+    kubectl delete httproute "$ROUTE_NAME" -n "$NS" \
+      --ignore-not-found >/dev/null 2>&1 || true
+    orphan_routes=$((orphan_routes + 1))
+  done < "$ROUTES_FILE"
+fi
 
 log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped orphan_routes=$orphan_routes"

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -1,0 +1,276 @@
+#!/bin/sh
+# sandbox-housekeeper sweep — invoked once per CronJob run.
+#
+# Inputs (env, set by the CronJob spec):
+#   NS                     namespace to scan (always agent-sandbox-system today).
+#   TTL_MS                 idle TTL in ms — claims with idleMs >= this are reaped.
+#   STUCK_TTL_MS           consecutive probe failures older than this trigger a
+#                          StuckReady reap (catches wedged daemons that present
+#                          TCP but don't reply meaningfully).
+#   PROBE_TIMEOUT_SEC      curl --max-time per probe and per re-probe.
+#   CLAIM_SELECTOR         label selector for studio claims (mirrors mesh's
+#                          buildClaim labels in runner.ts).
+#   POD_SELECTOR           label selector for claimed sandbox pods.
+#   RUN_ID                 cronjob pod name (downward API).
+#
+# Output: structured stdout (one event per line, key=value).
+# Side effects: kubectl annotate / delete on claims and httproutes; create on
+# Events. Probe failures escalate to reap only after STUCK_TTL_MS; transient
+# failures skip the claim, leaving idle accounting untouched.
+
+set -eu
+
+: "${NS:?must be set}"
+: "${TTL_MS:?must be set}"
+: "${STUCK_TTL_MS:?must be set}"
+: "${PROBE_TIMEOUT_SEC:?must be set}"
+: "${CLAIM_SELECTOR:?must be set}"
+: "${POD_SELECTOR:?must be set}"
+: "${RUN_ID:?must be set}"
+
+PROBE_FAIL_ANNOT="studio.decocms.com/probe-fail-since"
+PROBE_FAIL_DETAIL_ANNOT="studio.decocms.com/probe-fail-detail"
+DAEMON_PORT=9000
+IDLE_PATH="/_decopilot_vm/idle"
+
+now_iso()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+now_secs() { date -u +%s; }
+
+log() {
+  printf '[%s] [housekeeper] run=%s %s\n' "$(now_iso)" "$RUN_ID" "$*"
+}
+
+# GNU date `-d` parses ISO 8601 timestamps. bitnami/kubectl ships GNU
+# coreutils so this works; if a future image swaps to busybox date the
+# fallback returns now() and the StuckReady age starts fresh.
+iso_to_secs() {
+  date -u -d "$1" +%s 2>/dev/null || now_secs
+}
+
+# JSONPath escapes dots in label/annotation keys with a backslash. Escape
+# once so callers can pass the raw key.
+jsonpath_for_annotation() {
+  printf '%s' "$1" | sed 's/\./\\./g'
+}
+
+# Emit a Kubernetes Event referencing the SandboxClaim. Best-effort: failures
+# are swallowed so a misconfigured Event API doesn't block the reap.
+emit_event() {
+  claim="$1"; reason="$2"; action="$3"; msg="$4"
+  ts=$(now_iso)
+  kubectl create -f - <<YAML >/dev/null 2>&1 || true
+apiVersion: v1
+kind: Event
+metadata:
+  generateName: ${claim}-housekeeper-
+  namespace: ${NS}
+involvedObject:
+  apiVersion: extensions.agents.x-k8s.io/v1alpha1
+  kind: SandboxClaim
+  name: ${claim}
+  namespace: ${NS}
+type: Normal
+reason: ${reason}
+action: ${action}
+message: ${msg}
+source:
+  component: sandbox-housekeeper
+firstTimestamp: ${ts}
+lastTimestamp: ${ts}
+YAML
+}
+
+# Probe http://<podIP>:9000/_decopilot_vm/idle. Echoes one of:
+#   <digits>          → idleMs reported by the daemon (success).
+#   __unreachable__   → connect/timeout (network or pod down).
+#   __not_found__     → HTTP 404 (endpoint absent — daemon image drift).
+#   __server_error__  → HTTP 5xx (daemon error).
+#   __bad_shape__     → HTTP 200 but body has no parseable idleMs.
+#
+# Distinguishing these in logs lets ops tell "cluster-wide NetworkPolicy
+# regression" (lots of __unreachable__) from "daemon shape drift" (lots of
+# __not_found__ or __bad_shape__) without needing a debugger.
+probe_daemon() {
+  ip="$1"
+  body=$(mktemp)
+  if ! code=$(curl -s -o "$body" \
+                --max-time "$PROBE_TIMEOUT_SEC" \
+                --retry 1 --retry-all-errors --retry-delay 1 \
+                -w '%{http_code}' \
+                "http://${ip}:${DAEMON_PORT}${IDLE_PATH}" 2>/dev/null); then
+    rm -f "$body"
+    echo "__unreachable__"
+    return
+  fi
+  case "$code" in
+    2*)
+      idle=$(sed -n 's/.*"idleMs"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$body")
+      rm -f "$body"
+      case "$idle" in
+        ''|*[!0-9]*) echo "__bad_shape__" ;;
+        *)           echo "$idle" ;;
+      esac
+      ;;
+    404) rm -f "$body"; echo "__not_found__" ;;
+    5*)  rm -f "$body"; echo "__server_error__" ;;
+    *)   rm -f "$body"; echo "__bad_shape__" ;;
+  esac
+}
+
+# Stamp first-failed-at on the claim. If already stamped, preserves the
+# original timestamp so consecutive-failure age accumulates across sweeps.
+# Echoes the (possibly preserved) ISO timestamp.
+mark_probe_failure() {
+  claim="$1"; detail="$2"
+  jp=$(jsonpath_for_annotation "$PROBE_FAIL_ANNOT")
+  existing=$(kubectl get sandboxclaim "$claim" -n "$NS" \
+    -o jsonpath="{.metadata.annotations.${jp}}" 2>/dev/null || true)
+  if [ -z "$existing" ]; then
+    ts=$(now_iso)
+    kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
+      "${PROBE_FAIL_ANNOT}=${ts}" \
+      "${PROBE_FAIL_DETAIL_ANNOT}=${detail}" >/dev/null 2>&1 || true
+    echo "$ts"
+  else
+    echo "$existing"
+  fi
+}
+
+clear_probe_failure() {
+  claim="$1"
+  kubectl annotate sandboxclaim "$claim" -n "$NS" \
+    "${PROBE_FAIL_ANNOT}-" \
+    "${PROBE_FAIL_DETAIL_ANNOT}-" >/dev/null 2>&1 || true
+}
+
+reap_claim() {
+  claim="$1"; reason="$2"; detail="$3"
+  log "reap claim=$claim reason=$reason detail=\"$detail\""
+  # Annotate first so kube-audit retains *why* this claim disappeared.
+  # Best-effort breadcrumbs — survives only as long as the claim object,
+  # which is why we also emit a Kubernetes Event below.
+  kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
+    "studio.decocms.com/reap-reason=${reason}" \
+    "studio.decocms.com/reap-detail=${detail}" \
+    "studio.decocms.com/reap-at=$(now_iso)" \
+    "studio.decocms.com/reap-run=${RUN_ID}" >/dev/null 2>&1 || true
+  emit_event "$claim" "SandboxReaped" "Reap" "housekeeper: $reason ($detail)"
+  # Route deletion first so traffic stops resolving to the pod before it
+  # enters termination (avoids 502s during the SIGTERM drain window).
+  # Selector matches LABEL_KEYS.sandboxHandle in mesh runner.ts:1570.
+  kubectl delete httproute -n "$NS" \
+    -l "studio.decocms.com/sandbox-handle=${claim}" \
+    --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete sandboxclaim "$claim" -n "$NS" \
+    --ignore-not-found >/dev/null 2>&1 || true
+}
+
+# === main ===
+log "starting (ttl=${TTL_MS}ms stuck_ttl=${STUCK_TTL_MS}ms probe_timeout=${PROBE_TIMEOUT_SEC}s)"
+
+CLAIMS_FILE=$(mktemp)
+PODS_FILE=$(mktemp)
+trap 'rm -f "$CLAIMS_FILE" "$PODS_FILE"' EXIT
+
+# Single API call returns name + Ready + reason for every studio claim.
+# Pipe-delimited so `read` can split without jq (which isn't guaranteed in
+# the bitnami/kubectl image).
+kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
+  -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
+  > "$CLAIMS_FILE" 2>/dev/null || true
+
+if ! [ -s "$CLAIMS_FILE" ]; then
+  log "heartbeat ok claims=0 reaped=0 skipped=0"
+  exit 0
+fi
+
+# Pod IPs in one call, keyed by sandbox-handle. mesh's runner.ts stamps
+# studio.decocms.com/sandbox-handle and studio.decocms.com/role=claimed
+# on every claimed pod via additionalPodMetadata.
+kubectl get pods -n "$NS" -l "$POD_SELECTOR" \
+  -o jsonpath='{range .items[*]}{.metadata.labels.studio\.decocms\.com/sandbox-handle}|{.status.podIP}{"\n"}{end}' \
+  > "$PODS_FILE" 2>/dev/null || true
+
+total=0
+reaped=0
+skipped=0
+
+# Read from a redirected file (NOT a pipe-into-while). Pipe-into-while
+# runs the loop in a subshell so set -eu and counter mutations don't
+# propagate; the redirect form keeps the loop in the parent shell.
+while IFS='|' read -r CLAIM READY REASON; do
+  [ -z "$CLAIM" ] && continue
+  total=$((total + 1))
+
+  # Operator-side liveness: claim is broken, no point probing.
+  if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
+    reap_claim "$CLAIM" "ReconcilerError" "operator failed to reconcile"
+    reaped=$((reaped + 1))
+    continue
+  fi
+
+  if [ "$READY" != "True" ]; then
+    log "skip claim=$CLAIM reason=not-ready ready=${READY:-<none>} status_reason=${REASON:-<none>}"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  POD_IP=$(awk -F'|' -v h="$CLAIM" '$1==h && $2!="" { print $2; exit }' "$PODS_FILE")
+  if [ -z "$POD_IP" ]; then
+    log "skip claim=$CLAIM reason=no-pod-ip"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  RESULT=$(probe_daemon "$POD_IP")
+  case "$RESULT" in
+    __unreachable__|__not_found__|__server_error__|__bad_shape__)
+      detail="$RESULT"
+      since=$(mark_probe_failure "$CLAIM" "$detail")
+      since_s=$(iso_to_secs "$since")
+      age_ms=$(( ($(now_secs) - since_s) * 1000 ))
+      if [ "$age_ms" -ge "$STUCK_TTL_MS" ]; then
+        reap_claim "$CLAIM" "StuckReady" "probe failing for ${age_ms}ms (last detail: $detail)"
+        reaped=$((reaped + 1))
+      else
+        log "skip claim=$CLAIM reason=probe-failed detail=$detail age_ms=$age_ms"
+        skipped=$((skipped + 1))
+      fi
+      ;;
+    *)
+      # Probe succeeded — RESULT is digits. Clear any prior failure mark.
+      IDLE_MS="$RESULT"
+      clear_probe_failure "$CLAIM"
+      if [ "$IDLE_MS" -lt "$TTL_MS" ]; then
+        log "keep claim=$CLAIM idle_ms=$IDLE_MS remaining_ms=$((TTL_MS - IDLE_MS))"
+        continue
+      fi
+      # Re-probe right before delete to close the race window between
+      # "decided to reap" and "delete completes". If a request hit the
+      # daemon in the gap, idleMs resets and we abort the reap. This
+      # narrows but does not eliminate the race; an in-flight request
+      # arriving after the second probe still gets connection-reset.
+      RESULT2=$(probe_daemon "$POD_IP")
+      case "$RESULT2" in
+        __*)
+          # Re-probe failed where the first one succeeded. Conservative:
+          # don't reap from this branch — next sweep will pick it up via
+          # the probe-failure path (which has its own StuckReady escalation).
+          log "abort-reap claim=$CLAIM reason=re-probe-failed first_idle_ms=$IDLE_MS detail=$RESULT2"
+          skipped=$((skipped + 1))
+          ;;
+        *)
+          if [ "$RESULT2" -lt "$TTL_MS" ]; then
+            log "abort-reap claim=$CLAIM reason=activity-during-decide first_idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2"
+            skipped=$((skipped + 1))
+          else
+            reap_claim "$CLAIM" "Idle" "idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2 ttl_ms=$TTL_MS"
+            reaped=$((reaped + 1))
+          fi
+          ;;
+      esac
+      ;;
+  esac
+done < "$CLAIMS_FILE"
+
+log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped"

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -1,32 +1,9 @@
 #!/bin/sh
-# sandbox-housekeeper sweep — invoked once per CronJob run.
+# sandbox-housekeeper sweep — one CronJob run.
 #
-# Inputs (env, set by the CronJob spec):
-#   NS                     namespace to scan (always agent-sandbox-system today).
-#   TTL_MS                 idle TTL in ms — claims with idleMs >= this are reaped.
-#   STUCK_TTL_MS           consecutive probe failures older than this trigger a
-#                          StuckReady reap (catches wedged daemons that present
-#                          TCP but don't reply meaningfully).
-#   PROBE_TIMEOUT_SEC      curl --max-time per probe and per re-probe.
-#   CLAIM_SELECTOR         label selector for studio claims (mirrors mesh's
-#                          buildClaim labels in runner.ts).
-#   POD_SELECTOR           label selector for claimed sandbox pods.
-#   RUN_ID                 cronjob pod name (downward API).
-#
-# Output: structured stdout (one event per line, key=value).
-# Side effects:
-#   - Idle / StuckReady reaps patch spec.lifecycle.shutdownTime so the
-#     agent-sandbox operator drains the pod gracefully (SIGTERM →
-#     terminationGracePeriodSeconds → delete). Same contract mesh uses
-#     for per-ensure() refresh in client.ts:patchSandboxClaimShutdown.
-#   - ReconcilerError reaps fall through to a direct kubectl delete because
-#     the operator has already given up; patching shutdownTime would never
-#     be honored.
-#   - Both paths annotate the claim, emit a Kubernetes Event for
-#     post-mortem, and delete the per-claim HTTPRoute first so traffic
-#     stops resolving to the pod before SIGTERM lands.
-# Probe failures escalate to a StuckReady reap only after STUCK_TTL_MS;
-# transient failures skip the claim, leaving idle accounting untouched.
+# Env (set by the CronJob spec):
+#   NS, TTL_MS, STUCK_TTL_MS, PROBE_TIMEOUT_SEC,
+#   CLAIM_SELECTOR, POD_SELECTOR, RUN_ID.
 
 set -eu
 
@@ -50,27 +27,21 @@ log() {
   printf '[%s] [housekeeper] run=%s %s\n' "$(now_iso)" "$RUN_ID" "$*"
 }
 
-# Normalize ISO 8601 ("2026-04-30T00:44:41Z") into the
-# "YYYY-MM-DD HH:MM:SS" form that both busybox `date` (alpine) and GNU
-# `date` (Debian) accept — busybox rejects the `T` separator and trailing
-# `Z`. Fractional seconds (operator-emitted timestamps may carry them) are
-# stripped too. Falls back to now() if `date -d` still rejects, which keeps
-# the script working under future image swaps but resets the StuckReady
-# age clock for that sweep — log lines will show age_ms ≈ 0 if you hit
-# this fallback.
+# Normalize ISO 8601 to a form busybox `date` (alpine) accepts —
+# busybox rejects the `T` separator and trailing `Z`. Fractional seconds
+# stripped too. Falls back to now() if `date -d` still rejects (resets
+# the StuckReady age clock for that sweep — age_ms ≈ 0 in logs).
 iso_to_secs() {
   norm=$(printf '%s' "$1" | tr 'T' ' ' | sed 's/\.[0-9]*Z$//; s/Z$//')
   date -u -d "$norm" +%s 2>/dev/null || now_secs
 }
 
-# JSONPath escapes dots in label/annotation keys with a backslash. Escape
-# once so callers can pass the raw key.
+# JSONPath escapes dots in keys with a backslash.
 jsonpath_for_annotation() {
   printf '%s' "$1" | sed 's/\./\\./g'
 }
 
-# Emit a Kubernetes Event referencing the SandboxClaim. Best-effort: failures
-# are swallowed so a misconfigured Event API doesn't block the reap.
+# Best-effort — a misconfigured Event API shouldn't block the reap.
 emit_event() {
   claim="$1"; reason="$2"; action="$3"; msg="$4"
   ts=$(now_iso)
@@ -96,16 +67,12 @@ lastTimestamp: ${ts}
 YAML
 }
 
-# Probe http://<podIP>:9000/_decopilot_vm/idle. Echoes one of:
-#   <digits>          → idleMs reported by the daemon (success).
-#   __unreachable__   → connect/timeout (network or pod down).
-#   __not_found__     → HTTP 404 (endpoint absent — daemon image drift).
-#   __server_error__  → HTTP 5xx (daemon error).
-#   __bad_shape__     → HTTP 200 but body has no parseable idleMs.
-#
-# Distinguishing these in logs lets ops tell "cluster-wide NetworkPolicy
-# regression" (lots of __unreachable__) from "daemon shape drift" (lots of
-# __not_found__ or __bad_shape__) without needing a debugger.
+# Probe /_decopilot_vm/idle. Echoes one of:
+#   <digits>          idleMs (success)
+#   __unreachable__   connect/timeout
+#   __not_found__     HTTP 404
+#   __server_error__  HTTP 5xx
+#   __bad_shape__     HTTP 200 but no parseable idleMs
 probe_daemon() {
   ip="$1"
   body=$(mktemp)
@@ -133,9 +100,8 @@ probe_daemon() {
   esac
 }
 
-# Stamp first-failed-at on the claim. If already stamped, preserves the
-# original timestamp so consecutive-failure age accumulates across sweeps.
-# Echoes the (possibly preserved) ISO timestamp.
+# Echoes the ISO timestamp; preserves the existing stamp on repeats so
+# consecutive-failure age accumulates across sweeps.
 mark_probe_failure() {
   claim="$1"; detail="$2"
   jp=$(jsonpath_for_annotation "$PROBE_FAIL_ANNOT")
@@ -159,34 +125,24 @@ clear_probe_failure() {
     "${PROBE_FAIL_DETAIL_ANNOT}-" >/dev/null 2>&1 || true
 }
 
-# Stamp annotation breadcrumbs + Kubernetes Event + delete the per-claim
-# HTTPRoute. Shared prelude for both reap paths; the caller decides whether
-# to follow up with a shutdown patch (graceful) or a direct delete (force).
+# Shared prelude for both reap paths.
 mark_for_reap() {
   claim="$1"; reason="$2"; detail="$3"; action="$4"
-  # Annotate so kube-audit retains *why* this claim was reaped. Best-effort
-  # breadcrumbs — survive only as long as the claim object, which is why we
-  # also emit a Kubernetes Event.
   kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
     "studio.decocms.com/reap-reason=${reason}" \
     "studio.decocms.com/reap-detail=${detail}" \
     "studio.decocms.com/reap-at=$(now_iso)" \
     "studio.decocms.com/reap-run=${RUN_ID}" >/dev/null 2>&1 || true
   emit_event "$claim" "SandboxReaped" "$action" "housekeeper: $reason ($detail)"
-  # HTTPRoute deletion first so traffic stops resolving to the pod before
-  # it enters termination — avoids 502s during the SIGTERM drain window.
-  # Selector matches LABEL_KEYS.sandboxHandle in mesh runner.ts.
+  # Delete HTTPRoute first so traffic stops resolving to the pod before
+  # SIGTERM lands — avoids 502s during the drain window.
   kubectl delete httproute -n "$NS" \
     -l "studio.decocms.com/sandbox-handle=${claim}" \
     --ignore-not-found >/dev/null 2>&1 || true
 }
 
-# Healthy-claim reap: patch spec.lifecycle.shutdownTime to "now" so the
-# operator handles the actual drain (SIGTERM → terminationGracePeriodSeconds
-# → delete pod → delete claim). Used for Idle and StuckReady — both cases
-# where the operator is functional and a graceful drain is preferable to
-# a direct delete. Mirrors the contract used by mesh's per-ensure() refresh
-# in `patchSandboxClaimShutdown` (packages/sandbox/.../client.ts).
+# Graceful path: operator drains the pod via shutdownTime. Used for Idle
+# and StuckReady where the operator is still functional.
 request_shutdown() {
   claim="$1"; reason="$2"; detail="$3"
   log "shutdown claim=$claim reason=$reason detail=\"$detail\""
@@ -197,9 +153,7 @@ request_shutdown() {
     >/dev/null 2>&1 || true
 }
 
-# Forceful reap: direct kubectl delete, no graceful drain. Used only for
-# ReconcilerError — the operator has already given up on the claim, so
-# patching shutdownTime would never be honored.
+# ReconcilerError path: operator has given up, so shutdownTime is unhonored.
 force_delete_claim() {
   claim="$1"; reason="$2"; detail="$3"
   log "delete claim=$claim reason=$reason detail=\"$detail\""
@@ -215,9 +169,7 @@ CLAIMS_FILE=$(mktemp)
 PODS_FILE=$(mktemp)
 trap 'rm -f "$CLAIMS_FILE" "$PODS_FILE"' EXIT
 
-# Single API call returns name + Ready + reason for every studio claim.
-# Pipe-delimited so `read` can split without jq — keeps the script
-# portable across kubectl images that don't ship jq.
+# Pipe-delimited so `read` can split without jq.
 kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
   -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
   > "$CLAIMS_FILE" 2>/dev/null || true
@@ -227,9 +179,6 @@ if ! [ -s "$CLAIMS_FILE" ]; then
   exit 0
 fi
 
-# Pod IPs in one call, keyed by sandbox-handle. mesh's runner.ts stamps
-# studio.decocms.com/sandbox-handle and studio.decocms.com/role=claimed
-# on every claimed pod via additionalPodMetadata.
 kubectl get pods -n "$NS" -l "$POD_SELECTOR" \
   -o jsonpath='{range .items[*]}{.metadata.labels.studio\.decocms\.com/sandbox-handle}|{.status.podIP}{"\n"}{end}' \
   > "$PODS_FILE" 2>/dev/null || true
@@ -238,15 +187,12 @@ total=0
 reaped=0
 skipped=0
 
-# Read from a redirected file (NOT a pipe-into-while). Pipe-into-while
-# runs the loop in a subshell so set -eu and counter mutations don't
-# propagate; the redirect form keeps the loop in the parent shell.
+# Redirect (not pipe) so the loop stays in the parent shell — pipe-into-
+# while subshells the body and counter mutations would be lost.
 while IFS='|' read -r CLAIM READY REASON; do
   [ -z "$CLAIM" ] && continue
   total=$((total + 1))
 
-  # Operator-side liveness: claim is broken, no point probing or asking
-  # the operator to drain it. Direct delete.
   if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
     force_delete_claim "$CLAIM" "ReconcilerError" "operator failed to reconcile"
     reaped=$((reaped + 1))
@@ -282,24 +228,20 @@ while IFS='|' read -r CLAIM READY REASON; do
       fi
       ;;
     *)
-      # Probe succeeded — RESULT is digits. Clear any prior failure mark.
       IDLE_MS="$RESULT"
       clear_probe_failure "$CLAIM"
       if [ "$IDLE_MS" -lt "$TTL_MS" ]; then
         log "keep claim=$CLAIM idle_ms=$IDLE_MS remaining_ms=$((TTL_MS - IDLE_MS))"
         continue
       fi
-      # Re-probe right before delete to close the race window between
-      # "decided to reap" and "delete completes". If a request hit the
-      # daemon in the gap, idleMs resets and we abort the reap. This
-      # narrows but does not eliminate the race; an in-flight request
-      # arriving after the second probe still gets connection-reset.
+      # Re-probe right before reap to narrow (not eliminate) the
+      # activity-during-decide race. An in-flight request arriving after
+      # this second probe still gets connection-reset.
       RESULT2=$(probe_daemon "$POD_IP")
       case "$RESULT2" in
         __*)
-          # Re-probe failed where the first one succeeded. Conservative:
-          # don't reap from this branch — next sweep will pick it up via
-          # the probe-failure path (which has its own StuckReady escalation).
+          # Conservative: next sweep picks it up via the probe-failure
+          # path with its own StuckReady escalation.
           log "abort-reap claim=$CLAIM reason=re-probe-failed first_idle_ms=$IDLE_MS detail=$RESULT2"
           skipped=$((skipped + 1))
           ;;

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -20,20 +20,12 @@ PROBE_FAIL_DETAIL_ANNOT="studio.decocms.com/probe-fail-detail"
 DAEMON_PORT=9000
 IDLE_PATH="/_decopilot_vm/idle"
 
-now_iso()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
-now_secs() { date -u +%s; }
+now_iso()   { date -u +%Y-%m-%dT%H:%M:%SZ; }
+now_micro() { date -u +%Y-%m-%dT%H:%M:%S.000000Z; }
+now_secs()  { date -u +%s; }
 
 log() {
   printf '[%s] [housekeeper] run=%s %s\n' "$(now_iso)" "$RUN_ID" "$*"
-}
-
-# Normalize ISO 8601 to a form busybox `date` (alpine) accepts —
-# busybox rejects the `T` separator and trailing `Z`. Fractional seconds
-# stripped too. Falls back to now() if `date -d` still rejects (resets
-# the StuckReady age clock for that sweep — age_ms ≈ 0 in logs).
-iso_to_secs() {
-  norm=$(printf '%s' "$1" | tr 'T' ' ' | sed 's/\.[0-9]*Z$//; s/Z$//')
-  date -u -d "$norm" +%s 2>/dev/null || now_secs
 }
 
 # JSONPath escapes dots in keys with a backslash.
@@ -42,28 +34,30 @@ jsonpath_for_annotation() {
 }
 
 # Best-effort — a misconfigured Event API shouldn't block the reap.
+# events.k8s.io/v1 is the current API; the legacy v1 Events API is
+# deprecated. `kubectl get events` and `kubectl describe sandboxclaim`
+# aggregate from both, so consumers see these unchanged.
 emit_event() {
   claim="$1"; reason="$2"; action="$3"; msg="$4"
-  ts=$(now_iso)
+  ts=$(now_micro)
   kubectl create -f - <<YAML >/dev/null 2>&1 || true
-apiVersion: v1
+apiVersion: events.k8s.io/v1
 kind: Event
 metadata:
   generateName: ${claim}-housekeeper-
   namespace: ${NS}
-involvedObject:
+eventTime: ${ts}
+type: Normal
+reason: ${reason}
+action: ${action}
+note: ${msg}
+reportingController: sandbox-housekeeper
+reportingInstance: ${RUN_ID}
+regarding:
   apiVersion: extensions.agents.x-k8s.io/v1alpha1
   kind: SandboxClaim
   name: ${claim}
   namespace: ${NS}
-type: Normal
-reason: ${reason}
-action: ${action}
-message: ${msg}
-source:
-  component: sandbox-housekeeper
-firstTimestamp: ${ts}
-lastTimestamp: ${ts}
 YAML
 }
 
@@ -100,22 +94,32 @@ probe_daemon() {
   esac
 }
 
-# Echoes the ISO timestamp; preserves the existing stamp on repeats so
-# consecutive-failure age accumulates across sweeps.
+# Echoes the failure-since marker as epoch seconds. Stored as a plain
+# integer (not ISO) so age math is bulletproof — no busybox `date -d`
+# parsing path that could silently fall back and reset the clock. Humans
+# can decode with `date -d @<epoch>`.
+#
+# Preserves the existing stamp on repeats so consecutive-failure age
+# accumulates across sweeps. If a previous-version sweep wrote an ISO
+# string, the non-numeric value is rewritten as a fresh failure (resets
+# the clock once during upgrade — conservative).
 mark_probe_failure() {
   claim="$1"; detail="$2"
   jp=$(jsonpath_for_annotation "$PROBE_FAIL_ANNOT")
   existing=$(kubectl get sandboxclaim "$claim" -n "$NS" \
     -o jsonpath="{.metadata.annotations.${jp}}" 2>/dev/null || true)
-  if [ -z "$existing" ]; then
-    ts=$(now_iso)
-    kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
-      "${PROBE_FAIL_ANNOT}=${ts}" \
-      "${PROBE_FAIL_DETAIL_ANNOT}=${detail}" >/dev/null 2>&1 || true
-    echo "$ts"
-  else
-    echo "$existing"
-  fi
+  case "$existing" in
+    ''|*[!0-9]*)
+      secs=$(now_secs)
+      kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
+        "${PROBE_FAIL_ANNOT}=${secs}" \
+        "${PROBE_FAIL_DETAIL_ANNOT}=${detail}" >/dev/null 2>&1 || true
+      echo "$secs"
+      ;;
+    *)
+      echo "$existing"
+      ;;
+  esac
 }
 
 clear_probe_failure() {
@@ -167,15 +171,27 @@ log "starting (ttl=${TTL_MS}ms stuck_ttl=${STUCK_TTL_MS}ms probe_timeout=${PROBE
 
 CLAIMS_FILE=$(mktemp)
 PODS_FILE=$(mktemp)
-trap 'rm -f "$CLAIMS_FILE" "$PODS_FILE"' EXIT
+ROUTES_FILE=$(mktemp)
+trap 'rm -f "$CLAIMS_FILE" "$PODS_FILE" "$ROUTES_FILE"' EXIT
 
 # Pipe-delimited so `read` can split without jq.
 kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
   -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
   > "$CLAIMS_FILE" 2>/dev/null || true
 
+# Selector-mismatch detector: most common operator misconfiguration after
+# enabling the housekeeper is forgetting to set STUDIO_ENV on mesh, so the
+# scoped selector matches zero claims even though studio is happily creating
+# them. A silent `claims=0` heartbeat hides this — log loudly when the
+# unscoped query disagrees.
 if ! [ -s "$CLAIMS_FILE" ]; then
-  log "heartbeat ok claims=0 reaped=0 skipped=0"
+  unscoped=$(kubectl get sandboxclaims -n "$NS" \
+    -l "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox" \
+    -o name 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+  if [ "${unscoped:-0}" -gt 0 ]; then
+    log "WARN selector matched zero claims but ${unscoped} studio-managed claim(s) exist in ${NS} — verify STUDIO_ENV is set on the mesh deployment and matches the chart's envName (current selector: ${CLAIM_SELECTOR})"
+  fi
+  log "heartbeat ok claims=0 reaped=0 skipped=0 orphan_routes=0"
   exit 0
 fi
 
@@ -216,9 +232,8 @@ while IFS='|' read -r CLAIM READY REASON; do
   case "$RESULT" in
     __unreachable__|__not_found__|__server_error__|__bad_shape__)
       detail="$RESULT"
-      since=$(mark_probe_failure "$CLAIM" "$detail")
-      since_s=$(iso_to_secs "$since")
-      age_ms=$(( ($(now_secs) - since_s) * 1000 ))
+      since_secs=$(mark_probe_failure "$CLAIM" "$detail")
+      age_ms=$(( ($(now_secs) - since_secs) * 1000 ))
       if [ "$age_ms" -ge "$STUCK_TTL_MS" ]; then
         request_shutdown "$CLAIM" "StuckReady" "probe failing for ${age_ms}ms (last detail: $detail)"
         reaped=$((reaped + 1))
@@ -259,4 +274,32 @@ while IFS='|' read -r CLAIM READY REASON; do
   esac
 done < "$CLAIMS_FILE"
 
-log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped"
+# === orphan HTTPRoute GC ===
+# Routes whose backing claim is gone. Reachable when a runner stop() raced
+# with pod death and the per-claim HTTPRoute teardown didn't land — the
+# runner code path swallows the failure ("garbage-collection sweep will
+# clean it up") and this is that sweep. Reuses CLAIM_SELECTOR because mesh
+# stamps the same managed-by/name/env labels on routes (runner.ts).
+#
+# Limited to routes with a sandbox-handle label so a hand-managed route
+# accidentally tagged with managed-by=studio doesn't get nuked.
+orphan_routes=0
+kubectl get httproutes -n "$NS" -l "$CLAIM_SELECTOR" \
+  -o jsonpath='{range .items[*]}{.metadata.name}|{.metadata.labels.studio\.decocms\.com/sandbox-handle}{"\n"}{end}' \
+  > "$ROUTES_FILE" 2>/dev/null || true
+
+while IFS='|' read -r ROUTE_NAME ROUTE_HANDLE; do
+  [ -z "$ROUTE_NAME" ] && continue
+  [ -z "$ROUTE_HANDLE" ] && continue
+  # Live-claim membership test against col 1 of CLAIMS_FILE.
+  if awk -F'|' -v h="$ROUTE_HANDLE" '$1==h { exit 0 } END { exit 1 }' \
+       "$CLAIMS_FILE"; then
+    continue
+  fi
+  log "orphan-route-gc route=$ROUTE_NAME handle=$ROUTE_HANDLE"
+  kubectl delete httproute "$ROUTE_NAME" -n "$NS" \
+    --ignore-not-found >/dev/null 2>&1 || true
+  orphan_routes=$((orphan_routes + 1))
+done < "$ROUTES_FILE"
+
+log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped orphan_routes=$orphan_routes"

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -14,9 +14,19 @@
 #   RUN_ID                 cronjob pod name (downward API).
 #
 # Output: structured stdout (one event per line, key=value).
-# Side effects: kubectl annotate / delete on claims and httproutes; create on
-# Events. Probe failures escalate to reap only after STUCK_TTL_MS; transient
-# failures skip the claim, leaving idle accounting untouched.
+# Side effects:
+#   - Idle / StuckReady reaps patch spec.lifecycle.shutdownTime so the
+#     agent-sandbox operator drains the pod gracefully (SIGTERM →
+#     terminationGracePeriodSeconds → delete). Same contract mesh uses
+#     for per-ensure() refresh in client.ts:patchSandboxClaimShutdown.
+#   - ReconcilerError reaps fall through to a direct kubectl delete because
+#     the operator has already given up; patching shutdownTime would never
+#     be honored.
+#   - Both paths annotate the claim, emit a Kubernetes Event for
+#     post-mortem, and delete the per-claim HTTPRoute first so traffic
+#     stops resolving to the pod before SIGTERM lands.
+# Probe failures escalate to a StuckReady reap only after STUCK_TTL_MS;
+# transient failures skip the claim, leaving idle accounting untouched.
 
 set -eu
 
@@ -40,11 +50,17 @@ log() {
   printf '[%s] [housekeeper] run=%s %s\n' "$(now_iso)" "$RUN_ID" "$*"
 }
 
-# GNU date `-d` parses ISO 8601 timestamps. bitnami/kubectl ships GNU
-# coreutils so this works; if a future image swaps to busybox date the
-# fallback returns now() and the StuckReady age starts fresh.
+# Normalize ISO 8601 ("2026-04-30T00:44:41Z") into the
+# "YYYY-MM-DD HH:MM:SS" form that both busybox `date` (alpine) and GNU
+# `date` (Debian) accept — busybox rejects the `T` separator and trailing
+# `Z`. Fractional seconds (operator-emitted timestamps may carry them) are
+# stripped too. Falls back to now() if `date -d` still rejects, which keeps
+# the script working under future image swaps but resets the StuckReady
+# age clock for that sweep — log lines will show age_ms ≈ 0 if you hit
+# this fallback.
 iso_to_secs() {
-  date -u -d "$1" +%s 2>/dev/null || now_secs
+  norm=$(printf '%s' "$1" | tr 'T' ' ' | sed 's/\.[0-9]*Z$//; s/Z$//')
+  date -u -d "$norm" +%s 2>/dev/null || now_secs
 }
 
 # JSONPath escapes dots in label/annotation keys with a backslash. Escape
@@ -143,24 +159,51 @@ clear_probe_failure() {
     "${PROBE_FAIL_DETAIL_ANNOT}-" >/dev/null 2>&1 || true
 }
 
-reap_claim() {
-  claim="$1"; reason="$2"; detail="$3"
-  log "reap claim=$claim reason=$reason detail=\"$detail\""
-  # Annotate first so kube-audit retains *why* this claim disappeared.
-  # Best-effort breadcrumbs — survives only as long as the claim object,
-  # which is why we also emit a Kubernetes Event below.
+# Stamp annotation breadcrumbs + Kubernetes Event + delete the per-claim
+# HTTPRoute. Shared prelude for both reap paths; the caller decides whether
+# to follow up with a shutdown patch (graceful) or a direct delete (force).
+mark_for_reap() {
+  claim="$1"; reason="$2"; detail="$3"; action="$4"
+  # Annotate so kube-audit retains *why* this claim was reaped. Best-effort
+  # breadcrumbs — survive only as long as the claim object, which is why we
+  # also emit a Kubernetes Event.
   kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
     "studio.decocms.com/reap-reason=${reason}" \
     "studio.decocms.com/reap-detail=${detail}" \
     "studio.decocms.com/reap-at=$(now_iso)" \
     "studio.decocms.com/reap-run=${RUN_ID}" >/dev/null 2>&1 || true
-  emit_event "$claim" "SandboxReaped" "Reap" "housekeeper: $reason ($detail)"
-  # Route deletion first so traffic stops resolving to the pod before it
-  # enters termination (avoids 502s during the SIGTERM drain window).
-  # Selector matches LABEL_KEYS.sandboxHandle in mesh runner.ts:1570.
+  emit_event "$claim" "SandboxReaped" "$action" "housekeeper: $reason ($detail)"
+  # HTTPRoute deletion first so traffic stops resolving to the pod before
+  # it enters termination — avoids 502s during the SIGTERM drain window.
+  # Selector matches LABEL_KEYS.sandboxHandle in mesh runner.ts.
   kubectl delete httproute -n "$NS" \
     -l "studio.decocms.com/sandbox-handle=${claim}" \
     --ignore-not-found >/dev/null 2>&1 || true
+}
+
+# Healthy-claim reap: patch spec.lifecycle.shutdownTime to "now" so the
+# operator handles the actual drain (SIGTERM → terminationGracePeriodSeconds
+# → delete pod → delete claim). Used for Idle and StuckReady — both cases
+# where the operator is functional and a graceful drain is preferable to
+# a direct delete. Mirrors the contract used by mesh's per-ensure() refresh
+# in `patchSandboxClaimShutdown` (packages/sandbox/.../client.ts).
+request_shutdown() {
+  claim="$1"; reason="$2"; detail="$3"
+  log "shutdown claim=$claim reason=$reason detail=\"$detail\""
+  mark_for_reap "$claim" "$reason" "$detail" "Shutdown"
+  ts=$(now_iso)
+  kubectl patch sandboxclaim "$claim" -n "$NS" --type=merge \
+    -p "{\"spec\":{\"lifecycle\":{\"shutdownPolicy\":\"Delete\",\"shutdownTime\":\"${ts}\"}}}" \
+    >/dev/null 2>&1 || true
+}
+
+# Forceful reap: direct kubectl delete, no graceful drain. Used only for
+# ReconcilerError — the operator has already given up on the claim, so
+# patching shutdownTime would never be honored.
+force_delete_claim() {
+  claim="$1"; reason="$2"; detail="$3"
+  log "delete claim=$claim reason=$reason detail=\"$detail\""
+  mark_for_reap "$claim" "$reason" "$detail" "Delete"
   kubectl delete sandboxclaim "$claim" -n "$NS" \
     --ignore-not-found >/dev/null 2>&1 || true
 }
@@ -173,8 +216,8 @@ PODS_FILE=$(mktemp)
 trap 'rm -f "$CLAIMS_FILE" "$PODS_FILE"' EXIT
 
 # Single API call returns name + Ready + reason for every studio claim.
-# Pipe-delimited so `read` can split without jq (which isn't guaranteed in
-# the bitnami/kubectl image).
+# Pipe-delimited so `read` can split without jq — keeps the script
+# portable across kubectl images that don't ship jq.
 kubectl get sandboxclaims -n "$NS" -l "$CLAIM_SELECTOR" \
   -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
   > "$CLAIMS_FILE" 2>/dev/null || true
@@ -202,9 +245,10 @@ while IFS='|' read -r CLAIM READY REASON; do
   [ -z "$CLAIM" ] && continue
   total=$((total + 1))
 
-  # Operator-side liveness: claim is broken, no point probing.
+  # Operator-side liveness: claim is broken, no point probing or asking
+  # the operator to drain it. Direct delete.
   if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
-    reap_claim "$CLAIM" "ReconcilerError" "operator failed to reconcile"
+    force_delete_claim "$CLAIM" "ReconcilerError" "operator failed to reconcile"
     reaped=$((reaped + 1))
     continue
   fi
@@ -230,7 +274,7 @@ while IFS='|' read -r CLAIM READY REASON; do
       since_s=$(iso_to_secs "$since")
       age_ms=$(( ($(now_secs) - since_s) * 1000 ))
       if [ "$age_ms" -ge "$STUCK_TTL_MS" ]; then
-        reap_claim "$CLAIM" "StuckReady" "probe failing for ${age_ms}ms (last detail: $detail)"
+        request_shutdown "$CLAIM" "StuckReady" "probe failing for ${age_ms}ms (last detail: $detail)"
         reaped=$((reaped + 1))
       else
         log "skip claim=$CLAIM reason=probe-failed detail=$detail age_ms=$age_ms"
@@ -264,7 +308,7 @@ while IFS='|' read -r CLAIM READY REASON; do
             log "abort-reap claim=$CLAIM reason=activity-during-decide first_idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2"
             skipped=$((skipped + 1))
           else
-            reap_claim "$CLAIM" "Idle" "idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2 ttl_ms=$TTL_MS"
+            request_shutdown "$CLAIM" "Idle" "idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2 ttl_ms=$TTL_MS"
             reaped=$((reaped + 1))
           fi
           ;;

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -136,3 +136,10 @@ atomic and gives a pointer to the right install command.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Housekeeper CronJob / ServiceAccount / Role / RoleBinding name.
+*/}}
+{{- define "sandbox-env.housekeeperName" -}}
+{{- printf "sandbox-housekeeper-%s" (include "sandbox-env.envName" .) -}}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -137,34 +137,20 @@ atomic and gives a pointer to the right install command.
 {{- end }}
 {{- end }}
 
-{{/*
-Housekeeper CronJob / ServiceAccount / Role / RoleBinding name.
-*/}}
 {{- define "sandbox-env.housekeeperName" -}}
 {{- printf "sandbox-housekeeper-%s" (include "sandbox-env.envName" .) -}}
 {{- end }}
 
 {{/*
-Default housekeeper claim selector. Mirrors the labels mesh's runner.ts
-buildClaim stamps on every SandboxClaim, with the env scope appended so
-each env release only sweeps its own claims (mesh stamps
-studio.decocms.com/env=<envName> when STUDIO_ENV is set).
-
-Operators that haven't rolled mesh with STUDIO_ENV yet should override
-.Values.housekeeper.claimSelector to the unscoped 2-label selector
-(README has the copy-paste) until they roll the upgrade — the scoped
-selector matches zero claims if STUDIO_ENV isn't propagated, and the
-housekeeper does nothing useful in that state.
+Default housekeeper selectors. Mirror the labels mesh stamps in runner.ts
+(`studio.decocms.com/env=<envName>` requires STUDIO_ENV); during phased
+rollout, .Values.housekeeper.{claimSelector,podSelector} can be overridden
+to drop the env scope. README has copy-paste values.
 */}}
 {{- define "sandbox-env.housekeeperClaimSelector" -}}
 {{- printf "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox,studio.decocms.com/env=%s" (include "sandbox-env.envName" .) -}}
 {{- end }}
 
-{{/*
-Default housekeeper pod selector. Same env-scoping idea — mesh stamps
-studio.decocms.com/env on additionalPodMetadata so each housekeeper only
-enumerates its env's pods.
-*/}}
 {{- define "sandbox-env.housekeeperPodSelector" -}}
 {{- printf "studio.decocms.com/role=claimed,studio.decocms.com/env=%s" (include "sandbox-env.envName" .) -}}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -143,3 +143,28 @@ Housekeeper CronJob / ServiceAccount / Role / RoleBinding name.
 {{- define "sandbox-env.housekeeperName" -}}
 {{- printf "sandbox-housekeeper-%s" (include "sandbox-env.envName" .) -}}
 {{- end }}
+
+{{/*
+Default housekeeper claim selector. Mirrors the labels mesh's runner.ts
+buildClaim stamps on every SandboxClaim, with the env scope appended so
+each env release only sweeps its own claims (mesh stamps
+studio.decocms.com/env=<envName> when STUDIO_ENV is set).
+
+Operators that haven't rolled mesh with STUDIO_ENV yet should override
+.Values.housekeeper.claimSelector to the unscoped 2-label selector
+(README has the copy-paste) until they roll the upgrade — the scoped
+selector matches zero claims if STUDIO_ENV isn't propagated, and the
+housekeeper does nothing useful in that state.
+*/}}
+{{- define "sandbox-env.housekeeperClaimSelector" -}}
+{{- printf "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox,studio.decocms.com/env=%s" (include "sandbox-env.envName" .) -}}
+{{- end }}
+
+{{/*
+Default housekeeper pod selector. Same env-scoping idea — mesh stamps
+studio.decocms.com/env on additionalPodMetadata so each housekeeper only
+enumerates its env's pods.
+*/}}
+{{- define "sandbox-env.housekeeperPodSelector" -}}
+{{- printf "studio.decocms.com/role=claimed,studio.decocms.com/env=%s" (include "sandbox-env.envName" .) -}}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -4,22 +4,26 @@ Idle-reap housekeeper for studio sandbox claims.
 
 What it does:
 - Probes each Ready sandbox's daemon at /_decopilot_vm/idle every
-  `housekeeper.schedule` minutes, deletes claims idle ≥ idleTtlSeconds.
-- Clears claims stuck in ReconcilerError (operator gave up).
-- Escalates "Ready but unreachable" claims to a StuckReady reap once they
-  exceed stuckReadyTtlSeconds (catches wedged daemons that present TCP
-  but don't respond meaningfully).
-- Re-probes immediately before delete to narrow the activity-during-reap
-  race window.
+  `housekeeper.schedule` minutes. When idle ≥ idleTtlSeconds, patches
+  spec.lifecycle.shutdownTime so the agent-sandbox operator drains the
+  pod gracefully (SIGTERM → terminationGracePeriodSeconds → delete).
+- Direct-deletes claims stuck in ReconcilerError — the operator has
+  already given up, so a shutdownTime patch would never be honored.
+- Escalates "Ready but unreachable" claims to a StuckReady shutdown once
+  they exceed stuckReadyTtlSeconds (catches wedged daemons that present
+  TCP but don't respond meaningfully).
+- Re-probes immediately before requesting shutdown to narrow the
+  activity-during-reap race window.
 - Emits a Kubernetes Event per reap so post-mortem via `kubectl get events`
   works after the claim is gone.
 
-Multi-housekeeper warning:
-SandboxClaims carry no env label today, so every enabled housekeeper in
-agent-sandbox-system sweeps the *same* set of claims. Enable in exactly
-ONE env release per cluster. Per-env scoping requires a follow-up to
-runner.ts (stamp studio.decocms.com/env on the claim) plus this chart's
-selector picking that label up.
+Per-env scoping:
+Mesh stamps studio.decocms.com/env=<envName> on every SandboxClaim,
+claimed Pod, and per-claim HTTPRoute when STUDIO_ENV is set in the studio
+chart's configMap. The default selectors here pick that label up so each
+env release sweeps only its own claims. See values.yaml for the override
+to use during a phased rollout (before mesh has been upgraded with
+STUDIO_ENV propagation).
 
 Layout:
 - ConfigMap holds the sweep script (files/housekeeper-sweep.sh) — keeps
@@ -56,7 +60,9 @@ metadata:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 rules:
   # Reap target: list to discover, get to read probe-fail annotations,
-  # patch to stamp annotations, delete to actually reap.
+  # patch to stamp annotations + spec.lifecycle.shutdownTime (the graceful
+  # path for Idle / StuckReady), delete for ReconcilerError fall-through
+  # where the operator can't honor a shutdownTime patch.
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
     verbs: ["get", "list", "patch", "delete"]

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -1,35 +1,7 @@
 {{- if .Values.housekeeper.enabled }}
 {{- /*
-Idle-reap housekeeper for studio sandbox claims.
-
-What it does:
-- Probes each Ready sandbox's daemon at /_decopilot_vm/idle every
-  `housekeeper.schedule` minutes. When idle ≥ idleTtlSeconds, patches
-  spec.lifecycle.shutdownTime so the agent-sandbox operator drains the
-  pod gracefully (SIGTERM → terminationGracePeriodSeconds → delete).
-- Direct-deletes claims stuck in ReconcilerError — the operator has
-  already given up, so a shutdownTime patch would never be honored.
-- Escalates "Ready but unreachable" claims to a StuckReady shutdown once
-  they exceed stuckReadyTtlSeconds (catches wedged daemons that present
-  TCP but don't respond meaningfully).
-- Re-probes immediately before requesting shutdown to narrow the
-  activity-during-reap race window.
-- Emits a Kubernetes Event per reap so post-mortem via `kubectl get events`
-  works after the claim is gone.
-
-Per-env scoping:
-Mesh stamps studio.decocms.com/env=<envName> on every SandboxClaim,
-claimed Pod, and per-claim HTTPRoute when STUDIO_ENV is set in the studio
-chart's configMap. The default selectors here pick that label up so each
-env release sweeps only its own claims. See values.yaml for the override
-to use during a phased rollout (before mesh has been upgraded with
-STUDIO_ENV propagation).
-
-Layout:
-- ConfigMap holds the sweep script (files/housekeeper-sweep.sh) — keeps
-  this YAML readable and lets the script be lint-tested in isolation.
-- CronJob mounts the ConfigMap at /scripts/sweep.sh and passes config via
-  env vars, so the script has zero Helm-templating inside it.
+Idle-reap housekeeper for studio sandbox claims. See values.yaml for the
+behavior contract; sweep logic lives in files/housekeeper-sweep.sh.
 */ -}}
 ---
 apiVersion: v1
@@ -59,23 +31,18 @@ metadata:
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 rules:
-  # Reap target: list to discover, get to read probe-fail annotations,
-  # patch to stamp annotations + spec.lifecycle.shutdownTime (the graceful
-  # path for Idle / StuckReady), delete for ReconcilerError fall-through
-  # where the operator can't honor a shutdownTime patch.
+  # patch = annotate + spec.lifecycle.shutdownTime (graceful Idle/StuckReady);
+  # delete = ReconcilerError fall-through where shutdownTime is unhonored.
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
     verbs: ["get", "list", "patch", "delete"]
-  # Pod IPs come from a label-selected list (studio.decocms.com/role=claimed).
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list"]
-  # Reap events for post-mortem after the claim object is gone.
+  # Reap events outlive the claim object — used for post-mortem.
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create"]
-  # Per-claim HTTPRoute deletion is by sandbox-handle label, which needs
-  # list in addition to delete.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["list", "delete"]
@@ -104,15 +71,12 @@ metadata:
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
   annotations:
-    # Roll the CronJob template when the script content changes so the next
-    # scheduled run picks up new logic without an explicit redeploy of the
-    # CronJob spec.
+    # Rolls the CronJob spec when sweep.sh changes so the next run picks
+    # up new logic without an explicit redeploy.
     checksum/script: {{ .Files.Get "files/housekeeper-sweep.sh" | sha256sum }}
 spec:
   schedule: {{ .Values.housekeeper.schedule | quote }}
   concurrencyPolicy: Forbid
-  # Without this, a missed slot (controller-manager downtime, scheduling
-  # pressure) is silently skipped instead of catching up.
   startingDeadlineSeconds: {{ .Values.housekeeper.startingDeadlineSeconds }}
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
@@ -127,8 +91,6 @@ spec:
         spec:
           serviceAccountName: {{ include "sandbox-env.housekeeperName" . }}
           restartPolicy: Never
-          # Restricted-PSS-compliant: non-root, no privilege escalation,
-          # read-only rootfs, no capabilities.
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001
@@ -148,8 +110,6 @@ spec:
               resources:
                 {{- toYaml .Values.housekeeper.resources | nindent 16 }}
               env:
-                # Cronjob pod name as run id — used in log lines and on the
-                # reap-run annotation so a sweep's effects are traceable.
                 - name: RUN_ID
                   valueFrom:
                     fieldRef:

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -1,34 +1,43 @@
 {{- if .Values.housekeeper.enabled }}
-# CronJob that probes each Ready sandbox daemon's /_decopilot_vm/idle endpoint
-# and deletes claims that exceed the configured idle TTL. Also removes claims
-# stuck in ReconcilerError so broken sandboxes don't accumulate.
-#
-# The housekeeper is the activity-based counterpart to the operator's
-# time-based spec.lifecycle.shutdownTime: mesh sets a hard ceiling at
-# provision time; this job cuts claims earlier when the daemon reports the
-# pod has been idle for longer than idleTtlSeconds.
-#
-# Probe failure handling: a single connect error or timeout is retried once
-# (`curl --retry 1 --retry-all-errors --max-time 2 --retry-delay 1`). If both
-# attempts fail OR the body has no parseable idleMs the claim is SKIPPED, not
-# reaped. Truly broken pods are caught by the ReconcilerError branch above
-# (operator-side liveness) — reaping a Ready=True pod just because the script
-# couldn't reach it once means a NetworkPolicy/CNI/DNS blip wipes every
-# sandbox in one sweep. Cost of skipping: at most one extra TTL window of
-# resource hold; cost of false reap: user loses live work.
-#
-# Each reap also deletes the per-claim HTTPRoute first so traffic stops
-# resolving to the pod before it enters termination (avoids 502s in the
-# shutdown window). The route is matched by label
-# `studio.decocms.com/sandbox-handle=<claim>` rather than by name so this
-# survives any future change to the operator's route-naming convention.
-# (mesh stamps both the route name AND the handle label — see
-#  packages/sandbox/server/runner/agent-sandbox/runner.ts:1039,1043)
-#
-# Enable in exactly ONE env release per namespace — SandboxClaims carry no
-# env label so every enabled housekeeper sweeps all studio claims in
-# agent-sandbox-system. Multiple active housekeepers cause duplicate probes
-# and competing deletes (harmless but wasteful).
+{{- /*
+Idle-reap housekeeper for studio sandbox claims.
+
+What it does:
+- Probes each Ready sandbox's daemon at /_decopilot_vm/idle every
+  `housekeeper.schedule` minutes, deletes claims idle ≥ idleTtlSeconds.
+- Clears claims stuck in ReconcilerError (operator gave up).
+- Escalates "Ready but unreachable" claims to a StuckReady reap once they
+  exceed stuckReadyTtlSeconds (catches wedged daemons that present TCP
+  but don't respond meaningfully).
+- Re-probes immediately before delete to narrow the activity-during-reap
+  race window.
+- Emits a Kubernetes Event per reap so post-mortem via `kubectl get events`
+  works after the claim is gone.
+
+Multi-housekeeper warning:
+SandboxClaims carry no env label today, so every enabled housekeeper in
+agent-sandbox-system sweeps the *same* set of claims. Enable in exactly
+ONE env release per cluster. Per-env scoping requires a follow-up to
+runner.ts (stamp studio.decocms.com/env on the claim) plus this chart's
+selector picking that label up.
+
+Layout:
+- ConfigMap holds the sweep script (files/housekeeper-sweep.sh) — keeps
+  this YAML readable and lets the script be lint-tested in isolation.
+- CronJob mounts the ConfigMap at /scripts/sweep.sh and passes config via
+  env vars, so the script has zero Helm-templating inside it.
+*/ -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sandbox-env.housekeeperName" . }}-script
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+data:
+  sweep.sh: |
+{{ .Files.Get "files/housekeeper-sweep.sh" | indent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -46,20 +55,21 @@ metadata:
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 rules:
-  # SandboxClaim is the reap target. Annotate is used to stamp the reap
-  # reason just before delete so kube-audit retains a breadcrumb.
+  # Reap target: list to discover, get to read probe-fail annotations,
+  # patch to stamp annotations, delete to actually reap.
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
     verbs: ["get", "list", "patch", "delete"]
-  # Pod IPs are read directly via a label-selected list, so we don't need
-  # `agents.x-k8s.io/sandboxes` get permission anymore. Pods carry the
-  # `studio.decocms.com/sandbox-handle` label set by mesh's runner.ts
-  # buildClaim → additionalPodMetadata path.
+  # Pod IPs come from a label-selected list (studio.decocms.com/role=claimed).
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list"]
-  # HTTPRoute deletion is by label selector (studio.decocms.com/sandbox-handle),
-  # which requires `list` in addition to `delete`.
+  # Reap events for post-mortem after the claim object is gone.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+  # Per-claim HTTPRoute deletion is by sandbox-handle label, which needs
+  # list in addition to delete.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["list", "delete"]
@@ -87,21 +97,23 @@ metadata:
   namespace: agent-sandbox-system
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
+  annotations:
+    # Roll the CronJob template when the script content changes so the next
+    # scheduled run picks up new logic without an explicit redeploy of the
+    # CronJob spec.
+    checksum/script: {{ .Files.Get "files/housekeeper-sweep.sh" | sha256sum }}
 spec:
   schedule: {{ .Values.housekeeper.schedule | quote }}
   concurrencyPolicy: Forbid
   # Without this, a missed slot (controller-manager downtime, scheduling
-  # pressure) is silently skipped instead of catching up. 240s gives the
-  # next sweep ~one schedule interval to recover before being abandoned.
-  startingDeadlineSeconds: 240
+  # pressure) is silently skipped instead of catching up.
+  startingDeadlineSeconds: {{ .Values.housekeeper.startingDeadlineSeconds }}
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ .Values.housekeeper.activeDeadlineSeconds }}
-      # Clean up finished pod objects faster than failedJobsHistoryLimit
-      # alone — keeps `kubectl get pods` in agent-sandbox-system tidy.
-      ttlSecondsAfterFinished: 300
+      ttlSecondsAfterFinished: {{ .Values.housekeeper.ttlSecondsAfterFinished }}
       template:
         metadata:
           labels:
@@ -109,9 +121,8 @@ spec:
         spec:
           serviceAccountName: {{ include "sandbox-env.housekeeperName" . }}
           restartPolicy: Never
-          # Restricted-PSS-compliant: runs as non-root, no privilege
-          # escalation, no capabilities, read-only rootfs. /tmp is mounted
-          # via emptyDir for any temporary scratch curl/sh might need.
+          # Restricted-PSS-compliant: non-root, no privilege escalation,
+          # read-only rootfs, no capabilities.
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001
@@ -130,138 +141,40 @@ spec:
                   drop: ["ALL"]
               resources:
                 {{- toYaml .Values.housekeeper.resources | nindent 16 }}
-              volumeMounts:
-                - name: tmp
-                  mountPath: /tmp
               env:
+                # Cronjob pod name as run id — used in log lines and on the
+                # reap-run annotation so a sweep's effects are traceable.
                 - name: RUN_ID
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
-              command: ["/bin/sh", "-c"]
-              args:
-                - |
-                  set -eu
-                  NS="agent-sandbox-system"
-                  TTL_MS={{ mul .Values.housekeeper.idleTtlSeconds 1000 }}
-                  NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                  echo "[housekeeper] run=$RUN_ID ttl=${TTL_MS}ms ns=$NS — scanning"
-
-                  # The selector below mirrors STUDIO_CLAIM_LABEL_SELECTOR /
-                  # buildClaim() in mesh's runner.ts (~line 877). Keep both
-                  # in sync; if mesh ever adds a third selector label, this
-                  # silently drifts to wrong scope otherwise.
-                  CLAIM_SELECTOR="app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox"
-
-                  # Single API call returns name + Ready status + Ready reason
-                  # for every studio claim. One JSONPath line per claim, fields
-                  # separated by '|' so awk/cut can split without jq.
-                  CLAIMS_TSV=$(kubectl get sandboxclaims -n "$NS" \
-                    -l "$CLAIM_SELECTOR" \
-                    -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
-                    2>/dev/null || true)
-
-                  if [ -z "$CLAIMS_TSV" ]; then
-                    echo "[housekeeper] no studio sandbox claims found"
-                    exit 0
-                  fi
-
-                  # Pod IPs in one call, keyed by sandbox-handle. The
-                  # additionalPodMetadata path in mesh runner.ts:892 stamps
-                  # `studio.decocms.com/sandbox-handle=<handle>` and
-                  # `studio.decocms.com/role=claimed` on every claimed pod.
-                  PODS_TSV=$(kubectl get pods -n "$NS" \
-                    -l "studio.decocms.com/role=claimed" \
-                    -o jsonpath='{range .items[*]}{.metadata.labels.studio\.decocms\.com/sandbox-handle}|{.status.podIP}{"\n"}{end}' \
-                    2>/dev/null || true)
-
-                  pod_ip_for() {
-                    # $1 = claim handle. Echoes pod IP or empty.
-                    printf '%s\n' "$PODS_TSV" \
-                      | awk -F'|' -v h="$1" '$1==h && $2!="" { print $2; exit }'
-                  }
-
-                  reap_claim() {
-                    # $1 = claim handle, $2 = reason (idle|reconciler-error)
-                    local claim="$1" reason="$2"
-                    # Annotate first so kube-audit retains why this claim
-                    # disappeared. The annotation lives only as long as the
-                    # claim object itself, so this is best-effort breadcrumbs
-                    # rather than long-term forensics.
-                    kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
-                      "studio.decocms.com/reap-reason=$reason" \
-                      "studio.decocms.com/reap-at=$NOW_ISO" \
-                      "studio.decocms.com/reap-run=$RUN_ID" >/dev/null 2>&1 || true
-                    # Route deletion uses the sandbox-handle label
-                    # (LABEL_KEYS.sandboxHandle in mesh runner.ts:1570) to
-                    # survive any future operator route-naming change.
-                    kubectl delete httproute -n "$NS" \
-                      -l "studio.decocms.com/sandbox-handle=$claim" \
-                      --ignore-not-found >/dev/null 2>&1 || true
-                    kubectl delete sandboxclaim "$claim" -n "$NS" \
-                      --ignore-not-found >/dev/null 2>&1 || true
-                    echo "[housekeeper] reap=ok claim=$claim reason=$reason"
-                  }
-
-                  # Strip blank lines, then iterate.
-                  echo "$CLAIMS_TSV" | awk -F'|' 'NF>=1 && $1!=""' | while IFS='|' read -r CLAIM READY REASON; do
-                    if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
-                      reap_claim "$CLAIM" "reconciler-error"
-                      continue
-                    fi
-
-                    if [ "$READY" != "True" ]; then
-                      echo "[housekeeper] skip=not-ready claim=$CLAIM ready=${READY:-<none>} reason=${REASON:-<none>}"
-                      continue
-                    fi
-
-                    POD_IP=$(pod_ip_for "$CLAIM")
-                    if [ -z "$POD_IP" ]; then
-                      echo "[housekeeper] skip=no-pod-ip claim=$CLAIM"
-                      continue
-                    fi
-
-                    # Probe daemon. `--retry 1 --retry-all-errors --retry-delay 1`
-                    # absorbs a single transient blip (CNI churn, brief net hiccup).
-                    # Two failed attempts → SKIP (don't reap); see top-of-file
-                    # rationale.
-                    #
-                    # Daemon contract: 200 OK with body `{"idleMs":<int>,...}`.
-                    # Coupling lives at /_decopilot_vm/idle in the daemon image.
-                    # If that field is renamed or nested, the sed regex below
-                    # silently produces no match and the claim is skipped.
-                    if RESPONSE=$(curl -sf --max-time 2 \
-                          --retry 1 --retry-all-errors --retry-delay 1 \
-                          "http://${POD_IP}:9000/_decopilot_vm/idle" 2>/dev/null); then
-                      :
-                    else
-                      echo "[housekeeper] skip=probe-failed claim=$CLAIM pod_ip=$POD_IP"
-                      continue
-                    fi
-
-                    IDLE_MS=$(printf '%s' "$RESPONSE" \
-                      | sed -n 's/.*"idleMs"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
-
-                    # Defensive: only digits past this point. set -eu would
-                    # otherwise abort the loop on a bad numeric compare.
-                    case "$IDLE_MS" in
-                      ''|*[!0-9]*)
-                        echo "[housekeeper] skip=bad-response claim=$CLAIM body=$(printf '%s' "$RESPONSE" | head -c 80)"
-                        continue
-                        ;;
-                    esac
-
-                    if [ "$IDLE_MS" -ge "$TTL_MS" ]; then
-                      echo "[housekeeper] decision=reap claim=$CLAIM idle_ms=$IDLE_MS ttl_ms=$TTL_MS"
-                      reap_claim "$CLAIM" "idle"
-                    else
-                      REMAINING=$((TTL_MS - IDLE_MS))
-                      echo "[housekeeper] decision=keep claim=$CLAIM idle_ms=$IDLE_MS remaining_ms=$REMAINING"
-                    fi
-                  done
-
-                  echo "[housekeeper] run=$RUN_ID done"
+                - name: NS
+                  value: agent-sandbox-system
+                - name: TTL_MS
+                  value: {{ mul .Values.housekeeper.idleTtlSeconds 1000 | quote }}
+                - name: STUCK_TTL_MS
+                  value: {{ mul .Values.housekeeper.stuckReadyTtlSeconds 1000 | quote }}
+                - name: PROBE_TIMEOUT_SEC
+                  value: {{ .Values.housekeeper.probeTimeoutSeconds | quote }}
+                - name: CLAIM_SELECTOR
+                  value: {{ .Values.housekeeper.claimSelector | quote }}
+                - name: POD_SELECTOR
+                  value: {{ .Values.housekeeper.podSelector | quote }}
+              command: ["/bin/sh", "/scripts/sweep.sh"]
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
           volumes:
+            - name: script
+              configMap:
+                name: {{ include "sandbox-env.housekeeperName" . }}-script
+                defaultMode: 0555
+                items:
+                  - key: sweep.sh
+                    path: sweep.sh
             - name: tmp
               emptyDir: {}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -157,9 +157,9 @@ spec:
                 - name: PROBE_TIMEOUT_SEC
                   value: {{ .Values.housekeeper.probeTimeoutSeconds | quote }}
                 - name: CLAIM_SELECTOR
-                  value: {{ .Values.housekeeper.claimSelector | quote }}
+                  value: {{ default (include "sandbox-env.housekeeperClaimSelector" .) .Values.housekeeper.claimSelector | quote }}
                 - name: POD_SELECTOR
-                  value: {{ .Values.housekeeper.podSelector | quote }}
+                  value: {{ default (include "sandbox-env.housekeeperPodSelector" .) .Values.housekeeper.podSelector | quote }}
               command: ["/bin/sh", "/scripts/sweep.sh"]
               volumeMounts:
                 - name: script

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -8,19 +8,27 @@
 # provision time; this job cuts claims earlier when the daemon reports the
 # pod has been idle for longer than idleTtlSeconds.
 #
-# Probe failure (network error, non-2xx, timeout) is treated as idle — an
-# unreachable daemon means a broken pod that should be reaped. The 2s curl
-# timeout is intentionally short; a healthy daemon responds in <50ms.
+# Probe failure handling: a single connect error or timeout is retried once
+# (`curl --retry 1 --retry-all-errors --max-time 2 --retry-delay 1`). If both
+# attempts fail OR the body has no parseable idleMs the claim is SKIPPED, not
+# reaped. Truly broken pods are caught by the ReconcilerError branch above
+# (operator-side liveness) — reaping a Ready=True pod just because the script
+# couldn't reach it once means a NetworkPolicy/CNI/DNS blip wipes every
+# sandbox in one sweep. Cost of skipping: at most one extra TTL window of
+# resource hold; cost of false reap: user loses live work.
+#
+# Each reap also deletes the per-claim HTTPRoute first so traffic stops
+# resolving to the pod before it enters termination (avoids 502s in the
+# shutdown window). The route is matched by label
+# `studio.decocms.com/sandbox-handle=<claim>` rather than by name so this
+# survives any future change to the operator's route-naming convention.
+# (mesh stamps both the route name AND the handle label — see
+#  packages/sandbox/server/runner/agent-sandbox/runner.ts:1039,1043)
 #
 # Enable in exactly ONE env release per namespace — SandboxClaims carry no
 # env label so every enabled housekeeper sweeps all studio claims in
 # agent-sandbox-system. Multiple active housekeepers cause duplicate probes
 # and competing deletes (harmless but wasteful).
-#
-# Each reap also deletes the per-claim HTTPRoute (same name as the claim,
-# created by the operator for preview URL routing). The operator does not
-# attach an ownerReference from HTTPRoute → SandboxClaim, so without this
-# the routes leak into agent-sandbox-system every time a claim disappears.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -38,18 +46,23 @@ metadata:
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 rules:
+  # SandboxClaim is the reap target. Annotate is used to stamp the reap
+  # reason just before delete so kube-audit retains a breadcrumb.
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
-    verbs: ["get", "list", "delete"]
-  - apiGroups: ["agents.x-k8s.io"]
-    resources: ["sandboxes"]
-    verbs: ["get"]
+    verbs: ["get", "list", "patch", "delete"]
+  # Pod IPs are read directly via a label-selected list, so we don't need
+  # `agents.x-k8s.io/sandboxes` get permission anymore. Pods carry the
+  # `studio.decocms.com/sandbox-handle` label set by mesh's runner.ts
+  # buildClaim → additionalPodMetadata path.
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get"]
+    verbs: ["list"]
+  # HTTPRoute deletion is by label selector (studio.decocms.com/sandbox-handle),
+  # which requires `list` in addition to `delete`.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
-    verbs: ["delete"]
+    verbs: ["list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -77,11 +90,18 @@ metadata:
 spec:
   schedule: {{ .Values.housekeeper.schedule | quote }}
   concurrencyPolicy: Forbid
+  # Without this, a missed slot (controller-manager downtime, scheduling
+  # pressure) is silently skipped instead of catching up. 240s gives the
+  # next sweep ~one schedule interval to recover before being abandoned.
+  startingDeadlineSeconds: 240
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ .Values.housekeeper.activeDeadlineSeconds }}
+      # Clean up finished pod objects faster than failedJobsHistoryLimit
+      # alone — keeps `kubectl get pods` in agent-sandbox-system tidy.
+      ttlSecondsAfterFinished: 300
       template:
         metadata:
           labels:
@@ -89,90 +109,159 @@ spec:
         spec:
           serviceAccountName: {{ include "sandbox-env.housekeeperName" . }}
           restartPolicy: Never
+          # Restricted-PSS-compliant: runs as non-root, no privilege
+          # escalation, no capabilities, read-only rootfs. /tmp is mounted
+          # via emptyDir for any temporary scratch curl/sh might need.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: housekeeper
-              image: bitnami/kubectl:latest
+              image: {{ .Values.housekeeper.image.repository }}:{{ .Values.housekeeper.image.tag }}
+              imagePullPolicy: {{ .Values.housekeeper.image.pullPolicy }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.housekeeper.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              env:
+                - name: RUN_ID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
               command: ["/bin/sh", "-c"]
               args:
                 - |
-                  set -e
+                  set -eu
                   NS="agent-sandbox-system"
                   TTL_MS={{ mul .Values.housekeeper.idleTtlSeconds 1000 }}
-                  echo "[housekeeper] idle TTL=${TTL_MS}ms — scanning claims..."
+                  NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  echo "[housekeeper] run=$RUN_ID ttl=${TTL_MS}ms ns=$NS — scanning"
 
-                  # Delete the HTTPRoute before the SandboxClaim so traffic
-                  # stops resolving to the pod before it enters termination
-                  # (avoids 502s in the shutdown window). The operator
-                  # creates the HTTPRoute with metadata.name = claim name,
-                  # so we can address it by the claim name directly.
-                  reap_claim() {
-                    local claim="$1"
-                    kubectl delete httproute "$claim" -n "$NS" --ignore-not-found || true
-                    kubectl delete sandboxclaim "$claim" -n "$NS" --ignore-not-found || true
-                  }
+                  # The selector below mirrors STUDIO_CLAIM_LABEL_SELECTOR /
+                  # buildClaim() in mesh's runner.ts (~line 877). Keep both
+                  # in sync; if mesh ever adds a third selector label, this
+                  # silently drifts to wrong scope otherwise.
+                  CLAIM_SELECTOR="app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox"
 
-                  CLAIMS=$(kubectl get sandboxclaims -n "$NS" \
-                    -l "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox" \
-                    -o jsonpath='{.items[*].metadata.name}')
+                  # Single API call returns name + Ready status + Ready reason
+                  # for every studio claim. One JSONPath line per claim, fields
+                  # separated by '|' so awk/cut can split without jq.
+                  CLAIMS_TSV=$(kubectl get sandboxclaims -n "$NS" \
+                    -l "$CLAIM_SELECTOR" \
+                    -o jsonpath='{range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=="Ready")].status}|{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
+                    2>/dev/null || true)
 
-                  if [ -z "$CLAIMS" ]; then
+                  if [ -z "$CLAIMS_TSV" ]; then
                     echo "[housekeeper] no studio sandbox claims found"
                     exit 0
                   fi
 
-                  for CLAIM in $CLAIMS; do
-                    echo "[housekeeper] checking $CLAIM"
+                  # Pod IPs in one call, keyed by sandbox-handle. The
+                  # additionalPodMetadata path in mesh runner.ts:892 stamps
+                  # `studio.decocms.com/sandbox-handle=<handle>` and
+                  # `studio.decocms.com/role=claimed` on every claimed pod.
+                  PODS_TSV=$(kubectl get pods -n "$NS" \
+                    -l "studio.decocms.com/role=claimed" \
+                    -o jsonpath='{range .items[*]}{.metadata.labels.studio\.decocms\.com/sandbox-handle}|{.status.podIP}{"\n"}{end}' \
+                    2>/dev/null || true)
 
-                    READY=$(kubectl get sandboxclaim "$CLAIM" -n "$NS" \
-                      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' \
-                      2>/dev/null || true)
-                    REASON=$(kubectl get sandboxclaim "$CLAIM" -n "$NS" \
-                      -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' \
-                      2>/dev/null || true)
+                  pod_ip_for() {
+                    # $1 = claim handle. Echoes pod IP or empty.
+                    printf '%s\n' "$PODS_TSV" \
+                      | awk -F'|' -v h="$1" '$1==h && $2!="" { print $2; exit }'
+                  }
 
+                  reap_claim() {
+                    # $1 = claim handle, $2 = reason (idle|reconciler-error)
+                    local claim="$1" reason="$2"
+                    # Annotate first so kube-audit retains why this claim
+                    # disappeared. The annotation lives only as long as the
+                    # claim object itself, so this is best-effort breadcrumbs
+                    # rather than long-term forensics.
+                    kubectl annotate sandboxclaim "$claim" -n "$NS" --overwrite \
+                      "studio.decocms.com/reap-reason=$reason" \
+                      "studio.decocms.com/reap-at=$NOW_ISO" \
+                      "studio.decocms.com/reap-run=$RUN_ID" >/dev/null 2>&1 || true
+                    # Route deletion uses the sandbox-handle label
+                    # (LABEL_KEYS.sandboxHandle in mesh runner.ts:1570) to
+                    # survive any future operator route-naming change.
+                    kubectl delete httproute -n "$NS" \
+                      -l "studio.decocms.com/sandbox-handle=$claim" \
+                      --ignore-not-found >/dev/null 2>&1 || true
+                    kubectl delete sandboxclaim "$claim" -n "$NS" \
+                      --ignore-not-found >/dev/null 2>&1 || true
+                    echo "[housekeeper] reap=ok claim=$claim reason=$reason"
+                  }
+
+                  # Strip blank lines, then iterate.
+                  echo "$CLAIMS_TSV" | awk -F'|' 'NF>=1 && $1!=""' | while IFS='|' read -r CLAIM READY REASON; do
                     if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
-                      echo "[housekeeper] $CLAIM stuck in ReconcilerError — reaping"
-                      reap_claim "$CLAIM"
+                      reap_claim "$CLAIM" "reconciler-error"
                       continue
                     fi
 
                     if [ "$READY" != "True" ]; then
-                      echo "[housekeeper] $CLAIM not ready (ready=$READY reason=$REASON) — skipping"
+                      echo "[housekeeper] skip=not-ready claim=$CLAIM ready=${READY:-<none>} reason=${REASON:-<none>}"
                       continue
                     fi
 
-                    POD_NAME=$(kubectl get sandbox "$CLAIM" -n "$NS" \
-                      -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}' \
-                      2>/dev/null || true)
-                    if [ -z "$POD_NAME" ]; then
-                      echo "[housekeeper] $CLAIM: no pod annotation — skipping"
-                      continue
-                    fi
-
-                    POD_IP=$(kubectl get pod "$POD_NAME" -n "$NS" \
-                      -o jsonpath='{.status.podIP}' 2>/dev/null || true)
+                    POD_IP=$(pod_ip_for "$CLAIM")
                     if [ -z "$POD_IP" ]; then
-                      echo "[housekeeper] $POD_NAME: no pod IP — skipping"
+                      echo "[housekeeper] skip=no-pod-ip claim=$CLAIM"
                       continue
                     fi
 
-                    # Probe the daemon. Failure (network error, non-2xx, timeout)
-                    # falls back to TTL_MS so the claim is treated as idle and reaped.
-                    RESPONSE=$(curl -sf --max-time 2 \
-                      "http://${POD_IP}:9000/_decopilot_vm/idle" 2>/dev/null \
-                      || printf '{"idleMs":%s}' "$TTL_MS")
+                    # Probe daemon. `--retry 1 --retry-all-errors --retry-delay 1`
+                    # absorbs a single transient blip (CNI churn, brief net hiccup).
+                    # Two failed attempts → SKIP (don't reap); see top-of-file
+                    # rationale.
+                    #
+                    # Daemon contract: 200 OK with body `{"idleMs":<int>,...}`.
+                    # Coupling lives at /_decopilot_vm/idle in the daemon image.
+                    # If that field is renamed or nested, the sed regex below
+                    # silently produces no match and the claim is skipped.
+                    if RESPONSE=$(curl -sf --max-time 2 \
+                          --retry 1 --retry-all-errors --retry-delay 1 \
+                          "http://${POD_IP}:9000/_decopilot_vm/idle" 2>/dev/null); then
+                      :
+                    else
+                      echo "[housekeeper] skip=probe-failed claim=$CLAIM pod_ip=$POD_IP"
+                      continue
+                    fi
+
                     IDLE_MS=$(printf '%s' "$RESPONSE" \
-                      | sed -n 's/.*"idleMs":\([0-9][0-9]*\).*/\1/p')
-                    IDLE_MS=${IDLE_MS:-$TTL_MS}
+                      | sed -n 's/.*"idleMs"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+
+                    # Defensive: only digits past this point. set -eu would
+                    # otherwise abort the loop on a bad numeric compare.
+                    case "$IDLE_MS" in
+                      ''|*[!0-9]*)
+                        echo "[housekeeper] skip=bad-response claim=$CLAIM body=$(printf '%s' "$RESPONSE" | head -c 80)"
+                        continue
+                        ;;
+                    esac
 
                     if [ "$IDLE_MS" -ge "$TTL_MS" ]; then
-                      echo "[housekeeper] reaping $CLAIM — idle ${IDLE_MS}ms >= ttl ${TTL_MS}ms"
-                      reap_claim "$CLAIM"
+                      echo "[housekeeper] decision=reap claim=$CLAIM idle_ms=$IDLE_MS ttl_ms=$TTL_MS"
+                      reap_claim "$CLAIM" "idle"
                     else
                       REMAINING=$((TTL_MS - IDLE_MS))
-                      echo "[housekeeper] $CLAIM active — idle ${IDLE_MS}ms, ${REMAINING}ms until ttl"
+                      echo "[housekeeper] decision=keep claim=$CLAIM idle_ms=$IDLE_MS remaining_ms=$REMAINING"
                     fi
                   done
 
-                  echo "[housekeeper] done"
+                  echo "[housekeeper] run=$RUN_ID done"
+          volumes:
+            - name: tmp
+              emptyDir: {}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -31,7 +31,7 @@ metadata:
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 rules:
-  # patch = annotate + spec.lifecycle.shutdownTime (graceful Idle/StuckReady);
+  # patch = annotate + spec.lifecycle.shutdownTime (graceful Idle reap);
   # delete = ReconcilerError fall-through where shutdownTime is unhonored.
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
@@ -121,8 +121,6 @@ spec:
                   value: agent-sandbox-system
                 - name: TTL_MS
                   value: {{ mul .Values.housekeeper.idleTtlSeconds 1000 | quote }}
-                - name: STUCK_TTL_MS
-                  value: {{ mul .Values.housekeeper.stuckReadyTtlSeconds 1000 | quote }}
                 - name: PROBE_TIMEOUT_SEC
                   value: {{ .Values.housekeeper.probeTimeoutSeconds | quote }}
                 - name: CLAIM_SELECTOR

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -16,6 +16,11 @@
 # env label so every enabled housekeeper sweeps all studio claims in
 # agent-sandbox-system. Multiple active housekeepers cause duplicate probes
 # and competing deletes (harmless but wasteful).
+#
+# Each reap also deletes the per-claim HTTPRoute (same name as the claim,
+# created by the operator for preview URL routing). The operator does not
+# attach an ownerReference from HTTPRoute → SandboxClaim, so without this
+# the routes leak into agent-sandbox-system every time a claim disappears.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -42,6 +47,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -92,6 +100,17 @@ spec:
                   TTL_MS={{ mul .Values.housekeeper.idleTtlSeconds 1000 }}
                   echo "[housekeeper] idle TTL=${TTL_MS}ms — scanning claims..."
 
+                  # Delete the HTTPRoute before the SandboxClaim so traffic
+                  # stops resolving to the pod before it enters termination
+                  # (avoids 502s in the shutdown window). The operator
+                  # creates the HTTPRoute with metadata.name = claim name,
+                  # so we can address it by the claim name directly.
+                  reap_claim() {
+                    local claim="$1"
+                    kubectl delete httproute "$claim" -n "$NS" --ignore-not-found || true
+                    kubectl delete sandboxclaim "$claim" -n "$NS" --ignore-not-found || true
+                  }
+
                   CLAIMS=$(kubectl get sandboxclaims -n "$NS" \
                     -l "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox" \
                     -o jsonpath='{.items[*].metadata.name}')
@@ -112,8 +131,8 @@ spec:
                       2>/dev/null || true)
 
                     if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
-                      echo "[housekeeper] $CLAIM stuck in ReconcilerError — deleting"
-                      kubectl delete sandboxclaim "$CLAIM" -n "$NS" || true
+                      echo "[housekeeper] $CLAIM stuck in ReconcilerError — reaping"
+                      reap_claim "$CLAIM"
                       continue
                     fi
 
@@ -147,8 +166,8 @@ spec:
                     IDLE_MS=${IDLE_MS:-$TTL_MS}
 
                     if [ "$IDLE_MS" -ge "$TTL_MS" ]; then
-                      echo "[housekeeper] deleting $CLAIM — idle ${IDLE_MS}ms >= ttl ${TTL_MS}ms"
-                      kubectl delete sandboxclaim "$CLAIM" -n "$NS" || true
+                      echo "[housekeeper] reaping $CLAIM — idle ${IDLE_MS}ms >= ttl ${TTL_MS}ms"
+                      reap_claim "$CLAIM"
                     else
                       REMAINING=$((TTL_MS - IDLE_MS))
                       echo "[housekeeper] $CLAIM active — idle ${IDLE_MS}ms, ${REMAINING}ms until ttl"

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -40,9 +40,12 @@ rules:
     resources: ["pods"]
     verbs: ["list"]
   # Reap events outlive the claim object — used for post-mortem.
-  - apiGroups: [""]
+  # events.k8s.io/v1 is the current API; legacy `[""] events` is deprecated.
+  # `kubectl get events` aggregates from both, so consumers are unaffected.
+  - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create"]
+  # list = orphan HTTPRoute GC pass + per-claim reap deletes.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["list", "delete"]

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -1,0 +1,159 @@
+{{- if .Values.housekeeper.enabled }}
+# CronJob that probes each Ready sandbox daemon's /_decopilot_vm/idle endpoint
+# and deletes claims that exceed the configured idle TTL. Also removes claims
+# stuck in ReconcilerError so broken sandboxes don't accumulate.
+#
+# The housekeeper is the activity-based counterpart to the operator's
+# time-based spec.lifecycle.shutdownTime: mesh sets a hard ceiling at
+# provision time; this job cuts claims earlier when the daemon reports the
+# pod has been idle for longer than idleTtlSeconds.
+#
+# Probe failure (network error, non-2xx, timeout) is treated as idle — an
+# unreachable daemon means a broken pod that should be reaped. The 2s curl
+# timeout is intentionally short; a healthy daemon responds in <50ms.
+#
+# Enable in exactly ONE env release per namespace — SandboxClaims carry no
+# env label so every enabled housekeeper sweeps all studio claims in
+# agent-sandbox-system. Multiple active housekeepers cause duplicate probes
+# and competing deletes (harmless but wasteful).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sandbox-env.housekeeperName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sandbox-env.housekeeperName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sandbox-env.housekeeperName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sandbox-env.housekeeperName" . }}
+    namespace: agent-sandbox-system
+roleRef:
+  kind: Role
+  name: {{ include "sandbox-env.housekeeperName" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "sandbox-env.housekeeperName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.housekeeper.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ .Values.housekeeper.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "sandbox-env.housekeeperName" . }}
+        spec:
+          serviceAccountName: {{ include "sandbox-env.housekeeperName" . }}
+          restartPolicy: Never
+          containers:
+            - name: housekeeper
+              image: bitnami/kubectl:latest
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  NS="agent-sandbox-system"
+                  TTL_MS={{ mul .Values.housekeeper.idleTtlSeconds 1000 }}
+                  echo "[housekeeper] idle TTL=${TTL_MS}ms — scanning claims..."
+
+                  CLAIMS=$(kubectl get sandboxclaims -n "$NS" \
+                    -l "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox" \
+                    -o jsonpath='{.items[*].metadata.name}')
+
+                  if [ -z "$CLAIMS" ]; then
+                    echo "[housekeeper] no studio sandbox claims found"
+                    exit 0
+                  fi
+
+                  for CLAIM in $CLAIMS; do
+                    echo "[housekeeper] checking $CLAIM"
+
+                    READY=$(kubectl get sandboxclaim "$CLAIM" -n "$NS" \
+                      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' \
+                      2>/dev/null || true)
+                    REASON=$(kubectl get sandboxclaim "$CLAIM" -n "$NS" \
+                      -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' \
+                      2>/dev/null || true)
+
+                    if [ "$READY" = "False" ] && [ "$REASON" = "ReconcilerError" ]; then
+                      echo "[housekeeper] $CLAIM stuck in ReconcilerError — deleting"
+                      kubectl delete sandboxclaim "$CLAIM" -n "$NS" || true
+                      continue
+                    fi
+
+                    if [ "$READY" != "True" ]; then
+                      echo "[housekeeper] $CLAIM not ready (ready=$READY reason=$REASON) — skipping"
+                      continue
+                    fi
+
+                    POD_NAME=$(kubectl get sandbox "$CLAIM" -n "$NS" \
+                      -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}' \
+                      2>/dev/null || true)
+                    if [ -z "$POD_NAME" ]; then
+                      echo "[housekeeper] $CLAIM: no pod annotation — skipping"
+                      continue
+                    fi
+
+                    POD_IP=$(kubectl get pod "$POD_NAME" -n "$NS" \
+                      -o jsonpath='{.status.podIP}' 2>/dev/null || true)
+                    if [ -z "$POD_IP" ]; then
+                      echo "[housekeeper] $POD_NAME: no pod IP — skipping"
+                      continue
+                    fi
+
+                    # Probe the daemon. Failure (network error, non-2xx, timeout)
+                    # falls back to TTL_MS so the claim is treated as idle and reaped.
+                    RESPONSE=$(curl -sf --max-time 2 \
+                      "http://${POD_IP}:9000/_decopilot_vm/idle" 2>/dev/null \
+                      || printf '{"idleMs":%s}' "$TTL_MS")
+                    IDLE_MS=$(printf '%s' "$RESPONSE" \
+                      | sed -n 's/.*"idleMs":\([0-9][0-9]*\).*/\1/p')
+                    IDLE_MS=${IDLE_MS:-$TTL_MS}
+
+                    if [ "$IDLE_MS" -ge "$TTL_MS" ]; then
+                      echo "[housekeeper] deleting $CLAIM — idle ${IDLE_MS}ms >= ttl ${TTL_MS}ms"
+                      kubectl delete sandboxclaim "$CLAIM" -n "$NS" || true
+                    else
+                      REMAINING=$((TTL_MS - IDLE_MS))
+                      echo "[housekeeper] $CLAIM active — idle ${IDLE_MS}ms, ${REMAINING}ms until ttl"
+                    fi
+                  done
+
+                  echo "[housekeeper] done"
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-network-policy.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-network-policy.yaml
@@ -66,9 +66,8 @@ spec:
           port: 9000
     {{- end }}
     {{- if .Values.housekeeper.enabled }}
-    # Housekeeper — probes /_decopilot_vm/idle to reap idle sandboxes.
-    # Runs in agent-sandbox-system (same ns as pods), so no namespaceSelector
-    # needed; scoped to the housekeeper pod by its app.kubernetes.io/name label.
+    # Housekeeper probes /_decopilot_vm/idle. Same namespace as pods, so
+    # podSelector alone is enough (no namespaceSelector).
     - from:
         - podSelector:
             matchLabels:

--- a/deploy/helm/sandbox-env/templates/sandbox-network-policy.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-network-policy.yaml
@@ -65,6 +65,18 @@ spec:
         - protocol: TCP
           port: 9000
     {{- end }}
+    {{- if .Values.housekeeper.enabled }}
+    # Housekeeper — probes /_decopilot_vm/idle to reap idle sandboxes.
+    # Runs in agent-sandbox-system (same ns as pods), so no namespaceSelector
+    # needed; scoped to the housekeeper pod by its app.kubernetes.io/name label.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "sandbox-env.housekeeperName" . }}
+      ports:
+        - protocol: TCP
+          port: 9000
+    {{- end }}
     {{- with .Values.networkPolicy.previewGatewayNamespace }}
     # DEPRECATED — direct ingress on dev port 3000 from a configured
     # gateway namespace. Only needed for setups that route preview traffic

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -285,11 +285,20 @@ housekeeper:
   # Clean up finished pod objects faster than failedJobsHistoryLimit.
   ttlSecondsAfterFinished: 300
 
-  # Label selectors that match what mesh stamps on claims and pods. Mirrors
-  # buildClaim in packages/sandbox/server/runner/agent-sandbox/runner.ts.
-  # Override only if mesh's selector changes — the two MUST stay in sync.
-  claimSelector: "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox"
-  podSelector: "studio.decocms.com/role=claimed"
+  # Label selectors. Empty = chart computes env-scoped defaults via the
+  # housekeeperClaimSelector / housekeeperPodSelector helpers, which match
+  # only this env's claims and pods (mesh stamps studio.decocms.com/env=
+  # <envName> when STUDIO_ENV is set in the studio chart's configMap).
+  #
+  # Override to an explicit string only during a phased rollout, before
+  # mesh has been upgraded with STUDIO_ENV — without the env label being
+  # stamped on claims, the env-scoped selector matches nothing. Use the
+  # broad selector to keep sweeping during the transition:
+  #   claimSelector: "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox"
+  #   podSelector: "studio.decocms.com/role=claimed"
+  # and switch back to "" once every claim is env-labeled.
+  claimSelector: ""
+  podSelector: ""
 
   # Pinned for reproducibility — `latest` would silently change behavior
   # at the next scheduled run. Bump deliberately.

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -234,3 +234,21 @@ mesh:
   podSelectorLabels:
     app.kubernetes.io/name: "chart-deco-studio"
     app.kubernetes.io/instance: "deco-studio"
+
+# ── idle-reap housekeeper ──────────────────────────────────────────────
+# CronJob that probes each Ready sandbox daemon's /_decopilot_vm/idle and
+# deletes claims idle longer than idleTtlSeconds. Also clears claims stuck
+# in ReconcilerError.
+#
+# Enable in exactly ONE env release per namespace — SandboxClaims carry no
+# env label so every active housekeeper sweeps all studio claims in
+# agent-sandbox-system.
+housekeeper:
+  enabled: false
+  # Seconds of inactivity before a claim is deleted. Should match (or be
+  # shorter than) DEFAULT_IDLE_TTL_MS in runner.ts (default 900s / 15min).
+  idleTtlSeconds: 900
+  # How often to sweep. Every 5min gives ≤5min overshoot on a 15min TTL.
+  schedule: "*/5 * * * *"
+  # Hard job deadline. 300s handles ~100 sandboxes at 2s/probe with headroom.
+  activeDeadlineSeconds: 300

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -236,33 +236,69 @@ mesh:
     app.kubernetes.io/instance: "deco-studio"
 
 # ── idle-reap housekeeper ──────────────────────────────────────────────
-# CronJob that probes each Ready sandbox daemon's /_decopilot_vm/idle and
-# deletes claims idle longer than idleTtlSeconds. Also clears claims stuck
-# in ReconcilerError. Probe failures are SKIPPED (not reaped) — see
-# templates/sandbox-housekeeper.yaml header for the full rationale.
+# CronJob that sweeps studio sandboxes:
+#   1. Reaps claims stuck in ReconcilerError (operator-side broken).
+#   2. Probes /_decopilot_vm/idle on each Ready claim's daemon. Idle ≥
+#      idleTtlSeconds → re-probe → delete (the re-probe narrows the
+#      activity-during-reap race).
+#   3. Tracks consecutive probe failures via annotation. Failures older
+#      than stuckReadyTtlSeconds escalate to a StuckReady reap (catches
+#      wedged daemons that present TCP but don't respond meaningfully).
+# A Kubernetes Event is emitted on every reap so post-mortem via
+# `kubectl get events` works after the claim object is gone.
 #
-# Enable in exactly ONE env release per namespace — SandboxClaims carry no
-# env label so every active housekeeper sweeps all studio claims in
-# agent-sandbox-system.
+# Multi-housekeeper warning: SandboxClaims today carry no env label, so
+# every enabled housekeeper sweeps the SAME set of claims. Enable in
+# exactly ONE env release per cluster. See README for the per-env scoping
+# follow-up.
 housekeeper:
   enabled: false
-  # Seconds of inactivity before a claim is deleted. Should match (or be
+
+  # Cron expression. Default sweeps every 5 min; with the 15 min idle TTL
+  # below this gives at most ~5 min of "stale-idle overshoot" before reap.
+  schedule: "*/5 * * * *"
+
+  # Seconds of inactivity before a claim is reaped. Should match (or be
   # shorter than) DEFAULT_IDLE_TTL_MS in mesh's runner.ts (default 900s).
   idleTtlSeconds: 900
-  # How often to sweep. Every 5min gives ≤5min overshoot on a 15min TTL.
-  schedule: "*/5 * * * *"
-  # Hard job deadline. The script now batches API calls (1 list of claims +
-  # 1 list of pods) instead of 4 per-claim, so the bottleneck is the curl
-  # probe at ~1.5s/claim worst-case. 600s ≈ 400 sandboxes with headroom.
+
+  # Consecutive probe-failure window before a Ready-but-unreachable claim
+  # is escalated to a StuckReady reap. Default 30 min: long enough to
+  # outlast typical CNI/NetworkPolicy churn, short enough that a wedged
+  # daemon doesn't sit until the operator's hard ceiling.
+  stuckReadyTtlSeconds: 1800
+
+  # Per-probe curl --max-time. The healthy daemon responds in <50ms; this
+  # only matters for the failure path. Two attempts (one retry) cap total
+  # probe latency at ~2× this value plus retry-delay.
+  probeTimeoutSeconds: 2
+
+  # Hard job deadline. The script batches API calls (1 list of claims +
+  # 1 list of pods) so the bottleneck is curl probes at ~1.5s/claim
+  # worst-case. 600s ≈ 400 sandboxes/sweep with headroom.
   activeDeadlineSeconds: 600
+
+  # Recover missed slots when controller-manager was down at the
+  # scheduled time. 240s = 4 min of grace before the slot is abandoned.
+  startingDeadlineSeconds: 240
+
+  # Clean up finished pod objects faster than failedJobsHistoryLimit.
+  ttlSecondsAfterFinished: 300
+
+  # Label selectors that match what mesh stamps on claims and pods. Mirrors
+  # buildClaim in packages/sandbox/server/runner/agent-sandbox/runner.ts.
+  # Override only if mesh's selector changes — the two MUST stay in sync.
+  claimSelector: "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox"
+  podSelector: "studio.decocms.com/role=claimed"
+
   # Pinned for reproducibility — `latest` would silently change behavior
-  # at the next scheduled run. Bump on a deliberate version refresh.
+  # at the next scheduled run. Bump deliberately.
   image:
     repository: bitnami/kubectl
     tag: "1.32"
     pullPolicy: IfNotPresent
+
   # Tight by design: the script does N kubectl calls + N curls and exits.
-  # Scale up only if you observe OOMKills under high claim counts.
   resources:
     requests:
       cpu: 50m

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -238,7 +238,8 @@ mesh:
 # ── idle-reap housekeeper ──────────────────────────────────────────────
 # CronJob that probes each Ready sandbox daemon's /_decopilot_vm/idle and
 # deletes claims idle longer than idleTtlSeconds. Also clears claims stuck
-# in ReconcilerError.
+# in ReconcilerError. Probe failures are SKIPPED (not reaped) — see
+# templates/sandbox-housekeeper.yaml header for the full rationale.
 #
 # Enable in exactly ONE env release per namespace — SandboxClaims carry no
 # env label so every active housekeeper sweeps all studio claims in
@@ -246,9 +247,26 @@ mesh:
 housekeeper:
   enabled: false
   # Seconds of inactivity before a claim is deleted. Should match (or be
-  # shorter than) DEFAULT_IDLE_TTL_MS in runner.ts (default 900s / 15min).
+  # shorter than) DEFAULT_IDLE_TTL_MS in mesh's runner.ts (default 900s).
   idleTtlSeconds: 900
   # How often to sweep. Every 5min gives ≤5min overshoot on a 15min TTL.
   schedule: "*/5 * * * *"
-  # Hard job deadline. 300s handles ~100 sandboxes at 2s/probe with headroom.
-  activeDeadlineSeconds: 300
+  # Hard job deadline. The script now batches API calls (1 list of claims +
+  # 1 list of pods) instead of 4 per-claim, so the bottleneck is the curl
+  # probe at ~1.5s/claim worst-case. 600s ≈ 400 sandboxes with headroom.
+  activeDeadlineSeconds: 600
+  # Pinned for reproducibility — `latest` would silently change behavior
+  # at the next scheduled run. Bump on a deliberate version refresh.
+  image:
+    repository: bitnami/kubectl
+    tag: "1.32"
+    pullPolicy: IfNotPresent
+  # Tight by design: the script does N kubectl calls + N curls and exits.
+  # Scale up only if you observe OOMKills under high claim counts.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -236,83 +236,48 @@ mesh:
     app.kubernetes.io/instance: "deco-studio"
 
 # ── idle-reap housekeeper ──────────────────────────────────────────────
-# CronJob that sweeps studio sandboxes:
-#   1. Direct-deletes claims stuck in ReconcilerError — the operator has
-#      already given up, so asking it to drain wouldn't work.
-#   2. Probes /_decopilot_vm/idle on each Ready claim's daemon. Idle ≥
-#      idleTtlSeconds → re-probe → patch spec.lifecycle.shutdownTime so
-#      the operator drains the pod gracefully. Same contract mesh uses
-#      for per-ensure() refresh, so the in-process and out-of-process
-#      paths interoperate cleanly.
-#   3. Tracks consecutive probe failures via annotation. Failures older
-#      than stuckReadyTtlSeconds escalate to a StuckReady shutdown
-#      (catches wedged daemons that present TCP but don't respond
-#      meaningfully).
-# A Kubernetes Event is emitted on every reap so post-mortem via
-# `kubectl get events` works after the claim object is gone.
+# CronJob that sweeps studio sandboxes: direct-deletes ReconcilerError
+# claims, gracefully shuts down idle Ready claims (idleTtlSeconds), and
+# escalates Ready-but-unreachable claims to a StuckReady shutdown
+# (stuckReadyTtlSeconds). Each reap emits a Kubernetes Event for
+# post-mortem via `kubectl get events`.
 housekeeper:
   enabled: false
 
-  # Cron expression. Default sweeps every 5 min; with the 15 min idle TTL
-  # below this gives at most ~5 min of "stale-idle overshoot" before reap.
   schedule: "*/5 * * * *"
 
-  # Seconds of inactivity before a claim is reaped. Should match (or be
-  # shorter than) DEFAULT_IDLE_TTL_MS in mesh's runner.ts (default 900s).
+  # Should match (or be shorter than) DEFAULT_IDLE_TTL_MS in runner.ts.
   idleTtlSeconds: 900
 
-  # Consecutive probe-failure window before a Ready-but-unreachable claim
-  # is escalated to a StuckReady reap. Default 30 min: long enough to
-  # outlast typical CNI/NetworkPolicy churn, short enough that a wedged
-  # daemon doesn't sit until the operator's hard ceiling.
+  # Long enough to outlast CNI/NetworkPolicy churn; short enough that a
+  # wedged daemon doesn't sit until the operator's hard ceiling.
   stuckReadyTtlSeconds: 1800
 
-  # Per-probe curl --max-time. The healthy daemon responds in <50ms; this
-  # only matters for the failure path. Two attempts (one retry) cap total
-  # probe latency at ~2× this value plus retry-delay.
+  # Healthy daemon responds <50ms; this only matters on the failure path.
   probeTimeoutSeconds: 2
 
-  # Hard job deadline. The script batches API calls (1 list of claims +
-  # 1 list of pods) so the bottleneck is curl probes at ~1.5s/claim
-  # worst-case. 600s ≈ 400 sandboxes/sweep with headroom.
+  # 600s ≈ 400 sandboxes/sweep at ~1.5s/claim worst case.
   activeDeadlineSeconds: 600
 
-  # Recover missed slots when controller-manager was down at the
-  # scheduled time. 240s = 4 min of grace before the slot is abandoned.
+  # Grace window for slots missed during controller-manager downtime.
   startingDeadlineSeconds: 240
 
-  # Clean up finished pod objects faster than failedJobsHistoryLimit.
   ttlSecondsAfterFinished: 300
 
-  # Label selectors. Empty = chart computes env-scoped defaults via the
-  # housekeeperClaimSelector / housekeeperPodSelector helpers, which match
-  # only this env's claims and pods (mesh stamps studio.decocms.com/env=
-  # <envName> when STUDIO_ENV is set in the studio chart's configMap).
-  #
-  # Override to an explicit string only during a phased rollout, before
-  # mesh has been upgraded with STUDIO_ENV — without the env label being
-  # stamped on claims, the env-scoped selector matches nothing. Use the
-  # broad selector to keep sweeping during the transition:
-  #   claimSelector: "app.kubernetes.io/managed-by=studio,app.kubernetes.io/name=studio-sandbox"
-  #   podSelector: "studio.decocms.com/role=claimed"
-  # and switch back to "" once every claim is env-labeled.
+  # Empty = use env-scoped defaults from the housekeeper{Claim,Pod}Selector
+  # helpers. Override during phased rollout (before mesh propagates
+  # STUDIO_ENV) — the env-scoped default matches zero claims without the
+  # label. README has the unscoped copy-paste.
   claimSelector: ""
   podSelector: ""
 
-  # Pinned for reproducibility — `latest` would silently change behavior
-  # at the next scheduled run. Bump deliberately.
-  #
-  # alpine/k8s bundles kubectl + curl + jq + yq + helm in one image; the
-  # script needs both kubectl (list/patch/delete claims) and curl (probe
-  # the daemon's /idle endpoint), so a single-tool image like
-  # bitnami/kubectl doesn't work. Tag matches a recent kubectl minor close
-  # to the cluster's API version — kubectl skew of ±1 minor is supported.
+  # alpine/k8s bundles kubectl + curl in one image (the sweep needs both).
+  # Tag pinned — `latest` would silently change at the next scheduled run.
   image:
     repository: alpine/k8s
     tag: "1.32.0"
     pullPolicy: IfNotPresent
 
-  # Tight by design: the script does N kubectl calls + N curls and exits.
   resources:
     requests:
       cpu: 50m

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -237,20 +237,19 @@ mesh:
 
 # ── idle-reap housekeeper ──────────────────────────────────────────────
 # CronJob that sweeps studio sandboxes:
-#   1. Reaps claims stuck in ReconcilerError (operator-side broken).
+#   1. Direct-deletes claims stuck in ReconcilerError — the operator has
+#      already given up, so asking it to drain wouldn't work.
 #   2. Probes /_decopilot_vm/idle on each Ready claim's daemon. Idle ≥
-#      idleTtlSeconds → re-probe → delete (the re-probe narrows the
-#      activity-during-reap race).
+#      idleTtlSeconds → re-probe → patch spec.lifecycle.shutdownTime so
+#      the operator drains the pod gracefully. Same contract mesh uses
+#      for per-ensure() refresh, so the in-process and out-of-process
+#      paths interoperate cleanly.
 #   3. Tracks consecutive probe failures via annotation. Failures older
-#      than stuckReadyTtlSeconds escalate to a StuckReady reap (catches
-#      wedged daemons that present TCP but don't respond meaningfully).
+#      than stuckReadyTtlSeconds escalate to a StuckReady shutdown
+#      (catches wedged daemons that present TCP but don't respond
+#      meaningfully).
 # A Kubernetes Event is emitted on every reap so post-mortem via
 # `kubectl get events` works after the claim object is gone.
-#
-# Multi-housekeeper warning: SandboxClaims today carry no env label, so
-# every enabled housekeeper sweeps the SAME set of claims. Enable in
-# exactly ONE env release per cluster. See README for the per-env scoping
-# follow-up.
 housekeeper:
   enabled: false
 
@@ -302,9 +301,15 @@ housekeeper:
 
   # Pinned for reproducibility — `latest` would silently change behavior
   # at the next scheduled run. Bump deliberately.
+  #
+  # alpine/k8s bundles kubectl + curl + jq + yq + helm in one image; the
+  # script needs both kubectl (list/patch/delete claims) and curl (probe
+  # the daemon's /idle endpoint), so a single-tool image like
+  # bitnami/kubectl doesn't work. Tag matches a recent kubectl minor close
+  # to the cluster's API version — kubectl skew of ±1 minor is supported.
   image:
-    repository: bitnami/kubectl
-    tag: "1.32"
+    repository: alpine/k8s
+    tag: "1.32.0"
     pullPolicy: IfNotPresent
 
   # Tight by design: the script does N kubectl calls + N curls and exits.

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -236,11 +236,8 @@ mesh:
     app.kubernetes.io/instance: "deco-studio"
 
 # ── idle-reap housekeeper ──────────────────────────────────────────────
-# CronJob that sweeps studio sandboxes: direct-deletes ReconcilerError
-# claims, gracefully shuts down idle Ready claims (idleTtlSeconds), and
-# escalates Ready-but-unreachable claims to a StuckReady shutdown
-# (stuckReadyTtlSeconds). Each reap emits a Kubernetes Event for
-# post-mortem via `kubectl get events`.
+# CronJob that direct-deletes ReconcilerError claims and gracefully shuts
+# down idle Ready claims. Emits a Kubernetes Event per reap.
 housekeeper:
   enabled: false
 
@@ -249,11 +246,6 @@ housekeeper:
   # Should match (or be shorter than) DEFAULT_IDLE_TTL_MS in runner.ts.
   idleTtlSeconds: 900
 
-  # Long enough to outlast CNI/NetworkPolicy churn; short enough that a
-  # wedged daemon doesn't sit until the operator's hard ceiling.
-  stuckReadyTtlSeconds: 1800
-
-  # Healthy daemon responds <50ms; this only matters on the failure path.
   probeTimeoutSeconds: 2
 
   # 600s ≈ 400 sandboxes/sweep at ~1.5s/claim worst case.

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -262,19 +262,10 @@ export interface AgentSandboxRunnerOptions {
   /** SandboxTemplate all claims reference. */
   sandboxTemplateName?: string;
   /**
-   * Studio environment name (e.g. "prod", "staging"). When set, every
-   * SandboxClaim, claimed Pod, and per-claim HTTPRoute is stamped with
-   * `studio.decocms.com/env=<envName>` so the sandbox-env Helm chart's
-   * housekeeper can scope its sweep to a single environment instead of
-   * every studio claim in the namespace.
-   *
-   * Optional — single-env installs that don't run a per-env housekeeper
-   * can leave this unset and the label is omitted (no behavioral change
-   * for them). Mesh wires it from `STUDIO_ENV`.
-   *
-   * Constraint: must be a DNS-label-safe value (a-z0-9-, starts with a
-   * letter, ≤63 chars). Validated at construction; an invalid value
-   * throws rather than letting the operator silently reject the claim.
+   * Studio environment name. When set, stamped as
+   * `studio.decocms.com/env=<envName>` on claims/pods/HTTPRoutes so the
+   * sandbox-env housekeeper can scope per-env. Must be DNS-label-safe;
+   * validated at construction.
    */
   envName?: string;
   /**
@@ -1558,9 +1549,6 @@ const LABEL_KEYS = {
   sandboxHandle: "studio.decocms.com/sandbox-handle",
   orgId: "studio.decocms.com/org-id",
   userId: "studio.decocms.com/user-id",
-  // Stamped on claims, claimed pods, and per-claim HTTPRoutes when the
-  // runner is constructed with envName, so the sandbox-env Helm chart's
-  // housekeeper can scope its sweep to a single environment.
   env: "studio.decocms.com/env",
 } as const;
 
@@ -1576,11 +1564,9 @@ function sanitizeLabelValue(value: string): string {
   return LABEL_VALUE_RE.test(truncated) ? truncated : "";
 }
 
-// Same DNS-label rules the sandbox-env chart enforces on envName: lowercase
-// alphanumeric or '-', start with a letter, end alphanumeric, ≤32 chars.
-// Tighter than the generic LABEL_VALUE_RE because envName flows into K8s
-// resource names (housekeeper-<env>, studio-sandbox-<env>) where the longer
-// charset would break things.
+// Tighter than LABEL_VALUE_RE — envName flows into K8s resource names
+// (e.g. studio-sandbox-<env>), which require this restricted charset.
+// Must match the regex the sandbox-env chart enforces on envName.
 const ENV_NAME_RE = /^[a-z]([a-z0-9-]{0,30}[a-z0-9])?$/;
 
 function normalizeEnvName(raw: string | undefined): string | null {

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -861,7 +861,7 @@ export class AgentSandboxRunner implements SandboxRunner {
         labels: {
           "app.kubernetes.io/name": "studio-sandbox",
           "app.kubernetes.io/managed-by": "studio",
-          ...(this.envName ? { [ENV_LABEL_KEY]: this.envName } : {}),
+          ...(this.envName ? { [LABEL_KEYS.env]: this.envName } : {}),
           ...buildTenantLabels(opts.tenant),
         },
       },
@@ -876,7 +876,7 @@ export class AgentSandboxRunner implements SandboxRunner {
           labels: buildTenantLabels(opts.tenant, {
             [LABEL_KEYS.role]: "claimed",
             [LABEL_KEYS.sandboxHandle]: handle,
-            ...(this.envName ? { [ENV_LABEL_KEY]: this.envName } : {}),
+            ...(this.envName ? { [LABEL_KEYS.env]: this.envName } : {}),
           }),
         },
         // `valueFrom.secretKeyRef` isn't supported on SandboxClaim env; RBAC
@@ -1030,7 +1030,7 @@ export class AgentSandboxRunner implements SandboxRunner {
           [LABEL_KEYS.sandboxHandle]: handle,
           "app.kubernetes.io/name": "studio-sandbox",
           "app.kubernetes.io/managed-by": "studio",
-          ...(this.envName ? { [ENV_LABEL_KEY]: this.envName } : {}),
+          ...(this.envName ? { [LABEL_KEYS.env]: this.envName } : {}),
         }),
       },
       spec: {
@@ -1558,6 +1558,10 @@ const LABEL_KEYS = {
   sandboxHandle: "studio.decocms.com/sandbox-handle",
   orgId: "studio.decocms.com/org-id",
   userId: "studio.decocms.com/user-id",
+  // Stamped on claims, claimed pods, and per-claim HTTPRoutes when the
+  // runner is constructed with envName, so the sandbox-env Helm chart's
+  // housekeeper can scope its sweep to a single environment.
+  env: "studio.decocms.com/env",
 } as const;
 
 // K8s label values: ≤63 chars, must match `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`.
@@ -1571,12 +1575,6 @@ function sanitizeLabelValue(value: string): string {
   const truncated = value.slice(0, MAX_LABEL_VALUE_LEN);
   return LABEL_VALUE_RE.test(truncated) ? truncated : "";
 }
-
-// Studio environment label key. Stamped on claims, claimed pods, and
-// per-claim HTTPRoutes when a runner is constructed with envName, so the
-// sandbox-env Helm chart's housekeeper can scope its sweep to a single
-// environment. Same key shape as the chart's studio.decocms.com/env.
-const ENV_LABEL_KEY = "studio.decocms.com/env";
 
 // Same DNS-label rules the sandbox-env chart enforces on envName: lowercase
 // alphanumeric or '-', start with a letter, end alphanumeric, ≤32 chars.

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -262,6 +262,22 @@ export interface AgentSandboxRunnerOptions {
   /** SandboxTemplate all claims reference. */
   sandboxTemplateName?: string;
   /**
+   * Studio environment name (e.g. "prod", "staging"). When set, every
+   * SandboxClaim, claimed Pod, and per-claim HTTPRoute is stamped with
+   * `studio.decocms.com/env=<envName>` so the sandbox-env Helm chart's
+   * housekeeper can scope its sweep to a single environment instead of
+   * every studio claim in the namespace.
+   *
+   * Optional — single-env installs that don't run a per-env housekeeper
+   * can leave this unset and the label is omitted (no behavioral change
+   * for them). Mesh wires it from `STUDIO_ENV`.
+   *
+   * Constraint: must be a DNS-label-safe value (a-z0-9-, starts with a
+   * letter, ≤63 chars). Validated at construction; an invalid value
+   * throws rather than letting the operator silently reject the claim.
+   */
+  envName?: string;
+  /**
    * Deterministic DAEMON_TOKEN override — tests inject a fixed value so
    * recorded fetch payloads are stable. Prod leaves this undefined.
    */
@@ -316,6 +332,7 @@ export class AgentSandboxRunner implements SandboxRunner {
   private readonly portForward: PortForward;
   private readonly namespace: string;
   private readonly sandboxTemplateName: string;
+  private readonly envName: string | null;
   private readonly tokenGenerator: () => string;
   private readonly idleTtlMs: number;
   /**
@@ -340,6 +357,7 @@ export class AgentSandboxRunner implements SandboxRunner {
     this.namespace = opts.namespace ?? DEFAULT_NAMESPACE;
     this.sandboxTemplateName =
       opts.sandboxTemplateName ?? DEFAULT_TEMPLATE_NAME;
+    this.envName = normalizeEnvName(opts.envName);
     this.tokenGenerator =
       opts.tokenGenerator ??
       (() => randomBytes(DAEMON_TOKEN_BYTES).toString("hex"));
@@ -843,6 +861,7 @@ export class AgentSandboxRunner implements SandboxRunner {
         labels: {
           "app.kubernetes.io/name": "studio-sandbox",
           "app.kubernetes.io/managed-by": "studio",
+          ...(this.envName ? { [ENV_LABEL_KEY]: this.envName } : {}),
           ...buildTenantLabels(opts.tenant),
         },
       },
@@ -857,6 +876,7 @@ export class AgentSandboxRunner implements SandboxRunner {
           labels: buildTenantLabels(opts.tenant, {
             [LABEL_KEYS.role]: "claimed",
             [LABEL_KEYS.sandboxHandle]: handle,
+            ...(this.envName ? { [ENV_LABEL_KEY]: this.envName } : {}),
           }),
         },
         // `valueFrom.secretKeyRef` isn't supported on SandboxClaim env; RBAC
@@ -1010,6 +1030,7 @@ export class AgentSandboxRunner implements SandboxRunner {
           [LABEL_KEYS.sandboxHandle]: handle,
           "app.kubernetes.io/name": "studio-sandbox",
           "app.kubernetes.io/managed-by": "studio",
+          ...(this.envName ? { [ENV_LABEL_KEY]: this.envName } : {}),
         }),
       },
       spec: {
@@ -1549,6 +1570,31 @@ const MAX_LABEL_VALUE_LEN = 63;
 function sanitizeLabelValue(value: string): string {
   const truncated = value.slice(0, MAX_LABEL_VALUE_LEN);
   return LABEL_VALUE_RE.test(truncated) ? truncated : "";
+}
+
+// Studio environment label key. Stamped on claims, claimed pods, and
+// per-claim HTTPRoutes when a runner is constructed with envName, so the
+// sandbox-env Helm chart's housekeeper can scope its sweep to a single
+// environment. Same key shape as the chart's studio.decocms.com/env.
+const ENV_LABEL_KEY = "studio.decocms.com/env";
+
+// Same DNS-label rules the sandbox-env chart enforces on envName: lowercase
+// alphanumeric or '-', start with a letter, end alphanumeric, ≤32 chars.
+// Tighter than the generic LABEL_VALUE_RE because envName flows into K8s
+// resource names (housekeeper-<env>, studio-sandbox-<env>) where the longer
+// charset would break things.
+const ENV_NAME_RE = /^[a-z]([a-z0-9-]{0,30}[a-z0-9])?$/;
+
+function normalizeEnvName(raw: string | undefined): string | null {
+  if (raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  if (!ENV_NAME_RE.test(trimmed)) {
+    throw new Error(
+      `AgentSandboxRunner: envName=${JSON.stringify(trimmed)} is not a valid DNS-label-safe environment name (lowercase alphanumeric or '-', starts with a letter, ends alphanumeric, ≤32 chars). Mesh sets this from STUDIO_ENV; check the studio chart's configMap.`,
+    );
+  }
+  return trimmed;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `sandbox-housekeeper` CronJob to the `sandbox-env` chart, gated behind `housekeeper.enabled` (default `false`)
- CronJob probes each Ready sandbox's daemon at `/_decopilot_vm/idle` (port 9000) every 5 min and deletes claims idle >= `idleTtlSeconds` (default 900s / 15min)
- Also clears claims stuck in `ReconcilerError` — same pattern as the existing deco-environment housekeeper in `infra_applications`
- Adds a NetworkPolicy ingress rule for the housekeeper pod → sandbox pods on port 9000 (without it the default-deny policy blocks the probe and every pod gets reaped immediately)

Follows the established pattern from `infra_applications/provisioning/agent-sandbox/eks-envs/templates/housekeeper.yaml`, adapted for the studio daemon endpoint and claim labels.

## Notes

- `app.kubernetes.io/name=studio-sandbox` label selector is confirmed correct — hardcoded in `runner.ts:buildClaim` and `STUDIO_CLAIM_LABEL_SELECTOR`, no env suffix
- Enable in **exactly one** env release per namespace — claims carry no env label so multiple active housekeepers sweep the same set
- Probe failure (network error, timeout, non-2xx) → treated as idle, claim deleted. Silence from an unreachable pod is the right signal to reap
- JSON parsing uses `sed` rather than `jq` since `bitnami/kubectl` availability of `jq` is not guaranteed

## Test plan

- [ ] `helm lint deploy/helm/sandbox-env --set envName=ci` passes
- [ ] `helm template ... --set housekeeper.enabled=true` renders CronJob + SA + Role + RoleBinding + NetworkPolicy ingress rule
- [ ] `helm template ... --set housekeeper.enabled=false` (default) renders none of the above
- [ ] Deploy to a kind cluster, set `idleTtlSeconds=60`, leave a sandbox idle for 60s, confirm the claim is deleted
- [ ] Confirm an active sandbox (daemon reporting `idleMs < TTL`) is not deleted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an idle-reap `sandbox-housekeeper` CronJob to the `sandbox-env` chart to safely clean up inactive or `ReconcilerError` studio sandboxes, scoped per env via a `studio.decocms.com/env` label. Bumps the chart to 0.5.0 and updates docs.

- New Features
  - CronJob + SA/Role/RoleBinding gated by `housekeeper.enabled` (default false); script runs from a ConfigMap with checksum; every 5 min with `startingDeadlineSeconds`, `activeDeadlineSeconds`, and `ttlSecondsAfterFinished`; pinned `alpine/k8s:1.32.0`; Restricted-PSS securityContext, tight resources, and a NetworkPolicy rule to probe port 9000.
  - Sweep logic: probes `/_decopilot_vm/idle` on port 9000; idle ≥ `idleTtlSeconds` → re-probe then patch `spec.lifecycle.shutdownTime` (graceful shutdown); `ReconcilerError` → direct delete; deletes per-claim `HTTPRoute`s first and GC’s orphan routes; emits Kubernetes Events; skips transient probe failures; batches API lists and validates `idleMs`.
  - Per-env scoping: mesh stamps `studio.decocms.com/env=<env>` on SandboxClaims, claimed Pods, and per-claim `HTTPRoute`s when `STUDIO_ENV` is set; default claim/pod selectors are env-scoped via helpers and can be overridden during rollout.

- Migration
  - Set `STUDIO_ENV=<env>` in the studio chart, then enable with `--set housekeeper.enabled=true` and tune `idleTtlSeconds`, `schedule`, and `activeDeadlineSeconds`. Prefer `--reset-then-reuse-values` (or re-pass full values) when upgrading to pull new defaults.
  - During rollout, old claims without the env label are ignored by env-scoped selectors; temporarily set `housekeeper.claimSelector`/`podSelector` to broad unscoped values to sweep them, then revert.

<sup>Written for commit e76f98699274fef8dc67186bb12f3aa650d346f2. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3219?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

