### PR TITLE
fix(tests): unbreak context-factory tests; harden CI SIGILL fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,16 @@ jobs:
           bun test $files 2>&1 | tee /tmp/test-output.txt
           exit_code=${PIPESTATUS[0]}
           set -e
+          # Detect failures via per-test markers AND the summary line. The
+          # SIGILL crash can happen before bun prints its "N fail" summary,
+          # so relying on the summary alone hides real failures.
+          if grep -qE '^\(fail\)|[1-9][0-9]* fail' /tmp/test-output.txt; then
+            echo "❌ Test failures detected in output"
+            exit 1
+          fi
           if [ $exit_code -eq 0 ]; then
             exit 0
-          elif [ $exit_code -eq 132 ] && ! grep -q '[1-9][0-9]* fail' /tmp/test-output.txt; then
+          elif [ $exit_code -eq 132 ]; then
             echo "⚠️  Bun exited with SIGILL (known WASM cleanup bug) but all tests passed"
             exit 0
           else

--- a/apps/mesh/src/core/context-factory.test.ts
+++ b/apps/mesh/src/core/context-factory.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable no-explicit-any */
 import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
-import type { Meter, Tracer } from "@opentelemetry/api";
+import { type Meter, trace } from "@opentelemetry/api";
 import {
   createTestDatabase,
   closeTestDatabase,
@@ -90,7 +90,7 @@ describe("createMeshContextFactory", () => {
         auth: createMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -117,7 +117,7 @@ describe("createMeshContextFactory", () => {
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -145,7 +145,7 @@ describe("createMeshContextFactory", () => {
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -168,7 +168,7 @@ describe("createMeshContextFactory", () => {
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -198,7 +198,7 @@ describe("createMeshContextFactory", () => {
         auth: createMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -236,7 +236,7 @@ describe("createMeshContextFactory", () => {
         auth: authWithoutOrg as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -257,7 +257,7 @@ describe("createMeshContextFactory", () => {
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -283,7 +283,7 @@ describe("createMeshContextFactory", () => {
         auth: createMinimalMockAuth() as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -334,7 +334,7 @@ describe("createMeshContextFactory", () => {
         auth: mockAuthWithOrgInApiKey as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -376,7 +376,7 @@ describe("createMeshContextFactory", () => {
         auth: mockAuthWithoutOrg as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -418,7 +418,7 @@ describe("createMeshContextFactory", () => {
         auth: mockAuthOrgA as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
@@ -456,7 +456,7 @@ describe("createMeshContextFactory", () => {
         auth: mockAuthOrgB as unknown as BetterAuthInstance,
         encryption: { key: "test_key" },
         observability: {
-          tracer: {} as unknown as Tracer,
+          tracer: trace.getTracer("test"),
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),


### PR DESCRIPTION
## Summary

- `apps/mesh/src/core/context-factory.test.ts` was stubbing `tracer` as `{} as unknown as Tracer`. Since [`68c635dca`](https://github.com/decocms/studio/commit/68c635dca) (feat(observability): integrate OpenTelemetry spans for connection and client operations), the factory calls `config.observability.tracer.startActiveSpan(...)` in the auth path, which made 10/11 tests fail with `TypeError: ... is not a function`. Use `trace.getTracer("test")` (NoopTracer) so the calls succeed.
- The SIGILL fallback in `.github/workflows/test.yml` only grepped for bun's summary line (`N fail`). Bun 1.3.5's WASM cleanup crash can trigger **before** the summary is printed, so the heuristic was masking real failures. Now also grep for per-test `(fail)` markers and fail the job if any are found.

## Why this slipped through

The customer's pipeline (sequential `awk "NR % 4 == 3"` sharding + 3-attempt retry) surfaced this on 2.310.0+. Our own CI on `main` was green — but CI run [25506336034](https://github.com/decocms/studio/actions/runs/25506336034) on `main` actually had 10 `(fail)` lines from this exact test in shard 0; the SIGILL crash hit before the summary, the heuristic shrugged, and the job exited 0.

## Test plan

- [x] `bun test apps/mesh/src/core/context-factory.test.ts` — 11 pass / 0 fail locally
- [ ] Watch this PR's CI run to confirm the test passes and the workflow change still treats clean SIGILL exits as success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing context-factory tests by using a real OpenTelemetry tracer and tightens CI so SIGILL crashes don’t hide real test failures. Prevents TypeErrors in tests and makes CI failure detection more reliable.

- **Bug Fixes**
  - Tests: replace `{} as Tracer` with `trace.getTracer("test")` from `@opentelemetry/api` so `startActiveSpan` calls in the auth path succeed.
  - CI: update `.github/workflows/test.yml` to grep per-test `(fail)` markers and the summary; fail the job if any are found. Continue treating Bun’s SIGILL (exit 132) as success only when no failures are detected.

<sup>Written for commit 6eb81d1d40295a099090ce4ebc88d152ecec8a68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

