### PR TITLE
feat(sandbox): user-data skill for org-scoped file access

### DIFF
--- a/apps/mesh/migrations/073-sandbox-runner-state-token-index.ts
+++ b/apps/mesh/migrations/073-sandbox-runner-state-token-index.ts
@@ -1,0 +1,18 @@
+/**
+ * Btree index on `sandbox_runner_state.state->>'token'` so the
+ * sandbox-user-data bearer middleware can resolve a DAEMON_TOKEN to its
+ * sandbox row in O(log n) instead of scanning every active sandbox.
+ */
+
+import { sql, type Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX IF NOT EXISTS sandbox_runner_state_token_idx
+    ON sandbox_runner_state ((state ->> 'token'))
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS sandbox_runner_state_token_idx`.execute(db);
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -71,6 +71,7 @@ import * as migration069sandboxrunnerstate from "./069-sandbox-runner-state.ts";
 import * as migration070modelcategories from "./070-model-categories.ts";
 import * as migration071defaulthomeagents from "./071-default-home-agents.ts";
 import * as migration072aiproviderkeypresetid from "./072-ai-provider-key-preset-id.ts";
+import * as migration073sandboxrunnerstatetokenindex from "./073-sandbox-runner-state-token-index.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -156,6 +157,8 @@ const migrations: Record<string, Migration> = {
   "070-model-categories": migration070modelcategories,
   "071-default-home-agents": migration071defaulthomeagents,
   "072-ai-provider-key-preset-id": migration072aiproviderkeypresetid,
+  "073-sandbox-runner-state-token-index":
+    migration073sandboxrunnerstatetokenindex,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -47,6 +47,7 @@ import oauthProxyRoutes, {
 import openaiCompatRoutes from "./routes/openai-compat";
 import proxyRoutes from "./routes/proxy";
 import { createKVRoutes } from "./routes/kv";
+import { createSandboxUserDataRoutes } from "./routes/sandbox-user-data";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
@@ -1379,6 +1380,12 @@ export async function createApp(options: CreateAppOptions = {}) {
   // KV store (org-scoped, for external MCPs to persist state)
   const kvStorage = new KyselyKVStorage(database.db);
   app.route("/api", createKVRoutes({ kvStorage }));
+
+  // Sandbox user-data routes (DAEMON_TOKEN-authed, no user session)
+  app.route(
+    "/api/sandbox/user-data",
+    createSandboxUserDataRoutes({ db: database.db }),
+  );
 
   // Public Events endpoint
   app.post("/org/:organizationId/events/:type", async (c) => {

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -112,7 +112,16 @@ export const GLOB_DESCRIPTION =
 
 export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
-  "Working directory is the project root. Timeout default 30s, max 2min.";
+  "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
+  "Pre-installed skills live at `/mnt/skills/public/<name>/SKILL.md`. " +
+  "Run `ls /mnt/skills/public/` for the index and " +
+  "`cat /mnt/skills/public/<name>/SKILL.md` before using one. " +
+  "Skills cover common file operations: pptx (PowerPoint), docx (Word), " +
+  "xlsx (Excel), pdf, file-reading (router), and user-data " +
+  "(org-scoped storage). " +
+  "For `mesh-storage://` URIs from chat, use `user-data-download` first " +
+  "to pull the file onto the sandbox FS, then chain into the right " +
+  "format-specific skill.";
 
 // read/grep/glob are non-mutating; write/edit/bash mutate.
 export const TOOL_APPROVAL = {

--- a/apps/mesh/src/api/routes/sandbox-user-data.ts
+++ b/apps/mesh/src/api/routes/sandbox-user-data.ts
@@ -1,0 +1,149 @@
+/**
+ * Sandbox User-Data Routes
+ *
+ * Read-only file access for code running inside a mesh-managed sandbox.
+ * Authenticated by the per-sandbox `DAEMON_TOKEN` (the same secret mesh
+ * uses to talk to the daemon, presented in reverse direction here). The
+ * bearer middleware looks the token up in `sandbox_runner_state` and
+ * pulls the owning org from the row's persisted `tenant.orgId`, so the
+ * sandbox cannot name another org's keys — `BoundObjectStorage` auto
+ * prefixes with the looked-up orgId.
+ *
+ * Routes (mounted under `/api/sandbox/user-data`):
+ *   GET /list?prefix=&continuationToken=&maxKeys=
+ *     Lists object keys in the org's bucket. No prefix restriction —
+ *     auto-org-prefix is the security boundary; all six existing
+ *     prefixes (chat-uploads/, screenshots/, generated-images/,
+ *     inspect-pages/, scraped-pages/, web-search/) are model-relevant.
+ *   GET /get?key=<key>
+ *     302 redirect to a fresh presigned GET URL. Single code path; no
+ *     inline-bytes branch.
+ *
+ * The `shouldSkipMeshContext` allowlist must include this prefix so the
+ * user-session middleware doesn't reject requests for lacking a session.
+ */
+
+import { Hono } from "hono";
+import { sql, type Kysely } from "kysely";
+import type { Database } from "@/storage/types";
+import { getObjectStorageS3Service } from "@/object-storage/factory";
+import { createBoundObjectStorage } from "@/object-storage/bound-object-storage";
+
+interface SandboxIdentity {
+  orgId: string;
+  sandboxHandle: string;
+}
+
+type Variables = {
+  sandboxIdentity: SandboxIdentity;
+};
+
+interface SandboxUserDataDeps {
+  db: Kysely<Database>;
+}
+
+const MAX_KEYS_CAP = 200;
+
+export function createSandboxUserDataRoutes(deps: SandboxUserDataDeps) {
+  const app = new Hono<{ Variables: Variables }>();
+
+  // Bearer middleware: resolve DAEMON_TOKEN → orgId via sandbox_runner_state.
+  // No fallback to user-session auth — this prefix is for sandbox callbacks.
+  app.use("*", async (c, next) => {
+    const auth = c.req.header("Authorization") ?? "";
+    const match = auth.match(/^Bearer\s+(.+)$/i);
+    if (!match) {
+      return c.json({ error: "Missing bearer token" }, 401);
+    }
+    const token = match[1]!;
+
+    const row = await deps.db
+      .selectFrom("sandbox_runner_state")
+      .select(["handle", "state"])
+      .where(sql<string>`state ->> 'token'`, "=", token)
+      .executeTakeFirst()
+      .catch(() => undefined);
+
+    if (!row) {
+      return c.json({ error: "Invalid sandbox token" }, 401);
+    }
+
+    const state = row.state as Record<string, unknown> | null;
+    const tenant = state?.tenant as { orgId?: string } | undefined;
+    if (!tenant?.orgId) {
+      // Pre-tenant-persistence rows (sandboxes provisioned before this
+      // change shipped) can't be resolved. Caller falls through to a
+      // 401; user reprovisions on next ensure() and gets a fresh token.
+      return c.json({ error: "Sandbox missing tenant info" }, 401);
+    }
+
+    c.set("sandboxIdentity", {
+      orgId: tenant.orgId,
+      sandboxHandle: row.handle as string,
+    });
+    return next();
+  });
+
+  app.get("/list", async (c) => {
+    const { orgId } = c.get("sandboxIdentity");
+    const s3 = getObjectStorageS3Service();
+    if (!s3) {
+      return c.json({ error: "Object storage not configured" }, 503);
+    }
+    const storage = createBoundObjectStorage(s3, orgId);
+
+    const rawPrefix = c.req.query("prefix") ?? "";
+    if (rawPrefix.includes("..") || rawPrefix.startsWith("/")) {
+      return c.json({ error: "Invalid prefix" }, 400);
+    }
+    const continuationToken = c.req.query("continuationToken");
+    const maxKeysParam = Number.parseInt(c.req.query("maxKeys") ?? "", 10);
+    const maxKeys = Number.isFinite(maxKeysParam)
+      ? Math.min(Math.max(maxKeysParam, 1), MAX_KEYS_CAP)
+      : 100;
+
+    const result = await storage.list({
+      prefix: rawPrefix || undefined,
+      maxKeys,
+      continuationToken,
+    });
+
+    return c.json({
+      objects: result.objects.map((o) => ({
+        key: o.key,
+        size: o.size,
+        uploadedAt: o.lastModified?.toISOString(),
+      })),
+      isTruncated: result.isTruncated,
+      ...(result.nextContinuationToken
+        ? { nextContinuationToken: result.nextContinuationToken }
+        : {}),
+    });
+  });
+
+  app.get("/get", async (c) => {
+    const { orgId } = c.get("sandboxIdentity");
+    const s3 = getObjectStorageS3Service();
+    if (!s3) {
+      return c.json({ error: "Object storage not configured" }, 503);
+    }
+    const storage = createBoundObjectStorage(s3, orgId);
+
+    const key = c.req.query("key");
+    if (!key) {
+      return c.json({ error: "Missing key" }, 400);
+    }
+    if (key.includes("..") || key.startsWith("/")) {
+      return c.json({ error: "Invalid key" }, 400);
+    }
+
+    const presignedUrl = await storage.presignedGetUrl(key).catch(() => null);
+    if (!presignedUrl) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    return c.redirect(presignedUrl, 302);
+  });
+
+  return app;
+}

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -86,6 +86,9 @@ export function shouldSkipMeshContext(path: string): boolean {
     path === "/" ||
     path.startsWith(PATH_PREFIXES.API_AUTH) ||
     path === "/api/trigger-callback" ||
+    // Sandbox-user-data routes auth via DAEMON_TOKEN bearer; they have no
+    // user session and resolve org from the sandbox row themselves.
+    path.startsWith("/api/sandbox/user-data/") ||
     isSystemPath(path) ||
     // Static file extension check only applies to non-API paths (e.g. Vite assets).
     // API paths like /api/:org/files/image.jpeg still need MeshContext for auth.

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -136,6 +136,7 @@ async function instantiate(
         envName: readEnvName(),
         previewGateway: readPreviewGateway(),
         meter,
+        meshUrl: process.env.STUDIO_MESH_URL,
       });
     }
     default: {

--- a/packages/sandbox/image/skills/_bin/user-data-download
+++ b/packages/sandbox/image/skills/_bin/user-data-download
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /mnt/skills/public/user-data/download.py "$@"

--- a/packages/sandbox/image/skills/_bin/user-data-list
+++ b/packages/sandbox/image/skills/_bin/user-data-list
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /mnt/skills/public/user-data/list.py "$@"

--- a/packages/sandbox/image/skills/user-data/SKILL.md
+++ b/packages/sandbox/image/skills/user-data/SKILL.md
@@ -12,7 +12,7 @@ skills (pptx, docx, pdf, ...) can act on them.
 | List a prefix                         | `user-data-list chat-uploads/`                       |
 | Page through results                  | `user-data-list --page-token <token>`                |
 | JSON output (for piping to `jq`)      | `user-data-list --json`                              |
-| Download by stable URI                | `user-data-download mesh-storage:chat-uploads/x.pdf` |
+| Download by stable URI                | `user-data-download mesh-storage://chat-uploads/x.pdf` |
 | Download by bare key                  | `user-data-download chat-uploads/x.pdf`              |
 | Download from a presigned URL         | `user-data-download "https://..."`                   |
 | Override save path                    | `user-data-download <input> --out /tmp/x.pdf`        |
@@ -46,15 +46,15 @@ Accepts three input shapes:
 
 1. `https://…` / `http://…` — fetched directly (e.g. a presigned URL the
    model already has).
-2. `mesh-storage:KEY` — the stable URI shape you'll see in chat
-   annotations like `[Uploaded files] - foo.pdf: mesh-storage:chat-uploads/abc.pdf`.
+2. `mesh-storage://KEY` — the stable URI shape you'll see in chat
+   annotations like `[Uploaded files] - foo.pdf: mesh-storage://chat-uploads/abc.pdf`.
 3. A bare `KEY` like `chat-uploads/abc.pdf`.
 
 Defaults the save path to `/home/sandbox/<basename>`. Prints the final
 path on stdout — pipe straight into another skill:
 
 ```sh
-pptx-extract "$(user-data-download mesh-storage:chat-uploads/deck.pptx)"
+pptx-extract "$(user-data-download mesh-storage://chat-uploads/deck.pptx)"
 ```
 
 ## Environment

--- a/packages/sandbox/image/skills/user-data/SKILL.md
+++ b/packages/sandbox/image/skills/user-data/SKILL.md
@@ -1,0 +1,63 @@
+# user-data — org-scoped file access
+
+Read-only access to files stored in the org's object storage. Use this to
+list files and download them onto the sandbox filesystem so the other
+skills (pptx, docx, pdf, ...) can act on them.
+
+## Quick reference
+
+| Task                                  | Command                                              |
+| ------------------------------------- | ---------------------------------------------------- |
+| List all files                        | `user-data-list`                                     |
+| List a prefix                         | `user-data-list chat-uploads/`                       |
+| Page through results                  | `user-data-list --page-token <token>`                |
+| JSON output (for piping to `jq`)      | `user-data-list --json`                              |
+| Download by stable URI                | `user-data-download mesh-storage:chat-uploads/x.pdf` |
+| Download by bare key                  | `user-data-download chat-uploads/x.pdf`              |
+| Download from a presigned URL         | `user-data-download "https://..."`                   |
+| Override save path                    | `user-data-download <input> --out /tmp/x.pdf`        |
+
+## File layout
+
+The org's bucket holds files under several known prefixes:
+
+- `chat-uploads/` — files the user attached in chat
+- `screenshots/` — screenshots taken by the model in earlier turns
+- `generated-images/` — images the model generated previously
+- `inspect-pages/` — large page-inspection results
+- `scraped-pages/` — large scrape results
+- `web-search/` — large web-search results
+
+`user-data-list` with no prefix lists everything; pass a prefix to narrow.
+
+## Listing
+
+`user-data-list [prefix] [--page-token TOKEN] [--limit N] [--json]`
+
+Default output is a human table (key, size, uploadedAt). When the result is
+truncated, the next-page token is printed on stderr — pass it back via
+`--page-token`. `--limit` caps to 200 (server max).
+
+## Downloading
+
+`user-data-download <input> [--out PATH]`
+
+Accepts three input shapes:
+
+1. `https://…` / `http://…` — fetched directly (e.g. a presigned URL the
+   model already has).
+2. `mesh-storage:KEY` — the stable URI shape you'll see in chat
+   annotations like `[Uploaded files] - foo.pdf: mesh-storage:chat-uploads/abc.pdf`.
+3. A bare `KEY` like `chat-uploads/abc.pdf`.
+
+Defaults the save path to `/home/sandbox/<basename>`. Prints the final
+path on stdout — pipe straight into another skill:
+
+```sh
+pptx-extract "$(user-data-download mesh-storage:chat-uploads/deck.pptx)"
+```
+
+## Environment
+
+Both commands read `MESH_URL` and `DAEMON_TOKEN` from env. These are
+injected at sandbox provision time — you don't need to set them.

--- a/packages/sandbox/image/skills/user-data/download.py
+++ b/packages/sandbox/image/skills/user-data/download.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Download a file from org storage onto the sandbox filesystem.
+
+Accepts three input shapes:
+  1. https://…     — fetched directly
+  2. mesh-storage:KEY — resolved via mesh /api/sandbox/user-data/get
+  3. bare KEY      — resolved via mesh /api/sandbox/user-data/get
+
+Doesn't depend on the tool-arg substitution interceptor — works whether
+or not the URI was rewritten before reaching the sandbox.
+"""
+
+import argparse
+import os
+import shutil
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+MESH_STORAGE_PREFIX = "mesh-storage:"
+
+
+def _resolve(input_str: str) -> tuple[str, bool]:
+    """Return (url, needs_bearer). For direct URLs no bearer is added."""
+    if input_str.startswith(("https://", "http://")):
+        return input_str, False
+
+    key = (
+        input_str[len(MESH_STORAGE_PREFIX) :]
+        if input_str.startswith(MESH_STORAGE_PREFIX)
+        else input_str
+    )
+    if not key or key.startswith("/") or ".." in key:
+        print(f"invalid key: {key!r}", file=sys.stderr)
+        raise SystemExit(2)
+
+    mesh_url = os.environ.get("MESH_URL")
+    if not mesh_url:
+        print("MESH_URL must be set in env", file=sys.stderr)
+        raise SystemExit(2)
+    qs = urllib.parse.urlencode({"key": key})
+    return f"{mesh_url.rstrip('/')}/api/sandbox/user-data/get?{qs}", True
+
+
+def _basename_from_key(input_str: str) -> str:
+    if input_str.startswith(MESH_STORAGE_PREFIX):
+        input_str = input_str[len(MESH_STORAGE_PREFIX) :]
+    if input_str.startswith(("http://", "https://")):
+        path = urllib.parse.urlparse(input_str).path
+        return os.path.basename(path) or "download.bin"
+    return os.path.basename(input_str) or "download.bin"
+
+
+def _download(url: str, needs_bearer: bool, out_path: str) -> None:
+    """Fetch URL → out_path. urllib follows 302 to the S3 presigned URL and
+    drops the Authorization header on cross-origin redirect (Python ≥3.0),
+    which is what we want — S3 carries its own signature in the URL."""
+    headers: dict[str, str] = {}
+    if needs_bearer:
+        token = os.environ.get("DAEMON_TOKEN", "")
+        if not token:
+            print("DAEMON_TOKEN must be set in env", file=sys.stderr)
+            raise SystemExit(2)
+        headers["Authorization"] = f"Bearer {token}"
+
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp, open(out_path, "wb") as f:
+            shutil.copyfileobj(resp, f)
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="replace")
+        print(f"download failed: HTTP {e.code} {msg}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Download an org-scoped file into the sandbox."
+    )
+    parser.add_argument(
+        "input",
+        help="URL, mesh-storage:KEY, or bare object key",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Target path (default: /home/sandbox/<basename>)",
+    )
+    args = parser.parse_args(argv)
+
+    out = args.out or os.path.join("/home/sandbox", _basename_from_key(args.input))
+    url, needs_bearer = _resolve(args.input)
+    _download(url, needs_bearer, out)
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packages/sandbox/image/skills/user-data/download.py
+++ b/packages/sandbox/image/skills/user-data/download.py
@@ -2,9 +2,9 @@
 """Download a file from org storage onto the sandbox filesystem.
 
 Accepts three input shapes:
-  1. https://…     — fetched directly
-  2. mesh-storage:KEY — resolved via mesh /api/sandbox/user-data/get
-  3. bare KEY      — resolved via mesh /api/sandbox/user-data/get
+  1. https://…           — fetched directly
+  2. mesh-storage://KEY  — resolved via mesh /api/sandbox/user-data/get
+  3. bare KEY            — resolved via mesh /api/sandbox/user-data/get
 
 Doesn't depend on the tool-arg substitution interceptor — works whether
 or not the URI was rewritten before reaching the sandbox.
@@ -19,7 +19,17 @@ import urllib.parse
 import urllib.request
 
 
-MESH_STORAGE_PREFIX = "mesh-storage:"
+# The canonical scheme is `mesh-storage://` (see
+# apps/mesh/src/api/routes/decopilot/mesh-storage-uri.ts). The single-colon
+# form is accepted as a forgiving fallback in case anything ever produces it.
+MESH_STORAGE_SCHEMES = ("mesh-storage://", "mesh-storage:")
+
+
+def _strip_scheme(s: str) -> str:
+    for scheme in MESH_STORAGE_SCHEMES:
+        if s.startswith(scheme):
+            return s[len(scheme) :]
+    return s
 
 
 def _resolve(input_str: str) -> tuple[str, bool]:
@@ -27,11 +37,7 @@ def _resolve(input_str: str) -> tuple[str, bool]:
     if input_str.startswith(("https://", "http://")):
         return input_str, False
 
-    key = (
-        input_str[len(MESH_STORAGE_PREFIX) :]
-        if input_str.startswith(MESH_STORAGE_PREFIX)
-        else input_str
-    )
+    key = _strip_scheme(input_str)
     if not key or key.startswith("/") or ".." in key:
         print(f"invalid key: {key!r}", file=sys.stderr)
         raise SystemExit(2)
@@ -45,18 +51,28 @@ def _resolve(input_str: str) -> tuple[str, bool]:
 
 
 def _basename_from_key(input_str: str) -> str:
-    if input_str.startswith(MESH_STORAGE_PREFIX):
-        input_str = input_str[len(MESH_STORAGE_PREFIX) :]
     if input_str.startswith(("http://", "https://")):
         path = urllib.parse.urlparse(input_str).path
         return os.path.basename(path) or "download.bin"
-    return os.path.basename(input_str) or "download.bin"
+    return os.path.basename(_strip_scheme(input_str)) or "download.bin"
+
+
+# urllib's default redirect handler follows 3xx but does NOT strip the
+# Authorization header on cross-origin redirects (unlike `requests`). When
+# mesh /get returns 302 → presigned S3 URL, sending the Bearer along makes
+# S3 reject the request as a malformed AWS-signed call. Suppress auto-follow
+# and handle the redirect explicitly below.
+class _NoFollowRedirect(urllib.request.HTTPRedirectHandler):
+    def http_error_301(self, req, fp, code, msg, headers):  # noqa: ARG002
+        return None
+
+    http_error_302 = http_error_301
+    http_error_303 = http_error_301
+    http_error_307 = http_error_301
+    http_error_308 = http_error_301
 
 
 def _download(url: str, needs_bearer: bool, out_path: str) -> None:
-    """Fetch URL → out_path. urllib follows 302 to the S3 presigned URL and
-    drops the Authorization header on cross-origin redirect (Python ≥3.0),
-    which is what we want — S3 carries its own signature in the URL."""
     headers: dict[str, str] = {}
     if needs_bearer:
         token = os.environ.get("DAEMON_TOKEN", "")
@@ -65,14 +81,41 @@ def _download(url: str, needs_bearer: bool, out_path: str) -> None:
             raise SystemExit(2)
         headers["Authorization"] = f"Bearer {token}"
 
+    opener = urllib.request.build_opener(_NoFollowRedirect)
     req = urllib.request.Request(url, headers=headers)
+
     try:
-        with urllib.request.urlopen(req) as resp, open(out_path, "wb") as f:
-            shutil.copyfileobj(resp, f)
+        resp = opener.open(req)
     except urllib.error.HTTPError as e:
+        # Non-following redirect handler returns None → urllib raises
+        # HTTPError with the 3xx code and Location header intact.
+        if e.code in (301, 302, 303, 307, 308):
+            location = e.headers.get("Location")
+            if not location:
+                print(
+                    f"redirect {e.code} without Location header",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1) from None
+            try:
+                # Second hop: no Authorization. Presigned URLs carry their
+                # own signature in the query string.
+                with (
+                    urllib.request.urlopen(location) as r2,
+                    open(out_path, "wb") as f,
+                ):
+                    shutil.copyfileobj(r2, f)
+                return
+            except urllib.error.HTTPError as e2:
+                msg = e2.read().decode("utf-8", errors="replace")
+                print(f"download failed: HTTP {e2.code} {msg}", file=sys.stderr)
+                raise SystemExit(1) from None
         msg = e.read().decode("utf-8", errors="replace")
         print(f"download failed: HTTP {e.code} {msg}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from None
+
+    with resp, open(out_path, "wb") as f:
+        shutil.copyfileobj(resp, f)
 
 
 def main(argv: list[str]) -> int:
@@ -81,7 +124,7 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "input",
-        help="URL, mesh-storage:KEY, or bare object key",
+        help="URL, mesh-storage://KEY, or bare object key",
     )
     parser.add_argument(
         "--out",

--- a/packages/sandbox/image/skills/user-data/list.py
+++ b/packages/sandbox/image/skills/user-data/list.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""List org-scoped files via the mesh user-data endpoint."""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def _fetch(mesh_url: str, token: str, query: dict[str, str]) -> dict:
+    qs = urllib.parse.urlencode({k: v for k, v in query.items() if v})
+    url = f"{mesh_url.rstrip('/')}/api/sandbox/user-data/list?{qs}"
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {token}"}
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="replace")
+        print(f"list failed: HTTP {e.code} {msg}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="List files in the org's storage."
+    )
+    parser.add_argument("prefix", nargs="?", default="", help="Optional prefix")
+    parser.add_argument("--page-token", default="", help="Continuation token")
+    parser.add_argument("--limit", type=int, default=100, help="Max items (≤200)")
+    parser.add_argument("--json", action="store_true", help="Print raw JSON")
+    args = parser.parse_args(argv)
+
+    mesh_url = os.environ.get("MESH_URL")
+    token = os.environ.get("DAEMON_TOKEN")
+    if not mesh_url or not token:
+        print("MESH_URL and DAEMON_TOKEN must be set in env", file=sys.stderr)
+        return 2
+
+    body = _fetch(
+        mesh_url,
+        token,
+        {
+            "prefix": args.prefix,
+            "continuationToken": args.page_token,
+            "maxKeys": str(args.limit),
+        },
+    )
+
+    if args.json:
+        print(json.dumps(body, indent=2))
+        return 0
+
+    objects = body.get("objects", [])
+    if not objects:
+        print("(no files)")
+    else:
+        # Compact human table; the model picks a key and feeds it to download.
+        widest_key = max(len(o["key"]) for o in objects)
+        for o in objects:
+            size = o.get("size", 0)
+            uploaded = o.get("uploadedAt", "")
+            print(f"{o['key']:<{widest_key}}  {size:>10}  {uploaded}")
+
+    if body.get("isTruncated"):
+        token = body.get("nextContinuationToken", "")
+        print(
+            f"(truncated; pass --page-token {token} for next page)",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -120,6 +120,7 @@ const RESERVED_ENV_KEYS = new Set([
   "GIT_USER_NAME",
   "GIT_USER_EMAIL",
   "PACKAGE_MANAGER",
+  "MESH_URL",
 ]);
 
 const DEFAULT_IDLE_TTL_MS = 15 * 60 * 1000;
@@ -319,6 +320,12 @@ export interface AgentSandboxRunnerOptions {
     name: string;
     namespace: string;
   };
+  /**
+   * Cluster-internal URL the in-sandbox user-data skill calls back to mesh
+   * via. Surfaced to the container as `MESH_URL`. When unset, the env var
+   * is omitted and the skill scripts fail clearly with "MESH_URL not set".
+   */
+  meshUrl?: string;
 }
 
 export class AgentSandboxRunner implements SandboxRunner {
@@ -348,6 +355,7 @@ export class AgentSandboxRunner implements SandboxRunner {
    * adopt, and delete.
    */
   private readonly previewGateway: { name: string; namespace: string } | null;
+  private readonly meshUrl: string | null;
   private closed = false;
 
   constructor(opts: AgentSandboxRunnerOptions = {}) {
@@ -364,6 +372,7 @@ export class AgentSandboxRunner implements SandboxRunner {
       (() => randomBytes(DAEMON_TOKEN_BYTES).toString("hex"));
     this.idleTtlMs = opts.idleTtlMs ?? DEFAULT_IDLE_TTL_MS;
     this.metrics = opts.meter ? buildRunnerMetrics(opts.meter) : null;
+    this.meshUrl = opts.meshUrl ?? null;
     // HTTPRoute routing requires both pieces — the hostname template (so we
     // know what host to attach) and the gateway parent (so we know where).
     // Either alone is meaningless, so refuse to half-enable.
@@ -862,6 +871,7 @@ export class AgentSandboxRunner implements SandboxRunner {
       ...(opts.workload?.packageManager
         ? { PACKAGE_MANAGER: opts.workload.packageManager }
         : {}),
+      ...(this.meshUrl ? { MESH_URL: this.meshUrl } : {}),
     };
   }
 

--- a/packages/sandbox/server/runner/docker/runner.ts
+++ b/packages/sandbox/server/runner/docker/runner.ts
@@ -92,6 +92,12 @@ interface DockerRecord {
    * container restarts.
    */
   daemonBootId: string;
+  /**
+   * Tenant identity (orgId/userId) — persisted so sandbox-user-data routes
+   * can resolve a DAEMON_TOKEN bearer back to its owning org for
+   * BoundObjectStorage scoping. K8s runner persists the same field.
+   */
+  tenant?: { orgId: string; userId: string };
 }
 
 interface PersistedDockerState {
@@ -104,6 +110,7 @@ interface PersistedDockerState {
   workload?: Workload | null;
   /** Per-boot UUID from the daemon's /health; round-tripped through state. */
   daemonBootId?: string;
+  tenant?: { orgId: string; userId: string };
   [k: string]: unknown;
 }
 
@@ -305,6 +312,13 @@ export class DockerSandboxRunner implements SandboxRunner {
       PROXY_PORT: String(DAEMON_PORT),
       DEV_PORT: String(devContainerPort),
       RUNTIME: runtime,
+      // Mesh URL the in-sandbox user-data skill calls back into. Bridge
+      // network containers can't reach `localhost` on the host directly;
+      // `host.docker.internal` resolves to the host-gateway address added
+      // via --add-host below.
+      ...(process.env.STUDIO_MESH_URL
+        ? { MESH_URL: process.env.STUDIO_MESH_URL }
+        : { MESH_URL: "http://host.docker.internal:3000" }),
       ...(repo
         ? {
             CLONE_URL: repo.cloneUrl,
@@ -361,6 +375,10 @@ export class DockerSandboxRunner implements SandboxRunner {
           `127.0.0.1:0:${DAEMON_PORT}`,
           "-p",
           `127.0.0.1:0:${devContainerPort}`,
+          // Linux: `host.docker.internal` doesn't auto-resolve to the host;
+          // host-gateway makes it work uniformly across Mac/Win/Linux so the
+          // user-data skill can reach mesh.
+          "--add-host=host.docker.internal:host-gateway",
           ...Object.entries(env).flatMap(([k, v]) => ["-e", `${k}=${v}`]),
         ],
       });
@@ -415,6 +433,7 @@ export class DockerSandboxRunner implements SandboxRunner {
       devContainerPort,
       workload: opts.workload ?? null,
       daemonBootId,
+      ...(opts.tenant ? { tenant: opts.tenant } : {}),
     };
   }
 
@@ -466,6 +485,7 @@ export class DockerSandboxRunner implements SandboxRunner {
       devContainerPort,
       daemonBootId: health.bootId,
       workload: state.workload ?? null,
+      ...(state.tenant ? { tenant: state.tenant } : {}),
     };
   }
 
@@ -596,6 +616,7 @@ export class DockerSandboxRunner implements SandboxRunner {
       devContainerPort: rec.devContainerPort,
       workload: rec.workload,
       daemonBootId: rec.daemonBootId,
+      ...(rec.tenant ? { tenant: rec.tenant } : {}),
     };
     await ops.put(rec.id, RUNNER_KIND, { handle: rec.handle, state });
   }


### PR DESCRIPTION
## What is this contribution about?

Adds a read-only `user-data` skill to the sandbox image so resident skills (pptx, docx, ...) can act on files stored in the org's object storage. Two new mesh endpoints (`/api/sandbox/user-data/list` + `/get`) authenticate via the existing per-sandbox `DAEMON_TOKEN` — `BoundObjectStorage`'s auto-org-prefix is the security boundary, so the sandbox can never name another org's keys. Also extends the `bash` tool description so the model discovers `/mnt/skills/public/` and the canonical `user-data → format-skill` chain.

Manually verified end-to-end (list, download via `mesh-storage://`, chain into pptx).

## How to Test

1. `bun run --cwd=apps/mesh migrate` to apply migration 073.
2. `bun run dev`, attach a file in chat, then exec into the sandbox:
   - `user-data-list chat-uploads/` shows the upload.
   - `user-data-download mesh-storage://chat-uploads/<key>` lands at `/home/sandbox/<basename>`.
   - Chain into a format skill (e.g. `pptx-extract \"\$(user-data-download mesh-storage://...)\"`).

## Migration Notes

- Applies migration `073-sandbox-runner-state-token-index` (btree on `state ->> 'token'`).
- Set `STUDIO_MESH_URL` to the in-cluster mesh DNS for prod K8s deploys; Docker dev defaults to `http://host.docker.internal:3000` via host-gateway.
- Sandboxes provisioned before this PR have no `state.tenant` and will return 401 on user-data calls until reprovisioned (next `ensure()` mints fresh state).

The sandbox→user file-share path (model produces an artifact, user gets a download chip) is split into a follow-up PR — branch `viktormarinho/user-data-share`.