### PR TITLE
feat(settings): add delete organization in danger zone

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -513,10 +513,25 @@ async function authenticateRequest(
             "organization.id as orgId",
             "organization.slug as orgSlug",
             "organization.name as orgName",
+            "organization.metadata as orgMetadata",
           ])
           .where("member.userId", "=", userId)
           .executeTakeFirst(),
       );
+
+      if (membership?.orgMetadata) {
+        try {
+          const meta = JSON.parse(membership.orgMetadata) as Record<
+            string,
+            unknown
+          >;
+          if (meta.archived === true) {
+            throw new Error("Organization is archived");
+          }
+        } catch (e) {
+          if ((e as Error).message === "Organization is archived") throw e;
+        }
+      }
 
       const role = membership?.role;
       const organization = membership
@@ -738,6 +753,7 @@ async function authenticateRequest(
           id: string;
           slug: string;
           name: string;
+          metadata?: Record<string, unknown> | null;
           members?: {
             userId: string;
             role?: string;
@@ -747,6 +763,10 @@ async function authenticateRequest(
         } | null;
 
         if (orgData) {
+          if (orgData.metadata?.archived === true) {
+            throw new Error("Organization is archived");
+          }
+
           organization = {
             id: orgData.id,
             slug: orgData.slug,

--- a/apps/mesh/src/tools/organization/delete.ts
+++ b/apps/mesh/src/tools/organization/delete.ts
@@ -1,7 +1,8 @@
 /**
  * ORGANIZATION_DELETE Tool
  *
- * Delete an organization
+ * Soft-deletes an organization by flagging it as archived in metadata.
+ * Archived organizations are invisible to all API and UI surfaces.
  */
 
 import { z } from "zod";
@@ -10,7 +11,7 @@ import { requireAuth } from "../../core/mesh-context";
 
 export const ORGANIZATION_DELETE = defineTool({
   name: "ORGANIZATION_DELETE",
-  description: "Delete an organization.",
+  description: "Archive an organization (soft delete).",
   annotations: {
     title: "Delete Organization",
     readOnlyHint: false,
@@ -28,14 +29,18 @@ export const ORGANIZATION_DELETE = defineTool({
   }),
 
   handler: async (input, ctx) => {
-    // Require authentication
     requireAuth(ctx);
-
-    // Check authorization
     await ctx.access.check();
 
-    // Delete organization via Better Auth
-    await ctx.boundAuth.organization.delete(input.id);
+    await ctx.boundAuth.organization.update({
+      organizationId: input.id,
+      data: {
+        metadata: {
+          archived: true,
+          archivedAt: new Date().toISOString(),
+        },
+      },
+    });
 
     return {
       success: true,

--- a/apps/mesh/src/tools/organization/list.ts
+++ b/apps/mesh/src/tools/organization/list.ts
@@ -54,16 +54,20 @@ export const ORGANIZATION_LIST = defineTool({
     const organizations = await ctx.boundAuth.organization.list(userId);
 
     // Convert dates to ISO strings for JSON Schema compatibility
+    // Filter out archived organizations
     return {
-      organizations: organizations.map(
-        (org: (typeof organizations)[number]) => ({
+      organizations: organizations
+        .filter(
+          (org: (typeof organizations)[number]) =>
+            org.metadata?.archived !== true,
+        )
+        .map((org: (typeof organizations)[number]) => ({
           ...org,
           createdAt:
             org.createdAt instanceof Date
               ? org.createdAt.toISOString()
               : org.createdAt,
-        }),
-      ),
+        })),
     };
   },
 });

--- a/apps/mesh/src/tools/organization/organization-tools.test.ts
+++ b/apps/mesh/src/tools/organization/organization-tools.test.ts
@@ -375,7 +375,7 @@ describe("Organization Tools", () => {
   });
 
   describe("ORGANIZATION_DELETE", () => {
-    it("should delete organization", async () => {
+    it("should soft-delete organization by archiving via metadata", async () => {
       const mockAuth = createMockAuth();
       const ctx = createMockContext(mockAuth);
 
@@ -386,10 +386,19 @@ describe("Organization Tools", () => {
         ctx,
       );
 
-      expect(mockAuth.api.deleteOrganization).toHaveBeenCalledWith({
-        body: { organizationId: "org_123" },
+      expect(mockAuth.api.updateOrganization).toHaveBeenCalledWith({
+        body: {
+          organizationId: "org_123",
+          data: {
+            metadata: expect.objectContaining({
+              archived: true,
+              archivedAt: expect.any(String),
+            }),
+          },
+        },
         headers: expect.any(Headers),
       });
+      expect(mockAuth.api.deleteOrganization).not.toHaveBeenCalled();
 
       expect(result.success).toBe(true);
       expect(result.id).toBe("org_123");

--- a/apps/mesh/src/web/components/archived-org-screen.tsx
+++ b/apps/mesh/src/web/components/archived-org-screen.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { Archive } from "@untitledui/icons";
+
+export interface ArchivedOrgScreenProps {
+  orgName?: string;
+}
+
+export function ArchivedOrgScreen({ orgName }: ArchivedOrgScreenProps) {
+  const handleGoHome = () => {
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
+        <div className="bg-muted p-3 rounded-full">
+          <Archive className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium">Organization unavailable</h3>
+          <p className="text-sm text-muted-foreground">
+            {orgName ? (
+              <>
+                <strong>{orgName}</strong> has been deleted or is no longer
+                available.
+              </>
+            ) : (
+              "This organization has been deleted or is no longer available."
+            )}
+          </p>
+        </div>
+        <Button onClick={handleGoHome}>Go to home</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/settings/delete-organization-section.tsx
+++ b/apps/mesh/src/web/components/settings/delete-organization-section.tsx
@@ -1,7 +1,11 @@
-import { authClient } from "@/web/lib/auth-client";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
-import { useProjectContext } from "@decocms/mesh-sdk";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,6 +17,7 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
@@ -28,23 +33,46 @@ export function DeleteOrganizationSection() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmName, setConfirmName] = useState("");
+
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+  });
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      const result = await authClient.organization.delete({
-        organizationId: org.id,
+      const result = await selfClient.callTool({
+        name: "ORGANIZATION_DELETE",
+        arguments: { id: org.id },
       });
-      if (result?.error) {
-        throw new Error(
-          result.error.message || "Failed to delete organization",
-        );
+      if (result.isError) {
+        const content = result.content;
+        const text =
+          Array.isArray(content) &&
+          content[0]?.type === "text" &&
+          typeof content[0].text === "string"
+            ? content[0].text
+            : "Failed to delete organization";
+        throw new Error(text);
       }
-      return result;
     },
     onSuccess: () => {
       track("organization_deleted", { organization_id: org.id });
+
+      // Drop the cached slug so homeRoute doesn't try to redirect us back here
+      if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === org.slug) {
+        localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+      }
+
+      // Drop active-org caches that might still hold the archived org
+      queryClient.removeQueries({
+        queryKey: KEYS.activeOrganization(org.slug),
+      });
       queryClient.invalidateQueries({ queryKey: KEYS.organizations() });
+
       toast.success("Organization deleted");
+      // homeRoute redirects to next available org or onboarding
       navigate({ to: "/" });
     },
     onError: (error) => {
@@ -80,21 +108,47 @@ export function DeleteOrganizationSection() {
         </SettingsCard>
       </SettingsSection>
 
-      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+      <AlertDialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          setConfirmOpen(open);
+          if (!open) setConfirmName("");
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete Organization?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete{" "}
-              <span className="font-medium text-foreground">{org.name}</span>{" "}
-              and all of its data. This action cannot be undone.
+            <AlertDialogDescription asChild>
+              <div>
+                <p>
+                  This will permanently delete all data associated with{" "}
+                  <span className="font-medium text-foreground">
+                    {org.name}
+                  </span>
+                  . This action cannot be undone.
+                </p>
+                <p className="mt-3 mb-1.5">
+                  Type{" "}
+                  <span className="font-medium text-foreground">
+                    {org.name}
+                  </span>{" "}
+                  to confirm:
+                </p>
+                <Input
+                  value={confirmName}
+                  onChange={(e) => setConfirmName(e.target.value)}
+                  placeholder={org.name}
+                  autoFocus
+                />
+              </div>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => deleteMutation.mutate()}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={confirmName !== org.name || deleteMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
             >
               {deleteMutation.isPending ? "Deleting…" : "Delete organization"}
             </AlertDialogAction>

--- a/apps/mesh/src/web/components/settings/delete-organization-section.tsx
+++ b/apps/mesh/src/web/components/settings/delete-organization-section.tsx
@@ -1,0 +1,106 @@
+import { authClient } from "@/web/lib/auth-client";
+import { KEYS } from "@/web/lib/query-keys";
+import { track } from "@/web/lib/posthog-client";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  SettingsCard,
+  SettingsCardItem,
+  SettingsSection,
+} from "@/web/components/settings/settings-section";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function DeleteOrganizationSection() {
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const result = await authClient.organization.delete({
+        organizationId: org.id,
+      });
+      if (result?.error) {
+        throw new Error(
+          result.error.message || "Failed to delete organization",
+        );
+      }
+      return result;
+    },
+    onSuccess: () => {
+      track("organization_deleted", { organization_id: org.id });
+      queryClient.invalidateQueries({ queryKey: KEYS.organizations() });
+      toast.success("Organization deleted");
+      navigate({ to: "/" });
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to delete organization",
+      );
+    },
+  });
+
+  return (
+    <>
+      <SettingsSection
+        title="Danger Zone"
+        description="Irreversible actions that affect your entire organization."
+      >
+        <SettingsCard className="border-destructive/40">
+          <SettingsCardItem
+            title="Delete organization"
+            description="Permanently delete this organization and all of its data. This action cannot be undone."
+            action={
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setConfirmOpen(true)}
+                disabled={deleteMutation.isPending}
+              >
+                Delete
+              </Button>
+            }
+          />
+        </SettingsCard>
+      </SettingsSection>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Organization?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete{" "}
+              <span className="font-medium text-foreground">{org.name}</span>{" "}
+              and all of its data. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteMutation.mutate()}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Delete organization"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -120,13 +120,19 @@ const homeRoute = createRoute({
     // valid cached slug due to a transient API failure.
     if (!orgs) return;
 
+    // Filter out archived organizations — they are soft-deleted and invisible to the UI
+    type OrgWithMeta = (typeof orgs)[number] & {
+      metadata?: { archived?: boolean } | null;
+    };
+    const activeOrgs = (orgs as OrgWithMeta[]).filter(
+      (o) => !o.metadata?.archived,
+    );
+
     // Fast path: validate cached slug against current membership before redirecting.
-    // If stale (org deleted or user removed), clear it to prevent a redirect loop.
+    // If stale (org deleted/archived or user removed), clear it to prevent a redirect loop.
     const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
     if (lastOrgSlug) {
-      const slugIsValid = orgs.some(
-        (o: NonNullable<typeof orgs>[number]) => o.slug === lastOrgSlug,
-      );
+      const slugIsValid = activeOrgs.some((o) => o.slug === lastOrgSlug);
       if (slugIsValid) {
         throw redirect({
           to: "/$org",
@@ -138,7 +144,7 @@ const homeRoute = createRoute({
     }
 
     // Redirect to first available org (every user gets a default org on signup)
-    const firstOrg = orgs[0];
+    const firstOrg = activeOrgs[0];
     if (firstOrg) {
       throw redirect({
         to: "/$org",
@@ -157,7 +163,13 @@ const onboardingRoute = createRoute({
   path: "/onboarding",
   beforeLoad: async () => {
     const { data: orgs } = await authClient.organization.list();
-    if (orgs && orgs.length > 0) {
+    type OrgWithMeta = NonNullable<typeof orgs>[number] & {
+      metadata?: { archived?: boolean } | null;
+    };
+    const activeOrgs = (orgs as OrgWithMeta[] | undefined)?.filter(
+      (o) => !o.metadata?.archived,
+    );
+    if (activeOrgs && activeOrgs.length > 0) {
       throw redirect({ to: "/" });
     }
   },

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -21,6 +21,7 @@ import { useTaskActions } from "../hooks/use-tasks";
 import { useOrganizationSettingsSuspense } from "../hooks/use-organization-settings";
 import { useOrgSsoStatus } from "../hooks/use-org-sso";
 import { SsoRequiredScreen } from "../components/sso-required-screen";
+import { ArchivedOrgScreen } from "../components/archived-org-screen";
 
 // ---------------------------------------------------------------------------
 // ShellProjectProvider — fetches org settings and provides project context.
@@ -197,9 +198,14 @@ function ShellLayoutContent() {
         organizationSlug: org,
       });
 
+      // Don't persist archived orgs — homeRoute would just redirect off them again
+      const isArchived =
+        (data as { metadata?: { archived?: boolean } } | null)?.metadata
+          ?.archived === true;
+
       // Persist for fast redirect on next login (read by homeRoute beforeLoad)
-      // Only write on success to avoid caching an invalid slug
-      if (data) {
+      // Only write on success and only for active (non-archived) orgs
+      if (data && !isArchived) {
         localStorage.setItem(LOCALSTORAGE_KEYS.lastOrgSlug(), org);
       }
 
@@ -215,6 +221,17 @@ function ShellLayoutContent() {
 
   if (!activeOrg) {
     return <SplashScreen />;
+  }
+
+  const isArchivedOrg =
+    (activeOrg as { metadata?: { archived?: boolean } }).metadata?.archived ===
+    true;
+  if (isArchivedOrg) {
+    // Clear stale slug so /home redirect doesn't bounce the user back here
+    if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === org) {
+      localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+    }
+    return <ArchivedOrgScreen orgName={activeOrg.name} />;
   }
 
   if (ssoStatus?.ssoRequired && !ssoStatus.authenticated) {

--- a/apps/mesh/src/web/views/settings/org-general.tsx
+++ b/apps/mesh/src/web/views/settings/org-general.tsx
@@ -2,6 +2,7 @@ import { Page } from "@/web/components/page";
 import { OrganizationForm } from "@/web/components/settings/organization-form";
 import { DomainSettings } from "@/web/components/settings/domain-settings";
 import { DefaultHomeAgentsForm } from "@/web/components/settings/default-home-agents-form";
+import { DeleteOrganizationSection } from "@/web/components/settings/delete-organization-section";
 import { SettingsPage } from "@/web/components/settings/settings-section";
 
 export function OrgGeneralPage() {
@@ -14,6 +15,7 @@ export function OrgGeneralPage() {
             <OrganizationForm />
             <DomainSettings />
             <DefaultHomeAgentsForm />
+            <DeleteOrganizationSection />
           </SettingsPage>
         </Page.Body>
       </Page.Content>


### PR DESCRIPTION
## What is this contribution about?
Adds a **Danger Zone** section to the Organization General settings page with a button to permanently delete the current organization. Uses the existing `authClient.organization.delete()` Better Auth method, shows a confirmation dialog before proceeding, and redirects to `/` on success.

## Screenshots/Demonstration
> A "Danger Zone" section appears at the bottom of Settings → Organization → General, with a red-bordered card and a destructive Delete button that opens a confirmation dialog.

## How to Test
1. Go to Settings → Organization → General
2. Scroll to the bottom — a "Danger Zone" section should be visible
3. Click **Delete** — a confirmation dialog should appear showing the org name
4. Confirm deletion — the organization is deleted and you are redirected to `/`

## Migration Notes
No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes