### PR TITLE
fix(cli): propagate K8s discovery + sandbox preview env to worker subprocesses

### DIFF
--- a/apps/mesh/src/cli/build-child-env.ts
+++ b/apps/mesh/src/cli/build-child-env.ts
@@ -82,6 +82,24 @@ export function buildChildEnv(
     // it with envName). Workers must inherit so claim creation hits the
     // right template.
     STUDIO_SANDBOX_TEMPLATE_NAME: process.env.STUDIO_SANDBOX_TEMPLATE_NAME,
+    // Preview-URL templating + per-claim HTTPRoute parent. Mesh in workers
+    // creates SandboxClaims and mints HTTPRoutes; without these the runner
+    // silently falls back to in-process proxying / no preview URL.
+    STUDIO_SANDBOX_PREVIEW_URL_PATTERN:
+      process.env.STUDIO_SANDBOX_PREVIEW_URL_PATTERN,
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME:
+      process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME,
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE:
+      process.env.STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE,
+    // In-cluster K8s API discovery vars, set by Kubernetes when a service
+    // account is mounted. The agent-sandbox runner's `KubeConfig.loadFromDefault()`
+    // reads these from `process.env` to build the API URL — workers without
+    // them fall through to `https://undefined:undefined/...` and every claim
+    // creation throws a transport error. The primary thread inherits env
+    // naturally from PID 1 and works fine, which is why this surfaces as
+    // "sometimes weirdly works" (~1/N of requests succeed when N threads).
+    KUBERNETES_SERVICE_HOST: process.env.KUBERNETES_SERVICE_HOST,
+    KUBERNETES_SERVICE_PORT: process.env.KUBERNETES_SERVICE_PORT,
     FREESTYLE_API_KEY: process.env.FREESTYLE_API_KEY,
 
     // Browserless


### PR DESCRIPTION
## Summary

Adds five env vars to the worker-process allowlist in `apps/mesh/src/cli/build-child-env.ts`:

- `KUBERNETES_SERVICE_HOST` / `KUBERNETES_SERVICE_PORT` — read by `@kubernetes/client-node`'s in-cluster auth
- `STUDIO_SANDBOX_PREVIEW_URL_PATTERN`
- `STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME`
- `STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE`

## The bug

stg has been throwing this on ~75% of `VM_START` calls today:

```
Error: Failed to create SandboxClaim: studio-sb-fierce-mesa-…
(transport error: "https://undefined:undefined/apis/extensions.agents.x-k8s.io/v1alpha1/namespaces/agent-sandbox-system/sandboxclaims" cannot be parsed as a URL.)
```

Symptom shape: **"sometimes weirdly works"**. That was the smoking gun.

### Root cause

The mesh deployment runs with `--num-threads 4`. On Linux, `apps/mesh/src/cli/commands/serve.ts:181` spawns `numThreads - 1` worker subprocesses via `Bun.spawn(..., { env: workerEnv })`. `workerEnv` comes from `buildChildEnv()`, which is an **explicit allowlist**, not `...process.env`. (Header comment: *"Uses an allowlist of all Settings fields rather than inheriting the full parent process.env. This ensures workers get the correct dynamically-resolved values… and makes the secret surface intentional and reviewable."*)

`KUBERNETES_SERVICE_HOST` is set in the container by Kubernetes (when an SA is mounted), but it wasn't in the allowlist, so workers booted with it undefined.

When a `VM_START` lands on a worker:

1. Worker constructs `AgentSandboxRunner` → `KubeConfig.loadFromDefault()`
2. Lib finds the SA token at `/var/run/secrets/kubernetes.io/serviceaccount/token` (it's a file mount, not env), so it falls through to `loadFromCluster()`
3. `loadFromCluster()` reads `process.env.KUBERNETES_SERVICE_HOST` → `undefined` → builds `server: \`https://${host}:${port}\`` → `"https://undefined:undefined"`
4. First fetch with that "URL" throws

The primary thread (descended directly from PID 1) inherits env naturally and works fine. With `--num-threads 4`, requests are load-balanced via SO_REUSEPORT across 1 healthy primary + 3 broken workers ⇒ ~75% failure rate.

I confirmed this by inspecting `/proc/$pid/environ` on a live mesh-stg pod:

```
pid=1  comm=bun  args: bun run deco --no-local-mode --num-threads 4   KUBERNETES_SERVICE_HOST=172.20.0.1  ✅
pid=7  comm=bun  args: bun /app/.../decocms/dist/server/cli.js          KUBERNETES_SERVICE_HOST=172.20.0.1  ✅  primary
pid=21 comm=bun args: bun /app/.../decocms/dist/server/server.js       (no KUBERNETES_SERVICE_HOST)        ❌  worker
pid=22 comm=bun args: bun /app/.../decocms/dist/server/server.js       (no KUBERNETES_SERVICE_HOST)        ❌  worker
pid=23 comm=bun args: bun /app/.../decocms/dist/server/server.js       (no KUBERNETES_SERVICE_HOST)        ❌  worker
```

### Latent issues swept up

The three `STUDIO_SANDBOX_PREVIEW_*` vars were also missing. Workers were silently constructing the runner with `previewUrlPattern: undefined` and `previewGateway: null`, which pushes them onto the legacy in-process proxying fallback and skips per-claim HTTPRoute minting. Same root cause, just less obvious — and since claim creation was already failing, this wasn't observable. Folding them into the same fix.

## Why allowlist (and how to avoid this next time)

The allowlist exists for good reasons (auditable secret surface, dynamically-resolved settings like the embedded-postgres port). The cost is exactly this: any new `process.env.X` read at request time has to be added here, or workers get `undefined` while the primary works fine.

A grep-time invariant for new env-driven config:

```bash
grep -rnE "process\.env\.(NEW_VAR)" apps/mesh/src packages/sandbox
```

…then check it appears in `buildChildEnv()`.

## Test plan

- [ ] Locally reproduce: `bun run deco serve --num-threads 4 --no-local-mode` against a kind cluster, hit `VM_START`, verify all 4 thread distributions succeed (e.g. by repeatedly creating claims and watching for transport errors).
- [ ] Deploy to stg via the next image bump.
- [ ] Watch stg mesh logs for `"https://undefined:undefined"` over 30 minutes — should be zero. (Today's baseline: 4-14 occurrences per pod over a few hours.)
- [ ] Confirm `kubectl get sandboxclaims -n agent-sandbox-system` shows new claims being created from worker-served requests.

## Out of scope

- The chart-side AZ spread + chart 0.4.0 bump are separate PRs (decocms/studio#3236, argo-deploy-mesh#39).
- A more defensive fix would be to make `AgentSandboxRunner` validate the resolved kubeconfig at construction (throw early on `https://undefined:*`) so the failure mode isn't a per-request transport error stack trace. Worth a follow-up but doesn't need to block this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates Kubernetes discovery and sandbox preview env vars to mesh worker subprocesses to stop intermittent `VM_START` failures and ensure preview routes are created.

- **Bug Fixes**
  - Allowlist `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` so workers using `@kubernetes/client-node` build a valid in-cluster URL (no more `https://undefined:undefined`).
  - Allowlist `STUDIO_SANDBOX_PREVIEW_URL_PATTERN`, `STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME`, and `STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE` so workers mint per-claim `HTTPRoute`s and emit preview URLs.

<sup>Written for commit ef1ac4910778a18b669f3dfb45f5b2d7ffbd67a7. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3238?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

