### PR TITLE
fix(sites): open chat panel by default when importing a site

### DIFF
--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -195,6 +195,7 @@ export function ImportFromDecoDialog({
                     id: connId,
                     toolName: "file_explorer",
                   },
+                  chatDefaultOpen: true,
                 },
               },
             },


### PR DESCRIPTION
## What is this contribution about?

When a deco site is imported (or opened), the UI was only showing the task and preview panels. This fix adds `chatDefaultOpen: true` to the layout metadata set during site import, so the chat panel opens alongside the preview by default — matching the intended UX of task + chat + preview all visible on first open.

## Screenshots/Demonstration

> N/A — layout behavior change, no visual asset needed beyond manual testing.

## How to Test

1. Open Studio and import a deco site via the import dialog.
2. Observe that the site opens with **task**, **chat**, and **preview** panels all visible by default.
3. Previously, only task and preview were open.

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the chat panel by default when importing a deco site so users see task + chat + preview on first open.

- **Bug Fixes**
  - Set `chatDefaultOpen: true` in layout metadata during site import.

<sup>Written for commit cf570b4592b864daf05fb08b6e46ce5bd156f16f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

