### PR TITLE
Fix/agent sandbox pod name resolution

### DIFF
--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
@@ -628,7 +628,9 @@ async function watchEvents(
         resolve(claimName);
         return;
       }
-      signal.addEventListener("abort", () => resolve(claimName), { once: true });
+      signal.addEventListener("abort", () => resolve(claimName), {
+        once: true,
+      });
     }),
   ]);
 

--- a/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/lifecycle-watcher.ts
@@ -213,6 +213,16 @@ export async function* watchClaimLifecycle(
   const deadlineMs = Math.max(0, schedulingTimeoutMs - (now() - startedAt));
   const deadlineTimer = setTimeout(() => push("tick"), deadlineMs + 100);
 
+  // Resolved to the actual pod name when watchPod first observes the pod.
+  // For cold-start the pod name equals claimName; for warm-pool adoption the
+  // operator binds a pool pod whose generated name differs from the claim.
+  // watchEvents needs the real pod name so its involvedObject.name fieldSelector
+  // hits the right events.
+  let resolvePodName!: (name: string) => void;
+  const podNamePromise = new Promise<string>((r) => {
+    resolvePodName = r;
+  });
+
   // Run watches concurrently. They each push signals into the queue and
   // never throw out of the watch loop — closure is via `controller.abort()`.
   const watches = Promise.allSettled([
@@ -224,6 +234,7 @@ export async function* watchClaimLifecycle(
       state,
       push,
       now,
+      resolvePodName,
     ),
     watchSandbox(
       opts.kc,
@@ -237,6 +248,7 @@ export async function* watchClaimLifecycle(
       opts.kc,
       opts.namespace,
       opts.claimName,
+      podNamePromise,
       controller.signal,
       state,
       push,
@@ -506,6 +518,7 @@ async function watchPod(
   state: State,
   push: (k: SignalKind) => void,
   now: () => number,
+  onPodName: (name: string) => void,
 ): Promise<void> {
   // labelSelector pins to mesh-managed claims; fieldSelector by name is
   // belt-and-suspenders (operator names pod after the claim).
@@ -526,6 +539,7 @@ async function watchPod(
       // pod the operator stamped with `sandbox-handle=<claimName>`, so the
       // first match IS the right pod regardless of its name.
       const pod = envelope.object;
+      if (pod.metadata?.name) onPodName(pod.metadata.name);
       applyPodSnapshot(pod, state, now);
       push("pod");
     },
@@ -596,21 +610,34 @@ async function watchEvents(
   kc: KubeConfig,
   namespace: string,
   claimName: string,
+  podNamePromise: Promise<string>,
   signal: AbortSignal,
   state: State,
   push: (k: SignalKind) => void,
   now: () => number,
 ): Promise<void> {
-  // K8s field selectors don't support arbitrary boolean composition; the
-  // closest we can get server-side is `involvedObject.name=<podName>`,
-  // which (because pod name === claim name in our world) is a tight filter.
-  // Kind=Pod is appended because event objects can target many kinds and
-  // we don't want to react to e.g. SandboxClaim events here (those go via
-  // the Sandbox CR watch).
+  // Resolve the actual pod name before subscribing to events. For cold-start
+  // the pod name equals claimName so this is a no-op; for warm-pool adoption
+  // the operator binds a pool pod whose name differs from the claim handle,
+  // and involvedObject.name must match the real pod name to receive events.
+  // Falls back to claimName if the signal aborts before a pod is seen.
+  const podName = await Promise.race([
+    podNamePromise,
+    new Promise<string>((resolve) => {
+      if (signal.aborted) {
+        resolve(claimName);
+        return;
+      }
+      signal.addEventListener("abort", () => resolve(claimName), { once: true });
+    }),
+  ]);
+
+  if (signal.aborted) return;
+
   const path =
     `/api/v1/namespaces/${encodeURIComponent(namespace)}/events` +
     `?watch=true&fieldSelector=${encodeURIComponent(
-      `involvedObject.name=${claimName},involvedObject.kind=Pod`,
+      `involvedObject.name=${podName},involvedObject.kind=Pod`,
     )}`;
 
   return runWatch<KubeEvent>({


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pod name resolution in the agent sandbox lifecycle watcher so event filtering uses the real pod name, not the claim name. This prevents missed events during warm-pool adoption and makes lifecycle handling more reliable.

- **Bug Fixes**
  - Resolve the actual pod name when `watchPod` first sees the pod and share it via a promise.
  - `watchEvents` now awaits the resolved name and filters by it; falls back to the claim name if aborted.
  - No change for cold starts (pod name equals claim name); fixes event matching for warm-pool adoption scenarios.

<sup>Written for commit e727c455b78e114341846d4f8856a81705b5f432. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

