### PR TITLE
fix(auth): bind ctx.organization to x-org-id hint for OAuth sessions

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -500,11 +500,18 @@ async function authenticateRequest(
     if (session) {
       const userId = session.userId;
 
-      // For MCP OAuth sessions, we need to query the database directly
-      // because getFullOrganization requires a browser session (cookies)
-      // Query user's first organization membership
-      const membership = await timings.measure("auth_query_membership", () =>
-        db
+      // For MCP OAuth sessions we need to query the database directly because
+      // getFullOrganization requires a browser session (cookies). The OAuth
+      // grant doesn't carry org context, so prefer an explicit hint from the
+      // request (x-org-id / x-org-slug) and fall back to the user's first
+      // membership only when no hint is given. Without the hint, multi-org
+      // users get a non-deterministic pick and end up with the wrong
+      // ctx.organization on every request that doesn't target their first org.
+      const orgIdHint = req.headers.get("x-org-id");
+      const orgSlugHint = req.headers.get("x-org-slug");
+
+      const membership = await timings.measure("auth_query_membership", () => {
+        const base = db
           .selectFrom("member")
           .innerJoin("organization", "organization.id", "member.organizationId")
           .select([
@@ -514,9 +521,20 @@ async function authenticateRequest(
             "organization.slug as orgSlug",
             "organization.name as orgName",
           ])
-          .where("member.userId", "=", userId)
-          .executeTakeFirst(),
-      );
+          .where("member.userId", "=", userId);
+
+        if (orgIdHint) {
+          return base
+            .where("organization.id", "=", orgIdHint)
+            .executeTakeFirst();
+        }
+        if (orgSlugHint) {
+          return base
+            .where("organization.slug", "=", orgSlugHint)
+            .executeTakeFirst();
+        }
+        return base.executeTakeFirst();
+      });
 
       const role = membership?.role;
       const organization = membership

--- a/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -46,6 +46,7 @@ interface ShareButtonProps {
 
 interface ShareWithNameProps extends ShareButtonProps {
   serverName: string;
+  organizationId: string;
 }
 
 /**
@@ -87,7 +88,12 @@ function CopyUrlButton({ url, agentId }: ShareButtonProps) {
 /**
  * Install on Cursor Button Component
  */
-function InstallCursorButton({ url, serverName, agentId }: ShareWithNameProps) {
+function InstallCursorButton({
+  url,
+  serverName,
+  agentId,
+  organizationId,
+}: ShareWithNameProps) {
   const handleInstall = () => {
     track("agent_connect_action", {
       agent_id: agentId,
@@ -99,6 +105,7 @@ function InstallCursorButton({ url, serverName, agentId }: ShareWithNameProps) {
       url: url,
       headers: {
         "x-mesh-client": "Cursor",
+        "x-org-id": organizationId,
       },
     };
     const base64Config = utf8ToBase64(
@@ -134,7 +141,12 @@ function InstallCursorButton({ url, serverName, agentId }: ShareWithNameProps) {
 /**
  * Install on Claude Code Button Component
  */
-function InstallClaudeButton({ url, serverName, agentId }: ShareWithNameProps) {
+function InstallClaudeButton({
+  url,
+  serverName,
+  agentId,
+  organizationId,
+}: ShareWithNameProps) {
   const [copied, setCopied] = useState(false);
 
   const handleInstall = async () => {
@@ -148,6 +160,7 @@ function InstallClaudeButton({ url, serverName, agentId }: ShareWithNameProps) {
       url: url,
       headers: {
         "x-mesh-client": "Claude Code",
+        "x-org-id": organizationId,
       },
     };
     const configJson = JSON.stringify(connectionConfig, null, 2);
@@ -403,11 +416,13 @@ export function VirtualMCPShareModal({
             url={virtualMcpUrl.href}
             serverName={serverName}
             agentId={virtualMcp.id}
+            organizationId={virtualMcp.organization_id}
           />
           <InstallClaudeButton
             url={virtualMcpUrl.href}
             serverName={serverName}
             agentId={virtualMcp.id}
+            organizationId={virtualMcp.organization_id}
           />
         </div>
       </div>


### PR DESCRIPTION
## What is this contribution about?

The MCP OAuth grant doesn't carry org context, so `authenticateRequest` fell back to `executeTakeFirst()` on the `member` table to pick a "first" org for the user — a non-deterministic pick that lands on the wrong org for multi-org users, surfacing as `Forbidden: Agent does not belong to your organization` when connecting a shared virtual MCP from Cursor/Claude Code in production. This PR honors `x-org-id` (or `x-org-slug`) on the request so `ctx.organization` resolves deterministically when the client provides a hint, and bakes `x-org-id` into the share-modal configs so new Cursor/Claude installs carry the hint automatically. No-hint requests fall back to today's behavior, so existing clients are unaffected.

## How to Test

1. Sign in as a user that's a member of two organizations (call them A and B), where the user's "first" membership in `member` is A.
2. From an org **B** project, open a virtual MCP and click **Install on Cursor** (or **Install on Claude Code**).
3. Confirm the new install connects without the `Forbidden: Agent does not belong to your organization` error.
4. Repeat from org A — should also keep working.
5. Optionally, manually edit the Cursor MCP config to remove `x-org-id` and verify it still connects when the virtual MCP belongs to the user's first-membership org (legacy fallback).

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `x-org-id`/`x-org-slug` for MCP OAuth sessions and include `x-org-id` in the virtual MCP share-modal configs so installs bind to the correct org. This prevents "Forbidden: Agent does not belong to your organization" for multi-org users in Cursor/Claude Code.

- **Bug Fixes**
  - Scope membership lookup in `authenticateRequest` by `x-org-id` or `x-org-slug`; fallback to first membership when no hint is provided.
  - Add `x-org-id` to Cursor and Claude Code connection configs in the virtual MCP share modal.

<sup>Written for commit c5021775eea4129fcd2131120c61397f63c20712. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

