### PR TITLE
feat(daemon/web): surface git setup phases in publish button

### DIFF
--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import type { BranchStatus } from "@/web/components/vm/hooks/use-vm-events";
+import type {
+  BranchStatus,
+  BranchStatusReady,
+} from "@/web/components/vm/hooks/use-vm-events";
 import { selectHeaderButton } from "./panel-state";
 import type { CheckRun, PrSummary } from "./use-pr-data";
 import type { PrReviewSignals } from "./use-pr-reviews";
 
-function bs(over: Partial<BranchStatus> = {}): BranchStatus {
+function bs(over: Partial<BranchStatusReady> = {}): BranchStatusReady {
   return {
+    kind: "ready",
     branch: "feat/x",
     base: "main",
     workingTreeDirty: false,
@@ -80,6 +84,67 @@ describe("selectHeaderButton", () => {
     });
     expect(r.label).toBe("Loading…");
     expect(r.loading).toBe(true);
+  });
+
+  test("kind=initializing → 'Starting sandbox…' (disabled, spinner)", () => {
+    const r = selectHeaderButton({
+      branchStatus: { kind: "initializing" } as BranchStatus,
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Starting sandbox…");
+    expect(r.disabled).toBe(true);
+    expect(r.loading).toBe(true);
+    expect(r.variant).toBe("outline");
+  });
+
+  test("kind=cloning → 'Cloning repo…' (disabled, spinner)", () => {
+    const r = selectHeaderButton({
+      branchStatus: { kind: "cloning" } as BranchStatus,
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Cloning repo…");
+    expect(r.loading).toBe(true);
+  });
+
+  test("kind=clone-failed → 'Clone failed' with error tooltip", () => {
+    const r = selectHeaderButton({
+      branchStatus: { kind: "clone-failed", error: "exit 128" } as BranchStatus,
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Clone failed");
+    expect(r.disabled).toBe(true);
+    expect(r.tooltip).toBe("exit 128");
+  });
+
+  test("kind=checking-out → 'Switching to <branch>…'", () => {
+    const r = selectHeaderButton({
+      branchStatus: { kind: "checking-out", to: "feat/y" } as BranchStatus,
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Switching to feat/y…");
+    expect(r.loading).toBe(true);
+  });
+
+  test("kind=checkout-failed → 'Checkout failed' with error tooltip", () => {
+    const r = selectHeaderButton({
+      branchStatus: {
+        kind: "checkout-failed",
+        error: "dirty working tree",
+      } as BranchStatus,
+      pr: null,
+      checks: [],
+      reviews: null,
+    });
+    expect(r.label).toBe("Checkout failed");
+    expect(r.tooltip).toBe("dirty working tree");
   });
 
   test("no diff anywhere → Up to date (disabled, outline)", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -77,8 +77,53 @@ export function selectHeaderButton(input: {
     };
   }
 
-  const hasLocalWork =
-    branchStatus.workingTreeDirty || branchStatus.unpushed > 0;
+  switch (branchStatus.kind) {
+    case "initializing":
+      return {
+        label: "Starting sandbox…",
+        disabled: true,
+        loading: true,
+        variant: "outline",
+        tooltip: "Waiting for the sandbox daemon to come online",
+      };
+    case "cloning":
+      return {
+        label: "Cloning repo…",
+        disabled: true,
+        loading: true,
+        variant: "outline",
+        tooltip: "Cloning the project repository",
+      };
+    case "clone-failed":
+      return {
+        label: "Clone failed",
+        disabled: true,
+        variant: "outline",
+        tooltip: branchStatus.error || "git clone failed — see setup logs",
+      };
+    case "checking-out":
+      return {
+        label: `Switching to ${branchStatus.to}…`,
+        disabled: true,
+        loading: true,
+        variant: "outline",
+        tooltip: `Checking out ${branchStatus.to}`,
+      };
+    case "checkout-failed":
+      return {
+        label: "Checkout failed",
+        disabled: true,
+        variant: "outline",
+        tooltip: branchStatus.error || "git checkout failed — see setup logs",
+      };
+    case "ready":
+      break;
+  }
+
+  // From here on, branchStatus.kind === "ready" — narrow it.
+  const ready = branchStatus;
+
+  const hasLocalWork = ready.workingTreeDirty || ready.unpushed > 0;
   if (hasLocalWork) {
     return {
       label: "Save changes",
@@ -96,9 +141,7 @@ export function selectHeaderButton(input: {
   // the branch's HEAD sha to the PR's head sha to decide.
   if (pr?.merged) {
     const branchAdvanced =
-      !!branchStatus.headSha &&
-      !!pr.headSha &&
-      branchStatus.headSha !== pr.headSha;
+      !!ready.headSha && !!pr.headSha && ready.headSha !== pr.headSha;
     if (branchAdvanced) {
       return {
         label: "Continue",
@@ -115,7 +158,7 @@ export function selectHeaderButton(input: {
     };
   }
 
-  if (branchStatus.aheadOfBase > 0) {
+  if (ready.aheadOfBase > 0) {
     if (pr && pr.state === "closed" && !pr.merged) {
       return {
         label: "Reopen",
@@ -129,7 +172,7 @@ export function selectHeaderButton(input: {
         label: "Submit for review",
         action: "create-pr",
         variant: "default",
-        tooltip: `Open a PR for ${branchStatus.branch} → ${branchStatus.base}`,
+        tooltip: `Open a PR for ${ready.branch} → ${ready.base}`,
       };
     }
 
@@ -211,6 +254,6 @@ export function selectHeaderButton(input: {
     label: "Up to date",
     disabled: true,
     variant: "outline",
-    tooltip: `Branch is in sync with ${branchStatus.base}`,
+    tooltip: `Branch is in sync with ${ready.base}`,
   };
 }

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -118,6 +118,11 @@ export function selectHeaderButton(input: {
       };
     case "ready":
       break;
+    default: {
+      const _exhaustive: never = branchStatus;
+      void _exhaustive;
+      break;
+    }
   }
 
   // From here on, branchStatus.kind === "ready" — narrow it.

--- a/apps/mesh/src/web/components/vm/hooks/use-vm-events.ts
+++ b/apps/mesh/src/web/components/vm/hooks/use-vm-events.ts
@@ -9,6 +9,7 @@ import {
 
 export type {
   BranchStatus,
+  BranchStatusReady,
   ChunkHandler,
   ReloadHandler,
   VmStatus,

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -58,7 +58,8 @@ export interface AppStatus {
   lastExitCode: number | null;
 }
 
-export interface BranchStatus {
+export interface BranchStatusReady {
+  kind: "ready";
   branch: string;
   base: string;
   workingTreeDirty: boolean;
@@ -68,6 +69,14 @@ export interface BranchStatus {
   /** HEAD sha (falls back to origin/<branch>). Empty if the daemon couldn't compute it. */
   headSha: string;
 }
+
+export type BranchStatus =
+  | { kind: "initializing" }
+  | { kind: "cloning" }
+  | { kind: "clone-failed"; error: string }
+  | { kind: "checking-out"; to: string }
+  | { kind: "checkout-failed"; error: string }
+  | BranchStatusReady;
 
 export type ChunkHandler = (source: string, data: string) => void;
 export type ReloadHandler = () => void;
@@ -347,15 +356,37 @@ export function VmEventsProvider({
             }
           }
         } else if (e.type === "branch-status") {
-          setBranchStatus({
-            branch: String(data.branch ?? ""),
-            base: String(data.base ?? "main"),
-            workingTreeDirty: Boolean(data.workingTreeDirty),
-            unpushed: Number(data.unpushed ?? 0),
-            aheadOfBase: Number(data.aheadOfBase ?? 0),
-            behindBase: Number(data.behindBase ?? 0),
-            headSha: String(data.headSha ?? ""),
-          });
+          const kind = String(
+            data.kind ?? "initializing",
+          ) as BranchStatus["kind"];
+          switch (kind) {
+            case "ready":
+              setBranchStatus({
+                kind: "ready",
+                branch: String(data.branch ?? ""),
+                base: String(data.base ?? "main"),
+                workingTreeDirty: Boolean(data.workingTreeDirty),
+                unpushed: Number(data.unpushed ?? 0),
+                aheadOfBase: Number(data.aheadOfBase ?? 0),
+                behindBase: Number(data.behindBase ?? 0),
+                headSha: String(data.headSha ?? ""),
+              });
+              break;
+            case "cloning":
+            case "initializing":
+              setBranchStatus({ kind });
+              break;
+            case "clone-failed":
+            case "checkout-failed":
+              setBranchStatus({ kind, error: String(data.error ?? "") });
+              break;
+            case "checking-out":
+              setBranchStatus({
+                kind: "checking-out",
+                to: String(data.to ?? ""),
+              });
+              break;
+          }
         }
       } catch {
         // ignore parse errors

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -356,9 +356,7 @@ export function VmEventsProvider({
             }
           }
         } else if (e.type === "branch-status") {
-          const kind = String(
-            data.kind ?? "initializing",
-          ) as BranchStatus["kind"];
+          const kind = String(data.kind ?? "initializing");
           switch (kind) {
             case "ready":
               setBranchStatus({
@@ -372,19 +370,33 @@ export function VmEventsProvider({
                 headSha: String(data.headSha ?? ""),
               });
               break;
-            case "cloning":
             case "initializing":
-              setBranchStatus({ kind });
+              setBranchStatus({ kind: "initializing" });
+              break;
+            case "cloning":
+              setBranchStatus({ kind: "cloning" });
               break;
             case "clone-failed":
+              setBranchStatus({
+                kind: "clone-failed",
+                error: String(data.error ?? ""),
+              });
+              break;
             case "checkout-failed":
-              setBranchStatus({ kind, error: String(data.error ?? "") });
+              setBranchStatus({
+                kind: "checkout-failed",
+                error: String(data.error ?? ""),
+              });
               break;
             case "checking-out":
               setBranchStatus({
                 kind: "checking-out",
                 to: String(data.to ?? ""),
               });
+              break;
+            default:
+              console.warn("[vm-events] unknown branch-status kind:", kind);
+              setBranchStatus({ kind: "initializing" });
               break;
           }
         }

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -47,7 +47,7 @@ import { makeScriptsHandler } from "./routes/scripts";
 import { discoverScripts } from "./process/script-discovery";
 import { SetupOrchestrator } from "./setup/orchestrator";
 import { isResume } from "./setup/resume";
-import type { TenantConfig } from "./types";
+import type { Config, TenantConfig } from "./types";
 import { makeWsUpgrader, type WsProxyData } from "./ws-proxy";
 
 if (!process.env.DAEMON_BOOT_ID) {
@@ -119,6 +119,18 @@ const appService = new ApplicationService({
   },
 });
 
+const branchStatus = new BranchStatusMonitor(
+  {
+    appRoot: bootConfig.appRoot,
+    repoDir: bootConfig.repoDir,
+    daemonToken: bootConfig.daemonToken,
+    daemonBootId: bootConfig.daemonBootId,
+    proxyPort: bootConfig.proxyPort,
+    dropPrivileges: false,
+  } as Config,
+  broadcaster,
+);
+
 const orchestrator = new SetupOrchestrator({
   bootConfig: { appRoot: bootConfig.appRoot, repoDir: bootConfig.repoDir },
   store,
@@ -127,9 +139,9 @@ const orchestrator = new SetupOrchestrator({
   installState,
   logsDir: TMP_DIR,
   phaseManager,
+  branchStatus,
 });
 
-let branchStatus: BranchStatusMonitor | null = null;
 let discoveredScripts: string[] | null = null;
 let lastWrittenProxyPort: number | undefined;
 
@@ -143,29 +155,7 @@ broadcaster.broadcastEvent = (event: string, data: unknown) => {
 
 store.subscribe((event) => {
   orchestrator.handle(event.transition);
-  if (event.transition.kind === "first-bootstrap") {
-    refreshBranchStatusMonitor();
-  }
 });
-
-function refreshBranchStatusMonitor(): void {
-  const enriched = store.read();
-  if (!enriched) {
-    branchStatus = null;
-    return;
-  }
-  // BranchStatusMonitor expects the legacy Config shape; pass a thin proxy.
-  const config = {
-    ...enriched,
-    daemonToken: bootConfig.daemonToken,
-    daemonBootId: bootConfig.daemonBootId,
-    proxyPort: bootConfig.proxyPort,
-    appRoot: bootConfig.appRoot,
-    repoDir: bootConfig.repoDir,
-    dropPrivileges: false,
-  };
-  branchStatus = new BranchStatusMonitor(config, broadcaster);
-}
 
 const excludeFromDiscovery = new Set<number>([bootConfig.proxyPort]);
 const getDiscoveredPorts = () => {
@@ -264,7 +254,7 @@ const eventsH = makeEventsHandler({
   getDiscoveredScripts: () => discoveredScripts,
   getActiveTasks,
   getAppStatus: () => appService.snapshot(),
-  getLastBranchStatus: () => (branchStatus ? branchStatus.getLast() : null),
+  getLastBranchStatus: () => branchStatus.getLast(),
 });
 
 const idleH = makeIdleHandler();
@@ -312,7 +302,6 @@ function hydrate(): void {
   if (!initial) return;
 
   store.hydrate(initial);
-  refreshBranchStatusMonitor();
   // Decide whether this is a fresh first-bootstrap or a resume of an
   // existing clone+install.
   const transitionKind: "resume" | "first-bootstrap" = isResume(

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -429,6 +429,7 @@ Bun.serve<WsProxyData, never>({
 process.on("SIGTERM", () => {
   taskManager.shutdown();
   appService.shutdown();
+  branchStatus.stop();
   const branch = store.read()?.git?.repository?.branch;
   if (branch) {
     try {

--- a/packages/sandbox/daemon/events/sse.ts
+++ b/packages/sandbox/daemon/events/sse.ts
@@ -1,3 +1,4 @@
+import type { BranchStatus } from "../types";
 import type { Broadcaster } from "./broadcast";
 import { sseFormat } from "./sse-format";
 
@@ -12,7 +13,7 @@ export interface SseHandshakeDeps {
   getDiscoveredScripts: () => string[] | null;
   getActiveTasks: () => Array<{ id: string; command: string }>;
   getAppStatus: () => unknown;
-  getLastBranchStatus: () => unknown | null;
+  getLastBranchStatus: () => BranchStatus;
   maxClients: number;
 }
 
@@ -75,14 +76,12 @@ export function makeSseStream(
       );
 
       const lastBranch = deps.getLastBranchStatus();
-      if (lastBranch) {
-        c.enqueue(
-          sseFormat(
-            "branch-status",
-            JSON.stringify({ type: "branch-status", ...lastBranch }),
-          ),
-        );
-      }
+      c.enqueue(
+        sseFormat(
+          "branch-status",
+          JSON.stringify({ type: "branch-status", ...lastBranch }),
+        ),
+      );
 
       deps.broadcaster.register(controller);
 

--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -101,14 +101,16 @@ describe("BranchStatusMonitor", () => {
     expect(events.length).toBe(before);
   });
 
-  it("setPhase to a different kind always broadcasts even with same kind", () => {
+  it("setPhase deduplicates identical consecutive phases", () => {
     const m = newMonitor();
     m.setPhase({ kind: "cloning" });
     m.setPhase({ kind: "cloning" });
-    const branchStatusEvents = events.filter(
-      (e) => e.event === "branch-status",
+    const cloningEvents = events.filter(
+      (e) =>
+        e.event === "branch-status" &&
+        (e.data as { kind?: string }).kind === "cloning",
     );
-    expect(branchStatusEvents.length).toBe(1);
+    expect(cloningEvents.length).toBe(1);
   });
 
   it("setPhase overwrites a sticky 'clone-failed'", () => {

--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Broadcaster } from "../events/broadcast";
+import { gitSync } from "./git-sync";
+import { BranchStatusMonitor } from "./branch-status";
+
+function makeRepo(): { repoDir: string; cleanup: () => void } {
+  const repoDir = mkdtempSync(join(tmpdir(), "branch-status-"));
+  gitSync(["init", "-b", "main"], { cwd: repoDir, asUser: false });
+  gitSync(["config", "user.email", "test@example.com"], {
+    cwd: repoDir,
+    asUser: false,
+  });
+  gitSync(["config", "user.name", "Test"], { cwd: repoDir, asUser: false });
+  gitSync(["commit", "--allow-empty", "-m", "init"], {
+    cwd: repoDir,
+    asUser: false,
+  });
+  return {
+    repoDir,
+    cleanup: () => rmSync(repoDir, { recursive: true, force: true }),
+  };
+}
+
+describe("BranchStatusMonitor", () => {
+  let repo: ReturnType<typeof makeRepo>;
+  let broadcaster: Broadcaster;
+  let events: Array<{ event: string; data: unknown }>;
+
+  beforeEach(() => {
+    repo = makeRepo();
+    broadcaster = new Broadcaster(1024);
+    events = [];
+    const orig = broadcaster.broadcastEvent.bind(broadcaster);
+    broadcaster.broadcastEvent = (event, data) => {
+      events.push({ event, data });
+      orig(event, data);
+    };
+  });
+
+  afterEach(() => repo.cleanup());
+
+  function newMonitor(): BranchStatusMonitor {
+    const config = {
+      appRoot: repo.repoDir,
+      repoDir: repo.repoDir,
+      daemonToken: "",
+      daemonBootId: "",
+      proxyPort: 0,
+      dropPrivileges: false,
+    } as never;
+    return new BranchStatusMonitor(config, broadcaster);
+  }
+
+  it("starts in 'initializing' on construction", () => {
+    const m = newMonitor();
+    expect(m.getLast()).toEqual({ kind: "initializing" });
+  });
+
+  it("setPhase('cloning') broadcasts and updates last", () => {
+    const m = newMonitor();
+    m.setPhase({ kind: "cloning" });
+    expect(m.getLast()).toEqual({ kind: "cloning" });
+    expect(events).toContainEqual({
+      event: "branch-status",
+      data: { type: "branch-status", kind: "cloning" },
+    });
+  });
+
+  it("setPhase('clone-failed') carries the error", () => {
+    const m = newMonitor();
+    m.setPhase({ kind: "clone-failed", error: "exit 128" });
+    expect(m.getLast()).toEqual({ kind: "clone-failed", error: "exit 128" });
+    const last = events.at(-1);
+    expect(last?.event).toBe("branch-status");
+    expect(last?.data).toEqual({
+      type: "branch-status",
+      kind: "clone-failed",
+      error: "exit 128",
+    });
+  });
+
+  it("markReady() computes git status and emits 'ready'", () => {
+    const m = newMonitor();
+    m.markReady();
+    const last = m.getLast();
+    if (last?.kind !== "ready") throw new Error("expected ready");
+    expect(last.branch).toBe("main");
+    expect(last.workingTreeDirty).toBe(false);
+    expect(last.headSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(events.at(-1)?.event).toBe("branch-status");
+  });
+
+  it("markReady() does not re-broadcast identical state", () => {
+    const m = newMonitor();
+    m.markReady();
+    const before = events.length;
+    m.markReady();
+    expect(events.length).toBe(before);
+  });
+
+  it("setPhase to a different kind always broadcasts even with same kind", () => {
+    const m = newMonitor();
+    m.setPhase({ kind: "cloning" });
+    m.setPhase({ kind: "cloning" });
+    const branchStatusEvents = events.filter(
+      (e) => e.event === "branch-status",
+    );
+    expect(branchStatusEvents.length).toBe(1);
+  });
+
+  it("setPhase overwrites a sticky 'clone-failed'", () => {
+    const m = newMonitor();
+    m.setPhase({ kind: "clone-failed", error: "x" });
+    m.setPhase({ kind: "cloning" });
+    expect(m.getLast()).toEqual({ kind: "cloning" });
+  });
+});

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -86,6 +86,9 @@ export class BranchStatusMonitor {
       this.watcher = fs.watch(gitDir, { recursive: true }, () =>
         this.schedule(),
       );
+      // Swallow errors (e.g. ENOENT when .git is removed during shutdown)
+      // — without this the FSWatcher emits an unhandled 'error' event.
+      this.watcher.on("error", () => {});
     } catch {
       this.pollFallback = setInterval(() => {
         if (this.last.kind === "ready") this.markReady();

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -1,59 +1,103 @@
 import fs from "node:fs";
 import type { Broadcaster } from "../events/broadcast";
-import type { Config, BranchStatus } from "../types";
+import type { BranchStatus, BranchStatusReady, Config } from "../types";
 import { gitSync as rawGitSync } from "./git-sync";
 
 const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
   rawGitSync(["-c", "safe.directory=*", ...args], opts);
 
 export class BranchStatusMonitor {
-  private last: BranchStatus | null = null;
+  private last: BranchStatus = { kind: "initializing" };
   private timer: ReturnType<typeof setTimeout> | null = null;
   private watcher: ReturnType<typeof fs.watch> | null = null;
+  private pollFallback: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly config: Config,
     private readonly broadcaster: Broadcaster,
-  ) {}
+  ) {
+    // Emit initial 'initializing' so newly-connected SSE clients see something
+    // even if the orchestrator hasn't dispatched a transition yet.
+    this.broadcast(this.last);
+  }
 
-  getLast(): BranchStatus | null {
+  getLast(): BranchStatus {
     return this.last;
   }
 
-  emit(): void {
+  /** Set a non-ready phase. Always broadcasts when the kind/payload changed. */
+  setPhase(next: Exclude<BranchStatus, BranchStatusReady>): void {
+    if (this.equal(this.last, next)) return;
+    this.last = next;
+    this.broadcast(next);
+  }
+
+  /**
+   * Compute git status and enter 'ready'. Idempotent: skips broadcast when
+   * the computed status equals the last 'ready' value. Starts the .git
+   * watcher on first call.
+   */
+  markReady(): void {
     const next = this.compute();
     if (!next) return;
-    if (this.last && JSON.stringify(this.last) === JSON.stringify(next)) {
-      return;
-    }
+    if (this.equal(this.last, next)) return;
     this.last = next;
+    this.broadcast(next);
+    this.ensureWatch();
+  }
+
+  /** Stop the .git watcher and any polling fallback. */
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+    if (this.pollFallback) {
+      clearInterval(this.pollFallback);
+      this.pollFallback = null;
+    }
+  }
+
+  private broadcast(s: BranchStatus): void {
     this.broadcaster.broadcastEvent("branch-status", {
       type: "branch-status",
-      ...next,
+      ...s,
     });
   }
 
-  schedule(): void {
+  private equal(a: BranchStatus, b: BranchStatus): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  private schedule(): void {
     if (this.timer) return;
     this.timer = setTimeout(() => {
       this.timer = null;
-      this.emit();
+      // fs.watch fires meaningfully only once we're already in 'ready';
+      // ignore otherwise (orchestrator owns non-ready transitions).
+      if (this.last.kind === "ready") this.markReady();
     }, 250);
   }
 
-  watch(): void {
-    if (this.watcher) return;
+  private ensureWatch(): void {
+    if (this.watcher || this.pollFallback) return;
     const gitDir = `${this.config.appRoot}/.git`;
     try {
       this.watcher = fs.watch(gitDir, { recursive: true }, () =>
         this.schedule(),
       );
     } catch {
-      setInterval(() => this.emit(), 5000);
+      this.pollFallback = setInterval(() => {
+        if (this.last.kind === "ready") this.markReady();
+      }, 5000);
     }
   }
 
-  private compute(): BranchStatus | null {
+  private compute(): BranchStatusReady | null {
     const run = (args: string[]) => {
       try {
         return gitSync(args, { cwd: this.config.appRoot });
@@ -96,6 +140,7 @@ export class BranchStatusMonitor {
       }
       const headSha = run(["rev-parse", branchRef]);
       return {
+        kind: "ready",
         branch,
         base,
         workingTreeDirty: dirty,

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -15,11 +15,7 @@ export class BranchStatusMonitor {
   constructor(
     private readonly config: Config,
     private readonly broadcaster: Broadcaster,
-  ) {
-    // Emit initial 'initializing' so newly-connected SSE clients see something
-    // even if the orchestrator hasn't dispatched a transition yet.
-    this.broadcast(this.last);
-  }
+  ) {}
 
   getLast(): BranchStatus {
     return this.last;

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Broadcaster } from "../events/broadcast";
+import type { BranchStatusMonitor } from "../git/branch-status";
+import { SetupOrchestrator } from "./orchestrator";
+
+function tempRoot(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "orch-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function makeMonitorSpy() {
+  const calls: Array<{ method: string; arg?: unknown }> = [];
+  const monitor = {
+    setPhase(arg: unknown) {
+      calls.push({ method: "setPhase", arg });
+    },
+    markReady() {
+      calls.push({ method: "markReady" });
+    },
+  } as unknown as BranchStatusMonitor;
+  return { monitor, calls };
+}
+
+describe("SetupOrchestrator branch-status integration", () => {
+  it("setPhase('cloning') is called before clone, 'clone-failed' on non-zero exit", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      const broadcaster = new Broadcaster(1024);
+      const { monitor, calls } = makeMonitorSpy();
+
+      // Build orchestrator with a config that points to an unreachable
+      // cloneUrl so spawnClone exits non-zero quickly.
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
+        store: {
+          read: () => ({
+            git: {
+              repository: { cloneUrl: "https://invalid.example.invalid/x.git" },
+            },
+            application: { intent: "paused" },
+          }),
+        } as never,
+        appService: { stop: async () => {}, snapshot: () => ({}) } as never,
+        broadcaster,
+        installState: { isInstalledFor: () => false } as never,
+        logsDir: dir,
+        branchStatus: monitor,
+      });
+
+      orchestrator.handle({
+        kind: "first-bootstrap",
+        config: {} as never,
+      });
+
+      // Poll until the orchestrator finishes the queue (or 15s timeout)
+      const deadline = Date.now() + 15_000;
+      while (orchestrator.isRunning() || orchestrator.pendingCount() > 0) {
+        if (Date.now() > deadline) throw new Error("orchestrator hung");
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      expect(calls[0]).toEqual({
+        method: "setPhase",
+        arg: { kind: "cloning" },
+      });
+      const failed = calls.find(
+        (c) =>
+          c.method === "setPhase" &&
+          (c.arg as { kind: string })?.kind === "clone-failed",
+      );
+      expect(failed).toBeTruthy();
+      expect(calls.some((c) => c.method === "markReady")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("setPhase('checking-out') / 'checkout-failed' on branchChange error", async () => {
+    const { dir, cleanup } = tempRoot();
+    try {
+      mkdirSync(join(dir, "repo"));
+      // No git repo at appRoot, so checkout will fail
+      const broadcaster = new Broadcaster(1024);
+      const { monitor, calls } = makeMonitorSpy();
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
+        store: {
+          read: () => ({
+            git: { repository: { cloneUrl: "" } },
+            application: { intent: "paused" },
+          }),
+        } as never,
+        appService: { stop: async () => {}, snapshot: () => ({}) } as never,
+        broadcaster,
+        installState: { isInstalledFor: () => false } as never,
+        logsDir: dir,
+        branchStatus: monitor,
+      });
+
+      orchestrator.handle({
+        kind: "branch-change",
+        from: "main",
+        to: "feat/x",
+      });
+
+      const deadline = Date.now() + 5_000;
+      while (orchestrator.isRunning() || orchestrator.pendingCount() > 0) {
+        if (Date.now() > deadline) throw new Error("orchestrator hung");
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      expect(calls[0]).toEqual({
+        method: "setPhase",
+        arg: { kind: "checking-out", to: "feat/x" },
+      });
+      const failed = calls.find(
+        (c) =>
+          c.method === "setPhase" &&
+          (c.arg as { kind: string })?.kind === "checkout-failed",
+      );
+      expect(failed).toBeTruthy();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -10,6 +10,7 @@ import {
   pmRunCommand,
 } from "../constants";
 import type { Broadcaster } from "../events/broadcast";
+import type { BranchStatusMonitor } from "../git/branch-status";
 import { gitSync } from "../git/git-sync";
 import type { InstallState } from "../install/install-state";
 import { InstallState as InstallStateClass } from "../install/install-state";
@@ -36,6 +37,7 @@ export interface SetupOrchestratorDeps {
   logsDir: string;
   /** When provided, setup phases are tracked via the phase manager. */
   phaseManager?: PhaseManager;
+  branchStatus: BranchStatusMonitor;
 }
 
 /**
@@ -176,6 +178,7 @@ export class SetupOrchestrator {
 
     const cloneUrl = config.git?.repository?.cloneUrl;
     if (cloneUrl && !isResume(config.repoDir)) {
+      this.deps.branchStatus.setPhase({ kind: "cloning" });
       const cloneTaskId = this.deps.phaseManager?.begin("clone");
       const cloneLogPath = appLogPath(this.deps.logsDir, "clone");
       try {
@@ -196,6 +199,10 @@ export class SetupOrchestrator {
         this.chunk(`\r\n[orchestrator] clone failed (exit ${code})\r\n`);
         if (cloneTaskId)
           this.deps.phaseManager?.fail(cloneTaskId, `exit ${code}`);
+        this.deps.branchStatus.setPhase({
+          kind: "clone-failed",
+          error: `exit ${code}`,
+        });
         return;
       }
       if (cloneTaskId) this.deps.phaseManager?.done(cloneTaskId);
@@ -207,6 +214,7 @@ export class SetupOrchestrator {
     // into — earlier order tripped posix_spawn ENOENT (it reads cwd before
     // exec, and repoDir doesn't exist until clone returns).
     await this.gitSetup(config);
+    this.deps.branchStatus.markReady();
 
     if (config.application?.intent === "running") {
       const installed = await this.runInstall();
@@ -222,6 +230,7 @@ export class SetupOrchestrator {
     const config = this.currentConfig();
     if (!config) return;
     await this.gitSetup(config);
+    this.deps.branchStatus.markReady();
 
     if (config.application?.intent === "running") {
       if (
@@ -242,15 +251,17 @@ export class SetupOrchestrator {
   private async branchChange(to: string): Promise<void> {
     await this.deps.appService.stop();
     this.chunk(`[orchestrator] checking out branch: ${to}\r\n`);
+    this.deps.branchStatus.setPhase({ kind: "checking-out", to });
     try {
       await this.checkoutBranch(to);
     } catch (e) {
-      this.chunk(
-        `\r\n[orchestrator] branch-change failed: ${(e as Error).message}\r\n`,
-      );
+      const error = (e as Error).message;
+      this.chunk(`\r\n[orchestrator] branch-change failed: ${error}\r\n`);
+      this.deps.branchStatus.setPhase({ kind: "checkout-failed", error });
       return;
     }
     this.refreshBranchHead();
+    this.deps.branchStatus.markReady();
     const ok = await this.runInstall();
     if (ok) await this.startIfReady();
   }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -187,13 +187,23 @@ export class SetupOrchestrator {
         /* not present */
       }
       const cloneTee = new LogTee(cloneLogPath, INSTALL_LOG_MAX_BYTES);
-      const code = await spawnClone({
-        config,
-        onChunk: (_src, data) => {
-          this.chunk(data);
-          cloneTee.write(data);
-        },
-      });
+      let code: number;
+      try {
+        code = await spawnClone({
+          config,
+          onChunk: (_src, data) => {
+            this.chunk(data);
+            cloneTee.write(data);
+          },
+        });
+      } catch (e) {
+        cloneTee.close();
+        const error = (e as Error).message;
+        this.chunk(`\r\n[orchestrator] clone failed: ${error}\r\n`);
+        if (cloneTaskId) this.deps.phaseManager?.fail(cloneTaskId, error);
+        this.deps.branchStatus.setPhase({ kind: "clone-failed", error });
+        return;
+      }
       cloneTee.close();
       if (code !== 0) {
         this.chunk(`\r\n[orchestrator] clone failed (exit ${code})\r\n`);

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -103,12 +103,21 @@ export interface SseFrame {
   readonly payload: string;
 }
 
-export interface BranchStatus {
-  branch: string;
-  base: string;
-  workingTreeDirty: boolean;
-  unpushed: number;
-  aheadOfBase: number;
-  behindBase: number;
-  headSha: string;
-}
+export type BranchStatusReady = {
+  readonly kind: "ready";
+  readonly branch: string;
+  readonly base: string;
+  readonly workingTreeDirty: boolean;
+  readonly unpushed: number;
+  readonly aheadOfBase: number;
+  readonly behindBase: number;
+  readonly headSha: string;
+};
+
+export type BranchStatus =
+  | { readonly kind: "initializing" }
+  | { readonly kind: "cloning" }
+  | { readonly kind: "clone-failed"; readonly error: string }
+  | { readonly kind: "checking-out"; readonly to: string }
+  | { readonly kind: "checkout-failed"; readonly error: string }
+  | BranchStatusReady;


### PR DESCRIPTION
## What is this contribution about?

Refactors `BranchStatus` into a discriminated union (`initializing` | `cloning` | `clone-failed` | `checking-out` | `checkout-failed` | `ready`) so the publish button in the thread header can reflect the sandbox's actual git lifecycle instead of flickering between empty and ready. The daemon's `BranchStatusMonitor` becomes a small state machine driven by the `SetupOrchestrator` (which now calls `setPhase`/`markReady` around clone and checkout), is constructed once at boot, replays unconditionally over SSE, and is torn down on SIGTERM. The web `vm-events-context` mirrors the union, and `selectHeaderButton` renders dedicated labels/tooltips for each non-ready phase with an exhaustiveness check on `kind`. New unit + integration tests cover the monitor's dedup/sticky-failure behavior, orchestrator phase transitions, and per-kind button rendering.

## Screenshots/Demonstration
N/A — UI text/spinner states only; covered by `panel-state.test.ts`.

## How to Test
1. `bun test packages/sandbox/daemon/git/branch-status.test.ts packages/sandbox/daemon/setup/orchestrator.test.ts apps/mesh/src/web/components/thread/github/panel-state.test.ts`
2. Run `bun run dev`, open a workspace that needs cloning, and watch the publish button transition: \"Starting sandbox…\" → \"Cloning repo…\" → \"Up to date\" / \"Save changes\".
3. Force a checkout failure (e.g. dirty tree + branch switch) and confirm the button shows \"Checkout failed\" with the git error in the tooltip.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show git setup phases directly in the publish button to remove flicker and make status clear during clone, checkout, and initial boot. The daemon now runs a `BranchStatus` state machine driven by the setup orchestrator, and SSE replays the latest status (including `initializing`) to every new client.

- New Features
  - `BranchStatus` union kinds: `initializing`, `cloning`, `clone-failed`, `checking-out`, `checkout-failed`, `ready`.
  - `BranchStatusMonitor` is constructed at boot, starts as `initializing`, watches `.git` with a polling fallback, dedups repeats, and stops on SIGTERM.
  - Orchestrator calls `setPhase` around clone/checkout and `markReady()` after git setup and branch changes.
  - SSE handshake unconditionally replays the last `BranchStatus` to new clients.
  - Web: `vm-events-context` mirrors the union; `selectHeaderButton` renders per-phase labels/spinners and error tooltips with an exhaustiveness check.

- Bug Fixes
  - Handle `spawnClone` non-zero exits and throws; both set `clone-failed` with the error.
  - Swallow `.git` watcher errors to prevent unhandled crashes.

<sup>Written for commit a0135f8db09fd86866400e2f79092c6695d81b95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

