### PR TITLE
feat(cli): revive 'deco link' as 'decocms link' + add auth namespace

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -50,6 +50,7 @@
     "@aws-sdk/client-s3": "^3.1013.0",
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@clickhouse/client": "^1.8.1",
+    "@deco-cx/warp-node": "0.3.21-debug.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/client-s3": "^3.1013.0",
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@clickhouse/client": "^1.8.1",
-    "@deco-cx/warp-node": "0.3.21-debug.2",
+    "@deco-cx/warp-node": "^0.3.20",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -76,11 +76,13 @@ if (values.help) {
 Deco CMS — Open-source control plane for your AI agents
 
 Usage:
-  deco [options]                  Start server with Ink UI
-  deco dev [options]              Start dev server (Vite + hot reload)
-  deco services <up|down|status>  Manage services (Postgres, NATS)
-  deco init <directory>           Scaffold a new MCP app
-  deco completion [shell]         Install shell completions
+  deco [options]                     Start server with Ink UI
+  deco dev [options]                 Start dev server (Vite + hot reload)
+  deco services <up|down|status>     Manage services (Postgres, NATS)
+  deco init <directory>              Scaffold a new MCP app
+  deco auth <login|whoami|logout>    Manage CLI authentication
+  deco link [options] [-- <cmd>]     Tunnel a local port to a stable deco.host URL
+  deco completion [shell]            Install shell completions
 
 Server Options:
   -p, --port <port>     Port to listen on (default: 3000, or PORT env var)
@@ -97,6 +99,15 @@ Dev Options:
   --vite-port <port>    Vite dev server port (default: 4000)
   --base-url <url>      Base URL for the server
 
+Auth Options:
+  --target <url>        Decocms target (default: https://studio.decocms.com)
+
+Link Options:
+  -p, --port <port>     Local port to tunnel (default: 8787)
+  -e, --env <name>      Env var to inject the tunnel URL into when spawning
+                        a child command (default: BASE_URL)
+  -- <command>          Optional command to spawn after the tunnel opens
+
 Environment Variables:
   PORT                  Port to listen on (default: 3000)
   DATA_DIR              Data directory (default: ~/deco/)
@@ -108,15 +119,12 @@ Environment Variables:
 Examples:
   deco                            Start with defaults (~/deco/)
   deco -p 8080                    Start on port 8080
-  deco --home ~/my-project        Custom data directory
-  deco --no-local-mode             Disable auto-login (production)
   deco dev                        Start dev server
-  deco dev --vite-port 5000       Dev server with custom Vite port
-  deco services up                Start Postgres and NATS
-  deco services status            Show service status
-  deco services down              Stop services
   deco init my-app                Scaffold a new MCP app
-  deco --no-tui                   Start without terminal UI
+  deco auth login                 Log in to studio.decocms.com
+  deco auth whoami                Show current session
+  deco link -p 3000 -- bun dev    Tunnel localhost:3000, run "bun dev"
+  deco link -p 8787               Tunnel an already-running service on 8787
 
 Documentation:
   https://decocms.com/studio

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -64,6 +64,8 @@ const { values, positionals } = parseArgs({
       type: "boolean",
       default: false,
     },
+    target: { type: "string" },
+    env: { type: "string", short: "e" },
   },
   allowPositionals: true,
 });
@@ -185,6 +187,75 @@ if (command === "services") {
   process.exit(0);
 }
 
+// ── Auth / Link helpers ────────────────────────────────────────────────
+function resolveDataDir(): string {
+  return (
+    values.home ||
+    process.env.DATA_DIR ||
+    process.env.DECOCMS_HOME ||
+    join(homedir(), "deco")
+  );
+}
+
+// ── Auth command ───────────────────────────────────────────────────────
+if (command === "auth") {
+  const sub = positionals[1];
+  const dataDir = resolveDataDir();
+
+  if (sub === "login") {
+    const { loginCommand } = await import("./cli/commands/auth/login");
+    const code = await loginCommand({
+      dataDir,
+      target: values.target,
+    });
+    process.exit(code);
+  }
+  if (sub === "whoami") {
+    const { whoamiCommand } = await import("./cli/commands/auth/whoami");
+    const code = await whoamiCommand({ dataDir });
+    process.exit(code);
+  }
+  if (sub === "logout") {
+    const { logoutCommand } = await import("./cli/commands/auth/logout");
+    const code = await logoutCommand({ dataDir });
+    process.exit(code);
+  }
+  console.error(`Usage: decocms auth <login|whoami|logout>`);
+  process.exit(1);
+}
+
+// ── Link command ───────────────────────────────────────────────────────
+if (command === "link") {
+  const dataDir = resolveDataDir();
+  const port = Number(values.port);
+  if (!Number.isInteger(port) || port <= 0) {
+    console.error(`Invalid --port value: ${values.port}`);
+    process.exit(1);
+  }
+  const env = values.env ?? "BASE_URL";
+
+  // Trailing args after `--` are the run command. parseArgs gives us positionals
+  // including everything after `--`; we re-derive the boundary from the raw argv.
+  const dashDashIdx = process.argv.indexOf("--");
+  const runCommand =
+    dashDashIdx >= 0 ? process.argv.slice(dashDashIdx + 1) : [];
+
+  const { linkCommand } = await import("./cli/commands/link");
+  const result = linkCommand({
+    cwd: process.cwd(),
+    dataDir,
+    port,
+    env,
+    runCommand,
+  });
+
+  // Forward Ctrl-C to the link command for graceful shutdown.
+  process.on("SIGINT", () => void result.cancel());
+  process.on("SIGTERM", () => void result.cancel());
+
+  process.exit(await result.exit);
+}
+
 // ── Dev command (Ink TUI + dev servers) ─────────────────────────────────
 if (command === "dev") {
   const decoHome =
@@ -249,7 +320,10 @@ if (command === "dev") {
   }
 }
 
-if (command && !["init", "completion", "dev", "services"].includes(command)) {
+if (
+  command &&
+  !["init", "completion", "dev", "services", "auth", "link"].includes(command)
+) {
   console.error(`Unknown command: ${command}`);
   process.exit(1);
 }

--- a/apps/mesh/src/cli/commands/auth/login.test.ts
+++ b/apps/mesh/src/cli/commands/auth/login.test.ts
@@ -59,24 +59,21 @@ function mockTarget(target: string) {
       expect(body.get("grant_type")).toBe("authorization_code");
       expect(body.get("code")).toBe(issuedCode ?? "");
       expect(body.get("client_id")).toBe(issuedClientId ?? "");
+      const idTokenPayload = Buffer.from(
+        JSON.stringify({
+          sub: "user-123",
+          email: "tlgimenes@gmail.com",
+          name: "TL Gimenes",
+        }),
+      ).toString("base64url");
+      const idToken = `header.${idTokenPayload}.signature`;
       return new Response(
         JSON.stringify({
           access_token: issuedAccessToken,
           token_type: "Bearer",
           expires_in: 3600,
           refresh_token: "rt_xyz",
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    }
-    if (url === `${target}/api/auth/mcp/userinfo`) {
-      const auth = (init?.headers as Record<string, string>)?.Authorization;
-      expect(auth).toBe(`Bearer ${issuedAccessToken}`);
-      return new Response(
-        JSON.stringify({
-          sub: "user-123",
-          email: "tlgimenes@gmail.com",
-          name: "TL Gimenes",
+          id_token: idToken,
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );

--- a/apps/mesh/src/cli/commands/auth/login.test.ts
+++ b/apps/mesh/src/cli/commands/auth/login.test.ts
@@ -1,0 +1,119 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import { rm, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readSession } from "../../lib/session";
+import { loginCommand } from "./login";
+
+let dir: string;
+let logSpy: ReturnType<typeof spyOn>;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "deco-login-"));
+  logSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  logSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("loginCommand", () => {
+  it("opens the target login URL and exchanges the callback code for a session", async () => {
+    let openedUrl: string | undefined;
+    const openBrowser = mock(async (url: string) => {
+      openedUrl = url;
+      // Simulate the browser hitting the callback once the CLI has started its listener.
+      const parsed = new URL(url);
+      const callback = parsed.searchParams.get("callback")!;
+      const state = parsed.searchParams.get("state")!;
+      // Race condition guard: small delay so the CLI is past startOAuthCallbackServer.
+      await new Promise((r) => setTimeout(r, 10));
+      await fetch(`${callback}?code=code-xyz&state=${state}`);
+    });
+
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://studio.decocms.com/api/auth/cli/exchange");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(init?.body as string) as { code: string };
+      expect(body.code).toBe("code-xyz");
+      return new Response(
+        JSON.stringify({
+          token: "tok_new",
+          workspace: "tlgimenes",
+          user: { id: "u_1", email: "tlgimenes@gmail.com" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const code = await loginCommand({
+      dataDir: dir,
+      target: "https://studio.decocms.com",
+      openBrowser,
+      fetch: fetchMock,
+    });
+
+    expect(code).toBe(0);
+    expect(openedUrl).toMatch(
+      /^https:\/\/studio\.decocms\.com\/auth\/cli\?callback=http%3A%2F%2F127\.0\.0\.1%3A\d+&state=/,
+    );
+    const session = await readSession(dir);
+    expect(session?.target).toBe("https://studio.decocms.com");
+    expect(session?.workspace).toBe("tlgimenes");
+    expect(session?.user.email).toBe("tlgimenes@gmail.com");
+    expect(session?.token).toBe("tok_new");
+  });
+
+  it("defaults the target to https://studio.decocms.com", async () => {
+    let openedUrl: string | undefined;
+    const openBrowser = mock(async (url: string) => {
+      openedUrl = url;
+      const parsed = new URL(url);
+      const callback = parsed.searchParams.get("callback")!;
+      const state = parsed.searchParams.get("state")!;
+      await new Promise((r) => setTimeout(r, 10));
+      await fetch(`${callback}?code=c&state=${state}`);
+    });
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            token: "t",
+            workspace: "w",
+            user: { id: "u", email: "u@x" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    await loginCommand({ dataDir: dir, openBrowser, fetch: fetchMock });
+    expect(openedUrl).toMatch(/^https:\/\/studio\.decocms\.com\//);
+  });
+
+  it("returns non-zero and writes no session when exchange fails", async () => {
+    const openBrowser = mock(async (url: string) => {
+      const parsed = new URL(url);
+      const callback = parsed.searchParams.get("callback")!;
+      const state = parsed.searchParams.get("state")!;
+      await new Promise((r) => setTimeout(r, 10));
+      await fetch(`${callback}?code=c&state=${state}`);
+    });
+    const fetchMock = mock(async () => new Response("nope", { status: 401 }));
+    const code = await loginCommand({
+      dataDir: dir,
+      target: "https://studio.decocms.com",
+      openBrowser,
+      fetch: fetchMock,
+    });
+    expect(code).not.toBe(0);
+    expect(await readSession(dir)).toBeNull();
+  });
+});

--- a/apps/mesh/src/cli/commands/auth/login.test.ts
+++ b/apps/mesh/src/cli/commands/auth/login.test.ts
@@ -15,14 +15,17 @@ import { loginCommand } from "./login";
 
 let dir: string;
 let logSpy: ReturnType<typeof spyOn>;
+let errSpy: ReturnType<typeof spyOn>;
 
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "deco-login-"));
   logSpy = spyOn(console, "log").mockImplementation(() => {});
+  errSpy = spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(async () => {
   logSpy.mockRestore();
+  errSpy.mockRestore();
   await rm(dir, { recursive: true, force: true });
 });
 
@@ -107,6 +110,31 @@ describe("loginCommand", () => {
       await fetch(`${callback}?code=c&state=${state}`);
     });
     const fetchMock = mock(async () => new Response("nope", { status: 401 }));
+    const code = await loginCommand({
+      dataDir: dir,
+      target: "https://studio.decocms.com",
+      openBrowser,
+      fetch: fetchMock,
+    });
+    expect(code).not.toBe(0);
+    expect(await readSession(dir)).toBeNull();
+  });
+
+  it("returns non-zero and writes no session when exchange returns incomplete data", async () => {
+    const openBrowser = mock(async (url: string) => {
+      const parsed = new URL(url);
+      const callback = parsed.searchParams.get("callback")!;
+      const state = parsed.searchParams.get("state")!;
+      await new Promise((r) => setTimeout(r, 10));
+      await fetch(`${callback}?code=c&state=${state}`);
+    });
+    const fetchMock = mock(
+      async () =>
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
     const code = await loginCommand({
       dataDir: dir,
       target: "https://studio.decocms.com",

--- a/apps/mesh/src/cli/commands/auth/login.test.ts
+++ b/apps/mesh/src/cli/commands/auth/login.test.ts
@@ -7,7 +7,7 @@ import {
   mock,
   spyOn,
 } from "bun:test";
-import { rm, mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readSession } from "../../lib/session";
@@ -29,90 +29,153 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-describe("loginCommand", () => {
-  it("opens the target login URL and exchanges the callback code for a session", async () => {
-    let openedUrl: string | undefined;
-    const openBrowser = mock(async (url: string) => {
-      openedUrl = url;
-      // Simulate the browser hitting the callback once the CLI has started its listener.
-      const parsed = new URL(url);
-      const callback = parsed.searchParams.get("callback")!;
-      const state = parsed.searchParams.get("state")!;
-      // Race condition guard: small delay so the CLI is past startOAuthCallbackServer.
-      await new Promise((r) => setTimeout(r, 10));
-      await fetch(`${callback}?code=code-xyz&state=${state}`);
-    });
+/**
+ * Stand up a fake decocms server that handles dynamic registration, the
+ * authorize redirect (back to the CLI's callback with a code), the token
+ * exchange, and userinfo. The mock simulates the browser by hitting the
+ * CLI's callback URL inside `openBrowser`.
+ */
+function mockTarget(target: string) {
+  let issuedClientId: string | undefined;
+  let issuedAccessToken: string | undefined;
+  let issuedCode: string | undefined;
+  let pkceVerifier: string | undefined;
 
-    const fetchMock = mock(async (url: string, init?: RequestInit) => {
-      expect(url).toBe("https://studio.decocms.com/api/auth/cli/exchange");
-      expect(init?.method).toBe("POST");
-      const body = JSON.parse(init?.body as string) as { code: string };
-      expect(body.code).toBe("code-xyz");
+  const fetchMock = mock(async (url: string, init?: RequestInit) => {
+    if (url === `${target}/api/auth/mcp/register`) {
+      issuedClientId = `client_${Math.random().toString(36).slice(2, 8)}`;
       return new Response(
         JSON.stringify({
-          token: "tok_new",
-          workspace: "tlgimenes",
-          user: { id: "u_1", email: "tlgimenes@gmail.com" },
+          client_id: issuedClientId,
+          redirect_uris: ["http://127.0.0.1:0/"],
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
-    });
+    }
+    if (url === `${target}/api/auth/mcp/token`) {
+      const body = new URLSearchParams(init?.body as string);
+      pkceVerifier = body.get("code_verifier") ?? undefined;
+      issuedAccessToken = `at_${Math.random().toString(36).slice(2, 10)}`;
+      expect(body.get("grant_type")).toBe("authorization_code");
+      expect(body.get("code")).toBe(issuedCode ?? "");
+      expect(body.get("client_id")).toBe(issuedClientId ?? "");
+      return new Response(
+        JSON.stringify({
+          access_token: issuedAccessToken,
+          token_type: "Bearer",
+          expires_in: 3600,
+          refresh_token: "rt_xyz",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url === `${target}/api/auth/mcp/userinfo`) {
+      const auth = (init?.headers as Record<string, string>)?.Authorization;
+      expect(auth).toBe(`Bearer ${issuedAccessToken}`);
+      return new Response(
+        JSON.stringify({
+          sub: "user-123",
+          email: "tlgimenes@gmail.com",
+          name: "TL Gimenes",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  const openBrowser = mock(async (url: string) => {
+    const parsed = new URL(url);
+    const redirectUri = parsed.searchParams.get("redirect_uri")!;
+    const state = parsed.searchParams.get("state")!;
+    expect(parsed.searchParams.get("client_id")).toBe(issuedClientId ?? "");
+    expect(parsed.searchParams.get("response_type")).toBe("code");
+    expect(parsed.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(parsed.searchParams.get("code_challenge")).toMatch(
+      /^[A-Za-z0-9_-]+$/,
+    );
+    issuedCode = `code_${Math.random().toString(36).slice(2, 8)}`;
+    // Simulate the browser hitting the CLI callback after auth.
+    await new Promise((r) => setTimeout(r, 10));
+    await fetch(`${redirectUri}?code=${issuedCode}&state=${state}`);
+  });
+
+  return {
+    fetchMock,
+    openBrowser,
+    getIssuedAccessToken: () => issuedAccessToken,
+    getIssuedClientId: () => issuedClientId,
+    getPkceVerifier: () => pkceVerifier,
+  };
+}
+
+describe("loginCommand", () => {
+  it("performs the full OAuth flow and persists a session", async () => {
+    const target = "https://studio.decocms.com";
+    const m = mockTarget(target);
 
     const code = await loginCommand({
       dataDir: dir,
-      target: "https://studio.decocms.com",
-      openBrowser,
-      fetch: fetchMock,
+      target,
+      openBrowser: m.openBrowser,
+      fetch: m.fetchMock,
     });
 
     expect(code).toBe(0);
-    expect(openedUrl).toMatch(
-      /^https:\/\/studio\.decocms\.com\/auth\/cli\?callback=http%3A%2F%2F127\.0\.0\.1%3A\d+&state=/,
-    );
+
     const session = await readSession(dir);
-    expect(session?.target).toBe("https://studio.decocms.com");
-    expect(session?.workspace).toBe("tlgimenes");
+    expect(session?.target).toBe(target);
+    expect(session?.clientId).toBe(m.getIssuedClientId());
+    expect(session?.accessToken).toBe(m.getIssuedAccessToken());
+    expect(session?.refreshToken).toBe("rt_xyz");
+    expect(session?.user.sub).toBe("user-123");
     expect(session?.user.email).toBe("tlgimenes@gmail.com");
-    expect(session?.token).toBe("tok_new");
+    expect(session?.expiresAt).toBeGreaterThan(0);
+
+    // PKCE verifier was actually sent to the token endpoint.
+    expect(m.getPkceVerifier()).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it("defaults the target to https://studio.decocms.com", async () => {
+    const m = mockTarget("https://studio.decocms.com");
     let openedUrl: string | undefined;
-    const openBrowser = mock(async (url: string) => {
+    const captureOpen = mock(async (url: string) => {
       openedUrl = url;
-      const parsed = new URL(url);
-      const callback = parsed.searchParams.get("callback")!;
-      const state = parsed.searchParams.get("state")!;
-      await new Promise((r) => setTimeout(r, 10));
-      await fetch(`${callback}?code=c&state=${state}`);
+      await m.openBrowser(url);
     });
-    const fetchMock = mock(
-      async () =>
-        new Response(
-          JSON.stringify({
-            token: "t",
-            workspace: "w",
-            user: { id: "u", email: "u@x" },
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        ),
-    );
-    await loginCommand({ dataDir: dir, openBrowser, fetch: fetchMock });
-    expect(openedUrl).toMatch(/^https:\/\/studio\.decocms\.com\//);
+
+    await loginCommand({
+      dataDir: dir,
+      openBrowser: captureOpen,
+      fetch: m.fetchMock,
+    });
+    expect(openedUrl).toMatch(/^https:\/\/studio\.decocms\.com\/login\?/);
   });
 
-  it("returns non-zero and writes no session when exchange fails", async () => {
+  it("returns non-zero and writes no session when token exchange fails", async () => {
+    const target = "https://studio.decocms.com";
+    const fetchMock = mock(async (url: string) => {
+      if (url.endsWith("/register")) {
+        return new Response(JSON.stringify({ client_id: "client_x" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/token")) {
+        return new Response("invalid_grant", { status: 400 });
+      }
+      throw new Error(`Unexpected: ${url}`);
+    });
     const openBrowser = mock(async (url: string) => {
       const parsed = new URL(url);
-      const callback = parsed.searchParams.get("callback")!;
+      const callback = parsed.searchParams.get("redirect_uri")!;
       const state = parsed.searchParams.get("state")!;
       await new Promise((r) => setTimeout(r, 10));
       await fetch(`${callback}?code=c&state=${state}`);
     });
-    const fetchMock = mock(async () => new Response("nope", { status: 401 }));
     const code = await loginCommand({
       dataDir: dir,
-      target: "https://studio.decocms.com",
+      target,
       openBrowser,
       fetch: fetchMock,
     });
@@ -120,21 +183,16 @@ describe("loginCommand", () => {
     expect(await readSession(dir)).toBeNull();
   });
 
-  it("returns non-zero and writes no session when exchange returns incomplete data", async () => {
-    const openBrowser = mock(async (url: string) => {
-      const parsed = new URL(url);
-      const callback = parsed.searchParams.get("callback")!;
-      const state = parsed.searchParams.get("state")!;
-      await new Promise((r) => setTimeout(r, 10));
-      await fetch(`${callback}?code=c&state=${state}`);
+  it("returns non-zero when client registration fails", async () => {
+    const fetchMock = mock(async (url: string) => {
+      if (url.endsWith("/register")) {
+        return new Response("forbidden", { status: 403 });
+      }
+      throw new Error(`Unexpected: ${url}`);
     });
-    const fetchMock = mock(
-      async () =>
-        new Response(JSON.stringify({}), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-    );
+    const openBrowser = mock(async () => {
+      throw new Error("openBrowser should not be called");
+    });
     const code = await loginCommand({
       dataDir: dir,
       target: "https://studio.decocms.com",

--- a/apps/mesh/src/cli/commands/auth/login.ts
+++ b/apps/mesh/src/cli/commands/auth/login.ts
@@ -1,7 +1,8 @@
-import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { startOAuthCallbackServer } from "../../lib/oauth-callback";
-import { writeSession, type Session } from "../../lib/session";
+import { generatePkcePair } from "../../lib/pkce";
+import { type Session, writeSession } from "../../lib/session";
 
 export interface LoginOptions {
   dataDir: string;
@@ -14,60 +15,86 @@ export interface LoginOptions {
 
 export const DEFAULT_TARGET = "https://studio.decocms.com";
 
+const SCOPES = "openid profile email offline_access";
+
+interface RegisterResponse {
+  client_id: string;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+interface UserInfoResponse {
+  sub: string;
+  email?: string;
+  name?: string;
+}
+
 export async function loginCommand(options: LoginOptions): Promise<number> {
   const target = (options.target ?? DEFAULT_TARGET).replace(/\/$/, "");
   const fetchImpl = options.fetch ?? fetch;
   const openImpl = options.openBrowser ?? defaultOpenBrowser;
 
   const state = randomUUID();
+  const pkce = generatePkcePair();
+
   const server = await startOAuthCallbackServer({ expectedState: state });
   try {
-    const callback = encodeURIComponent(server.url);
-    const url = `${target}/auth/cli?callback=${callback}&state=${state}`;
+    const redirectUri = `${server.url}/`;
+
+    // 1. Dynamically register this CLI install as an OAuth client.
+    const clientId = await registerClient(fetchImpl, target, redirectUri);
+
+    // 2. Build the /login URL — this triggers the existing OAuth-aware login UI,
+    //    which routes to /api/auth/mcp/authorize after the user signs in.
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      state,
+      scope: SCOPES,
+      code_challenge: pkce.challenge,
+      code_challenge_method: "S256",
+    });
+    const url = `${target}/login?${params.toString()}`;
+
     console.log(`Opening ${url} in your browser...`);
     await openImpl(url);
 
+    // 3. Wait for the browser to redirect back with an authorization code.
     const { code } = await server.waitForCallback();
 
-    const exchangeRes = await fetchImpl(`${target}/api/auth/cli/exchange`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ code }),
-    });
-    if (!exchangeRes.ok) {
-      console.error(
-        `Token exchange failed: HTTP ${exchangeRes.status} ${await exchangeRes.text().catch(() => "")}`,
-      );
-      return 1;
-    }
-    const data = (await exchangeRes.json()) as {
-      token: string;
-      workspace: string;
-      user: { id: string; email: string };
-    };
+    // 4. Exchange the code for an access token at the standard token endpoint.
+    const token = await exchangeToken(
+      fetchImpl,
+      target,
+      clientId,
+      code,
+      redirectUri,
+      pkce.verifier,
+    );
 
-    if (
-      typeof data?.token !== "string" ||
-      typeof data?.workspace !== "string" ||
-      typeof data?.user?.id !== "string" ||
-      typeof data?.user?.email !== "string"
-    ) {
-      console.error(
-        "Token exchange failed: server returned incomplete response",
-      );
-      return 1;
-    }
+    // 5. Fetch the user profile with the new access token.
+    const user = await fetchUserInfo(fetchImpl, target, token.access_token);
 
     const session: Session = {
       target,
-      workspace: data.workspace,
-      user: data.user,
-      token: data.token,
+      clientId,
+      user: { sub: user.sub, email: user.email, name: user.name },
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token,
+      expiresAt: token.expires_in
+        ? Math.floor(Date.now() / 1000) + token.expires_in
+        : undefined,
       createdAt: new Date().toISOString(),
     };
     await writeSession(options.dataDir, session);
 
-    console.log(`Logged in as ${data.user.email} (${data.workspace}).`);
+    console.log(`Logged in as ${user.email ?? user.sub}.`);
     return 0;
   } catch (err) {
     console.error(
@@ -77,6 +104,87 @@ export async function loginCommand(options: LoginOptions): Promise<number> {
   } finally {
     server.close();
   }
+}
+
+async function registerClient(
+  fetchImpl: (input: string, init?: RequestInit) => Promise<Response>,
+  target: string,
+  redirectUri: string,
+): Promise<string> {
+  const res = await fetchImpl(`${target}/api/auth/mcp/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_name: "decocms-cli",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      application_type: "native",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Client registration failed: HTTP ${res.status} ${await res.text().catch(() => "")}`,
+    );
+  }
+  const data = (await res.json()) as RegisterResponse;
+  if (typeof data?.client_id !== "string") {
+    throw new Error("Client registration returned no client_id");
+  }
+  return data.client_id;
+}
+
+async function exchangeToken(
+  fetchImpl: (input: string, init?: RequestInit) => Promise<Response>,
+  target: string,
+  clientId: string,
+  code: string,
+  redirectUri: string,
+  verifier: string,
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: clientId,
+    code_verifier: verifier,
+  });
+  const res = await fetchImpl(`${target}/api/auth/mcp/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Token exchange failed: HTTP ${res.status} ${await res.text().catch(() => "")}`,
+    );
+  }
+  const data = (await res.json()) as TokenResponse;
+  if (typeof data?.access_token !== "string") {
+    throw new Error("Token endpoint returned no access_token");
+  }
+  return data;
+}
+
+async function fetchUserInfo(
+  fetchImpl: (input: string, init?: RequestInit) => Promise<Response>,
+  target: string,
+  accessToken: string,
+): Promise<UserInfoResponse> {
+  const res = await fetchImpl(`${target}/api/auth/mcp/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Userinfo failed: HTTP ${res.status} ${await res.text().catch(() => "")}`,
+    );
+  }
+  const data = (await res.json()) as UserInfoResponse;
+  if (typeof data?.sub !== "string") {
+    throw new Error("Userinfo returned no sub");
+  }
+  return data;
 }
 
 async function defaultOpenBrowser(url: string): Promise<void> {

--- a/apps/mesh/src/cli/commands/auth/login.ts
+++ b/apps/mesh/src/cli/commands/auth/login.ts
@@ -13,7 +13,7 @@ export interface LoginOptions {
   fetch?: (input: string, init?: RequestInit) => Promise<Response>;
 }
 
-export const DEFAULT_TARGET = "https://studio.decocms.com";
+const DEFAULT_TARGET = "https://studio.decocms.com";
 
 const SCOPES = "openid profile email offline_access";
 

--- a/apps/mesh/src/cli/commands/auth/login.ts
+++ b/apps/mesh/src/cli/commands/auth/login.ts
@@ -24,11 +24,12 @@ interface RegisterResponse {
 interface TokenResponse {
   access_token: string;
   refresh_token?: string;
+  id_token?: string;
   expires_in?: number;
   token_type?: string;
 }
 
-interface UserInfoResponse {
+interface IdTokenClaims {
   sub: string;
   email?: string;
   name?: string;
@@ -68,7 +69,7 @@ export async function loginCommand(options: LoginOptions): Promise<number> {
     // 3. Wait for the browser to redirect back with an authorization code.
     const { code } = await server.waitForCallback();
 
-    // 4. Exchange the code for an access token at the standard token endpoint.
+    // 4. Exchange the code for an access + id token.
     const token = await exchangeToken(
       fetchImpl,
       target,
@@ -78,13 +79,17 @@ export async function loginCommand(options: LoginOptions): Promise<number> {
       pkce.verifier,
     );
 
-    // 5. Fetch the user profile with the new access token.
-    const user = await fetchUserInfo(fetchImpl, target, token.access_token);
+    // 5. Read the user from the id_token (the OIDC standard way — userinfo
+    //    endpoint is advertised but not implemented upstream).
+    if (!token.id_token) {
+      throw new Error("Token endpoint returned no id_token");
+    }
+    const claims = decodeIdToken(token.id_token);
 
     const session: Session = {
       target,
       clientId,
-      user: { sub: user.sub, email: user.email, name: user.name },
+      user: { sub: claims.sub, email: claims.email, name: claims.name },
       accessToken: token.access_token,
       refreshToken: token.refresh_token,
       expiresAt: token.expires_in
@@ -94,7 +99,7 @@ export async function loginCommand(options: LoginOptions): Promise<number> {
     };
     await writeSession(options.dataDir, session);
 
-    console.log(`Logged in as ${user.email ?? user.sub}.`);
+    console.log(`Logged in as ${claims.email ?? claims.sub}.`);
     return 0;
   } catch (err) {
     console.error(
@@ -167,24 +172,22 @@ async function exchangeToken(
   return data;
 }
 
-async function fetchUserInfo(
-  fetchImpl: (input: string, init?: RequestInit) => Promise<Response>,
-  target: string,
-  accessToken: string,
-): Promise<UserInfoResponse> {
-  const res = await fetchImpl(`${target}/api/auth/mcp/userinfo`, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(
-      `Userinfo failed: HTTP ${res.status} ${await res.text().catch(() => "")}`,
-    );
+function decodeIdToken(idToken: string): IdTokenClaims {
+  const parts = idToken.split(".");
+  if (parts.length !== 3 || !parts[1]) {
+    throw new Error("id_token is not a valid JWT");
   }
-  const data = (await res.json()) as UserInfoResponse;
-  if (typeof data?.sub !== "string") {
-    throw new Error("Userinfo returned no sub");
+  const payload = JSON.parse(
+    Buffer.from(parts[1], "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+  if (typeof payload.sub !== "string") {
+    throw new Error("id_token has no sub claim");
   }
-  return data;
+  return {
+    sub: payload.sub,
+    email: typeof payload.email === "string" ? payload.email : undefined,
+    name: typeof payload.name === "string" ? payload.name : undefined,
+  };
 }
 
 async function defaultOpenBrowser(url: string): Promise<void> {

--- a/apps/mesh/src/cli/commands/auth/login.ts
+++ b/apps/mesh/src/cli/commands/auth/login.ts
@@ -98,7 +98,12 @@ async function defaultOpenBrowser(url: string): Promise<void> {
   }
   await new Promise<void>((resolve) => {
     const child = spawn(command, args, { stdio: "ignore", detached: true });
-    child.on("error", () => resolve());
+    child.on("error", () => {
+      console.log(
+        `Could not open browser automatically. Please open this URL manually:\n  ${url}`,
+      );
+      resolve();
+    });
     child.on("spawn", () => {
       child.unref();
       resolve();

--- a/apps/mesh/src/cli/commands/auth/login.ts
+++ b/apps/mesh/src/cli/commands/auth/login.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { startOAuthCallbackServer } from "../../lib/oauth-callback";
+import { writeSession, type Session } from "../../lib/session";
+
+export interface LoginOptions {
+  dataDir: string;
+  target?: string;
+  /** Injectable for tests. Defaults to opening the user's default browser. */
+  openBrowser?: (url: string) => Promise<void>;
+  /** Injectable for tests. */
+  fetch?: typeof fetch;
+}
+
+export const DEFAULT_TARGET = "https://studio.decocms.com";
+
+export async function loginCommand(options: LoginOptions): Promise<number> {
+  const target = (options.target ?? DEFAULT_TARGET).replace(/\/$/, "");
+  const fetchImpl = options.fetch ?? fetch;
+  const openImpl = options.openBrowser ?? defaultOpenBrowser;
+
+  const state = randomUUID();
+  const server = await startOAuthCallbackServer({ expectedState: state });
+  try {
+    const callback = encodeURIComponent(server.url);
+    const url = `${target}/auth/cli?callback=${callback}&state=${state}`;
+    console.log(`Opening ${url} in your browser...`);
+    await openImpl(url);
+
+    const { code } = await server.waitForCallback();
+
+    const exchangeRes = await fetchImpl(`${target}/api/auth/cli/exchange`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    if (!exchangeRes.ok) {
+      console.error(
+        `Token exchange failed: HTTP ${exchangeRes.status} ${await exchangeRes.text().catch(() => "")}`,
+      );
+      return 1;
+    }
+    const data = (await exchangeRes.json()) as {
+      token: string;
+      workspace: string;
+      user: { id: string; email: string };
+    };
+
+    const session: Session = {
+      target,
+      workspace: data.workspace,
+      user: data.user,
+      token: data.token,
+      createdAt: new Date().toISOString(),
+    };
+    await writeSession(options.dataDir, session);
+
+    console.log(`Logged in as ${data.user.email} (${data.workspace}).`);
+    return 0;
+  } catch (err) {
+    console.error(
+      `Login failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  } finally {
+    server.close();
+  }
+}
+
+async function defaultOpenBrowser(url: string): Promise<void> {
+  let command: string;
+  let args: string[];
+  switch (process.platform) {
+    case "darwin":
+      command = "open";
+      args = [url];
+      break;
+    case "win32":
+      command = "cmd";
+      args = ["/c", "start", "", url];
+      break;
+    default:
+      command = "xdg-open";
+      args = [url];
+      break;
+  }
+  await new Promise<void>((resolve) => {
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", () => resolve());
+    child.on("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}

--- a/apps/mesh/src/cli/commands/auth/login.ts
+++ b/apps/mesh/src/cli/commands/auth/login.ts
@@ -9,7 +9,7 @@ export interface LoginOptions {
   /** Injectable for tests. Defaults to opening the user's default browser. */
   openBrowser?: (url: string) => Promise<void>;
   /** Injectable for tests. */
-  fetch?: typeof fetch;
+  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
 }
 
 export const DEFAULT_TARGET = "https://studio.decocms.com";
@@ -45,6 +45,18 @@ export async function loginCommand(options: LoginOptions): Promise<number> {
       workspace: string;
       user: { id: string; email: string };
     };
+
+    if (
+      typeof data?.token !== "string" ||
+      typeof data?.workspace !== "string" ||
+      typeof data?.user?.id !== "string" ||
+      typeof data?.user?.email !== "string"
+    ) {
+      console.error(
+        "Token exchange failed: server returned incomplete response",
+      );
+      return 1;
+    }
 
     const session: Session = {
       target,

--- a/apps/mesh/src/cli/commands/auth/logout.test.ts
+++ b/apps/mesh/src/cli/commands/auth/logout.test.ts
@@ -1,16 +1,7 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
-import { rm } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdtemp } from "node:fs/promises";
 import { readSession, writeSession } from "../../lib/session";
 import { logoutCommand } from "./logout";
 
@@ -28,49 +19,22 @@ afterEach(async () => {
 });
 
 describe("logoutCommand", () => {
-  it("posts to the revoke endpoint, deletes the session, and exits 0", async () => {
+  it("clears the session and exits 0 when logged in", async () => {
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "tlgimenes",
-      user: { id: "u_1", email: "tlgimenes@gmail.com" },
-      token: "tok_abc",
+      clientId: "client_abc",
+      user: { sub: "u_1", email: "tlgimenes@gmail.com" },
+      accessToken: "tok_abc",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 
-    const fetchMock = mock(async (url: string, init?: RequestInit) => {
-      expect(url).toBe("https://studio.decocms.com/api/auth/cli/revoke");
-      expect(init?.method).toBe("POST");
-      const headers = (init?.headers ?? {}) as Record<string, string>;
-      expect(headers.Authorization).toBe("Bearer tok_abc");
-      return new Response("", { status: 204 });
-    });
-
-    const code = await logoutCommand({ dataDir: dir, fetch: fetchMock });
-    expect(code).toBe(0);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(await readSession(dir)).toBeNull();
-  });
-
-  it("still deletes the session when revoke fails", async () => {
-    await writeSession(dir, {
-      target: "https://studio.decocms.com",
-      workspace: "ws",
-      user: { id: "u", email: "u@x" },
-      token: "t",
-      createdAt: "2026-05-04T00:00:00.000Z",
-    });
-    const fetchMock = mock(async () => {
-      throw new Error("network down");
-    });
-    const code = await logoutCommand({ dataDir: dir, fetch: fetchMock });
+    const code = await logoutCommand({ dataDir: dir });
     expect(code).toBe(0);
     expect(await readSession(dir)).toBeNull();
   });
 
   it("is a no-op + exit 0 when no session is present", async () => {
-    const fetchMock = mock(async () => new Response("", { status: 204 }));
-    const code = await logoutCommand({ dataDir: dir, fetch: fetchMock });
+    const code = await logoutCommand({ dataDir: dir });
     expect(code).toBe(0);
-    expect(fetchMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/apps/mesh/src/cli/commands/auth/logout.test.ts
+++ b/apps/mesh/src/cli/commands/auth/logout.test.ts
@@ -40,9 +40,8 @@ describe("logoutCommand", () => {
     const fetchMock = mock(async (url: string, init?: RequestInit) => {
       expect(url).toBe("https://studio.decocms.com/api/auth/cli/revoke");
       expect(init?.method).toBe("POST");
-      expect((init?.headers as Record<string, string>).Authorization).toBe(
-        "Bearer tok_abc",
-      );
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer tok_abc");
       return new Response("", { status: 204 });
     });
 

--- a/apps/mesh/src/cli/commands/auth/logout.test.ts
+++ b/apps/mesh/src/cli/commands/auth/logout.test.ts
@@ -1,0 +1,77 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { readSession, writeSession } from "../../lib/session";
+import { logoutCommand } from "./logout";
+
+let dir: string;
+let logSpy: ReturnType<typeof spyOn>;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "deco-logout-"));
+  logSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  logSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("logoutCommand", () => {
+  it("posts to the revoke endpoint, deletes the session, and exits 0", async () => {
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "tlgimenes",
+      user: { id: "u_1", email: "tlgimenes@gmail.com" },
+      token: "tok_abc",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://studio.decocms.com/api/auth/cli/revoke");
+      expect(init?.method).toBe("POST");
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer tok_abc",
+      );
+      return new Response("", { status: 204 });
+    });
+
+    const code = await logoutCommand({ dataDir: dir, fetch: fetchMock });
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await readSession(dir)).toBeNull();
+  });
+
+  it("still deletes the session when revoke fails", async () => {
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "ws",
+      user: { id: "u", email: "u@x" },
+      token: "t",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+    const fetchMock = mock(async () => {
+      throw new Error("network down");
+    });
+    const code = await logoutCommand({ dataDir: dir, fetch: fetchMock });
+    expect(code).toBe(0);
+    expect(await readSession(dir)).toBeNull();
+  });
+
+  it("is a no-op + exit 0 when no session is present", async () => {
+    const fetchMock = mock(async () => new Response("", { status: 204 }));
+    const code = await logoutCommand({ dataDir: dir, fetch: fetchMock });
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/mesh/src/cli/commands/auth/logout.ts
+++ b/apps/mesh/src/cli/commands/auth/logout.ts
@@ -1,0 +1,29 @@
+import { clearSession, readSession } from "../../lib/session";
+
+export interface LogoutOptions {
+  dataDir: string;
+  /** Injectable for tests. */
+  fetch?: typeof fetch;
+}
+
+export async function logoutCommand(options: LogoutOptions): Promise<number> {
+  const session = await readSession(options.dataDir);
+  if (!session) {
+    console.log("Already logged out.");
+    return 0;
+  }
+
+  const fetchImpl = options.fetch ?? fetch;
+  try {
+    await fetchImpl(`${session.target}/api/auth/cli/revoke`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${session.token}` },
+    });
+  } catch {
+    // Best-effort revoke; we still clear the local session.
+  }
+
+  await clearSession(options.dataDir);
+  console.log("Logged out.");
+  return 0;
+}

--- a/apps/mesh/src/cli/commands/auth/logout.ts
+++ b/apps/mesh/src/cli/commands/auth/logout.ts
@@ -3,7 +3,7 @@ import { clearSession, readSession } from "../../lib/session";
 export interface LogoutOptions {
   dataDir: string;
   /** Injectable for tests. */
-  fetch?: typeof fetch;
+  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
 }
 
 export async function logoutCommand(options: LogoutOptions): Promise<number> {

--- a/apps/mesh/src/cli/commands/auth/logout.ts
+++ b/apps/mesh/src/cli/commands/auth/logout.ts
@@ -2,8 +2,6 @@ import { clearSession, readSession } from "../../lib/session";
 
 export interface LogoutOptions {
   dataDir: string;
-  /** Injectable for tests. */
-  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
 }
 
 export async function logoutCommand(options: LogoutOptions): Promise<number> {
@@ -12,17 +10,6 @@ export async function logoutCommand(options: LogoutOptions): Promise<number> {
     console.log("Already logged out.");
     return 0;
   }
-
-  const fetchImpl = options.fetch ?? fetch;
-  try {
-    await fetchImpl(`${session.target}/api/auth/cli/revoke`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${session.token}` },
-    });
-  } catch {
-    // Best-effort revoke; we still clear the local session.
-  }
-
   await clearSession(options.dataDir);
   console.log("Logged out.");
   return 0;

--- a/apps/mesh/src/cli/commands/auth/whoami.test.ts
+++ b/apps/mesh/src/cli/commands/auth/whoami.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeSession } from "../../lib/session";
+import { whoamiCommand } from "./whoami";
+
+let dir: string;
+let logs: string[];
+let logSpy: ReturnType<typeof spyOn>;
+let errSpy: ReturnType<typeof spyOn>;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "deco-whoami-"));
+  logs = [];
+  logSpy = spyOn(console, "log").mockImplementation((msg: unknown) => {
+    logs.push(String(msg));
+  });
+  errSpy = spyOn(console, "error").mockImplementation((msg: unknown) => {
+    logs.push(String(msg));
+  });
+});
+
+afterEach(async () => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("whoamiCommand", () => {
+  it("prints session details and exits 0 when logged in", async () => {
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "tlgimenes",
+      user: { id: "u_1", email: "tlgimenes@gmail.com" },
+      token: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const code = await whoamiCommand({ dataDir: dir });
+    const joined = logs.join("\n");
+
+    expect(code).toBe(0);
+    expect(joined).toContain("https://studio.decocms.com");
+    expect(joined).toContain("tlgimenes");
+    expect(joined).toContain("tlgimenes@gmail.com");
+  });
+
+  it("prints a hint and exits 1 when no session is present", async () => {
+    const code = await whoamiCommand({ dataDir: dir });
+    expect(code).toBe(1);
+    expect(logs.join("\n")).toMatch(/Not logged in.*decocms auth login/);
+  });
+});

--- a/apps/mesh/src/cli/commands/auth/whoami.test.ts
+++ b/apps/mesh/src/cli/commands/auth/whoami.test.ts
@@ -31,9 +31,9 @@ describe("whoamiCommand", () => {
   it("prints session details and exits 0 when logged in", async () => {
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "tlgimenes",
-      user: { id: "u_1", email: "tlgimenes@gmail.com" },
-      token: "tok",
+      clientId: "client_abc",
+      user: { sub: "u_1", email: "tlgimenes@gmail.com" },
+      accessToken: "tok",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 
@@ -42,7 +42,6 @@ describe("whoamiCommand", () => {
 
     expect(code).toBe(0);
     expect(joined).toContain("https://studio.decocms.com");
-    expect(joined).toContain("tlgimenes");
     expect(joined).toContain("tlgimenes@gmail.com");
   });
 

--- a/apps/mesh/src/cli/commands/auth/whoami.ts
+++ b/apps/mesh/src/cli/commands/auth/whoami.ts
@@ -1,0 +1,17 @@
+import { readSession } from "../../lib/session";
+
+export interface WhoamiOptions {
+  dataDir: string;
+}
+
+export async function whoamiCommand(options: WhoamiOptions): Promise<number> {
+  const session = await readSession(options.dataDir);
+  if (!session) {
+    console.error("Not logged in. Run `decocms auth login` to authenticate.");
+    return 1;
+  }
+  console.log(`Target:    ${session.target}`);
+  console.log(`Workspace: ${session.workspace}`);
+  console.log(`User:      ${session.user.email}`);
+  return 0;
+}

--- a/apps/mesh/src/cli/commands/auth/whoami.ts
+++ b/apps/mesh/src/cli/commands/auth/whoami.ts
@@ -10,8 +10,7 @@ export async function whoamiCommand(options: WhoamiOptions): Promise<number> {
     console.error("Not logged in. Run `decocms auth login` to authenticate.");
     return 1;
   }
-  console.log(`Target:    ${session.target}`);
-  console.log(`Workspace: ${session.workspace}`);
-  console.log(`User:      ${session.user.email}`);
+  console.log(`Target: ${session.target}`);
+  console.log(`User:   ${session.user.email ?? session.user.sub}`);
   return 0;
 }

--- a/apps/mesh/src/cli/commands/link.test.ts
+++ b/apps/mesh/src/cli/commands/link.test.ts
@@ -230,4 +230,65 @@ describe("linkCommand", () => {
     expect(envSeen?.BASE_URL).toBeUndefined();
     await result.cancel();
   });
+
+  it("stops reconnecting when the spawned child exits", async () => {
+    cwdDir = await makeProject("my-app");
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "ws",
+      user: { id: "u", email: "u@x" },
+      token: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const childExitHandlers: Array<(code: number | null) => void> = [];
+    const childSpawn: SpawnFn = mock(() => {
+      const fakeChild = {
+        on: (event: string, handler: (code: number | null) => void) => {
+          if (event === "exit") childExitHandlers.push(handler);
+        },
+        kill: () => {},
+        exitCode: null,
+      };
+      return fakeChild as unknown as import("node:child_process").ChildProcess;
+    });
+
+    let openCount = 0;
+    const tunnelOpener: TunnelOpener = mock(async () => {
+      openCount += 1;
+      let resolveClosed!: () => void;
+      const closed = new Promise<void>((r) => {
+        resolveClosed = r;
+      });
+      return { closed, close: () => resolveClosed() };
+    });
+
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port: 8787,
+      env: "BASE_URL",
+      runCommand: ["node", "server.js"],
+      tunnelOpener,
+      portWaiter: async () => "127.0.0.1",
+      copyClipboard: async () => false,
+      ensureSession: async () => null,
+      spawn: childSpawn,
+      reconnectDelayMs: 5,
+    });
+
+    // Wait for the first tunnel to open.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(openCount).toBe(1);
+    expect(childExitHandlers.length).toBe(1);
+
+    // Simulate child crash.
+    childExitHandlers[0]?.(42);
+
+    // The tunnel should close, the reconnect loop should NOT iterate again,
+    // and the exit code should be the child's exit code.
+    expect(await result.exit).toBe(42);
+    // Confirm we did not re-open after the child died.
+    expect(openCount).toBe(1);
+  });
 });

--- a/apps/mesh/src/cli/commands/link.test.ts
+++ b/apps/mesh/src/cli/commands/link.test.ts
@@ -43,13 +43,13 @@ describe("linkCommand", () => {
     cwdDir = await makeProject("my-app");
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "tlgimenes",
-      user: { id: "u_1", email: "u@x" },
-      token: "tok_link",
+      clientId: "client_abc",
+      user: { sub: "u_1", email: "u@x" },
+      accessToken: "tok_link",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 
-    const expectedDomain = computeAppDomain("tlgimenes", "my-app");
+    const expectedDomain = computeAppDomain("u_1", "my-app");
     const tunnelOpener = mock<TunnelOpener>(async (params) => {
       expect(params.domain).toBe(expectedDomain);
       expect(params.localAddr).toBe("http://127.0.0.1:8787");
@@ -87,9 +87,9 @@ describe("linkCommand", () => {
     cwdDir = await makeProject("my-app");
     const ensureSession = mock(async () => ({
       target: "https://studio.decocms.com",
-      workspace: "ws",
-      user: { id: "u", email: "u@x" },
-      token: "tok",
+      clientId: "client_x",
+      user: { sub: "u", email: "u@x" },
+      accessToken: "tok",
       createdAt: "2026-05-04T00:00:00.000Z",
     }));
     const tunnelOpener = mock<TunnelOpener>(async () => ({
@@ -119,9 +119,9 @@ describe("linkCommand", () => {
     cwdDir = await makeProject("my-app");
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "ws",
-      user: { id: "u", email: "u@x" },
-      token: "tok",
+      clientId: "client_x",
+      user: { sub: "u", email: "u@x" },
+      accessToken: "tok",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 
@@ -159,9 +159,9 @@ describe("linkCommand", () => {
     await writeFile(join(cwdDir, "package.json"), "{}");
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "ws",
-      user: { id: "u", email: "u@x" },
-      token: "tok",
+      clientId: "client_x",
+      user: { sub: "u", email: "u@x" },
+      accessToken: "tok",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 
@@ -188,9 +188,9 @@ describe("linkCommand", () => {
     cwdDir = await makeProject("my-app");
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "ws",
-      user: { id: "u", email: "u@x" },
-      token: "tok",
+      clientId: "client_x",
+      user: { sub: "u", email: "u@x" },
+      accessToken: "tok",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 
@@ -235,9 +235,9 @@ describe("linkCommand", () => {
     cwdDir = await makeProject("my-app");
     await writeSession(dir, {
       target: "https://studio.decocms.com",
-      workspace: "ws",
-      user: { id: "u", email: "u@x" },
-      token: "tok",
+      clientId: "client_x",
+      user: { sub: "u", email: "u@x" },
+      accessToken: "tok",
       createdAt: "2026-05-04T00:00:00.000Z",
     });
 

--- a/apps/mesh/src/cli/commands/link.test.ts
+++ b/apps/mesh/src/cli/commands/link.test.ts
@@ -1,0 +1,233 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { computeAppDomain } from "../lib/app-domain";
+import { writeSession } from "../lib/session";
+import { linkCommand, type SpawnFn, type TunnelOpener } from "./link";
+
+let dir: string;
+let cwdDir: string;
+let logSpy: ReturnType<typeof spyOn>;
+
+async function makeProject(name: string): Promise<string> {
+  const projectDir = await mkdtemp(join(tmpdir(), "deco-link-cwd-"));
+  await writeFile(
+    join(projectDir, "package.json"),
+    JSON.stringify({ name }, null, 2),
+  );
+  return projectDir;
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "deco-link-"));
+  logSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  logSpy.mockRestore();
+  await rm(dir, { recursive: true, force: true });
+  if (cwdDir) await rm(cwdDir, { recursive: true, force: true });
+});
+
+describe("linkCommand", () => {
+  it("opens a tunnel to localhost-<sha1-8>.deco.host with the session token", async () => {
+    cwdDir = await makeProject("my-app");
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "tlgimenes",
+      user: { id: "u_1", email: "u@x" },
+      token: "tok_link",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const expectedDomain = computeAppDomain("tlgimenes", "my-app");
+    const tunnelOpener = mock<TunnelOpener>(async (params) => {
+      expect(params.domain).toBe(expectedDomain);
+      expect(params.localAddr).toBe("http://127.0.0.1:8787");
+      expect(params.apiKey).toBe("tok_link");
+      expect(params.server).toBe(`wss://${expectedDomain}`);
+      return { closed: new Promise<void>(() => {}), close: () => {} };
+    });
+
+    const port = 8787;
+    // Pretend the port is already listening so waitForPort returns instantly.
+    const portWaiter = mock(async () => "127.0.0.1");
+
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port,
+      env: "BASE_URL",
+      runCommand: [],
+      tunnelOpener,
+      portWaiter,
+      copyClipboard: async () => true,
+      ensureSession: async () => null, // session is already present
+    });
+
+    // Give the command a tick to call tunnelOpener and reach the await on closed.
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(tunnelOpener).toHaveBeenCalledTimes(1);
+
+    // Cleanup so the test actually finishes.
+    await result.cancel();
+  });
+
+  it("auto-triggers ensureSession when no session is present", async () => {
+    cwdDir = await makeProject("my-app");
+    const ensureSession = mock(async () => ({
+      target: "https://studio.decocms.com",
+      workspace: "ws",
+      user: { id: "u", email: "u@x" },
+      token: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    }));
+    const tunnelOpener = mock<TunnelOpener>(async () => ({
+      closed: new Promise<void>(() => {}),
+      close: () => {},
+    }));
+
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port: 8787,
+      env: "BASE_URL",
+      runCommand: [],
+      tunnelOpener,
+      portWaiter: async () => "127.0.0.1",
+      copyClipboard: async () => false,
+      ensureSession,
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(ensureSession).toHaveBeenCalledTimes(1);
+    expect(tunnelOpener).toHaveBeenCalledTimes(1);
+    await result.cancel();
+  });
+
+  it("reconnects when the tunnel closes mid-session", async () => {
+    cwdDir = await makeProject("my-app");
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "ws",
+      user: { id: "u", email: "u@x" },
+      token: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    let openCount = 0;
+    const tunnelOpener = mock<TunnelOpener>(async () => {
+      openCount += 1;
+      // First call: a tunnel that closes immediately. Second: never closes.
+      if (openCount === 1) {
+        return { closed: Promise.resolve(), close: () => {} };
+      }
+      return { closed: new Promise<void>(() => {}), close: () => {} };
+    });
+
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port: 8787,
+      env: "BASE_URL",
+      runCommand: [],
+      tunnelOpener,
+      portWaiter: async () => "127.0.0.1",
+      copyClipboard: async () => false,
+      ensureSession: async () => null,
+      reconnectDelayMs: 5,
+    });
+
+    // Allow time for the first tunnel to close and reconnect.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(openCount).toBeGreaterThanOrEqual(2);
+    await result.cancel();
+  });
+
+  it("returns non-zero when package.json is missing a name", async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), "deco-link-noname-"));
+    await writeFile(join(cwdDir, "package.json"), "{}");
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "ws",
+      user: { id: "u", email: "u@x" },
+      token: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const tunnelOpener = mock<TunnelOpener>(async () => ({
+      closed: new Promise<void>(() => {}),
+      close: () => {},
+    }));
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port: 8787,
+      env: "BASE_URL",
+      runCommand: [],
+      tunnelOpener,
+      portWaiter: async () => "127.0.0.1",
+      copyClipboard: async () => false,
+      ensureSession: async () => null,
+    });
+    expect(await result.exit).not.toBe(0);
+    expect(tunnelOpener).toHaveBeenCalledTimes(0);
+  });
+
+  it("uses BASE_URL by default and respects the -e flag", async () => {
+    cwdDir = await makeProject("my-app");
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      workspace: "ws",
+      user: { id: "u", email: "u@x" },
+      token: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    let envSeen: NodeJS.ProcessEnv | undefined;
+    const childSpawn = mock<SpawnFn>((_cmd, _args, opts) => {
+      envSeen = opts.env;
+      return {
+        on: () => {},
+        kill: () => {},
+        exitCode: null,
+      } as unknown as import("node:child_process").ChildProcess;
+    });
+
+    const tunnelOpener = mock<TunnelOpener>(async () => ({
+      closed: new Promise<void>(() => {}),
+      close: () => {},
+    }));
+
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port: 8787,
+      env: "MY_PUBLIC_URL",
+      runCommand: ["node", "server.js"],
+      tunnelOpener,
+      portWaiter: async () => "127.0.0.1",
+      copyClipboard: async () => false,
+      ensureSession: async () => null,
+      spawn: childSpawn,
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(childSpawn).toHaveBeenCalledTimes(1);
+    expect(envSeen?.MY_PUBLIC_URL).toMatch(
+      /^https:\/\/localhost-[0-9a-f]{8}\.deco\.host$/,
+    );
+    expect(envSeen?.BASE_URL).toBeUndefined();
+    await result.cancel();
+  });
+});

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -1,0 +1,221 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { computeAppDomain } from "../lib/app-domain";
+import { copyToClipboard } from "../lib/clipboard";
+import { waitForPort } from "../lib/port-wait";
+import { readSession, type Session } from "../lib/session";
+import { loginCommand } from "./auth/login";
+
+export interface TunnelHandle {
+  closed: Promise<void>;
+  close: () => void;
+}
+
+export type TunnelOpener = (params: {
+  domain: string;
+  localAddr: string;
+  apiKey: string;
+  server: string;
+}) => Promise<TunnelHandle>;
+
+/** Minimal spawn signature used by linkCommand — compatible with node:child_process spawn. */
+export type SpawnFn = (
+  command: string,
+  args: string[],
+  options: { stdio: "inherit"; shell: boolean; env: NodeJS.ProcessEnv },
+) => ChildProcess;
+
+export interface LinkOptions {
+  cwd: string;
+  dataDir: string;
+  port: number;
+  env: string;
+  runCommand: string[];
+  /** Injectable: defaults to defaultTunnelOpener (dynamic import of @deco-cx/warp-node). */
+  tunnelOpener?: TunnelOpener;
+  /** Injectable: defaults to waitForPort. */
+  portWaiter?: (port: number) => Promise<string>;
+  /** Injectable: defaults to copyToClipboard. */
+  copyClipboard?: (text: string) => Promise<boolean>;
+  /** Called when no session is present. Returns the new session or null on failure. */
+  ensureSession?: () => Promise<Session | null>;
+  /** Injectable: defaults to node:child_process spawn. */
+  spawn?: SpawnFn;
+  /** Reconnect delay after a tunnel disconnect (default 500ms, matches legacy). */
+  reconnectDelayMs?: number;
+}
+
+export interface LinkRunResult {
+  exit: Promise<number>;
+  cancel: () => Promise<void>;
+}
+
+export function linkCommand(options: LinkOptions): LinkRunResult {
+  let resolveExit!: (n: number) => void;
+  const exit = new Promise<number>((r) => {
+    resolveExit = r;
+  });
+
+  let child: ChildProcess | undefined;
+  let tunnel: TunnelHandle | undefined;
+  let cancelled = false;
+
+  const cancel = async () => {
+    cancelled = true;
+    try {
+      child?.kill("SIGTERM");
+    } catch {}
+    try {
+      tunnel?.close();
+    } catch {}
+    resolveExit(0);
+  };
+
+  void (async () => {
+    try {
+      let session = await readSession(options.dataDir);
+      if (!session) {
+        const ensure =
+          options.ensureSession ?? defaultEnsureSession(options.dataDir);
+        console.log("No session found — opening login...");
+        session = await ensure();
+        if (!session) {
+          console.error("Login failed; cannot open tunnel.");
+          resolveExit(1);
+          return;
+        }
+      }
+
+      const appName = await readPackageName(options.cwd);
+      if (!appName) {
+        console.error(
+          "Could not read `name` from package.json. Run `decocms link` from a project directory.",
+        );
+        resolveExit(1);
+        return;
+      }
+
+      const domain = computeAppDomain(session.workspace, appName);
+      const publicUrl = `https://${domain}`;
+
+      const spawnImpl: SpawnFn = options.spawn ?? nodeSpawn;
+      if (options.runCommand.length > 0) {
+        const [cmd, ...args] = options.runCommand;
+        if (!cmd) {
+          console.error("runCommand must not be empty");
+          resolveExit(1);
+          return;
+        }
+        console.log(`Starting: ${cmd} ${args.join(" ")}`);
+        const spawned = spawnImpl(cmd, args, {
+          stdio: "inherit",
+          shell: true,
+          env: { ...process.env, [options.env]: publicUrl },
+        });
+        child = spawned;
+        spawned.on("exit", (code) => {
+          if (!cancelled) resolveExit(code ?? 0);
+        });
+      } else {
+        console.log(
+          `Tunnel will connect to existing service on port ${options.port}.`,
+        );
+      }
+
+      const wait = options.portWaiter ?? ((p: number) => waitForPort(p));
+      const opener = options.tunnelOpener ?? defaultTunnelOpener;
+      const copy = options.copyClipboard ?? copyToClipboard;
+      const reconnectDelay = options.reconnectDelayMs ?? 500;
+
+      // Loop: open tunnel, wait for it to close, reconnect after a small delay.
+      // Matches legacy behavior — exits only when the user cancels.
+      let firstOpen = true;
+      while (!cancelled) {
+        const host = await wait(options.port);
+        try {
+          tunnel = await opener({
+            domain,
+            localAddr: `http://${host}:${options.port}`,
+            apiKey: session.token,
+            server: `wss://${domain}`,
+          });
+        } catch (err) {
+          console.error(
+            `Tunnel connect failed, retrying: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          await sleep(reconnectDelay);
+          continue;
+        }
+
+        if (firstOpen) {
+          console.log(`Tunnel open: ${publicUrl}`);
+          if (await copy(publicUrl)) {
+            console.log("(URL copied to clipboard)");
+          }
+          firstOpen = false;
+        } else {
+          console.log("Tunnel reconnected.");
+        }
+
+        await tunnel.closed;
+        if (cancelled) break;
+        console.log("Tunnel closed, reconnecting...");
+        await sleep(reconnectDelay);
+      }
+
+      if (!cancelled) resolveExit(0);
+    } catch (err) {
+      console.error(
+        `Link failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      resolveExit(1);
+    }
+  })();
+
+  return { exit, cancel };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readPackageName(cwd: string): Promise<string | null> {
+  try {
+    const raw = await readFile(join(cwd, "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === "string" && parsed.name.length > 0
+      ? parsed.name
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultEnsureSession(dataDir: string): () => Promise<Session | null> {
+  return async () => {
+    const code = await loginCommand({ dataDir });
+    if (code !== 0) return null;
+    return readSession(dataDir);
+  };
+}
+
+const defaultTunnelOpener: TunnelOpener = async (params) => {
+  // @ts-expect-error — @deco-cx/warp-node has no types
+  const { connect } = await import("@deco-cx/warp-node");
+  const tunnel = await connect({
+    domain: params.domain,
+    localAddr: params.localAddr,
+    server: params.server,
+    apiKey: params.apiKey,
+  });
+  await tunnel.registered;
+  return {
+    closed: tunnel.closed,
+    close: () => {
+      try {
+        tunnel.close?.();
+      } catch {}
+    },
+  };
+};

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -208,7 +208,6 @@ function defaultEnsureSession(dataDir: string): () => Promise<Session | null> {
 }
 
 const defaultTunnelOpener: TunnelOpener = async (params) => {
-  // @ts-expect-error — @deco-cx/warp-node has no types
   const { connect } = await import("@deco-cx/warp-node");
   const tunnel = await connect({
     domain: params.domain,
@@ -218,11 +217,12 @@ const defaultTunnelOpener: TunnelOpener = async (params) => {
   });
   await tunnel.registered;
   return {
-    closed: tunnel.closed,
+    // Connected.closed resolves with Error | undefined; we discard the value
+    // to satisfy TunnelHandle.closed: Promise<void>.
+    closed: tunnel.closed.then(() => undefined),
     close: () => {
-      try {
-        tunnel.close?.();
-      } catch {}
+      // @deco-cx/warp-node Connected has no close() method; the connection
+      // closes on its own when the server drops it.
     },
   };
 };

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -10,6 +10,8 @@ import { loginCommand } from "./auth/login";
 export interface TunnelHandle {
   closed: Promise<void>;
   close: () => void;
+  // TODO: surface auth failure separately so the caller can show the
+  // "session may be expired" hint described in the spec.
 }
 
 export type TunnelOpener = (params: {
@@ -115,7 +117,12 @@ export function linkCommand(options: LinkOptions): LinkRunResult {
         });
         child = spawned;
         spawned.on("exit", (code) => {
-          if (!cancelled) resolveExit(code ?? 0);
+          if (cancelled) return;
+          cancelled = true;
+          try {
+            tunnel?.close();
+          } catch {}
+          resolveExit(code ?? 0);
         });
       } else {
         console.log(

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -98,7 +98,7 @@ export function linkCommand(options: LinkOptions): LinkRunResult {
         return;
       }
 
-      const domain = computeAppDomain(session.workspace, appName);
+      const domain = computeAppDomain(session.user.sub, appName);
       const publicUrl = `https://${domain}`;
 
       const spawnImpl: SpawnFn = options.spawn ?? nodeSpawn;
@@ -144,7 +144,7 @@ export function linkCommand(options: LinkOptions): LinkRunResult {
           tunnel = await opener({
             domain,
             localAddr: `http://${host}:${options.port}`,
-            apiKey: session.token,
+            apiKey: session.accessToken,
             server: `wss://${domain}`,
           });
         } catch (err) {

--- a/apps/mesh/src/cli/lib/app-domain.test.ts
+++ b/apps/mesh/src/cli/lib/app-domain.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { computeAppDomain, computeAppHash } from "./app-domain";
+
+describe("computeAppHash", () => {
+  it("is the first 8 hex chars of sha1(`${workspace}-${app}`)", () => {
+    // Golden value computed once with: echo -n "tlgimenes-my-app" | shasum -a 1
+    // sha1 = "eca5dde8..." — first 8 chars match legacy getAppUUID exactly.
+    expect(computeAppHash("tlgimenes", "my-app")).toBe("eca5dde8");
+  });
+
+  it("is stable across calls", () => {
+    expect(computeAppHash("ws", "app")).toBe(computeAppHash("ws", "app"));
+  });
+
+  it("differs for different workspaces", () => {
+    expect(computeAppHash("a", "x")).not.toBe(computeAppHash("b", "x"));
+  });
+
+  it("differs for different apps", () => {
+    expect(computeAppHash("a", "x")).not.toBe(computeAppHash("a", "y"));
+  });
+});
+
+describe("computeAppDomain", () => {
+  it("returns localhost-<hash>.deco.host", () => {
+    expect(computeAppDomain("tlgimenes", "my-app")).toBe(
+      "localhost-eca5dde8.deco.host",
+    );
+  });
+});

--- a/apps/mesh/src/cli/lib/app-domain.test.ts
+++ b/apps/mesh/src/cli/lib/app-domain.test.ts
@@ -2,17 +2,16 @@ import { describe, expect, it } from "bun:test";
 import { computeAppDomain, computeAppHash } from "./app-domain";
 
 describe("computeAppHash", () => {
-  it("is the first 8 hex chars of sha1(`${workspace}-${app}`)", () => {
-    // Golden value computed once with: echo -n "tlgimenes-my-app" | shasum -a 1
-    // sha1 = "eca5dde8..." — first 8 chars match legacy getAppUUID exactly.
-    expect(computeAppHash("tlgimenes", "my-app")).toBe("eca5dde8");
+  it("is the first 8 hex chars of sha1(`${principal}-${app}`)", () => {
+    // Golden value computed once with: echo -n "user-123-my-app" | shasum -a 1
+    expect(computeAppHash("user-123", "my-app")).toBe("e54ab40b");
   });
 
   it("is stable across calls", () => {
     expect(computeAppHash("ws", "app")).toBe(computeAppHash("ws", "app"));
   });
 
-  it("differs for different workspaces", () => {
+  it("differs for different principals", () => {
     expect(computeAppHash("a", "x")).not.toBe(computeAppHash("b", "x"));
   });
 
@@ -23,8 +22,8 @@ describe("computeAppHash", () => {
 
 describe("computeAppDomain", () => {
   it("returns localhost-<hash>.deco.host", () => {
-    expect(computeAppDomain("tlgimenes", "my-app")).toBe(
-      "localhost-eca5dde8.deco.host",
+    expect(computeAppDomain("user-123", "my-app")).toBe(
+      "localhost-e54ab40b.deco.host",
     );
   });
 });

--- a/apps/mesh/src/cli/lib/app-domain.ts
+++ b/apps/mesh/src/cli/lib/app-domain.ts
@@ -1,23 +1,27 @@
 import { createHash } from "node:crypto";
 
 /**
- * Legacy-compatible app hash. Returns the first 8 hex characters of
- * sha1(`${workspace}-${app}`). Preserved exactly from packages/cli's
- * getAppUUID so existing tunnel subdomains remain valid.
+ * Stable app hash for tunnel subdomains. Returns the first 8 hex
+ * characters of sha1(`${principal}-${app}`).
  *
- * (Yes, the legacy function was named md5Hash but used sha1.)
+ * `principal` is the per-user identifier from the OAuth session
+ * (typically the OIDC `sub` claim); `app` is the local project name.
+ * Same inputs always produce the same subdomain so tunnel registrations
+ * are stable across reconnects.
  *
- * The hyphen separator is intentional legacy behavior — the hash collides
- * for inputs like ("a-b", "c") and ("a", "b-c"). Do not change the
- * separator; doing so would invalidate existing tunnel registrations.
+ * The algorithm is preserved exactly from the legacy `getAppUUID`
+ * (which was misleadingly named `md5Hash` but used sha1) so the
+ * subdomain shape stays consistent. The hyphen separator means inputs
+ * like ("a-b", "c") and ("a", "b-c") collide — keep the separator
+ * unchanged so existing registrations remain valid.
  */
-export function computeAppHash(workspace: string, app: string): string {
+export function computeAppHash(principal: string, app: string): string {
   return createHash("sha1")
-    .update(`${workspace}-${app}`)
+    .update(`${principal}-${app}`)
     .digest("hex")
     .slice(0, 8);
 }
 
-export function computeAppDomain(workspace: string, app: string): string {
-  return `localhost-${computeAppHash(workspace, app)}.deco.host`;
+export function computeAppDomain(principal: string, app: string): string {
+  return `localhost-${computeAppHash(principal, app)}.deco.host`;
 }

--- a/apps/mesh/src/cli/lib/app-domain.ts
+++ b/apps/mesh/src/cli/lib/app-domain.ts
@@ -6,6 +6,10 @@ import { createHash } from "node:crypto";
  * getAppUUID so existing tunnel subdomains remain valid.
  *
  * (Yes, the legacy function was named md5Hash but used sha1.)
+ *
+ * The hyphen separator is intentional legacy behavior — the hash collides
+ * for inputs like ("a-b", "c") and ("a", "b-c"). Do not change the
+ * separator; doing so would invalidate existing tunnel registrations.
  */
 export function computeAppHash(workspace: string, app: string): string {
   return createHash("sha1")

--- a/apps/mesh/src/cli/lib/app-domain.ts
+++ b/apps/mesh/src/cli/lib/app-domain.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Legacy-compatible app hash. Returns the first 8 hex characters of
+ * sha1(`${workspace}-${app}`). Preserved exactly from packages/cli's
+ * getAppUUID so existing tunnel subdomains remain valid.
+ *
+ * (Yes, the legacy function was named md5Hash but used sha1.)
+ */
+export function computeAppHash(workspace: string, app: string): string {
+  return createHash("sha1")
+    .update(`${workspace}-${app}`)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+export function computeAppDomain(workspace: string, app: string): string {
+  return `localhost-${computeAppHash(workspace, app)}.deco.host`;
+}

--- a/apps/mesh/src/cli/lib/app-domain.ts
+++ b/apps/mesh/src/cli/lib/app-domain.ts
@@ -1,19 +1,10 @@
 import { createHash } from "node:crypto";
 
 /**
- * Stable app hash for tunnel subdomains. Returns the first 8 hex
- * characters of sha1(`${principal}-${app}`).
- *
- * `principal` is the per-user identifier from the OAuth session
- * (typically the OIDC `sub` claim); `app` is the local project name.
- * Same inputs always produce the same subdomain so tunnel registrations
- * are stable across reconnects.
- *
- * The algorithm is preserved exactly from the legacy `getAppUUID`
- * (which was misleadingly named `md5Hash` but used sha1) so the
- * subdomain shape stays consistent. The hyphen separator means inputs
- * like ("a-b", "c") and ("a", "b-c") collide — keep the separator
- * unchanged so existing registrations remain valid.
+ * Stable subdomain for a user's tunnel of a given app.
+ * `principal` is typically the OAuth `sub`; `app` the project name.
+ * Algorithm matches the legacy `getAppUUID` (sha1, despite its name)
+ * so existing tunnel registrations remain valid.
  */
 export function computeAppHash(principal: string, app: string): string {
   return createHash("sha1")

--- a/apps/mesh/src/cli/lib/clipboard.ts
+++ b/apps/mesh/src/cli/lib/clipboard.ts
@@ -1,0 +1,36 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Best-effort copy of `text` to the system clipboard. Returns true on success,
+ * false if the platform tool is missing or fails. Never throws.
+ */
+export function copyToClipboard(text: string): Promise<boolean> {
+  let command: string;
+  let args: string[] = [];
+  switch (process.platform) {
+    case "darwin":
+      command = "pbcopy";
+      break;
+    case "win32":
+      command = "clip";
+      break;
+    case "linux":
+      command = "xclip";
+      args = ["-selection", "clipboard"];
+      break;
+    default:
+      return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(command, args, { stdio: "pipe" });
+      child.on("error", () => resolve(false));
+      child.on("close", (code) => resolve(code === 0));
+      child.stdin.write(text);
+      child.stdin.end();
+    } catch {
+      resolve(false);
+    }
+  });
+}

--- a/apps/mesh/src/cli/lib/oauth-callback.test.ts
+++ b/apps/mesh/src/cli/lib/oauth-callback.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { startOAuthCallbackServer } from "./oauth-callback";
+
+describe("startOAuthCallbackServer", () => {
+  it("resolves with code + state when the browser hits the callback URL", async () => {
+    const server = await startOAuthCallbackServer({ expectedState: "nonce-1" });
+    try {
+      const result = fetch(`${server.url}/?code=abc&state=nonce-1`).then((r) =>
+        r.text(),
+      );
+      const callback = await server.waitForCallback();
+      expect(callback).toEqual({ code: "abc" });
+      const body = await result;
+      expect(body).toContain("You can return to your terminal");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects waitForCallback when state does not match", async () => {
+    const server = await startOAuthCallbackServer({ expectedState: "nonce-1" });
+    try {
+      await fetch(`${server.url}/?code=abc&state=wrong`);
+      await expect(server.waitForCallback()).rejects.toThrow(/state mismatch/i);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects waitForCallback when code is missing", async () => {
+    const server = await startOAuthCallbackServer({ expectedState: "nonce-1" });
+    try {
+      await fetch(`${server.url}/?state=nonce-1`);
+      await expect(server.waitForCallback()).rejects.toThrow(/missing code/i);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/apps/mesh/src/cli/lib/oauth-callback.test.ts
+++ b/apps/mesh/src/cli/lib/oauth-callback.test.ts
@@ -36,4 +36,19 @@ describe("startOAuthCallbackServer", () => {
       server.close();
     }
   });
+
+  it("returns 204 to follow-up requests after the promise has settled", async () => {
+    const server = await startOAuthCallbackServer({ expectedState: "nonce-1" });
+    try {
+      await fetch(`${server.url}/?code=abc&state=nonce-1`);
+      const callback = await server.waitForCallback();
+      expect(callback).toEqual({ code: "abc" });
+
+      // A second request (e.g. browser favicon prefetch) should be ignored.
+      const followUp = await fetch(`${server.url}/?code=other&state=nonce-1`);
+      expect(followUp.status).toBe(204);
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/apps/mesh/src/cli/lib/oauth-callback.ts
+++ b/apps/mesh/src/cli/lib/oauth-callback.ts
@@ -5,6 +5,7 @@ export interface OAuthCallback {
 export interface OAuthCallbackServer {
   url: string;
   waitForCallback: () => Promise<OAuthCallback>;
+  /** Always call this after waitForCallback resolves or rejects (e.g., via try/finally). */
   close: () => void;
 }
 
@@ -26,23 +27,30 @@ export async function startOAuthCallbackServer(
   // Suppress unhandled-rejection warnings; callers consume via waitForCallback().
   callbackPromise.catch(() => {});
 
+  let settled = false;
   const server = Bun.serve({
     port: options.port ?? 0,
     hostname: "127.0.0.1",
     fetch(req) {
+      if (settled) {
+        return new Response("", { status: 204 });
+      }
       const url = new URL(req.url);
       const code = url.searchParams.get("code");
       const state = url.searchParams.get("state");
       if (state !== options.expectedState) {
+        settled = true;
         rejectCallback(new Error("OAuth state mismatch"));
         return new Response("State mismatch — close this tab.", {
           status: 400,
         });
       }
       if (!code) {
+        settled = true;
         rejectCallback(new Error("OAuth callback missing code"));
         return new Response("Missing code — close this tab.", { status: 400 });
       }
+      settled = true;
       resolveCallback({ code });
       return new Response(SUCCESS_PAGE, {
         headers: { "content-type": "text/html; charset=utf-8" },

--- a/apps/mesh/src/cli/lib/oauth-callback.ts
+++ b/apps/mesh/src/cli/lib/oauth-callback.ts
@@ -1,0 +1,63 @@
+export interface OAuthCallback {
+  code: string;
+}
+
+export interface OAuthCallbackServer {
+  url: string;
+  waitForCallback: () => Promise<OAuthCallback>;
+  close: () => void;
+}
+
+export interface StartOptions {
+  expectedState: string;
+  /** If provided, bind to this port. Defaults to 0 (OS-chosen). */
+  port?: number;
+}
+
+export async function startOAuthCallbackServer(
+  options: StartOptions,
+): Promise<OAuthCallbackServer> {
+  let resolveCallback!: (value: OAuthCallback) => void;
+  let rejectCallback!: (err: Error) => void;
+  const callbackPromise = new Promise<OAuthCallback>((resolve, reject) => {
+    resolveCallback = resolve;
+    rejectCallback = reject;
+  });
+  // Suppress unhandled-rejection warnings; callers consume via waitForCallback().
+  callbackPromise.catch(() => {});
+
+  const server = Bun.serve({
+    port: options.port ?? 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const url = new URL(req.url);
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      if (state !== options.expectedState) {
+        rejectCallback(new Error("OAuth state mismatch"));
+        return new Response("State mismatch — close this tab.", {
+          status: 400,
+        });
+      }
+      if (!code) {
+        rejectCallback(new Error("OAuth callback missing code"));
+        return new Response("Missing code — close this tab.", { status: 400 });
+      }
+      resolveCallback({ code });
+      return new Response(SUCCESS_PAGE, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    },
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    waitForCallback: () => callbackPromise,
+    close: () => server.stop(true),
+  };
+}
+
+const SUCCESS_PAGE = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Login complete</title>
+<style>body{font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#0b0b0b;color:#0f0}</style>
+</head><body><div><h1>You're logged in.</h1><p>You can return to your terminal.</p></div></body></html>`;

--- a/apps/mesh/src/cli/lib/pkce.test.ts
+++ b/apps/mesh/src/cli/lib/pkce.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { generatePkcePair } from "./pkce";
+
+describe("generatePkcePair", () => {
+  it("returns a verifier between 43 and 128 base64url chars (RFC 7636)", () => {
+    const { verifier } = generatePkcePair();
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("derives the challenge as base64url(sha256(verifier))", () => {
+    const { verifier, challenge } = generatePkcePair();
+    const expected = createHash("sha256")
+      .update(verifier)
+      .digest("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(challenge).toBe(expected);
+  });
+
+  it("produces different pairs on each call", () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+  });
+});

--- a/apps/mesh/src/cli/lib/pkce.ts
+++ b/apps/mesh/src/cli/lib/pkce.ts
@@ -1,0 +1,24 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Generate an OAuth 2.1 PKCE pair (RFC 7636).
+ *
+ * Returns a high-entropy code_verifier and its derived S256 code_challenge.
+ * The verifier is sent to the token endpoint to prove possession; the
+ * challenge is sent up-front to the authorize endpoint.
+ */
+export function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64UrlEncode(randomBytes(32));
+  const challenge = base64UrlEncode(
+    createHash("sha256").update(verifier).digest(),
+  );
+  return { verifier, challenge };
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}

--- a/apps/mesh/src/cli/lib/port-wait.test.ts
+++ b/apps/mesh/src/cli/lib/port-wait.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { type Server, createServer } from "node:net";
+import { findRunningAddr, waitForPort } from "./port-wait";
+
+const openServers: Server[] = [];
+
+async function listenOn(host: string, port: number): Promise<void> {
+  const srv = createServer();
+  await new Promise<void>((resolve, reject) => {
+    srv.once("error", reject);
+    srv.listen(port, host, () => resolve());
+  });
+  openServers.push(srv);
+}
+
+async function ephemeralPort(): Promise<number> {
+  const srv = createServer();
+  return new Promise<number>((resolve, reject) => {
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+afterEach(() => {
+  while (openServers.length) {
+    const srv = openServers.pop();
+    srv?.close();
+  }
+});
+
+describe("findRunningAddr", () => {
+  it("returns null when the port is unused", async () => {
+    const port = await ephemeralPort();
+    expect(await findRunningAddr(port)).toBeNull();
+  });
+
+  it("returns the host when something is listening", async () => {
+    const port = await ephemeralPort();
+    await listenOn("127.0.0.1", port);
+    expect(await findRunningAddr(port)).toBe("127.0.0.1");
+  });
+});
+
+describe("waitForPort", () => {
+  it("resolves immediately when the port is already in use", async () => {
+    const port = await ephemeralPort();
+    await listenOn("127.0.0.1", port);
+    expect(await waitForPort(port, { intervalMs: 10 })).toBe("127.0.0.1");
+  });
+
+  it("waits until the port becomes available, then resolves", async () => {
+    const port = await ephemeralPort();
+    const promise = waitForPort(port, { intervalMs: 20 });
+    setTimeout(() => {
+      void listenOn("127.0.0.1", port);
+    }, 60);
+    expect(await promise).toBe("127.0.0.1");
+  });
+});

--- a/apps/mesh/src/cli/lib/port-wait.test.ts
+++ b/apps/mesh/src/cli/lib/port-wait.test.ts
@@ -43,6 +43,32 @@ describe("findRunningAddr", () => {
     await listenOn("127.0.0.1", port);
     expect(await findRunningAddr(port)).toBe("127.0.0.1");
   });
+
+  it("returns null when bind fails for a non-EADDRINUSE reason", async () => {
+    // Privileged port < 1024 returns EACCES for non-root users on POSIX.
+    // On platforms where this somehow succeeds (e.g., macOS recent versions
+    // allow port 80 in some configs), skip the test.
+    if (process.platform === "win32" || process.getuid?.() === 0) {
+      return; // skip on Windows or when running as root
+    }
+    // Probe all localhost-flavoured addresses that findRunningAddr probes.
+    // If ANY of them allow binding port 80 without EACCES, this environment
+    // doesn't restrict privileged ports — skip to avoid false failures.
+    const hosts = ["localhost", "127.0.0.1", "0.0.0.0"];
+    for (const host of hosts) {
+      const code = await new Promise<string | undefined>((resolve) => {
+        const probe = createServer();
+        probe.once("error", (err: NodeJS.ErrnoException) => {
+          resolve(err.code);
+        });
+        probe.listen(80, host, () => {
+          probe.close(() => resolve(undefined));
+        });
+      });
+      if (code !== "EACCES") return; // platform allows binding or different error; skip
+    }
+    expect(await findRunningAddr(80)).toBeNull();
+  });
 });
 
 describe("waitForPort", () => {

--- a/apps/mesh/src/cli/lib/port-wait.ts
+++ b/apps/mesh/src/cli/lib/port-wait.ts
@@ -1,0 +1,44 @@
+import { createServer } from "node:net";
+
+const LOCALHOST_ENDPOINTS = ["localhost", "127.0.0.1", "0.0.0.0"];
+
+/**
+ * Probe each localhost-flavoured endpoint and return the first one where
+ * binding `port` fails — i.e. something is already listening there.
+ * Returns null if the port is free everywhere.
+ */
+export async function findRunningAddr(port: number): Promise<string | null> {
+  for (const host of LOCALHOST_ENDPOINTS) {
+    const inUse = await isInUse(host, port);
+    if (inUse) return host;
+  }
+  return null;
+}
+
+export interface WaitForPortOptions {
+  intervalMs?: number;
+}
+
+/**
+ * Resolve when something is listening on `port`. Polls every `intervalMs`.
+ */
+export async function waitForPort(
+  port: number,
+  { intervalMs = 1000 }: WaitForPortOptions = {},
+): Promise<string> {
+  for (;;) {
+    const addr = await findRunningAddr(port);
+    if (addr) return addr;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+function isInUse(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once("error", () => resolve(true));
+    srv.listen(port, host, () => {
+      srv.close(() => resolve(false));
+    });
+  });
+}

--- a/apps/mesh/src/cli/lib/port-wait.ts
+++ b/apps/mesh/src/cli/lib/port-wait.ts
@@ -36,7 +36,9 @@ export async function waitForPort(
 function isInUse(host: string, port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const srv = createServer();
-    srv.once("error", () => resolve(true));
+    srv.once("error", (err: NodeJS.ErrnoException) => {
+      resolve(err.code === "EADDRINUSE");
+    });
     srv.listen(port, host, () => {
       srv.close(() => resolve(false));
     });

--- a/apps/mesh/src/cli/lib/session.test.ts
+++ b/apps/mesh/src/cli/lib/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, rm, writeFile, stat } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -51,6 +51,21 @@ describe("writeSession + readSession", () => {
     const s = await stat(sessionPath(dir));
     // Mask off the file-type bits and compare permission bits.
     expect(s.mode & 0o777).toBe(0o600);
+  });
+
+  it("forces mode 0600 even when overwriting an existing file with looser permissions", async () => {
+    const path = sessionPath(dir);
+    // Pre-create the file with mode 0644 to simulate a broken prior state.
+    await writeFile(path, "{}", { mode: 0o644 });
+    await chmod(path, 0o644); // ensure 0644 even if writeFile honored mode
+    const before = await stat(path);
+    expect(before.mode & 0o777).toBe(0o644);
+
+    await writeSession(dir, sample);
+
+    const after = await stat(path);
+    expect(after.mode & 0o777).toBe(0o600);
+    expect(await readSession(dir)).toEqual(sample);
   });
 });
 

--- a/apps/mesh/src/cli/lib/session.test.ts
+++ b/apps/mesh/src/cli/lib/session.test.ts
@@ -22,9 +22,9 @@ afterEach(async () => {
 
 const sample: Session = {
   target: "https://studio.decocms.com",
-  workspace: "tlgimenes",
-  user: { id: "u_1", email: "tlgimenes@gmail.com" },
-  token: "tok_abc",
+  clientId: "client_abc",
+  user: { sub: "u_1", email: "tlgimenes@gmail.com" },
+  accessToken: "tok_abc",
   createdAt: "2026-05-04T12:00:00.000Z",
 };
 

--- a/apps/mesh/src/cli/lib/session.test.ts
+++ b/apps/mesh/src/cli/lib/session.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type Session,
+  readSession,
+  writeSession,
+  clearSession,
+  sessionPath,
+} from "./session";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "deco-session-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+const sample: Session = {
+  target: "https://studio.decocms.com",
+  workspace: "tlgimenes",
+  user: { id: "u_1", email: "tlgimenes@gmail.com" },
+  token: "tok_abc",
+  createdAt: "2026-05-04T12:00:00.000Z",
+};
+
+describe("sessionPath", () => {
+  it("places session.json directly in the given data dir", () => {
+    expect(sessionPath("/tmp/x")).toBe("/tmp/x/session.json");
+  });
+});
+
+describe("writeSession + readSession", () => {
+  it("round-trips a session object", async () => {
+    await writeSession(dir, sample);
+    expect(await readSession(dir)).toEqual(sample);
+  });
+
+  it("creates the data dir if it does not exist", async () => {
+    const nested = join(dir, "nested", "deeper");
+    await writeSession(nested, sample);
+    expect(await readSession(nested)).toEqual(sample);
+  });
+
+  it("writes the file with mode 0600", async () => {
+    await writeSession(dir, sample);
+    const s = await stat(sessionPath(dir));
+    // Mask off the file-type bits and compare permission bits.
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("readSession", () => {
+  it("returns null when the file does not exist", async () => {
+    expect(await readSession(dir)).toBeNull();
+  });
+
+  it("returns null and does not throw when the file is malformed JSON", async () => {
+    await writeFile(sessionPath(dir), "not-json", { mode: 0o600 });
+    expect(await readSession(dir)).toBeNull();
+  });
+
+  it("returns null when the file is missing required fields", async () => {
+    await writeFile(sessionPath(dir), JSON.stringify({ target: "x" }), {
+      mode: 0o600,
+    });
+    expect(await readSession(dir)).toBeNull();
+  });
+});
+
+describe("clearSession", () => {
+  it("removes the session file", async () => {
+    await writeSession(dir, sample);
+    await clearSession(dir);
+    expect(await readSession(dir)).toBeNull();
+  });
+
+  it("is a no-op when the file does not exist", async () => {
+    await clearSession(dir);
+    expect(await readSession(dir)).toBeNull();
+  });
+});

--- a/apps/mesh/src/cli/lib/session.ts
+++ b/apps/mesh/src/cli/lib/session.ts
@@ -1,4 +1,11 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 export interface Session {
@@ -30,7 +37,12 @@ export async function writeSession(
 ): Promise<void> {
   const path = sessionPath(dataDir);
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(session, null, 2), { mode: 0o600 });
+  // Write to a temp path, force mode 0600 (writeFile's `mode` is ignored when
+  // overwriting an existing file), then atomically rename into place.
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, JSON.stringify(session, null, 2), { mode: 0o600 });
+  await chmod(tmp, 0o600);
+  await rename(tmp, path);
 }
 
 export async function clearSession(dataDir: string): Promise<void> {

--- a/apps/mesh/src/cli/lib/session.ts
+++ b/apps/mesh/src/cli/lib/session.ts
@@ -1,0 +1,53 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export interface Session {
+  target: string;
+  workspace: string;
+  user: { id: string; email: string };
+  token: string;
+  createdAt: string;
+}
+
+export function sessionPath(dataDir: string): string {
+  return join(dataDir, "session.json");
+}
+
+export async function readSession(dataDir: string): Promise<Session | null> {
+  try {
+    const raw = await readFile(sessionPath(dataDir), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isSession(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSession(
+  dataDir: string,
+  session: Session,
+): Promise<void> {
+  const path = sessionPath(dataDir);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(session, null, 2), { mode: 0o600 });
+}
+
+export async function clearSession(dataDir: string): Promise<void> {
+  await rm(sessionPath(dataDir), { force: true });
+}
+
+function isSession(value: unknown): value is Session {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.target === "string" &&
+    typeof v.workspace === "string" &&
+    typeof v.token === "string" &&
+    typeof v.createdAt === "string" &&
+    typeof v.user === "object" &&
+    v.user !== null &&
+    typeof (v.user as Record<string, unknown>).id === "string" &&
+    typeof (v.user as Record<string, unknown>).email === "string"
+  );
+}

--- a/apps/mesh/src/cli/lib/session.ts
+++ b/apps/mesh/src/cli/lib/session.ts
@@ -9,10 +9,19 @@ import {
 import { dirname, join } from "node:path";
 
 export interface Session {
+  /** OAuth issuer / decocms target (e.g. https://studio.decocms.com). */
   target: string;
-  workspace: string;
-  user: { id: string; email: string };
-  token: string;
+  /** Dynamically-registered OAuth client id for this CLI install. */
+  clientId: string;
+  /** OIDC subject identifier (stable per user). */
+  user: { sub: string; email?: string; name?: string };
+  /** Bearer token used for API + Warp tunnel auth. */
+  accessToken: string;
+  /** Refresh token for renewing the access token (when granted). */
+  refreshToken?: string;
+  /** Unix epoch (seconds) when accessToken expires, when known. */
+  expiresAt?: number;
+  /** ISO timestamp when this session was minted. */
   createdAt: string;
 }
 
@@ -52,14 +61,16 @@ export async function clearSession(dataDir: string): Promise<void> {
 function isSession(value: unknown): value is Session {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
-  return (
-    typeof v.target === "string" &&
-    typeof v.workspace === "string" &&
-    typeof v.token === "string" &&
-    typeof v.createdAt === "string" &&
-    typeof v.user === "object" &&
-    v.user !== null &&
-    typeof (v.user as Record<string, unknown>).id === "string" &&
-    typeof (v.user as Record<string, unknown>).email === "string"
-  );
+  if (
+    typeof v.target !== "string" ||
+    typeof v.clientId !== "string" ||
+    typeof v.accessToken !== "string" ||
+    typeof v.createdAt !== "string"
+  ) {
+    return false;
+  }
+  if (!v.user || typeof v.user !== "object") return false;
+  const u = v.user as Record<string, unknown>;
+  if (typeof u.sub !== "string") return false;
+  return true;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "@aws-sdk/client-s3": "^3.1013.0",
         "@aws-sdk/s3-request-presigner": "^3.1013.0",
         "@clickhouse/client": "^1.8.1",
-        "@deco-cx/warp-node": "0.3.21-debug.2",
+        "@deco-cx/warp-node": "^0.3.20",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -681,7 +681,7 @@
 
     "@daveyplate/better-auth-ui": ["@daveyplate/better-auth-ui@3.4.0", "", { "dependencies": { "@better-auth/api-key": "^1.5.6", "@better-fetch/fetch": "^1.1.21", "@hcaptcha/react-hcaptcha": "^2.0.2", "@noble/hashes": "^2.0.1", "@react-email/components": "^1.0.10", "@wojtekmaj/react-recaptcha-v3": "^0.1.4", "better-call": "2.0.2", "bowser": "^2.11.0", "react-google-recaptcha": "^3.1.0", "react-qr-code": "^2.0.18", "vaul": "^1.1.2" }, "peerDependencies": { "@better-auth/passkey": ">=1.4.6", "@captchafox/react": "^1.10.0", "@daveyplate/better-auth-tanstack": "^1.3.6", "@hookform/resolvers": ">=5.2.0", "@instantdb/react": ">=0.18.0", "@marsidev/react-turnstile": ">=1.1.0", "@radix-ui/react-avatar": ">=1.1.0", "@radix-ui/react-checkbox": ">=1.1.0", "@radix-ui/react-context": ">=1.1.0", "@radix-ui/react-dialog": ">=1.1.0", "@radix-ui/react-dropdown-menu": ">=2.1.0", "@radix-ui/react-label": ">=2.1.0", "@radix-ui/react-primitive": ">=2.0.0", "@radix-ui/react-select": ">=2.2.0", "@radix-ui/react-separator": ">=1.1.0", "@radix-ui/react-slot": ">=1.1.0", "@radix-ui/react-tabs": ">=1.1.0", "@radix-ui/react-tooltip": ">=1.2.0", "@radix-ui/react-use-callback-ref": ">=1.1.0", "@radix-ui/react-use-layout-effect": ">=1.1.0", "@tanstack/react-query": ">=5.66.0", "@triplit/client": ">=1.0.0", "@triplit/react": ">=1.0.0", "better-auth": "^1.4.6", "class-variance-authority": ">=0.7.0", "clsx": ">=2.1.0", "input-otp": ">=1.4.0", "lucide-react": ">=0.469.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-hook-form": ">=7.55.0", "sonner": ">=1.7.0", "tailwind-merge": ">=2.6.0", "tailwindcss": ">=3.0.0", "zod": ">=3.0.0" } }, "sha512-mGA0cKsAk0AcoKkxjff2xQOviMrUDDN+9SsRusURP/kiTmoLvWAv8utaPex0GFLHKm1w3BrLBdJRg9B2LkT7Bw=="],
 
-    "@deco-cx/warp-node": ["@deco-cx/warp-node@0.3.21-debug.2", "", { "dependencies": { "undici": "^6.21.0", "ws": "^8.18.0" } }, "sha512-60MyUXPWYBDdRiQNIbEZQwnYmarpv82HjH+HxqtT0nx7LA4hElSiXCF3SR7jIuXxFt29gqJ3+6GHYSmr/VI14w=="],
+    "@deco-cx/warp-node": ["@deco-cx/warp-node@0.3.20", "", { "dependencies": { "undici": "^6.21.0", "ws": "^8.18.0" } }, "sha512-rdRWrT5eMhu1zhAzliRkoQCUr2j6Dg9npUKoP4uP+rV9wIbYKSmXJbM2z/fOiy5FVvzQlpvY16ACNRIRz+UWqw=="],
 
     "@deco/ui": ["@deco/ui@workspace:packages/ui"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.297.0",
+      "version": "2.302.6",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -65,6 +65,7 @@
         "@aws-sdk/client-s3": "^3.1013.0",
         "@aws-sdk/s3-request-presigner": "^3.1013.0",
         "@clickhouse/client": "^1.8.1",
+        "@deco-cx/warp-node": "0.3.21-debug.2",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -295,7 +296,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "0.2.1",
+      "version": "0.3.2",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
         "@opentelemetry/api": "^1.9.0",
@@ -679,6 +680,8 @@
     "@daveyplate/better-auth-tanstack": ["@daveyplate/better-auth-tanstack@1.3.6", "", { "peerDependencies": { "@tanstack/query-core": ">=5.65.0", "@tanstack/react-query": ">=5.65.0", "better-auth": ">=1.2.8", "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-GvIGdbjRMZCEfAffU7LeWpGpie4vSli8V9jmNFCQOziZZMEFbO4cd53HBFmAushC9oEYIyhSNZBgV2ADzW94Ww=="],
 
     "@daveyplate/better-auth-ui": ["@daveyplate/better-auth-ui@3.4.0", "", { "dependencies": { "@better-auth/api-key": "^1.5.6", "@better-fetch/fetch": "^1.1.21", "@hcaptcha/react-hcaptcha": "^2.0.2", "@noble/hashes": "^2.0.1", "@react-email/components": "^1.0.10", "@wojtekmaj/react-recaptcha-v3": "^0.1.4", "better-call": "2.0.2", "bowser": "^2.11.0", "react-google-recaptcha": "^3.1.0", "react-qr-code": "^2.0.18", "vaul": "^1.1.2" }, "peerDependencies": { "@better-auth/passkey": ">=1.4.6", "@captchafox/react": "^1.10.0", "@daveyplate/better-auth-tanstack": "^1.3.6", "@hookform/resolvers": ">=5.2.0", "@instantdb/react": ">=0.18.0", "@marsidev/react-turnstile": ">=1.1.0", "@radix-ui/react-avatar": ">=1.1.0", "@radix-ui/react-checkbox": ">=1.1.0", "@radix-ui/react-context": ">=1.1.0", "@radix-ui/react-dialog": ">=1.1.0", "@radix-ui/react-dropdown-menu": ">=2.1.0", "@radix-ui/react-label": ">=2.1.0", "@radix-ui/react-primitive": ">=2.0.0", "@radix-ui/react-select": ">=2.2.0", "@radix-ui/react-separator": ">=1.1.0", "@radix-ui/react-slot": ">=1.1.0", "@radix-ui/react-tabs": ">=1.1.0", "@radix-ui/react-tooltip": ">=1.2.0", "@radix-ui/react-use-callback-ref": ">=1.1.0", "@radix-ui/react-use-layout-effect": ">=1.1.0", "@tanstack/react-query": ">=5.66.0", "@triplit/client": ">=1.0.0", "@triplit/react": ">=1.0.0", "better-auth": "^1.4.6", "class-variance-authority": ">=0.7.0", "clsx": ">=2.1.0", "input-otp": ">=1.4.0", "lucide-react": ">=0.469.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-hook-form": ">=7.55.0", "sonner": ">=1.7.0", "tailwind-merge": ">=2.6.0", "tailwindcss": ">=3.0.0", "zod": ">=3.0.0" } }, "sha512-mGA0cKsAk0AcoKkxjff2xQOviMrUDDN+9SsRusURP/kiTmoLvWAv8utaPex0GFLHKm1w3BrLBdJRg9B2LkT7Bw=="],
+
+    "@deco-cx/warp-node": ["@deco-cx/warp-node@0.3.21-debug.2", "", { "dependencies": { "undici": "^6.21.0", "ws": "^8.18.0" } }, "sha512-60MyUXPWYBDdRiQNIbEZQwnYmarpv82HjH+HxqtT0nx7LA4hElSiXCF3SR7jIuXxFt29gqJ3+6GHYSmr/VI14w=="],
 
     "@deco/ui": ["@deco/ui@workspace:packages/ui"],
 
@@ -3250,7 +3253,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+    "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -3797,6 +3800,8 @@
     "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 


### PR DESCRIPTION
## Summary

Brings back the legacy `deco link` Warp tunnel as `bunx decocms link` and adds a new `auth` namespace (`login`, `whoami`, `logout`) so the CLI can authenticate against a remote decocms instance (default `https://studio.decocms.com`).

**The CLI is a standard OAuth 2.1 + PKCE client of the existing Better Auth MCP plugin.** It dynamically registers itself as a public client, opens the production `/login` page so users see the same UI they're used to, then exchanges the authorization code at the standard token endpoint. No new server-side endpoints were needed.

```
bunx decocms auth login [--target <url>]   # browser OAuth → persists session
bunx decocms auth whoami                   # show target / user
bunx decocms auth logout                   # clear session

bunx decocms link [-p <port>] [-e <env>] [-- <command>]
```

`link` tunnels a local port to a stable `https://localhost-<sha1-8>.deco.host` URL bound to the user's OIDC `sub`, optionally spawning a child dev server with the public URL injected as `BASE_URL` (or a custom env var via `-e`). Reconnects forever until cancelled or until a spawned child exits. Auto-triggers `auth login` if no session is present.

The Warp tunnel is now authenticated with the user's OAuth access token. Subdomains use the same `sha1(...).slice(0,8)` algorithm as the legacy CLI for backward-compatible URL shape; the inputs change from workspace+app to sub+app since the auth model itself changed.

## OAuth flow

1. `POST /api/auth/mcp/register` — dynamic client registration (RFC 7591).
2. Generate PKCE pair (RFC 7636, S256).
3. Open `/login?client_id=...&redirect_uri=...&response_type=code&state=...&code_challenge=...&code_challenge_method=S256` — the existing `/login` UI handles auth and routes to `/api/auth/mcp/authorize` after sign-in.
4. Browser is redirected to a local callback listener at `http://127.0.0.1:<port>/?code=...&state=...`.
5. `POST /api/auth/mcp/token` with the `code_verifier` exchanges the code for an access + id token.
6. Decode the id_token JWT to extract `sub`, `email`, `name` (the `userinfo` endpoint is advertised in the OAuth metadata but returns 404 in upstream; the id_token has the same claims).

## What's new

- 6 lib primitives under `apps/mesh/src/cli/lib/`: `app-domain`, `session`, `port-wait`, `clipboard`, `oauth-callback`, `pkce`.
- 4 commands under `apps/mesh/src/cli/commands/`: `auth/login`, `auth/whoami`, `auth/logout`, `link`.
- `apps/mesh/src/cli.ts` gains `auth` and `link` subcommand routing plus `--target`/`-e` flags and updated `--help` text.
- Adds `@deco-cx/warp-node@^0.3.20` as a runtime dependency.
- 41 CLI tests, all using real I/O via dependency injection.

## End-to-end test (against `bun run dev`)

Verified using a driver that simulates the browser via the local-mode auto-login endpoint:

```
=== auth login ===
Opening http://localhost:3000/login?client_id=...&redirect_uri=...&response_type=code&...
Logged in as gimenes@localhost.mesh.
exit=0

=== auth whoami ===
Target: http://localhost:3000
User:   gimenes@localhost.mesh
exit=0

=== link (with mock tunnelOpener) ===
Tunnel will connect to existing service on port 9999.
tunnelOpener called with:
  domain:    localhost-7aa4cca4.deco.host
  localAddr: http://127.0.0.1:9999
  apiKey:    ZqHYywIDgLBA... (32 chars)
  server:    wss://localhost-7aa4cca4.deco.host
Tunnel open: https://localhost-7aa4cca4.deco.host
```

The OAuth access token is correctly forwarded to the Warp tunnel client.

## Known follow-ups (out of scope)

- **Warp server token verification:** Warp must verify the bearer token against the requesting subject (was the legacy hardcoded shared key). Tracked separately. The CLI side is ready.
- **Token refresh:** session persists `refreshToken` and `expiresAt`, but no auto-refresh logic yet. `auth login` re-runs as needed.
- **Tunnel auth-failure surface:** `TunnelHandle` has a TODO to surface auth rejection so `link` can break the reconnect loop with a "session may be expired" hint instead of retrying generically.

## Test plan

- [x] `bun test apps/mesh/src/cli` — 41/41 passing
- [x] `bun run check` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run fmt:check` — clean
- [x] `bun run knip` — no unused exports
- [x] End-to-end against `bun run dev`: login, whoami, logout, link (mocked Warp opener) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)