### PR TITLE
chore(sandbox): enhance release workflows and error handling

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -3,6 +3,10 @@ name: Release Mesh
 on:
   push:
     branches: [main]
+    # Keep this in sync with apps/mesh/package.json's workspace deps —
+    # any path mesh imports from at build time should fire the release,
+    # otherwise a fix landed only in a workspace package (like the
+    # agent-sandbox runner under packages/sandbox) ships nothing.
     paths:
       - "apps/mesh/**"
       - "packages/runtime/**"

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -1,17 +1,33 @@
 name: Release Tagging
 
 on:
+  # Keep these path lists in sync with release-mesh.yaml — anything that
+  # ships in the mesh image needs to fire the version-bump tagging too,
+  # otherwise a workspace-only change merges to main without a tag and
+  # the user has to touch apps/mesh/ by hand to force a release.
   pull_request_target:
     types: [opened, synchronize]
     paths:
       - "apps/mesh/**"
+      - "packages/bindings/**"
+      - "packages/mcp-utils/**"
       - "packages/mesh-plugin-*/**"
+      - "packages/mesh-sdk/**"
+      - "packages/runtime/**"
+      - "packages/sandbox/**"
+      - "packages/vite-plugin-deco/**"
   push:
     branches:
       - main
     paths:
       - "apps/mesh/**"
+      - "packages/bindings/**"
+      - "packages/mcp-utils/**"
       - "packages/mesh-plugin-*/**"
+      - "packages/mesh-sdk/**"
+      - "packages/runtime/**"
+      - "packages/sandbox/**"
+      - "packages/vite-plugin-deco/**"
 
 permissions:
   contents: write

--- a/packages/sandbox/server/runner/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { K8S_CONSTANTS } from "./constants";
+import {
+  K8S_CONSTANTS,
+  SandboxAlreadyExistsError,
+  SandboxTimeoutError,
+} from "./constants";
 import {
   createSandboxClaim,
   deleteSandboxClaim,
@@ -8,6 +12,7 @@ import {
   patchSandboxClaimShutdown,
   type SandboxClaim,
   type SandboxResource,
+  waitForSandboxClaimGone,
   waitForSandboxReady,
 } from "./client";
 
@@ -156,16 +161,99 @@ describe("createSandboxClaim", () => {
 
   it("wraps non-2xx errors in SandboxError with the claim name", async () => {
     fetchImpl = async () =>
+      jsonResponse(403, {
+        kind: "Status",
+        status: "Failure",
+        reason: "Forbidden",
+        message: "forbidden",
+        code: 403,
+      });
+    await expect(
+      createSandboxClaim(makeKc(), NS, makeClaim("denied")),
+    ).rejects.toThrow(/Failed to create SandboxClaim: denied/);
+  });
+
+  it("throws SandboxAlreadyExistsError on 409 so the runner can wait+retry", async () => {
+    // Operator's idle-TTL deleted the prior claim but finalizers haven't
+    // drained yet — the API server still has the resource and rejects
+    // create with 409. Surfacing this as a distinct subclass lets
+    // provision() catch it specifically and wait for the resource to be
+    // GC'd before retrying, instead of bubbling to the user as a
+    // "Failed to create SandboxClaim" toast they have to manually recover
+    // from (see screenshot in the bug report).
+    fetchImpl = async () =>
       jsonResponse(409, {
         kind: "Status",
         status: "Failure",
         reason: "AlreadyExists",
-        message: "already exists",
+        message:
+          'object is being deleted: sandboxclaims.extensions.agents.x-k8s.io "dup" already exists',
         code: 409,
       });
     await expect(
       createSandboxClaim(makeKc(), NS, makeClaim("dup")),
-    ).rejects.toThrow(/Failed to create SandboxClaim: dup/);
+    ).rejects.toBeInstanceOf(SandboxAlreadyExistsError);
+  });
+});
+
+describe("waitForSandboxClaimGone", () => {
+  it("returns immediately when the claim is already gone", async () => {
+    fetchImpl = async () =>
+      jsonResponse(404, {
+        kind: "Status",
+        reason: "NotFound",
+        message: "not found",
+      });
+    await expect(
+      waitForSandboxClaimGone(makeKc(), NS, "gone", 1_000),
+    ).resolves.toBeUndefined();
+    // Single GET → 404 → return; no polling loop fires.
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.init.method).toBe("GET");
+  });
+
+  it("polls until the claim disappears, then resolves", async () => {
+    // First two GETs see the resource still terminating (deletionTimestamp
+    // set, Ready=False); the third returns 404. The helper must not give up
+    // on the terminating responses — that's the whole point.
+    let calls = 0;
+    fetchImpl = async () => {
+      calls++;
+      if (calls < 3) {
+        return jsonResponse(200, {
+          metadata: {
+            name: "draining",
+            deletionTimestamp: "2026-04-29T17:48:55Z",
+          },
+          status: { conditions: [{ type: "Ready", status: "False" }] },
+        });
+      }
+      return jsonResponse(404, {
+        kind: "Status",
+        reason: "NotFound",
+        message: "not found",
+      });
+    };
+    await expect(
+      waitForSandboxClaimGone(makeKc(), NS, "draining", 5_000),
+    ).resolves.toBeUndefined();
+    expect(calls).toBe(3);
+  });
+
+  it("times out with SandboxTimeoutError when the claim never disappears", async () => {
+    fetchImpl = async () =>
+      jsonResponse(200, {
+        metadata: {
+          name: "stuck",
+          deletionTimestamp: "2026-04-29T17:48:55Z",
+        },
+        status: { conditions: [{ type: "Ready", status: "False" }] },
+      });
+    // Tight timeout — we just need to confirm the error type and that the
+    // helper does eventually give up rather than spinning forever.
+    await expect(
+      waitForSandboxClaimGone(makeKc(), NS, "stuck", 100),
+    ).rejects.toBeInstanceOf(SandboxTimeoutError);
   });
 });
 

--- a/packages/sandbox/server/runner/agent-sandbox/client.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.ts
@@ -24,7 +24,12 @@ import {
   type KubeConfig,
   type V1Status as V1StatusUpstream,
 } from "@kubernetes/client-node";
-import { K8S_CONSTANTS, SandboxError, SandboxTimeoutError } from "./constants";
+import {
+  K8S_CONSTANTS,
+  SandboxAlreadyExistsError,
+  SandboxError,
+  SandboxTimeoutError,
+} from "./constants";
 
 type V1Status = Partial<V1StatusUpstream> & { reason?: string };
 
@@ -86,6 +91,20 @@ export interface SandboxResource {
     name?: string;
     labels?: Record<string, string>;
     annotations?: Record<string, string>;
+    /**
+     * Set by the API server when a delete is in flight. While the resource
+     * still has finalizers, GETs return the object with this field populated
+     * and a Ready=False condition. The runner uses this to detect the
+     * terminating window and avoid recreating into a 409 AlreadyExists.
+     */
+    deletionTimestamp?: string;
+    /**
+     * Finalizer keys the API server must see drained before it actually
+     * removes the resource. Surfaced so the runner can log which controller
+     * is blocking deletion when `waitForSandboxClaimGone` times out — that's
+     * the difference between "operator is slow" and "operator is broken".
+     */
+    finalizers?: string[];
   };
   /**
    * Present when this came back from `getSandboxClaim` (CRD has a spec);
@@ -282,14 +301,82 @@ export async function createSandboxClaim(
   claim: SandboxClaim,
 ): Promise<void> {
   const path = `${CLAIM_PATH_PREFIX}/${encodeURIComponent(namespace)}/${K8S_CONSTANTS.CLAIM_PLURAL}`;
+  let resp: Response;
   try {
-    const resp = await kubeFetch(kc, { method: "POST", path, body: claim });
-    await ensureOk(resp, "createSandboxClaim");
+    resp = await kubeFetch(kc, { method: "POST", path, body: claim });
   } catch (error) {
     throw new SandboxError(
       `Failed to create SandboxClaim: ${claim.metadata.name}`,
       error,
     );
+  }
+  if (resp.ok) return;
+  // The status + reason + message must reach the surface — when the user
+  // sees "Failed to create SandboxClaim" with no further context, we have no
+  // way to tell whether this was a 409 finalizer-drain race (recoverable),
+  // a 422 admission-webhook rejection (claim shape problem), a 403/RBAC, or
+  // a stuck-terminating claim that the operator never finishes deleting.
+  const body = await readStatusBody(resp);
+  const reason = body?.reason ? ` ${body.reason}` : "";
+  const detail = body?.message ?? resp.statusText;
+  const summary = `Failed to create SandboxClaim: ${claim.metadata.name} (${resp.status}${reason}: ${detail})`;
+  // Server-side log mirrors the surface error and adds the response body so
+  // operators triaging an incident can tell which K8s subsystem rejected
+  // the create even if the only artifact in front of them is the user's
+  // toast/MCP response.
+  console.warn(
+    `[agent-sandbox/client] createSandboxClaim ${claim.metadata.name} rejected: status=${resp.status} reason=${body?.reason ?? "<none>"} message=${detail}`,
+  );
+  // 409 is split out so the runner can wait for the still-terminating prior
+  // claim to drain finalizers and retry. This is the canonical race when the
+  // operator's idle-TTL just reaped a claim and mesh's next ensure() hits
+  // before the resource is fully GC'd. Stuck-finalizer cases also surface as
+  // 409 but never recover from a wait — those need operator intervention.
+  if (resp.status === 409) {
+    throw new SandboxAlreadyExistsError(summary);
+  }
+  throw new SandboxError(summary);
+}
+
+/**
+ * Poll until the named SandboxClaim no longer exists in the API server (i.e.
+ * its DELETE has drained all finalizers and the API server has GC'd the
+ * resource). Returns immediately if the claim is already gone.
+ *
+ * The agent-sandbox operator's idle-TTL deletes the claim, but pod teardown +
+ * any per-claim finalizers can take several seconds. Recreating during that
+ * window 409s; this helper bridges the gap so the runner's recreate path is
+ * deterministic instead of probabilistic. Polling at 500ms keeps the recovery
+ * latency low without hammering the API server (≤120 requests over a 60s
+ * window).
+ */
+export async function waitForSandboxClaimGone(
+  kc: KubeConfig,
+  namespace: string,
+  claimName: string,
+  timeoutMs = 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const intervalMs = 500;
+  let lastClaim: SandboxResource | undefined;
+  while (true) {
+    const claim = await getSandboxClaim(kc, namespace, claimName).catch(
+      () => undefined,
+    );
+    if (!claim) return;
+    lastClaim = claim;
+    if (Date.now() >= deadline) {
+      // Include the deletionTimestamp + finalizer set in the error: a
+      // stuck finalizer is the most plausible non-recoverable cause and
+      // distinguishes "operator is slow" from "operator dropped the claim
+      // on the floor and won't ever finish".
+      const finalizers = lastClaim.metadata?.finalizers ?? [];
+      const since = lastClaim.metadata?.deletionTimestamp ?? "<unknown>";
+      throw new SandboxTimeoutError(
+        `SandboxClaim ${claimName} still terminating after ${timeoutMs}ms (deletionTimestamp=${since}, finalizers=[${finalizers.join(", ")}])`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
 }
 

--- a/packages/sandbox/server/runner/agent-sandbox/constants.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/constants.ts
@@ -36,3 +36,16 @@ export class SandboxTimeoutError extends SandboxError {
     this.name = "SandboxTimeoutError";
   }
 }
+
+/**
+ * Surfaced when the API server rejects a SandboxClaim create with 409
+ * AlreadyExists — typically because the operator's idle-TTL deletion of a
+ * prior claim is still draining finalizers when mesh tries to recreate.
+ * Callers wait for the resource to fully disappear and retry.
+ */
+export class SandboxAlreadyExistsError extends SandboxError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "SandboxAlreadyExistsError";
+  }
+}

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -69,12 +69,17 @@ import {
   getSandboxClaim,
   HTTPROUTE_CONSTANTS,
   patchSandboxClaimShutdown,
+  waitForSandboxClaimGone,
   waitForSandboxReady,
   type HttpRoute,
   type SandboxClaim,
   type SandboxResource,
 } from "./client";
-import { K8S_CONSTANTS, SandboxError } from "./constants";
+import {
+  K8S_CONSTANTS,
+  SandboxAlreadyExistsError,
+  SandboxError,
+} from "./constants";
 
 const RUNNER_KIND = "agent-sandbox" as const;
 const LOG_LABEL = "AgentSandboxRunner";
@@ -672,23 +677,52 @@ export class AgentSandboxRunner implements SandboxRunner {
       handle,
     ).catch(() => undefined);
     if (existing) {
-      const adopted = await this.adopt(id, handle, existing).catch((err) => {
-        console.warn(
-          `[${LOG_LABEL}] adopt ${handle} failed, recreating: ${err instanceof Error ? err.message : String(err)}`,
+      // Terminating claim (operator's idle-TTL fired, finalizers still
+      // draining): skip adopt entirely — the pod is going away, port-forward
+      // would fail, and the claim is on its way out. Wait for the API server
+      // to fully GC the resource before falling through to provision so we
+      // don't race into a 409 AlreadyExists.
+      if (existing.metadata?.deletionTimestamp) {
+        await waitForSandboxClaimGone(
+          this.kubeConfig,
+          this.namespace,
+          handle,
+        ).catch((err) => {
+          console.warn(
+            `[${LOG_LABEL}] wait for terminating claim ${handle} failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+      } else {
+        const adopted = await this.adopt(id, handle, existing).catch((err) => {
+          console.warn(
+            `[${LOG_LABEL}] adopt ${handle} failed, recreating: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          return null;
+        });
+        if (adopted)
+          return this.finish(
+            adopted,
+            ops,
+            /* persistNow */ true,
+            /* patchTtl */ true,
+            "adopt",
+          );
+        await deleteSandboxClaim(this.kubeConfig, this.namespace, handle).catch(
+          () => {},
         );
-        return null;
-      });
-      if (adopted)
-        return this.finish(
-          adopted,
-          ops,
-          /* persistNow */ true,
-          /* patchTtl */ true,
-          "adopt",
-        );
-      await deleteSandboxClaim(this.kubeConfig, this.namespace, handle).catch(
-        () => {},
-      );
+        // Same wait as the terminating branch — our DELETE just queued a
+        // teardown that still has to drain finalizers before the next
+        // create won't 409.
+        await waitForSandboxClaimGone(
+          this.kubeConfig,
+          this.namespace,
+          handle,
+        ).catch((err) => {
+          console.warn(
+            `[${LOG_LABEL}] wait for deleted claim ${handle} failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+      }
     }
     // 3. Fresh provision.
     const fresh = await this.provision(id, handle, opts);
@@ -856,7 +890,24 @@ export class AgentSandboxRunner implements SandboxRunner {
       daemonBootId,
       workdir,
     });
-    await createSandboxClaim(this.kubeConfig, this.namespace, claim);
+    try {
+      await createSandboxClaim(this.kubeConfig, this.namespace, claim);
+    } catch (err) {
+      // ensureLocked already waits for a known-terminating prior claim before
+      // falling through here. This catch covers the residual races: a
+      // concurrent ensure() from another mesh replica raced ours to create,
+      // or an external delete (operator TTL, kubectl) finished after we
+      // checked but before our POST landed. Wait for the resource to fully
+      // disappear and retry exactly once — re-raising AlreadyExists straight
+      // to the user surfaces as the "Failed to create SandboxClaim" toast
+      // they have to manually recover from.
+      if (err instanceof SandboxAlreadyExistsError) {
+        await waitForSandboxClaimGone(this.kubeConfig, this.namespace, handle);
+        await createSandboxClaim(this.kubeConfig, this.namespace, claim);
+      } else {
+        throw err;
+      }
+    }
     const { podName } = await waitForSandboxReady(
       this.kubeConfig,
       this.namespace,


### PR DESCRIPTION
- Updated release-mesh.yaml and release-tagging.yaml to include additional paths for sandbox and related packages, ensuring proper triggering of releases and version bumps.
- Introduced new error classes, SandboxAlreadyExistsError and SandboxTimeoutError, to improve error handling in sandbox operations.
- Enhanced client and runner logic to handle sandbox claim creation and deletion more robustly, including waiting for claims to be fully deleted before retrying creation to avoid race conditions.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves sandbox runner reliability by handling terminating claims and classifying 409 races, and updates release workflows so workspace-only changes trigger mesh releases and tags.

- **Bug Fixes**
  - Expanded `release-mesh.yaml` and `release-tagging.yaml` paths to include `packages/sandbox/**`, `packages/runtime/**`, `packages/mesh-sdk/**`, `packages/bindings/**`, `packages/mcp-utils/**`, `packages/vite-plugin-deco/**`, and `packages/mesh-plugin-*/**` so changes ship and get tagged.
  - Added `SandboxAlreadyExistsError` and `SandboxTimeoutError`; `createSandboxClaim` now surfaces K8s status and treats 409s as retriable.
  - Introduced `waitForSandboxClaimGone` and updated the runner to wait for claim GC before recreate and to retry once on 409.
  - Extended tests to cover new error types and the wait-for-deletion flow.

<sup>Written for commit fcb0596542ffc2610f39ac22b86ad36b41172602. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3232?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

