### PR TITLE
chore(database): log DATABASES_RUN_SQL invocations for deprecation probe

### DIFF
--- a/apps/mesh/src/tools/database/index.ts
+++ b/apps/mesh/src/tools/database/index.ts
@@ -231,6 +231,15 @@ export const DATABASES_RUN_SQL = defineTool({
       throw new Error("Connection context required for database access");
     }
 
+    // Usage probe — evaluating whether to deprecate this tool. Filter on
+    // `tool.deprecation_probe = "DATABASES_RUN_SQL"` in OTLP logs.
+    console.warn("DATABASES_RUN_SQL invoked", {
+      "tool.deprecation_probe": "DATABASES_RUN_SQL",
+      "connection.id": ctx.connectionId,
+      "organization.id": ctx.organization?.id ?? null,
+      "user.id": ctx.auth.user?.id ?? null,
+    });
+
     const schemaName = getSchemaName(ctx.connectionId);
     const roleName = getRoleName(ctx.connectionId);
 


### PR DESCRIPTION
## What is this contribution about?
Adds a warn-level OTLP log inside the `DATABASES_RUN_SQL` handler so we can measure real prod usage before deciding whether to remove the tool. The intent is to deprecate `DATABASES_RUN_SQL` (and clean up the per-connection `app_*` Postgres schemas/roles it creates), but we want to confirm nobody is actively calling it first.

## How to Test
1. Run `bun run dev`.
2. Invoke `DATABASES_RUN_SQL` against any connection.
3. Confirm a `WARN` log appears with body `DATABASES_RUN_SQL invoked` and attributes `tool.deprecation_probe`, `connection.id`, `organization.id`, `user.id`. In prod, filter OTLP logs on `tool.deprecation_probe = "DATABASES_RUN_SQL"` to see invocations.

## Migration Notes
None. Pure observability addition; tool behavior is unchanged.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a warn-level OTLP log on each `DATABASES_RUN_SQL` invocation to measure real usage before deprecating the tool. The log includes `tool.deprecation_probe`, `connection.id`, `organization.id`, and `user.id`; no behavior changes.

<sup>Written for commit fce13ca5d2797c07431d6b8e5b1f5a6f6923afb4. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3239?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

