### PR TITLE
fix(chat): use sessionStorage and clear autosend after send

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1201,7 +1201,7 @@ export function ActiveTaskProvider({
   };
 
   // Autosend consumer: the URL carries only `autosend=true`; the message
-  // body lives in localStorage keyed by locator + taskId. It only boots empty
+  // body lives in sessionStorage keyed by locator + taskId. It only boots empty
   // threads, and the stored status gates duplicate sends across remounts.
   const autosendSearch = useSearch({ strict: false }) as { autosend?: string };
   const shouldAutosend = autosendSearch.autosend === AUTOSEND_QUERY_VALUE;

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -28,7 +28,7 @@ import { useChat as useAIChat, type UseChatHelpers } from "@ai-sdk/react";
 import {
   AUTOSEND_QUERY_VALUE,
   claimStoredAutosend,
-  markStoredAutosendSent,
+  clearStoredAutosend,
   writeStoredAutosend,
 } from "@/web/lib/autosend";
 import {
@@ -812,7 +812,7 @@ export function ChatContextProvider({
     const newId = crypto.randomUUID();
     const targetVmcp = params.virtualMcpId ?? virtualMcpId;
     const carryBranch = targetVmcp === virtualMcpId ? currentBranch : null;
-    writeStoredAutosend(localStorage, locator, newId, params.message);
+    writeStoredAutosend(sessionStorage, locator, newId, params.message);
     void taskActions.create
       .mutateAsync({
         id: newId,
@@ -1210,11 +1210,11 @@ export function ActiveTaskProvider({
     if (!shouldAutosend) return;
     if (messages.length > 0) return;
 
-    const payload = claimStoredAutosend(localStorage, locator, taskId);
+    const payload = claimStoredAutosend(sessionStorage, locator, taskId);
     if (!payload) return;
 
     void sendMessageInternal(payload.message).then(() => {
-      markStoredAutosendSent(localStorage, locator, taskId);
+      clearStoredAutosend(sessionStorage, locator, taskId);
     });
     // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- storage status, not function identity, gates duplicate sends
   }, [shouldAutosend, messages.length, locator, taskId, sendMessageInternal]);

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -278,7 +278,7 @@ function useHomeSubmit() {
     const newId = crypto.randomUUID();
     const targetVmcp =
       virtualMcp?.id ?? getWellKnownDecopilotVirtualMCP(org.id).id;
-    writeStoredAutosend(localStorage, locator, newId, { tiptapDoc });
+    writeStoredAutosend(sessionStorage, locator, newId, { tiptapDoc });
     navigate({
       to: "/$org/$taskId",
       params: { org: org.slug, taskId: newId },

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -259,7 +259,7 @@ function FileDropZone({
 
 /**
  * Submit handler for the home composer. No active task exists; we write
- * the tiptap doc to localStorage and navigate to a fresh /$org/$taskId.
+ * the tiptap doc to sessionStorage and navigate to a fresh /$org/$taskId.
  * The new task page's useEnsureTask creates the thread (server-side
  * idempotent on id) and ActiveTaskProvider's autosend consumer fires
  * sendMessage on mount.

--- a/apps/mesh/src/web/lib/autosend.test.ts
+++ b/apps/mesh/src/web/lib/autosend.test.ts
@@ -4,7 +4,7 @@ import {
   AUTOSEND_QUERY_VALUE,
   autosendStorageKey,
   claimStoredAutosend,
-  markStoredAutosendSent,
+  clearStoredAutosend,
   readStoredAutosend,
   writeStoredAutosend,
   type AutosendPayload,
@@ -108,7 +108,7 @@ describe("autosend storage", () => {
     expect(readStoredAutosend(storage, "org/project", "task-1")).toBeNull();
   });
 
-  test("mark sent stores sent status", () => {
+  test("clear removes the stored payload", () => {
     const storage = new MemoryStorage();
     writeStoredAutosend(
       storage,
@@ -118,10 +118,11 @@ describe("autosend storage", () => {
       1_700_000_000_000,
     );
 
-    markStoredAutosendSent(storage, "org/project", "task-1");
+    clearStoredAutosend(storage, "org/project", "task-1");
 
-    expect(readStoredAutosend(storage, "org/project", "task-1")?.status).toBe(
-      "sent",
+    expect(readStoredAutosend(storage, "org/project", "task-1")).toBeNull();
+    expect(storage.getItem(autosendStorageKey("org/project", "task-1"))).toBe(
+      null,
     );
   });
 

--- a/apps/mesh/src/web/lib/autosend.ts
+++ b/apps/mesh/src/web/lib/autosend.ts
@@ -10,7 +10,7 @@ export interface AutosendPayload {
   createdAt: number;
 }
 
-export type AutosendStatus = "pending" | "sending" | "sent";
+export type AutosendStatus = "pending" | "sending";
 
 export interface StoredAutosendPayload extends AutosendPayload {
   status: AutosendStatus;
@@ -26,7 +26,7 @@ export function autosendStorageKey(
 }
 
 function isValidStatus(status: unknown): status is AutosendStatus {
-  return status === "pending" || status === "sending" || status === "sent";
+  return status === "pending" || status === "sending";
 }
 
 function parseStoredAutosend(
@@ -99,13 +99,10 @@ export function claimStoredAutosend(
   return { message: payload.message, createdAt: payload.createdAt };
 }
 
-export function markStoredAutosendSent(
+export function clearStoredAutosend(
   storage: StorageLike,
   locator: ProjectLocator | string,
   taskId: string,
 ): void {
-  const key = autosendStorageKey(locator, taskId);
-  const payload = readStoredAutosend(storage, locator, taskId);
-  if (!payload) return;
-  storage.setItem(key, JSON.stringify({ ...payload, status: "sent" }));
+  storage.removeItem(autosendStorageKey(locator, taskId));
 }


### PR DESCRIPTION
## What is this contribution about?

The home composer's autosend handoff was writing to `localStorage` and only flipping the entry's status to `"sent"` after delivery, so entries accumulated indefinitely (one per task created). Once the per-origin quota was exceeded, `writeStoredAutosend`'s uncaught `QuotaExceededError` broke `sendMessage` and users could no longer send chat messages. This PR switches the autosend store to `sessionStorage` (still survives the route handoff but is scoped to the tab) and replaces `markStoredAutosendSent` with `clearStoredAutosend` (`removeItem`), so the entry is gone immediately after the send resolves.

## How to Test

1. Open the home composer, type a message, send — observe a fresh task is created and the message is sent.
2. In DevTools, confirm `sessionStorage` no longer contains a `mesh:chat:autosend:*` key after the send completes.
3. Repeat many times in the same tab — storage stays clean, no `QuotaExceededError`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`bun test apps/mesh/src/web/lib/autosend.test.ts`, `bun run --cwd apps/mesh check`)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a chat send failure caused by autosend data piling up in `localStorage`. Autosend now uses `sessionStorage` and the entry is deleted right after a successful send to prevent quota errors.

- **Bug Fixes**
  - Store autosend handoff data in `sessionStorage` (tab-scoped, still survives route handoff).
  - Delete the autosend entry after send with `clearStoredAutosend` and remove the `"sent"` status; updated call sites, tests, and inline docs/comments.

<sup>Written for commit ff8c96733d6ea014673ff35c26c0ed368422c8bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

