### PR TITLE
docs: rename Mesh to Studio across markdown

### DIFF
--- a/.cursor/skills/add-mcp-tools/SKILL.md
+++ b/.cursor/skills/add-mcp-tools/SKILL.md
@@ -3,9 +3,9 @@ name: add-mcp-tools
 description: Guide for adding new MCP tools with consistent patterns for schemas, tool definitions, registry updates, and Better Auth integration
 ---
 
-# Adding New MCP Tools to MCP Mesh
+# Adding New MCP Tools to Studio
 
-This guide documents the pattern for adding new MCP tools to the MCP Mesh codebase. Follow this checklist to ensure consistency with existing tools.
+This guide documents the pattern for adding new MCP tools to Studio codebase. Follow this checklist to ensure consistency with existing tools.
 
 ## Overview
 

--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,6 +1,6 @@
 # Milestones
 
-## v1.0 — Core Mesh (shipped, on main)
+## v1.0 — Core Studio (shipped, on main)
 
 **Shipped:** 2026-02 (pre-planning-system)
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,12 +1,12 @@
-# MCP Mesh
+# Studio
 
 ## What This Is
 
-MCP Mesh is an open-source control plane for Model Context Protocol (MCP) traffic. It provides a unified layer for authentication, routing, and observability between MCP clients (Cursor, Claude, VS Code) and MCP servers. The system is a monorepo using Bun workspaces with TypeScript, Hono (API), and React 19 (UI), with a plugin system where each plugin exposes sidebar navigation, server tools, and client UI.
+Studio is an open-source control plane for Model Context Protocol (MCP) traffic. It provides a unified layer for authentication, routing, and observability between MCP clients (Cursor, Claude, VS Code) and MCP servers. The system is a monorepo using Bun workspaces with TypeScript, Hono (API), and React 19 (UI), with a plugin system where each plugin exposes sidebar navigation, server tools, and client UI.
 
 ## Core Value
 
-Developers can connect any MCP server to Mesh and immediately get auth, routing, observability, and a polished admin UI — including a full visual site editor for Deco-compatible sites.
+Developers can connect any MCP server to Studio and immediately get auth, routing, observability, and a polished admin UI — including a full visual site editor for Deco-compatible sites.
 
 ## Current Milestone: v1.3 — Local-First Development
 
@@ -42,7 +42,7 @@ Developers can connect any MCP server to Mesh and immediately get auth, routing,
 
 - Remote hosting / Kubernetes daemon — local-first only for this milestone
 - GitHub integration for projects — deferred to v1.4
-- Tunnel / deco link for remote Mesh — deferred to v1.4
+- Tunnel / deco link for remote Studio — deferred to v1.4
 - Multi-user local setup — single developer workflow only
 
 ## Context

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,8 +1,8 @@
-# Requirements: MCP Mesh
+# Requirements: Studio
 
 **Defined:** 2026-02-20
 **Amended:** 2026-02-20 — lead engineer feedback: bash over git tools, deco-cli as entry point, projects as virtual MCPs
-**Core Value:** Developers can connect any MCP server to Mesh and get auth, routing, observability, and a polished admin UI — including a full visual site editor for Deco-compatible sites.
+**Core Value:** Developers can connect any MCP server to Studio and get auth, routing, observability, and a polished admin UI — including a full visual site editor for Deco-compatible sites.
 
 ## v1.3 Requirements
 
@@ -12,9 +12,9 @@
 - [ ] **LDV-02**: local-dev exposes full filesystem tools (read, write, edit, list, tree, search, delete, copy) scoped to the target folder
 - [ ] **LDV-03**: local-dev exposes OBJECT_STORAGE_BINDING tools (LIST_OBJECTS, GET/PUT_PRESIGNED_URL, DELETE_OBJECT, GET_ROOT) backed by local filesystem with embedded HTTP server for presigned URLs
 - [ ] **LDV-04**: local-dev exposes an unrestricted bash execution tool scoped to the project folder (covers git, dev server, build commands, etc. — like Claude Code's bash)
-- [ ] **LDV-05**: local-dev exposes a readiness endpoint (`/_ready`) that Mesh polls before marking the project online
+- [ ] **LDV-05**: local-dev exposes a readiness endpoint (`/_ready`) that Studio polls before marking the project online
 - [ ] **LDV-06**: local-dev forwards SIGTERM to any spawned processes for clean shutdown
-- [ ] **LDV-07**: local-dev exposes SSE `/watch` stream for filesystem change events (real-time file edits visible in Mesh UI)
+- [ ] **LDV-07**: local-dev exposes SSE `/watch` stream for filesystem change events (real-time file edits visible in Studio UI)
 
 > **Note:** Git-specific tools (GIT_STATUS, GIT_DIFF, etc.) were removed — all git operations go through **LDV-04** (bash). Dev server management is also covered by bash (e.g. `bash("bun dev")`).
 
@@ -40,7 +40,7 @@
 - [ ] **EDT-09**: User can preview the page live in an iframe with edit/interact mode toggle
 - [ ] **EDT-10**: User can undo and redo changes in the composer
 - [ ] **EDT-11**: User sees pending changes (sections added/modified/deleted vs git HEAD) with diff badges — powered by bash git calls via local-dev
-- [ ] **EDT-12**: User can commit pending changes from Mesh UI with a Claude-generated commit message — via bash git commit
+- [ ] **EDT-12**: User can commit pending changes from Studio UI with a Claude-generated commit message — via bash git commit
 - [ ] **EDT-13**: User can view git history for the current page with commit list and diff preview — via bash git log/show
 - [ ] **EDT-14**: User can revert to a previous commit with a confirmation dialog — via bash git checkout
 - [ ] **EDT-15**: Site editor activates automatically when the project connection implements DECO_BLOCKS_BINDING
@@ -49,16 +49,16 @@
 
 ### `deco link` command (`packages/cli/`)
 
-- [ ] **LNK-01**: Developer can run `deco link ./my-folder` to register a local project folder with a running Mesh instance
+- [ ] **LNK-01**: Developer can run `deco link ./my-folder` to register a local project folder with a running Studio instance
 - [ ] **LNK-02**: `deco link` starts a local-dev daemon for the given folder (or connects to an already-running one)
-- [ ] **LNK-03**: `deco link` creates (or reuses) a Connection in Mesh pointing at the local-dev daemon
-- [ ] **LNK-04**: `deco link` creates (or reuses) a Project in Mesh wired to that Connection
+- [ ] **LNK-03**: `deco link` creates (or reuses) a Connection in Studio pointing at the local-dev daemon
+- [ ] **LNK-04**: `deco link` creates (or reuses) a Project in Studio wired to that Connection
 - [ ] **LNK-05**: If the folder is a deco site (`.deco/` present), `deco link` auto-enables the site-editor plugin on the project
-- [ ] **LNK-06**: `deco link` opens the browser to the project URL in Mesh, already logged in
+- [ ] **LNK-06**: `deco link` opens the browser to the project URL in Studio, already logged in
 - [ ] **LNK-07**: `deco link` keeps running as a daemon — when Ctrl+C is pressed, local-dev shuts down cleanly
-- [ ] **LNK-08**: `deco link` is designed for both local Mesh (v1.3) and remote Mesh via tunnel (v1.4) — the Mesh URL is configurable
+- [ ] **LNK-08**: `deco link` is designed for both local Studio (v1.3) and remote Studio via tunnel (v1.4) — Studio URL is configurable
 
-> **Note:** deco-cli (`packages/cli`) already exists with login support. `deco link` is a new command added to it. The CLI is the portable piece; Mesh can be local or remote.
+> **Note:** deco-cli (`packages/cli`) already exists with login support. `deco link` is a new command added to it. The CLI is the portable piece; Studio can be local or remote.
 
 ## v2 Requirements
 
@@ -70,7 +70,7 @@
 
 ### Remote & Collaboration (v1.4)
 
-- **RMT-01**: `deco link` can connect local folder to a remote Mesh instance via tunnel
+- **RMT-01**: `deco link` can connect local folder to a remote Studio instance via tunnel
 - **RMT-02**: Project can be linked to a GitHub repository
 - **RMT-03**: User can switch between "local" and "branch on GitHub" views in a project
 
@@ -80,7 +80,7 @@
 |---------|--------|
 | Kubernetes / remote daemon | Local-first only for this milestone |
 | GitHub integration | Deferred to v1.4 |
-| Tunnel / remote Mesh | Deferred to v1.4 |
+| Tunnel / remote Studio | Deferred to v1.4 |
 | Projects as virtual MCPs (local proxy) | Deferred to v1.4 |
 | Multi-user local setup | Single developer workflow only |
 | Mobile / responsive site editor | Desktop workflow only |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,14 +1,14 @@
-# Roadmap: MCP Mesh
+# Roadmap: Studio
 
 ## Milestones
 
-- ✅ **v1.0 — Core Mesh** - Phases 1–5 (shipped, on main)
+- ✅ **v1.0 — Core Studio** - Phases 1–5 (shipped, on main)
 - ✅ **v1.1 — Site Editor Foundation** - Phases 6–9 (shipped, on gui/site-builder)
 - ✅ **v1.2 — Git-Native Editing** - Phases 11–14 (shipped, on gui/site-builder)
 - 🚧 **v1.3 — Local-First Development** - Phases 15–18 (current)
 
 <details>
-<summary>✅ v1.0 — Core Mesh (Phases 1–5) — SHIPPED</summary>
+<summary>✅ v1.0 — Core Studio (Phases 1–5) — SHIPPED</summary>
 
 Core platform: auth (Better Auth), connections, organizations, projects, plugin system, event bus, observability, Kysely storage. No site editor yet. Not tracked in GSD.
 
@@ -39,7 +39,7 @@ Git site binding tools, pending changes UI, commit dialog with Claude-generated 
 - [ ] **Phase 15: local-dev daemon** - MCP server for local filesystem, object storage, git, and dev server management
 - [ ] **Phase 16: plugin-deco-blocks** - Standalone deco blocks framework: scanners, DECO_BLOCKS_BINDING, Claude skill
 - [ ] **Phase 17: site-editor plugin** - Full site editor UI with visual composer and git UX
-- [ ] **Phase 18: deco link command** - `deco link ./folder` in packages/cli connects local project to Mesh
+- [ ] **Phase 18: deco link command** - `deco link ./folder` in packages/cli connects local project to Studio
 
 ## Phase Details
 
@@ -49,9 +49,9 @@ Git site binding tools, pending changes UI, commit dialog with Claude-generated 
 **Requirements**: LDV-01, LDV-02, LDV-03, LDV-04, LDV-05, LDV-06, LDV-07
 **Success Criteria** (what must be TRUE):
   1. Developer runs a single command pointing at a folder and gets a running MCP daemon — no config files required
-  2. Mesh (or any MCP client) can call filesystem tools: read, write, edit, list, tree, search, delete, copy — all scoped to the target folder
-  3. Mesh can call OBJECT_STORAGE_BINDING tools (LIST_OBJECTS, GET/PUT_PRESIGNED_URL, DELETE_OBJECT, GET_ROOT) and they resolve to local files with an embedded HTTP server for presigned URLs
-  4. Mesh can run any bash command scoped to the project folder (git, bun, deno, arbitrary scripts) — unrestricted, like Claude Code's bash tool
+  2. Studio (or any MCP client) can call filesystem tools: read, write, edit, list, tree, search, delete, copy — all scoped to the target folder
+  3. Studio can call OBJECT_STORAGE_BINDING tools (LIST_OBJECTS, GET/PUT_PRESIGNED_URL, DELETE_OBJECT, GET_ROOT) and they resolve to local files with an embedded HTTP server for presigned URLs
+  4. Studio can run any bash command scoped to the project folder (git, bun, deno, arbitrary scripts) — unrestricted, like Claude Code's bash tool
   5. Daemon responds to `/_ready`, forwards SIGTERM cleanly, and streams filesystem change events via SSE `/watch`
 **Plans**: TBD
 
@@ -69,7 +69,7 @@ Git site binding tools, pending changes UI, commit dialog with Claude-generated 
 **Plans**: TBD
 
 ### Phase 17: site-editor plugin
-**Goal**: Users with a deco site project can navigate pages, compose sections visually, edit props, preview live, and manage git history — all from the Mesh UI; the plugin activates automatically when DECO_BLOCKS_BINDING is detected
+**Goal**: Users with a deco site project can navigate pages, compose sections visually, edit props, preview live, and manage git history — all from Studio UI; the plugin activates automatically when DECO_BLOCKS_BINDING is detected
 **Depends on**: Phase 16 (plugin-deco-blocks)
 **Requirements**: EDT-01, EDT-02, EDT-03, EDT-04, EDT-05, EDT-06, EDT-07, EDT-08, EDT-09, EDT-10, EDT-11, EDT-12, EDT-13, EDT-14, EDT-15
 **Success Criteria** (what must be TRUE):
@@ -81,18 +81,18 @@ Git site binding tools, pending changes UI, commit dialog with Claude-generated 
 **Plans**: TBD
 
 ### Phase 18: deco link command
-**Goal**: A developer can run `deco link ./my-folder` (from the existing deco-cli) and immediately see their local project in a running Mesh instance — browser opens, project ready, no manual wiring
+**Goal**: A developer can run `deco link ./my-folder` (from the existing deco-cli) and immediately see their local project in a running Studio instance — browser opens, project ready, no manual wiring
 **Depends on**: Phase 15 (local-dev daemon), Phase 17 (site-editor plugin for auto-enable detection)
 **Requirements**: LNK-01, LNK-02, LNK-03, LNK-04, LNK-05, LNK-06, LNK-07, LNK-08
 **Success Criteria** (what must be TRUE):
-  1. Running `deco link ./my-folder` starts local-dev, registers it as a Connection in Mesh, creates a Project, and opens the browser to the project — already logged in
+  1. Running `deco link ./my-folder` starts local-dev, registers it as a Connection in Studio, creates a Project, and opens the browser to the project — already logged in
   2. If the folder is a deco site (`.deco/` present), the site-editor plugin is automatically enabled and the user lands on the site editor
   3. Running the same command again on an existing setup reuses the existing Connection and Project — nothing is duplicated
-  4. Pressing Ctrl+C shuts down local-dev cleanly — the project goes offline in Mesh
-  5. The Mesh URL is configurable so the same `deco link` command can target a remote Mesh instance (tunnel wiring deferred to v1.4, but the config surface is ready)
+  4. Pressing Ctrl+C shuts down local-dev cleanly — the project goes offline in Studio
+  5. Studio URL is configurable so the same `deco link` command can target a remote Studio instance (tunnel wiring deferred to v1.4, but the config surface is ready)
 **Plans**: TBD
 
-> **Amended 2026-02-20:** Replaced `npx @decocms/mesh ./folder` with `deco link` in packages/cli (deco-cli). CLI is the portable piece — Mesh can be local or remote. Auto-setup (admin/admin) remains needed for local Mesh but lives in Mesh startup, not in the CLI.
+> **Amended 2026-02-20:** Replaced `npx @decocms/mesh ./folder` with `deco link` in packages/cli (deco-cli). CLI is the portable piece — Studio can be local or remote. Auto-setup (admin/admin) remains needed for local Studio but lives in Studio startup, not in the CLI.
 
 ## Progress
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@
 
 See: .planning/PROJECT.md (updated 2026-02-20)
 
-**Core value:** Developers can connect any MCP server to Mesh and get auth, routing, observability, and a visual site editor for Deco sites.
+**Core value:** Developers can connect any MCP server to Studio and get auth, routing, observability, and a visual site editor for Deco sites.
 **Current focus:** Milestone v1.3 — Phase 15: local-dev daemon (ready to plan)
 
 ## Current Position
@@ -45,7 +45,7 @@ Recent decisions affecting current work:
 - site-editor checks connection capabilities at runtime — does not directly depend on local-dev package
 - **AMENDED**: Git tools removed from local-dev — bash tool (unrestricted) covers git + dev server + everything
 - **AMENDED**: Entry point is `deco link` in packages/cli (deco-cli), not `npx @decocms/mesh`
-- **AMENDED**: CLI is portable/separate from Mesh — Mesh can be local or remote (tunnel = v1.4)
+- **AMENDED**: CLI is portable/separate from Studio — Studio can be local or remote (tunnel = v1.4)
 - **AMENDED**: Projects as virtual MCPs with local proxy deferred to v1.4
 - Bash tool is unrestricted, scoped to project folder — like Claude Code's bash
 - deco-cli (packages/cli) already exists with login; `deco link` is a new command added to it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides guidance when working with code in this repository, including
 
 ## Overview
 
-MCP Mesh is an open-source control plane for Model Context Protocol (MCP) traffic. It provides a unified layer for authentication, routing, and observability between MCP clients (Cursor, Claude, VS Code) and MCP servers. The system is built as a monorepo using Bun workspaces with TypeScript, Hono (API), and React 19 (UI).
+Studio is an open-source control plane for Model Context Protocol (MCP) traffic. It provides a unified layer for authentication, routing, and observability between MCP clients (Cursor, Claude, VS Code) and MCP servers. The system is built as a monorepo using Bun workspaces with TypeScript, Hono (API), and React 19 (UI).
 
 ## Commands
 
@@ -150,7 +150,7 @@ export const EXAMPLE_TOOL = defineTool({
 
 ### Project Structure & Module Organization
 
-The workspace is managed via Bun workspaces. The main application lives in `apps/mesh/` and contains the full-stack MCP Mesh implementation (Hono API server + Vite/React client). Documentation site lives in `apps/docs/` (Astro-based).
+The workspace is managed via Bun workspaces. The main application lives in `apps/mesh/` and contains the full-stack Studio implementation (Hono API server + Vite/React client). Documentation site lives in `apps/docs/` (Astro-based).
 
 **apps/mesh/** - Main full-stack application
 - `src/api/` - Hono HTTP routes + MCP proxy routes

--- a/apps/docs/client/src/content/deco-chat/en/introduction.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/introduction.mdx
@@ -17,7 +17,7 @@ If MCP is the standard interface for tool access, deco CMS is the **production l
 **Official links:**
 
 - **deco CMS**: [decocms.com](https://www.decocms.com/)
-- **Studio**: [decocms.com/mesh](https://www.decocms.com/mesh)
+- **Studio**: [decocms.com/studio](https://www.decocms.com/studio)
 - **MCP Studio**: [decocms.com/mcp-studio](https://www.decocms.com/mcp-studio)
 
 If you know us from before (as **deco.cx**) and you’re looking for **headless CMS + storefront** capabilities, visit [deco.cx](https://www.decocms.com/use-case/deco-cx). See the deco.cx docs at [docs.deco.cx](https://docs.deco.cx/en/getting-started/overview).

--- a/apps/docs/client/src/content/deco-chat/en/introduction.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/introduction.mdx
@@ -17,12 +17,12 @@ If MCP is the standard interface for tool access, deco CMS is the **production l
 **Official links:**
 
 - **deco CMS**: [decocms.com](https://www.decocms.com/)
-- **The MCP Mesh**: [decocms.com/mesh](https://www.decocms.com/mesh)
+- **Studio**: [decocms.com/mesh](https://www.decocms.com/mesh)
 - **MCP Studio**: [decocms.com/mcp-studio](https://www.decocms.com/mcp-studio)
 
 If you know us from before (as **deco.cx**) and you’re looking for **headless CMS + storefront** capabilities, visit [deco.cx](https://www.decocms.com/use-case/deco-cx). See the deco.cx docs at [docs.deco.cx](https://docs.deco.cx/en/getting-started/overview).
 
-## Start with the MCP Mesh
+## Start with Studio
 
 Choose one:
 
@@ -87,9 +87,9 @@ The application will be available at `http://localhost:8080`.
 
 **More details:** [Kubernetes: Helm Chart](/latest/en/mcp-mesh/deploy/kubernetes-helm-chart)
 
-## Learn the Mesh (concepts + product surfaces)
+## Learn Studio (concepts + product surfaces)
 
-- **[MCP Mesh Overview](/latest/en/mcp-mesh/overview)**
+- **[Studio Overview](/latest/en/mcp-mesh/overview)**
 - **[Quickstart](/latest/en/mcp-mesh/quickstart)**
 - **[Concepts](/latest/en/mcp-mesh/concepts)**
 - **[MCP Servers (Connections)](/latest/en/mcp-mesh/mcp-servers)**
@@ -100,10 +100,10 @@ The application will be available at `http://localhost:8080`.
 <Callout type="warning">
   **Docs split (quick guide):**
 
-  - **The MCP Mesh** → Self-hosting, deploying, and operating the Mesh (recommended).
+  - **Studio** → Self-hosting, deploying, and operating Studio (recommended).
   - **Legacy Admin** → If you’re using `admin.decocms.com` (still supported, **deprecated soon**).
 
-  We’re launching **MCP Studio** (on top of the Mesh), which will bring the current SaaS admin capabilities to the Mesh (including a hosted option by us) and replace the legacy SaaS over time.
+  We’re launching **MCP Studio** (on top of Studio), which will bring the current SaaS admin capabilities to Studio (including a hosted option by us) and replace the legacy SaaS over time.
 </Callout>
 
 ## Problem: the production gap
@@ -118,16 +118,16 @@ As tool surfaces and teams grow, most orgs run into the same production constrai
 
 For more context on our platform-level thesis, read [The architecture of an AI-native company](https://www.decocms.com/blog/post/ai-native-company).
 
-## Platform structure: Mesh → Studio → Apps & Store
+## Platform structure: Studio → Studio → Apps & Store
 
-### The MCP Mesh (foundation)
+### Studio (foundation)
 An open-source **control plane for MCP traffic**. It sits between your MCP clients (Cursor, Claude, VS Code, custom agents) and your MCP servers, providing a unified layer for auth, policy, and observability.
 
 ### MCP Studio (development)
 A no-code admin + SDK to package MCP capabilities as reusable building blocks.
 
 <Callout type="info">
-  **Coming soon:** This is the successor to the current SaaS admin, built on top of the MCP Mesh.
+  **Coming soon:** This is the successor to the current SaaS admin, built on top of Studio.
 </Callout>
 
 ### MCP Apps & Store (distribution)

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/api-keys.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/api-keys.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## What are API keys for?
 
-API keys are the simplest way to give an agent/app access to the Mesh without an interactive login flow. Keys are:
+API keys are the simplest way to give an agent/app access to Studio without an interactive login flow. Keys are:
 
 - **scoped** (explicit permissions)
 - **revocable**

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/api-reference.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: The core HTTP endpoints exposed by the Mesh for MCP, agents, OAuth, and ops
+description: The core HTTP endpoints exposed by Studio for MCP, agents, OAuth, and ops
 icon: Code
 ---
 

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/authentication.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/authentication.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## What’s supported
 
-The Mesh uses Better Auth and supports:
+Studio uses Better Auth and supports:
 
 - **Email/password**
 - **Magic link**

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/authorization-and-roles.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/authorization-and-roles.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## The model
 
-The Mesh enforces access control at two layers:
+Studio enforces access control at two layers:
 
 - **Organization roles** (member permissions inside an org)
 - **Tool permissions** (what an API key or user session is allowed to call)

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/concepts.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/concepts.mdx
@@ -11,13 +11,13 @@ icon: BookOpen
 - **Roles**: role assignments for members, used by access control checks.
 - **Connection**: a configured upstream MCP endpoint (usually HTTP), optionally with stored credentials.
 - **Agent**: a virtual MCP server that aggregates multiple connections into a single MCP surface.
-- **Tool call**: a `tools/call` request routed through the Mesh to a downstream MCP server (or via an agent).
+- **Tool call**: a `tools/call` request routed through Studio to a downstream MCP server (or via an agent).
 - **Monitoring log**: a record of a tool call (inputs, outputs, duration, error), used for debugging and ops.
 
 ## Data and security boundaries
 
 - **Credential Vault**: sensitive connection credentials are encrypted at rest (vaulted) and only decrypted at request time.
-- **Permissions**: API keys are scoped to tool permissions; the Mesh enforces authorization before proxying.
+- **Permissions**: API keys are scoped to tool permissions; Studio enforces authorization before proxying.
 
 ## How requests flow
 
@@ -26,6 +26,6 @@ icon: BookOpen
    - the **Management MCP** (admin tools), or
    - a **Proxy endpoint** (one connection), or
    - an **Agent endpoint** (aggregated tools/resources/prompts).
-3. The Mesh authorizes, loads credentials, proxies to the downstream Connection(s), and logs monitoring events.
+3. Studio authorizes, loads credentials, proxies to the downstream Connection(s), and logs monitoring events.
 
 

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/connect-clients.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/connect-clients.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect MCP Clients
-description: How Cursor/Claude/custom clients authenticate to the Mesh and consume tools via MCP
+description: How Cursor/Claude/custom clients authenticate to Studio and consume tools via MCP
 icon: PlugZap
 ---
 
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## Client options
 
-There are two common ways to connect clients to the Mesh:
+There are two common ways to connect clients to Studio:
 
 - **OAuth (recommended for interactive clients)**: supports standard OAuth flows, consent, and organization-aware access.
 - **API Keys (recommended for servers/agents)**: scoped keys with explicit tool permissions.

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/kubernetes-helm-chart.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/kubernetes-helm-chart.mdx
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"  
+  url: "postgresql://mesh_user:mesh_password@postgres.example.com:5432/mesh_db"  
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/kubernetes-helm-chart.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/kubernetes-helm-chart.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Kubernetes: Helm Chart"
-description: Deploy MCP Mesh on Kubernetes using the Helm chart
+description: Deploy Studio on Kubernetes using the Helm chart
 icon: Rocket
 ---
 
 import Callout from "../../../../../components/ui/Callout.astro";
 
-This guide explains how to deploy the MCP Mesh on Kubernetes using the Helm chart.
+This guide explains how to deploy Studio on Kubernetes using the Helm chart.
 
-Learn more: [the MCP Mesh product page](https://www.decocms.com/mesh)
+Learn more: [Studio product page](https://www.decocms.com/mesh)
 
 Helm chart source: [decocms/helm-chart-deco-mcp-mesh](https://github.com/decocms/helm-chart-deco-mcp-mesh)
 
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@mesh.example.com:5432/mesh_db"  
+  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"  
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/kubernetes-helm-chart.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/kubernetes-helm-chart.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../../components/ui/Callout.astro";
 
 This guide explains how to deploy Studio on Kubernetes using the Helm chart.
 
-Learn more: [Studio product page](https://www.decocms.com/mesh)
+Learn more: [Studio product page](https://www.decocms.com/studio)
 
 Helm chart source: [decocms/helm-chart-deco-mcp-mesh](https://github.com/decocms/helm-chart-deco-mcp-mesh)
 

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/local-docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/local-docker-compose.mdx
@@ -6,9 +6,9 @@ icon: Container
 
 import Callout from "../../../../../components/ui/Callout.astro";
 
-This guide covers deploying the MCP Mesh locally using Docker Compose for quick testing and development.
+This guide covers deploying Studio locally using Docker Compose for quick testing and development.
 
-Learn more: [the MCP Mesh product page](https://www.decocms.com/mesh)
+Learn more: [Studio product page](https://www.decocms.com/mesh)
 
 Source (Docker Compose + README): [decocms/mesh/deploy](https://github.com/decocms/mesh/tree/main/deploy)
 
@@ -47,7 +47,7 @@ open http://localhost:3000
 ```
 
 <Callout type="tip">
-  These configurations are all you need to start testing with MCP-MESH. If you need other options, check the sections below.
+  These configurations are all you need to start testing with Studio. If you need other options, check the sections below.
 </Callout>
 
 ### Minimum Configuration
@@ -187,7 +187,7 @@ volumes:
 
 #### When it's Loaded
 
-The Mesh application loads this file on startup to configure:
+Studio application loads this file on startup to configure:
 
 - Email/Password authentication
 - Social providers (Google, GitHub)

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/local-docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/deploy/local-docker-compose.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../../components/ui/Callout.astro";
 
 This guide covers deploying Studio locally using Docker Compose for quick testing and development.
 
-Learn more: [Studio product page](https://www.decocms.com/mesh)
+Learn more: [Studio product page](https://www.decocms.com/studio)
 
 Source (Docker Compose + README): [decocms/mesh/deploy](https://github.com/decocms/mesh/tree/main/deploy)
 

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/mcp-gateways.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/mcp-gateways.mdx
@@ -54,7 +54,7 @@ Every new organization gets a **Default Agent**:
 
 - **Strategy**: `passthrough`
 - **Mode**: `exclusion`
-- **Default exclusions**: the built-in **Mesh MCP** connection (management tools) and the **Store/Registry** connection are excluded by default
+- **Default exclusions**: the built-in **Studio MCP** connection (management tools) and the **Store/Registry** connection are excluded by default
 - **Default behavior**: everything else in the org is included — so as you connect Integrations, this endpoint becomes the "all tools in the org" Agent
 
 This is the endpoint most teams use as the single aggregated MCP surface for an org.

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/mcp-servers.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/mcp-servers.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## What is a connection?
 
-A **Connection** in the Mesh is a configured upstream MCP endpoint (typically HTTP). The Mesh stores its configuration and (optionally) credentials, and can then proxy MCP requests to it.
+A **Connection** in Studio is a configured upstream MCP endpoint (typically HTTP). Studio stores its configuration and (optionally) credentials, and can then proxy MCP requests to it.
 
 ## In the UI
 
@@ -24,7 +24,7 @@ Once you have a connection ID, clients can call tools via:
 
 - `POST /mcp/:connectionId`
 
-The Mesh will:
+Studio will:
 
 1. authenticate the caller
 2. authorize the tool call

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/monitoring.mdx
@@ -6,7 +6,7 @@ icon: Activity
 
 ## What gets recorded
 
-The Mesh records monitoring logs for proxied tool calls, including:
+Studio records monitoring logs for proxied tool calls, including:
 
 - tool name
 - connection / agent attribution

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/overview.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/overview.mdx
@@ -6,9 +6,9 @@ icon: Network
 
 import Callout from "../../../../components/ui/Callout.astro";
 
-## What is the MCP Mesh?
+## What is Studio?
 
-The **MCP Mesh** is a **control plane for MCP traffic**. It sits between MCP clients (Cursor, Claude Desktop, custom agents) and MCP servers, providing a centralized layer for **authentication, authorization, credential management, and observability**.
+The **Studio** is a **control plane for MCP traffic**. It sits between MCP clients (Cursor, Claude Desktop, custom agents) and MCP servers, providing a centralized layer for **authentication, authorization, credential management, and observability**.
 
 ## The problem
 
@@ -19,7 +19,7 @@ When MCP moves from a few PoCs to production usage, teams start paying an “int
 - **Operational blind spots**: no unified logs/traces to debug failures end-to-end
 - **Tool surface explosion**: too many tools increases context size, latency, and tool-selection errors
 
-The Mesh centralizes these concerns once, so you can operate MCP traffic like any other production surface.
+Studio centralizes these concerns once, so you can operate MCP traffic like any other production surface.
 
 ## High-level architecture
 
@@ -33,7 +33,7 @@ The Mesh centralizes these concerns once, so you can operate MCP traffic like an
                         └──────────────────┘
 ```
 
-## What the Mesh centralizes
+## What Studio centralizes
 
 - **Routing + execution**: which MCP to call and how to authenticate it
 - **Policy enforcement**: who can access which tools (and through which agents)
@@ -51,7 +51,7 @@ The Mesh centralizes these concerns once, so you can operate MCP traffic like an
 - **Deploy**: self-host locally (npx / Docker Compose) or on Kubernetes (Helm).
 
 <Callout type="info">
-  We’re releasing the MCP Mesh to the open-source community in **December 2025**.
+  We’re releasing Studio to the open-source community in **December 2025**.
   It’s new, so these docs reflect what exists **in production today** — but we ship new features every week and will keep updating this documentation as those features land. 
 </Callout>
 

--- a/apps/docs/client/src/content/deco-chat/en/mcp-mesh/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-mesh/quickstart.mdx
@@ -1,12 +1,12 @@
 ---
 title: Quickstart
-description: Run Mesh locally, connect an Integration, create an Agent, and verify monitoring
+description: Run Studio locally, connect an Integration, create an Agent, and verify monitoring
 icon: Rocket
 ---
 
 import Callout from "../../../../components/ui/Callout.astro";
 
-## 1) Run the Mesh
+## 1) Run Studio
 
 Pick one:
 
@@ -73,7 +73,7 @@ The application will be available at `http://localhost:8080`.
 
 ## 2) Create a Connection
 
-When you open a new organization, the Mesh will prompt you to:
+When you open a new organization, Studio will prompt you to:
 
 - **Browse Store** or
 - **Create Connection** directly - provide the MCP URL (HTTP endpoint) and any required credentials

--- a/apps/docs/client/src/content/deco-chat/en/mcp-studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/mcp-studio/overview.mdx
@@ -20,12 +20,12 @@ Use it to turn **tools + schemas + workflows** into apps with:
 - A safe path for other teams to adopt what works
 
 <Callout type="info">
-  **Coming soon:** MCP Studio is being built on top of **the MCP Mesh** and will replace the legacy SaaS admin (`admin.decocms.com`) over time (including a hosted option by us).
+  **Coming soon:** MCP Studio is being built on top of **Studio** and will replace the legacy SaaS admin (`admin.decocms.com`) over time (including a hosted option by us).
 </Callout>
 
 ## Where does it fit?
 
-- **The MCP Mesh (foundation):** connect, govern, and observe MCP traffic
+- **Studio (foundation):** connect, govern, and observe MCP traffic
 - **MCP Studio (development):** package and curate reusable capabilities
 - **MCP Apps & Store (distribution):** distribute what works across teams
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/introduction.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/introduction.mdx
@@ -17,7 +17,7 @@ Se MCP é a interface padrão para acesso a tools, o deco CMS é a **camada de p
 **Links oficiais:**
 
 - **deco CMS**: [decocms.com](https://www.decocms.com/)
-- **O Studio**: [decocms.com/mesh](https://www.decocms.com/mesh)
+- **O Studio**: [decocms.com/studio](https://www.decocms.com/studio)
 - **MCP Studio**: [decocms.com/mcp-studio](https://www.decocms.com/mcp-studio)
 
 Se você conheceu a gente antes, como **deco.cx**, e está buscando **headless CMS + storefront**, visite [deco.cx](https://www.decocms.com/use-case/deco-cx). Veja a documentação do deco.cx em [docs.deco.cx](https://docs.deco.cx/en/getting-started/overview).

--- a/apps/docs/client/src/content/deco-chat/pt-br/introduction.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/introduction.mdx
@@ -17,12 +17,12 @@ Se MCP é a interface padrão para acesso a tools, o deco CMS é a **camada de p
 **Links oficiais:**
 
 - **deco CMS**: [decocms.com](https://www.decocms.com/)
-- **O MCP Mesh**: [decocms.com/mesh](https://www.decocms.com/mesh)
+- **O Studio**: [decocms.com/mesh](https://www.decocms.com/mesh)
 - **MCP Studio**: [decocms.com/mcp-studio](https://www.decocms.com/mcp-studio)
 
 Se você conheceu a gente antes, como **deco.cx**, e está buscando **headless CMS + storefront**, visite [deco.cx](https://www.decocms.com/use-case/deco-cx). Veja a documentação do deco.cx em [docs.deco.cx](https://docs.deco.cx/en/getting-started/overview).
 
-## Comece pelo MCP Mesh
+## Comece pelo Studio
 
 Escolha uma opção:
 
@@ -87,7 +87,7 @@ A aplicação ficará disponível em `http://localhost:8080`.
 
 **Mais detalhes:** [Kubernetes: Helm Chart](/pt-br/mcp-mesh/deploy/kubernetes-helm-chart)
 
-## Aprenda o Mesh (conceitos + superfícies do produto)
+## Aprenda o Studio (conceitos + superfícies do produto)
 
 - **[Visão geral](/pt-br/mcp-mesh/overview)**
 - **[Quickstart](/pt-br/mcp-mesh/quickstart)**
@@ -101,10 +101,10 @@ A aplicação ficará disponível em `http://localhost:8080`.
 <Callout type="warning">
   **Divisão da documentação (guia rápido):**
 
-  - **O MCP Mesh** → Auto-hospedagem, deploy e operação do Mesh (recomendado).
+  - **O Studio** → Auto-hospedagem, deploy e operação do Studio (recomendado).
   - **Admin Legado** → Se você usa `admin.decocms.com` (ainda suportado, **em breve descontinuado**).
 
-  Estamos lançando o **MCP Studio** (em cima do Mesh), que vai trazer as capacidades do admin SaaS atual para o Mesh (incluindo uma versão hospedada por nós) e substituir o SaaS legado ao longo do tempo.
+  Estamos lançando o **MCP Studio** (em cima do Studio), que vai trazer as capacidades do admin SaaS atual para o Studio (incluindo uma versão hospedada por nós) e substituir o SaaS legado ao longo do tempo.
 </Callout>
 
 ## Problema: a lacuna entre demo e produção
@@ -119,16 +119,16 @@ IA é fácil de demonstrar e difícil de **operar**.
 
 Para contexto sobre a visão da plataforma, leia [The architecture of an AI-native company](https://www.decocms.com/blog/post/ai-native-company).
 
-## Estrutura da plataforma: Mesh → Studio → Apps & Store
+## Estrutura da plataforma: Studio → Studio → Apps & Store
 
-### O MCP Mesh (fundação)
+### O Studio (fundação)
 Um **control plane** open-source para tráfego MCP. Ele fica entre seus clientes MCP (Cursor, Claude, VS Code, agentes customizados) e seus servidores MCP, oferecendo uma camada unificada de auth, policy e observabilidade.
 
 ### MCP Studio (desenvolvimento)
 Um admin no-code + SDK para empacotar capacidades MCP como blocos reutilizáveis.
 
 <Callout type="info">
-  **Em breve:** este é o sucessor do admin SaaS atual, construído em cima do MCP Mesh.
+  **Em breve:** este é o sucessor do admin SaaS atual, construído em cima do Studio.
 </Callout>
 
 ### MCP Apps & Store (distribuição)

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/api-keys.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/api-keys.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## Para que servem as API keys?
 
-API keys são a forma mais simples de dar acesso ao Mesh para um agente/app sem um fluxo de login interativo. As chaves são:
+API keys são a forma mais simples de dar acesso ao Studio para um agente/app sem um fluxo de login interativo. As chaves são:
 
 - **com escopo** (permissões explícitas)
 - **revogáveis**

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/api-reference.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Referência da API
-description: Os endpoints HTTP principais expostos pelo Mesh para MCP, agents, OAuth e operação
+description: Os endpoints HTTP principais expostos pelo Studio para MCP, agents, OAuth e operação
 icon: Code
 ---
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/authentication.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/authentication.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## O que é suportado
 
-O Mesh usa Better Auth e suporta:
+O Studio usa Better Auth e suporta:
 
 - **Email/senha**
 - **Magic link**

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/authorization-and-roles.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/authorization-and-roles.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## O modelo
 
-O Mesh aplica controle de acesso em duas camadas:
+O Studio aplica controle de acesso em duas camadas:
 
 - **Roles de organização** (permissões de membros dentro da org)
 - **Permissões de tool** (o que uma API key ou sessão de usuário pode chamar)

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/concepts.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/concepts.mdx
@@ -11,13 +11,13 @@ icon: BookOpen
 - **Roles**: papéis dentro da org (usados para permissões).
 - **Conexão**: um endpoint MCP upstream configurado (normalmente HTTP), com credenciais no vault quando necessário.
 - **Agent**: um "MCP virtual" que agrega múltiplas connections em um único endpoint.
-- **Tool call**: uma requisição `tools/call` roteada pelo Mesh para uma connection (ou via agent).
+- **Tool call**: uma requisição `tools/call` roteada pelo Studio para uma connection (ou via agent).
 - **Monitoring log**: registro de tool call (inputs/outputs, duração, erro) para debug e operação.
 
 ## Limites de segurança
 
 - **Credential Vault**: credenciais sensíveis ficam criptografadas em repouso e só são descriptografadas quando necessário.
-- **Permissões**: a Mesh valida permissões antes de fazer proxy da chamada.
+- **Permissões**: a Studio valida permissões antes de fazer proxy da chamada.
 
 ## Como uma chamada flui
 
@@ -26,6 +26,6 @@ icon: BookOpen
    - **Management MCP** (admin tools), ou
    - **Proxy** (uma connection), ou
    - **Agent** (agregação).
-3. O Mesh autoriza, carrega credenciais, faz proxy para a Conexão upstream e registra monitoring.
+3. O Studio autoriza, carrega credenciais, faz proxy para a Conexão upstream e registra monitoring.
 
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/connect-clients.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/connect-clients.mdx
@@ -1,6 +1,6 @@
 ---
 title: Conectar Clientes MCP
-description: Como Cursor/Claude/clientes customizados autenticam no Mesh e consomem tools via MCP
+description: Como Cursor/Claude/clientes customizados autenticam no Studio e consomem tools via MCP
 icon: PlugZap
 ---
 
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## Opções de cliente
 
-Existem duas formas comuns de conectar clientes ao Mesh:
+Existem duas formas comuns de conectar clientes ao Studio:
 
 - **OAuth (recomendado para clientes interativos)**: suporta fluxos OAuth padrão, consentimento e acesso por organização.
 - **API Keys (recomendado para servidores/agentes)**: chaves com escopo e permissões explícitas de tools.

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/kubernetes-helm-chart.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/kubernetes-helm-chart.mdx
@@ -6,9 +6,9 @@ icon: Rocket
 
 import Callout from "../../../../../components/ui/Callout.astro";
 
-Este guia explica como fazer deploy do MCP Mesh no Kubernetes usando o Helm chart.
+Este guia explica como fazer deploy do Studio no Kubernetes usando o Helm chart.
 
-Saiba mais: [página do MCP Mesh](https://www.decocms.com/mesh)
+Saiba mais: [página do Studio](https://www.decocms.com/mesh)
 
 Código-fonte do Helm chart: [decocms/helm-chart-deco-mcp-mesh](https://github.com/decocms/helm-chart-deco-mcp-mesh)
 
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@mesh.example.com:5432/mesh_db"  
+  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"  
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/kubernetes-helm-chart.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/kubernetes-helm-chart.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../../components/ui/Callout.astro";
 
 Este guia explica como fazer deploy do Studio no Kubernetes usando o Helm chart.
 
-Saiba mais: [página do Studio](https://www.decocms.com/mesh)
+Saiba mais: [página do Studio](https://www.decocms.com/studio)
 
 Código-fonte do Helm chart: [decocms/helm-chart-deco-mcp-mesh](https://github.com/decocms/helm-chart-deco-mcp-mesh)
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/kubernetes-helm-chart.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/kubernetes-helm-chart.mdx
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"  
+  url: "postgresql://mesh_user:mesh_password@postgres.example.com:5432/mesh_db"  
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/local-docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/local-docker-compose.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Local: Docker Compose"
-description: Deploy do MCP Mesh localmente usando Docker Compose para testes e desenvolvimento
+description: Deploy do Studio localmente usando Docker Compose para testes e desenvolvimento
 icon: Container
 ---
 
 import Callout from "../../../../../components/ui/Callout.astro";
 
-Este guia cobre o deploy do MCP Mesh localmente usando Docker Compose para testes rápidos e desenvolvimento.
+Este guia cobre o deploy do Studio localmente usando Docker Compose para testes rápidos e desenvolvimento.
 
-Saiba mais: [página do MCP Mesh](https://www.decocms.com/mesh)
+Saiba mais: [página do Studio](https://www.decocms.com/mesh)
 
 Código-fonte (Docker Compose + README): [decocms/mesh/deploy](https://github.com/decocms/mesh/tree/main/deploy)
 
@@ -47,7 +47,7 @@ open http://localhost:3000
 ```
 
 <Callout type="tip">
-  Essas configurações são tudo que você precisa para começar a testar com o MCP-MESH. Se precisar de outras opções, confira as seções abaixo.
+  Essas configurações são tudo que você precisa para começar a testar com o Studio. Se precisar de outras opções, confira as seções abaixo.
 </Callout>
 
 ### Configuração Mínima
@@ -187,7 +187,7 @@ volumes:
 
 #### Quando é Carregado
 
-A aplicação Mesh carrega este arquivo na inicialização para configurar:
+A aplicação Studio carrega este arquivo na inicialização para configurar:
 
 - Autenticação por Email/Senha
 - Provedores sociais (Google, GitHub)

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/local-docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/deploy/local-docker-compose.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../../components/ui/Callout.astro";
 
 Este guia cobre o deploy do Studio localmente usando Docker Compose para testes rápidos e desenvolvimento.
 
-Saiba mais: [página do Studio](https://www.decocms.com/mesh)
+Saiba mais: [página do Studio](https://www.decocms.com/studio)
 
 Código-fonte (Docker Compose + README): [decocms/mesh/deploy](https://github.com/decocms/mesh/tree/main/deploy)
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/mcp-gateways.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/mcp-gateways.mdx
@@ -54,7 +54,7 @@ Toda organização nova recebe um **Default Agent**:
 
 - **Strategy**: `passthrough`
 - **Mode**: `exclusion`
-- **Exclusões padrão**: a connection interna **Mesh MCP** (tools de administração) e a connection da **Store/Registry** são excluídas por padrão
+- **Exclusões padrão**: a connection interna **Studio MCP** (tools de administração) e a connection da **Store/Registry** são excluídas por padrão
 - **Comportamento padrão**: todo o resto na org é incluído -- então, conforme você conecta Integrações, esse endpoint se torna o Agent "com todas as tools da org"
 
 Esse é o endpoint que a maioria dos times usa como a superfície MCP agregada única da organização.

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/mcp-servers.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/mcp-servers.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## O que é uma conexão?
 
-Uma **Conexão** no Mesh é um endpoint MCP upstream configurado (tipicamente HTTP). O Mesh armazena sua configuração e (opcionalmente) credenciais, e pode então fazer proxy de requisições MCP para ele.
+Uma **Conexão** no Studio é um endpoint MCP upstream configurado (tipicamente HTTP). O Studio armazena sua configuração e (opcionalmente) credenciais, e pode então fazer proxy de requisições MCP para ele.
 
 ## Na interface
 
@@ -24,7 +24,7 @@ Uma vez que você tenha o ID da conexão, clientes podem chamar tools via:
 
 - `POST /mcp/:connectionId`
 
-O Mesh vai:
+O Studio vai:
 
 1. autenticar o chamador
 2. autorizar a tool call

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/monitoring.mdx
@@ -6,7 +6,7 @@ icon: Activity
 
 ## O que é registrado
 
-O Mesh registra logs de monitoring para tool calls proxied, incluindo:
+O Studio registra logs de monitoring para tool calls proxied, incluindo:
 
 - nome da tool
 - atribuição de connection / agent

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/overview.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/overview.mdx
@@ -6,9 +6,9 @@ icon: Network
 
 import Callout from "../../../../components/ui/Callout.astro";
 
-## O que é o MCP Mesh?
+## O que é o Studio?
 
-O **MCP Mesh** é um **control plane para tráfego MCP**. Ele fica entre clientes MCP (Cursor, Claude Desktop, agentes) e servidores MCP, oferecendo uma camada centralizada de **autenticação, autorização, vault de credenciais e observabilidade**.
+O **Studio** é um **control plane para tráfego MCP**. Ele fica entre clientes MCP (Cursor, Claude Desktop, agentes) e servidores MCP, oferecendo uma camada centralizada de **autenticação, autorização, vault de credenciais e observabilidade**.
 
 ## O problema
 
@@ -19,7 +19,7 @@ Quando MCP sai de alguns PoCs e vai para produção, os times começam a pagar u
 - **Pontos cegos operacionais**: falta um lugar único para ver logs/traces e depurar ponta a ponta
 - **Explosão de tools**: muitas tools aumentam contexto, latência e pioram a seleção de tool
 
-O Mesh centraliza isso uma vez, para você operar MCP como qualquer outra superfície de produção.
+O Studio centraliza isso uma vez, para você operar MCP como qualquer outra superfície de produção.
 
 ## Arquitetura (alto nível)
 
@@ -33,7 +33,7 @@ O Mesh centraliza isso uma vez, para você operar MCP como qualquer outra superf
                         └──────────────────┘
 ```
 
-## O que o Mesh centraliza
+## O que o Studio centraliza
 
 - **Roteamento + execução**: qual MCP chamar e como autenticar
 - **Policy enforcement**: quem pode acessar quais tools (e via quais agents)
@@ -51,7 +51,7 @@ O Mesh centraliza isso uma vez, para você operar MCP como qualquer outra superf
 - **Deploy**: auto-hospedar localmente (npx / Docker Compose) ou em Kubernetes (Helm).
 
 <Callout type="info">
-  Estamos lançando o MCP Mesh para a comunidade open-source em **dezembro de 2025**.
+  Estamos lançando o Studio para a comunidade open-source em **dezembro de 2025**.
   Ele ainda é novo: esta documentação reflete o que existe **em produção hoje**, mas estamos lançando features toda semana e vamos atualizar os docs conforme elas forem chegando.
 </Callout>
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-mesh/quickstart.mdx
@@ -1,12 +1,12 @@
 ---
 title: Quickstart
-description: Rode o Mesh, conecte uma Integração, crie um Agent e valide o monitoring
+description: Rode o Studio, conecte uma Integração, crie um Agent e valide o monitoring
 icon: Rocket
 ---
 
 import Callout from "../../../../components/ui/Callout.astro";
 
-## 1) Rodar o Mesh
+## 1) Rodar o Studio
 
 Escolha uma opção:
 
@@ -73,7 +73,7 @@ A aplicação ficará disponível em `http://localhost:8080`.
 
 ## 2) Criar uma Conexão
 
-Ao abrir uma organização nova, o Mesh normalmente te leva para:
+Ao abrir uma organização nova, o Studio normalmente te leva para:
 
 - **Browse Store** (recomendado), ou
 - **Create Connection** direto (URL MCP via HTTP + credenciais, se necessário)

--- a/apps/docs/client/src/content/deco-chat/pt-br/mcp-studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/mcp-studio/overview.mdx
@@ -20,12 +20,12 @@ Ele transforma **tools + schemas + workflows** em apps com:
 - Um caminho seguro para outros times adotarem o que funciona
 
 <Callout type="info">
-  **Em breve:** o MCP Studio está sendo construído em cima do **MCP Mesh** e vai substituir o admin SaaS legado (`admin.decocms.com`) ao longo do tempo (incluindo uma versão hospedada por nós).
+  **Em breve:** o MCP Studio está sendo construído em cima do **Studio** e vai substituir o admin SaaS legado (`admin.decocms.com`) ao longo do tempo (incluindo uma versão hospedada por nós).
 </Callout>
 
 ## Onde isso se encaixa?
 
-- **O MCP Mesh (fundação):** conectar, governar e observar tráfego MCP
+- **O Studio (fundação):** conectar, governar e observar tráfego MCP
 - **MCP Studio (desenvolvimento):** empacotar e curar capacidades reutilizáveis
 - **MCP Apps & Store (distribuição):** distribuir o que funciona entre times
 

--- a/apps/docs/client/src/content/deco-studio/en/full-code-guides/deployment.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/full-code-guides/deployment.mdx
@@ -42,7 +42,7 @@ Update `app.json` with your app's details before publishing:
 - **`connection.url`** — your deployed MCP endpoint (must end with `/api/mcp`)
 - **`configSchema`** — JSON Schema for configuration options shown to users who install your app
 
-## Publishing to Deco Mesh
+## Publishing to Deco Studio
 
 1. Update `app.json` with your app's name, description, and deployed connection URL
 2. Push to your repository

--- a/apps/docs/client/src/content/deco-studio/en/studio/agent-bindings.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/agent-bindings.mdx
@@ -163,7 +163,7 @@ If you need to call a decopilot agent outside the binding system (e.g. from a sc
 import { createDecopilotClient } from "@decocms/runtime/decopilot";
 
 const client = createDecopilotClient({
-  baseUrl: "https://mesh.decocms.com/api",
+  baseUrl: "https://studio.decocms.com/api",
   orgSlug: "my-org",
   token: "your-api-key",
 });

--- a/apps/docs/client/src/content/deco-studio/en/studio/api-keys.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/api-keys.mdx
@@ -46,7 +46,7 @@ Add the API key to your MCP client configuration:
 {
   "mcpServers": {
     "deco": {
-      "url": "https://mesh.decocms.com/mcp/agent/your-agent-id",
+      "url": "https://studio.decocms.com/mcp/agent/your-agent-id",
       "transport": "http",
       "headers": {
         "Authorization": "Bearer mcp_key_abc123..."

--- a/apps/docs/client/src/content/deco-studio/en/studio/api-reference/connection-proxy.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/api-reference/connection-proxy.mdx
@@ -237,7 +237,7 @@ Connect Cursor or Claude Desktop directly to a specific upstream MCP:
 {
   "mcpServers": {
     "github-production": {
-      "url": "https://mesh.example.com/mcp/conn_abc123",
+      "url": "https://studio.example.com/mcp/conn_abc123",
       "headers": {
         "Authorization": "Bearer YOUR_API_KEY"
       }
@@ -251,7 +251,7 @@ Connect Cursor or Claude Desktop directly to a specific upstream MCP:
 Build custom clients that need access to a specific MCP server's tools without Virtual MCP composition:
 
 ```typescript
-const response = await fetch('https://mesh.example.com/mcp/conn_abc123', {
+const response = await fetch('https://studio.example.com/mcp/conn_abc123', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"  
+  url: "postgresql://mesh_user:mesh_password@postgres.example.com:5432/mesh_db"  
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@mesh.example.com:5432/mesh_db"  
+  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"  
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/agent-bindings.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/agent-bindings.mdx
@@ -142,7 +142,7 @@ Se voce precisa chamar um agente do decopilot fora do sistema de bindings (ex: d
 import { createDecopilotClient } from "@decocms/runtime/decopilot";
 
 const client = createDecopilotClient({
-  baseUrl: "https://mesh.decocms.com/api",
+  baseUrl: "https://studio.decocms.com/api",
   orgSlug: "minha-org",
   token: "sua-api-key",
 });

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/api-keys.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/api-keys.mdx
@@ -46,7 +46,7 @@ Adicione a API key na configuração do seu cliente MCP:
 {
   "mcpServers": {
     "deco": {
-      "url": "https://mesh.decocms.com/mcp/agent/your-agent-id",
+      "url": "https://studio.decocms.com/mcp/agent/your-agent-id",
       "transport": "http",
       "headers": {
         "Authorization": "Bearer mcp_key_abc123..."

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/api-reference/connection-proxy.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/api-reference/connection-proxy.mdx
@@ -237,7 +237,7 @@ Conectar Cursor ou Claude Desktop diretamente a um MCP upstream específico:
 {
   "mcpServers": {
     "github-production": {
-      "url": "https://mesh.example.com/mcp/conn_abc123",
+      "url": "https://studio.example.com/mcp/conn_abc123",
       "headers": {
         "Authorization": "Bearer YOUR_API_KEY"
       }
@@ -251,7 +251,7 @@ Conectar Cursor ou Claude Desktop diretamente a um MCP upstream específico:
 Construir clientes customizados que precisam de acesso às ferramentas de um servidor MCP específico sem composição de MCP Virtual:
 
 ```typescript
-const response = await fetch('https://mesh.example.com/mcp/conn_abc123', {
+const response = await fetch('https://studio.example.com/mcp/conn_abc123', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"
+  url: "postgresql://mesh_user:mesh_password@postgres.example.com:5432/mesh_db"
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -213,7 +213,7 @@ service:
 
 database:
   engine: postgresql
-  url: "postgresql://mesh_user:mesh_password@mesh.example.com:5432/mesh_db"
+  url: "postgresql://mesh_user:mesh_password@studio.example.com:5432/mesh_db"
   caCert: |
     -----BEGIN CERTIFICATE-----
     aaaaaaaabbbbbbcccccccccddddddd

--- a/apps/mesh/README.md
+++ b/apps/mesh/README.md
@@ -1,10 +1,10 @@
-# MCP Mesh
+# Studio
 
 > **Context Management System for AI Applications**
 
-MCP Mesh is an open-source platform that centralizes **Model Context Protocol (MCP)** connection management for teams and organizations. It provides secure credential storage, fine-grained access control, and unified observability for AI tool orchestration.
+Studio is an open-source platform that centralizes **Model Context Protocol (MCP)** connection management for teams and organizations. It provides secure credential storage, fine-grained access control, and unified observability for AI tool orchestration.
 
-## What is MCP Mesh?
+## What is Studio?
 
 When AI assistants use tools via the Model Context Protocol, managing connections across a team becomes challenging:
 
@@ -13,7 +13,7 @@ When AI assistants use tools via the Model Context Protocol, managing connection
 - **No audit trail**: Who called which tool, when, and with what result?
 - **Tool isolation**: MCP services can't compose or share dependencies 
 
-MCP Mesh solves these problems by acting as a **secure proxy** between AI clients and MCP services:
+Studio solves these problems by acting as a **secure proxy** between AI clients and MCP services:
 
 ```
 ┌─────────────────┐     ┌──────────────┐     ┌─────────────────┐
@@ -236,7 +236,7 @@ The proxy:
 
 ### OAuth Discovery
 
-MCP Mesh implements the full MCP OAuth specification:
+Studio implements the full MCP OAuth specification:
 
 ```bash
 # Protected Resource Metadata

--- a/apps/mesh/spec/001.md
+++ b/apps/mesh/spec/001.md
@@ -32,9 +32,9 @@ This new paradigm introduces significant challenges for teams and organizations:
 
 **Tool Orchestration**: MCP services operate in isolation, with no standard way to compose tools from multiple services or manage dependencies between them.
 
-### Our Solution: MCP Mesh
+### Our Solution: Studio
 
-We're building the first open-source MCP Mesh — a unified platform that solves these challenges by:
+We're building the first open-source Studio — a unified platform that solves these challenges by:
 
 1. **Centralizing MCP connections**: Connect all your MCP services in one place with unified authentication
 
@@ -46,15 +46,15 @@ We're building the first open-source MCP Mesh — a unified platform that solves
 
 3. **Enabling tool composition**: Allow MCP services to depend on each other, eliminating redundant account connections
 
-4. **Providing zero-config deployment**: Run the MCP Mesh locally without complex setup
+4. **Providing zero-config deployment**: Run Studio locally without complex setup
 
-5. **Being MCP-native**: The Mesh itself exposes an MCP interface, allowing it to be used by any MCP-compatible client
+5. **Being MCP-native**: Studio itself exposes an MCP interface, allowing it to be used by any MCP-compatible client
 
 ### Apps: Extending MCP
 
-In MCP Mesh, we use "App" and "MCP service" interchangeably. Apps are a superset of MCP — we extend the protocol to support additional features such as:
+In Studio, we use "App" and "MCP service" interchangeably. Apps are a superset of MCP — we extend the protocol to support additional features such as:
 
-- **Native multi-tenancy**: Apps can expose configuration schemas via tool calls, which the Mesh renders as user-friendly forms
+- **Native multi-tenancy**: Apps can expose configuration schemas via tool calls, which Studio renders as user-friendly forms
 - **Tool dependencies**: Apps can declare dependencies on other apps' tools
 - **Unified discovery**: Browse and install apps from a centralized marketplace
 - **Team-based ACLs**: Built-in support for team hierarchies, roles, and fine-grained permissions
@@ -72,7 +72,7 @@ The result is a composable, secure, open-source infrastructure layer for the AI-
    - The database connection itself represents the system boundary
    - Organizations provide isolation for resources, teams, and audit logs
 
-2. **MCP-Native API**: Instead of REST, the Mesh uses MCP tools for all management operations. This makes the Mesh itself an MCP service that can be accessed programmatically or via AI agents.
+2. **MCP-Native API**: Instead of REST, Studio uses MCP tools for all management operations. This makes Studio itself an MCP service that can be accessed programmatically or via AI agents.
 
 3. **Minimal Configuration**: Only one environment variable (`DATABASE_URL`). All authentication configuration is file-based (`auth-config.json`).
 
@@ -82,7 +82,7 @@ The result is a composable, secure, open-source infrastructure layer for the AI-
 
 6. **Zero-Config SQLite**: Uses Bun's native SQLite by default. No database setup required. Upgrade to PostgreSQL when needed.
 
-7. **Credential Isolation**: Original service tokens never leave the Mesh. The proxy replaces Mesh tokens with actual credentials at request time.
+7. **Credential Isolation**: Original service tokens never leave Studio. The proxy replaces Studio tokens with actual credentials at request time.
 
 8. **Simple URL Structure**:
    - `/mcp` - Management API (CONNECTION_* tools, organization management via Better Auth)
@@ -232,7 +232,7 @@ interface MeshContext {
   meter: Meter;             // For metrics collection
   
   // Base URL (derived from request, used for OAuth callbacks, metadata URLs, etc.)
-  baseUrl: string;          // e.g., "https://mesh.example.com" or "http://localhost:3000"
+  baseUrl: string;          // e.g., "https://studio.example.com" or "http://localhost:3000"
   
   // Request metadata (non-HTTP specific)
   metadata: {
@@ -801,7 +801,7 @@ export class ConnectionStorage implements ConnectionStoragePort {
 
 #### 5. Authentication via Better Auth
 
-The Mesh uses [Better Auth's MCP plugin](https://www.better-auth.com/docs/plugins/mcp) for OAuth-based MCP client authentication, along with the [API Key plugin](https://www.better-auth.com/docs/plugins/api-key) for direct tool access:
+Studio uses [Better Auth's MCP plugin](https://www.better-auth.com/docs/plugins/mcp) for OAuth-based MCP client authentication, along with the [API Key plugin](https://www.better-auth.com/docs/plugins/api-key) for direct tool access:
 
 **Configuration:**
 
@@ -1035,14 +1035,14 @@ The permission model uses two types of resources:
 
 **Understanding Permission Resources:**
 
-The Mesh uses a resource-based permission model with two main resource types:
+Studio uses a resource-based permission model with two main resource types:
 
 1. **`"self"`** - Management API resource
    - **Special resource name** that grants access to management tools
    - Exposed at the `/mcp` endpoint (not `/mcp/:connectionId`)
-   - Contains tools for managing the Mesh itself: connections, etc.
+   - Contains tools for managing Studio itself: connections, etc.
    - Example tools: `CONNECTION_CREATE`, `CONNECTION_LIST`, `CONNECTION_GET`, `CONNECTION_DELETE`, `CONNECTION_TEST`
-   - These tools don't proxy to downstream connections - they operate on the Mesh database
+   - These tools don't proxy to downstream connections - they operate on Studio database
    - Example: `{ "self": ["CONNECTION_CREATE", "CONNECTION_LIST", "CONNECTION_GET"] }`
    - **Authorization flow:** When calling tools at `/mcp`, AccessControl checks permissions on resource `"self"`
 
@@ -1072,12 +1072,12 @@ The Mesh uses a resource-based permission model with two main resource types:
 
 **When to use each resource:**
 
-- Use `"self"` when granting permissions to **manage the Mesh** (manage connections, organizations, etc.)
+- Use `"self"` when granting permissions to **manage Studio** (manage connections, organizations, etc.)
 - Use `"conn_<UUID>"` when granting permissions to **use specific downstream connections** (call tools on those connections)
 
 #### 5.1 Organization Management
 
-The Mesh uses [Better Auth's Organization plugin](https://www.better-auth.com/docs/plugins/organization) for multi-tenant organization management. This provides:
+Studio uses [Better Auth's Organization plugin](https://www.better-auth.com/docs/plugins/organization) for multi-tenant organization management. This provides:
 
 - Organization creation and management
 - Member management (add, remove, update roles)
@@ -1354,7 +1354,7 @@ export default app;
 
 #### 6. Observability with OpenTelemetry
 
-The Mesh includes comprehensive observability using [OpenTelemetry](https://opentelemetry.io/) for distributed tracing and metrics:
+Studio includes comprehensive observability using [OpenTelemetry](https://opentelemetry.io/) for distributed tracing and metrics:
 
 **Configuration:**
 
@@ -1528,7 +1528,7 @@ export function defineTool<TInput extends z.ZodType, TOutput extends z.ZodType>(
 
 **Standard Metrics:**
 
-The Mesh automatically tracks:
+Studio automatically tracks:
 
 1. **Tool Execution Metrics:**
    - `tool.execution.duration` - Histogram of execution times
@@ -1549,7 +1549,7 @@ The Mesh automatically tracks:
 
 **Tracing Context Propagation:**
 
-When proxying MCP calls, the Mesh propagates trace context:
+When proxying MCP calls, Studio propagates trace context:
 
 ```typescript
 // Proxy with trace propagation
@@ -1564,7 +1564,7 @@ const response = await fetch(connection.url, { headers });
 
 #### 7. Downstream MCP OAuth Client
 
-The Mesh acts as an **OAuth client** to connect to downstream MCPs that require OAuth authentication. This allows the Mesh to proxy requests to third-party OAuth-protected MCPs while keeping credentials secure.
+Studio acts as an **OAuth client** to connect to downstream MCPs that require OAuth authentication. This allows Studio to proxy requests to third-party OAuth-protected MCPs while keeping credentials secure.
 
 **Three OAuth Roles:**
 
@@ -1591,7 +1591,7 @@ The Mesh acts as an **OAuth client** to connect to downstream MCPs that require 
 
 **Connecting to Downstream OAuth-Protected MCPs:**
 
-When creating a connection to a downstream MCP that supports OAuth, the Mesh can act as an OAuth client to obtain tokens. See the "Discovering and Connecting to Downstream OAuth MCPs" section below for implementation details.
+When creating a connection to a downstream MCP that supports OAuth, Studio can act as an OAuth client to obtain tokens. See the "Discovering and Connecting to Downstream OAuth MCPs" section below for implementation details.
 
 **Database Schema for OAuth (Kysely TypeScript Interfaces):**
 
@@ -1670,7 +1670,7 @@ export function requireMcpAuth(requiredScopes: string[] = []) {
 
 **MCP Proxy with OAuth:**
 
-When proxying to downstream MCPs, the Mesh obtains and uses proper tokens:
+When proxying to downstream MCPs, Studio obtains and uses proper tokens:
 
 ```typescript
 // Proxy MCP request with OAuth token
@@ -1835,7 +1835,7 @@ export interface Database {
 
 **Important**: OAuth discovery and client registration only happen **once** when creating or configuring a connection. The proxy itself doesn't perform OAuth discovery on every request - it uses the stored OAuth configuration from the connection.
 
-When creating a connection to a downstream MCP that supports OAuth, the Mesh follows the [MCP Authorization Discovery flow](https://modelcontextprotocol.io/specification/draft/basic/authorization):
+When creating a connection to a downstream MCP that supports OAuth, Studio follows the [MCP Authorization Discovery flow](https://modelcontextprotocol.io/specification/draft/basic/authorization):
 
 ```typescript
 // tools/connection/discover-oauth.ts
@@ -1888,7 +1888,7 @@ export async function discoverDownstreamOAuth(url: string): Promise<OAuthConfig 
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           client_name: 'MCP Mesh',
-          redirect_uris: [`https://mesh.example.com/oauth/callback`], // Use configured base URL
+          redirect_uris: [`https://studio.example.com/oauth/callback`], // Use configured base URL
           grant_types: ['authorization_code', 'refresh_token', 'client_credentials'],
           token_endpoint_auth_method: 'client_secret_basic',
           scope: resourceMetadata.scopes_supported?.join(' '),
@@ -2174,7 +2174,7 @@ oauthCallbackRouter.get('/oauth/callback', async (c) => {
 });
 ```
 
-**Complete Example: MCP Client Using the Mesh:**
+**Complete Example: MCP Client Using Studio:**
 
 ```typescript
 // Example: Claude Desktop or any MCP client connecting to the Mesh
@@ -2183,7 +2183,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-const MESH_URL = 'https://mesh.example.com/mcp';
+const MESH_URL = 'https://studio.example.com/mcp';
 
 async function connectToMesh() {
   // Step 1: Discover OAuth metadata
@@ -2494,7 +2494,7 @@ export const STORAGE_BINDING = {
 
 **Binding Detection:**
 
-The Mesh automatically detects which bindings a connection implements:
+Studio automatically detects which bindings a connection implements:
 
 ```typescript
 // core/binding-detector.ts
@@ -3146,18 +3146,18 @@ export class ConnectionStorage {
 
 **Two Distinct MCP Servers:**
 
-The Mesh implements two separate MCP servers:
+Studio implements two separate MCP servers:
 
 1. **Management MCP Server** (`/mcp`) - Exposes management tools
 2. **Proxy MCP Server** (`/mcp/:connectionId`) - Proxies to downstream connections
 
 **HttpServerTransport:**
 
-The Mesh uses a custom `WebStandardHttpTransport`
+Studio uses a custom `WebStandardHttpTransport`
 
 **MCP Server Builder Pattern:**
 
-The Mesh uses a builder pattern (`api/utils/mcp.ts`) to create MCP servers with middleware support:
+Studio uses a builder pattern (`api/utils/mcp.ts`) to create MCP servers with middleware support:
 
 ```typescript
 // api/utils/mcp.ts - Simplified version
@@ -3299,7 +3299,7 @@ app.post('/:connectionId', async (c) => {
 
 | Aspect | Management API (`/mcp`) | Proxy API (`/mcp/:connectionId`) |
 |--------|------------------------|----------------------------------|
-| **Purpose** | Expose Mesh management tools | Proxy to downstream connections |
+| **Purpose** | Expose Studio management tools | Proxy to downstream connections |
 | **Tools Source** | `tools/` directory (PROJECT_*, CONNECTION_*) | Downstream MCP (via `client.listTools()`) |
 | **Authorization Resource** | `"self"` | `"conn_<UUID>"` |
 | **Handler** | Directly executes tool from registry | Proxies to downstream client |
@@ -3595,7 +3595,7 @@ bun run better-auth:migrate
 bun run start
 ```
 
-That's it! The Mesh will automatically:
+That's it! Studio will automatically:
 
 - Create a local SQLite database at `./data/mesh.db`
 - Run all necessary migrations (application tables)
@@ -3799,7 +3799,7 @@ interface ApiKey {
 
 **Better Auth Integration:**
 
-MCP Mesh uses Better Auth for flexible authentication with multiple providers. All authentication configuration is done via an optional `auth-config.json` file—no environment variables needed!
+Studio uses Better Auth for flexible authentication with multiple providers. All authentication configuration is done via an optional `auth-config.json` file—no environment variables needed!
 
 **Supported Auth Methods:**
 
@@ -3919,9 +3919,9 @@ export function createDatabase(databaseUrl: string): Kysely<DatabaseSchema> {
 
 **MCP-Native API Architecture:**
 
-The Mesh exposes two main endpoints following the MCP protocol:
+Studio exposes two main endpoints following the MCP protocol:
 
-**Management API** (`/mcp`) - MCP Server for Mesh Management:
+**Management API** (`/mcp`) - MCP Server for Studio Management:
 
 ```
 POST /mcp
@@ -3969,7 +3969,7 @@ Better Auth API keys include permissions that determine which connections and to
 interface MeshTokenPayload {
   // Standard JWT claims (RFC 7519)
   sub: string;           // Subject: Token ID or User ID
-  iss: string;           // Issuer: Mesh instance base URL (e.g., "https://mesh.example.com")
+  iss: string;           // Issuer: Mesh instance base URL (e.g., "https://studio.example.com")
   iat: number;           // Issued at: Unix timestamp
   exp: number;           // Expiration: Unix timestamp
   nbf: number;           // Not before: Unix timestamp (prevents premature use)
@@ -3989,7 +3989,7 @@ interface MeshTokenPayload {
 
 #### Organization Management (via Better Auth Plugin + MCP Tools)
 
-MCP Mesh wraps Better Auth's organization plugin APIs as MCP tools for programmatic access.
+Studio wraps Better Auth's organization plugin APIs as MCP tools for programmatic access.
 For direct API access, see [Better Auth Organization Plugin](https://www.better-auth.com/docs/plugins/organization).
 
 **ORGANIZATION_CREATE**
@@ -4274,7 +4274,7 @@ const connections = await CONNECTION_LIST({});
 
 #### API Key Management
 
-MCP Mesh exposes Better Auth's API Key plugin functionality through MCP tools. Users can create, list, update, and delete their own API keys.
+Studio exposes Better Auth's API Key plugin functionality through MCP tools. Users can create, list, update, and delete their own API keys.
 
 **Important Security Note:** API key values are only returned once at creation time. After creation, only metadata (name, permissions, etc.) can be retrieved - the key value cannot be shown again.
 
@@ -4388,7 +4388,7 @@ When creating new API keys via Better Auth, the following tools are available by
 
 #### Organization Roles & Teams (via Better Auth Organization Plugin)
 
-Better Auth's organization plugin handles all organization-level access control. The Mesh does NOT provide separate POLICY_*, ROLE_*, TOKEN_*, or TEAM_* tools because Better Auth already provides comprehensive APIs for these.
+Better Auth's organization plugin handles all organization-level access control. Studio does NOT provide separate POLICY_*, ROLE_*, TOKEN_*, or TEAM_* tools because Better Auth already provides comprehensive APIs for these.
 
 **Organization Management Features (via Better Auth):**
 
@@ -4440,15 +4440,15 @@ For complete organization management documentation, see [Better Auth Organizatio
 
 ---
 
-### The MCP Mesh Proxy API
+### Studio Proxy API
 
 **Core Concept:**
 
-The MCP Mesh Proxy is the heart of the system. It acts as a secure intermediary that:
+Studio Proxy is the heart of the system. It acts as a secure intermediary that:
 
 1. Accepts requests with organization-scoped OAuth tokens or API keys
 2. Validates tokens and checks permissions (via Better Auth)
-3. Replaces Mesh tokens with actual service credentials
+3. Replaces Studio tokens with actual service credentials
 4. Proxies requests to target MCP services
 5. Logs all activity for auditing
 
@@ -4500,7 +4500,7 @@ Content-Type: application/json
 }
 ```
 
-The Mesh encrypts and stores `gmail-secret-token-XPTO` securely within the organization.
+Studio encrypts and stores `gmail-secret-token-XPTO` securely within the organization.
 
 #### Step 3: Create an API Key with Permissions
 
@@ -4546,7 +4546,7 @@ Content-Type: application/json
 
 **Behind the Scenes:**
 
-1. Mesh validates the API key `mcp_abc123...`
+1. Studio validates the API key `mcp_abc123...`
 2. Checks if key has permission for `SEND_EMAIL` on `conn_abc123`
 3. Retrieves connection config and decrypts the Gmail token: `gmail-secret-token-XPTO`
 4. Proxies the request to `https://mcp.gmail.com/mcp`:
@@ -4687,7 +4687,7 @@ docker-compose up -d
 
 **Option 4: Docker with PostgreSQL (Optional - for scale)**
 
-Only needed if you expect high concurrent usage or want to run multiple Mesh instances.
+Only needed if you expect high concurrent usage or want to run multiple Studio instances.
 
 ```yaml
 # docker-compose.yml
@@ -4720,7 +4720,7 @@ volumes:
 
 **Environment Variables:**
 
-MCP Mesh is designed with minimal configuration. Only **one** environment variable is supported:
+Studio is designed with minimal configuration. Only **one** environment variable is supported:
 
 ```bash
 # Database (optional - defaults to SQLite at ./data/mesh.db)
@@ -4831,4 +4831,4 @@ We welcome contributions! Please see our [CONTRIBUTING.md](./CONTRIBUTING.md) fo
 
 ## License
 
-MCP Mesh is open-source software licensed under the [MIT License](./LICENSE).
+Studio is open-source software licensed under the [MIT License](./LICENSE).

--- a/apps/mesh/spec/monitoring-share-plugin.md
+++ b/apps/mesh/spec/monitoring-share-plugin.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Extend the plugin system to support root-level public routes, then create a Mesh plugin (`mesh-plugin-monitoring-share`) that enables sharing read-only, data-scoped monitoring dashboards with external clients via presigned URLs.
+Extend the plugin system to support root-level public routes, then create a Studio plugin (`mesh-plugin-monitoring-share`) that enables sharing read-only, data-scoped monitoring dashboards with external clients via presigned URLs.
 
 ### Key Features
 - Presigned URLs with embedded tokens (no login required, time-limited)

--- a/packages/mesh-plugin-workflows/README.md
+++ b/packages/mesh-plugin-workflows/README.md
@@ -1,6 +1,6 @@
 # Workflows Plugin
 
-Server + client plugin for MCP Mesh that provides workflow creation, management, and execution for platform end-users.
+Server + client plugin for Studio that provides workflow creation, management, and execution for platform end-users.
 
 ## Overview
 
@@ -313,7 +313,7 @@ How the type magic works:
 - **Tool output schemas are auto-injected** — when a referenced tool has an `outputSchema`, the builder writes it into the step's `outputSchema` field so fingerprint changes propagate correctly
 - **Code steps** work too: `{ action: { code: "export default function(stepInput) { ... }" } }`
 
-### `Workflow.sync()` — Automatic Sync to Mesh
+### `Workflow.sync()` — Automatic Sync to Studio
 
 Called during `ON_MCP_CONFIGURATION`, this syncs declared `WorkflowDefinition[]` to the mesh as `workflow_collection` entries. The sync is declarative and convergent:
 

--- a/packages/mesh-sdk/README.md
+++ b/packages/mesh-sdk/README.md
@@ -1,6 +1,6 @@
 # @decocms/mesh-sdk
 
-SDK for building external apps that integrate with Mesh MCP servers. Provides React hooks and utilities for managing connections, authenticating with OAuth, and calling MCP tools.
+SDK for building external apps that integrate with Studio MCP servers. Provides React hooks and utilities for managing connections, authenticating with OAuth, and calling MCP tools.
 
 ## Installation
 
@@ -22,7 +22,7 @@ npm install sonner
 
 ### 1. Create an API Key
 
-In Mesh, call the `API_KEY_CREATE` tool to create an API key with the appropriate scopes for the connections you want to access. The API key will be used to authenticate your external app.
+In Studio, call the `API_KEY_CREATE` tool to create an API key with the appropriate scopes for the connections you want to access. The API key will be used to authenticate your external app.
 
 ```typescript
 // Example: Create an API key via MCP
@@ -35,7 +35,7 @@ await client.callTool({
 });
 ```
 
-### 2. Server-Side: Connect to Mesh
+### 2. Server-Side: Connect to Studio
 
 ```typescript
 // server.ts (Node.js / Bun / your backend)
@@ -213,12 +213,12 @@ const result = await specificClient.callTool({
 
 ### `createMCPClient(options)` - Server-Side
 
-Creates and connects an MCP client to a Mesh server. **Use on server only** - don't expose your API key to the client.
+Creates and connects an MCP client to a Studio server. **Use on server only** - don't expose your API key to the client.
 
 ```typescript
 // server-side only
 const client = await createMCPClient({
-  meshUrl: "https://mesh.example.com",  // Required for external apps
+  meshUrl: "https://studio.example.com",  // Required for external apps
   connectionId: "self",                  // "self" for management API, or connection ID
   orgId: "org_xxx",                      // Organization ID
   token: process.env.MESH_API_KEY,       // API key from environment
@@ -227,7 +227,7 @@ const client = await createMCPClient({
 
 ### `useMCPClient(options)` - Client-Side (Same-Origin Only)
 
-React hook version of `createMCPClient`. Uses Suspense. **Only use when running on the same origin as Mesh** (e.g., inside the Mesh app itself).
+React hook version of `createMCPClient`. Uses Suspense. **Only use when running on the same origin as Studio** (e.g., inside Studio app itself).
 
 ```typescript
 // client-side - only for same-origin apps
@@ -249,7 +249,7 @@ Triggers OAuth authentication flow for an MCP connection. **This runs client-sid
 ```typescript
 // client-side - safe to use in browser
 const result = await authenticateMcp({
-  meshUrl: "https://mesh.example.com",  // Required for external apps
+  meshUrl: "https://studio.example.com",  // Required for external apps
   connectionId: "conn_xxx",              // Connection to authenticate
   callbackUrl: "https://your-app.com/oauth/callback",  // Your OAuth callback URL
   timeout: 120000,                       // Timeout in ms (default: 120000)
@@ -274,9 +274,9 @@ Check if a connection is authenticated. Can be used on either server or client.
 
 ```typescript
 const status = await isConnectionAuthenticated({
-  url: "https://mesh.example.com/mcp/conn_xxx",
+  url: "https://studio.example.com/mcp/conn_xxx",
   token: "bearer_token",  // Optional
-  meshUrl: "https://mesh.example.com",  // For API calls
+  meshUrl: "https://studio.example.com",  // For API calls
 });
 
 console.log(status.isAuthenticated);  // boolean
@@ -286,7 +286,7 @@ console.log(status.hasOAuthToken);    // boolean
 
 ### Collection Hooks - Client-Side (Same-Origin Only)
 
-When using with `ProjectContextProvider`, you get access to collection hooks. **Only use when running on the same origin as Mesh** (e.g., inside the Mesh app or plugins).
+When using with `ProjectContextProvider`, you get access to collection hooks. **Only use when running on the same origin as Studio** (e.g., inside Studio app or plugins).
 
 ```typescript
 // client-side - only for same-origin apps (inside Mesh)

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -27,7 +27,7 @@ Four runner backends live behind the common `SandboxRunner` interface
   runner is selected.
 - **agent-sandbox** (`./runner/agent-sandbox`) — one `SandboxClaim` per sandbox
   against the [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
-  operator. Mesh talks to pods via apiserver port-forward in dev; in prod,
+  operator. Studio talks to pods via apiserver port-forward in dev; in prod,
   `previewUrlPattern` switches the preview URL to real ingress and skips the
   dev forward.
 

--- a/packages/typegen/README.md
+++ b/packages/typegen/README.md
@@ -1,6 +1,6 @@
 # @decocms/typegen
 
-Generate typed TypeScript clients for [Mesh](https://github.com/decocms/mesh) Virtual MCPs.
+Generate typed TypeScript clients for [Studio](https://github.com/decocms/mesh) Virtual MCPs.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Renames the product name from **MCP Mesh** to **Studio** across all markdown and MDX documentation. Code, package names, and infra identifiers are intentionally untouched and will be migrated in a follow-up alongside the code rename.

## What changed

- Prose substitutions (EN + PT-BR): `MCP Mesh` / `the Mesh` / `o Mesh` / bare `Mesh` → `Studio`
- Example URLs: `mesh.decocms.com` → `studio.decocms.com`, `mesh.example.com` → `studio.example.com`
- Marketing URL: `decocms.com/mesh` → `decocms.com/studio`

## What was preserved

To avoid breaking references to real code, the following were left untouched:

- Code identifiers: `MeshContext`, `MESH_URL`, `MESH_API_KEY`, `MESH_REQUEST_CONTEXT`, `meshUrl`, `meshClient`, etc.
- Filesystem paths: `apps/mesh/`, `packages/mesh-sdk/`, `packages/mesh-plugin-workflows/`
- Package names: `@decocms/mesh-sdk`
- Docker images / k8s namespaces: `mcp-mesh/server:latest`, `deco-mcp-mesh`
- DB / config values: `POSTGRES_DB: mesh`, `mcp_mesh`, `mesh.db`
- Internal doc folder names (`mcp-mesh/`) and links (`/mcp-mesh/...`) — folder rename is a separate step

## Commits

- `b80e6e7` — main rename pass (53 files)
- `cc27699` — `decocms.com/mesh` → `decocms.com/studio` (6 files)

## Test plan

- [ ] Visual review of rendered docs (EN + PT-BR) for grammatical leftovers
- [ ] Verify example URLs resolve (`studio.decocms.com`, `decocms.com/studio`)
- [ ] Confirm no code/package references were accidentally renamed

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRd3TuVZUdMwArePevv6SF)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the product name from “MCP Mesh” to “Studio” across all Markdown/MDX docs. Updated example and marketing URLs, and fixed DB host placeholders in Helm docs; no code, package, or infra identifiers were changed in this pass.

- **Refactors**
  - Prose (EN + PT-BR): `MCP Mesh`/`the Mesh`/`o Mesh` → `Studio`
  - URLs: `mesh.decocms.com` → `studio.decocms.com`, `mesh.example.com` → `studio.example.com`, `decocms.com/mesh` → `decocms.com/studio`
  - Helm examples: `postgres.example.com` used as DB host placeholder (replacing app URL placeholders)
  - Preserved identifiers to avoid breaking references: `MeshContext`, `MESH_URL`, `apps/mesh/`, `@decocms/mesh-sdk`, Docker/k8s names, DB/config values, and internal `/mcp-mesh/` doc paths

<sup>Written for commit 66914876eaaef29dff1a2272c31b86d82ea35b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

