### PR TITLE
fix(auth): create organizationRole/Resource tables in migrate paths

### DIFF
--- a/apps/mesh/src/auth/migrate.ts
+++ b/apps/mesh/src/auth/migrate.ts
@@ -35,10 +35,17 @@ export async function migrateBetterAuth(databaseUrl?: string): Promise<string> {
 
   // Minimal options — only needs plugins to discover which tables to create.
   // Does not need auth config, rate limiting, hooks, etc.
+  //
+  // Plugin options that change which tables get created (e.g. organization's
+  // dynamicAccessControl, which gates the organizationRole and
+  // organizationResource tables) must mirror the real auth config in
+  // ../auth/index.ts so the in-process migration matches the CLI migration.
   const options = {
     database: freshDatabase,
     plugins: [
-      organization(),
+      organization({
+        dynamicAccessControl: { enabled: true, enableCustomResources: true },
+      }),
       adminPlugin(),
       apiKey(),
       jwt(),

--- a/apps/mesh/src/storage/test-helpers.ts
+++ b/apps/mesh/src/storage/test-helpers.ts
@@ -128,6 +128,31 @@ export async function createBetterAuthTables(
     .addColumn("createdAt", "text", (col) => col.notNull())
     .execute();
 
+  // organizationRole / organizationResource (Better Auth organization plugin
+  // with dynamicAccessControl enabled). Mirrors the schema produced by
+  // `getMigrations()` so tests can query custom roles like prod.
+  await db.schema
+    .createTable("organizationRole")
+    .ifNotExists()
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("organizationId", "text", (col) => col.notNull())
+    .addColumn("role", "text", (col) => col.notNull())
+    .addColumn("permission", "text", (col) => col.notNull())
+    .addColumn("createdAt", "text", (col) => col.notNull())
+    .addColumn("updatedAt", "text")
+    .execute();
+
+  await db.schema
+    .createTable("organizationResource")
+    .ifNotExists()
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("organizationId", "text", (col) => col.notNull())
+    .addColumn("resource", "text", (col) => col.notNull())
+    .addColumn("permissions", "text", (col) => col.notNull())
+    .addColumn("createdAt", "text", (col) => col.notNull())
+    .addColumn("updatedAt", "text")
+    .execute();
+
   // API Key table (Better Auth API key plugin)
   await db.schema
     .createTable("apiKey")


### PR DESCRIPTION
## Summary

The in-process Better Auth migration helper (`apps/mesh/src/auth/migrate.ts`, used by `bun run migrate` and the CLI startup pipeline) constructs a stripped-down Better Auth options object. It calls `organization()` with no arguments, while the runtime config in `apps/mesh/src/auth/index.ts` enables `dynamicAccessControl: { enabled: true }`.

The `@decocms/better-auth` organization plugin gates the `organizationRole` and `organizationResource` tables on `dynamicAccessControl.enabled` — so without the option, `getMigrations()` doesn't include those tables, and they never get created by the in-process runner. Empirically verified locally: dropping the tables and running `bun run migrate` with the old code does not recreate them.

This is a latent bug since OSS init (`d1e5f1f43`, Nov 2025). It went unnoticed because no one creates custom roles in self-hosted environments — the runtime would otherwise fail with `relation "organizationRole" does not exist` on the first INSERT.

## Changes

- **`apps/mesh/src/auth/migrate.ts`**: pass `dynamicAccessControl: { enabled: true, enableCustomResources: true }` to mirror the runtime auth config. Adds a comment explaining that plugin options affecting schema must stay in sync with `auth/index.ts`.
- **`apps/mesh/src/storage/test-helpers.ts`**: add `organizationRole` and `organizationResource` table definitions to `createBetterAuthTables()` so pglite-backed tests don't trip the same gap.

## Test plan

- [x] Drop both tables, run `bun run migrate` against fresh DB → tables created
- [x] `bun run --cwd apps/mesh check` passes
- [x] 1373 unit/integration tests in `apps/mesh/src` pass (vs 41 failing before with the missing tables)

## Notes

Self-hosted prods that already have these tables (presumably created by a manual `bun run better-auth:migrate` run during initial setup) are not affected — the in-process migrate is idempotent on existing tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)