### PR TITLE
feat(mesh): add minimal PWA manifest for Chrome install

### DIFF
--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -25,6 +25,8 @@
     <meta name="twitter:description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
     <meta name="twitter:image" content="/og-image.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#D0EC1A" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -14,14 +14,14 @@
       })();
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>deco Studio</title>
+    <title>deco CMS</title>
     <meta name="description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
-    <meta property="og:title" content="deco Studio" />
+    <meta property="og:title" content="deco CMS" />
     <meta property="og:description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
     <meta property="og:image" content="/og-image.png" />
-    <meta property="og:site_name" content="deco Studio" />
+    <meta property="og:site_name" content="deco CMS" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="deco Studio" />
+    <meta name="twitter:title" content="deco CMS" />
     <meta name="twitter:description" content="Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in." />
     <meta name="twitter:image" content="/og-image.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/apps/mesh/public/manifest.webmanifest
+++ b/apps/mesh/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "deco Studio",
+  "short_name": "deco Studio",
+  "description": "Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#D0EC1A",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/apps/mesh/public/manifest.webmanifest
+++ b/apps/mesh/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "deco Studio",
-  "short_name": "deco Studio",
+  "name": "deco CMS",
+  "short_name": "deco CMS",
   "description": "Hire specialized agents, give them access to your tools, and let them deliver real projects — with planning, verification, and observability built in.",
   "start_url": "/",
   "scope": "/",


### PR DESCRIPTION
## Summary
- Adds `apps/mesh/public/manifest.webmanifest` with `name`, `short_name`, `start_url`, `display: standalone`, `theme_color`, and the existing `favicon.svg` as the icon (`sizes: "any"`).
- Links the manifest and adds a `theme-color` meta in `apps/mesh/index.html`.
- No service worker, no caching — minimum needed for Chrome to surface the install option.

## Test plan
- [ ] Run `bun run dev`, open Chrome → URL bar shows install icon.
- [ ] DevTools → Application → Manifest parses without warnings.
- [ ] Trigger install; app opens in standalone window with correct name/icon.
- [ ] Verify production build (`bun run --cwd=apps/mesh build:client && bun run --cwd=apps/mesh start`) serves `/manifest.webmanifest` with correct MIME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a minimal Web App Manifest and theme color so Chrome shows the install option. Update app branding to “deco CMS”; use existing `favicon.svg` as the icon, no service worker or caching.

- **New Features**
  - Added `/manifest.webmanifest` with name/short_name “deco CMS”, start_url `/`, scope `/`, display `standalone`, background/theme colors, and `/favicon.svg` icon.
  - Linked the manifest and `<meta name="theme-color" />`; updated page title and OG/Twitter tags to “deco CMS” in `apps/mesh/index.html`.

<sup>Written for commit a02dacd84d6576a418a20b2be1eb22c574f5ed93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

