### PR TITLE
fix(decopilot): destructive tools require user approval and new model allow all

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/helpers.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.test.ts
@@ -422,8 +422,8 @@ describe("toolNeedsApproval", () => {
     });
   });
 
-  describe('approval level: "yolo"', () => {
-    const level: ToolApprovalLevel = "yolo";
+  describe('approval level: "trust-all"', () => {
+    const level: ToolApprovalLevel = "trust-all";
 
     test("returns false for read-only tools", () => {
       expect(toolNeedsApproval(level, true)).toBe(false);

--- a/apps/mesh/src/api/routes/decopilot/helpers.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.test.ts
@@ -380,4 +380,45 @@ describe("toolNeedsApproval", () => {
       expect(toolNeedsApproval(level, undefined)).toBe(true);
     });
   });
+
+  describe("destructiveHint always requires approval", () => {
+    test("returns true even when level is auto", () => {
+      expect(toolNeedsApproval("auto", false, { destructiveHint: true })).toBe(
+        true,
+      );
+    });
+
+    test("returns true even when readOnlyHint is true", () => {
+      expect(toolNeedsApproval("auto", true, { destructiveHint: true })).toBe(
+        true,
+      );
+    });
+
+    test("returns true for readonly level", () => {
+      expect(
+        toolNeedsApproval("readonly", false, { destructiveHint: true }),
+      ).toBe(true);
+    });
+
+    test("does not affect non-destructive tools", () => {
+      expect(toolNeedsApproval("auto", false, { destructiveHint: false })).toBe(
+        false,
+      );
+    });
+
+    test("does not affect when destructiveHint is undefined", () => {
+      expect(
+        toolNeedsApproval("auto", false, { destructiveHint: undefined }),
+      ).toBe(false);
+    });
+
+    test("plan mode hard-block takes precedence over destructiveHint for non-readOnly tools", () => {
+      expect(
+        toolNeedsApproval("auto", false, {
+          isPlanMode: true,
+          destructiveHint: true,
+        }),
+      ).toBe("hard-block");
+    });
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/helpers.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.test.ts
@@ -421,4 +421,32 @@ describe("toolNeedsApproval", () => {
       ).toBe("hard-block");
     });
   });
+
+  describe('approval level: "yolo"', () => {
+    const level: ToolApprovalLevel = "yolo";
+
+    test("returns false for read-only tools", () => {
+      expect(toolNeedsApproval(level, true)).toBe(false);
+    });
+
+    test("returns false for non-read-only tools", () => {
+      expect(toolNeedsApproval(level, false)).toBe(false);
+    });
+
+    test("returns false even for destructive tools", () => {
+      expect(toolNeedsApproval(level, false, { destructiveHint: true })).toBe(
+        false,
+      );
+    });
+
+    test("plan mode still hard-blocks non-read-only tools", () => {
+      expect(toolNeedsApproval(level, false, { isPlanMode: true })).toBe(
+        "hard-block",
+      );
+    });
+
+    test("plan mode allows read-only tools", () => {
+      expect(toolNeedsApproval(level, true, { isPlanMode: true })).toBe(false);
+    });
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -34,22 +34,25 @@ import {
 export type ToolApprovalLevel = "auto" | "readonly";
 
 /**
- * Determine if a tool needs approval based on approval level and readOnlyHint
+ * Determine if a tool needs approval based on approval level and annotations
  *
  * @param level - The approval level setting
  * @param readOnlyHint - Optional hint from MCP tool annotations
  * @param options.isPlanMode - When true (chat `mode: "plan"`), non-read-only tools are hard-blocked
+ * @param options.destructiveHint - When true, the tool always requires approval regardless of level
  * @returns true if the tool requires approval, false if auto-approved
  */
 export function toolNeedsApproval(
   level: ToolApprovalLevel,
   readOnlyHint?: boolean,
-  options?: { isPlanMode?: boolean },
+  options?: { isPlanMode?: boolean; destructiveHint?: boolean },
 ): boolean | "hard-block" {
   if (options?.isPlanMode) {
     if (readOnlyHint === true) return false;
     return "hard-block";
   }
+  // Destructive tools always require approval
+  if (options?.destructiveHint === true) return true;
   if (level === "auto") return false;
   // "readonly": auto-approve only if explicitly marked readOnly
   return readOnlyHint !== true;
@@ -165,6 +168,7 @@ export async function toolsFromMCP(
         needsApproval:
           toolNeedsApproval(toolApprovalLevel, annotations?.readOnlyHint, {
             isPlanMode: options?.isPlanMode,
+            destructiveHint: annotations?.destructiveHint,
           }) !== false,
         execute: async (input, callOptions) => {
           const startTime = performance.now();

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -31,7 +31,7 @@ import {
 /**
  * Tool approval levels determine which tools require user approval before executing
  */
-export type ToolApprovalLevel = "auto" | "readonly" | "yolo";
+export type ToolApprovalLevel = "auto" | "readonly" | "trust-all";
 
 /**
  * Determine if a tool needs approval based on approval level and annotations
@@ -51,8 +51,8 @@ export function toolNeedsApproval(
     if (readOnlyHint === true) return false;
     return "hard-block";
   }
-  // "yolo": auto-approve everything, including destructive tools
-  if (level === "yolo") return false;
+  // "trust-all": auto-approve everything, including destructive tools
+  if (level === "trust-all") return false;
   // Destructive tools always require approval (unless yolo)
   if (options?.destructiveHint === true) return true;
   if (level === "auto") return false;

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -31,7 +31,7 @@ import {
 /**
  * Tool approval levels determine which tools require user approval before executing
  */
-export type ToolApprovalLevel = "auto" | "readonly";
+export type ToolApprovalLevel = "auto" | "readonly" | "yolo";
 
 /**
  * Determine if a tool needs approval based on approval level and annotations
@@ -51,7 +51,9 @@ export function toolNeedsApproval(
     if (readOnlyHint === true) return false;
     return "hard-block";
   }
-  // Destructive tools always require approval
+  // "yolo": auto-approve everything, including destructive tools
+  if (level === "yolo") return false;
+  // Destructive tools always require approval (unless yolo)
   if (options?.destructiveHint === true) return true;
   if (level === "auto") return false;
   // "readonly": auto-approve only if explicitly marked readOnly

--- a/apps/mesh/src/web/components/chat/highlight/approval.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/approval.tsx
@@ -43,6 +43,7 @@ const APPROVAL_LEVEL_OPTIONS: {
 }[] = [
   { value: "readonly", label: "Ask before edit" },
   { value: "auto", label: "Auto approve" },
+  { value: "yolo", label: "YOLO" },
 ];
 
 // ============================================================================
@@ -55,7 +56,7 @@ function ApprovalLevelSelect({ onYolo }: { onYolo: () => void }) {
   const handleLevelChange = (value: string) => {
     const newLevel = value as ToolApprovalLevel;
     setPreferences({ ...preferences, toolApprovalLevel: newLevel });
-    if (newLevel === "auto") {
+    if (newLevel === "auto" || newLevel === "yolo") {
       onYolo();
     }
   };

--- a/apps/mesh/src/web/components/chat/highlight/approval.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/approval.tsx
@@ -43,7 +43,7 @@ const APPROVAL_LEVEL_OPTIONS: {
 }[] = [
   { value: "readonly", label: "Ask before edit" },
   { value: "auto", label: "Auto approve" },
-  { value: "yolo", label: "YOLO" },
+  { value: "trust-all", label: "Trust all" },
 ];
 
 // ============================================================================
@@ -56,7 +56,7 @@ function ApprovalLevelSelect({ onYolo }: { onYolo: () => void }) {
   const handleLevelChange = (value: string) => {
     const newLevel = value as ToolApprovalLevel;
     setPreferences({ ...preferences, toolApprovalLevel: newLevel });
-    if (newLevel === "auto" || newLevel === "yolo") {
+    if (newLevel === "auto" || newLevel === "trust-all") {
       onYolo();
     }
   };

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "./use-local-storage.ts";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys.ts";
 
-export type ToolApprovalLevel = "auto" | "readonly" | "yolo";
+export type ToolApprovalLevel = "auto" | "readonly" | "trust-all";
 export type ThemeMode = "light" | "dark" | "system";
 interface Preferences {
   toolApprovalLevel: ToolApprovalLevel;
@@ -22,7 +22,7 @@ const DEFAULT_PREFERENCES: Preferences = {
 const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = [
   "auto",
   "readonly",
-  "yolo",
+  "trust-all",
 ];
 
 const VALID_THEME_MODES: ThemeMode[] = ["light", "dark", "system"];

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "./use-local-storage.ts";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys.ts";
 
-export type ToolApprovalLevel = "auto" | "readonly";
+export type ToolApprovalLevel = "auto" | "readonly" | "yolo";
 export type ThemeMode = "light" | "dark" | "system";
 interface Preferences {
   toolApprovalLevel: ToolApprovalLevel;
@@ -19,7 +19,11 @@ const DEFAULT_PREFERENCES: Preferences = {
   experimental_vibecode: false,
 };
 
-const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];
+const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = [
+  "auto",
+  "readonly",
+  "yolo",
+];
 
 const VALID_THEME_MODES: ThemeMode[] = ["light", "dark", "system"];
 

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -244,7 +244,7 @@ function PreferencesSection() {
                   {{
                     readonly: "Ask before edit",
                     auto: "Auto approve",
-                    yolo: "YOLO",
+                    "trust-all": "Trust all",
                   }[preferences.toolApprovalLevel] ?? "Ask before edit"}
                 </span>
               </SelectTrigger>
@@ -265,9 +265,9 @@ function PreferencesSection() {
                     </span>
                   </div>
                 </SelectItem>
-                <SelectItem value="yolo" textValue="YOLO">
+                <SelectItem value="trust-all" textValue="Trust all">
                   <div className="flex flex-col gap-0.5">
-                    <span className="font-medium">YOLO</span>
+                    <span className="font-medium">Trust all</span>
                     <span className="text-xs text-muted-foreground">
                       Execute all without approval
                     </span>

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -244,6 +244,7 @@ function PreferencesSection() {
                   {{
                     readonly: "Ask before edit",
                     auto: "Auto approve",
+                    yolo: "YOLO",
                   }[preferences.toolApprovalLevel] ?? "Ask before edit"}
                 </span>
               </SelectTrigger>
@@ -259,6 +260,14 @@ function PreferencesSection() {
                 <SelectItem value="auto" textValue="Auto approve">
                   <div className="flex flex-col gap-0.5">
                     <span className="font-medium">Auto approve</span>
+                    <span className="text-xs text-muted-foreground">
+                      Ask before destructive tools
+                    </span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="yolo" textValue="YOLO">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="font-medium">YOLO</span>
                     <span className="text-xs text-muted-foreground">
                       Execute all without approval
                     </span>


### PR DESCRIPTION
## Summary
- Tools annotated with `destructiveHint: true` now **always** require user approval, regardless of the `ToolApprovalLevel` setting (`auto` or `readonly`)
- Previously `destructiveHint` was only used for UI badges and analytics — the approval gate only checked `readOnlyHint`
- Passthrough MCP tools now forward `annotations.destructiveHint` to `toolNeedsApproval`

## Test plan
- [x] Added 6 new tests covering destructive approval behavior
- [x] All 55 existing tests still pass
- [ ] Verify in the UI that a destructive MCP tool triggers the approval prompt even with `auto` approval level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Destructive MCP tools with `destructiveHint: true` now require approval on `auto` and `readonly`. A new `trust-all` level skips all approval prompts, including destructive tools. Passthrough tools now forward `annotations.destructiveHint` to `toolNeedsApproval`.

- **New Features**
  - Added `trust-all` `ToolApprovalLevel`; `toolNeedsApproval` auto-approves everything on `trust-all`.
  - Updated chat selector and Profile Preferences to include `trust-all` with clear labels; preferences validation accepts `trust-all`.
  - Added tests for `trust-all` and destructive approval; plan mode still hard-blocks non-read-only tools.

<sup>Written for commit ed93659ba5fd61804bc9dc10e2bc496f20f20602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

