### PR TITLE
fix(automations): keep org list resilient when virtual_mcp_id is orphaned

### DIFF
--- a/apps/mesh/src/web/components/settings/organization-form.tsx
+++ b/apps/mesh/src/web/components/settings/organization-form.tsx
@@ -1,20 +1,19 @@
 import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
+import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
 import { KEYS } from "@/web/lib/query-keys";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   SettingsCard,
-  SettingsCardActions,
   SettingsCardItem,
   SettingsSection,
 } from "@/web/components/settings/settings-section";
-import { useRef, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useRef } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { track } from "@/web/lib/posthog-client";
@@ -98,7 +97,6 @@ export function OrganizationForm() {
   const { org } = useProjectContext();
   const orgAuth = useOrgAuthClient();
   const queryClient = useQueryClient();
-  const [isSaving, setIsSaving] = useState(false);
 
   const form = useForm<OrganizationSettingsFormValues>({
     resolver: zodResolver(organizationSettingsSchema),
@@ -132,16 +130,15 @@ export function OrganizationForm() {
 
       return result;
     },
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       track("organization_settings_updated", {
         organization_id: org.id,
-        fields: Object.keys(form.formState.dirtyFields),
+        fields: Object.keys(variables),
       });
       queryClient.invalidateQueries({ queryKey: KEYS.organizations() });
       queryClient.invalidateQueries({
         queryKey: KEYS.activeOrganization(org.slug),
       });
-      toast.success("Organization settings updated successfully");
 
       if (data?.data?.slug && data.data.slug !== org.slug) {
         navigate({
@@ -150,10 +147,10 @@ export function OrganizationForm() {
         });
       }
     },
-    onError: (error) => {
+    onError: (error, variables) => {
       track("organization_settings_update_failed", {
         organization_id: org.id,
-        fields: Object.keys(form.formState.dirtyFields),
+        fields: Object.keys(variables),
         error: error instanceof Error ? error.message : String(error),
       });
       toast.error(
@@ -162,120 +159,118 @@ export function OrganizationForm() {
           : "Failed to update organization",
       );
     },
-    onSettled: () => {
-      setIsSaving(false);
+  });
+
+  const { schedule: scheduleSave, flush: flushAndSave } = useDebouncedAutosave({
+    save: async () => {
+      if (!form.formState.isDirty) return;
+      const valid = await form.trigger();
+      if (!valid) return;
+      await updateOrgMutation.mutateAsync(form.getValues());
     },
   });
 
-  const onSubmit = (data: OrganizationSettingsFormValues) => {
-    setIsSaving(true);
-    updateOrgMutation.mutate(data);
-  };
-
-  const hasChanges = form.formState.isDirty;
   const errors = form.formState.errors;
   const urlOrigin =
     typeof window !== "undefined" ? `${window.location.host}/` : "";
 
   return (
-    <form
-      onSubmit={form.handleSubmit(onSubmit)}
-      className="flex flex-col gap-3"
-    >
-      <SettingsSection>
-        <SettingsCard>
-          <SettingsCardItem
-            title="Logo"
-            description="Recommended size is 256x256px"
-            action={
-              <CompactLogoUpload
-                value={form.watch("logo")}
-                onChange={(val) =>
-                  form.setValue("logo", val ?? "", { shouldDirty: true })
-                }
-                name={form.watch("name")}
-                disabled={isSaving}
-              />
-            }
-          />
-          <SettingsCardItem
-            title="Name"
-            action={
-              <Input
-                id="org-name"
-                {...form.register("name")}
-                placeholder="Organization name"
-                disabled={isSaving}
-                className="w-[280px]"
-              />
-            }
-          />
-          <SettingsCardItem
-            title="URL"
-            action={
-              <div className="flex items-center w-[280px] rounded-md border border-input bg-input/30 focus-within:ring-2 focus-within:ring-ring/50 overflow-hidden">
-                {urlOrigin && (
-                  <span className="pl-3 text-sm text-muted-foreground select-none">
-                    {urlOrigin}
-                  </span>
-                )}
-                <input
-                  id="org-slug"
-                  {...form.register("slug")}
-                  placeholder="my-organization"
-                  disabled={isSaving}
-                  className="flex-1 min-w-0 bg-transparent px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/60 outline-none"
+    <SettingsSection>
+      <SettingsCard>
+        <SettingsCardItem
+          title="Logo"
+          description="Recommended size is 256x256px"
+          action={
+            <CompactLogoUpload
+              value={form.watch("logo")}
+              onChange={(val) => {
+                form.setValue("logo", val ?? "", { shouldDirty: true });
+                flushAndSave();
+              }}
+              name={form.watch("name")}
+            />
+          }
+        />
+        <SettingsCardItem
+          title="Name"
+          action={
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Input
+                  id="org-name"
+                  {...field}
                   onChange={(e) => {
-                    const sanitized = e.target.value
-                      .toLowerCase()
-                      .replace(/[^a-z0-9-]/g, "");
-                    form.setValue("slug", sanitized, {
-                      shouldDirty: true,
-                      shouldTouch: true,
-                      shouldValidate: true,
-                    });
+                    field.onChange(e);
+                    scheduleSave();
                   }}
+                  onBlur={() => {
+                    field.onBlur();
+                    flushAndSave();
+                  }}
+                  placeholder="Organization name"
+                  className="w-[280px]"
                 />
-              </div>
-            }
-          />
-          {(errors.name || errors.slug || errors.logo) && (
-            <div className="px-5 pb-3 flex flex-col gap-1">
-              {errors.name && (
-                <p className="text-xs text-destructive">
-                  {errors.name.message}
-                </p>
               )}
-              {errors.slug && (
-                <p className="text-xs text-destructive">
-                  {errors.slug.message}
-                </p>
+            />
+          }
+        />
+        <SettingsCardItem
+          title="URL"
+          action={
+            <div className="flex items-center w-[280px] rounded-md border border-input bg-input/30 focus-within:ring-2 focus-within:ring-ring/50 overflow-hidden">
+              {urlOrigin && (
+                <span className="pl-3 text-sm text-muted-foreground select-none">
+                  {urlOrigin}
+                </span>
               )}
-              {errors.logo && (
-                <p className="text-xs text-destructive">
-                  {errors.logo.message}
-                </p>
-              )}
+              <Controller
+                control={form.control}
+                name="slug"
+                render={({ field }) => (
+                  <input
+                    id="org-slug"
+                    value={field.value ?? ""}
+                    name={field.name}
+                    ref={field.ref}
+                    placeholder="my-organization"
+                    className="flex-1 min-w-0 bg-transparent px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/60 outline-none"
+                    onChange={(e) => {
+                      const sanitized = e.target.value
+                        .toLowerCase()
+                        .replace(/[^a-z0-9-]/g, "");
+                      form.setValue("slug", sanitized, {
+                        shouldDirty: true,
+                        shouldTouch: true,
+                        shouldValidate: true,
+                      });
+                      scheduleSave();
+                    }}
+                    onBlur={() => {
+                      field.onBlur();
+                      flushAndSave();
+                    }}
+                  />
+                )}
+              />
             </div>
-          )}
-          {hasChanges && (
-            <SettingsCardActions>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => form.reset()}
-                disabled={isSaving}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isSaving} size="sm">
-                {isSaving ? "Saving…" : "Save"}
-              </Button>
-            </SettingsCardActions>
-          )}
-        </SettingsCard>
-      </SettingsSection>
-    </form>
+          }
+        />
+        {(errors.name || errors.slug || errors.logo) && (
+          <div className="px-5 pb-3 flex flex-col gap-1">
+            {errors.name && (
+              <p className="text-xs text-destructive">{errors.name.message}</p>
+            )}
+            {errors.slug && (
+              <p className="text-xs text-destructive">{errors.slug.message}</p>
+            )}
+            {errors.logo && (
+              <p className="text-xs text-destructive">{errors.logo.message}</p>
+            )}
+          </div>
+        )}
+      </SettingsCard>
+    </SettingsSection>
   );
 }

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -254,11 +254,11 @@ export function useAutomationActions() {
     },
     onSuccess: () => {
       invalidateAll();
+      toast.success("Automation created successfully");
     },
-    onError: (error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to create automation",
-      );
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to create automation: ${message}`);
     },
   });
 
@@ -275,11 +275,11 @@ export function useAutomationActions() {
       if (typeof variables.id === "string") {
         invalidateOne(variables.id);
       }
+      toast.success("Automation updated successfully");
     },
-    onError: (error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to update automation",
-      );
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to update automation: ${message}`);
     },
   });
 
@@ -294,11 +294,11 @@ export function useAutomationActions() {
     onSuccess: (_data, id) => {
       queryClient.removeQueries({ queryKey: KEYS.automation(org.id, id) });
       invalidateAll();
+      toast.success("Automation deleted successfully");
     },
-    onError: (error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to delete automation",
-      );
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Failed to delete automation: ${message}`);
     },
   });
 

--- a/apps/mesh/src/web/hooks/use-debounced-autosave.ts
+++ b/apps/mesh/src/web/hooks/use-debounced-autosave.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+
+interface UseDebouncedAutosaveOptions<R> {
+  /** Save function. The latest closure is always invoked, so it can read
+   * current state without callers needing their own ref. */
+  save: () => Promise<R>;
+  /** Debounce window. Defaults to 1000ms. */
+  delayMs?: number;
+}
+
+interface UseDebouncedAutosaveReturn<R> {
+  /** Schedule a save after the debounce window. Resets the window on each
+   * call. */
+  schedule: () => void;
+  /** Cancel any pending save and run the save now. Returns whatever `save`
+   * returns. */
+  flush: () => Promise<R>;
+}
+
+/**
+ * Debounced save with flush-on-unmount.
+ *
+ * Encapsulates the timer, the always-fresh-closure dance, and the unmount
+ * cleanup that drops trailing edits if the user navigates within the debounce
+ * window.
+ */
+export function useDebouncedAutosave<R>({
+  save,
+  delayMs = 1000,
+}: UseDebouncedAutosaveOptions<R>): UseDebouncedAutosaveReturn<R> {
+  // Always-fresh ref so the deferred timer invokes the latest closure rather
+  // than whichever one was in scope when the timer was scheduled.
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const schedule = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      saveRef.current();
+    }, delayMs);
+  };
+
+  const flush = (): Promise<R> => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    return saveRef.current();
+  };
+
+  // Flush any pending save on unmount so navigating away within the debounce
+  // window doesn't drop the last edit.
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        saveRef.current();
+      }
+    };
+  }, []);
+
+  return { schedule, flush };
+}

--- a/apps/mesh/src/web/routes/orgs/settings/automations.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/automations.tsx
@@ -7,7 +7,11 @@ import { EmptyState } from "@/web/components/empty-state.tsx";
 import { useAutomations } from "@/web/hooks/use-automations";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { AutomationListRow } from "@/web/views/automations/automation-list-row";
-import { useVirtualMCPs, useProjectContext } from "@decocms/mesh-sdk";
+import {
+  getDecopilotId,
+  useVirtualMCPs,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { track } from "@/web/lib/posthog-client";
 
@@ -31,12 +35,15 @@ export default function SettingsAutomationsPage() {
   });
 
   const handleRowClick = (automationId: string, agentId: string) => {
+    // Fall back to Decopilot when the automation's virtual_mcp_id no longer
+    // resolves (orphaned reference); otherwise the detail panel can't mount.
+    const target = agentMap.has(agentId) ? agentId : getDecopilotId(org.id);
     track("automations_list_row_clicked", {
       automation_id: automationId,
-      agent_id: agentId,
+      agent_id: target,
       source: "settings_automations",
     });
-    navigateToAgent(agentId, {
+    navigateToAgent(target, {
       search: { main: "automation:" + automationId },
     });
   };

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -41,8 +41,9 @@ import {
   XClose,
   Zap,
 } from "@untitledui/icons";
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useRef, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
+import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
 import { toast } from "sonner";
 import type { Metadata } from "@/web/components/chat/types.ts";
 import {
@@ -314,7 +315,6 @@ export function SettingsTab({
   const [cronInput, setCronInput] = useState("");
   const [showEventForm, setShowEventForm] = useState(false);
   const editorInitializedRef = useRef(false);
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tiptapDirtyRef = useRef(false);
   // The save runs from a debounced setTimeout. Reading state through a closure
   // there would give us the value from the render that scheduled the timer,
@@ -405,12 +405,23 @@ export function SettingsTab({
     editSessionSaveCountRef.current = 0;
   };
 
+  // Track which form fields have been edited since the last successful save.
+  // We don't read formState.dirtyFields because RHF's lazy proxy subscriptions
+  // make it easy to silently miss fields that aren't read during render — that
+  // is exactly how the title autosave regressed.
+  const formDirtyFieldsRef = useRef<Set<keyof SettingsFormData>>(new Set());
+
+  const markFormDirty = (field: keyof SettingsFormData) => {
+    formDirtyFieldsRef.current.add(field);
+  };
+
   const saveForm = async (): Promise<boolean> => {
-    const hasDirtyFields = Object.keys(form.formState.dirtyFields).length > 0;
+    const dirtyFormKeys = Array.from(formDirtyFieldsRef.current);
+    const hasDirtyFields = dirtyFormKeys.length > 0;
     if (!hasDirtyFields && !tiptapDirtyRef.current) return true;
-    const dirtyFormKeys = Object.keys(form.formState.dirtyFields);
     const tiptapWasDirty = tiptapDirtyRef.current;
     tiptapDirtyRef.current = false;
+    formDirtyFieldsRef.current = new Set();
 
     const values = form.getValues();
     const tiptapDocAtSave = tiptapDocRef.current;
@@ -450,48 +461,27 @@ export function SettingsTab({
         EDIT_SESSION_QUIET_MS,
       );
 
-      // keepDirtyValues: any field the user kept editing during the in-flight
-      // mutation stays at its current value AND keeps its dirty flag, so the
-      // queued debouncedSave actually persists those edits on its next fire.
-      // Without this, reset would clear dirty state and the next saveForm
-      // would early-return on hasDirtyFields=false, stranding the keystrokes
-      // in the UI but never sending them to the server.
-      form.reset(
-        {
-          ...values,
-          credential_id: coercedCredentialId,
-          model_id: coercedModelId,
-        },
-        { keepDirtyValues: true },
-      );
+      if (coercedCredentialId !== values.credential_id) {
+        form.setValue("credential_id", coercedCredentialId);
+      }
+      if (coercedModelId !== values.model_id) {
+        form.setValue("model_id", coercedModelId);
+      }
       return true;
     } catch {
       tiptapDirtyRef.current = true;
+      for (const key of dirtyFormKeys) formDirtyFieldsRef.current.add(key);
       return false;
     }
   };
 
-  // Always-fresh ref to saveForm so debounced timers and the form-watch
-  // subscription (which is registered once) call the latest closure that reads
-  // current state, not whichever closure happened to be in scope at scheduling
-  // time.
-  const saveFormRef = useRef(saveForm);
-  saveFormRef.current = saveForm;
+  const { schedule: scheduleSave, flush: flushAndSave } = useDebouncedAutosave({
+    save: saveForm,
+  });
 
-  const debouncedSave = () => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(() => {
-      saveTimerRef.current = null;
-      saveFormRef.current();
-    }, 1000);
-  };
-
-  const flushAndSave = async () => {
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-    }
-    return saveFormRef.current();
+  const debouncedSave = (field?: keyof SettingsFormData) => {
+    if (field) markFormDirty(field);
+    scheduleSave();
   };
 
   const setTiptapDoc = (doc: Metadata["tiptapDoc"]) => {
@@ -502,29 +492,8 @@ export function SettingsTab({
       return;
     }
     tiptapDirtyRef.current = true;
-    debouncedSave();
+    scheduleSave();
   };
-
-  const watchSubscribedRef = useRef(false);
-  if (!watchSubscribedRef.current) {
-    watchSubscribedRef.current = true;
-    form.watch(() => {
-      debouncedSave();
-    });
-  }
-
-  // Flush any pending save on unmount so navigating away within the 1s
-  // debounce window doesn't drop the last edit.
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect
-  useEffect(() => {
-    return () => {
-      if (saveTimerRef.current) {
-        clearTimeout(saveTimerRef.current);
-        saveTimerRef.current = null;
-        saveFormRef.current();
-      }
-    };
-  }, []);
 
   const handleRunClick = async () => {
     track("automation_test_clicked", {
@@ -568,11 +537,21 @@ export function SettingsTab({
         {/* Header: Name + Status + Creator */}
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center justify-between gap-4">
-            <Input
-              {...form.register("name")}
-              placeholder="Automation name"
-              className="border border-transparent shadow-none px-0 text-lg font-medium h-auto focus-visible:ring-0 focus-visible:border-border bg-transparent flex-1"
-              style={{ boxShadow: "none" }}
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    debouncedSave("name");
+                  }}
+                  placeholder="Automation name"
+                  className="border border-transparent shadow-none px-0 text-lg font-medium h-auto focus-visible:ring-0 focus-visible:border-border bg-transparent flex-1"
+                  style={{ boxShadow: "none" }}
+                />
+              )}
             />
             {onDelete && (
               <Button
@@ -594,6 +573,7 @@ export function SettingsTab({
                   checked={field.value}
                   onCheckedChange={(checked) => {
                     field.onChange(checked);
+                    markFormDirty("active");
                     setTimeout(() => flushAndSave(), 0);
                   }}
                   className="cursor-pointer"
@@ -786,16 +766,16 @@ export function SettingsTab({
                   isLoading={isModelsLoading}
                   credentialId={watchConnectionId || null}
                   onCredentialChange={(id) => {
-                    form.setValue("credential_id", id ?? "", {
-                      shouldDirty: true,
-                    });
-                    form.setValue("model_id", "", { shouldDirty: true });
+                    form.setValue("credential_id", id ?? "");
+                    form.setValue("model_id", "");
+                    markFormDirty("credential_id");
+                    markFormDirty("model_id");
+                    scheduleSave();
                   }}
-                  onModelChange={(model) =>
-                    form.setValue("model_id", model.modelId, {
-                      shouldDirty: true,
-                    })
-                  }
+                  onModelChange={(model) => {
+                    form.setValue("model_id", model.modelId);
+                    debouncedSave("model_id");
+                  }}
                   placeholder="Model"
                 />
                 <Tooltip>

--- a/apps/mesh/src/web/views/automations/automation-list-row.tsx
+++ b/apps/mesh/src/web/views/automations/automation-list-row.tsx
@@ -78,10 +78,10 @@ export function AutomationListRow({
           }
         />
 
-        {showAgent && agent && (
+        {showAgent && (
           <AgentAvatar
-            icon={agent.icon ?? null}
-            name={agent.title}
+            icon={agent?.icon ?? null}
+            name={agent?.title ?? automation.name}
             size="xs"
             className="shrink-0"
           />

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useState, useEffect } from "react";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
 import { Controller, useForm } from "react-hook-form";
+import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -1459,27 +1460,26 @@ function SimpleModeSection() {
     isSuccess,
   } = useUpdateSimpleMode();
 
-  // Autosave: watch form state; 250ms after the last dirty change, persist.
-  // The debounce coalesces multi-field writes from handleToggle and Effect 2
-  // into a single mutation. The save callback is inlined so the effect's
-  // deps only reference library-stable values (updateSimpleMode/form) and
-  // query-stable ones (simpleMode).
-  const watched = form.watch();
   const isDirty = form.formState.isDirty;
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — autosave subscribes to derived form state over time
-  useEffect(() => {
-    if (!isDirty) return;
-    const id = setTimeout(() => {
-      updateSimpleMode(watched, {
-        onSuccess: () => form.reset(watched, { keepValues: true }),
+
+  // Autosave: 250ms after the last dirty change, persist. The debounce
+  // coalesces multi-field writes from handleToggle and Effect 2 into a single
+  // mutation. Callers `schedule()` from each field handler (Controllers and
+  // handleToggle) so we don't depend on a render-time form.watch subscription.
+  const { schedule: scheduleAutosave } = useDebouncedAutosave({
+    delayMs: 250,
+    save: async () => {
+      if (!form.formState.isDirty) return;
+      const values = form.getValues();
+      updateSimpleMode(values, {
+        onSuccess: () => form.reset(values, { keepValues: true }),
         onError: (err) => {
           form.reset(simpleMode);
           toast.error(`Failed to save: ${err.message}`);
         },
       });
-    }, 250);
-    return () => clearTimeout(id);
-  }, [watched, isDirty, updateSimpleMode, form, simpleMode]);
+    },
+  });
 
   // Lazily load models for the first 3 keys so we can pre-fill defaults.
   // Hooks can't run in loops; capping at 3 is sufficient for defaults —
@@ -1516,6 +1516,7 @@ function SimpleModeSection() {
     } else {
       form.setValue("enabled", enabled, { shouldDirty: true });
     }
+    scheduleAutosave();
   };
 
   // Effect 1: Clear form when all providers are removed.
@@ -1628,7 +1629,10 @@ function SimpleModeSection() {
                       <SimpleModeModelRow
                         slot={field.value}
                         defaultKeyId={allKeys[0]?.id ?? null}
-                        onSlotChange={(slot) => field.onChange(slot)}
+                        onSlotChange={(slot) => {
+                          field.onChange(slot);
+                          scheduleAutosave();
+                        }}
                       />
                     }
                   />
@@ -1647,7 +1651,10 @@ function SimpleModeSection() {
                       slot={field.value}
                       defaultKeyId={allKeys[0]?.id ?? null}
                       filterModels={filterImageModels}
-                      onSlotChange={(slot) => field.onChange(slot)}
+                      onSlotChange={(slot) => {
+                        field.onChange(slot);
+                        scheduleAutosave();
+                      }}
                     />
                   }
                 />
@@ -1664,7 +1671,10 @@ function SimpleModeSection() {
                       slot={field.value}
                       defaultKeyId={allKeys[0]?.id ?? null}
                       filterModels={filterWebResearchModels}
-                      onSlotChange={(slot) => field.onChange(slot)}
+                      onSlotChange={(slot) => {
+                        field.onChange(slot);
+                        scheduleAutosave();
+                      }}
                     />
                   }
                 />

--- a/apps/mesh/src/web/views/settings/org-brand-context.tsx
+++ b/apps/mesh/src/web/views/settings/org-brand-context.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { Controller, useForm, type UseFormReturn } from "react-hook-form";
 import {
   useProjectContext,
   useMCPClient,
@@ -8,13 +9,10 @@ import {
 import {
   ChevronDown,
   ChevronRight,
-  Edit03,
   LinkExternal01,
-  Check,
   Plus,
   Star01,
   Trash01,
-  X,
   Globe02,
   Zap,
 } from "@untitledui/icons";
@@ -37,6 +35,7 @@ import { Page } from "@/web/components/page";
 import { KEYS } from "@/web/lib/query-keys";
 import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
 import { usePublicConfig } from "@/web/hooks/use-public-config";
+import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
 import { track } from "@/web/lib/posthog-client";
 
 // --- Types ---
@@ -71,70 +70,48 @@ type BrandContext = {
   isDefault?: boolean;
 };
 
-// --- Editable card ---
+// --- Section card wrapper (visual container only — autosave handles saves) ---
 
 function BrandCard({
   title,
   children,
-  onEdit,
-  editing,
-  onSave,
-  onCancel,
   className,
 }: {
   title: string;
   children: React.ReactNode;
-  onEdit?: () => void;
-  editing?: boolean;
-  onSave?: () => void;
-  onCancel?: () => void;
   className?: string;
 }) {
   return (
     <div
       className={cn(
-        "group relative rounded-2xl border border-border/60 bg-background p-5",
-        editing && "ring-2 ring-ring/30",
+        "rounded-2xl border border-border/60 bg-background p-5",
         className,
       )}
     >
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4">
         <span className="text-xs font-medium text-muted-foreground">
           {title}
         </span>
-        {editing ? (
-          <div className="flex gap-1">
-            <button
-              type="button"
-              onClick={onCancel}
-              className="flex h-7 w-7 items-center justify-center rounded-lg bg-muted hover:bg-muted-foreground/15"
-            >
-              <X size={13} className="text-muted-foreground" />
-            </button>
-            <button
-              type="button"
-              onClick={onSave}
-              className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary/10 hover:bg-primary/20"
-            >
-              <Check size={13} className="text-primary" />
-            </button>
-          </div>
-        ) : (
-          onEdit && (
-            <button
-              type="button"
-              onClick={onEdit}
-              className="flex h-7 w-7 items-center justify-center rounded-lg bg-muted opacity-0 transition-opacity duration-150 hover:bg-muted-foreground/15 group-hover:opacity-100"
-            >
-              <Edit03 size={13} className="text-muted-foreground" />
-            </button>
-          )
-        )}
       </div>
       {children}
     </div>
   );
 }
+
+// --- Form data covering all editable brand fields ---
+
+interface BrandFormData {
+  name: string;
+  domain: string;
+  overview: string;
+  logo: string;
+  favicon: string;
+  ogImage: string;
+  fonts: BrandFonts;
+  colors: BrandColors;
+}
+
+type BrandFormReturn = UseFormReturn<BrandFormData>;
 
 // --- Auto-extract banner ---
 
@@ -188,272 +165,218 @@ function AutoExtractBanner({
   );
 }
 
-// --- Section: Company Overview (editable) ---
+// --- Section: Company Overview ---
 
 function OverviewSection({
-  brand,
-  onSave,
+  form,
+  onFieldChange,
+  onFieldCommit,
 }: {
-  brand: Partial<BrandContext>;
-  onSave: (data: Partial<BrandContext>) => void;
+  form: BrandFormReturn;
+  onFieldChange: () => void;
+  onFieldCommit: () => void;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [name, setName] = useState(brand.name ?? "");
-  const [domain, setDomain] = useState(brand.domain ?? "");
-  const [overview, setOverview] = useState(brand.overview ?? "");
-
-  const startEdit = () => {
-    setName(brand.name ?? "");
-    setDomain(brand.domain ?? "");
-    setOverview(brand.overview ?? "");
-    setEditing(true);
-  };
-
-  const save = () => {
-    onSave({ name, domain, overview });
-    setEditing(false);
-  };
-
-  const isEmpty = !brand.name && !brand.domain && !brand.overview;
+  const domain = form.watch("domain");
 
   return (
-    <BrandCard
-      title="Company Overview"
-      onEdit={startEdit}
-      editing={editing}
-      onSave={save}
-      onCancel={() => setEditing(false)}
-    >
-      {editing ? (
-        <div className="space-y-3">
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="mb-1 block text-xs text-muted-foreground">
-                Company name
-              </label>
-              <Input
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Acme Corp"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs text-muted-foreground">
-                Domain
-              </label>
-              <Input
-                value={domain}
-                onChange={(e) => setDomain(e.target.value)}
-                placeholder="acme.com"
-              />
-            </div>
-          </div>
+    <BrandCard title="Company Overview">
+      <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
           <div>
             <label className="mb-1 block text-xs text-muted-foreground">
-              Overview
+              Company name
             </label>
-            <Textarea
-              value={overview}
-              onChange={(e) => setOverview(e.target.value)}
-              placeholder="Brief description of what the company does..."
-              rows={3}
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    onFieldChange();
+                  }}
+                  onBlur={() => {
+                    field.onBlur();
+                    onFieldCommit();
+                  }}
+                  placeholder="Acme Corp"
+                />
+              )}
+            />
+          </div>
+          <div>
+            <label className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+              <span>Domain</span>
+              {domain && (
+                <a
+                  href={`https://${domain}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 transition-colors hover:text-foreground"
+                >
+                  <LinkExternal01 size={10} />
+                  open
+                </a>
+              )}
+            </label>
+            <Controller
+              control={form.control}
+              name="domain"
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    onFieldChange();
+                  }}
+                  onBlur={() => {
+                    field.onBlur();
+                    onFieldCommit();
+                  }}
+                  placeholder="acme.com"
+                />
+              )}
             />
           </div>
         </div>
-      ) : isEmpty ? (
-        <p className="text-sm text-muted-foreground/60">
-          No company info yet. Click edit to add your company name, domain, and
-          overview.
-        </p>
-      ) : (
-        <>
-          <div className="mb-3 flex items-start justify-between gap-4">
-            <h2 className="text-xl font-semibold leading-tight text-foreground">
-              {brand.name}
-            </h2>
-            {brand.domain && (
-              <a
-                href={`https://${brand.domain}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-0.5 flex shrink-0 items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <LinkExternal01 size={11} />
-                {brand.domain}
-              </a>
+        <div>
+          <label className="mb-1 block text-xs text-muted-foreground">
+            Overview
+          </label>
+          <Controller
+            control={form.control}
+            name="overview"
+            render={({ field }) => (
+              <Textarea
+                {...field}
+                onChange={(e) => {
+                  field.onChange(e);
+                  onFieldChange();
+                }}
+                onBlur={() => {
+                  field.onBlur();
+                  onFieldCommit();
+                }}
+                placeholder="Brief description of what the company does..."
+                rows={3}
+              />
             )}
-          </div>
-          {brand.overview && (
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              {brand.overview}
-            </p>
-          )}
-        </>
-      )}
+          />
+        </div>
+      </div>
     </BrandCard>
   );
 }
 
 // --- Section: Logos ---
 
-function LogosSection({
-  brand,
-  onSave,
+const CHECKERED_BG = {
+  backgroundImage:
+    "linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%), linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%)",
+  backgroundSize: "8px 8px",
+  backgroundPosition: "0 0, 4px 4px",
+  backgroundColor: "#fff",
+};
+
+function LogoFieldRow({
+  form,
+  name,
+  label,
+  imgClassName = "h-full w-full object-contain p-3",
+  onFieldChange,
+  onFieldCommit,
 }: {
-  brand: Partial<BrandContext>;
-  onSave: (data: Partial<BrandContext>) => void;
+  form: BrandFormReturn;
+  name: "logo" | "favicon" | "ogImage";
+  label: string;
+  imgClassName?: string;
+  onFieldChange: () => void;
+  onFieldCommit: () => void;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [logo, setLogo] = useState(brand.logo ?? "");
-  const [favicon, setFavicon] = useState(brand.favicon ?? "");
-  const [ogImage, setOgImage] = useState(brand.ogImage ?? "");
-
-  const startEdit = () => {
-    setLogo(brand.logo ?? "");
-    setFavicon(brand.favicon ?? "");
-    setOgImage(brand.ogImage ?? "");
-    setEditing(true);
-  };
-
-  const save = () => {
-    onSave({
-      logo: logo || null,
-      favicon: favicon || null,
-      ogImage: ogImage || null,
-    });
-    setEditing(false);
-  };
-
-  const hasLogos = brand.logo || brand.favicon || brand.ogImage;
-
+  const value = form.watch(name);
   return (
-    <BrandCard
-      title="Logos & Images"
-      onEdit={startEdit}
-      editing={editing}
-      onSave={save}
-      onCancel={() => setEditing(false)}
-    >
-      {editing ? (
-        <div className="space-y-3">
-          <div>
-            <label className="mb-1 block text-xs text-muted-foreground">
-              Logo URL
-            </label>
+    <div className="flex items-start gap-3">
+      <div
+        className="flex aspect-video w-28 shrink-0 items-center justify-center overflow-hidden rounded-xl"
+        style={CHECKERED_BG}
+      >
+        {value ? (
+          <img
+            src={value}
+            alt={label}
+            className={imgClassName}
+            loading="lazy"
+          />
+        ) : (
+          <span className="text-[10px] text-muted-foreground/70">
+            No {label.toLowerCase()}
+          </span>
+        )}
+      </div>
+      <div className="flex-1">
+        <label className="mb-1 block text-xs text-muted-foreground">
+          {label} URL
+        </label>
+        <Controller
+          control={form.control}
+          name={name}
+          render={({ field }) => (
             <Input
-              value={logo}
-              onChange={(e) => setLogo(e.target.value)}
+              {...field}
+              onChange={(e) => {
+                field.onChange(e);
+                onFieldChange();
+              }}
+              onBlur={() => {
+                field.onBlur();
+                onFieldCommit();
+              }}
               placeholder="https://..."
             />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-muted-foreground">
-              Favicon URL
-            </label>
-            <Input
-              value={favicon}
-              onChange={(e) => setFavicon(e.target.value)}
-              placeholder="https://..."
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-muted-foreground">
-              OG Image URL
-            </label>
-            <Input
-              value={ogImage}
-              onChange={(e) => setOgImage(e.target.value)}
-              placeholder="https://..."
-            />
-          </div>
-        </div>
-      ) : hasLogos ? (
-        <div className="grid grid-cols-3 gap-3">
-          <div className="flex flex-col gap-1.5">
-            <div
-              className="flex aspect-video w-full items-center justify-center overflow-hidden rounded-xl"
-              style={{
-                backgroundImage:
-                  "linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%), linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%)",
-                backgroundSize: "8px 8px",
-                backgroundPosition: "0 0, 4px 4px",
-                backgroundColor: "#fff",
-              }}
-            >
-              {brand.logo ? (
-                <img
-                  src={brand.logo}
-                  alt="Logo"
-                  className="h-full w-full object-contain p-3"
-                />
-              ) : (
-                <span className="text-[10px] text-muted-foreground/70">
-                  No logo
-                </span>
-              )}
-            </div>
-            <span className="text-[10px] text-muted-foreground">Logo</span>
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <div
-              className="flex aspect-video w-full items-center justify-center overflow-hidden rounded-xl"
-              style={{
-                backgroundImage:
-                  "linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%), linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%)",
-                backgroundSize: "8px 8px",
-                backgroundPosition: "0 0, 4px 4px",
-                backgroundColor: "#fff",
-              }}
-            >
-              {brand.favicon ? (
-                <img
-                  src={brand.favicon}
-                  alt="Favicon"
-                  className="h-12 w-12 object-contain"
-                />
-              ) : (
-                <span className="text-[10px] text-muted-foreground/70">
-                  No favicon
-                </span>
-              )}
-            </div>
-            <span className="text-[10px] text-muted-foreground">Favicon</span>
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <div
-              className="flex aspect-video w-full items-center justify-center overflow-hidden rounded-xl"
-              style={{
-                backgroundImage:
-                  "linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%), linear-gradient(45deg, #e5e7eb 25%, transparent 25%, transparent 75%, #e5e7eb 75%)",
-                backgroundSize: "8px 8px",
-                backgroundPosition: "0 0, 4px 4px",
-                backgroundColor: "#fff",
-              }}
-            >
-              {brand.ogImage ? (
-                <img
-                  src={brand.ogImage}
-                  alt="OG"
-                  className="h-full w-full object-contain"
-                  loading="lazy"
-                />
-              ) : (
-                <span className="text-[10px] text-muted-foreground/70">
-                  No SEO image
-                </span>
-              )}
-            </div>
-            <span className="text-[10px] text-muted-foreground">
-              SEO / OG image
-            </span>
-          </div>
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground/60">
-          No logos added yet. Click edit to add logo, favicon, and OG image
-          URLs.
-        </p>
-      )}
+          )}
+        />
+      </div>
+    </div>
+  );
+}
+
+function LogosSection({
+  form,
+  onFieldChange,
+  onFieldCommit,
+}: {
+  form: BrandFormReturn;
+  onFieldChange: () => void;
+  onFieldCommit: () => void;
+}) {
+  return (
+    <BrandCard title="Logos & Images">
+      <div className="space-y-3">
+        <LogoFieldRow
+          form={form}
+          name="logo"
+          label="Logo"
+          onFieldChange={onFieldChange}
+          onFieldCommit={onFieldCommit}
+        />
+        <LogoFieldRow
+          form={form}
+          name="favicon"
+          label="Favicon"
+          imgClassName="h-12 w-12 object-contain"
+          onFieldChange={onFieldChange}
+          onFieldCommit={onFieldCommit}
+        />
+        <LogoFieldRow
+          form={form}
+          name="ogImage"
+          label="SEO / OG image"
+          imgClassName="h-full w-full object-contain"
+          onFieldChange={onFieldChange}
+          onFieldCommit={onFieldCommit}
+        />
+      </div>
     </BrandCard>
   );
 }
@@ -467,77 +390,59 @@ const FONT_ROLES = [
 ];
 
 function FontsSection({
-  brand,
-  onSave,
+  form,
+  onFieldChange,
+  onFieldCommit,
 }: {
-  brand: Partial<BrandContext>;
-  onSave: (data: Partial<BrandContext>) => void;
+  form: BrandFormReturn;
+  onFieldChange: () => void;
+  onFieldCommit: () => void;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [fonts, setFonts] = useState<BrandFonts>(brand.fonts ?? {});
-
-  const startEdit = () => {
-    setFonts(brand.fonts ?? {});
-    setEditing(true);
-  };
-
-  const save = () => {
-    const hasAny = Object.values(fonts).some((v) => v?.trim());
-    onSave({ fonts: hasAny ? fonts : null });
-    setEditing(false);
-  };
-
-  const hasFonts =
-    brand.fonts && Object.values(brand.fonts).some((v) => v?.trim());
-
   return (
-    <BrandCard
-      title="Fonts"
-      onEdit={startEdit}
-      editing={editing}
-      onSave={save}
-      onCancel={() => setEditing(false)}
-    >
-      {editing ? (
-        <div className="space-y-2">
-          {FONT_ROLES.map(({ key, label }) => (
+    <BrandCard title="Fonts">
+      <div className="space-y-2">
+        {FONT_ROLES.map(({ key, label }) => {
+          const fieldName = `fonts.${key}` as const;
+          const value = form.watch(fieldName);
+          return (
             <div key={key}>
-              <label className="mb-1 block text-xs text-muted-foreground">
-                {label}
-              </label>
-              <Input
-                value={fonts[key] ?? ""}
-                onChange={(e) => setFonts({ ...fonts, [key]: e.target.value })}
-                placeholder={`Font family for ${label.toLowerCase()}`}
-              />
-            </div>
-          ))}
-        </div>
-      ) : hasFonts ? (
-        <div className="space-y-3">
-          {FONT_ROLES.filter(({ key }) => brand.fonts?.[key]).map(
-            ({ key, label }) => (
-              <div key={key} className="flex items-center gap-3">
-                <span className="w-9 text-xl font-medium leading-none text-foreground">
+              <label className="mb-1 flex items-center gap-3 text-xs text-muted-foreground">
+                <span className="w-7 text-base font-medium leading-none text-foreground">
                   Aa
                 </span>
-                <div>
-                  <p className="text-sm font-medium leading-none text-foreground">
-                    {brand.fonts![key]}
-                  </p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    {label}
-                  </p>
-                </div>
-              </div>
-            ),
-          )}
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground/60">
-          No fonts defined. Click edit to add your brand fonts.
-        </p>
-      )}
+                <span>{label}</span>
+                {value && (
+                  <span
+                    className="ml-auto truncate text-foreground"
+                    style={{ fontFamily: value }}
+                  >
+                    {value}
+                  </span>
+                )}
+              </label>
+              <Controller
+                control={form.control}
+                name={fieldName}
+                render={({ field }) => (
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    onChange={(e) => {
+                      field.onChange(e);
+                      onFieldChange();
+                    }}
+                    onBlur={() => {
+                      field.onBlur();
+                      onFieldCommit();
+                    }}
+                    placeholder={`Font family for ${label.toLowerCase()}`}
+                  />
+                )}
+              />
+            </div>
+          );
+        })}
+      </div>
     </BrandCard>
   );
 }
@@ -553,91 +458,61 @@ const COLOR_ROLES = [
 ];
 
 function ColorsSection({
-  brand,
-  onSave,
+  form,
+  onFieldChange,
+  onFieldCommit,
 }: {
-  brand: Partial<BrandContext>;
-  onSave: (data: Partial<BrandContext>) => void;
+  form: BrandFormReturn;
+  onFieldChange: () => void;
+  onFieldCommit: () => void;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [colors, setColors] = useState<BrandColors>(brand.colors ?? {});
-
-  const startEdit = () => {
-    setColors(brand.colors ?? {});
-    setEditing(true);
-  };
-
-  const save = () => {
-    const hasAny = Object.values(colors).some((v) => v?.trim());
-    onSave({ colors: hasAny ? colors : null });
-    setEditing(false);
-  };
-
-  const hasColors =
-    brand.colors && Object.values(brand.colors).some((v) => v?.trim());
-
   return (
-    <BrandCard
-      title="Colors"
-      onEdit={startEdit}
-      editing={editing}
-      onSave={save}
-      onCancel={() => setEditing(false)}
-    >
-      {editing ? (
-        <div className="space-y-2">
-          {COLOR_ROLES.map(({ key, label }) => (
-            <div key={key} className="flex items-center gap-2">
-              <input
-                type="color"
-                value={colors[key] ?? "#000000"}
-                onChange={(e) =>
-                  setColors({ ...colors, [key]: e.target.value })
-                }
-                className="h-9 w-9 shrink-0 cursor-pointer rounded-lg border border-border bg-transparent p-0.5"
-              />
-              <Input
-                value={colors[key] ?? ""}
-                onChange={(e) =>
-                  setColors({ ...colors, [key]: e.target.value })
-                }
-                placeholder="#000000"
-                className="w-28"
-              />
-              <span className="flex-1 text-xs text-muted-foreground">
-                {label}
-              </span>
-            </div>
-          ))}
-        </div>
-      ) : hasColors ? (
-        <div className="flex flex-wrap gap-4">
-          {COLOR_ROLES.filter(({ key }) => brand.colors?.[key]).map(
-            ({ key, label }) => (
-              <div key={key} className="flex flex-col items-center gap-2">
-                <div
-                  className="h-14 w-14 rounded-full shadow-sm"
-                  style={{
-                    backgroundColor: brand.colors![key],
-                    border:
-                      brand.colors![key] === "#FFFFFF"
-                        ? "1px solid #e5e7eb"
-                        : undefined,
-                  }}
-                />
-                <p className="font-mono text-[10px] text-muted-foreground">
-                  {brand.colors![key]}
-                </p>
-                <p className="text-[10px] text-muted-foreground">{label}</p>
-              </div>
-            ),
-          )}
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground/60">
-          No colors defined. Click edit to add your brand palette.
-        </p>
-      )}
+    <BrandCard title="Colors">
+      <div className="space-y-2">
+        {COLOR_ROLES.map(({ key, label }) => {
+          const fieldName = `colors.${key}` as const;
+          return (
+            <Controller
+              key={key}
+              control={form.control}
+              name={fieldName}
+              render={({ field }) => (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="color"
+                    value={field.value ?? "#000000"}
+                    onChange={(e) => {
+                      field.onChange(e.target.value);
+                      onFieldChange();
+                    }}
+                    onBlur={() => {
+                      field.onBlur();
+                      onFieldCommit();
+                    }}
+                    className="h-9 w-9 shrink-0 cursor-pointer rounded-lg border border-border bg-transparent p-0.5"
+                  />
+                  <Input
+                    value={field.value ?? ""}
+                    onChange={(e) => {
+                      field.onChange(e.target.value);
+                      onFieldChange();
+                    }}
+                    onBlur={() => {
+                      field.onBlur();
+                      onFieldCommit();
+                    }}
+                    placeholder="#000000"
+                    className="w-28"
+                  />
+                  <span className="flex-1 text-xs text-muted-foreground">
+                    {label}
+                  </span>
+                </div>
+              )}
+            />
+          );
+        })}
+      </div>
     </BrandCard>
   );
 }
@@ -656,34 +531,57 @@ function ExpandableBrandEntry({
   const [expanded, setExpanded] = useState(brand.isDefault ?? false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
-  const { mutate: saveBrand } = useMutation({
-    mutationFn: async (data: Partial<BrandContext>) => {
+  const form = useForm<BrandFormData>({
+    values: {
+      name: brand.name ?? "",
+      domain: brand.domain ?? "",
+      overview: brand.overview ?? "",
+      logo: brand.logo ?? "",
+      favicon: brand.favicon ?? "",
+      ogImage: brand.ogImage ?? "",
+      fonts: brand.fonts ?? {},
+      colors: brand.colors ?? {},
+    },
+  });
+
+  const updateBrandMutation = useMutation({
+    mutationFn: async (values: BrandFormData) => {
+      const fontsHasAny = Object.values(values.fonts).some((v) => v?.trim());
+      const colorsHasAny = Object.values(values.colors).some((v) => v?.trim());
       const merged = {
         id: brand.id,
-        name: data.name ?? brand.name ?? "",
-        domain: data.domain ?? brand.domain ?? "",
-        overview: data.overview ?? brand.overview ?? "",
-        logo: "logo" in data ? data.logo : brand.logo,
-        favicon: "favicon" in data ? data.favicon : brand.favicon,
-        ogImage: "ogImage" in data ? data.ogImage : brand.ogImage,
-        fonts: "fonts" in data ? data.fonts : brand.fonts,
-        colors: "colors" in data ? data.colors : brand.colors,
-        images: "images" in data ? data.images : brand.images,
+        name: values.name,
+        domain: values.domain,
+        overview: values.overview,
+        logo: values.logo || null,
+        favicon: values.favicon || null,
+        ogImage: values.ogImage || null,
+        fonts: fontsHasAny ? values.fonts : null,
+        colors: colorsHasAny ? values.colors : null,
+        images: brand.images,
       };
       await client.callTool({
         name: "BRAND_CONTEXT_UPDATE",
         arguments: merged,
       });
     },
-    onSuccess: (_res, data) => {
+    onSuccess: (_res, values) => {
       track("brand_updated", {
         brand_id: brand.id,
-        fields: Object.keys(data),
+        fields: Object.keys(form.formState.dirtyFields),
       });
+      form.reset(values);
       onChanged();
-      toast.success("Brand context saved");
     },
     onError: () => toast.error("Failed to save brand context"),
+  });
+
+  const { schedule: scheduleSave, flush: flushAndSave } = useDebouncedAutosave({
+    delayMs: 500,
+    save: async () => {
+      if (!form.formState.isDirty) return;
+      await updateBrandMutation.mutateAsync(form.getValues());
+    },
   });
 
   const { mutate: deleteBrand, isPending: isDeleting } = useMutation({
@@ -864,11 +762,27 @@ function ExpandableBrandEntry({
       {/* Expanded content */}
       {expanded && (
         <div className="space-y-3 px-5 pb-5">
-          <OverviewSection brand={brand} onSave={saveBrand} />
-          <LogosSection brand={brand} onSave={saveBrand} />
+          <OverviewSection
+            form={form}
+            onFieldChange={scheduleSave}
+            onFieldCommit={flushAndSave}
+          />
+          <LogosSection
+            form={form}
+            onFieldChange={scheduleSave}
+            onFieldCommit={flushAndSave}
+          />
           <div className="grid grid-cols-2 gap-3">
-            <ColorsSection brand={brand} onSave={saveBrand} />
-            <FontsSection brand={brand} onSave={saveBrand} />
+            <ColorsSection
+              form={form}
+              onFieldChange={scheduleSave}
+              onFieldCommit={flushAndSave}
+            />
+            <FontsSection
+              form={form}
+              onFieldChange={scheduleSave}
+              onFieldCommit={flushAndSave}
+            />
           </div>
         </div>
       )}

--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Page } from "@/web/components/page";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
@@ -13,50 +12,52 @@ import {
   ToggleGroupItem,
 } from "@deco/ui/components/toggle-group.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
-import { Button } from "@deco/ui/components/button.tsx";
 import { Moon01, Monitor01, Play, Sun } from "@untitledui/icons";
+import { Controller, useForm } from "react-hook-form";
 import { authClient } from "@/web/lib/auth-client";
 import {
   usePreferences,
   type ThemeMode,
   type ToolApprovalLevel,
 } from "@/web/hooks/use-preferences.ts";
+import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
 import { playSound } from "@deco/ui/lib/sound-engine.ts";
 import { question004Sound } from "@deco/ui/lib/question-004.ts";
 import { toast } from "@deco/ui/components/sonner.js";
 import { track } from "@/web/lib/posthog-client";
 import {
   SettingsCard,
-  SettingsCardActions,
   SettingsCardItem,
   SettingsPage,
   SettingsSection,
 } from "@/web/components/settings/settings-section";
 
+interface ProfileFormValues {
+  name: string;
+}
+
 function ProfileSection() {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const userImage = (user as { image?: string } | undefined)?.image;
-  const [editedName, setEditedName] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
 
-  const name = editedName ?? user?.name ?? "";
-  const isDirty = editedName !== null && editedName !== (user?.name ?? "");
+  const form = useForm<ProfileFormValues>({
+    values: { name: user?.name ?? "" },
+  });
 
-  const handleSave = async () => {
-    if (!isDirty) return;
-    setSaving(true);
-    try {
-      await authClient.updateUser({ name });
-      track("profile_updated", { fields: ["name"] });
-      setEditedName(null);
-      toast.success("Profile updated");
-    } catch {
-      toast.error("Failed to update profile");
-    } finally {
-      setSaving(false);
-    }
-  };
+  const { schedule: scheduleSave, flush: flushAndSave } = useDebouncedAutosave({
+    save: async () => {
+      if (!form.formState.isDirty) return;
+      const { name } = form.getValues();
+      try {
+        await authClient.updateUser({ name });
+        track("profile_updated", { fields: ["name"] });
+        form.reset({ name });
+      } catch {
+        toast.error("Failed to update profile");
+      }
+    },
+  });
 
   if (isPending) return null;
 
@@ -77,15 +78,28 @@ function ProfileSection() {
         <SettingsCardItem
           title="Display name"
           action={
-            <Input
-              id="display-name"
-              value={name}
-              onChange={(e) => setEditedName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void handleSave();
-              }}
-              placeholder="Your name"
-              className="w-[280px]"
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Input
+                  id="display-name"
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    scheduleSave();
+                  }}
+                  onBlur={() => {
+                    field.onBlur();
+                    flushAndSave();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void flushAndSave();
+                  }}
+                  placeholder="Your name"
+                  className="w-[280px]"
+                />
+              )}
             />
           }
         />
@@ -95,21 +109,6 @@ function ProfileSection() {
             <span className="text-sm text-muted-foreground">{user?.email}</span>
           }
         />
-        {isDirty && (
-          <SettingsCardActions>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setEditedName(null)}
-              disabled={saving}
-            >
-              Cancel
-            </Button>
-            <Button onClick={handleSave} disabled={saving} size="sm">
-              {saving ? "Saving…" : "Save"}
-            </Button>
-          </SettingsCardActions>
-        )}
       </SettingsCard>
     </SettingsSection>
   );

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -78,6 +78,7 @@ import {
 } from "@untitledui/icons";
 import { Suspense, useReducer, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
 import { toast } from "sonner";
 import { IconPicker } from "../../components/icon-picker";
 import { SimpleIconPicker } from "../../components/simple-icon-picker";
@@ -1131,8 +1132,6 @@ function VirtualMcpDetailViewWithData({
     createNewTask();
   };
 
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   // Session-based tracking for agent_updated. Auto-saves persist every ~1s but
   // we only emit one PostHog event per edit-session (aggregated fields +
   // save_count + edit_duration_ms). A session ends after 30s of quiet.
@@ -1165,11 +1164,6 @@ function VirtualMcpDetailViewWithData({
   };
 
   const saveForm = async () => {
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-    }
-
     const dirtyKeys = Object.keys(form.formState.dirtyFields);
     if (dirtyKeys.length === 0) return;
     const instructionsDirty = dirtyKeys.includes("metadata");
@@ -1201,12 +1195,7 @@ function VirtualMcpDetailViewWithData({
     form.reset(data);
   };
 
-  const debouncedSave = () => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(() => {
-      saveForm();
-    }, 1000);
-  };
+  const { schedule: debouncedSave } = useDebouncedAutosave({ save: saveForm });
 
   const watchSubscribedRef = useRef(false);
   if (!watchSubscribedRef.current) {

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -87,7 +87,11 @@ import { AddConnectionDialog } from "./add-connection-dialog";
 import { track } from "@/web/lib/posthog-client";
 import { DependencySelectionDialog } from "./dependency-selection-dialog";
 import { ALL_ITEMS_SELECTED } from "./selection-utils";
-import { VirtualMcpFormSchema, type VirtualMcpFormData } from "./types";
+import {
+  VirtualMcpFormSchema,
+  type VirtualMcpFormData,
+  type VirtualMcpFormReturn,
+} from "./types";
 import { VirtualMCPShareModal } from "./virtual-mcp-share-modal";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { FIXED_SYSTEM_TABS } from "@/web/layouts/main-panel-tabs/tab-id";
@@ -513,7 +517,7 @@ interface PinnedView {
   connectionId: string;
   toolName: string;
   label: string;
-  icon: string | null;
+  icon?: string | null;
 }
 
 interface ConnectionWithTools {
@@ -524,14 +528,23 @@ interface ConnectionWithTools {
   uiTools: UITool[];
 }
 
-function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
+function LayoutTabContent({
+  virtualMcpId,
+  form,
+  debouncedSave,
+  flushAndSave,
+}: {
+  virtualMcpId: string;
+  form: VirtualMcpFormReturn;
+  debouncedSave: () => void;
+  flushAndSave: () => Promise<unknown>;
+}) {
   const { org } = useProjectContext();
   const client = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
     orgSlug: org.slug,
   });
-  const queryClient = useQueryClient();
 
   const virtualMcp = useVirtualMCP(virtualMcpId);
 
@@ -593,54 +606,33 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   const fixedTabTypeSet = new Set<string>(FIXED_SYSTEM_TABS);
 
-  // Current pinned views from virtual MCP metadata
-  const uiMeta = virtualMcp?.metadata?.ui as
-    | {
-        pinnedViews?: PinnedView[] | null;
-        layout?: {
-          defaultMainView?: {
-            type: string;
-            id?: string;
-            toolName?: string;
-          } | null;
-          chatDefaultOpen?: boolean | null;
-        } | null;
-      }
-    | null
-    | undefined;
+  // Layout state lives in the parent form under metadata.ui.{pinnedViews, layout}.
+  // form.watch subscribes the component to changes from any source — direct user
+  // edits, the orphan-pin reconciliation below, or a server refetch.
+  const pinnedViews = form.watch("metadata.ui.pinnedViews") ?? [];
+  const layoutMeta = form.watch("metadata.ui.layout") ?? null;
+  const currentDefaultMain = layoutMeta?.defaultMainView ?? null;
+  const chatDefaultOpen = layoutMeta?.chatDefaultOpen ?? false;
 
-  const serverPinned: PinnedView[] = uiMeta?.pinnedViews ?? [];
-  const serverDefaultMain = uiMeta?.layout?.defaultMainView ?? null;
-  const serverChatDefaultOpen = uiMeta?.layout?.chatDefaultOpen ?? false;
-
-  const serverDefaultMainKey = (() => {
-    if (!serverDefaultMain || serverDefaultMain.type === "chat") return "chat";
-    // Legacy: instructions/connections/layout were separate tabs that have
-    // since been unified into the Settings tab.
+  // Convert the stored {type, id, toolName} object into the string composite
+  // key used by the <Select> UI. Legacy tab types fold into "settings".
+  const defaultMainView = (() => {
+    if (!currentDefaultMain || currentDefaultMain.type === "chat")
+      return "chat";
     if (
-      serverDefaultMain.type === "instructions" ||
-      serverDefaultMain.type === "connections" ||
-      serverDefaultMain.type === "layout"
+      currentDefaultMain.type === "instructions" ||
+      currentDefaultMain.type === "connections" ||
+      currentDefaultMain.type === "layout"
     ) {
       return "settings";
     }
-    if (fixedTabTypeSet.has(serverDefaultMain.type)) {
-      return serverDefaultMain.type;
+    if (fixedTabTypeSet.has(currentDefaultMain.type)) {
+      return currentDefaultMain.type;
     }
-    return `${serverDefaultMain.type}:${serverDefaultMain.id ?? ""}:${serverDefaultMain.toolName ?? ""}`;
+    return `${currentDefaultMain.type}:${currentDefaultMain.id ?? ""}:${currentDefaultMain.toolName ?? ""}`;
   })();
 
-  const [pinnedViews, setPinnedViews] = useState<PinnedView[]>(serverPinned);
-  const [defaultMainView, setDefaultMainView] =
-    useState<string>(serverDefaultMainKey);
-  const [chatDefaultOpen, setChatDefaultOpen] = useState<boolean>(
-    serverChatDefaultOpen,
-  );
-  const [isSaving, setIsSaving] = useState(false);
-
-  // Parse default main view from composite key.
-  // Plain fixed-system tab ids round-trip as { type: "<id>" }.
-  // ext-apps uses "ext-apps:<connectionId>:<toolName>".
+  // Inverse — converts the string composite key back to the stored object form.
   const parseDefaultMainView = (value: string) => {
     const [type, id, toolName] = value.split(":");
     if (!type) return null;
@@ -651,6 +643,21 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
     if (type === "ext-apps" && id)
       return { type: "ext-apps" as const, id, toolName: toolName || undefined };
     return null;
+  };
+
+  const writePinned = (next: PinnedView[]) => {
+    form.setValue("metadata.ui.pinnedViews", next, { shouldDirty: true });
+  };
+
+  const writeLayout = (next: {
+    defaultMainView?: { type: string; id?: string; toolName?: string } | null;
+    chatDefaultOpen?: boolean | null;
+  }) => {
+    form.setValue(
+      "metadata.ui.layout",
+      { ...layoutMeta, ...next },
+      { shouldDirty: true },
+    );
   };
 
   // Reconcile orphaned pinned views once tool data is available.
@@ -665,9 +672,6 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
   ) {
     reconciledRef.current = true;
 
-    // Build set of connection IDs that were successfully fetched.
-    // Pins for connections that failed to fetch are kept to avoid
-    // permanent deletion from transient errors.
     const fetchedOkIds = new Set(
       (connectionsWithTools ?? []).filter((c) => c.fetchOk).map((c) => c.id),
     );
@@ -675,118 +679,47 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
       connectionsData.flatMap((c) => c.uiTools.map((t) => `${c.id}:${t.name}`)),
     );
 
-    // Only filter pins for connections we successfully got data for
-    const validPinned = serverPinned.filter(
+    const validPinned = pinnedViews.filter(
       (pv) =>
         !fetchedOkIds.has(pv.connectionId) ||
         validKeys.has(`${pv.connectionId}:${pv.toolName}`),
     );
 
-    if (validPinned.length !== serverPinned.length) {
-      setPinnedViews(validPinned);
+    if (validPinned.length !== pinnedViews.length) {
+      writePinned(validPinned);
 
       // If the default view was an ext-app that got removed, reset to chat
-      let nextDefault = defaultMainView;
       if (
-        serverDefaultMain?.type === "ext-apps" &&
+        currentDefaultMain?.type === "ext-apps" &&
         !validPinned.some(
           (pv) =>
-            pv.connectionId === serverDefaultMain.id &&
-            pv.toolName === serverDefaultMain.toolName,
+            pv.connectionId === currentDefaultMain.id &&
+            pv.toolName === currentDefaultMain.toolName,
         )
       ) {
-        nextDefault = "chat";
-        setDefaultMainView(nextDefault);
+        writeLayout({ defaultMainView: { type: "chat" } });
       }
 
-      // Persist cleaned pins; revert local state on failure
-      client
-        .callTool({
-          name: "VIRTUAL_MCP_PINNED_VIEWS_UPDATE",
-          arguments: {
-            virtualMcpId,
-            pinnedViews: validPinned,
-            layout: {
-              defaultMainView: parseDefaultMainView(nextDefault),
-              chatDefaultOpen,
-            },
-          },
-        })
-        .then((result) => {
-          unwrapToolResult(result);
-          queryClient.invalidateQueries({
-            predicate: (query) =>
-              Array.isArray(query.queryKey) &&
-              query.queryKey.includes("collection") &&
-              query.queryKey.includes("VIRTUAL_MCP"),
-          });
-        })
-        .catch(() => {
-          // Revert to server state so UI stays consistent
-          setPinnedViews(serverPinned);
-          setDefaultMainView(serverDefaultMainKey);
-        });
+      debouncedSave();
     }
   }
-
-  // Auto-save helper that persists given state
-  const saveLayout = (
-    nextPinned: PinnedView[],
-    nextDefaultMain: string,
-    nextChatDefaultOpen?: boolean,
-  ) => {
-    setIsSaving(true);
-    const doSave = async () => {
-      try {
-        const result = await client.callTool({
-          name: "VIRTUAL_MCP_PINNED_VIEWS_UPDATE",
-          arguments: {
-            virtualMcpId,
-            pinnedViews: nextPinned,
-            layout: {
-              defaultMainView: parseDefaultMainView(nextDefaultMain),
-              chatDefaultOpen: nextChatDefaultOpen ?? chatDefaultOpen,
-            },
-          },
-        });
-        unwrapToolResult(result);
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            Array.isArray(query.queryKey) &&
-            query.queryKey.includes("collection") &&
-            query.queryKey.includes("VIRTUAL_MCP"),
-        });
-        toast.success("Layout updated");
-      } catch (error) {
-        toast.error(
-          "Failed to update layout: " +
-            (error instanceof Error ? error.message : "Unknown error"),
-        );
-      } finally {
-        setIsSaving(false);
-      }
-    };
-    doSave();
-  };
 
   const handleTogglePin = (connectionId: string, toolName: string) => {
     const pinned = pinnedViews.some(
       (v) => v.connectionId === connectionId && v.toolName === toolName,
     );
-    let nextPinned: PinnedView[];
-    let nextDefault = defaultMainView;
     if (pinned) {
-      nextPinned = pinnedViews.filter(
+      const nextPinned = pinnedViews.filter(
         (v) => !(v.connectionId === connectionId && v.toolName === toolName),
       );
+      writePinned(nextPinned);
       // If the unpinned view was the default, reset to chat
       const unpinnedKey = `ext-apps:${connectionId}:${toolName}`;
       if (defaultMainView === unpinnedKey) {
-        nextDefault = "chat";
-        setDefaultMainView(nextDefault);
+        writeLayout({ defaultMainView: { type: "chat" } });
       }
     } else {
-      nextPinned = [
+      writePinned([
         ...pinnedViews,
         {
           connectionId,
@@ -794,10 +727,9 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
           label: toTitleCase(toolName),
           icon: null,
         },
-      ];
+      ]);
     }
-    setPinnedViews(nextPinned);
-    saveLayout(nextPinned, nextDefault);
+    flushAndSave();
   };
 
   const handleLabelChange = (
@@ -805,17 +737,18 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
     toolName: string,
     label: string,
   ) => {
-    setPinnedViews((prev) =>
-      prev.map((v) =>
+    writePinned(
+      pinnedViews.map((v) =>
         v.connectionId === connectionId && v.toolName === toolName
           ? { ...v, label }
           : v,
       ),
     );
+    debouncedSave();
   };
 
   const handleLabelBlur = () => {
-    saveLayout(pinnedViews, defaultMainView);
+    flushAndSave();
   };
 
   const handleIconChange = (
@@ -823,24 +756,19 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
     toolName: string,
     icon: string | null,
   ) => {
-    setPinnedViews((prev) =>
-      prev.map((v) =>
+    writePinned(
+      pinnedViews.map((v) =>
         v.connectionId === connectionId && v.toolName === toolName
           ? { ...v, icon }
           : v,
       ),
     );
-    const nextPinned = pinnedViews.map((v) =>
-      v.connectionId === connectionId && v.toolName === toolName
-        ? { ...v, icon }
-        : v,
-    );
-    saveLayout(nextPinned, defaultMainView);
+    flushAndSave();
   };
 
   const handleDefaultMainViewChange = (value: string) => {
-    setDefaultMainView(value);
-    saveLayout(pinnedViews, value);
+    writeLayout({ defaultMainView: parseDefaultMainView(value) });
+    flushAndSave();
   };
 
   const noConnections = connectionIds.length === 0;
@@ -923,10 +851,10 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
                     checked={
                       defaultMainView === "chat" ? true : chatDefaultOpen
                     }
-                    disabled={defaultMainView === "chat" || isSaving}
+                    disabled={defaultMainView === "chat"}
                     onCheckedChange={(checked) => {
-                      setChatDefaultOpen(checked);
-                      saveLayout(pinnedViews, defaultMainView, checked);
+                      writeLayout({ chatDefaultOpen: checked });
+                      flushAndSave();
                     }}
                   />
                 </span>
@@ -1010,7 +938,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
                                   onChange={(icon) =>
                                     handleIconChange(conn.id, tool.name, icon)
                                   }
-                                  disabled={!pinned || isSaving}
+                                  disabled={!pinned}
                                 />
                                 <Input
                                   value={
@@ -1027,7 +955,7 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
                                   }
                                   onBlur={handleLabelBlur}
                                   className="h-7 text-sm w-40"
-                                  disabled={!pinned || isSaving}
+                                  disabled={!pinned}
                                   readOnly={!pinned}
                                 />
                               </div>
@@ -1036,7 +964,6 @@ function LayoutTabContent({ virtualMcpId }: { virtualMcpId: string }) {
                                 onCheckedChange={() =>
                                   handleTogglePin(conn.id, tool.name)
                                 }
-                                disabled={isSaving}
                               />
                             </div>
                           );
@@ -1195,15 +1122,9 @@ function VirtualMcpDetailViewWithData({
     form.reset(data);
   };
 
-  const { schedule: debouncedSave } = useDebouncedAutosave({ save: saveForm });
-
-  const watchSubscribedRef = useRef(false);
-  if (!watchSubscribedRef.current) {
-    watchSubscribedRef.current = true;
-    form.watch(() => {
-      debouncedSave();
-    });
-  }
+  const { schedule: debouncedSave, flush: flushAndSave } = useDebouncedAutosave(
+    { save: saveForm },
+  );
 
   const handleOpenAddDialog = () => {
     track("connections_dialog_opened", {
@@ -1231,6 +1152,7 @@ function VirtualMcpDetailViewWithData({
       ],
       { shouldDirty: true },
     );
+    debouncedSave();
     dispatch({ type: "SET_ADD_DIALOG_OPEN", payload: false });
 
     // Auto-trigger OAuth if the connection needs authorization
@@ -1252,6 +1174,7 @@ function VirtualMcpDetailViewWithData({
     const current = form.getValues("connections");
     const filtered = current.filter((c) => c.connection_id !== connectionId);
     form.setValue("connections", filtered, { shouldDirty: true });
+    debouncedSave();
   };
 
   const handleSwitchInstance = (oldId: string, newId: string) => {
@@ -1268,6 +1191,7 @@ function VirtualMcpDetailViewWithData({
       ),
       { shouldDirty: true },
     );
+    debouncedSave();
   };
 
   const handleNewInstance = async (connectionId: string) => {
@@ -1451,6 +1375,7 @@ Define step-by-step how the agent should handle requests.
 </workflows>`;
     const next = current.trim() ? `${current}\n\n${template}` : template;
     form.setValue("metadata.instructions", next, { shouldDirty: true });
+    debouncedSave();
   };
 
   const addedConnectionIds = new Set(connections.map((c) => c.connection_id));
@@ -1514,13 +1439,13 @@ Define step-by-step how the agent should handle requests.
                     value={field.value ?? null}
                     onChange={(icon) => {
                       field.onChange(icon);
-                      saveForm();
+                      flushAndSave();
                     }}
                     onColorChange={(color) => {
                       form.setValue("metadata.ui.themeColor", color, {
                         shouldDirty: true,
                       });
-                      saveForm();
+                      flushAndSave();
                     }}
                     name={form.watch("title") || "Agent"}
                     size="md"
@@ -1539,9 +1464,13 @@ Define step-by-step how the agent should handle requests.
                       {...field}
                       type="text"
                       value={field.value ?? ""}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        debouncedSave();
+                      }}
                       onBlur={() => {
                         field.onBlur();
-                        saveForm();
+                        flushAndSave();
                       }}
                       disabled={hasGithubRepo}
                       placeholder="Agent name"
@@ -1557,9 +1486,13 @@ Define step-by-step how the agent should handle requests.
                       {...field}
                       type="text"
                       value={field.value ?? ""}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        debouncedSave();
+                      }}
                       onBlur={() => {
                         field.onBlur();
-                        saveForm();
+                        flushAndSave();
                       }}
                       disabled={hasGithubRepo}
                       placeholder="Add a description..."
@@ -1719,9 +1652,13 @@ Define step-by-step how the agent should handle requests.
                     <Textarea
                       {...field}
                       value={field.value ?? ""}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        debouncedSave();
+                      }}
                       onBlur={() => {
                         field.onBlur();
-                        saveForm();
+                        flushAndSave();
                       }}
                       disabled={hasGithubRepo}
                       placeholder="Define how this agent should behave, what tone to use, any constraints or guidelines..."
@@ -1749,7 +1686,12 @@ Define step-by-step how the agent should handle requests.
             </section>
 
             {/* Layout section */}
-            <LayoutTabContent virtualMcpId={virtualMcp.id} />
+            <LayoutTabContent
+              virtualMcpId={virtualMcp.id}
+              form={form}
+              debouncedSave={debouncedSave}
+              flushAndSave={flushAndSave}
+            />
 
             {/* Danger zone */}
             <section className="flex items-center justify-between border-t border-border pt-6">
@@ -1845,9 +1787,13 @@ Define step-by-step how the agent should handle requests.
                 <Textarea
                   {...field}
                   value={field.value ?? ""}
+                  onChange={(e) => {
+                    field.onChange(e);
+                    debouncedSave();
+                  }}
                   onBlur={() => {
                     field.onBlur();
-                    saveForm();
+                    flushAndSave();
                   }}
                   disabled={hasGithubRepo}
                   placeholder="Define how this agent should behave, what tone to use, any constraints or guidelines..."


### PR DESCRIPTION
## Summary

- Always render the agent avatar in the org-level Automations list, falling back to a deterministic icon seeded from the automation name when `useVirtualMCP(virtual_mcp_id)` returns null.
- Route the row click through Decopilot when the referenced `virtual_mcp_id` is missing from the loaded virtual MCPs map, so the automation detail panel still mounts.

## Why

After #3288 the org-level Automations list reads only `automation.virtual_mcp_id`. Migration 076 backfilled NULL values from the dropped `agent.id` JSON but left pre-existing drift untouched — rows whose `virtual_mcp_id` no longer maps to a virtual MCP showed no icon and clicked into a shell that couldn't mount, which is what the bug reporter described as "the related agent icon and link to the detail broke."

## Test plan

- [ ] Open `/{org}/settings/automations` with healthy data: each row shows the agent's icon and title; clicking opens the agent shell with the automation tab.
- [ ] With an automation whose `virtual_mcp_id` references a deleted/non-VIRTUAL connection: row still shows a fallback avatar derived from the automation name, and clicking opens the automation detail in Decopilot's shell.
- [ ] `bun run check`, `bun run lint`, `bun run fmt:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org-level Automations list when an automation’s `virtual_mcp_id` is orphaned and rolls out a shared debounced autosave across detail and settings views so edits aren’t lost.

- **Bug Fixes**
  - Always render `AgentAvatar`; fall back to a deterministic icon from the automation name and use `automation.name` if agent data is missing.
  - On row click, if the agent isn’t in the loaded map, route through Decopilot using `getDecopilotId(org.id)` so the detail panel mounts; tracking uses the resolved target ID. Imports updated to include `getDecopilotId` from `@decocms/mesh-sdk`.
  - Fix autosave gaps by tracking edited fields explicitly and flushing on unmount; the name field now saves via a `Controller` with explicit dirty marking. Virtual MCP Layout now writes through the parent form autosave, cleans up orphaned pinned views, and resets default view to chat when a pinned ext-app is removed.

- **Refactors**
  - Extracted `useDebouncedAutosave` and adopted it in Automation Detail, Virtual MCP Detail (including Layout), Organization settings, Org AI Providers (simple mode), Brand Context, and Profile Preferences, removing duplicated timers and save buttons.
  - Aligned `useAutomationActions` toasts with collection patterns: show success toasts on create/update/delete and clearer error messages.

<sup>Written for commit 453a91e9a0c4fa40c96be1a459b775a3c215147a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

