### PR TITLE
feat(sandbox-env): add topologySpreadConstraints passthrough

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,12 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.4.0: SandboxTemplate now passes `topologySpreadConstraints` from
+# values into the pod spec. Empty default preserves prior behaviour.
+# Use it to spread sandbox pods across AZs so a single-AZ spot reclaim
+# doesn't take half the pool out simultaneously — see values.yaml for
+# the recommended config.
+#
 # 0.3.0: mesh runner now Server-Side Applies `port: 9000` onto each
 # operator-created Service after the SandboxClaim becomes Ready, taking
 # ownership of `spec.ports[name=daemon]` under field manager
@@ -30,7 +36,7 @@ type: application
 # an ingress rule from `previewGateway.namespace` to sandbox port 9000.
 # Upgraders MUST bump mesh to the matching version that creates per-claim
 # HTTPRoutes — otherwise preview URLs stop resolving.
-version: 0.3.0
+version: 0.4.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.1.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -149,6 +149,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `image.tag` | chart `appVersion` | bump in lockstep with packages/sandbox/package.json |
 | `resources.*` | 0.5/2 CPU, 1/4Gi RAM | per sandbox pod |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
+| `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `hostUsers` | `false` | userns remap; flip to `true` if kernel/containerd doesn't support userns |
 | `readOnlyRootFilesystem` | `true` | RO rootfs + emptyDirs on /app, /tmp, /home |
 | `networkPolicy.enabled` | `true` | locks down ingress/egress |

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -55,6 +55,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if not .Values.hostUsers }}
       # User namespace remap: UID 1000 inside the pod maps to a high
       # subordinate UID on the node, so a container escape lands as a

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -106,6 +106,31 @@ tolerations: []
 # nodeSelector can't express. Empty default = scheduler picks.
 affinity: {}
 
+# Topology spread constraints merged into the sandbox PodSpec. Useful
+# for spreading sandbox pods across availability zones so a single-AZ
+# spot reclaim doesn't take the whole pool out at once. Empty default
+# = no spread (scheduler / Karpenter cost-bias may concentrate pods in
+# one AZ).
+#
+# When using this, the labelSelector must match the per-env pod label
+# stamped by this chart (see templates/sandbox-template.yaml):
+#   app.kubernetes.io/name: studio-sandbox-<envName>
+#
+# Recommended for production:
+#
+# topologySpreadConstraints:
+#   - maxSkew: 1
+#     topologyKey: topology.kubernetes.io/zone
+#     # ScheduleAnyway, not DoNotSchedule — we don't want a sandbox
+#     # claim to fail because Karpenter hasn't yet provisioned a node
+#     # in the second AZ. The constraint is a soft preference; over
+#     # time pods drift toward an even spread as new nodes come up.
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: studio-sandbox-<envName>
+topologySpreadConstraints: []
+
 # ── sandbox-pod hardening ──────────────────────────────────────────────
 # User namespace remap (`spec.hostUsers: false`): UID 1000 inside the pod
 # maps to a high, unprivileged subordinate UID on the node, so a


### PR DESCRIPTION
## Summary

- Adds `topologySpreadConstraints` to the `sandbox-env` chart's pod spec, passed straight through from values.
- Empty default → no behavioural change for existing installs.
- Chart version `0.3.0` → `0.4.0` (additive, backwards compatible).

## Why

Today's sandbox-stg incident (2026-04-29): two `c7i.large` spot nodes in `sa-east-1c` went `NotReady` within ~25s of each other (`Kubelet stopped posting node status`). The Karpenter `sandbox` NodePool has all three AZs in its requirements, but spot-pricing bias landed every node in `sa-east-1c`, so a single-AZ event hit half the pool.

There was no chart knob for spread — `affinity:` was passed through, `topologySpreadConstraints` wasn't. Hand-applying it via `kubectl edit sandboxtemplate` works once but gets reconciled away on the next Argo sync. This adds the missing passthrough.

`affinity.podAntiAffinity` was a candidate but doesn't compose well with Karpenter at scale (preferred constraints don't trigger node provisioning across AZs the way `topologySpreadConstraints` does, and required constraints can deadlock claim creation when a second-AZ node hasn't yet been provisioned).

## What this changes

- `templates/sandbox-template.yaml` — render `topologySpreadConstraints` block under `with .Values.topologySpreadConstraints` so the field only appears when set.
- `values.yaml` — `topologySpreadConstraints: []` default + commented recommended config (maxSkew=1, topologyKey=zone, **ScheduleAnyway** — soft so a claim doesn't fail when a second-AZ node hasn't come up yet).
- `Chart.yaml` — version bump + changelog comment.
- `README.md` — values table row.

## Recommended consumer config (paste into per-env `values-custom.yaml` once chart is bumped)

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        app.kubernetes.io/name: studio-sandbox-<envName>
```

The `app.kubernetes.io/name` label is stamped by this chart's `SandboxTemplate` on every produced pod, so this matches all sandbox claims for the env.

## Follow-ups

1. Publish the chart to `ghcr.io/decocms/studio/charts:0.4.0` (whatever release workflow handles that).
2. Bump `targetRevision` in `decocms/argo-deploy-mesh/agent-sandbox/sandbox-stg/argocd-application.yaml` and add the `topologySpreadConstraints` block to `values-custom.yaml`.
3. Sandbox NodePool changes (e.g. `instance-size NotIn [large]`, AZ requirement tightening) live elsewhere — separate work.

## Test plan

- [x] `helm lint` passes.
- [x] `helm template` with empty default — no `topologySpreadConstraints` field rendered (confirmed: 0 occurrences).
- [x] `helm template` with the recommended config — `topologySpreadConstraints` block present in `SandboxTemplate.spec.podTemplate.spec` with all four fields wired correctly.
- [ ] Deploy to stg, verify Karpenter provisions sandbox nodes in at least two AZs after a few claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `topologySpreadConstraints` passthrough to the `sandbox-env` chart to let sandbox pods spread across AZs. Default is empty, so existing installs behave the same. Chart bumped to `0.4.0`.

- **New Features**
  - `templates/sandbox-template.yaml`: renders `topologySpreadConstraints` into the pod spec when set.
  - `values.yaml`: adds `topologySpreadConstraints: []` and a recommended example (maxSkew=1, topologyKey=zone, ScheduleAnyway) using `labelSelector` for `app.kubernetes.io/name: studio-sandbox-<envName>`.
  - `README.md`: documents the new value.

- **Migration**
  - Update to `sandbox-env` `0.4.0`.
  - Optionally set `topologySpreadConstraints` in per-env values to spread pods across zones.

<sup>Written for commit d6685a69c3e2840ff73fe16ece6b1e163b3f7190. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3236?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

