### PR TITLE
feat(sandbox): enhance error handling in createSandboxClaim

### DIFF
--- a/packages/sandbox/server/runner/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.test.ts
@@ -173,6 +173,15 @@ describe("createSandboxClaim", () => {
     ).rejects.toThrow(/Failed to create SandboxClaim: denied/);
   });
 
+  it("surfaces transport-layer failures (fetch throws) with the cause message", async () => {
+    fetchImpl = async () => {
+      throw new Error("fetch failed: TLS connection reset by peer");
+    };
+    await expect(
+      createSandboxClaim(makeKc(), NS, makeClaim("blip")),
+    ).rejects.toThrow(/transport error: fetch failed: TLS connection reset/);
+  });
+
   it("throws SandboxAlreadyExistsError on 409 so the runner can wait+retry", async () => {
     // Operator's idle-TTL deleted the prior claim but finalizers haven't
     // drained yet — the API server still has the resource and rejects

--- a/packages/sandbox/server/runner/agent-sandbox/client.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.ts
@@ -305,8 +305,12 @@ export async function createSandboxClaim(
   try {
     resp = await kubeFetch(kc, { method: "POST", path, body: claim });
   } catch (error) {
+    const causeMsg = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[agent-sandbox/client] createSandboxClaim ${claim.metadata.name} transport error: ${causeMsg}`,
+    );
     throw new SandboxError(
-      `Failed to create SandboxClaim: ${claim.metadata.name}`,
+      `Failed to create SandboxClaim: ${claim.metadata.name} (transport error: ${causeMsg})`,
       error,
     );
   }


### PR DESCRIPTION
- Added a new test to verify that transport-layer failures are correctly surfaced with detailed error messages.
- Updated the createSandboxClaim function to log transport errors with specific cause messages, improving debugging and error tracking.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface transport-layer failures in the sandbox by including the underlying cause in `createSandboxClaim` errors and logs. Adds a test to ensure fetch exceptions are exposed with clear messages for easier debugging.

- **New Features**
  - `createSandboxClaim` now logs transport errors and throws a `SandboxError` that includes the cause message.
  - Added a unit test that verifies fetch failures (e.g., TLS reset) are surfaced in the thrown error message.

<sup>Written for commit 5b3a22a88c13cbca75bc91f911b873d2b9f41656. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3237?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

