### PR TITLE
feat(sandbox): implement Server-Side Apply for Service ports in sandbox

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,20 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.3.0: mesh runner now Server-Side Applies `port: 9000` onto each
+# operator-created Service after the SandboxClaim becomes Ready, taking
+# ownership of `spec.ports[name=daemon]` under field manager
+# `mesh-sandbox-runner`. agent-sandbox v0.4.x ships Services with
+# `spec.ports: []` (the operator assumes direct pod-IP DNS), which makes
+# Istio's k8s service registry refuse to register an upstream cluster —
+# HTTPRoutes "Accept" but Envoy returns 500 with no body, surfacing as a
+# phantom CORS error in browsers. SSA (vs. plain PATCH) means a future
+# operator reconciler that tries to reset ports[] will hit a
+# managed-fields conflict rather than silently breaking routing. RBAC
+# gains `services: [get, patch]` in `agent-sandbox-system`. Upgraders
+# MUST bump mesh to the matching version; without the new RBAC the
+# runner fails to apply the Service and per-claim previews stop routing.
+#
 # 0.2.0: per-claim HTTPRoutes minted by mesh runner. The chart no longer
 # renders the cluster-wide HTTPRoute that backed the in-process preview
 # proxy; mesh now mints one HTTPRoute per SandboxClaim. RBAC gains
@@ -16,7 +30,7 @@ type: application
 # an ingress rule from `previewGateway.namespace` to sandbox port 9000.
 # Upgraders MUST bump mesh to the matching version that creates per-claim
 # HTTPRoutes — otherwise preview URLs stop resolving.
-version: 0.2.0
+version: 0.3.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.1.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -72,6 +72,28 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "create", "delete"]
+  # Per-claim Service port ownership. agent-sandbox v0.4.x creates the
+  # Service for each Sandbox with `spec.ports: []` (the operator's
+  # contract is that callers reach pods via direct pod-IP DNS). Istio's
+  # k8s service registry only registers an upstream cluster when the
+  # Service declares at least one port, so the runner Server-Side Applies
+  # `port: 9000` onto the Service right after the SandboxClaim becomes
+  # Ready and before creating the HTTPRoute. SSA is used over a plain
+  # PATCH so that mesh becomes the recorded field manager for
+  # `spec.ports[name=daemon]` — if a future operator revision tries to
+  # reset ports[] under its own field manager, the API server surfaces a
+  # managed-fields conflict instead of silently breaking routing in prod.
+  # Without this, the HTTPRoute is "Accepted" but Envoy has no cluster to
+  # route to and returns an empty 500 — which the browser misreports as a
+  # CORS error.
+  #
+  # `patch` is the verb K8s requires for SSA writes (apply-patch is just
+  # a content type — the verb on the subresource is still PATCH). `get`
+  # is here for parity with the HTTPRoute rule (debug visibility); the
+  # runner doesn't read Services on the hot path.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {

--- a/packages/sandbox/server/runner/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.test.ts
@@ -3,6 +3,7 @@ import { K8S_CONSTANTS } from "./constants";
 import {
   createSandboxClaim,
   deleteSandboxClaim,
+  ensureServicePort,
   getSandboxClaim,
   patchSandboxClaimShutdown,
   type SandboxClaim,
@@ -280,6 +281,84 @@ describe("patchSandboxClaimShutdown", () => {
         "2026-04-01T12:00:00.000Z",
       ),
     ).rejects.toThrow(/Failed to patch SandboxClaim shutdownTime: busy/);
+  });
+});
+
+describe("ensureServicePort", () => {
+  it("server-side applies the Service ports with field manager + force", async () => {
+    fetchImpl = async () => jsonResponse(200, { kind: "Service" });
+    await ensureServicePort(makeKc(), NS, "studio-sb-abc", {
+      name: "daemon",
+      port: 9000,
+      targetPort: 9000,
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    const [call] = fetchCalls;
+    const url = new URL(call!.url);
+    expect(url.pathname).toBe(
+      `/api/v1/namespaces/${NS}/services/studio-sb-abc`,
+    );
+    // SSA contract: fieldManager identifies the writer, force=true takes
+    // ownership of fields previously owned by another manager (the
+    // operator's empty ports[]).
+    expect(url.searchParams.get("fieldManager")).toBe("mesh-sandbox-runner");
+    expect(url.searchParams.get("force")).toBe("true");
+
+    expect(call!.init.method).toBe("PATCH");
+    const headers = call!.init.headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("application/apply-patch+yaml");
+
+    // SSA bodies must be self-describing: apiVersion + kind + metadata.name
+    // are required so the API server can resolve the target without reading
+    // path params. spec.ports is the field we want to own.
+    expect(JSON.parse(String(call!.init.body))).toEqual({
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: { name: "studio-sb-abc" },
+      spec: {
+        ports: [
+          { name: "daemon", port: 9000, targetPort: 9000, protocol: "TCP" },
+        ],
+      },
+    });
+  });
+
+  it("defaults protocol to TCP when not provided", async () => {
+    fetchImpl = async () => jsonResponse(200, { kind: "Service" });
+    await ensureServicePort(makeKc(), NS, "svc", {
+      name: "daemon",
+      port: 9000,
+      targetPort: 9000,
+    });
+    const body = JSON.parse(String(fetchCalls[0]!.init.body));
+    expect(body.spec.ports[0].protocol).toBe("TCP");
+  });
+
+  it("URL-encodes the service name", async () => {
+    fetchImpl = async () => jsonResponse(200, { kind: "Service" });
+    await ensureServicePort(makeKc(), NS, "weird/name", {
+      name: "daemon",
+      port: 9000,
+      targetPort: 9000,
+    });
+    expect(fetchCalls[0]!.url).toContain("/services/weird%2Fname");
+  });
+
+  it("wraps non-2xx errors in SandboxError with the service name", async () => {
+    fetchImpl = async () =>
+      jsonResponse(404, {
+        kind: "Status",
+        reason: "NotFound",
+        message: "service not found",
+      });
+    await expect(
+      ensureServicePort(makeKc(), NS, "missing", {
+        name: "daemon",
+        port: 9000,
+        targetPort: 9000,
+      }),
+    ).rejects.toThrow(/Failed to apply Service ports: missing/);
   });
 });
 

--- a/packages/sandbox/server/runner/agent-sandbox/client.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.ts
@@ -174,9 +174,14 @@ interface KubeFetchInit {
   headers?: Record<string, string>;
   /**
    * Required iff `method === "PATCH"`. Drives the patch content-type:
-   * RFC 7396 merge-patch (CRDs) vs. strategic-merge (built-in types).
+   *   - `merge`           — RFC 7396 merge-patch (default; CRDs).
+   *   - `strategic-merge` — strategic-merge-patch (built-in types).
+   *   - `apply`           — Server-Side Apply (declarative; tracks field
+   *                         ownership via `?fieldManager=<name>`). Caller
+   *                         is responsible for appending `fieldManager`
+   *                         (and optionally `force=true`) to `path`.
    */
-  patchType?: "merge" | "strategic-merge";
+  patchType?: "merge" | "strategic-merge" | "apply";
 }
 
 /**
@@ -191,10 +196,16 @@ async function kubeFetch(
   const auth = await resolveKubeAuth(kc);
   const headers: Record<string, string> = { ...auth.headers, ...init.headers };
   if (init.method === "PATCH") {
+    // SSA's canonical content-type is `application/apply-patch+yaml`; the
+    // API server treats JSON as a strict YAML subset, so we serialize the
+    // body as JSON and label it `+yaml` for compat with K8s <1.32 (the
+    // `+json` variant only landed in 1.32).
     headers["content-type"] =
-      init.patchType === "strategic-merge"
-        ? "application/strategic-merge-patch+json"
-        : "application/merge-patch+json";
+      init.patchType === "apply"
+        ? "application/apply-patch+yaml"
+        : init.patchType === "strategic-merge"
+          ? "application/strategic-merge-patch+json"
+          : "application/merge-patch+json";
   } else if (init.body !== undefined && !("content-type" in headers)) {
     headers["content-type"] = "application/json";
   }
@@ -465,6 +476,101 @@ export const HTTPROUTE_CONSTANTS = {
   API_VERSION: HTTPROUTE_API_VERSION,
   PLURAL: HTTPROUTE_PLURAL,
 } as const;
+
+// ---- Service port patching -------------------------------------------------
+
+/**
+ * Field-manager identity asserted on Server-Side Apply calls. K8s tracks
+ * ownership per-field by this string; reusing it across calls (and across
+ * mesh restarts) is what lets the second SSA see "I already own ports[]"
+ * and treat it as a no-op rather than a conflict.
+ */
+const SSA_FIELD_MANAGER = "mesh-sandbox-runner";
+
+/**
+ * Server-Side Apply a single named port onto a core Service. Establishes
+ * `mesh-sandbox-runner` as the field manager for `spec.ports[name=daemon]`,
+ * which prevents the operator's reconciler from silently reverting the
+ * field on its next pass.
+ *
+ * Why this exists: agent-sandbox v0.4.x creates per-Sandbox Services with
+ * `spec.ports: []` — the operator assumes callers reach pods via direct
+ * pod-IP DNS (`<pod>.<svc>.<ns>.svc.cluster.local`). Istio's k8s service
+ * registry only builds an upstream cluster when the Service has at least
+ * one declared port. With an empty ports list, an HTTPRoute backed by that
+ * Service is "Accepted" by the gateway controller but routes to nowhere:
+ * Envoy returns 500 with no body, which the browser misreports as a CORS
+ * error (because the empty 500 also has no `access-control-allow-origin`).
+ *
+ * Why SSA over strategic-merge-patch:
+ *   - SSA establishes mesh as the *owner* of `spec.ports`. If a future
+ *     operator revision performs a full Update of the Service (Get →
+ *     mutate → Put), the API server rejects the conflicting write unless
+ *     the operator explicitly forces — which would surface in operator
+ *     logs as a managed-fields conflict rather than silently breaking
+ *     routing in production.
+ *   - Re-applying the same body is a guaranteed no-op (the API server
+ *     diffs against our recorded managed-fields), so the call is safe
+ *     to issue from both fresh provision and adopt-backfill paths
+ *     without any caller-side "already applied?" check.
+ *
+ * `force=true` is set so the *first* apply takes ownership even if the
+ * operator initially set `ports: []` under its own field manager. After
+ * the first call, the API server records us as the owner and subsequent
+ * applies are no-ops.
+ *
+ * 404 is NOT swallowed: a missing Service when we expected one indicates
+ * a race against operator Service creation, which the caller should
+ * surface and potentially retry.
+ */
+export async function ensureServicePort(
+  kc: KubeConfig,
+  namespace: string,
+  serviceName: string,
+  port: {
+    name: string;
+    port: number;
+    targetPort: number;
+    protocol?: "TCP" | "UDP";
+  },
+): Promise<void> {
+  // SSA requires apiVersion + kind + metadata.name in the body so the API
+  // server can resolve the target type without reading it from the path.
+  const body = {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: { name: serviceName },
+    spec: {
+      ports: [
+        {
+          name: port.name,
+          port: port.port,
+          targetPort: port.targetPort,
+          protocol: port.protocol ?? "TCP",
+        },
+      ],
+    },
+  };
+  const query = new URLSearchParams({
+    fieldManager: SSA_FIELD_MANAGER,
+    force: "true",
+  });
+  const path = `/api/v1/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(serviceName)}?${query}`;
+  try {
+    const resp = await kubeFetch(kc, {
+      method: "PATCH",
+      path,
+      patchType: "apply",
+      body,
+    });
+    await ensureOk(resp, "ensureServicePort");
+  } catch (error) {
+    throw new SandboxError(
+      `Failed to apply Service ports: ${serviceName}`,
+      error,
+    );
+  }
+}
 
 export interface WaitForSandboxReadyResult {
   sandboxName: string;

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -65,6 +65,7 @@ import {
   createSandboxClaim,
   deleteHttpRoute,
   deleteSandboxClaim,
+  ensureServicePort,
   getSandboxClaim,
   HTTPROUTE_CONSTANTS,
   patchSandboxClaimShutdown,
@@ -851,12 +852,16 @@ export class AgentSandboxRunner implements SandboxRunner {
       handle,
     );
 
-    // Mint per-claim HTTPRoute before opening the port-forward so that, by
-    // the time `Sandbox.previewUrl` reaches the caller, the gateway already
-    // has a route attached. If this fails the claim is still healthy but
-    // the preview URL would be unroutable, which is worse than a fast-fail
-    // — roll back the claim so the caller's retry hits a clean slate.
+    // Patch the operator-created Service to declare port 9000, then mint the
+    // per-claim HTTPRoute. Both happen before the port-forward opens so that,
+    // by the time `Sandbox.previewUrl` reaches the caller, the gateway has a
+    // route AND its backend cluster is registered. The Service patch is a
+    // workaround for agent-sandbox v0.4.x shipping ports-less Services
+    // (`ensureServicePort` doc explains why this matters for Istio). If
+    // either step fails the claim is healthy but unroutable — roll back so
+    // the caller's retry hits a clean slate.
     try {
+      await this.ensureServicePortForHandle(handle);
       await this.ensureHttpRouteForHandle(handle, opts.tenant ?? null);
     } catch (err) {
       await deleteSandboxClaim(this.kubeConfig, this.namespace, handle).catch(
@@ -895,6 +900,24 @@ export class AgentSandboxRunner implements SandboxRunner {
       tenant: opts.tenant ?? null,
       ensureOpts: stripEnsureOpts(opts),
     };
+  }
+
+  /**
+   * No-op when `previewGateway` isn't configured. Otherwise Server-Side
+   * Apply port 9000 (named "daemon") onto the operator-created Service
+   * `<handle>`. The agent-sandbox operator (v0.4.x) ships Services with
+   * empty `spec.ports`, which makes Istio refuse to register an upstream
+   * cluster — `ensureServicePort` doc has the full rationale. Idempotent:
+   * once mesh owns `spec.ports[name=daemon]` (first SSA), subsequent calls
+   * with the same body are recorded as no-ops by the API server.
+   */
+  private async ensureServicePortForHandle(handle: string): Promise<void> {
+    if (!this.previewGateway || !this.previewUrlPattern) return;
+    await ensureServicePort(this.kubeConfig, this.namespace, handle, {
+      name: "daemon",
+      port: DAEMON_CONTAINER_PORT,
+      targetPort: DAEMON_CONTAINER_PORT,
+    });
   }
 
   /**
@@ -1026,13 +1049,21 @@ export class AgentSandboxRunner implements SandboxRunner {
     if (!live) return null;
 
     const tenant = readClaimTenant(claim);
-    // Backfill the HTTPRoute for legacy claims provisioned before per-claim
-    // routing existed. createHttpRoute swallows 409, so the steady-state
-    // path (route already present from a prior provision) is a no-op.
-    // Failures here don't block adoption — preview traffic just stays
-    // unrouted until the next ensure() picks it up; the rest of the
-    // sandbox surface (exec, port-forward) is unaffected.
+    // Backfill the Service port + HTTPRoute for legacy claims provisioned
+    // before per-claim routing existed. Both calls are idempotent — Service
+    // patch is a no-op once `port: 9000` is already declared, and
+    // createHttpRoute swallows 409. Failures here don't block adoption:
+    // preview traffic stays unrouted until the next ensure() picks it up;
+    // the rest of the sandbox surface (exec, port-forward) is unaffected.
+    // Service patch first so that, if the route is missing, recreating it
+    // immediately after will already see a working cluster on the gateway
+    // side.
     if (this.previewGateway) {
+      await this.ensureServicePortForHandle(handle).catch((err) => {
+        console.warn(
+          `[${LOG_LABEL}] Service port backfill failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
       await this.ensureHttpRouteForHandle(handle, tenant).catch((err) => {
         console.warn(
           `[${LOG_LABEL}] HTTPRoute backfill failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -46,7 +46,7 @@ import {
 import {
   Inflight,
   applyPreviewPattern,
-  hashSandboxId,
+  computeHandle as composeBranchHandle,
   withSandboxLock,
 } from "../shared";
 import type { RunnerStateStore, RunnerStateStoreOps } from "../state-store";
@@ -121,7 +121,15 @@ const RESERVED_ENV_KEYS = new Set([
 // abandoned sandboxes roll off at T+15m via the operator.
 const DEFAULT_IDLE_TTL_MS = 15 * 60 * 1000;
 
-/** Handle prefix + 16-hex hash = 24 chars, well under K8s's 63-char label cap. */
+/**
+ * Handle shape: `studio-sb-<slug>-<hash16>` when a branch is supplied,
+ * `studio-sb-<hash16>` otherwise. With prefix(10) + slug(≤24) + 1 + hash(16)
+ * = 51 chars max — under K8s's 63-char DNS label cap with margin for
+ * suffixed env names. The 16-char hash (~64 bits) is preserved over the
+ * shared default of 5 because the handle is the *only* authorization on
+ * the public preview URL (Vercel-style "URL is the secret"); 20-bit hashes
+ * are brute-forceable at a busy gateway in minutes.
+ */
 export const HANDLE_PREFIX = "studio-sb-";
 const HANDLE_HASH_LEN = 16;
 
@@ -344,7 +352,10 @@ export class AgentSandboxRunner implements SandboxRunner {
   // ---- SandboxRunner surface ------------------------------------------------
 
   async ensure(id: SandboxId, opts: EnsureOptions = {}): Promise<Sandbox> {
-    const handle = this.computeHandle(id);
+    // Branch is the slug source; absent when caller didn't pass `repo`
+    // (tool-only sandboxes, smoke tests). The shared computeHandle falls
+    // back to a bare hash in that case, preserving stable identity.
+    const handle = this.computeHandle(id, opts.repo?.branch ?? null);
     return this.inflight.run(handle, () =>
       withSandboxLock(this.stateStore, id, RUNNER_KIND, (ops) =>
         this.ensureLocked(id, handle, opts, ops),
@@ -1208,8 +1219,8 @@ export class AgentSandboxRunner implements SandboxRunner {
 
   // ---- Identity + preview URL ----------------------------------------------
 
-  private computeHandle(id: SandboxId): string {
-    return `${HANDLE_PREFIX}${hashSandboxId(id, HANDLE_HASH_LEN)}`;
+  private computeHandle(id: SandboxId, branch: string | null): string {
+    return `${HANDLE_PREFIX}${composeBranchHandle(id, branch, { hashLen: HANDLE_HASH_LEN })}`;
   }
 
   // Local mode: route preview traffic through the daemon port-forward, not

--- a/packages/sandbox/server/runner/shared/handle.test.ts
+++ b/packages/sandbox/server/runner/shared/handle.test.ts
@@ -87,4 +87,16 @@ describe("computeHandle", () => {
     const expectedHash = hashSandboxId(ID, 5);
     expect(handle.endsWith(`-${expectedHash}`)).toBe(true);
   });
+
+  it("honors a custom hashLen (used by runners exposing handles publicly)", () => {
+    const handle = computeHandle(ID, "deco/mellow-flint", { hashLen: 16 });
+    expect(handle).toMatch(/^mellow-flint-[0-9a-f]{16}$/);
+    expect(handle.endsWith(`-${hashSandboxId(ID, 16)}`)).toBe(true);
+  });
+
+  it("returns a bare hash of the requested length when branch is empty", () => {
+    const handle = computeHandle(ID, null, { hashLen: 16 });
+    expect(handle).toMatch(/^[0-9a-f]{16}$/);
+    expect(handle).toBe(hashSandboxId(ID, 16));
+  });
 });

--- a/packages/sandbox/server/runner/shared/handle.ts
+++ b/packages/sandbox/server/runner/shared/handle.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { sandboxIdKey, type SandboxId } from "../types";
 
 const SLUG_MAX = 24;
-const HANDLE_HASH_LEN = 5;
+const DEFAULT_HASH_LEN = 5;
 
 /** Stable short hash of a SandboxId. Length in hex chars (default 16). */
 export function hashSandboxId(id: SandboxId, length = 16): string {
@@ -13,15 +13,30 @@ export function hashSandboxId(id: SandboxId, length = 16): string {
 }
 
 /**
- * Human-readable URL handle for a sandbox: `<slug>-<hash5>`, where `slug` is
- * derived from the last `/`-segment of the branch and `hash5` is the first
- * 5 hex chars of `SHA256(userId:projectRef)`. Falls back to a bare 5-char
- * hash when the branch is missing or sanitizes to empty.
+ * Human-readable URL handle for a sandbox: `<slug>-<hashN>`, where `slug` is
+ * derived from the last `/`-segment of the branch and `hashN` is the first
+ * `N` hex chars of `SHA256(userId:projectRef)`. Falls back to a bare hash
+ * when the branch is missing or sanitizes to empty.
  *
- * Total max length: 24 + 1 + 5 = 30 chars (under the 63-char DNS label cap).
+ * Hash length defaults to 5 chars (~20 bits) — sufficient for runners whose
+ * handle is local (Docker container name, Freestyle internal ID). Runners
+ * that expose the handle as a public hostname (agent-sandbox preview URLs,
+ * Vercel-style) should pass `{ hashLen: 16 }` (~64 bits) — the handle is
+ * the only authorization on those URLs, so brute-forcing 20 bits at an
+ * unrate-limited gateway (~17 min at 1k req/s) is meaningfully easier
+ * than 64 bits.
+ *
+ * Total max length: 24 + 1 + hashLen chars. With hashLen=16: 41 chars
+ * (under the 63-char DNS label cap with room for a runner-specific
+ * prefix).
  */
-export function computeHandle(id: SandboxId, branch?: string | null): string {
-  const hash = hashSandboxId(id, HANDLE_HASH_LEN);
+export function computeHandle(
+  id: SandboxId,
+  branch?: string | null,
+  opts: { hashLen?: number } = {},
+): string {
+  const hashLen = opts.hashLen ?? DEFAULT_HASH_LEN;
+  const hash = hashSandboxId(id, hashLen);
   const slug = slugifyBranch(branch);
   return slug ? `${slug}-${hash}` : hash;
 }


### PR DESCRIPTION
- Updated Helm chart to version 0.3.0, introducing Server-Side Apply for Service ports to ensure proper routing with Istio.
- Added RBAC permissions for managing Service resources, allowing the mesh runner to take ownership of Service ports.
- Implemented `ensureServicePort` function to handle Service port patching, ensuring that the Service is correctly configured for routing.
- Enhanced the sandbox runner to call `ensureServicePort` before creating per-claim HTTPRoutes, ensuring that the Service is ready for traffic.

This change addresses issues with routing failures due to empty Service port configurations in agent-sandbox v0.4.x.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Server-Side Apply to set port 9000 on sandbox Services so Istio registers backends and per-claim preview routes work. Also updates preview handles to include branch slugs for clearer, stable URLs without reducing security.

- **New Features**
  - Added `ensureServicePort` to apply `spec.ports[name="daemon"]=9000` via SSA with field manager `mesh-sandbox-runner` (idempotent). Runner calls this before creating per-claim `HTTPRoute`s and during adoption.
  - Preview handle now includes the branch slug: `studio-sb-<slug>-<hash16>` (falls back to `studio-sb-<hash16>` when no branch), keeping a 16-hex hash for public URL hardening.

- **Migration**
  - Upgrade Helm chart `sandbox-env` to 0.3.0; adds RBAC for `services` (`get`, `patch`) so the runner can apply ports.
  - Deploy the matching runner; without the new RBAC, the apply will fail and previews will not route.

<sup>Written for commit 73f336e700576fd1b6e584c5cca90cf54ef128f7. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3230?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

