### PR TITLE
fix(mesh-image): install python3 + build-essential for node-pty native build

### DIFF
--- a/apps/mesh/Dockerfile
+++ b/apps/mesh/Dockerfile
@@ -5,8 +5,13 @@ FROM oven/bun:1-slim
 # Version to install (override with --build-arg MESH_VERSION=1.0.0)
 ARG MESH_VERSION=latest
 
-# Install runtime dependencies (unzip needed by embedded-postgres)
-RUN apt-get update && apt-get install -y --no-install-recommends unzip && \
+# Install runtime dependencies (unzip needed by embedded-postgres) plus the
+# toolchain needed to compile node-pty from source. node-pty ships prebuilt
+# binaries only for darwin/win32, so on Linux `bun add` always falls back to
+# `node-gyp rebuild` — which needs python3 + build-essential. We purge the
+# build toolchain after install to keep the layer lean.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      unzip python3 build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and app directories
@@ -21,6 +26,12 @@ WORKDIR /app/apps/mesh
 
 # Install the package locally during build (cached in image layer)
 RUN bun add decocms@${MESH_VERSION}
+
+# Drop the build toolchain now that native modules have been compiled.
+USER root
+RUN apt-get purge -y --auto-remove python3 build-essential && \
+    rm -rf /var/lib/apt/lists/*
+USER bunuser
 
 # Expose the default port
 EXPOSE 3000


### PR DESCRIPTION
## What is this contribution about?

Self-hosters building `apps/mesh/Dockerfile` against `decocms@2.297+` hit a hard failure during `bun add decocms@${MESH_VERSION}`:

```
gyp ERR! find Python — Could not find any Python installation to use
error: install script from "node-pty" exited with 1
```

The host-runner work in #3252 promoted `node-pty` to a runtime dependency of the published `decocms` package. `node-pty@1.1.0` only ships prebuilt binaries for darwin/win32 — on Linux `bun add` always falls back to `node-gyp rebuild`, which needs `python3` + `build-essential`. The `oven/bun:1-slim` base image has neither, so every customer-side image build of 2.297.x explodes. (We didn't notice in `release-mesh.yaml` because it short-circuits when the GHCR tag already exists, and `packages/sandbox/image/Dockerfile` already had this fix.)

Add `python3` + `build-essential` to the apt install before `bun add`, then drop back to `root` afterwards to `apt-get purge --auto-remove` and clear apt lists. Mirrors `packages/sandbox/image/Dockerfile:64-72`. Runtime layer size is essentially unchanged — only the build step is affected.

## How to Test

1. `cd apps/mesh && docker build --build-arg MESH_VERSION=2.297.3 -t mesh-test .`
2. The `[5/5] RUN bun add decocms@2.297.3` step should complete (node-pty compiles from source).
3. Final image still runs: `docker run --rm -p 3000:3000 mesh-test`.

## Migration Notes

None — Dockerfile-only change.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `python3` and `build-essential` to the `apps/mesh` Docker build so `node-pty` can compile on Linux during `bun add decocms@2.297+`, fixing self-hosted build failures. The tools are purged after install to keep the final image slim.

- **Bug Fixes**
  - Install `python3` and `build-essential` before `bun add`, then `apt-get purge --auto-remove` them and clean apt lists.
  - Matches `packages/sandbox/image/Dockerfile` and unblocks builds on `oven/bun:1-slim`.

<sup>Written for commit 7370b33f7b90d690b4aded6956733047d6fe3a0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

