### PR TITLE
feat(vm-events): enhance stale VM handling and cleanup process

### DIFF
--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -54,7 +54,7 @@ import {
   type MeshContext,
 } from "../../core/mesh-context";
 import { KyselySandboxRunnerStateStore } from "../../storage/sandbox-runner-state";
-import { removeVmMapEntry } from "../../tools/vm/vm-map";
+import { readVmMap, resolveVm } from "../../tools/vm/vm-map";
 import type { Env } from "../hono-env";
 
 /**
@@ -113,6 +113,22 @@ app.get("/", async (c) => {
   });
   const claimName = composeClaimName({ userId, projectRef }, branch);
 
+  // Snapshot vmMap from the same metadata read used for the org-ownership
+  // check. Used below to gate the stale-handle probe: we only treat a
+  // missing claim as "evicted" when this user already had a vmMap entry
+  // pointing at this exact claim under the agent-sandbox runner. Without
+  // this gate, an SSE that opens during VM_START's claim-creation window
+  // (~250ms–1.2s before `createSandboxClaim` lands) would observe
+  // alive=false and emit a spurious `gone`.
+  const existingVmEntry = resolveVm(
+    readVmMap(virtualMcp.metadata as Record<string, unknown> | null),
+    userId,
+    branch,
+  );
+  const expectingClaim =
+    existingVmEntry?.runnerKind === "agent-sandbox" &&
+    existingVmEntry.vmId === claimName;
+
   const runnerKind = tryResolveRunnerKindFromEnv();
   const runner = await getOrInitSharedRunner();
 
@@ -144,17 +160,10 @@ app.get("/", async (c) => {
     });
 
     try {
-      if (runnerKind === "agent-sandbox") {
+      if (runnerKind === "agent-sandbox" && expectingClaim) {
         const stale = await isStaleHandle(runner, claimName);
         if (stale) {
-          await cleanupStaleEntry({
-            ctx,
-            userId,
-            virtualMcpId,
-            projectRef,
-            branch,
-            runnerKind,
-          });
+          await cleanupStaleEntry({ ctx, userId, projectRef, runnerKind });
           await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
           return;
         }
@@ -201,41 +210,38 @@ async function isStaleHandle(
 }
 
 /**
- * Best-effort: remove the stale runner-state row + vmMap entry so the next
- * VM_START provisions a fresh handle instead of resurrecting the dead one.
+ * Best-effort: drop the stale runner-state row so the next VM_START's
+ * `runner.ensure` skips the rehydrate path (which would chase a dead
+ * port-forward and timeout) and falls through to cluster-adopt or fresh
+ * provision instead.
+ *
+ * We deliberately do NOT touch the vmMap entry. Two reasons:
+ *   1. `runner.ensure` resumes from the state-store, not vmMap — vmMap is
+ *      informational metadata read by tools/UI, never the source of truth
+ *      for provisioning.
+ *   2. Removing it here would race with a concurrent VM_START's
+ *      `setVmMapEntry` on the same metadata JSON column (read-modify-write
+ *      is not atomic; see vm-map.ts). The next VM_START overwrites the
+ *      entry with a fresh one anyway — the `vmId` is deterministic
+ *      (composeClaimName), so the entry's identity is stable across
+ *      reprovisions.
+ *
  * Failures are logged, not thrown — the user-visible flow (emit `gone` →
- * browser self-heal) is what matters; cleanup is correctness hygiene.
+ * browser self-heal) is what matters; this is a fast-path optimisation.
  */
 async function cleanupStaleEntry(args: {
   ctx: MeshContext;
   userId: string;
-  virtualMcpId: string;
   projectRef: string;
-  branch: string;
   runnerKind: "docker" | "freestyle" | "agent-sandbox";
 }): Promise<void> {
-  const { ctx, userId, virtualMcpId, projectRef, branch, runnerKind } = args;
+  const { ctx, userId, projectRef, runnerKind } = args;
   try {
     const stateStore = new KyselySandboxRunnerStateStore(ctx.db);
     await stateStore.delete({ userId, projectRef }, runnerKind);
   } catch (err) {
     console.warn(
       `[vm-events] sandbox_runner_state delete failed for ${userId}/${projectRef}/${runnerKind}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-  try {
-    await removeVmMapEntry(
-      ctx.storage.virtualMcps,
-      virtualMcpId,
-      userId,
-      userId,
-      branch,
-    );
-  } catch (err) {
-    console.warn(
-      `[vm-events] vmMap remove failed for ${virtualMcpId}/${userId}/${branch}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -51,7 +51,10 @@ import {
   getUserId,
   requireAuth,
   requireOrganization,
+  type MeshContext,
 } from "../../core/mesh-context";
+import { KyselySandboxRunnerStateStore } from "../../storage/sandbox-runner-state";
+import { removeVmMapEntry } from "../../tools/vm/vm-map";
 import type { Env } from "../hono-env";
 
 /**
@@ -141,6 +144,22 @@ app.get("/", async (c) => {
     });
 
     try {
+      if (runnerKind === "agent-sandbox") {
+        const stale = await isStaleHandle(runner, claimName);
+        if (stale) {
+          await cleanupStaleEntry({
+            ctx,
+            userId,
+            virtualMcpId,
+            projectRef,
+            branch,
+            runnerKind,
+          });
+          await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+          return;
+        }
+      }
+
       // ---- Phase 1: lifecycle (pre-Ready) ---------------------------------
       const lifecycleOk = await emitLifecycle({
         stream,
@@ -163,6 +182,65 @@ app.get("/", async (c) => {
     }
   });
 });
+
+async function isStaleHandle(
+  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>,
+  claimName: string,
+): Promise<boolean> {
+  try {
+    const exists = await runner.alive(claimName);
+    return !exists;
+  } catch (err) {
+    console.warn(
+      `[vm-events] alive probe failed for ${claimName}; assuming alive: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Best-effort: remove the stale runner-state row + vmMap entry so the next
+ * VM_START provisions a fresh handle instead of resurrecting the dead one.
+ * Failures are logged, not thrown — the user-visible flow (emit `gone` →
+ * browser self-heal) is what matters; cleanup is correctness hygiene.
+ */
+async function cleanupStaleEntry(args: {
+  ctx: MeshContext;
+  userId: string;
+  virtualMcpId: string;
+  projectRef: string;
+  branch: string;
+  runnerKind: "docker" | "freestyle" | "agent-sandbox";
+}): Promise<void> {
+  const { ctx, userId, virtualMcpId, projectRef, branch, runnerKind } = args;
+  try {
+    const stateStore = new KyselySandboxRunnerStateStore(ctx.db);
+    await stateStore.delete({ userId, projectRef }, runnerKind);
+  } catch (err) {
+    console.warn(
+      `[vm-events] sandbox_runner_state delete failed for ${userId}/${projectRef}/${runnerKind}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  try {
+    await removeVmMapEntry(
+      ctx.storage.virtualMcps,
+      virtualMcpId,
+      userId,
+      userId,
+      branch,
+    );
+  } catch (err) {
+    console.warn(
+      `[vm-events] vmMap remove failed for ${virtualMcpId}/${userId}/${branch}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
 
 /**
  * Drives the lifecycle phase stream (or its no-op equivalent for

--- a/apps/mesh/src/web/components/vm/env/env.tsx
+++ b/apps/mesh/src/web/components/vm/env/env.tsx
@@ -180,25 +180,19 @@ export function EnvContent({ daemonOpen = false }: { daemonOpen?: boolean }) {
   const vmEvents = useVmEvents();
   useVmChunkHandler(handleChunk);
 
-  // Cross-component inflight signal — the layout/preview may have fired
-  // VM_START for this (vmcp, branch); our local `useMutation` instances only
-  // see self-initiated mutations, so without this the tab falls through to
-  // the idle/runtime-picker UI and flickers to the terminal once vmMap
-  // catches up.
   const vmStartPending = useIsVmStartPending(
     inset?.entity?.id,
     currentBranch ?? undefined,
   );
-
-  // Final status = user-initiated override, else derived from (vmData, SSE,
-  // inflight VM_START).
   const derivedStatus: ViewStatus = vmEvents.suspended
     ? "suspended"
-    : vmData
-      ? "running"
-      : vmStartPending
-        ? "creating"
-        : "idle";
+    : vmEvents.notFound
+      ? "creating"
+      : vmData
+        ? "running"
+        : vmStartPending
+          ? "creating"
+          : "idle";
   const status: ViewStatus = override ?? derivedStatus;
 
   // Clear the override when the derived state catches up.
@@ -491,10 +485,13 @@ export function EnvContent({ daemonOpen = false }: { daemonOpen?: boolean }) {
   }
 
   if (status === "creating") {
+    const label = vmEvents.notFound
+      ? "Sandbox was stopped, we're restarting it…"
+      : statusLabel;
     return (
       <div className="flex flex-col items-center justify-center w-full h-full gap-4">
         <Loading01 size={24} className="animate-spin text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">{statusLabel}</p>
+        <p className="text-sm text-muted-foreground">{label}</p>
         <LiveTimer since={startedAtRef.current} />
       </div>
     );

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -421,21 +421,22 @@ export function PreviewContent() {
           </div>
         )}
 
-        {!lastStartError && (booting || starting || lifecycleActive) && (
-          <div className="absolute inset-0 z-30 flex items-center justify-center bg-background">
-            <VmBootingState
-              since={
-                booting ? bootTrackedRef.current.at : startingSinceRef.current
-              }
-              hasSetupData={vmEvents.hasData("setup")}
-              scripts={vmEvents.scripts}
-              activeProcesses={vmEvents.activeProcesses}
-              onViewLogs={openEnv}
-              claimPhase={previewUrl ? null : claimPhase}
-              onRetry={retryAutoStart}
-            />
-          </div>
-        )}
+        {!lastStartError &&
+          (booting || starting || lifecycleActive || vmEvents.notFound) && (
+            <div className="absolute inset-0 z-30 flex items-center justify-center bg-background">
+              <VmBootingState
+                since={
+                  booting ? bootTrackedRef.current.at : startingSinceRef.current
+                }
+                hasSetupData={vmEvents.hasData("setup")}
+                scripts={vmEvents.scripts}
+                activeProcesses={vmEvents.activeProcesses}
+                onViewLogs={openEnv}
+                claimPhase={previewUrl ? null : claimPhase}
+                onRetry={retryAutoStart}
+              />
+            </div>
+          )}
 
         {viewMode === "visual" && !visualElement && (
           <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
@@ -449,7 +450,7 @@ export function PreviewContent() {
             onDismiss={() => setVisualElement(null)}
           />
         )}
-        {previewUrl && !booting && (
+        {previewUrl && !booting && !vmEvents.notFound && (
           <iframe
             // Key on previewUrl: `src` mutations don't reliably refetch in all
             // browsers and leak in-frame state across branches.

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-version: 0.5.1
+version: 0.5.2
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "0.2.0"
+appVersion: "0.2.1"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "0.2.0"
+  tag: "0.2.1"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -51,39 +51,23 @@ const branchStatus = new BranchStatusMonitor(config, broadcaster);
 
 let discoveredScripts: string[] | null = null;
 
-// Build the ordered candidate-port list each tick:
-//   1. Ports any descendant of a daemon-managed dev process is listening on
-//      (Vite v7 / Next / Astro / etc. mostly ignore PORT=$DEV_PORT, so this
-//      is the source of truth.)
-//   2. config.devPort — the env-hint fallback. Honored by frameworks that
-//      respect PORT, and used by the e2e tests where there's no managed
-//      dev process and the upstream is started externally.
 const excludeFromDiscovery = new Set<number>([config.proxyPort]);
-const getCandidatePorts = (): number[] => {
-  const ordered: number[] = [];
-  const seen = new Set<number>();
-  const push = (p: number) => {
-    if (!seen.has(p)) {
-      seen.add(p);
-      ordered.push(p);
-    }
-  };
+const getDiscoveredPorts = (): number[] => {
   const rootPids = processManager.allPids();
-  if (rootPids.length > 0) {
-    for (const port of discoverDescendantListeningPorts({
-      rootPids,
-      excludePorts: excludeFromDiscovery,
-    })) {
-      push(port);
-    }
-  }
-  push(config.devPort);
-  return ordered;
+  if (rootPids.length === 0) return [];
+  return discoverDescendantListeningPorts({
+    rootPids,
+    excludePorts: excludeFromDiscovery,
+  });
 };
 
 const lastStatus = startUpstreamProbe({
   upstreamHost: "localhost",
-  getCandidatePorts,
+  getDiscoveredPorts,
+  // Untrusted: only used until /proc shows a listener. Honored by frameworks
+  // that respect PORT, and used in e2e tests where there's no managed dev
+  // process and the upstream is started externally.
+  getFallbackPort: () => config.devPort,
   onChange: (s) =>
     broadcaster.broadcastEvent("status", { type: "status", ...s }),
 });

--- a/packages/sandbox/daemon/probe.ts
+++ b/packages/sandbox/daemon/probe.ts
@@ -11,10 +11,11 @@ export interface ProbeDeps {
   upstreamHost: string;
   /**
    * Ports owned by descendants of the daemon's managed dev process, per
-   * /proc inspection. Authoritative: if /proc says the dev server holds
-   * a TCP listener, the server *is* up — `ready: true` flips immediately
-   * without waiting on a slow first compile. HEAD-probing these is only
-   * to enrich `htmlSupport`, not to gate readiness.
+   * /proc inspection. The discovery list picks the candidate port (so the
+   * preview reverse-proxy lands on the right socket), but `ready` is still
+   * gated on at least one HEAD response — a process that's bound the port
+   * but isn't accepting yet (early bind during framework bootstrap, lazy
+   * compile that times out the HEAD) shouldn't read as ready.
    */
   getDiscoveredPorts: () => number[];
   /**
@@ -118,7 +119,7 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
       const responded = results.filter((r) => r.responded);
       const best = responded.sort((a, b) => b.score - a.score)[0] ?? results[0];
       state.port = best.port;
-      state.ready = true;
+      state.ready = responded.length > 0;
       state.htmlSupport = best.htmlSupport;
     } else {
       // Untrusted fallback: env-hint port only, gated on a successful HEAD.

--- a/packages/sandbox/daemon/probe.ts
+++ b/packages/sandbox/daemon/probe.ts
@@ -10,11 +10,21 @@ export interface ProbeState {
 export interface ProbeDeps {
   upstreamHost: string;
   /**
-   * Candidate ports to score each tick. All are probed in parallel; the
-   * one with the highest "looks like the dev preview" score wins. Empty
-   * array → state stays { ready:false, port:null }.
+   * Ports owned by descendants of the daemon's managed dev process, per
+   * /proc inspection. Authoritative: if /proc says the dev server holds
+   * a TCP listener, the server *is* up — `ready: true` flips immediately
+   * without waiting on a slow first compile. HEAD-probing these is only
+   * to enrich `htmlSupport`, not to gate readiness.
    */
-  getCandidatePorts: () => number[];
+  getDiscoveredPorts: () => number[];
+  /**
+   * Env-hint fallback (DEV_PORT). Used only when no descendant ports
+   * have been discovered yet — typically the brief window between
+   * daemon boot and the dev process binding, or in tests where there's
+   * no managed dev process at all. Treated as untrusted: gated on a
+   * successful HEAD probe.
+   */
+  getFallbackPort: () => number;
   onChange: (state: ProbeState) => void;
 }
 
@@ -55,11 +65,17 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
   const state: ProbeState = { ready: false, htmlSupport: false, port: null };
   let count = 0;
 
+  // First-request compile in Next/Vite/etc. can run 8–20s on big apps; the
+  // probe blocks on it because HEAD `/` triggers the same lazy-compile path
+  // as GET. A short timeout here false-negatives the htmlSupport check for
+  // the entire compile window. 30s comfortably absorbs typical first-compiles
+  // without reacting to dead-server ECONNREFUSED any slower (that fails fast).
+  const HEAD_TIMEOUT_MS = 30_000;
   const head = async (url: string): Promise<HeadResult | null> => {
     try {
       const res = await fetch(url, {
         method: "HEAD",
-        signal: AbortSignal.timeout(5000),
+        signal: AbortSignal.timeout(HEAD_TIMEOUT_MS),
       });
       const ct = (res.headers.get("content-type") ?? "").toLowerCase();
       return {
@@ -72,7 +88,7 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
     }
   };
 
-  const tryOne = async (port: number): Promise<ProbeResult> => {
+  const probeOne = async (port: number): Promise<ProbeResult> => {
     const base = `http://${deps.upstreamHost}:${port}`;
     // Probe `/` first; only ask `/@vite/client` if root looks like a real
     // HTML responder. Avoids hammering ports that don't speak HTTP.
@@ -94,22 +110,30 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
     const prevReady = state.ready;
     const prevPort = state.port;
     const prevHtml = state.htmlSupport;
-    const candidates = deps.getCandidatePorts();
-    const results = await Promise.all(candidates.map(tryOne));
-    // Highest score wins; on tie, the candidate-list order (already
-    // discovered-first) breaks it — `Array.sort` is stable in modern JS.
-    const best = results
-      .filter((r) => r.responded)
-      .sort((a, b) => b.score - a.score)[0];
-    if (best) {
+
+    const discovered = deps.getDiscoveredPorts();
+
+    if (discovered.length > 0) {
+      const results = await Promise.all(discovered.map(probeOne));
+      const responded = results.filter((r) => r.responded);
+      const best = responded.sort((a, b) => b.score - a.score)[0] ?? results[0];
       state.port = best.port;
-      state.ready = best.ready;
+      state.ready = true;
       state.htmlSupport = best.htmlSupport;
     } else {
-      state.port = null;
-      state.ready = false;
-      state.htmlSupport = false;
+      // Untrusted fallback: env-hint port only, gated on a successful HEAD.
+      const result = await probeOne(deps.getFallbackPort());
+      if (result.responded) {
+        state.port = result.port;
+        state.ready = result.ready;
+        state.htmlSupport = result.htmlSupport;
+      } else {
+        state.port = null;
+        state.ready = false;
+        state.htmlSupport = false;
+      }
     }
+
     if (
       prevReady !== state.ready ||
       prevPort !== state.port ||

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {

--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -426,8 +426,8 @@ export class AgentSandboxRunner implements SandboxRunner {
       this.kubeConfig,
       this.namespace,
       handle,
-    ).catch(() => undefined);
-    return claim ? isSandboxReady(claim) : false;
+    );
+    return claim !== undefined;
   }
 
   /**


### PR DESCRIPTION
- Introduced `isStaleHandle` function to check for stale VM runners and trigger cleanup if necessary.
- Added `cleanupStaleEntry` function to remove stale runner-state and VM map entries, ensuring fresh handles are provisioned.
- Updated the VM event handling logic to emit a "gone" event when a stale entry is cleaned up, improving user experience during VM lifecycle management.
- Adjusted UI components to reflect changes in VM status, including handling cases where the VM is not found.

These changes improve the reliability and responsiveness of the VM lifecycle management system.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes