### PR TITLE
fix(oauth): prefer path slug over session active org in protected-resource metadata

### DIFF
--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -280,6 +280,52 @@ describe("org-scoped API coexistence", () => {
     }
   });
 
+  it("well-known prefix discovery uses the path slug, not the session's active org", async () => {
+    // Regression for #3272 fallout: multi-org users hitting another org's
+    // URL would 404 here because the handler resolved `orgSlug` as
+    // `ctx.organization?.slug ?? c.req.param("org")`. The well-known prefix
+    // route is mounted at the URL root (outside `/api/:org`), so
+    // `resolveOrgFromPath` doesn't run — `ctx.organization` falls through to
+    // the session's `activeOrganizationId`, which silently overrode the path
+    // slug. For a user whose active org is `org_456`, a discovery probe at
+    // `/api/org_1/mcp/conn_1` would scope the lookup to `org_456` and 404
+    // even though the path AND the connection both belong to `org_1`. Fix:
+    // path param takes priority — `c.req.param("org") ?? ctx.organization?.slug`.
+    mockApiKey("user_1", "org_456", "org_456");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      _input,
+      init,
+    ) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST") {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate":
+              'Bearer realm="origin", resource_metadata="https://example.test/.well-known/oauth-protected-resource"',
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    try {
+      const res = await app.fetch(
+        new Request(
+          "http://mesh.localhost/.well-known/oauth-protected-resource/api/org_1/mcp/conn_1",
+          { headers: { Authorization: "Bearer test-key" } },
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { resource: string };
+      expect(body.resource).toBe("http://mesh.localhost/api/org_1/mcp/conn_1");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("well-known prefix discovery 404s when :org doesn't match the connection's org", async () => {
     // The synthesized PRM URL embeds :org as part of the resource path, so
     // the handler MUST refuse to vouch for (org, connection) tuples that

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -393,15 +393,22 @@ export const protectedResourceMetadataHandler = async (c: {
 
   const requestUrl = fixProtocol(new URL(c.req.url));
   // Org slug sources (in priority order):
-  // 1. `ctx.organization?.slug` — set by `resolveOrgFromPath` for routes
-  //    inside the `/api/:org` sub-app.
-  // 2. `c.req.param("org")` — present on the top-level well-known prefix
-  //    route `/.well-known/oauth-protected-resource/api/:org/mcp/:id`, which
-  //    sits outside the sub-app so `resolveOrgFromPath` never runs.
-  // 3. undefined — legacy routes (`/mcp/:id/.well-known/...`,
-  //    `/.well-known/.../mcp/:id`) have no slug; the prefix is empty and
+  // 1. `c.req.param("org")` — present on the top-level well-known prefix
+  //    route `/.well-known/oauth-protected-resource/api/:org/mcp/:id` and
+  //    on the `/api/:org`-mounted variant. The path slug is the source of
+  //    truth: the URL literally names which org's connection the SDK is
+  //    asking metadata for. The path-mounted variant lives outside the
+  //    sub-app so `resolveOrgFromPath` never runs there — without honoring
+  //    the path param first, `ctx.organization` falls back to the session's
+  //    `activeOrganizationId`, and multi-org users hitting another org's URL
+  //    silently lookup against their active org and 404.
+  // 2. `ctx.organization?.slug` — set by `resolveOrgFromPath` for routes
+  //    inside the `/api/:org` sub-app, or by the meshContext factory from
+  //    the session's active org. Used only when the path doesn't carry a
+  //    slug (legacy `/mcp/:id/.well-known/...` mount).
+  // 3. undefined — legacy routes have no slug; the prefix is empty and
   //    we issue legacy-shape metadata URLs.
-  const orgSlug = ctx.organization?.slug ?? c.req.param("org");
+  const orgSlug = c.req.param("org") ?? ctx.organization?.slug;
 
   // When :org is in scope, the connection MUST belong to that org. Resolve
   // the slug to an org id so the connection lookup filters on it; otherwise


### PR DESCRIPTION
## Summary

The well-known prefix route `/.well-known/oauth-protected-resource/api/:org/mcp/:id` is mounted at the URL root (RFC 9728 Format 2 anchors the well-known prefix at the origin), so `resolveOrgFromPath` never runs there. The handler used `ctx.organization?.slug ?? c.req.param("org")` to pick the org slug — but for any authenticated request `ctx.organization` is populated by the meshContext factory from the session's `activeOrganizationId`. The `??` silently let that shadow the path slug.

For multi-org users hitting another org's URL, OAuth discovery 404'd because the connection lookup was scoped to their session's active org instead of the org named in the URL. The MCP SDK then aborted, and the GitHub auto-install hook's cleanup deleted the orphaned connection — leaving no trace.

The path slug is the source of truth: the URL literally names which org's connection the SDK is asking metadata for. Swapping the `??` order makes the path win.

Same anti-pattern exists in two legacy handlers (`eventsHandler` and `watchHandler` in `app.ts`); skipping those since both are already deprecation-logged for removal.

## Test plan

- [x] New regression test `well-known prefix discovery uses the path slug, not the session's active org` — fails with 404 on the unfixed code, passes on the fix
- [x] Verified against prod DB: confirmed user's session `activeOrganizationId` (`tiago-guarana-labs`) ≠ URL slug (`gimenes`), and the missing connection was the cleanup-deleted artifact
- [x] All 32 tests in `integration-org-scoped.test.ts` + `oauth-proxy.test.ts` pass
- [x] `tsc --noEmit` clean

## Repro before fix

1. Be a member of multiple orgs.
2. Switch active org to org A in one tab.
3. In another tab, navigate to `studio.example.com/<orgB>` and click "Import from GitHub".
4. Auto-install creates a connection in org B, but OAuth discovery 404s and cleanup deletes it. No persistent state, no error message — github "is just off".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth protected-resource metadata to prefer the org slug from the URL over the session’s active org. Restores discovery for multi-org users and unblocks GitHub auto-install and other OAuth flows.

- **Bug Fixes**
  - Updated `protectedResourceMetadataHandler` to use `c.req.param("org") ?? ctx.organization?.slug`, so lookups always scope to the org named in the URL.
  - Added a regression test to ensure the well-known route uses the path slug and no longer 404s for multi-org users.

<sup>Written for commit 122f2185f05e0924fa416be8f815e345e4f6cdc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

