### PR TITLE
fix(oauth): emit org-scoped DCR endpoint URLs to unblock popup

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -230,10 +230,13 @@ function buildDecoOAuthParams(projectLocator: string | null): URLSearchParams {
 /**
  * Handle OAuth-proxy requests for an MCP connection.
  *
- * Resolves the org from the path (when mounted under `/api/:org/...`) and
- * enforces that the connection's `organization_id` matches that org. When
- * mounted at the legacy `/oauth-proxy/...` path (no org in URL) the check
- * is skipped — the legacy path remains org-agnostic.
+ * On the org-scoped mount (`/api/:org/oauth-proxy/...`) `resolveOrgFromPath`
+ * has populated `ctx.organization`; we scope the connection lookup to it so
+ * slug-spoofing (asking under org A for a connection that belongs to org B)
+ * returns null. The legacy `/oauth-proxy/...` mount has no org in the URL and
+ * does an unscoped lookup — using the session's `activeOrganizationId` there
+ * would silently 404 multi-org users whose active session org differs from
+ * the connection's owner.
  */
 const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
   const connectionId = c.req.param("connectionId");
@@ -252,20 +255,12 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
     c.set("meshContext", ctx);
   }
 
-  // Get connection URL
-  const connection = await ctx.storage.connections.findById(connectionId);
+  const orgScope = c.req.param("org") ? ctx.organization?.id : undefined;
+  const connection = await ctx.storage.connections.findById(
+    connectionId,
+    orgScope,
+  );
   if (!connection?.connection_url) {
-    return c.json({ error: "Connection not found" }, 404);
-  }
-
-  // Cross-org enforcement on the new `/api/:org/oauth-proxy/...` mount.
-  // Prevents slug-spoofing: a member of org A cannot proxy OAuth for a
-  // connection that belongs to org B by asking under org A's slug. The
-  // legacy `/oauth-proxy/:connectionId/*` path skips this (no org in URL).
-  if (
-    ctx.organization?.id &&
-    connection.organization_id !== ctx.organization.id
-  ) {
     return c.json({ error: "Connection not found" }, 404);
   }
 

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -358,4 +358,150 @@ describe("org-scoped API coexistence", () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it("auth-server metadata advertises org-scoped OAuth endpoint URLs", async () => {
+    // Regression for the popup-not-opening bug: the AS metadata route lives at
+    // the legacy global path (kept stable for SDK cache + Better Auth catch-all
+    // reasons), but the OAuth endpoint URLs *inside* must point at the
+    // canonical `/api/:org/oauth-proxy/...` mount. Otherwise DCR
+    // (POST /register) lands on the legacy mount, where `ctx.organization`
+    // falls back to the session's `activeOrganizationId` and silently 404s
+    // multi-org users whose active session org doesn't match the connection's.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes("oauth-protected-resource")) {
+        return new Response(
+          JSON.stringify({
+            resource: "https://example.test",
+            authorization_servers: ["https://example.test"],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("oauth-authorization-server")) {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://example.test",
+            authorization_endpoint: "https://example.test/authorize",
+            token_endpoint: "https://example.test/token",
+            registration_endpoint: "https://example.test/register",
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    try {
+      const res = await app.fetch(
+        new Request(
+          "http://mesh.localhost/.well-known/oauth-authorization-server/oauth-proxy/conn_1",
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        authorization_endpoint: string;
+        token_endpoint: string;
+        registration_endpoint: string;
+      };
+      expect(body.authorization_endpoint).toBe(
+        "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/authorize",
+      );
+      expect(body.token_endpoint).toBe(
+        "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/token",
+      );
+      expect(body.registration_endpoint).toBe(
+        "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/register",
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("DCR survives a multi-org user whose session active org differs from the path", async () => {
+    // The popup-not-opening bug surfaced because DCR (the SDK's
+    // POST /register call right before opening the authorize popup) hit the
+    // legacy `/oauth-proxy/:connectionId/*` mount and 404'd against the
+    // session's `activeOrganizationId`. With the AS metadata now pointing at
+    // `/api/:org/oauth-proxy/...`, `resolveOrgFromPath` resolves the org from
+    // the URL and verifies membership instead — independent of session state.
+
+    // Seed user_1 into a second org and switch the active session there. The
+    // path under test still names org_1 (where conn_1 lives).
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES ('mem_1_456', 'user_1', 'org_456', 'member', ${new Date().toISOString()})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+    mockApiKey("user_1", "org_456", "org_456");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      // Origin's AS metadata exposes a registration endpoint.
+      if (url.includes("oauth-authorization-server")) {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://example.test",
+            authorization_endpoint: "https://example.test/authorize",
+            token_endpoint: "https://example.test/token",
+            registration_endpoint: "https://example.test/register",
+          }),
+          { status: 200 },
+        );
+      }
+      // Origin accepts our DCR proxy.
+      if (url.endsWith("/register") && method === "POST") {
+        return new Response(
+          JSON.stringify({ client_id: "client_xyz", client_secret: "secret" }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    try {
+      const res = await app.fetch(
+        new Request(
+          "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/register",
+          {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer test-key",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              client_name: "test",
+              redirect_uris: ["http://mesh.localhost/oauth/callback"],
+            }),
+          },
+        ),
+      );
+
+      // Pre-fix: 404 ("Connection not found") because the legacy mount's
+      // cross-org check fired against the session's active org (org_456) and
+      // mismatched conn_1's owning org (org_1).
+      expect(res.status).not.toBe(404);
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(400);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -504,4 +504,33 @@ describe("org-scoped API coexistence", () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it("oauth-proxy refuses slug-spoofing on the org-scoped mount", async () => {
+    // Member of both org_1 and org_456 asks for an org_1 connection under
+    // org_456's slug. The path-resolved org scopes the connection lookup, so
+    // findById returns null and the handler 404s — preventing OAuth proxying
+    // for connections that don't belong to the URL's org.
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES ('mem_1_456_spoof', 'user_1', 'org_456', 'member', ${now})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+
+    const res = await app.fetch(
+      new Request(
+        "http://mesh.localhost/api/org_456/oauth-proxy/conn_1/register",
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer test-key",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ client_name: "test" }),
+        },
+      ),
+    );
+
+    expect(res.status).toBe(404);
+  });
 });

--- a/apps/mesh/src/api/routes/oauth-proxy.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.test.ts
@@ -445,18 +445,45 @@ describe("OAuth Proxy Routes", () => {
   });
 
   describe("Authorization Server Metadata Proxy", () => {
+    // Default org slug used by mocked connections. The handler emits OAuth
+    // endpoint URLs under `/api/${slug}/oauth-proxy/...` so it can route DCR
+    // through `resolveOrgFromPath`. Tests that assert the rewritten URLs use
+    // this slug.
+    const TEST_ORG_SLUG = "org-test";
+
+    const mockOrgDb = (slug: string | null) => ({
+      selectFrom: () => ({
+        select: () => ({
+          where: () => ({
+            executeTakeFirst: () =>
+              slug ? Promise.resolve({ slug }) : Promise.resolve(undefined),
+          }),
+        }),
+      }),
+    });
+
     const mockConnectionWithAuthServer = (
-      connection: { connection_url?: string } | null,
+      connection:
+        | ({ connection_url?: string; organization_id?: string } | null)
+        | undefined,
       protectedResourceResponse?: Response,
+      orgSlug: string | null = TEST_ORG_SLUG,
     ) => {
       (ContextFactory.create as ReturnType<typeof mock>).mockImplementation(
         () =>
           Promise.resolve({
             storage: {
               connections: {
-                findById: mock(() => Promise.resolve(connection)),
+                findById: mock(() =>
+                  Promise.resolve(
+                    connection
+                      ? { organization_id: "org_test", ...connection }
+                      : connection,
+                  ),
+                ),
               },
             },
+            db: mockOrgDb(orgSlug),
           }),
       );
 
@@ -502,10 +529,12 @@ describe("OAuth Proxy Routes", () => {
                 findById: mock(() =>
                   Promise.resolve({
                     connection_url: "https://origin.example.com/mcp",
+                    organization_id: "org_test",
                   }),
                 ),
               },
             },
+            db: mockOrgDb(TEST_ORG_SLUG),
           }),
       );
 
@@ -552,12 +581,13 @@ describe("OAuth Proxy Routes", () => {
         authorization_endpoint: string;
         token_endpoint: string;
       };
-      // URLs should be rewritten to go through our proxy
+      // URLs are rewritten through our proxy under the org-scoped mount so DCR
+      // benefits from `resolveOrgFromPath` membership enforcement.
       expect(body.authorization_endpoint).toBe(
-        "http://localhost:3000/oauth-proxy/conn_123/authorize",
+        `http://localhost:3000/api/${TEST_ORG_SLUG}/oauth-proxy/conn_123/authorize`,
       );
       expect(body.token_endpoint).toBe(
-        "http://localhost:3000/oauth-proxy/conn_123/token",
+        `http://localhost:3000/api/${TEST_ORG_SLUG}/oauth-proxy/conn_123/token`,
       );
     });
 
@@ -580,18 +610,45 @@ describe("OAuth Proxy Routes", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
 
-      // Should rewrite endpoints to our proxy
+      // Endpoints are rewritten under the org-scoped mount so DCR / token /
+      // authorize benefit from `resolveOrgFromPath` cross-org enforcement.
       expect(body.authorization_endpoint).toBe(
-        "http://localhost:3000/oauth-proxy/conn_123/authorize",
+        `http://localhost:3000/api/${TEST_ORG_SLUG}/oauth-proxy/conn_123/authorize`,
       );
       expect(body.token_endpoint).toBe(
-        "http://localhost:3000/oauth-proxy/conn_123/token",
+        `http://localhost:3000/api/${TEST_ORG_SLUG}/oauth-proxy/conn_123/token`,
       );
       expect(body.registration_endpoint).toBe(
-        "http://localhost:3000/oauth-proxy/conn_123/register",
+        `http://localhost:3000/api/${TEST_ORG_SLUG}/oauth-proxy/conn_123/register`,
       );
       // Should preserve issuer
       expect(body.issuer).toBe("https://origin.example.com");
+    });
+
+    test("falls back to legacy proxy path when connection has no resolvable org slug", async () => {
+      // Defensive: orphaned connections (org row missing) keep working via the
+      // legacy mount instead of emitting `/api//oauth-proxy/...` URLs.
+      mockConnectionWithAuthServer(
+        { connection_url: "https://origin.example.com/mcp" },
+        new Response(
+          JSON.stringify({
+            resource: "https://origin.example.com/mcp",
+            authorization_servers: ["https://origin.example.com"],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        null, // org lookup returns no slug
+      );
+
+      const res = await app.request(
+        "http://localhost:3000/.well-known/oauth-authorization-server/oauth-proxy/conn_123",
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { authorization_endpoint: string };
+      expect(body.authorization_endpoint).toBe(
+        "http://localhost:3000/oauth-proxy/conn_123/authorize",
+      );
     });
 
     test("handles root path auth server without trailing slash", async () => {

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -214,12 +214,8 @@ export async function fetchProtectedResourceMetadata(
  * since many servers (like Apify) expose /.well-known/oauth-authorization-server at the root.
  */
 async function getOriginAuthServer(
-  connectionId: string,
-  ctx: MeshContext,
+  connectionUrl: string,
 ): Promise<string | null> {
-  const connectionUrl = await getConnectionUrl(connectionId, ctx);
-  if (!connectionUrl) return null;
-
   // Parse URL upfront - if invalid, bail early
   let origin: string;
   try {
@@ -710,7 +706,7 @@ const authServerMetadataHandler = async (c: {
     return c.json({ error: "Connection not found or no auth server" }, 404);
   }
 
-  const originAuthServer = await getOriginAuthServer(connectionId, ctx);
+  const originAuthServer = await getOriginAuthServer(connection.connection_url);
   if (!originAuthServer) {
     return c.json({ error: "Connection not found or no auth server" }, 404);
   }

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -441,13 +441,16 @@ export const protectedResourceMetadataHandler = async (c: {
 
   const prefix = buildPathPrefix(orgSlug);
   const proxyResourceUrl = `${requestUrl.origin}${prefix}/mcp/${connectionId}`;
-  // Auth-server URL stays on the legacy `/oauth-proxy/:connectionId` path
-  // regardless of the resource path family. The well-known auth-server
-  // metadata route (`createWellKnownAuthServerRoutes`) only exists at the
-  // legacy URL, and third-party OAuth providers may have it registered as a
-  // redirect_uri base — moving it to `/api/:org/...` would land the SDK on
-  // Better Auth's catch-all metadata handler (which returns Better Auth's
-  // own MCP gateway endpoints) and break DCR with `invalid_client`.
+  // Auth-server URL (the value advertised in `authorization_servers`) stays on
+  // the legacy `/oauth-proxy/:connectionId` path regardless of the resource
+  // path family. The well-known auth-server metadata route
+  // (`createWellKnownAuthServerRoutes`) only exists at the legacy URL, and
+  // moving it to `/api/:org/...` would land the SDK on Better Auth's catch-all
+  // metadata handler (which returns Better Auth's own MCP gateway endpoints)
+  // and break DCR with `invalid_client`. The OAuth endpoint URLs *inside*
+  // that metadata document (authorize/token/register) are emitted under the
+  // org-scoped mount by `authServerMetadataHandler` so they benefit from
+  // `resolveOrgFromPath` membership enforcement.
   const proxyAuthServer = `${requestUrl.origin}/oauth-proxy/${connectionId}`;
 
   try {
@@ -699,10 +702,30 @@ const authServerMetadataHandler = async (c: {
   const connectionId = c.req.param("connectionId");
   const ctx = await ensureContext(c);
 
+  // Fetch the connection (unscoped — connection IDs are globally unique) so we
+  // can derive both the origin auth server and the owning org slug for
+  // org-scoped endpoint URLs.
+  const connection = await ctx.storage.connections.findById(connectionId);
+  if (!connection?.connection_url) {
+    return c.json({ error: "Connection not found or no auth server" }, 404);
+  }
+
   const originAuthServer = await getOriginAuthServer(connectionId, ctx);
   if (!originAuthServer) {
     return c.json({ error: "Connection not found or no auth server" }, 404);
   }
+
+  // Look up the connection's owning org slug. The endpoints inside this
+  // metadata document route through the canonical `/api/:org/oauth-proxy/...`
+  // mount — `resolveOrgFromPath` runs there and enforces cross-org access via
+  // membership. The legacy `/oauth-proxy/:connectionId/*` mount can't tell the
+  // path-resolved org apart from the session's `activeOrganizationId` and
+  // silently 404s multi-org users on DCR (`POST /register`).
+  const org = await ctx.db
+    .selectFrom("organization")
+    .select("slug")
+    .where("id", "=", connection.organization_id)
+    .executeTakeFirst();
 
   try {
     // Fetch auth server metadata, trying all well-known URL formats
@@ -719,14 +742,18 @@ const authServerMetadataHandler = async (c: {
     // Parse and rewrite URLs to point to our proxy
     const data = (await response.json()) as Record<string, unknown>;
     const requestUrl = fixProtocol(new URL(c.req.url));
-    // Auth-server metadata stays at the legacy global path
-    // (`/.well-known/oauth-authorization-server/oauth-proxy/:connectionId`).
-    // Third-party OAuth providers may have these URLs registered as
-    // redirect_uri bases — we keep them stable. The rewritten endpoint URLs
-    // therefore continue to point at the legacy `/oauth-proxy/:connectionId`
-    // path. (Both the legacy `/oauth-proxy/...` and the new
-    // `/api/:org/oauth-proxy/...` mounts share the same handler in app.ts.)
-    const proxyBase = `${requestUrl.origin}/oauth-proxy/${connectionId}`;
+    // The AS metadata route itself stays at the legacy global path
+    // (`/.well-known/oauth-authorization-server/oauth-proxy/:connectionId`)
+    // because the SDK derives it from the `authorization_servers` value in the
+    // protected-resource metadata, which we keep legacy for cache stability
+    // and to avoid landing on Better Auth's catch-all metadata handler.
+    // The endpoint URLs *inside* this metadata, however, move to the canonical
+    // org-scoped mount so DCR/token/authorize benefit from `resolveOrgFromPath`
+    // membership enforcement. Connections without a resolvable org slug
+    // (orphaned data) fall back to the legacy proxy path.
+    const proxyBase = org?.slug
+      ? `${requestUrl.origin}/api/${org.slug}/oauth-proxy/${connectionId}`
+      : `${requestUrl.origin}/oauth-proxy/${connectionId}`;
 
     // Rewrite OAuth endpoint URLs to go through our proxy
     const rewrittenData = {


### PR DESCRIPTION
## What is this contribution about?

Follow-up to #3296. Discovery now succeeds, but Dynamic Client Registration was still 404ing on the legacy `/oauth-proxy/conn_X/register` mount because the handler resolved the org from the session's `activeOrganizationId` — for multi-org users whose session active org didn't match the connection's org, DCR failed and the authorize popup never opened (the SDK aborts before `window.open`). This PR rewrites the `authorize`/`token`/`register` URLs inside AS metadata to the canonical `/api/:org/oauth-proxy/...` mount so `resolveOrgFromPath` enforces membership from the URL itself; the AS metadata route stays at the legacy global path to keep SDK caches stable and avoid Better Auth's catch-all metadata handler.

## How to Test

1. Sign in as a user who is a member of two orgs (orgA + orgB) with their session's active org set to orgB.
2. Visit `/<orgA-slug>/...` and trigger an OAuth-gated MCP install (e.g. GitHub).
3. Expected: the OAuth popup opens. Before the fix, DCR 404'd silently and the popup never appeared.

Also covered by new integration tests:
- `auth-server metadata advertises org-scoped OAuth endpoint URLs`
- `DCR survives a multi-org user whose session active org differs from the path`

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth popup not opening for multi‑org users by emitting org‑scoped OAuth endpoint URLs and scoping connection lookups by the path org. This unblocks DCR, prevents slug‑spoofing, and keeps the legacy mount org‑agnostic.

- **Bug Fixes**
  - Rewrote `authorize`/`token`/`register` URLs in AS metadata to `/api/:org/oauth-proxy/:connectionId/...`.
  - Kept the well-known AS metadata route on the legacy path to preserve SDK caches and avoid Better Auth’s catch‑all handler.
  - Scoped connection lookup via `findById(connectionId, orgId)` on the org‑scoped mount; removed the post‑lookup cross‑org guard so the legacy mount stays org‑agnostic, while org‑scoped requests 404 slug‑spoofing.
  - Added fallback to the legacy proxy when the org slug can’t be resolved, removed a duplicate connection lookup in the AS metadata handler, and expanded tests for org‑scoped endpoints, DCR with mismatched active org, slug‑spoofing, and legacy fallback.

<sup>Written for commit 377557308808d41065bf87df72055d4ceabd7539. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

