### PR TITLE
feat(agents): show creator and creation date in agent settings

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
+import { User } from "@/web/components/user/user";
 import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
 
 import {
@@ -1597,6 +1598,23 @@ Define step-by-step how the agent should handle requests.
                 </span>
                 Connect
               </Button>
+            </div>
+
+            {/* Creator metadata */}
+            <div className="flex items-center gap-2 -mt-6 text-muted-foreground">
+              <User
+                id={virtualMcp.created_by}
+                size="2xs"
+                className="text-sm text-muted-foreground"
+              />
+              <span className="text-muted-foreground/50 text-sm">·</span>
+              <span className="text-sm">
+                {new Date(virtualMcp.created_at).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </span>
             </div>
 
             {/* Connections section */}


### PR DESCRIPTION
## What is this contribution about?

Adds creator info and creation date to the agent settings page. Below the agent's name/description header, a small metadata row now shows the avatar + name of whoever created the agent and the date it was created — matching the same pattern used in automation settings.

## Screenshots/Demonstration

> Creator avatar, name, and formatted creation date (e.g. "Apr 29, 2025") appear just below the identity header in agent settings.

## How to Test

1. Open any agent's Settings page.
2. Below the agent name and description, verify a row shows the creator's avatar + name and a formatted creation date.
3. Expected: displays correctly for existing agents; resolves to "Unknown User" gracefully if the creator account no longer exists.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a creator metadata row to agent settings that shows the creator’s avatar/name and the agent’s creation date, matching the automation settings pattern. It appears below the agent name/description; the date is formatted like "Apr 29, 2026" and falls back to "Unknown User" if the account is missing.

<sup>Written for commit 0d0bfc27a498e07327a83851872707812ad65ff3. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3229?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

