### PR TITLE
feat(decopilot): enhance tool name sanitization and collision handling

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/enable-tools.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/enable-tools.ts
@@ -11,7 +11,14 @@ import { z } from "zod";
 const enableToolsInputSchema = z.object({
   tools: z
     .array(z.string())
-    .describe("List of tool names to enable from the available tools catalog"),
+    .optional()
+    .describe("Specific tool names to enable"),
+  connections: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Connection IDs from <available-connections> — enables all tools in those connections",
+    ),
 });
 
 /**
@@ -19,11 +26,13 @@ const enableToolsInputSchema = z.object({
  *
  * @param enabledTools - Shared set that tracks which tools have been enabled
  * @param availableToolNames - Set of all tool names from the passthrough client
+ * @param connectionToolsMap - Map of connection ID → safe tool names in that connection
  * @param options - Optional config for plan-mode gating
  */
 export function createEnableToolsTool(
   enabledTools: Set<string>,
   availableToolNames: Set<string>,
+  connectionToolsMap: Map<string, string[]>,
   options?: {
     isPlanMode?: boolean;
     toolAnnotations?: Map<string, { readOnlyHint?: boolean }>;
@@ -34,16 +43,27 @@ export function createEnableToolsTool(
       "Enable tools from the available tools catalog so they can be called in subsequent steps. " +
       "Call this before using any tool listed in <available-connections>.\n\n" +
       "Usage notes:\n" +
-      "- Batch related tools in a single call to minimize round-trips.\n" +
-      "- Enable only the tools you need for your next step — you can always enable more later.\n" +
+      "- Pass connection IDs from <available-connections> to enable all tools in a connection at once.\n" +
+      "- Pass specific tool names to enable individual tools.\n" +
       "- Built-in tools (user_ask, subtask, agent_search, read_tool_output) are always available and do not need enabling.",
     inputSchema: enableToolsInputSchema,
-    execute: async ({ tools }) => {
+    execute: async ({ tools = [], connections = [] }) => {
       const enabled: string[] = [];
       const notFound: string[] = [];
       const blocked: string[] = [];
 
-      for (const name of tools) {
+      // Expand connection IDs to their tool names
+      const toolsToEnable = [...tools];
+      for (const connId of connections) {
+        const connTools = connectionToolsMap.get(connId);
+        if (!connTools || connTools.length === 0) {
+          notFound.push(connId);
+          continue;
+        }
+        toolsToEnable.push(...connTools);
+      }
+
+      for (const name of toolsToEnable) {
         if (!availableToolNames.has(name)) {
           notFound.push(name);
           continue;

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -78,8 +78,10 @@ export function ensureOrganization(
  * only [a-zA-Z0-9_.\-:], and be at most 128 characters.
  */
 export function sanitizeToolName(name: string): string {
-  // Replace any character outside the allowed set with an underscore
-  let safe = name.replace(/[^a-zA-Z0-9_.\-:]/g, "_");
+  // Replace everything outside [a-zA-Z0-9_] with underscore.
+  // Hyphens are intentionally excluded: many LLMs normalize hyphens to
+  // underscores when invoking tools, causing "unavailable tool" errors.
+  let safe = name.replace(/[^a-zA-Z0-9_]/g, "_");
   // Ensure it starts with a letter or underscore
   if (safe.length === 0 || !/^[a-zA-Z_]/.test(safe)) {
     safe = `_${safe}`;
@@ -102,8 +104,7 @@ export function buildSanitizedNameMap(names: string[]): Map<string, string> {
   for (const name of names) {
     let safeName = sanitizeToolName(name);
     if (usedNames.has(safeName)) {
-      // Reserve room for the suffix (up to "_999") within the 128-char limit
-      const maxBase = 128 - 4; // "_" + up to 3 digits
+      const maxBase = 128 - 4;
       const base =
         safeName.length > maxBase ? safeName.slice(0, maxBase) : safeName;
       let i = 2;
@@ -112,6 +113,69 @@ export function buildSanitizedNameMap(names: string[]): Map<string, string> {
     }
     usedNames.add(safeName);
     map.set(name, safeName);
+  }
+  return map;
+}
+
+/**
+ * Strip the GatewayClient namespace prefix (`slugify(clientId) + "_"`) from a tool name.
+ */
+function stripGatewayPrefix(
+  namespacedName: string,
+  gatewayClientId: string,
+): string {
+  const slug = gatewayClientId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const prefix = `${slug}_`;
+  return namespacedName.startsWith(prefix)
+    ? namespacedName.slice(prefix.length)
+    : namespacedName;
+}
+
+/**
+ * Build a collision-aware name map from MCP tools.
+ * Uses the short (un-namespaced) tool name when it's unique across all
+ * connections; only prepends the connection prefix when two connections
+ * expose a tool with the same base name.
+ *
+ * Examples (no collision): "search_repositories", "list_objects"
+ * Examples (collision):    "conn_togsm0_search_code", "conn_abc_search_code"
+ */
+export function buildShortNameMap(
+  tools: Array<{ name: string; _meta?: Record<string, unknown> }>,
+): Map<string, string> {
+  // Pass 1: count how many tools share each sanitized short name
+  const shortCount = new Map<string, number>();
+  for (const t of tools) {
+    const connId = (t._meta?.gatewayClientId as string) ?? "";
+    const short = connId ? stripGatewayPrefix(t.name, connId) : t.name;
+    const safe = sanitizeToolName(short);
+    shortCount.set(safe, (shortCount.get(safe) ?? 0) + 1);
+  }
+
+  // Pass 2: assign safe names, prefixing only on collision
+  const used = new Set<string>();
+  const map = new Map<string, string>();
+  for (const t of tools) {
+    const connId = (t._meta?.gatewayClientId as string) ?? "";
+    const short = connId ? stripGatewayPrefix(t.name, connId) : t.name;
+    const safeShort = sanitizeToolName(short);
+    const unique = (shortCount.get(safeShort) ?? 0) <= 1;
+
+    let safeName = unique ? safeShort : sanitizeToolName(`${connId}_${short}`);
+
+    // Suffix for any remaining collision (same conn + same tool name)
+    if (used.has(safeName)) {
+      const base = safeName.slice(0, 124);
+      let i = 2;
+      while (used.has(`${base}_${i}`)) i++;
+      safeName = `${base}_${i}`;
+    }
+
+    used.add(safeName);
+    map.set(t.name, safeName);
   }
   return map;
 }
@@ -150,7 +214,7 @@ export async function toolsFromMCP(
   const list = await client.listTools();
   const visibleTools = list.tools.filter(isToolVisibleToModel);
 
-  const nameMap = buildSanitizedNameMap(visibleTools.map((t) => t.name));
+  const nameMap = buildShortNameMap(visibleTools);
   const toolEntries = visibleTools.map((t) => {
     const { name, title, description, inputSchema, annotations, _meta } = t;
     const safeName = nameMap.get(name)!;

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -78,10 +78,8 @@ export function ensureOrganization(
  * only [a-zA-Z0-9_.\-:], and be at most 128 characters.
  */
 export function sanitizeToolName(name: string): string {
-  // Replace everything outside [a-zA-Z0-9_] with underscore.
-  // Hyphens are intentionally excluded: many LLMs normalize hyphens to
-  // underscores when invoking tools, causing "unavailable tool" errors.
-  let safe = name.replace(/[^a-zA-Z0-9_]/g, "_");
+  // Replace any character outside the allowed set with an underscore.
+  let safe = name.replace(/[^a-zA-Z0-9_.\-:]/g, "_");
   // Ensure it starts with a letter or underscore
   if (safe.length === 0 || !/^[a-zA-Z_]/.test(safe)) {
     safe = `_${safe}`;
@@ -135,6 +133,15 @@ function stripGatewayPrefix(
 }
 
 /**
+ * Sanitize a tool name for LLM use: same as sanitizeToolName but also
+ * converts hyphens to underscores, since many LLMs normalize hyphens when
+ * invoking tool names, causing "tool not found" errors.
+ */
+function sanitizeForLlm(name: string): string {
+  return sanitizeToolName(name).replace(/-/g, "_");
+}
+
+/**
  * Build a collision-aware name map from MCP tools.
  * Uses the short (un-namespaced) tool name when it's unique across all
  * connections; only prepends the connection prefix when two connections
@@ -149,9 +156,12 @@ function buildShortNameMap(
   // Pass 1: count how many tools share each sanitized short name
   const shortCount = new Map<string, number>();
   for (const t of tools) {
-    const connId = (t._meta?.gatewayClientId as string) ?? "";
+    const connId =
+      typeof t._meta?.gatewayClientId === "string"
+        ? t._meta.gatewayClientId
+        : "";
     const short = connId ? stripGatewayPrefix(t.name, connId) : t.name;
-    const safe = sanitizeToolName(short);
+    const safe = sanitizeForLlm(short);
     shortCount.set(safe, (shortCount.get(safe) ?? 0) + 1);
   }
 
@@ -159,12 +169,17 @@ function buildShortNameMap(
   const used = new Set<string>();
   const map = new Map<string, string>();
   for (const t of tools) {
-    const connId = (t._meta?.gatewayClientId as string) ?? "";
+    const connId =
+      typeof t._meta?.gatewayClientId === "string"
+        ? t._meta.gatewayClientId
+        : "";
     const short = connId ? stripGatewayPrefix(t.name, connId) : t.name;
-    const safeShort = sanitizeToolName(short);
+    const safeShort = sanitizeForLlm(short);
     const unique = (shortCount.get(safeShort) ?? 0) <= 1;
 
-    let safeName = unique ? safeShort : sanitizeToolName(`${connId}_${short}`);
+    // For the collision prefix, normalize the connId too so hyphens in
+    // connection IDs don't produce names the LLM will mangle.
+    let safeName = unique ? safeShort : sanitizeForLlm(`${connId}_${short}`);
 
     // Suffix for any remaining collision (same conn + same tool name)
     if (used.has(safeName)) {

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -143,7 +143,7 @@ function stripGatewayPrefix(
  * Examples (no collision): "search_repositories", "list_objects"
  * Examples (collision):    "conn_togsm0_search_code", "conn_abc_search_code"
  */
-export function buildShortNameMap(
+function buildShortNameMap(
   tools: Array<{ name: string; _meta?: Record<string, unknown> }>,
 ): Map<string, string> {
   // Pass 1: count how many tools share each sanitized short name

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -844,17 +844,6 @@ async function streamCoreInner(
           },
         });
 
-        const requestDebug = {
-          threadId: mem.thread.id,
-          system: systemPrompts.map((p) => ({
-            chars: p.length,
-            preview: p.slice(0, 80).replace(/\s+/g, " "),
-          })),
-          tools: Object.keys(tools).length,
-          activeStep0: builtInToolNames.length + 1 + enabledTools.size,
-        };
-        console.log("[decopilot:turn]", JSON.stringify(requestDebug));
-
         let result;
         try {
           result = streamText({

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -22,7 +22,9 @@ import {
   createUIMessageStream,
   stepCountIs,
   streamText,
+  tool,
 } from "ai";
+import { z } from "zod";
 import { getBuiltInTools, type PendingImage } from "./built-in-tools";
 import { createEnableToolsTool } from "./built-in-tools/enable-tools";
 import {
@@ -461,11 +463,16 @@ async function streamCoreInner(
       execute: async ({ writer }) => {
         const modeConfig = resolveModeConfig(input.mode, { isCliAgent });
 
+        // superUser=true: the user is already authenticated as an org member,
+        // the virtual MCP enforces which connections are in scope, and the
+        // per-tool AuthTransport check would block every non-public connection
+        // tool (GitHub, Slack, etc.) for users who don't have explicit per-tool
+        // permissions configured — the wrong enforcement layer for chat.
         const passthroughClient = await createVirtualClientFrom(
           virtualMcp,
           ctx,
           "passthrough",
-          false,
+          true,
           { listTimeoutMs: 1_000 },
         );
 
@@ -564,14 +571,29 @@ async function streamCoreInner(
           }
         }
 
+        // Build connection title map once — used by catalog, list_connection_tools, and enable_tools.
+        const connectionTitleMap = isCliAgent
+          ? new Map<string, string>()
+          : passthroughClient.getConnectionTitleMap();
+
+        // Declared before tools so enable_tools can close over it.
+        // Populated after buildToolCatalog runs below (before streamText starts).
+        const connectionToolsMap = new Map<string, string[]>();
+
         const tools = isCliAgent
           ? {}
           : {
               ...passthroughTools,
               ...builtInTools,
+              list_connection_tools: createListConnectionToolsTool(
+                passthroughClient,
+                passthroughNameMap,
+                connectionTitleMap,
+              ),
               enable_tools: createEnableToolsTool(
                 enabledTools,
                 passthroughToolNames,
+                connectionToolsMap,
                 {
                   isPlanMode: modeConfig.isPlanMode,
                   toolAnnotations,
@@ -582,10 +604,21 @@ async function streamCoreInner(
         // Build composable system prompt array
         const basePrompt = buildBasePlatformPrompt();
 
-        const [toolCatalog, promptCatalog] = await Promise.all([
-          buildToolCatalog(passthroughClient, enabledTools, passthroughNameMap),
+        const [catalogResult, promptCatalog] = await Promise.all([
+          buildToolCatalog(
+            passthroughClient,
+            enabledTools,
+            passthroughNameMap,
+            connectionTitleMap,
+          ),
           buildPromptCatalog(passthroughClient),
         ]);
+
+        // Populate connectionToolsMap in-place so enable_tools closure sees it
+        for (const [k, v] of catalogResult.connectionToolsMap.entries()) {
+          connectionToolsMap.set(k, v);
+        }
+        const toolCatalog = catalogResult.catalog;
 
         // Agent prompt: decopilot-specific or custom agent instructions
         const serverInstructions = passthroughClient.getInstructions();
@@ -603,6 +636,19 @@ async function streamCoreInner(
         const repoEnvironmentPrompt = vmMetadata?.githubRepo
           ? buildRepoEnvironmentPrompt(vmMetadata.githubRepo)
           : null;
+
+        // Step-0 system prompt: includes the tool catalog for initial discovery.
+        // The catalog is built once before streamText runs — it's already stale by step 1
+        // (doesn't reflect tools the model enables mid-turn), so subsequent steps use
+        // systemPromptsBase which omits it to keep context lean.
+        const systemPromptsBase = [
+          basePrompt,
+          planModePrompt,
+          webSearchPrompt,
+          repoEnvironmentPrompt,
+          promptCatalog,
+          agentPrompt,
+        ].filter((s): s is string => Boolean(s?.trim()));
 
         const systemPrompts = [
           basePrompt,
@@ -798,6 +844,17 @@ async function streamCoreInner(
           },
         });
 
+        const requestDebug = {
+          threadId: mem.thread.id,
+          system: systemPrompts.map((p) => ({
+            chars: p.length,
+            preview: p.slice(0, 80).replace(/\s+/g, " "),
+          })),
+          tools: Object.keys(tools).length,
+          activeStep0: builtInToolNames.length + 1 + enabledTools.size,
+        };
+        console.log("[decopilot:turn]", JSON.stringify(requestDebug));
+
         let result;
         try {
           result = streamText({
@@ -880,6 +937,7 @@ async function streamCoreInner(
 
                       let activeToolNames = [
                         ...builtInToolNames,
+                        "list_connection_tools",
                         "enable_tools",
                         ...enabledTools,
                       ];
@@ -891,7 +949,8 @@ async function streamCoreInner(
                           // Built-in tools and enable_tools are always allowed
                           if (
                             builtInToolNames.includes(name) ||
-                            name === "enable_tools"
+                            name === "enable_tools" ||
+                            name === "list_connection_tools"
                           ) {
                             return true;
                           }
@@ -916,6 +975,18 @@ async function streamCoreInner(
                             type: "tool" as const,
                             toolName: forcedToolName as never,
                           },
+                        }),
+                        // From step 1 onwards, drop the tool catalog from the system
+                        // prompt. The catalog is already in the model's context from
+                        // step 0, and is stale (built before this turn started).
+                        ...(!isFirstStep && {
+                          system: [
+                            ...systemPromptsBase.map((content) => ({
+                              role: "system" as const,
+                              content,
+                            })),
+                            ...processedSystemMessages,
+                          ],
                         }),
                       };
                     };
@@ -1070,6 +1141,14 @@ async function streamCoreInner(
                   },
                 },
                 created_at: new Date(),
+                _request: {
+                  systemSections: systemPrompts.map((p) => ({
+                    chars: p.length,
+                    preview: p.slice(0, 80).replace(/\s+/g, " "),
+                  })),
+                  tools: Object.keys(tools).length,
+                  activeTools: builtInToolNames.length + 1 + enabledTools.size,
+                },
                 thread_id: mem.thread.id,
               };
             }
@@ -1370,7 +1449,12 @@ function reconstructEnabledTools(
         const result = part.result as { enabled?: string[] };
         if (Array.isArray(result.enabled)) {
           for (const name of result.enabled) {
-            if (availableToolNames.has(name)) {
+            // Normalize stored names: old threads may have hyphenated names
+            // (e.g. conn-togsm0..._tool) while current safe names use underscores.
+            const normalized = name.replace(/[^a-zA-Z0-9_]/g, "_");
+            if (availableToolNames.has(normalized)) {
+              enabled.add(normalized);
+            } else if (availableToolNames.has(name)) {
               enabled.add(name);
             }
           }
@@ -1381,23 +1465,14 @@ function reconstructEnabledTools(
   return enabled;
 }
 
-const REDUNDANT_PREFIXES =
-  /^(this tool |use this to |allows you to |a tool that |a tool to |tool to |tool that )/i;
-
-function trimToolDescription(desc: string, maxLen = 80): string {
-  let trimmed = desc.replace(REDUNDANT_PREFIXES, "").trim();
-  if (trimmed.length > 0) {
-    trimmed = trimmed[0]!.toUpperCase() + trimmed.slice(1);
-  }
-  if (trimmed.length > maxLen) {
-    return trimmed.slice(0, maxLen - 1) + "…";
-  }
-  return trimmed;
-}
+const CATALOG_PREVIEW_COUNT = 5;
 
 /**
- * Build a compact tool catalog for the system prompt, grouped by connection.
- * Format: <available-connections><connection name="..." id="...">TOOL|desc</connection></available-connections>
+ * Build a compact connection-level catalog for the system prompt.
+ * Shows each connection's name, id, tool count, and up to 5 representative
+ * tool names so the model can route to the right connection without needing
+ * a list_connection_tools round trip.
+ * Also returns connectionToolsMap for enable_tools({ connections }) expansion.
  */
 async function buildToolCatalog(
   client: {
@@ -1411,41 +1486,147 @@ async function buildToolCatalog(
   },
   enabledTools: Set<string>,
   nameMap: Map<string, string>,
-): Promise<string | null> {
+  connectionTitleMap: Map<string, string>,
+): Promise<{
+  catalog: string | null;
+  connectionToolsMap: Map<string, string[]>;
+}> {
   const { tools } = await client.listTools();
 
   const connections = new Map<
     string,
-    { name: string; id: string; lines: string[] }
+    { name: string; totalCount: number; preview: string[] }
   >();
+  const connectionToolsMap = new Map<string, string[]>();
 
   for (const t of tools) {
     const safeName = nameMap.get(t.name);
-    if (!safeName || enabledTools.has(safeName)) continue;
+    if (!safeName) continue;
     if (!isToolVisibleToModel(t)) continue;
 
-    const connId = (t._meta?.connectionId as string) ?? "unknown";
-    const connName = connId;
-    const desc = trimToolDescription(t.description ?? "");
+    const connId = (t._meta?.gatewayClientId as string) ?? "unknown";
+    const prefix = `${connId}_`;
+    const shortName = safeName.startsWith(prefix)
+      ? safeName.slice(prefix.length)
+      : safeName;
+
+    // Track all tools per connection for enable_tools expansion
+    let toolList = connectionToolsMap.get(connId);
+    if (!toolList) {
+      toolList = [];
+      connectionToolsMap.set(connId, toolList);
+    }
+    toolList.push(safeName);
+
+    // Only include in catalog if not already enabled
+    if (enabledTools.has(safeName)) continue;
 
     let group = connections.get(connId);
     if (!group) {
-      group = { name: connName, id: connId, lines: [] };
+      group = {
+        name: connectionTitleMap.get(connId) ?? connId,
+        totalCount: 0,
+        preview: [],
+      };
       connections.set(connId, group);
     }
-    group.lines.push(`${safeName}|${desc}`);
+    group.totalCount++;
+    if (group.preview.length < CATALOG_PREVIEW_COUNT) {
+      group.preview.push(shortName);
+    }
   }
 
-  if (connections.size === 0) return null;
+  const pending = [...connections.entries()].filter(
+    ([, g]) => g.totalCount > 0,
+  );
+  if (pending.length === 0) return { catalog: null, connectionToolsMap };
 
-  const sections: string[] = [];
-  for (const { name, id, lines } of connections.values()) {
-    sections.push(
-      `<connection name="${escapeXmlAttr(name)}" id="${escapeXmlAttr(id)}">\n${lines.join("\n")}\n</connection>`,
-    );
-  }
+  const lines = pending.map(([id, { name, totalCount, preview }]) => {
+    const more = totalCount - preview.length;
+    const hint = preview.join(", ") + (more > 0 ? `, +${more} more` : "");
+    return `<connection name="${escapeXmlAttr(name)}" id="${escapeXmlAttr(id)}" tools="${totalCount}">${escapeXmlAttr(hint)}</connection>`;
+  });
 
-  return `\n\n<available-connections>\n${sections.join("\n")}\n</available-connections>`;
+  return {
+    catalog: `\n\n<available-connections>\n${lines.join("\n")}\n</available-connections>`,
+    connectionToolsMap,
+  };
+}
+
+/**
+ * Creates the list_connection_tools built-in tool.
+ * Returns tool names and descriptions for a given connection ID so the model
+ * can discover what's available before deciding what to enable.
+ */
+function createListConnectionToolsTool(
+  client: {
+    listTools(): Promise<{
+      tools: Array<{
+        name: string;
+        description?: string;
+        _meta?: Record<string, unknown>;
+      }>;
+    }>;
+  },
+  nameMap: Map<string, string>,
+  connectionTitleMap: Map<string, string>,
+) {
+  return tool({
+    description:
+      "List the tools available in a specific connection, including their names and descriptions. " +
+      "Call this to discover what a connection can do before enabling tools with enable_tools.",
+    inputSchema: z.object({
+      connection_id: z
+        .string()
+        .describe("The connection id from <available-connections>"),
+    }),
+    execute: async ({ connection_id }) => {
+      const { tools } = await client.listTools();
+      const result: { name: string; safe_name: string; description: string }[] =
+        [];
+      // The model may pass a normalized (underscore) version of the connection
+      // id, but _meta.gatewayClientId still has the original (hyphenated) form.
+      // Build a lookup that matches either form.
+      const normalizedInput = connection_id
+        .replace(/[^a-zA-Z0-9_]/g, "_")
+        .toLowerCase();
+      for (const t of tools) {
+        const safeName = nameMap.get(t.name);
+        if (!safeName) continue;
+        if (!isToolVisibleToModel(t)) continue;
+        const connId = (t._meta?.gatewayClientId as string) ?? "unknown";
+        const normalizedConnId = connId
+          .replace(/[^a-zA-Z0-9_]/g, "_")
+          .toLowerCase();
+        if (normalizedConnId !== normalizedInput && connId !== connection_id) {
+          continue;
+        }
+        // Use the safe name's prefix to derive the short name
+        const safePrefix = `${normalizedConnId}_`;
+        const shortName = safeName.toLowerCase().startsWith(safePrefix)
+          ? safeName.slice(safePrefix.length)
+          : safeName;
+        result.push({
+          name: shortName,
+          safe_name: safeName,
+          description: t.description ?? "",
+        });
+      }
+      // Resolve connection name: try original id first, then normalized lookup
+      const connName =
+        connectionTitleMap.get(connection_id) ??
+        [...connectionTitleMap.entries()].find(
+          ([id]) =>
+            id.replace(/[^a-zA-Z0-9_]/g, "_").toLowerCase() === normalizedInput,
+        )?.[1] ??
+        connection_id;
+      return {
+        connection: connName,
+        connection_id,
+        tools: result,
+      };
+    },
+  });
 }
 
 function escapeXmlAttr(s: string): string {

--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -69,7 +69,7 @@ export async function createVirtualClientFrom(
   _strategy: "passthrough",
   superUser = false,
   options?: { listTimeoutMs?: number },
-): Promise<Client> {
+): Promise<PassthroughClient> {
   // Inclusion mode: use only the connections specified in virtual MCP
   const connectionIds = virtualMcp.connections.map((c) => c.connection_id);
 

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -73,4 +73,8 @@ export class PassthroughClient extends GatewayClient {
   override getInstructions(): string | undefined {
     return this.options.virtualMcp.metadata?.instructions ?? undefined;
   }
+
+  getConnectionTitleMap(): Map<string, string> {
+    return new Map(this.options.connections.map((c) => [c.id, c.title]));
+  }
 }

--- a/apps/mesh/src/web/components/chat/context-panel.tsx
+++ b/apps/mesh/src/web/components/chat/context-panel.tsx
@@ -469,9 +469,88 @@ export function ChatContextPanel({
                       )}
                     </button>
                     {isExpanded && (
-                      <pre className="text-xs font-mono bg-muted px-3 py-2 overflow-auto whitespace-pre-wrap break-all border-t border-border/50 max-h-64">
-                        {JSON.stringify(m, null, 2)}
-                      </pre>
+                      <>
+                        {m.role === "assistant" &&
+                          (() => {
+                            const req = (
+                              m.metadata as {
+                                _request?: {
+                                  systemSections?: {
+                                    chars: number;
+                                    preview: string;
+                                  }[];
+                                  tools?: number;
+                                  activeTools?: number;
+                                };
+                              }
+                            )?._request;
+                            if (!req) return null;
+                            const sections = req.systemSections ?? [];
+                            const maxChars = Math.max(
+                              1,
+                              ...sections.map((s) => s.chars),
+                            );
+                            const totalChars = sections.reduce(
+                              (sum, s) => sum + s.chars,
+                              0,
+                            );
+                            return (
+                              <div className="border-t border-border/50 px-3 py-2.5 text-xs space-y-2.5">
+                                <div className="flex items-center justify-between">
+                                  <span className="font-medium text-foreground">
+                                    Request
+                                  </span>
+                                  <span className="text-muted-foreground tabular-nums">
+                                    {req.activeTools ?? 0} / {req.tools ?? 0}{" "}
+                                    tools active
+                                  </span>
+                                </div>
+                                {sections.length > 0 && (
+                                  <div className="space-y-1.5">
+                                    <div className="text-muted-foreground">
+                                      System prompt{" "}
+                                      <span className="tabular-nums">
+                                        ~
+                                        {Math.round(
+                                          totalChars / 4,
+                                        ).toLocaleString()}{" "}
+                                        tok
+                                      </span>
+                                    </div>
+                                    {sections.map((s, i) => {
+                                      const tag =
+                                        s.preview.match(/^<([a-z-]+)/i)?.[1] ??
+                                        `section ${i}`;
+                                      const pct = (s.chars / maxChars) * 100;
+                                      const tok = Math.round(s.chars / 4);
+                                      return (
+                                        <div key={i} className="space-y-0.5">
+                                          <div className="flex items-center justify-between gap-2">
+                                            <span className="font-mono text-foreground truncate">
+                                              {tag}
+                                            </span>
+                                            <span className="text-muted-foreground tabular-nums shrink-0">
+                                              ~{tok.toLocaleString()} tok
+                                            </span>
+                                          </div>
+                                          <div className="h-1 w-full rounded-full bg-muted overflow-hidden">
+                                            <div
+                                              className="h-full rounded-full bg-chart-3"
+                                              style={{ width: `${pct}%` }}
+                                            />
+                                          </div>
+                                        </div>
+                                      );
+                                    })}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })()}
+                        <pre className="text-xs font-mono bg-muted px-3 py-2 overflow-auto whitespace-pre-wrap break-all border-t border-border/50 max-h-64">
+                          {JSON.stringify(m, null, 2)}
+                        </pre>
+                      </>
                     )}
                   </div>
                 );


### PR DESCRIPTION
Updated the `sanitizeToolName` function to exclude hyphens from replacement, addressing issues with LLMs normalizing hyphens to underscores. Introduced `stripGatewayPrefix` to remove the GatewayClient namespace from tool names. Implemented `buildShortNameMap` to create a collision-aware mapping of tool names, ensuring unique names across connections. Adjusted `toolsFromMCP` to utilize the new name mapping function. Enhanced the `enable-tools` schema to support enabling tools by connection IDs.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps Decopilot tool discovery and naming to reduce collisions and “tool not found” errors. Adds connection-aware listing/enabling and a compact connection catalog to cut round trips and context size.

- New Features
  - System prompt shows a compact connection catalog: name, id, tool count, and short preview (`<available-connections>`).
  - New built-in tool `list_connection_tools` to list tools for a specific connection.
  - `enable_tools` accepts `connections: string[]` to enable all tools in those connections.
  - Chat panel shows request stats (system sections, token estimates, active tools).

- Refactors
  - LLM-safe naming: `sanitizeToolName` now preserves hyphens; new `sanitizeForLlm` converts hyphens to underscores; old stored names normalized on load.
  - Collision-aware mapping via `buildShortNameMap` and `stripGatewayPrefix`; prefer short names, prefix with connection only on conflicts; used in `toolsFromMCP` (internal, not exported).
  - Build the catalog once for step 0; drop it in later steps to keep context lean.
  - Passthrough client returns a `connectionTitleMap` and is created with `superUser` to avoid per-tool auth gating in chat.

<sup>Written for commit 95b8129372f0dd0c12dc8249ba9f3f4db081f317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

