### PR TITLE
feat(vm-events): introduce unified VM events SSE for lifecycle phases

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -37,6 +37,7 @@ import authRoutes from "./routes/auth";
 import orgSsoRoutes from "./routes/org-sso";
 import { createDecopilotRoutes } from "./routes/decopilot";
 import downstreamTokenRoutes from "./routes/downstream-token";
+import { vmEventsRoutes } from "./routes/vm-events";
 import decoSitesRoutes from "./routes/deco-sites";
 import virtualMcpRoutes from "./routes/virtual-mcp";
 import oauthProxyRoutes, {
@@ -1494,6 +1495,12 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Deco.cx sites list (requires meshContext / auth)
   app.route("/api/deco-sites", decoSitesRoutes);
+
+  // Unified VM events SSE — single auth-gated stream that emits pre-Ready
+  // lifecycle phases, then proxies the daemon's `/_decopilot_vm/events` once
+  // the sandbox is up. Replaces the prior split between `/api/vm-lifecycle`
+  // and the browser's direct daemon EventSource.
+  app.route("/api/vm-events", vmEventsRoutes);
 
   // ============================================================================
   // Server Plugin Routes

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -1,0 +1,429 @@
+/**
+ * Unified VM events SSE.
+ *
+ * Single browser-facing stream for everything happening to a sandbox keyed
+ * on (virtualMcpId, branch, callerUserId):
+ *
+ *   1. Pre-Ready lifecycle phases (`event: phase`) — surfaces the gap between
+ *      VM_START posting a SandboxClaim and the daemon coming online.
+ *      Agent-sandbox runner emits real K8s phases; other runners emit a
+ *      single synthetic `ready`.
+ *   2. Daemon events (`event: log|status|scripts|processes|reload|branch-status`)
+ *      — proxied from the in-pod daemon's `/_decopilot_vm/events` SSE once
+ *      lifecycle reaches `ready`. Wire format is preserved verbatim by raw
+ *      byte-piping the upstream body, so daemon and client speak the same
+ *      protocol they always have.
+ *   3. `event: gone` — synthetic. Mesh's upstream daemon fetch returned 404
+ *      (sandbox handle missing → operator evicted on idle TTL, etc). Client
+ *      maps to `notFound` and triggers self-heal via VM_START.
+ *   4. `event: keepalive` — heartbeat. 15s matches the existing daemon SSE.
+ *
+ * Auth model:
+ *   - Caller must be authenticated.
+ *   - Caller's organization must own the requested virtualMcp.
+ *   - Claim name is derived deterministically from
+ *     (orgId, virtualMcpId, branch, callerUserId), so a caller only sees
+ *     events for *their own* sandbox; another user in the same org would
+ *     compute a different handle.
+ *
+ * Why one stream instead of two: prior design had the browser open
+ * `/api/vm-lifecycle` (mesh) plus a direct EventSource to the daemon's public
+ * `/_decopilot_vm/events`. The daemon endpoint is unauthenticated (Vercel-style
+ * "URL is the secret") and putting two long-lived SSEs in every tab burned
+ * the EventSource budget. Routing through mesh authenticates the surface and
+ * collapses to one connection per session.
+ */
+
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import {
+  composeSandboxRef,
+  tryResolveRunnerKindFromEnv,
+} from "@decocms/sandbox/runner";
+import { composeClaimName } from "@decocms/sandbox/runner/agent-sandbox";
+import type { ClaimPhase } from "@decocms/sandbox/runner/agent-sandbox";
+import {
+  asLifecycleWatchable,
+  getOrInitSharedRunner,
+} from "../../sandbox/lifecycle";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "../../core/mesh-context";
+import type { Env } from "../hono-env";
+
+/**
+ * Hard cap on how long we'll keep the SSE open if a claim never materializes
+ * (e.g. caller raced VM_START but VM_START failed before
+ * `createSandboxClaim`). Prevents indefinite "claiming" streams.
+ */
+const NO_CLAIM_MAX_MS = 5 * 60 * 1000;
+
+const HEARTBEAT_MS = 15_000;
+
+const app = new Hono<Env>();
+
+app.get("/", async (c) => {
+  const ctx = c.var.meshContext;
+  try {
+    requireAuth(ctx);
+  } catch {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  const userId = getUserId(ctx);
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  let organization: ReturnType<typeof requireOrganization>;
+  try {
+    organization = requireOrganization(ctx);
+  } catch {
+    return c.json({ error: "Organization scope required" }, 403);
+  }
+
+  const virtualMcpId = c.req.query("virtualMcpId");
+  const branch = c.req.query("branch");
+  if (!virtualMcpId || !branch) {
+    return c.json({ error: "virtualMcpId and branch are required" }, 400);
+  }
+
+  // Verify caller's org actually owns this virtualMcp. Without this check,
+  // an authenticated user could probe arbitrary virtualMcpIds — the claim
+  // hash includes their userId so they couldn't *observe* anyone else's
+  // events, but the 404 vs not-yet-created surface would still leak
+  // existence/identity information.
+  const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
+  if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+    return c.json({ error: "Virtual MCP not found" }, 404);
+  }
+
+  const projectRef = composeSandboxRef({
+    orgId: organization.id,
+    virtualMcpId,
+    branch,
+  });
+  const claimName = composeClaimName({ userId, projectRef }, branch);
+
+  const runnerKind = tryResolveRunnerKindFromEnv();
+  const runner = await getOrInitSharedRunner();
+
+  // No runner configured at all → can't proxy daemon SSE. Surface a failed
+  // phase rather than a silent close so the UI shows a meaningful error.
+  if (!runner) {
+    return streamSSE(c, async (stream) => {
+      await stream.writeSSE({
+        event: "phase",
+        data: JSON.stringify({
+          kind: "failed",
+          reason: "unknown",
+          message: "No sandbox runner configured on this mesh.",
+        } satisfies ClaimPhase),
+      });
+    });
+  }
+
+  return streamSSE(c, async (stream) => {
+    const abortCtl = new AbortController();
+    const heartbeat = setInterval(() => {
+      stream.writeSSE({ event: "keepalive", data: "" }).catch(() => {
+        clearInterval(heartbeat);
+      });
+    }, HEARTBEAT_MS);
+    stream.onAbort(() => {
+      abortCtl.abort();
+      clearInterval(heartbeat);
+    });
+
+    try {
+      // ---- Phase 1: lifecycle (pre-Ready) ---------------------------------
+      const lifecycleOk = await emitLifecycle({
+        stream,
+        runnerKind,
+        claimName,
+        runner,
+        signal: abortCtl.signal,
+      });
+      if (!lifecycleOk || abortCtl.signal.aborted) return;
+
+      // ---- Phase 2: daemon SSE proxy --------------------------------------
+      await proxyDaemonEvents({
+        stream,
+        runner,
+        claimName,
+        signal: abortCtl.signal,
+      });
+    } finally {
+      clearInterval(heartbeat);
+    }
+  });
+});
+
+/**
+ * Drives the lifecycle generator (or its no-op equivalent for non-agent-sandbox
+ * runners) until a terminal phase. Returns `true` if the terminal phase was
+ * `ready` (caller proceeds to daemon proxy), `false` otherwise (failed,
+ * aborted, or watchdog-tripped).
+ */
+async function emitLifecycle(args: {
+  stream: import("hono/streaming").SSEStreamingApi;
+  runnerKind: ReturnType<typeof tryResolveRunnerKindFromEnv>;
+  claimName: string;
+  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
+  signal: AbortSignal;
+}): Promise<boolean> {
+  const { stream, runnerKind, claimName, runner, signal } = args;
+
+  // Non-agent-sandbox runners (Docker/Freestyle) have no equivalent
+  // pre-Ready window worth surfacing — Docker is local-fast, Freestyle's
+  // setup is end-to-end. Emit a single `ready` and proceed straight to
+  // daemon proxy.
+  if (runnerKind !== "agent-sandbox") {
+    await stream.writeSSE({
+      event: "phase",
+      data: JSON.stringify({ kind: "ready" } satisfies ClaimPhase),
+    });
+    return true;
+  }
+
+  const watchable = asLifecycleWatchable(runner);
+  if (!watchable) {
+    // Runner kind says agent-sandbox but the instance doesn't expose the
+    // watch capability (e.g. older module loaded). Treat as no-op.
+    await stream.writeSSE({
+      event: "phase",
+      data: JSON.stringify({ kind: "ready" } satisfies ClaimPhase),
+    });
+    return true;
+  }
+
+  const startedAt = Date.now();
+  let claimSeen = false;
+
+  // Watchdog: if we've been streaming for NO_CLAIM_MAX_MS and the watcher
+  // has only ever surfaced `claiming` (i.e. the SandboxClaim never
+  // materialized), close with a `claim-never-created` failure. Prevents
+  // zombie streams when VM_START failed before posting the claim.
+  const watchdogAbort = new AbortController();
+  const composedSignal = composeSignals(signal, watchdogAbort.signal);
+  const watchdog = setInterval(() => {
+    if (claimSeen) return;
+    if (Date.now() - startedAt < NO_CLAIM_MAX_MS) return;
+    stream
+      .writeSSE({
+        event: "phase",
+        data: JSON.stringify({
+          kind: "failed",
+          reason: "claim-never-created",
+          message:
+            "Sandbox claim was never created. The VM_START call may have failed earlier — check the start error.",
+        } satisfies ClaimPhase),
+      })
+      .catch(() => {});
+    watchdogAbort.abort();
+  }, 30_000);
+
+  try {
+    for await (const phaseUntyped of watchable.watchClaimLifecycle(
+      claimName,
+      composedSignal,
+    )) {
+      const phase = phaseUntyped as ClaimPhase;
+      if (phase.kind !== "claiming") claimSeen = true;
+      await stream.writeSSE({
+        event: "phase",
+        data: JSON.stringify(phase),
+      });
+      if (phase.kind === "ready") return true;
+      if (phase.kind === "failed") return false;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await stream
+      .writeSSE({
+        event: "phase",
+        data: JSON.stringify({
+          kind: "failed",
+          reason: "unknown",
+          message,
+        } satisfies ClaimPhase),
+      })
+      .catch(() => {});
+  } finally {
+    clearInterval(watchdog);
+  }
+  return false;
+}
+
+/**
+ * Budget for the "lifecycle says ready but mesh hasn't finished its
+ * post-Ready bookkeeping" race. The Sandbox CR Ready=True signal fires the
+ * moment the operator's reconciliation completes; `runner.ensure()` then
+ * does Service-patch + HTTPRoute-mint + port-forward + daemon health probe
+ * before inserting the state-store row that `proxyDaemonRequest` reads. In
+ * a real cluster that post-Ready window is typically 2–10s. Without this
+ * retry the unified stream would 404 here, emit `gone`, and force the
+ * browser to reconnect — the symptom that motivated this fix.
+ */
+const PROXY_OPEN_RETRY_BUDGET_MS = 60_000;
+const PROXY_OPEN_RETRY_DELAY_MS = 500;
+
+/**
+ * Open the daemon's `/_decopilot_vm/events` SSE through the runner and pipe
+ * raw bytes to the client. Daemon emits a stable wire format the browser's
+ * EventSource already groks, so byte-passthrough preserves event names,
+ * payloads, and frame boundaries without parsing.
+ *
+ * 404 handling: retry within `PROXY_OPEN_RETRY_BUDGET_MS` rather than
+ * surfacing `gone` immediately. The most common cause of an immediate 404
+ * is the lifecycle-vs-ensure race described above — `gone` is reserved for
+ * genuine eviction, where the handle is absent from K8s + state-store after
+ * the budget expires.
+ *
+ * Non-404 upstream failure → `failed` phase. Caller's UI surfaces the
+ * existing error state.
+ */
+async function proxyDaemonEvents(args: {
+  stream: import("hono/streaming").SSEStreamingApi;
+  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
+  claimName: string;
+  signal: AbortSignal;
+}): Promise<void> {
+  const { stream, runner, claimName, signal } = args;
+
+  const openedAt = Date.now();
+  let upstream: Response | null = null;
+
+  while (!signal.aborted) {
+    let attempt: Response | null = null;
+    try {
+      attempt = await runner.proxyDaemonRequest(
+        claimName,
+        "/_decopilot_vm/events",
+        {
+          method: "GET",
+          headers: new Headers({ accept: "text/event-stream" }),
+          body: null,
+          signal,
+        },
+      );
+    } catch (err) {
+      if (signal.aborted) return;
+      // Network-level failure (port-forward not yet open, daemon health
+      // probe still failing, ...). Same race window as 404 — retry, then
+      // surface as failed if the budget elapses.
+      if (Date.now() - openedAt < PROXY_OPEN_RETRY_BUDGET_MS) {
+        await sleepAbortable(PROXY_OPEN_RETRY_DELAY_MS, signal);
+        continue;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      await stream
+        .writeSSE({
+          event: "phase",
+          data: JSON.stringify({
+            kind: "failed",
+            reason: "unknown",
+            message: `Upstream daemon SSE error: ${message}`,
+          } satisfies ClaimPhase),
+        })
+        .catch(() => {});
+      return;
+    }
+
+    if (attempt.status === 404) {
+      try {
+        await attempt.body?.cancel();
+      } catch {
+        /* ignore */
+      }
+      if (Date.now() - openedAt < PROXY_OPEN_RETRY_BUDGET_MS) {
+        await sleepAbortable(PROXY_OPEN_RETRY_DELAY_MS, signal);
+        continue;
+      }
+      // Budget elapsed and handle still missing — genuine eviction. Emit
+      // `gone` so the client's self-heal (VM_START) takes over.
+      await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+      return;
+    }
+
+    if (!attempt.ok || !attempt.body) {
+      try {
+        await attempt.body?.cancel();
+      } catch {
+        /* ignore */
+      }
+      await stream
+        .writeSSE({
+          event: "phase",
+          data: JSON.stringify({
+            kind: "failed",
+            reason: "unknown",
+            message: `Upstream daemon SSE failed (${attempt.status}).`,
+          } satisfies ClaimPhase),
+        })
+        .catch(() => {});
+      return;
+    }
+
+    upstream = attempt;
+    break;
+  }
+
+  if (!upstream || !upstream.body) return;
+
+  const reader = upstream.body.getReader();
+  try {
+    while (!signal.aborted) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) await stream.write(value);
+    }
+  } catch {
+    // Upstream errored or client aborted mid-read. Either way we're done —
+    // the client will EventSource-reconnect if it wants to keep watching.
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Sleep that resolves immediately when the abort signal fires. */
+function sleepAbortable(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Combine two AbortSignals into one. Aborts whenever either source aborts.
+ * Used so the lifecycle generator stops both on client disconnect *and* on
+ * the no-claim watchdog tripping.
+ */
+function composeSignals(a: AbortSignal, b: AbortSignal): AbortSignal {
+  if (a.aborted) return a;
+  if (b.aborted) return b;
+  const composed = new AbortController();
+  const onAbortA = () => composed.abort();
+  const onAbortB = () => composed.abort();
+  a.addEventListener("abort", onAbortA, { once: true });
+  b.addEventListener("abort", onAbortB, { once: true });
+  return composed.signal;
+}
+
+export const vmEventsRoutes = app;

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -45,6 +45,7 @@ import type { ClaimPhase } from "@decocms/sandbox/runner/agent-sandbox";
 import {
   asLifecycleWatchable,
   getOrInitSharedRunner,
+  subscribeLifecycle,
 } from "../../sandbox/lifecycle";
 import {
   getUserId,
@@ -54,11 +55,14 @@ import {
 import type { Env } from "../hono-env";
 
 /**
- * Hard cap on how long we'll keep the SSE open if a claim never materializes
- * (e.g. caller raced VM_START but VM_START failed before
- * `createSandboxClaim`). Prevents indefinite "claiming" streams.
+ * Cap on how long we keep the SSE open if a claim never materializes (e.g.
+ * caller raced VM_START but VM_START failed before `createSandboxClaim`).
+ * 90s is enough to absorb karpenter cold-start (~60–90s) plus a few seconds
+ * of operator latency; longer waits indicate VM_START never posted the claim
+ * and the user benefits from a faster failure surface so the retry button
+ * appears promptly.
  */
-const NO_CLAIM_MAX_MS = 5 * 60 * 1000;
+const NO_CLAIM_MAX_MS = 90_000;
 
 const HEARTBEAT_MS = 15_000;
 
@@ -161,10 +165,13 @@ app.get("/", async (c) => {
 });
 
 /**
- * Drives the lifecycle generator (or its no-op equivalent for non-agent-sandbox
- * runners) until a terminal phase. Returns `true` if the terminal phase was
- * `ready` (caller proceeds to daemon proxy), `false` otherwise (failed,
- * aborted, or watchdog-tripped).
+ * Drives the lifecycle phase stream (or its no-op equivalent for
+ * non-agent-sandbox runners) until a terminal phase. Returns `true` if the
+ * terminal phase was `ready` (caller proceeds to daemon proxy), `false`
+ * otherwise (failed, aborted, or watchdog-tripped).
+ *
+ * Subscribes via `subscribeLifecycle` so multiple SSE clients for the same
+ * claim (multi-tab) share one underlying set of K8s watches.
  */
 async function emitLifecycle(args: {
   stream: import("hono/streaming").SSEStreamingApi;
@@ -198,62 +205,53 @@ async function emitLifecycle(args: {
     return true;
   }
 
-  const startedAt = Date.now();
-  let claimSeen = false;
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let claimSeen = false;
+    let handle: { unsubscribe(): void } | null = null;
 
-  // Watchdog: if we've been streaming for NO_CLAIM_MAX_MS and the watcher
-  // has only ever surfaced `claiming` (i.e. the SandboxClaim never
-  // materialized), close with a `claim-never-created` failure. Prevents
-  // zombie streams when VM_START failed before posting the claim.
-  const watchdogAbort = new AbortController();
-  const composedSignal = composeSignals(signal, watchdogAbort.signal);
-  const watchdog = setInterval(() => {
-    if (claimSeen) return;
-    if (Date.now() - startedAt < NO_CLAIM_MAX_MS) return;
-    stream
-      .writeSSE({
-        event: "phase",
-        data: JSON.stringify({
-          kind: "failed",
-          reason: "claim-never-created",
-          message:
-            "Sandbox claim was never created. The VM_START call may have failed earlier — check the start error.",
-        } satisfies ClaimPhase),
-      })
-      .catch(() => {});
-    watchdogAbort.abort();
-  }, 30_000);
+    const settle = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdogTimer);
+      signal.removeEventListener("abort", onAbort);
+      handle?.unsubscribe();
+      resolve(result);
+    };
 
-  try {
-    for await (const phaseUntyped of watchable.watchClaimLifecycle(
-      claimName,
-      composedSignal,
-    )) {
-      const phase = phaseUntyped as ClaimPhase;
+    // Watchdog: if the source has only ever surfaced `claiming` after
+    // NO_CLAIM_MAX_MS, the SandboxClaim was never posted (VM_START likely
+    // failed earlier). Surface `claim-never-created` so the UI shows the
+    // retry affordance instead of stalling.
+    const watchdogTimer = setTimeout(() => {
+      if (claimSeen || settled) return;
+      stream
+        .writeSSE({
+          event: "phase",
+          data: JSON.stringify({
+            kind: "failed",
+            reason: "claim-never-created",
+            message:
+              "Sandbox claim was never created. The VM_START call may have failed earlier — check the start error.",
+          } satisfies ClaimPhase),
+        })
+        .catch(() => {});
+      settle(false);
+    }, NO_CLAIM_MAX_MS);
+
+    const onAbort = () => settle(false);
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    handle = subscribeLifecycle(watchable, claimName, (phase) => {
+      if (settled) return;
       if (phase.kind !== "claiming") claimSeen = true;
-      await stream.writeSSE({
-        event: "phase",
-        data: JSON.stringify(phase),
-      });
-      if (phase.kind === "ready") return true;
-      if (phase.kind === "failed") return false;
-    }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    await stream
-      .writeSSE({
-        event: "phase",
-        data: JSON.stringify({
-          kind: "failed",
-          reason: "unknown",
-          message,
-        } satisfies ClaimPhase),
-      })
-      .catch(() => {});
-  } finally {
-    clearInterval(watchdog);
-  }
-  return false;
+      stream
+        .writeSSE({ event: "phase", data: JSON.stringify(phase) })
+        .catch(() => {});
+      if (phase.kind === "ready") settle(true);
+      else if (phase.kind === "failed") settle(false);
+    });
+  });
 }
 
 /**
@@ -408,22 +406,6 @@ function sleepAbortable(ms: number, signal: AbortSignal): Promise<void> {
     };
     signal.addEventListener("abort", onAbort, { once: true });
   });
-}
-
-/**
- * Combine two AbortSignals into one. Aborts whenever either source aborts.
- * Used so the lifecycle generator stops both on client disconnect *and* on
- * the no-claim watchdog tripping.
- */
-function composeSignals(a: AbortSignal, b: AbortSignal): AbortSignal {
-  if (a.aborted) return a;
-  if (b.aborted) return b;
-  const composed = new AbortController();
-  const onAbortA = () => composed.abort();
-  const onAbortB = () => composed.abort();
-  a.addEventListener("abort", onAbortA, { once: true });
-  b.addEventListener("abort", onAbortB, { once: true });
-  return composed.signal;
 }
 
 export const vmEventsRoutes = app;

--- a/apps/mesh/src/sandbox/lifecycle.test.ts
+++ b/apps/mesh/src/sandbox/lifecycle.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { DockerSandboxRunner } from "@decocms/sandbox/runner";
+import type { ClaimPhase } from "@decocms/sandbox/runner/agent-sandbox";
 import type { MeshContext } from "@/core/mesh-context";
-import { asDockerRunner, getRunnerByKind } from "./lifecycle";
+import {
+  __resetSharedLifecyclesForTesting,
+  asDockerRunner,
+  getRunnerByKind,
+  subscribeLifecycle,
+  type SupportsLifecycleWatch,
+} from "./lifecycle";
 
 // Minimal MeshContext stub — lifecycle only reads ctx.db, and only to hand
 // it to the KyselySandboxRunnerStateStore constructor (no queries run until
@@ -57,5 +64,152 @@ describe("getRunnerByKind caching", () => {
     const b = await getRunnerByKind(stubCtx, "docker");
     expect(a).toBe(b);
     expect(a).toBeInstanceOf(DockerSandboxRunner);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribeLifecycle — multi-tab dedup
+// ---------------------------------------------------------------------------
+
+interface FakeWatchableHandle {
+  watchable: SupportsLifecycleWatch;
+  /** How many times the source generator has been started. */
+  starts: () => number;
+  /** Push a phase to the active source generator. */
+  emit: (phase: ClaimPhase) => Promise<void>;
+  /** Resolve when all listeners attached to the source unsubscribe. */
+  endedSignal: () => AbortSignal;
+}
+
+/**
+ * Synthesize a `SupportsLifecycleWatch` whose `watchClaimLifecycle` is an
+ * async generator we can drive frame-by-frame from the test. Tracks how many
+ * times the generator has been instantiated (so we can prove dedup).
+ */
+function makeFakeWatchable(): FakeWatchableHandle {
+  let starts = 0;
+  let pushNext: ((phase: ClaimPhase | null) => void) | null = null;
+  let endedAbort = new AbortController();
+
+  async function* gen(
+    _claim: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<ClaimPhase, void, unknown> {
+    starts += 1;
+    endedAbort = new AbortController();
+    while (true) {
+      const phase = await new Promise<ClaimPhase | null>((resolve) => {
+        pushNext = resolve;
+        if (signal?.aborted) resolve(null);
+        signal?.addEventListener("abort", () => resolve(null), { once: true });
+      });
+      if (phase === null) {
+        endedAbort.abort();
+        return;
+      }
+      yield phase;
+      if (phase.kind === "ready" || phase.kind === "failed") {
+        endedAbort.abort();
+        return;
+      }
+    }
+  }
+
+  return {
+    watchable: {
+      kind: "agent-sandbox",
+      watchClaimLifecycle: gen,
+    } as unknown as SupportsLifecycleWatch,
+    starts: () => starts,
+    emit: async (phase: ClaimPhase) => {
+      pushNext?.(phase);
+      // let the generator's microtask drain (yield then emit to listeners)
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    endedSignal: () => endedAbort.signal,
+  };
+}
+
+describe("subscribeLifecycle", () => {
+  beforeEach(() => {
+    __resetSharedLifecyclesForTesting();
+  });
+
+  it("fans out one source to multiple listeners", async () => {
+    const fake = makeFakeWatchable();
+    const seenA: ClaimPhase[] = [];
+    const seenB: ClaimPhase[] = [];
+
+    const a = subscribeLifecycle(fake.watchable, "claim-x", (p) =>
+      seenA.push(p),
+    );
+    const b = subscribeLifecycle(fake.watchable, "claim-x", (p) =>
+      seenB.push(p),
+    );
+
+    expect(fake.starts()).toBe(1); // dedup: one source for two listeners
+
+    await fake.emit({ kind: "claiming", since: 1 });
+    await fake.emit({ kind: "pulling-image", since: 1 });
+
+    expect(seenA.map((p) => p.kind)).toEqual(["claiming", "pulling-image"]);
+    expect(seenB.map((p) => p.kind)).toEqual(["claiming", "pulling-image"]);
+
+    a.unsubscribe();
+    b.unsubscribe();
+  });
+
+  it("replays the most recent phase to a late joiner", async () => {
+    const fake = makeFakeWatchable();
+    const seenA: ClaimPhase[] = [];
+    const a = subscribeLifecycle(fake.watchable, "claim-y", (p) =>
+      seenA.push(p),
+    );
+    await fake.emit({ kind: "claiming", since: 1 });
+    await fake.emit({ kind: "pulling-image", since: 1 });
+
+    const seenB: ClaimPhase[] = [];
+    const b = subscribeLifecycle(fake.watchable, "claim-y", (p) =>
+      seenB.push(p),
+    );
+
+    // Late joiner immediately gets the cached `pulling-image`.
+    expect(seenB.map((p) => p.kind)).toEqual(["pulling-image"]);
+    expect(fake.starts()).toBe(1); // still one source
+
+    a.unsubscribe();
+    b.unsubscribe();
+  });
+
+  it("aborts the source when the last listener unsubscribes", async () => {
+    const fake = makeFakeWatchable();
+    const a = subscribeLifecycle(fake.watchable, "claim-z", () => {});
+    await fake.emit({ kind: "claiming", since: 1 });
+    expect(fake.endedSignal().aborted).toBe(false);
+
+    a.unsubscribe();
+    // Drain microtasks so the generator's abort listener runs.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fake.endedSignal().aborted).toBe(true);
+  });
+
+  it("rebuilds the source after a terminal phase clears the entry", async () => {
+    const fake = makeFakeWatchable();
+    const a = subscribeLifecycle(fake.watchable, "claim-t", () => {});
+    await fake.emit({ kind: "ready" });
+    expect(fake.starts()).toBe(1);
+
+    // Ready already terminated and the cache entry was deleted in the
+    // generator's finally — the next subscribe must spin up a fresh source.
+    // Drain microtasks to let the generator's finally run.
+    await Promise.resolve();
+    await Promise.resolve();
+    const b = subscribeLifecycle(fake.watchable, "claim-t", () => {});
+    expect(fake.starts()).toBe(2);
+
+    a.unsubscribe();
+    b.unsubscribe();
   });
 });

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -180,3 +180,33 @@ export function asDockerRunner(
 ): DockerSandboxRunner | null {
   return runner instanceof DockerSandboxRunner ? runner : null;
 }
+
+/**
+ * Optional capability: agent-sandbox runner exposes a phase stream for the
+ * pre-Ready window. Other runners don't (Docker/Freestyle have no equivalent
+ * black hole — Docker is local-fast, Freestyle's setup is end-to-end).
+ *
+ * Duck-check rather than `instanceof AgentSandboxRunner` so we don't have to
+ * statically import the K8s-laden module just for type narrowing.
+ */
+export interface SupportsLifecycleWatch {
+  readonly kind: RunnerKind;
+  watchClaimLifecycle(
+    handle: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<unknown, void, unknown>;
+}
+
+export function asLifecycleWatchable(
+  runner: SandboxRunner | null,
+): SupportsLifecycleWatch | null {
+  if (!runner) return null;
+  if (runner.kind !== "agent-sandbox") return null;
+  if (
+    typeof (runner as Partial<SupportsLifecycleWatch>).watchClaimLifecycle !==
+    "function"
+  ) {
+    return null;
+  }
+  return runner as unknown as SupportsLifecycleWatch;
+}

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -14,6 +14,7 @@ import {
   type RunnerKind,
   type SandboxRunner,
 } from "@decocms/sandbox/runner";
+import type { ClaimPhase } from "@decocms/sandbox/runner/agent-sandbox";
 import { getDb } from "@/database";
 import type { Kysely } from "kysely";
 import { meter } from "@/observability";
@@ -209,4 +210,198 @@ export function asLifecycleWatchable(
     return null;
   }
   return runner as unknown as SupportsLifecycleWatch;
+}
+
+// ---------------------------------------------------------------------------
+// Shared lifecycle subscriptions (multi-tab dedup)
+//
+// Each browser tab opening `/api/vm-events` for the same `(orgId, virtualMcpId,
+// branch, callerUserId)` produces the same `claimName` — so without dedup,
+// every tab would open its own set of K8s watches (Pod / Sandbox CR / Events
+// = 3 long-lived API streams per tab). Real users keep 2–3 tabs of the same
+// project open while iterating.
+//
+// `subscribeLifecycle` collapses those onto a single source generator per
+// claim, ref-counted by listener. Last unsubscribe aborts the source and
+// removes the cache entry. New subscribers get the most recent phase replayed
+// synchronously so they don't appear stuck on `claiming` while waiting for
+// the next watch event.
+// ---------------------------------------------------------------------------
+
+interface SharedLifecycleEntry {
+  /** Last phase emitted by the source. Replayed to late joiners. */
+  lastPhase: ClaimPhase | null;
+  /** True after the source emitted a terminal (`ready`/`failed`) phase. */
+  terminated: boolean;
+  /** Active subscriber callbacks. Source is torn down when this hits zero. */
+  listeners: Set<(phase: ClaimPhase) => void>;
+  /** Aborted when listeners drains; closes the underlying watches. */
+  abort: AbortController;
+}
+
+const sharedLifecycles = new Map<string, SharedLifecycleEntry>();
+
+export interface LifecycleHandle {
+  unsubscribe(): void;
+}
+
+/**
+ * Subscribe to a SandboxClaim's lifecycle phase stream. Multiple subscribers
+ * for the same `claimName` share one underlying watcher; `onPhase` is called
+ * for every phase transition observed, plus an immediate replay of the last
+ * known phase if the entry already exists.
+ *
+ * The returned handle's `unsubscribe()` is idempotent. The source watcher is
+ * aborted when the last listener drops or when a terminal phase has been
+ * observed (whichever comes first).
+ */
+export function subscribeLifecycle(
+  watchable: SupportsLifecycleWatch,
+  claimName: string,
+  onPhase: (phase: ClaimPhase) => void,
+): LifecycleHandle {
+  let entry = sharedLifecycles.get(claimName);
+
+  if (entry) {
+    // Already terminated entries are kept around only briefly (until the
+    // generator's finally clears them) — replay the terminal phase to the
+    // new subscriber and skip the listener add. Caller doesn't need more
+    // events from a finished lifecycle.
+    if (entry.terminated) {
+      if (entry.lastPhase) {
+        try {
+          onPhase(entry.lastPhase);
+        } catch {
+          /* swallow */
+        }
+      }
+      return { unsubscribe: noopUnsubscribe };
+    }
+    entry.listeners.add(onPhase);
+    if (entry.lastPhase) {
+      try {
+        onPhase(entry.lastPhase);
+      } catch {
+        /* swallow */
+      }
+    }
+    return makeUnsubscribeHandle(claimName, entry, onPhase);
+  }
+
+  // First subscriber for this claim — create the entry and pump the source.
+  const abort = new AbortController();
+  const newEntry: SharedLifecycleEntry = {
+    lastPhase: null,
+    terminated: false,
+    listeners: new Set([onPhase]),
+    abort,
+  };
+  sharedLifecycles.set(claimName, newEntry);
+
+  void pumpLifecycleSource(watchable, claimName, newEntry);
+
+  return makeUnsubscribeHandle(claimName, newEntry, onPhase);
+}
+
+function noopUnsubscribe() {
+  /* no-op */
+}
+
+function makeUnsubscribeHandle(
+  claimName: string,
+  entry: SharedLifecycleEntry,
+  onPhase: (phase: ClaimPhase) => void,
+): LifecycleHandle {
+  return {
+    unsubscribe() {
+      // Guard against the entry having been recycled — only mutate the entry
+      // we attached to.
+      if (sharedLifecycles.get(claimName) !== entry) return;
+      entry.listeners.delete(onPhase);
+      if (entry.listeners.size === 0) {
+        // Synchronous cleanup avoids a window where a fresh subscribe would
+        // attach to a soon-to-be-aborted entry. The source's finally clause
+        // only deletes if the map still points at this entry.
+        sharedLifecycles.delete(claimName);
+        entry.abort.abort();
+      }
+    },
+  };
+}
+
+async function pumpLifecycleSource(
+  watchable: SupportsLifecycleWatch,
+  claimName: string,
+  entry: SharedLifecycleEntry,
+): Promise<void> {
+  let sourceError: unknown = null;
+  try {
+    for await (const phaseUntyped of watchable.watchClaimLifecycle(
+      claimName,
+      entry.abort.signal,
+    )) {
+      if (entry.abort.signal.aborted) break;
+      const phase = phaseUntyped as ClaimPhase;
+      entry.lastPhase = phase;
+      const isTerminal = phase.kind === "ready" || phase.kind === "failed";
+      if (isTerminal) entry.terminated = true;
+      // Snapshot the listener set — a callback may unsubscribe synchronously
+      // and we don't want to skip subsequent listeners or re-iterate.
+      const snapshot = Array.from(entry.listeners);
+      for (const listener of snapshot) {
+        try {
+          listener(phase);
+        } catch {
+          /* swallow — one bad subscriber shouldn't break the others */
+        }
+      }
+      if (isTerminal) break;
+    }
+  } catch (err) {
+    sourceError = err;
+  } finally {
+    // Source ended without a terminal phase (kube client gave up, generator
+    // threw, etc) and listeners are still attached — surface a synthetic
+    // `failed: unknown` so they don't hang. Listeners that already saw a
+    // terminal phase won't trigger this branch (entry.terminated short-
+    // circuits the loop earlier).
+    if (
+      !entry.terminated &&
+      !entry.abort.signal.aborted &&
+      entry.listeners.size > 0
+    ) {
+      const synthetic: ClaimPhase = {
+        kind: "failed",
+        reason: "unknown",
+        message:
+          sourceError instanceof Error
+            ? sourceError.message
+            : "Lifecycle watcher ended unexpectedly",
+      };
+      entry.lastPhase = synthetic;
+      entry.terminated = true;
+      for (const listener of Array.from(entry.listeners)) {
+        try {
+          listener(synthetic);
+        } catch {
+          /* swallow */
+        }
+      }
+    }
+    if (sharedLifecycles.get(claimName) === entry) {
+      sharedLifecycles.delete(claimName);
+    }
+  }
+}
+
+/**
+ * Test-only escape hatch: the in-memory shared-lifecycle cache is pod-local
+ * and survives across requests. Tests that exercise the dedup flow need to
+ * reset it between runs.
+ *
+ * @internal
+ */
+export function __resetSharedLifecyclesForTesting(): void {
+  for (const entry of sharedLifecycles.values()) entry.abort.abort();
+  sharedLifecycles.clear();
 }

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -16,9 +16,10 @@
  *      (sandbox handle missing → operator-evicted on idle TTL). Mapped to
  *      `notFound` which preview.tsx's self-heal flow turns into a VM_START.
  *
- * `ClaimPhase` is duplicated from the server's discriminated union rather
- * than imported — the canonical type lives in `@decocms/sandbox/runner/agent-sandbox`
- * which pulls in K8s deps and is server-only.
+ * `ClaimPhase` is imported as a type-only reference from the canonical
+ * server-side definition; `import type` is erased at build time, so the
+ * web bundle does not pull in `@kubernetes/client-node` or any of the
+ * runner's runtime code.
  */
 
 import {
@@ -29,27 +30,12 @@ import {
   type ReactNode,
 } from "react";
 
-export type ClaimFailureReason =
-  | "image-pull-backoff"
-  | "crash-loop-backoff"
-  | "scheduling-timeout"
-  | "claim-never-created"
-  | "reconciler-error"
-  | "unknown";
+import type {
+  ClaimFailureReason,
+  ClaimPhase,
+} from "@decocms/sandbox/runner/agent-sandbox";
 
-export type ClaimPhase =
-  | { kind: "claiming"; since: number }
-  | {
-      kind: "waiting-for-capacity";
-      since: number;
-      message?: string;
-      nodeClaim?: string;
-    }
-  | { kind: "pulling-image"; since: number }
-  | { kind: "starting-container"; since: number }
-  | { kind: "warming-daemon"; since: number }
-  | { kind: "ready" }
-  | { kind: "failed"; reason: ClaimFailureReason; message: string };
+export type { ClaimFailureReason, ClaimPhase };
 
 export interface VmStatus {
   ready: boolean;
@@ -241,7 +227,26 @@ export function VmEventsProvider({
     };
 
     const handleGone = () => {
+      // The sandbox is gone (idle-evicted, VM_DELETE'd, or its pod terminated
+      // and mesh has stopped finding the handle). Everything we've cached is
+      // about to be stale, so reset:
+      //   - phase: residual `ready` would otherwise keep `lifecycleActive`
+      //     stuck on "Almost ready" in the booting overlay even though
+      //     nothing is starting.
+      //   - status / scripts / processes / branchStatus / log buffers: these
+      //     describe a sandbox that no longer exists. preview.tsx's
+      //     `bootTrackedRef` keys on previewUrl, so flipping `status.ready`
+      //     to false ensures the next provisioned sandbox is treated as a
+      //     fresh boot rather than instantly-ready.
+      // `notFound = true` then drives preview.tsx's self-heal flow when a
+      // vmEntry exists; the empty "Start Server" state when it doesn't.
       setNotFound(true);
+      setPhase(null);
+      setStatus({ ready: false, htmlSupport: false });
+      setScripts([]);
+      setActiveProcesses([]);
+      setBranchStatus(null);
+      buffers.current.clear();
     };
 
     const handleDaemonEvent = (e: MessageEvent) => {

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -1,9 +1,24 @@
 /**
- * Single SSE connection to the VM daemon, fanned out via context — one
- * EventSource instead of per-consumer (which would hit MAX_SSE_CLIENTS).
- * daemonBaseUrl is the VM's previewUrl (daemon serves /_decopilot_vm/* on
- * the same host). Provider appends `/_decopilot_vm/events`. The daemon
- * serves this surface unauthenticated.
+ * Single SSE connection to mesh's `/api/vm-events`, fanned out via context.
+ *
+ * Keyed on `(virtualMcpId, branch)` — mesh derives the userId from the
+ * authenticated session and composes the same claim handle a racing
+ * VM_START would. The stream emits in two phases on one connection:
+ *
+ *   1. `event: phase` — `ClaimPhase` JSON for the pre-Ready lifecycle.
+ *      Surfaces what's happening between VM_START posting a SandboxClaim
+ *      and the daemon coming online (capacity wait, image pull, etc).
+ *   2. `event: log/status/scripts/processes/reload/branch-status` — passthrough
+ *      from the in-pod daemon's `/_decopilot_vm/events`. Same wire format the
+ *      browser used to consume directly.
+ *
+ *   3. `event: gone` — synthetic. Mesh's upstream daemon fetch returned 404
+ *      (sandbox handle missing → operator-evicted on idle TTL). Mapped to
+ *      `notFound` which preview.tsx's self-heal flow turns into a VM_START.
+ *
+ * `ClaimPhase` is duplicated from the server's discriminated union rather
+ * than imported — the canonical type lives in `@decocms/sandbox/runner/agent-sandbox`
+ * which pulls in K8s deps and is server-only.
  */
 
 import {
@@ -13,6 +28,28 @@ import {
   useState,
   type ReactNode,
 } from "react";
+
+export type ClaimFailureReason =
+  | "image-pull-backoff"
+  | "crash-loop-backoff"
+  | "scheduling-timeout"
+  | "claim-never-created"
+  | "reconciler-error"
+  | "unknown";
+
+export type ClaimPhase =
+  | { kind: "claiming"; since: number }
+  | {
+      kind: "waiting-for-capacity";
+      since: number;
+      message?: string;
+      nodeClaim?: string;
+    }
+  | { kind: "pulling-image"; since: number }
+  | { kind: "starting-container"; since: number }
+  | { kind: "warming-daemon"; since: number }
+  | { kind: "ready" }
+  | { kind: "failed"; reason: ClaimFailureReason; message: string };
 
 export interface VmStatus {
   ready: boolean;
@@ -34,9 +71,17 @@ export type ChunkHandler = (source: string, data: string) => void;
 export type ReloadHandler = () => void;
 
 export interface VmEventsValue {
+  /**
+   * Latest `ClaimPhase` from the lifecycle portion of the stream. Null until
+   * the first phase arrives. Stays at `ready`/`failed` after a terminal
+   * phase — callers that want to gate UI on "boot in progress" should pair
+   * this with their own signal (e.g. VM_START in flight, previewUrl
+   * present).
+   */
+  phase: ClaimPhase | null;
   status: VmStatus;
   suspended: boolean;
-  /** 404 on daemon endpoint = handle gone; reprovision via VM_START. Cleared on daemonBaseUrl change. */
+  /** True after a `gone` event — handle gone, reprovision via VM_START. */
   notFound: boolean;
   scripts: string[];
   activeProcesses: string[];
@@ -49,6 +94,7 @@ export interface VmEventsValue {
 }
 
 const DEFAULT_VALUE: VmEventsValue = {
+  phase: null,
   status: { ready: false, htmlSupport: false },
   suspended: false,
   notFound: false,
@@ -82,14 +128,14 @@ class ChunkBuffer {
 }
 
 // Keyed on connection state (NOT event silence) — a ready dev server has
-// nothing to emit. Daemon sends a 15s SSE heartbeat to keep TCP warm so
-// EventSource.onerror fires promptly when the VM actually goes away.
+// nothing to emit. Mesh sends a 15s SSE heartbeat so EventSource.onerror
+// fires promptly when mesh or the daemon goes away.
 const SUSPENDED_AFTER_ERROR_MS = 60_000;
 
 const BASE_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
-const EVENT_TYPES = [
+const DAEMON_EVENT_TYPES = [
   "log",
   "status",
   "scripts",
@@ -99,12 +145,15 @@ const EVENT_TYPES = [
 ] as const;
 
 export function VmEventsProvider({
-  daemonBaseUrl,
+  virtualMcpId,
+  branch,
   children,
 }: {
-  daemonBaseUrl: string | null;
+  virtualMcpId: string | null;
+  branch: string | null;
   children: ReactNode;
 }) {
+  const [phase, setPhase] = useState<ClaimPhase | null>(null);
   const [status, setStatus] = useState<VmStatus>({
     ready: false,
     htmlSupport: false,
@@ -114,7 +163,8 @@ export function VmEventsProvider({
   const [scripts, setScripts] = useState<string[]>([]);
   const [activeProcesses, setActiveProcesses] = useState<string[]>([]);
   const [branchStatus, setBranchStatus] = useState<BranchStatus | null>(null);
-  // Bumped on log chunks so getBuffer/hasData consumers re-render; buffer mutation alone doesn't.
+  // Bumped on log chunks so getBuffer/hasData consumers re-render; buffer
+  // mutation alone doesn't.
   const [, setLogTick] = useState(0);
 
   const buffers = useRef(new Map<string, ChunkBuffer>());
@@ -132,7 +182,8 @@ export function VmEventsProvider({
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — SSE subscription lifecycle requires cleanup on unmount; single EventSource with reconnect logic
   useEffect(() => {
-    // Reset on daemon URL change so stale data doesn't linger across branches.
+    // Reset on key change so stale data doesn't linger across branches.
+    setPhase(null);
     setStatus({ ready: false, htmlSupport: false });
     setSuspended(false);
     setNotFound(false);
@@ -141,40 +192,19 @@ export function VmEventsProvider({
     setBranchStatus(null);
     buffers.current.clear();
 
-    if (!daemonBaseUrl) return;
+    if (!virtualMcpId || !branch) return;
 
-    const sseUrl = `${daemonBaseUrl}/_decopilot_vm/events`;
+    const sseUrl =
+      `/api/vm-events?virtualMcpId=${encodeURIComponent(virtualMcpId)}` +
+      `&branch=${encodeURIComponent(branch)}`;
 
     let disposed = false;
-    let hasProbed = false;
     let reconnectAttempt = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let suspendTimer: ReturnType<typeof setTimeout> | null = null;
     let es: EventSource | null = null;
-    const probeAbort = new AbortController();
-
-    // EventSource.onerror doesn't expose HTTP status; fetch once to distinguish
-    // 404 (sandbox deleted, permanent) from a transient disconnect.
-    async function probeMissing(): Promise<boolean> {
-      try {
-        const res = await fetch(sseUrl, {
-          method: "GET",
-          headers: { Accept: "text/event-stream" },
-          cache: "no-store",
-          signal: probeAbort.signal,
-        });
-        if (res.body) {
-          try {
-            await res.body.cancel();
-          } catch {
-            /* ignore */
-          }
-        }
-        return res.status === 404;
-      } catch {
-        return false;
-      }
-    }
+    /** Latched to true after a `failed` phase — terminal, no reconnect. */
+    let terminalFailure = false;
 
     const enterSuspendTimerIfIdle = () => {
       if (!suspendTimer) {
@@ -191,7 +221,30 @@ export function VmEventsProvider({
       }
     };
 
-    const handler = (e: MessageEvent) => {
+    const handlePhase = (e: MessageEvent) => {
+      try {
+        const next = JSON.parse(e.data) as ClaimPhase;
+        setPhase(next);
+        // A fresh non-terminal phase means the lifecycle is making progress
+        // again — clear notFound from a prior `gone` so the self-heal UI
+        // settles back into the booting overlay.
+        if (next.kind !== "failed") {
+          setNotFound(false);
+        }
+        if (next.kind === "failed") {
+          terminalFailure = true;
+          es?.close();
+        }
+      } catch (err) {
+        console.warn("[vm-events] bad phase payload", err);
+      }
+    };
+
+    const handleGone = () => {
+      setNotFound(true);
+    };
+
+    const handleDaemonEvent = (e: MessageEvent) => {
       try {
         const data = JSON.parse(e.data);
 
@@ -242,7 +295,7 @@ export function VmEventsProvider({
     };
 
     function connect() {
-      if (disposed) return;
+      if (disposed || terminalFailure) return;
 
       es = new EventSource(sseUrl);
 
@@ -254,32 +307,24 @@ export function VmEventsProvider({
 
       es.onerror = () => {
         if (es?.readyState !== EventSource.CLOSED) return;
+        // After a terminal `failed` phase the connection is gone for good
+        // and the UI already shows a dedicated error state — surfacing
+        // `suspended` on top of that would just stack confusing overlays.
+        if (terminalFailure) return;
         // Timer runs only while disconnected; onopen clears it on reconnect.
         enterSuspendTimerIfIdle();
-        if (hasProbed) {
-          scheduleReconnect();
-          return;
-        }
-        hasProbed = true;
-        probeMissing().then((missing) => {
-          if (disposed) return;
-          if (missing) {
-            // Sandbox gone — stop reconnecting; caller reprovisions via VM_START,
-            // which changes daemonBaseUrl and remounts this effect.
-            setNotFound(true);
-            return;
-          }
-          scheduleReconnect();
-        });
+        scheduleReconnect();
       };
 
-      for (const type of EVENT_TYPES) {
-        es.addEventListener(type, handler);
+      es.addEventListener("phase", handlePhase);
+      es.addEventListener("gone", handleGone);
+      for (const type of DAEMON_EVENT_TYPES) {
+        es.addEventListener(type, handleDaemonEvent);
       }
     }
 
     function scheduleReconnect() {
-      if (disposed || reconnectTimer) return;
+      if (disposed || reconnectTimer || terminalFailure) return;
 
       const delay = Math.min(
         BASE_RECONNECT_DELAY_MS * 2 ** reconnectAttempt,
@@ -299,14 +344,14 @@ export function VmEventsProvider({
 
     return () => {
       disposed = true;
-      probeAbort.abort();
       es?.close();
       if (reconnectTimer) clearTimeout(reconnectTimer);
       clearSuspendTimer();
     };
-  }, [daemonBaseUrl]);
+  }, [virtualMcpId, branch]);
 
   const value: VmEventsValue = {
+    phase,
     status,
     suspended,
     notFound,

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -39,7 +39,11 @@ import {
 } from "./visual-editor-script";
 import { VisualEditorPrompt } from "./visual-editor-prompt";
 import { useVmEvents, useVmReloadHandler } from "../hooks/use-vm-events";
-import { useVmStart, type VmStartArgs } from "../hooks/use-vm-start";
+import {
+  useIsVmStartPending,
+  useVmStart,
+  type VmStartArgs,
+} from "../hooks/use-vm-start";
 import { VmSuspendedState } from "../vm-suspended-state";
 import { VmBootingState } from "../vm-booting-state";
 import { VmErrorState } from "../vm-error-state";
@@ -92,9 +96,10 @@ export function PreviewContent() {
   const hasHtmlPreview = vmEvents.status.htmlSupport;
   const suspended = vmEvents.suspended;
 
-  // Gate iframe on upstream readiness to avoid "didn't send any data" page;
-  // keep mounted once ever-ready so HMR hiccups don't re-show the boot screen.
-  // `at` uses server-stamped vmEntry.createdAt so the timer survives remounts.
+  // Gate iframe on upstream readiness to avoid the daemon's "Server is
+  // starting..." placeholder; keep mounted once ever-ready so HMR hiccups
+  // don't re-show the boot screen. `at` uses server-stamped
+  // vmEntry.createdAt so the timer survives remounts.
   const bootTrackedRef = useRef<{ url: string; at: number; ready: boolean }>({
     url: "",
     at: 0,
@@ -129,14 +134,27 @@ export function PreviewContent() {
   });
   const startVm = useVmStart(mcpClient);
   const lastStartError = startVm.error?.message ?? null;
-  if (startVm.isPending) {
+  const vmStartPending = useIsVmStartPending(
+    virtualMcpId ?? undefined,
+    branch ?? undefined,
+  );
+  if (vmStartPending) {
     if (!startingSinceRef.current) startingSinceRef.current = Date.now();
   } else if (previewUrl) {
     startingSinceRef.current = 0;
   }
-  const starting = startVm.isPending && !previewUrl && !suspended;
+  const starting = vmStartPending && !previewUrl && !suspended;
   const autoStartedForTaskRef = useRef<string | null>(null);
   const reprovisionedForVmIdRef = useRef<string | null>(null);
+
+  const claimPhase = vmEvents.phase;
+  // Only meaningful during the pre-previewUrl gap (VM_START mutation
+  // resolved → vmMap refetch lands). Once previewUrl is set, the booting
+  // overlay is driven by `booting` and dismisses on ready=true; if we kept
+  // lifecycleActive=true here, the overlay would never dismiss because
+  // `claimPhase` stays at `ready` for the lifetime of the SSE.
+  const lifecycleActive =
+    !previewUrl && !!claimPhase && claimPhase.kind !== "failed";
 
   // ref-latest pattern: effects below depend only on upstream signals, not
   // on this closure's churning captures (branch, mutation, setter).
@@ -377,7 +395,7 @@ export function PreviewContent() {
       )}
 
       <div className="flex-1 relative overflow-hidden">
-        {!previewUrl && !starting && !lastStartError && (
+        {!previewUrl && !starting && !lastStartError && !lifecycleActive && (
           <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-4 bg-background">
             <Monitor04 size={48} className="text-muted-foreground/40" />
             <h3 className="text-lg font-medium">Preview</h3>
@@ -403,7 +421,7 @@ export function PreviewContent() {
           </div>
         )}
 
-        {!lastStartError && (booting || starting) && (
+        {!lastStartError && (booting || starting || lifecycleActive) && (
           <div className="absolute inset-0 z-30 flex items-center justify-center bg-background">
             <VmBootingState
               since={
@@ -413,6 +431,8 @@ export function PreviewContent() {
               scripts={vmEvents.scripts}
               activeProcesses={vmEvents.activeProcesses}
               onViewLogs={openEnv}
+              claimPhase={previewUrl ? null : claimPhase}
+              onRetry={retryAutoStart}
             />
           </div>
         )}

--- a/apps/mesh/src/web/components/vm/vm-booting-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-booting-state.tsx
@@ -2,6 +2,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { Terminal } from "@untitledui/icons";
 import type { ReactNode } from "react";
 import { GridLoader } from "@/web/components/grid-loader";
+import type { ClaimPhase } from "./hooks/vm-events-context";
 import { useVmEvents } from "./hooks/use-vm-events";
 
 interface VmBootingStateProps {
@@ -12,6 +13,17 @@ interface VmBootingStateProps {
   scripts: string[];
   activeProcesses: string[];
   onViewLogs: () => void;
+  /**
+   * Pre-daemon lifecycle phase (agent-sandbox runner only). When non-null
+   * and not `ready`, the component renders a lifecycle-driven pre-daemon
+   * UI; otherwise it falls through to the existing 3-phase daemon-driven
+   * UI. Callers pass `null` when the runner doesn't surface lifecycle
+   * phases (Docker/Freestyle) or once the lifecycle has reached `ready`
+   * AND VM_START has resolved (so we don't flash back to lifecycle copy).
+   */
+  claimPhase?: ClaimPhase | null;
+  /** Optional retry handler shown on terminal `failed` phases. */
+  onRetry?: () => void;
 }
 
 const PHASES = [
@@ -80,7 +92,24 @@ export function VmBootingState({
   scripts,
   activeProcesses,
   onViewLogs,
+  claimPhase,
+  onRetry,
 }: VmBootingStateProps) {
+  // Lifecycle-driven pre-daemon UI takes precedence whenever the caller
+  // supplies a phase. The caller (preview.tsx) decides when to drop it —
+  // typically once VM_START's promise resolves and a previewUrl is in
+  // hand, so we don't briefly flash the 3-phase UI between
+  // Sandbox.Ready=True and VM_START.success.
+  if (claimPhase != null) {
+    return (
+      <ClaimLifecycleView
+        phase={claimPhase}
+        onRetry={onRetry}
+        onViewLogs={onViewLogs}
+      />
+    );
+  }
+
   const phase = getPhaseIndex(hasSetupData, scripts, activeProcesses);
   const currentLabel = PHASES[phase]?.label ?? PHASES[0].label;
 
@@ -323,4 +352,167 @@ function PreviewContent() {
       </div>
     </div>
   );
+}
+
+// ---- Lifecycle (pre-daemon) UI --------------------------------------------
+
+/**
+ * Copy for each pre-daemon phase. Headlines stay short for the pill;
+ * `body` is only shown for phases where the user benefits from knowing why
+ * the wait exists (capacity provisioning, image pull on a fresh node).
+ *
+ * `failed` is intentionally absent here — failure copy is phase-reason
+ * driven (see `failureCopy`) and renders a Try-Again affordance.
+ */
+const LIFECYCLE_COPY: Record<
+  Exclude<ClaimPhase["kind"], "ready" | "failed">,
+  { headline: string; body?: string }
+> = {
+  claiming: {
+    headline: "Reserving sandbox",
+    body: "Posting your claim to the cluster…",
+  },
+  "waiting-for-capacity": {
+    headline: "Waiting for cluster capacity",
+    body: "The cluster may need to provision a new node — typically 60–90s.",
+  },
+  "pulling-image": {
+    headline: "Downloading sandbox image",
+    body: "First boot on this node — subsequent runs reuse the cached image.",
+  },
+  "starting-container": {
+    headline: "Starting your sandbox",
+  },
+  "warming-daemon": {
+    headline: "Connecting to your sandbox",
+  },
+};
+
+function failureCopy(phase: Extract<ClaimPhase, { kind: "failed" }>): {
+  headline: string;
+  body: string;
+} {
+  switch (phase.reason) {
+    case "image-pull-backoff":
+      return {
+        headline: "Sandbox image failed to download",
+        body: phase.message,
+      };
+    case "crash-loop-backoff":
+      return {
+        headline: "Sandbox crashed during startup",
+        body: phase.message,
+      };
+    case "scheduling-timeout":
+      return {
+        headline: "Couldn't get cluster capacity in time",
+        body: phase.message,
+      };
+    case "claim-never-created":
+      return {
+        headline: "Sandbox claim was never posted",
+        body: phase.message,
+      };
+    case "reconciler-error":
+      return {
+        headline: "Sandbox controller reported an error",
+        body: phase.message,
+      };
+    case "unknown":
+    default:
+      return {
+        headline: "Sandbox failed to start",
+        body: phase.message,
+      };
+  }
+}
+
+function ClaimLifecycleView({
+  phase,
+  onRetry,
+  onViewLogs,
+}: {
+  phase: ClaimPhase;
+  onRetry?: () => void;
+  onViewLogs: () => void;
+}) {
+  if (phase.kind === "failed") {
+    const copy = failureCopy(phase);
+    return (
+      <div className="relative flex flex-col items-center justify-center w-full h-full overflow-hidden select-none gap-6 px-6">
+        <div className="flex flex-col items-center gap-2 text-center max-w-[440px]">
+          <span className="text-sm font-medium text-foreground">
+            {copy.headline}
+          </span>
+          <span className="text-xs text-muted-foreground">{copy.body}</span>
+        </div>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="rounded-md border border-foreground/15 bg-background px-3 py-1.5 text-xs font-medium hover:bg-foreground/[0.04] transition-colors"
+          >
+            Try again
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onViewLogs}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-200"
+        >
+          <Terminal size={11} />
+          View logs
+        </button>
+      </div>
+    );
+  }
+
+  // `ready` is reached when Sandbox.Ready=True, but VM_START still has the
+  // Service-patch + HTTPRoute-mint + port-forward window before previewUrl
+  // exists. Show "almost ready" until the caller drops `claimPhase`
+  // (= VM_START's promise resolved).
+  const copy =
+    phase.kind === "ready"
+      ? { headline: "Almost ready", body: undefined }
+      : LIFECYCLE_COPY[phase.kind];
+  const subline =
+    phase.kind === "ready" ? undefined : (nodeClaimSubline(phase) ?? copy.body);
+
+  return (
+    <div className="relative flex flex-col items-center justify-center w-full h-full overflow-hidden select-none gap-6">
+      <div className="flex items-center gap-2 rounded-full border border-foreground/10 bg-background px-3.5 py-1.5 shadow-[0_4px_20px_-4px_rgb(0_0_0_/_0.12)]">
+        <GridLoader />
+        <span
+          key={phase.kind}
+          className="text-[13px] font-medium text-foreground/85 animate-in fade-in duration-500"
+        >
+          {copy.headline}…
+        </span>
+      </div>
+
+      {subline && (
+        <span
+          key={subline}
+          className="block max-w-[440px] truncate text-center text-xs text-muted-foreground/70 animate-in fade-in duration-300"
+        >
+          {subline}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={onViewLogs}
+        className="absolute bottom-5 left-1/2 -translate-x-1/2 flex items-center gap-1.5 text-xs text-muted-foreground/50 hover:text-muted-foreground transition-colors duration-200"
+      >
+        <Terminal size={11} />
+        View logs
+      </button>
+    </div>
+  );
+}
+
+function nodeClaimSubline(phase: ClaimPhase): string | undefined {
+  if (phase.kind !== "waiting-for-capacity") return undefined;
+  if (!phase.nodeClaim) return undefined;
+  return `Provisioning node ${phase.nodeClaim}…`;
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -134,10 +134,11 @@ function MobileToolbar({ onOpenSidebar }: { onOpenSidebar: () => void }) {
 }
 
 // ---------------------------------------------------------------------------
-// VmEventsBridge — derives the daemon URL from thread.branch and runs
-// auto-start. Lives inside Chat.Provider so it can read useChatTask, which
-// keeps the VM SSE connection in sync with the active task as the user
-// navigates between tasks (different tasks may pin different branches).
+// VmEventsBridge — passes (virtualMcpId, branch) to the unified VM events
+// SSE provider and runs auto-start. Lives inside Chat.Provider so it can
+// read useChatTask, which keeps the SSE connection in sync with the active
+// task as the user navigates between tasks (different tasks may pin
+// different branches).
 // ---------------------------------------------------------------------------
 
 function VmEventsBridge({
@@ -155,14 +156,6 @@ function VmEventsBridge({
   const { currentBranch } = useChatTask();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
-
-  const vmEntry =
-    userId && currentBranch ? (vmMap?.[userId]?.[currentBranch] ?? null) : null;
-  // Browser talks to the daemon directly via previewUrl. Trailing slash
-  // stripped because the SSE URL appends `/_decopilot_vm/events`.
-  const vmDaemonBaseUrl = vmEntry?.previewUrl
-    ? vmEntry.previewUrl.replace(/\/$/, "")
-    : null;
 
   // Auto-start the VM when the active task points at a branch without a
   // registered vmMap entry. Routed through useVmStart so concurrent mounts
@@ -203,7 +196,10 @@ function VmEventsBridge({
   ]);
 
   return (
-    <VmEventsProvider daemonBaseUrl={vmDaemonBaseUrl}>
+    <VmEventsProvider
+      virtualMcpId={virtualMcpId}
+      branch={currentBranch ?? null}
+    >
       {children}
     </VmEventsProvider>
   );

--- a/packages/sandbox/server/runner/agent-sandbox/client.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.ts
@@ -207,8 +207,12 @@ interface KubeFetchInit {
  * Thin wrapper around `fetch` that threads TLS + auth from the kubeconfig.
  * Returns the raw `Response` so streaming callers (watch) can consume the
  * body themselves; non-streaming callers parse JSON explicitly.
+ *
+ * Package-internal: re-exported only for sibling modules in this directory
+ * (e.g. lifecycle-watcher) that need the same transport. Not surfaced via
+ * `index.ts` — callers outside the runner should not depend on this.
  */
-async function kubeFetch(
+export async function kubeFetch(
   kc: KubeConfig,
   init: KubeFetchInit,
 ): Promise<Response> {
@@ -801,8 +805,13 @@ export function waitForSandboxReady(
   return promise;
 }
 
-/** ND-JSON line reader over a WHATWG ReadableStream. */
-async function* readNdJson<T>(
+/**
+ * ND-JSON line reader over a WHATWG ReadableStream.
+ *
+ * Package-internal export: sibling modules (lifecycle-watcher) consume the
+ * same kube watch streams and parse them this way. Not exposed via index.ts.
+ */
+export async function* readNdJson<T>(
   stream: ReadableStream<Uint8Array>,
 ): AsyncGenerator<T, void, unknown> {
   const reader = stream.getReader();

--- a/packages/sandbox/server/runner/agent-sandbox/client.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/client.ts
@@ -208,9 +208,10 @@ interface KubeFetchInit {
  * Returns the raw `Response` so streaming callers (watch) can consume the
  * body themselves; non-streaming callers parse JSON explicitly.
  *
- * Package-internal: re-exported only for sibling modules in this directory
- * (e.g. lifecycle-watcher) that need the same transport. Not surfaced via
- * `index.ts` — callers outside the runner should not depend on this.
+ * @internal Package-internal — re-exported only for sibling modules in this
+ *   directory (e.g. lifecycle-watcher) that need the same transport. Not
+ *   surfaced via `index.ts` and not part of the package's public API.
+ *   External consumers must use `proxyDaemonRequest` or the runner methods.
  */
 export async function kubeFetch(
   kc: KubeConfig,
@@ -808,8 +809,9 @@ export function waitForSandboxReady(
 /**
  * ND-JSON line reader over a WHATWG ReadableStream.
  *
- * Package-internal export: sibling modules (lifecycle-watcher) consume the
- * same kube watch streams and parse them this way. Not exposed via index.ts.
+ * @internal Package-internal — sibling modules (lifecycle-watcher) consume the
+ *   same kube watch streams and parse them this way. Not exposed via
+ *   `index.ts` and not part of the package's public API.
  */
 export async function* readNdJson<T>(
   stream: ReadableStream<Uint8Array>,

--- a/packages/sandbox/server/runner/agent-sandbox/index.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/index.ts
@@ -26,8 +26,7 @@ export {
   composeClaimName,
 } from "./runner";
 export type { AgentSandboxRunnerOptions } from "./runner";
-export type {
-  ClaimFailureReason,
-  ClaimPhase,
-  WatchClaimLifecycleOptions,
-} from "./lifecycle-watcher";
+// Lifecycle types live in their own module (no K8s deps) so type-only
+// consumers — notably the studio web bundle — can import them safely.
+export type { ClaimFailureReason, ClaimPhase } from "./lifecycle-types";
+export type { WatchClaimLifecycleOptions } from "./lifecycle-watcher";

--- a/packages/sandbox/server/runner/agent-sandbox/index.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/index.ts
@@ -20,5 +20,14 @@ export type {
   SandboxResource,
   WaitForSandboxReadyResult,
 } from "./client";
-export { AgentSandboxRunner, HANDLE_PREFIX } from "./runner";
+export {
+  AgentSandboxRunner,
+  HANDLE_PREFIX,
+  composeClaimName,
+} from "./runner";
 export type { AgentSandboxRunnerOptions } from "./runner";
+export type {
+  ClaimFailureReason,
+  ClaimPhase,
+  WatchClaimLifecycleOptions,
+} from "./lifecycle-watcher";

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-types.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-types.ts
@@ -1,0 +1,32 @@
+/**
+ * Public lifecycle types for SandboxClaim phase reporting.
+ *
+ * Lives in its own module (rather than co-located with the watcher) so that
+ * type-only consumers — notably the studio web bundle — can import them
+ * without dragging `@kubernetes/client-node` through the dependency graph.
+ * `import type` already erases at build time, but a dedicated types file
+ * makes the boundary explicit and tool-friendly.
+ */
+
+export type ClaimFailureReason =
+  | "image-pull-backoff"
+  | "crash-loop-backoff"
+  | "scheduling-timeout"
+  | "claim-never-created"
+  | "reconciler-error"
+  | "unknown";
+
+export type ClaimPhase =
+  | { kind: "claiming"; since: number }
+  | {
+      kind: "waiting-for-capacity";
+      since: number;
+      message?: string;
+      /** Karpenter-emitted nodeclaim name when a node is being provisioned. */
+      nodeClaim?: string;
+    }
+  | { kind: "pulling-image"; since: number }
+  | { kind: "starting-container"; since: number }
+  | { kind: "warming-daemon"; since: number }
+  | { kind: "ready" }
+  | { kind: "failed"; reason: ClaimFailureReason; message: string };

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts
@@ -10,7 +10,8 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { derivePhase, type ClaimPhase } from "./lifecycle-watcher";
+import { derivePhase } from "./lifecycle-watcher";
+import type { ClaimPhase } from "./lifecycle-types";
 
 type State = Parameters<typeof derivePhase>[0];
 

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Reducer tests for the claim lifecycle watcher.
+ *
+ * The watch transports (kubeFetch + ndjson) are exercised end-to-end by the
+ * existing client.test.ts and by integration runs against a real cluster.
+ * What's worth unit-testing here is the pure phase reducer — it's the part
+ * that encodes the contract between observed K8s state and what the user
+ * sees, and it's the part most likely to grow new branches as we learn more
+ * failure modes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { derivePhase, type ClaimPhase } from "./lifecycle-watcher";
+
+type State = Parameters<typeof derivePhase>[0];
+
+const T0 = 1_000_000;
+const fixedNow =
+  (t = T0) =>
+  () =>
+    t;
+
+function baseState(): State {
+  return {
+    pod: {},
+    sandbox: {},
+    events: { hasPulling: false, hasPulled: false },
+    startedAt: T0,
+  };
+}
+
+const TIMEOUT_MS = 5 * 60 * 1000;
+
+describe("derivePhase", () => {
+  it("defaults to claiming when nothing is observed", () => {
+    const phase = derivePhase(baseState(), TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("claiming");
+  });
+
+  it("ready trumps everything when Sandbox.Ready=True", () => {
+    const state = baseState();
+    state.sandbox.ready = true;
+    // Stuff conflicting signals in to make sure they're ignored.
+    state.pod.containerWaitingReason = "ImagePullBackOff";
+    state.events.lastFailedSchedulingAt = T0;
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("ready");
+  });
+
+  it("waits for capacity when PodScheduled=False", () => {
+    const state = baseState();
+    state.pod.scheduled = false;
+    state.pod.scheduledFalseReason = "Unschedulable";
+    state.pod.scheduledFalseMessage = "0/15 nodes are available";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("waiting-for-capacity");
+    if (phase.kind === "waiting-for-capacity") {
+      expect(phase.message).toBe("0/15 nodes are available");
+    }
+  });
+
+  it("waits for capacity when only a FailedScheduling event has been seen", () => {
+    const state = baseState();
+    state.events.lastFailedSchedulingAt = T0;
+    state.events.failedSchedulingMessage = "Insufficient memory";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("waiting-for-capacity");
+    if (phase.kind === "waiting-for-capacity") {
+      expect(phase.message).toBe("Insufficient memory");
+    }
+  });
+
+  it("surfaces karpenter nodeClaim hint inside waiting-for-capacity", () => {
+    const state = baseState();
+    state.pod.scheduledFalseReason = "Unschedulable";
+    state.events.nominatedNodeClaim = "sandbox-fr6gf";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("waiting-for-capacity");
+    if (phase.kind === "waiting-for-capacity") {
+      expect(phase.nodeClaim).toBe("sandbox-fr6gf");
+    }
+  });
+
+  it("emits pulling-image when Pulling has been observed but not Pulled", () => {
+    const state = baseState();
+    state.pod.scheduled = true;
+    state.events.hasPulling = true;
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("pulling-image");
+  });
+
+  it("emits starting-container when ContainerCreating + Pulled", () => {
+    const state = baseState();
+    state.pod.scheduled = true;
+    state.pod.containerWaitingReason = "ContainerCreating";
+    state.events.hasPulling = true;
+    state.events.hasPulled = true;
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("starting-container");
+  });
+
+  it("emits warming-daemon when container is running but not yet ready", () => {
+    const state = baseState();
+    state.pod.scheduled = true;
+    state.pod.containerRunning = true;
+    state.pod.containerReady = false;
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("warming-daemon");
+  });
+
+  it("ignores warming-daemon when container is also ready (sandbox-ready takes over via separate signal)", () => {
+    // The Sandbox CR's Ready=True is the canonical readiness; container.ready
+    // alone (without sandbox.ready) shouldn't be treated as terminal because
+    // there's still ~the Service patch + HTTPRoute mint window before the
+    // operator flips Ready=True. Keep emitting warming-daemon until
+    // sandbox.ready arrives.
+    const state = baseState();
+    state.pod.scheduled = true;
+    state.pod.containerRunning = true;
+    state.pod.containerReady = true;
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    // containerReady=true means the reducer falls through warming-daemon
+    // (running && !ready is false) — it doesn't auto-terminate. The next
+    // best signal is the events/scheduling state. With a scheduled pod and
+    // no waiting reason, that resolves to claiming (no other signals set).
+    expect(phase.kind).toBe("claiming");
+  });
+
+  it("fails on ImagePullBackOff", () => {
+    const state = baseState();
+    state.pod.containerWaitingReason = "ImagePullBackOff";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("failed");
+    if (phase.kind === "failed") {
+      expect(phase.reason).toBe("image-pull-backoff");
+    }
+  });
+
+  it("fails on ErrImagePull", () => {
+    const state = baseState();
+    state.pod.containerWaitingReason = "ErrImagePull";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("failed");
+    if (phase.kind === "failed") {
+      expect(phase.reason).toBe("image-pull-backoff");
+    }
+  });
+
+  it("fails on CrashLoopBackOff", () => {
+    const state = baseState();
+    state.pod.containerWaitingReason = "CrashLoopBackOff";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("failed");
+    if (phase.kind === "failed") {
+      expect(phase.reason).toBe("crash-loop-backoff");
+    }
+  });
+
+  it("fails on scheduling-timeout only after FailedScheduling AND elapsed > timeout", () => {
+    const state = baseState();
+    state.events.lastFailedSchedulingAt = T0;
+    state.events.failedSchedulingMessage = "0/15 nodes are available";
+    // Just below the timeout — still waiting-for-capacity.
+    const stillWaiting = derivePhase(
+      state,
+      TIMEOUT_MS,
+      fixedNow(T0 + TIMEOUT_MS - 1),
+    );
+    expect(stillWaiting.kind).toBe("waiting-for-capacity");
+    // Just above — flips to failed.
+    const failed = derivePhase(
+      state,
+      TIMEOUT_MS,
+      fixedNow(T0 + TIMEOUT_MS + 1),
+    );
+    expect(failed.kind).toBe("failed");
+    if (failed.kind === "failed") {
+      expect(failed.reason).toBe("scheduling-timeout");
+      expect(failed.message).toContain("0/15 nodes are available");
+    }
+  });
+
+  it("does NOT scheduling-timeout without a FailedScheduling event", () => {
+    // Slow PodScheduled=True transition shouldn't be misread as a timeout.
+    const state = baseState();
+    const phase = derivePhase(
+      state,
+      TIMEOUT_MS,
+      fixedNow(T0 + TIMEOUT_MS * 10),
+    );
+    expect(phase.kind).toBe("claiming");
+  });
+});
+
+describe("watchClaimLifecycle progression (sequenced by reducer)", () => {
+  // End-to-end progression covering the realistic happy path observed on
+  // staging:
+  //   claim posted → unschedulable → karpenter nominates → pulling →
+  //   pulled+creating → running-not-ready → ready
+  it("walks the happy karpenter path", () => {
+    const state = baseState();
+    const seen: ClaimPhase["kind"][] = [];
+    const observe = () => {
+      const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+      const last = seen[seen.length - 1];
+      if (last !== phase.kind) seen.push(phase.kind);
+    };
+
+    observe(); // claiming
+    state.pod.scheduledFalseReason = "Unschedulable";
+    state.events.lastFailedSchedulingAt = T0;
+    state.events.failedSchedulingMessage = "0/15 nodes are available";
+    observe(); // waiting-for-capacity
+    state.events.nominatedNodeClaim = "sandbox-fr6gf";
+    observe(); // still waiting-for-capacity (nodeClaim doesn't change phase kind)
+    state.pod.scheduled = true;
+    state.pod.scheduledFalseReason = undefined;
+    state.events.hasPulling = true;
+    observe(); // pulling-image
+    state.pod.containerWaitingReason = "ContainerCreating";
+    state.events.hasPulled = true;
+    observe(); // starting-container
+    state.pod.containerWaitingReason = undefined;
+    state.pod.containerRunning = true;
+    state.pod.containerReady = false;
+    observe(); // warming-daemon
+    state.sandbox.ready = true;
+    observe(); // ready
+
+    expect(seen).toEqual([
+      "claiming",
+      "waiting-for-capacity",
+      "pulling-image",
+      "starting-container",
+      "warming-daemon",
+      "ready",
+    ]);
+  });
+});

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
@@ -1,0 +1,746 @@
+/**
+ * Per-claim lifecycle watcher for agent-sandbox SandboxClaims.
+ *
+ * Bridges the visibility gap between `VM_START` posting a SandboxClaim and
+ * the daemon SSE coming online. Synthesizes a coarse phase signal from
+ * three K8s primitives:
+ *
+ *   - the Pod (label-selected by `studio.decocms.com/sandbox-handle`),
+ *   - kubelet/scheduler Events on that Pod,
+ *   - the Sandbox CR (Ready condition),
+ *
+ * and emits a typed `ClaimPhase` whenever the inferred phase changes.
+ *
+ * Single-claim design: one set of watches per subscriber. Lifecycle SSEs
+ * are short-lived (~30–120s) so the cost of opening per-claim streams is
+ * dominated by the time-to-Ready rather than informer overhead. Avoids the
+ * complexity of a shared namespace informer with demux + ref counting.
+ *
+ * Phase derivation (in order of monotonic forward progress, only the first
+ * matching rule applies):
+ *
+ *   ready              – Sandbox CR has condition Ready=True.
+ *   failed             – Pod's main container is in ImagePullBackOff /
+ *                        ErrImagePull / CrashLoopBackOff, OR scheduling
+ *                        has been failing past `schedulingTimeoutMs`.
+ *   warming-daemon     – Container is running but not yet Ready.
+ *   starting-container – Image is pulled; container is being created.
+ *   pulling-image      – Pull in flight (Pulling event, no Pulled yet).
+ *   waiting-for-capacity
+ *                      – PodScheduled=False with reason `Unschedulable`,
+ *                        or a recent `FailedScheduling` event.
+ *   claiming           – Default: SandboxClaim posted, no Pod yet.
+ *
+ * Container name `sandbox` and pod label `studio.decocms.com/sandbox-handle`
+ * are mesh conventions verified against the running cluster — do not rely
+ * on operator-set labels (e.g. `agents.x-k8s.io/sandbox-name`), which exist
+ * only as truncated `-hash` variants.
+ */
+
+import { type KubeConfig } from "@kubernetes/client-node";
+import { K8S_CONSTANTS } from "./constants";
+import { kubeFetch, readNdJson } from "./client";
+import type { SandboxResource } from "./client";
+
+const SANDBOX_HANDLE_LABEL = "studio.decocms.com/sandbox-handle";
+const MAIN_CONTAINER_NAME = "sandbox";
+
+const DEFAULT_SCHEDULING_TIMEOUT_MS = 5 * 60 * 1000;
+
+// ---- Public types -----------------------------------------------------------
+
+export type ClaimFailureReason =
+  | "image-pull-backoff"
+  | "crash-loop-backoff"
+  | "scheduling-timeout"
+  | "claim-never-created"
+  | "reconciler-error"
+  | "unknown";
+
+export type ClaimPhase =
+  | { kind: "claiming"; since: number }
+  | {
+      kind: "waiting-for-capacity";
+      since: number;
+      message?: string;
+      /** Karpenter-emitted nodeclaim name when a node is being provisioned. */
+      nodeClaim?: string;
+    }
+  | { kind: "pulling-image"; since: number }
+  | { kind: "starting-container"; since: number }
+  | { kind: "warming-daemon"; since: number }
+  | { kind: "ready" }
+  | { kind: "failed"; reason: ClaimFailureReason; message: string };
+
+export interface WatchClaimLifecycleOptions {
+  kc: KubeConfig;
+  namespace: string;
+  /** SandboxClaim name. Mesh convention: pod name === claim name. */
+  claimName: string;
+  signal?: AbortSignal;
+  /**
+   * Hard ceiling for "scheduling never succeeded" — if FailedScheduling has
+   * been observed without a successful Pulling/Pulled progression after this
+   * many ms from watch start, emit `failed: scheduling-timeout`. Default 5min.
+   *
+   * On a karpenter cluster this rarely trips (nodes get provisioned within
+   * 60–90s); on a fixed-capacity cluster (e.g. local kind) it surfaces a
+   * genuine scheduling problem instead of hanging indefinitely.
+   */
+  schedulingTimeoutMs?: number;
+  /**
+   * Optional clock injection for tests. Defaults to `Date.now()`.
+   */
+  now?: () => number;
+}
+
+// ---- Internal types ---------------------------------------------------------
+
+interface PodSnapshot {
+  /** PodScheduled condition reason when status=False (`Unschedulable`). */
+  scheduledFalseReason?: string;
+  /** Optional message attached to PodScheduled=False. */
+  scheduledFalseMessage?: string;
+  /** True once PodScheduled=True is observed. */
+  scheduled?: boolean;
+  /**
+   * Waiting-state reason on the `sandbox` container, if any. Includes
+   * `ContainerCreating`, `PodInitializing`, `ImagePullBackOff`,
+   * `ErrImagePull`, `CrashLoopBackOff`.
+   */
+  containerWaitingReason?: string;
+  /** True once `sandbox` container's state.running is set. */
+  containerRunning?: boolean;
+  /** True once `sandbox` container reports `ready: true`. */
+  containerReady?: boolean;
+}
+
+interface SandboxSnapshot {
+  ready?: boolean;
+  /**
+   * Non-Ready condition reason — surfaced into a `reconciler-error` failure
+   * when paired with status=False, otherwise informational.
+   */
+  notReadyReason?: string;
+  notReadyMessage?: string;
+}
+
+interface EventsSnapshot {
+  /** Last `Pulling` event seen on the pod. */
+  hasPulling: boolean;
+  /** Last `Pulled` event seen — fires both for fresh pulls and cache hits. */
+  hasPulled: boolean;
+  /** Most recent `FailedScheduling` event timestamp (ms since epoch). */
+  lastFailedSchedulingAt?: number;
+  /** Latest scheduling failure message. */
+  failedSchedulingMessage?: string;
+  /** Latest `Nominated` (karpenter) target nodeclaim, if any. */
+  nominatedNodeClaim?: string;
+}
+
+interface State {
+  pod: PodSnapshot;
+  sandbox: SandboxSnapshot;
+  events: EventsSnapshot;
+  /** First time we observed a Pod/Sandbox/Event for this claim. */
+  startedAt: number;
+}
+
+type SignalKind = "pod" | "sandbox" | "event" | "tick";
+
+// ---- Public entry point -----------------------------------------------------
+
+/**
+ * Async generator that yields `ClaimPhase` whenever the inferred phase
+ * changes. Closes the underlying watches when the generator is returned
+ * (consumer breaks the loop) or when `signal` aborts.
+ *
+ * Terminal phases: `ready`, `failed`. Consumers should break the loop when
+ * either is observed.
+ *
+ * Initial phase: emitted synchronously after the first watch handshake. If
+ * the claim doesn't exist yet (caller raced VM_START), the first phase is
+ * `claiming` and stays there until the operator creates the Sandbox/Pod.
+ */
+export async function* watchClaimLifecycle(
+  opts: WatchClaimLifecycleOptions,
+): AsyncGenerator<ClaimPhase, void, unknown> {
+  const now = opts.now ?? (() => Date.now());
+  const startedAt = now();
+  const schedulingTimeoutMs =
+    opts.schedulingTimeoutMs ?? DEFAULT_SCHEDULING_TIMEOUT_MS;
+
+  const state: State = {
+    pod: {},
+    sandbox: {},
+    events: { hasPulling: false, hasPulled: false },
+    startedAt,
+  };
+
+  const queue: SignalKind[] = [];
+  let pendingResolve: ((s: SignalKind | null) => void) | null = null;
+  let closed = false;
+
+  const push = (kind: SignalKind) => {
+    if (closed) return;
+    if (pendingResolve) {
+      const r = pendingResolve;
+      pendingResolve = null;
+      r(kind);
+    } else {
+      queue.push(kind);
+    }
+  };
+
+  const next = (): Promise<SignalKind | null> => {
+    if (queue.length > 0) return Promise.resolve(queue.shift()!);
+    if (closed) return Promise.resolve(null);
+    return new Promise<SignalKind | null>((resolve) => {
+      pendingResolve = resolve;
+    });
+  };
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    if (pendingResolve) {
+      const r = pendingResolve;
+      pendingResolve = null;
+      r(null);
+    }
+  };
+
+  const controller = new AbortController();
+  const onAbort = () => {
+    controller.abort();
+    close();
+  };
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      controller.abort();
+      close();
+    } else {
+      opts.signal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  // Periodic tick re-evaluates the phase reducer without needing a fresh
+  // watch event — used to drive the scheduling-timeout failure transition
+  // when the cluster goes silent (no fresh FailedScheduling events for a
+  // while but also no progress).
+  const tickInterval = setInterval(() => push("tick"), 5_000);
+
+  // Run watches concurrently. They each push signals into the queue and
+  // never throw out of the watch loop — closure is via `controller.abort()`.
+  const watches = Promise.allSettled([
+    watchPod(
+      opts.kc,
+      opts.namespace,
+      opts.claimName,
+      controller.signal,
+      state,
+      push,
+      now,
+    ),
+    watchSandbox(
+      opts.kc,
+      opts.namespace,
+      opts.claimName,
+      controller.signal,
+      state,
+      push,
+    ),
+    watchEvents(
+      opts.kc,
+      opts.namespace,
+      opts.claimName,
+      controller.signal,
+      state,
+      push,
+      now,
+    ),
+  ]);
+
+  try {
+    let lastEmittedKey: string | null = null;
+    let lastEmitted: ClaimPhase | null = null;
+    // Monotonic floor: track the highest non-terminal phase we've emitted so
+    // we don't regress on transient observations (e.g. a container that
+    // briefly enters `terminated` state between restarts has no waiting
+    // reason and no `running` flag, which would otherwise reduce to
+    // `claiming`). Terminal phases bypass the floor — `failed` must always
+    // be emitted regardless of prior progress.
+    let highestRank = -1;
+
+    // Emit an initial phase immediately so the caller sees something even
+    // before the first watch event lands.
+    const initial = derivePhase(state, schedulingTimeoutMs, now);
+    lastEmitted = initial;
+    lastEmittedKey = phaseKey(initial);
+    if (!isTerminal(initial)) highestRank = phaseRank(initial);
+    yield initial;
+    if (isTerminal(initial)) return;
+
+    while (!closed) {
+      const signal = await next();
+      if (signal === null) break;
+
+      const phase = derivePhase(state, schedulingTimeoutMs, now);
+      // Terminal always wins — but only emit once.
+      if (isTerminal(phase)) {
+        const key = phaseKey(phase);
+        if (key !== lastEmittedKey) {
+          lastEmitted = phase;
+          lastEmittedKey = key;
+          yield phase;
+        }
+        return;
+      }
+      const rank = phaseRank(phase);
+      if (rank < highestRank) continue; // Don't regress.
+      const key = phaseKey(phase);
+      if (key !== lastEmittedKey) {
+        lastEmitted = phase;
+        lastEmittedKey = key;
+        highestRank = rank;
+        yield phase;
+      }
+    }
+
+    // Closed without a terminal phase — yield the last seen phase if it
+    // hasn't been emitted, otherwise nothing to do.
+    if (!lastEmitted) {
+      const phase = derivePhase(state, schedulingTimeoutMs, now);
+      yield phase;
+    }
+  } finally {
+    clearInterval(tickInterval);
+    controller.abort();
+    if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+    close();
+    // Don't surface watch errors back to the consumer — the generator's
+    // contract is "phases until terminal or close"; transient kube errors
+    // are logged inside the watches.
+    await watches.catch(() => {});
+  }
+}
+
+// ---- Phase reducer ----------------------------------------------------------
+
+/**
+ * Pure function over the current observed state. Exported for unit tests —
+ * the reducer is the part most likely to need behavior tweaks as we learn
+ * more about real-cluster failure modes.
+ */
+export function derivePhase(
+  state: State,
+  schedulingTimeoutMs: number,
+  now: () => number,
+): ClaimPhase {
+  const { pod, sandbox, events, startedAt } = state;
+
+  // 1. Terminal: Sandbox CR Ready=True is the canonical "claim is up".
+  if (sandbox.ready) return { kind: "ready" };
+
+  // 2. Terminal: container is in a stuck waiting state.
+  const containerWaitingReason = pod.containerWaitingReason;
+  if (
+    containerWaitingReason === "ImagePullBackOff" ||
+    containerWaitingReason === "ErrImagePull"
+  ) {
+    return {
+      kind: "failed",
+      reason: "image-pull-backoff",
+      message:
+        "Sandbox image failed to download. The cluster may be missing pull credentials or the image tag may not exist.",
+    };
+  }
+  if (containerWaitingReason === "CrashLoopBackOff") {
+    return {
+      kind: "failed",
+      reason: "crash-loop-backoff",
+      message:
+        "Sandbox crashed during startup and is now in CrashLoopBackOff. Check pod logs.",
+    };
+  }
+
+  // 3. Terminal: scheduling timed out. Only consider it a timeout if we
+  // have observed at least one FailedScheduling event AND we've waited
+  // longer than the threshold AND we still don't have a scheduled pod.
+  // Without the FailedScheduling guard, a slow PodScheduled=True transition
+  // would prematurely surface as a timeout.
+  if (
+    !pod.scheduled &&
+    events.lastFailedSchedulingAt !== undefined &&
+    now() - startedAt > schedulingTimeoutMs
+  ) {
+    return {
+      kind: "failed",
+      reason: "scheduling-timeout",
+      message:
+        events.failedSchedulingMessage ??
+        `Pod could not be scheduled within ${Math.round(schedulingTimeoutMs / 1000)}s.`,
+    };
+  }
+
+  // 4. warming-daemon: container is running, just hasn't reached Ready yet.
+  if (pod.containerRunning && !pod.containerReady) {
+    return { kind: "warming-daemon", since: startedAt };
+  }
+
+  // 5. starting-container: image pulled, container being created.
+  if (containerWaitingReason === "ContainerCreating" && events.hasPulled) {
+    return { kind: "starting-container", since: startedAt };
+  }
+
+  // 6. pulling-image: a Pulling event has fired but Pulled hasn't yet.
+  if (events.hasPulling && !events.hasPulled) {
+    return { kind: "pulling-image", since: startedAt };
+  }
+
+  // 7. waiting-for-capacity: PodScheduled=False with reason Unschedulable,
+  // or a recent FailedScheduling. Surface karpenter's `Nominated` target
+  // when present so the UI can say "provisioning a new node".
+  const isUnschedulable =
+    pod.scheduledFalseReason === "Unschedulable" ||
+    (events.lastFailedSchedulingAt !== undefined && !pod.scheduled);
+  if (isUnschedulable) {
+    return {
+      kind: "waiting-for-capacity",
+      since: startedAt,
+      message: events.failedSchedulingMessage ?? pod.scheduledFalseMessage,
+      nodeClaim: events.nominatedNodeClaim,
+    };
+  }
+
+  // 8. Default: claim posted, no informative pod state yet.
+  return { kind: "claiming", since: startedAt };
+}
+
+function isTerminal(phase: ClaimPhase): boolean {
+  return phase.kind === "ready" || phase.kind === "failed";
+}
+
+/**
+ * Ordinal rank for non-terminal phases. Used by the generator's monotonic
+ * floor to suppress transient regressions. Terminal phases are not ranked
+ * (the generator handles them separately).
+ */
+function phaseRank(phase: ClaimPhase): number {
+  switch (phase.kind) {
+    case "claiming":
+      return 0;
+    case "waiting-for-capacity":
+      return 1;
+    case "pulling-image":
+      return 2;
+    case "starting-container":
+      return 3;
+    case "warming-daemon":
+      return 4;
+    case "ready":
+    case "failed":
+      return 99;
+  }
+}
+
+/**
+ * Stable string key per phase identity. Used to dedupe consecutive identical
+ * phases without firing on incidental timestamp churn. `since` is excluded
+ * from the key (it's a constant per-stream value), but `message`/`nodeClaim`
+ * variants are included so we re-emit when capacity diagnostics change.
+ */
+function phaseKey(phase: ClaimPhase): string {
+  switch (phase.kind) {
+    case "claiming":
+    case "pulling-image":
+    case "starting-container":
+    case "warming-daemon":
+      return phase.kind;
+    case "waiting-for-capacity":
+      return `waiting-for-capacity:${phase.message ?? ""}:${phase.nodeClaim ?? ""}`;
+    case "ready":
+      return "ready";
+    case "failed":
+      return `failed:${phase.reason}:${phase.message}`;
+  }
+}
+
+// ---- Watch loops ------------------------------------------------------------
+
+interface PodResource {
+  metadata?: {
+    name?: string;
+    labels?: Record<string, string>;
+  };
+  status?: {
+    conditions?: Array<{
+      type?: string;
+      status?: string;
+      reason?: string;
+      message?: string;
+    }>;
+    containerStatuses?: Array<{
+      name?: string;
+      ready?: boolean;
+      state?: {
+        waiting?: { reason?: string; message?: string };
+        running?: { startedAt?: string };
+        terminated?: { reason?: string };
+      };
+    }>;
+  };
+}
+
+interface KubeEvent {
+  reason?: string;
+  message?: string;
+  type?: "Normal" | "Warning";
+  lastTimestamp?: string;
+  eventTime?: string;
+  involvedObject?: {
+    kind?: string;
+    name?: string;
+    namespace?: string;
+  };
+}
+
+interface WatchEnvelope<T> {
+  type: "ADDED" | "MODIFIED" | "DELETED" | "BOOKMARK" | "ERROR";
+  object: T;
+}
+
+async function watchPod(
+  kc: KubeConfig,
+  namespace: string,
+  claimName: string,
+  signal: AbortSignal,
+  state: State,
+  push: (k: SignalKind) => void,
+  now: () => number,
+): Promise<void> {
+  // labelSelector pins to mesh-managed claims; fieldSelector by name is
+  // belt-and-suspenders (operator names pod after the claim).
+  const path =
+    `/api/v1/namespaces/${encodeURIComponent(namespace)}/pods` +
+    `?watch=true&labelSelector=${encodeURIComponent(`${SANDBOX_HANDLE_LABEL}=${claimName}`)}`;
+
+  return runWatch<PodResource>({
+    kc,
+    path,
+    signal,
+    label: `pod/${claimName}`,
+    onEvent: (envelope) => {
+      if (envelope.type !== "ADDED" && envelope.type !== "MODIFIED") return;
+      const pod = envelope.object;
+      if (pod.metadata?.name !== claimName) return;
+      applyPodSnapshot(pod, state, now);
+      push("pod");
+    },
+  });
+}
+
+function applyPodSnapshot(pod: PodResource, state: State, _now: () => number) {
+  const conditions = pod.status?.conditions ?? [];
+  const scheduled = conditions.find((c) => c.type === "PodScheduled");
+  if (scheduled?.status === "True") {
+    state.pod.scheduled = true;
+    state.pod.scheduledFalseReason = undefined;
+    state.pod.scheduledFalseMessage = undefined;
+  } else if (scheduled?.status === "False") {
+    state.pod.scheduled = false;
+    state.pod.scheduledFalseReason = scheduled.reason;
+    state.pod.scheduledFalseMessage = scheduled.message;
+  }
+
+  const main = (pod.status?.containerStatuses ?? []).find(
+    (c) => c.name === MAIN_CONTAINER_NAME,
+  );
+  if (main) {
+    state.pod.containerWaitingReason = main.state?.waiting?.reason;
+    state.pod.containerRunning = !!main.state?.running;
+    state.pod.containerReady = main.ready === true;
+  }
+}
+
+async function watchSandbox(
+  kc: KubeConfig,
+  namespace: string,
+  claimName: string,
+  signal: AbortSignal,
+  state: State,
+  push: (k: SignalKind) => void,
+): Promise<void> {
+  const path =
+    `/apis/${K8S_CONSTANTS.SANDBOX_API_GROUP}/${K8S_CONSTANTS.SANDBOX_API_VERSION}` +
+    `/namespaces/${encodeURIComponent(namespace)}/${K8S_CONSTANTS.SANDBOX_PLURAL}` +
+    `?watch=true&fieldSelector=${encodeURIComponent(`metadata.name=${claimName}`)}`;
+
+  return runWatch<SandboxResource>({
+    kc,
+    path,
+    signal,
+    label: `sandbox/${claimName}`,
+    onEvent: (envelope) => {
+      if (envelope.type !== "ADDED" && envelope.type !== "MODIFIED") return;
+      const sandbox = envelope.object;
+      const ready = sandbox.status?.conditions?.find((c) => c.type === "Ready");
+      if (!ready) return;
+      if (ready.status === "True") {
+        state.sandbox.ready = true;
+        state.sandbox.notReadyReason = undefined;
+        state.sandbox.notReadyMessage = undefined;
+      } else {
+        state.sandbox.ready = false;
+        state.sandbox.notReadyReason = ready.reason;
+        state.sandbox.notReadyMessage = ready.message;
+      }
+      push("sandbox");
+    },
+  });
+}
+
+async function watchEvents(
+  kc: KubeConfig,
+  namespace: string,
+  claimName: string,
+  signal: AbortSignal,
+  state: State,
+  push: (k: SignalKind) => void,
+  now: () => number,
+): Promise<void> {
+  // K8s field selectors don't support arbitrary boolean composition; the
+  // closest we can get server-side is `involvedObject.name=<podName>`,
+  // which (because pod name === claim name in our world) is a tight filter.
+  // Kind=Pod is appended because event objects can target many kinds and
+  // we don't want to react to e.g. SandboxClaim events here (those go via
+  // the Sandbox CR watch).
+  const path =
+    `/api/v1/namespaces/${encodeURIComponent(namespace)}/events` +
+    `?watch=true&fieldSelector=${encodeURIComponent(
+      `involvedObject.name=${claimName},involvedObject.kind=Pod`,
+    )}`;
+
+  return runWatch<KubeEvent>({
+    kc,
+    path,
+    signal,
+    label: `events/${claimName}`,
+    onEvent: (envelope) => {
+      if (envelope.type !== "ADDED" && envelope.type !== "MODIFIED") return;
+      const event = envelope.object;
+      const reason = event.reason;
+      if (!reason) return;
+      switch (reason) {
+        case "Pulling":
+          state.events.hasPulling = true;
+          break;
+        case "Pulled":
+          state.events.hasPulling = true;
+          state.events.hasPulled = true;
+          break;
+        case "FailedScheduling":
+          state.events.lastFailedSchedulingAt = now();
+          state.events.failedSchedulingMessage = event.message;
+          break;
+        case "Nominated": {
+          // Karpenter message form:
+          //   "Pod should schedule on: nodeclaim/sandbox-fr6gf"
+          // Best-effort parse — when the format drifts we just lose the
+          // optional nodeClaim sub-message, the phase still progresses.
+          const match = event.message?.match(/nodeclaim\/([\w-]+)/);
+          if (match) state.events.nominatedNodeClaim = match[1];
+          break;
+        }
+        default:
+          return;
+      }
+      push("event");
+    },
+  });
+}
+
+interface RunWatchOpts<T> {
+  kc: KubeConfig;
+  path: string;
+  signal: AbortSignal;
+  label: string;
+  onEvent: (envelope: WatchEnvelope<T>) => void;
+}
+
+/**
+ * Watch loop with reconnect. K8s watch streams close on their own (300s
+ * timeout, control-plane upgrade) — we re-establish until the abort signal
+ * fires. Reconnect uses exponential backoff to avoid hammering the API
+ * server during a control-plane outage.
+ *
+ * Errors are logged and swallowed: the generator's contract is to keep
+ * yielding phases as long as it can; a transient watch failure shouldn't
+ * tear down the user-facing SSE.
+ */
+async function runWatch<T>(opts: RunWatchOpts<T>): Promise<void> {
+  const { kc, path, signal, label, onEvent } = opts;
+  let attempt = 0;
+  while (!signal.aborted) {
+    try {
+      const resp = await kubeFetch(kc, {
+        method: "GET",
+        path,
+        signal,
+        headers: { accept: "application/json" },
+      });
+      if (!resp.ok || !resp.body) {
+        // Drain body before throwing so the connection can be reused.
+        try {
+          await resp.body?.cancel();
+        } catch {
+          /* ignore */
+        }
+        throw new Error(
+          `watch handshake failed: ${resp.status} ${resp.statusText}`,
+        );
+      }
+      attempt = 0;
+      for await (const envelope of readNdJson<WatchEnvelope<T>>(resp.body)) {
+        if (signal.aborted) return;
+        try {
+          onEvent(envelope);
+        } catch (err) {
+          // A bad event shouldn't crash the watch.
+          console.warn(
+            `[lifecycle-watcher] ${label} onEvent threw: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+    } catch (err) {
+      if (signal.aborted) return;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[lifecycle-watcher] ${label} watch ended: ${msg}`);
+    }
+    if (signal.aborted) return;
+    // Backoff: 250ms, 500ms, 1s, 2s, capped at 5s.
+    const delayMs = Math.min(250 * 2 ** attempt, 5_000);
+    attempt += 1;
+    await sleep(delayMs, signal);
+  }
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
@@ -41,36 +41,17 @@ import { type KubeConfig } from "@kubernetes/client-node";
 import { K8S_CONSTANTS } from "./constants";
 import { kubeFetch, readNdJson } from "./client";
 import type { SandboxResource } from "./client";
+import type { ClaimPhase } from "./lifecycle-types";
+
+export type {
+  ClaimFailureReason,
+  ClaimPhase,
+} from "./lifecycle-types";
 
 const SANDBOX_HANDLE_LABEL = "studio.decocms.com/sandbox-handle";
 const MAIN_CONTAINER_NAME = "sandbox";
 
 const DEFAULT_SCHEDULING_TIMEOUT_MS = 5 * 60 * 1000;
-
-// ---- Public types -----------------------------------------------------------
-
-export type ClaimFailureReason =
-  | "image-pull-backoff"
-  | "crash-loop-backoff"
-  | "scheduling-timeout"
-  | "claim-never-created"
-  | "reconciler-error"
-  | "unknown";
-
-export type ClaimPhase =
-  | { kind: "claiming"; since: number }
-  | {
-      kind: "waiting-for-capacity";
-      since: number;
-      message?: string;
-      /** Karpenter-emitted nodeclaim name when a node is being provisioned. */
-      nodeClaim?: string;
-    }
-  | { kind: "pulling-image"; since: number }
-  | { kind: "starting-container"; since: number }
-  | { kind: "warming-daemon"; since: number }
-  | { kind: "ready" }
-  | { kind: "failed"; reason: ClaimFailureReason; message: string };
 
 export interface WatchClaimLifecycleOptions {
   kc: KubeConfig;
@@ -224,11 +205,13 @@ export async function* watchClaimLifecycle(
     }
   }
 
-  // Periodic tick re-evaluates the phase reducer without needing a fresh
-  // watch event — used to drive the scheduling-timeout failure transition
-  // when the cluster goes silent (no fresh FailedScheduling events for a
-  // while but also no progress).
-  const tickInterval = setInterval(() => push("tick"), 5_000);
+  // The only time-based transition the reducer makes is `scheduling-timeout`,
+  // which fires when `now() - startedAt > schedulingTimeoutMs` *and* a
+  // FailedScheduling event has been observed. A single deadline timer is
+  // therefore enough to drive that transition — no need to poll every 5s.
+  // Anything earlier is reducer-driven by a fresh pod/sandbox/event signal.
+  const deadlineMs = Math.max(0, schedulingTimeoutMs - (now() - startedAt));
+  const deadlineTimer = setTimeout(() => push("tick"), deadlineMs + 100);
 
   // Run watches concurrently. They each push signals into the queue and
   // never throw out of the watch loop — closure is via `controller.abort()`.
@@ -263,7 +246,6 @@ export async function* watchClaimLifecycle(
 
   try {
     let lastEmittedKey: string | null = null;
-    let lastEmitted: ClaimPhase | null = null;
     // Monotonic floor: track the highest non-terminal phase we've emitted so
     // we don't regress on transient observations (e.g. a container that
     // briefly enters `terminated` state between restarts has no waiting
@@ -275,7 +257,6 @@ export async function* watchClaimLifecycle(
     // Emit an initial phase immediately so the caller sees something even
     // before the first watch event lands.
     const initial = derivePhase(state, schedulingTimeoutMs, now);
-    lastEmitted = initial;
     lastEmittedKey = phaseKey(initial);
     if (!isTerminal(initial)) highestRank = phaseRank(initial);
     yield initial;
@@ -290,7 +271,6 @@ export async function* watchClaimLifecycle(
       if (isTerminal(phase)) {
         const key = phaseKey(phase);
         if (key !== lastEmittedKey) {
-          lastEmitted = phase;
           lastEmittedKey = key;
           yield phase;
         }
@@ -300,21 +280,13 @@ export async function* watchClaimLifecycle(
       if (rank < highestRank) continue; // Don't regress.
       const key = phaseKey(phase);
       if (key !== lastEmittedKey) {
-        lastEmitted = phase;
         lastEmittedKey = key;
         highestRank = rank;
         yield phase;
       }
     }
-
-    // Closed without a terminal phase — yield the last seen phase if it
-    // hasn't been emitted, otherwise nothing to do.
-    if (!lastEmitted) {
-      const phase = derivePhase(state, schedulingTimeoutMs, now);
-      yield phase;
-    }
   } finally {
-    clearInterval(tickInterval);
+    clearTimeout(deadlineTimer);
     controller.abort();
     if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
     close();

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -80,6 +80,7 @@ import {
   SandboxAlreadyExistsError,
   SandboxError,
 } from "./constants";
+import { watchClaimLifecycle, type ClaimPhase } from "./lifecycle-watcher";
 
 const RUNNER_KIND = "agent-sandbox" as const;
 const LOG_LABEL = "AgentSandboxRunner";
@@ -137,6 +138,17 @@ const DEFAULT_IDLE_TTL_MS = 15 * 60 * 1000;
  */
 export const HANDLE_PREFIX = "studio-sb-";
 const HANDLE_HASH_LEN = 16;
+
+/**
+ * Server-side helper for callers (mesh routes, lifecycle SSE) that need to
+ * compute a claim name without instantiating an `AgentSandboxRunner`.
+ * Always produces the exact same string the runner would for the same
+ * `(SandboxId, branch)` pair — the lifecycle SSE depends on this so it can
+ * subscribe to the claim a racing `VM_START` is about to create.
+ */
+export function composeClaimName(id: SandboxId, branch: string | null): string {
+  return `${HANDLE_PREFIX}${composeBranchHandle(id, branch, { hashLen: HANDLE_HASH_LEN })}`;
+}
 
 /**
  * Headers stripped before re-issuing the preview proxy fetch. Hop-by-hop per
@@ -409,6 +421,27 @@ export class AgentSandboxRunner implements SandboxRunner {
       handle,
     ).catch(() => undefined);
     return claim ? isSandboxReady(claim) : false;
+  }
+
+  /**
+   * Stream of phase transitions for a SandboxClaim's pre-Ready lifecycle.
+   * Used by mesh's lifecycle SSE route to surface what's happening between
+   * `VM_START` posting a claim and the daemon SSE coming online.
+   *
+   * Generator closes on terminal phase (`ready`/`failed`) or on
+   * `signal.abort()`. Safe to call before the claim exists — the generator
+   * stays in `claiming` until the operator creates the Sandbox/Pod.
+   */
+  watchClaimLifecycle(
+    handle: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<ClaimPhase, void, unknown> {
+    return watchClaimLifecycle({
+      kc: this.kubeConfig,
+      namespace: this.namespace,
+      claimName: handle,
+      signal,
+    });
   }
 
   async getPreviewUrl(handle: string): Promise<string | null> {
@@ -1271,7 +1304,7 @@ export class AgentSandboxRunner implements SandboxRunner {
   // ---- Identity + preview URL ----------------------------------------------
 
   private computeHandle(id: SandboxId, branch: string | null): string {
-    return `${HANDLE_PREFIX}${composeBranchHandle(id, branch, { hashLen: HANDLE_HASH_LEN })}`;
+    return composeClaimName(id, branch);
   }
 
   // Local mode: route preview traffic through the daemon port-forward, not

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -80,7 +80,8 @@ import {
   SandboxAlreadyExistsError,
   SandboxError,
 } from "./constants";
-import { watchClaimLifecycle, type ClaimPhase } from "./lifecycle-watcher";
+import { watchClaimLifecycle } from "./lifecycle-watcher";
+import type { ClaimPhase } from "./lifecycle-types";
 
 const RUNNER_KIND = "agent-sandbox" as const;
 const LOG_LABEL = "AgentSandboxRunner";


### PR DESCRIPTION
- Added a new route `/api/vm-events` to handle a single SSE connection for VM lifecycle events, replacing the previous split between `/api/vm-lifecycle` and direct daemon EventSource.
- Implemented `vmEventsRoutes` to emit lifecycle phases and daemon events, enhancing the user experience during VM startup.
- Updated `VmBootingState` component to support rendering based on the new `ClaimPhase` type, allowing for a more informative UI during the pre-daemon lifecycle.
- Refactored related components and hooks to integrate with the new lifecycle event system, ensuring seamless data flow and state management.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies VM lifecycle and daemon events behind a single auth-gated SSE at `/api/vm-events`, improving startup UX with clear pre-Ready phases, more reliable connections, and deduped per-claim watches to reduce K8s load.

- **New Features**
  - Added `/api/vm-events` SSE: emits pre-Ready `ClaimPhase`, then proxies daemon `/_decopilot_vm/events`; includes 15s `keepalive`, a `gone` event on confirmed eviction, a 60s open-retry budget to avoid false 404s during post-Ready setup, and a 90s watchdog for “claim never created.”
  - Implemented agent-sandbox lifecycle watcher (`watchClaimLifecycle`) deriving phases: claiming → waiting-for-capacity (with optional `nodeClaim`) → pulling-image → starting-container → warming-daemon → ready; failure reasons include image pull, crash loop, scheduling timeout; unit tests added.
  - Added shared lifecycle subscriptions in mesh (`subscribeLifecycle`) to fan out one K8s watch per claim to multiple clients/tabs, replay the latest phase to late joiners, and auto-tear down on last unsubscribe; covered by tests.
  - Updated `VmEventsProvider` to key by `virtualMcpId` + `branch`, subscribe to `/api/vm-events`, expose `phase` and `notFound`, reset state on `gone`, and stop reconnecting on terminal failures.
  - Enhanced `VmBootingState` to show lifecycle-driven copy with a retry on terminal failures; falls back to daemon-driven view once the preview is available.
  - Exported helpers/types from `agent-sandbox`: `composeClaimName`, `ClaimPhase`, and the lifecycle watch; internal transport utilities were adjusted to support the watcher.

- **Migration**
  - `VmEventsProvider` props changed: pass `virtualMcpId` and `branch` instead of a daemon `previewUrl`.
  - No other changes required; existing flows auto-start and self-heal via the new SSE.

<sup>Written for commit 2518ee06519520f1e0503116d749e24c40945a39. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3240?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

