### PR TITLE
fix(decopilot): preserve generator shape in built-in tool instrumentation

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts
@@ -253,7 +253,7 @@ async function buildAllTools(
  * tools. Preserves the original tool shape so AI SDK can't tell the wrapper
  * is there.
  */
-function instrumentBuiltIns<T extends Record<string, unknown>>(
+export function instrumentBuiltIns<T extends Record<string, unknown>>(
   tools: T,
   params: BuiltinToolParams,
   ctx: MeshContext,
@@ -269,40 +269,61 @@ function instrumentBuiltIns<T extends Record<string, unknown>>(
       continue;
     }
     const hints = BUILTIN_TOOL_ANNOTATIONS[name];
-    result[name] = {
-      ...t,
-      execute: async (input: unknown, options: unknown) => {
-        const startTime = performance.now();
-        let isError = false;
-        try {
-          return await originalExecute.call(t, input, options);
-        } catch (err) {
-          isError = true;
-          throw err;
-        } finally {
-          const latencyMs = performance.now() - startTime;
-          if (orgId && userId) {
-            posthog.capture({
-              distinctId: userId,
-              event: "tool_called",
-              groups: { organization: orgId },
-              properties: {
-                organization_id: orgId,
-                tool_source: "builtin",
-                tool_name: name,
-                tool_safe_name: name,
-                read_only: hints?.readOnly ?? null,
-                destructive: hints?.destructive ?? null,
-                idempotent: null,
-                open_world: null,
-                latency_ms: Math.round(latencyMs),
-                is_error: isError,
-              },
-            });
+    const isAsyncGen =
+      originalExecute.constructor?.name === "AsyncGeneratorFunction";
+    const captureToolCalled = (latencyMs: number, isError: boolean) => {
+      if (!orgId || !userId) return;
+      posthog.capture({
+        distinctId: userId,
+        event: "tool_called",
+        groups: { organization: orgId },
+        properties: {
+          organization_id: orgId,
+          tool_source: "builtin",
+          tool_name: name,
+          tool_safe_name: name,
+          read_only: hints?.readOnly ?? null,
+          destructive: hints?.destructive ?? null,
+          idempotent: null,
+          open_world: null,
+          latency_ms: Math.round(latencyMs),
+          is_error: isError,
+        },
+      });
+    };
+    // Generator-shaped execute must stay generator-shaped, otherwise the
+    // AI SDK's isAsyncIterable check fails on the returned Promise and the
+    // streamed yields are dropped (subtask "No output available" bug).
+    const wrappedExecute = isAsyncGen
+      ? async function* (input: unknown, options: unknown) {
+          const startTime = performance.now();
+          let isError = false;
+          try {
+            yield* originalExecute.call(
+              t,
+              input,
+              options,
+            ) as AsyncIterable<unknown>;
+          } catch (err) {
+            isError = true;
+            throw err;
+          } finally {
+            captureToolCalled(performance.now() - startTime, isError);
           }
         }
-      },
-    };
+      : async (input: unknown, options: unknown) => {
+          const startTime = performance.now();
+          let isError = false;
+          try {
+            return await originalExecute.call(t, input, options);
+          } catch (err) {
+            isError = true;
+            throw err;
+          } finally {
+            captureToolCalled(performance.now() - startTime, isError);
+          }
+        };
+    result[name] = { ...t, execute: wrappedExecute };
   }
   return result as T;
 }

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/instrument-built-ins.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/instrument-built-ins.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for instrumentBuiltIns wrapper.
+ *
+ * The AI SDK's executeTool checks isAsyncIterable on the value returned from
+ * tool.execute(). If a tool's execute is `async function*` (a generator),
+ * wrapping it in a plain `async function` produces a Promise — and the AI SDK
+ * never iterates it, dropping every preliminary yield and capturing the bare
+ * generator object as the final output. That's how `subtask` results showed
+ * "No output available" on every call. These tests pin the wrapper down so the
+ * generator surface survives instrumentation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { instrumentBuiltIns, type BuiltinToolParams } from "./index";
+
+const mockParams: BuiltinToolParams = {
+  provider: null,
+  organization: { id: "org_test" } as never,
+  models: { connectionId: "conn_test", thinking: { id: "m" } } as never,
+  toolOutputMap: new Map(),
+  pendingImages: [],
+  passthroughClient: {} as never,
+};
+
+const mockCtx = { auth: { user: { id: "user_test" } } } as never;
+
+describe("instrumentBuiltIns", () => {
+  test("preserves async-generator execute as async-iterable and yields all values", async () => {
+    const yielded = ["a", "b", "final"];
+    const tools = {
+      gen_tool: {
+        description: "test gen tool",
+        execute: async function* (_input: unknown, _options: unknown) {
+          for (const v of yielded) yield v;
+        },
+      },
+    };
+
+    const wrapped = instrumentBuiltIns(tools, mockParams, mockCtx);
+    const result = wrapped.gen_tool.execute({}, {});
+
+    expect(
+      typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator],
+    ).toBe("function");
+
+    const collected: unknown[] = [];
+    for await (const v of result as AsyncIterable<unknown>) {
+      collected.push(v);
+    }
+    expect(collected).toEqual(yielded);
+  });
+
+  test("propagates errors thrown inside async-generator execute", async () => {
+    const tools = {
+      gen_throws: {
+        description: "throws",
+        execute: async function* (_input: unknown, _options: unknown) {
+          yield "first";
+          throw new Error("boom");
+        },
+      },
+    };
+
+    const wrapped = instrumentBuiltIns(tools, mockParams, mockCtx);
+    const collected: unknown[] = [];
+    let caught: unknown;
+    try {
+      for await (const v of wrapped.gen_throws.execute(
+        {},
+        {},
+      ) as AsyncIterable<unknown>) {
+        collected.push(v);
+      }
+    } catch (err) {
+      caught = err;
+    }
+    expect(collected).toEqual(["first"]);
+    expect((caught as Error)?.message).toBe("boom");
+  });
+
+  test("keeps plain async execute working unchanged", async () => {
+    const tools = {
+      plain_tool: {
+        description: "plain",
+        execute: async (input: { n: number }, _options: unknown) => ({
+          doubled: input.n * 2,
+        }),
+      },
+    };
+
+    const wrapped = instrumentBuiltIns(tools, mockParams, mockCtx);
+    const result = await wrapped.plain_tool.execute({ n: 21 }, {});
+    expect(result).toEqual({ doubled: 42 });
+  });
+});

--- a/packages/sandbox/daemon/config-store/store.ts
+++ b/packages/sandbox/daemon/config-store/store.ts
@@ -82,7 +82,7 @@ export class TenantConfigStore {
         if (!entry) break;
         try {
           entry.resolve(await this.runOne(entry.patch));
-        } catch (e) {
+        } catch {
           entry.resolve({
             kind: "rejected",
             reason: REJECTION_REASONS.APPLY_FAILED,
@@ -123,7 +123,7 @@ export class TenantConfigStore {
 
     try {
       writeConfig(merged, this.deps.storageDir);
-    } catch (e) {
+    } catch {
       return {
         kind: "rejected",
         reason: REJECTION_REASONS.PERSISTENCE_FAILED,


### PR DESCRIPTION
## What is this contribution about?

The subtask tool was rendering "No output available" in the chat UI on every call. Root cause: `instrumentBuiltIns` (apps/mesh/src/api/routes/decopilot/built-in-tools/index.ts) wrapped every built-in tool's `execute` in a plain `async` function. For `subtask`, whose execute is `async function*`, the wrapper returned `Promise<AsyncGenerator>`; AI SDK's `isAsyncIterable` check failed on that Promise and fell through to the non-streaming branch, dropping every preliminary yield and capturing the bare generator object as the final output — which serialized to `{}` and made `extractTextFromOutput` fall back to "No output available". Fix detects `AsyncGeneratorFunction` and wraps with a generator that `yield*`s through; PostHog instrumentation extracted into a shared `captureToolCalled` helper. New unit test pins the generator surface, error propagation, and the unchanged plain-async path.

## How to Test

1. Open the chat UI and have the agent call a subtask (e.g. @-mention an agent so it routes through `subtask`).
2. Expand the subtask in the message — the Result section now shows the subagent's actual output.
3. Run `bun test apps/mesh/src/api/routes/decopilot/built-in-tools/` — 91 pass, 0 fail.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing subtask results by preserving async generator streaming in built-in tool instrumentation. The chat now streams `subtask` yields instead of showing "No output available".

- **Bug Fixes**
  - Detect `AsyncGeneratorFunction` and wrap with `async function*` that `yield*`s the original `execute`, preserving the async-iterable shape.
  - Added tests for streaming, error propagation, and plain async behavior.

- **Refactors**
  - Extracted PostHog capture into `captureToolCalled` and exported `instrumentBuiltIns` for testing; no behavior changes.
  - Dropped unused catch bindings in `packages/sandbox/daemon/config-store/store.ts` to satisfy lint; no behavior change.

<sup>Written for commit d2914a2dead8c5ce98e392df1a1d8bd03fd9357b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

