### PR TITLE
feat(sandbox): implement per-claim HTTPRoute for sandbox previews

### DIFF
--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -67,16 +67,32 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
-// Per-claim HTTPRoute attaches to this Gateway. When set together with
-// STUDIO_SANDBOX_PREVIEW_URL_PATTERN, mesh mints one HTTPRoute per
-// SandboxClaim so the wildcard Gateway can route directly to each
-// sandbox's Service:9000 (mesh leaves the data path). Both vars unset →
-// the runner falls back to in-process preview proxying via mesh.
+// Per-claim HTTPRoute attaches to this Gateway. When NAME + NAMESPACE are
+// set alongside STUDIO_SANDBOX_PREVIEW_URL_PATTERN, mesh mints one
+// HTTPRoute per SandboxClaim so the wildcard Gateway can route directly
+// to each sandbox's Service:9000 (mesh leaves the data path).
+//
+// Both required — no default — because the runner is Gateway-API-generic
+// (Istio, Envoy Gateway, Cilium, Kong, ...) and there's no portable
+// "default gateway namespace": Istio classic uses istio-system, Istio
+// ambient prefers a separate `istio-ingress`/`gateway` ns, and other
+// implementations vary. A wrong default would silently write routes that
+// fail to attach (parentRef → non-existent Gateway) and the failure mode
+// is a 404 from the gateway with no log on the mesh side.
+//
+// Both unset → runner falls back to in-process preview proxying (legacy).
+// Half-configured (one set, the other not) → fail fast at boot rather
+// than silently choose a behavior the operator didn't ask for.
 function readPreviewGateway(): { name: string; namespace: string } | undefined {
   const name = process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME?.trim();
   const namespace =
     process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE?.trim();
-  if (!name || !namespace) return undefined;
+  if (!name && !namespace) return undefined;
+  if (!name || !namespace) {
+    throw new Error(
+      "STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME and STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE must both be set, or both unset. Half-configured per-claim HTTPRoute routing would silently fail to attach.",
+    );
+  }
   return { name, namespace };
 }
 

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -67,6 +67,19 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
+// Per-claim HTTPRoute attaches to this Gateway. When set together with
+// STUDIO_SANDBOX_PREVIEW_URL_PATTERN, mesh mints one HTTPRoute per
+// SandboxClaim so the wildcard Gateway can route directly to each
+// sandbox's Service:9000 (mesh leaves the data path). Both vars unset →
+// the runner falls back to in-process preview proxying via mesh.
+function readPreviewGateway(): { name: string; namespace: string } | undefined {
+  const name = process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME?.trim();
+  const namespace =
+    process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE?.trim();
+  if (!name || !namespace) return undefined;
+  return { name, namespace };
+}
+
 async function instantiate(
   kind: RunnerKind,
   db: Kysely<DatabaseSchema>,
@@ -98,6 +111,7 @@ async function instantiate(
         stateStore,
         previewUrlPattern,
         sandboxTemplateName: readSandboxTemplateName(),
+        previewGateway: readPreviewGateway(),
         meter,
       });
     }

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,7 +9,14 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-version: 0.1.0
+# 0.2.0: per-claim HTTPRoutes minted by mesh runner. The chart no longer
+# renders the cluster-wide HTTPRoute that backed the in-process preview
+# proxy; mesh now mints one HTTPRoute per SandboxClaim. RBAC gains
+# `httproutes` (gateway.networking.k8s.io) perms, and NetworkPolicy gains
+# an ingress rule from `previewGateway.namespace` to sandbox port 9000.
+# Upgraders MUST bump mesh to the matching version that creates per-claim
+# HTTPRoutes — otherwise preview URLs stop resolving.
+version: 0.2.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.1.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -12,8 +12,8 @@ Renders:
   ServiceAccount of THIS env's studio install)
 - `NetworkPolicy` `studio-sandbox-<envName>` (per-env podSelector)
 - `SandboxWarmPool` `studio-sandbox-<envName>` (optional)
-- `Gateway` + `HTTPRoute` + `Certificate`
-  `agent-sandbox-preview-<envName>` (optional)
+- `Gateway` + `Certificate` `agent-sandbox-preview-<envName>` (optional;
+  per-claim HTTPRoutes are minted by the mesh runner, not by this chart)
 
 Requires the [`sandbox-operator`](../sandbox-operator/) chart to already be
 installed (it ships the CRDs + controller).
@@ -77,6 +77,11 @@ configMap:
     STUDIO_SANDBOX_RUNNER: "agent-sandbox"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
+    # Per-claim HTTPRoute attaches to this Gateway. Without these two,
+    # mesh falls back to its in-process preview proxy — which the chart
+    # no longer wires up, so set them whenever previewGateway.enabled=true.
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-staging"
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "istio-system"
 ```
 
 ### ArgoCD Application (one per env)
@@ -127,7 +132,7 @@ sandbox-env/
     ├── sandbox-network-policy.yaml      # NetworkPolicy on sandbox pods (per-env)
     ├── sandbox-rbac.yaml                # Role + cross-ns RoleBinding to mesh SA
     ├── sandbox-preview-cert.yaml        # cert-manager Certificate (optional)
-    └── sandbox-preview-gateway.yaml     # Gateway + HTTPRoute (optional)
+    └── sandbox-preview-gateway.yaml     # Gateway only — per-claim HTTPRoutes are minted by mesh
 ```
 
 ## Values
@@ -148,6 +153,6 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `previewGateway.enabled` | `false` | wildcard `*.preview.<domain>` Gateway + cert |
 | `mesh.namespace` | `deco-studio` | studio release namespace (this env's) |
 | `mesh.serviceAccountName` | `deco-studio` | mesh ServiceAccount that gets the RoleBinding |
-| `mesh.serviceName` | `deco-studio` | mesh Service the preview HTTPRoute targets |
-| `mesh.servicePort` | `80` | match studio's `service.port` |
+| `mesh.serviceName` | `deco-studio` | _deprecated, unused since per-claim HTTPRoutes_ |
+| `mesh.servicePort` | `80` | _deprecated, unused since per-claim HTTPRoutes_ |
 | `mesh.podSelectorLabels` | `chart-deco-studio` / `deco-studio` | for the NetworkPolicy ingress rule |

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -77,9 +77,12 @@ configMap:
     STUDIO_SANDBOX_RUNNER: "agent-sandbox"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
-    # Per-claim HTTPRoute attaches to this Gateway. Without these two,
-    # mesh falls back to its in-process preview proxy — which the chart
-    # no longer wires up, so set them whenever previewGateway.enabled=true.
+    # Per-claim HTTPRoute attaches to this Gateway. Both required whenever
+    # previewGateway.enabled=true — without them mesh falls back to its
+    # in-process preview proxy, which the chart no longer wires up.
+    # NAMESPACE must match `previewGateway.namespace` from the chart values
+    # (no default — different gateway controllers live in different
+    # namespaces, and a wrong default would silently fail to attach).
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-staging"
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "istio-system"
 ```

--- a/deploy/helm/sandbox-env/templates/sandbox-network-policy.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-network-policy.yaml
@@ -33,12 +33,12 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Daemon port (9000) — mesh server pods call this to exec tools, stream
-    # logs, etc. Also the *preview* request path: when previewGateway is
-    # enabled, mesh reverse-proxies `*.preview.<domain>` traffic to the
-    # daemon here so the daemon's CSP/HMR rewrites apply (port 3000 would
-    # bypass them). Selectors point at the studio release identified via
-    # `mesh.namespace` + `mesh.podSelectorLabels`.
+    # Daemon port (9000) — mesh server pods call this for control-plane
+    # operations (tool exec, log streaming) when path-2 in-cluster routing
+    # is used. The control plane also reaches the daemon over the API
+    # server's port-forward channel, which doesn't transit a Pod IP and
+    # therefore doesn't need a NetworkPolicy rule; this entry covers the
+    # direct-Service path.
     - from:
         - namespaceSelector:
             matchLabels:
@@ -49,6 +49,22 @@ spec:
       ports:
         - protocol: TCP
           port: 9000
+    {{- if .Values.previewGateway.enabled }}
+    # Per-claim HTTPRoutes in `agent-sandbox-system` route `*.<domain>`
+    # traffic from the wildcard Gateway directly to each sandbox's headless
+    # Service:9000. The actual sender is the gateway controller's data plane
+    # Pod, which lives in `previewGateway.namespace` (Istio default:
+    # `istio-system`). Without this rule the route attaches but the Envoy
+    # proxy can't reach the sandbox pod and the browser sees a connect
+    # timeout. Mesh is no longer in this path.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.previewGateway.namespace }}
+      ports:
+        - protocol: TCP
+          port: 9000
+    {{- end }}
     {{- with .Values.networkPolicy.previewGatewayNamespace }}
     # DEPRECATED — direct ingress on dev port 3000 from a configured
     # gateway namespace. Only needed for setups that route preview traffic

--- a/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
@@ -4,20 +4,23 @@
 {{- $gwNamespace := .Values.previewGateway.namespace }}
 {{- $tlsSecretName := include "sandbox-env.previewTlsSecretName" . }}
 {{- $hostname := printf "*.%s" $domain }}
-{{- $meshNamespace := required "mesh.namespace is required" .Values.mesh.namespace }}
-{{- $meshServiceName := required "mesh.serviceName is required" .Values.mesh.serviceName }}
 {{- $previewName := include "sandbox-env.previewName" . }}
-# Wildcard preview-URL ingress. A single Gateway + HTTPRoute terminate
-# `*.preview.<domain>` and forward to the mesh Service; mesh inspects the
-# Host header and reverse-proxies to the matching sandbox's daemon at port
-# 9000 (daemon owns the public surface; routing browsers straight at dev
-# port 3000 would bypass the daemon's CSP/HMR rewrites and break iframe
-# embedding + SSE).
+# Wildcard preview-URL ingress. The Gateway terminates TLS for
+# `*.<domain>`; per-claim HTTPRoutes are minted by the mesh runner against
+# this Gateway and route directly to each sandbox's headless Service at
+# port 9000 (daemon owns the public surface — routing straight at the dev
+# port 3000 would bypass CSP/HMR rewrites and break iframe embedding + SSE).
 #
-# Mesh stays in the request path for the first ship; the longer-term plan
-# is per-claim HTTPRoutes that bypass mesh entirely. Switching to that
-# requires per-Service routing + RBAC for mesh to mint HTTPRoutes, which
-# is deferred.
+# This chart creates ONLY the Gateway + Certificate. It deliberately does
+# NOT render a wildcard HTTPRoute backed by mesh — keeping mesh in the
+# request path was the previous design, and it's been replaced by per-claim
+# routing. Mesh now creates one HTTPRoute per SandboxClaim in
+# `agent-sandbox-system` (same namespace as the operator's Service, no
+# ReferenceGrant needed) and tears it down on claim delete. RBAC for that
+# lives in templates/sandbox-rbac.yaml.
+#
+# Browser → Gateway → HTTPRoute(handle) → Service(handle):9000 → pod.
+# Mesh is no longer the data-path proxy.
 #
 # AUTH MODEL — read before exposing this. The Host header carries the
 # sandbox handle, which is the *only* authorization on the preview path
@@ -62,30 +65,12 @@ spec:
             namespace: {{ $gwNamespace }}
       allowedRoutes:
         namespaces:
-          # HTTPRoute lives in the mesh namespace, so we have to explicitly
-          # allow cross-namespace attachment from there. Without an explicit
-          # selector the route would silently drop.
+          # Per-claim HTTPRoutes live in `agent-sandbox-system` (same
+          # namespace as the operator-created Service they back) so mesh
+          # can write them with the same Role used for SandboxClaim
+          # CRUD. Without this selector the routes would silently drop.
           from: Selector
           selector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ $meshNamespace }}
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: {{ $previewName }}
-  namespace: {{ $meshNamespace }}
-  labels:
-    {{- include "sandbox-env.sandboxPreviewLabels" . | nindent 4 }}
-spec:
-  parentRefs:
-    - kind: Gateway
-      name: {{ $previewName }}
-      namespace: {{ $gwNamespace }}
-  hostnames:
-    - {{ $hostname | quote }}
-  rules:
-    - backendRefs:
-        - name: {{ $meshServiceName }}
-          port: {{ .Values.mesh.servicePort }}
+              kubernetes.io/metadata.name: agent-sandbox-system
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -61,6 +61,17 @@ rules:
     # as a `GET` against the subresource. Without `get`, the upgrade returns
     # 403 and the runner sees `[object ErrorEvent]`.
     verbs: ["get", "create"]
+  # Per-claim HTTPRoute lifecycle. The runner mints one HTTPRoute per
+  # SandboxClaim (same name, same namespace) so the wildcard Gateway in
+  # `istio-system` (or wherever `previewGateway.namespace` points) can
+  # route `<handle>.<domain>` traffic directly to the operator-created
+  # headless Service — bypassing mesh as a proxy. `delete` mirrors the
+  # claim teardown path. `get` is used for the create-if-missing branch
+  # in `adopt()` so legacy claims (provisioned before this rolled out)
+  # get their HTTPRoute backfilled.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -138,15 +138,23 @@ warmPool:
   size: 0
 
 # ── preview URL gateway (optional) ─────────────────────────────────────
-# Wildcard preview-URL ingress (Approach B in the K8s sandbox plan).
-# Renders an Istio Gateway + HTTPRoute that send all *.preview.<domain>
-# traffic to the mesh Service; mesh recognises the Host header and
-# reverse-proxies to the matching sandbox's daemon at port 9000 (daemon,
-# not dev port 3000 — the daemon's reverse proxy injects the HMR
-# bootstrap + strips CSP that the iframe needs).
+# Wildcard preview-URL ingress. Renders an Istio Gateway (HTTPS, terminates
+# `*.<domain>`) + a cert-manager Certificate. Per-claim HTTPRoutes are NOT
+# rendered here — the mesh runner mints one HTTPRoute per SandboxClaim in
+# `agent-sandbox-system` and tears it down on claim delete, so each preview
+# URL routes directly to its sandbox Service:9000. Mesh is no longer in
+# the data path; it only writes the routing config.
+#
+# Wiring on the studio side (chart-deco-studio configMap.meshConfig):
+#   STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.<domain>"
+#   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-<envName>"
+#   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "<previewGateway.namespace>"
+# Without those, mesh falls back to in-process proxying via its own Service
+# (the previous design). That fallback also requires a separate cluster-wide
+# HTTPRoute that this chart no longer creates.
 #
 # Manual prerequisites (not templated):
-#   1. DNS: Cloudflare (or other) wildcard `*.preview.<domain>` → cluster
+#   1. DNS: Cloudflare (or other) wildcard `*.<domain>` → cluster
 #      external LB hostname.
 #   2. cert-manager ClusterIssuer for the wildcard cert. DNS-01 is
 #      required (HTTP-01 doesn't work for wildcards). Set `clusterIssuer`
@@ -188,11 +196,13 @@ mesh:
   # SandboxClaim CRUD + portforward against agent-sandbox-system.
   # Conventionally the studio release name (chart.fullname).
   serviceAccountName: "deco-studio"
-  # Name of the mesh Service the preview HTTPRoute forwards traffic to.
-  # Conventionally the studio release name.
+  # DEPRECATED: previously the cluster-wide preview HTTPRoute backendRef'd
+  # the mesh Service so mesh could reverse-proxy preview traffic in
+  # process. The chart no longer renders that HTTPRoute (per-claim routes
+  # are minted by mesh and bypass mesh as a proxy), so these are unused.
+  # Kept to avoid breaking values overrides on existing installs; will be
+  # removed in a future chart version.
   serviceName: "deco-studio"
-  # Port on the mesh Service the preview HTTPRoute targets. Match
-  # studio's `service.port` (default 80).
   servicePort: 80
   # Pod selector labels that identify mesh pods for the NetworkPolicy
   # ingress rule. Should match the studio chart's selectorLabels.

--- a/packages/sandbox/server/runner/agent-sandbox/client.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.ts
@@ -350,6 +350,122 @@ export async function getSandboxClaim(
   return found ?? undefined;
 }
 
+// ---- HTTPRoute (Gateway API) ------------------------------------------------
+
+/**
+ * Minimal HTTPRoute shape for per-claim preview routing. Mirrors the v1
+ * Gateway API surface, scoped to the fields the runner writes — listener
+ * attachment via `parentRefs`, exact-host match via `hostnames`, and a
+ * single same-namespace `backendRefs` to the operator-created Service.
+ *
+ * Cross-namespace backendRefs are deliberately not modeled: HTTPRoute and
+ * Service both live in `agent-sandbox-system`, which avoids the
+ * ReferenceGrant dance.
+ */
+export interface HttpRoute {
+  apiVersion: string;
+  kind: "HTTPRoute";
+  metadata: {
+    name: string;
+    namespace?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    parentRefs: Array<{
+      kind?: "Gateway";
+      group?: "gateway.networking.k8s.io";
+      name: string;
+      namespace: string;
+      sectionName?: string;
+    }>;
+    hostnames: string[];
+    rules: Array<{
+      backendRefs: Array<{
+        group?: "";
+        kind?: "Service";
+        name: string;
+        port: number;
+      }>;
+    }>;
+  };
+}
+
+const HTTPROUTE_API_GROUP = "gateway.networking.k8s.io";
+const HTTPROUTE_API_VERSION = "v1";
+const HTTPROUTE_PLURAL = "httproutes";
+const HTTPROUTE_PATH_PREFIX = `/apis/${HTTPROUTE_API_GROUP}/${HTTPROUTE_API_VERSION}/namespaces`;
+
+function httpRoutePath(namespace: string, routeName: string): string {
+  return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}/${encodeURIComponent(routeName)}`;
+}
+
+function httpRouteCollectionPath(namespace: string): string {
+  return `${HTTPROUTE_PATH_PREFIX}/${encodeURIComponent(namespace)}/${HTTPROUTE_PLURAL}`;
+}
+
+/**
+ * Create an HTTPRoute. 409 (AlreadyExists) is swallowed because the runner
+ * calls this from both the fresh-provision path and the adopt-backfill
+ * path — a pre-existing route from an earlier provision attempt is the
+ * intended steady state, not an error.
+ */
+export async function createHttpRoute(
+  kc: KubeConfig,
+  namespace: string,
+  route: HttpRoute,
+): Promise<void> {
+  try {
+    const resp = await kubeFetch(kc, {
+      method: "POST",
+      path: httpRouteCollectionPath(namespace),
+      body: route,
+    });
+    if (resp.status === 409) return;
+    await ensureOk(resp, "createHttpRoute");
+  } catch (error) {
+    if (error instanceof KubeHttpError && error.status === 409) return;
+    throw new SandboxError(
+      `Failed to create HTTPRoute: ${route.metadata.name}`,
+      error,
+    );
+  }
+}
+
+export async function deleteHttpRoute(
+  kc: KubeConfig,
+  namespace: string,
+  routeName: string,
+): Promise<void> {
+  await callSwallowing404(
+    kc,
+    { method: "DELETE", path: httpRoutePath(namespace, routeName) },
+    "deleteHttpRoute",
+    `Failed to delete HTTPRoute: ${routeName}`,
+  );
+}
+
+export async function getHttpRoute(
+  kc: KubeConfig,
+  namespace: string,
+  routeName: string,
+): Promise<HttpRoute | undefined> {
+  const found = await callSwallowing404<HttpRoute>(
+    kc,
+    { method: "GET", path: httpRoutePath(namespace, routeName) },
+    "getHttpRoute",
+    `Failed to get HTTPRoute: ${routeName}`,
+    "json",
+  );
+  return found ?? undefined;
+}
+
+export const HTTPROUTE_CONSTANTS = {
+  API_GROUP: HTTPROUTE_API_GROUP,
+  API_VERSION: HTTPROUTE_API_VERSION,
+  PLURAL: HTTPROUTE_PLURAL,
+} as const;
+
 export interface WaitForSandboxReadyResult {
   sandboxName: string;
   podName: string;

--- a/packages/sandbox/server/runner/agent-sandbox/index.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/index.ts
@@ -3,12 +3,17 @@
 export { KubeConfig } from "@kubernetes/client-node";
 export { K8S_CONSTANTS, SandboxError, SandboxTimeoutError } from "./constants";
 export {
+  createHttpRoute,
   createSandboxClaim,
+  deleteHttpRoute,
   deleteSandboxClaim,
+  getHttpRoute,
   getSandboxClaim,
+  HTTPROUTE_CONSTANTS,
   waitForSandboxReady,
 } from "./client";
 export type {
+  HttpRoute,
   SandboxClaim,
   SandboxClaimEnvVar,
   SandboxCondition,

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -61,15 +61,19 @@ import type {
   Workload,
 } from "../types";
 import {
+  createHttpRoute,
   createSandboxClaim,
+  deleteHttpRoute,
   deleteSandboxClaim,
   getSandboxClaim,
+  HTTPROUTE_CONSTANTS,
   patchSandboxClaimShutdown,
   waitForSandboxReady,
+  type HttpRoute,
   type SandboxClaim,
   type SandboxResource,
 } from "./client";
-import { K8S_CONSTANTS } from "./constants";
+import { K8S_CONSTANTS, SandboxError } from "./constants";
 
 const RUNNER_KIND = "agent-sandbox" as const;
 const LOG_LABEL = "AgentSandboxRunner";
@@ -261,6 +265,23 @@ export interface AgentSandboxRunnerOptions {
    * undefined; mesh wires `metrics.getMeter("mesh", "1.0.0")`.
    */
   meter?: Meter;
+  /**
+   * Per-claim HTTPRoute parent. When set together with `previewUrlPattern`,
+   * the runner mints one HTTPRoute per SandboxClaim (same name + namespace
+   * as the claim) and tears it down on `delete`. The route attaches to
+   * `parentRef = { name, namespace }` and routes `<handle>.<host>` exact
+   * matches to the operator-created Service:9000 in `this.namespace`.
+   *
+   * When unset (or `previewUrlPattern` unset), the runner does NOT touch
+   * HTTPRoute resources. Preview traffic still works in that mode through
+   * mesh's in-process proxy (the previous design), provided someone else
+   * (the chart, an operator, hand-rolled YAML) has wired a wildcard
+   * HTTPRoute backed by mesh.
+   */
+  previewGateway?: {
+    name: string;
+    namespace: string;
+  };
 }
 
 export class AgentSandboxRunner implements SandboxRunner {
@@ -282,6 +303,13 @@ export class AgentSandboxRunner implements SandboxRunner {
    * still allocate and dispatch on every call.
    */
   private readonly metrics: RunnerMetrics | null;
+  /**
+   * Non-null only when both `previewUrlPattern` and `previewGateway` were
+   * provided — the two together define the full route shape (hostname +
+   * parent). Used as the gate for HTTPRoute mutations across provision,
+   * adopt, and delete.
+   */
+  private readonly previewGateway: { name: string; namespace: string } | null;
 
   constructor(opts: AgentSandboxRunnerOptions = {}) {
     this.stateStore = opts.stateStore ?? null;
@@ -296,6 +324,13 @@ export class AgentSandboxRunner implements SandboxRunner {
       (() => randomBytes(DAEMON_TOKEN_BYTES).toString("hex"));
     this.idleTtlMs = opts.idleTtlMs ?? DEFAULT_IDLE_TTL_MS;
     this.metrics = opts.meter ? buildRunnerMetrics(opts.meter) : null;
+    // HTTPRoute routing requires both pieces — the hostname template (so we
+    // know what host to attach) and the gateway parent (so we know where).
+    // Either alone is meaningless, so refuse to half-enable.
+    this.previewGateway =
+      opts.previewGateway && opts.previewUrlPattern
+        ? { ...opts.previewGateway }
+        : null;
   }
 
   // ---- SandboxRunner surface ------------------------------------------------
@@ -324,6 +359,18 @@ export class AgentSandboxRunner implements SandboxRunner {
       // was never incremented for this handle in this process.
       this.metrics?.active.add(-1, tenantAttrs(rec.tenant));
     }
+    // Drop the HTTPRoute first so traffic stops resolving immediately —
+    // the operator's claim teardown can take a few seconds, and we don't
+    // want browsers landing on a half-deleted Service in the interim.
+    // Failures here are logged and continue: a stale HTTPRoute backed by a
+    // deleted Service simply 502s, and the next delete attempt (or a
+    // garbage-collection sweep) will clean it up. Blocking claim deletion
+    // on a transient gateway-API error would be worse for the caller.
+    await this.deleteHttpRouteIfManaged(handle).catch((err) => {
+      console.warn(
+        `[${LOG_LABEL}] HTTPRoute delete failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
     await deleteSandboxClaim(this.kubeConfig, this.namespace, handle);
     if (this.stateStore) {
       if (rec) await this.stateStore.delete(rec.id, RUNNER_KIND);
@@ -797,6 +844,20 @@ export class AgentSandboxRunner implements SandboxRunner {
       handle,
     );
 
+    // Mint per-claim HTTPRoute before opening the port-forward so that, by
+    // the time `Sandbox.previewUrl` reaches the caller, the gateway already
+    // has a route attached. If this fails the claim is still healthy but
+    // the preview URL would be unroutable, which is worse than a fast-fail
+    // — roll back the claim so the caller's retry hits a clean slate.
+    try {
+      await this.ensureHttpRouteForHandle(handle, opts.tenant ?? null);
+    } catch (err) {
+      await deleteSandboxClaim(this.kubeConfig, this.namespace, handle).catch(
+        () => {},
+      );
+      throw err;
+    }
+
     const daemonForward = await this.openForwarder(
       podName,
       DAEMON_CONTAINER_PORT,
@@ -807,6 +868,7 @@ export class AgentSandboxRunner implements SandboxRunner {
       await waitForDaemonReady(daemonUrl);
     } catch (err) {
       this.closeForwarder(daemonForward);
+      await this.deleteHttpRouteIfManaged(handle).catch(() => {});
       await deleteSandboxClaim(this.kubeConfig, this.namespace, handle).catch(
         () => {},
       );
@@ -826,6 +888,69 @@ export class AgentSandboxRunner implements SandboxRunner {
       tenant: opts.tenant ?? null,
       ensureOpts: stripEnsureOpts(opts),
     };
+  }
+
+  /**
+   * No-op when `previewGateway` isn't configured. Otherwise PUT-or-create
+   * the HTTPRoute that maps `<handle>.<base>` → operator Service `<handle>`
+   * port 9000. createHttpRoute swallows 409, so this is safe to call from
+   * both fresh-provision and adopt-backfill paths.
+   */
+  private async ensureHttpRouteForHandle(
+    handle: string,
+    tenant: RunnerTenant | null,
+  ): Promise<void> {
+    if (!this.previewGateway || !this.previewUrlPattern) return;
+    const hostname = previewHostnameForHandle(this.previewUrlPattern, handle);
+    if (!hostname) {
+      throw new SandboxError(
+        `Unable to derive preview hostname for ${handle} from pattern: ${this.previewUrlPattern}`,
+      );
+    }
+    const route: HttpRoute = {
+      apiVersion: `${HTTPROUTE_CONSTANTS.API_GROUP}/${HTTPROUTE_CONSTANTS.API_VERSION}`,
+      kind: "HTTPRoute",
+      metadata: {
+        name: handle,
+        namespace: this.namespace,
+        labels: buildTenantLabels(tenant ?? undefined, {
+          [LABEL_KEYS.role]: "claimed",
+          [LABEL_KEYS.sandboxHandle]: handle,
+          "app.kubernetes.io/name": "studio-sandbox",
+          "app.kubernetes.io/managed-by": "studio",
+        }),
+      },
+      spec: {
+        parentRefs: [
+          {
+            kind: "Gateway",
+            group: "gateway.networking.k8s.io",
+            name: this.previewGateway.name,
+            namespace: this.previewGateway.namespace,
+          },
+        ],
+        hostnames: [hostname],
+        rules: [
+          {
+            backendRefs: [
+              {
+                group: "",
+                kind: "Service",
+                name: handle,
+                port: DAEMON_CONTAINER_PORT,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    await createHttpRoute(this.kubeConfig, this.namespace, route);
+  }
+
+  /** No-op when `previewGateway` isn't configured. 404-tolerant otherwise. */
+  private async deleteHttpRouteIfManaged(handle: string): Promise<void> {
+    if (!this.previewGateway) return;
+    await deleteHttpRoute(this.kubeConfig, this.namespace, handle);
   }
 
   /**
@@ -893,6 +1018,21 @@ export class AgentSandboxRunner implements SandboxRunner {
     const live = await this.openAndProbeDaemon(podName, handle);
     if (!live) return null;
 
+    const tenant = readClaimTenant(claim);
+    // Backfill the HTTPRoute for legacy claims provisioned before per-claim
+    // routing existed. createHttpRoute swallows 409, so the steady-state
+    // path (route already present from a prior provision) is a no-op.
+    // Failures here don't block adoption — preview traffic just stays
+    // unrouted until the next ensure() picks it up; the rest of the
+    // sandbox surface (exec, port-forward) is unaffected.
+    if (this.previewGateway) {
+      await this.ensureHttpRouteForHandle(handle, tenant).catch((err) => {
+        console.warn(
+          `[${LOG_LABEL}] HTTPRoute backfill failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }
+
     return {
       id,
       handle,
@@ -906,7 +1046,7 @@ export class AgentSandboxRunner implements SandboxRunner {
       // Recovered from claim labels written at provision time. Null if the
       // claim pre-dates tenant labelling (back-compat with already-running
       // sandboxes when this code rolls out).
-      tenant: readClaimTenant(claim),
+      tenant,
       // Adopt happens when the state-store is empty but a claim with our
       // deterministic name still exists in the cluster (e.g. mesh restart
       // without state-store, or state-store wipe). The original opts aren't
@@ -1371,6 +1511,25 @@ function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   if (opts.env && Object.keys(opts.env).length > 0) out.env = opts.env;
   if (opts.tenant) out.tenant = opts.tenant;
   return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Extract the bare hostname `<handle>.<base>` from a preview URL pattern.
+ * Reuses `applyPreviewPattern` to guarantee parity with the URL the runner
+ * advertises in `Sandbox.previewUrl` — drift between "URL the user sees"
+ * and "hostname the gateway routes" would silently break iframe loading.
+ * Returns null when the pattern doesn't parse as a URL (e.g. someone set
+ * `{handle}/foo` without a scheme).
+ */
+function previewHostnameForHandle(
+  pattern: string,
+  handle: string,
+): string | null {
+  try {
+    return new URL(applyPreviewPattern(pattern, handle)).hostname || null;
+  } catch {
+    return null;
+  }
 }
 
 /** Fallback for when callers don't provide `repo.displayName`. */

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -272,6 +272,13 @@ export interface AgentSandboxRunnerOptions {
    * `parentRef = { name, namespace }` and routes `<handle>.<host>` exact
    * matches to the operator-created Service:9000 in `this.namespace`.
    *
+   * `namespace` is the gateway's namespace, NOT the route's — the route
+   * always lives in `this.namespace` (same as the Service it backends).
+   * Both `name` and `namespace` are required when this option is provided;
+   * the runner makes no assumption about which gateway controller (Istio,
+   * Envoy Gateway, Cilium, ...) is downstream and therefore can't pick a
+   * default namespace.
+   *
    * When unset (or `previewUrlPattern` unset), the runner does NOT touch
    * HTTPRoute resources. Preview traffic still works in that mode through
    * mesh's in-process proxy (the previous design), provided someone else


### PR DESCRIPTION
- Introduced a new function to read the preview gateway configuration from environment variables.
- Updated the sandbox runner to create and manage per-claim HTTPRoutes, allowing direct routing from the wildcard Gateway to each sandbox's service.
- Modified Helm chart to reflect the removal of the cluster-wide HTTPRoute and added necessary RBAC permissions for managing HTTPRoutes.
- Enhanced documentation to clarify the new routing model and configuration requirements for the preview gateway.
- Deprecated unused service name and port values in the Helm chart to streamline configuration.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements per-claim `HTTPRoute` for sandbox previews. The `agent-sandbox` runner now attaches `<handle>.<domain>` traffic from a wildcard `Gateway` directly to each sandbox `Service:9000`, removing mesh from the data path.

- **New Features**
  - Runner manages per-claim `HTTPRoute` via Gateway API; backfills on adopt; gated by `STUDIO_SANDBOX_PREVIEW_URL_PATTERN` + `STUDIO_SANDBOX_PREVIEW_GATEWAY_{NAME,NAMESPACE}` with strict both-or-none validation (unset → legacy proxy fallback).
  - Helm drops the cluster-wide preview `HTTPRoute`; keeps only the wildcard `Gateway` + cert; adds RBAC for `httproutes`, a NetworkPolicy ingress from `previewGateway.namespace` to port 9000, and allows routes from `agent-sandbox-system`.
  - Deprecates `mesh.serviceName` and `mesh.servicePort` values (unused with per-claim routes).

- **Migration**
  - Upgrade the `sandbox-env` chart to `0.2.0` and mesh to the version that supports per-claim routes.
  - Ensure DNS wildcard (`*.<domain>`) and a cert-manager ClusterIssuer exist.
  - Set `STUDIO_SANDBOX_PREVIEW_URL_PATTERN`, `STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME`, and `STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE` when `previewGateway.enabled=true`; both are required (half-configured fails fast). Leaving both unset keeps the legacy proxy but requires a separate cluster-wide `HTTPRoute` that this chart no longer creates.
  - Remove any custom cluster-wide preview `HTTPRoute` backed by mesh.

<sup>Written for commit 87292b7df176607d25ae2a87a313268b257039aa. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3228?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

