### PR TITLE
fix(connections): keep custom connection on OAuth failure in agent add dialog

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -825,8 +825,7 @@ export function AddConnectionDialog({
             error: error ?? "no_token",
           });
           toast.warning("Couldn't sign in to this connection", {
-            description:
-              "It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings.",
+            description: `It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings. (${error ?? "no token received"})`,
           });
           trackAttach(id, connectionData.app_name ?? null, "new");
           onAdd(id);
@@ -970,8 +969,7 @@ export function AddConnectionDialog({
                 error: error ?? "no_token",
               });
               toast.warning("Couldn't sign in to this connection", {
-                description:
-                  "It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings.",
+                description: `It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings. (${error ?? "no token received"})`,
               });
               trackAttach(id, null, "custom");
               onAdd(id);

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -824,7 +824,10 @@ export function AddConnectionDialog({
             flow: "connect_new",
             error: error ?? "no_token",
           });
-          toast.error(`Authentication failed: ${error ?? "no token received"}`);
+          toast.warning("Couldn't sign in to this connection", {
+            description:
+              "It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings.",
+          });
           trackAttach(id, connectionData.app_name ?? null, "new");
           onAdd(id);
           return;
@@ -966,9 +969,10 @@ export function AddConnectionDialog({
                 flow: "custom_create",
                 error: error ?? "no_token",
               });
-              toast.error(
-                `Authentication failed: ${error ?? "no token received"}`,
-              );
+              toast.warning("Couldn't sign in to this connection", {
+                description:
+                  "It was added to your agent, but its sign-in setup looks off. You can try authenticating again later from the connection's settings.",
+              });
               trackAttach(id, null, "custom");
               onAdd(id);
               onOpenChange(false);

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -969,7 +969,9 @@ export function AddConnectionDialog({
               toast.error(
                 `Authentication failed: ${error ?? "no token received"}`,
               );
-              await connectionActions.delete.mutateAsync(id);
+              trackAttach(id, null, "custom");
+              onAdd(id);
+              onOpenChange(false);
               return;
             }
             track("connection_oauth_succeeded", {


### PR DESCRIPTION
## What is this contribution about?
Creating a custom connection from the agent screen's add-connection dialog could insta-delete the row, surfacing as a misleading "deleted successfully" toast. The dialog's `onCreated` callback ran an OAuth probe after create and called `connectionActions.delete.mutateAsync(id)` whenever the probe failed (e.g. URLs that return 401 with a `WWW-Authenticate` header but aren't real OAuth-enabled MCPs). The sibling catalog flow (`handleConnectAndAdd`) already handles OAuth failure by toasting and still attaching the connection — this PR mirrors that behavior so the user can authenticate later from the connection's settings sheet.

## How to Test
1. Open an agent and click "Add connection" → "Custom Connection".
2. Submit a custom HTTP connection whose URL doesn't have a working OAuth flow (e.g. any URL that returns 401).
3. Expected: an "Authentication failed" toast appears, the connection stays in the org and is attached to the agent. Previously it was deleted.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep custom connections when the post-create OAuth probe fails in the agent Add Connection dialog. We now show a friendly warning toast that includes the raw error in parentheses, attach the connection for both catalog and custom flows, and close the dialog after custom create so users can retry from the connection’s settings.

<sup>Written for commit 757997fc5c104f964578ffa1dae5707b4a08bcbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

