### PR TITLE
refactor(sandbox): share buildConfigPayload across runners

### DIFF
--- a/packages/sandbox/server/runner/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/runner/agent-sandbox/runner.ts
@@ -44,10 +44,10 @@ import {
   proxyDaemonRequest,
   waitForDaemonReady,
 } from "../../daemon-client";
-import type { PackageManagerConfig, TenantConfig } from "../../../daemon/types";
 import {
   Inflight,
   applyPreviewPattern,
+  buildConfigPayload,
   computeHandle as composeBranchHandle,
   withSandboxLock,
 } from "../shared";
@@ -1868,68 +1868,4 @@ function previewHostnameForHandle(
   } catch {
     return null;
   }
-}
-
-/** Fallback for when callers don't provide `repo.displayName`. */
-function deriveRepoLabel(cloneUrl: string): string {
-  try {
-    const u = new URL(cloneUrl);
-    const trimmed = u.pathname.replace(/^\/+/, "").replace(/\.git$/, "");
-    return trimmed || u.hostname;
-  } catch {
-    return cloneUrl;
-  }
-}
-
-/**
- * Mirrors the host/docker runners' `buildConfigPayload`: collapses caller
- * intent into the daemon's TenantConfig shape. Intent defaults to "running"
- * when a packageManager is provided so the dev server auto-starts after
- * the orchestrator's clone+install completes.
- */
-function buildConfigPayload(args: {
-  runtime: "node" | "bun" | "deno";
-  packageManager: PackageManagerConfig | null;
-  desiredPort?: number;
-  repo: NonNullable<EnsureOptions["repo"]> | null;
-}): Partial<TenantConfig> | null {
-  const repo = args.repo;
-  const git = repo
-    ? {
-        repository: {
-          cloneUrl: repo.cloneUrl,
-          repoName: repo.displayName ?? deriveRepoLabel(repo.cloneUrl),
-          ...(repo.branch ? { branch: repo.branch } : {}),
-        },
-        identity: {
-          userName: repo.userName,
-          userEmail: repo.userEmail,
-        },
-      }
-    : undefined;
-
-  const packageManager = args.packageManager
-    ? {
-        name: args.packageManager.name,
-        ...(args.packageManager.path ? { path: args.packageManager.path } : {}),
-      }
-    : undefined;
-
-  const application = packageManager
-    ? {
-        packageManager,
-        runtime: args.runtime,
-        intent: "running" as const,
-        ...(args.desiredPort !== undefined
-          ? { desiredPort: args.desiredPort }
-          : {}),
-        proxy: {},
-      }
-    : undefined;
-
-  if (!git && !application) return null;
-  return {
-    ...(git ? { git } : {}),
-    ...(application ? { application } : {}),
-  };
 }

--- a/packages/sandbox/server/runner/docker/runner.ts
+++ b/packages/sandbox/server/runner/docker/runner.ts
@@ -27,6 +27,7 @@ import { ensureSandboxImage } from "../../image-build";
 import {
   Inflight,
   applyPreviewPattern,
+  buildConfigPayload,
   computeHandle,
   hashSandboxId,
   withSandboxLock,
@@ -43,7 +44,6 @@ import type {
   Workload,
 } from "../types";
 import type { ClaimPhase } from "../lifecycle-types";
-import type { PackageManagerConfig, TenantConfig } from "../../../daemon/types";
 
 const RUNNER_KIND = "docker" as const;
 const LABEL_ROOT = "studio-sandbox";
@@ -681,68 +681,4 @@ export class DockerSandboxRunner implements SandboxRunner {
     if (tail) parts.push(`logs:\n${tail}`);
     return parts.length ? ` (${parts.join(" ")})` : "";
   }
-}
-
-/** Fallback for when callers don't provide `repo.displayName`. */
-function deriveRepoLabel(cloneUrl: string): string {
-  try {
-    const u = new URL(cloneUrl);
-    const trimmed = u.pathname.replace(/^\/+/, "").replace(/\.git$/, "");
-    return trimmed || u.hostname;
-  } catch {
-    return cloneUrl;
-  }
-}
-
-/**
- * Mirrors the host runner's `buildConfigPayload`: collapses caller intent
- * into the daemon's TenantConfig shape. Intent defaults to "running" when
- * a packageManager is provided so the dev server auto-starts after the
- * orchestrator's clone+install completes.
- */
-function buildConfigPayload(args: {
-  runtime: "node" | "bun" | "deno";
-  packageManager: PackageManagerConfig | null;
-  desiredPort?: number;
-  repo: NonNullable<EnsureOptions["repo"]> | null;
-}): Partial<TenantConfig> | null {
-  const repo = args.repo;
-  const git = repo
-    ? {
-        repository: {
-          cloneUrl: repo.cloneUrl,
-          repoName: repo.displayName ?? deriveRepoLabel(repo.cloneUrl),
-          ...(repo.branch ? { branch: repo.branch } : {}),
-        },
-        identity: {
-          userName: repo.userName,
-          userEmail: repo.userEmail,
-        },
-      }
-    : undefined;
-
-  const packageManager = args.packageManager
-    ? {
-        name: args.packageManager.name,
-        ...(args.packageManager.path ? { path: args.packageManager.path } : {}),
-      }
-    : undefined;
-
-  const application = packageManager
-    ? {
-        packageManager,
-        runtime: args.runtime,
-        intent: "running" as const,
-        ...(args.desiredPort !== undefined
-          ? { desiredPort: args.desiredPort }
-          : {}),
-        proxy: {},
-      }
-    : undefined;
-
-  if (!git && !application) return null;
-  return {
-    ...(git ? { git } : {}),
-    ...(application ? { application } : {}),
-  };
 }

--- a/packages/sandbox/server/runner/freestyle/runner.ts
+++ b/packages/sandbox/server/runner/freestyle/runner.ts
@@ -17,7 +17,12 @@ import { VmBun } from "@freestyle-sh/with-bun";
 import { VmDeno } from "@freestyle-sh/with-deno";
 import { VmNodeJs } from "@freestyle-sh/with-nodejs";
 import { freestyle, VmSpec } from "freestyle-sandboxes";
-import { computeHandle, Inflight, withSandboxLock } from "../shared";
+import {
+  computeHandle,
+  deriveRepoLabel,
+  Inflight,
+  withSandboxLock,
+} from "../shared";
 import type { RunnerStateStore, RunnerStateStoreOps } from "../state-store";
 import {
   sandboxIdKey,
@@ -688,16 +693,6 @@ function workloadEquals(a: Workload | null, b: Workload | null): boolean {
     a.packageManager === b.packageManager &&
     a.devPort === b.devPort
   );
-}
-
-function deriveRepoLabel(cloneUrl: string): string {
-  try {
-    const u = new URL(cloneUrl);
-    const trimmed = u.pathname.replace(/^\/+/, "").replace(/\.git$/, "");
-    return trimmed || u.hostname;
-  } catch {
-    return cloneUrl;
-  }
 }
 
 /** Mirrors the decode path in the daemon's `parseJsonBody`. */

--- a/packages/sandbox/server/runner/host/runner.ts
+++ b/packages/sandbox/server/runner/host/runner.ts
@@ -25,7 +25,11 @@ import {
   daemonBash,
 } from "../../daemon-client";
 import type { ConfigResponse, DaemonHealth } from "../../daemon-client";
-import { applyPreviewPattern, computeHandle } from "../shared";
+import {
+  applyPreviewPattern,
+  buildConfigPayload,
+  computeHandle,
+} from "../shared";
 import type { RunnerStateStore } from "../state-store";
 import type {
   EnsureOptions,
@@ -37,7 +41,7 @@ import type {
   SandboxRunner,
 } from "../types";
 import type { ClaimPhase } from "../lifecycle-types";
-import type { PackageManagerConfig, TenantConfig } from "../../../daemon/types";
+import type { TenantConfig } from "../../../daemon/types";
 
 const RUNNER_KIND = "host" as const;
 const READY_TIMEOUT_MS = 30_000;
@@ -186,7 +190,7 @@ export class HostSandboxRunner implements SandboxRunner {
           }
         : null,
       repo: opts.repo ?? null,
-      devPort: opts.workload?.devPort ?? devPort,
+      desiredPort: opts.workload?.devPort ?? devPort,
     });
 
     const proc = await this.spawnFn({ workdir, env, daemonPort });
@@ -492,64 +496,6 @@ function buildDaemonEnv(args: {
     SANDBOX_INGRESS_PORT: String(args.ingressPort),
     ...(args.extraEnv ?? {}),
   };
-}
-
-function buildConfigPayload(args: {
-  runtime: "node" | "bun" | "deno";
-  packageManager: PackageManagerConfig | null;
-  devPort?: number;
-  repo: NonNullable<EnsureOptions["repo"]> | null;
-}): Partial<TenantConfig> | null {
-  const repo = args.repo;
-  const git = repo
-    ? {
-        repository: {
-          cloneUrl: repo.cloneUrl,
-          repoName: repo.displayName ?? deriveRepoLabel(repo.cloneUrl),
-          ...(repo.branch ? { branch: repo.branch } : {}),
-        },
-        identity: {
-          userName: repo.userName,
-          userEmail: repo.userEmail,
-        },
-      }
-    : undefined;
-
-  const packageManager = args.packageManager
-    ? {
-        name: args.packageManager.name,
-        ...(args.packageManager.path ? { path: args.packageManager.path } : {}),
-      }
-    : undefined;
-
-  // Intent defaults to "running" when a packageManager is provided —
-  // matches the previous host runner's auto-start behavior so the dev
-  // server fires up after install completes.
-  const application = packageManager
-    ? {
-        packageManager,
-        runtime: args.runtime,
-        intent: "running" as const,
-        ...(args.devPort !== undefined ? { desiredPort: args.devPort } : {}),
-        proxy: {},
-      }
-    : undefined;
-
-  if (!git && !application) return null;
-  return {
-    ...(git ? { git } : {}),
-    ...(application ? { application } : {}),
-  };
-}
-
-function deriveRepoLabel(cloneUrl: string): string {
-  try {
-    const u = new URL(cloneUrl);
-    const trimmed = u.pathname.replace(/^\/+/, "").replace(/\.git$/, "");
-    return trimmed || u.hostname;
-  } catch {
-    return cloneUrl;
-  }
 }
 
 // ---- Daemon executable resolution ------------------------------------------

--- a/packages/sandbox/server/runner/shared/build-config-payload.ts
+++ b/packages/sandbox/server/runner/shared/build-config-payload.ts
@@ -1,0 +1,64 @@
+import type { PackageManagerConfig, TenantConfig } from "../../../daemon/types";
+import type { EnsureOptions } from "../types";
+
+/**
+ * Collapses caller intent into the daemon's TenantConfig shape. Intent
+ * defaults to "running" when a packageManager is provided so the dev
+ * server auto-starts after the orchestrator's clone+install completes.
+ */
+export function buildConfigPayload(args: {
+  runtime: "node" | "bun" | "deno";
+  packageManager: PackageManagerConfig | null;
+  desiredPort?: number;
+  repo: NonNullable<EnsureOptions["repo"]> | null;
+}): Partial<TenantConfig> | null {
+  const repo = args.repo;
+  const git = repo
+    ? {
+        repository: {
+          cloneUrl: repo.cloneUrl,
+          repoName: repo.displayName ?? deriveRepoLabel(repo.cloneUrl),
+          ...(repo.branch ? { branch: repo.branch } : {}),
+        },
+        identity: {
+          userName: repo.userName,
+          userEmail: repo.userEmail,
+        },
+      }
+    : undefined;
+
+  const packageManager = args.packageManager
+    ? {
+        name: args.packageManager.name,
+        ...(args.packageManager.path ? { path: args.packageManager.path } : {}),
+      }
+    : undefined;
+
+  const application = packageManager
+    ? {
+        packageManager,
+        runtime: args.runtime,
+        intent: "running" as const,
+        ...(args.desiredPort !== undefined
+          ? { desiredPort: args.desiredPort }
+          : {}),
+        proxy: {},
+      }
+    : undefined;
+
+  if (!git && !application) return null;
+  return {
+    ...(git ? { git } : {}),
+    ...(application ? { application } : {}),
+  };
+}
+
+export function deriveRepoLabel(cloneUrl: string): string {
+  try {
+    const u = new URL(cloneUrl);
+    const trimmed = u.pathname.replace(/^\/+/, "").replace(/\.git$/, "");
+    return trimmed || u.hostname;
+  } catch {
+    return cloneUrl;
+  }
+}

--- a/packages/sandbox/server/runner/shared/index.ts
+++ b/packages/sandbox/server/runner/shared/index.ts
@@ -2,3 +2,7 @@ export { Inflight } from "./inflight";
 export { withSandboxLock } from "./lock";
 export { computeHandle, hashSandboxId } from "./handle";
 export { applyPreviewPattern } from "./preview-url";
+export {
+  buildConfigPayload,
+  deriveRepoLabel,
+} from "./build-config-payload";


### PR DESCRIPTION
## What is this contribution about?

The `buildConfigPayload` helper that builds the daemon's `/config` (TenantConfig) request body was duplicated across the `agent-sandbox`, `docker`, and `host` runners — the agent-sandbox copy even had a comment saying "Mirrors the host/docker runners'". `deriveRepoLabel` was duplicated in those three plus `freestyle`. This PR extracts both into `packages/sandbox/server/runner/shared/build-config-payload.ts` so the three runners can't drift, and renames the host runner's local `devPort` parameter to `desiredPort` to match the canonical `TenantConfig.application.desiredPort` field name (host was the only outlier). Net change: -183 lines, single source of truth.

## How to Test

1. `bun run check` — type-check passes across all workspaces
2. `bun test packages/sandbox/server` — 131 pass, 0 fail
3. Sandbox provisioning still works via host/docker/agent-sandbox runners (the `/config` POST is byte-identical to before)

## Migration Notes

None — pure refactor with no runtime behavior change.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the `/config` payload builder across sandbox runners to keep the daemon config consistent and prevent drift.

- **Refactors**
  - Moved `buildConfigPayload` and `deriveRepoLabel` to `packages/sandbox/server/runner/shared/build-config-payload.ts` and re-exported via `shared/index.ts`.
  - Updated `agent-sandbox`, `docker`, `host`, and `freestyle` runners to use the shared helpers; removed duplicated code (net −183 LOC).
  - Renamed host runner option `devPort` to `desiredPort` to match `TenantConfig.application.desiredPort`.
  - Pure refactor; no behavior change (daemon `/config` POST remains unchanged).

<sup>Written for commit e709e0f3ae7f20bcb14873148609a164ecafa66e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

