### PR TITLE
feat(oauth-proxy): inject org into DCR metadata for downstream MCPs

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -432,7 +432,7 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
         .where("id", "=", connection.organization_id)
         .executeTakeFirst();
       const rawText = await c.req.text();
-      let parsed: Record<string, unknown> = {};
+      let parsed: unknown = {};
       try {
         parsed = rawText ? JSON.parse(rawText) : {};
       } catch {
@@ -440,18 +440,28 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
         // 400, rather than us masking the client error.
         requestBody = rawText;
       }
+      // Only mutate plain objects. Arrays, null, and primitives are non-spec
+      // for DCR and would either throw on property assignment (null/primitive)
+      // or be silently dropped by `JSON.stringify` (array). Pass them through
+      // and let origin return the appropriate 4xx.
+      const isPlainObject =
+        typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+      if (requestBody === undefined && !isPlainObject) {
+        requestBody = rawText;
+      }
       if (requestBody === undefined) {
+        const obj = parsed as Record<string, unknown>;
         const existingMetadata =
-          parsed.metadata && typeof parsed.metadata === "object"
-            ? (parsed.metadata as Record<string, unknown>)
+          obj.metadata && typeof obj.metadata === "object"
+            ? (obj.metadata as Record<string, unknown>)
             : {};
-        parsed.metadata = {
+        obj.metadata = {
           ...existingMetadata,
           organization_id: connection.organization_id,
           ...(org?.slug ? { organization_slug: org.slug } : {}),
           ...(org?.name ? { organization_name: org.name } : {}),
         };
-        requestBody = JSON.stringify(parsed);
+        requestBody = JSON.stringify(obj);
         headers["Content-Type"] = "application/json";
       }
     } else {

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -420,6 +420,40 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
         params.append(key, value.toString());
       }
       requestBody = params.toString();
+    } else if (endpoint === "register") {
+      // Inject the connection's owning org into the DCR `metadata` field so the
+      // downstream MCP App can scope the registered OAuth client to a tenant
+      // without depending on user session state. RFC 7591 §2 reserves
+      // `metadata` for arbitrary client metadata extensions; downstream servers
+      // that don't recognize the field MUST ignore it.
+      const org = await ctx.db
+        .selectFrom("organization")
+        .select(["id", "slug", "name"])
+        .where("id", "=", connection.organization_id)
+        .executeTakeFirst();
+      const rawText = await c.req.text();
+      let parsed: Record<string, unknown> = {};
+      try {
+        parsed = rawText ? JSON.parse(rawText) : {};
+      } catch {
+        // Body isn't JSON — pass through unchanged so origin returns its own
+        // 400, rather than us masking the client error.
+        requestBody = rawText;
+      }
+      if (requestBody === undefined) {
+        const existingMetadata =
+          parsed.metadata && typeof parsed.metadata === "object"
+            ? (parsed.metadata as Record<string, unknown>)
+            : {};
+        parsed.metadata = {
+          ...existingMetadata,
+          organization_id: connection.organization_id,
+          ...(org?.slug ? { organization_slug: org.slug } : {}),
+          ...(org?.name ? { organization_name: org.name } : {}),
+        };
+        requestBody = JSON.stringify(parsed);
+        headers["Content-Type"] = "application/json";
+      }
     } else {
       // For other content types, pass through as-is
       requestBody = c.req.raw.body ?? undefined;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -420,12 +420,18 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
         params.append(key, value.toString());
       }
       requestBody = params.toString();
-    } else if (endpoint === "register") {
+    } else if (
+      endpoint === "register" &&
+      contentType?.includes("application/json")
+    ) {
       // Inject the connection's owning org into the DCR `metadata` field so the
       // downstream MCP App can scope the registered OAuth client to a tenant
       // without depending on user session state. RFC 7591 §2 reserves
       // `metadata` for arbitrary client metadata extensions; downstream servers
       // that don't recognize the field MUST ignore it.
+      // Gated on JSON content type so non-JSON DCR bodies (spec-violating but
+      // possible) get byte-perfect passthrough via the raw-body branch below
+      // instead of a lossy UTF-8 decode/re-encode round trip.
       const org = await ctx.db
         .selectFrom("organization")
         .select(["id", "slug", "name"])

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -422,7 +422,11 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
       requestBody = params.toString();
     } else if (
       endpoint === "register" &&
-      contentType?.includes("application/json")
+      // Media types are case-insensitive (RFC 7231 §3.1.1.1) — normalize so
+      // `Application/JSON` etc. don't bypass the injection.
+      contentType
+        ?.toLowerCase()
+        .includes("application/json")
     ) {
       // Inject the connection's owning org into the DCR `metadata` field so the
       // downstream MCP App can scope the registered OAuth client to a tenant

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -685,4 +685,72 @@ describe("org-scoped API coexistence", () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it("DCR with non-JSON content type passes through byte-for-byte", async () => {
+    // RFC 7591 mandates JSON, but a misbehaving client could POST /register
+    // with a different content type. The metadata-injection branch is gated on
+    // `application/json` so non-JSON bodies hit the raw-body passthrough and
+    // reach origin unchanged (no UTF-8 decode/re-encode, no Content-Type
+    // override).
+    const captured: { body: string | null; contentType: string | null } = {
+      body: null,
+      contentType: null,
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("oauth-authorization-server")) {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://example.test",
+            authorization_endpoint: "https://example.test/authorize",
+            token_endpoint: "https://example.test/token",
+            registration_endpoint: "https://example.test/register",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/register") && method === "POST") {
+        captured.body =
+          typeof init?.body === "string"
+            ? init.body
+            : await new Response(init?.body).text();
+        const headers = new Headers(init?.headers as HeadersInit | undefined);
+        captured.contentType = headers.get("Content-Type");
+        return new Response("ok", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    try {
+      const rawBody = "client_name=test&redirect_uris=http://x";
+      const res = await app.fetch(
+        new Request(
+          "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/register",
+          {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer test-key",
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: rawBody,
+          },
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      expect(captured.body).toBe(rawBody);
+      expect(captured.contentType).toBe("application/x-www-form-urlencoded");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -533,4 +533,88 @@ describe("org-scoped API coexistence", () => {
 
     expect(res.status).toBe(404);
   });
+
+  it("DCR injects the connection's owning org into the registration metadata", async () => {
+    // The downstream MCP App needs to know which studio org an OAuth client
+    // belongs to *at registration time* — there is no per-user "active org"
+    // concept on the server, and querying it back from a bearer token has no
+    // standard. The proxy threads `connection.organization_id` (plus slug/name
+    // for human-readable references) into the RFC 7591 `metadata` field, which
+    // downstream servers can read off the persisted oauthApplication row on
+    // every subsequent request.
+    let capturedBody: string | null = null;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("oauth-authorization-server")) {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://example.test",
+            authorization_endpoint: "https://example.test/authorize",
+            token_endpoint: "https://example.test/token",
+            registration_endpoint: "https://example.test/register",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/register") && method === "POST") {
+        capturedBody =
+          typeof init?.body === "string"
+            ? init.body
+            : await new Response(init?.body).text();
+        return new Response(
+          JSON.stringify({ client_id: "client_xyz", client_secret: "secret" }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    try {
+      const res = await app.fetch(
+        new Request(
+          "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/register",
+          {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer test-key",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              client_name: "test",
+              redirect_uris: ["http://mesh.localhost/oauth/callback"],
+              metadata: { existing_key: "preserved" },
+            }),
+          },
+        ),
+      );
+
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(400);
+      expect(capturedBody).not.toBeNull();
+      const forwarded = JSON.parse(capturedBody!);
+      // Original fields untouched.
+      expect(forwarded.client_name).toBe("test");
+      expect(forwarded.redirect_uris).toEqual([
+        "http://mesh.localhost/oauth/callback",
+      ]);
+      // Org metadata injected; pre-existing metadata keys preserved.
+      expect(forwarded.metadata).toEqual({
+        existing_key: "preserved",
+        organization_id: "org_1",
+        organization_slug: "org_1",
+        organization_name: "org_1",
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -586,7 +586,9 @@ describe("org-scoped API coexistence", () => {
             method: "POST",
             headers: {
               Authorization: "Bearer test-key",
-              "Content-Type": "application/json",
+              // Mixed-case media type — case-insensitive per RFC 7231 §3.1.1.1.
+              // Locks in that the injection branch normalizes before matching.
+              "Content-Type": "Application/JSON",
             },
             body: JSON.stringify({
               client_name: "test",

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -617,4 +617,72 @@ describe("org-scoped API coexistence", () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it("DCR passes through non-object JSON bodies unchanged", async () => {
+    // null/array/primitive bodies are non-spec for DCR (RFC 7591 requires a
+    // JSON object). The proxy must not try to attach `metadata` to them —
+    // null/primitive would throw on property assignment, and arrays would
+    // silently lose the property at JSON.stringify time. We forward unchanged
+    // and let origin return its own 4xx.
+    const captured: string[] = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("oauth-authorization-server")) {
+        return new Response(
+          JSON.stringify({
+            issuer: "https://example.test",
+            authorization_endpoint: "https://example.test/authorize",
+            token_endpoint: "https://example.test/token",
+            registration_endpoint: "https://example.test/register",
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/register") && method === "POST") {
+        const body =
+          typeof init?.body === "string"
+            ? init.body
+            : await new Response(init?.body).text();
+        captured.push(body);
+        return new Response(
+          JSON.stringify({ error: "invalid_client_metadata" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch);
+
+    try {
+      for (const body of ["null", "[1,2,3]", "42"]) {
+        const res = await app.fetch(
+          new Request(
+            "http://mesh.localhost/api/org_1/oauth-proxy/conn_1/register",
+            {
+              method: "POST",
+              headers: {
+                Authorization: "Bearer test-key",
+                "Content-Type": "application/json",
+              },
+              body,
+            },
+          ),
+        );
+        // Proxy didn't crash (would have been a 500); origin's 400 is what
+        // surfaces to the client.
+        expect(res.status).toBe(400);
+      }
+      expect(captured).toEqual(["null", "[1,2,3]", "42"]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## What is this contribution about?

Studio's mesh proxy now injects the connection's owning org into the RFC 7591 `metadata` field of every Dynamic Client Registration body it forwards to downstream MCP Apps. Until now a downstream MCP App (e.g. slide-maker) validating an incoming bearer could see the user (`sub`) and the OAuth client (`clientId`), but had no standard-compliant way to learn which studio org the request was acting under — there is no server-side "active org" concept (correctly so; it's a UI session property), and `/api/auth/organization/list` rejects OIDC access tokens. Setting org on the OAuth client at registration time is the right model: the org is known when studio creates a connection, and the binding is permanent for the lifetime of that client.

The change is in `oauthProxyHandler` (`apps/mesh/src/api/app.ts`): on `POST /register` it looks up `id`/`slug`/`name` for `connection.organization_id` via `ctx.db`, parses the inbound JSON, merges `{ organization_id, organization_slug, organization_name }` into `metadata` (preserving any pre-existing keys), and re-serializes before forwarding. Pass-through is unchanged for non-JSON bodies, and downstream MCPs that don't recognize the field MUST ignore it per RFC 7591 §2 — so the change is purely additive on the wire and existing connections continue to work.

## How to Test

1. From inside an org X in studio, click "Connect MCP App" against any OAuth-capable MCP server.
2. Inspect the proxied registration request that lands at the downstream MCP's `/register` (server logs or a packet capture).
3. Expected: the JSON body contains `metadata.organization_id`, `metadata.organization_slug`, and `metadata.organization_name` matching org X. Existing connections still authenticate normally.

A new integration test (`apps/mesh/src/api/integration-org-scoped.test.ts`) intercepts the proxied origin call and asserts the forwarded body has the org metadata injected and any pre-existing `metadata.*` keys preserved. `bun test apps/mesh/src/api/integration-org-scoped.test.ts` is green (11/11), `bun run --cwd=apps/mesh check` is clean, `bun run fmt` applied.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject the connection’s org (id, slug, name) into RFC 7591 `metadata` for proxied Dynamic Client Registration (`POST /register`) so downstream MCP apps can tenant-scope OAuth clients without session state. Handles JSON `Content-Type` case-insensitively and passes through non-JSON or non-object JSON bodies unchanged.

- **New Features**
  - In `apps/mesh/src/api/app.ts`, `oauthProxyHandler` injects org data into JSON `metadata` on `/register` while preserving existing keys; matches `Content-Type` case-insensitively; only parses when JSON; non-JSON and non-object JSON bodies pass through byte-for-byte.
  - Updated `apps/mesh/src/api/integration-org-scoped.test.ts` to verify metadata injection, key preservation, mixed-case `Content-Type` handling, and passthrough for null/array/primitive JSON and non-JSON content types.

<sup>Written for commit e3d84dcd6da67ebdeb8237a75b0517c12599844c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

