### PR TITLE
fix(runtime): use literal method name for tools/list cache key

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/runtime",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -7,13 +7,12 @@ import {
 } from "@decocms/bindings";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport as HttpServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import {
-  ListToolsRequestSchema,
-  type CallToolResult,
-  type GetPromptResult,
-  type Implementation,
-  type ListToolsResult,
-  type ToolAnnotations,
+import type {
+  CallToolResult,
+  GetPromptResult,
+  Implementation,
+  ListToolsResult,
+  ToolAnnotations,
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { ZodSchema, ZodTypeAny } from "zod";
@@ -1096,6 +1095,10 @@ export const createMCPServer = <
     // `Protocol.connect`), so each request still spins up a fresh Server +
     // Transport — but the listTools render is by far the dominant cost for
     // large tool surfaces, and it's pure of request-scoped state.
+    // Hardcoded per MCP spec — Zod 4 stores literal values at `_zod.def.value`,
+    // not `.value`, so introspecting `ListToolsRequestSchema.shape.method` is
+    // brittle across zod versions. The string is the protocol method name.
+    const TOOLS_LIST_METHOD = "tools/list";
     const innerHandlers = (
       server.server as unknown as {
         _requestHandlers: Map<
@@ -1104,22 +1107,17 @@ export const createMCPServer = <
         >;
       }
     )._requestHandlers;
-    const sdkListToolsHandler = innerHandlers.get(
-      ListToolsRequestSchema.shape.method.value,
-    );
+    const sdkListToolsHandler = innerHandlers.get(TOOLS_LIST_METHOD);
     if (sdkListToolsHandler) {
-      innerHandlers.set(
-        ListToolsRequestSchema.shape.method.value,
-        async (req, extra) => {
-          if (!cachedListToolsResult) {
-            cachedListToolsResult = (await sdkListToolsHandler(
-              req,
-              extra,
-            )) as ListToolsResult;
-          }
-          return cachedListToolsResult;
-        },
-      );
+      innerHandlers.set(TOOLS_LIST_METHOD, async (req, extra) => {
+        if (!cachedListToolsResult) {
+          cachedListToolsResult = (await sdkListToolsHandler(
+            req,
+            extra,
+          )) as ListToolsResult;
+        }
+        return cachedListToolsResult;
+      });
     }
 
     return { server, ...registrations };


### PR DESCRIPTION
## Summary
Follow-up to #3299. The previous patch looked up the SDK's \`tools/list\` handler in \`server.server._requestHandlers\` using \`ListToolsRequestSchema.shape.method.value\`. In zod 4, literal values live at \`_zod.def.value\`, not \`.value\`, so the lookup returned \`undefined\` and the cache wrapper never installed. End result: 1.6.1 was deployed to vtex but \`tools/list\` latency was unchanged at ~5–8s/call.

Hardcode the method name \`"tools/list"\` — it's defined by the MCP spec and won't change. Bumps runtime to 1.6.2.

## Test plan
- [x] \`bun run check\` clean
- [x] \`bun test\` — 56 pass, 0 fail
- [ ] After release: bump vtex to ^1.6.2, redeploy, confirm warm \`tools/list\` drops to ms-scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `tools/list` cache by using the literal method name so the SDK handler is wrapped and responses are cached again. Restores the latency win for large MCPs and bumps `@decocms/runtime` to 1.6.2.

- **Bug Fixes**
  - Hardcode `"tools/list"` when reading `_requestHandlers` (Zod 4 moved literal values, making schema-based lookup brittle).
  - Wrap the SDK `tools/list` handler to return a cached `ListToolsResult` per isolate.

<sup>Written for commit 0a8ba156a8f88a916535a99091078d697f0323eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

