### PR TITLE
fix(sandbox/daemon): resolve branch status from repoDir, not appRoot

### DIFF
--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Broadcaster } from "../events/broadcast";
@@ -118,5 +118,61 @@ describe("BranchStatusMonitor", () => {
     m.setPhase({ kind: "clone-failed", error: "x" });
     m.setPhase({ kind: "cloning" });
     expect(m.getLast()).toEqual({ kind: "cloning" });
+  });
+
+  // Regression: when appRoot != repoDir AND appRoot is nested inside another
+  // git worktree (e.g. host runner: <project>/.deco/sandboxes/<handle>/repo
+  // sits under the project's own .git), git's parent-directory walk used to
+  // hijack the lookup and report the outer repo's branch. The monitor must
+  // resolve git from repoDir and refuse to escape it.
+  it("compute() uses repoDir, not appRoot, and does not walk into a parent git repo", () => {
+    const outer = mkdtempSync(join(tmpdir(), "branch-status-outer-"));
+    try {
+      gitSync(["init", "-b", "outer-branch"], { cwd: outer, asUser: false });
+      gitSync(["config", "user.email", "outer@example.com"], {
+        cwd: outer,
+        asUser: false,
+      });
+      gitSync(["config", "user.name", "Outer"], { cwd: outer, asUser: false });
+      gitSync(["commit", "--allow-empty", "-m", "outer"], {
+        cwd: outer,
+        asUser: false,
+      });
+
+      const appRoot = join(outer, "sandbox-app");
+      const repoDir = join(appRoot, "repo");
+      mkdirSync(repoDir, { recursive: true });
+      gitSync(["init", "-b", "inner-branch"], { cwd: repoDir, asUser: false });
+      gitSync(["config", "user.email", "inner@example.com"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+      gitSync(["config", "user.name", "Inner"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+      gitSync(["commit", "--allow-empty", "-m", "inner"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+
+      const config = {
+        appRoot,
+        repoDir,
+        daemonToken: "",
+        daemonBootId: "",
+        proxyPort: 0,
+        dropPrivileges: false,
+      } as never;
+      const monitor = new BranchStatusMonitor(config, broadcaster);
+      monitor.markReady();
+
+      const last = monitor.getLast();
+      if (last?.kind !== "ready")
+        throw new Error(`expected ready, got ${last?.kind}`);
+      expect(last.branch).toBe("inner-branch");
+    } finally {
+      rmSync(outer, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -81,7 +81,7 @@ export class BranchStatusMonitor {
 
   private ensureWatch(): void {
     if (this.watcher || this.pollFallback) return;
-    const gitDir = `${this.config.appRoot}/.git`;
+    const gitDir = `${this.config.repoDir}/.git`;
     try {
       this.watcher = fs.watch(gitDir, { recursive: true }, () =>
         this.schedule(),
@@ -99,7 +99,13 @@ export class BranchStatusMonitor {
   private compute(): BranchStatusReady | null {
     const run = (args: string[]) => {
       try {
-        return gitSync(args, { cwd: this.config.appRoot });
+        return gitSync(args, {
+          cwd: this.config.repoDir,
+          // Pin discovery to repoDir so a parent .git (e.g. the host's
+          // workspace tree containing .deco/sandboxes/<handle>/repo) can't
+          // hijack the lookup and report the wrong branch.
+          env: { ...process.env, GIT_CEILING_DIRECTORIES: this.config.repoDir },
+        });
       } catch {
         return "";
       }


### PR DESCRIPTION
## Summary

- `BranchStatusMonitor` ran git from `appRoot`, which is the workspace container — the actual worktree lives at `repoDir = appRoot/repo`. On the docker runner `appRoot=/app` has no `.git`, so `compute()` returned `null` and the SSE `branch-status` event was stuck on `cloning` forever (UI never advanced).
- On the host runner the bug was masked: `.deco/sandboxes/<handle>` is nested inside the project's own worktree, so git's parent-directory walk hijacked the lookup and emitted a `ready` event carrying the **outer repo's** branch and SHA — wrong data, but enough to unstick the UI.
- Pin git's cwd to `repoDir` and set `GIT_CEILING_DIRECTORIES` so a parent `.git` cannot hijack the lookup before the inner repo is cloned. Same fix applied to the `.git` watcher in `ensureWatch()`.

## Test plan

- [x] New regression test in `branch-status.test.ts` creates an outer git repo, places `appRoot=outer/sandbox-app, repoDir=outer/sandbox-app/repo` (inner branch `inner-branch`) inside it, and asserts the monitor reports the inner branch (not the outer one). Without the fix this fails the exact way the production bug did.
- [x] `bun test packages/sandbox/daemon` — 146 pass / 0 fail.
- [x] `tsc --noEmit` clean for the sandbox package.
- [x] Manually verified end-to-end: docker runner sandbox now transitions `cloning` → `ready` and the UI unsticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix branch status resolution by running git from the inner repo (`repoDir`) instead of the workspace (`appRoot`). This unsticks the sandbox from "cloning" on Docker and reports the correct branch on host runners.

- **Bug Fixes**
  - Run git with `cwd = repoDir` and set `GIT_CEILING_DIRECTORIES` to block parent repo discovery.
  - Watch `repoDir/.git` instead of `appRoot/.git` in `ensureWatch()`.
  - Added a regression test to ensure the inner repo’s branch is reported when nested inside an outer repo.

<sup>Written for commit bea7b9ee2b44c964d7a6ea2629e2b4fbe8031241. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

