### PR TITLE
fix(automations): reliable autosave + working Test button

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -17,6 +17,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useRef,
   useState,
   type PropsWithChildren,
@@ -125,12 +126,6 @@ export interface ChatTaskContextValue {
   ownerFilter: TaskOwnerFilter;
   setOwnerFilter: (filter: TaskOwnerFilter) => void;
   isFilterChangePending: boolean;
-  pendingMessage: {
-    taskId: string;
-    message: SendMessageParams;
-    createdAt: number;
-  } | null;
-  clearPendingMessage: () => void;
 }
 
 export interface ChatPrefsContextValue {
@@ -235,6 +230,32 @@ function resolveActiveTier(
 const MAX_APP_CONTEXT_LENGTH = 10_000;
 const MAX_APP_CONTEXT_SOURCES = 10;
 const PENDING_MESSAGE_TTL_MS = 10_000;
+
+/**
+ * Module-level pending-message store, keyed by taskId.
+ *
+ * Lives outside the React tree because `Chat.Provider` is remounted (via
+ * `key={chatVirtualMcpId}`) whenever navigation crosses to a different vMCP
+ * — e.g. an automation's "Test" button creating a chat under the
+ * automation's agent. Holding pending messages in component state would
+ * destroy them across that remount, which manifests as an empty new chat.
+ */
+const pendingMessages = new Map<
+  string,
+  { message: SendMessageParams; createdAt: number }
+>();
+
+function setPendingMessage(taskId: string, message: SendMessageParams) {
+  pendingMessages.set(taskId, { message, createdAt: Date.now() });
+}
+
+function takePendingMessage(taskId: string): SendMessageParams | null {
+  const entry = pendingMessages.get(taskId);
+  if (!entry) return null;
+  pendingMessages.delete(taskId);
+  if (Date.now() - entry.createdAt >= PENDING_MESSAGE_TTL_MS) return null;
+  return entry.message;
+}
 
 const BRIDGE_NOOP: ChatBridgeValue = {
   sendMessage: async () => {
@@ -539,15 +560,6 @@ export function ChatContextProvider({
   // Bridge ref — ActiveTaskProvider registers sendMessage here
   const bridgeRef = useRef<ChatBridgeValue>(BRIDGE_NOOP);
 
-  // Pending message state (replaces module-level Map from useSendToChat)
-  const [pendingMessage, setPendingMessage] = useState<{
-    taskId: string;
-    message: SendMessageParams;
-    createdAt: number;
-  } | null>(null);
-
-  const clearPendingMessage = () => setPendingMessage(null);
-
   const navigateToTask = (taskId: string, opts?: { virtualMcpId?: string }) => {
     markTaskRead(taskId);
     rawNavigateToTask(taskId, {
@@ -608,11 +620,7 @@ export function ChatContextProvider({
           virtualMcpId: params.virtualMcpId,
         });
       });
-    setPendingMessage({
-      taskId: newId,
-      message: params.message,
-      createdAt: Date.now(),
-    });
+    setPendingMessage(newId, params.message);
   };
 
   // Hide task (switch to next after hiding)
@@ -650,8 +658,6 @@ export function ChatContextProvider({
     ownerFilter: taskManager.ownerFilter,
     setOwnerFilter: taskManager.setOwnerFilter,
     isFilterChangePending: taskManager.isFilterChangePending ?? false,
-    pendingMessage,
-    clearPendingMessage,
   };
 
   const prefsValue: ChatPrefsContextValue = {
@@ -728,13 +734,7 @@ export function ActiveTaskProvider({
   taskId,
   children,
 }: PropsWithChildren<{ taskId: string }>) {
-  const {
-    virtualMcpId,
-    tasks,
-    pendingMessage,
-    clearPendingMessage,
-    currentBranch,
-  } = useChatTask();
+  const { virtualMcpId, tasks, currentBranch } = useChatTask();
 
   // Fire chat_opened once per (page session × taskId). Runs during render, but
   // the Set gate keeps it idempotent. Fires for every thread a user views —
@@ -981,27 +981,22 @@ export function ActiveTaskProvider({
     isStreaming: chat.status === "submitted" || chat.status === "streaming",
   };
 
-  // Consume pending message when this task is the target
+  // Consume pending message when this task is the target. Read from the
+  // module-level store rather than React state so messages survive a
+  // Chat.Provider remount on cross-vMCP navigation. Runs in useEffect so the
+  // chat instance and its transport are fully wired up after commit — sending
+  // during render let the optimistic message + streaming state get lost.
   const pendingConsumedRef = useRef<string | null>(null);
-  if (
-    pendingMessage &&
-    pendingMessage.taskId === taskId &&
-    pendingConsumedRef.current !== taskId
-  ) {
-    // TTL check: discard stale messages
-    const age = Date.now() - pendingMessage.createdAt;
-    if (age < PENDING_MESSAGE_TTL_MS) {
-      pendingConsumedRef.current = taskId;
-      const msg = pendingMessage.message;
-      queueMicrotask(() => {
-        void sendMessageInternal(msg);
-        clearPendingMessage();
-      });
-    } else {
-      // Stale — silently discard
-      queueMicrotask(() => clearPendingMessage());
-    }
-  }
+  const sendMessageInternalRef = useRef(sendMessageInternal);
+  sendMessageInternalRef.current = sendMessageInternal;
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    if (!taskId || pendingConsumedRef.current === taskId) return;
+    const msg = takePendingMessage(taskId);
+    if (!msg) return;
+    pendingConsumedRef.current = taskId;
+    void sendMessageInternalRef.current(msg);
+  }, [taskId]);
 
   const streamValue: ChatStreamContextValue = {
     messages,

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -455,20 +455,20 @@ export function SettingsTab({
         EDIT_SESSION_QUIET_MS,
       );
 
-      // Re-read values at reset time so any keystrokes that landed during the
-      // in-flight mutation aren't clobbered by a stale snapshot.
-      const latestValues = form.getValues();
-      form.reset({
-        ...latestValues,
-        credential_id:
-          latestValues.credential_id === values.credential_id
-            ? coercedCredentialId
-            : latestValues.credential_id,
-        model_id:
-          latestValues.model_id === values.model_id
-            ? coercedModelId
-            : latestValues.model_id,
-      });
+      // keepDirtyValues: any field the user kept editing during the in-flight
+      // mutation stays at its current value AND keeps its dirty flag, so the
+      // queued debouncedSave actually persists those edits on its next fire.
+      // Without this, reset would clear dirty state and the next saveForm
+      // would early-return on hasDirtyFields=false, stranding the keystrokes
+      // in the UI but never sending them to the server.
+      form.reset(
+        {
+          ...values,
+          credential_id: coercedCredentialId,
+          model_id: coercedModelId,
+        },
+        { keepDirtyValues: true },
+      );
       return true;
     } catch {
       tiptapDirtyRef.current = true;

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -41,7 +41,7 @@ import {
   XClose,
   Zap,
 } from "@untitledui/icons";
-import { Suspense, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { toast } from "sonner";
 import type { Metadata } from "@/web/components/chat/types.ts";
@@ -318,6 +318,10 @@ export function SettingsTab({
   const editorInitializedRef = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tiptapDirtyRef = useRef(false);
+  // The save runs from a debounced setTimeout. Reading state through a closure
+  // there would give us the value from the render that scheduled the timer,
+  // not the latest keystroke — that's how trailing characters got lost.
+  const tiptapDocRef = useRef<Metadata["tiptapDoc"]>(initialTiptapDoc);
 
   const handleImprovePrompt = () => {
     const parts = derivePartsFromTiptapDoc(tiptapDoc);
@@ -411,6 +415,7 @@ export function SettingsTab({
     tiptapDirtyRef.current = false;
 
     const values = form.getValues();
+    const tiptapDocAtSave = tiptapDocRef.current;
     try {
       const coercedCredentialId =
         values.credential_id && values.model_id ? values.credential_id : "";
@@ -430,7 +435,7 @@ export function SettingsTab({
             id: coercedModelId,
           },
         },
-        messages: tiptapDocToMessages(tiptapDoc),
+        messages: tiptapDocToMessages(tiptapDocAtSave),
         temperature: 0,
       };
       await updateMutation.mutateAsync(updatePayload);
@@ -450,10 +455,19 @@ export function SettingsTab({
         EDIT_SESSION_QUIET_MS,
       );
 
+      // Re-read values at reset time so any keystrokes that landed during the
+      // in-flight mutation aren't clobbered by a stale snapshot.
+      const latestValues = form.getValues();
       form.reset({
-        ...values,
-        credential_id: coercedCredentialId,
-        model_id: coercedModelId,
+        ...latestValues,
+        credential_id:
+          latestValues.credential_id === values.credential_id
+            ? coercedCredentialId
+            : latestValues.credential_id,
+        model_id:
+          latestValues.model_id === values.model_id
+            ? coercedModelId
+            : latestValues.model_id,
       });
       return true;
     } catch {
@@ -462,19 +476,31 @@ export function SettingsTab({
     }
   };
 
+  // Always-fresh ref to saveForm so debounced timers and the form-watch
+  // subscription (which is registered once) call the latest closure that reads
+  // current state, not whichever closure happened to be in scope at scheduling
+  // time.
+  const saveFormRef = useRef(saveForm);
+  saveFormRef.current = saveForm;
+
   const debouncedSave = () => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     saveTimerRef.current = setTimeout(() => {
-      saveForm();
+      saveTimerRef.current = null;
+      saveFormRef.current();
     }, 1000);
   };
 
   const flushAndSave = async () => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    return saveForm();
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    return saveFormRef.current();
   };
 
   const setTiptapDoc = (doc: Metadata["tiptapDoc"]) => {
+    tiptapDocRef.current = doc;
     setTiptapDocRaw(doc);
     if (!editorInitializedRef.current) {
       editorInitializedRef.current = true;
@@ -491,6 +517,19 @@ export function SettingsTab({
       debouncedSave();
     });
   }
+
+  // Flush any pending save on unmount so navigating away within the 1s
+  // debounce window doesn't drop the last edit.
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+        saveFormRef.current();
+      }
+    };
+  }, []);
 
   const handleRunClick = async () => {
     track("automation_test_clicked", {


### PR DESCRIPTION
## What is this contribution about?

Fixes three bugs on the automation detail screen.

**Autosave dropped the last keystroke.** `saveForm` read `tiptapDoc` through a closure inside the 1s debounced `setTimeout`, so it saw the value from the render that scheduled the timer rather than the latest keystroke. `saveForm` now reads from `tiptapDocRef` (synced synchronously in `setTiptapDoc`), the debounce calls through `saveFormRef.current` so any caller hits the latest closure, the cleanup effect flushes a pending save on unmount, and the post-save `form.reset` re-reads `getValues()` so keystrokes landing during an in-flight mutation aren't clobbered.

**Test button created an empty chat.** `Chat.Provider` is mounted with `key={chatVirtualMcpId}`, so navigating to a different vMCP (the automation's agent) remounts it. The pending message lived in that provider's React state and was destroyed across the remount. Moved the pending-message store to a module-level `Map<taskId, …>` keyed by taskId so it survives the remount; `ActiveTaskProvider` consumes via `takePendingMessage(taskId)` which honors the existing 10s TTL.

**Test button streaming wasn't visible.** Even after the message was being sent, the chat appeared empty until the run finished. The consume ran in render via `queueMicrotask`, which fires before commit-phase effects, so `chat.sendMessage` lost its optimistic message and streaming state even though the HTTP request reached the server. Moved the consume into `useEffect([taskId])` so the chat instance is fully wired up first.

## How to Test
1. Open an automation, edit the instructions input rapidly, then look at what was persisted — last character should no longer be dropped.
2. Edit the instructions and immediately navigate away within the 1s debounce window — the edit should still be saved.
3. Click **Test** on an automation. A new chat opens, the user message appears immediately, and streaming is visible (not just the final message).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes autosave in the automation detail screen so the last keystroke is saved and edits aren’t lost on navigation. Restores the Test button so a new chat shows the user message immediately and streams live.

- **Bug Fixes**
  - Autosave: read `tiptapDoc` from a ref, route debounced saves via `saveFormRef`, flush on unmount, and use `form.reset(..., { keepDirtyValues: true })` so in-flight edits keep dirty state and get saved.
  - Empty chat on Test: move the pending message to a module-level `Map<taskId, …>` so it survives `Chat.Provider` remounts when switching vMCPs.
  - Missing streaming: consume the pending message in `useEffect([taskId])` after commit instead of `queueMicrotask` in render to keep the optimistic message and streaming state.

<sup>Written for commit cff8fe90677cf64a4668d77570c2b332be47f1f9. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3227?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

