### PR TITLE
fix(housekeeper): correct exit status handling in claim membership test

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-version: 0.5.0
+version: 0.5.1
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "0.1.0"
+appVersion: "0.2.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -229,7 +229,11 @@ if [ "$selector_mismatch" -eq 0 ]; then
     [ -z "$ROUTE_NAME" ] && continue
     [ -z "$ROUTE_HANDLE" ] && continue
     # Live-claim membership test against col 1 of CLAIMS_FILE.
-    if awk -F'|' -v h="$ROUTE_HANDLE" '$1==h { exit 0 } END { exit 1 }' \
+    # `exit` from a main-block jumps to END, whose own `exit` overrides the
+    # status — so `{ exit 0 } END { exit 1 }` always returns 1 and every
+    # route gets nuked. Track via a flag and let END be authoritative.
+    if awk -F'|' -v h="$ROUTE_HANDLE" \
+         '$1==h { found=1; exit } END { exit !found }' \
          "$CLAIMS_FILE"; then
       continue
     fi

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "0.1.0"
+  tag: "0.2.0"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updated the housekeeper-sweep script to fix the exit status logic in the claim membership test. The previous implementation incorrectly returned an exit status of 1 for all cases due to the structure of the awk command. The new logic introduces a flag to track if a match is found, allowing the END block to determine the exit status accurately. This change ensures that only claims with a matching route handle are preserved during the sweep process.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the claim membership check in `housekeeper-sweep.sh` so the sweep no longer deletes routes with valid claims. Also bumps the `sandbox-env` chart to 0.5.1 and updates `appVersion`/image tag to 0.2.0.

- **Bug Fixes**
  - Replaces always-1 exit logic with a `found` flag in awk: `$1==h { found=1; exit } END { exit !found }`.

<sup>Written for commit b639f87c92c7f3246a43aa5ada5fbb61bef4ca84. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3242?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

