### PR TITLE
fix(mesh): show correct provider logo for claude-code models

### DIFF
--- a/apps/mesh/src/web/utils/ai-providers-logos.ts
+++ b/apps/mesh/src/web/utils/ai-providers-logos.ts
@@ -35,15 +35,18 @@ export function getProviderLogo(model: {
   providerId: string;
   modelId: string;
 }): string {
-  if (model.modelId.includes("/")) {
-    const upstream = model.modelId.split("/")[0];
-    if (PROVIDER_LOGOS[upstream]) return PROVIDER_LOGOS[upstream];
-  }
-  if (PROVIDER_LOGOS[model.providerId]) {
-    return PROVIDER_LOGOS[model.providerId];
-  }
+  const upstream = model.modelId.includes("/")
+    ? model.modelId.split("/")[0]
+    : undefined;
+  const fromUpstream = upstream ? PROVIDER_LOGOS[upstream] : undefined;
+  if (fromUpstream) return fromUpstream;
+
+  const fromProvider = PROVIDER_LOGOS[model.providerId];
+  if (fromProvider) return fromProvider;
+
   const inferred = inferUpstreamFromModelId(model.modelId);
-  return (inferred && PROVIDER_LOGOS[inferred]) || DEFAULT_LOGO;
+  const fromInferred = inferred ? PROVIDER_LOGOS[inferred] : undefined;
+  return fromInferred ?? DEFAULT_LOGO;
 }
 
 export const PROVIDER_LOGOS: Record<string, string> = {

--- a/apps/mesh/src/web/utils/ai-providers-logos.ts
+++ b/apps/mesh/src/web/utils/ai-providers-logos.ts
@@ -35,14 +35,15 @@ export function getProviderLogo(model: {
   providerId: string;
   modelId: string;
 }): string {
-  const upstreamProvider = model.modelId.includes("/")
-    ? model.modelId.split("/")[0]
-    : inferUpstreamFromModelId(model.modelId);
-  return (
-    (upstreamProvider && PROVIDER_LOGOS[upstreamProvider]) ||
-    PROVIDER_LOGOS[model.providerId] ||
-    DEFAULT_LOGO
-  );
+  if (model.modelId.includes("/")) {
+    const upstream = model.modelId.split("/")[0];
+    if (PROVIDER_LOGOS[upstream]) return PROVIDER_LOGOS[upstream];
+  }
+  if (PROVIDER_LOGOS[model.providerId]) {
+    return PROVIDER_LOGOS[model.providerId];
+  }
+  const inferred = inferUpstreamFromModelId(model.modelId);
+  return (inferred && PROVIDER_LOGOS[inferred]) || DEFAULT_LOGO;
 }
 
 export const PROVIDER_LOGOS: Record<string, string> = {


### PR DESCRIPTION
## What is this contribution about?
Reorder `getProviderLogo()` in `apps/mesh/src/web/utils/ai-providers-logos.ts` so the explicit `providerId` is checked before the name-based heuristic. Previously, claude-code models (modelId like `claude-code:haiku`) matched the `claude-` prefix in `inferUpstreamFromModelId()` and rendered the Anthropic logo instead of the Claude Code logo. The slash-prefix path runs first, so OpenRouter models still surface their upstream vendor logo (e.g. `anthropic/claude-3.5-sonnet` keeps the Anthropic icon).

## How to Test
1. Open the model selector in the chat UI.
2. Confirm Claude Code models (Haiku, Sonnet, Opus) show the Claude Code icon.
3. Confirm OpenRouter models still show their upstream vendor icon, and direct Anthropic / OpenAI models are unchanged.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider icons for Claude Code models by checking the explicit providerId before name-based inference in `getProviderLogo()`. OpenRouter models with "vendor/model" still show the upstream vendor logo.

- **Bug Fixes**
  - Claude Code models (e.g., `claude-code:haiku`) now show the Claude Code icon instead of Anthropic.
  - Logo resolution order: upstream from slash, then providerId, then inferred prefix.

- **Refactors**
  - Satisfy `noUncheckedIndexedAccess` by using intermediate variables for split results and logo lookups.

<sup>Written for commit 70d94add929351b80df568b64056f24361f298ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

