### PR TITLE
fix(api): forward path-resolved role to proxied tool access checks

### DIFF
--- a/apps/mesh/src/api/middleware/resolve-org-from-path.test.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.test.ts
@@ -144,6 +144,36 @@ describe("resolveOrgFromPath", () => {
     expect(body.orgSlug).toBe("acme");
   });
 
+  it("exposes the caller's path-resolved role on ctx.organization", async () => {
+    // AuthTransport constructs a fresh AccessControl per proxied tool call
+    // and reads the role from ctx.organization?.role to decide the
+    // admin/owner bypass — without this, owners 403 on every proxied tool
+    // when the session's active org differs from the URL org.
+    const app = new Hono<{ Variables: Variables }>();
+    app.use("*", async (c, next) => {
+      c.set("meshContext", {
+        auth: { user: { id: "user-1" } },
+        db: db.db,
+        baseUrl: "http://test",
+        access: {
+          setOrganizationId: () => {},
+          setRole: () => {},
+        },
+        storage: { threads: { setOrganizationId: () => {} } },
+        objectStorage: null,
+      } as unknown as MeshContext);
+      await next();
+    });
+    app.use("/api/:org/*", resolveOrgFromPath);
+    app.get("/api/:org/role", (c) => {
+      const ctx = c.get("meshContext");
+      return c.json({ role: ctx.organization?.role });
+    });
+    const res = await app.request("/api/acme/role");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ role: "member" });
+  });
+
   it("passes unauthenticated requests through with org set (so MCP OAuth discovery works)", async () => {
     // Cursor/Claude rely on mcpAuth returning 401 with a WWW-Authenticate header
     // pointing at the protected-resource metadata URL. If this middleware blocks

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -56,7 +56,12 @@ export const resolveOrgFromPath: MiddlewareHandler<{
     pathRole = membership.role;
   }
 
-  ctx.organization = { id: org.id, slug: org.slug, name: org.name };
+  ctx.organization = {
+    id: org.id,
+    slug: org.slug,
+    name: org.name,
+    role: pathRole,
+  };
   // Tell AccessControl to use the path-resolved org for permission checks.
   // Without this, boundAuth.hasPermission falls back to the session's
   // activeOrganizationId — which races with signup in CI and can be stale or

--- a/apps/mesh/src/core/mesh-context.ts
+++ b/apps/mesh/src/core/mesh-context.ts
@@ -206,6 +206,14 @@ export interface OrganizationScope {
   id: string;
   slug?: string;
   name?: string;
+  /**
+   * Caller's role within this organization (e.g. "owner", "admin", "member").
+   * Set by `resolveOrgFromPath` when the org is resolved from the URL slug,
+   * so downstream code (notably AuthTransport, which constructs a fresh
+   * AccessControl per proxied tool call) can use the path-resolved role
+   * instead of the session's active-org role — they may differ.
+   */
+  role?: string;
 }
 
 // ============================================================================

--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -159,14 +159,20 @@ export class AuthTransport extends WrapperTransport {
 
     // Create AccessControl with connectionId set
     // This checks: does user have permission for this TOOL on this CONNECTION?
+    //
+    // Prefer the path-resolved org+role (set by resolveOrgFromPath) over the
+    // session-derived ones. The session's active-org role may not match the
+    // org in the URL — e.g. owner of /api/foo with no/different active org
+    // would otherwise lose the admin/owner bypass and 403 on every tool call.
     const connectionAccessControl = new AccessControl(
       ctx.authInstance,
       ctx.auth.user?.id ?? ctx.auth.apiKey?.userId,
       toolName, // Tool being called
       ctx.boundAuth, // Bound auth client (encapsulates headers)
-      ctx.auth.user?.role, // Role for built-in role bypass
+      ctx.organization?.role ?? ctx.auth.user?.role, // Role for built-in role bypass
       connection.id, // Connection ID for permission check
       getToolMeta, // Callback for public tool check
+      ctx.organization?.id, // Path-resolved org for permission checks
     );
 
     await connectionAccessControl.check(toolName);


### PR DESCRIPTION
## What is this contribution about?

Owners of an org were getting spurious \`Access denied to: <TOOL_NAME>\` (JSON-RPC -32603) on every proxied tool call when the URL org differed from the session's active org — e.g. \`COLLECTION_REGISTRY_APP_GET\` on \`{org}_registry\` from the Deco Store sidebar after #3272.

\`AuthTransport.authorizeToolCall\` constructs a fresh \`AccessControl\` per proxied call and was reading \`ctx.auth.user?.role\` (session-derived) with no path-resolved \`organizationId\`. The fix in #3272's last commit only covered \`ctx.access\` used by locally-defined tools — the proxy code path missed the same propagation. This PR stores the path-resolved role on \`ctx.organization.role\` in \`resolveOrgFromPath\` and has \`AuthTransport\` prefer it (and pass \`ctx.organization?.id\` through), restoring the admin/owner bypass for proxied tools.

## How to Test

1. As an org owner whose session active-org differs (or is unset), call any proxied tool on a connection in another owned org via \`/api/:org/mcp/:connectionId\`. Easiest repro: open the Deco Store on a fresh login.
2. Before this PR: \`{ "error": { "code": -32603, "message": "Access denied to: COLLECTION_REGISTRY_APP_GET" } }\`.
3. After this PR: tool call returns the expected result.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (regression test added in \`resolve-org-from-path.test.ts\`)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 403s on proxied tool calls by forwarding the path-resolved org role and id, restoring owner/admin bypass when the URL org differs from the session’s active org. Example: owners no longer see “Access denied to: `COLLECTION_REGISTRY_APP_GET`” when using the Deco Store sidebar.

- **Bug Fixes**
  - `resolveOrgFromPath` now sets `ctx.organization.role` alongside org id/slug/name.
  - `AuthTransport` prefers `ctx.organization.role` over `ctx.auth.user?.role` and passes `ctx.organization?.id` to `AccessControl`.
  - Added a regression test to verify the role is exposed on `ctx.organization`.

<sup>Written for commit 7c46323ed9d18bcca853ff6a70f878873e4a3743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

