### PR TITLE
feat(settings): add permission-based access control for settings pages

### DIFF
--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -563,4 +563,57 @@ app.post("/domain-setup", async (c) => {
   }
 });
 
+/**
+ * My Role Permissions Endpoint (authenticated)
+ *
+ * Returns the current user's own role and its permissions for the active org.
+ * Unlike Better Auth's /organization/list-roles, this requires no special
+ * permissions — every member can read their own role definition.
+ *
+ * Route: GET /api/auth/custom/my-role
+ */
+app.get("/my-role", async (c) => {
+  const session = (await auth.api.getSession({
+    headers: c.req.raw.headers,
+  })) as {
+    user?: { id: string };
+    session?: { activeOrganizationId?: string };
+  } | null;
+
+  if (!session?.user) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const organizationId = session.session?.activeOrganizationId;
+  if (!organizationId) {
+    return c.json({ error: "No active organization" }, 400);
+  }
+
+  const db = getDb().db;
+
+  const member = await db
+    .selectFrom("member")
+    .select(["role"])
+    .where("userId", "=", session.user.id)
+    .where("organizationId", "=", organizationId)
+    .executeTakeFirst();
+
+  if (!member) {
+    return c.json({ error: "Not a member of this organization" }, 403);
+  }
+
+  const roleRow = await db
+    .selectFrom("organizationRole")
+    .select(["permission"])
+    .where("organizationId", "=", organizationId)
+    .where("role", "=", member.role)
+    .executeTakeFirst();
+
+  const permission = roleRow?.permission
+    ? (JSON.parse(roleRow.permission) as Record<string, string[]>)
+    : null;
+
+  return c.json({ role: member.role, permission });
+});
+
 export default app;

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -97,17 +97,17 @@ const statement = { ...defaultStatements, self: ["*", ...allTools] };
 const ac = createAccessControl(statement);
 
 const user = ac.newRole({
-  self: ["*"],
+  self: ["*", ...allTools],
   ...adminAc.statements,
 }) as Role;
 
 const admin = ac.newRole({
-  self: ["*"],
+  self: ["*", ...allTools],
   ...adminAc.statements,
 }) as Role;
 
 const owner = ac.newRole({
-  self: ["*"],
+  self: ["*", ...allTools],
   ...adminAc.statements,
 }) as Role;
 

--- a/apps/mesh/src/auth/migrate.ts
+++ b/apps/mesh/src/auth/migrate.ts
@@ -38,7 +38,9 @@ export async function migrateBetterAuth(databaseUrl?: string): Promise<string> {
   const options = {
     database: freshDatabase,
     plugins: [
-      organization(),
+      organization({
+        dynamicAccessControl: { enabled: true, enableCustomResources: true },
+      }),
       adminPlugin(),
       apiKey(),
       jwt(),

--- a/apps/mesh/src/web/components/settings-permission-guard.tsx
+++ b/apps/mesh/src/web/components/settings-permission-guard.tsx
@@ -1,0 +1,60 @@
+import { useCurrentMemberPermissions } from "@/web/hooks/use-member-permissions";
+import { Page } from "@/web/components/page";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Loading01, Lock01 } from "@untitledui/icons";
+import { Link, useParams } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+interface SettingsPermissionGuardProps {
+  requiredTool: string;
+  children: ReactNode;
+}
+
+export function SettingsPermissionGuard({
+  requiredTool,
+  children,
+}: SettingsPermissionGuardProps) {
+  const perms = useCurrentMemberPermissions();
+  const { org } = useParams({ from: "/shell/$org" });
+
+  if (perms.isLoading) {
+    return (
+      <Page>
+        <div className="flex items-center justify-center h-full">
+          <Loading01 size={32} className="animate-spin text-muted-foreground" />
+        </div>
+      </Page>
+    );
+  }
+
+  const hasAccess =
+    perms.isAdmin ||
+    perms.hasAll ||
+    (requiredTool !== "__admin_only__" && perms.tools.has(requiredTool));
+
+  if (!hasAccess) {
+    return (
+      <Page>
+        <div className="flex flex-col items-center justify-center gap-6 h-full text-center px-4">
+          <div className="flex items-center justify-center size-12 rounded-full bg-muted">
+            <Lock01 size={20} className="text-muted-foreground" />
+          </div>
+          <div className="flex flex-col gap-2">
+            <h2 className="text-lg font-semibold">Access restricted</h2>
+            <p className="text-sm text-muted-foreground max-w-xs">
+              You don&apos;t have permission to view this page. Contact your
+              organization admin to request access.
+            </p>
+          </div>
+          <Button asChild variant="outline">
+            <Link to="/$org" params={{ org }}>
+              Go back to home
+            </Link>
+          </Button>
+        </div>
+      </Page>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mesh/src/web/hooks/use-organization-roles.ts
+++ b/apps/mesh/src/web/hooks/use-organization-roles.ts
@@ -186,11 +186,6 @@ export function useOrganizationRoles() {
       const roleName = customRole.role;
       if (!roleName) continue;
 
-      // Skip if it's a built-in role name (owner, admin, user)
-      if (BUILTIN_ROLES.some((b) => b.value === roleName)) {
-        continue;
-      }
-
       const {
         staticPermissions,
         allowsAllStaticPermissions,
@@ -201,6 +196,30 @@ export function useOrganizationRoles() {
         modelCount,
         allowsAllModels,
       } = parsePermission(customRole.permission);
+
+      // If it matches a built-in role (admin/user), merge stored data into it
+      const builtinIdx = allRoles.findIndex(
+        (r) => r.isBuiltin && r.role === roleName,
+      );
+      const existingBuiltin = allRoles[builtinIdx];
+      if (builtinIdx !== -1 && existingBuiltin) {
+        allRoles[builtinIdx] = {
+          ...existingBuiltin,
+          id: customRole.id,
+          permission: customRole.permission ?? undefined,
+          staticPermissionCount: allowsAllStaticPermissions
+            ? -1
+            : staticPermissions.length,
+          allowsAllStaticPermissions,
+          connectionCount: allowsAllConnections ? -1 : connectionIds.length,
+          allowsAllConnections,
+          toolCount: allowsAllTools ? -1 : toolNames.length,
+          allowsAllTools,
+          modelCount: allowsAllModels ? -1 : modelCount,
+          allowsAllModels,
+        };
+        continue;
+      }
 
       allRoles.push({
         id: customRole.id,

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -46,6 +46,7 @@ import { pluginSettingsSidebarItems } from "@/web/index";
 import { useStatusSounds } from "../hooks/use-status-sounds";
 import { authClient } from "@/web/lib/auth-client";
 import { track } from "@/web/lib/posthog-client";
+import { useCurrentMemberPermissions } from "@/web/hooks/use-member-permissions";
 
 interface SettingsNavItem {
   key: string;
@@ -59,9 +60,35 @@ interface SettingsNavGroup {
   items: SettingsNavItem[];
 }
 
+// Maps sidebar item keys to a representative tool that gates access.
+// If the current user has this tool (or is admin), the item is visible.
+// Items without an entry are always visible.
+const SIDEBAR_ITEM_REQUIRED_TOOL: Record<string, string> = {
+  "brand-context": "BRAND_CONTEXT_LIST",
+  "ai-providers": "AI_PROVIDERS_LIST",
+  connections: "COLLECTION_CONNECTIONS_LIST",
+  agents: "COLLECTION_VIRTUAL_MCP_LIST",
+  automations: "AUTOMATION_LIST",
+  monitor: "MONITORING_LOGS_LIST",
+  members: "ORGANIZATION_MEMBER_LIST",
+  roles: "ORGANIZATION_MEMBER_LIST",
+  sso: "__admin_only__",
+};
+
 function useSettingsSidebarGroups(): SettingsNavGroup[] {
   const currentProject = useProjectContext().project;
   const enabledPlugins = currentProject.enabledPlugins ?? [];
+  const perms = useCurrentMemberPermissions();
+
+  const canAccess = (key: string): boolean => {
+    // While loading, show all items (fail open)
+    if (perms.isLoading) return true;
+    if (perms.isAdmin || perms.hasAll) return true;
+    const requiredTool = SIDEBAR_ITEM_REQUIRED_TOOL[key];
+    if (!requiredTool) return true;
+    if (requiredTool === "__admin_only__") return false;
+    return perms.tools.has(requiredTool);
+  };
 
   const enabledSettingsItems = pluginSettingsSidebarItems
     .filter((item) => enabledPlugins.includes(item.pluginId))
@@ -77,36 +104,36 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           icon: <Building02 size={14} />,
           to: "/$org/settings/general",
         },
-        {
+        canAccess("brand-context") && {
           key: "brand-context",
           label: "Brand Context",
           icon: <BookOpen01 size={14} />,
           to: "/$org/settings/brand-context",
         },
-        {
+        canAccess("ai-providers") && {
           key: "ai-providers",
           label: "AI Providers",
           icon: <CpuChip01 size={14} />,
           to: "/$org/settings/ai-providers",
         },
-      ],
+      ].filter(Boolean) as SettingsNavItem[],
     },
     {
       label: "Build",
       items: [
-        {
+        canAccess("connections") && {
           key: "connections",
           label: "Connections",
           icon: <ZapSquare size={14} />,
           to: "/$org/settings/connections",
         },
-        {
+        canAccess("agents") && {
           key: "agents",
           label: "Agents",
           icon: <Users03 size={14} />,
           to: "/$org/settings/agents",
         },
-        {
+        canAccess("automations") && {
           key: "automations",
           label: "Automations",
           icon: <Zap size={14} />,
@@ -118,36 +145,36 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           icon: <PackageCheck size={14} />,
           to: "/$org/settings/store",
         },
-      ],
+      ].filter(Boolean) as SettingsNavItem[],
     },
     {
       label: "Manage",
       items: [
-        {
+        canAccess("monitor") && {
           key: "monitor",
           label: "Monitor",
           icon: <BarChart10 size={14} />,
           to: "/$org/settings/monitor",
         },
-        {
+        canAccess("members") && {
           key: "members",
           label: "Members",
           icon: <Users03 size={14} />,
           to: "/$org/settings/members",
         },
-        {
+        canAccess("roles") && {
           key: "roles",
           label: "Roles",
           icon: <Shield01 size={14} />,
           to: "/$org/settings/roles",
         },
-        {
+        canAccess("sso") && {
           key: "sso",
           label: "Security",
           icon: <Lock01 size={14} />,
           to: "/$org/settings/sso",
         },
-      ],
+      ].filter(Boolean) as SettingsNavItem[],
     },
     {
       label: "Extensions",
@@ -172,7 +199,7 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
         },
       ],
     },
-  ];
+  ].filter((group) => group.items.length > 0);
 
   return groups;
 }

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -79,6 +79,10 @@ export const KEYS = {
   activeOrganization: (org: string | undefined) =>
     ["activeOrganization", org] as const,
 
+  // Current user's own role + permissions for the active org
+  myRolePermissions: (orgId: string | undefined) =>
+    ["my-role-permissions", orgId] as const,
+
   // Models list (scoped by organization)
   modelsList: (orgId: string) => ["models-list", orgId] as const,
 

--- a/apps/mesh/src/web/routes/orgs/settings/ai-providers.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/ai-providers.tsx
@@ -1,5 +1,10 @@
 import { OrgAiProvidersPage } from "@/web/views/settings/org-ai-providers";
+import { SettingsPermissionGuard } from "@/web/components/settings-permission-guard";
 
 export default function AiProvidersRoute() {
-  return <OrgAiProvidersPage />;
+  return (
+    <SettingsPermissionGuard requiredTool="AI_PROVIDERS_LIST">
+      <OrgAiProvidersPage />
+    </SettingsPermissionGuard>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/automations.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/automations.tsx
@@ -10,8 +10,9 @@ import { AutomationListRow } from "@/web/views/automations/automation-list-row";
 import { useVirtualMCPs, useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { track } from "@/web/lib/posthog-client";
+import { SettingsPermissionGuard } from "@/web/components/settings-permission-guard";
 
-export default function SettingsAutomationsPage() {
+function AutomationsPageContent() {
   const { org } = useProjectContext();
   const { data: automations = [] } = useAutomations(undefined);
   const agents = useVirtualMCPs();
@@ -100,5 +101,13 @@ export default function SettingsAutomationsPage() {
         </Page.Body>
       </Page.Content>
     </Page>
+  );
+}
+
+export default function SettingsAutomationsPage() {
+  return (
+    <SettingsPermissionGuard requiredTool="AUTOMATION_LIST">
+      <AutomationsPageContent />
+    </SettingsPermissionGuard>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/brand-context.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/brand-context.tsx
@@ -1,5 +1,10 @@
 import { OrgBrandContextPage } from "@/web/views/settings/org-brand-context";
+import { SettingsPermissionGuard } from "@/web/components/settings-permission-guard";
 
 export default function BrandContextRoute() {
-  return <OrgBrandContextPage />;
+  return (
+    <SettingsPermissionGuard requiredTool="BRAND_CONTEXT_LIST">
+      <OrgBrandContextPage />
+    </SettingsPermissionGuard>
+  );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/members.tsx
@@ -1,1 +1,10 @@
-export { default } from "@/web/routes/orgs/members";
+import MembersPage from "@/web/routes/orgs/members";
+import { SettingsPermissionGuard } from "@/web/components/settings-permission-guard";
+
+export default function SettingsMembersRoute() {
+  return (
+    <SettingsPermissionGuard requiredTool="ORGANIZATION_MEMBER_LIST">
+      <MembersPage />
+    </SettingsPermissionGuard>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/settings/roles.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/roles.tsx
@@ -3,6 +3,7 @@ import {
   type OrganizationRole,
   useOrganizationRoles,
 } from "@/web/hooks/use-organization-roles";
+import { SettingsPermissionGuard } from "@/web/components/settings-permission-guard";
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
@@ -126,7 +127,7 @@ function RolesPageContent() {
 
   const { locator } = useProjectContext();
   const queryClient = useQueryClient();
-  const { customRoles, refetch: refetchRoles } = useOrganizationRoles();
+  const { customRoles, roles, refetch: refetchRoles } = useOrganizationRoles();
 
   const setActiveRole = (value: string | undefined) =>
     navigate({
@@ -139,7 +140,15 @@ function RolesPageContent() {
     if (roleParam === "new") return { kind: "new" };
     if (roleParam.startsWith("builtin-")) {
       const slug = roleParam.slice(8) as "owner" | "admin" | "user";
-      return { kind: "builtin", role: slug };
+      const storedRole = roles.find(
+        (r) => r.isBuiltin && r.role === slug && r.id,
+      );
+      return {
+        kind: "builtin",
+        role: slug,
+        storedId: storedRole?.id,
+        storedPermission: storedRole?.permission,
+      };
     }
     const custom = customRoles.find((r) => r.id === roleParam);
     return custom ? { kind: "custom", role: custom } : null;
@@ -216,7 +225,7 @@ function RolesPageContent() {
           <span className="text-sm font-medium text-foreground truncate">
             {row.role.label}
           </span>
-          {row.kind === "builtin" && (
+          {row.kind === "builtin" && row.role.role === "owner" && (
             <Lock01 size={12} className="text-muted-foreground shrink-0" />
           )}
         </div>
@@ -427,31 +436,33 @@ function RolesPageContent() {
 
 export default function RolesPage() {
   return (
-    <ErrorBoundary
-      fallback={
-        <Page>
-          <div className="flex items-center justify-center h-full">
-            <div className="text-sm text-muted-foreground">
-              Failed to load roles
-            </div>
-          </div>
-        </Page>
-      }
-    >
-      <Suspense
+    <SettingsPermissionGuard requiredTool="ORGANIZATION_MEMBER_LIST">
+      <ErrorBoundary
         fallback={
           <Page>
             <div className="flex items-center justify-center h-full">
-              <Loading01
-                size={32}
-                className="animate-spin text-muted-foreground"
-              />
+              <div className="text-sm text-muted-foreground">
+                Failed to load roles
+              </div>
             </div>
           </Page>
         }
       >
-        <RolesPageContent />
-      </Suspense>
-    </ErrorBoundary>
+        <Suspense
+          fallback={
+            <Page>
+              <div className="flex items-center justify-center h-full">
+                <Loading01
+                  size={32}
+                  className="animate-spin text-muted-foreground"
+                />
+              </div>
+            </Page>
+          }
+        >
+          <RolesPageContent />
+        </Suspense>
+      </ErrorBoundary>
+    </SettingsPermissionGuard>
   );
 }

--- a/apps/mesh/src/web/routes/orgs/settings/sso.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/sso.tsx
@@ -1,5 +1,10 @@
 import { OrgSsoPage } from "@/web/views/settings/org-sso";
+import { SettingsPermissionGuard } from "@/web/components/settings-permission-guard";
 
 export default function SsoRoute() {
-  return <OrgSsoPage />;
+  return (
+    <SettingsPermissionGuard requiredTool="__admin_only__">
+      <OrgSsoPage />
+    </SettingsPermissionGuard>
+  );
 }


### PR DESCRIPTION
## Summary

Stacks on top of #3223 (capability redesign) to add permission-based access control for settings pages.

- Adds `SettingsPermissionGuard` component that checks the current member's tools and renders an "Access restricted" screen otherwise
- Wraps settings routes (ai-providers, automations, brand-context, members, roles, sso) with the guard
- Updates the settings sidebar to hide items the member doesn't have permission for via a `SIDEBAR_ITEM_REQUIRED_TOOL` map
- Adds `/api/auth/custom/my-role` endpoint and `useCurrentMemberPermissions` hook to expose the current member's effective tools (admins/owners get full access)

Built-in roles (`owner`, `admin`) bypass the checks. Custom roles with `"*"` in `self` bypass too.

## Stacked on

PR #3223 — merge that first.

## Test plan

- [ ] As an `owner`, all settings pages and sidebar items remain visible
- [ ] As a custom role with no tools, settings pages show "Access restricted" and the sidebar hides them
- [ ] Toggle a tool on a custom role and confirm the corresponding page/sidebar item becomes available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add permission-based access control to org settings so members only see and open pages they have tools for. Owners/admins and wildcard roles keep full access.

- **New Features**
  - Added `SettingsPermissionGuard` that checks member tools and shows an “Access restricted” screen; bypass for built-in owners/admins and roles with `self: "*"`.
  - Wrapped settings pages (AI Providers, Automations, Brand Context, Members, Roles); Security/SSO is admin-only via `__admin_only__`.
  - Settings sidebar hides items using a required tool map; while permissions load, items remain visible.
  - Added `GET /api/auth/custom/my-role`, `useCurrentMemberPermissions`, and a query key to fetch the current member’s tools.
  - Enabled dynamic access control in auth and included all tools in built-in roles’ `self`; updated roles hook to merge stored data into built-in roles.

<sup>Written for commit adcaa745f658112f7068f1f815ccc66a16b1c06d. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3235?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

