### PR TITLE
feat(mesh): always-on Virtual MCP publish button with color-coded states

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -1,6 +1,7 @@
 import { useProjectContext, useVirtualMCP } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Separator } from "@deco/ui/components/separator.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
 import {
   Tooltip,
   TooltipContent,
@@ -25,10 +26,10 @@ interface Props {
  * PR state. The button never performs the action directly; clicks send a
  * templated prompt into the chat for the agent to execute.
  *
- * Gated on `!!githubRepo?.connectionId && !!branch` (the caller also gates).
- * When the VM is not yet connected (no branchStatus event received), renders
- * null — avoids flashing a misleading label before we know the working-tree
- * state.
+ * Gated on `!!githubRepo?.connectionId && !!branch`. Once GitHub is wired
+ * up, the button always renders — disabled status pills (Loading…, Up to
+ * date, Published, Awaiting review, Running tests…) cover the cases where
+ * there is no actionable next step.
  */
 export function HeaderActions({ virtualMcpId }: Props) {
   const { org } = useProjectContext();
@@ -72,9 +73,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
     pr,
     checks: checksQuery.data ?? [],
     reviews: reviewsQuery.data ?? null,
+    loading: prQuery.isPending,
   });
-
-  if (!button) return null;
 
   const send = (text: string) =>
     chat.sendMessage({ parts: [{ type: "text", text }] });
@@ -143,7 +143,9 @@ function HeaderButtonRenderer(props: {
 }) {
   const { button, isStreaming } = props;
   const disabled = Boolean(button.disabled) || isStreaming;
-  const tooltipLabel = isStreaming ? "Chat is running" : null;
+  const tooltipLabel = isStreaming
+    ? "Chat is running"
+    : (button.tooltip ?? null);
 
   if (button.action === "merge-split" && props.prNumber != null) {
     return (
@@ -161,10 +163,11 @@ function HeaderButtonRenderer(props: {
     <WithTooltip label={tooltipLabel}>
       <Button
         size="sm"
-        variant={button.disabled ? "outline" : "default"}
+        variant={button.variant}
         disabled={disabled}
         onClick={() => props.onActivate(button.action)}
       >
+        {button.loading ? <Spinner size="xs" variant="default" /> : null}
         {button.label}
       </Button>
     </WithTooltip>

--- a/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
+++ b/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
@@ -27,7 +27,8 @@ export function MergeSplitButton({ prNumber, disabled, send }: Props) {
     <div className="inline-flex items-stretch rounded-md">
       <Button
         size="sm"
-        className="rounded-r-none border-r border-primary-foreground/20"
+        variant="success"
+        className="rounded-r-none border-r border-success-foreground/20"
         disabled={disabled}
         onClick={squash}
       >
@@ -37,6 +38,7 @@ export function MergeSplitButton({ prNumber, disabled, send }: Props) {
         <DropdownMenuTrigger asChild>
           <Button
             size="sm"
+            variant="success"
             className="rounded-l-none px-2"
             disabled={disabled}
             aria-label="More actions"

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -57,26 +57,41 @@ function reviews(over: Partial<PrReviewSignals> = {}): PrReviewSignals {
 }
 
 describe("selectHeaderButton", () => {
-  test("returns null when branchStatus is missing", () => {
-    expect(
-      selectHeaderButton({
-        branchStatus: null,
-        pr: null,
-        checks: [],
-        reviews: null,
-      }),
-    ).toBeNull();
+  test("branchStatus missing → Loading… (disabled, spinner)", () => {
+    const r = selectHeaderButton({
+      branchStatus: null,
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Loading…");
+    expect(r.disabled).toBe(true);
+    expect(r.loading).toBe(true);
+    expect(r.variant).toBe("outline");
   });
 
-  test("returns null when there is no diff anywhere", () => {
-    expect(
-      selectHeaderButton({
-        branchStatus: bs(),
-        pr: null,
-        checks: [],
-        reviews: null,
-      }),
-    ).toBeNull();
+  test("loading flag → Loading… even when branchStatus present", () => {
+    const r = selectHeaderButton({
+      branchStatus: bs(),
+      pr: null,
+      checks: [],
+      reviews: null,
+      loading: true,
+    });
+    expect(r.label).toBe("Loading…");
+    expect(r.loading).toBe(true);
+  });
+
+  test("no diff anywhere → Up to date (disabled, outline)", () => {
+    const r = selectHeaderButton({
+      branchStatus: bs(),
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Up to date");
+    expect(r.disabled).toBe(true);
+    expect(r.variant).toBe("outline");
   });
 
   test("dirty working tree → Commit & Push", () => {
@@ -86,9 +101,9 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: null,
     });
-    expect(r?.label).toBe("Save changes");
-    expect(r?.action).toBe("commit-and-push");
-    expect(r?.disabled).toBeFalsy();
+    expect(r.label).toBe("Save changes");
+    expect(r.action).toBe("commit-and-push");
+    expect(r.disabled).toBeFalsy();
   });
 
   test("unpushed commits → Commit & Push", () => {
@@ -98,7 +113,7 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: null,
     });
-    expect(r?.label).toBe("Save changes");
+    expect(r.label).toBe("Save changes");
   });
 
   test("ahead of base + closed non-merged PR → Reopen PR", () => {
@@ -108,11 +123,11 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: null,
     });
-    expect(r?.label).toBe("Reopen");
-    expect(r?.action).toBe("reopen");
+    expect(r.label).toBe("Reopen");
+    expect(r.action).toBe("reopen");
   });
 
-  test("merged PR, branch at merge head → null (work shipped)", () => {
+  test("merged PR, branch at merge head → Published (disabled, outline)", () => {
     const r = selectHeaderButton({
       branchStatus: bs({ aheadOfBase: 3, headSha: "abc123" }),
       pr: pr({
@@ -124,10 +139,12 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: null,
     });
-    expect(r).toBeNull();
+    expect(r.label).toBe("Published");
+    expect(r.disabled).toBe(true);
+    expect(r.variant).toBe("outline");
   });
 
-  test("merged PR, branch advanced past merge head → Submit for review", () => {
+  test("merged PR, branch advanced past merge head → Continue (special)", () => {
     const r = selectHeaderButton({
       branchStatus: bs({ aheadOfBase: 4, headSha: "def456" }),
       pr: pr({
@@ -139,8 +156,9 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: null,
     });
-    expect(r?.label).toBe("Submit for review");
-    expect(r?.action).toBe("create-pr");
+    expect(r.label).toBe("Continue");
+    expect(r.action).toBe("create-pr");
+    expect(r.variant).toBe("special");
   });
 
   test("ahead of base + no PR → Create PR", () => {
@@ -150,7 +168,7 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: null,
     });
-    expect(r?.label).toBe("Submit for review");
+    expect(r.label).toBe("Submit for review");
   });
 
   test("PR open + mergeable_state=dirty → Rebase on main", () => {
@@ -160,8 +178,8 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: reviews({ mergeableState: "dirty" }),
     });
-    expect(r?.label).toBe("Sync with main");
-    expect(r?.action).toBe("rebase");
+    expect(r.label).toBe("Sync with main");
+    expect(r.action).toBe("rebase");
   });
 
   test("PR open + failed check → Fix checks with failing list", () => {
@@ -171,9 +189,9 @@ describe("selectHeaderButton", () => {
       checks: [check({ conclusion: "failure", name: "unit-test" })],
       reviews: reviews(),
     });
-    expect(r?.label).toBe("Fix tests");
-    expect(r?.action).toBe("fix-checks");
-    expect(r?.meta?.failingChecks).toEqual(["unit-test"]);
+    expect(r.label).toBe("Fix tests");
+    expect(r.action).toBe("fix-checks");
+    expect(r.meta?.failingChecks).toEqual(["unit-test"]);
   });
 
   test("PR open + check in-progress → Waiting for checks (disabled)", () => {
@@ -183,8 +201,10 @@ describe("selectHeaderButton", () => {
       checks: [check({ status: "in_progress", conclusion: null })],
       reviews: reviews(),
     });
-    expect(r?.label).toBe("Running tests…");
-    expect(r?.disabled).toBe(true);
+    expect(r.label).toBe("Running tests…");
+    expect(r.disabled).toBe(true);
+    expect(r.loading).toBe(true);
+    expect(r.variant).toBe("outline");
   });
 
   test("PR open + draft → Mark ready for review", () => {
@@ -194,8 +214,8 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: reviews({ draft: true }),
     });
-    expect(r?.label).toBe("Mark ready");
-    expect(r?.action).toBe("mark-ready");
+    expect(r.label).toBe("Mark ready");
+    expect(r.action).toBe("mark-ready");
   });
 
   test("PR open + unresolved conversations → Resolve review comments", () => {
@@ -205,8 +225,8 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: reviews({ unresolvedConversations: 2 }),
     });
-    expect(r?.label).toBe("Address feedback");
-    expect(r?.action).toBe("resolve-comments");
+    expect(r.label).toBe("Address feedback");
+    expect(r.action).toBe("resolve-comments");
   });
 
   test("PR open + missing approvals → Waiting for review (disabled)", () => {
@@ -216,8 +236,8 @@ describe("selectHeaderButton", () => {
       checks: [],
       reviews: reviews({ missingRequiredApprovals: true }),
     });
-    expect(r?.label).toBe("Awaiting review");
-    expect(r?.disabled).toBe(true);
+    expect(r.label).toBe("Awaiting review");
+    expect(r.disabled).toBe(true);
   });
 
   test("PR open + all clear → Merge", () => {
@@ -227,8 +247,9 @@ describe("selectHeaderButton", () => {
       checks: [check()],
       reviews: reviews(),
     });
-    expect(r?.label).toBe("Publish");
-    expect(r?.action).toBe("merge-split");
+    expect(r.label).toBe("Publish");
+    expect(r.action).toBe("merge-split");
+    expect(r.variant).toBe("success");
   });
 
   test("priority: dirty beats everything else", () => {
@@ -238,7 +259,7 @@ describe("selectHeaderButton", () => {
       checks: [check({ conclusion: "failure" })],
       reviews: reviews({ mergeableState: "dirty" }),
     });
-    expect(r?.label).toBe("Save changes");
+    expect(r.label).toBe("Save changes");
   });
 
   test("priority inside PR open: conflicts beat failed checks", () => {
@@ -248,7 +269,7 @@ describe("selectHeaderButton", () => {
       checks: [check({ conclusion: "failure" })],
       reviews: reviews({ mergeableState: "dirty" }),
     });
-    expect(r?.label).toBe("Sync with main");
+    expect(r.label).toBe("Sync with main");
   });
 
   test("priority: failed checks beat in-progress checks", () => {
@@ -261,6 +282,6 @@ describe("selectHeaderButton", () => {
       ],
       reviews: reviews(),
     });
-    expect(r?.label).toBe("Fix tests");
+    expect(r.label).toBe("Fix tests");
   });
 });

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -4,9 +4,15 @@ import type { PrReviewSignals } from "./use-pr-reviews.ts";
 
 /**
  * Descriptor returned by selectHeaderButton. Callers translate action →
- * prompt via the message-templates module. `disabled: true` means the
- * button renders as a status indicator (e.g., "Running tests…"), not
- * clickable.
+ * prompt via the message-templates module.
+ *
+ * `disabled: true` means the button renders as a status indicator (e.g.,
+ * "Running tests…", "Awaiting review"), not clickable. `loading: true`
+ * adds a spinner; use it for "data is fetching" and for "server-side work
+ * in progress" (CI running). `variant` selects the button color: success
+ * (green) for the happy-path Publish, special (purple) for post-merge
+ * Continue, default for other actionable states, outline for non-actionable
+ * status pills.
  */
 export type HeaderButton = {
   label: string;
@@ -20,6 +26,9 @@ export type HeaderButton = {
     | "resolve-comments"
     | "merge-split";
   disabled?: boolean;
+  loading?: boolean;
+  variant: "default" | "outline" | "success" | "special";
+  tooltip?: string;
   meta?: {
     failingChecks?: string[];
   };
@@ -54,15 +63,29 @@ export function selectHeaderButton(input: {
   pr: PrSummary | null;
   checks: CheckRun[];
   reviews: PrReviewSignals | null;
-}): HeaderButton | null {
-  const { branchStatus, pr, checks, reviews } = input;
+  loading?: boolean;
+}): HeaderButton {
+  const { branchStatus, pr, checks, reviews, loading } = input;
 
-  if (!branchStatus) return null;
+  if (!branchStatus || loading) {
+    return {
+      label: "Loading…",
+      disabled: true,
+      loading: true,
+      variant: "outline",
+      tooltip: "Loading branch and pull request status",
+    };
+  }
 
   const hasLocalWork =
     branchStatus.workingTreeDirty || branchStatus.unpushed > 0;
   if (hasLocalWork) {
-    return { label: "Save changes", action: "commit-and-push" };
+    return {
+      label: "Save changes",
+      action: "commit-and-push",
+      variant: "default",
+      tooltip: "Commit and push local changes",
+    };
   }
 
   // Merged PR is terminal UNLESS the branch has advanced past the PR's
@@ -77,24 +100,49 @@ export function selectHeaderButton(input: {
       !!pr.headSha &&
       branchStatus.headSha !== pr.headSha;
     if (branchAdvanced) {
-      return { label: "Submit for review", action: "create-pr" };
+      return {
+        label: "Continue",
+        action: "create-pr",
+        variant: "special",
+        tooltip: "Open a new PR with the latest commits",
+      };
     }
-    return null;
+    return {
+      label: "Published",
+      disabled: true,
+      variant: "outline",
+      tooltip: `PR #${pr.number} merged into ${pr.base}`,
+    };
   }
 
   if (branchStatus.aheadOfBase > 0) {
     if (pr && pr.state === "closed" && !pr.merged) {
-      return { label: "Reopen", action: "reopen" };
+      return {
+        label: "Reopen",
+        action: "reopen",
+        variant: "default",
+        tooltip: `Reopen PR #${pr.number}`,
+      };
     }
     if (!pr) {
-      return { label: "Submit for review", action: "create-pr" };
+      return {
+        label: "Submit for review",
+        action: "create-pr",
+        variant: "default",
+        tooltip: `Open a PR for ${branchStatus.branch} → ${branchStatus.base}`,
+      };
     }
 
     // pr.state === "open"
     const mergeableState = reviews?.mergeableState ?? "unknown";
 
     if (mergeableState === "dirty") {
-      return { label: `Sync with ${pr.base}`, action: "rebase" };
+      return {
+        label: `Sync with ${pr.base}`,
+        action: "rebase",
+        variant: "default",
+        tooltip: `Resolve conflicts with ${pr.base} before merging`,
+      };
     }
 
     const failing = checks.filter(isCheckFailed).map((c) => c.name);
@@ -102,31 +150,67 @@ export function selectHeaderButton(input: {
       return {
         label: "Fix tests",
         action: "fix-checks",
+        variant: "default",
+        tooltip: `Failing: ${failing.join(", ")}`,
         meta: { failingChecks: failing },
       };
     }
 
-    if (checks.some(isCheckInProgress)) {
-      return { label: "Running tests…", disabled: true };
+    const inProgress = checks.filter(isCheckInProgress);
+    if (inProgress.length > 0) {
+      return {
+        label: "Running tests…",
+        disabled: true,
+        loading: true,
+        variant: "outline",
+        tooltip: `Waiting on ${inProgress.length} check${
+          inProgress.length === 1 ? "" : "s"
+        } to finish`,
+      };
     }
 
     if (reviews?.draft) {
-      return { label: "Mark ready", action: "mark-ready" };
+      return {
+        label: "Mark ready",
+        action: "mark-ready",
+        variant: "default",
+        tooltip: "Mark draft PR ready for review",
+      };
     }
 
-    if ((reviews?.unresolvedConversations ?? 0) > 0) {
+    const unresolved = reviews?.unresolvedConversations ?? 0;
+    if (unresolved > 0) {
       return {
         label: "Address feedback",
         action: "resolve-comments",
+        variant: "default",
+        tooltip: `${unresolved} unresolved conversation${
+          unresolved === 1 ? "" : "s"
+        }`,
       };
     }
 
     if (reviews?.missingRequiredApprovals) {
-      return { label: "Awaiting review", disabled: true };
+      return {
+        label: "Awaiting review",
+        disabled: true,
+        variant: "outline",
+        tooltip: "Waiting for required approvals",
+      };
     }
 
-    return { label: "Publish", action: "merge-split" };
+    return {
+      label: "Publish",
+      action: "merge-split",
+      variant: "success",
+      tooltip: `Squash-merge PR #${pr.number} into ${pr.base}`,
+    };
   }
 
-  return null;
+  return {
+    label: "Up to date",
+    disabled: true,
+    variant: "outline",
+    tooltip: `Branch is in sync with ${branchStatus.base}`,
+  };
 }

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -16,6 +16,10 @@ const buttonVariants = cva(
           "text-foreground bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50 card-shadow",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        success:
+          "bg-success text-success-foreground hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40",
+        special:
+          "bg-special text-special-foreground hover:bg-special/90 focus-visible:ring-special/20 dark:focus-visible:ring-special/40",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-foreground/80 hover:text-foreground",

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -8,7 +8,8 @@ const variants = cva("animate-spin", {
       default: "fill-primary text-gray-200",
       destructive: "fill-destructive text-gray-200",
       secondary: "fill-secondary text-gray-200",
-      special: "fill-special text-backround",
+      success: "fill-success text-gray-200",
+      special: "fill-special text-background",
     },
     size: {
       default: "h-7 w-7",

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -72,6 +72,8 @@
   --success-foreground: oklch(0.98 0.02 156);
   --warning: oklch(0.62 0.17 70);
   --warning-foreground: oklch(0.99 0.02 95);
+  --special: oklch(0.55 0.18 290);
+  --special-foreground: oklch(0.98 0.02 295);
 
   --sidebar: oklch(0.975 0.006 80);
   --sidebar-foreground: oklch(0.2 0.01 60);
@@ -136,6 +138,8 @@
   --success-foreground: oklch(0.97 0.02 156);
   --warning: oklch(0.65 0.15 70);
   --warning-foreground: oklch(0.98 0.02 95);
+  --special: oklch(0.6 0.16 290);
+  --special-foreground: oklch(0.97 0.02 295);
 
   --sidebar: oklch(0.155 0.005 60);
   --sidebar-foreground: oklch(0.96 0.005 60);
@@ -177,6 +181,8 @@
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-special: var(--special);
+  --color-special-foreground: var(--special-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);


### PR DESCRIPTION
## What is this contribution about?

Reworks the Virtual MCP header action button so it always renders once a GitHub repo is configured. Previously the button disappeared in several cases (data still loading, branch in sync, PR already merged) which made the UI feel unstable; now those states render as disabled status pills (Loading…, Up to date, Published, Awaiting review, Running tests…) with descriptive tooltips, and loading states show a spinner. Also introduces a consistent button color scheme: green `success` for Publish, purple `special` for the post-merge "Continue" follow-up, `default` for other actionable states, `outline` for non-actionable status. Along the way: adds `success`/`special` variants to the shared `Button`, defines the missing `--special` design token, fixes a `text-backround` typo on `Spinner`, and adds a `success` spinner variant.

## How to Test

1. Open a Virtual MCP that has a GitHub repo configured.
2. With nothing changed, the header should show **Up to date** (disabled, outline).
3. Edit a file in the workspace → button switches to **Save changes** (default). Push it → flows through **Submit for review**, **Running tests…** (with spinner), **Publish** (green). Merge → **Published** (disabled). Push again → **Continue** (purple).
4. Hover any state to see the tooltip; loading/test states show a spinner.

## Migration Notes

None. New CSS tokens (`--special`, `--special-foreground`) and new `Button` variants (`success`, `special`) are additive.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (19 unit tests pass; type check + lint clean)
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the Virtual MCP header action once a GitHub repo is connected, replacing disappearing states with clear, color-coded status pills and spinners. Adds `success`/`special` variants to support green Publish and purple Continue.

- **New Features**
  - Header action always visible with state labels and tooltips (Loading…, Up to date, Published, Awaiting review, Running tests…).
  - Consistent colors: `success` (green) for Publish, `special` (purple) for post-merge Continue, `outline` for non-actionable states.
  - `@deco/ui` `Button` gains `success` and `special`; `Spinner` gains `success`; added `--special` and `--special-foreground` tokens.
  - Selector now returns a stable button with `variant`, `loading`, and `tooltip` instead of null; merge-split uses `success`.

- **Bug Fixes**
  - Fixed `Spinner` color typo (`text-backround` → `text-background`).

<sup>Written for commit 7023d09bbe7b0ad087ca07ba4b94d1bd30e0b693. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

