### PR TITLE
fix(files): use org slug instead of id in /api/:org/files URLs

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/vm-tools/index.ts
@@ -94,11 +94,11 @@ function sanitizeFilename(name: string): string | null {
  */
 function toFileDownloadUrl(
   baseUrl: string,
-  orgId: string,
+  orgSlug: string,
   key: string,
 ): string {
   const encodedKey = key.split("/").map(encodeURIComponent).join("/");
-  return `${baseUrl}/api/${encodeURIComponent(orgId)}/files/${encodedKey}`;
+  return `${baseUrl}/api/${encodeURIComponent(orgSlug)}/files/${encodedKey}`;
 }
 
 export type { VmToolsParams } from "./types";
@@ -293,9 +293,9 @@ export function createVmTools(params: VmToolsParams) {
     description: SHARE_WITH_USER_DESCRIPTION,
     inputSchema: zodSchema(ShareWithUserInputSchema),
     execute: async (input) => {
-      const orgId = ctx.organization?.id;
+      const orgSlug = ctx.organization?.slug;
       const storage = ctx.objectStorage;
-      if (!orgId || !storage) {
+      if (!orgSlug || !storage) {
         throw new Error("Object storage is not configured for this org");
       }
       const filename = sanitizeFilename(
@@ -313,7 +313,7 @@ export function createVmTools(params: VmToolsParams) {
       return {
         key,
         filename,
-        downloadUrl: toFileDownloadUrl(ctx.baseUrl, orgId, key),
+        downloadUrl: toFileDownloadUrl(ctx.baseUrl, orgSlug, key),
       };
     },
   });

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -29,10 +29,10 @@ import {
 /** Build the stable redirect URL the UI / tools use to access a file. */
 function toFileRedirectUrl(
   baseUrl: string,
-  orgId: string,
+  orgSlug: string,
   key: string,
 ): string {
-  return `${baseUrl}/api/${orgId}/files/${key}`;
+  return `${baseUrl}/api/${orgSlug}/files/${key}`;
 }
 
 /**
@@ -169,7 +169,8 @@ export async function uploadFileParts(
   ctx: MeshContext,
 ): Promise<ChatMessage[]> {
   if (!ctx.organization) return messages;
-  const orgId = ctx.organization.id;
+  const orgSlug = ctx.organization.slug;
+  if (!orgSlug) return messages;
 
   const lastUserIdx = messages.findLastIndex((m) => m.role === "user");
   if (lastUserIdx === -1) return messages;
@@ -216,7 +217,7 @@ export async function uploadFileParts(
       return {
         dataUrl: part.url,
         meshStorageUrl: toMeshStorageUri(uploadedKey),
-        redirectUrl: toFileRedirectUrl(ctx.baseUrl, orgId, uploadedKey),
+        redirectUrl: toFileRedirectUrl(ctx.baseUrl, orgSlug, uploadedKey),
         filename,
       };
     }),

--- a/apps/mesh/src/api/routes/thread-outputs.ts
+++ b/apps/mesh/src/api/routes/thread-outputs.ts
@@ -28,8 +28,8 @@ export const createThreadOutputsRoutes = () => {
     if (!userId) {
       throw new HTTPException(401, { message: "Unauthorized" });
     }
-    const orgId = ctx.organization?.id;
-    if (!orgId) {
+    const orgSlug = ctx.organization?.slug;
+    if (!orgSlug) {
       throw new HTTPException(400, { message: "Organization required" });
     }
 
@@ -75,7 +75,7 @@ export const createThreadOutputsRoutes = () => {
           filename,
           size: o.size,
           uploadedAt: o.lastModified?.toISOString(),
-          downloadUrl: `${ctx.baseUrl}/api/${encodeURIComponent(orgId)}/files/${encodedKey}`,
+          downloadUrl: `${ctx.baseUrl}/api/${encodeURIComponent(orgSlug)}/files/${encodedKey}`,
         };
       }),
     });

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -15,9 +15,9 @@ import type { UsageStats } from "@/web/lib/usage-utils.ts";
 import { formatDuration } from "@/web/lib/format-time.ts";
 import { parseMeshStorageKey } from "@/api/routes/decopilot/mesh-storage-uri";
 
-function resolveImageSrc(uri: string, orgId: string): string {
+function resolveImageSrc(uri: string, orgSlug: string): string {
   const key = parseMeshStorageKey(uri);
-  if (key !== null) return `/api/${orgId}/files/${key}`;
+  if (key !== null) return `/api/${orgSlug}/files/${key}`;
   // data: URIs or any other URL — use as-is
   return uri;
 }
@@ -57,8 +57,14 @@ function extractUsage(
   };
 }
 
-function ReferenceImageChip({ uri, orgId }: { uri: string; orgId: string }) {
-  const src = resolveImageSrc(uri, orgId);
+function ReferenceImageChip({
+  uri,
+  orgSlug,
+}: {
+  uri: string;
+  orgSlug: string;
+}) {
+  const src = resolveImageSrc(uri, orgSlug);
   const label =
     parseMeshStorageKey(uri) !== null
       ? uri.slice(uri.lastIndexOf("/") + 1)
@@ -147,7 +153,9 @@ export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
               </span>
               {refImages.map((ref, i) => {
                 const raw = (ref.uri ?? ref.url)!;
-                return <ReferenceImageChip key={i} uri={raw} orgId={org.id} />;
+                return (
+                  <ReferenceImageChip key={i} uri={raw} orgSlug={org.slug} />
+                );
               })}
             </div>
           )}
@@ -157,7 +165,7 @@ export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
         {images.map((img, i) => {
           const raw = img.uri ?? img.url;
           if (!raw) return null;
-          const src = resolveImageSrc(raw, org.id);
+          const src = resolveImageSrc(raw, org.slug);
           return (
             <ImageLightbox
               key={i}

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/web-search.tsx
@@ -18,9 +18,9 @@ import {
 } from "@decocms/mesh-sdk";
 import { parseMeshStorageKey } from "@/api/routes/decopilot/mesh-storage-uri";
 
-function resolveStorageUri(uri: string, orgId: string): string {
+function resolveStorageUri(uri: string, orgSlug: string): string {
   const key = parseMeshStorageKey(uri);
-  if (key !== null) return `/api/${orgId}/files/${key}`;
+  if (key !== null) return `/api/${orgSlug}/files/${key}`;
   return uri;
 }
 
@@ -180,7 +180,7 @@ export function WebSearchPart({
 
   // Resolve blob-stored content for large results
   const blobUrl = result?.uri
-    ? resolveStorageUri(result.uri, org.id)
+    ? resolveStorageUri(result.uri, org.slug)
     : undefined;
 
   const { data: blobContent } = useQuery({


### PR DESCRIPTION
## What is this contribution about?

After the `/api/:org/...` migration, every `<img>` and download chip pointing at `/api/<org>/files/<key>` was returning `404 organization not found` in prod. The redirect-URL builders were passing the org **id** (e.g. `Es15tftjNu8...`), but `resolveOrgFromPath` only looks up by **slug**. Switched all five generators (`file-materializer`, `thread-outputs`, `vm-tools` `share_with_user`, `generate-image.tsx`, `web-search.tsx`) to pass `ctx.organization.slug` / `org.slug`. URLs aren't persisted (the DB stores opaque `mesh-storage:KEY` URIs and rebuilds the redirect URL on each render), so chat history is unaffected.

## How to Test
1. Open a chat that contains a generated image or an uploaded file reference.
2. Confirm the `<img>` resolves via `/api/<slug>/files/...` (200, not 404).
3. Hit a `share_with_user` download URL and a `thread-outputs` download URL — both should resolve.

## Migration Notes
None — URLs are computed live from the user's current org context.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (typecheck, lint, format pass; no co-located tests for these modules)
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404s on file/image downloads by using organization slug instead of id in `/api/:org/files` URLs. Images and downloads now resolve across chats and thread outputs.

- **Bug Fixes**
  - Build file redirect URLs with `org.slug` in: `file-materializer`, `thread-outputs`, `vm-tools` (share_with_user), `generate-image.tsx`, `web-search.tsx`.
  - Applies to generated images, web search blobs, and share links; no persisted URLs or history affected.

<sup>Written for commit 9ae2c0d9dceb558040712c2141bb16bedf859776. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

