### PR TITLE
feat(docs): add product switcher linking to docs.deco.cx

### DIFF
--- a/apps/docs/client/src/components/ui/ProductSwitcher.tsx
+++ b/apps/docs/client/src/components/ui/ProductSwitcher.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import { Logo } from "../atoms/Logo";
 import { Icon } from "../atoms/Icon";
-import { products, CURRENT_PRODUCT_ID, type Product } from "../../config/products";
+import {
+  products,
+  CURRENT_PRODUCT_ID,
+  type Product,
+} from "../../config/products";
 
 interface ProductSwitcherProps {
   /** Which product is "this site". Defaults to decocms. */
@@ -96,7 +100,11 @@ interface ProductMenuItemProps {
   onSelect: () => void;
 }
 
-function ProductMenuItem({ product, isCurrent, onSelect }: ProductMenuItemProps) {
+function ProductMenuItem({
+  product,
+  isCurrent,
+  onSelect,
+}: ProductMenuItemProps) {
   const sharedClasses = `flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
     isCurrent ? "bg-primary/5" : "hover:bg-muted"
   }`;
@@ -129,7 +137,11 @@ function ProductMenuItem({ product, isCurrent, onSelect }: ProductMenuItemProps)
 
   if (isCurrent || !product.href) {
     return (
-      <div role="menuitem" aria-current={isCurrent ? "true" : undefined} className={sharedClasses}>
+      <div
+        role="menuitem"
+        aria-current={isCurrent ? "true" : undefined}
+        className={sharedClasses}
+      >
         {body}
       </div>
     );

--- a/apps/docs/client/src/components/ui/ProductSwitcher.tsx
+++ b/apps/docs/client/src/components/ui/ProductSwitcher.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+import { Logo } from "../atoms/Logo";
+import { Icon } from "../atoms/Icon";
+import { products, CURRENT_PRODUCT_ID, type Product } from "../../config/products";
+
+interface ProductSwitcherProps {
+  /** Which product is "this site". Defaults to decocms. */
+  current?: string;
+  className?: string;
+}
+
+export function ProductSwitcher({
+  current = CURRENT_PRODUCT_ID,
+  className = "",
+}: ProductSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Switch product docs"
+        className="flex items-center gap-1.5 px-1.5 py-1 -mx-1.5 -my-1 rounded-md hover:bg-muted transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        <Logo width={67} height={28} />
+        <Icon
+          name="ChevronDown"
+          size={14}
+          className={`text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Product docs"
+          className="absolute left-0 top-[calc(100%+8px)] z-50 w-64 rounded-lg border border-border bg-app-background shadow-lg overflow-hidden"
+        >
+          <div className="px-3 py-2 border-b border-border/60">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Docs
+            </span>
+          </div>
+          <div className="py-1">
+            {products.map((product) => (
+              <ProductMenuItem
+                key={product.id}
+                product={product}
+                isCurrent={product.id === current}
+                onSelect={() => setOpen(false)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ProductMenuItemProps {
+  product: Product;
+  isCurrent: boolean;
+  onSelect: () => void;
+}
+
+function ProductMenuItem({ product, isCurrent, onSelect }: ProductMenuItemProps) {
+  const sharedClasses = `flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+    isCurrent ? "bg-primary/5" : "hover:bg-muted"
+  }`;
+
+  const body = (
+    <>
+      <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+        <span
+          className={`text-sm font-medium truncate ${
+            isCurrent ? "text-primary" : "text-foreground"
+          }`}
+        >
+          {product.label}
+        </span>
+        <span className="text-xs text-muted-foreground truncate">
+          {product.description}
+        </span>
+      </div>
+      {isCurrent ? (
+        <Icon name="Check" size={16} className="text-primary shrink-0" />
+      ) : product.external ? (
+        <Icon
+          name="ArrowUpRight"
+          size={16}
+          className="text-muted-foreground shrink-0"
+        />
+      ) : null}
+    </>
+  );
+
+  if (isCurrent || !product.href) {
+    return (
+      <div role="menuitem" aria-current={isCurrent ? "true" : undefined} className={sharedClasses}>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <a
+      href={product.href}
+      target={product.external ? "_blank" : undefined}
+      rel={product.external ? "noopener noreferrer" : undefined}
+      role="menuitem"
+      className={sharedClasses}
+      onClick={onSelect}
+    >
+      {body}
+    </a>
+  );
+}

--- a/apps/docs/client/src/components/ui/Sidebar.tsx
+++ b/apps/docs/client/src/components/ui/Sidebar.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { navigate } from "astro:transitions/client";
-import { Logo } from "../../components/atoms/Logo";
 import { Icon } from "../../components/atoms/Icon";
 import { Select } from "../../components/atoms/Select";
 import { LanguageSelector } from "./LanguageSelector";
+import { ProductSwitcher } from "./ProductSwitcher";
 import { ThemeToggle } from "./ThemeToggle";
 import { versions, VERSION_IDS, LATEST_VERSION } from "../../config/versions";
 
@@ -553,7 +553,7 @@ export default function Sidebar({
     <div className="flex flex-col h-screen bg-app-background border-r border-border w-[19rem] lg:w-[19rem] w-full max-w-[19rem]">
       {/* Header - hidden on mobile */}
       <div className="hidden lg:flex items-center justify-between px-4 lg:px-6 py-3 shrink-0 border-b border-border">
-        <Logo width={67} height={28} />
+        <ProductSwitcher />
         <div className="flex items-center gap-1.5">
           <LanguageSelector locale={locale} compact />
           <ThemeToggle />

--- a/apps/docs/client/src/config/products.ts
+++ b/apps/docs/client/src/config/products.ts
@@ -1,0 +1,27 @@
+export interface Product {
+  id: string;
+  label: string;
+  description: string;
+  /** Absolute URL. `null` for the current product. */
+  href: string | null;
+  external: boolean;
+}
+
+export const products: readonly Product[] = [
+  {
+    id: "decocms",
+    label: "decocms",
+    description: "AI agents & MCP control plane",
+    href: null,
+    external: false,
+  },
+  {
+    id: "deco-cx",
+    label: "deco.cx",
+    description: "Storefront platform",
+    href: "https://docs.deco.cx",
+    external: true,
+  },
+];
+
+export const CURRENT_PRODUCT_ID = "decocms";

--- a/apps/docs/client/src/layouts/DocsLayout.astro
+++ b/apps/docs/client/src/layouts/DocsLayout.astro
@@ -3,9 +3,9 @@ import BaseHead from "../components/ui/BaseHead.astro";
 import Footer from "../components/ui/Footer.astro";
 import Sidebar from "../components/ui/Sidebar.astro";
 import TableOfContents from "../components/ui/TableOfContents.astro";
-import { Logo } from "../components/atoms/Logo";
 import { Icon } from "../components/atoms/Icon";
 import { LanguageSelector } from "../components/ui/LanguageSelector";
+import { ProductSwitcher } from "../components/ui/ProductSwitcher";
 import { ThemeToggle } from "../components/ui/ThemeToggle";
 import { getCollection } from "astro:content";
 import { siteConfig } from "../config/site";
@@ -286,7 +286,7 @@ const editUrl = doc
               >
                 <Icon name="Menu" size={24} />
               </button>
-              <Logo width={67} height={28} client:load />
+              <ProductSwitcher client:load />
             </div>
             <div class="flex items-center gap-2">
               <LanguageSelector client:load locale={locale} className="w-32" />


### PR DESCRIPTION
## Summary

- Replaces the static deco logo in the docs sidebar/mobile header with a clickable product switcher.
- Adds a popover with two entries: **decocms** (current, marked active) and **deco.cx** (external link to `docs.deco.cx`, opens in a new tab).
- Introduces `apps/docs/client/src/config/products.ts` as the single source of truth for the product list — adding a third docs property later is a one-line change.

## Motivation

Users routinely land on `docs.decocms.com` when they're actually looking for `docs.deco.cx` (the storefront platform docs), and there was no in-product escape hatch. Previously, the only way to switch was guessing the URL.

## What you'll see

- **Desktop sidebar header**: deco logo gets a small `▾` chevron and is now a button. Clicking opens a 256px-wide popover anchored below.
- **Mobile top bar**: same switcher replaces the static logo, sits next to the menu button.
- **Active product**: rendered with the primary color and a check icon (matches sidebar tree active styling).
- **External products**: rendered with the existing `ArrowUpRight` icon used elsewhere in the sidebar (Discord row).

## Accessibility

- Trigger is a real `<button>` with `aria-expanded`, `aria-haspopup="menu"`, and an `aria-label`.
- Menu uses `role="menu"` / `role="menuitem"`, with `aria-current` on the active row.
- Closes on outside click and `Escape`; `Escape` also returns focus to the trigger.

## Test plan

- [ ] On desktop, clicking the deco logo opens the switcher; clicking outside closes it.
- [ ] Pressing `Escape` closes the menu and returns focus to the logo button.
- [ ] Clicking **deco.cx** opens `https://docs.deco.cx` in a new tab.
- [ ] Clicking **decocms** (active row) is a no-op (it just stays — same behavior as Stripe/Vercel product switchers).
- [ ] On mobile, the switcher renders correctly next to the menu button and the popover doesn't overflow the viewport.
- [ ] Theme toggle still works (logo swaps light/dark inside the trigger button).
- [ ] Astro view transitions don't break popover state across navigations.

## Out of scope (intentional follow-ups)

- **Reciprocal link on `docs.deco.cx`**: the bigger win is the other direction (legacy SEO-richer domain). Worth a separate PR in `deco-sites/docs`.
- **i18n for product descriptions**: descriptions are English-only. If pt-br copy is needed, expand `Product.description` to a `Record<Locale, string>` and pass `locale` into the switcher.

Made with [Cursor](https://cursor.com)