### PR TITLE
feat(chat): add tool display map with custom icons and labels

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -43,6 +43,7 @@ import {
   RefreshCw01,
   XClose,
 } from "@untitledui/icons";
+import { TOOL_DISPLAY_MAP } from "./tool-display-map.ts";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import type React from "react";
 import { Suspense } from "react";
@@ -213,7 +214,9 @@ export function GenericToolCallPart({
   const meta = toolDef?._meta ?? toolMeta;
   const gatewayClientId = getGatewayClientId(meta);
   const toolName = stripToolNamespace(mcpStrippedName, gatewayClientId);
-  const friendlyName = toolDef?.title ?? toTitleCase(toolName);
+  const toolDisplay = TOOL_DISPLAY_MAP[toolName];
+  const friendlyName =
+    toolDef?.title ?? toolDisplay?.label ?? toTitleCase(toolName);
   const uiResourceUri = getUIResourceUri(meta);
 
   const hasMCPApp = !!uiResourceUri && part.state === "output-available";
@@ -313,15 +316,15 @@ export function GenericToolCallPart({
   return (
     <div>
       <ToolCallShell
-        icon={
-          isCancelled ? (
-            <XClose />
-          ) : hasMCPApp ? (
-            <LayersTwo01 className="size-4 text-muted-foreground" />
-          ) : (
-            <Atom02 className="size-4 text-muted-foreground" />
-          )
-        }
+        icon={(() => {
+          if (isCancelled) return <XClose />;
+          if (hasMCPApp)
+            return <LayersTwo01 className="size-4 text-muted-foreground" />;
+          const MappedIcon = toolDisplay?.icon;
+          if (MappedIcon)
+            return <MappedIcon className="size-4 text-muted-foreground" />;
+          return <Atom02 className="size-4 text-muted-foreground" />;
+        })()}
         iconDestructive={isCancelled}
         trailing={
           <AnnotationBadges annotations={annotations} toolMeta={toolMeta} />

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
@@ -54,7 +54,7 @@ export const TOOL_DISPLAY_MAP: Record<string, ToolDisplay> = {
 
   // Sandbox / code execution tools
   sandbox: { icon: Code02, label: "Run Code" },
-  copy_to_sandbox: { icon: Download01, label: "Copy to Sandbox" },
+  copy_to_sandbox: { icon: Download01, label: "Load File" },
   share_with_user: { icon: Upload01, label: "Share with User" },
 
   // Browser / web tools

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
@@ -1,0 +1,56 @@
+import type React from "react";
+import {
+  BookOpen01,
+  Code01,
+  Database01,
+  Edit01,
+  Edit02,
+  File06,
+  Folder,
+  Globe02,
+  Monitor01,
+  SearchMd,
+  Server01,
+  TerminalSquare,
+  Tool01,
+  Users03,
+} from "@untitledui/icons";
+
+export interface ToolDisplay {
+  /** Icon component — rendered with `size-4 text-muted-foreground` by the caller */
+  icon: React.ComponentType<{ className?: string; size?: number }>;
+  /** Human-readable label; overrides the toTitleCase fallback when set */
+  label?: string;
+}
+
+/**
+ * Maps clean tool names (after prefix-stripping) to display metadata.
+ * Only built-in tools need entries here — MCP passthrough tools get their
+ * titles from listTools and fall back to Atom02 / toTitleCase.
+ */
+export const TOOL_DISPLAY_MAP: Record<string, ToolDisplay> = {
+  // VM file tools
+  read: { icon: File06, label: "Read File" },
+  write: { icon: Edit01, label: "Write File" },
+  edit: { icon: Edit02, label: "Edit File" },
+  grep: { icon: SearchMd, label: "Search Content" },
+  glob: { icon: Folder, label: "Find Files" },
+  bash: { icon: TerminalSquare, label: "Run Command" },
+
+  // Agent / orchestration tools
+  agent_search: { icon: Users03, label: "Search Agents" },
+
+  // Resource / context tools
+  read_tool_output: { icon: File06, label: "Read Tool Output" },
+  read_resource: { icon: Database01, label: "Read Resource" },
+  read_prompt: { icon: BookOpen01, label: "Read Prompt" },
+
+  // System tools
+  enable_tools: { icon: Tool01, label: "Enable Tools" },
+  open_in_agent: { icon: Server01, label: "Open in Agent" },
+
+  // Browser / web tools
+  take_screenshot: { icon: Monitor01, label: "Take Screenshot" },
+  scrape_url: { icon: Globe02, label: "Scrape URL" },
+  inspect_page: { icon: Code01, label: "Inspect Page" },
+};

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/tool-display-map.ts
@@ -2,7 +2,9 @@ import type React from "react";
 import {
   BookOpen01,
   Code01,
+  Code02,
   Database01,
+  Download01,
   Edit01,
   Edit02,
   File06,
@@ -13,6 +15,7 @@ import {
   Server01,
   TerminalSquare,
   Tool01,
+  Upload01,
   Users03,
 } from "@untitledui/icons";
 
@@ -48,6 +51,11 @@ export const TOOL_DISPLAY_MAP: Record<string, ToolDisplay> = {
   // System tools
   enable_tools: { icon: Tool01, label: "Enable Tools" },
   open_in_agent: { icon: Server01, label: "Open in Agent" },
+
+  // Sandbox / code execution tools
+  sandbox: { icon: Code02, label: "Run Code" },
+  copy_to_sandbox: { icon: Download01, label: "Copy to Sandbox" },
+  share_with_user: { icon: Upload01, label: "Share with User" },
 
   // Browser / web tools
   take_screenshot: { icon: Monitor01, label: "Take Screenshot" },

--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -1347,7 +1347,7 @@ function RoleDetailPageInner({
         await syncMembers(formData.role.slug!);
         return formData;
       } else if (isEditableBuiltinFirstSave) {
-        const r = await authClient.organization.createRole({
+        const r = await orgAuth.organization.createRole({
           role: formData.role.slug!,
           permission,
         });


### PR DESCRIPTION
## What is this contribution about?

Adds a `tool-display-map.ts` file that maps built-in tool names to purpose-specific icons and human-readable labels in the chat UI. Previously all built-in tools (read, write, edit, grep, glob, bash, etc.) fell back to the generic `Atom02` icon. Now each has a meaningful icon (e.g. `File06` for read, `TerminalSquare` for bash, `Folder` for glob) and a descriptive label (e.g. "Read File", "Run Command", "Find Files"). MCP passthrough tools are unaffected — they still use their `listTools` title and `Atom02`.

## Screenshots/Demonstration

> UI changes visible in the chat tool call cards when built-in tools are invoked.

## How to Test

1. Open a chat and trigger built-in file tools (read, write, edit, grep, glob, bash)
2. Verify each tool call card shows a distinct icon and label instead of the generic atom icon
3. Verify MCP passthrough tool calls still show the atom icon and their server-defined title

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes