### PR TITLE
fix(toolbar): remove overflow-x-auto clipping active tab ring

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
@@ -125,12 +125,7 @@ function ToolbarCenter({ children }: { children: ReactNode }) {
 
 function ToolbarTabsSlot() {
   const { setTabsEl } = useToolbarCtx();
-  return (
-    <div
-      ref={setTabsEl}
-      className="shrink-0 flex items-center overflow-x-auto"
-    />
-  );
+  return <div ref={setTabsEl} className="shrink-0 flex items-center" />;
 }
 
 function ToolbarTabs({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## What is this contribution about?

Removes `overflow-x-auto` from `ToolbarTabsSlot` in the agent shell toolbar. This property was clipping the active/focused tab's selection ring in the top-right tab bar (Preview, Assets, Releases, etc.). Since `MainPanelTabsBar` already handles overflow internally via `TabOverflowMenu` (capped at 6 visible tabs), the scroll constraint was redundant and only caused the visual clipping.

## Screenshots/Demonstration

Before: the selected tab's border ring was cut off at the container edge.
After: the ring renders fully without any padding changes.

## How to Test

1. Open any agent with multiple tabs visible in the top-right tab bar.
2. Click a tab to select it — the selection ring should render fully without being cut off.
3. Verify tabs beyond 6 still collapse into the `...` overflow menu correctly.

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `overflow-x-auto` from the toolbar tabs slot to fix the active tab’s focus/selection ring being clipped in the top-right tab bar. Overflow is already handled by `MainPanelTabsBar` via `TabOverflowMenu` (6 visible tabs), so behavior stays the same aside from the visual fix.

<sup>Written for commit c33988176dd8ece23498dea13be061b84a2e0430. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

