### PR TITLE
fix(mesh): guard MCP streaming responses against mid-flight errors

### DIFF
--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -17,6 +17,7 @@ import { Context, Hono } from "hono";
 import { endTime, startTime } from "hono/timing";
 import type { MeshContext } from "../../core/mesh-context";
 import { managementMCP } from "../../tools";
+import { guardResponseStream } from "../utils/stream-guard";
 import { handleAuthError } from "./oauth-proxy";
 import { handleVirtualMcpRequest } from "./virtual-mcp";
 export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
@@ -82,7 +83,8 @@ export const createProxyRoutes = () => {
           false,
       });
       await server.connect(transport);
-      return await transport.handleRequest(c.req.raw);
+      const selfResponse = await transport.handleRequest(c.req.raw);
+      return guardResponseStream(selfResponse, `mcp:self:${connectionId}`);
     }
 
     try {
@@ -150,7 +152,7 @@ export const createProxyRoutes = () => {
         startTime(c, "mcp.handle_request");
         const response = await transport.handleRequest(c.req.raw);
         endTime(c, "mcp.handle_request");
-        return response;
+        return guardResponseStream(response, `mcp:${connectionId}`);
       } catch (error) {
         // Check if this is an auth error - if so, return appropriate 401
         // Note: This only applies to HTTP connections

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -21,6 +21,7 @@ import type { MeshContext } from "../../core/mesh-context";
 import { MCP_TOOL_CALL_TIMEOUT_MS } from "@/core/constants";
 import { createVirtualClientFrom } from "../../mcp-clients/virtual-mcp";
 import type { Env } from "../hono-env";
+import { guardResponseStream } from "../utils/stream-guard";
 
 // ============================================================================
 // Route Handler (shared between /gateway and /virtual-mcp endpoints for backward compat)
@@ -153,7 +154,11 @@ export async function handleVirtualMcpRequest(
     // Connect server to transport
     await server.connect(transport);
 
-    return await transport.handleRequest(c.req.raw);
+    const response = await transport.handleRequest(c.req.raw);
+    return guardResponseStream(
+      response,
+      `virtual-mcp:${virtualMcp.id ?? "decopilot"}`,
+    );
   } catch (error) {
     const err = error as Error;
     console.error("[virtual-mcp] Error handling virtual MCP request:", err);

--- a/apps/mesh/src/api/utils/stream-guard.test.ts
+++ b/apps/mesh/src/api/utils/stream-guard.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import { guardResponseStream } from "./stream-guard";
+
+const collect = async (response: Response): Promise<string> => {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value);
+  }
+  return out;
+};
+
+describe("guardResponseStream", () => {
+  it("passes a normal stream through unchanged", async () => {
+    const encoder = new TextEncoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("hello "));
+        controller.enqueue(encoder.encode("world"));
+        controller.close();
+      },
+    });
+    const original = new Response(source, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const guarded = guardResponseStream(original, "test:normal");
+
+    expect(guarded.status).toBe(200);
+    expect(guarded.headers.get("content-type")).toBe("text/event-stream");
+    expect(await collect(guarded)).toBe("hello world");
+  });
+
+  it("closes cleanly when the source errors mid-stream", async () => {
+    const encoder = new TextEncoder();
+    let phase = 0;
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        // First pull: emit a chunk. Second pull: error.
+        // Splitting across pulls ensures the consumer sees the chunk before
+        // the error surfaces, mirroring the realistic case where some bytes
+        // have already gone over the wire when the upstream fails.
+        if (phase === 0) {
+          phase = 1;
+          controller.enqueue(encoder.encode("partial"));
+        } else {
+          controller.error(new Error("upstream exploded"));
+        }
+      },
+    });
+    const original = new Response(source, { status: 200 });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const guarded = guardResponseStream(original, "test:erroring");
+
+    // The guard must resolve (clean close), not reject — that's the whole point
+    const body = await collect(guarded);
+    expect(body).toBe("partial");
+    expect(errSpy).toHaveBeenCalled();
+    const firstCall = errSpy.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    expect(String(firstCall![0])).toContain("test:erroring");
+    expect(String(firstCall![1])).toContain("upstream exploded");
+
+    errSpy.mockRestore();
+  });
+
+  it("returns the response unchanged when there is no body", () => {
+    const original = new Response(null, { status: 204 });
+    const guarded = guardResponseStream(original, "test:empty");
+    expect(guarded).toBe(original);
+  });
+
+  it("forwards cancellation upstream", async () => {
+    const cancelFn = mock(() => {});
+    const source = new ReadableStream<Uint8Array>({
+      start() {
+        // never push, never close — keep the stream open until cancellation
+      },
+      cancel: cancelFn,
+    });
+    const original = new Response(source, { status: 200 });
+
+    const guarded = guardResponseStream(original, "test:cancel");
+    // Touch the body so the guard's start() runs and acquires the reader
+    // before we cancel.
+    const reader = guarded.body!.getReader();
+    await reader.cancel("client gone");
+
+    expect(cancelFn).toHaveBeenCalledWith("client gone");
+  });
+});

--- a/apps/mesh/src/api/utils/stream-guard.ts
+++ b/apps/mesh/src/api/utils/stream-guard.ts
@@ -1,0 +1,60 @@
+/**
+ * Wraps a streaming Response so a mid-flight error in the body's ReadableStream
+ * results in a clean close instead of an abrupt abort.
+ *
+ * Without this guard, when the underlying source throws after the Response has
+ * already been returned to Hono (e.g. an MCP bridge call to an upstream tool
+ * fails during a `tools/list` aggregation), the stream propagates the error and
+ * the connection drops mid-body — Cloudflare interprets that as a malformed
+ * origin response and serves the client a generic 520 instead of letting the
+ * client see the truncated stream and retry.
+ *
+ * The guard catches the error, logs it for the operator, and closes the
+ * controller cleanly. The client receives a well-formed but truncated SSE
+ * response and can recover via its own retry/reconnect logic.
+ */
+export function guardResponseStream(
+  response: Response,
+  label: string,
+): Response {
+  if (!response.body) return response;
+
+  const source = response.body;
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  const guarded = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      reader = source.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) return;
+          controller.enqueue(value);
+        }
+      } catch (err) {
+        console.error(`[stream-guard] ${label} stream errored:`, err);
+      } finally {
+        try {
+          controller.close();
+        } catch {
+          // controller may already be closed (e.g. via downstream cancel)
+        }
+      }
+    },
+    async cancel(reason) {
+      // The source has a reader locked from start(); cancelling via the reader
+      // both releases the lock and propagates the cancel reason upstream.
+      if (reader) {
+        await reader.cancel(reason).catch(() => {});
+      } else {
+        await source.cancel(reason).catch(() => {});
+      }
+    },
+  });
+
+  return new Response(guarded, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}


### PR DESCRIPTION
## What is this contribution about?

Addresses Cloudflare 520 errors observed on `studio.decocms.com` when an upstream MCP call fails after the streaming `Response` has already been returned to Hono. The underlying `ReadableStream` propagates the error and the connection drops mid-body, which Cloudflare interprets as a malformed origin response.

This adds a `guardResponseStream(response, label)` wrapper that catches source errors, logs them with a contextual label, and closes the controller cleanly. The client receives a well-formed (truncated) SSE response and the MCP SDK's retry path can take over, while the operator gets a `[stream-guard] <label>` log pointing at the actual upstream failure. Applied to `/mcp/:connectionId` (regular and the `_self` self-MCP path) and `/mcp/virtual-mcp/:virtualMcpId`. The decopilot `/stream` and `/runtime/stream` endpoints already serialize errors via ai-sdk's `streamText({ onError })` and don't need the guard.

## How to Test

1. Hit any of the patched routes with a request that exercises an upstream that will error mid-stream (e.g. a virtual MCP whose child connection has an expired OAuth token, or kill an upstream worker mid `tools/list`).
2. Confirm the response no longer aborts with a TCP-level reset / Cloudflare 520 — the body terminates as a clean (possibly truncated) SSE stream and `apps/mesh` logs `[stream-guard] <label> stream errored: ...`.
3. Run `bun test apps/mesh/src/api/utils/stream-guard.test.ts` — covers passthrough, mid-stream error, no-body, and cancellation propagation.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard MCP streaming responses against mid-flight errors to stop Cloudflare 520 disconnects. Streams now close cleanly (truncated SSE), enabling client retries and better logs.

- Bug Fixes
  - Added `guardResponseStream(response, label)` to catch body errors, log `[stream-guard] <label>`, and close the stream.
  - Applied to `/mcp/:connectionId` (including `_self`) and `/mcp/virtual-mcp/:virtualMcpId`; decopilot `/stream` and `/runtime/stream` unchanged.
  - Added tests for passthrough, mid-stream error, no-body, and cancellation.

<sup>Written for commit 0b78f4a98880eac179390f8178c9b62ac121c511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

