### PR TITLE
fix(tests): install python3/make/g++ for node-pty native build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.293.4",
+      "version": "2.297.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -294,7 +294,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
         "@opentelemetry/api": "^1.9.0",
@@ -396,6 +396,7 @@
     },
   },
   "trustedDependencies": [
+    "node-pty",
     "@duckdb/node-bindings",
     "@duckdb/node-api",
   ],

--- a/tests/resilience/Dockerfile.studio
+++ b/tests/resilience/Dockerfile.studio
@@ -1,6 +1,11 @@
 FROM oven/bun:1-slim
 
-RUN apt-get update && apt-get install -y unzip bash && rm -rf /var/lib/apt/lists/*
+# unzip + bash are runtime deps; python3/make/g++ are needed because node-pty
+# (used by @decocms/sandbox) ships prebuilds only for darwin/win32 — on Linux it
+# falls back to building from source via node-gyp.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends unzip bash python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## What is this contribution about?

The `Resilience Tests` workflow began failing on `main` after `node-pty@1.1.0` was added as a transitive dependency via `packages/sandbox`. node-pty only ships prebuilt binaries for `darwin-*` and `win32-*`, so on the `oven/bun:1-slim` Linux image used by `tests/resilience/Dockerfile.studio` it falls back to building from source via node-gyp — which needs Python and a C++ toolchain that the slim image lacks. This PR installs `python3`, `make`, and `g++` in the studio image so `bun install` can compile the native binding. The workspace also includes a `bun.lock` resync to match the current `apps/mesh@2.297.0` and `@decocms/sandbox@0.2.1` versions.

## How to Test

1. `docker build -f tests/resilience/Dockerfile.studio .` succeeds locally (verified)
2. The `Resilience Tests` workflow's "Start infrastructure" step gets past the `bun install` for the studio image
3. Resilience suite proceeds to the actual test scenarios

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes