### PR TITLE
feat(pwa): enable window controls overlay for installed app

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -7,6 +7,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    padding-top: env(titlebar-area-height, 0);
   }
   svg {
     stroke-width: 1.75;

--- a/apps/mesh/public/manifest.webmanifest
+++ b/apps/mesh/public/manifest.webmanifest
@@ -5,6 +5,7 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
+  "display_override": ["window-controls-overlay"],
   "background_color": "#ffffff",
   "theme_color": "#D0EC1A",
   "icons": [


### PR DESCRIPTION
## What is this contribution about?
Enables the [Window Controls Overlay](https://developer.mozilla.org/en-US/docs/Web/Manifest/display_override) display mode for the installed PWA so the app content extends into the OS title bar area instead of leaving an empty native title bar above it. Adds `display_override: ["window-controls-overlay"]` to the manifest (with `display: standalone` retained as fallback) and sets `padding-top: env(titlebar-area-height, 0)` on `body` so layout reserves room for the traffic-light buttons.

## How to Test
1. Pull this branch and run the app.
2. Uninstall any previously-installed PWA copy, then reinstall via "Install app" / "Add to Dock" (manifest changes only apply on fresh installs).
3. Open the installed app — the OS title bar area should now be part of the app content, with content offset to avoid the window controls.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Window Controls Overlay for the installed PWA so content extends into the OS title bar. Adds manifest `display_override: ["window-controls-overlay"]` and `padding-top: env(titlebar-area-height, 0)` to avoid overlapping the window controls.

<sup>Written for commit 32c29153ba2c5a575b9183617e5a008ecbcafe5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

