### PR TITLE
fix(cli): unblock 'decocms link' — revert Warp apiKey to legacy shared key + add registration timeout

### DIFF
--- a/apps/mesh/src/cli/commands/link.test.ts
+++ b/apps/mesh/src/cli/commands/link.test.ts
@@ -154,6 +154,58 @@ describe("linkCommand", () => {
     await result.cancel();
   });
 
+  it("logs and retries when tunnelOpener throws (e.g. registration timeout)", async () => {
+    cwdDir = await makeProject("my-app");
+    await writeSession(dir, {
+      target: "https://studio.decocms.com",
+      clientId: "client_x",
+      user: { sub: "u", email: "u@x" },
+      accessToken: "tok",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    const errMessages: string[] = [];
+    const errSpy = spyOn(console, "error").mockImplementation(
+      (msg: unknown) => {
+        errMessages.push(String(msg));
+      },
+    );
+
+    let openCount = 0;
+    const tunnelOpener = mock<TunnelOpener>(async () => {
+      openCount += 1;
+      if (openCount === 1) {
+        throw new Error("Tunnel registration timed out after 15s");
+      }
+      return { closed: new Promise<void>(() => {}), close: () => {} };
+    });
+
+    const result = linkCommand({
+      cwd: cwdDir,
+      dataDir: dir,
+      port: 8787,
+      env: "BASE_URL",
+      runCommand: [],
+      tunnelOpener,
+      portWaiter: async () => "127.0.0.1",
+      copyClipboard: async () => false,
+      ensureSession: async () => null,
+      reconnectDelayMs: 5,
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(openCount).toBeGreaterThanOrEqual(2);
+    expect(
+      errMessages.some((m) =>
+        m.includes(
+          "Tunnel connect failed, retrying: Tunnel registration timed out",
+        ),
+      ),
+    ).toBe(true);
+    await result.cancel();
+    errSpy.mockRestore();
+  });
+
   it("returns non-zero when package.json is missing a name", async () => {
     cwdDir = await mkdtemp(join(tmpdir(), "deco-link-noname-"));
     await writeFile(join(cwdDir, "package.json"), "{}");

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -207,15 +207,39 @@ function defaultEnsureSession(dataDir: string): () => Promise<Session | null> {
   };
 }
 
+// The Warp tunnel server still expects the legacy shared key — it does not
+// yet verify OAuth bearer tokens. Until that lands, fall back to this
+// hardcoded value (overridable via DECO_TUNNEL_SERVER_TOKEN) so `link`
+// works end-to-end. The session's OAuth access token from `params.apiKey`
+// is intentionally ignored here for now; we keep storing it on the
+// session so we can flip the source back in one line once Warp is ready.
+const LEGACY_TUNNEL_TOKEN = "c309424a-2dc4-46fe-bfc7-a7c10df59477";
+
+// If `tunnel.registered` doesn't resolve within this window, the Warp
+// server most likely silently rejected the auth. Surface that as an
+// error instead of hanging indefinitely.
+const REGISTRATION_TIMEOUT_MS = 15_000;
+
 const defaultTunnelOpener: TunnelOpener = async (params) => {
   const { connect } = await import("@deco-cx/warp-node");
   const tunnel = await connect({
     domain: params.domain,
     localAddr: params.localAddr,
     server: params.server,
-    apiKey: params.apiKey,
+    apiKey: process.env.DECO_TUNNEL_SERVER_TOKEN ?? LEGACY_TUNNEL_TOKEN,
   });
-  await tunnel.registered;
+  await Promise.race([
+    tunnel.registered,
+    new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(
+          new Error(
+            `Tunnel registration timed out after ${REGISTRATION_TIMEOUT_MS / 1000}s — Warp server may have rejected the auth. Try upgrading the CLI.`,
+          ),
+        );
+      }, REGISTRATION_TIMEOUT_MS);
+    }),
+  ]);
   return {
     // Connected.closed resolves with Error | undefined; we discard the value
     // to satisfy TunnelHandle.closed: Promise<void>.


### PR DESCRIPTION
## Problem

`bunx decocms@2.304.0 link -p <port> -- bun run dev` completes the OAuth login flow but then **hangs silently** with no tunnel URL ever printed. Reported in https://github.com/decocms/studio/pull/3282.

## Root cause

PR #3282 pivoted the CLI to send the user's OAuth access token as the Warp tunnel apiKey, but the Warp tunnel server still expects the legacy shared key for the register handshake — it has not yet been updated to verify OAuth bearer tokens.

When the OAuth token is sent:
1. The WebSocket connects.
2. The CLI sends `{ type: "register", apiKey: <oauthToken>, domain: ... }`.
3. The Warp server silently drops the registration (no "registered" message, no error message).
4. `tunnel.registered` never resolves.
5. Our `defaultTunnelOpener` does `await tunnel.registered` indefinitely.
6. User sees `"Starting: bun run dev"` and then total silence.

## Fix

Two changes in `apps/mesh/src/cli/commands/link.ts`:

1. **`defaultTunnelOpener` now sends the legacy shared key** for the Warp connect (overridable via `DECO_TUNNEL_SERVER_TOKEN`), restoring end-to-end functionality today. The OAuth access token is still persisted on the session — we'll flip the source back in one line once the Warp server is updated.

2. **`tunnel.registered` is wrapped in a 15s timeout.** If Warp ever silently drops the registration again (auth changes, infra hiccup), the user sees a clear error message instead of a silent hang:

   ```
   Tunnel connect failed, retrying: Tunnel registration timed out after 15s — Warp server may have rejected the auth. Try upgrading the CLI.
   ```

   The existing reconnect loop surfaces this every 15s so it stays visible.

## Test plan

- [x] New unit test verifies `tunnelOpener` throwing on registration is logged and retried (`link.test.ts`)
- [x] `bun test apps/mesh/src/cli` — 42/42 passing
- [x] `bun run check` — clean
- [x] `bun run lint` — clean
- [x] Manual smoke against published `bun run dev` — link reaches "Tunnel open" with a working URL
- [ ] Bump version + publish so `bunx decocms@latest link` actually works for users

## Follow-up tracked

The Warp tunnel server still needs to verify OAuth access tokens for proper per-user auth. Once that lands, change one line in `defaultTunnelOpener` from the env-fallback to `params.apiKey`. The 15s timeout will then act as a safety net during the cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks `decocms link` by restoring Warp tunnel registration with the legacy shared key and adding a 15s registration timeout. This fixes the silent hang after OAuth login so the tunnel URL is printed.

- **Bug Fixes**
  - `defaultTunnelOpener` now sends the legacy shared key to the Warp server (override via `DECO_TUNNEL_SERVER_TOKEN`); the OAuth token remains stored for a future switch.
  - Wrapped `tunnel.registered` in a 15s timeout to show a clear error and trigger reconnects instead of hanging.
  - Added a unit test to confirm the CLI logs the failure and retries when registration times out.

<sup>Written for commit 315ea8df77523f9dc7a7702ba54f44a75b4848c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

