### PR TITLE
fix: update error message for advisory lock and improve handle functi…

### DIFF
--- a/apps/mesh/src/storage/sandbox-runner-state.ts
+++ b/apps/mesh/src/storage/sandbox-runner-state.ts
@@ -196,7 +196,7 @@ export class KyselySandboxRunnerStateStore implements RunnerStateStore {
       } catch (err) {
         if (isStatementTimeoutError(err)) {
           throw new Error(
-            `sandbox advisory lock busy >${LOCK_WAIT_MS}ms for user=${id.userId} projectRef=${id.projectRef} kind=${kind} — another provisioner is slow or stuck; retry shortly`,
+            `sandbox advisory lock busy >${LOCK_WAIT_MS}ms for user=${id.userId} projectRef=${id.projectRef} kind=${kind} — provisioner is slow or stuck; retry shortly`,
           );
         }
         throw err;
@@ -207,7 +207,7 @@ export class KyselySandboxRunnerStateStore implements RunnerStateStore {
   }
 }
 
-/** Generous enough to cover a cold freestyle.vms.create; short enough that a stuck holder isn't invisible. */
+/** Generous enough to cover agent-sandbox waitForSandboxReady (180s) + buffer; short enough that a stuck holder isn't invisible. */
 const LOCK_WAIT_MS = 90_000;
 
 /** pg SQLSTATE 57014 = query_canceled — what `statement_timeout` raises. */

--- a/packages/sandbox/server/runner/shared/handle.test.ts
+++ b/packages/sandbox/server/runner/shared/handle.test.ts
@@ -39,29 +39,29 @@ describe("computeHandle", () => {
     expect(match![1]!.endsWith("-")).toBe(false);
   });
 
-  it("returns a bare 5-char hash when branch is null", () => {
+  it("returns s-<hash> when branch is null (DNS-1035: must start with letter)", () => {
     const handle = computeHandle(ID, null);
-    expect(handle).toMatch(/^[0-9a-f]{5}$/);
+    expect(handle).toMatch(/^s-[0-9a-f]{5}$/);
   });
 
-  it("returns a bare 5-char hash when branch is undefined", () => {
+  it("returns s-<hash> when branch is undefined", () => {
     const handle = computeHandle(ID);
-    expect(handle).toMatch(/^[0-9a-f]{5}$/);
+    expect(handle).toMatch(/^s-[0-9a-f]{5}$/);
   });
 
-  it("returns a bare 5-char hash when branch is empty string", () => {
+  it("returns s-<hash> when branch is empty string", () => {
     const handle = computeHandle(ID, "");
-    expect(handle).toMatch(/^[0-9a-f]{5}$/);
+    expect(handle).toMatch(/^s-[0-9a-f]{5}$/);
   });
 
-  it("returns a bare 5-char hash when branch sanitizes to empty", () => {
+  it("returns s-<hash> when branch sanitizes to empty", () => {
     const handle = computeHandle(ID, "///");
-    expect(handle).toMatch(/^[0-9a-f]{5}$/);
+    expect(handle).toMatch(/^s-[0-9a-f]{5}$/);
   });
 
-  it("returns a bare 5-char hash when branch is whitespace-only", () => {
+  it("returns s-<hash> when branch is whitespace-only", () => {
     const handle = computeHandle(ID, "   ");
-    expect(handle).toMatch(/^[0-9a-f]{5}$/);
+    expect(handle).toMatch(/^s-[0-9a-f]{5}$/);
   });
 
   it("is deterministic for the same (id, branch) pair", () => {
@@ -94,9 +94,9 @@ describe("computeHandle", () => {
     expect(handle.endsWith(`-${hashSandboxId(ID, 16)}`)).toBe(true);
   });
 
-  it("returns a bare hash of the requested length when branch is empty", () => {
+  it("returns s-<hash> of the requested length when branch is empty", () => {
     const handle = computeHandle(ID, null, { hashLen: 16 });
-    expect(handle).toMatch(/^[0-9a-f]{16}$/);
-    expect(handle).toBe(hashSandboxId(ID, 16));
+    expect(handle).toMatch(/^s-[0-9a-f]{16}$/);
+    expect(handle).toBe(`s-${hashSandboxId(ID, 16)}`);
   });
 });

--- a/packages/sandbox/server/runner/shared/handle.ts
+++ b/packages/sandbox/server/runner/shared/handle.ts
@@ -38,7 +38,7 @@ export function computeHandle(
   const hashLen = opts.hashLen ?? DEFAULT_HASH_LEN;
   const hash = hashSandboxId(id, hashLen);
   const slug = slugifyBranch(branch);
-  return slug ? `${slug}-${hash}` : hash;
+  return slug ? `${slug}-${hash}` : `s-${hash}`;
 }
 
 function slugifyBranch(branch: string | null | undefined): string {


### PR DESCRIPTION
…on to prefix hashes with 's-'

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure sandbox handles always start with a letter by prefixing bare hashes with `s-`, and clarify the advisory lock timeout message. This avoids DNS‑1035 violations and improves debugging.

- **Bug Fixes**
  - `computeHandle`: when branch is missing/empty, return `s-<hash>` instead of a bare hash to satisfy DNS‑1035 (tests updated).
  - `KyselySandboxRunnerStateStore`: clearer timeout error (“provisioner is slow or stuck; retry shortly”) and comment now references agent-sandbox `waitForSandboxReady` (180s); `LOCK_WAIT_MS` stays 90s.

<sup>Written for commit 9abd643a29ca78b21b2c3eb4e3d4a05285836896. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

