### PR TITLE
fix(sandbox): fail-fast on stalled HTTP clones to escape NAT blackholes

### DIFF
--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -47,6 +47,13 @@ const TRANSIENT_ERRORS = [
   "unexpected disconnect",
   "Connection reset by peer",
   "Connection timed out",
+  // libcurl CURLE_OPERATION_TIMEDOUT triggered by http.lowSpeedLimit/Time —
+  // fires when the egress NAT silently drops in-flight packets (e.g. fck-nat
+  // ASG instance refresh) and the stream stalls below the threshold.
+  "Operation too slow",
+  "transfer closed with",
+  "RPC failed",
+  "the remote end hung up",
 ];
 const CLONE_MAX_RETRIES = 3;
 const CLONE_RETRY_DELAY_MS = 3000;

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -44,6 +44,13 @@ RUN pip3 install --break-system-packages --no-cache-dir \
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
+# Convert silent stalls (NAT instance replacement, PMTUD blackholes, mid-stream
+# packet drops) into fast errors that the daemon's clone retry loop can catch.
+# Without this, libcurl waits on TCP keepalive (~2h default) and the clone
+# hangs at "Receiving objects" indefinitely.
+RUN git config --system http.lowSpeedLimit 1000 \
+  && git config --system http.lowSpeedTime 30
+
 # Non-root sandbox user. The bun image comes with a 'bun' user (UID 1000),
 # but we drop privileges further by replacing it with a 'sandbox' user.
 RUN userdel --remove bun \

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## Summary

- Set `http.lowSpeedLimit=1000` / `http.lowSpeedTime=30` in the system git config baked into the sandbox image, so libcurl aborts any clone stream whose throughput drops below ~1 KB/s for 30 s.
- Extend `TRANSIENT_ERRORS` in `packages/sandbox/daemon/setup/clone.ts` with the libcurl/git outputs the new threshold produces (`"Operation too slow"`, `"transfer closed with"`, `"RPC failed"`, `"the remote end hung up"`), so the existing 3-attempt retry loop actually fires on these failures.

## Why

Sandbox pods clone user repositories over HTTPS through fck-nat instances on `eks-decocms` (sa-east-1, three single-instance ASGs, one per AZ). When a NAT instance is replaced (e.g. ASG instance refresh) or otherwise drops in-flight packets, the clone's TCP stream is silently blackholed: the kernel waits on the keepalive default (~2 h) before raising any error, so the user-visible symptom is an indefinite hang at "Receiving objects" with no diagnostic.

Today's investigation against the prod cluster confirmed all three fck-nat instances were replaced via instance refresh between `2026-05-08T17:13Z` and `17:18Z`, which lines up with the reported intermittent failures.

This change converts that silent hang into a fail-fast error within ~30 s. Combined with the retry loop in `clone.ts`, most affected clones will recover transparently. The structural NAT-layer fixes (HA per AZ / Managed NAT Gateway) are tracked separately and require infra/SRE work.

## Test plan

- [ ] Build the sandbox image locally and confirm `git config --system --get http.lowSpeedLimit` returns `1000` and `http.lowSpeedTime` returns `30` inside the container.
- [ ] Smoke-test a normal `git clone --depth 1` of a small repo — completes unchanged.
- [ ] Simulate a stalled stream (`iptables -A OUTPUT -p tcp --sport <github-conn> -j DROP` mid-clone) and verify the clone aborts within ~30 s with `Operation too slow` / `RPC failed`, then the daemon retries and succeeds.
- [ ] Roll the new image through `studio-sandbox` chart bump in stg, monitor `Receiving objects` failure rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sandbox HTTP git clones fail fast by setting image-level low-speed thresholds (`http.lowSpeedLimit=1000`, `http.lowSpeedTime=30`) and treating the resulting curl/git messages as transient so the 3-retry loop kicks in. Bumped `@decocms/sandbox` to 0.4.6 to ship the change; hangs at "Receiving objects" during NAT blackholes now fail in ~30s and auto-retry.

<sup>Written for commit c2a77083e56ad89eacfd8c8419338e95bf6b86c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

