### PR TITLE
feat(sandbox): copy_to_sandbox + share_with_user tools

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -50,6 +50,7 @@ import { createKVRoutes } from "./routes/kv";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import publicConfigRoutes from "./routes/public-config";
 import filesRoutes from "./routes/files";
+import threadOutputsRoutes from "./routes/thread-outputs";
 import selfRoutes from "./routes/self";
 import { shouldSkipMeshContext, SYSTEM_PATHS } from "./utils/paths";
 import {
@@ -1363,6 +1364,9 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Stable file redirect endpoint (resolves mesh-storage: URIs to presigned URLs)
   app.route("/api", filesRoutes);
+
+  // Thread outputs (model-shared files surfaced as download chips in the chat)
+  app.route("/api", threadOutputsRoutes);
 
   // OpenAI-compatible LLM API routes
   app.route("/api", openaiCompatRoutes);

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -57,6 +57,13 @@ export type VmContext = {
   virtualMcpId: string;
   branch: string;
   userId: string;
+  /**
+   * Current chat thread id. Used by `share_with_user` to scope artifacts
+   * under `model-outputs/<threadId>/`. Required because one ephemeral
+   * sandbox serves multiple threads of the same (user, agent), so the
+   * thread isn't deducible from the sandbox identity alone.
+   */
+  threadId: string;
 };
 
 export interface BuiltinToolParams {
@@ -170,6 +177,8 @@ async function buildAllTools(
         toolOutputMap,
         needsApproval: vmNeedsApproval,
         pendingImages,
+        ctx,
+        threadId: vmContext.threadId,
       }),
     );
   }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -8,11 +8,14 @@
  */
 
 import { tool, zodSchema } from "ai";
+import path from "node:path";
 import type { SandboxRunner } from "@decocms/sandbox/runner";
 import { maybeTruncate } from "./common";
 import {
   BASH_DESCRIPTION,
   BashInputSchema,
+  COPY_TO_SANDBOX_DESCRIPTION,
+  CopyToSandboxInputSchema,
   EDIT_DESCRIPTION,
   EditInputSchema,
   GLOB_DESCRIPTION,
@@ -21,11 +24,56 @@ import {
   GrepInputSchema,
   READ_DESCRIPTION,
   ReadInputSchema,
+  SHARE_WITH_USER_DESCRIPTION,
+  ShareWithUserInputSchema,
   TOOL_APPROVAL,
   WRITE_DESCRIPTION,
   WriteInputSchema,
 } from "./schemas";
 import type { VmToolsParams } from "./types";
+
+const MESH_STORAGE_SCHEME = "mesh-storage://";
+
+/**
+ * Resolve any of three input shapes to a fetchable URL the daemon can GET:
+ *   - https:// or http:// → returned as-is
+ *   - mesh-storage://KEY  → minted presigned GET via ctx.objectStorage
+ *   - bare KEY            → same as mesh-storage://KEY
+ *
+ * The tool-arg interceptor (`resolveArgsStorageRefs` in file-materializer)
+ * substitutes mesh-storage:// → presigned-URL before this handler runs in
+ * the happy path. This function is the safety net when interception didn't
+ * happen and as the path for bare keys (which the interceptor doesn't
+ * touch since they have no scheme).
+ */
+async function resolveSourceUrl(
+  raw: string,
+  ctx: VmToolsParams["ctx"],
+): Promise<string> {
+  if (raw.startsWith("https://") || raw.startsWith("http://")) return raw;
+  const key = raw.startsWith(MESH_STORAGE_SCHEME)
+    ? raw.slice(MESH_STORAGE_SCHEME.length)
+    : raw;
+  if (!key || key.startsWith("/") || key.includes("..")) {
+    throw new Error(`Invalid source: ${raw}`);
+  }
+  const storage = ctx.objectStorage;
+  if (!storage) {
+    throw new Error("Object storage is not configured for this org");
+  }
+  return storage.presignedGetUrl(key);
+}
+
+function sanitizeFilename(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes("/") || trimmed.includes("\\")) return null;
+  if (trimmed === "." || trimmed === ".." || trimmed.includes("..")) {
+    return null;
+  }
+  if (trimmed.length > 255) return null;
+  return trimmed;
+}
 
 export type { VmToolsParams } from "./types";
 
@@ -89,12 +137,19 @@ async function daemonRequest(
 }
 
 export function createVmTools(params: VmToolsParams) {
-  const { runner, ensureHandle, toolOutputMap, needsApproval, pendingImages } =
-    params;
+  const {
+    runner,
+    ensureHandle,
+    toolOutputMap,
+    needsApproval,
+    pendingImages,
+    ctx,
+    threadId,
+  } = params;
   const approvalFor = (mutating: boolean) => (mutating ? needsApproval : false);
-  const call = async (path: string, input: Record<string, unknown>) => {
+  const call = async (daemonPath: string, input: Record<string, unknown>) => {
     const handle = await ensureHandle();
-    return daemonRequest(runner, handle, path, input);
+    return daemonRequest(runner, handle, daemonPath, input);
   };
 
   const read = tool({
@@ -175,5 +230,58 @@ export function createVmTools(params: VmToolsParams) {
     },
   });
 
-  return { read, write, edit, grep, glob, bash };
+  const copy_to_sandbox = tool({
+    needsApproval: approvalFor(TOOL_APPROVAL.copy_to_sandbox),
+    description: COPY_TO_SANDBOX_DESCRIPTION,
+    inputSchema: zodSchema(CopyToSandboxInputSchema),
+    execute: async (input) => {
+      const sourceUrl = await resolveSourceUrl(input.url, ctx);
+      const result = await call("/_decopilot_vm/write_from_url", {
+        url: sourceUrl,
+        path: input.target,
+      });
+      return result as { ok: boolean; path: string; size: number };
+    },
+  });
+
+  const share_with_user = tool({
+    needsApproval: approvalFor(TOOL_APPROVAL.share_with_user),
+    description: SHARE_WITH_USER_DESCRIPTION,
+    inputSchema: zodSchema(ShareWithUserInputSchema),
+    execute: async (input) => {
+      const orgId = ctx.organization?.id;
+      const storage = ctx.objectStorage;
+      if (!orgId || !storage) {
+        throw new Error("Object storage is not configured for this org");
+      }
+      const filename = sanitizeFilename(
+        input.name ?? path.basename(input.source),
+      );
+      if (!filename) {
+        throw new Error(`Invalid filename: ${input.name ?? input.source}`);
+      }
+      const key = `model-outputs/${threadId}/${filename}`;
+      const presignedPutUrl = await storage.presignedPutUrl(key);
+      await call("/_decopilot_vm/upload_to_url", {
+        path: input.source,
+        url: presignedPutUrl,
+      });
+      return {
+        key,
+        filename,
+        downloadUrl: `${ctx.baseUrl}/api/${orgId}/files/${key}`,
+      };
+    },
+  });
+
+  return {
+    read,
+    write,
+    edit,
+    grep,
+    glob,
+    bash,
+    copy_to_sandbox,
+    share_with_user,
+  };
 }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -87,6 +87,48 @@ function sanitizeFilename(name: string): string | null {
 }
 
 /**
+ * Find a non-colliding key by appending `-1`, `-2`, ... before the
+ * extension on collision. Avoids the silent-overwrite footgun when the
+ * model regenerates an artifact under the same default name in two
+ * turns of the same thread — both files end up in the chip list, the
+ * user can pick.
+ *
+ * Cap at COLLISION_LIMIT to bound HEAD-request cost on a pathological
+ * input. Race with another concurrent share_with_user is theoretical
+ * (single user, mostly sequential turns) — skip the If-None-Match dance.
+ */
+const COLLISION_LIMIT = 100;
+async function findFreeKey(
+  storage: NonNullable<VmToolsParams["ctx"]["objectStorage"]>,
+  baseKey: string,
+): Promise<string> {
+  const exists = async (k: string): Promise<boolean> => {
+    try {
+      await storage.head(k);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (!(await exists(baseKey))) return baseKey;
+
+  const slashIdx = baseKey.lastIndexOf("/");
+  const dir = baseKey.slice(0, slashIdx + 1);
+  const fname = baseKey.slice(slashIdx + 1);
+  const dotIdx = fname.lastIndexOf(".");
+  const stem = dotIdx > 0 ? fname.slice(0, dotIdx) : fname;
+  const ext = dotIdx > 0 ? fname.slice(dotIdx) : "";
+
+  for (let i = 1; i <= COLLISION_LIMIT; i++) {
+    const candidate = `${dir}${stem}-${i}${ext}`;
+    if (!(await exists(candidate))) return candidate;
+  }
+  throw new Error(
+    `Could not find a free key after ${COLLISION_LIMIT} attempts for ${baseKey}`,
+  );
+}
+
+/**
  * Build a stable file-redirect URL. Must encode each path segment so
  * keys carrying URL-special chars (`?`, `#`, `&`, space, ...) survive
  * round-trip — the `/api/:org/files/*` route reads `c.req.path` which
@@ -280,13 +322,19 @@ export function createVmTools(params: VmToolsParams) {
       if (!orgId || !storage) {
         throw new Error("Object storage is not configured for this org");
       }
-      const filename = sanitizeFilename(
+      const requestedFilename = sanitizeFilename(
         input.name ?? path.basename(input.source),
       );
-      if (!filename) {
+      if (!requestedFilename) {
         throw new Error(`Invalid filename: ${input.name ?? input.source}`);
       }
-      const key = `model-outputs/${threadId}/${filename}`;
+      const baseKey = `model-outputs/${threadId}/${requestedFilename}`;
+      // Dedupe key on collision so a regenerated artifact lands as
+      // `report-1.csv` instead of silently clobbering `report.csv`. The
+      // chip UI picks both up. The response surfaces the actual key /
+      // filename used so the model can mention the right name in its reply.
+      const key = await findFreeKey(storage, baseKey);
+      const filename = key.split("/").pop() ?? requestedFilename;
       const presignedPutUrl = await storage.presignedPutUrl(key);
       await call("/_decopilot_vm/upload_to_url", {
         path: input.source,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -75,6 +75,21 @@ function sanitizeFilename(name: string): string | null {
   return trimmed;
 }
 
+/**
+ * Build a stable file-redirect URL. Must encode each path segment so
+ * keys carrying URL-special chars (`?`, `#`, `&`, space, ...) survive
+ * round-trip — the `/api/:org/files/*` route reads `c.req.path` which
+ * truncates at the first unescaped `?`.
+ */
+function toFileDownloadUrl(
+  baseUrl: string,
+  orgId: string,
+  key: string,
+): string {
+  const encodedKey = key.split("/").map(encodeURIComponent).join("/");
+  return `${baseUrl}/api/${encodeURIComponent(orgId)}/files/${encodedKey}`;
+}
+
 export type { VmToolsParams } from "./types";
 
 async function daemonRequest(
@@ -269,7 +284,7 @@ export function createVmTools(params: VmToolsParams) {
       return {
         key,
         filename,
-        downloadUrl: `${ctx.baseUrl}/api/${orgId}/files/${key}`,
+        downloadUrl: toFileDownloadUrl(ctx.baseUrl, orgId, key),
       };
     },
   });

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -87,48 +87,6 @@ function sanitizeFilename(name: string): string | null {
 }
 
 /**
- * Find a non-colliding key by appending `-1`, `-2`, ... before the
- * extension on collision. Avoids the silent-overwrite footgun when the
- * model regenerates an artifact under the same default name in two
- * turns of the same thread — both files end up in the chip list, the
- * user can pick.
- *
- * Cap at COLLISION_LIMIT to bound HEAD-request cost on a pathological
- * input. Race with another concurrent share_with_user is theoretical
- * (single user, mostly sequential turns) — skip the If-None-Match dance.
- */
-const COLLISION_LIMIT = 100;
-async function findFreeKey(
-  storage: NonNullable<VmToolsParams["ctx"]["objectStorage"]>,
-  baseKey: string,
-): Promise<string> {
-  const exists = async (k: string): Promise<boolean> => {
-    try {
-      await storage.head(k);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-  if (!(await exists(baseKey))) return baseKey;
-
-  const slashIdx = baseKey.lastIndexOf("/");
-  const dir = baseKey.slice(0, slashIdx + 1);
-  const fname = baseKey.slice(slashIdx + 1);
-  const dotIdx = fname.lastIndexOf(".");
-  const stem = dotIdx > 0 ? fname.slice(0, dotIdx) : fname;
-  const ext = dotIdx > 0 ? fname.slice(dotIdx) : "";
-
-  for (let i = 1; i <= COLLISION_LIMIT; i++) {
-    const candidate = `${dir}${stem}-${i}${ext}`;
-    if (!(await exists(candidate))) return candidate;
-  }
-  throw new Error(
-    `Could not find a free key after ${COLLISION_LIMIT} attempts for ${baseKey}`,
-  );
-}
-
-/**
  * Build a stable file-redirect URL. Must encode each path segment so
  * keys carrying URL-special chars (`?`, `#`, `&`, space, ...) survive
  * round-trip — the `/api/:org/files/*` route reads `c.req.path` which
@@ -322,19 +280,13 @@ export function createVmTools(params: VmToolsParams) {
       if (!orgId || !storage) {
         throw new Error("Object storage is not configured for this org");
       }
-      const requestedFilename = sanitizeFilename(
+      const filename = sanitizeFilename(
         input.name ?? path.basename(input.source),
       );
-      if (!requestedFilename) {
+      if (!filename) {
         throw new Error(`Invalid filename: ${input.name ?? input.source}`);
       }
-      const baseKey = `model-outputs/${threadId}/${requestedFilename}`;
-      // Dedupe key on collision so a regenerated artifact lands as
-      // `report-1.csv` instead of silently clobbering `report.csv`. The
-      // chip UI picks both up. The response surfaces the actual key /
-      // filename used so the model can mention the right name in its reply.
-      const key = await findFreeKey(storage, baseKey);
-      const filename = key.split("/").pop() ?? requestedFilename;
+      const key = `model-outputs/${threadId}/${filename}`;
       const presignedPutUrl = await storage.presignedPutUrl(key);
       await call("/_decopilot_vm/upload_to_url", {
         path: input.source,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -35,22 +35,33 @@ import type { VmToolsParams } from "./types";
 const MESH_STORAGE_SCHEME = "mesh-storage://";
 
 /**
- * Resolve any of three input shapes to a fetchable URL the daemon can GET:
- *   - https:// or http:// → returned as-is
- *   - mesh-storage://KEY  → minted presigned GET via ctx.objectStorage
- *   - bare KEY            → same as mesh-storage://KEY
+ * Resolve a `copy_to_sandbox` input to a fetchable URL the daemon can GET.
+ * Accepts only org-scoped storage references — `mesh-storage://KEY` (the
+ * shape that lands in chat annotations) or a bare KEY. Both are minted
+ * to a presigned GET via `ctx.objectStorage`, so the daemon only ever
+ * fetches from S3/R2 endpoints mesh controls.
+ *
+ * Arbitrary `http(s)://` URLs are intentionally rejected: for public
+ * URLs the model can use `bash` + `curl` (which is approval-gated, like
+ * any shell command), and excluding them keeps the daemon's fetch path
+ * free of SSRF concerns.
  *
  * The tool-arg interceptor (`resolveArgsStorageRefs` in file-materializer)
  * substitutes mesh-storage:// → presigned-URL before this handler runs in
  * the happy path. This function is the safety net when interception didn't
- * happen and as the path for bare keys (which the interceptor doesn't
- * touch since they have no scheme).
+ * happen, plus the path for bare keys.
  */
 async function resolveSourceUrl(
   raw: string,
   ctx: VmToolsParams["ctx"],
 ): Promise<string> {
-  if (raw.startsWith("https://") || raw.startsWith("http://")) return raw;
+  if (raw.startsWith("https://") || raw.startsWith("http://")) {
+    throw new Error(
+      "copy_to_sandbox does not accept arbitrary URLs — pass a " +
+        "mesh-storage:// URI or a bare org storage key. For public URLs, " +
+        "use the bash tool (curl).",
+    );
+  }
   const key = raw.startsWith(MESH_STORAGE_SCHEME)
     ? raw.slice(MESH_STORAGE_SCHEME.length)
     : raw;

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -170,10 +170,16 @@ export const SHARE_WITH_USER_DESCRIPTION =
   "automatically when the turn finishes.";
 
 // read/grep/glob are non-mutating; write/edit/bash mutate.
-// copy_to_sandbox writes to sandbox FS → mutates; share_with_user uploads
-// to S3 from a read of the sandbox FS → not a sandbox mutation per se,
-// but treat as approval-worthy because it's an external side effect (the
-// artifact appears for the user).
+//
+// copy_to_sandbox + share_with_user are intentionally NOT approval-gated.
+// Both write side effects technically mutate state — copy_to_sandbox
+// drops bytes on the sandbox FS (already gated by `safePath`, no escape
+// outside `/app`), and share_with_user uploads to a thread-scoped S3
+// prefix the user already owns. Gating either would surface an approval
+// prompt on the most natural path the model takes for chat artifacts
+// (download → process → share), which is high-friction for a flow the
+// user just initiated by attaching a file. Reserve approvals for shell
+// + project-FS mutation where the blast radius is broader.
 export const TOOL_APPROVAL = {
   read: false,
   write: true,

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -79,12 +79,46 @@ export const BashInputSchema = z.object({
     .describe("Timeout in milliseconds (default 30000, max 120000)"),
 });
 
+export const CopyToSandboxInputSchema = z.object({
+  url: z
+    .string()
+    .describe(
+      "Source URL. Accepts mesh-storage:// URIs from chat (e.g. " +
+        "mesh-storage://chat-uploads/abc.pdf), https:// URLs (e.g. presigned " +
+        "S3 URLs), or bare org-storage keys (e.g. chat-uploads/abc.pdf).",
+    ),
+  target: z
+    .string()
+    .describe(
+      "Destination path on the sandbox FS (relative to project root). " +
+        "Parent directories are created as needed.",
+    ),
+});
+
+export const ShareWithUserInputSchema = z.object({
+  source: z
+    .string()
+    .describe(
+      "Path to a file on the sandbox FS to share back to the user. " +
+        "Must be a single file (not a directory).",
+    ),
+  name: z
+    .string()
+    .optional()
+    .describe(
+      "Filename to surface in the chat UI (default: basename of source). " +
+        "Cannot contain slashes.",
+    ),
+});
+
 export type ReadInput = z.infer<typeof ReadInputSchema>;
 export type WriteInput = z.infer<typeof WriteInputSchema>;
 export type EditInput = z.infer<typeof EditInputSchema>;
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 export type GlobInput = z.infer<typeof GlobInputSchema>;
 export type BashInput = z.infer<typeof BashInputSchema>;
+export type CopyToSandboxInput = z.infer<typeof CopyToSandboxInputSchema>;
+export type ShareWithUserInput = z.infer<typeof ShareWithUserInputSchema>;
 
 export const READ_DESCRIPTION =
   "Read a file. For text files, returns content with line numbers (use offset " +
@@ -112,9 +146,34 @@ export const GLOB_DESCRIPTION =
 
 export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
-  "Working directory is the project root. Timeout default 30s, max 2min.";
+  "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
+  "Pre-installed skills live at `/mnt/skills/public/<name>/SKILL.md`. " +
+  "Run `ls /mnt/skills/public/` for the index and " +
+  "`cat /mnt/skills/public/<name>/SKILL.md` before using one. " +
+  "Skills cover common file operations: pptx (PowerPoint), docx (Word), " +
+  "xlsx (Excel), pdf, file-reading (router).\n\n" +
+  "To bring chat attachments / presigned URLs into the sandbox FS use " +
+  "`copy_to_sandbox` (NOT bash + curl). To deliver a file you produced " +
+  "back to the user as a download chip, use `share_with_user`.";
+
+export const COPY_TO_SANDBOX_DESCRIPTION =
+  "Copy a file from chat / org storage / a presigned URL into the sandbox " +
+  "filesystem at `target`. Use this BEFORE running format-specific skills " +
+  "(pptx-extract, pdf, docx, ...) on user-uploaded files. Bytes are streamed " +
+  "directly from the source — they do not pass through the model.";
+
+export const SHARE_WITH_USER_DESCRIPTION =
+  "Upload a file from the sandbox FS back to the user's chat as a download " +
+  "chip on this turn. Use this for artifacts the user should be able to " +
+  "save (CSV reports, generated decks, zipped builds, etc). The file " +
+  "lands under the current thread's outputs prefix; the UI surfaces it " +
+  "automatically when the turn finishes.";
 
 // read/grep/glob are non-mutating; write/edit/bash mutate.
+// copy_to_sandbox writes to sandbox FS → mutates; share_with_user uploads
+// to S3 from a read of the sandbox FS → not a sandbox mutation per se,
+// but treat as approval-worthy because it's an external side effect (the
+// artifact appears for the user).
 export const TOOL_APPROVAL = {
   read: false,
   write: true,
@@ -122,4 +181,6 @@ export const TOOL_APPROVAL = {
   grep: false,
   glob: false,
   bash: true,
+  copy_to_sandbox: false,
+  share_with_user: false,
 } as const;

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -83,9 +83,10 @@ export const CopyToSandboxInputSchema = z.object({
   url: z
     .string()
     .describe(
-      "Source URL. Accepts mesh-storage:// URIs from chat (e.g. " +
-        "mesh-storage://chat-uploads/abc.pdf), https:// URLs (e.g. presigned " +
-        "S3 URLs), or bare org-storage keys (e.g. chat-uploads/abc.pdf).",
+      "Org-scoped storage reference. Accepts a mesh-storage:// URI from " +
+        "chat (e.g. mesh-storage://chat-uploads/abc.pdf) or a bare key " +
+        "(e.g. chat-uploads/abc.pdf). Arbitrary http(s):// URLs are NOT " +
+        "accepted — for public URLs use the bash tool with curl.",
     ),
   target: z
     .string()
@@ -157,10 +158,12 @@ export const BASH_DESCRIPTION =
   "back to the user as a download chip, use `share_with_user`.";
 
 export const COPY_TO_SANDBOX_DESCRIPTION =
-  "Copy a file from chat / org storage / a presigned URL into the sandbox " +
-  "filesystem at `target`. Use this BEFORE running format-specific skills " +
-  "(pptx-extract, pdf, docx, ...) on user-uploaded files. Bytes are streamed " +
-  "directly from the source — they do not pass through the model.";
+  "Copy a chat-attached or org-storage file into the sandbox filesystem " +
+  "at `target`. Use this BEFORE running format-specific skills " +
+  "(pptx-extract, pdf, docx, ...) on user-uploaded files. Accepts " +
+  "mesh-storage:// URIs and bare org-storage keys only — for arbitrary " +
+  "public URLs use bash + curl. Bytes stream directly from S3 to the " +
+  "sandbox; they do not pass through the model.";
 
 export const SHARE_WITH_USER_DESCRIPTION =
   "Upload a file from the sandbox FS back to the user's chat as a download " +

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/types.ts
@@ -1,4 +1,5 @@
 import type { SandboxRunner } from "@decocms/sandbox/runner";
+import type { MeshContext } from "@/core/mesh-context";
 import type { PendingImage } from "../take-screenshot";
 
 export interface VmToolsParams {
@@ -16,4 +17,15 @@ export interface VmToolsParams {
    * queue is flushed by `prepareStep` in stream-core.ts.
    */
   readonly pendingImages: PendingImage[];
+  /**
+   * Mesh context for tools that need to mint presigned URLs against the
+   * org's object storage (`copy_to_sandbox`, `share_with_user`) or
+   * resolve the org id for stable file URLs.
+   */
+  readonly ctx: MeshContext;
+  /**
+   * Current chat thread id. `share_with_user` writes artifacts under
+   * `model-outputs/<threadId>/<filename>` so the chat UI can list them.
+   */
+  readonly threadId: string;
 }

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -35,6 +35,33 @@ function toFileRedirectUrl(
   return `${baseUrl}/api/${orgId}/files/${key}`;
 }
 
+/**
+ * MIME types we never hand to providers as native file parts.
+ * Provider support for Office formats is uneven (Anthropic chokes with
+ * "Failed to parse [file://...]", others silently ignore the file), and
+ * the sandbox skills (pptx-extract, docx, xlsx) consistently produce
+ * better results than any provider's native parser. The model picks
+ * these up from the annotation text emitted by uploadFileParts and
+ * pulls them in via copy_to_sandbox.
+ *
+ * PDFs stay on the native path — every provider with a `file` capability
+ * handles them fine and going through the sandbox would be a regression.
+ */
+const SANDBOX_ONLY_MIME_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+function isSandboxOnlyFilePart(part: { type: string }): boolean {
+  return (
+    part.type === "file" &&
+    "mediaType" in part &&
+    typeof (part as { mediaType?: unknown }).mediaType === "string" &&
+    SANDBOX_ONLY_MIME_TYPES.has((part as { mediaType: string }).mediaType)
+  );
+}
+
 // ============================================================================
 // Data URL parsing
 // ============================================================================
@@ -268,9 +295,21 @@ export async function resolveStorageRefs(
 ): Promise<ChatMessage[]> {
   if (!ctx.organization) return messages;
 
-  // Collect unique mesh-storage: keys from file parts only (not text)
+  // First pass: drop sandbox-only file parts (Office formats). The model
+  // reads these via copy_to_sandbox using the mesh-storage URI in the
+  // annotation text emitted by uploadFileParts.
+  const filtered = messages.map((msg) => {
+    const filteredParts = msg.parts.filter(
+      (part) => !isSandboxOnlyFilePart(part),
+    );
+    return filteredParts.length === msg.parts.length
+      ? msg
+      : { ...msg, parts: filteredParts };
+  });
+
+  // Collect unique mesh-storage: keys from remaining file parts (not text)
   const keysToResolve = new Set<string>();
-  for (const msg of messages) {
+  for (const msg of filtered) {
     for (const part of msg.parts) {
       if (
         part.type === "file" &&
@@ -293,12 +332,12 @@ export async function resolveStorageRefs(
   );
 
   if (keyToPresigned.size === 0) {
-    // No mesh-storage: refs in file parts — safety net for legacy data: URLs
-    return legacyMaterialize(messages, ctx);
+    // No mesh-storage: refs in remaining file parts — safety net for legacy data: URLs
+    return legacyMaterialize(filtered, ctx);
   }
 
   // Replace mesh-storage: in file part URLs only; leave text parts untouched
-  const resolved = messages.map((msg) => {
+  const resolved = filtered.map((msg) => {
     const newParts = msg.parts.map((part) => {
       if (
         part.type === "file" &&

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -491,6 +491,10 @@ async function streamCoreInner(
                 ? "ephemeral"
                 : (input.branch ?? `thread:${mem.thread.id}`),
               userId: input.userId,
+              // Used by share_with_user to scope artifacts under
+              // model-outputs/<threadId>/. Cannot be derived from the
+              // sandbox row since one ephemeral sandbox serves many threads.
+              threadId: mem.thread.id,
             }
           : null;
 

--- a/apps/mesh/src/api/routes/thread-outputs.ts
+++ b/apps/mesh/src/api/routes/thread-outputs.ts
@@ -1,0 +1,69 @@
+/**
+ * Thread Outputs Route
+ *
+ * Lists files the model has shared back to the user via the
+ * `share_with_user` tool. Files live under `model-outputs/<thread_id>/`
+ * and the chat UI polls this endpoint on assistant-turn completion to
+ * render download chips on the producing turn.
+ *
+ * Route: GET /api/threads/:threadId/outputs
+ *
+ * Auth: standard `meshContext` user-session middleware. The thread
+ * lookup uses `OrgScopedThreadStorage` so an authenticated user can
+ * only see threads belonging to their org.
+ */
+
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { MeshContext } from "@/core/mesh-context";
+
+type Variables = { meshContext: MeshContext };
+
+const app = new Hono<{ Variables: Variables }>();
+
+app.get("/threads/:threadId/outputs", async (c) => {
+  const ctx = c.get("meshContext");
+  const userId = ctx.auth?.user?.id;
+  if (!userId) {
+    throw new HTTPException(401, { message: "Unauthorized" });
+  }
+  const orgId = ctx.organization?.id;
+  if (!orgId) {
+    throw new HTTPException(400, { message: "Organization required" });
+  }
+
+  const threadId = c.req.param("threadId");
+  if (!threadId || /[.*>\s]/.test(threadId)) {
+    throw new HTTPException(400, { message: "Invalid thread ID" });
+  }
+
+  const thread = await ctx.storage.threads.get(threadId);
+  if (!thread) {
+    throw new HTTPException(404, { message: "Thread not found" });
+  }
+
+  const storage = ctx.objectStorage;
+  if (!storage) {
+    return c.json({ objects: [] });
+  }
+  const result = await storage.list({
+    prefix: `model-outputs/${threadId}/`,
+    maxKeys: 200,
+  });
+
+  const origin = new URL(c.req.url).origin;
+  return c.json({
+    objects: result.objects.map((o) => {
+      const filename = o.key.split("/").pop() ?? o.key;
+      return {
+        key: o.key,
+        filename,
+        size: o.size,
+        uploadedAt: o.lastModified?.toISOString(),
+        downloadUrl: `${origin}/api/${orgId}/files/${o.key}`,
+      };
+    }),
+  });
+});
+
+export default app;

--- a/apps/mesh/src/api/routes/thread-outputs.ts
+++ b/apps/mesh/src/api/routes/thread-outputs.ts
@@ -55,12 +55,16 @@ app.get("/threads/:threadId/outputs", async (c) => {
   return c.json({
     objects: result.objects.map((o) => {
       const filename = o.key.split("/").pop() ?? o.key;
+      // Encode each path segment — keys may carry URL-special chars
+      // (?, #, &, space) and `c.req.path` in the files route truncates
+      // at the first unescaped `?`.
+      const encodedKey = o.key.split("/").map(encodeURIComponent).join("/");
       return {
         key: o.key,
         filename,
         size: o.size,
         uploadedAt: o.lastModified?.toISOString(),
-        downloadUrl: `${origin}/api/${orgId}/files/${o.key}`,
+        downloadUrl: `${origin}/api/${encodeURIComponent(orgId)}/files/${encodedKey}`,
       };
     }),
   });

--- a/apps/mesh/src/api/routes/thread-outputs.ts
+++ b/apps/mesh/src/api/routes/thread-outputs.ts
@@ -33,7 +33,12 @@ app.get("/threads/:threadId/outputs", async (c) => {
   }
 
   const threadId = c.req.param("threadId");
-  if (!threadId || /[.*>\s]/.test(threadId)) {
+  // Allow-list — every thread-id format the codebase produces (nanoid
+  // / UUID) fits these chars. Stricter than the legacy deny-list in
+  // validateThreadAccess (which only blocks `.*> \s`) and clearer
+  // about intent. Downstream usage is parameterised SQL + S3 prefix
+  // listing so this is hygiene, not a security boundary.
+  if (!threadId || !/^[A-Za-z0-9_-]+$/.test(threadId)) {
     throw new HTTPException(400, { message: "Invalid thread ID" });
   }
 
@@ -51,7 +56,12 @@ app.get("/threads/:threadId/outputs", async (c) => {
     maxKeys: 200,
   });
 
-  const origin = new URL(c.req.url).origin;
+  // Use ctx.baseUrl (canonical, set during context creation from
+  // forwarded-host headers / env) rather than `new URL(c.req.url).origin`
+  // — behind a TLS-terminating proxy the latter resolves to the
+  // internal listen address, causing a freshly-shared file's
+  // share_with_user URL (which already uses ctx.baseUrl) to disagree
+  // with subsequent listings.
   return c.json({
     objects: result.objects.map((o) => {
       const filename = o.key.split("/").pop() ?? o.key;
@@ -64,7 +74,7 @@ app.get("/threads/:threadId/outputs", async (c) => {
         filename,
         size: o.size,
         uploadedAt: o.lastModified?.toISOString(),
-        downloadUrl: `${origin}/api/${encodeURIComponent(orgId)}/files/${encodedKey}`,
+        downloadUrl: `${ctx.baseUrl}/api/${encodeURIComponent(orgId)}/files/${encodedKey}`,
       };
     }),
   });

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -23,6 +23,7 @@ import {
   type PropsWithChildren,
 } from "react";
 import { useSearch } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { useChat as useAIChat, type UseChatHelpers } from "@ai-sdk/react";
 import {
   AUTOSEND_QUERY_VALUE,
@@ -82,6 +83,7 @@ import type {
 import { useLocalStorage } from "../../hooks/use-local-storage";
 import { chatModeForTransportRef } from "../../lib/chat-mode-sync";
 import { LOCALSTORAGE_KEYS } from "../../lib/localstorage-keys";
+import { KEYS } from "../../lib/query-keys";
 import { useSimpleMode } from "../../hooks/use-organization-settings";
 
 // ============================================================================
@@ -986,6 +988,7 @@ export function ActiveTaskProvider({
   const [chatError, setChatError] = useState<Error | null>(null);
 
   const onToolCall = useInvalidateCollectionsOnToolCall();
+  const queryClient = useQueryClient();
 
   // AI SDK — useChat with taskId as id (multiplexed)
   const chat = useAIChat<ChatMessage>({
@@ -997,6 +1000,13 @@ export function ActiveTaskProvider({
       lastAssistantMessageIsCompleteWithApprovalResponses({ messages }),
     onFinish: (payload: FinishPayload) => {
       setFinishReason(payload.finishReason ?? null);
+
+      // Refresh download chips for files share_with_user produced this turn.
+      if (taskId) {
+        queryClient.invalidateQueries({
+          queryKey: KEYS.threadOutputs(taskId),
+        });
+      }
 
       const serverThreadId = (payload.message.metadata as Metadata | undefined)
         ?.thread_id;

--- a/apps/mesh/src/web/components/chat/hooks/use-stream-manager.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-stream-manager.ts
@@ -52,6 +52,13 @@ export function useStreamManager(
     });
   };
 
+  const invalidateThreadOutputs = () => {
+    if (!threadId) return;
+    queryClient.invalidateQueries({
+      queryKey: KEYS.threadOutputs(threadId),
+    });
+  };
+
   const isChatActive = () =>
     chat.status === "submitted" || chat.status === "streaming";
 
@@ -114,6 +121,9 @@ export function useStreamManager(
     taskId: threadId,
     onStep: () => tryResumeStream("sse-step"),
     onFinish: () => {
+      // Always refresh download chips — fires for both active and resume
+      // paths. Cheap (one GET, prefix-scoped listing).
+      invalidateThreadOutputs();
       if (!isChatActive()) {
         resumeInFlightRef.current = false;
         resumeFailCountRef.current = 0;

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -21,13 +21,14 @@ import {
   UserAskPart,
 } from "./parts/tool-call-part/index.ts";
 import { SmartAutoScroll } from "./smart-auto-scroll.tsx";
+import { ThreadOutputs } from "./thread-outputs.tsx";
 import {
   type DataParts,
   type RenderItem,
   useFilterParts,
 } from "./use-filter-parts.ts";
 import { addUsage, emptyUsageStats } from "@decocms/mesh-sdk";
-import { useOptionalChatStream } from "../context.tsx";
+import { useOptionalChatStream, useOptionalChatTask } from "../context.tsx";
 import { LiveTimer } from "../../live-timer.tsx";
 import { GridLoader } from "../../grid-loader.tsx";
 import { formatDuration } from "../../../lib/format-time.ts";
@@ -549,6 +550,7 @@ export function MessageAssistant({
   isLast = false,
 }: MessageAssistantProps) {
   const { isRunInProgress = false } = useOptionalChatStream() ?? {};
+  const taskId = useOptionalChatTask()?.taskId ?? null;
   const isStreaming = status === "streaming";
   const isSubmitted = status === "submitted";
   const isLoading = isStreaming || isSubmitted;
@@ -652,6 +654,9 @@ export function MessageAssistant({
           })}
           {isLast && isLoading && startedAt !== null && (
             <GeneratingFooter startedAt={startedAt} />
+          )}
+          {isLast && !isLoading && taskId && (
+            <ThreadOutputs threadId={taskId} />
           )}
         </div>
       ) : isLoading ? (

--- a/apps/mesh/src/web/components/chat/message/thread-outputs.tsx
+++ b/apps/mesh/src/web/components/chat/message/thread-outputs.tsx
@@ -1,0 +1,85 @@
+/**
+ * ThreadOutputs — download chips for files the model has shared back
+ * to the user via the `share_with_user` tool. Files live under
+ * `model-outputs/<thread_id>/` and are listed by
+ * `GET /api/threads/:threadId/outputs`. The query is invalidated on
+ * assistant-turn completion (see useStreamManager + chat onFinish).
+ *
+ * Attribution caveat: outputs are aggregated under the *last* assistant
+ * message of the thread rather than per-producing-message. Future
+ * iterations can encode the message id in the storage key to attribute
+ * each chip to its producing turn.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { Download01 } from "@untitledui/icons";
+import { KEYS } from "../../../lib/query-keys";
+
+interface ThreadOutput {
+  key: string;
+  filename: string;
+  size: number;
+  uploadedAt?: string;
+  downloadUrl: string;
+}
+
+interface ThreadOutputsResponse {
+  objects: ThreadOutput[];
+}
+
+async function fetchThreadOutputs(threadId: string): Promise<ThreadOutput[]> {
+  const res = await fetch(
+    `/api/threads/${encodeURIComponent(threadId)}/outputs`,
+    {
+      credentials: "include",
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch thread outputs: ${res.status}`);
+  }
+  const body = (await res.json()) as ThreadOutputsResponse;
+  return body.objects ?? [];
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function ThreadOutputs({ threadId }: { threadId: string }) {
+  const { data: outputs } = useQuery({
+    queryKey: KEYS.threadOutputs(threadId),
+    queryFn: () => fetchThreadOutputs(threadId),
+    // Stale immediately so refetch on invalidation is fresh.
+    staleTime: 0,
+  });
+
+  if (!outputs || outputs.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5 py-2">
+      <div className="text-[12px] text-muted-foreground/70 uppercase tracking-wide">
+        Files shared in this chat
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {outputs.map((file) => (
+          <a
+            key={file.key}
+            href={file.downloadUrl}
+            download={file.filename}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border bg-muted/30 hover:bg-muted/60 text-[13px] transition-colors"
+          >
+            <Download01 className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="font-medium text-foreground">{file.filename}</span>
+            <span className="text-muted-foreground">
+              {formatSize(file.size)}
+            </span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -975,6 +975,8 @@ const IMAGE_MIME_TYPES = [
  */
 const SKILL_HANDLED_MIME_TYPES = [
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ] as const;
 
 export function modelSupportsFiles(
@@ -1047,7 +1049,7 @@ export function getSupportedFileTypesLabel(
   if (caps.includes("file")) parts.push("PDFs");
   if (caps.includes("audio")) parts.push("audio");
   if (caps.includes("video")) parts.push("video");
-  if (modelSupportsFiles(selectedModel)) parts.push("PowerPoint");
+  if (modelSupportsFiles(selectedModel)) parts.push("Office files");
 
   if (parts.length === 0) return "text only";
   if (parts.length === 1) return parts[0]!;

--- a/apps/mesh/src/web/components/chat/select-model.tsx
+++ b/apps/mesh/src/web/components/chat/select-model.tsx
@@ -965,6 +965,18 @@ const IMAGE_MIME_TYPES = [
   "image/webp",
 ] as const;
 
+/**
+ * MIME types that no model handles natively but are usable end-to-end
+ * via sandbox skills: the model invokes `copy_to_sandbox` to bring the
+ * file in, then runs the matching skill (e.g. pptx-extract) to get
+ * text/images it can reason over. Allowed whenever the model has any
+ * file-bearing capability — text output is universal and thumbnail
+ * images need vision, both already covered by the existing checks.
+ */
+const SKILL_HANDLED_MIME_TYPES = [
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+] as const;
+
 export function modelSupportsFiles(
   selectedModel: AiProviderModel | null | undefined,
 ): boolean {
@@ -990,6 +1002,12 @@ export function isFileTypeSupportedByModel(
   if (hasFile && mimeType === "application/pdf") return true;
   if (hasAudio && mimeType.startsWith("audio/")) return true;
   if (hasVideo && mimeType.startsWith("video/")) return true;
+  if (
+    modelSupportsFiles(selectedModel) &&
+    SKILL_HANDLED_MIME_TYPES.includes(mimeType as never)
+  ) {
+    return true;
+  }
 
   return false;
 }
@@ -1012,6 +1030,9 @@ export function getAcceptedMimeTypesForModel(
   if (caps.includes("video")) {
     accepted.push("video/*");
   }
+  if (modelSupportsFiles(selectedModel)) {
+    accepted.push(...SKILL_HANDLED_MIME_TYPES);
+  }
 
   return accepted.join(",");
 }
@@ -1026,6 +1047,7 @@ export function getSupportedFileTypesLabel(
   if (caps.includes("file")) parts.push("PDFs");
   if (caps.includes("audio")) parts.push("audio");
   if (caps.includes("video")) parts.push("video");
+  if (modelSupportsFiles(selectedModel)) parts.push("PowerPoint");
 
   if (parts.length === 0) return "text only";
   if (parts.length === 1) return parts[0]!;

--- a/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
@@ -14,7 +14,7 @@ import {
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { useCurrentEditor, type Editor } from "@tiptap/react";
 import { useEffect, useRef, useState, type ChangeEvent } from "react";
-import { AlertTriangle, Attachment01, X } from "@untitledui/icons";
+import { AlertTriangle, Attachment01 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
   getAcceptedMimeTypesForModel,
@@ -61,7 +61,7 @@ export async function processFile(
       onUnsupportedFile({ fileName: file.name, modelName, accepted });
     } else {
       toast.error(`"${file.name}" can't be attached`, {
-        description: `${modelName} accepts ${accepted}. Word and Excel files aren't supported yet.`,
+        description: `${modelName} accepts ${accepted}.`,
       });
     }
     return;
@@ -307,11 +307,6 @@ export function FileUploadButton({
   );
 }
 
-const UNSUPPORTED_EXAMPLES = [
-  "Word documents (.docx)",
-  "Excel spreadsheets (.xlsx)",
-] as const;
-
 /**
  * Dialog shown when the user tries to attach a file whose MIME type the
  * selected model doesn't support.
@@ -372,20 +367,6 @@ export function UnsupportedFileDialog({
               <Attachment01 size={14} className="text-muted-foreground" />
               <span className="capitalize">{info?.accepted}</span>
             </div>
-          </div>
-
-          <div className="rounded-xl bg-muted/25 border border-border/50 p-4 space-y-2">
-            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Not supported yet
-            </div>
-            {UNSUPPORTED_EXAMPLES.map((label) => (
-              <div key={label} className="flex items-center gap-3">
-                <div className="flex items-center justify-center size-5 rounded-full bg-muted shrink-0">
-                  <X size={10} className="text-muted-foreground" />
-                </div>
-                <span className="text-sm text-foreground/80">{label}</span>
-              </div>
-            ))}
           </div>
         </div>
 

--- a/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
@@ -61,7 +61,7 @@ export async function processFile(
       onUnsupportedFile({ fileName: file.name, modelName, accepted });
     } else {
       toast.error(`"${file.name}" can't be attached`, {
-        description: `${modelName} accepts ${accepted}. PowerPoint, Word, and Excel files aren't supported yet.`,
+        description: `${modelName} accepts ${accepted}. Word and Excel files aren't supported yet.`,
       });
     }
     return;
@@ -308,7 +308,6 @@ export function FileUploadButton({
 }
 
 const UNSUPPORTED_EXAMPLES = [
-  "PowerPoint (.pptx)",
   "Word documents (.docx)",
   "Excel spreadsheets (.xlsx)",
 ] as const;

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -178,6 +178,7 @@ export const KEYS = {
     ["threads", "metadata", threadId] as const,
   threadSandbox: (orgKey: string, taskId: string | undefined) =>
     ["thread-sandbox", "v2", orgKey, taskId] as const,
+  threadOutputs: (threadId: string) => ["thread-outputs", threadId] as const,
 
   // Virtual MCP tools (for tool definition lookup in chat)
   // null virtualMcpId means default virtual MCP

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -10,6 +10,8 @@ import {
   makeEditHandler,
   makeGrepHandler,
   makeGlobHandler,
+  makeWriteFromUrlHandler,
+  makeUploadToUrlHandler,
 } from "./routes/fs";
 import { makeBashHandler } from "./routes/bash";
 import { makeExecHandler } from "./routes/exec";
@@ -107,6 +109,14 @@ const writeH = makeWriteHandler({ appRoot: config.appRoot, dropPrivileges });
 const editH = makeEditHandler({ appRoot: config.appRoot, dropPrivileges });
 const grepH = makeGrepHandler({ appRoot: config.appRoot, dropPrivileges });
 const globH = makeGlobHandler({ appRoot: config.appRoot, dropPrivileges });
+const writeFromUrlH = makeWriteFromUrlHandler({
+  appRoot: config.appRoot,
+  dropPrivileges,
+});
+const uploadToUrlH = makeUploadToUrlHandler({
+  appRoot: config.appRoot,
+  dropPrivileges,
+});
 const bashH = makeBashHandler({ appRoot: config.appRoot, dropPrivileges });
 const execH = makeExecHandler({
   config,
@@ -168,6 +178,8 @@ Bun.serve<WsProxyData, never>({
       if (p === "/_decopilot_vm/edit") return editH(req);
       if (p === "/_decopilot_vm/grep") return grepH(req);
       if (p === "/_decopilot_vm/glob") return globH(req);
+      if (p === "/_decopilot_vm/write_from_url") return writeFromUrlH(req);
+      if (p === "/_decopilot_vm/upload_to_url") return uploadToUrlH(req);
       if (p === "/_decopilot_vm/bash") return bashH(req);
       if (p.startsWith("/_decopilot_vm/exec/")) return execH(req);
       if (p.startsWith("/_decopilot_vm/kill/")) return killH(req);

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,9 +1,119 @@
 import fs from "node:fs";
 import path from "node:path";
+import net from "node:net";
+import { promises as dnsPromises } from "node:dns";
 import { spawn } from "node:child_process";
 import { DECO_UID, DECO_GID } from "../constants";
 import { safePath } from "../paths";
 import { parseBase64JsonBody, jsonResponse } from "./body-parser";
+
+/**
+ * SSRF guard for `write_from_url`. The model can supply arbitrary
+ * https URLs to `copy_to_sandbox`, which the daemon then GETs from
+ * inside the sandbox container. Without this check the model could
+ * make the daemon fetch cloud-metadata services
+ * (`http://169.254.169.254/...`), localhost, or RFC1918 endpoints —
+ * exfiltrating credentials or pivoting into the cluster network.
+ *
+ * Policy:
+ *   - http/https only (no file://, gopher://, etc.)
+ *   - Hostname must resolve to a public unicast address
+ *   - Reject loopback, link-local, RFC1918 / unique-local, IPv4-mapped
+ *     IPv6 forms of any of the above
+ *
+ * Redirects are revalidated on every hop in `fetchWithSsrfGuard`.
+ */
+function isPrivateIp(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) {
+    const parts = ip.split(".").map(Number);
+    const [a, b] = parts;
+    if (a === undefined || b === undefined) return true;
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 0) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a >= 224) return true; // multicast / reserved
+    return false;
+  }
+  if (family === 6) {
+    const lower = ip.toLowerCase();
+    if (lower === "::1" || lower === "::") return true;
+    if (lower.startsWith("fe80:") || lower.startsWith("febf:")) return true;
+    if (
+      lower.startsWith("fc") ||
+      lower.startsWith("fd") ||
+      lower.startsWith("ff")
+    ) {
+      return true;
+    }
+    if (lower.startsWith("::ffff:")) {
+      return isPrivateIp(lower.slice("::ffff:".length));
+    }
+    return false;
+  }
+  return true; // not an IP — caller resolves hostnames
+}
+
+async function assertSafeFetchUrl(rawUrl: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`Disallowed URL scheme: ${parsed.protocol}`);
+  }
+  const host = parsed.hostname;
+  if (net.isIP(host)) {
+    if (isPrivateIp(host)) {
+      throw new Error(`URL points to a private/loopback address: ${host}`);
+    }
+    return;
+  }
+  let addrs: { address: string; family: number }[];
+  try {
+    addrs = await dnsPromises.lookup(host, { all: true });
+  } catch {
+    throw new Error(`Could not resolve host: ${host}`);
+  }
+  for (const addr of addrs) {
+    if (isPrivateIp(addr.address)) {
+      throw new Error(
+        `URL host resolves to a private/loopback address: ${host} → ${addr.address}`,
+      );
+    }
+  }
+}
+
+const MAX_REDIRECT_HOPS = 5;
+
+/**
+ * Wrap fetch with the SSRF guard, revalidating each redirect. Returns
+ * the final 2xx/4xx/5xx response; throws on disallowed targets, too
+ * many hops, or DNS failures.
+ */
+async function fetchWithSsrfGuard(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    await assertSafeFetchUrl(current);
+    const resp = await fetch(current, { ...init, redirect: "manual" });
+    if (resp.status >= 300 && resp.status < 400) {
+      const location = resp.headers.get("Location");
+      if (!location) return resp;
+      current = new URL(location, current).toString();
+      continue;
+    }
+    return resp;
+  }
+  throw new Error(`Too many redirects (>${MAX_REDIRECT_HOPS})`);
+}
 
 export interface FsDeps {
   appRoot: string;
@@ -326,11 +436,11 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
 
     let resp: Response;
     try {
-      resp = await fetch(body.url);
+      resp = await fetchWithSsrfGuard(body.url);
     } catch (err) {
       return jsonResponse(
         { error: `fetch failed: ${(err as Error).message}` },
-        502,
+        400,
       );
     }
     if (!resp.ok || !resp.body) {
@@ -423,18 +533,24 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
       );
     }
 
-    const bytes = fs.readFileSync(filePath);
     const headers: Record<string, string> = {
       "Content-Length": String(stat.size),
     };
     if (body.contentType) headers["Content-Type"] = body.contentType;
 
+    // Stream the file body — readFileSync at MAX_TRANSFER_BYTES would peg
+    // ~25% of the daemon's memory cap on a single concurrent upload.
+    // Bun.file().stream() returns a ReadableStream<Uint8Array> that fetch
+    // accepts directly; backpressure stays on the network socket.
     let resp: Response;
     try {
       resp = await fetch(body.url, {
         method: "PUT",
-        body: bytes,
+        body: Bun.file(filePath).stream(),
         headers,
+        // No SSRF revalidation here — the URL is mesh-minted (presigned
+        // PUT to S3/R2), so the model can't influence where bytes go.
+        // upload PUTs don't redirect under S3/R2 semantics anyway.
       });
     } catch (err) {
       return jsonResponse(

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -24,6 +24,11 @@ function spawnOpts(
  * vision input ceiling and keeps tool result payloads bounded. */
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
+/** Cap on bytes for write_from_url / upload_to_url. Matches the share
+ * pipeline's expected file sizes (CSVs, decks, zips). Files past this
+ * are out of scope for the chat artifact flow. */
+const MAX_TRANSFER_BYTES = 500 * 1024 * 1024;
+
 /** Magic-byte sniffer for the image types Claude vision accepts.
  * Returns null for everything else; we don't try to be clever about
  * arbitrary binary formats. */
@@ -295,6 +300,158 @@ export function makeGrepHandler(deps: FsDeps) {
         500,
       );
     return jsonResponse({ results: stdout, matchCount: lineCount });
+  };
+}
+
+/**
+ * GET a remote URL (typically a presigned S3 URL) and stream the bytes to
+ * a path on the sandbox FS. Mesh mints the URL and asks the daemon to
+ * fetch it directly so bytes never round-trip through mesh.
+ *
+ * Body: { path: string; url: string }
+ */
+export function makeWriteFromUrlHandler(deps: FsDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { path?: string; url?: string };
+    try {
+      body = (await parseBase64JsonBody(req)) as typeof body;
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    if (typeof body.url !== "string" || !body.url) {
+      return jsonResponse({ error: "url is required" }, 400);
+    }
+    const filePath = safePath(deps.appRoot, body.path ?? "");
+    if (!filePath) return jsonResponse({ error: "Path escapes /app" }, 400);
+
+    let resp: Response;
+    try {
+      resp = await fetch(body.url);
+    } catch (err) {
+      return jsonResponse(
+        { error: `fetch failed: ${(err as Error).message}` },
+        502,
+      );
+    }
+    if (!resp.ok || !resp.body) {
+      return jsonResponse(
+        { error: `upstream returned HTTP ${resp.status}` },
+        502,
+      );
+    }
+    const contentLengthHeader = resp.headers.get("content-length");
+    const declaredSize = contentLengthHeader
+      ? Number.parseInt(contentLengthHeader, 10)
+      : null;
+    if (declaredSize !== null && declaredSize > MAX_TRANSFER_BYTES) {
+      return jsonResponse(
+        {
+          error: `Payload too large (${declaredSize} > ${MAX_TRANSFER_BYTES})`,
+        },
+        413,
+      );
+    }
+
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const out = fs.createWriteStream(filePath);
+    let written = 0;
+    const reader = resp.body.getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        written += value.byteLength;
+        if (written > MAX_TRANSFER_BYTES) {
+          out.destroy();
+          fs.rmSync(filePath, { force: true });
+          return jsonResponse(
+            { error: `Stream exceeded ${MAX_TRANSFER_BYTES} bytes` },
+            413,
+          );
+        }
+        if (!out.write(value)) {
+          await new Promise<void>((resolve) => out.once("drain", resolve));
+        }
+      }
+    } finally {
+      out.end();
+      await new Promise<void>((resolve, reject) => {
+        out.on("close", resolve);
+        out.on("error", reject);
+      }).catch(() => {});
+    }
+    return jsonResponse({ ok: true, path: body.path, size: written });
+  };
+}
+
+/**
+ * Read a file from the sandbox FS and PUT it to a remote URL (typically
+ * a presigned S3 URL). Mesh mints the URL and asks the daemon to upload
+ * directly so bytes never round-trip through mesh.
+ *
+ * Body: { path: string; url: string; contentType?: string }
+ */
+export function makeUploadToUrlHandler(deps: FsDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { path?: string; url?: string; contentType?: string };
+    try {
+      body = (await parseBase64JsonBody(req)) as typeof body;
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    if (typeof body.url !== "string" || !body.url) {
+      return jsonResponse({ error: "url is required" }, 400);
+    }
+    const filePath = resolveReadPath(deps.appRoot, body.path ?? "");
+    if (!filePath) {
+      return jsonResponse({ error: "Path escapes project root" }, 400);
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      return jsonResponse({ error: `File not found: ${body.path}` }, 400);
+    }
+    if (stat.isDirectory()) {
+      return jsonResponse({ error: "Path is a directory" }, 400);
+    }
+    if (stat.size > MAX_TRANSFER_BYTES) {
+      return jsonResponse(
+        { error: `File too large (${stat.size} > ${MAX_TRANSFER_BYTES})` },
+        413,
+      );
+    }
+
+    const bytes = fs.readFileSync(filePath);
+    const headers: Record<string, string> = {
+      "Content-Length": String(stat.size),
+    };
+    if (body.contentType) headers["Content-Type"] = body.contentType;
+
+    let resp: Response;
+    try {
+      resp = await fetch(body.url, {
+        method: "PUT",
+        body: bytes,
+        headers,
+      });
+    } catch (err) {
+      return jsonResponse(
+        { error: `upload failed: ${(err as Error).message}` },
+        502,
+      );
+    }
+    if (!resp.ok) {
+      const errText = await resp.text().catch(() => "");
+      return jsonResponse(
+        {
+          error: `upstream returned HTTP ${resp.status}: ${errText.slice(0, 500)}`,
+        },
+        502,
+      );
+    }
+    return jsonResponse({ ok: true, size: stat.size });
   };
 }
 

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -69,6 +69,19 @@ function isPrivateIp(ip: string): boolean {
 }
 
 const MAX_REDIRECT_HOPS = 5;
+/**
+ * Socket-idle timeout for write_from_url. `req.setTimeout` fires both
+ * pre-response (slow-loris: server SYN-ACKs but never sends headers)
+ * and during streaming (server sends headers but trickles 1 byte/min).
+ * 60s is generous for a CDN miss yet kills any cheap per-turn DoS.
+ */
+const REQUEST_IDLE_TIMEOUT_MS = 60_000;
+/**
+ * Wall-clock cap for upload_to_url. Defends against an S3 endpoint that
+ * accepts the connection but never finalizes the multi-part write —
+ * worst-case the daemon ties up a request slot for the cap then aborts.
+ */
+const UPLOAD_DEADLINE_MS = 5 * 60_000;
 
 interface SafeFetchResult {
   status: number;
@@ -151,6 +164,14 @@ async function safeFetch(rawUrl: string, hops = 0): Promise<SafeFetchResult> {
       ) => {
         cb(null, pinnedIp, pinnedFamily);
       }) as never,
+    });
+    req.setTimeout(REQUEST_IDLE_TIMEOUT_MS);
+    req.on("timeout", () => {
+      req.destroy(
+        new Error(
+          `Request idle timeout (${REQUEST_IDLE_TIMEOUT_MS}ms) for ${url.hostname}`,
+        ),
+      );
     });
     req.on("response", (res) => {
       const status = res.statusCode ?? 0;
@@ -606,21 +627,33 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
     // ~25% of the daemon's memory cap on a single concurrent upload.
     // Bun.file().stream() returns a ReadableStream<Uint8Array> that fetch
     // accepts directly; backpressure stays on the network socket.
+    const abortController = new AbortController();
+    const deadlineTimer = setTimeout(
+      () => abortController.abort(),
+      UPLOAD_DEADLINE_MS,
+    );
     let resp: Response;
     try {
       resp = await fetch(body.url, {
         method: "PUT",
         body: Bun.file(filePath).stream(),
         headers,
+        signal: abortController.signal,
         // No SSRF revalidation here — the URL is mesh-minted (presigned
         // PUT to S3/R2), so the model can't influence where bytes go.
         // upload PUTs don't redirect under S3/R2 semantics anyway.
       });
     } catch (err) {
       return jsonResponse(
-        { error: `upload failed: ${(err as Error).message}` },
+        {
+          error: abortController.signal.aborted
+            ? `upload deadline exceeded (${UPLOAD_DEADLINE_MS}ms)`
+            : `upload failed: ${(err as Error).message}`,
+        },
         502,
       );
+    } finally {
+      clearTimeout(deadlineTimer);
     }
     if (!resp.ok) {
       const errText = await resp.text().catch(() => "");

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -52,7 +52,13 @@ function isPrivateIp(ip: string): boolean {
   if (family === 6) {
     const lower = ip.toLowerCase();
     if (lower === "::1" || lower === "::") return true;
-    if (lower.startsWith("fe80:") || lower.startsWith("febf:")) return true;
+    // fe80::/10 — link-local. The first 10 bits are 1111111010, so the
+    // first u16 ranges 0xfe80 to 0xfebf. A naive
+    // `startsWith("fe80:") || startsWith("febf:")` only catches the
+    // boundaries and lets fe90::1, fea0::1, etc. through.
+    const firstHextet = Number.parseInt(lower.split(":")[0] ?? "0", 16);
+    if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) return true;
+    // fc00::/7 unique-local + ff00::/8 multicast.
     if (
       lower.startsWith("fc") ||
       lower.startsWith("fd") ||

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,206 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
-import net from "node:net";
-import http from "node:http";
-import https from "node:https";
-import { Transform, type Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { promises as dnsPromises } from "node:dns";
 import { spawn } from "node:child_process";
 import { DECO_UID, DECO_GID } from "../constants";
 import { safePath } from "../paths";
 import { parseBase64JsonBody, jsonResponse } from "./body-parser";
 
 /**
- * SSRF guard for `write_from_url`. The model can supply arbitrary
- * https URLs to `copy_to_sandbox`, which the daemon then GETs from
- * inside the sandbox container. Without this check the model could
- * make the daemon fetch cloud-metadata services
- * (`http://169.254.169.254/...`), localhost, or RFC1918 endpoints —
- * exfiltrating credentials or pivoting into the cluster network.
- *
- * Policy:
- *   - http/https only (no file://, gopher://, etc.)
- *   - Hostname must resolve to a public unicast address
- *   - Reject loopback, link-local, RFC1918 / unique-local, IPv4-mapped
- *     IPv6 forms of any of the above
- *
- * DNS rebinding TOCTOU defense: we resolve once and pin the connection
- * to the validated IP via `https.request`'s `lookup` option. Without
- * this, a low-TTL attacker-controlled hostname returning a public IP
- * for the validation lookup and a private IP for the `fetch()` socket
- * connect would bypass the guard entirely.
- *
- * Redirects are revalidated on every hop in `safeFetch` (each hop is
- * a fresh DNS resolve + pin, capped at MAX_REDIRECT_HOPS).
+ * Wall-clock cap for fetches in write_from_url / upload_to_url.
+ * Both endpoints only ever talk to mesh-minted presigned S3/R2 URLs,
+ * so the model has no path to influence the destination — the cap is
+ * just defense against a hung S3 endpoint tying up a request slot.
  */
-function isPrivateIp(ip: string): boolean {
-  const family = net.isIP(ip);
-  if (family === 4) {
-    const parts = ip.split(".").map(Number);
-    const [a, b] = parts;
-    if (a === undefined || b === undefined) return true;
-    if (a === 10) return true;
-    if (a === 127) return true;
-    if (a === 0) return true;
-    if (a === 169 && b === 254) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a >= 224) return true; // multicast / reserved
-    return false;
-  }
-  if (family === 6) {
-    const lower = ip.toLowerCase();
-    if (lower === "::1" || lower === "::") return true;
-    // fe80::/10 — link-local. The first 10 bits are 1111111010, so the
-    // first u16 ranges 0xfe80 to 0xfebf. A naive
-    // `startsWith("fe80:") || startsWith("febf:")` only catches the
-    // boundaries and lets fe90::1, fea0::1, etc. through.
-    const firstHextet = Number.parseInt(lower.split(":")[0] ?? "0", 16);
-    if (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) return true;
-    // fc00::/7 unique-local + ff00::/8 multicast.
-    if (
-      lower.startsWith("fc") ||
-      lower.startsWith("fd") ||
-      lower.startsWith("ff")
-    ) {
-      return true;
-    }
-    if (lower.startsWith("::ffff:")) {
-      return isPrivateIp(lower.slice("::ffff:".length));
-    }
-    return false;
-  }
-  return true; // unknown family — fail closed
-}
-
-const MAX_REDIRECT_HOPS = 5;
-/**
- * Socket-idle timeout for write_from_url. `req.setTimeout` fires both
- * pre-response (slow-loris: server SYN-ACKs but never sends headers)
- * and during streaming (server sends headers but trickles 1 byte/min).
- * 60s is generous for a CDN miss yet kills any cheap per-turn DoS.
- */
-const REQUEST_IDLE_TIMEOUT_MS = 60_000;
-/**
- * Wall-clock cap for upload_to_url. Defends against an S3 endpoint that
- * accepts the connection but never finalizes the multi-part write —
- * worst-case the daemon ties up a request slot for the cap then aborts.
- */
-const UPLOAD_DEADLINE_MS = 5 * 60_000;
-
-interface SafeFetchResult {
-  status: number;
-  headers: Record<string, string>;
-  body: Readable;
-}
-
-/**
- * GET a URL with SSRF protection: resolve hostname once, validate the
- * IP, then issue the request via `node:https`/`node:http` with a
- * `lookup` that pins the socket to the validated IP. Hostname stays
- * the URL hostname for SNI / TLS cert verification / Host header.
- *
- * Redirects are revalidated end-to-end (each hop re-resolves + re-pins).
- */
-async function safeFetch(rawUrl: string, hops = 0): Promise<SafeFetchResult> {
-  if (hops > MAX_REDIRECT_HOPS) {
-    throw new Error(`Too many redirects (>${MAX_REDIRECT_HOPS})`);
-  }
-  let url: URL;
-  try {
-    url = new URL(rawUrl);
-  } catch {
-    throw new Error("Invalid URL");
-  }
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new Error(`Disallowed URL scheme: ${url.protocol}`);
-  }
-
-  let pinnedIp: string;
-  let pinnedFamily: 4 | 6;
-  if (net.isIP(url.hostname)) {
-    if (isPrivateIp(url.hostname)) {
-      throw new Error(
-        `URL points to a private/loopback address: ${url.hostname}`,
-      );
-    }
-    pinnedIp = url.hostname;
-    pinnedFamily = net.isIP(url.hostname) as 4 | 6;
-  } else {
-    let addrs: { address: string; family: number }[];
-    try {
-      addrs = await dnsPromises.lookup(url.hostname, { all: true });
-    } catch {
-      throw new Error(`Could not resolve host: ${url.hostname}`);
-    }
-    if (addrs.length === 0) {
-      throw new Error(`No addresses for host: ${url.hostname}`);
-    }
-    for (const addr of addrs) {
-      if (isPrivateIp(addr.address)) {
-        throw new Error(
-          `URL host resolves to a private/loopback address: ${url.hostname} → ${addr.address}`,
-        );
-      }
-    }
-    const first = addrs[0]!;
-    pinnedIp = first.address;
-    pinnedFamily = first.family as 4 | 6;
-  }
-
-  const lib = url.protocol === "https:" ? https : http;
-  const port = url.port
-    ? Number.parseInt(url.port, 10)
-    : url.protocol === "https:"
-      ? 443
-      : 80;
-
-  return new Promise<SafeFetchResult>((resolve, reject) => {
-    const req = lib.request({
-      method: "GET",
-      protocol: url.protocol,
-      hostname: url.hostname,
-      port,
-      path: `${url.pathname}${url.search}`,
-      lookup: ((
-        _h: string,
-        _opts: unknown,
-        cb: (err: Error | null, addr: string, fam: number) => void,
-      ) => {
-        cb(null, pinnedIp, pinnedFamily);
-      }) as never,
-    });
-    req.setTimeout(REQUEST_IDLE_TIMEOUT_MS);
-    req.on("timeout", () => {
-      req.destroy(
-        new Error(
-          `Request idle timeout (${REQUEST_IDLE_TIMEOUT_MS}ms) for ${url.hostname}`,
-        ),
-      );
-    });
-    req.on("response", (res) => {
-      const status = res.statusCode ?? 0;
-      if (status >= 300 && status < 400) {
-        const loc = res.headers.location;
-        if (typeof loc === "string" && loc.length > 0) {
-          const next = new URL(loc, url).toString();
-          res.resume(); // drain so the socket can close cleanly
-          safeFetch(next, hops + 1).then(resolve, reject);
-          return;
-        }
-      }
-      const headers: Record<string, string> = {};
-      for (const [k, v] of Object.entries(res.headers)) {
-        if (typeof v === "string") headers[k] = v;
-        else if (Array.isArray(v)) headers[k] = v.join(",");
-      }
-      resolve({ status, headers, body: res });
-    });
-    req.on("error", reject);
-    req.end();
-  });
-}
+const TRANSFER_DEADLINE_MS = 5 * 60_000;
 
 export interface FsDeps {
   appRoot: string;
@@ -521,28 +334,42 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
     const filePath = safePath(deps.appRoot, body.path ?? "");
     if (!filePath) return jsonResponse({ error: "Path escapes /app" }, 400);
 
-    let resp: SafeFetchResult;
+    // The URL here is mesh-minted (presigned GET to S3/R2) — the model
+    // can't supply arbitrary URLs through copy_to_sandbox, so SSRF +
+    // DNS-rebinding defenses aren't needed. Plain fetch with a wall-
+    // clock deadline is enough.
+    const abortController = new AbortController();
+    const deadlineTimer = setTimeout(
+      () => abortController.abort(),
+      TRANSFER_DEADLINE_MS,
+    );
+    let resp: Response;
     try {
-      resp = await safeFetch(body.url);
+      resp = await fetch(body.url, { signal: abortController.signal });
     } catch (err) {
+      clearTimeout(deadlineTimer);
       return jsonResponse(
-        { error: `fetch failed: ${(err as Error).message}` },
-        400,
+        {
+          error: abortController.signal.aborted
+            ? `fetch deadline exceeded (${TRANSFER_DEADLINE_MS}ms)`
+            : `fetch failed: ${(err as Error).message}`,
+        },
+        502,
       );
     }
-    if (resp.status < 200 || resp.status >= 300) {
-      resp.body.resume(); // drain
+    if (!resp.ok || !resp.body) {
+      clearTimeout(deadlineTimer);
       return jsonResponse(
         { error: `upstream returned HTTP ${resp.status}` },
         502,
       );
     }
-    const contentLengthHeader = resp.headers["content-length"];
+    const contentLengthHeader = resp.headers.get("content-length");
     const declaredSize = contentLengthHeader
       ? Number.parseInt(contentLengthHeader, 10)
       : null;
     if (declaredSize !== null && declaredSize > MAX_TRANSFER_BYTES) {
-      resp.body.resume();
+      clearTimeout(deadlineTimer);
       return jsonResponse(
         {
           error: `Payload too large (${declaredSize} > ${MAX_TRANSFER_BYTES})`,
@@ -570,16 +397,22 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
     });
     const out = fs.createWriteStream(filePath);
     try {
-      await pipeline(resp.body, cap, out);
+      await pipeline(Readable.fromWeb(resp.body as never), cap, out);
     } catch (err) {
       // Any failure (network RST, TLS error, size cap, write fault)
       // leaves a partial file. Remove it so a later skill step can't
       // read a half-baked artifact.
       fs.rmSync(filePath, { force: true });
       return jsonResponse(
-        { error: `stream failed: ${(err as Error).message}` },
+        {
+          error: abortController.signal.aborted
+            ? `fetch deadline exceeded (${TRANSFER_DEADLINE_MS}ms)`
+            : `stream failed: ${(err as Error).message}`,
+        },
         502,
       );
+    } finally {
+      clearTimeout(deadlineTimer);
     }
     return jsonResponse({ ok: true, path: body.path, size: written });
   };
@@ -636,7 +469,7 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
     const abortController = new AbortController();
     const deadlineTimer = setTimeout(
       () => abortController.abort(),
-      UPLOAD_DEADLINE_MS,
+      TRANSFER_DEADLINE_MS,
     );
     let resp: Response;
     try {
@@ -653,7 +486,7 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
       return jsonResponse(
         {
           error: abortController.signal.aborted
-            ? `upload deadline exceeded (${UPLOAD_DEADLINE_MS}ms)`
+            ? `upload deadline exceeded (${TRANSFER_DEADLINE_MS}ms)`
             : `upload failed: ${(err as Error).message}`,
         },
         502,

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import net from "node:net";
+import http from "node:http";
+import https from "node:https";
+import { Transform, type Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { promises as dnsPromises } from "node:dns";
 import { spawn } from "node:child_process";
 import { DECO_UID, DECO_GID } from "../constants";
@@ -21,7 +25,14 @@ import { parseBase64JsonBody, jsonResponse } from "./body-parser";
  *   - Reject loopback, link-local, RFC1918 / unique-local, IPv4-mapped
  *     IPv6 forms of any of the above
  *
- * Redirects are revalidated on every hop in `fetchWithSsrfGuard`.
+ * DNS rebinding TOCTOU defense: we resolve once and pin the connection
+ * to the validated IP via `https.request`'s `lookup` option. Without
+ * this, a low-TTL attacker-controlled hostname returning a public IP
+ * for the validation lookup and a private IP for the `fetch()` socket
+ * connect would bypass the guard entirely.
+ *
+ * Redirects are revalidated on every hop in `safeFetch` (each hop is
+ * a fresh DNS resolve + pin, capped at MAX_REDIRECT_HOPS).
  */
 function isPrivateIp(ip: string): boolean {
   const family = net.isIP(ip);
@@ -54,65 +65,114 @@ function isPrivateIp(ip: string): boolean {
     }
     return false;
   }
-  return true; // not an IP — caller resolves hostnames
-}
-
-async function assertSafeFetchUrl(rawUrl: string): Promise<void> {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    throw new Error("Invalid URL");
-  }
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    throw new Error(`Disallowed URL scheme: ${parsed.protocol}`);
-  }
-  const host = parsed.hostname;
-  if (net.isIP(host)) {
-    if (isPrivateIp(host)) {
-      throw new Error(`URL points to a private/loopback address: ${host}`);
-    }
-    return;
-  }
-  let addrs: { address: string; family: number }[];
-  try {
-    addrs = await dnsPromises.lookup(host, { all: true });
-  } catch {
-    throw new Error(`Could not resolve host: ${host}`);
-  }
-  for (const addr of addrs) {
-    if (isPrivateIp(addr.address)) {
-      throw new Error(
-        `URL host resolves to a private/loopback address: ${host} → ${addr.address}`,
-      );
-    }
-  }
+  return true; // unknown family — fail closed
 }
 
 const MAX_REDIRECT_HOPS = 5;
 
+interface SafeFetchResult {
+  status: number;
+  headers: Record<string, string>;
+  body: Readable;
+}
+
 /**
- * Wrap fetch with the SSRF guard, revalidating each redirect. Returns
- * the final 2xx/4xx/5xx response; throws on disallowed targets, too
- * many hops, or DNS failures.
+ * GET a URL with SSRF protection: resolve hostname once, validate the
+ * IP, then issue the request via `node:https`/`node:http` with a
+ * `lookup` that pins the socket to the validated IP. Hostname stays
+ * the URL hostname for SNI / TLS cert verification / Host header.
+ *
+ * Redirects are revalidated end-to-end (each hop re-resolves + re-pins).
  */
-async function fetchWithSsrfGuard(
-  url: string,
-  init?: RequestInit,
-): Promise<Response> {
-  let current = url;
-  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
-    await assertSafeFetchUrl(current);
-    const resp = await fetch(current, { ...init, redirect: "manual" });
-    if (resp.status >= 300 && resp.status < 400) {
-      const location = resp.headers.get("Location");
-      if (!location) return resp;
-      current = new URL(location, current).toString();
-      continue;
-    }
-    return resp;
+async function safeFetch(rawUrl: string, hops = 0): Promise<SafeFetchResult> {
+  if (hops > MAX_REDIRECT_HOPS) {
+    throw new Error(`Too many redirects (>${MAX_REDIRECT_HOPS})`);
   }
-  throw new Error(`Too many redirects (>${MAX_REDIRECT_HOPS})`);
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`Disallowed URL scheme: ${url.protocol}`);
+  }
+
+  let pinnedIp: string;
+  let pinnedFamily: 4 | 6;
+  if (net.isIP(url.hostname)) {
+    if (isPrivateIp(url.hostname)) {
+      throw new Error(
+        `URL points to a private/loopback address: ${url.hostname}`,
+      );
+    }
+    pinnedIp = url.hostname;
+    pinnedFamily = net.isIP(url.hostname) as 4 | 6;
+  } else {
+    let addrs: { address: string; family: number }[];
+    try {
+      addrs = await dnsPromises.lookup(url.hostname, { all: true });
+    } catch {
+      throw new Error(`Could not resolve host: ${url.hostname}`);
+    }
+    if (addrs.length === 0) {
+      throw new Error(`No addresses for host: ${url.hostname}`);
+    }
+    for (const addr of addrs) {
+      if (isPrivateIp(addr.address)) {
+        throw new Error(
+          `URL host resolves to a private/loopback address: ${url.hostname} → ${addr.address}`,
+        );
+      }
+    }
+    const first = addrs[0]!;
+    pinnedIp = first.address;
+    pinnedFamily = first.family as 4 | 6;
+  }
+
+  const lib = url.protocol === "https:" ? https : http;
+  const port = url.port
+    ? Number.parseInt(url.port, 10)
+    : url.protocol === "https:"
+      ? 443
+      : 80;
+
+  return new Promise<SafeFetchResult>((resolve, reject) => {
+    const req = lib.request({
+      method: "GET",
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port,
+      path: `${url.pathname}${url.search}`,
+      lookup: ((
+        _h: string,
+        _opts: unknown,
+        cb: (err: Error | null, addr: string, fam: number) => void,
+      ) => {
+        cb(null, pinnedIp, pinnedFamily);
+      }) as never,
+    });
+    req.on("response", (res) => {
+      const status = res.statusCode ?? 0;
+      if (status >= 300 && status < 400) {
+        const loc = res.headers.location;
+        if (typeof loc === "string" && loc.length > 0) {
+          const next = new URL(loc, url).toString();
+          res.resume(); // drain so the socket can close cleanly
+          safeFetch(next, hops + 1).then(resolve, reject);
+          return;
+        }
+      }
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(res.headers)) {
+        if (typeof v === "string") headers[k] = v;
+        else if (Array.isArray(v)) headers[k] = v.join(",");
+      }
+      resolve({ status, headers, body: res });
+    });
+    req.on("error", reject);
+    req.end();
+  });
 }
 
 export interface FsDeps {
@@ -434,26 +494,28 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
     const filePath = safePath(deps.appRoot, body.path ?? "");
     if (!filePath) return jsonResponse({ error: "Path escapes /app" }, 400);
 
-    let resp: Response;
+    let resp: SafeFetchResult;
     try {
-      resp = await fetchWithSsrfGuard(body.url);
+      resp = await safeFetch(body.url);
     } catch (err) {
       return jsonResponse(
         { error: `fetch failed: ${(err as Error).message}` },
         400,
       );
     }
-    if (!resp.ok || !resp.body) {
+    if (resp.status < 200 || resp.status >= 300) {
+      resp.body.resume(); // drain
       return jsonResponse(
         { error: `upstream returned HTTP ${resp.status}` },
         502,
       );
     }
-    const contentLengthHeader = resp.headers.get("content-length");
+    const contentLengthHeader = resp.headers["content-length"];
     const declaredSize = contentLengthHeader
       ? Number.parseInt(contentLengthHeader, 10)
       : null;
     if (declaredSize !== null && declaredSize > MAX_TRANSFER_BYTES) {
+      resp.body.resume();
       return jsonResponse(
         {
           error: `Payload too large (${declaredSize} > ${MAX_TRANSFER_BYTES})`,
@@ -463,32 +525,34 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
     }
 
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    const out = fs.createWriteStream(filePath);
+
+    // pipeline() guarantees: backpressure honored, errors propagate
+    // through the chain, all streams destroyed on failure. The Transform
+    // tracks running byte count so we fail fast when a server lies in
+    // (or omits) Content-Length.
     let written = 0;
-    const reader = resp.body.getReader();
-    try {
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        written += value.byteLength;
+    const cap = new Transform({
+      transform(chunk: Buffer, _enc, cb) {
+        written += chunk.byteLength;
         if (written > MAX_TRANSFER_BYTES) {
-          out.destroy();
-          fs.rmSync(filePath, { force: true });
-          return jsonResponse(
-            { error: `Stream exceeded ${MAX_TRANSFER_BYTES} bytes` },
-            413,
-          );
+          cb(new Error(`Stream exceeded ${MAX_TRANSFER_BYTES} bytes`));
+          return;
         }
-        if (!out.write(value)) {
-          await new Promise<void>((resolve) => out.once("drain", resolve));
-        }
-      }
-    } finally {
-      out.end();
-      await new Promise<void>((resolve, reject) => {
-        out.on("close", resolve);
-        out.on("error", reject);
-      }).catch(() => {});
+        cb(null, chunk);
+      },
+    });
+    const out = fs.createWriteStream(filePath);
+    try {
+      await pipeline(resp.body, cap, out);
+    } catch (err) {
+      // Any failure (network RST, TLS error, size cap, write fault)
+      // leaves a partial file. Remove it so a later skill step can't
+      // read a half-baked artifact.
+      fs.rmSync(filePath, { force: true });
+      return jsonResponse(
+        { error: `stream failed: ${(err as Error).message}` },
+        502,
+      );
     }
     return jsonResponse({ ok: true, path: body.path, size: written });
   };


### PR DESCRIPTION
## What is this contribution about?

Replaces the user-data skill design (PR #3243, sandbox→studio HTTP) with two tools that fit the existing studio→sandbox channel: `copy_to_sandbox({ url, target })` and `share_with_user({ source, name? })`. No new auth surface, no migration, no token plumbing — mesh has full `meshContext` when the tool runs, so org id, storage, and thread id are directly in scope. Bytes stream `S3 ↔ daemon` directly via two new daemon endpoints (`write_from_url`, `upload_to_url`); mesh only mints presigned URLs.

UI surfaces shared files as download chips on the assistant turn, listed by a user-session-authed `GET /api/threads/:threadId/outputs`. Invalidated on both active-stream and SSE `onFinish` so chips appear right when the turn completes.

## How to Test

1. `bun run dev`, attach a file in chat.
2. The model invokes `copy_to_sandbox({ url: "mesh-storage://chat-uploads/...", target: "/app/foo.pdf" })` and chains into `pptx-extract` / `pdf-extract` / etc.
3. Ask the model to produce something and call `share_with_user({ source: "/app/report.csv" })`.
4. After the turn finishes, a download chip should appear on the assistant message; clicking it downloads the file.

## Migration Notes

No DB migrations, no new env vars, no infra changes. Drop-in.

## Notes

- Supersedes #3243.
- Bytes never pass through mesh — daemon talks to S3 directly via presigned URLs (1 hour TTL, single-key scope).
- `mem.thread.id` is plumbed through `vmContext` because ephemeral sandboxes serve multiple chat threads of the same (user, agent) and the thread isn't deducible from the sandbox row.