### PR TITLE
feat(sidebar): resume last thread on agent / Home click

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -23,7 +23,11 @@ import {
 } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useChat as useAIChat, type UseChatHelpers } from "@ai-sdk/react";
-import { AUTOSEND_TTL_MS, decodeAutosend } from "@/web/lib/autosend";
+import {
+  AUTOSEND_TTL_MS,
+  decodeAutosend,
+  encodeAutosend,
+} from "@/web/lib/autosend";
 import {
   lastAssistantMessageIsCompleteWithToolCalls,
   lastAssistantMessageIsCompleteWithApprovalResponses,
@@ -550,10 +554,14 @@ export function ChatContextProvider({
 
   const clearPendingMessage = () => setPendingMessage(null);
 
-  const navigateToTask = (taskId: string, opts?: { virtualMcpId?: string }) => {
+  const navigateToTask = (
+    taskId: string,
+    opts?: { virtualMcpId?: string; autosend?: string },
+  ) => {
     markTaskRead(taskId);
     rawNavigateToTask(taskId, {
       virtualMcpId: opts?.virtualMcpId,
+      autosend: opts?.autosend,
     });
   };
 
@@ -584,9 +592,11 @@ export function ChatContextProvider({
     return newId;
   };
 
-  // Create task + queue a pending message. Propagates currentBranch only
-  // when the new task is on the same vMCP (different vMCPs have their own
-  // vmMap, so carrying a branch across them would land on a cold sandbox).
+  // Create task + hand off the message via URL ?autosend= so the new
+  // task's ActiveTaskProvider fires it on mount. Propagates currentBranch
+  // only when the new task is on the same vMCP (different vMCPs have their
+  // own vmMap, so carrying a branch across them would land on a cold
+  // sandbox).
   const createTaskWithMessage = (params: {
     message: SendMessageParams;
     virtualMcpId?: string;
@@ -594,6 +604,10 @@ export function ChatContextProvider({
     const newId = crypto.randomUUID();
     const targetVmcp = params.virtualMcpId ?? virtualMcpId;
     const carryBranch = targetVmcp === virtualMcpId ? currentBranch : null;
+    const autosend = encodeAutosend({
+      message: params.message,
+      createdAt: Date.now(),
+    });
     void taskActions.create
       .mutateAsync({
         id: newId,
@@ -603,18 +617,15 @@ export function ChatContextProvider({
       .then(() =>
         navigateToTask(newId, {
           virtualMcpId: params.virtualMcpId,
+          autosend,
         }),
       )
       .catch(() => {
         navigateToTask(newId, {
           virtualMcpId: params.virtualMcpId,
+          autosend,
         });
       });
-    setPendingMessage({
-      taskId: newId,
-      message: params.message,
-      createdAt: Date.now(),
-    });
   };
 
   // Hide task (switch to next after hiding)

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -289,6 +289,223 @@ const ChatBridgeCtx = createContext<React.RefObject<ChatBridgeValue>>({
 const TaskInternalsCtx = createContext<TaskProviderInternals | null>(null);
 
 // ============================================================================
+// ChatPrefsProvider — standalone-mountable prefs context
+// ============================================================================
+
+/**
+ * Mounts the prefs context (model/agent/mode selection) without the rest
+ * of the chat infrastructure. Use on routes that have a chat composer but
+ * no active stream — currently `/$org/`. Localstorage-backed selections
+ * (chat model, image model, deep research model, simple-mode tier) sync
+ * automatically with any other mount of this provider via storage events.
+ *
+ * `virtualMcpId` is derived from the URL search param (`virtualmcpid`) with
+ * a decopilot fallback, matching `useChatNavigation` — so the same
+ * provider works on `/$org/` and `/$org/$taskId`.
+ *
+ * On routes that mount `ChatContextProvider`, that wrapper internally
+ * mounts its own `ChatPrefsCtx.Provider` for backwards compatibility; the
+ * inner mount shadows this one. Persistent state still syncs via
+ * localStorage; transient state (chatMode, tiptapDoc, appContexts) is
+ * scoped to whichever mount the consumer is reading from — fine for our
+ * flows because home submit clears the editor and the task page starts
+ * fresh.
+ */
+export function ChatPrefsProvider({ children }: PropsWithChildren) {
+  const { locator } = useProjectContext();
+  const { virtualMcpId: urlVirtualMcpId } = useChatNavigation();
+
+  // Model selection (localStorage-backed)
+  const [storedChatRef, setStoredChatRef] = useLocalStorage<ModelRef | null>(
+    LOCALSTORAGE_KEYS.chatSelectedModel(locator),
+    null,
+  );
+  const [storedImageRef, setStoredImageRef] = useLocalStorage<ModelRef | null>(
+    LOCALSTORAGE_KEYS.chatSelectedImageModel(locator),
+    null,
+  );
+  const [storedDeepResearchRef, setStoredDeepResearchRef] =
+    useLocalStorage<ModelRef | null>(
+      LOCALSTORAGE_KEYS.chatSelectedDeepResearchModel(locator),
+      null,
+    );
+
+  const [sessionCredentialId, setSessionCredentialId] = useState<string | null>(
+    null,
+  );
+
+  const [chatMode, setChatMode] = useState<ChatMode>("default");
+  chatModeForTransportRef.current = chatMode;
+
+  // Simple Model Mode
+  const simpleMode = useSimpleMode();
+  const [storedTier, setStoredTier] = useLocalStorage<SimpleTier | null>(
+    LOCALSTORAGE_KEYS.chatSimpleModeTier(locator),
+    null,
+  );
+  const activeTier = resolveActiveTier(storedTier, simpleMode);
+
+  // AI provider keys + models
+  const keys = useAiProviderKeys();
+  const effectiveKeyId =
+    sessionCredentialId && keys.some((k) => k.id === sessionCredentialId)
+      ? sessionCredentialId
+      : storedChatRef && keys.some((k) => k.id === storedChatRef.keyId)
+        ? storedChatRef.keyId
+        : (keys[0]?.id ?? null);
+  const { models: allKeyModels, isLoading: isModelsQueryLoading } =
+    useAiProviderModels(effectiveKeyId ?? undefined);
+  const effectiveProviderId =
+    keys.find((k) => k.id === effectiveKeyId)?.providerId ?? "anthropic";
+  const defaultModel = selectDefaultModel(
+    allKeyModels,
+    effectiveProviderId,
+    effectiveKeyId ?? undefined,
+  );
+
+  const activeChatSlot = simpleMode.chat[activeTier];
+  const { models: simpleChatModels } = useAiProviderModels(
+    activeChatSlot?.keyId,
+  );
+  const { models: simpleImageModels } = useAiProviderModels(
+    simpleMode.image?.keyId,
+  );
+  const { models: simpleWebResearchModels } = useAiProviderModels(
+    simpleMode.webResearch?.keyId,
+  );
+
+  const validatedStoredChat = findModel(storedChatRef, keys, allKeyModels);
+  const selectedModel: AiProviderModel | null = simpleMode.enabled
+    ? findModel(activeChatSlot, keys, simpleChatModels, activeChatSlot?.title)
+    : (validatedStoredChat ?? defaultModel);
+  const isModelsLoading = !storedChatRef && isModelsQueryLoading;
+
+  const imageModels = allKeyModels.filter((m) =>
+    m.capabilities?.includes("image"),
+  );
+  const validatedStoredImage = findModel(storedImageRef, keys, imageModels);
+  const resolvedImageModel: AiProviderModel | null = simpleMode.enabled
+    ? findModel(
+        simpleMode.image,
+        keys,
+        simpleImageModels,
+        simpleMode.image?.title,
+      )
+    : (validatedStoredImage ?? imageModels[0] ?? null);
+
+  const deepResearchModels = allKeyModels.filter((m) => {
+    const n = m.modelId.toLowerCase().replace(/[^a-z0-9]/g, "");
+    return n.includes("sonar") || n.includes("deepresearch");
+  });
+  const validatedStoredDeepResearch = findModel(
+    storedDeepResearchRef,
+    keys,
+    deepResearchModels,
+  );
+  const defaultDeepResearchModel =
+    deepResearchModels.find((m) => m.modelId === "perplexity/sonar") ??
+    deepResearchModels[0] ??
+    null;
+  const resolvedDeepResearchModel: AiProviderModel | null = simpleMode.enabled
+    ? findModel(
+        simpleMode.webResearch,
+        keys,
+        simpleWebResearchModels,
+        simpleMode.webResearch?.title,
+      )
+    : (validatedStoredDeepResearch ?? defaultDeepResearchModel);
+
+  // selectedVirtualMcp — URL-derived
+  const selectedVirtualMcpData = useVirtualMCP(urlVirtualMcpId);
+  const selectedVirtualMcp: VirtualMCPInfo = selectedVirtualMcpData ?? {
+    id: urlVirtualMcpId,
+    title: "",
+    description: null,
+    icon: null,
+  };
+
+  // App contexts
+  const [appContexts, setAppContextsState] = useState<Record<string, string>>(
+    {},
+  );
+  const setAppContext = (sourceId: string, params: SetAppContextParams) => {
+    const textParts: string[] = [];
+    for (const block of params.content ?? []) {
+      if (block.type === "text" && block.text?.trim()) {
+        textParts.push(block.text.trim());
+      }
+    }
+    const text = textParts.join("\n");
+    if (!text) {
+      clearAppContext(sourceId);
+      return;
+    }
+    if (new TextEncoder().encode(text).length > MAX_APP_CONTEXT_LENGTH) return;
+    setAppContextsState((prev) => {
+      if (
+        Object.keys(prev).length >= MAX_APP_CONTEXT_SOURCES &&
+        !(sourceId in prev)
+      )
+        return prev;
+      return { ...prev, [sourceId]: text };
+    });
+  };
+  const clearAppContext = (sourceId: string) => {
+    setAppContextsState((prev) => {
+      const { [sourceId]: _, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  // Tiptap doc (transient UI state)
+  const [tiptapDoc, setTiptapDoc] = useState<Metadata["tiptapDoc"]>(undefined);
+  const tiptapDocRef = useRef<Metadata["tiptapDoc"]>(tiptapDoc);
+  tiptapDocRef.current = tiptapDoc;
+
+  const value: ChatPrefsContextValue = {
+    selectedModel,
+    setModel: (model: AiProviderModel) => {
+      if (!model.keyId) return;
+      setStoredChatRef({ keyId: model.keyId, modelId: model.modelId });
+      setSessionCredentialId(null);
+    },
+    credentialId: effectiveKeyId,
+    setCredentialId: setSessionCredentialId,
+    allModelsConnections: keys,
+    isModelsLoading,
+    selectedVirtualMcp,
+    imageModel: resolvedImageModel,
+    setImageModel: (model: AiProviderModel | null) => {
+      setStoredImageRef(
+        model?.keyId ? { keyId: model.keyId, modelId: model.modelId } : null,
+      );
+    },
+    deepResearchModel: resolvedDeepResearchModel,
+    setDeepResearchModel: (model: AiProviderModel | null) => {
+      setStoredDeepResearchRef(
+        model?.keyId ? { keyId: model.keyId, modelId: model.modelId } : null,
+      );
+    },
+    chatMode,
+    setChatMode,
+    appContexts,
+    setAppContext,
+    clearAppContext,
+    tiptapDoc,
+    setTiptapDoc,
+    tiptapDocRef,
+    resetInteraction: () => {},
+    simpleModeEnabled: simpleMode.enabled,
+    simpleModeTier: activeTier,
+    setSimpleModeTier: setStoredTier,
+  };
+
+  return (
+    <ChatPrefsCtx.Provider value={value}>{children}</ChatPrefsCtx.Provider>
+  );
+}
+
+// ============================================================================
 // TaskProvider (outer)
 // ============================================================================
 

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -21,7 +21,9 @@ import {
   useState,
   type PropsWithChildren,
 } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useChat as useAIChat, type UseChatHelpers } from "@ai-sdk/react";
+import { AUTOSEND_TTL_MS, decodeAutosend } from "@/web/lib/autosend";
 import {
   lastAssistantMessageIsCompleteWithToolCalls,
   lastAssistantMessageIsCompleteWithApprovalResponses,
@@ -1000,6 +1002,49 @@ export function ActiveTaskProvider({
     } else {
       // Stale — silently discard
       queueMicrotask(() => clearPendingMessage());
+    }
+  }
+
+  // Autosend consumer — read the queued message from the URL search param
+  // (set by /$org/ submit or createTaskWithMessage), fire it once, then
+  // strip the param so reload doesn't refire.
+  const autosendNavigate = useNavigate();
+  const autosendSearch = useSearch({ strict: false }) as { autosend?: string };
+  const autosendConsumedRef = useRef<string | null>(null);
+  if (autosendSearch.autosend) {
+    const decoded = decodeAutosend(autosendSearch.autosend);
+    const consumeKey = `${taskId}:${decoded?.createdAt ?? "?"}`;
+    if (
+      decoded &&
+      Date.now() - decoded.createdAt < AUTOSEND_TTL_MS &&
+      autosendConsumedRef.current !== consumeKey
+    ) {
+      autosendConsumedRef.current = consumeKey;
+      const msg = decoded.message;
+      queueMicrotask(() => {
+        void sendMessageInternal(msg);
+        autosendNavigate({
+          to: ".",
+          search: (prev: Record<string, unknown>) => {
+            const { autosend: _omit, ...rest } = prev;
+            return rest;
+          },
+          replace: true,
+        });
+      });
+    } else if (autosendConsumedRef.current !== consumeKey) {
+      // Invalid or stale — silently strip it.
+      autosendConsumedRef.current = consumeKey;
+      queueMicrotask(() => {
+        autosendNavigate({
+          to: ".",
+          search: (prev: Record<string, unknown>) => {
+            const { autosend: _omit, ...rest } = prev;
+            return rest;
+          },
+          replace: true,
+        });
+      });
     }
   }
 

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -131,12 +131,6 @@ export interface ChatTaskContextValue {
   ownerFilter: TaskOwnerFilter;
   setOwnerFilter: (filter: TaskOwnerFilter) => void;
   isFilterChangePending: boolean;
-  pendingMessage: {
-    taskId: string;
-    message: SendMessageParams;
-    createdAt: number;
-  } | null;
-  clearPendingMessage: () => void;
 }
 
 export interface ChatPrefsContextValue {
@@ -240,7 +234,6 @@ function resolveActiveTier(
 
 const MAX_APP_CONTEXT_LENGTH = 10_000;
 const MAX_APP_CONTEXT_SOURCES = 10;
-const PENDING_MESSAGE_TTL_MS = 10_000;
 
 const BRIDGE_NOOP: ChatBridgeValue = {
   sendMessage: async () => {
@@ -762,15 +755,6 @@ export function ChatContextProvider({
   // Bridge ref — ActiveTaskProvider registers sendMessage here
   const bridgeRef = useRef<ChatBridgeValue>(BRIDGE_NOOP);
 
-  // Pending message state (replaces module-level Map from useSendToChat)
-  const [pendingMessage, setPendingMessage] = useState<{
-    taskId: string;
-    message: SendMessageParams;
-    createdAt: number;
-  } | null>(null);
-
-  const clearPendingMessage = () => setPendingMessage(null);
-
   const navigateToTask = (
     taskId: string,
     opts?: { virtualMcpId?: string; autosend?: string },
@@ -880,8 +864,6 @@ export function ChatContextProvider({
     ownerFilter: taskManager.ownerFilter,
     setOwnerFilter: taskManager.setOwnerFilter,
     isFilterChangePending: taskManager.isFilterChangePending ?? false,
-    pendingMessage,
-    clearPendingMessage,
   };
 
   const prefsValue: ChatPrefsContextValue = {
@@ -958,13 +940,7 @@ export function ActiveTaskProvider({
   taskId,
   children,
 }: PropsWithChildren<{ taskId: string }>) {
-  const {
-    virtualMcpId,
-    tasks,
-    pendingMessage,
-    clearPendingMessage,
-    currentBranch,
-  } = useChatTask();
+  const { virtualMcpId, tasks, currentBranch } = useChatTask();
 
   // Fire chat_opened once per (page session × taskId). Runs during render, but
   // the Set gate keeps it idempotent. Fires for every thread a user views —
@@ -1210,28 +1186,6 @@ export function ActiveTaskProvider({
     sendMessage: sendMessageInternal,
     isStreaming: chat.status === "submitted" || chat.status === "streaming",
   };
-
-  // Consume pending message when this task is the target
-  const pendingConsumedRef = useRef<string | null>(null);
-  if (
-    pendingMessage &&
-    pendingMessage.taskId === taskId &&
-    pendingConsumedRef.current !== taskId
-  ) {
-    // TTL check: discard stale messages
-    const age = Date.now() - pendingMessage.createdAt;
-    if (age < PENDING_MESSAGE_TTL_MS) {
-      pendingConsumedRef.current = taskId;
-      const msg = pendingMessage.message;
-      queueMicrotask(() => {
-        void sendMessageInternal(msg);
-        clearPendingMessage();
-      });
-    } else {
-      // Stale — silently discard
-      queueMicrotask(() => clearPendingMessage());
-    }
-  }
 
   // Autosend consumer — read the queued message from the URL search param
   // (set by /$org/ submit or createTaskWithMessage), fire it once, then

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1389,6 +1389,10 @@ export function useOptionalChatPrefs(): ChatPrefsContextValue | null {
   return useContext(ChatPrefsCtx);
 }
 
+export function useOptionalChatTask(): ChatTaskContextValue | null {
+  return useContext(ChatTaskCtx);
+}
+
 export function useChatBridge(): ChatBridgeValue {
   const ref = useContext(ChatBridgeCtx);
   // Return wrappers that read .current at call time. Destructuring

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1302,61 +1302,6 @@ export function ActiveTaskProvider({
 }
 
 // ============================================================================
-// IdleChatStreamProvider — ChatStream for routes without an active task
-// ============================================================================
-
-/**
- * Provides a minimal `ChatStreamCtx` for routes that don't have an active
- * task — currently just the org home page at `/$org/`. `sendMessage`
- * delegates to `createTaskWithMessage` (from the surrounding TaskProvider),
- * which creates a new thread, queues the message via `pendingMessage`, and
- * navigates to it; the message auto-sends when the new task mounts its
- * own ActiveTaskProvider.
- *
- * All other ChatStream values are inert placeholders since there is no
- * chat to read messages from or stream into. The AI SDK helpers are
- * no-ops typed via `as` because they're never invoked on the home page —
- * only `Chat.Input` reads sendMessage / isStreaming, and it has nothing
- * to stop or update.
- */
-export function IdleChatStreamProvider({ children }: PropsWithChildren) {
-  const { createTaskWithMessage } = useChatTask();
-
-  const sendMessage = async (
-    params: SendMessageParams | Metadata["tiptapDoc"],
-  ): Promise<void> => {
-    const message: SendMessageParams =
-      params && typeof params === "object" && "type" in params
-        ? { tiptapDoc: params as Metadata["tiptapDoc"] }
-        : (params as SendMessageParams);
-    createTaskWithMessage({ message });
-  };
-
-  const value: ChatStreamContextValue = {
-    messages: [],
-    status: "ready",
-    sendMessage,
-    stop: () => {},
-    setMessages: (() => {}) as ChatStreamContextValue["setMessages"],
-    addToolOutput: (() => {}) as ChatStreamContextValue["addToolOutput"],
-    addToolApprovalResponse:
-      (() => {}) as ChatStreamContextValue["addToolApprovalResponse"],
-    error: null,
-    clearError: () => {},
-    finishReason: null,
-    clearFinishReason: () => {},
-    isStreaming: false,
-    isChatEmpty: true,
-    isWaitingForApprovals: false,
-    isRunInProgress: false,
-  };
-
-  return (
-    <ChatStreamCtx.Provider value={value}>{children}</ChatStreamCtx.Provider>
-  );
-}
-
-// ============================================================================
 // Hooks
 // ============================================================================
 

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1029,6 +1029,61 @@ export function ActiveTaskProvider({
 }
 
 // ============================================================================
+// IdleChatStreamProvider — ChatStream for routes without an active task
+// ============================================================================
+
+/**
+ * Provides a minimal `ChatStreamCtx` for routes that don't have an active
+ * task — currently just the org home page at `/$org/`. `sendMessage`
+ * delegates to `createTaskWithMessage` (from the surrounding TaskProvider),
+ * which creates a new thread, queues the message via `pendingMessage`, and
+ * navigates to it; the message auto-sends when the new task mounts its
+ * own ActiveTaskProvider.
+ *
+ * All other ChatStream values are inert placeholders since there is no
+ * chat to read messages from or stream into. The AI SDK helpers are
+ * no-ops typed via `as` because they're never invoked on the home page —
+ * only `Chat.Input` reads sendMessage / isStreaming, and it has nothing
+ * to stop or update.
+ */
+export function IdleChatStreamProvider({ children }: PropsWithChildren) {
+  const { createTaskWithMessage } = useChatTask();
+
+  const sendMessage = async (
+    params: SendMessageParams | Metadata["tiptapDoc"],
+  ): Promise<void> => {
+    const message: SendMessageParams =
+      params && typeof params === "object" && "type" in params
+        ? { tiptapDoc: params as Metadata["tiptapDoc"] }
+        : (params as SendMessageParams);
+    createTaskWithMessage({ message });
+  };
+
+  const value: ChatStreamContextValue = {
+    messages: [],
+    status: "ready",
+    sendMessage,
+    stop: () => {},
+    setMessages: (() => {}) as ChatStreamContextValue["setMessages"],
+    addToolOutput: (() => {}) as ChatStreamContextValue["addToolOutput"],
+    addToolApprovalResponse:
+      (() => {}) as ChatStreamContextValue["addToolApprovalResponse"],
+    error: null,
+    clearError: () => {},
+    finishReason: null,
+    clearFinishReason: () => {},
+    isStreaming: false,
+    isChatEmpty: true,
+    isWaitingForApprovals: false,
+    isRunInProgress: false,
+  };
+
+  return (
+    <ChatStreamCtx.Provider value={value}>{children}</ChatStreamCtx.Provider>
+  );
+}
+
+// ============================================================================
 // Hooks
 // ============================================================================
 

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -17,16 +17,18 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useRef,
   useState,
   type PropsWithChildren,
 } from "react";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useSearch } from "@tanstack/react-router";
 import { useChat as useAIChat, type UseChatHelpers } from "@ai-sdk/react";
 import {
-  AUTOSEND_TTL_MS,
-  decodeAutosend,
-  encodeAutosend,
+  AUTOSEND_QUERY_VALUE,
+  claimStoredAutosend,
+  markStoredAutosendSent,
+  writeStoredAutosend,
 } from "@/web/lib/autosend";
 import {
   lastAssistantMessageIsCompleteWithToolCalls,
@@ -757,7 +759,7 @@ export function ChatContextProvider({
 
   const navigateToTask = (
     taskId: string,
-    opts?: { virtualMcpId?: string; autosend?: string },
+    opts?: { virtualMcpId?: string; autosend?: boolean },
   ) => {
     markTaskRead(taskId);
     rawNavigateToTask(taskId, {
@@ -805,10 +807,7 @@ export function ChatContextProvider({
     const newId = crypto.randomUUID();
     const targetVmcp = params.virtualMcpId ?? virtualMcpId;
     const carryBranch = targetVmcp === virtualMcpId ? currentBranch : null;
-    const autosend = encodeAutosend({
-      message: params.message,
-      createdAt: Date.now(),
-    });
+    writeStoredAutosend(localStorage, locator, newId, params.message);
     void taskActions.create
       .mutateAsync({
         id: newId,
@@ -818,13 +817,13 @@ export function ChatContextProvider({
       .then(() =>
         navigateToTask(newId, {
           virtualMcpId: params.virtualMcpId,
-          autosend,
+          autosend: true,
         }),
       )
       .catch(() => {
         navigateToTask(newId, {
           virtualMcpId: params.virtualMcpId,
-          autosend,
+          autosend: true,
         });
       });
   };
@@ -978,7 +977,7 @@ export function ActiveTaskProvider({
     bridgeRef,
   } = internals;
 
-  const { org } = useProjectContext();
+  const { org, locator } = useProjectContext();
 
   // Messages for current task (from React Query / server) — this is what suspends
   const serverMessages = useTaskMessages(taskId || null);
@@ -1187,48 +1186,24 @@ export function ActiveTaskProvider({
     isStreaming: chat.status === "submitted" || chat.status === "streaming",
   };
 
-  // Autosend consumer — read the queued message from the URL search param
-  // (set by /$org/ submit or createTaskWithMessage), fire it once, then
-  // strip the param so reload doesn't refire.
-  const autosendNavigate = useNavigate();
+  // Autosend consumer: the URL carries only `autosend=true`; the message
+  // body lives in localStorage keyed by locator + taskId. It only boots empty
+  // threads, and the stored status gates duplicate sends across remounts.
   const autosendSearch = useSearch({ strict: false }) as { autosend?: string };
-  const autosendConsumedRef = useRef<string | null>(null);
-  if (autosendSearch.autosend) {
-    const decoded = decodeAutosend(autosendSearch.autosend);
-    const consumeKey = `${taskId}:${decoded?.createdAt ?? "?"}`;
-    if (
-      decoded &&
-      Date.now() - decoded.createdAt < AUTOSEND_TTL_MS &&
-      autosendConsumedRef.current !== consumeKey
-    ) {
-      autosendConsumedRef.current = consumeKey;
-      const msg = decoded.message;
-      queueMicrotask(() => {
-        void sendMessageInternal(msg);
-        autosendNavigate({
-          to: ".",
-          search: (prev: Record<string, unknown>) => {
-            const { autosend: _omit, ...rest } = prev;
-            return rest;
-          },
-          replace: true,
-        });
-      });
-    } else if (autosendConsumedRef.current !== consumeKey) {
-      // Invalid or stale — silently strip it.
-      autosendConsumedRef.current = consumeKey;
-      queueMicrotask(() => {
-        autosendNavigate({
-          to: ".",
-          search: (prev: Record<string, unknown>) => {
-            const { autosend: _omit, ...rest } = prev;
-            return rest;
-          },
-          replace: true,
-        });
-      });
-    }
-  }
+  const shouldAutosend = autosendSearch.autosend === AUTOSEND_QUERY_VALUE;
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect, react-hooks/exhaustive-deps -- storage status, not function identity, gates duplicate sends
+  useEffect(() => {
+    if (!shouldAutosend) return;
+    if (messages.length > 0) return;
+
+    const payload = claimStoredAutosend(localStorage, locator, taskId);
+    if (!payload) return;
+
+    void sendMessageInternal(payload.message).then(() => {
+      markStoredAutosendSent(localStorage, locator, taskId);
+    });
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- storage status, not function identity, gates duplicate sends
+  }, [shouldAutosend, messages.length, locator, taskId, sendMessageInternal]);
 
   const streamValue: ChatStreamContextValue = {
     messages,

--- a/apps/mesh/src/web/components/chat/context.tsx
+++ b/apps/mesh/src/web/components/chat/context.tsx
@@ -9,9 +9,11 @@
 
 export {
   ChatContextProvider as ChatProvider,
+  ChatPrefsProvider,
   ActiveTaskProvider,
   useChatBridge,
   useChatTask,
+  useOptionalChatTask,
   useChatStream,
   useOptionalChatStream,
   useChatPrefs,

--- a/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
@@ -2,16 +2,17 @@ import { useRef } from "react";
 import { getWellKnownDecopilotVirtualMCP } from "@decocms/mesh-sdk";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useProjectContext } from "@decocms/mesh-sdk";
+import { AUTOSEND_QUERY_VALUE } from "@/web/lib/autosend";
 
 export interface ChatNavigation {
   /** Resolved vMCP for the current chat — either the URL param or the well-known decopilot. */
   virtualMcpId: string;
   /** Always defined — `/$org/$taskId` path param, or a stable fallback for routes that don't have it. */
   taskId: string;
-  /** Navigate to a task. `virtualMcpId` becomes `?virtualmcpid=` — used as bootstrap for the route loader. `autosend` carries an encoded message for the new task to consume. */
+  /** Navigate to a task. `virtualMcpId` becomes `?virtualmcpid=`. `autosend` tells the task route to consume the stored handoff message. */
   navigateToTask: (
     taskId: string,
-    opts?: { virtualMcpId?: string; autosend?: string },
+    opts?: { virtualMcpId?: string; autosend?: boolean },
   ) => void;
 }
 
@@ -26,7 +27,7 @@ export function useChatNavigation(): ChatNavigation {
 
   const navigateToTask = (
     taskId: string,
-    opts?: { virtualMcpId?: string; autosend?: string },
+    opts?: { virtualMcpId?: string; autosend?: boolean },
   ) => {
     navigate({
       to: "/$org/$taskId",
@@ -36,7 +37,7 @@ export function useChatNavigation(): ChatNavigation {
         const vmcp = opts?.virtualMcpId ?? prev.virtualmcpid;
         if (vmcp) next.virtualmcpid = vmcp;
         if (prev.tasks) next.tasks = prev.tasks;
-        if (opts?.autosend) next.autosend = opts.autosend;
+        if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;
         return next;
       },
     });

--- a/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
@@ -8,8 +8,11 @@ export interface ChatNavigation {
   virtualMcpId: string;
   /** Always defined — `/$org/$taskId` path param, or a stable fallback for routes that don't have it. */
   taskId: string;
-  /** Navigate to a task. `virtualMcpId` becomes `?virtualmcpid=` — used as bootstrap for the route loader. */
-  navigateToTask: (taskId: string, opts?: { virtualMcpId?: string }) => void;
+  /** Navigate to a task. `virtualMcpId` becomes `?virtualmcpid=` — used as bootstrap for the route loader. `autosend` carries an encoded message for the new task to consume. */
+  navigateToTask: (
+    taskId: string,
+    opts?: { virtualMcpId?: string; autosend?: string },
+  ) => void;
 }
 
 export function useChatNavigation(): ChatNavigation {
@@ -21,7 +24,10 @@ export function useChatNavigation(): ChatNavigation {
   const virtualMcpId =
     search.virtualmcpid ?? getWellKnownDecopilotVirtualMCP(org.id).id;
 
-  const navigateToTask = (taskId: string, opts?: { virtualMcpId?: string }) => {
+  const navigateToTask = (
+    taskId: string,
+    opts?: { virtualMcpId?: string; autosend?: string },
+  ) => {
     navigate({
       to: "/$org/$taskId",
       params: { org: org.slug, taskId },
@@ -30,6 +36,7 @@ export function useChatNavigation(): ChatNavigation {
         const vmcp = opts?.virtualMcpId ?? prev.virtualmcpid;
         if (vmcp) next.virtualmcpid = vmcp;
         if (prev.tasks) next.tasks = prev.tasks;
+        if (opts?.autosend) next.autosend = opts.autosend;
         return next;
       },
     });

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -1,6 +1,6 @@
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import { calculateUsageStats } from "@/web/lib/usage-utils.ts";
-import { encodeAutosend } from "@/web/lib/autosend";
+import { AUTOSEND_QUERY_VALUE, writeStoredAutosend } from "@/web/lib/autosend";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   DropdownMenu,
@@ -258,15 +258,15 @@ function FileDropZone({
 // ============================================================================
 
 /**
- * Submit handler for the home composer. No active task exists; we encode
- * the tiptap doc into ?autosend= and navigate to a fresh /$org/$taskId.
+ * Submit handler for the home composer. No active task exists; we write
+ * the tiptap doc to localStorage and navigate to a fresh /$org/$taskId.
  * The new task page's useEnsureTask creates the thread (server-side
  * idempotent on id) and ActiveTaskProvider's autosend consumer fires
  * sendMessage on mount.
  */
 function useHomeSubmit() {
   const navigate = useNavigate();
-  const { org } = useProjectContext();
+  const { org, locator } = useProjectContext();
 
   return ({
     tiptapDoc,
@@ -278,14 +278,11 @@ function useHomeSubmit() {
     const newId = crypto.randomUUID();
     const targetVmcp =
       virtualMcp?.id ?? getWellKnownDecopilotVirtualMCP(org.id).id;
-    const autosend = encodeAutosend({
-      message: { tiptapDoc },
-      createdAt: Date.now(),
-    });
+    writeStoredAutosend(localStorage, locator, newId, { tiptapDoc });
     navigate({
       to: "/$org/$taskId",
       params: { org: org.slug, taskId: newId },
-      search: { virtualmcpid: targetVmcp, autosend },
+      search: { virtualmcpid: targetVmcp, autosend: AUTOSEND_QUERY_VALUE },
     });
   };
 }

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -490,8 +490,10 @@ export function ChatInput({
             <div className="absolute inset-0 rounded-2xl pointer-events-none bg-muted/50" />
           )}
 
-          {/* Highlight floats above the form area */}
-          <ChatHighlight />
+          {/* Highlight floats above the form area. Only renders when there's
+              an active task — it depends on useChatStream + useChatTask, both
+              absent on the home composer. */}
+          {stream && taskCtx && <ChatHighlight />}
 
           <TiptapProvider
             key={taskId}

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -1,5 +1,6 @@
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import { calculateUsageStats } from "@/web/lib/usage-utils.ts";
+import { encodeAutosend } from "@/web/lib/autosend";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   DropdownMenu,
@@ -12,6 +13,7 @@ import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,
 } from "@decocms/mesh-sdk";
+import { useNavigate } from "@tanstack/react-router";
 import {
   ArrowUp,
   Atom01,
@@ -31,7 +33,12 @@ import {
 import type { FormEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import type { Metadata } from "./types.ts";
-import { useChatStream, useChatTask, useChatPrefs } from "./context";
+import {
+  useChatPrefs,
+  useOptionalChatStream,
+  useOptionalChatTask,
+} from "./context";
+import type { VirtualMCPInfo } from "./select-virtual-mcp";
 import { ChatHighlight } from "./highlight";
 import { ModelSelector } from "./select-model";
 import { getSupportedFileTypesLabel, modelSupportsFiles } from "./select-model";
@@ -250,6 +257,39 @@ function FileDropZone({
 // ChatInput - Merged component with virtual MCP wrapper, banners, and selectors
 // ============================================================================
 
+/**
+ * Submit handler for the home composer. No active task exists; we encode
+ * the tiptap doc into ?autosend= and navigate to a fresh /$org/$taskId.
+ * The new task page's useEnsureTask creates the thread (server-side
+ * idempotent on id) and ActiveTaskProvider's autosend consumer fires
+ * sendMessage on mount.
+ */
+function useHomeSubmit() {
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+
+  return ({
+    tiptapDoc,
+    virtualMcp,
+  }: {
+    tiptapDoc: Metadata["tiptapDoc"];
+    virtualMcp: VirtualMCPInfo | null;
+  }) => {
+    const newId = crypto.randomUUID();
+    const targetVmcp =
+      virtualMcp?.id ?? getWellKnownDecopilotVirtualMCP(org.id).id;
+    const autosend = encodeAutosend({
+      message: { tiptapDoc },
+      createdAt: Date.now(),
+    });
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: org.slug, taskId: newId },
+      search: { virtualmcpid: targetVmcp, autosend },
+    });
+  };
+}
+
 export function ChatInput({
   onOpenContextPanel,
   showConnectionsBanner = false,
@@ -257,9 +297,15 @@ export function ChatInput({
   onOpenContextPanel?: () => void;
   showConnectionsBanner?: boolean;
 }) {
-  const { messages, isStreaming, isRunInProgress, sendMessage, stop } =
-    useChatStream();
-  const { taskId, tasks } = useChatTask();
+  const stream = useOptionalChatStream();
+  const taskCtx = useOptionalChatTask();
+  const messages = stream?.messages ?? [];
+  const isStreaming = stream?.isStreaming ?? false;
+  const isRunInProgress = stream?.isRunInProgress ?? false;
+  const stop = stream?.stop ?? (() => {});
+  const taskId = taskCtx?.taskId ?? "";
+  const tasks = taskCtx?.tasks ?? [];
+  const homeSubmit = useHomeSubmit();
   const {
     selectedModel,
     selectedVirtualMcp,
@@ -407,7 +453,7 @@ export function ChatInput({
       stop();
     } else if (canSubmit && tiptapDoc) {
       track("chat_message_sent", {
-        thread_id: taskId,
+        thread_id: taskId || null,
         mode: chatMode,
         model_id: selectedModel?.modelId ?? null,
         model_provider: selectedModel?.providerId ?? null,
@@ -415,7 +461,11 @@ export function ChatInput({
         submission: e ? "button_or_enter" : "programmatic",
       });
       playClickSound();
-      void sendMessage(tiptapDoc);
+      if (stream) {
+        void stream.sendMessage(tiptapDoc);
+      } else {
+        homeSubmit({ tiptapDoc, virtualMcp: selectedVirtualMcp });
+      }
       setTiptapDoc(undefined);
     }
   };

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -1,17 +1,12 @@
-import { AgentsList } from "@/web/components/home/agents-list.tsx";
-import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { authClient } from "@/web/lib/auth-client";
-import { KEYS } from "@/web/lib/query-keys";
-import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,
   useVirtualMCP,
 } from "@decocms/mesh-sdk";
-import { ArrowRight, Users03 } from "@untitledui/icons";
-import { useQuery } from "@tanstack/react-query";
+import { Users03 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { ErrorBoundary } from "../error-boundary";
 
@@ -23,181 +18,6 @@ import { BranchPicker } from "../thread/github/branch-picker.tsx";
 
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
-
-// ---------- Import deco.cx Banner ----------
-
-const DECO_BANNER_GRADIENT = [
-  "radial-gradient(ellipse 25% 220% at -5% 120%, rgba(165,149,255,0.35) 0%, transparent 100%)",
-  "radial-gradient(ellipse 25% 220% at 105% -20%, rgba(208,236,26,0.32) 0%, transparent 100%)",
-].join(", ");
-const DECO_BANNER_TEXTURE = "/decotexture.svg";
-
-function ImportDecoSiteBanner({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="w-full relative flex items-center gap-4 px-4 py-4 rounded-lg border border-border bg-background overflow-hidden transition-colors text-left cursor-pointer group"
-      style={{ backgroundImage: DECO_BANNER_GRADIENT }}
-    >
-      <div className="relative shrink-0 p-1.5 bg-[var(--brand-green-light)] rounded-lg border border-border">
-        <IntegrationIcon
-          icon="/logos/deco%20logo.svg"
-          name="deco.cx"
-          size="xs"
-          className="border-0 rounded-none bg-transparent"
-        />
-      </div>
-      <p className="flex-1 relative text-sm font-medium text-foreground leading-none whitespace-nowrap">
-        Import your deco.cx site
-      </p>
-      <img
-        src={DECO_BANNER_TEXTURE}
-        alt=""
-        aria-hidden
-        className="absolute pointer-events-none"
-        style={{
-          width: "274.5px",
-          height: "272.25px",
-          left: "calc(50% + 145.5px)",
-          top: "calc(50% + 40px)",
-          transform: "translate(-50%, -50%)",
-        }}
-      />
-      <div className="relative bg-background flex items-center justify-center size-8 rounded-md shrink-0">
-        <ArrowRight
-          size={16}
-          className="text-foreground transition-transform group-hover:translate-x-0.5"
-        />
-      </div>
-    </button>
-  );
-}
-
-function useIsDecoUser() {
-  const { data: session } = authClient.useSession();
-  const { data } = useQuery({
-    queryKey: KEYS.decoProfile(session?.user?.email),
-    queryFn: async () => {
-      const res = await fetch("/api/deco-sites/profile");
-      if (!res.ok) return { isDecoUser: false };
-      return res.json() as Promise<{ isDecoUser: boolean }>;
-    },
-    enabled: Boolean(session?.user?.email),
-    staleTime: 5 * 60_000,
-  });
-  return data?.isDecoUser ?? false;
-}
-
-// ---------- Home empty state (greeting, agents, ice breakers, banner) ----------
-
-function HomeEmptyState({
-  onOpenContextPanel,
-}: {
-  onOpenContextPanel: () => void;
-}) {
-  const { data: session } = authClient.useSession();
-  const [importOpen, setImportOpen] = useState(false);
-  const isDecoUser = useIsDecoUser();
-  const isMobile = useIsMobile();
-  const {
-    hasDecoKey,
-    isZeroBalance,
-    isInitialFreeCredit,
-    balanceDollars,
-    hasOnlyDecoProvider,
-  } = useDecoCredits();
-
-  const userName = session?.user?.name?.split(" ")[0] || "there";
-
-  // Only show the eyebrow for the initial free $2 credit (onboarding)
-  const showEyebrow =
-    hasDecoKey && isInitialFreeCredit && balanceDollars != null;
-  const showNoCreditsEyebrow =
-    hasDecoKey && isZeroBalance && hasOnlyDecoProvider;
-
-  if (isMobile) {
-    return (
-      <>
-        <div className="flex-1 relative flex flex-col items-center px-4">
-          {/* Centered greeting */}
-          <div className="flex-1 flex flex-col items-center justify-center w-full">
-            {showEyebrow && (
-              <div className="mb-4">
-                <Chat.CreditsEyebrow balanceDollars={balanceDollars} />
-              </div>
-            )}
-            {showNoCreditsEyebrow && (
-              <div className="mb-4">
-                <Chat.NoCreditsEyebrow />
-              </div>
-            )}
-            <p className="text-3xl font-medium text-foreground text-center max-w-[280px]">
-              What's on your mind, {userName}?
-            </p>
-          </div>
-          {/* Agents above input at bottom */}
-          <div className="w-full flex flex-col gap-4 pb-4">
-            <AgentsList />
-            <Chat.Input
-              onOpenContextPanel={onOpenContextPanel}
-              showConnectionsBanner
-            />
-          </div>
-          {isDecoUser && (
-            <div className="w-full">
-              <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
-            </div>
-          )}
-        </div>
-        <ImportFromDecoDialog open={importOpen} onOpenChange={setImportOpen} />
-      </>
-    );
-  }
-
-  return (
-    <>
-      <div className="flex-1 relative flex flex-col items-center px-10">
-        <div className="flex-1 flex flex-col items-center justify-center w-full">
-          <div className="flex flex-col items-center w-full max-w-[672px]">
-            <div className="text-center mb-10">
-              {showEyebrow && (
-                <div className="mb-4">
-                  <Chat.CreditsEyebrow balanceDollars={balanceDollars} />
-                </div>
-              )}
-              {showNoCreditsEyebrow && (
-                <div className="mb-4">
-                  <Chat.NoCreditsEyebrow />
-                </div>
-              )}
-              <p className="text-3xl font-medium text-foreground">
-                What's on your mind, {userName}?
-              </p>
-            </div>
-            <div className="w-full">
-              <Chat.Input
-                onOpenContextPanel={onOpenContextPanel}
-                showConnectionsBanner
-              />
-            </div>
-          </div>
-          <div className="w-full mt-10 mx-auto">
-            <AgentsList />
-          </div>
-        </div>
-        {isDecoUser && (
-          <div className="absolute bottom-6 left-0 right-0 px-10">
-            <div className="w-full max-w-[500px] mx-auto">
-              <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
-            </div>
-          </div>
-        )}
-      </div>
-      <ImportFromDecoDialog open={importOpen} onOpenChange={setImportOpen} />
-    </>
-  );
-}
 
 // ---------- Default sidebar empty state ----------
 
@@ -256,7 +76,7 @@ function SidebarEmptyState() {
 
 // ---------- Panel content ----------
 
-function ChatPanelContent({ variant }: { variant?: "home" | "default" }) {
+function ChatPanelContent(_: { variant?: "home" | "default" }) {
   const { org } = useProjectContext();
   const allKeys = useAiProviderKeys();
   const { isChatEmpty } = useChatStream();
@@ -309,10 +129,6 @@ function ChatPanelContent({ variant }: { variant?: "home" | "default" }) {
               />
             </Chat.Footer>
           </>
-        ) : variant === "home" ? (
-          <HomeEmptyState
-            onOpenContextPanel={() => setActivePanel("context")}
-          />
         ) : (
           <>
             <Chat.Main>

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -76,7 +76,7 @@ function SidebarEmptyState() {
 
 // ---------- Panel content ----------
 
-function ChatPanelContent(_: { variant?: "home" | "default" }) {
+function ChatPanelContent() {
   const { org } = useProjectContext();
   const allKeys = useAiProviderKeys();
   const { isChatEmpty } = useChatStream();
@@ -158,11 +158,11 @@ function ChatPanelContent(_: { variant?: "home" | "default" }) {
   );
 }
 
-export function ChatPanel({ variant }: { variant?: "home" | "default" }) {
+export function ChatPanel() {
   return (
     <ErrorBoundary fallback={<Chat.Skeleton />}>
       <Suspense fallback={<Chat.Skeleton />}>
-        <ChatPanelContent variant={variant} />
+        <ChatPanelContent />
       </Suspense>
     </ErrorBoundary>
   );

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -37,7 +37,7 @@ import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recrui
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-healing-repo-flow.tsx";
 import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
-import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { useNavigateToAgentThread } from "@/web/hooks/use-navigate-to-agent-thread";
 import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { Suspense, useState } from "react";
 import { track } from "@/web/lib/posthog-client";
@@ -64,7 +64,7 @@ function AgentPreview({
     title: string;
     icon?: string | null;
   };
-  onSpecialClick?: () => void;
+  onSpecialClick?: () => void | Promise<unknown>;
   tracking: {
     template_id: string | null;
     tile_kind: TileKind;
@@ -83,7 +83,7 @@ function AgentPreview({
       action: tracking.action,
     });
     if (onSpecialClick) {
-      onSpecialClick();
+      void onSpecialClick();
     } else {
       const taskId = crypto.randomUUID();
       navigate({
@@ -243,7 +243,7 @@ function findExistingForTemplate(
 
 function AgentsListContent() {
   const virtualMcps = useVirtualMCPs();
-  const { locator } = useProjectContext();
+  const { locator, org } = useProjectContext();
   const orgDefaults = useDefaultHomeAgents();
   const [importDecoOpen, setImportDecoOpen] = useState(false);
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
@@ -253,7 +253,7 @@ function AgentsListContent() {
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
   const [selfHealingOpen, setSelfHealingOpen] = useState(false);
   const [preferences] = usePreferences();
-  const navigateToAgent = useNavigateToAgent();
+  const navigateToAgentThread = useNavigateToAgentThread(org.slug);
 
   const siteEditorAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "site-editor",
@@ -506,7 +506,7 @@ function AgentsListContent() {
       <AgentPreview
         key={tile.key}
         agent={tile.agent}
-        onSpecialClick={() => navigateToAgent(tile.agent.id)}
+        onSpecialClick={() => navigateToAgentThread(tile.agent.id)}
         tracking={{
           template_id: tile.templateId,
           tile_kind: tile.templateId ? "existing" : "recent",

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -80,13 +80,19 @@ import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-moda
 import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
 import { useTaskActions } from "@/web/hooks/use-tasks";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
+import { readCachedLastThread } from "@/web/lib/read-cached-last-thread";
+import { authClient } from "@/web/lib/auth-client";
 
 /**
- * Hook for sidebar "spawn task on this vMCP" buttons. When the user clicks
- * a vMCP that matches the URL's current virtualmcpid, the active task's
- * branch is carried into the new thread so the new task lands on the same
- * warm sandbox. When the clicked vMCP differs, no branch is passed and the
- * server picks the most-recently-touched vmMap entry for that vMCP.
+ * Hook for "spawn task on this vMCP" buttons (used by the browse-agents
+ * popover). When the user clicks a vMCP that matches the URL's current
+ * virtualmcpid, the active task's branch is carried into the new thread
+ * so the new task lands on the same warm sandbox. When the clicked vMCP
+ * differs, no branch is passed and the server picks the most-recently-
+ * touched vmMap entry for that vMCP.
+ *
+ * The sidebar pinned-agent click uses `useNavigateToAgentThread` instead,
+ * which resumes the user's last thread when one exists.
  */
 function useNavigateToNewTaskWithBranchCarry(orgSlug: string) {
   const navigate = useNavigate();
@@ -119,6 +125,63 @@ function useNavigateToNewTaskWithBranchCarry(orgSlug: string) {
     });
   };
 }
+
+/**
+ * Hook for sidebar pinned-agent clicks. Resumes the user's most recent
+ * thread with the clicked vMCP when one is in the local TanStack cache;
+ * otherwise falls back to creating a new thread. The branch-carry
+ * behavior (carrying the active task's branch into a brand-new thread
+ * for the same vMCP) is preserved on the create path.
+ *
+ * Returns `{ resumed }` so the call site can emit the right analytics.
+ */
+function useNavigateToAgentThread(orgSlug: string) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const taskActions = useTaskActions();
+  const { locator } = useProjectContext();
+  const params = useParams({ strict: false }) as { taskId?: string };
+  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+
+  return async (clickedVirtualMcpId: string): Promise<{ resumed: boolean }> => {
+    const last = userId
+      ? readCachedLastThread(queryClient, locator, clickedVirtualMcpId, userId)
+      : null;
+
+    if (last) {
+      navigate({
+        to: "/$org/$taskId",
+        params: { org: orgSlug, taskId: last.id },
+        search: { virtualmcpid: clickedVirtualMcpId },
+      });
+      return { resumed: true };
+    }
+
+    const taskId = crypto.randomUUID();
+    const carryBranch =
+      clickedVirtualMcpId === search.virtualmcpid
+        ? readCachedTaskBranch(queryClient, locator, params.taskId ?? "")
+        : null;
+    try {
+      await taskActions.create.mutateAsync({
+        id: taskId,
+        virtual_mcp_id: clickedVirtualMcpId,
+        ...(carryBranch ? { branch: carryBranch } : {}),
+      });
+    } catch {
+      // Toast already fired; navigate anyway so the route loader's
+      // ensure-fallback can retry.
+    }
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: orgSlug, taskId },
+      search: { virtualmcpid: clickedVirtualMcpId },
+    });
+    return { resumed: false };
+  };
+}
 function AgentListItem({
   agent,
   org,
@@ -132,7 +195,7 @@ function AgentListItem({
 }) {
   const navigate = useNavigate();
   const { isMobile, setOpenMobile } = useSidebar();
-  const navigateToNewTask = useNavigateToNewTaskWithBranchCarry(org);
+  const navigateToAgentThread = useNavigateToAgentThread(org);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isActive = pathname.startsWith(`/${org}/${agent.id}`);
   const [buttonRect, setButtonRect] = useState<DOMRect | null>(null);
@@ -183,13 +246,14 @@ function AgentListItem({
           <SidebarMenuButton
             tooltip={buttonRect ? undefined : agent.title}
             isActive={isActive}
-            onClick={() => {
+            onClick={async () => {
+              if (isMobile) setOpenMobile(false);
+              const { resumed } = await navigateToAgentThread(agent.id);
               track("sidebar_agent_pin_clicked", {
                 agent_id: agent.id,
                 agent_title: agent.title,
+                resumed,
               });
-              navigateToNewTask(agent.id);
-              if (isMobile) setOpenMobile(false);
             }}
             onMouseEnter={handleIconMouseEnter}
             onMouseLeave={handleIconMouseLeave}

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -80,8 +80,7 @@ import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-moda
 import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
 import { useTaskActions } from "@/web/hooks/use-tasks";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
-import { readCachedLastThread } from "@/web/lib/read-cached-last-thread";
-import { authClient } from "@/web/lib/auth-client";
+import { useNavigateToAgentThread } from "@/web/hooks/use-navigate-to-agent-thread";
 
 /**
  * Hook for "spawn task on this vMCP" buttons (used by the browse-agents
@@ -126,62 +125,6 @@ function useNavigateToNewTaskWithBranchCarry(orgSlug: string) {
   };
 }
 
-/**
- * Hook for sidebar pinned-agent clicks. Resumes the user's most recent
- * thread with the clicked vMCP when one is in the local TanStack cache;
- * otherwise falls back to creating a new thread. The branch-carry
- * behavior (carrying the active task's branch into a brand-new thread
- * for the same vMCP) is preserved on the create path.
- *
- * Returns `{ resumed }` so the call site can emit the right analytics.
- */
-function useNavigateToAgentThread(orgSlug: string) {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const taskActions = useTaskActions();
-  const { locator } = useProjectContext();
-  const params = useParams({ strict: false }) as { taskId?: string };
-  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
-  const { data: session } = authClient.useSession();
-  const userId = session?.user?.id;
-
-  return async (clickedVirtualMcpId: string): Promise<{ resumed: boolean }> => {
-    const last = userId
-      ? readCachedLastThread(queryClient, locator, clickedVirtualMcpId, userId)
-      : null;
-
-    if (last) {
-      navigate({
-        to: "/$org/$taskId",
-        params: { org: orgSlug, taskId: last.id },
-        search: { virtualmcpid: clickedVirtualMcpId },
-      });
-      return { resumed: true };
-    }
-
-    const taskId = crypto.randomUUID();
-    const carryBranch =
-      clickedVirtualMcpId === search.virtualmcpid
-        ? readCachedTaskBranch(queryClient, locator, params.taskId ?? "")
-        : null;
-    try {
-      await taskActions.create.mutateAsync({
-        id: taskId,
-        virtual_mcp_id: clickedVirtualMcpId,
-        ...(carryBranch ? { branch: carryBranch } : {}),
-      });
-    } catch {
-      // Toast already fired; navigate anyway so the route loader's
-      // ensure-fallback can retry.
-    }
-    navigate({
-      to: "/$org/$taskId",
-      params: { org: orgSlug, taskId },
-      search: { virtualmcpid: clickedVirtualMcpId },
-    });
-    return { resumed: false };
-  };
-}
 function AgentListItem({
   agent,
   org,

--- a/apps/mesh/src/web/hooks/use-ensure-task.ts
+++ b/apps/mesh/src/web/hooks/use-ensure-task.ts
@@ -4,8 +4,13 @@
  * Returns a discriminated union so the consumer can render the right UI:
  *   - { status: "loading" }   — initial GET in flight
  *   - { status: "creating" }  — create mutation in flight (after a 404)
- *   - { status: "ready", task: Task } — resolved
+ *   - { status: "ready", task: Task | null } — resolved (null when id is empty)
  *   - { status: "error", error: Error } — non-404 failure
+ *
+ * Empty id is a no-op: GET and CREATE are skipped and the hook returns a
+ * ready state with `task: null`. Lets routes that don't have a taskId in
+ * URL params (e.g. /$org/) call the hook unconditionally so Rules of Hooks
+ * stays happy across the home/task branch.
  *
  * Race safety: the create mutation is server-side idempotent (`INSERT … ON
  * CONFLICT DO NOTHING RETURNING *`). Two tabs hitting the same URL both end
@@ -25,7 +30,7 @@ import type { Task } from "./use-tasks";
 type State =
   | { status: "loading" }
   | { status: "creating" }
-  | { status: "ready"; task: Task }
+  | { status: "ready"; task: Task | null }
   | { status: "error"; error: Error };
 
 export function useEnsureTask(id: string, virtualMcpId: string): State {
@@ -47,6 +52,7 @@ export function useEnsureTask(id: string, virtualMcpId: string): State {
         .structuredContent as { item?: Task } | undefined;
       return payload?.item ?? null;
     },
+    enabled: id.length > 0,
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -101,12 +107,14 @@ export function useEnsureTask(id: string, virtualMcpId: string): State {
   // the duplicate request and the private mutation has no toast.
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
+    if (!id) return;
     if (!query.isSuccess || query.data) return;
     if (ensureCreate.isPending) return;
     if (ensureCreate.variables === id) return;
     ensureCreate.mutate(id);
   }, [id, query.isSuccess, query.data, ensureCreate]);
 
+  if (!id) return { status: "ready", task: null };
   if (query.isLoading) return { status: "loading" };
   if (query.isError) return { status: "error", error: query.error as Error };
   if (query.isSuccess && query.data) {

--- a/apps/mesh/src/web/hooks/use-navigate-to-agent-thread.ts
+++ b/apps/mesh/src/web/hooks/use-navigate-to-agent-thread.ts
@@ -1,0 +1,65 @@
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useTaskActions } from "@/web/hooks/use-tasks";
+import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
+import { readCachedLastThread } from "@/web/lib/read-cached-last-thread";
+import { authClient } from "@/web/lib/auth-client";
+
+/**
+ * Hook for sidebar agent entry points (pinned-agent icons and the Home
+ * button). Resumes the user's most recent thread with the target vMCP
+ * when one is in the local TanStack cache; otherwise falls back to
+ * creating a new thread. The branch-carry behavior (carrying the active
+ * task's branch into a brand-new thread for the same vMCP) is preserved
+ * on the create path.
+ *
+ * Returns `{ resumed }` so the call site can emit the right analytics.
+ */
+export function useNavigateToAgentThread(orgSlug: string) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const taskActions = useTaskActions();
+  const { locator } = useProjectContext();
+  const params = useParams({ strict: false }) as { taskId?: string };
+  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+
+  return async (targetVirtualMcpId: string): Promise<{ resumed: boolean }> => {
+    const last = userId
+      ? readCachedLastThread(queryClient, locator, targetVirtualMcpId, userId)
+      : null;
+
+    if (last) {
+      navigate({
+        to: "/$org/$taskId",
+        params: { org: orgSlug, taskId: last.id },
+        search: { virtualmcpid: targetVirtualMcpId },
+      });
+      return { resumed: true };
+    }
+
+    const taskId = crypto.randomUUID();
+    const carryBranch =
+      targetVirtualMcpId === search.virtualmcpid
+        ? readCachedTaskBranch(queryClient, locator, params.taskId ?? "")
+        : null;
+    try {
+      await taskActions.create.mutateAsync({
+        id: taskId,
+        virtual_mcp_id: targetVirtualMcpId,
+        ...(carryBranch ? { branch: carryBranch } : {}),
+      });
+    } catch {
+      // Toast already fired; navigate anyway so the route loader's
+      // ensure-fallback can retry.
+    }
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: orgSlug, taskId },
+      search: { virtualmcpid: targetVirtualMcpId },
+    });
+    return { resumed: false };
+  };
+}

--- a/apps/mesh/src/web/hooks/use-navigate-to-agent-thread.ts
+++ b/apps/mesh/src/web/hooks/use-navigate-to-agent-thread.ts
@@ -7,12 +7,11 @@ import { readCachedLastThread } from "@/web/lib/read-cached-last-thread";
 import { authClient } from "@/web/lib/auth-client";
 
 /**
- * Hook for sidebar agent entry points (pinned-agent icons and the Home
- * button). Resumes the user's most recent thread with the target vMCP
- * when one is in the local TanStack cache; otherwise falls back to
- * creating a new thread. The branch-carry behavior (carrying the active
- * task's branch into a brand-new thread for the same vMCP) is preserved
- * on the create path.
+ * Hook for sidebar pinned-agent entry points. Resumes the user's most
+ * recent thread with the target vMCP when one is in the local TanStack
+ * cache; otherwise falls back to creating a new thread. The branch-carry
+ * behavior (carrying the active task's branch into a brand-new thread
+ * for the same vMCP) is preserved on the create path.
  *
  * Returns `{ resumed }` so the call site can emit the right analytics.
  */

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -1,4 +1,4 @@
-import { getDecopilotId, useProjectContext } from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import type {
   NavigationSidebarItem,
   SidebarSection,
@@ -15,7 +15,6 @@ import { usePanelActions } from "@/web/layouts/shell-layout";
 import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { pluginRootSidebarItems, pluginSidebarGroups } from "../index.tsx";
 import { PLUGIN_ID as WORKFLOWS_PLUGIN_ID } from "mesh-plugin-workflows/shared";
-import { useNavigateToAgentThread } from "@/web/hooks/use-navigate-to-agent-thread";
 
 export function useProjectSidebarItems(): SidebarSection[] {
   const { org: orgContext } = useProjectContext();
@@ -24,7 +23,6 @@ export function useProjectSidebarItems(): SidebarSection[] {
   const { setTasksOpen, openTab } = usePanelActions();
   const org = orgContext.slug;
   const currentProject = useProjectContext().project;
-  const navigateToAgentThread = useNavigateToAgentThread(org);
 
   const routeParams = useParams({ strict: false }) as {
     taskId?: string;
@@ -159,7 +157,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
     isActive: pathname === `/${org}` || pathname === `/${org}/`,
     onClick: () => {
       setTasksOpen(false);
-      void navigateToAgentThread(getDecopilotId(orgContext.id));
+      navigate({ to: "/$org", params: { org } });
     },
   };
 

--- a/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
+++ b/apps/mesh/src/web/hooks/use-project-sidebar-items.tsx
@@ -1,4 +1,4 @@
-import { useProjectContext } from "@decocms/mesh-sdk";
+import { getDecopilotId, useProjectContext } from "@decocms/mesh-sdk";
 import type {
   NavigationSidebarItem,
   SidebarSection,
@@ -15,6 +15,7 @@ import { usePanelActions } from "@/web/layouts/shell-layout";
 import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { pluginRootSidebarItems, pluginSidebarGroups } from "../index.tsx";
 import { PLUGIN_ID as WORKFLOWS_PLUGIN_ID } from "mesh-plugin-workflows/shared";
+import { useNavigateToAgentThread } from "@/web/hooks/use-navigate-to-agent-thread";
 
 export function useProjectSidebarItems(): SidebarSection[] {
   const { org: orgContext } = useProjectContext();
@@ -23,6 +24,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
   const { setTasksOpen, openTab } = usePanelActions();
   const org = orgContext.slug;
   const currentProject = useProjectContext().project;
+  const navigateToAgentThread = useNavigateToAgentThread(org);
 
   const routeParams = useParams({ strict: false }) as {
     taskId?: string;
@@ -157,7 +159,7 @@ export function useProjectSidebarItems(): SidebarSection[] {
     isActive: pathname === `/${org}` || pathname === `/${org}/`,
     onClick: () => {
       setTasksOpen(false);
-      navigate({ to: "/$org", params: { org } });
+      void navigateToAgentThread(getDecopilotId(orgContext.id));
     },
   };
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -199,6 +199,7 @@ const unifiedChatSearchSchema = z.object({
   tasks: z.number().optional(),
   mainOpen: z.number().optional(),
   chat: z.number().optional(),
+  autosend: z.string().optional(),
 });
 
 const unifiedChatRoute = createRoute({

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -175,11 +175,23 @@ const orgLayout = createRoute({
 });
 
 // ============================================
-// AGENT SHELL LAYOUT (pathless — wraps agent/org-home routes with sidebar + 3-panel)
+// ORG SHELL LAYOUT (pathless — sidebar + Toolbar + ChatPrefsProvider for / and /$taskId)
+// ============================================
+
+const orgShellLayout = createRoute({
+  getParentRoute: () => orgLayout,
+  id: "org-shell",
+  component: lazyRouteComponent(
+    () => import("./layouts/org-shell-layout/index.tsx"),
+  ),
+});
+
+// ============================================
+// AGENT SHELL LAYOUT (pathless — per-task chrome under orgShellLayout)
 // ============================================
 
 const agentShellLayout = createRoute({
-  getParentRoute: () => orgLayout,
+  getParentRoute: () => orgShellLayout,
   id: "agent-shell",
   component: lazyRouteComponent(
     () => import("./layouts/agent-shell-layout/index.tsx"),
@@ -209,12 +221,12 @@ const unifiedChatRoute = createRoute({
   component: () => null,
 });
 
-// Org index renders the home page (handled by AgentInsetProvider's
-// branch on params.taskId).
+// Org index renders the home landing page (single-panel + HomePage), no
+// agent shell.
 const orgIndexRoute = createRoute({
-  getParentRoute: () => agentShellLayout,
+  getParentRoute: () => orgShellLayout,
   path: "/",
-  component: () => null,
+  component: lazyRouteComponent(() => import("./layouts/org-home/index.tsx")),
 });
 
 // ============================================
@@ -535,13 +547,17 @@ const unifiedChatWithChildren = unifiedChatRoute.addChildren([
 ]);
 
 const agentShellWithChildren = agentShellLayout.addChildren([
-  orgIndexRoute,
   unifiedChatWithChildren,
   orgPluginRoute,
 ]);
 
-const orgLayoutWithChildren = orgLayout.addChildren([
+const orgShellWithChildren = orgShellLayout.addChildren([
+  orgIndexRoute,
   agentShellWithChildren,
+]);
+
+const orgLayoutWithChildren = orgLayout.addChildren([
+  orgShellWithChildren,
   settingsWithChildren,
 ]);
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -208,17 +208,11 @@ const unifiedChatRoute = createRoute({
   component: () => null,
 });
 
-// Org index redirects to a fresh decopilot task
+// Org index renders the home page (handled by AgentInsetProvider's
+// branch on params.taskId).
 const orgIndexRoute = createRoute({
   getParentRoute: () => agentShellLayout,
   path: "/",
-  beforeLoad: ({ params }) => {
-    const taskId = crypto.randomUUID();
-    throw redirect({
-      to: "/$org/$taskId",
-      params: { org: params.org, taskId },
-    });
-  },
   component: () => null,
 });
 

--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -61,7 +61,6 @@ export interface ChatMainPanelGroupProps {
   taskId: string;
   chatOpen: boolean;
   mainOpen: boolean;
-  variant?: "home" | "default";
   /** Optional override for the chat panel content — lets the outer layout
    * wrap ChatCenterPanel in its own Suspense/ErrorBoundary/ActiveTaskProvider. */
   chatContent?: React.ReactNode;
@@ -72,7 +71,6 @@ export function ChatMainPanelGroup({
   taskId,
   chatOpen,
   mainOpen,
-  variant,
   chatContent,
 }: ChatMainPanelGroupProps) {
   const sizes = computeChatMainSizes(chatOpen, mainOpen);
@@ -105,7 +103,7 @@ export function ChatMainPanelGroup({
       <PersistentChatPanel defaultSize={sizes.chat}>
         <div className="h-full p-0.5 pt-0.25">
           <div className="h-full bg-background rounded-[0.75rem] overflow-hidden card-shadow">
-            {chatContent ?? <ChatCenterPanel variant={variant} />}
+            {chatContent ?? <ChatCenterPanel />}
           </div>
         </div>
       </PersistentChatPanel>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -44,7 +44,6 @@ import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { AlertCircle, Loading01, Menu01 } from "@untitledui/icons";
 import {
-  getDecopilotId,
   getWellKnownDecopilotVirtualMCP,
   SELF_MCP_ALIAS_ID,
   useMCPClient,
@@ -94,13 +93,7 @@ export function useInsetContext(): InsetContextValue | null {
 // Agent inset sub-components
 // ---------------------------------------------------------------------------
 
-function ActiveTaskBoundary({
-  children,
-  variant,
-}: {
-  children?: React.ReactNode;
-  variant?: "home" | "default";
-}) {
+function ActiveTaskBoundary({ children }: { children?: React.ReactNode }) {
   const { taskId } = useChatTask();
   return (
     <ErrorBoundary
@@ -112,7 +105,7 @@ function ActiveTaskBoundary({
     >
       <Suspense fallback={<Chat.Skeleton />}>
         <Chat.ActiveTaskProvider taskId={taskId}>
-          {children ?? <ChatCenterPanel variant={variant} />}
+          {children ?? <ChatCenterPanel />}
         </Chat.ActiveTaskProvider>
       </Suspense>
     </ErrorBoundary>
@@ -251,8 +244,6 @@ function AgentInsetProvider() {
   };
   const virtualMcpId =
     search.virtualmcpid ?? getWellKnownDecopilotVirtualMCP(org.id).id;
-  const isDecopilot = virtualMcpId === getDecopilotId(org.id);
-  const isAgentRoute = !isDecopilot;
 
   // Ensure the thread row exists for this URL before rendering the chat. On
   // 404 the hook fires COLLECTION_THREADS_CREATE (idempotent) and surfaces a
@@ -276,7 +267,7 @@ function AgentInsetProvider() {
   const layout = useChatMainPanelState(entityMetadata, {
     virtualMcpId,
     orgSlug,
-    isAgentRoute,
+    isAgentRoute: true,
   });
 
   const { setOpenMobile, openMobile: mobileSidebarOpen } = useSidebar();
@@ -404,13 +395,7 @@ function AgentInsetProvider() {
               />
               <MobileToolbar onOpenSidebar={() => setMobileSidebarOpen(true)} />
               <div className="flex-1 min-h-0 overflow-hidden">
-                {params.taskId ? (
-                  <ActiveTaskBoundary
-                    variant={isDecopilot ? "home" : undefined}
-                  />
-                ) : (
-                  <HomePage />
-                )}
+                {params.taskId ? <ActiveTaskBoundary /> : <HomePage />}
               </div>
               {mobileSidebarSheet}
             </VmEventsBridge>
@@ -425,7 +410,6 @@ function AgentInsetProvider() {
     <InsetContext value={insetContextValue}>
       <Toolbar.Toggles>
         <ToggleButtons
-          isDecopilot={isDecopilot}
           chatOpen={layout.chatOpen}
           toggleChat={layout.toggleChat}
           onNewTask={tasksOpen ? undefined : layout.createNewTask}
@@ -433,7 +417,7 @@ function AgentInsetProvider() {
       </Toolbar.Toggles>
 
       <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-        {params.taskId && !isDecopilot && (
+        {params.taskId && (
           <Toolbar.Tabs>
             <MainPanelTabsBar
               virtualMcpId={virtualMcpId}
@@ -449,7 +433,7 @@ function AgentInsetProvider() {
         >
           {params.taskId ? (
             <>
-              {!isDecopilot && <VirtualMcpHeaderInfo virtualMcp={entity} />}
+              <VirtualMcpHeaderInfo virtualMcp={entity} />
               <NewTaskBridge
                 onNewTaskRef={onNewTask}
                 createNewTask={layout.createNewTask}
@@ -459,11 +443,7 @@ function AgentInsetProvider() {
                 taskId={layout.taskId}
                 chatOpen={layout.chatOpen}
                 mainOpen={layout.mainOpen}
-                chatContent={
-                  <ActiveTaskBoundary
-                    variant={isDecopilot ? "home" : undefined}
-                  />
-                }
+                chatContent={<ActiveTaskBoundary />}
               />
             </>
           ) : (

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -73,6 +73,7 @@ import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { VmEventsProvider } from "@/web/components/vm/hooks/vm-events-context.tsx";
 import type { VmMapEntry } from "@decocms/mesh-sdk";
 import { useEnsureTask } from "@/web/hooks/use-tasks";
+import { HomePage } from "@/web/layouts/home-page";
 
 // ---------------------------------------------------------------------------
 // Types & Context
@@ -403,9 +404,13 @@ function AgentInsetProvider() {
               />
               <MobileToolbar onOpenSidebar={() => setMobileSidebarOpen(true)} />
               <div className="flex-1 min-h-0 overflow-hidden">
-                <ActiveTaskBoundary
-                  variant={isDecopilot ? "home" : undefined}
-                />
+                {params.taskId ? (
+                  <ActiveTaskBoundary
+                    variant={isDecopilot ? "home" : undefined}
+                  />
+                ) : (
+                  <HomePage />
+                )}
               </div>
               {mobileSidebarSheet}
             </VmEventsBridge>
@@ -428,7 +433,7 @@ function AgentInsetProvider() {
       </Toolbar.Toggles>
 
       <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-        {!isDecopilot && (
+        {params.taskId && !isDecopilot && (
           <Toolbar.Tabs>
             <MainPanelTabsBar
               virtualMcpId={virtualMcpId}
@@ -442,20 +447,28 @@ function AgentInsetProvider() {
           hasActiveGithubRepo={hasActiveGithubRepo}
           vmMap={entity?.metadata?.vmMap}
         >
-          {!isDecopilot && <VirtualMcpHeaderInfo virtualMcp={entity} />}
-          <NewTaskBridge
-            onNewTaskRef={onNewTask}
-            createNewTask={layout.createNewTask}
-          />
-          <ChatMainPanelGroup
-            virtualMcpId={virtualMcpId}
-            taskId={layout.taskId}
-            chatOpen={layout.chatOpen}
-            mainOpen={layout.mainOpen}
-            chatContent={
-              <ActiveTaskBoundary variant={isDecopilot ? "home" : undefined} />
-            }
-          />
+          {params.taskId ? (
+            <>
+              {!isDecopilot && <VirtualMcpHeaderInfo virtualMcp={entity} />}
+              <NewTaskBridge
+                onNewTaskRef={onNewTask}
+                createNewTask={layout.createNewTask}
+              />
+              <ChatMainPanelGroup
+                virtualMcpId={virtualMcpId}
+                taskId={layout.taskId}
+                chatOpen={layout.chatOpen}
+                mainOpen={layout.mainOpen}
+                chatContent={
+                  <ActiveTaskBoundary
+                    variant={isDecopilot ? "home" : undefined}
+                  />
+                }
+              />
+            </>
+          ) : (
+            <HomePage />
+          )}
         </VmEventsBridge>
       </Chat.Provider>
     </InsetContext>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -8,7 +8,7 @@
  *   │   • Toolbar.TabsSlot    (portal target — main-panel tab bar)
  *   │   • Toolbar.TogglesSlot (portal target — tasks/chat)
  *   └── flex-row
- *       ├── TasksPanelColumn               (outside Suspense, 212px fixed)
+ *       ├── TasksPanelColumn               (owned by org-shell-layout)
  *       └── Suspense
  *           └── AgentInsetProvider
  *               • useVirtualMCP (suspends here)
@@ -56,7 +56,6 @@ import { useChatMainPanelState } from "@/web/hooks/use-layout-state";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { useOptionalTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
 import { Toolbar } from "./toolbar";
-import { TasksPanelColumn } from "./tasks-panel-column";
 import { ChatMainPanelGroup } from "./chat-main-panel-group";
 import { ToggleButtons } from "./toggle-buttons";
 import { MainPanelTabsBar } from "@/web/layouts/main-panel-tabs/main-panel-tabs-bar";
@@ -212,7 +211,7 @@ function VmEventsBridge({
 
 // ---------------------------------------------------------------------------
 // AgentInsetProvider — resolves virtualMcpId, provides InsetContext,
-// wraps in Chat.Provider, renders chat+main panel group.
+// wraps in Chat.Provider, renders the task-scoped chat+main panel group.
 // ---------------------------------------------------------------------------
 
 function AgentInsetProvider() {
@@ -394,61 +393,58 @@ function AgentInsetProvider() {
   }
 
   // Desktop — portal toggle buttons into outer toolbar, render chat+main group.
-  // Renders alongside <TasksPanelColumn /> as siblings inside the org-shell-layout's
-  // flex-row outlet, so this branch returns a fragment of [tasks column, content].
+  // The org-wide tasks column is owned by org-shell-layout, outside this
+  // Suspense boundary, so it stays mounted while this task-scoped content loads.
   return (
-    <>
-      <TasksPanelColumn />
-      <div className="flex-1 min-w-0 flex flex-col">
-        <InsetContext value={insetContextValue}>
-          <Toolbar.Toggles>
-            <ToggleButtons
-              chatOpen={layout.chatOpen}
-              toggleChat={layout.toggleChat}
-              onNewTask={tasksOpen ? undefined : layout.createNewTask}
-            />
-          </Toolbar.Toggles>
+    <div className="flex-1 min-w-0 flex flex-col">
+      <InsetContext value={insetContextValue}>
+        <Toolbar.Toggles>
+          <ToggleButtons
+            chatOpen={layout.chatOpen}
+            toggleChat={layout.toggleChat}
+            onNewTask={tasksOpen ? undefined : layout.createNewTask}
+          />
+        </Toolbar.Toggles>
 
-          <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-            <Toolbar.Tabs>
-              <MainPanelTabsBar
-                virtualMcpId={virtualMcpId}
-                taskId={layout.taskId}
-              />
-            </Toolbar.Tabs>
-
-            <VmEventsBridge
+        <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
+          <Toolbar.Tabs>
+            <MainPanelTabsBar
               virtualMcpId={virtualMcpId}
-              hasActiveGithubRepo={hasActiveGithubRepo}
-              vmMap={entity?.metadata?.vmMap}
-            >
-              <VirtualMcpHeaderInfo virtualMcp={entity} />
-              <NewTaskBridge
-                onNewTaskRef={onNewTask}
-                createNewTask={layout.createNewTask}
-              />
-              <ChatMainPanelGroup
-                virtualMcpId={virtualMcpId}
-                taskId={layout.taskId}
-                chatOpen={layout.chatOpen}
-                mainOpen={layout.mainOpen}
-                chatContent={<ActiveTaskBoundary />}
-              />
-            </VmEventsBridge>
-          </Chat.Provider>
-        </InsetContext>
-      </div>
-    </>
+              taskId={layout.taskId}
+            />
+          </Toolbar.Tabs>
+
+          <VmEventsBridge
+            virtualMcpId={virtualMcpId}
+            hasActiveGithubRepo={hasActiveGithubRepo}
+            vmMap={entity?.metadata?.vmMap}
+          >
+            <VirtualMcpHeaderInfo virtualMcp={entity} />
+            <NewTaskBridge
+              onNewTaskRef={onNewTask}
+              createNewTask={layout.createNewTask}
+            />
+            <ChatMainPanelGroup
+              virtualMcpId={virtualMcpId}
+              taskId={layout.taskId}
+              chatOpen={layout.chatOpen}
+              mainOpen={layout.mainOpen}
+              chatContent={<ActiveTaskBoundary />}
+            />
+          </VmEventsBridge>
+        </Chat.Provider>
+      </InsetContext>
+    </div>
   );
 }
 
 // ---------------------------------------------------------------------------
 // Default export — the per-task content for /$org/$taskId.
 //
-// Sidebar, toolbar shell, ChatPrefsProvider, and TasksPanelStateProvider all
-// live in `org-shell-layout` (the parent route). This component just renders
-// the per-task chrome inside the flex-row Outlet on desktop, or directly
-// inside SidebarInset on mobile.
+// Sidebar, toolbar shell, org-wide tasks panel, ChatPrefsProvider, and
+// TasksPanelStateProvider all live in `org-shell-layout` (the parent route).
+// This component just renders the per-task chrome inside the flex-row Outlet
+// on desktop, or directly inside SidebarInset on mobile.
 // ---------------------------------------------------------------------------
 
 export default function AgentShellLayout() {

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -294,64 +294,53 @@ function AgentInsetProvider() {
     entity,
   };
 
-  if (ensureState.status === "creating" || ensureState.status === "loading") {
-    return (
-      <InsetContext value={insetContextValue}>
-        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-          <div className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground">
-            <Loading01 className="size-4 animate-spin mr-2" />
-            Creating task…
+  // The route may transition between states (loading task → ready → loading
+  // a new task) without unmounting `Chat.Provider`. Hoisting the provider
+  // above these branches preserves TaskProvider state — notably
+  // `pendingMessage`, which the home → task autosend flow depends on.
+  const stateBranch =
+    ensureState.status === "creating" || ensureState.status === "loading" ? (
+      <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+        <div className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground">
+          <Loading01 className="size-4 animate-spin mr-2" />
+          Creating task…
+        </div>
+      </div>
+    ) : ensureState.status === "error" ? (
+      <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+        <div className="flex flex-col h-full items-center justify-center gap-2 bg-background card-shadow rounded-[0.75rem] p-8 text-sm">
+          <div className="font-medium">Task unavailable</div>
+          <div className="text-muted-foreground">
+            {ensureState.error.message}
           </div>
         </div>
-      </InsetContext>
-    );
-  }
+      </div>
+    ) : !entity ? (
+      <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+        <div className="flex flex-col h-full bg-background overflow-hidden card-shadow rounded-[0.75rem]">
+          <EmptyState
+            image={<AlertCircle size={48} className="text-muted-foreground" />}
+            title="Agent not found"
+            description={`The agent "${virtualMcpId}" does not exist in this organization.`}
+            actions={
+              <Button
+                variant="outline"
+                onClick={() =>
+                  navigate({
+                    to: "/$org",
+                    params: { org: orgSlug },
+                  })
+                }
+              >
+                Go to organization home
+              </Button>
+            }
+          />
+        </div>
+      </div>
+    ) : null;
 
-  if (ensureState.status === "error") {
-    return (
-      <InsetContext value={insetContextValue}>
-        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-          <div className="flex flex-col h-full items-center justify-center gap-2 bg-background card-shadow rounded-[0.75rem] p-8 text-sm">
-            <div className="font-medium">Task unavailable</div>
-            <div className="text-muted-foreground">
-              {ensureState.error.message}
-            </div>
-          </div>
-        </div>
-      </InsetContext>
-    );
-  }
-
-  if (!entity) {
-    return (
-      <InsetContext value={insetContextValue}>
-        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-          <div className="flex flex-col h-full bg-background overflow-hidden card-shadow rounded-[0.75rem]">
-            <EmptyState
-              image={
-                <AlertCircle size={48} className="text-muted-foreground" />
-              }
-              title="Agent not found"
-              description={`The agent "${virtualMcpId}" does not exist in this organization.`}
-              actions={
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    navigate({
-                      to: "/$org",
-                      params: { org: orgSlug },
-                    })
-                  }
-                >
-                  Go to organization home
-                </Button>
-              }
-            />
-          </div>
-        </div>
-      </InsetContext>
-    );
-  }
+  const showShell = stateBranch === null;
 
   // Mobile layout — unchanged semantics, just inlined here for clarity.
   if (isMobile) {
@@ -384,21 +373,27 @@ function AgentInsetProvider() {
       <InsetContext value={insetContextValue}>
         <div className="flex flex-col flex-1 bg-background min-h-0">
           <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-            <VmEventsBridge
-              virtualMcpId={virtualMcpId}
-              hasActiveGithubRepo={hasActiveGithubRepo}
-              vmMap={entity?.metadata?.vmMap}
-            >
-              <NewTaskBridge
-                onNewTaskRef={onNewTask}
-                createNewTask={layout.createNewTask}
-              />
-              <MobileToolbar onOpenSidebar={() => setMobileSidebarOpen(true)} />
-              <div className="flex-1 min-h-0 overflow-hidden">
-                {params.taskId ? <ActiveTaskBoundary /> : <HomePage />}
-              </div>
-              {mobileSidebarSheet}
-            </VmEventsBridge>
+            {showShell ? (
+              <VmEventsBridge
+                virtualMcpId={virtualMcpId}
+                hasActiveGithubRepo={hasActiveGithubRepo}
+                vmMap={entity?.metadata?.vmMap}
+              >
+                <NewTaskBridge
+                  onNewTaskRef={onNewTask}
+                  createNewTask={layout.createNewTask}
+                />
+                <MobileToolbar
+                  onOpenSidebar={() => setMobileSidebarOpen(true)}
+                />
+                <div className="flex-1 min-h-0 overflow-hidden">
+                  {params.taskId ? <ActiveTaskBoundary /> : <HomePage />}
+                </div>
+                {mobileSidebarSheet}
+              </VmEventsBridge>
+            ) : (
+              stateBranch
+            )}
           </Chat.Provider>
         </div>
       </InsetContext>
@@ -408,48 +403,56 @@ function AgentInsetProvider() {
   // Desktop — portal toggle buttons into outer toolbar, render chat+main group.
   return (
     <InsetContext value={insetContextValue}>
-      <Toolbar.Toggles>
-        <ToggleButtons
-          chatOpen={layout.chatOpen}
-          toggleChat={layout.toggleChat}
-          onNewTask={tasksOpen ? undefined : layout.createNewTask}
-        />
-      </Toolbar.Toggles>
+      {showShell && (
+        <Toolbar.Toggles>
+          <ToggleButtons
+            chatOpen={layout.chatOpen}
+            toggleChat={layout.toggleChat}
+            onNewTask={tasksOpen ? undefined : layout.createNewTask}
+          />
+        </Toolbar.Toggles>
+      )}
 
       <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-        {params.taskId && (
-          <Toolbar.Tabs>
-            <MainPanelTabsBar
-              virtualMcpId={virtualMcpId}
-              taskId={layout.taskId}
-            />
-          </Toolbar.Tabs>
-        )}
+        {showShell ? (
+          <>
+            {params.taskId && (
+              <Toolbar.Tabs>
+                <MainPanelTabsBar
+                  virtualMcpId={virtualMcpId}
+                  taskId={layout.taskId}
+                />
+              </Toolbar.Tabs>
+            )}
 
-        <VmEventsBridge
-          virtualMcpId={virtualMcpId}
-          hasActiveGithubRepo={hasActiveGithubRepo}
-          vmMap={entity?.metadata?.vmMap}
-        >
-          {params.taskId ? (
-            <>
-              <VirtualMcpHeaderInfo virtualMcp={entity} />
-              <NewTaskBridge
-                onNewTaskRef={onNewTask}
-                createNewTask={layout.createNewTask}
-              />
-              <ChatMainPanelGroup
-                virtualMcpId={virtualMcpId}
-                taskId={layout.taskId}
-                chatOpen={layout.chatOpen}
-                mainOpen={layout.mainOpen}
-                chatContent={<ActiveTaskBoundary />}
-              />
-            </>
-          ) : (
-            <HomePage />
-          )}
-        </VmEventsBridge>
+            <VmEventsBridge
+              virtualMcpId={virtualMcpId}
+              hasActiveGithubRepo={hasActiveGithubRepo}
+              vmMap={entity?.metadata?.vmMap}
+            >
+              {params.taskId && entity ? (
+                <>
+                  <VirtualMcpHeaderInfo virtualMcp={entity} />
+                  <NewTaskBridge
+                    onNewTaskRef={onNewTask}
+                    createNewTask={layout.createNewTask}
+                  />
+                  <ChatMainPanelGroup
+                    virtualMcpId={virtualMcpId}
+                    taskId={layout.taskId}
+                    chatOpen={layout.chatOpen}
+                    mainOpen={layout.mainOpen}
+                    chatContent={<ActiveTaskBoundary />}
+                  />
+                </>
+              ) : (
+                <HomePage />
+              )}
+            </VmEventsBridge>
+          </>
+        ) : (
+          stateBranch
+        )}
       </Chat.Provider>
     </InsetContext>
   );

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -33,13 +33,8 @@ import { ChatCenterPanel } from "@/web/layouts/chat-center-panel";
 import { TasksPanel } from "@/web/layouts/tasks-panel";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
-import { StudioSidebar, StudioSidebarMobile } from "@/web/components/sidebar";
-import {
-  SidebarInset,
-  SidebarLayout,
-  SidebarProvider,
-  useSidebar,
-} from "@deco/ui/components/sidebar.tsx";
+import { StudioSidebarMobile } from "@/web/components/sidebar";
+import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { AlertCircle, Loading01, Menu01 } from "@untitledui/icons";
@@ -59,10 +54,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { EmptyState } from "@/web/components/empty-state";
 import { useChatMainPanelState } from "@/web/hooks/use-layout-state";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
-import {
-  TasksPanelStateProvider,
-  useOptionalTasksPanelState,
-} from "@/web/hooks/use-tasks-panel-state";
+import { useOptionalTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
 import { Toolbar } from "./toolbar";
 import { TasksPanelColumn } from "./tasks-panel-column";
 import { ChatMainPanelGroup } from "./chat-main-panel-group";
@@ -72,7 +64,6 @@ import { VirtualMcpHeaderInfo } from "../../views/virtual-mcp/header-info.tsx";
 import { VmEventsProvider } from "@/web/components/vm/hooks/vm-events-context.tsx";
 import type { VmMapEntry } from "@decocms/mesh-sdk";
 import { useEnsureTask } from "@/web/hooks/use-tasks";
-import { HomePage } from "@/web/layouts/home-page";
 
 // ---------------------------------------------------------------------------
 // Types & Context
@@ -294,53 +285,61 @@ function AgentInsetProvider() {
     entity,
   };
 
-  // The route may transition between states (loading task → ready → loading
-  // a new task) without unmounting `Chat.Provider`. Hoisting the provider
-  // above these branches preserves TaskProvider state — notably
-  // `pendingMessage`, which the home → task autosend flow depends on.
-  const stateBranch =
-    ensureState.status === "creating" || ensureState.status === "loading" ? (
-      <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-        <div className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground">
-          <Loading01 className="size-4 animate-spin mr-2" />
-          Creating task…
-        </div>
-      </div>
-    ) : ensureState.status === "error" ? (
-      <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-        <div className="flex flex-col h-full items-center justify-center gap-2 bg-background card-shadow rounded-[0.75rem] p-8 text-sm">
-          <div className="font-medium">Task unavailable</div>
-          <div className="text-muted-foreground">
-            {ensureState.error.message}
+  if (ensureState.status === "creating" || ensureState.status === "loading") {
+    return (
+      <InsetContext value={insetContextValue}>
+        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+          <div className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground">
+            <Loading01 className="size-4 animate-spin mr-2" />
+            Creating task…
           </div>
         </div>
-      </div>
-    ) : !entity ? (
-      <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-        <div className="flex flex-col h-full bg-background overflow-hidden card-shadow rounded-[0.75rem]">
-          <EmptyState
-            image={<AlertCircle size={48} className="text-muted-foreground" />}
-            title="Agent not found"
-            description={`The agent "${virtualMcpId}" does not exist in this organization.`}
-            actions={
-              <Button
-                variant="outline"
-                onClick={() =>
-                  navigate({
-                    to: "/$org",
-                    params: { org: orgSlug },
-                  })
-                }
-              >
-                Go to organization home
-              </Button>
-            }
-          />
-        </div>
-      </div>
-    ) : null;
+      </InsetContext>
+    );
+  }
 
-  const showShell = stateBranch === null;
+  if (ensureState.status === "error") {
+    return (
+      <InsetContext value={insetContextValue}>
+        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+          <div className="flex flex-col h-full items-center justify-center gap-2 bg-background card-shadow rounded-[0.75rem] p-8 text-sm">
+            <div className="font-medium">Task unavailable</div>
+            <div className="text-muted-foreground">
+              {ensureState.error.message}
+            </div>
+          </div>
+        </div>
+      </InsetContext>
+    );
+  }
+
+  if (!entity) {
+    return (
+      <InsetContext value={insetContextValue}>
+        <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+          <div className="flex flex-col h-full bg-background overflow-hidden card-shadow rounded-[0.75rem]">
+            <EmptyState
+              image={
+                <AlertCircle size={48} className="text-muted-foreground" />
+              }
+              title="Agent not found"
+              description={`The agent "${virtualMcpId}" does not exist in this organization.`}
+              actions={
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    navigate({ to: "/$org", params: { org: orgSlug } })
+                  }
+                >
+                  Go to organization home
+                </Button>
+              }
+            />
+          </div>
+        </div>
+      </InsetContext>
+    );
+  }
 
   // Mobile layout — unchanged semantics, just inlined here for clarity.
   if (isMobile) {
@@ -373,27 +372,21 @@ function AgentInsetProvider() {
       <InsetContext value={insetContextValue}>
         <div className="flex flex-col flex-1 bg-background min-h-0">
           <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-            {showShell ? (
-              <VmEventsBridge
-                virtualMcpId={virtualMcpId}
-                hasActiveGithubRepo={hasActiveGithubRepo}
-                vmMap={entity?.metadata?.vmMap}
-              >
-                <NewTaskBridge
-                  onNewTaskRef={onNewTask}
-                  createNewTask={layout.createNewTask}
-                />
-                <MobileToolbar
-                  onOpenSidebar={() => setMobileSidebarOpen(true)}
-                />
-                <div className="flex-1 min-h-0 overflow-hidden">
-                  {params.taskId ? <ActiveTaskBoundary /> : <HomePage />}
-                </div>
-                {mobileSidebarSheet}
-              </VmEventsBridge>
-            ) : (
-              stateBranch
-            )}
+            <VmEventsBridge
+              virtualMcpId={virtualMcpId}
+              hasActiveGithubRepo={hasActiveGithubRepo}
+              vmMap={entity?.metadata?.vmMap}
+            >
+              <NewTaskBridge
+                onNewTaskRef={onNewTask}
+                createNewTask={layout.createNewTask}
+              />
+              <MobileToolbar onOpenSidebar={() => setMobileSidebarOpen(true)} />
+              <div className="flex-1 min-h-0 overflow-hidden">
+                <ActiveTaskBoundary />
+              </div>
+              {mobileSidebarSheet}
+            </VmEventsBridge>
           </Chat.Provider>
         </div>
       </InsetContext>
@@ -401,150 +394,73 @@ function AgentInsetProvider() {
   }
 
   // Desktop — portal toggle buttons into outer toolbar, render chat+main group.
+  // Renders alongside <TasksPanelColumn /> as siblings inside the org-shell-layout's
+  // flex-row outlet, so this branch returns a fragment of [tasks column, content].
   return (
-    <InsetContext value={insetContextValue}>
-      {showShell && (
-        <Toolbar.Toggles>
-          <ToggleButtons
-            chatOpen={layout.chatOpen}
-            toggleChat={layout.toggleChat}
-            onNewTask={tasksOpen ? undefined : layout.createNewTask}
-          />
-        </Toolbar.Toggles>
-      )}
+    <>
+      <TasksPanelColumn />
+      <div className="flex-1 min-w-0 flex flex-col">
+        <InsetContext value={insetContextValue}>
+          <Toolbar.Toggles>
+            <ToggleButtons
+              chatOpen={layout.chatOpen}
+              toggleChat={layout.toggleChat}
+              onNewTask={tasksOpen ? undefined : layout.createNewTask}
+            />
+          </Toolbar.Toggles>
 
-      <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
-        {showShell ? (
-          <>
-            {params.taskId && (
-              <Toolbar.Tabs>
-                <MainPanelTabsBar
-                  virtualMcpId={virtualMcpId}
-                  taskId={layout.taskId}
-                />
-              </Toolbar.Tabs>
-            )}
+          <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
+            <Toolbar.Tabs>
+              <MainPanelTabsBar
+                virtualMcpId={virtualMcpId}
+                taskId={layout.taskId}
+              />
+            </Toolbar.Tabs>
 
             <VmEventsBridge
               virtualMcpId={virtualMcpId}
               hasActiveGithubRepo={hasActiveGithubRepo}
               vmMap={entity?.metadata?.vmMap}
             >
-              {params.taskId && entity ? (
-                <>
-                  <VirtualMcpHeaderInfo virtualMcp={entity} />
-                  <NewTaskBridge
-                    onNewTaskRef={onNewTask}
-                    createNewTask={layout.createNewTask}
-                  />
-                  <ChatMainPanelGroup
-                    virtualMcpId={virtualMcpId}
-                    taskId={layout.taskId}
-                    chatOpen={layout.chatOpen}
-                    mainOpen={layout.mainOpen}
-                    chatContent={<ActiveTaskBoundary />}
-                  />
-                </>
-              ) : (
-                <HomePage />
-              )}
+              <VirtualMcpHeaderInfo virtualMcp={entity} />
+              <NewTaskBridge
+                onNewTaskRef={onNewTask}
+                createNewTask={layout.createNewTask}
+              />
+              <ChatMainPanelGroup
+                virtualMcpId={virtualMcpId}
+                taskId={layout.taskId}
+                chatOpen={layout.chatOpen}
+                mainOpen={layout.mainOpen}
+                chatContent={<ActiveTaskBoundary />}
+              />
             </VmEventsBridge>
-          </>
-        ) : (
-          stateBranch
-        )}
-      </Chat.Provider>
-    </InsetContext>
+          </Chat.Provider>
+        </InsetContext>
+      </div>
+    </>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Default export — the shell layout component for agent routes
+// Default export — the per-task content for /$org/$taskId.
+//
+// Sidebar, toolbar shell, ChatPrefsProvider, and TasksPanelStateProvider all
+// live in `org-shell-layout` (the parent route). This component just renders
+// the per-task chrome inside the flex-row Outlet on desktop, or directly
+// inside SidebarInset on mobile.
 // ---------------------------------------------------------------------------
 
 export default function AgentShellLayout() {
-  const isMobile = useIsMobile();
-
   return (
-    <SidebarProvider defaultOpen={false}>
-      <div className="flex flex-col h-dvh overflow-hidden">
-        <SidebarLayout
-          className="flex-1 bg-sidebar"
-          style={
-            {
-              "--sidebar-width-icon": "3.5rem",
-            } as Record<string, string>
-          }
-        >
-          <StudioSidebar />
-          <SidebarInset
-            className="flex flex-col"
-            style={{
-              background: "transparent",
-              containerType: "inline-size",
-            }}
-          >
-            {isMobile ? (
-              <Suspense
-                fallback={
-                  <div className="flex-1 flex items-center justify-center">
-                    <Loading01
-                      size={20}
-                      className="animate-spin text-muted-foreground"
-                    />
-                  </div>
-                }
-              >
-                <AgentInsetProvider />
-              </Suspense>
-            ) : (
-              <Suspense
-                fallback={
-                  <div className="flex-1 flex items-center justify-center">
-                    <Loading01
-                      size={20}
-                      className="animate-spin text-muted-foreground"
-                    />
-                  </div>
-                }
-              >
-                <TasksPanelStateProvider>
-                  <Toolbar>
-                    <Toolbar.Header>
-                      <Toolbar.LeftColumn>
-                        <Toolbar.Nav />
-                        <Toolbar.TogglesSlot />
-                      </Toolbar.LeftColumn>
-                      <Toolbar.CenterSlot />
-                      <Toolbar.RightColumn>
-                        <Toolbar.TabsSlot />
-                        <Toolbar.RightSlot />
-                      </Toolbar.RightColumn>
-                    </Toolbar.Header>
-                    <div className="flex-1 min-h-0 flex flex-row">
-                      <TasksPanelColumn />
-                      <div className="flex-1 min-w-0 flex flex-col">
-                        <Suspense
-                          fallback={
-                            <div className="flex-1 flex items-center justify-center">
-                              <Loading01
-                                size={20}
-                                className="animate-spin text-muted-foreground"
-                              />
-                            </div>
-                          }
-                        >
-                          <AgentInsetProvider />
-                        </Suspense>
-                      </div>
-                    </div>
-                  </Toolbar>
-                </TasksPanelStateProvider>
-              </Suspense>
-            )}
-          </SidebarInset>
-        </SidebarLayout>
-      </div>
-    </SidebarProvider>
+    <Suspense
+      fallback={
+        <div className="flex-1 flex items-center justify-center">
+          <Loading01 size={20} className="animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <AgentInsetProvider />
+    </Suspense>
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -1,14 +1,10 @@
 /**
  * ToggleButtons — left/right panel toggles portal'd into the outer Toolbar.
  *
- * Layout differs by virtual MCP:
- *   - Non-decopilot agents: tasks + chat toggles (main panel opens/closes
- *     via the header tab bar).
- *   - Decopilot: tasks toggle only (no layout icon on home).
- *
- * When the tasks panel is closed, an additional "new task" button slides
- * in via a grid-cols animation so the shortcut is always reachable
- * without stealing visual weight when tasks are already visible.
+ * Renders the tasks toggle, chat toggle, and (when armed) the new-task
+ * button. When the tasks panel is closed, the new-task button slides in
+ * via a grid-cols animation so the shortcut is always reachable without
+ * stealing visual weight when tasks are already visible.
  */
 
 import { Edit05, Menu02, MessageCircle01 } from "@untitledui/icons";
@@ -22,7 +18,8 @@ import { useTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
 import { track } from "@/web/lib/posthog-client";
 
 export interface ToggleButtonsProps {
-  isDecopilot: boolean;
+  /** @deprecated unused after home/decopilot decoupling — removed in next commit */
+  isDecopilot?: boolean;
   chatOpen: boolean;
   toggleChat: () => void;
   /** When set, reveals an animated "new task" button next to the chat toggle. */
@@ -36,7 +33,6 @@ const TOGGLE_INACTIVE =
   "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground";
 
 export function ToggleButtons({
-  isDecopilot,
   chatOpen,
   toggleChat,
   onNewTask,
@@ -68,30 +64,28 @@ export function ToggleButtons({
         </TooltipTrigger>
         <TooltipContent side="bottom">Tasks</TooltipContent>
       </Tooltip>
-      {!isDecopilot && (
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => {
-                track("agent_toolbar_toggled", {
-                  button: "chat",
-                  next_state: !chatOpen ? "open" : "closed",
-                });
-                toggleChat();
-              }}
-              aria-pressed={chatOpen}
-              className={cn(
-                TOGGLE_BASE,
-                chatOpen ? TOGGLE_ACTIVE : TOGGLE_INACTIVE,
-              )}
-            >
-              <MessageCircle01 size={16} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Chat</TooltipContent>
-        </Tooltip>
-      )}
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => {
+              track("agent_toolbar_toggled", {
+                button: "chat",
+                next_state: !chatOpen ? "open" : "closed",
+              });
+              toggleChat();
+            }}
+            aria-pressed={chatOpen}
+            className={cn(
+              TOGGLE_BASE,
+              chatOpen ? TOGGLE_ACTIVE : TOGGLE_INACTIVE,
+            )}
+          >
+            <MessageCircle01 size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Chat</TooltipContent>
+      </Tooltip>
       <div
         className={cn(
           "grid transition-[grid-template-columns] duration-200 ease-[var(--ease-out-quart)]",

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -18,8 +18,6 @@ import { useTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
 import { track } from "@/web/lib/posthog-client";
 
 export interface ToggleButtonsProps {
-  /** @deprecated unused after home/decopilot decoupling — removed in next commit */
-  isDecopilot?: boolean;
   chatOpen: boolean;
   toggleChat: () => void;
   /** When set, reveals an animated "new task" button next to the chat toggle. */

--- a/apps/mesh/src/web/layouts/chat-center-panel/index.tsx
+++ b/apps/mesh/src/web/layouts/chat-center-panel/index.tsx
@@ -1,9 +1,6 @@
 /**
  * ChatCenterPanel — center-panel entry point for the unified chat layout.
  *
- * Thin wrapper around the existing `ChatPanel` implementation. `variant="home"`
- * is handed to the panel for the decopilot (org-home) case; otherwise the
- * default sidebar empty state is used. The three-panel shell in
- * `agent-shell-layout` wires the appropriate variant.
+ * Thin wrapper around the existing `ChatPanel` implementation.
  */
 export { ChatPanel as ChatCenterPanel } from "@/web/components/chat/side-panel-chat";

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,6 +1,5 @@
 import { AgentsList } from "@/web/components/home/agents-list.tsx";
 import { Chat } from "@/web/components/chat";
-import { IdleChatStreamProvider } from "@/web/components/chat/chat-context";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { authClient } from "@/web/lib/auth-client";
@@ -75,14 +74,6 @@ function useIsDecoUser() {
 }
 
 export function HomePage() {
-  return (
-    <IdleChatStreamProvider>
-      <HomePageContent />
-    </IdleChatStreamProvider>
-  );
-}
-
-function HomePageContent() {
   const { data: session } = authClient.useSession();
   const [importOpen, setImportOpen] = useState(false);
   const isDecoUser = useIsDecoUser();

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,5 +1,6 @@
 import { AgentsList } from "@/web/components/home/agents-list.tsx";
 import { Chat } from "@/web/components/chat";
+import { IdleChatStreamProvider } from "@/web/components/chat/chat-context";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { authClient } from "@/web/lib/auth-client";
@@ -74,6 +75,14 @@ function useIsDecoUser() {
 }
 
 export function HomePage() {
+  return (
+    <IdleChatStreamProvider>
+      <HomePageContent />
+    </IdleChatStreamProvider>
+  );
+}
+
+function HomePageContent() {
   const { data: session } = authClient.useSession();
   const [importOpen, setImportOpen] = useState(false);
   const isDecoUser = useIsDecoUser();

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,0 +1,169 @@
+import { AgentsList } from "@/web/components/home/agents-list.tsx";
+import { Chat } from "@/web/components/chat";
+import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
+import { IntegrationIcon } from "@/web/components/integration-icon";
+import { authClient } from "@/web/lib/auth-client";
+import { KEYS } from "@/web/lib/query-keys";
+import { useDecoCredits } from "@/web/hooks/use-deco-credits";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { ArrowRight } from "@untitledui/icons";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+const DECO_BANNER_GRADIENT = [
+  "radial-gradient(ellipse 25% 220% at -5% 120%, rgba(165,149,255,0.35) 0%, transparent 100%)",
+  "radial-gradient(ellipse 25% 220% at 105% -20%, rgba(208,236,26,0.32) 0%, transparent 100%)",
+].join(", ");
+const DECO_BANNER_TEXTURE = "/decotexture.svg";
+
+function ImportDecoSiteBanner({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full relative flex items-center gap-4 px-4 py-4 rounded-lg border border-border bg-background overflow-hidden transition-colors text-left cursor-pointer group"
+      style={{ backgroundImage: DECO_BANNER_GRADIENT }}
+    >
+      <div className="relative shrink-0 p-1.5 bg-[var(--brand-green-light)] rounded-lg border border-border">
+        <IntegrationIcon
+          icon="/logos/deco%20logo.svg"
+          name="deco.cx"
+          size="xs"
+          className="border-0 rounded-none bg-transparent"
+        />
+      </div>
+      <p className="flex-1 relative text-sm font-medium text-foreground leading-none whitespace-nowrap">
+        Import your deco.cx site
+      </p>
+      <img
+        src={DECO_BANNER_TEXTURE}
+        alt=""
+        aria-hidden
+        className="absolute pointer-events-none"
+        style={{
+          width: "274.5px",
+          height: "272.25px",
+          left: "calc(50% + 145.5px)",
+          top: "calc(50% + 40px)",
+          transform: "translate(-50%, -50%)",
+        }}
+      />
+      <div className="relative bg-background flex items-center justify-center size-8 rounded-md shrink-0">
+        <ArrowRight
+          size={16}
+          className="text-foreground transition-transform group-hover:translate-x-0.5"
+        />
+      </div>
+    </button>
+  );
+}
+
+function useIsDecoUser() {
+  const { data: session } = authClient.useSession();
+  const { data } = useQuery({
+    queryKey: KEYS.decoProfile(session?.user?.email),
+    queryFn: async () => {
+      const res = await fetch("/api/deco-sites/profile");
+      if (!res.ok) return { isDecoUser: false };
+      return res.json() as Promise<{ isDecoUser: boolean }>;
+    },
+    enabled: Boolean(session?.user?.email),
+    staleTime: 5 * 60_000,
+  });
+  return data?.isDecoUser ?? false;
+}
+
+export function HomePage() {
+  const { data: session } = authClient.useSession();
+  const [importOpen, setImportOpen] = useState(false);
+  const isDecoUser = useIsDecoUser();
+  const isMobile = useIsMobile();
+  const {
+    hasDecoKey,
+    isZeroBalance,
+    isInitialFreeCredit,
+    balanceDollars,
+    hasOnlyDecoProvider,
+  } = useDecoCredits();
+
+  const userName = session?.user?.name?.split(" ")[0] || "there";
+
+  const showEyebrow =
+    hasDecoKey && isInitialFreeCredit && balanceDollars != null;
+  const showNoCreditsEyebrow =
+    hasDecoKey && isZeroBalance && hasOnlyDecoProvider;
+
+  if (isMobile) {
+    return (
+      <>
+        <div className="flex-1 relative flex flex-col items-center px-4">
+          <div className="flex-1 flex flex-col items-center justify-center w-full">
+            {showEyebrow && (
+              <div className="mb-4">
+                <Chat.CreditsEyebrow balanceDollars={balanceDollars} />
+              </div>
+            )}
+            {showNoCreditsEyebrow && (
+              <div className="mb-4">
+                <Chat.NoCreditsEyebrow />
+              </div>
+            )}
+            <p className="text-3xl font-medium text-foreground text-center max-w-[280px]">
+              What's on your mind, {userName}?
+            </p>
+          </div>
+          <div className="w-full flex flex-col gap-4 pb-4">
+            <AgentsList />
+            <Chat.Input showConnectionsBanner />
+          </div>
+          {isDecoUser && (
+            <div className="w-full">
+              <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
+            </div>
+          )}
+        </div>
+        <ImportFromDecoDialog open={importOpen} onOpenChange={setImportOpen} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex-1 relative flex flex-col items-center px-10">
+        <div className="flex-1 flex flex-col items-center justify-center w-full">
+          <div className="flex flex-col items-center w-full max-w-[672px]">
+            <div className="text-center mb-10">
+              {showEyebrow && (
+                <div className="mb-4">
+                  <Chat.CreditsEyebrow balanceDollars={balanceDollars} />
+                </div>
+              )}
+              {showNoCreditsEyebrow && (
+                <div className="mb-4">
+                  <Chat.NoCreditsEyebrow />
+                </div>
+              )}
+              <p className="text-3xl font-medium text-foreground">
+                What's on your mind, {userName}?
+              </p>
+            </div>
+            <div className="w-full">
+              <Chat.Input showConnectionsBanner />
+            </div>
+          </div>
+          <div className="w-full mt-10 mx-auto">
+            <AgentsList />
+          </div>
+        </div>
+        {isDecoUser && (
+          <div className="absolute bottom-6 left-0 right-0 px-10">
+            <div className="w-full max-w-[500px] mx-auto">
+              <ImportDecoSiteBanner onClick={() => setImportOpen(true)} />
+            </div>
+          </div>
+        )}
+      </div>
+      <ImportFromDecoDialog open={importOpen} onOpenChange={setImportOpen} />
+    </>
+  );
+}

--- a/apps/mesh/src/web/layouts/org-home/index.tsx
+++ b/apps/mesh/src/web/layouts/org-home/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * OrgHome — leaf component for /$org/. Renders HomePage inside the same
+ * panel chrome the chat surface uses, full-bleed (no chat-main split).
+ *
+ * No Chat.Provider, no ActiveTaskProvider — the home composer is wired
+ * to the home submit path (URL autosend handoff) via Chat.Input's
+ * optional-context fallback.
+ */
+
+import { HomePage } from "@/web/layouts/home-page";
+
+export default function OrgHome() {
+  return (
+    <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+      <div className="flex h-full flex-col bg-background overflow-hidden card-shadow rounded-[0.75rem]">
+        <HomePage />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/org-home/index.tsx
+++ b/apps/mesh/src/web/layouts/org-home/index.tsx
@@ -11,7 +11,7 @@ import { HomePage } from "@/web/layouts/home-page";
 
 export default function OrgHome() {
   return (
-    <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
+    <div className="flex-1 min-h-0 p-1.5 overflow-hidden">
       <div className="flex h-full flex-col bg-background overflow-hidden card-shadow rounded-[0.75rem]">
         <HomePage />
       </div>

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -1,0 +1,86 @@
+/**
+ * Org Shell Layout
+ *
+ * Shared parent for `/$org/` (home) and `/$org/$taskId` (chat). Owns the
+ * sidebar + toolbar shell + ChatPrefsProvider. Per-task chrome (toggles,
+ * tabs, tasks panel, Chat.Provider) lives in agent-shell-layout, which
+ * sits below this one in the route tree.
+ */
+
+import { Suspense } from "react";
+import {
+  SidebarInset,
+  SidebarLayout,
+  SidebarProvider,
+} from "@deco/ui/components/sidebar.tsx";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { Loading01 } from "@untitledui/icons";
+import { Outlet } from "@tanstack/react-router";
+import { StudioSidebar } from "@/web/components/sidebar";
+import { ChatPrefsProvider } from "@/web/components/chat/context";
+import { TasksPanelStateProvider } from "@/web/hooks/use-tasks-panel-state";
+import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
+
+export default function OrgShellLayout() {
+  const isMobile = useIsMobile();
+
+  return (
+    <SidebarProvider defaultOpen={false}>
+      <div className="flex flex-col h-dvh overflow-hidden">
+        <SidebarLayout
+          className="flex-1 bg-sidebar"
+          style={
+            {
+              "--sidebar-width-icon": "3.5rem",
+            } as Record<string, string>
+          }
+        >
+          <StudioSidebar />
+          <SidebarInset
+            className="flex flex-col"
+            style={{
+              background: "transparent",
+              containerType: "inline-size",
+            }}
+          >
+            <ChatPrefsProvider>
+              <TasksPanelStateProvider>
+                <Suspense
+                  fallback={
+                    <div className="flex-1 flex items-center justify-center">
+                      <Loading01
+                        size={20}
+                        className="animate-spin text-muted-foreground"
+                      />
+                    </div>
+                  }
+                >
+                  {isMobile ? (
+                    <Outlet />
+                  ) : (
+                    <Toolbar>
+                      <Toolbar.Header>
+                        <Toolbar.LeftColumn>
+                          <Toolbar.Nav />
+                          <Toolbar.TogglesSlot />
+                        </Toolbar.LeftColumn>
+                        <Toolbar.CenterSlot />
+                        <Toolbar.RightColumn>
+                          <Toolbar.TabsSlot />
+                          <Toolbar.RightSlot />
+                        </Toolbar.RightColumn>
+                      </Toolbar.Header>
+                      <div className="flex-1 min-h-0 flex flex-row">
+                        <Outlet />
+                      </div>
+                    </Toolbar>
+                  )}
+                </Suspense>
+              </TasksPanelStateProvider>
+            </ChatPrefsProvider>
+          </SidebarInset>
+        </SidebarLayout>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -2,9 +2,9 @@
  * Org Shell Layout
  *
  * Shared parent for `/$org/` (home) and `/$org/$taskId` (chat). Owns the
- * sidebar + toolbar shell + ChatPrefsProvider. Per-task chrome (toggles,
- * tabs, tasks panel, Chat.Provider) lives in agent-shell-layout, which
- * sits below this one in the route tree.
+ * sidebar + toolbar shell + ChatPrefsProvider. The org-wide tasks panel lives
+ * here, outside child-route Suspense, so it stays mounted while the active
+ * task/chat content switches.
  */
 
 import { Suspense } from "react";
@@ -15,14 +15,25 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { Loading01 } from "@untitledui/icons";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useParams } from "@tanstack/react-router";
 import { StudioSidebar } from "@/web/components/sidebar";
 import { ChatPrefsProvider } from "@/web/components/chat/context";
 import { TasksPanelStateProvider } from "@/web/hooks/use-tasks-panel-state";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
+import { TasksPanelColumn } from "@/web/layouts/agent-shell-layout/tasks-panel-column";
+
+function RouteFallback() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <Loading01 size={20} className="animate-spin text-muted-foreground" />
+    </div>
+  );
+}
 
 export default function OrgShellLayout() {
   const isMobile = useIsMobile();
+  const params = useParams({ strict: false }) as { taskId?: string };
+  const hasTaskRoute = Boolean(params.taskId);
 
   return (
     <SidebarProvider defaultOpen={false}>
@@ -45,37 +56,31 @@ export default function OrgShellLayout() {
           >
             <ChatPrefsProvider>
               <TasksPanelStateProvider>
-                <Suspense
-                  fallback={
-                    <div className="flex-1 flex items-center justify-center">
-                      <Loading01
-                        size={20}
-                        className="animate-spin text-muted-foreground"
-                      />
-                    </div>
-                  }
-                >
-                  {isMobile ? (
+                {isMobile ? (
+                  <Suspense fallback={<RouteFallback />}>
                     <Outlet />
-                  ) : (
-                    <Toolbar>
-                      <Toolbar.Header>
-                        <Toolbar.LeftColumn>
-                          <Toolbar.Nav />
-                          <Toolbar.TogglesSlot />
-                        </Toolbar.LeftColumn>
-                        <Toolbar.CenterSlot />
-                        <Toolbar.RightColumn>
-                          <Toolbar.TabsSlot />
-                          <Toolbar.RightSlot />
-                        </Toolbar.RightColumn>
-                      </Toolbar.Header>
-                      <div className="flex-1 min-h-0 flex flex-row">
+                  </Suspense>
+                ) : (
+                  <Toolbar>
+                    <Toolbar.Header>
+                      <Toolbar.LeftColumn>
+                        <Toolbar.Nav />
+                        <Toolbar.TogglesSlot />
+                      </Toolbar.LeftColumn>
+                      <Toolbar.CenterSlot />
+                      <Toolbar.RightColumn>
+                        <Toolbar.TabsSlot />
+                        <Toolbar.RightSlot />
+                      </Toolbar.RightColumn>
+                    </Toolbar.Header>
+                    <div className="flex-1 min-h-0 flex flex-row">
+                      {hasTaskRoute && <TasksPanelColumn />}
+                      <Suspense fallback={<RouteFallback />}>
                         <Outlet />
-                      </div>
-                    </Toolbar>
-                  )}
-                </Suspense>
+                      </Suspense>
+                    </div>
+                  </Toolbar>
+                )}
               </TasksPanelStateProvider>
             </ChatPrefsProvider>
           </SidebarInset>

--- a/apps/mesh/src/web/layouts/tasks-panel/index.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/index.tsx
@@ -81,7 +81,7 @@ function TasksPanelContent() {
   }
 
   return (
-    <div className="flex flex-col h-full min-h-0 overflow-y-auto p-2 gap-3">
+    <div className="flex flex-col h-full min-h-0 p-2 gap-3">
       <TasksSection
         title="Tasks"
         tasks={allTasks}

--- a/apps/mesh/src/web/layouts/tasks-panel/task-row.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/task-row.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@deco/ui/lib/utils.js";
 import { Archive } from "@untitledui/icons";
+import { useEffect, useRef } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -29,9 +30,25 @@ export function TaskRow({
   const StatusIcon = config.icon;
   const virtualMcp = useVirtualMCP(task.virtual_mcp_id);
   const githubRepo = getActiveGithubRepo(virtualMcp);
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- syncs route-selected task row with the scrollable tasks panel DOM
+  useEffect(() => {
+    if (!isActive) return;
+    const row = rowRef.current;
+    if (!row) return;
+
+    row.focus({ preventScroll: true });
+    row.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+      inline: "nearest",
+    });
+  }, [isActive, task.id]);
 
   return (
     <div
+      ref={rowRef}
       role="button"
       tabIndex={0}
       onClick={onClick}

--- a/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
+++ b/apps/mesh/src/web/layouts/tasks-panel/tasks-section.tsx
@@ -65,8 +65,8 @@ export function TasksSection({
         : memberFiltered;
 
   return (
-    <div className="flex flex-col gap-0.5 mt-1">
-      <div className="pl-2 pr-1.5 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
+    <div className="flex flex-col h-full min-h-0 mt-1">
+      <div className="shrink-0 pl-2 pr-1.5 h-7 flex items-center justify-between text-xs font-medium text-muted-foreground mb-1">
         <span>{title}</span>
         <div className="flex items-center gap-0.5">
           <DropdownMenu>
@@ -153,37 +153,39 @@ export function TasksSection({
           )}
         </div>
       </div>
-      {visibleTasks.length === 0 && emptyLabel ? (
-        <div className="px-2 py-1.5 text-xs text-muted-foreground/70">
-          {emptyLabel}
-        </div>
-      ) : (
-        visibleTasks.map((t) => (
-          <TaskRow
-            key={t.id}
-            task={t}
-            isActive={activeTaskId === t.id}
-            onClick={() => {
-              if (activeTaskId !== t.id) {
-                track("tasks_panel_task_clicked", {
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
+        {visibleTasks.length === 0 && emptyLabel ? (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground/70">
+            {emptyLabel}
+          </div>
+        ) : (
+          visibleTasks.map((t) => (
+            <TaskRow
+              key={t.id}
+              task={t}
+              isActive={activeTaskId === t.id}
+              onClick={() => {
+                if (activeTaskId !== t.id) {
+                  track("tasks_panel_task_clicked", {
+                    thread_id: t.id,
+                    virtual_mcp_id: t.virtual_mcp_id ?? null,
+                    from_automation: Boolean(t.fromAutomation),
+                  });
+                }
+                onSelect(t);
+              }}
+              onArchive={() => {
+                track("tasks_panel_task_archived", {
                   thread_id: t.id,
                   virtual_mcp_id: t.virtual_mcp_id ?? null,
-                  from_automation: Boolean(t.fromAutomation),
                 });
-              }
-              onSelect(t);
-            }}
-            onArchive={() => {
-              track("tasks_panel_task_archived", {
-                thread_id: t.id,
-                virtual_mcp_id: t.virtual_mcp_id ?? null,
-              });
-              onArchive(t);
-            }}
-            showAutomationBadge={showAutomationBadge || t.fromAutomation}
-          />
-        ))
-      )}
+                onArchive(t);
+              }}
+              showAutomationBadge={showAutomationBadge || t.fromAutomation}
+            />
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/mesh/src/web/lib/autosend.test.ts
+++ b/apps/mesh/src/web/lib/autosend.test.ts
@@ -1,60 +1,142 @@
 import { describe, expect, test } from "bun:test";
 import {
   AUTOSEND_TTL_MS,
-  decodeAutosend,
-  encodeAutosend,
+  AUTOSEND_QUERY_VALUE,
+  autosendStorageKey,
+  claimStoredAutosend,
+  markStoredAutosendSent,
+  readStoredAutosend,
+  writeStoredAutosend,
   type AutosendPayload,
 } from "./autosend";
 
-describe("autosend encode/decode", () => {
-  test("round-trips a simple payload", () => {
+class MemoryStorage {
+  private items = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+}
+
+describe("autosend storage", () => {
+  test("writes and reads a pending payload", () => {
+    const storage = new MemoryStorage();
     const payload: AutosendPayload = {
       message: { tiptapDoc: { type: "doc", content: [] } },
       createdAt: 1_700_000_000_000,
     };
-    const encoded = encodeAutosend(payload);
-    expect(typeof encoded).toBe("string");
-    expect(encoded).not.toContain("=");
-    expect(encoded).not.toContain("/");
-    expect(encoded).not.toContain("+");
-    const decoded = decodeAutosend(encoded);
-    expect(decoded).toEqual(payload);
+
+    writeStoredAutosend(
+      storage,
+      "org/project",
+      "task-1",
+      payload.message,
+      payload.createdAt,
+    );
+
+    expect(readStoredAutosend(storage, "org/project", "task-1")).toEqual({
+      ...payload,
+      status: "pending",
+    });
   });
 
-  test("round-trips a payload with non-ASCII text", () => {
+  test("claim switches pending payload to sending", () => {
+    const storage = new MemoryStorage();
     const payload: AutosendPayload = {
-      message: {
-        tiptapDoc: {
-          type: "doc",
-          content: [
-            {
-              type: "paragraph",
-              content: [{ type: "text", text: "olá — café 🚀" }],
-            },
-          ],
-        },
-      },
-      createdAt: Date.now(),
+      message: { tiptapDoc: { type: "doc", content: [] } },
+      createdAt: 1_700_000_000_000,
     };
-    const decoded = decodeAutosend(encodeAutosend(payload));
-    expect(decoded).toEqual(payload);
+
+    writeStoredAutosend(
+      storage,
+      "org/project",
+      "task-1",
+      payload.message,
+      payload.createdAt,
+    );
+
+    expect(
+      claimStoredAutosend(storage, "org/project", "task-1", payload.createdAt),
+    ).toEqual(payload);
+    expect(readStoredAutosend(storage, "org/project", "task-1")?.status).toBe(
+      "sending",
+    );
   });
 
-  test("returns null for invalid base64", () => {
-    expect(decodeAutosend("not!!!base64")).toBeNull();
+  test("claim ignores non-pending payloads", () => {
+    const storage = new MemoryStorage();
+    writeStoredAutosend(
+      storage,
+      "org/project",
+      "task-1",
+      { tiptapDoc: { type: "doc", content: [] } },
+      1_700_000_000_000,
+    );
+    claimStoredAutosend(storage, "org/project", "task-1", 1_700_000_000_000);
+
+    expect(
+      claimStoredAutosend(storage, "org/project", "task-1", 1_700_000_000_000),
+    ).toBeNull();
   });
 
-  test("returns null for valid base64 but invalid JSON", () => {
-    const encoded = btoa("not json").replace(/=+$/, "");
-    expect(decodeAutosend(encoded)).toBeNull();
+  test("claim removes stale payloads", () => {
+    const storage = new MemoryStorage();
+    writeStoredAutosend(
+      storage,
+      "org/project",
+      "task-1",
+      { tiptapDoc: { type: "doc", content: [] } },
+      1_700_000_000_000,
+    );
+
+    expect(
+      claimStoredAutosend(
+        storage,
+        "org/project",
+        "task-1",
+        1_700_000_000_000 + AUTOSEND_TTL_MS,
+      ),
+    ).toBeNull();
+    expect(readStoredAutosend(storage, "org/project", "task-1")).toBeNull();
   });
 
-  test("returns null when shape is wrong", () => {
-    const encoded = btoa(JSON.stringify({ foo: 1 })).replace(/=+$/, "");
-    expect(decodeAutosend(encoded)).toBeNull();
+  test("mark sent stores sent status", () => {
+    const storage = new MemoryStorage();
+    writeStoredAutosend(
+      storage,
+      "org/project",
+      "task-1",
+      { tiptapDoc: { type: "doc", content: [] } },
+      1_700_000_000_000,
+    );
+
+    markStoredAutosendSent(storage, "org/project", "task-1");
+
+    expect(readStoredAutosend(storage, "org/project", "task-1")?.status).toBe(
+      "sent",
+    );
   });
 
-  test("AUTOSEND_TTL_MS is 10 seconds", () => {
+  test("invalid stored JSON is removed", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(autosendStorageKey("org/project", "task-1"), "not json");
+
+    expect(readStoredAutosend(storage, "org/project", "task-1")).toBeNull();
+    expect(storage.getItem(autosendStorageKey("org/project", "task-1"))).toBe(
+      null,
+    );
+  });
+
+  test("constants match expected URL handoff", () => {
     expect(AUTOSEND_TTL_MS).toBe(10_000);
+    expect(AUTOSEND_QUERY_VALUE).toBe("true");
   });
 });

--- a/apps/mesh/src/web/lib/autosend.test.ts
+++ b/apps/mesh/src/web/lib/autosend.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AUTOSEND_TTL_MS,
+  decodeAutosend,
+  encodeAutosend,
+  type AutosendPayload,
+} from "./autosend";
+
+describe("autosend encode/decode", () => {
+  test("round-trips a simple payload", () => {
+    const payload: AutosendPayload = {
+      message: { tiptapDoc: { type: "doc", content: [] } },
+      createdAt: 1_700_000_000_000,
+    };
+    const encoded = encodeAutosend(payload);
+    expect(typeof encoded).toBe("string");
+    expect(encoded).not.toContain("=");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("+");
+    const decoded = decodeAutosend(encoded);
+    expect(decoded).toEqual(payload);
+  });
+
+  test("round-trips a payload with non-ASCII text", () => {
+    const payload: AutosendPayload = {
+      message: {
+        tiptapDoc: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "olá — café 🚀" }],
+            },
+          ],
+        },
+      },
+      createdAt: Date.now(),
+    };
+    const decoded = decodeAutosend(encodeAutosend(payload));
+    expect(decoded).toEqual(payload);
+  });
+
+  test("returns null for invalid base64", () => {
+    expect(decodeAutosend("not!!!base64")).toBeNull();
+  });
+
+  test("returns null for valid base64 but invalid JSON", () => {
+    const encoded = btoa("not json").replace(/=+$/, "");
+    expect(decodeAutosend(encoded)).toBeNull();
+  });
+
+  test("returns null when shape is wrong", () => {
+    const encoded = btoa(JSON.stringify({ foo: 1 })).replace(/=+$/, "");
+    expect(decodeAutosend(encoded)).toBeNull();
+  });
+
+  test("AUTOSEND_TTL_MS is 10 seconds", () => {
+    expect(AUTOSEND_TTL_MS).toBe(10_000);
+  });
+});

--- a/apps/mesh/src/web/lib/autosend.ts
+++ b/apps/mesh/src/web/lib/autosend.ts
@@ -1,60 +1,111 @@
-/**
- * Autosend — encode a queued chat message into a URL search parameter so
- * the next route can consume it on mount. Replaces the in-memory
- * `pendingMessage` mechanism for the home → task message handoff.
- *
- * Shape mirrors today's `pendingMessage`: `{ message, createdAt }`. Callers
- * enforce the TTL (`AUTOSEND_TTL_MS`) at consumption time so a pasted-link
- * autosend doesn't fire after the URL has been sitting in someone's
- * clipboard for hours.
- */
-
 import type { SendMessageParams } from "@/web/components/chat/store/types";
+import type { ProjectLocator } from "@decocms/mesh-sdk";
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
 
 export const AUTOSEND_TTL_MS = 10_000;
+export const AUTOSEND_QUERY_VALUE = "true";
 
 export interface AutosendPayload {
   message: SendMessageParams;
   createdAt: number;
 }
 
-function toBase64Url(bytes: Uint8Array): string {
-  let bin = "";
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+export type AutosendStatus = "pending" | "sending" | "sent";
+
+export interface StoredAutosendPayload extends AutosendPayload {
+  status: AutosendStatus;
 }
 
-function fromBase64Url(s: string): Uint8Array {
-  const padded =
-    s.replace(/-/g, "+").replace(/_/g, "/") +
-    "=".repeat((4 - (s.length % 4)) % 4);
-  const bin = atob(padded);
-  const bytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-  return bytes;
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function autosendStorageKey(
+  locator: ProjectLocator | string,
+  taskId: string,
+): string {
+  return LOCALSTORAGE_KEYS.chatAutosend(locator, taskId);
 }
 
-export function encodeAutosend(payload: AutosendPayload): string {
-  const bytes = new TextEncoder().encode(JSON.stringify(payload));
-  return toBase64Url(bytes);
+function isValidStatus(status: unknown): status is AutosendStatus {
+  return status === "pending" || status === "sending" || status === "sent";
 }
 
-export function decodeAutosend(s: string): AutosendPayload | null {
-  let decoded: unknown;
+function parseStoredAutosend(
+  value: string | null,
+): StoredAutosendPayload | null {
+  if (!value) return null;
+  let parsed: unknown;
   try {
-    const bytes = fromBase64Url(s);
-    const json = new TextDecoder().decode(bytes);
-    decoded = JSON.parse(json);
+    parsed = JSON.parse(value);
   } catch {
     return null;
   }
   if (
-    !decoded ||
-    typeof decoded !== "object" ||
-    typeof (decoded as { createdAt?: unknown }).createdAt !== "number" ||
-    typeof (decoded as { message?: unknown }).message !== "object"
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { createdAt?: unknown }).createdAt !== "number" ||
+    typeof (parsed as { message?: unknown }).message !== "object" ||
+    !isValidStatus((parsed as { status?: unknown }).status)
   ) {
     return null;
   }
-  return decoded as AutosendPayload;
+  return parsed as StoredAutosendPayload;
+}
+
+export function writeStoredAutosend(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskId: string,
+  message: SendMessageParams,
+  createdAt = Date.now(),
+): StoredAutosendPayload {
+  const payload: StoredAutosendPayload = {
+    message,
+    createdAt,
+    status: "pending",
+  };
+  storage.setItem(autosendStorageKey(locator, taskId), JSON.stringify(payload));
+  return payload;
+}
+
+export function readStoredAutosend(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskId: string,
+): StoredAutosendPayload | null {
+  const key = autosendStorageKey(locator, taskId);
+  const payload = parseStoredAutosend(storage.getItem(key));
+  if (!payload) {
+    storage.removeItem(key);
+    return null;
+  }
+  return payload;
+}
+
+export function claimStoredAutosend(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskId: string,
+  now = Date.now(),
+): AutosendPayload | null {
+  const key = autosendStorageKey(locator, taskId);
+  const payload = readStoredAutosend(storage, locator, taskId);
+  if (!payload) return null;
+  if (payload.status !== "pending") return null;
+  if (now - payload.createdAt >= AUTOSEND_TTL_MS) {
+    storage.removeItem(key);
+    return null;
+  }
+  storage.setItem(key, JSON.stringify({ ...payload, status: "sending" }));
+  return { message: payload.message, createdAt: payload.createdAt };
+}
+
+export function markStoredAutosendSent(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskId: string,
+): void {
+  const key = autosendStorageKey(locator, taskId);
+  const payload = readStoredAutosend(storage, locator, taskId);
+  if (!payload) return;
+  storage.setItem(key, JSON.stringify({ ...payload, status: "sent" }));
 }

--- a/apps/mesh/src/web/lib/autosend.ts
+++ b/apps/mesh/src/web/lib/autosend.ts
@@ -20,7 +20,7 @@ export interface AutosendPayload {
 
 function toBase64Url(bytes: Uint8Array): string {
   let bin = "";
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  for (const b of bytes) bin += String.fromCharCode(b);
   return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 

--- a/apps/mesh/src/web/lib/autosend.ts
+++ b/apps/mesh/src/web/lib/autosend.ts
@@ -1,0 +1,60 @@
+/**
+ * Autosend — encode a queued chat message into a URL search parameter so
+ * the next route can consume it on mount. Replaces the in-memory
+ * `pendingMessage` mechanism for the home → task message handoff.
+ *
+ * Shape mirrors today's `pendingMessage`: `{ message, createdAt }`. Callers
+ * enforce the TTL (`AUTOSEND_TTL_MS`) at consumption time so a pasted-link
+ * autosend doesn't fire after the URL has been sitting in someone's
+ * clipboard for hours.
+ */
+
+import type { SendMessageParams } from "@/web/components/chat/store/types";
+
+export const AUTOSEND_TTL_MS = 10_000;
+
+export interface AutosendPayload {
+  message: SendMessageParams;
+  createdAt: number;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(s: string): Uint8Array {
+  const padded =
+    s.replace(/-/g, "+").replace(/_/g, "/") +
+    "=".repeat((4 - (s.length % 4)) % 4);
+  const bin = atob(padded);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+export function encodeAutosend(payload: AutosendPayload): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(payload));
+  return toBase64Url(bytes);
+}
+
+export function decodeAutosend(s: string): AutosendPayload | null {
+  let decoded: unknown;
+  try {
+    const bytes = fromBase64Url(s);
+    const json = new TextDecoder().decode(bytes);
+    decoded = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (
+    !decoded ||
+    typeof decoded !== "object" ||
+    typeof (decoded as { createdAt?: unknown }).createdAt !== "number" ||
+    typeof (decoded as { message?: unknown }).message !== "object"
+  ) {
+    return null;
+  }
+  return decoded as AutosendPayload;
+}

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -20,6 +20,8 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:selectedDeepResearchModel:${locator}`,
   chatSimpleModeTier: (locator: ProjectLocator) =>
     `mesh:chat:simpleModeTier:${locator}`,
+  chatAutosend: (locator: ProjectLocator | string, taskId: string) =>
+    `mesh:chat:autosend:${locator}:${taskId}`,
   assistantChatActiveTask: (locator: ProjectLocator) =>
     `mesh:assistant-chat:active-task:${locator}`,
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,

--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, mock } from "bun:test";
+import { describe, expect, test, beforeEach, afterAll, mock } from "bun:test";
 
 type GroupCall = [type: string, key: string, props: unknown];
 
@@ -8,9 +8,19 @@ let resetCount = 0;
 
 // `initPostHog` early-returns when `typeof window === "undefined"`. Bun's test
 // runtime has no DOM, so stub a minimal window before importing the module.
-if (typeof globalThis.window === "undefined") {
+// Track whether we own the stub so we can clean it up afterAll — leaving a
+// fake `window` on globalThis breaks other tests that check `typeof window`
+// and then dereference its DOM properties (e.g. PGlite's `window.location`).
+const windowStubbedHere = typeof globalThis.window === "undefined";
+if (windowStubbedHere) {
   (globalThis as unknown as { window: object }).window = {};
 }
+
+afterAll(() => {
+  if (windowStubbedHere) {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});
 
 mock.module("posthog-js", () => ({
   default: {

--- a/apps/mesh/src/web/lib/read-cached-last-thread.test.ts
+++ b/apps/mesh/src/web/lib/read-cached-last-thread.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import { KEYS } from "./query-keys";
+import { readCachedLastThread } from "./read-cached-last-thread";
+import type { Task, TasksQueryData } from "@/web/components/chat/task/types";
+
+const LOCATOR = "org/proj";
+const USER_ID = "user-1";
+const AGENT_ID = "agent-1";
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: "t-default",
+    title: "Test thread",
+    created_at: "2026-04-29T00:00:00.000Z",
+    updated_at: "2026-04-29T00:00:00.000Z",
+    created_by: USER_ID,
+    virtual_mcp_id: AGENT_ID,
+    ...overrides,
+  };
+}
+
+function seed(qc: QueryClient, filterTag: string, items: Task[]) {
+  const data: TasksQueryData = { items, hasMore: false };
+  qc.setQueryData(["tasks", LOCATOR, filterTag], data);
+}
+
+describe("readCachedLastThread", () => {
+  test("returns null when the cache is empty", () => {
+    const qc = new QueryClient();
+    expect(readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID)).toBeNull();
+  });
+
+  test("returns the single matching thread", () => {
+    const qc = new QueryClient();
+    seed(qc, "list-a", [
+      task({ id: "t1", updated_at: "2026-04-29T01:00:00.000Z" }),
+    ]);
+    const result = readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID);
+    expect(result?.id).toBe("t1");
+  });
+
+  test("picks the freshest match across multiple cached lists", () => {
+    const qc = new QueryClient();
+    seed(qc, "list-a", [
+      task({ id: "older", updated_at: "2026-04-29T01:00:00.000Z" }),
+    ]);
+    seed(qc, "list-b", [
+      task({ id: "newer", updated_at: "2026-04-29T05:00:00.000Z" }),
+      task({ id: "oldest", updated_at: "2026-04-28T00:00:00.000Z" }),
+    ]);
+    const result = readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID);
+    expect(result?.id).toBe("newer");
+  });
+
+  test("rejects threads for a different agent", () => {
+    const qc = new QueryClient();
+    seed(qc, "list-a", [
+      task({ id: "wrong-agent", virtual_mcp_id: "agent-2" }),
+    ]);
+    expect(readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID)).toBeNull();
+  });
+
+  test("rejects threads created by a different user", () => {
+    const qc = new QueryClient();
+    seed(qc, "list-a", [task({ id: "wrong-user", created_by: "user-2" })]);
+    expect(readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID)).toBeNull();
+  });
+
+  test("rejects archived (hidden) threads", () => {
+    const qc = new QueryClient();
+    seed(qc, "list-a", [
+      task({
+        id: "archived",
+        hidden: true,
+        updated_at: "2026-04-29T05:00:00.000Z",
+      }),
+      task({ id: "live", updated_at: "2026-04-29T01:00:00.000Z" }),
+    ]);
+    const result = readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID);
+    expect(result?.id).toBe("live");
+  });
+
+  test("does not match cache entries for a different locator", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["tasks", "other-locator", "list-a"], {
+      items: [task({ id: "elsewhere" })],
+      hasMore: false,
+    } satisfies TasksQueryData);
+    expect(readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID)).toBeNull();
+  });
+
+  test("ignores entries with empty/missing items", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(["tasks", LOCATOR, "empty"], {
+      items: [],
+      hasMore: false,
+    } satisfies TasksQueryData);
+    qc.setQueryData(["tasks", LOCATOR, "undef"], undefined);
+    expect(readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID)).toBeNull();
+  });
+
+  test("verifies KEYS.tasksPrefix is used as the matching prefix", () => {
+    const qc = new QueryClient();
+    const exactKey = KEYS.tasks(LOCATOR, {
+      owner: "me",
+      status: "open",
+      virtualMcpId: AGENT_ID,
+      userId: USER_ID,
+      hasTrigger: null,
+    });
+    qc.setQueryData(exactKey, {
+      items: [task({ id: "from-real-key" })],
+      hasMore: false,
+    } satisfies TasksQueryData);
+    expect(readCachedLastThread(qc, LOCATOR, AGENT_ID, USER_ID)?.id).toBe(
+      "from-real-key",
+    );
+  });
+});

--- a/apps/mesh/src/web/lib/read-cached-last-thread.ts
+++ b/apps/mesh/src/web/lib/read-cached-last-thread.ts
@@ -1,0 +1,32 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { KEYS } from "./query-keys";
+import type { Task, TasksQueryData } from "@/web/components/chat/task/types";
+
+/**
+ * Find the user's most recently updated thread with a given agent by
+ * scanning the local TanStack Query cache. Used by the sidebar pinned-agent
+ * click handler to resume the last conversation instead of always creating
+ * a new thread. Returns null when no matching, non-archived thread is in
+ * cache — callers should fall back to creating a new thread in that case.
+ */
+export function readCachedLastThread(
+  queryClient: QueryClient,
+  locator: string,
+  virtualMcpId: string,
+  userId: string,
+): Task | null {
+  const queries = queryClient.getQueriesData<TasksQueryData>({
+    queryKey: KEYS.tasksPrefix(locator),
+  });
+  let best: Task | null = null;
+  for (const [, data] of queries) {
+    if (!data?.items) continue;
+    for (const t of data.items) {
+      if (t.virtual_mcp_id !== virtualMcpId) continue;
+      if (t.created_by !== userId) continue;
+      if (t.hidden) continue;
+      if (!best || t.updated_at > best.updated_at) best = t;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## What is this contribution about?

Pinned-agent icons and the Home button in the left sidebar now **resume the user's most recent thread** with the target agent instead of always minting a new one. The lookup reads the local TanStack Query cache (which the tasks panel already populates, ordered by `updated_at desc`), so there are no extra network calls and no new MCP tools. When the cache holds no matching, non-archived thread for the user + agent, the click silently falls through to the existing create-new flow (preserving branch-carry). All other "new task" entry points — toolbar New Task, ⇧⌘S, sidebar context-menu Settings, browse-agents popover, and the `/$org` route-level redirect — are deliberately unchanged.

## Screenshots/Demonstration

N/A — behavior change only; no visual difference until you click an agent or Home.

## How to Test

1. Open a thread for any pinned agent (this populates the cache); send a message to bump `updated_at`.
2. Navigate away to the org root, then click that agent's sidebar pin → lands on the same thread, no new thread is created.
3. Repeat for the Home button: be in a decopilot thread, leave, click Home → lands back on the same decopilot thread.
4. Verify the toolbar "New Task" button, ⇧⌘S, sidebar Settings context menu, and browse-agents popover all still always create a fresh thread.
5. Click a sidebar pin in a fresh session (cold cache) → falls through to create-new.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (9 unit tests for the cache helper; typecheck/lint/format clean; manual smoke pending reviewer)
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a pinned agent now resumes your latest thread from the `@tanstack/react-query` cache; Home opens a new `/$org/` landing with a composer that creates a task and auto-sends via a URL flag and localStorage.

- **New Features**
  - Sidebar pins use `useNavigateToAgentThread` + `readCachedLastThread` to open the freshest non-archived thread; fall back to create-new; mobile sidebar closes.
  - Added `/$org/` HomePage; its composer navigates to `/$org/$taskId` with `?autosend=true` and auto-sends via a localStorage handoff; `ChatPrefsProvider` mounts org-wide.

- **Refactors**
  - Introduced `org-shell-layout` (sidebar, toolbar, tasks panel, `ChatPrefsProvider`) wrapping `/$org/` and `/$org/$taskId`; the agent shell is now per-task; removed the old `/$org/` redirect.
  - Replaced in-memory pending message with autosend storage (`writeStoredAutosend`/`claimStoredAutosend`/`markStoredAutosendSent`, 10s TTL) and a URL flag; `ActiveTaskProvider` consumes and marks sent; `navigateToTask` and `use-chat-navigation` pass `autosend`; `ChatInput` works without an active stream and only renders `ChatHighlight` when streams exist.
  - `use-ensure-task` no-ops on empty `taskId`; added tests for autosend and `readCachedLastThread`; fixed `posthog-client.test.ts` to clean up a `window` stub leak.
  - UI polish: task list scroll is scoped per section and the selected row auto-scrolls into view; fixed Home panel padding so borders render correctly.

<sup>Written for commit cfe3fe69858c0de46b16c967671d1f5bcce4a39a. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3226?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

