### PR TITLE
feat(analytics): bind active organization to PostHog browser session

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -5,6 +5,7 @@ import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
 import { authClient } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { PostHogGroupSync } from "@/web/providers/posthog-group-sync";
 import { ProjectContextProvider, useProjectContext } from "@decocms/mesh-sdk";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import {
@@ -228,6 +229,7 @@ function ShellLayoutContent() {
 
   return (
     <ShellProjectProvider org={{ ...activeOrg, logo: activeOrg.logo ?? null }}>
+      <PostHogGroupSync activeOrg={activeOrg} />
       <Outlet />
 
       {/* Keyboard Shortcuts Dialog */}

--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, beforeEach, mock } from "bun:test";
+
+type GroupCall = [type: string, key: string, props: unknown];
+
+const groupCalls: GroupCall[] = [];
+const initCalls: unknown[][] = [];
+let resetCount = 0;
+
+// `initPostHog` early-returns when `typeof window === "undefined"`. Bun's test
+// runtime has no DOM, so stub a minimal window before importing the module.
+if (typeof globalThis.window === "undefined") {
+  (globalThis as unknown as { window: object }).window = {};
+}
+
+mock.module("posthog-js", () => ({
+  default: {
+    init: (...args: unknown[]) => {
+      initCalls.push(args);
+    },
+    group: (type: string, key: string, props: unknown) => {
+      groupCalls.push([type, key, props]);
+    },
+    reset: () => {
+      resetCount += 1;
+    },
+    identify: () => {},
+    capture: () => {},
+    captureException: () => {},
+  },
+}));
+
+const { initPostHog, setOrganizationGroup, resetUser, __resetForTest } =
+  await import("./posthog-client");
+
+describe("posthog-client.setOrganizationGroup", () => {
+  beforeEach(() => {
+    groupCalls.length = 0;
+    initCalls.length = 0;
+    resetCount = 0;
+    __resetForTest();
+  });
+
+  test("is a no-op before initPostHog is called", () => {
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    expect(groupCalls).toHaveLength(0);
+  });
+
+  test("calls posthog.group with organization type after init", () => {
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    expect(groupCalls).toEqual([
+      ["organization", "org_1", { name: "Acme", slug: "acme" }],
+    ]);
+  });
+
+  test("de-dupes consecutive calls with the same orgId", () => {
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    expect(groupCalls).toHaveLength(1);
+  });
+
+  test("fires again when orgId changes", () => {
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    setOrganizationGroup("org_2", { name: "Beta", slug: "beta" });
+    expect(groupCalls).toHaveLength(2);
+    expect(groupCalls[1]).toEqual([
+      "organization",
+      "org_2",
+      { name: "Beta", slug: "beta" },
+    ]);
+  });
+
+  test("resetUser clears the cached org so the next setOrganizationGroup re-fires", () => {
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    resetUser();
+    expect(resetCount).toBe(1);
+
+    setOrganizationGroup("org_1", { name: "Acme", slug: "acme" });
+    expect(groupCalls).toHaveLength(2);
+  });
+});

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -12,6 +12,7 @@
 import posthog from "posthog-js";
 
 let initialized = false;
+let lastOrgGroupKey: string | null = null;
 
 export function initPostHog(key: string, host: string) {
   if (initialized || typeof window === "undefined") return;
@@ -52,11 +53,28 @@ export function identifyUser(
 export function resetUser() {
   if (!initialized) return;
   posthog.reset();
+  lastOrgGroupKey = null;
 }
 
 export function track(event: string, properties?: Record<string, unknown>) {
   if (!initialized) return;
   posthog.capture(event, properties);
+}
+
+/**
+ * Bind the current browser session to an organization group so that every
+ * subsequent autocaptured event carries `$groups: { organization: <id> }`.
+ * De-duped by orgId — calling this repeatedly with the same id is free.
+ * `resetUser()` clears the cache so re-login re-fires.
+ */
+export function setOrganizationGroup(
+  orgId: string,
+  props?: { name?: string; slug?: string },
+) {
+  if (!initialized) return;
+  if (orgId === lastOrgGroupKey) return;
+  posthog.group("organization", orgId, props);
+  lastOrgGroupKey = orgId;
 }
 
 /**
@@ -77,4 +95,13 @@ export function captureException(
   } catch {
     // Swallow — never let analytics break the error UI.
   }
+}
+
+/**
+ * Test-only: reset module-level state between tests. Not exported from any
+ * non-test consumer; kept here because module state is otherwise opaque.
+ */
+export function __resetForTest() {
+  initialized = false;
+  lastOrgGroupKey = null;
 }

--- a/apps/mesh/src/web/providers/posthog-group-sync.tsx
+++ b/apps/mesh/src/web/providers/posthog-group-sync.tsx
@@ -1,0 +1,30 @@
+/**
+ * Binds the current PostHog browser session to the active organization
+ * group. Render once `activeOrg` is resolved so that every subsequent
+ * autocaptured event carries `$groups: { organization: <id> }`.
+ *
+ * Side-effect during render is intentional and matches the project's
+ * existing `PostHogIdentitySync` pattern (see ban on `useEffect` in
+ * plugins/ban-use-effect.ts). De-duplication lives in
+ * `setOrganizationGroup` itself, so re-renders are cheap.
+ */
+
+import { setOrganizationGroup } from "@/web/lib/posthog-client";
+
+export function PostHogGroupSync({
+  activeOrg,
+}: {
+  activeOrg: {
+    id: string;
+    name?: string | null;
+    slug?: string | null;
+  } | null;
+}) {
+  if (activeOrg) {
+    setOrganizationGroup(activeOrg.id, {
+      name: activeOrg.name ?? undefined,
+      slug: activeOrg.slug ?? undefined,
+    });
+  }
+  return null;
+}


### PR DESCRIPTION
## What is this contribution about?

PostHog currently shows only ~4 organizations because the browser never associates events with org groups: `groupIdentify` is only called server-side in two narrow flows (signup default-org and corporate-domain setup), and the SPA itself never calls `posthog.group(...)`, so all autocaptured pageviews/clicks carry no org context. This PR adds a `setOrganizationGroup` helper to `apps/mesh/src/web/lib/posthog-client.ts` (with idempotent de-dup via `lastOrgGroupKey`, cleared inside `resetUser`) and a render-only `<PostHogGroupSync activeOrg={...} />` component that fires it once `activeOrg` is resolved in `ShellLayoutContent` — so every authenticated route binds the active org to the PostHog session for the rest of the visit. Side-effect-during-render mirrors the existing `PostHogIdentitySync` pattern (`useEffect` is banned by `plugins/ban-use-effect.ts`); 5 new `bun:test` cases cover the lib helper.

## How to Test

1. Add `POSTHOG_KEY=...` and `POSTHOG_HOST=...` to `apps/mesh/.env` (server reads these post-#3183 — `VITE_POSTHOG_*` alone is no longer enough).
2. `bun run dev`, then open the app and log in.
3. In DevTools → Network, filter `i.posthog.com` and inspect a captured `$pageview` event payload — confirm it carries `$groups: { organization: "<active-org-id>" }`.
4. Navigate to a different `/$org` slug; the next `$pageview` should carry the new org id.

## Migration Notes

Not applicable.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working (5 unit tests + browser smoke test via React fiber inspection + live module exercise)
- [ ] Documentation is updated (no docs changes needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the active organization to the PostHog browser session so all autocaptured events include org context, improving org-level analytics accuracy. Adds a small helper and a render-only sync component wired into the shell layout.

- **New Features**
  - Added `setOrganizationGroup(orgId, props)` in `apps/mesh/src/web/lib/posthog-client.ts`; de-duped by org; cleared on `resetUser()`.
  - Added `<PostHogGroupSync activeOrg={...} />` and mounted it in `ShellLayoutContent` to bind the org once resolved (render-time side effect; no `useEffect`).
  - Autocaptured events now carry `$groups: { organization: <id> }`.
  - Added unit tests for the new helper.

<sup>Written for commit 0b3c7bdcb03fa030038a633b59308128e5bfcaa3. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

