### PR TITLE
fix(tool-details): use optional chat stream on settings tool page

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -64,7 +64,7 @@ import { contentBlocksToTiptapDoc } from "@/mcp-apps/content-blocks.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { ToolAnnotationBadges } from "@/web/components/tools/tools-list.tsx";
 import {
-  useChatStream,
+  useOptionalChatStream,
   useOptionalChatPrefs,
 } from "@/web/components/chat/context.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
@@ -202,7 +202,7 @@ function ToolDetailsAuthenticated({
 
   const { org } = useProjectContext();
   const connection = useConnection(connectionId);
-  const { sendMessage } = useChatStream();
+  const chatStream = useOptionalChatStream();
   const chatPrefs = useOptionalChatPrefs();
   const { setChatOpen } = usePanelActions();
   const sourceId = `${connectionId}:${toolName}`;
@@ -219,10 +219,11 @@ function ToolDetailsAuthenticated({
   const uiResourceUri = getUIResourceUri(tool?._meta);
 
   const handleAppMessage = (params: McpUiMessageRequest["params"]) => {
+    if (!chatStream) return;
     const doc = contentBlocksToTiptapDoc(params.content);
     if (doc.content.length > 0) {
       setChatOpen(true);
-      sendMessage({ tiptapDoc: doc });
+      chatStream.sendMessage({ tiptapDoc: doc });
     }
   };
 


### PR DESCRIPTION
## What is this contribution about?

Opening any tool from the settings connections page (e.g. `/$org/settings/connections/dropbox-mcp/tools/dropbox_list_folder`) crashed with `useChatStream must be used within ActiveTaskProvider`. The settings layout doesn't mount `Chat.Provider`/`ActiveTaskProvider`, but `tool.tsx` was unconditionally calling `useChatStream()`. Switched to `useOptionalChatStream()` and guarded `handleAppMessage` so MCP UI app messages no-op when no chat is in scope (the value was only used to forward those messages back into chat).

## How to Test

1. Navigate to `/$org/settings/connections/<some-mcp>/tools/<some-tool>`.
2. The tool details page should render normally instead of throwing the React error.
3. Opening the same tool from inside an agent shell still forwards MCP UI app messages to the chat.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash (“useChatStream must be used within ActiveTaskProvider”) when opening a tool from Settings > Connections. Switches to `useOptionalChatStream` and guards MCP UI app messages so they only forward to chat when a chat is in scope.

<sup>Written for commit 58d0ee3201029badc8f79e643c246c232c1ddb36. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3234?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

