### PR TITLE
feat(vm-events): enhance VM event handling and introduce sandbox evic…

### DIFF
--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -8,7 +8,7 @@
  *      VM_START posting a SandboxClaim and the daemon coming online.
  *      Agent-sandbox runner emits real K8s phases; other runners emit a
  *      single synthetic `ready`.
- *   2. Daemon events (`event: log|status|scripts|processes|reload|branch-status`)
+ *   2. Daemon events (`event: log|status|scripts|tasks|intent|phases|branch-status|transition`)
  *      — proxied from the in-pod daemon's `/_decopilot_vm/events` SSE once
  *      lifecycle reaches `ready`. Wire format is preserved verbatim by raw
  *      byte-piping the upstream body, so daemon and client speak the same
@@ -36,11 +36,12 @@
 
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
+import type { SSEStreamingApi } from "hono/streaming";
 import {
   composeSandboxRef,
   resolveRunnerKindFromEnv,
 } from "@decocms/sandbox/runner";
-import type { ClaimPhase } from "@decocms/sandbox/runner";
+import type { ClaimPhase, RunnerKind } from "@decocms/sandbox/runner";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
 import {
   getOrInitSharedRunner,
@@ -66,7 +67,30 @@ import type { Env } from "../hono-env";
  */
 const NO_CLAIM_MAX_MS = 90_000;
 
+/**
+ * Shorter stale-sandbox detection window used only when `expectingHandle` is
+ * true (a prior sandbox was running). After this many ms stuck in `claiming`
+ * with no pod activity, we conclude the underlying pod was deleted while the
+ * SandboxClaim CRD still exists (runner.alive() returned true but the pod is
+ * gone). 30s is long enough for the operator to emit at least one scheduling
+ * event if it were actively creating a pod, yet short enough to surface a
+ * clear error quickly instead of making the user wait the full 90s.
+ */
+const STALE_CLAIM_DETECTION_MS = 30_000;
+
 const HEARTBEAT_MS = 15_000;
+
+type VmSseEvent =
+  | { event: "phase"; data: ClaimPhase }
+  | { event: "gone" }
+  | { event: "keepalive" };
+
+function writeSse(stream: SSEStreamingApi, e: VmSseEvent): Promise<void> {
+  return stream.writeSSE({
+    event: e.event,
+    data: "data" in e ? JSON.stringify(e.data) : "",
+  });
+}
 
 export const createVmEventsRoutes = () => {
   const app = new Hono<Env>();
@@ -95,11 +119,6 @@ export const createVmEventsRoutes = () => {
       return c.json({ error: "virtualMcpId and branch are required" }, 400);
     }
 
-    // Verify caller's org actually owns this virtualMcp. Without this check,
-    // an authenticated user could probe arbitrary virtualMcpIds — the claim
-    // hash includes their userId so they couldn't *observe* anyone else's
-    // events, but the 404 vs not-yet-created surface would still leak
-    // existence/identity information.
     const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
     if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
       return c.json({ error: "Virtual MCP not found" }, 404);
@@ -113,14 +132,6 @@ export const createVmEventsRoutes = () => {
     const claimName = computeClaimHandle({ userId, projectRef }, branch);
     const runnerKind = resolveRunnerKindFromEnv();
 
-    // Snapshot vmMap from the same metadata read used for the org-ownership
-    // check. Used below to gate the stale-handle probe: we only run it when
-    // this user already had a vmMap entry pointing at *this exact* claim.
-    // The vmId-match guard avoids racing VM_START's claim-creation window
-    // (~250ms–1.2s for agent-sandbox before `createSandboxClaim` lands;
-    // similar window for host/docker between `runner.ensure` returning and
-    // `setVmMapEntry` writing the row). Without it, an SSE that opens during
-    // that window would observe alive=false and emit a spurious `gone`.
     const existingVmEntry = resolveVm(
       readVmMap(virtualMcp.metadata as Record<string, unknown> | null),
       userId,
@@ -135,13 +146,13 @@ export const createVmEventsRoutes = () => {
     // phase rather than a silent close so the UI shows a meaningful error.
     if (!runner) {
       return streamSSE(c, async (stream) => {
-        await stream.writeSSE({
+        await writeSse(stream, {
           event: "phase",
-          data: JSON.stringify({
+          data: {
             kind: "failed",
             reason: "unknown",
             message: "No sandbox runner configured on this mesh.",
-          } satisfies ClaimPhase),
+          },
         });
       });
     }
@@ -152,7 +163,7 @@ export const createVmEventsRoutes = () => {
     return streamSSE(c, async (stream) => {
       const abortCtl = new AbortController();
       const heartbeat = setInterval(() => {
-        stream.writeSSE({ event: "keepalive", data: "" }).catch(() => {
+        writeSse(stream, { event: "keepalive" }).catch(() => {
           clearInterval(heartbeat);
         });
       }, HEARTBEAT_MS);
@@ -162,15 +173,24 @@ export const createVmEventsRoutes = () => {
       });
 
       try {
-        // Same probe for every runner. `runner.alive` is honest across
-        // host/docker/freestyle/agent-sandbox: each implementation queries
-        // its respective source-of-truth (state-store + pid for host, docker
-        // inspect, K8s API, freestyle daemon HTTP). When the prior vmMap
-        // entry's runner kind differs from the env's current runner, we
-        // route the stale-state cleanup through the *prior* kind so we
-        // don't leave behind rows in the wrong table.
-        if (expectingHandle) {
-          const stale = await isStaleHandle(runner, claimName);
+        const priorStateRow = await ctx.db
+          .selectFrom("sandbox_runner_state")
+          .select(["handle", "runner_kind"])
+          .where("user_id", "=", userId)
+          .where("project_ref", "=", projectRef)
+          .executeTakeFirst()
+          .catch(() => null);
+        const hasKnownClaim = expectingHandle || priorStateRow !== null;
+
+        if (hasKnownClaim) {
+          const priorKind = (existingRunnerKind ??
+            priorStateRow?.runner_kind ??
+            null) as RunnerKind | null;
+
+          const runnerMismatch = priorKind !== null && priorKind !== runnerKind;
+          const stale =
+            runnerMismatch || (await isStaleHandle(runner, claimName));
+
           if (stale) {
             await cleanupStaleEntry({
               ctx,
@@ -178,9 +198,24 @@ export const createVmEventsRoutes = () => {
               claimName,
               userId,
               projectRef,
-              runnerKind: existingRunnerKind ?? runnerKind,
+              runnerKind: priorKind ?? runnerKind,
             });
-            await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+            if (expectingHandle) {
+              // vmMap points at this claim → self-heal: browser triggers VM_START.
+              await writeSse(stream, { event: "gone" }).catch(() => {});
+            } else {
+              // State-store only (no vmMap entry) → manual prompt; auto-heal
+              // won't fire without a vmMap entry to give deadVmId a value.
+              await writeSse(stream, {
+                event: "phase",
+                data: {
+                  kind: "failed",
+                  reason: "sandbox-evicted",
+                  message:
+                    "The sandbox was removed. Start a new one to continue.",
+                },
+              }).catch(() => {});
+            }
             return;
           }
         }
@@ -191,6 +226,19 @@ export const createVmEventsRoutes = () => {
           claimName,
           runner,
           signal: abortCtl.signal,
+          hasExistingClaim: hasKnownClaim,
+          onStaleClaim: hasKnownClaim
+            ? async () => {
+                await cleanupStaleEntry({
+                  ctx,
+                  runner,
+                  claimName,
+                  userId,
+                  projectRef,
+                  runnerKind: existingRunnerKind ?? runnerKind,
+                });
+              }
+            : undefined,
         });
         if (!lifecycleOk || abortCtl.signal.aborted) return;
 
@@ -263,7 +311,7 @@ async function cleanupStaleEntry(args: {
   claimName: string;
   userId: string;
   projectRef: string;
-  runnerKind: "host" | "docker" | "freestyle" | "agent-sandbox";
+  runnerKind: RunnerKind;
 }): Promise<void> {
   const { ctx, runner, claimName, userId, projectRef, runnerKind } = args;
   try {
@@ -298,22 +346,39 @@ async function cleanupStaleEntry(args: {
  * `ready` phase and ends immediately.
  */
 async function emitLifecycle(args: {
-  stream: import("hono/streaming").SSEStreamingApi;
+  stream: SSEStreamingApi;
   claimName: string;
   runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
   signal: AbortSignal;
+  /**
+   * True when the caller had an existing vmMap entry pointing at this claim
+   * (i.e. a prior sandbox was running). Enables the shorter
+   * STALE_CLAIM_DETECTION_MS secondary timer: if the operator hasn't
+   * produced any pod activity within that window, the pod was likely deleted
+   * while the SandboxClaim CRD still exists.
+   */
+  hasExistingClaim: boolean;
+  /**
+   * Called before emitting `sandbox-evicted` when the secondary timer fires.
+   * Lets the caller drop the stale state-store row so VM_START's `ensure`
+   * path doesn't chase a dead port-forward on the next attempt.
+   */
+  onStaleClaim?: () => Promise<void>;
 }): Promise<boolean> {
-  const { stream, claimName, runner, signal } = args;
+  const { stream, claimName, runner, signal, hasExistingClaim, onStaleClaim } =
+    args;
 
   return new Promise<boolean>((resolve) => {
     let settled = false;
     let claimSeen = false;
     let handle: { unsubscribe(): void } | null = null;
+    let staleClaimTimer: ReturnType<typeof setTimeout> | null = null;
 
     const settle = (result: boolean) => {
       if (settled) return;
       settled = true;
       clearTimeout(watchdogTimer);
+      if (staleClaimTimer !== null) clearTimeout(staleClaimTimer);
       signal.removeEventListener("abort", onAbort);
       handle?.unsubscribe();
       resolve(result);
@@ -327,19 +392,47 @@ async function emitLifecycle(args: {
     // never fires.
     const watchdogTimer = setTimeout(() => {
       if (claimSeen || settled) return;
-      stream
-        .writeSSE({
-          event: "phase",
-          data: JSON.stringify({
-            kind: "failed",
-            reason: "claim-never-created",
-            message:
-              "Sandbox claim was never created. The VM_START call may have failed earlier — check the start error.",
-          } satisfies ClaimPhase),
-        })
-        .catch(() => {});
+      writeSse(stream, {
+        event: "phase",
+        data: {
+          kind: "failed",
+          reason: "claim-never-created",
+          message:
+            "Sandbox claim was never created. The VM_START call may have failed earlier — check the start error.",
+        },
+      }).catch(() => {});
       settle(false);
     }, NO_CLAIM_MAX_MS);
+
+    // Secondary stale-sandbox detection: only fires when the caller had a
+    // prior running sandbox (hasExistingClaim). If we're still in `claiming`
+    // after STALE_CLAIM_DETECTION_MS with no pod events, the SandboxClaim
+    // exists in K8s but its pod was deleted — runner.alive() returned true
+    // (claim present) but the operator isn't creating a new pod. Surface
+    // `sandbox-evicted` so the UI shows a targeted "start new sandbox"
+    // prompt rather than making the user wait the full 90s.
+    if (hasExistingClaim) {
+      staleClaimTimer = setTimeout(async () => {
+        if (claimSeen || settled) return;
+        try {
+          await onStaleClaim?.();
+        } catch {
+          /* swallow — cleanup failure doesn't block the user-visible flow */
+        }
+        // Re-check after the async cleanup to guard against a concurrent settle.
+        if (settled) return;
+        await writeSse(stream, {
+          event: "phase",
+          data: {
+            kind: "failed",
+            reason: "sandbox-evicted",
+            message:
+              "The sandbox is no longer running. The underlying pod may have been removed.",
+          },
+        }).catch(() => {});
+        settle(false);
+      }, STALE_CLAIM_DETECTION_MS);
+    }
 
     const onAbort = () => settle(false);
     signal.addEventListener("abort", onAbort, { once: true });
@@ -347,9 +440,7 @@ async function emitLifecycle(args: {
     handle = subscribeLifecycle(runner, claimName, (phase) => {
       if (settled) return;
       if (phase.kind !== "claiming") claimSeen = true;
-      stream
-        .writeSSE({ event: "phase", data: JSON.stringify(phase) })
-        .catch(() => {});
+      writeSse(stream, { event: "phase", data: phase }).catch(() => {});
       if (phase.kind === "ready") settle(true);
       else if (phase.kind === "failed") settle(false);
     });
@@ -385,7 +476,7 @@ const PROXY_OPEN_RETRY_DELAY_MS = 500;
  * existing error state.
  */
 async function proxyDaemonEvents(args: {
-  stream: import("hono/streaming").SSEStreamingApi;
+  stream: SSEStreamingApi;
   runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
   claimName: string;
   signal: AbortSignal;
@@ -418,16 +509,14 @@ async function proxyDaemonEvents(args: {
         continue;
       }
       const message = err instanceof Error ? err.message : String(err);
-      await stream
-        .writeSSE({
-          event: "phase",
-          data: JSON.stringify({
-            kind: "failed",
-            reason: "unknown",
-            message: `Upstream daemon SSE error: ${message}`,
-          } satisfies ClaimPhase),
-        })
-        .catch(() => {});
+      await writeSse(stream, {
+        event: "phase",
+        data: {
+          kind: "failed",
+          reason: "unknown",
+          message: `Upstream daemon SSE error: ${message}`,
+        },
+      }).catch(() => {});
       return;
     }
 
@@ -443,7 +532,7 @@ async function proxyDaemonEvents(args: {
       }
       // Budget elapsed and handle still missing — genuine eviction. Emit
       // `gone` so the client's self-heal (VM_START) takes over.
-      await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+      await writeSse(stream, { event: "gone" }).catch(() => {});
       return;
     }
 
@@ -453,16 +542,14 @@ async function proxyDaemonEvents(args: {
       } catch {
         /* ignore */
       }
-      await stream
-        .writeSSE({
-          event: "phase",
-          data: JSON.stringify({
-            kind: "failed",
-            reason: "unknown",
-            message: `Upstream daemon SSE failed (${attempt.status}).`,
-          } satisfies ClaimPhase),
-        })
-        .catch(() => {});
+      await writeSse(stream, {
+        event: "phase",
+        data: {
+          kind: "failed",
+          reason: "unknown",
+          message: `Upstream daemon SSE failed (${attempt.status}).`,
+        },
+      }).catch(() => {});
       return;
     }
 

--- a/apps/mesh/src/web/components/vm/env/env.tsx
+++ b/apps/mesh/src/web/components/vm/env/env.tsx
@@ -170,19 +170,28 @@ export function EnvContent({ daemonOpen = false }: { daemonOpen?: boolean }) {
 
   const vmEvents = useVmEvents();
 
+  // A terminal `sandbox-evicted` phase means the sandbox is gone and the user
+  // must manually start a new one. Treat it as idle so the Run button appears,
+  // regardless of whether vmData still has a stale entry.
+  const isEvicted =
+    vmEvents.phase?.kind === "failed" &&
+    vmEvents.phase.reason === "sandbox-evicted";
+
   const vmStartPending = useIsVmStartPending(
     inset?.entity?.id,
     currentBranch ?? undefined,
   );
   const derivedStatus: ViewStatus = vmEvents.suspended
     ? "suspended"
-    : vmEvents.notFound
-      ? "creating"
-      : vmData
-        ? "running"
-        : vmStartPending
-          ? "creating"
-          : "idle";
+    : isEvicted
+      ? "idle"
+      : vmEvents.notFound
+        ? "creating"
+        : vmData
+          ? "running"
+          : vmStartPending
+            ? "creating"
+            : "idle";
   const status: ViewStatus = override ?? derivedStatus;
 
   // Clear the override when the derived state catches up.
@@ -330,6 +339,10 @@ export function EnvContent({ daemonOpen = false }: { daemonOpen?: boolean }) {
     scriptsAppliedRef.current = false;
     setOpenScriptTabs([]);
     setActiveTab("setup");
+    // Reconnect the SSE so lifecycle events from the new sandbox are received.
+    // Required after a terminal `failed` phase (e.g. sandbox-evicted) which
+    // permanently closes the stream until resetConnection() is called.
+    vmEvents.resetConnection();
 
     try {
       if (!inset?.entity) throw new Error("No virtual MCP context");
@@ -452,6 +465,12 @@ export function EnvContent({ daemonOpen = false }: { daemonOpen?: boolean }) {
                 className="text-muted-foreground shrink-0"
               />
             </a>
+          )}
+
+          {isEvicted && (
+            <p className="text-xs text-muted-foreground text-center">
+              Sandbox was removed. Start a new one to continue.
+            </p>
           )}
 
           <div className="flex flex-wrap items-end justify-between gap-2 w-full">

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -8,9 +8,9 @@
  *   1. `event: phase` — `ClaimPhase` JSON for the pre-Ready lifecycle.
  *      Surfaces what's happening between VM_START posting a SandboxClaim
  *      and the daemon coming online (capacity wait, image pull, etc).
- *   2. `event: log/status/scripts/processes/reload/branch-status` — passthrough
- *      from the in-pod daemon's `/_decopilot_vm/events`. Same wire format the
- *      browser used to consume directly.
+ *   2. `event: log|status|scripts|tasks|intent|phases|branch-status|transition`
+ *      — passthrough from the in-pod daemon's `/_decopilot_vm/events`. Event
+ *      types are defined in `@decocms/sandbox/daemon` (DaemonEventMap).
  *
  *   3. `event: gone` — synthetic. Mesh's upstream daemon fetch returned 404
  *      (sandbox handle missing → operator-evicted on idle TTL). Mapped to
@@ -38,34 +38,20 @@ import type {
 
 export type { ClaimFailureReason, ClaimPhase };
 
-import type { UpstreamStatus } from "../upstream-status";
-export type { UpstreamStatus };
+import type {
+  BranchStatus,
+  BranchStatusReady,
+  DaemonEventType,
+  UpstreamStatus,
+} from "@decocms/sandbox/daemon";
+
+export type { BranchStatus, BranchStatusReady, UpstreamStatus };
 
 export interface VmStatus {
   status: UpstreamStatus;
   port: number | null;
   htmlSupport: boolean;
 }
-
-export interface BranchStatusReady {
-  kind: "ready";
-  branch: string;
-  base: string;
-  workingTreeDirty: boolean;
-  unpushed: number;
-  aheadOfBase: number;
-  behindBase: number;
-  /** HEAD sha (falls back to origin/<branch>). Empty if the daemon couldn't compute it. */
-  headSha: string;
-}
-
-export type BranchStatus =
-  | { kind: "initializing" }
-  | { kind: "cloning" }
-  | { kind: "clone-failed"; error: string }
-  | { kind: "checking-out"; to: string }
-  | { kind: "checkout-failed"; error: string }
-  | BranchStatusReady;
 
 export type ChunkHandler = (source: string, data: string) => void;
 export type ReloadHandler = () => void;
@@ -93,6 +79,13 @@ export interface VmEventsValue {
   subscribeChunks: (handler: ChunkHandler) => () => void;
   /** "reload" SSE fires on config edits framework HMR doesn't watch. */
   subscribeReload: (handler: ReloadHandler) => () => void;
+  /**
+   * Force-reconnect the SSE stream. Call after manually triggering VM_START
+   * (e.g. from a "Start new sandbox" retry button) so the new lifecycle
+   * events are received — a terminal `failed` phase closes the connection
+   * permanently until this is called.
+   */
+  resetConnection: () => void;
 }
 
 const DEFAULT_VALUE: VmEventsValue = {
@@ -109,6 +102,7 @@ const DEFAULT_VALUE: VmEventsValue = {
   hasData: () => false,
   subscribeChunks: () => () => {},
   subscribeReload: () => () => {},
+  resetConnection: () => {},
 };
 
 export const VmEventsContext = createContext<VmEventsValue>(DEFAULT_VALUE);
@@ -139,17 +133,16 @@ const SUSPENDED_AFTER_ERROR_MS = 60_000;
 const BASE_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
-const DAEMON_EVENT_TYPES = [
+const DAEMON_EVENT_TYPES: ReadonlyArray<DaemonEventType> = [
   "log",
   "status",
   "scripts",
-  "processes",
   "tasks",
   "intent",
   "phases",
-  "reload",
   "branch-status",
-] as const;
+  "transition",
+];
 
 export function VmEventsProvider({
   virtualMcpId,
@@ -180,6 +173,9 @@ export function VmEventsProvider({
   // Bumped on log chunks so getBuffer/hasData consumers re-render; buffer
   // mutation alone doesn't.
   const [, setLogTick] = useState(0);
+  // Bumped by resetConnection() to force the SSE effect to re-run and
+  // re-establish the connection after a terminal failure + manual retry.
+  const [connectionKey, setConnectionKey] = useState(0);
 
   const buffers = useRef(new Map<string, ChunkBuffer>());
   const chunkHandlers = useRef(new Set<ChunkHandler>());
@@ -197,7 +193,7 @@ export function VmEventsProvider({
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — SSE subscription lifecycle requires cleanup on unmount; single EventSource with reconnect logic
   useEffect(() => {
-    // Reset on key change so stale data doesn't linger across branches.
+    // Reset on key change so stale data doesn't linger across branches/retries.
     setPhase(null);
     setStatus({ status: "booting", port: null, htmlSupport: false });
     prevPortRef.current = null;
@@ -324,8 +320,6 @@ export function VmEventsProvider({
           }
         } else if (e.type === "scripts") {
           setScripts(data.scripts ?? []);
-        } else if (e.type === "processes") {
-          setActiveProcesses(data.active ?? []);
         } else if (e.type === "tasks") {
           // Daemon's task-manager surface; map to the activeProcesses array
           // of script names so the UI's Run/Restart button can render
@@ -357,14 +351,6 @@ export function VmEventsProvider({
           setInstalling(
             phases.some((p) => p.name === "install" && p.status === "running"),
           );
-        } else if (e.type === "reload") {
-          for (const fn of reloadHandlers.current) {
-            try {
-              fn();
-            } catch {
-              // swallow
-            }
-          }
         } else if (e.type === "branch-status") {
           const kind = String(data.kind ?? "initializing");
           switch (kind) {
@@ -469,7 +455,11 @@ export function VmEventsProvider({
       if (reconnectTimer) clearTimeout(reconnectTimer);
       clearSuspendTimer();
     };
-  }, [virtualMcpId, branch, org.slug]);
+  }, [virtualMcpId, branch, org.slug, connectionKey]);
+
+  const resetConnection = () => {
+    setConnectionKey((k) => k + 1);
+  };
 
   const value: VmEventsValue = {
     phase,
@@ -496,6 +486,7 @@ export function VmEventsProvider({
         reloadHandlers.current.delete(handler);
       };
     },
+    resetConnection,
   };
 
   return <VmEventsContext value={value}>{children}</VmEventsContext>;

--- a/apps/mesh/src/web/components/vm/preview/preview-state.ts
+++ b/apps/mesh/src/web/components/vm/preview/preview-state.ts
@@ -42,17 +42,16 @@ export function computePreviewState(input: PreviewStateInput): PreviewState {
   if (input.suspended || input.appPaused) {
     return { kind: "suspended" };
   }
+  if (input.claimPhase?.kind === "failed" && !input.vmStartPending) {
+    return { kind: "booting" };
+  }
   if (input.notFound) {
     return { kind: "booting" };
   }
   if (!input.previewUrl && input.vmStartPending) {
     return { kind: "booting" };
   }
-  if (
-    !input.previewUrl &&
-    input.claimPhase &&
-    input.claimPhase.kind !== "failed"
-  ) {
+  if (!input.previewUrl && input.claimPhase != null) {
     return { kind: "booting" };
   }
   if (!input.previewUrl) {

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -233,6 +233,7 @@ export function PreviewContent() {
     autoStartedForTaskRef.current = null;
     reprovisionedForVmIdRef.current = null;
     startVm.reset();
+    vmEvents.resetConnection();
     triggerStartRef.current("auto-start");
   };
 
@@ -451,7 +452,9 @@ export function PreviewContent() {
               scripts={vmEvents.scripts}
               activeProcesses={vmEvents.activeProcesses}
               onViewLogs={openEnv}
-              claimPhase={previewUrl ? null : claimPhase}
+              claimPhase={
+                previewUrl && claimPhase?.kind !== "failed" ? null : claimPhase
+              }
               onRetry={retryAutoStart}
             />
           </div>

--- a/apps/mesh/src/web/components/vm/upstream-status.ts
+++ b/apps/mesh/src/web/components/vm/upstream-status.ts
@@ -1,5 +1,1 @@
-/**
- * Upstream HTTP probe status emitted by the daemon over SSE.
- * Mirrors the daemon's `UpstreamStatus` (packages/sandbox/daemon/probe.ts).
- */
-export type UpstreamStatus = "booting" | "online" | "offline";
+export type { UpstreamStatus } from "@decocms/sandbox/daemon";

--- a/apps/mesh/src/web/components/vm/vm-booting-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-booting-state.tsx
@@ -391,6 +391,8 @@ const LIFECYCLE_COPY: Record<
 function failureCopy(phase: Extract<ClaimPhase, { kind: "failed" }>): {
   headline: string;
   body: string;
+  retryLabel?: string;
+  hideViewLogs?: boolean;
 } {
   switch (phase.reason) {
     case "image-pull-backoff":
@@ -412,6 +414,13 @@ function failureCopy(phase: Extract<ClaimPhase, { kind: "failed" }>): {
       return {
         headline: "Sandbox claim was never posted",
         body: phase.message,
+      };
+    case "sandbox-evicted":
+      return {
+        headline: "Sandbox was removed",
+        body: "The sandbox is no longer running. Start a new one to continue.",
+        retryLabel: "Start new sandbox",
+        hideViewLogs: true,
       };
     case "reconciler-error":
       return {
@@ -452,17 +461,19 @@ function ClaimLifecycleView({
             onClick={onRetry}
             className="rounded-md border border-foreground/15 bg-background px-3 py-1.5 text-xs font-medium hover:bg-foreground/[0.04] transition-colors"
           >
-            Try again
+            {copy.retryLabel ?? "Try again"}
           </button>
         )}
-        <button
-          type="button"
-          onClick={onViewLogs}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-200"
-        >
-          <Terminal size={11} />
-          View logs
-        </button>
+        {!copy.hideViewLogs && (
+          <button
+            type="button"
+            onClick={onViewLogs}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-200"
+          >
+            <Terminal size={11} />
+            View logs
+          </button>
+        )}
       </div>
     );
   }

--- a/packages/sandbox/daemon/event-types.ts
+++ b/packages/sandbox/daemon/event-types.ts
@@ -1,0 +1,79 @@
+/**
+ * Wire-format types for the daemon SSE stream at `/_decopilot_vm/events`.
+ *
+ * Pure types — no runtime imports — so type-only consumers (notably the
+ * studio web bundle) can pull them in without dragging daemon runtime deps
+ * through the dependency graph. Follows the same pattern as
+ * `server/runner/lifecycle-types.ts`.
+ *
+ * The daemon byte-pipes these events through mesh's `/api/:org/vm-events` SSE
+ * proxy verbatim, so the same types describe what the browser receives.
+ */
+
+// ---- Shared value types ------------------------------------------------------
+
+export type UpstreamStatus = "booting" | "online" | "offline";
+
+export type BranchStatusReady = {
+  readonly kind: "ready";
+  readonly branch: string;
+  readonly base: string;
+  readonly workingTreeDirty: boolean;
+  readonly unpushed: number;
+  readonly aheadOfBase: number;
+  readonly behindBase: number;
+  /** HEAD sha (falls back to origin/<branch>). Empty if the daemon couldn't compute it. */
+  readonly headSha: string;
+};
+
+export type BranchStatus =
+  | { readonly kind: "initializing" }
+  | { readonly kind: "cloning" }
+  | { readonly kind: "clone-failed"; readonly error: string }
+  | { readonly kind: "checking-out"; readonly to: string }
+  | { readonly kind: "checkout-failed"; readonly error: string }
+  | BranchStatusReady;
+
+export type PhaseStatus = "running" | "done" | "failed";
+
+export interface DaemonPhase {
+  id: string;
+  name: string;
+  status: PhaseStatus;
+  startedAt: number;
+  doneAt: number | null;
+  error?: string;
+}
+
+export interface DaemonTask {
+  id: string;
+  command: string;
+  logName?: string;
+}
+
+// ---- Event payload map (SSE event name → JSON payload shape) -----------------
+
+export interface DaemonEventMap {
+  /** Raw terminal output from a named source (script name, "setup", "daemon"). */
+  log: { source: string; data: string };
+  /** Upstream HTTP probe state — sent on connect and every 15 s as keepalive. */
+  status: { status: UpstreamStatus; port: number | null; htmlSupport: boolean };
+  /** npm/bun/etc scripts discovered in the repo's package.json. */
+  scripts: { scripts: string[] };
+  /** Running task-manager entries (supersedes the legacy `processes` event). */
+  tasks: { active: DaemonTask[] };
+  /** Operator intent: running (normal) or paused (manually stopped). */
+  intent: { state: "running" | "paused"; reason?: string };
+  /** Setup phase transitions (clone, install, config-driven transitions). */
+  phases: { phases: DaemonPhase[] };
+  /** Git branch state from the in-pod watcher. */
+  "branch-status": BranchStatus;
+  /** Config-driven orchestrator transition lifecycle. */
+  transition: {
+    kind: string;
+    phase: "start" | "done" | "failed";
+    error?: string;
+  };
+}
+
+export type DaemonEventType = keyof DaemonEventMap;

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {
@@ -11,6 +11,7 @@
   },
   "exports": {
     "./shared": "./shared.ts",
+    "./daemon": "./daemon/event-types.ts",
     "./runner": "./server/runner/index.ts",
     "./runner/agent-sandbox": "./server/runner/agent-sandbox/index.ts",
     "./runner/freestyle": "./server/runner/freestyle/index.ts"

--- a/packages/sandbox/server/runner/lifecycle-types.ts
+++ b/packages/sandbox/server/runner/lifecycle-types.ts
@@ -18,6 +18,7 @@ export type ClaimFailureReason =
   | "crash-loop-backoff"
   | "scheduling-timeout"
   | "claim-never-created"
+  | "sandbox-evicted"
   | "reconciler-error"
   | "unknown";
 


### PR DESCRIPTION
…tion logic

- Updated event types in `vm-events.ts` to include new daemon events.
- Added `STALE_CLAIM_DETECTION_MS` for improved stale sandbox detection.
- Implemented `writeSse` function for consistent SSE event writing.
- Enhanced UI to handle "sandbox-evicted" phase, prompting users to start a new sandbox.
- Updated `EnvContent` and `PreviewContent` components to reflect new eviction logic and reset SSE connection on retries.
- Refactored `VmEventsProvider` to manage SSE connection resets after terminal failures.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fast sandbox eviction detection and a clearer recovery flow. The app now surfaces a “Sandbox was removed” state and reconnects SSE cleanly after starting a new sandbox.

- New Features
  - Detects stale sandboxes in 30s when a prior claim exists, emitting a terminal phase with reason "sandbox-evicted" (or `gone` for self-heal cases).
  - Env and Preview UIs treat evicted state as idle and show “Start new sandbox”; logs link is hidden for this case.
  - `VmEventsProvider` exposes `resetConnection()` and the UI calls it on retries to re-establish SSE after terminal failures.
  - Expands daemon SSE support to `log|status|scripts|tasks|intent|phases|branch-status|transition`.
  - Adds `@decocms/sandbox/daemon` types; UI consumes `UpstreamStatus`, branch status, and daemon events from there.

- Refactors
  - Consolidated SSE writes with `writeSse()` and unified error emission.
  - Handles runner-kind mismatches when cleaning stale entries; avoids orphaned state.
  - Removes legacy `processes`/`reload` handling in favor of `tasks` and event-driven transitions.
  - Adds `sandbox-evicted` to `ClaimFailureReason`; bumps `@decocms/sandbox` to `0.4.3` and exports `./daemon`.

<sup>Written for commit 059db3a637941402eff212c4fd36232df5c472a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

