### PR TITLE
feat(improve-prompt): inline manager delegation for Improve buttons

### DIFF
--- a/apps/mesh/src/tools/guides/agents.ts
+++ b/apps/mesh/src/tools/guides/agents.ts
@@ -52,36 +52,6 @@ Checks:
 - Confirm the final agent definition matches the request.
 `,
   },
-  {
-    name: "writing-prompts",
-    title: "Improve Instructions",
-    description: "Improve instructions for an agent or automation.",
-    text: `# Writing instructions
-
-Goal: rewrite or refine instructions for either an agent or an automation so they clearly describe the purpose, constraints, and workflows in a reliable format.
-
-Read docs://agents.md for the instruction-writing pattern, XML-style structure, and workflow guidance. Read docs://automations.md if you are improving automation behavior rather than agent behavior.
-
-Recommended tool order:
-1. Identify whether the target is an agent or an automation.
-2. For agents, use COLLECTION_VIRTUAL_MCP_LIST or COLLECTION_VIRTUAL_MCP_GET to inspect the current instructions.
-3. For automations, use AUTOMATION_LIST or AUTOMATION_GET to inspect the current messages/instructions.
-4. Review the current instructions against docs://agents.md.
-5. If the intended purpose, audience, or boundaries are unclear, use user_ask before rewriting.
-6. Rewrite the instructions with explicit XML-style sections such as <role>, <capabilities>, <constraints>, and <workflows>.
-7. For agents, use COLLECTION_VIRTUAL_MCP_UPDATE to save the improved instructions.
-8. For automations, use AUTOMATION_UPDATE to save the improved messages/instructions.
-9. Re-read the updated entity with COLLECTION_VIRTUAL_MCP_GET or AUTOMATION_GET to verify the final stored version.
-
-Checks:
-- Make the purpose explicit in a <role> section.
-- Detect whether the current instructions already contain a workflow. If they do, improve the workflow to be concrete, ordered, and operational. If they do not, add one.
-- Keep workflows numbered and focused on real execution steps, not vague advice.
-- Add or tighten constraints when the current instructions are too open-ended.
-- Preserve the user's intended domain and responsibilities while improving clarity.
-- If the target is an automation, keep the instructions aligned with the trigger and expected background execution behavior.
-`,
-  },
 ];
 
 export const resources: GuideResource[] = [

--- a/apps/mesh/src/tools/virtual/studio-pack.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.ts
@@ -93,6 +93,17 @@ You are the Automation Manager. You create, configure, and manage automations â€
    a. Get the automation config with AUTOMATION_GET to review its setup.
    b. Run it manually with AUTOMATION_RUN.
    c. Report the result to the user.
+
+4. Improving an automation's instructions:
+   a. Read docs://automations.md for the messages/instructions pattern, then docs://agents.md for the XML-style structure.
+   b. Get the current automation with AUTOMATION_GET on the supplied automation id.
+   c. If the intended purpose, trigger context, or expected output is unclear, use user_ask before rewriting.
+   d. Rewrite the messages with explicit XML-style sections: <role>, <capabilities>, <constraints>, <workflows>.
+      - Keep the rewrite aligned with the automation's trigger and expected background-execution behavior.
+      - If a workflow already exists, sharpen it into concrete, ordered, operational steps. If none exists, add one.
+      - Tighten <constraints> when the current messages are too open-ended.
+   e. Save with AUTOMATION_UPDATE using the smallest change set.
+   f. Re-read with AUTOMATION_GET to verify the stored result.
 </workflows>`;
 
 const CONNECTION_MANAGER_INSTRUCTIONS = `<role>

--- a/apps/mesh/src/tools/virtual/studio-pack.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.ts
@@ -39,6 +39,18 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
    a. List all agents with COLLECTION_VIRTUAL_MCP_LIST.
    b. For detailed inspection, use COLLECTION_VIRTUAL_MCP_GET on specific agents.
    c. Cross-reference with COLLECTION_CONNECTIONS_LIST to identify unused or missing connections.
+
+4. Improving an agent's instructions:
+   a. Read docs://agents.md for the instruction-writing pattern (XML-style sections, explicit workflows).
+   b. Get the current instructions with COLLECTION_VIRTUAL_MCP_GET on the supplied agent id.
+   c. If the intended purpose, audience, or boundaries are unclear, use user_ask before rewriting.
+   d. Rewrite the instructions with explicit XML-style sections: <role>, <capabilities>, <constraints>, <workflows>.
+      - Make the purpose explicit in <role>.
+      - If a workflow already exists, sharpen it into concrete, ordered, operational steps. If none exists, add one that reflects how the agent should actually operate.
+      - Tighten <constraints> when the current instructions are too open-ended.
+      - Preserve the user's intended domain and responsibilities.
+   e. Save the rewritten instructions with COLLECTION_VIRTUAL_MCP_UPDATE using the smallest change set (only \`metadata.instructions\`).
+   f. Re-read with COLLECTION_VIRTUAL_MCP_GET to verify the stored result.
 </workflows>`;
 
 const AUTOMATION_MANAGER_INSTRUCTIONS = `<role>

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.test.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.test.ts
@@ -11,31 +11,32 @@ const baseInput = {
 };
 
 describe("buildImprovePromptDoc", () => {
-  test("produces a doc whose first inline node is an agent mention", () => {
+  test("starts with leading text, then the manager mention, then the trailing payload", () => {
     const doc = buildImprovePromptDoc(baseInput);
     expect(doc.type).toBe("doc");
     const para = doc.content?.[0];
     expect(para?.type).toBe("paragraph");
-    const first = para?.content?.[0];
-    expect(first?.type).toBe("mention");
-    expect(first?.attrs).toMatchObject({
+
+    const [leading, mention, trailing] = para?.content ?? [];
+    expect(leading?.type).toBe("text");
+    expect(leading?.text).toBe("Subtask to ");
+
+    expect(mention?.type).toBe("mention");
+    expect(mention?.attrs).toMatchObject({
       id: "agent_mgr_123",
       name: "Agent Manager",
       char: "@",
       metadata: { agentId: "agent_mgr_123", title: "Agent Manager" },
     });
-  });
 
-  test("includes XML payload after the mention", () => {
-    const doc = buildImprovePromptDoc(baseInput);
-    const text = doc.content?.[0]?.content?.[1];
-    expect(text?.type).toBe("text");
-    expect(text?.text).toContain("<task>improve_instructions</task>");
-    expect(text?.text).toContain('<entity kind="agent" id="vmcp_abc"');
-    expect(text?.text).toContain("<current_instructions>");
-    expect(text?.text).toContain("Help users with onboarding.");
-    expect(text?.text).toContain("Be concise.");
-    expect(text?.text).toContain("</current_instructions>");
+    expect(trailing?.type).toBe("text");
+    expect(trailing?.text).toContain(
+      'to improve the instructions of agent "vmcp_abc"',
+    );
+    expect(trailing?.text).toContain("Here's the current instructions");
+    expect(trailing?.text).toContain(
+      "<current_instructions>Help users with onboarding.\nBe concise.</current_instructions>",
+    );
   });
 
   test("compiles through derivePartsFromTiptapDoc into a DELEGATE directive", () => {
@@ -47,11 +48,12 @@ describe("buildImprovePromptDoc", () => {
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
       .map((p) => p.text)
       .join("\n");
+    expect(text).toContain("Subtask to @Agent Manager");
     expect(text).toContain(
       "[DELEGATE TO AGENT: Agent Manager (agent_id: agent_mgr_123)]",
     );
     expect(text).toContain("subtask tool");
-    expect(text).toContain("<task>improve_instructions</task>");
+    expect(text).toContain("<current_instructions>");
   });
 
   test("handles automation kind", () => {
@@ -62,7 +64,12 @@ describe("buildImprovePromptDoc", () => {
       id: "auto_42",
       instructions: "ping every minute",
     });
-    const text = doc.content?.[0]?.content?.[1]?.text ?? "";
-    expect(text).toContain('<entity kind="automation" id="auto_42"');
+    const trailing = doc.content?.[0]?.content?.[2]?.text ?? "";
+    expect(trailing).toContain(
+      'to improve the instructions of automation "auto_42"',
+    );
+    expect(trailing).toContain(
+      "<current_instructions>ping every minute</current_instructions>",
+    );
   });
 });

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.test.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.test.ts
@@ -19,7 +19,7 @@ describe("buildImprovePromptDoc", () => {
 
     const [leading, mention, trailing] = para?.content ?? [];
     expect(leading?.type).toBe("text");
-    expect(leading?.text).toBe("Subtask to ");
+    expect(leading?.text).toBe("Use ");
 
     expect(mention?.type).toBe("mention");
     expect(mention?.attrs).toMatchObject({
@@ -33,7 +33,7 @@ describe("buildImprovePromptDoc", () => {
     expect(trailing?.text).toContain(
       'to improve the instructions of agent "vmcp_abc"',
     );
-    expect(trailing?.text).toContain("Here's the current instructions");
+    expect(trailing?.text).toContain("Here are its current instructions.");
     expect(trailing?.text).toContain(
       "<current_instructions>Help users with onboarding.\nBe concise.</current_instructions>",
     );
@@ -48,7 +48,7 @@ describe("buildImprovePromptDoc", () => {
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
       .map((p) => p.text)
       .join("\n");
-    expect(text).toContain("Subtask to @Agent Manager");
+    expect(text).toContain("Use @Agent Manager to improve the instructions");
     expect(text).toContain(
       "[DELEGATE TO AGENT: Agent Manager (agent_id: agent_mgr_123)]",
     );

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.test.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { buildImprovePromptDoc } from "./build-improve-prompt-doc";
+import { derivePartsFromTiptapDoc } from "../derive-parts";
+
+const baseInput = {
+  managerAgentId: "agent_mgr_123",
+  managerName: "Agent Manager",
+  kind: "agent" as const,
+  id: "vmcp_abc",
+  instructions: "Help users with onboarding.\nBe concise.",
+};
+
+describe("buildImprovePromptDoc", () => {
+  test("produces a doc whose first inline node is an agent mention", () => {
+    const doc = buildImprovePromptDoc(baseInput);
+    expect(doc.type).toBe("doc");
+    const para = doc.content?.[0];
+    expect(para?.type).toBe("paragraph");
+    const first = para?.content?.[0];
+    expect(first?.type).toBe("mention");
+    expect(first?.attrs).toMatchObject({
+      id: "agent_mgr_123",
+      name: "Agent Manager",
+      char: "@",
+      metadata: { agentId: "agent_mgr_123", title: "Agent Manager" },
+    });
+  });
+
+  test("includes XML payload after the mention", () => {
+    const doc = buildImprovePromptDoc(baseInput);
+    const text = doc.content?.[0]?.content?.[1];
+    expect(text?.type).toBe("text");
+    expect(text?.text).toContain("<task>improve_instructions</task>");
+    expect(text?.text).toContain('<entity kind="agent" id="vmcp_abc"');
+    expect(text?.text).toContain("<current_instructions>");
+    expect(text?.text).toContain("Help users with onboarding.");
+    expect(text?.text).toContain("Be concise.");
+    expect(text?.text).toContain("</current_instructions>");
+  });
+
+  test("compiles through derivePartsFromTiptapDoc into a DELEGATE directive", () => {
+    const doc = buildImprovePromptDoc(baseInput);
+    const parts = derivePartsFromTiptapDoc(
+      doc as Parameters<typeof derivePartsFromTiptapDoc>[0],
+    );
+    const text = parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("\n");
+    expect(text).toContain(
+      "[DELEGATE TO AGENT: Agent Manager (agent_id: agent_mgr_123)]",
+    );
+    expect(text).toContain("subtask tool");
+    expect(text).toContain("<task>improve_instructions</task>");
+  });
+
+  test("handles automation kind", () => {
+    const doc = buildImprovePromptDoc({
+      managerAgentId: "agent_mgr_auto",
+      managerName: "Automation Manager",
+      kind: "automation",
+      id: "auto_42",
+      instructions: "ping every minute",
+    });
+    const text = doc.content?.[0]?.content?.[1]?.text ?? "";
+    expect(text).toContain('<entity kind="automation" id="auto_42"');
+  });
+});

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
@@ -1,0 +1,49 @@
+import type { JSONContent } from "@tiptap/core";
+
+export interface ImprovePromptDocInput {
+  managerAgentId: string;
+  managerName: string;
+  kind: "agent" | "automation";
+  id: string;
+  instructions: string;
+}
+
+/**
+ * Build a tiptap document that, when sent through the chat, becomes:
+ *   [@<Manager> chip][XML payload]
+ *
+ * The mention is shaped so derivePartsFromTiptapDoc emits the standard
+ * `[DELEGATE TO AGENT: ...]` directive that Decopilot's SUBTASK tool
+ * picks up. The XML payload carries the entity context for the manager.
+ */
+export function buildImprovePromptDoc(
+  input: ImprovePromptDocInput,
+): JSONContent {
+  const { managerAgentId, managerName, kind, id, instructions } = input;
+
+  const xmlPayload =
+    `\n<task>improve_instructions</task>\n` +
+    `<entity kind="${kind}" id="${id}" />\n` +
+    `<current_instructions>\n${instructions}\n</current_instructions>`;
+
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "mention",
+            attrs: {
+              id: managerAgentId,
+              name: managerName,
+              char: "@",
+              metadata: { agentId: managerAgentId, title: managerName },
+            },
+          },
+          { type: "text", text: xmlPayload },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
@@ -9,20 +9,22 @@ export interface ImprovePromptDocInput {
 }
 
 /**
- * Build a tiptap document that, when sent through the chat, becomes:
- *   [@<Manager> chip][XML payload]
+ * Build a tiptap document that, when sent through the chat, reads as:
+ *   Subtask to @<Manager>, to improve the instructions of <kind> "<id>".
+ *   Here's the current instructions
+ *   <current_instructions>{instructions}</current_instructions>
  *
  * The mention is shaped so derivePartsFromTiptapDoc emits the standard
  * `[DELEGATE TO AGENT: ...]` directive that Decopilot's SUBTASK tool
- * picks up. The XML payload carries the entity context for the manager.
+ * picks up.
  */
 export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
   const { managerAgentId, managerName, kind, id, instructions } = input;
 
-  const xmlPayload =
-    `\n<task>improve_instructions</task>\n` +
-    `<entity kind="${kind}" id="${id}" />\n` +
-    `<current_instructions>\n${instructions}\n</current_instructions>`;
+  const trailing =
+    `, to improve the instructions of ${kind} "${id}". ` +
+    `Here's the current instructions\n` +
+    `<current_instructions>${instructions}</current_instructions>`;
 
   return {
     type: "doc",
@@ -30,6 +32,7 @@ export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
       {
         type: "paragraph",
         content: [
+          { type: "text", text: "Subtask to " },
           {
             type: "mention",
             attrs: {
@@ -39,7 +42,7 @@ export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
               metadata: { agentId: managerAgentId, title: managerName },
             },
           },
-          { type: "text", text: xmlPayload },
+          { type: "text", text: trailing },
         ],
       },
     ],

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
@@ -1,4 +1,4 @@
-import type { JSONContent } from "@tiptap/core";
+import type { TiptapDoc } from "../types";
 
 export interface ImprovePromptDocInput {
   managerAgentId: string;
@@ -16,9 +16,7 @@ export interface ImprovePromptDocInput {
  * `[DELEGATE TO AGENT: ...]` directive that Decopilot's SUBTASK tool
  * picks up. The XML payload carries the entity context for the manager.
  */
-export function buildImprovePromptDoc(
-  input: ImprovePromptDocInput,
-): JSONContent {
+export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
   const { managerAgentId, managerName, kind, id, instructions } = input;
 
   const xmlPayload =

--- a/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/build-improve-prompt-doc.ts
@@ -10,8 +10,8 @@ export interface ImprovePromptDocInput {
 
 /**
  * Build a tiptap document that, when sent through the chat, reads as:
- *   Subtask to @<Manager>, to improve the instructions of <kind> "<id>".
- *   Here's the current instructions
+ *   Use @<Manager> to improve the instructions of <kind> "<id>".
+ *   Here are its current instructions.
  *   <current_instructions>{instructions}</current_instructions>
  *
  * The mention is shaped so derivePartsFromTiptapDoc emits the standard
@@ -22,8 +22,8 @@ export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
   const { managerAgentId, managerName, kind, id, instructions } = input;
 
   const trailing =
-    `, to improve the instructions of ${kind} "${id}". ` +
-    `Here's the current instructions\n` +
+    ` to improve the instructions of ${kind} "${id}". ` +
+    `Here are its current instructions.\n` +
     `<current_instructions>${instructions}</current_instructions>`;
 
   return {
@@ -32,7 +32,7 @@ export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
       {
         type: "paragraph",
         content: [
-          { type: "text", text: "Subtask to " },
+          { type: "text", text: "Use " },
           {
             type: "mention",
             attrs: {

--- a/apps/mesh/src/web/components/home/studio-pack-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/studio-pack-recruit-modal.tsx
@@ -22,13 +22,9 @@ import {
 import { Button } from "@deco/ui/components/button.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
-import {
-  WellKnownOrgMCPId,
-  useProjectContext,
-  useVirtualMCPActions,
-  useVirtualMCPs,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { STUDIO_PACK_AGENTS } from "@/tools/virtual/studio-pack";
+import { useEnsureStudioPack } from "./use-ensure-studio-pack";
 import { useNavigate } from "@tanstack/react-router";
 import { track } from "@/web/lib/posthog-client";
 
@@ -103,8 +99,7 @@ export function StudioPackRecruitModal({
 }: StudioPackRecruitModalProps) {
   const isMobile = useIsMobile();
   const { org } = useProjectContext();
-  const actions = useVirtualMCPActions();
-  const existingAgents = useVirtualMCPs();
+  const ensure = useEnsureStudioPack();
   const navigate = useNavigate();
   const [isInstalling, setIsInstalling] = useState(false);
 
@@ -119,36 +114,12 @@ export function StudioPackRecruitModal({
   const handleInstall = async () => {
     setIsInstalling(true);
     try {
-      const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
-      const existingTitles = new Set(existingAgents.map((a) => a.title));
-      let installedCount = 0;
-
-      for (const agent of STUDIO_PACK_AGENTS) {
-        if (existingTitles.has(agent.title)) continue;
-
-        await actions.create.mutateAsync({
-          title: agent.title,
-          description: agent.description,
-          icon: agent.icon,
-          status: "active",
-          metadata: {
-            instructions: agent.instructions,
-          },
-          connections: [
-            {
-              connection_id: selfConnectionId,
-              selected_tools: [...agent.selectedTools],
-              selected_resources: null,
-              selected_prompts: null,
-            },
-          ],
-        });
-        installedCount++;
-      }
+      const allTemplateIds = STUDIO_PACK_AGENTS.map((a) => a.id);
+      await ensure(allTemplateIds);
 
       track("agent_recruit_confirmed", {
         template_id: "studio-pack",
-        installed_count: installedCount,
+        installed_count: allTemplateIds.length,
       });
       onOpenChange(false);
       navigate({ to: "/$org", params: { org: org.slug } });

--- a/apps/mesh/src/web/components/home/use-ensure-studio-pack.ts
+++ b/apps/mesh/src/web/components/home/use-ensure-studio-pack.ts
@@ -1,0 +1,51 @@
+import {
+  WellKnownOrgMCPId,
+  useProjectContext,
+  useVirtualMCPActions,
+  useVirtualMCPs,
+} from "@decocms/mesh-sdk";
+import { STUDIO_PACK_AGENTS } from "@/tools/virtual/studio-pack";
+
+/**
+ * Returns an `ensure` function that idempotently installs the Studio Pack
+ * agents identified by their template ids (e.g. "studio-agent-manager").
+ * Existing agents (matched by title — same heuristic as the recruit modal)
+ * are skipped. Resolves once every requested template is present.
+ */
+export function useEnsureStudioPack() {
+  const { org } = useProjectContext();
+  const actions = useVirtualMCPActions();
+  const existingAgents = useVirtualMCPs();
+
+  return async function ensure(
+    templateIds: ReadonlyArray<(typeof STUDIO_PACK_AGENTS)[number]["id"]>,
+  ): Promise<void> {
+    const selfConnectionId = WellKnownOrgMCPId.SELF(org.id);
+    const existingTitles = new Set(existingAgents.map((a) => a.title));
+
+    const targets = STUDIO_PACK_AGENTS.filter((a) =>
+      templateIds.includes(a.id),
+    );
+
+    for (const agent of targets) {
+      if (existingTitles.has(agent.title)) continue;
+      await actions.create.mutateAsync({
+        title: agent.title,
+        description: agent.description,
+        icon: agent.icon,
+        status: "active",
+        metadata: { instructions: agent.instructions },
+        connections: [
+          {
+            connection_id: selfConnectionId,
+            selected_tools: [...agent.selectedTools],
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+      });
+    }
+  };
+}
+
+export type EnsureStudioPack = ReturnType<typeof useEnsureStudioPack>;

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -16,7 +16,11 @@ import {
   useTriggerList,
   type TriggerDefinition,
 } from "@/web/hooks/use-automations";
-import { useChatTask, useChatPrefs } from "@/web/components/chat/context";
+import {
+  useChatTask,
+  useChatPrefs,
+  useChatBridge,
+} from "@/web/components/chat/context";
 import { usePreferences } from "@/web/hooks/use-preferences";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
@@ -31,7 +35,6 @@ import {
   useConnections,
   useProjectContext,
 } from "@decocms/mesh-sdk";
-import { useChatBridge } from "@/web/components/chat/context";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { useEnsureStudioPack } from "@/web/components/home/use-ensure-studio-pack";
 import { buildImprovePromptDoc } from "@/web/components/chat/tiptap/build-improve-prompt-doc";
@@ -319,6 +322,7 @@ export function SettingsTab({
   const [showCustomCron, setShowCustomCron] = useState(false);
   const [cronInput, setCronInput] = useState("");
   const [showEventForm, setShowEventForm] = useState(false);
+  const [isImproving, setIsImproving] = useState(false);
   const editorInitializedRef = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tiptapDirtyRef = useRef(false);
@@ -328,6 +332,7 @@ export function SettingsTab({
   const tiptapDocRef = useRef<Metadata["tiptapDoc"]>(initialTiptapDoc);
 
   const handleImprovePrompt = async () => {
+    if (isImproving) return;
     const parts = derivePartsFromTiptapDoc(tiptapDoc);
     const instructionsText = parts
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
@@ -335,26 +340,31 @@ export function SettingsTab({
       .join("\n");
     if (!instructionsText.trim()) return;
 
-    flushEditSession();
-    track("automation_improve_clicked", {
-      automation_id: automationId,
-      agent_id: agentId,
-      instructions_length: instructionsText.length,
-    });
+    setIsImproving(true);
+    try {
+      flushEditSession();
+      track("automation_improve_clicked", {
+        automation_id: automationId,
+        agent_id: agentId,
+        instructions_length: instructionsText.length,
+      });
 
-    await ensureStudioPack(["studio-automation-manager"]);
+      await ensureStudioPack(["studio-automation-manager"]);
 
-    setChatOpen(true);
+      setChatOpen(true);
 
-    await sendMessage({
-      tiptapDoc: buildImprovePromptDoc({
-        managerAgentId: StudioPackAgentId.AUTOMATION_MANAGER(org.id),
-        managerName: "Automation Manager",
-        kind: "automation",
-        id: automationId,
-        instructions: instructionsText,
-      }),
-    });
+      await sendMessage({
+        tiptapDoc: buildImprovePromptDoc({
+          managerAgentId: StudioPackAgentId.AUTOMATION_MANAGER(org.id),
+          managerName: "Automation Manager",
+          kind: "automation",
+          id: automationId,
+          instructions: instructionsText,
+        }),
+      });
+    } finally {
+      setIsImproving(false);
+    }
   };
 
   const defaultCredentialId =
@@ -768,7 +778,7 @@ export function SettingsTab({
               variant="outline"
               size="sm"
               className="h-7 gap-1.5 px-2 text-xs"
-              disabled={!tiptapDoc}
+              disabled={isImproving || !tiptapDoc}
               onClick={handleImprovePrompt}
             >
               <Stars01 size={13} />

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -27,10 +27,14 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import {
-  getDecopilotId,
+  StudioPackAgentId,
   useConnections,
   useProjectContext,
 } from "@decocms/mesh-sdk";
+import { useChatBridge } from "@/web/components/chat/context";
+import { usePanelActions } from "@/web/layouts/shell-layout";
+import { useEnsureStudioPack } from "@/web/components/home/use-ensure-studio-pack";
+import { buildImprovePromptDoc } from "@/web/components/chat/tiptap/build-improve-prompt-doc";
 import {
   ArrowLeft,
   ArrowUp,
@@ -301,8 +305,10 @@ export function SettingsTab({
     setModel,
     credentialId: chatCredentialId,
     selectedModel: chatModel,
-    setChatMode,
   } = useChatPrefs();
+  const { setChatOpen } = usePanelActions();
+  const { sendMessage } = useChatBridge();
+  const ensureStudioPack = useEnsureStudioPack();
   const [preferences, setPreferences] = usePreferences();
   const initialTiptapDoc =
     (automation.messages?.[0] as { metadata?: Metadata } | undefined)?.metadata
@@ -321,7 +327,7 @@ export function SettingsTab({
   // not the latest keystroke — that's how trailing characters got lost.
   const tiptapDocRef = useRef<Metadata["tiptapDoc"]>(initialTiptapDoc);
 
-  const handleImprovePrompt = () => {
+  const handleImprovePrompt = async () => {
     const parts = derivePartsFromTiptapDoc(tiptapDoc);
     const instructionsText = parts
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
@@ -336,18 +342,18 @@ export function SettingsTab({
       instructions_length: instructionsText.length,
     });
 
-    setChatMode("plan");
+    await ensureStudioPack(["studio-automation-manager"]);
 
-    createTaskWithMessage({
-      virtualMcpId: getDecopilotId(org.id),
-      message: {
-        parts: [
-          {
-            type: "text",
-            text: `/writing-prompts for automation with id ${automationId}. The current message is\n\n<message>\n${instructionsText}\n</message>`,
-          },
-        ],
-      },
+    setChatOpen(true);
+
+    await sendMessage({
+      tiptapDoc: buildImprovePromptDoc({
+        managerAgentId: StudioPackAgentId.AUTOMATION_MANAGER(org.id),
+        managerName: "Automation Manager",
+        kind: "automation",
+        id: automationId,
+        instructions: instructionsText,
+      }),
     });
   };
 

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1,9 +1,11 @@
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import type { VirtualMCPEntity } from "@/tools/virtual/schema";
 import { getUIResourceUri } from "@/mcp-apps/types.ts";
-import { useChatPrefs, useChatTask } from "@/web/components/chat/context";
+import { useChatBridge } from "@/web/components/chat/context";
+import { buildImprovePromptDoc } from "@/web/components/chat/tiptap/build-improve-prompt-doc";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import { useEnsureStudioPack } from "@/web/components/home/use-ensure-studio-pack";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { User } from "@/web/components/user/user";
@@ -53,8 +55,8 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   type ConnectionEntity,
-  getDecopilotId,
   SELF_MCP_ALIAS_ID,
+  StudioPackAgentId,
   useConnection,
   useConnectionActions,
   useConnections,
@@ -1096,11 +1098,11 @@ function VirtualMcpDetailViewWithData({
   });
 
   const [instructionsFullscreen, setInstructionsFullscreen] = useState(false);
-  const { createTaskWithMessage } = useChatTask();
-  const { setChatMode } = useChatPrefs();
-  const { createNewTask } = usePanelActions();
+  const { createNewTask, setChatOpen } = usePanelActions();
+  const { sendMessage } = useChatBridge();
+  const ensureStudioPack = useEnsureStudioPack();
 
-  const handleImprovePrompt = () => {
+  const handleImprovePrompt = async () => {
     const currentInstructions = form.getValues("metadata.instructions");
     if (!currentInstructions?.trim()) return;
 
@@ -1110,18 +1112,18 @@ function VirtualMcpDetailViewWithData({
       instructions_length: currentInstructions.length,
     });
 
-    setChatMode("plan");
+    await ensureStudioPack(["studio-agent-manager"]);
 
-    createTaskWithMessage({
-      virtualMcpId: getDecopilotId(org.id),
-      message: {
-        parts: [
-          {
-            type: "text",
-            text: `/writing-prompts ${virtualMcp.id}\n\n<instructions>\n${currentInstructions}\n</instructions>`,
-          },
-        ],
-      },
+    setChatOpen(true);
+
+    await sendMessage({
+      tiptapDoc: buildImprovePromptDoc({
+        managerAgentId: StudioPackAgentId.AGENT_MANAGER(org.id),
+        managerName: "Agent Manager",
+        kind: "agent",
+        id: virtualMcp.id,
+        instructions: currentInstructions,
+      }),
     });
   };
 

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -1098,33 +1098,40 @@ function VirtualMcpDetailViewWithData({
   });
 
   const [instructionsFullscreen, setInstructionsFullscreen] = useState(false);
+  const [isImproving, setIsImproving] = useState(false);
   const { createNewTask, setChatOpen } = usePanelActions();
   const { sendMessage } = useChatBridge();
   const ensureStudioPack = useEnsureStudioPack();
 
   const handleImprovePrompt = async () => {
+    if (isImproving) return;
     const currentInstructions = form.getValues("metadata.instructions");
     if (!currentInstructions?.trim()) return;
 
-    flushEditSession();
-    track("agent_instructions_improve_clicked", {
-      agent_id: virtualMcp.id,
-      instructions_length: currentInstructions.length,
-    });
+    setIsImproving(true);
+    try {
+      flushEditSession();
+      track("agent_instructions_improve_clicked", {
+        agent_id: virtualMcp.id,
+        instructions_length: currentInstructions.length,
+      });
 
-    await ensureStudioPack(["studio-agent-manager"]);
+      await ensureStudioPack(["studio-agent-manager"]);
 
-    setChatOpen(true);
+      setChatOpen(true);
 
-    await sendMessage({
-      tiptapDoc: buildImprovePromptDoc({
-        managerAgentId: StudioPackAgentId.AGENT_MANAGER(org.id),
-        managerName: "Agent Manager",
-        kind: "agent",
-        id: virtualMcp.id,
-        instructions: currentInstructions,
-      }),
-    });
+      await sendMessage({
+        tiptapDoc: buildImprovePromptDoc({
+          managerAgentId: StudioPackAgentId.AGENT_MANAGER(org.id),
+          managerName: "Agent Manager",
+          kind: "agent",
+          id: virtualMcp.id,
+          instructions: currentInstructions,
+        }),
+      });
+    } finally {
+      setIsImproving(false);
+    }
   };
 
   const handleTestAgent = () => {
@@ -1715,7 +1722,10 @@ Define step-by-step how the agent should handle requests.
                     <Button
                       variant="outline"
                       size="sm"
-                      disabled={!form.watch("metadata.instructions")?.trim()}
+                      disabled={
+                        isImproving ||
+                        !form.watch("metadata.instructions")?.trim()
+                      }
                       onClick={handleImprovePrompt}
                     >
                       <Stars01 size={13} />

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -111,7 +111,7 @@ export function displayToolName(
 
 /**
  * Convert a kebab/snake-case prompt name to a human-readable Title Case string.
- * e.g. "writing-prompts" → "Writing Prompts"
+ * e.g. "agents-create" → "Agents Create"
  */
 function titleFromName(name: string): string {
   return name


### PR DESCRIPTION
## What is this contribution about?

Reworks the "Improve" buttons on the agent and automation edit screens. They previously created a fresh Decopilot task with a `/writing-prompts` slash prompt, yanking the user into a new chat thread. They now silently install the relevant Studio Pack manager (Agent Manager or Automation Manager), open the side chat panel in place, and `sendMessage` a tiptap doc that mentions the manager — Decopilot delegates via its existing `SUBTASK` tool. The `/writing-prompts` slash prompt is deleted; its prose is folded into the two manager agents' workflows so the rewriting capability lives where it semantically belongs. Adds `useEnsureStudioPack` (extracted from the recruit modal) and `buildImprovePromptDoc` (with unit tests), plus a double-click guard on both buttons.

## Screenshots/Demonstration

The new chat message reads:

> Use @Agent Manager to improve the instructions of agent "vir_xxx". Here are its current instructions.
> `<current_instructions>…</current_instructions>`

## How to Test

1. Open an agent's edit screen, write some loose instructions, click **Improve**.
2. Confirm: no navigation, chat panel opens, message contains the `@Agent Manager` chip + payload, Decopilot subtasks to Agent Manager, instructions get rewritten and saved (form refetches).
3. Repeat on an automation's edit screen — same flow with `@Automation Manager`.
4. Verify the Studio Pack recruit modal (sidebar `+` button) still installs all three agents.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (unit tests + typecheck/lint/format clean; manual UI smoke pending reviewer)
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline delegation for the Improve buttons: clicking Improve now opens the side chat and hands off to the Studio Pack manager in place, instead of creating a new task or navigating away. The old `/writing-prompts` slash prompt is removed; rewriting now lives inside the Agent/Automation Manager workflows.

- New Features
  - Improve buttons on agent and automation screens open chat and send a tiptap doc that mentions the relevant manager (delegation via SUBTASK), then saves the rewritten instructions.
  - Added `useEnsureStudioPack` to auto-install required Studio Pack agents; the recruit modal now uses the same idempotent install path.
  - Added `buildImprovePromptDoc` with unit tests for the mention + XML payload; added a double-click guard on Improve to prevent duplicate actions; updated Studio Pack managers with “improve instructions” workflows and removed the legacy guide entry.

<sup>Written for commit e36e6b869940b08001960c28ec8408041e0144c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

