### PR TITLE
fix(automations): align model selector with chat under Simple Mode

### DIFF
--- a/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
@@ -37,6 +37,8 @@ export function useChatNavigation(): ChatNavigation {
         const vmcp = opts?.virtualMcpId ?? prev.virtualmcpid;
         if (vmcp) next.virtualmcpid = vmcp;
         if (prev.tasks) next.tasks = prev.tasks;
+        if (prev.main) next.main = prev.main;
+        if (prev.chat) next.chat = prev.chat;
         if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;
         return next;
       },

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -2,12 +2,6 @@ import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import { calculateUsageStats } from "@/web/lib/usage-utils.ts";
 import { AUTOSEND_QUERY_VALUE, writeStoredAutosend } from "@/web/lib/autosend";
 import { Button } from "@deco/ui/components/button.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   getWellKnownDecopilotVirtualMCP,
@@ -16,16 +10,13 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import {
   ArrowUp,
-  Atom01,
   BookOpen01,
   Check,
   Globe02,
   Image01,
-  Lightning01,
   Lock01,
   Microphone01,
   Plus,
-  Stars01,
   Stop,
   Upload01,
   X,
@@ -42,6 +33,7 @@ import type { VirtualMCPInfo } from "./select-virtual-mcp";
 import { ChatHighlight } from "./highlight";
 import { ModelSelector } from "./select-model";
 import { getSupportedFileTypesLabel, modelSupportsFiles } from "./select-model";
+import { SimpleModeTierDropdown } from "./simple-mode-tier-dropdown";
 import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers";
 import {
   FileUploadButton,
@@ -67,76 +59,6 @@ import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dial
 import { ConnectionsBanner } from "./connections-banner";
 import { useVoiceInput } from "@/web/hooks/use-voice-input.ts";
 import { VoiceWaveform } from "./voice-input";
-
-// ============================================================================
-// SimpleModeTierDropdown
-// ============================================================================
-
-const TIER_OPTIONS = [
-  {
-    value: "fast" as const,
-    label: "Fast",
-    Icon: Lightning01,
-    description: "Quicker responses",
-  },
-  {
-    value: "smart" as const,
-    label: "Smart",
-    Icon: Stars01,
-    description: "Balanced quality",
-  },
-  {
-    value: "thinking" as const,
-    label: "Thinking",
-    Icon: Atom01,
-    description: "Deeper reasoning",
-  },
-] as const;
-
-function SimpleModeTierDropdown({
-  tier,
-  onSelect,
-}: {
-  tier: "fast" | "smart" | "thinking";
-  onSelect: (t: "fast" | "smart" | "thinking") => void;
-}) {
-  const current =
-    TIER_OPTIONS.find((o) => o.value === tier) ?? TIER_OPTIONS[1]!;
-  const Icon = current.Icon;
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="default"
-          className="text-muted-foreground hover:text-foreground"
-        >
-          <Icon size={14} />
-          <span className="hidden sm:inline">{current.label}</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-52 p-1.5">
-        {TIER_OPTIONS.map(({ value, label, Icon: TierIcon, description }) => (
-          <DropdownMenuItem key={value} onSelect={() => onSelect(value)}>
-            <TierIcon size={16} className="text-muted-foreground" />
-            <div className="flex flex-col gap-0.5 flex-1">
-              <span>{label}</span>
-              <span className="text-xs text-muted-foreground font-normal">
-                {description}
-              </span>
-            </div>
-            {tier === value && (
-              <span className="text-xs text-muted-foreground font-medium">
-                On
-              </span>
-            )}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
 
 // ============================================================================
 // useWindowFileDrop - Reusable hook for window-level file drag & drop

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import { Atom01, Lightning01, Stars01 } from "@untitledui/icons";
+
+export type SimpleModeTier = "fast" | "smart" | "thinking";
+
+export const SIMPLE_MODE_TIER_OPTIONS = [
+  {
+    value: "fast" as const,
+    label: "Fast",
+    Icon: Lightning01,
+    description: "Quicker responses",
+  },
+  {
+    value: "smart" as const,
+    label: "Smart",
+    Icon: Stars01,
+    description: "Balanced quality",
+  },
+  {
+    value: "thinking" as const,
+    label: "Thinking",
+    Icon: Atom01,
+    description: "Deeper reasoning",
+  },
+] as const;
+
+export function SimpleModeTierDropdown({
+  tier,
+  onSelect,
+}: {
+  tier: SimpleModeTier;
+  onSelect: (t: SimpleModeTier) => void;
+}) {
+  const current =
+    SIMPLE_MODE_TIER_OPTIONS.find((o) => o.value === tier) ??
+    SIMPLE_MODE_TIER_OPTIONS[1]!;
+  const Icon = current.Icon;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="default"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Icon size={14} />
+          <span className="hidden sm:inline">{current.label}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52 p-1.5">
+        {SIMPLE_MODE_TIER_OPTIONS.map(
+          ({ value, label, Icon: TierIcon, description }) => (
+            <DropdownMenuItem key={value} onSelect={() => onSelect(value)}>
+              <TierIcon size={16} className="text-muted-foreground" />
+              <div className="flex flex-col gap-0.5 flex-1">
+                <span>{label}</span>
+                <span className="text-xs text-muted-foreground font-normal">
+                  {description}
+                </span>
+              </div>
+              {tier === value && (
+                <span className="text-xs text-muted-foreground font-medium">
+                  On
+                </span>
+              )}
+            </DropdownMenuItem>
+          ),
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -9,7 +9,7 @@ import { Atom01, Lightning01, Stars01 } from "@untitledui/icons";
 
 export type SimpleModeTier = "fast" | "smart" | "thinking";
 
-export const SIMPLE_MODE_TIER_OPTIONS = [
+const SIMPLE_MODE_TIER_OPTIONS = [
   {
     value: "fast" as const,
     label: "Fast",

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -211,11 +211,19 @@ export function useAutomation(id: string) {
 // Helpers
 // ============================================================================
 
-export function buildDefaultAutomationInput(virtualMcpId: string) {
+export function buildDefaultAutomationInput(
+  virtualMcpId: string,
+  modelDefaults?: { credentialId: string; modelId: string } | null,
+) {
   return {
     name: "New Automation",
     messages: [],
-    models: { credentialId: "", thinking: { id: "" } },
+    models: modelDefaults
+      ? {
+          credentialId: modelDefaults.credentialId,
+          thinking: { id: modelDefaults.modelId },
+        }
+      : { credentialId: "", thinking: { id: "" } },
     temperature: 0.5,
     active: true,
     virtual_mcp_id: virtualMcpId,

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -555,6 +555,7 @@ export function SettingsTab({
       setModel({ ...selectedModel, keyId: watchConnectionId });
     }
 
+    setChatOpen(true);
     setPreferences({ ...preferences, toolApprovalLevel: "auto" });
 
     const parts = derivePartsFromTiptapDoc(tiptapDoc);

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -9,6 +9,11 @@ import {
   type AiProviderModel,
 } from "@/web/hooks/collections/use-ai-providers.ts";
 import { ModelSelector } from "@/web/components/chat/select-model.tsx";
+import {
+  SimpleModeTierDropdown,
+  type SimpleModeTier,
+} from "@/web/components/chat/simple-mode-tier-dropdown.tsx";
+import { useSimpleMode } from "@/web/hooks/use-organization-settings";
 import { User } from "@/web/components/user/user.tsx";
 import {
   useAutomation,
@@ -307,9 +312,11 @@ export function SettingsTab({
   const { createTaskWithMessage } = useChatTask();
   const {
     setModel,
+    setSimpleModeTier,
     credentialId: chatCredentialId,
     selectedModel: chatModel,
   } = useChatPrefs();
+  const simpleMode = useSimpleMode();
   const { setChatOpen } = usePanelActions();
   const { sendMessage } = useChatBridge();
   const ensureStudioPack = useEnsureStudioPack();
@@ -390,6 +397,23 @@ export function SettingsTab({
   );
   const selectedModel: AiProviderModel | null =
     models.find((m) => m.modelId === watchModelId) ?? null;
+
+  const activeSimpleModeTier: SimpleModeTier =
+    (["fast", "smart", "thinking"] as const).find(
+      (t) =>
+        simpleMode.chat[t]?.modelId === watchModelId &&
+        simpleMode.chat[t]?.keyId === watchConnectionId,
+    ) ?? "smart";
+
+  const handleSimpleModeTierSelect = (tier: SimpleModeTier) => {
+    const slot = simpleMode.chat[tier];
+    if (!slot) return;
+    form.setValue("credential_id", slot.keyId);
+    form.setValue("model_id", slot.modelId);
+    markFormDirty("credential_id");
+    markFormDirty("model_id");
+    scheduleSave();
+  };
 
   // Session-based tracking for automation_updated. Auto-saves persist every
   // ~1s but we only emit one PostHog event per edit-session (aggregated
@@ -525,7 +549,9 @@ export function SettingsTab({
       return;
     }
 
-    if (selectedModel && watchConnectionId) {
+    if (simpleMode.enabled) {
+      setSimpleModeTier(activeSimpleModeTier);
+    } else if (selectedModel && watchConnectionId) {
       setModel({ ...selectedModel, keyId: watchConnectionId });
     }
 
@@ -777,23 +803,30 @@ export function SettingsTab({
               />
 
               <div className="flex items-center justify-end gap-1.5 p-2.5">
-                <ModelSelector
-                  model={selectedModel}
-                  isLoading={isModelsLoading}
-                  credentialId={watchConnectionId || null}
-                  onCredentialChange={(id) => {
-                    form.setValue("credential_id", id ?? "");
-                    form.setValue("model_id", "");
-                    markFormDirty("credential_id");
-                    markFormDirty("model_id");
-                    scheduleSave();
-                  }}
-                  onModelChange={(model) => {
-                    form.setValue("model_id", model.modelId);
-                    debouncedSave("model_id");
-                  }}
-                  placeholder="Model"
-                />
+                {simpleMode.enabled ? (
+                  <SimpleModeTierDropdown
+                    tier={activeSimpleModeTier}
+                    onSelect={handleSimpleModeTierSelect}
+                  />
+                ) : (
+                  <ModelSelector
+                    model={selectedModel}
+                    isLoading={isModelsLoading}
+                    credentialId={watchConnectionId || null}
+                    onCredentialChange={(id) => {
+                      form.setValue("credential_id", id ?? "");
+                      form.setValue("model_id", "");
+                      markFormDirty("credential_id");
+                      markFormDirty("model_id");
+                      scheduleSave();
+                    }}
+                    onModelChange={(model) => {
+                      form.setValue("model_id", model.modelId);
+                      debouncedSave("model_id");
+                    }}
+                    placeholder="Model"
+                  />
+                )}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/apps/mesh/src/web/views/automations/automations-list.tsx
+++ b/apps/mesh/src/web/views/automations/automations-list.tsx
@@ -12,11 +12,14 @@ import {
 } from "@/web/hooks/use-automations";
 import { AutomationListRow } from "./automation-list-row";
 import { track } from "@/web/lib/posthog-client";
+import { useChatPrefs } from "@/web/components/chat/context";
 
 export function AutomationsList({ virtualMcpId }: { virtualMcpId: string }) {
   const navigate = useNavigate();
   const { data: automations = [] } = useAutomations(virtualMcpId);
   const { create } = useAutomationActions();
+  const { selectedModel: chatModel, credentialId: chatCredentialId } =
+    useChatPrefs();
   const [search, setSearch] = useState("");
 
   const lowerSearch = search.toLowerCase();
@@ -40,8 +43,12 @@ export function AutomationsList({ virtualMcpId }: { virtualMcpId: string }) {
       virtual_mcp_id: virtualMcpId,
       existing_count: automations.length,
     });
+    const modelDefaults =
+      chatModel?.modelId && chatCredentialId
+        ? { credentialId: chatCredentialId, modelId: chatModel.modelId }
+        : null;
     const created = await create.mutateAsync(
-      buildDefaultAutomationInput(virtualMcpId),
+      buildDefaultAutomationInput(virtualMcpId, modelDefaults),
     );
     goToDetail(created.id);
   };

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -1790,11 +1790,13 @@ function OrgAiProvidersContent() {
 
   return (
     <>
+      {allKeys.length > 0 && (
+        <Suspense fallback={<Skeleton className="h-16 w-full" />}>
+          <SimpleModeSection />
+        </Suspense>
+      )}
       <DecoCreditsHero />
       <ProviderCardGrid hideProviderId={hasDecoKey ? "deco" : undefined} />
-      <Suspense fallback={<Skeleton className="h-16 w-full" />}>
-        <SimpleModeSection />
-      </Suspense>
     </>
   );
 }


### PR DESCRIPTION
## What is this contribution about?

The automation model selector diverged from chat's: the picker showed concrete model names instead of Fast/Smart/Thinking tiers under Simple Mode, new automations always saved empty model fields, and the Test button left the chat running on the wrong tier. This PR brings the automation editor to parity with the chat input — same `SimpleModeTierDropdown`, same Simple-Mode-aware seeding for new rows, same model state when firing a test run.

Also surfaces the Simple Mode section first on the AI Providers settings page (and hides it when no keys are configured) since it's the org-wide model policy.

## How to Test

1. Enable Simple Mode in `/$org/settings/ai-providers` and configure all three tiers.
2. Open an automation: the picker shows Fast/Smart/Thinking, not a concrete model name. Switch tiers — the form's saved `models.thinking.id` updates to the resolved concrete model.
3. From the automation list, switch the chat tier to `thinking`, click "New automation": the created row's `models.thinking.id` matches the `thinking` slot.
4. With chat on `thinking`, open an automation pinned to `fast` and click **Test**: the chat tier switches to `fast` and the test run uses the `fast`-tier model.
5. Toggle Simple Mode off: the regular model picker returns and the Test button restores its previous concrete-model behavior. No regression.

## Migration Notes

None. Runtime payload shape (`{ credentialId, thinking: { id } }`) is unchanged; this is a UI/seeding alignment.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Automations model selector with Chat in Simple Mode and fixes tier/test behavior. Also keeps the automation panel and chat visible when a test creates a new thread.

- **Bug Fixes**
  - Automation model picker now shows Fast/Smart/Thinking tiers and saves the resolved model to `models.thinking.id`.
  - Test button syncs chat to the automation’s tier in Simple Mode (`setSimpleModeTier`); behavior unchanged when off.
  - New automations seed `credentialId`/`modelId` from the chat when available.
  - Test runs preserve panel and chat state (keep automation panel open and force-open chat on thread creation).

- **Refactors**
  - Extracted `SimpleModeTierDropdown` to a shared component and reused in chat and automations; removed unused `SIMPLE_MODE_TIER_OPTIONS` export.
  - Moved the Simple Mode section to the top of the org AI Providers page and hide it when no provider keys exist.

<sup>Written for commit 6332e3dc004a4b7cb40edc1e0fbe663cc39914bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

