### PR TITLE
fix(auth): redirect to invited org after accepting email invitation

### DIFF
--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -135,7 +135,7 @@ if (
 
     sendInvitationEmail = async (data) => {
       const inviterName = data.inviter.user?.name || data.inviter.user?.email;
-      const acceptUrl = `${getBaseUrl()}/auth/accept-invitation?invitationId=${data.invitation.id}&redirectTo=/`;
+      const acceptUrl = `${getBaseUrl()}/auth/accept-invitation?invitationId=${data.invitation.id}&redirectTo=/${data.organization.slug}`;
 
       await sendEmail({
         to: data.email,


### PR DESCRIPTION
## What is this contribution about?

When a user accepted an org invitation via email link, the `redirectTo` parameter was hardcoded to `/`, which sent them to the home route and then on to their default/last-used org instead of the invited one. This fixes the invite email URL to use the invited org's slug as the redirect target.

## Screenshots/Demonstration

N/A — backend-only change.

## How to Test

1. Invite a user to an org via email
2. Accept the invitation using the email link
3. Expected outcome: user lands on the invited org's dashboard, not their default org

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes