### PR TITLE
perf(runtime): cache tools/list payload across requests

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -7,14 +7,16 @@ import {
 } from "@decocms/bindings";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport as HttpServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import type {
-  CallToolResult,
-  GetPromptResult,
-  Implementation,
-  ToolAnnotations,
+import {
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type GetPromptResult,
+  type Implementation,
+  type ListToolsResult,
+  type ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import type { ZodRawShape, ZodSchema, ZodTypeAny } from "zod";
+import type { ZodSchema, ZodTypeAny } from "zod";
 import { BindingRegistry, injectBindingSchemas } from "./bindings.ts";
 import { Event, type EventHandlers } from "./events.ts";
 import type { DefaultEnv, User } from "./index.ts";
@@ -823,6 +825,12 @@ export const createMCPServer = <
   let cached: Registrations | null = null;
   let inflightResolve: Promise<Registrations> | null = null;
 
+  // The MCP SDK's `tools/list` handler runs `toJsonSchemaCompat()` for every
+  // registered tool on every request. For MCPs with hundreds of tools that
+  // dominates per-request latency (seconds, not ms). Cache the rendered
+  // payload across requests within the isolate.
+  let cachedListToolsResult: ListToolsResult | null = null;
+
   let _warnedFactoryDeprecation = false;
   const warnFactoryDeprecation = () => {
     if (!_warnedFactoryDeprecation) {
@@ -940,15 +948,19 @@ export const createMCPServer = <
           _meta: tool._meta,
           description: tool.description,
           annotations: tool.annotations,
+          // Pass the full ZodObject (not its `.shape`) so the SDK skips
+          // `objectFromShape(...)` (a fresh `z.object(shape)` per tool) inside
+          // `_createRegisteredTool`. The SDK's `getZodSchemaObject` returns
+          // an already-built object as-is.
           inputSchema:
             tool.inputSchema && "shape" in tool.inputSchema
-              ? (tool.inputSchema.shape as ZodRawShape)
-              : z.object({}).shape,
+              ? (tool.inputSchema as ZodTypeAny)
+              : z.object({}),
           outputSchema:
             tool.outputSchema &&
             typeof tool.outputSchema === "object" &&
             "shape" in tool.outputSchema
-              ? (tool.outputSchema.shape as ZodRawShape)
+              ? (tool.outputSchema as ZodTypeAny)
               : undefined,
         },
         async (args) => {
@@ -1077,6 +1089,38 @@ export const createMCPServer = <
 
     const registrations = await resolveRegistrations(bindings);
     registerAll(server, registrations);
+
+    // Wrap the SDK-installed `tools/list` handler so the rendered payload is
+    // computed once per isolate and reused across requests. The MCP Server
+    // itself can't be shared across requests (its transport is single-use, see
+    // `Protocol.connect`), so each request still spins up a fresh Server +
+    // Transport — but the listTools render is by far the dominant cost for
+    // large tool surfaces, and it's pure of request-scoped state.
+    const innerHandlers = (
+      server.server as unknown as {
+        _requestHandlers: Map<
+          string,
+          (req: unknown, extra: unknown) => Promise<unknown>
+        >;
+      }
+    )._requestHandlers;
+    const sdkListToolsHandler = innerHandlers.get(
+      ListToolsRequestSchema.shape.method.value,
+    );
+    if (sdkListToolsHandler) {
+      innerHandlers.set(
+        ListToolsRequestSchema.shape.method.value,
+        async (req, extra) => {
+          if (!cachedListToolsResult) {
+            cachedListToolsResult = (await sdkListToolsHandler(
+              req,
+              extra,
+            )) as ListToolsResult;
+          }
+          return cachedListToolsResult;
+        },
+      );
+    }
 
     return { server, ...registrations };
   };


### PR DESCRIPTION
## Summary
For MCPs with hundreds of registered tools, every \`tools/list\` request re-runs the MCP SDK's \`toJsonSchemaCompat()\` for every tool inside its handler — the conversion isn't cached anywhere in the SDK, and \`createServer\` builds a fresh \`McpServer\` per request, so this work repeats on every call.

Vtex (708 tools) was paying **~5s of per-request CPU** just to render the listTools response. After this patch, only the first request pays it; subsequent requests serve the cached payload.

## Changes
**1. Cache the rendered \`tools/list\` payload across requests within the isolate.**

The MCP Server itself can't be shared across requests (its transport is single-use — \`Protocol.connect\` throws if a transport is already attached), so each request still spins up a fresh Server + Transport. But the listTools render is pure of request-scoped state, so we wrap the SDK-installed \`tools/list\` handler with one that captures the SDK's response on first call and returns it from a module-scoped cache thereafter.

This requires reaching into \`server.server._requestHandlers\` to grab the SDK handler before overriding it — flagged with a comment. The alternative was reimplementing the SDK's listTools render in this package, which would couple us harder to SDK internals than this minimal touch.

**2. Pass the full \`ZodObject\` (not its \`.shape\`) to \`server.registerTool\`.**

The SDK's \`getZodSchemaObject\` returns an already-built \`ZodObject\` as-is, but rebuilds (\`z.object(shape)\`) when given a raw shape. Passing the object directly skips the rebuild on each per-request \`registerAll\` call. Smaller win, free.

## Why not memoize the McpServer entirely?

Tried it — \`Protocol.connect\` is single-transport and throws on a second \`connect()\` call. Workers can interleave concurrent requests on the same isolate, so a shared server would race. The cache approach sidesteps this: per-request server creation is cheap (the costly part is registerAll's per-tool work, which we still pay, but it's ms-scale rather than seconds).

## Why not support JSON Schema as \`inputSchema\` directly?

It would eliminate the conversion entirely and is the structurally cleanest fix, but requires:
- type system changes to \`Tool\`/\`CreateTool\`
- JSON Schema validator integration (the SDK uses Zod for \`validateToolInput\`)
- migration story for existing call sites

Worth doing as a follow-up, but this PR's caching gets the same per-request speedup without the API surface change.

## Test plan
- [x] \`bun run check\` clean
- [x] \`bun test\` — 56 pass, 0 fail (no regressions)
- [x] \`bunx oxlint packages/runtime/src/tools.ts\` clean
- [x] Patched the installed runtime in vtex (708 tools) and re-bundled with wrangler — typecheck + dry-run deploy clean
- [ ] After release: deploy vtex against the new runtime version and confirm warm \`tools/list\` drops from ~5s to <100ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the MCP `tools/list` response across requests to avoid repeated JSON Schema conversion in `@modelcontextprotocol/sdk`. Large MCPs drop warm-request latency from seconds to milliseconds.

- **Refactors**
  - Wrap the SDK `tools/list` handler to compute once per isolate and reuse; each request still builds a fresh `McpServer` and transport since `Protocol.connect` is single-use.
  - Pass the full `ZodObject` to `server.registerTool` to skip per-request `z.object(shape)` rebuilds.

- **Dependencies**
  - Bump `@decocms/runtime` to 1.6.1.

<sup>Written for commit 82234c265cc7ebed18ea35a284196763ad5bce78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

