### PR TITLE
feat(sandbox): surface validation reason on /config 400

### DIFF
--- a/packages/sandbox/daemon/config-store/store.ts
+++ b/packages/sandbox/daemon/config-store/store.ts
@@ -82,10 +82,13 @@ export class TenantConfigStore {
         if (!entry) break;
         try {
           entry.resolve(await this.runOne(entry.patch));
-        } catch {
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          console.warn(`[config-store] apply threw: ${detail}`);
           entry.resolve({
             kind: "rejected",
             reason: REJECTION_REASONS.APPLY_FAILED,
+            detail,
           });
         }
       }
@@ -100,7 +103,18 @@ export class TenantConfigStore {
 
     const validation = validateTenantConfig(merged);
     if (validation.kind === "invalid") {
-      return { kind: "rejected", reason: REJECTION_REASONS.INVALID };
+      // Surface the field-level reason from `validateTenantConfig` instead of
+      // the bare "invalid" constant — the wire response becomes
+      // `{"error":"invalid: <reason>"}` and pod logs get the same line, so a
+      // 400 from /config can be diagnosed without re-running with a debugger.
+      console.warn(
+        `[config-store] rejected payload as invalid: ${validation.reason}`,
+      );
+      return {
+        kind: "rejected",
+        reason: REJECTION_REASONS.INVALID,
+        detail: validation.reason,
+      };
     }
 
     const transition = classify(before, merged);


### PR DESCRIPTION
## What is this contribution about?

The daemon's \`TenantConfigStore\` was discarding the field-level \`reason\` produced by \`validateTenantConfig\` (e.g. \`runtime invalid: python\`, \`git.repository.cloneUrl is empty\`) and returning only the bare \`"invalid"\` rejection constant — so a 400 from \`POST /_decopilot_vm/config\` came back as the opaque \`{"error":"invalid"}\` with no way to tell which field failed without attaching a debugger. This PR forwards \`validation.reason\` as the rejection \`detail\` so the wire response becomes \`{"error":"invalid: <reason>"}\`, logs the same line via \`console.warn\` so it lands in pod logs, and additionally preserves the thrown error message under the \`apply-failed\` rejection so unexpected exceptions in the apply queue stop being silently flattened.

## How to Test

1. Boot a sandbox and POST a deliberately bad config (e.g. \`{"application": {"runtime": "python"}}\`)
2. Expected: response is \`HTTP 400 {"error":"invalid: runtime invalid: python"}\` (was previously \`{"error":"invalid"}\`)
3. Pod logs show \`[config-store] rejected payload as invalid: runtime invalid: python\`
4. \`bun run check\` and \`bun test packages/sandbox/server packages/sandbox/daemon/config-store\` pass

## Migration Notes

None. The wire shape stays \`{"error": string}\` with status 400; only the string content gets richer.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface field-level validation reasons in 400 responses from /_decopilot_vm/config and log them for easier debugging. Also keep thrown error messages when apply fails so failures aren’t silently flattened.

- **Bug Fixes**
  - Forward `validateTenantConfig` reason as rejection detail so clients see `{"error":"invalid: <reason>"}`.
  - Log invalid payloads and apply exceptions via `console.warn` for pod visibility.
  - Preserve the thrown error message under the `apply-failed` rejection.

<sup>Written for commit c2e305ff32f64645aa6e91d2aa923126006039b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

