### PR TITLE
fix(web): wrap main panel in error boundary

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -23,6 +23,7 @@ import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { computeChatMainSizes } from "@/web/hooks/use-layout-state";
 import { ChatCenterPanel } from "@/web/layouts/chat-center-panel";
 import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
+import { ErrorBoundary } from "@/web/components/error-boundary";
 
 function PersistentChatPanel({
   children,
@@ -129,7 +130,9 @@ export function ChatMainPanelGroup({
             )}
           >
             <div className="flex-1 min-h-0 overflow-hidden">
-              <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
+              <ErrorBoundary>
+                <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
+              </ErrorBoundary>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What is this contribution about?
The right-side main panel in the agent shell layout (`chat-main-panel-group.tsx`) renders `MainPanelContent` directly with no error boundary. The chat panel beside it is already wrapped via `ActiveTaskBoundary`, so a throw inside any main-panel tab would bubble past the panel group and take down the chat too. This wraps `MainPanelContent` in the existing `@/web/components/error-boundary` so a tab error stays contained, shows the default "Something went wrong" fallback with a Try again reset, and gets reported to PostHog.

## How to Test
1. Temporarily throw an error inside a component rendered by `MainPanelContent` (e.g. `throw new Error("boom")` in a tab).
2. Open the agent shell view — the main panel should show the fallback UI with a Try again button.
3. The chat panel on the left should keep working.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap `MainPanelContent` in `ErrorBoundary` so errors in any main-panel tab are contained and don’t crash the chat panel. Shows the default fallback with “Try again” and reports errors to PostHog.

<sup>Written for commit bbddab1b5a66e399dd71e384541250cc038e0ebb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

