### PR TITLE
[release]: (agent-sandbox): bump controller version to 0.1.1; update …

### DIFF
--- a/deploy/helm/sandbox-operator/Chart.yaml
+++ b/deploy/helm/sandbox-operator/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: sandbox-operator
 description: |
   Pure upstream kubernetes-sigs/agent-sandbox operator + CRDs (vendored —
-  upstream does not publish a Helm chart as of v0.4.2). Installs the
+  upstream does not publish a Helm chart as of v0.4.5). Installs the
   Namespace, ServiceAccount, Deployment, Service, and ClusterRoles /
   ClusterRoleBindings the operator needs. No Studio-specific resources
   live in this chart — see deploy/helm/sandbox-env for those.
 type: application
 # Chart version is independent of upstream agent-sandbox. Bump on any change.
-version: 0.1.0
+version: 0.1.1
 # Tracks the upstream agent-sandbox release pinned by vendor.sh.
-appVersion: "0.4.2"
+appVersion: "0.4.5"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-operator/crds/agent-sandbox-crds.yaml
+++ b/deploy/helm/sandbox-operator/crds/agent-sandbox-crds.yaml
@@ -1,4 +1,4 @@
-# Vendored from kubernetes-sigs/agent-sandbox v0.4.2 via vendor.sh.
+# Vendored from kubernetes-sigs/agent-sandbox v0.4.5 via vendor.sh.
 # Do not edit by hand — re-run vendor.sh to refresh.
 # Contains: CustomResourceDefinition docs only.
 apiVersion: apiextensions.k8s.io/v1
@@ -3955,6 +3955,7 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - podTemplate
             type: object
@@ -4090,6 +4091,10 @@ spec:
                   shutdownTime:
                     format: date-time
                     type: string
+                  ttlSecondsAfterFinished:
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               sandboxTemplateRef:
                 properties:
@@ -8189,6 +8194,115 @@ spec:
                 required:
                 - spec
                 type: object
+              volumeClaimTemplates:
+                items:
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                      type: object
+                    spec:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        dataSource:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          type: string
+                        volumeAttributesClassName:
+                          type: string
+                        volumeMode:
+                          type: string
+                        volumeName:
+                          type: string
+                      type: object
+                  required:
+                  - spec
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             required:
             - podTemplate
             type: object

--- a/deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml
+++ b/deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml
@@ -1,4 +1,4 @@
-# Vendored from kubernetes-sigs/agent-sandbox v0.4.2 via vendor.sh.
+# Vendored from kubernetes-sigs/agent-sandbox v0.4.5 via vendor.sh.
 # Do not edit by hand — re-run vendor.sh to refresh.
 # Contains: controller Deployments, RBAC, Namespace, Service, ServiceAccount.
 #
@@ -86,7 +86,7 @@ spec:
       serviceAccountName: agent-sandbox-controller
       containers:
       - name: agent-sandbox-controller
-        image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.2
+        image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.5
         args:
         - --leader-elect=true
         - --extensions
@@ -167,8 +167,6 @@ rules:
   resources:
   - pods
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/deploy/helm/sandbox-operator/vendor.sh
+++ b/deploy/helm/sandbox-operator/vendor.sh
@@ -16,10 +16,10 @@
 #   3. Verify the values out-of-band (release notes, signatures if any).
 #   4. Add the entry to KNOWN_CHECKSUMS, commit, re-run.
 #
-# Usage: ./vendor.sh [vX.Y.Z]   (default v0.4.2 — must match appVersion)
+# Usage: ./vendor.sh [vX.Y.Z]   (default v0.4.5 — must match appVersion)
 set -euo pipefail
 
-UPSTREAM_VERSION="${1:-v0.4.2}"
+UPSTREAM_VERSION="${1:-v0.4.5}"
 REPO="kubernetes-sigs/agent-sandbox"
 
 # Pinned sha256 digests for `${VERSION}:${ASSET}`. Keep entries sorted by
@@ -28,6 +28,8 @@ REPO="kubernetes-sigs/agent-sandbox"
 declare -A KNOWN_CHECKSUMS=(
   ["v0.4.2:manifest.yaml"]="93cb43a90b9093c84a7529a7dbeca409fcd944746df00b52e8a2781c237c6e18"
   ["v0.4.2:extensions.yaml"]="6ddcd6ce2d78714a5815d4c4304df858a075e0ed8fee971966b31af548c011bb"
+  ["v0.4.5:manifest.yaml"]="3489f6f47692941648450afc898aee8a8fde25e3d10d41d4b39daf59a8835094"
+  ["v0.4.5:extensions.yaml"]="3da56243138ea68f7b0604d38ba37bd052a9acb48e3ea55830942575fe151ce8"
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
…appVersion to 0.4.5

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `sandbox-operator` chart v0.1.1 with upstream `kubernetes-sigs/agent-sandbox` v0.4.5. Bumps controller image, updates CRDs (adds `ttlSecondsAfterFinished` and `volumeClaimTemplates`), aligns RBAC with upstream (drops pod create/delete), and refreshes `vendor.sh` defaults/checksums.

<sup>Written for commit 226cc067ebd27727fb45fa46ff737bd13b197ce4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

