### PR TITLE
fix(sandbox): emit starting-container during post-schedule window

### DIFF
--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts
@@ -100,6 +100,38 @@ describe("derivePhase", () => {
     expect(phase.kind).toBe("starting-container");
   });
 
+  it("emits starting-container on ContainerCreating even without a Pulled event (cached image)", () => {
+    // Real karpenter case: image is already on the node so kubelet skips
+    // straight from ContainerCreating to running, and the `Pulled` event
+    // either lags the container-status update or arrives as "image already
+    // present on machine" without a prior `Pulling`. Either way the user
+    // wants to see `starting-container`, not stay pinned at the prior phase.
+    const state = baseState();
+    state.pod.scheduled = true;
+    state.pod.containerWaitingReason = "ContainerCreating";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("starting-container");
+  });
+
+  it("emits starting-container on PodInitializing", () => {
+    const state = baseState();
+    state.pod.scheduled = true;
+    state.pod.containerWaitingReason = "PodInitializing";
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("starting-container");
+  });
+
+  it("emits starting-container after schedule even before kubelet reports a containerStatus", () => {
+    // Brief window between PodScheduled=True and the first containerStatus
+    // tick. Without this branch we'd fall through to `claiming` and the
+    // generator's monotonic floor would pin us at the prior
+    // `waiting-for-capacity` for the entire ContainerCreating window.
+    const state = baseState();
+    state.pod.scheduled = true;
+    const phase = derivePhase(state, TIMEOUT_MS, fixedNow());
+    expect(phase.kind).toBe("starting-container");
+  });
+
   it("emits warming-daemon when container is running but not yet ready", () => {
     const state = baseState();
     state.pod.scheduled = true;

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
@@ -360,14 +360,30 @@ export function derivePhase(
     return { kind: "warming-daemon", since: startedAt };
   }
 
-  // 5. starting-container: image pulled, container being created.
-  if (containerWaitingReason === "ContainerCreating" && events.hasPulled) {
-    return { kind: "starting-container", since: startedAt };
-  }
-
-  // 6. pulling-image: a Pulling event has fired but Pulled hasn't yet.
+  // 5. pulling-image: a Pulling event has fired but Pulled hasn't yet.
+  // Checked before `starting-container` because it's the more specific signal
+  // during the ContainerCreating window — if we know an image pull is in
+  // flight, the user wants to see that, not the generic "starting" phase.
   if (events.hasPulling && !events.hasPulled) {
     return { kind: "pulling-image", since: startedAt };
+  }
+
+  // 6. starting-container: pod has been scheduled and we're past pulling but
+  // the container isn't running yet. Covers three real-cluster sub-states the
+  // user-facing UI shouldn't need to distinguish:
+  //   - `ContainerCreating` waiting reason (with or without a `Pulled` event;
+  //     the event can lag the container-status update, or be absent entirely
+  //     when the image is already cached on a fresh node).
+  //   - `PodInitializing` waiting reason (init containers / volume mounts).
+  //   - Pod scheduled but kubelet hasn't reported any containerStatus yet —
+  //     a brief gap that would otherwise fall through to `claiming` and get
+  //     pinned by the monotonic floor at the prior `waiting-for-capacity`.
+  if (
+    containerWaitingReason === "ContainerCreating" ||
+    containerWaitingReason === "PodInitializing" ||
+    (pod.scheduled && !pod.containerRunning)
+  ) {
+    return { kind: "starting-container", since: startedAt };
   }
 
   // 7. waiting-for-capacity: PodScheduled=False with reason Unschedulable,


### PR DESCRIPTION
## Summary

The lifecycle reducer at `packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts` had a gap in the post-schedule / pre-running window. Two real-cluster cases fell through to `claiming` and got pinned by the monotonic floor at the prior `waiting-for-capacity`:

- **Cached image on a fresh karpenter node.** Kubelet skips straight from `ContainerCreating` to running, and the `Pulled` event either lags the container-status update or arrives as "image already present" without a prior `Pulling`. The old `starting-container` rule required `events.hasPulled`, so it didn't fire.
- **`PodInitializing` and the brief `PodScheduled=True` → first containerStatus gap.** Neither was recognized by any rule.

Result: the Preview UI showed nothing useful between scheduling success and warming-daemon — the user saw `waiting-for-capacity` for the entire ContainerCreating window even though the cluster was making progress.

## Changes

- Reorder the reducer so `pulling-image` (the more specific signal) is checked **before** `starting-container`. This preserves the pulling distinction now that `starting-container` matches more broadly.
- Broaden `starting-container` to fire on `ContainerCreating`, `PodInitializing`, or `pod.scheduled && !pod.containerRunning` (covers the kubelet-hasn't-reported-yet gap).
- Add three reducer tests covering the new branches: cached-image ContainerCreating, PodInitializing, and post-schedule pre-containerStatus.

## Test plan

- [x] `bun test packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.test.ts` — 18/18 pass (15 existing + 3 new)
- [x] `bun run fmt`
- [ ] Manual verification on a real cluster: trigger a sandbox claim on a node with the image cached and confirm the Preview UI transitions through `starting-container` instead of stalling at `waiting-for-capacity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)