### PR TITLE
[release]: bump @decocms/sandbox to 0.4.0

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump `@decocms/sandbox` from 0.3.13 to 0.4.0 (minor).

## Test plan
- [x] Version updated in `packages/sandbox/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/sandbox` from 0.3.13 to 0.4.0 to publish the latest minor release. Updates the version in `packages/sandbox/package.json` only.

<sup>Written for commit c722ffa31ed371cbc5b64e56bf9b1264219a461b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

