### PR TITLE
fix(preview): resilience to 404 on / — render no-html state instead of stuck boot overlay

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -50,10 +50,11 @@ import {
 } from "./routes/deco-sites";
 import { createVirtualMcpRoutes } from "./routes/virtual-mcp";
 import {
+  createLegacyWellKnownProtectedResourceRoutes,
   createWellKnownAuthServerRoutes,
-  createWellKnownProtectedResourceRoutes,
   fetchAuthorizationServerMetadata,
   fetchProtectedResourceMetadata,
+  protectedResourceMetadataHandler,
 } from "./routes/oauth-proxy";
 import openaiCompatRoutes from "./routes/openai-compat";
 import { createProxyRoutes } from "./routes/proxy";
@@ -965,13 +966,25 @@ export async function createApp(options: CreateAppOptions = {}) {
   // ============================================================================
 
   // OAuth Protected-Resource discovery metadata — proxied from the origin MCP
-  // server. Two URL shapes (well-known prefix vs resource-relative) are wired
-  // by the factory. Legacy mount gets the deprecation log; the new canonical
-  // mount under `/api/:org/...` is added inside `createOrgScopedApi` below.
+  // server. The legacy server-URL shape (`/mcp/:id`) gets a deprecation log;
+  // the resource-relative shape for the new `/api/:org/mcp/:id` family is
+  // mounted via `createOrgScopedApi` below.
   const legacyWellKnownProtectedResource =
-    createWellKnownProtectedResourceRoutes();
+    createLegacyWellKnownProtectedResourceRoutes();
   legacyWellKnownProtectedResource.use("*", logDeprecatedRoute);
   app.route("/", legacyWellKnownProtectedResource);
+
+  // Well-known *prefix* discovery for the new org-scoped server URL shape.
+  // RFC 9728 Format 2 anchors `/.well-known/oauth-protected-resource` at the
+  // origin and appends the resource path, so the SDK probes
+  // `/.well-known/oauth-protected-resource/api/:org/mcp/:connectionId` — that
+  // path lives at the URL root, NOT under the `/api/:org` sub-app, and must
+  // not be tagged as a deprecated route. The handler reads the org slug from
+  // the path via `detectOrgSlugFromPath`.
+  app.get(
+    "/.well-known/oauth-protected-resource/api/:org/mcp/:connectionId",
+    protectedResourceMetadataHandler,
+  );
 
   // Auth-server metadata stays at the legacy global path indefinitely —
   // third-party OAuth providers may have this URL registered as a

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -207,4 +207,76 @@ describe("org-scoped API coexistence", () => {
 
     expect(res.status).toBe(403);
   });
+
+  it("well-known prefix discovery for org-scoped MCP resolves the right org", async () => {
+    // The MCP SDK probes /.well-known/oauth-protected-resource{resource-path}
+    // (RFC 9728 Format 2 / Smithery-style) to discover OAuth metadata. With
+    // org-scoped server URLs the probe path is
+    // /.well-known/oauth-protected-resource/api/:org/mcp/:connectionId — this
+    // path lives at the *root* (the well-known prefix is anchored there), not
+    // under the /api/:org sub-app. Without a top-level mount the SDK gets a
+    // 404 here and falls back to treating the mesh root as the auth server,
+    // breaking every OAuth-gated MCP (GitHub import-from-repo, Cursor, etc.).
+
+    // Mock the origin: well-known endpoints 404, but the initialize probe
+    // returns a Bearer challenge with resource_metadata so checkOriginSupports
+    // OAuth resolves true. The handler then synthesizes metadata pointing at
+    // our proxy — and crucially MUST use the org-scoped /api/:org/... path
+    // (not the legacy /mcp/:id shape) for both `resource` and
+    // `authorization_servers`, otherwise the SDK's resource-allowed check
+    // fails.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      _input,
+      init,
+    ) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST") {
+        // Origin's MCP `initialize` probe — return an OAuth 401.
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate":
+              'Bearer realm="origin", resource_metadata="https://example.test/.well-known/oauth-protected-resource"',
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    // Use a localhost-shaped host so the handler's `fixProtocol` keeps the
+    // http scheme (it forces https for non-localhost hosts).
+    const reqHost = "http://mesh.localhost";
+    try {
+      const res = await app.fetch(
+        new Request(
+          `${reqHost}/.well-known/oauth-protected-resource/api/org_1/mcp/conn_1`,
+        ),
+      );
+
+      // Route must exist (was 404 before the fix — no route was mounted for
+      // this URL shape outside the /api/:org sub-app).
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as {
+        resource: string;
+        authorization_servers: string[];
+      };
+      // Synthetic metadata MUST use the org-scoped /api/:org/... path for
+      // `resource` so resourceUrlFromServerUrl(serverUrl) matches
+      // resourceMetadata.resource (the SDK's checkResourceAllowed check);
+      // otherwise OAuth fails with "Protected resource ... does not match
+      // expected ...".
+      expect(body.resource).toBe(`${reqHost}/api/org_1/mcp/conn_1`);
+      // The auth-server URL stays on the legacy `/oauth-proxy/:id` path so
+      // the SDK's RFC 8414 discovery hits the dedicated auth-server metadata
+      // handler (which proxies the origin's metadata) instead of falling
+      // through to Better Auth's catch-all — that path returns Better Auth's
+      // MCP gateway endpoints and DCR ends with `invalid_client`.
+      expect(body.authorization_servers[0]).toBe(
+        `${reqHost}/oauth-proxy/conn_1`,
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -279,4 +279,37 @@ describe("org-scoped API coexistence", () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it("well-known prefix discovery 404s when :org doesn't match the connection's org", async () => {
+    // The synthesized PRM URL embeds :org as part of the resource path, so
+    // the handler MUST refuse to vouch for (org, connection) tuples that
+    // don't match — otherwise an attacker could probe a victim's connection
+    // ID under their own org slug and get a credible-looking metadata
+    // document. We don't distinguish "unknown org" from "cross-org" in the
+    // response so we don't leak which slugs exist.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }) as never);
+
+    try {
+      // Cross-org: org_456 exists (seeded by seedCommonTestFixtures) but
+      // conn_1 belongs to org_1.
+      const crossOrg = await app.fetch(
+        new Request(
+          "http://mesh.localhost/.well-known/oauth-protected-resource/api/org_456/mcp/conn_1",
+        ),
+      );
+      expect(crossOrg.status).toBe(404);
+
+      // Unknown slug: same response shape as cross-org.
+      const unknownSlug = await app.fetch(
+        new Request(
+          "http://mesh.localhost/.well-known/oauth-protected-resource/api/does-not-exist/mcp/conn_1",
+        ),
+      );
+      expect(unknownSlug.status).toBe(404);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -41,14 +41,20 @@ const NO_METADATA_STATUSES = [404, 401, 406];
 // ============================================================================
 
 /**
- * Get connection URL from storage by connection ID
- * Does not require organization ID - connections are globally unique
+ * Get connection URL from storage by connection ID, optionally scoped to an
+ * organization. Connection IDs are globally unique, but callers that have an
+ * org slug in scope should pass `organizationId` so cross-org lookups return
+ * null instead of a connection from another org.
  */
 async function getConnectionUrl(
   connectionId: string,
   ctx: MeshContext,
+  organizationId?: string,
 ): Promise<string | null> {
-  const connection = await ctx.storage.connections.findById(connectionId);
+  const connection = await ctx.storage.connections.findById(
+    connectionId,
+    organizationId,
+  );
   return connection?.connection_url ?? null;
 }
 
@@ -385,11 +391,6 @@ export const protectedResourceMetadataHandler = async (c: {
   const connectionId = c.req.param("connectionId");
   const ctx = await ensureContext(c);
 
-  const connectionUrl = await getConnectionUrl(connectionId, ctx);
-  if (!connectionUrl) {
-    return c.json({ error: "Connection not found" }, 404);
-  }
-
   const requestUrl = fixProtocol(new URL(c.req.url));
   // Org slug sources (in priority order):
   // 1. `ctx.organization?.slug` — set by `resolveOrgFromPath` for routes
@@ -401,6 +402,36 @@ export const protectedResourceMetadataHandler = async (c: {
   //    `/.well-known/.../mcp/:id`) have no slug; the prefix is empty and
   //    we issue legacy-shape metadata URLs.
   const orgSlug = ctx.organization?.slug ?? c.req.param("org");
+
+  // When :org is in scope, the connection MUST belong to that org. Resolve
+  // the slug to an org id so the connection lookup filters on it; otherwise
+  // we'd hand back metadata claiming the connection is served at a path it
+  // doesn't actually resolve from. `resolveOrgFromPath` already cached the id
+  // for the sub-app mount; the top-level well-known prefix route resolves
+  // the slug here. Unknown slug or cross-org connection → 404 (we don't
+  // distinguish, to avoid leaking which slugs exist).
+  let scopedOrgId: string | undefined;
+  if (orgSlug) {
+    if (ctx.organization?.id && ctx.organization.slug === orgSlug) {
+      scopedOrgId = ctx.organization.id;
+    } else {
+      const org = await ctx.db
+        .selectFrom("organization")
+        .select("id")
+        .where("slug", "=", orgSlug)
+        .executeTakeFirst();
+      if (!org) {
+        return c.json({ error: "Connection not found" }, 404);
+      }
+      scopedOrgId = org.id;
+    }
+  }
+
+  const connectionUrl = await getConnectionUrl(connectionId, ctx, scopedOrgId);
+  if (!connectionUrl) {
+    return c.json({ error: "Connection not found" }, 404);
+  }
+
   const prefix = buildPathPrefix(orgSlug);
   const proxyResourceUrl = `${requestUrl.origin}${prefix}/mcp/${connectionId}`;
   // Auth-server URL stays on the legacy `/oauth-proxy/:connectionId` path

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -294,27 +294,6 @@ function buildPathPrefix(orgSlug: string | undefined): string {
 }
 
 /**
- * Detect the org slug from a request path of the form `/api/:slug/...`.
- * Returns the slug or undefined if the path is not under `/api/:slug/`.
- *
- * Note: `/api/auth/...` and other non-org-scoped `/api/...` routes are
- * filtered out by checking that the path matches the expected org-scoped
- * MCP/well-known shapes. Callers should also rely on `ctx.organization?.slug`
- * (set by `resolveOrgFromPath`) when available — this helper is a fallback.
- */
-function detectOrgSlugFromPath(path: string): string | undefined {
-  const m = path.match(/^\/api\/([^/]+)\//);
-  const slug = m?.[1];
-  if (!slug) return undefined;
-  // Filter out non-org `/api/...` segments. The full list of these lives in
-  // app.ts; we only care about the ones that could host MCP or oauth-proxy
-  // routes. None of those collide with org slugs in practice.
-  const reserved = new Set(["auth", "tools", "plugins", "deco-sites"]);
-  if (reserved.has(slug)) return undefined;
-  return slug;
-}
-
-/**
  * Handles 401 auth errors from MCP origin servers.
  *
  * Checks if the origin server supports OAuth by looking for WWW-Authenticate header.
@@ -392,8 +371,13 @@ const fixProtocol = (url: URL) => {
  * to our OAuth proxy. This enables OAuth flows for servers like Apify that use WWW-Authenticate
  * but don't expose .well-known/oauth-protected-resource.
  */
-const protectedResourceMetadataHandler = async (c: {
-  req: { param: (key: string) => string; raw: Request; url: string };
+export const protectedResourceMetadataHandler = async (c: {
+  req: {
+    param: ((key: "connectionId") => string) &
+      ((key: "org") => string | undefined);
+    raw: Request;
+    url: string;
+  };
   get: (key: "meshContext") => MeshContext | undefined;
   set: (key: "meshContext", value: MeshContext) => void;
   json: (data: unknown, status?: number) => Response;
@@ -407,16 +391,26 @@ const protectedResourceMetadataHandler = async (c: {
   }
 
   const requestUrl = fixProtocol(new URL(c.req.url));
-  // Determine the path prefix from the request. When called via the new
-  // `/api/:org/mcp/...` mount, `ctx.organization?.slug` is set by
-  // `resolveOrgFromPath`. Fall back to detecting the slug from the request
-  // path so callers that bypass meshContext still get correct URLs. Legacy
-  // callers (no `/api/:slug` prefix in the path) get legacy URLs back.
-  const orgSlug =
-    ctx.organization?.slug ?? detectOrgSlugFromPath(requestUrl.pathname);
+  // Org slug sources (in priority order):
+  // 1. `ctx.organization?.slug` — set by `resolveOrgFromPath` for routes
+  //    inside the `/api/:org` sub-app.
+  // 2. `c.req.param("org")` — present on the top-level well-known prefix
+  //    route `/.well-known/oauth-protected-resource/api/:org/mcp/:id`, which
+  //    sits outside the sub-app so `resolveOrgFromPath` never runs.
+  // 3. undefined — legacy routes (`/mcp/:id/.well-known/...`,
+  //    `/.well-known/.../mcp/:id`) have no slug; the prefix is empty and
+  //    we issue legacy-shape metadata URLs.
+  const orgSlug = ctx.organization?.slug ?? c.req.param("org");
   const prefix = buildPathPrefix(orgSlug);
   const proxyResourceUrl = `${requestUrl.origin}${prefix}/mcp/${connectionId}`;
-  const proxyAuthServer = `${requestUrl.origin}${prefix}/oauth-proxy/${connectionId}`;
+  // Auth-server URL stays on the legacy `/oauth-proxy/:connectionId` path
+  // regardless of the resource path family. The well-known auth-server
+  // metadata route (`createWellKnownAuthServerRoutes`) only exists at the
+  // legacy URL, and third-party OAuth providers may have it registered as a
+  // redirect_uri base — moving it to `/api/:org/...` would land the SDK on
+  // Better Auth's catch-all metadata handler (which returns Better Auth's
+  // own MCP gateway endpoints) and break DCR with `invalid_client`.
+  const proxyAuthServer = `${requestUrl.origin}/oauth-proxy/${connectionId}`;
 
   try {
     // Fetch from origin, trying both well-known URL formats
@@ -522,24 +516,44 @@ const protectedResourceMetadataHandler = async (c: {
 };
 
 /**
- * Factory for the two `.well-known/oauth-protected-resource` routes.
+ * Legacy `.well-known/oauth-protected-resource` routes for the pre-org-scoped
+ * server URL shape (`/mcp/:id`). Mounted at the URL root with a deprecation
+ * log; will be removed once the deprecation window closes.
  *
- * Two URL shapes are supported by MCP clients in the wild:
- * 1. `/.well-known/oauth-protected-resource/mcp/:connectionId` (well-known
- *    prefix, used by some clients)
- * 2. `/mcp/:connectionId/.well-known/oauth-protected-resource` (resource-
- *    relative, the more common shape)
- *
- * When mounted under `/api/:org/`, both expand to
- * `/api/:org/<original>` and the handler picks up the org slug from
- * `ctx.organization` (set by `resolveOrgFromPath`) so issued metadata
- * URLs point at the new path. Legacy mount uses the legacy URLs.
+ * Two URL shapes are served (both probed by MCP clients in the wild):
+ *  1. `/.well-known/oauth-protected-resource/mcp/:connectionId` — RFC 9728
+ *     Format 2 (well-known prefix), what `@modelcontextprotocol/sdk` probes.
+ *  2. `/mcp/:connectionId/.well-known/oauth-protected-resource` — RFC 9728
+ *     Format 1 (resource-relative), what the proxy's WWW-Authenticate
+ *     `resource_metadata` header points to.
  */
-export const createWellKnownProtectedResourceRoutes = () => {
+export const createLegacyWellKnownProtectedResourceRoutes = () => {
   const app = new Hono<HonoEnv>();
   app.get("/.well-known/oauth-protected-resource/mcp/:connectionId", (c) =>
     protectedResourceMetadataHandler(c),
   );
+  app.get("/mcp/:connectionId/.well-known/oauth-protected-resource", (c) =>
+    protectedResourceMetadataHandler(c),
+  );
+  return app;
+};
+
+/**
+ * Org-scoped resource-relative `.well-known/oauth-protected-resource` route.
+ * Mounted inside the `/api/:org` sub-app; expands to
+ * `/api/:org/mcp/:connectionId/.well-known/oauth-protected-resource`. This is
+ * the URL the proxy's WWW-Authenticate `resource_metadata` points to under
+ * the new path family — `resolveOrgFromPath` runs first, so the handler picks
+ * up `ctx.organization?.slug` directly.
+ *
+ * The well-known *prefix* shape for org-scoped server URLs
+ * (`/.well-known/oauth-protected-resource/api/:org/mcp/:connectionId`) is
+ * registered separately at the URL root in `app.ts` — RFC 9728 Format 2
+ * anchors the well-known prefix at the origin, so it must live outside any
+ * `/api/:org` sub-app.
+ */
+export const createOrgScopedWellKnownProtectedResourceRoutes = () => {
+  const app = new Hono<HonoEnv>();
   app.get("/mcp/:connectionId/.well-known/oauth-protected-resource", (c) =>
     protectedResourceMetadataHandler(c),
   );
@@ -730,6 +744,6 @@ export const createWellKnownAuthServerRoutes = () => {
  * legacy mounts and dual-mount under `/api/:org/...`.
  */
 const app = new Hono<HonoEnv>();
-app.route("/", createWellKnownProtectedResourceRoutes());
+app.route("/", createLegacyWellKnownProtectedResourceRoutes());
 app.route("/", createWellKnownAuthServerRoutes());
 export default app;

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -10,7 +10,7 @@ import { createDecoSitesOrgRoutes } from "./deco-sites";
 import { createDevAssetsRoutes } from "./dev-assets";
 import { createDownstreamTokenRoutes } from "./downstream-token";
 import { createKVRoutes } from "./kv";
-import { createWellKnownProtectedResourceRoutes } from "./oauth-proxy";
+import { createOrgScopedWellKnownProtectedResourceRoutes } from "./oauth-proxy";
 import { createSsoRoutes } from "./org-sso";
 import { createProxyRoutes } from "./proxy";
 import { createSelfRoutes } from "./self";
@@ -84,12 +84,13 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.use("/mcp/virtual-mcp/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/self", deps.mcpAuth);
 
-  // OAuth Protected-Resource discovery for connection MCPs. Both URL shapes
-  // get mounted; the handler picks `ctx.organization?.slug` (set by
-  // `resolveOrgFromPath` above) so issued metadata URLs point at the new
-  // `/api/:org/...` path. Must mount BEFORE the catch-all proxy routes so
-  // the well-known suffix wins.
-  app.route("/", createWellKnownProtectedResourceRoutes());
+  // OAuth Protected-Resource discovery for connection MCPs (resource-relative
+  // shape). Expands to
+  // `/api/:org/mcp/:connectionId/.well-known/oauth-protected-resource`, which
+  // is what the proxy's WWW-Authenticate `resource_metadata` header points to.
+  // The well-known *prefix* shape lives outside this sub-app — see app.ts.
+  // Must mount BEFORE the catch-all proxy routes so the well-known suffix wins.
+  app.route("/", createOrgScopedWellKnownProtectedResourceRoutes());
 
   // Better-Auth Protected Resource Metadata for the gateway-style URL family.
   // Mounted BEFORE the proxy routes for the same reason.

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -39,7 +39,10 @@ import type {
 export type { ClaimFailureReason, ClaimPhase };
 
 export interface VmStatus {
+  /** Active port answered with 2xx-3xx — content is expected to render. */
   ready: boolean;
+  /** Active port answered any HTTP status — port is up. Use to dismiss boot overlays. */
+  responded: boolean;
   htmlSupport: boolean;
   /** Currently active dev port (pinned `devPort` if responding, otherwise highest-scored discovered). */
   port: number | null;
@@ -96,7 +99,7 @@ export interface VmEventsValue {
 
 const DEFAULT_VALUE: VmEventsValue = {
   phase: null,
-  status: { ready: false, htmlSupport: false, port: null },
+  status: { ready: false, responded: false, htmlSupport: false, port: null },
   suspended: false,
   notFound: false,
   scripts: [],
@@ -161,6 +164,7 @@ export function VmEventsProvider({
   const [phase, setPhase] = useState<ClaimPhase | null>(null);
   const [status, setStatus] = useState<VmStatus>({
     ready: false,
+    responded: false,
     htmlSupport: false,
     port: null,
   });
@@ -191,7 +195,12 @@ export function VmEventsProvider({
   useEffect(() => {
     // Reset on key change so stale data doesn't linger across branches.
     setPhase(null);
-    setStatus({ ready: false, htmlSupport: false, port: null });
+    setStatus({
+      ready: false,
+      responded: false,
+      htmlSupport: false,
+      port: null,
+    });
     setSuspended(false);
     setNotFound(false);
     setScripts([]);
@@ -264,7 +273,12 @@ export function VmEventsProvider({
       // vmEntry exists; the empty "Start Server" state when it doesn't.
       setNotFound(true);
       setPhase(null);
-      setStatus({ ready: false, htmlSupport: false, port: null });
+      setStatus({
+        ready: false,
+        responded: false,
+        htmlSupport: false,
+        port: null,
+      });
       setScripts([]);
       setActiveProcesses([]);
       setAppStatus(null);
@@ -292,6 +306,7 @@ export function VmEventsProvider({
         } else if (e.type === "status") {
           setStatus({
             ready: Boolean(data.ready),
+            responded: Boolean(data.responded),
             htmlSupport: Boolean(data.htmlSupport),
             port: typeof data.port === "number" ? data.port : null,
           });

--- a/apps/mesh/src/web/components/vm/preview/preview-state.test.ts
+++ b/apps/mesh/src/web/components/vm/preview/preview-state.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { computePreviewState } from "./preview-state";
+import type { PreviewStateInput } from "./preview-state";
+
+const base: PreviewStateInput = {
+  previewUrl: "http://localhost:5173",
+  responded: false,
+  htmlSupport: false,
+  suspended: false,
+  appPaused: false,
+  vmStartPending: false,
+  lastStartError: null,
+  claimPhase: null,
+  notFound: false,
+  bootEverReady: false,
+};
+
+describe("computePreviewState", () => {
+  test("error wins over everything", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        lastStartError: "boom",
+        responded: true,
+        htmlSupport: true,
+      }),
+    ).toEqual({ kind: "error", error: "boom" });
+  });
+
+  test("suspended wins over content states", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        suspended: true,
+        responded: true,
+        htmlSupport: true,
+      }),
+    ).toEqual({ kind: "suspended" });
+  });
+
+  test("appPaused wins over content states", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        appPaused: true,
+        responded: true,
+        htmlSupport: true,
+      }),
+    ).toEqual({ kind: "suspended" });
+  });
+
+  test("notFound triggers booting overlay", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        notFound: true,
+      }),
+    ).toEqual({ kind: "booting" });
+  });
+
+  test("vmStartPending without previewUrl → booting", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+        vmStartPending: true,
+      }),
+    ).toEqual({ kind: "booting" });
+  });
+
+  test("previewUrl set, responded but not html → no-html empty state", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        responded: true,
+        htmlSupport: false,
+      }),
+    ).toEqual({ kind: "no-html", previewUrl: "http://localhost:5173" });
+  });
+
+  test("previewUrl set, responded and html → iframe", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        responded: true,
+        htmlSupport: true,
+      }),
+    ).toEqual({ kind: "iframe", previewUrl: "http://localhost:5173" });
+  });
+
+  test("previewUrl set, never responded yet → booting", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        responded: false,
+      }),
+    ).toEqual({ kind: "booting" });
+  });
+
+  test("bootEverReady persists iframe across transient probe-down (htmlSupport snapshot=true)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        responded: false,
+        htmlSupport: true,
+        bootEverReady: true,
+      }),
+    ).toEqual({ kind: "iframe", previewUrl: "http://localhost:5173" });
+  });
+
+  test("bootEverReady persists no-html across transient probe-down (htmlSupport snapshot=false)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        responded: false,
+        htmlSupport: false,
+        bootEverReady: true,
+      }),
+    ).toEqual({ kind: "no-html", previewUrl: "http://localhost:5173" });
+  });
+
+  test("no previewUrl, no startError, no pending, no lifecycle → idle", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+      }),
+    ).toEqual({ kind: "idle" });
+  });
+
+  test("lifecycleActive with no previewUrl → booting", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+        claimPhase: { kind: "claiming" },
+      }),
+    ).toEqual({ kind: "booting" });
+  });
+});

--- a/apps/mesh/src/web/components/vm/preview/preview-state.ts
+++ b/apps/mesh/src/web/components/vm/preview/preview-state.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure preview-state decision: maps the ~10 conditional inputs from
+ * preview.tsx into a discriminated state union. Extracted so it can be
+ * unit-tested without DOM/auth/SSE scaffolding.
+ *
+ * Priority order (highest first):
+ *   error → suspended → booting → no-html → iframe → idle
+ *
+ * `bootEverReady` is the latch that keeps the iframe (or no-html) state
+ * mounted across transient probe-down events (e.g. brief network hiccup
+ * after the server has already proved it's up). Once the active port has
+ * responded at least once, we trust the last-known `htmlSupport` rather
+ * than dropping back into "booting" on every probe miss.
+ */
+
+export type ClaimPhaseLike = { kind: string };
+
+export interface PreviewStateInput {
+  previewUrl: string | null;
+  responded: boolean;
+  htmlSupport: boolean;
+  suspended: boolean;
+  appPaused: boolean;
+  vmStartPending: boolean;
+  lastStartError: string | null;
+  claimPhase: ClaimPhaseLike | null;
+  notFound: boolean;
+  bootEverReady: boolean;
+}
+
+export type PreviewState =
+  | { kind: "idle" }
+  | { kind: "booting" }
+  | { kind: "error"; error: string }
+  | { kind: "suspended" }
+  | { kind: "no-html"; previewUrl: string }
+  | { kind: "iframe"; previewUrl: string };
+
+export function computePreviewState(input: PreviewStateInput): PreviewState {
+  if (input.lastStartError) {
+    return { kind: "error", error: input.lastStartError };
+  }
+  if (input.suspended || input.appPaused) {
+    return { kind: "suspended" };
+  }
+  if (input.notFound) {
+    return { kind: "booting" };
+  }
+  // VM_START in flight before previewUrl populates → boot overlay.
+  if (!input.previewUrl && input.vmStartPending) {
+    return { kind: "booting" };
+  }
+  // Pre-daemon lifecycle (capacity wait, image pull, etc.) without previewUrl yet.
+  if (
+    !input.previewUrl &&
+    input.claimPhase &&
+    input.claimPhase.kind !== "failed"
+  ) {
+    return { kind: "booting" };
+  }
+  if (!input.previewUrl) {
+    return { kind: "idle" };
+  }
+  // previewUrl set: decide between iframe / no-html / booting.
+  // Latch on `bootEverReady`: once port has responded, trust last-known htmlSupport.
+  if (input.responded || input.bootEverReady) {
+    if (input.htmlSupport) {
+      return { kind: "iframe", previewUrl: input.previewUrl };
+    }
+    return { kind: "no-html", previewUrl: input.previewUrl };
+  }
+  return { kind: "booting" };
+}

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -52,6 +52,7 @@ import {
 import { VmSuspendedState } from "../vm-suspended-state";
 import { VmBootingState } from "../vm-booting-state";
 import { VmErrorState } from "../vm-error-state";
+import { computePreviewState } from "./preview-state";
 import { track } from "@/web/lib/posthog-client";
 
 type PreviewViewMode = "preview" | "visual";
@@ -112,23 +113,34 @@ export function PreviewContent() {
   // starting..." placeholder; keep mounted once ever-ready so HMR hiccups
   // don't re-show the boot screen. `at` uses server-stamped
   // vmEntry.createdAt so the timer survives remounts.
-  const bootTrackedRef = useRef<{ url: string; at: number; ready: boolean }>({
+  // Latch on `responded` (any HTTP response), not `ready` (2xx-3xx).
+  // A server that returns 404 on `/` is up — we shouldn't get stuck on the
+  // booting overlay just because it doesn't serve HTML at `/`. Once latched,
+  // computePreviewState honors `bootEverReady` so brief probe-down hiccups
+  // don't drop the iframe back into the boot overlay.
+  const bootTrackedRef = useRef<{
+    url: string;
+    at: number;
+    everReady: boolean;
+  }>({
     url: "",
     at: 0,
-    ready: false,
+    everReady: false,
   });
   if (previewUrl && bootTrackedRef.current.url !== previewUrl) {
     bootTrackedRef.current = {
       url: previewUrl,
       at: vmEntry?.createdAt ?? Date.now(),
-      ready: false,
+      everReady: false,
     };
   }
-  if (previewUrl && vmEvents.status.ready && !bootTrackedRef.current.ready) {
-    bootTrackedRef.current.ready = true;
+  if (
+    previewUrl &&
+    vmEvents.status.responded &&
+    !bootTrackedRef.current.everReady
+  ) {
+    bootTrackedRef.current.everReady = true;
   }
-  const booting =
-    !!previewUrl && !bootTrackedRef.current.ready && !suspended && !appPaused;
 
   // Cover the gap between VM_START being submitted and vmMap populating a
   // previewUrl; otherwise the empty "No server running" state flashes while
@@ -158,18 +170,24 @@ export function PreviewContent() {
   } else if (previewUrl) {
     startingSinceRef.current = 0;
   }
-  const starting = vmStartPending && !previewUrl && !suspended;
   const autoStartedForTaskRef = useRef<string | null>(null);
   const reprovisionedForVmIdRef = useRef<string | null>(null);
 
   const claimPhase = vmEvents.phase;
-  // Only meaningful during the pre-previewUrl gap (VM_START mutation
-  // resolved → vmMap refetch lands). Once previewUrl is set, the booting
-  // overlay is driven by `booting` and dismisses on ready=true; if we kept
-  // lifecycleActive=true here, the overlay would never dismiss because
-  // `claimPhase` stays at `ready` for the lifetime of the SSE.
-  const lifecycleActive =
-    !previewUrl && !!claimPhase && claimPhase.kind !== "failed";
+
+  const previewState = computePreviewState({
+    previewUrl,
+    responded: vmEvents.status.responded,
+    htmlSupport: vmEvents.status.htmlSupport,
+    suspended,
+    appPaused,
+    vmStartPending,
+    lastStartError,
+    claimPhase,
+    notFound: vmEvents.notFound,
+    bootEverReady: bootTrackedRef.current.everReady,
+  });
+  const booting = previewState.kind === "booting";
 
   // ref-latest pattern: effects below depend only on upstream signals, not
   // on this closure's churning captures (branch, mutation, setter).
@@ -317,7 +335,7 @@ export function PreviewContent() {
 
   return (
     <div className="flex flex-col w-full h-full">
-      {previewUrl && (
+      {previewState.kind === "iframe" && (
         <div className="flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
           {/* Group 1: view mode toggle */}
           {hasHtmlPreview && (
@@ -385,7 +403,9 @@ export function PreviewContent() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => window.open(previewUrl, "_blank", "noopener")}
+                  onClick={() =>
+                    window.open(previewState.previewUrl, "_blank", "noopener")
+                  }
                 >
                   <LinkExternal01 size={14} />
                 </Button>
@@ -413,7 +433,7 @@ export function PreviewContent() {
       )}
 
       <div className="flex-1 relative overflow-hidden">
-        {!previewUrl && !starting && !lastStartError && !lifecycleActive && (
+        {previewState.kind === "idle" && (
           <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-4 bg-background">
             <Monitor04 size={48} className="text-muted-foreground/40" />
             <h3 className="text-lg font-medium">Preview</h3>
@@ -427,34 +447,51 @@ export function PreviewContent() {
           </div>
         )}
 
-        {lastStartError && (
+        {previewState.kind === "error" && (
           <div className="absolute inset-0 z-40 flex items-center justify-center bg-background">
-            <VmErrorState errorMsg={lastStartError} onRetry={retryAutoStart} />
+            <VmErrorState
+              errorMsg={previewState.error}
+              onRetry={retryAutoStart}
+            />
           </div>
         )}
 
-        {!lastStartError && (suspended || appPaused) && (
+        {previewState.kind === "suspended" && (
           <div className="absolute inset-0 z-30 bg-background/80 backdrop-blur-sm">
             <VmSuspendedState onResume={openEnv} />
           </div>
         )}
 
-        {!lastStartError &&
-          (booting || starting || lifecycleActive || vmEvents.notFound) && (
-            <div className="absolute inset-0 z-30 flex items-center justify-center bg-background">
-              <VmBootingState
-                since={
-                  booting ? bootTrackedRef.current.at : startingSinceRef.current
-                }
-                hasSetupData={vmEvents.hasData("setup")}
-                scripts={vmEvents.scripts}
-                activeProcesses={vmEvents.activeProcesses}
-                onViewLogs={openEnv}
-                claimPhase={previewUrl ? null : claimPhase}
-                onRetry={retryAutoStart}
-              />
-            </div>
-          )}
+        {previewState.kind === "booting" && (
+          <div className="absolute inset-0 z-30 flex items-center justify-center bg-background">
+            <VmBootingState
+              since={
+                booting ? bootTrackedRef.current.at : startingSinceRef.current
+              }
+              hasSetupData={vmEvents.hasData("setup")}
+              scripts={vmEvents.scripts}
+              activeProcesses={vmEvents.activeProcesses}
+              onViewLogs={openEnv}
+              claimPhase={previewUrl ? null : claimPhase}
+              onRetry={retryAutoStart}
+            />
+          </div>
+        )}
+
+        {previewState.kind === "no-html" && (
+          <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-4 bg-background">
+            <Server01 size={48} className="text-muted-foreground/40" />
+            <h3 className="text-lg font-medium">No web page at this URL</h3>
+            <p className="text-sm text-muted-foreground text-center max-w-sm">
+              The server is running, but doesn't serve a web page at /. This
+              preview only renders web pages.
+            </p>
+            <Button onClick={openEnv}>
+              <Server01 size={14} />
+              View Logs
+            </Button>
+          </div>
+        )}
 
         {viewMode === "visual" && !visualElement && (
           <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
@@ -468,13 +505,13 @@ export function PreviewContent() {
             onDismiss={() => setVisualElement(null)}
           />
         )}
-        {previewUrl && !booting && !vmEvents.notFound && !appPaused && (
+        {previewState.kind === "iframe" && (
           <iframe
             // Key on previewUrl: `src` mutations don't reliably refetch in all
             // browsers and leak in-frame state across branches.
-            key={previewUrl}
+            key={previewState.previewUrl}
             ref={previewIframeRef}
-            src={previewUrl}
+            src={previewState.previewUrl}
             className="w-full h-full border-0"
             title="Dev Server Preview"
             onLoad={() => {

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -187,7 +187,6 @@ export function PreviewContent() {
     notFound: vmEvents.notFound,
     bootEverReady: bootTrackedRef.current.everReady,
   });
-  const booting = previewState.kind === "booting";
 
   // ref-latest pattern: effects below depend only on upstream signals, not
   // on this closure's churning captures (branch, mutation, setter).
@@ -466,7 +465,9 @@ export function PreviewContent() {
           <div className="absolute inset-0 z-30 flex items-center justify-center bg-background">
             <VmBootingState
               since={
-                booting ? bootTrackedRef.current.at : startingSinceRef.current
+                previewUrl
+                  ? bootTrackedRef.current.at
+                  : startingSinceRef.current
               }
               hasSetupData={vmEvents.hasData("setup")}
               scripts={vmEvents.scripts}

--- a/packages/sandbox/daemon/daemon.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.e2e.test.ts
@@ -11,16 +11,10 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 
 const DAEMON_BUNDLE = join(import.meta.dir, "dist", "daemon.js");
 const DAEMON_TOKEN = "t".repeat(32);
-
-// Ripgrep isn't always installed on bare CI runners or dev machines; skip
-// the rg-dependent test when it's missing so the rest of the suite still runs.
-// Currently unused because the rg test is force-skipped (TODO #3259); kept for
-// when it's re-enabled.
-const _hasRipgrep = spawnSync("which", ["rg"]).status === 0;
 
 // CI cold-start of `bun` + the bundled daemon listener occasionally exceeds
 // Bun's default 5s hook timeout, especially on shared runners under load.
@@ -216,10 +210,9 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     );
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
-  // Test expectations predate the new daemon API; main passes only by shard
-  // luck. Re-enable after the daemon-state-machine maintainer updates the
-  // tests to the new contract.
+  // TODO(#3259): pre-existing failure since the daemon state-machine PR
+  // landed. Tests skipped to keep CI honest while the fixtures are updated
+  // to POST /config and adapt to the new proxy 503 / "No dev server" copy.
   it.skip("SSE replays buffered events on connect and delivers live broadcasts", async () => {
     // Fire a request to produce a log line in the "daemon" replay buffer.
     await fetch(`http://localhost:${daemonPort}/_decopilot_vm/scripts`, {
@@ -262,7 +255,6 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     ctrl.abort();
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
   it.skip("POST /_decopilot_vm/exec/setup returns { ok: true } when idle", async () => {
     // Boot autostart is stripped by patchForTest so the daemon is idle here.
     const res = await fetch(
@@ -274,7 +266,6 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     expect(body.ok).toBe(true);
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
   it.skip("POST /_decopilot_vm/exec/setup concurrent calls return [200, 409]", async () => {
     // A local HTTP server that accepts connections but never responds.
     // git clone's curl transport will hang in the headers-read phase, which
@@ -310,7 +301,6 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     }
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
   it.skip("POST /_decopilot_vm/exec/<unknown> before setup returns 400", async () => {
     const res = await fetch(
       `http://localhost:${daemonPort}/_decopilot_vm/exec/dev`,
@@ -321,7 +311,6 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     expect(body.error).toContain("setup not complete");
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
   it.skip("POST /_decopilot_vm/kill/<name> when process isn't running returns 400", async () => {
     const res = await fetch(
       `http://localhost:${daemonPort}/_decopilot_vm/kill/nonexistent`,
@@ -332,7 +321,6 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     expect(body.error).toContain("not running");
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
   it.skip("POST /_decopilot_vm/grep and /_decopilot_vm/glob succeed (confirms uid/gid stripped from spawn)", async () => {
     // Create a file in appDir to search
     const sampleFile = join(appDir, "needle.txt");
@@ -366,7 +354,6 @@ describe("daemon e2e (runs generated script under Bun)", () => {
     expect(globBody.files).toContain("needle.txt");
   });
 
-  // TODO(sandbox-daemon): broken since the state-machine refactor (#3259).
   it.skip("POST /_decopilot_vm/read returns file contents with line numbers", async () => {
     const sampleFile = join(appDir, "greet.txt");
     writeFileSync(sampleFile, "line1\nline2\nline3\n");
@@ -553,7 +540,10 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     }
   }, HOOK_TIMEOUT_MS);
 
-  it("injects BOOTSTRAP and strips XFO/CSP/content-encoding for HTML", async () => {
+  // TODO(#3259): pre-existing failure since the daemon state-machine PR
+  // landed. The proxy 503 page text/headers changed and the bootstrap
+  // requirement now blocks these flows; tests skipped pending fixture refresh.
+  it.skip("injects BOOTSTRAP and strips XFO/CSP/content-encoding for HTML", async () => {
     await startWithUpstream(
       () =>
         new Response("<html><body><h1>hi</h1></body></html>", {
@@ -578,7 +568,7 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     expect(body.indexOf("<script>")).toBeLessThan(body.lastIndexOf("</body>"));
   });
 
-  it("passes through non-HTML responses untouched", async () => {
+  it.skip("passes through non-HTML responses untouched", async () => {
     await startWithUpstream(() =>
       Response.json({ ok: true }, { headers: { "X-Frame-Options": "DENY" } }),
     );
@@ -590,7 +580,7 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     expect(body.ok).toBe(true);
   });
 
-  it("returns 503 'Server is starting' HTML when upstream is unreachable at /", async () => {
+  it.skip("returns 503 'Server is starting' HTML when upstream is unreachable at /", async () => {
     await startWithoutUpstream();
     const res = await fetch(`http://localhost:${daemonPort}/`);
     expect(res.status).toBe(503);
@@ -600,7 +590,7 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     expect(body).toContain("Server is starting");
   });
 
-  it("returns 502 JSON when upstream is unreachable at a non-root path", async () => {
+  it.skip("returns 502 JSON when upstream is unreachable at a non-root path", async () => {
     await startWithoutUpstream();
     const res = await fetch(`http://localhost:${daemonPort}/api/thing`);
     expect(res.status).toBe(502);
@@ -608,7 +598,7 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     expect(body.error).toContain("proxy error");
   });
 
-  it("forwards POST bodies to upstream", async () => {
+  it.skip("forwards POST bodies to upstream", async () => {
     let receivedBody = "";
     await startWithUpstream(async (req) => {
       receivedBody = await req.text();
@@ -624,7 +614,7 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     expect(receivedBody).toBe('{"hello":"world"}');
   });
 
-  it("forwards chunked POST bodies to upstream", async () => {
+  it.skip("forwards chunked POST bodies to upstream", async () => {
     let receivedBody = "";
     await startWithUpstream(async (req) => {
       receivedBody = await req.text();
@@ -649,7 +639,7 @@ describe.skip("daemon e2e (reverse proxy)", () => {
     expect(receivedBody).toBe("chunk1 chunk2");
   });
 
-  it("strips Authorization from the request seen by the dev server", async () => {
+  it.skip("strips Authorization from the request seen by the dev server", async () => {
     let seenAuth: string | null = "<<unset>>";
     await startWithUpstream((req) => {
       seenAuth = req.headers.get("authorization");

--- a/packages/sandbox/daemon/events/sse.test.ts
+++ b/packages/sandbox/daemon/events/sse.test.ts
@@ -5,7 +5,12 @@ import { makeSseStream } from "./sse";
 describe("makeSseStream", () => {
   const mkDeps = (b: Broadcaster) => ({
     broadcaster: b,
-    getLastStatus: () => ({ ready: false, htmlSupport: false, port: null }),
+    getLastStatus: () => ({
+      ready: false,
+      responded: false,
+      htmlSupport: false,
+      port: null,
+    }),
     getDiscoveredScripts: () => null,
     getActiveTasks: () => [],
     getAppStatus: () => ({}),

--- a/packages/sandbox/daemon/events/sse.ts
+++ b/packages/sandbox/daemon/events/sse.ts
@@ -5,6 +5,7 @@ export interface SseHandshakeDeps {
   broadcaster: Broadcaster;
   getLastStatus: () => {
     ready: boolean;
+    responded: boolean;
     htmlSupport: boolean;
     port: number | null;
   };

--- a/packages/sandbox/daemon/probe.test.ts
+++ b/packages/sandbox/daemon/probe.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import type { ProbeResult } from "./probe";
+import { selectActive } from "./probe";
+
+const r = (overrides: Partial<ProbeResult>): ProbeResult => ({
+  port: 3000,
+  responded: false,
+  ready: false,
+  htmlSupport: false,
+  score: 0,
+  ...overrides,
+});
+
+describe("selectActive", () => {
+  test("pinned port responded with 404 → responded=true, ready=false, htmlSupport=false, picks pin", () => {
+    const result = selectActive(
+      [
+        r({
+          port: 5173,
+          responded: true,
+          ready: false,
+          htmlSupport: false,
+          score: 10,
+        }),
+      ],
+      5173,
+    );
+    expect(result).toEqual({
+      port: 5173,
+      ready: false,
+      responded: true,
+      htmlSupport: false,
+    });
+  });
+
+  test("pinned port responded with 200 HTML → all three true, picks pin", () => {
+    const result = selectActive(
+      [
+        r({
+          port: 5173,
+          responded: true,
+          ready: true,
+          htmlSupport: true,
+          score: 100,
+        }),
+      ],
+      5173,
+    );
+    expect(result).toEqual({
+      port: 5173,
+      ready: true,
+      responded: true,
+      htmlSupport: true,
+    });
+  });
+
+  test("pinned port did not respond, descendant served HTML → falls back to descendant", () => {
+    const result = selectActive(
+      [
+        r({
+          port: 5173,
+          responded: false,
+          ready: false,
+          htmlSupport: false,
+          score: 0,
+        }),
+        r({
+          port: 3001,
+          responded: true,
+          ready: true,
+          htmlSupport: true,
+          score: 100,
+        }),
+      ],
+      5173,
+    );
+    expect(result).toEqual({
+      port: 3001,
+      ready: true,
+      responded: true,
+      htmlSupport: true,
+    });
+  });
+
+  test("pinned port responded with 404, descendant served HTML → sticks with pin (existing behavior)", () => {
+    const result = selectActive(
+      [
+        r({
+          port: 5173,
+          responded: true,
+          ready: false,
+          htmlSupport: false,
+          score: 10,
+        }),
+        r({
+          port: 3001,
+          responded: true,
+          ready: true,
+          htmlSupport: true,
+          score: 100,
+        }),
+      ],
+      5173,
+    );
+    expect(result).toEqual({
+      port: 5173,
+      ready: false,
+      responded: true,
+      htmlSupport: false,
+    });
+  });
+
+  test("no pin, single port responded with 404 → responded=true, ready=false", () => {
+    const result = selectActive(
+      [
+        r({
+          port: 3000,
+          responded: true,
+          ready: false,
+          htmlSupport: false,
+          score: 10,
+        }),
+      ],
+      null,
+    );
+    expect(result).toEqual({
+      port: 3000,
+      ready: false,
+      responded: true,
+      htmlSupport: false,
+    });
+  });
+
+  test("no pin, no probed ports → all null/false", () => {
+    const result = selectActive([], null);
+    expect(result).toEqual({
+      port: null,
+      ready: false,
+      responded: false,
+      htmlSupport: false,
+    });
+  });
+
+  test("no pin, port did not respond → ready=false, responded=false", () => {
+    const result = selectActive(
+      [
+        r({
+          port: 3000,
+          responded: false,
+          ready: false,
+          htmlSupport: false,
+          score: 0,
+        }),
+      ],
+      null,
+    );
+    expect(result).toEqual({
+      port: 3000,
+      ready: false,
+      responded: false,
+      htmlSupport: false,
+    });
+  });
+});

--- a/packages/sandbox/daemon/probe.ts
+++ b/packages/sandbox/daemon/probe.ts
@@ -12,7 +12,10 @@ export interface ProbePort {
 }
 
 export interface ProbeState {
+  /** Active port answered with 2xx-3xx (i.e. the iframe will render meaningful content). */
   ready: boolean;
+  /** Active port answered any HTTP status (including 4xx/5xx). Use to dismiss boot overlays. */
+  responded: boolean;
   htmlSupport: boolean;
   /** The currently-active dev port: pinned `devPort` if set & responding,
    * otherwise the highest-scored discovered descendant port. */
@@ -48,9 +51,11 @@ export interface ProbeDeps {
   onLog?: (msg: string) => void;
 }
 
-interface ProbeResult {
+export interface ProbeResult {
   port: number;
+  /** Got any HTTP response (including 4xx/5xx). */
   responded: boolean;
+  /** Got a 2xx-3xx response. */
   ready: boolean;
   htmlSupport: boolean;
   /** Higher = more likely to be the actual dev preview surface. */
@@ -80,10 +85,63 @@ function score(root: HeadResult | null, viteClient: HeadResult | null): number {
   return s;
 }
 
+/**
+ * Pure selection over already-probed results. Picks the active port and
+ * derives the three signals (`ready`, `responded`, `htmlSupport`) from
+ * the same per-port result, eliminating per-branch divergence.
+ */
+export function selectActive(
+  probedAll: ProbeResult[],
+  pinned: number | null,
+): {
+  port: number | null;
+  ready: boolean;
+  responded: boolean;
+  htmlSupport: boolean;
+} {
+  if (pinned !== null) {
+    const pinnedResult = probedAll.find((r) => r.port === pinned);
+    if (pinnedResult && pinnedResult.responded) {
+      return {
+        port: pinnedResult.port,
+        ready: pinnedResult.ready,
+        responded: pinnedResult.responded,
+        htmlSupport: pinnedResult.htmlSupport,
+      };
+    }
+    // Pin is stale — fall back to highest-scored other responded port.
+    const others = probedAll.filter((r) => r.responded && r.port !== pinned);
+    const best = others.sort((a, b) => b.score - a.score)[0];
+    if (best) {
+      return {
+        port: best.port,
+        ready: best.ready,
+        responded: best.responded,
+        htmlSupport: best.htmlSupport,
+      };
+    }
+    return { port: null, ready: false, responded: false, htmlSupport: false };
+  }
+
+  if (probedAll.length === 0) {
+    return { port: null, ready: false, responded: false, htmlSupport: false };
+  }
+
+  const responded = probedAll.filter((r) => r.responded);
+  const best = responded.sort((a, b) => b.score - a.score)[0] ?? probedAll[0];
+  return {
+    port: best.port,
+    ready: best.ready,
+    responded: best.responded,
+    htmlSupport: best.htmlSupport,
+  };
+}
+
 /** Kicks off the probe loop; returns the current state (live-updated). */
 export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
   const state: ProbeState = {
     ready: false,
+    responded: false,
     htmlSupport: false,
     port: null,
     ports: [],
@@ -135,6 +193,7 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
     const prevReady = state.ready;
     const prevPort = state.port;
     const prevHtml = state.htmlSupport;
+    const prevResponded = state.responded;
     const prevPortsKey = portsKey(state.ports);
 
     const discovered = deps.getDiscoveredPorts();
@@ -164,46 +223,11 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
       commandName: r.rootPid !== null ? deps.getCommandName(r.rootPid) : null,
     }));
 
-    if (pinned !== null) {
-      // Pinned: prefer the pinned port when responding. If the pin is stale
-      // (e.g., dev process restarted and bound a different port), fall back
-      // to the highest-scored discovered port so the proxy self-heals across
-      // pause/resume — entry.ts's writeback then updates the pin.
-      const pinnedResult = probedAll.find((r) => r.port === pinned);
-      if (pinnedResult && pinnedResult.responded) {
-        state.port = pinnedResult.port;
-        state.ready = pinnedResult.ready;
-        state.htmlSupport = pinnedResult.htmlSupport;
-      } else {
-        const responded = probedAll.filter(
-          (r) => r.responded && r.port !== pinned,
-        );
-        const best = responded.sort((a, b) => b.score - a.score)[0];
-        if (best) {
-          state.port = best.port;
-          state.ready = best.ready;
-          state.htmlSupport = best.htmlSupport;
-        } else {
-          state.port = null;
-          state.ready = false;
-          state.htmlSupport = false;
-        }
-      }
-    } else if (probedAll.length > 0) {
-      const responded = probedAll.filter((r) => r.responded);
-      const best =
-        responded.sort((a, b) => b.score - a.score)[0] ?? probedAll[0];
-      state.port = best.port;
-      state.ready = responded.length > 0;
-      state.htmlSupport = best.htmlSupport;
-    } else {
-      // No discovered descendants and no pin: nothing to surface. Don't fall
-      // back to a default like 3000 — on dev machines that's often the
-      // outer mesh, which would nest the studio UI inside its own iframe.
-      state.port = null;
-      state.ready = false;
-      state.htmlSupport = false;
-    }
+    const active = selectActive(probedAll, pinned);
+    state.port = active.port;
+    state.ready = active.ready;
+    state.responded = active.responded;
+    state.htmlSupport = active.htmlSupport;
 
     const newPortsKey = portsKey(state.ports);
     const portsChanged = prevPortsKey !== newPortsKey;
@@ -230,10 +254,12 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
       readyChanged ||
       portChanged ||
       prevHtml !== state.htmlSupport ||
+      prevResponded !== state.responded ||
       portsChanged
     ) {
       deps.onChange({
         ready: state.ready,
+        responded: state.responded,
         htmlSupport: state.htmlSupport,
         port: state.port,
         ports: state.ports.slice(),


### PR DESCRIPTION
## What is this contribution about?

Fixes the Preview tab bug where the "Installing packages" boot overlay gets stuck forever when the dev server is up but returns a non-2xx response on `HEAD /` (API-only servers, MCP-only servers, custom routing). The daemon probe now emits a `responded` peer signal alongside `ready` and `htmlSupport`, so the boot overlay dismisses as soon as the port answers HTTP. When the server is reachable but doesn't serve HTML at `/`, an inline empty-state ("No web page at this URL" + View Logs) renders in place of the iframe instead of the iframe loading the server's bare 404. State decisions are now centralized in a pure `computePreviewState` function with 12 unit tests; daemon's pinned/unpinned port-selection asymmetry was removed by extracting a pure `selectActive` function with 7 unit tests.

## How to Test

1. Start a virtual MCP whose dev server returns 404 on `HEAD /` (e.g. an API-only server, or temporarily add a catchall that 404s `/`).
2. Open the Task → Preview tab. The boot overlay should dismiss within ~5s of the port coming up; the inline "No web page at this URL" state should render with a "View Logs" button.
3. Edit the dev server to add `GET /` returning HTML — the iframe should swap in within one probe cycle without manual refresh. Edit back to remove `/` — UI swaps back to the empty state.
4. Verify no regressions: a normal HTML-serving dev server still mounts the iframe; a server still booting still shows the booting overlay; error/suspended/notFound paths unchanged.

## Migration Notes

None. The `responded` field is additive at every boundary (`ProbeState`, SSE payload, `VmStatus`); older clients ignore it.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (27/27 tests pass; `bun run check` clean)
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Preview tab getting stuck on the boot overlay when `/` returns 404, and restores and secures OAuth discovery for org‑scoped MCP URLs so OAuth‑gated flows work again.

- **Bug Fixes**
  - Added a `responded` signal from the daemon probe, plumbed through SSE to `VmStatus`, so the boot overlay dismisses as soon as the port answers HTTP.
  - When the server is reachable but doesn’t serve HTML at `/`, render an inline “No web page at this URL” state with “View Logs”; once the port has responded, keep this state (or the iframe) mounted across transient probe hiccups.
  - Fixed the boot overlay timer to use `startingSinceRef` during pre-`previewUrl` phases for correct elapsed time.
  - Restored OAuth Protected Resource discovery for `/api/:org/mcp/:id`:
    - Mounted `/.well-known/oauth-protected-resource/api/:org/mcp/:connectionId` at the URL root, and updated the handler to read `:org` from params.
    - Kept synthesized `authorization_servers` on the legacy `/oauth-proxy/:id` path to hit the dedicated auth-server metadata and avoid Better Auth’s catch-all.
    - Split routes into legacy (top-level, both shapes) and org‑scoped (resource‑relative) variants.
    - Scoped connection lookup to the request’s `:org`; unknown or cross‑org slugs now 404 to prevent leaking cross‑org connections.
  - Temporarily skipped broken daemon e2e tests pending fixture updates after the state‑machine changes.

- **Refactors**
  - Centralized preview decisions in a pure `computePreviewState` function with unit tests; the toolbar now keys off the iframe state directly.
  - Extracted a pure `selectActive` for port selection with unit tests; `ready`, `responded`, and `htmlSupport` now derive from the same per‑port result.

<sup>Written for commit 39bb1266e0f93ebb52e8b8168252b96ecd48969b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

