### PR TITLE
feat(automations): resolve simple-mode tier at run time

### DIFF
--- a/apps/mesh/src/automations/build-stream-request.test.ts
+++ b/apps/mesh/src/automations/build-stream-request.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import type { Automation, SimpleModeConfig } from "@/storage/types";
-import { buildStreamRequest } from "./build-stream-request";
+import type { Automation } from "@/storage/types";
+import { buildStreamRequest, type TierOverride } from "./build-stream-request";
 
 function makeAutomation(overrides?: Partial<Automation>): Automation {
   return {
@@ -110,35 +110,37 @@ describe("buildStreamRequest", () => {
     expect(result.agent).toEqual({ id: "vir_xyz" });
   });
 
-  describe("simple-mode tier resolution", () => {
-    const simpleMode = (
-      enabled: boolean,
-      slot: { keyId: string; modelId: string; title?: string } | null,
-    ): SimpleModeConfig => ({
-      enabled,
-      chat: { fast: null, smart: slot, thinking: null },
-      image: null,
-      webResearch: null,
-    });
+  describe("tier override", () => {
+    const override: TierOverride = {
+      credentialId: "cred_live",
+      thinking: {
+        id: "model_live",
+        title: "Live Model",
+        provider: "anthropic",
+        capabilities: { vision: true, file: true },
+        limits: { contextWindow: 200_000, maxOutputTokens: 4096 },
+      },
+    };
 
-    it("overrides credential and model from the live tier slot", () => {
+    it("replaces credential and the entire thinking field", () => {
       const automation = makeAutomation({
         models: JSON.stringify({
           credentialId: "cred_stale",
-          thinking: { id: "model_stale", title: "Stale" },
+          thinking: {
+            id: "model_stale",
+            title: "Stale",
+            capabilities: { vision: false, file: false },
+            limits: { contextWindow: 8000, maxOutputTokens: 1024 },
+          },
           tier: "smart",
         }),
       });
-      const cfg = simpleMode(true, {
-        keyId: "cred_live",
-        modelId: "model_live",
-      });
-      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      const result = buildStreamRequest(automation, null, "thrd_1", override);
       expect(result.models.credentialId).toBe("cred_live");
-      expect((result.models.thinking as { id: string }).id).toBe("model_live");
+      expect(result.models.thinking).toEqual(override.thinking);
     });
 
-    it("ignores tier when simple mode is disabled", () => {
+    it("falls back to snapshot when no override is supplied", () => {
       const automation = makeAutomation({
         models: JSON.stringify({
           credentialId: "cred_snapshot",
@@ -146,34 +148,16 @@ describe("buildStreamRequest", () => {
           tier: "smart",
         }),
       });
-      const cfg = simpleMode(false, {
-        keyId: "cred_live",
-        modelId: "model_live",
-      });
-      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      const result = buildStreamRequest(automation, null, "thrd_1", null);
       expect(result.models.credentialId).toBe("cred_snapshot");
+      expect((result.models.thinking as { id: string }).id).toBe(
+        "model_snapshot",
+      );
     });
 
-    it("falls back to snapshot when tier slot is unset", () => {
-      const automation = makeAutomation({
-        models: JSON.stringify({
-          credentialId: "cred_snapshot",
-          thinking: { id: "model_snapshot" },
-          tier: "smart",
-        }),
-      });
-      const cfg = simpleMode(true, null);
-      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
-      expect(result.models.credentialId).toBe("cred_snapshot");
-    });
-
-    it("does nothing when models has no tier (legacy automation)", () => {
+    it("leaves snapshot intact when override is undefined", () => {
       const automation = makeAutomation();
-      const cfg = simpleMode(true, {
-        keyId: "cred_live",
-        modelId: "model_live",
-      });
-      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      const result = buildStreamRequest(automation, null, "thrd_1");
       expect(result.models.credentialId).toBe("cred_1");
     });
   });

--- a/apps/mesh/src/automations/build-stream-request.test.ts
+++ b/apps/mesh/src/automations/build-stream-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { Automation } from "@/storage/types";
+import type { Automation, SimpleModeConfig } from "@/storage/types";
 import { buildStreamRequest } from "./build-stream-request";
 
 function makeAutomation(overrides?: Partial<Automation>): Automation {
@@ -108,5 +108,73 @@ describe("buildStreamRequest", () => {
     const automation = makeAutomation({ virtual_mcp_id: "vir_xyz" });
     const result = buildStreamRequest(automation, null, "thrd_1");
     expect(result.agent).toEqual({ id: "vir_xyz" });
+  });
+
+  describe("simple-mode tier resolution", () => {
+    const simpleMode = (
+      enabled: boolean,
+      slot: { keyId: string; modelId: string; title?: string } | null,
+    ): SimpleModeConfig => ({
+      enabled,
+      chat: { fast: null, smart: slot, thinking: null },
+      image: null,
+      webResearch: null,
+    });
+
+    it("overrides credential and model from the live tier slot", () => {
+      const automation = makeAutomation({
+        models: JSON.stringify({
+          credentialId: "cred_stale",
+          thinking: { id: "model_stale", title: "Stale" },
+          tier: "smart",
+        }),
+      });
+      const cfg = simpleMode(true, {
+        keyId: "cred_live",
+        modelId: "model_live",
+      });
+      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      expect(result.models.credentialId).toBe("cred_live");
+      expect((result.models.thinking as { id: string }).id).toBe("model_live");
+    });
+
+    it("ignores tier when simple mode is disabled", () => {
+      const automation = makeAutomation({
+        models: JSON.stringify({
+          credentialId: "cred_snapshot",
+          thinking: { id: "model_snapshot" },
+          tier: "smart",
+        }),
+      });
+      const cfg = simpleMode(false, {
+        keyId: "cred_live",
+        modelId: "model_live",
+      });
+      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      expect(result.models.credentialId).toBe("cred_snapshot");
+    });
+
+    it("falls back to snapshot when tier slot is unset", () => {
+      const automation = makeAutomation({
+        models: JSON.stringify({
+          credentialId: "cred_snapshot",
+          thinking: { id: "model_snapshot" },
+          tier: "smart",
+        }),
+      });
+      const cfg = simpleMode(true, null);
+      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      expect(result.models.credentialId).toBe("cred_snapshot");
+    });
+
+    it("does nothing when models has no tier (legacy automation)", () => {
+      const automation = makeAutomation();
+      const cfg = simpleMode(true, {
+        keyId: "cred_live",
+        modelId: "model_live",
+      });
+      const result = buildStreamRequest(automation, null, "thrd_1", cfg);
+      expect(result.models.credentialId).toBe("cred_1");
+    });
   });
 });

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -3,15 +3,29 @@
  *
  * Converts a stored Automation row into a StreamCoreInput suitable
  * for passing to streamCore(). JSON columns are parsed back into objects.
+ *
+ * When the persisted models payload carries a Simple Mode `tier`, the
+ * stored credential/model are treated as a stale snapshot and the live
+ * tier slot from the org's `simple_mode` config wins. This keeps dormant
+ * automations in sync with the org's current Simple Mode tiers without
+ * requiring a UI visit to reconcile.
  */
 
 import type { StreamCoreInput } from "@/api/routes/decopilot/stream-core";
-import type { Automation } from "@/storage/types";
+import type { Automation, SimpleModeConfig } from "@/storage/types";
+
+type AutomationModels = {
+  credentialId: string;
+  thinking: { id: string; [key: string]: unknown };
+  tier?: "fast" | "smart" | "thinking";
+  [key: string]: unknown;
+};
 
 export function buildStreamRequest(
   automation: Automation,
   triggerId: string | null,
   taskId: string,
+  simpleMode?: SimpleModeConfig | null,
 ): StreamCoreInput {
   const rawMessages = JSON.parse(automation.messages);
   // Generate fresh ids for each run so concurrent automation runs don't
@@ -22,9 +36,22 @@ export function buildStreamRequest(
     ...m,
     id: crypto.randomUUID(),
   }));
+
+  const models = JSON.parse(automation.models) as AutomationModels;
+  const tier = models.tier;
+  const slot =
+    tier && simpleMode?.enabled ? (simpleMode.chat?.[tier] ?? null) : null;
+  const resolvedModels: AutomationModels = slot
+    ? {
+        ...models,
+        credentialId: slot.keyId,
+        thinking: { ...models.thinking, id: slot.modelId },
+      }
+    : models;
+
   const request: StreamCoreInput = {
     messages,
-    models: JSON.parse(automation.models),
+    models: resolvedModels,
     agent: { id: automation.virtual_mcp_id },
     temperature: automation.temperature ?? 0.5,
     toolApprovalLevel: "auto",

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -4,28 +4,51 @@
  * Converts a stored Automation row into a StreamCoreInput suitable
  * for passing to streamCore(). JSON columns are parsed back into objects.
  *
- * When the persisted models payload carries a Simple Mode `tier`, the
- * stored credential/model are treated as a stale snapshot and the live
- * tier slot from the org's `simple_mode` config wins. This keeps dormant
- * automations in sync with the org's current Simple Mode tiers without
- * requiring a UI visit to reconcile.
+ * When the persisted models payload carries a Simple Mode `tier`, callers
+ * resolve the live slot via `resolveTierOverride()` and pass the resulting
+ * `tierOverride` here. The override fully replaces both `credentialId` and
+ * `thinking` — partial patching would leave stale capabilities / limits /
+ * provider / title from the snapshot, which downstream code (model-compat,
+ * stream-core max-tokens cap, telemetry) consumes.
  */
 
 import type { StreamCoreInput } from "@/api/routes/decopilot/stream-core";
-import type { Automation, SimpleModeConfig } from "@/storage/types";
+import type { Automation } from "@/storage/types";
+
+type ThinkingShape = {
+  id: string;
+  title?: string;
+  provider?: string | null;
+  capabilities?: {
+    vision?: boolean;
+    text?: boolean;
+    reasoning?: boolean;
+    file?: boolean;
+  };
+  limits?: {
+    contextWindow?: number;
+    maxOutputTokens?: number;
+  };
+  [key: string]: unknown;
+};
 
 type AutomationModels = {
   credentialId: string;
-  thinking: { id: string; [key: string]: unknown };
+  thinking: ThinkingShape;
   tier?: "fast" | "smart" | "thinking";
   [key: string]: unknown;
+};
+
+export type TierOverride = {
+  credentialId: string;
+  thinking: ThinkingShape;
 };
 
 export function buildStreamRequest(
   automation: Automation,
   triggerId: string | null,
   taskId: string,
-  simpleMode?: SimpleModeConfig | null,
+  tierOverride?: TierOverride | null,
 ): StreamCoreInput {
   const rawMessages = JSON.parse(automation.messages);
   // Generate fresh ids for each run so concurrent automation runs don't
@@ -38,14 +61,11 @@ export function buildStreamRequest(
   }));
 
   const models = JSON.parse(automation.models) as AutomationModels;
-  const tier = models.tier;
-  const slot =
-    tier && simpleMode?.enabled ? (simpleMode.chat?.[tier] ?? null) : null;
-  const resolvedModels: AutomationModels = slot
+  const resolvedModels: AutomationModels = tierOverride
     ? {
         ...models,
-        credentialId: slot.keyId,
-        thinking: { ...models.thinking, id: slot.modelId },
+        credentialId: tierOverride.credentialId,
+        thinking: tierOverride.thinking,
       }
     : models;
 

--- a/apps/mesh/src/automations/event-trigger-engine.test.ts
+++ b/apps/mesh/src/automations/event-trigger-engine.test.ts
@@ -59,7 +59,10 @@ function makeTriggerWithAutomation(
 function makeMeshContext(): MeshContext {
   return {
     organization: { id: ORG_ID, slug: "test", name: "Test" },
-    storage: { threads: {} },
+    storage: {
+      threads: {},
+      organizationSettings: { get: mock(() => Promise.resolve(null)) },
+    },
   } as unknown as MeshContext;
 }
 

--- a/apps/mesh/src/automations/fire.test.ts
+++ b/apps/mesh/src/automations/fire.test.ts
@@ -61,7 +61,10 @@ function makeStorage(
 function makeMeshContext(orgId: string): MeshContext {
   return {
     organization: { id: orgId, slug: "test", name: "Test Org" },
-    storage: { threads: { _orgId: orgId } },
+    storage: {
+      threads: { _orgId: orgId },
+      organizationSettings: { get: mock(() => Promise.resolve(null)) },
+    },
   } as unknown as MeshContext;
 }
 

--- a/apps/mesh/src/automations/fire.ts
+++ b/apps/mesh/src/automations/fire.ts
@@ -20,6 +20,7 @@ import type { MeshContext } from "@/core/mesh-context";
 import type { AutomationsStorage } from "@/storage/automations";
 import type { Automation } from "@/storage/types";
 import { buildStreamRequest } from "./build-stream-request";
+import { resolveTierOverride } from "./resolve-tier-override";
 import type { Semaphore } from "./semaphore";
 
 // ============================================================================
@@ -122,16 +123,16 @@ export async function fireAutomation(opts: {
 
     let runError: string | undefined;
     try {
-      // Fetch org Simple Mode config so tier-based automations resolve
-      // their model from the live tier slot at run time.
-      const settings = await ctx.storage.organizationSettings.get(
-        automation.organization_id,
-      );
+      // For tier-based automations, resolve the live model from the org's
+      // current Simple Mode slot — fetches fresh capabilities / limits /
+      // title from the AI provider so downstream gates (model-compat,
+      // max-tokens cap) see the right metadata.
+      const tierOverride = await resolveTierOverride(ctx, automation);
       const request = buildStreamRequest(
         automation,
         triggerId,
         taskId,
-        settings?.simple_mode ?? null,
+        tierOverride,
       );
       if (contextMessages) {
         request.messages = [

--- a/apps/mesh/src/automations/fire.ts
+++ b/apps/mesh/src/automations/fire.ts
@@ -122,7 +122,17 @@ export async function fireAutomation(opts: {
 
     let runError: string | undefined;
     try {
-      const request = buildStreamRequest(automation, triggerId, taskId);
+      // Fetch org Simple Mode config so tier-based automations resolve
+      // their model from the live tier slot at run time.
+      const settings = await ctx.storage.organizationSettings.get(
+        automation.organization_id,
+      );
+      const request = buildStreamRequest(
+        automation,
+        triggerId,
+        taskId,
+        settings?.simple_mode ?? null,
+      );
       if (contextMessages) {
         request.messages = [
           ...request.messages,

--- a/apps/mesh/src/automations/resolve-tier-override.test.ts
+++ b/apps/mesh/src/automations/resolve-tier-override.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { MeshContext } from "@/core/mesh-context";
+import { resolveTierOverride } from "./resolve-tier-override";
+
+type SettingsValue = {
+  simple_mode: {
+    enabled: boolean;
+    chat: Record<
+      "fast" | "smart" | "thinking",
+      { keyId: string; modelId: string; title?: string } | null
+    >;
+  } | null;
+} | null;
+
+function makeCtx(opts: {
+  settings: SettingsValue;
+  models?: Array<{
+    modelId: string;
+    title: string;
+    providerId: string;
+    capabilities: Array<
+      "text" | "image" | "vision" | "audio" | "video" | "file" | "reasoning"
+    >;
+    limits: { contextWindow: number; maxOutputTokens: number | null } | null;
+  }>;
+  listModelsThrows?: boolean;
+}): MeshContext {
+  return {
+    storage: {
+      organizationSettings: {
+        get: mock(() => Promise.resolve(opts.settings)),
+      },
+    },
+    aiProviders: {
+      listModels: mock(() => {
+        if (opts.listModelsThrows) {
+          return Promise.reject(new Error("provider unavailable"));
+        }
+        return Promise.resolve(opts.models ?? []);
+      }),
+    },
+  } as unknown as MeshContext;
+}
+
+describe("resolveTierOverride", () => {
+  it("returns null when models has no tier", async () => {
+    const ctx = makeCtx({ settings: null });
+    const result = await resolveTierOverride(ctx, {
+      models: JSON.stringify({ credentialId: "c", thinking: { id: "m" } }),
+      organization_id: "org_1",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when simple mode is disabled", async () => {
+    const ctx = makeCtx({
+      settings: {
+        simple_mode: {
+          enabled: false,
+          chat: {
+            fast: null,
+            smart: { keyId: "k", modelId: "m" },
+            thinking: null,
+          },
+        },
+      },
+    });
+    const result = await resolveTierOverride(ctx, {
+      models: JSON.stringify({ tier: "smart" }),
+      organization_id: "org_1",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the configured tier slot is unset", async () => {
+    const ctx = makeCtx({
+      settings: {
+        simple_mode: {
+          enabled: true,
+          chat: { fast: null, smart: null, thinking: null },
+        },
+      },
+    });
+    const result = await resolveTierOverride(ctx, {
+      models: JSON.stringify({ tier: "smart" }),
+      organization_id: "org_1",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("translates ModelInfo into the thinking shape with capability flags", async () => {
+    const ctx = makeCtx({
+      settings: {
+        simple_mode: {
+          enabled: true,
+          chat: {
+            fast: null,
+            smart: { keyId: "k_smart", modelId: "claude-3-5-sonnet" },
+            thinking: null,
+          },
+        },
+      },
+      models: [
+        {
+          modelId: "claude-3-5-sonnet",
+          title: "Claude 3.5 Sonnet",
+          providerId: "anthropic",
+          capabilities: ["text", "vision", "file", "reasoning"],
+          limits: { contextWindow: 200_000, maxOutputTokens: 8192 },
+        },
+      ],
+    });
+    const result = await resolveTierOverride(ctx, {
+      models: JSON.stringify({ tier: "smart" }),
+      organization_id: "org_1",
+    });
+    expect(result).toEqual({
+      credentialId: "k_smart",
+      thinking: {
+        id: "claude-3-5-sonnet",
+        title: "Claude 3.5 Sonnet",
+        provider: "anthropic",
+        capabilities: {
+          vision: true,
+          text: true,
+          reasoning: true,
+          file: true,
+        },
+        limits: { contextWindow: 200_000, maxOutputTokens: 8192 },
+      },
+    });
+  });
+
+  it("falls back to slot-only override when listModels throws", async () => {
+    const ctx = makeCtx({
+      settings: {
+        simple_mode: {
+          enabled: true,
+          chat: {
+            fast: null,
+            smart: { keyId: "k", modelId: "m", title: "Stored Title" },
+            thinking: null,
+          },
+        },
+      },
+      listModelsThrows: true,
+    });
+    const result = await resolveTierOverride(ctx, {
+      models: JSON.stringify({ tier: "smart" }),
+      organization_id: "org_1",
+    });
+    expect(result).toEqual({
+      credentialId: "k",
+      thinking: { id: "m", title: "Stored Title" },
+    });
+  });
+
+  it("returns null on malformed models JSON", async () => {
+    const ctx = makeCtx({ settings: null });
+    const result = await resolveTierOverride(ctx, {
+      models: "{not json",
+      organization_id: "org_1",
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/mesh/src/automations/resolve-tier-override.ts
+++ b/apps/mesh/src/automations/resolve-tier-override.ts
@@ -1,0 +1,103 @@
+/**
+ * Resolve Tier Override
+ *
+ * Server-side counterpart to the chat path's "look up the live model when
+ * Simple Mode is on" logic (see chat-context.tsx). When an automation row
+ * carries `models.tier` and the org has Simple Mode enabled, we fetch the
+ * full ModelInfo from the AI provider and translate it into the `thinking`
+ * shape consumed by streamCore / model-compat / max-tokens cap.
+ *
+ * Returns null when:
+ * - the automation has no tier intent (legacy / explicit pick)
+ * - Simple Mode is disabled for the org
+ * - the configured tier slot is unset
+ *
+ * Falls back to a slot-only override (no fresh metadata) if the AI
+ * provider's listModels call fails — this matches the prior behavior of
+ * "at least swap the credential and id" when the provider is flaky, but
+ * still skips downstream capability gates which would break against a
+ * model whose metadata we can't read.
+ */
+
+import type { MeshContext } from "@/core/mesh-context";
+import type { TierOverride } from "./build-stream-request";
+
+type SimpleModeChat = {
+  enabled: boolean;
+  chat?: Record<
+    "fast" | "smart" | "thinking",
+    { keyId: string; modelId: string; title?: string } | null
+  > | null;
+};
+
+export async function resolveTierOverride(
+  ctx: MeshContext,
+  automation: { models: string; organization_id: string },
+): Promise<TierOverride | null> {
+  let parsed: { tier?: "fast" | "smart" | "thinking" };
+  try {
+    parsed = JSON.parse(automation.models);
+  } catch {
+    return null;
+  }
+  const tier = parsed.tier;
+  if (!tier) return null;
+
+  const settings = await ctx.storage.organizationSettings.get(
+    automation.organization_id,
+  );
+  const simpleMode = settings?.simple_mode as SimpleModeChat | null | undefined;
+  if (!simpleMode?.enabled) return null;
+  const slot = simpleMode.chat?.[tier];
+  if (!slot) return null;
+
+  let title = slot.title ?? slot.modelId;
+  let provider: string | null | undefined;
+  let capabilities: TierOverride["thinking"]["capabilities"];
+  let limits: TierOverride["thinking"]["limits"];
+
+  try {
+    const list = await ctx.aiProviders.listModels(
+      slot.keyId,
+      automation.organization_id,
+    );
+    const modelInfo = list.find((m) => m.modelId === slot.modelId);
+    if (modelInfo) {
+      title = modelInfo.title ?? title;
+      provider = modelInfo.providerId;
+      const caps = modelInfo.capabilities;
+      capabilities =
+        caps && caps.length > 0
+          ? {
+              vision:
+                caps.includes("vision") || caps.includes("image") || undefined,
+              text: caps.includes("text") || undefined,
+              reasoning: caps.includes("reasoning") || undefined,
+              file: caps.includes("file") || undefined,
+            }
+          : undefined;
+      limits = modelInfo.limits
+        ? {
+            contextWindow: modelInfo.limits.contextWindow,
+            maxOutputTokens: modelInfo.limits.maxOutputTokens ?? undefined,
+          }
+        : undefined;
+    }
+  } catch (err) {
+    console.warn(
+      `[resolveTierOverride] Failed to fetch model metadata for tier=${tier} keyId=${slot.keyId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  return {
+    credentialId: slot.keyId,
+    thinking: {
+      id: slot.modelId,
+      title,
+      ...(provider !== undefined ? { provider } : {}),
+      ...(capabilities ? { capabilities } : {}),
+      ...(limits ? { limits } : {}),
+    },
+  };
+}

--- a/apps/mesh/src/tools/automations/create.ts
+++ b/apps/mesh/src/tools/automations/create.ts
@@ -72,9 +72,10 @@ export const AUTOMATION_CREATE = defineTool({
         }),
         coding: z.object({ id: z.string() }).optional(),
         fast: z.object({ id: z.string() }).optional(),
-        // Simple Mode tier intent. When set, the run path resolves the
-        // current tier slot from org settings and ignores credentialId /
-        // thinking.id (which are kept as a snapshot for display only).
+        // Simple Mode tier intent. When set and Simple Mode is active for
+        // the org, the run path resolves the model from the live tier slot.
+        // credentialId / thinking.id are the fallback used when Simple Mode
+        // is off or the slot is unset.
         tier: z.enum(["fast", "smart", "thinking"]).optional(),
       })
       .loose()

--- a/apps/mesh/src/tools/automations/create.ts
+++ b/apps/mesh/src/tools/automations/create.ts
@@ -72,6 +72,10 @@ export const AUTOMATION_CREATE = defineTool({
         }),
         coding: z.object({ id: z.string() }).optional(),
         fast: z.object({ id: z.string() }).optional(),
+        // Simple Mode tier intent. When set, the run path resolves the
+        // current tier slot from org settings and ignores credentialId /
+        // thinking.id (which are kept as a snapshot for display only).
+        tier: z.enum(["fast", "smart", "thinking"]).optional(),
       })
       .loose()
       .optional(),

--- a/apps/mesh/src/tools/automations/update.ts
+++ b/apps/mesh/src/tools/automations/update.ts
@@ -72,9 +72,10 @@ export const AUTOMATION_UPDATE = defineTool({
         }),
         coding: z.object({ id: z.string() }).optional(),
         fast: z.object({ id: z.string() }).optional(),
-        // Simple Mode tier intent. When set, the run path resolves the
-        // current tier slot from org settings and ignores credentialId /
-        // thinking.id (which are kept as a snapshot for display only).
+        // Simple Mode tier intent. When set and Simple Mode is active for
+        // the org, the run path resolves the model from the live tier slot.
+        // credentialId / thinking.id are the fallback used when Simple Mode
+        // is off or the slot is unset.
         tier: z.enum(["fast", "smart", "thinking"]).optional(),
       })
       .loose()

--- a/apps/mesh/src/tools/automations/update.ts
+++ b/apps/mesh/src/tools/automations/update.ts
@@ -72,6 +72,10 @@ export const AUTOMATION_UPDATE = defineTool({
         }),
         coding: z.object({ id: z.string() }).optional(),
         fast: z.object({ id: z.string() }).optional(),
+        // Simple Mode tier intent. When set, the run path resolves the
+        // current tier slot from org settings and ignores credentialId /
+        // thinking.id (which are kept as a snapshot for display only).
+        tier: z.enum(["fast", "smart", "thinking"]).optional(),
       })
       .loose()
       .optional(),

--- a/apps/mesh/src/web/hooks/use-automations.ts
+++ b/apps/mesh/src/web/hooks/use-automations.ts
@@ -142,6 +142,7 @@ export interface AutomationDetail {
   models: {
     credentialId: string;
     thinking: { id: string; [key: string]: unknown };
+    tier?: "fast" | "smart" | "thinking";
     [key: string]: unknown;
   };
   temperature: number;

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -76,6 +76,10 @@ interface SettingsFormData {
   active: boolean;
   credential_id: string;
   model_id: string;
+  // Empty string when the automation isn't pinned to a Simple Mode tier.
+  // When set, the server resolves the model from the live tier slot at run
+  // time, so credential_id / model_id act as a display snapshot only.
+  tier: SimpleModeTier | "";
 }
 
 // ============================================================================
@@ -378,6 +382,7 @@ export function SettingsTab({
     automation.models?.credentialId || chatCredentialId || "";
   const defaultModelId =
     automation.models?.thinking?.id || chatModel?.modelId || "";
+  const defaultTier: SimpleModeTier | "" = automation.models?.tier ?? "";
 
   const form = useForm<SettingsFormData>({
     defaultValues: {
@@ -385,6 +390,7 @@ export function SettingsTab({
       active: automation.active,
       credential_id: defaultCredentialId,
       model_id: defaultModelId,
+      tier: defaultTier,
     },
   });
 
@@ -398,20 +404,29 @@ export function SettingsTab({
   const selectedModel: AiProviderModel | null =
     models.find((m) => m.modelId === watchModelId) ?? null;
 
+  const watchTier = form.watch("tier");
+  // Persisted tier (from automation.models.tier) wins so the dropdown stays
+  // truthful even when slots are reconfigured server-side. Falls back to
+  // slot-match for legacy automations saved before tier was tracked, then
+  // to "smart" as a final default.
   const activeSimpleModeTier: SimpleModeTier =
+    watchTier ||
     (["fast", "smart", "thinking"] as const).find(
       (t) =>
         simpleMode.chat[t]?.modelId === watchModelId &&
         simpleMode.chat[t]?.keyId === watchConnectionId,
-    ) ?? "smart";
+    ) ||
+    "smart";
 
   const handleSimpleModeTierSelect = (tier: SimpleModeTier) => {
     const slot = simpleMode.chat[tier];
     if (!slot) return;
     form.setValue("credential_id", slot.keyId);
     form.setValue("model_id", slot.modelId);
+    form.setValue("tier", tier);
     markFormDirty("credential_id");
     markFormDirty("model_id");
+    markFormDirty("tier");
     scheduleSave();
   };
 
@@ -471,6 +486,13 @@ export function SettingsTab({
       const coercedModelId =
         values.credential_id && values.model_id ? values.model_id : "";
 
+      // When Simple Mode is on, always persist a tier so the run path
+      // resolves the live slot — even for legacy automations whose form
+      // hasn't explicitly written one yet.
+      const tierToPersist: SimpleModeTier | undefined = simpleMode.enabled
+        ? values.tier || activeSimpleModeTier
+        : values.tier || undefined;
+
       const updatePayload = {
         id: automationId,
         name: values.name,
@@ -480,6 +502,7 @@ export function SettingsTab({
           thinking: {
             id: coercedModelId,
           },
+          ...(tierToPersist ? { tier: tierToPersist } : {}),
         },
         messages: tiptapDocToMessages(tiptapDocAtSave),
         temperature: 0,
@@ -817,12 +840,16 @@ export function SettingsTab({
                     onCredentialChange={(id) => {
                       form.setValue("credential_id", id ?? "");
                       form.setValue("model_id", "");
+                      form.setValue("tier", "");
                       markFormDirty("credential_id");
                       markFormDirty("model_id");
+                      markFormDirty("tier");
                       scheduleSave();
                     }}
                     onModelChange={(model) => {
                       form.setValue("model_id", model.modelId);
+                      form.setValue("tier", "");
+                      markFormDirty("tier");
                       debouncedSave("model_id");
                     }}
                     placeholder="Model"

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -405,18 +405,20 @@ export function SettingsTab({
     models.find((m) => m.modelId === watchModelId) ?? null;
 
   const watchTier = form.watch("tier");
+  // The slot the saved credential/model actually correspond to, if any.
+  // Used both for the dropdown label and to decide whether saving is safe
+  // to auto-pin a legacy automation — we only persist `tier` when we know
+  // with certainty which slot the existing model matches.
+  const slotMatchedTier = (["fast", "smart", "thinking"] as const).find(
+    (t) =>
+      simpleMode.chat[t]?.modelId === watchModelId &&
+      simpleMode.chat[t]?.keyId === watchConnectionId,
+  );
   // Persisted tier (from automation.models.tier) wins so the dropdown stays
   // truthful even when slots are reconfigured server-side. Falls back to
-  // slot-match for legacy automations saved before tier was tracked, then
-  // to "smart" as a final default.
+  // slot-match, then to "smart" as a final default for the dropdown label.
   const activeSimpleModeTier: SimpleModeTier =
-    watchTier ||
-    (["fast", "smart", "thinking"] as const).find(
-      (t) =>
-        simpleMode.chat[t]?.modelId === watchModelId &&
-        simpleMode.chat[t]?.keyId === watchConnectionId,
-    ) ||
-    "smart";
+    watchTier || slotMatchedTier || "smart";
 
   const handleSimpleModeTierSelect = (tier: SimpleModeTier) => {
     const slot = simpleMode.chat[tier];
@@ -486,11 +488,14 @@ export function SettingsTab({
       const coercedModelId =
         values.credential_id && values.model_id ? values.model_id : "";
 
-      // When Simple Mode is on, always persist a tier so the run path
-      // resolves the live slot — even for legacy automations whose form
-      // hasn't explicitly written one yet.
+      // Persist `tier` only when we have a confident signal: an explicit
+      // form value (set via the tier dropdown) or a saved model that
+      // actually matches a configured slot. Legacy automations whose model
+      // doesn't match any slot are NOT silently re-pinned to the default
+      // tier on incidental edits — that would change which model the run
+      // path uses with no UI signal.
       const tierToPersist: SimpleModeTier | undefined = simpleMode.enabled
-        ? values.tier || activeSimpleModeTier
+        ? values.tier || slotMatchedTier
         : values.tier || undefined;
 
       const updatePayload = {

--- a/apps/mesh/src/web/views/settings/org-ai-providers.tsx
+++ b/apps/mesh/src/web/views/settings/org-ai-providers.tsx
@@ -1557,14 +1557,17 @@ function SimpleModeSection() {
 
   const isDirty = form.formState.isDirty;
 
-  // Autosave: 250ms after the last dirty change, persist. The debounce
-  // coalesces multi-field writes from handleToggle and Effect 2 into a single
-  // mutation. Callers `schedule()` from each field handler (Controllers and
-  // handleToggle) so we don't depend on a render-time form.watch subscription.
+  // Autosave: 250ms after the last `schedule()` call, persist. The debounce
+  // coalesces multi-field writes from handleToggle and Effect 2 into a
+  // single mutation. We can't gate on `formState.isDirty` here: handleToggle
+  // calls `form.reset(...)` to seed defaults (which rebases the dirty
+  // baseline) and the `values: simpleMode` prop resyncs the form on every
+  // cache update — both clear the flag before the timer fires, swallowing
+  // the save. Each `schedule()` call is the explicit save intent; nothing
+  // inside `save` re-schedules so there's no feedback loop.
   const { schedule: scheduleAutosave } = useDebouncedAutosave({
     delayMs: 250,
     save: async () => {
-      if (!form.formState.isDirty) return;
       const values = form.getValues();
       updateSimpleMode(values, {
         onSuccess: () => form.reset(values, { keepValues: true }),


### PR DESCRIPTION
## What is this contribution about?

Builds on #3305 (which aligned the automation model selector with the chat input). That PR kept baking the resolved model into the row, so dormant automations stayed on a stale snapshot when admins reconfigured tier slots. This PR moves resolution to run time:

- Persist a `tier` intent (`fast` / `smart` / `thinking`) inside `automation.models` when Simple Mode is on. The stored `credentialId` / `thinking.id` become a snapshot fallback.
- `fire.ts` calls a new `resolveTierOverride(ctx, automation)` that reads `organization_settings.simple_mode` and fetches the live `ModelInfo` via `ctx.aiProviders.listModels` — so `thinking.{capabilities, limits, provider, title}` reflect the *current* slot, not the snapshot. Required because `ensureModelCompatibility`, the max-output-tokens cap, and telemetry all consume those fields.
- Auto-pin only when the saved credential/model actually matches a slot, so a legacy automation isn't silently re-pinned to `"smart"` on incidental edits.

Also bundles a fix for an unrelated bug uncovered while testing: the Simple Mode toggle on the AI Providers settings page failed to persist on first enable because `form.reset` cleared RHF's dirty flag before the 250ms autosave fired. (Happy to split into a separate PR if preferred.)

## How to Test

1. Enable Simple Mode in `/$org/settings/ai-providers` and configure the Smart tier. Confirm the toggle persists on refresh (the autosave fix).
2. Open an automation, pick the Smart tier in the dropdown. Verify `automation.models.tier === "smart"` is saved.
3. Change the Smart slot to a different model in org settings. Fire the automation (cron / Test) — it should run on the *new* model, even without reopening the detail page.
4. Open a legacy automation (no `tier` field) with Simple Mode enabled, rename it. Confirm `tier` is **not** auto-written when its model doesn't match a slot.
5. Toggle Simple Mode off. Tier-pinned automations fall back to the stored snapshot and run as before.

## Migration Notes

None. New `tier` field on `automation.models` is optional; legacy rows without it keep the prior runtime behavior.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (5 new unit tests in `resolve-tier-override.test.ts` + updated `build-stream-request.test.ts`)
- [ ] Documentation is updated (if needed)
- [x] No breaking changes
