### PR TITLE
feat(ai-providers): allow editing API key labels

### DIFF
--- a/apps/mesh/src/storage/ai-provider-keys.ts
+++ b/apps/mesh/src/storage/ai-provider-keys.ts
@@ -178,6 +178,33 @@ export class AIProviderKeyStorage {
     };
   }
 
+  async updateLabel(
+    keyId: string,
+    organizationId: string,
+    label: string,
+  ): Promise<ProviderKeyInfo> {
+    const row = await this.db
+      .updateTable("ai_provider_keys")
+      .set({ label })
+      .where("id", "=", keyId)
+      .where("organization_id", "=", organizationId)
+      .returning([
+        "id",
+        "provider_id",
+        "label",
+        "preset_id",
+        "organization_id",
+        "created_by",
+        "created_at",
+      ])
+      .executeTakeFirst();
+
+    if (!row) {
+      throw new Error(`AI provider key ${keyId} not found`);
+    }
+    return this.rowToKeyInfo(row);
+  }
+
   async delete(keyId: string, organizationId: string): Promise<void> {
     const result = await this.db
       .deleteFrom("ai_provider_keys")

--- a/apps/mesh/src/tools/ai-providers/index.ts
+++ b/apps/mesh/src/tools/ai-providers/index.ts
@@ -3,6 +3,7 @@ export { AI_PROVIDERS_LIST_MODELS } from "./list-models";
 export { AI_PROVIDERS_ACTIVE } from "./list-active";
 export { AI_PROVIDER_KEY_CREATE } from "./key-create";
 export { AI_PROVIDER_KEY_DELETE } from "./key-delete";
+export { AI_PROVIDER_KEY_UPDATE } from "./key-update";
 export { AI_PROVIDER_KEY_LIST } from "./key-list";
 export { AI_PROVIDER_OAUTH_URL } from "./oauth-url";
 export { AI_PROVIDER_OAUTH_EXCHANGE } from "./oauth-exchange";

--- a/apps/mesh/src/tools/ai-providers/key-update.ts
+++ b/apps/mesh/src/tools/ai-providers/key-update.ts
@@ -1,0 +1,33 @@
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+import { providerKeyOutputSchema } from "./key-create";
+
+export const AI_PROVIDER_KEY_UPDATE = defineTool({
+  name: "AI_PROVIDER_KEY_UPDATE",
+  description: "Update the label of a stored AI provider API key.",
+  inputSchema: z.object({
+    keyId: z.string(),
+    label: z.string().min(1).max(100),
+  }),
+  outputSchema: providerKeyOutputSchema,
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const org = requireOrganization(ctx);
+    await ctx.access.check();
+
+    const key = await ctx.storage.aiProviderKeys.updateLabel(
+      input.keyId,
+      org.id,
+      input.label,
+    );
+
+    return {
+      id: key.id,
+      providerId: key.providerId,
+      label: key.label,
+      presetId: key.presetId,
+      createdAt: key.createdAt,
+    };
+  },
+});

--- a/apps/mesh/src/tools/ai-providers/oauth-exchange.ts
+++ b/apps/mesh/src/tools/ai-providers/oauth-exchange.ts
@@ -19,7 +19,7 @@ export const AI_PROVIDER_OAUTH_EXCHANGE = defineTool({
     stateToken: z
       .string()
       .describe("The stateToken returned by AI_PROVIDER_OAUTH_URL"),
-    label: z.string().min(1).max(100).default("Connected via OAuth"),
+    label: z.string().min(1).max(100),
   }),
   outputSchema: providerKeyOutputSchema,
   handler: async (input, ctx) => {

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -139,6 +139,7 @@ const CORE_TOOLS = [
   AiProvidersTools.AI_PROVIDERS_ACTIVE,
   AiProvidersTools.AI_PROVIDER_KEY_CREATE,
   AiProvidersTools.AI_PROVIDER_KEY_DELETE,
+  AiProvidersTools.AI_PROVIDER_KEY_UPDATE,
   AiProvidersTools.AI_PROVIDER_KEY_LIST,
   AiProvidersTools.AI_PROVIDER_OAUTH_URL,
   AiProvidersTools.AI_PROVIDER_OAUTH_EXCHANGE,

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -131,6 +131,7 @@ const ALL_TOOL_NAMES = [
   "AI_PROVIDER_KEY_CREATE",
   "AI_PROVIDER_KEY_LIST",
   "AI_PROVIDER_KEY_DELETE",
+  "AI_PROVIDER_KEY_UPDATE",
   "AI_PROVIDER_OAUTH_URL",
   "AI_PROVIDER_OAUTH_EXCHANGE",
   "AI_PROVIDER_PROVISION_KEY",
@@ -639,6 +640,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     dangerous: true,
   },
   {
+    name: "AI_PROVIDER_KEY_UPDATE",
+    description: "Update AI provider API key label",
+    category: "AI Providers",
+  },
+  {
     name: "AI_PROVIDER_OAUTH_URL",
     description: "Get OAuth URL for provider",
     category: "AI Providers",
@@ -1036,6 +1042,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "AI_PROVIDER_KEY_CREATE",
       "AI_PROVIDER_KEY_LIST",
       "AI_PROVIDER_KEY_DELETE",
+      "AI_PROVIDER_KEY_UPDATE",
       "AI_PROVIDER_OAUTH_URL",
       "AI_PROVIDER_OAUTH_EXCHANGE",
       "AI_PROVIDER_PROVISION_KEY",

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -594,7 +594,7 @@ function ProviderCard({
           providerId: provider.id,
           code,
           stateToken,
-          label: "Connected via OAuth",
+          label: provider.name,
         },
       })) as { isError?: boolean; content?: { text?: string }[] };
       if (result?.isError) {

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -13,6 +13,9 @@ import {
   AlertCircle,
   CheckCircle,
   RefreshCw01,
+  Edit01,
+  Check,
+  X,
 } from "@untitledui/icons";
 import { Page } from "@/web/components/page";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -98,7 +101,49 @@ function KeyList({
   isDeleting: boolean;
 }) {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [editTarget, setEditTarget] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState("");
   const targetKey = keys.find((k) => k.id === deleteTarget);
+
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  const { mutate: updateLabel, isPending: isUpdating } = useMutation({
+    mutationFn: async ({ keyId, label }: { keyId: string; label: string }) => {
+      await client.callTool({
+        name: "AI_PROVIDER_KEY_UPDATE",
+        arguments: { keyId, label },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });
+      setEditTarget(null);
+    },
+    onError: () => {
+      toast.error("Failed to update key label");
+    },
+  });
+
+  const startEdit = (key: AiProviderKey) => {
+    setEditTarget(key.id);
+    setEditLabel(key.label);
+  };
+
+  const cancelEdit = () => {
+    setEditTarget(null);
+    setEditLabel("");
+  };
+
+  const confirmEdit = (keyId: string) => {
+    const trimmed = editLabel.trim();
+    if (!trimmed) return;
+    updateLabel({ keyId, label: trimmed });
+  };
 
   return (
     <div className="flex flex-col gap-2 mt-4">
@@ -107,24 +152,74 @@ function KeyList({
           key={key.id}
           className="flex items-center justify-between p-2 rounded-md bg-muted/50 text-sm"
         >
-          <div className="flex items-center gap-2 overflow-hidden">
+          <div className="flex items-center gap-2 overflow-hidden flex-1 min-w-0">
             <Key01 size={14} className="text-muted-foreground shrink-0" />
-            <span className="font-medium truncate">{key.label}</span>
-            <span className="text-xs text-muted-foreground shrink-0">
-              added {formatDistanceToNow(new Date(key.createdAt))} ago
-            </span>
+            {editTarget === key.id ? (
+              <input
+                autoFocus
+                className="font-medium bg-transparent border-b border-border outline-none flex-1 min-w-0"
+                value={editLabel}
+                onChange={(e) => setEditLabel(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") confirmEdit(key.id);
+                  if (e.key === "Escape") cancelEdit();
+                }}
+              />
+            ) : (
+              <>
+                <span className="font-medium truncate">{key.label}</span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  added {formatDistanceToNow(new Date(key.createdAt))} ago
+                </span>
+              </>
+            )}
           </div>
-          {/* Stop propagation so trash click doesn't trigger card's onClick */}
-          <div onClick={(e) => e.stopPropagation()}>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6 text-muted-foreground hover:text-destructive"
-              disabled={isDeleting}
-              onClick={() => setDeleteTarget(key.id)}
-            >
-              <Trash01 size={14} />
-            </Button>
+          {/* Stop propagation so clicks don't trigger card's onClick */}
+          <div
+            className="flex items-center gap-0.5 shrink-0"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {editTarget === key.id ? (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                  disabled={isUpdating || !editLabel.trim()}
+                  onClick={() => confirmEdit(key.id)}
+                >
+                  <Check size={14} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                  onClick={cancelEdit}
+                >
+                  <X size={14} />
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                  onClick={() => startEdit(key)}
+                >
+                  <Edit01 size={14} />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                  disabled={isDeleting}
+                  onClick={() => setDeleteTarget(key.id)}
+                >
+                  <Trash01 size={14} />
+                </Button>
+              </>
+            )}
           </div>
         </div>
       ))}


### PR DESCRIPTION
## What is this contribution about?

Adds the ability for users to rename their AI provider API key labels inline from the settings page. Previously labels were read-only after creation.

- New `AI_PROVIDER_KEY_UPDATE` MCP tool + `updateLabel` storage method (single `UPDATE` query, org-scoped)
- Registered in core tools registry and `ai-providers:manage` permission group
- UI: pencil icon on each key row → inline `<input>` with Enter/Escape keyboard shortcuts + confirm/cancel buttons

## Screenshots/Demonstration

> Click the pencil icon on any key row in Settings → AI Providers to rename it inline.

## How to Test

1. Go to Settings → AI Providers and add an API key
2. Click the pencil icon on the key row
3. Edit the label and press Enter (or click the checkmark)
4. Confirm the label updates immediately

## Migration Notes

No migrations required — only updates the existing `label` column on `ai_provider_keys`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow users to rename AI provider API key labels inline in Settings → AI Providers. Also sets a better default label for OAuth-connected keys.

- **New Features**
  - Inline edit on each key row (pencil icon) with Enter/Escape and confirm/cancel; updates refresh immediately.
  - Added `AI_PROVIDER_KEY_UPDATE` MCP tool; registered in core tools and registry metadata; gated by `ai-providers:manage`.
  - Storage: `updateLabel(keyId, organizationId, label)` performs an org-scoped UPDATE on `ai_provider_keys` and returns the updated key.
  - No database migrations.

- **Bug Fixes**
  - OAuth-created keys now default to the provider name as the label (replaces "Connected via OAuth").

<sup>Written for commit 456d77de40064548d6f5471c7d6fef0d510fc49e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

