### PR TITLE
Refactor/sandbox daemon lifecycle

### DIFF
--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -19,6 +19,7 @@ import { createTriggerCallbackRoutes } from "./trigger-callback";
 import { createVirtualMcpRoutes } from "./virtual-mcp";
 import { createVmEventsRoutes } from "./vm-events";
 import { createVmExecRoutes } from "./vm-exec";
+import { createVmSetupRoutes } from "./vm-setup";
 
 interface OrgScopedDeps {
   kvStorage: KVStorage;
@@ -65,6 +66,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/", createKVRoutes({ kvStorage: deps.kvStorage }));
   app.route("/vm-events", createVmEventsRoutes()); // /api/:org/vm-events
   app.route("/vm-exec", createVmExecRoutes()); // /api/:org/vm-exec/{exec,kill}/:script
+  app.route("/vm-setup", createVmSetupRoutes()); // /api/:org/vm-setup/:step
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites
   app.route("/sso", createSsoRoutes()); // /api/:org/sso/* (renamed from /api/org-sso)
   app.route(

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -8,7 +8,7 @@
  *      VM_START posting a SandboxClaim and the daemon coming online.
  *      Agent-sandbox runner emits real K8s phases; other runners emit a
  *      single synthetic `ready`.
- *   2. Daemon events (`event: log|status|scripts|processes|reload|branch-status`)
+ *   2. Daemon events (`event: log|lifecycle|status|tasks|scripts|branch|reload`)
  *      — proxied from the in-pod daemon's `/_decopilot_vm/events` SSE once
  *      lifecycle reaches `ready`. Wire format is preserved verbatim by raw
  *      byte-piping the upstream body, so daemon and client speak the same

--- a/apps/mesh/src/api/routes/vm-setup.ts
+++ b/apps/mesh/src/api/routes/vm-setup.ts
@@ -1,0 +1,126 @@
+/**
+ * Browser-facing retry proxy for the daemon's setup pipeline.
+ *
+ * The daemon exposes `POST /_decopilot_vm/setup/{clone,install,start}` to
+ * resume the setup pipeline from a named step. Like the other mutating
+ * `/_decopilot_vm/*` routes, those require `Authorization: Bearer
+ * <DAEMON_TOKEN>`, which the browser doesn't hold — so retry buttons in the
+ * env panel route through here. We authenticate the user, derive their claim
+ * handle the same way `vm-events.ts` does, and forward through
+ * `runner.proxyDaemonRequest`, which injects the bearer inside the runner.
+ */
+
+import { Hono } from "hono";
+import { composeSandboxRef } from "@decocms/sandbox/runner";
+import { computeClaimHandle } from "../../sandbox/claim-handle";
+import { getOrInitSharedRunner } from "../../sandbox/lifecycle";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "../../core/mesh-context";
+import type { Env } from "../hono-env";
+
+const SETUP_STEPS = ["clone", "install", "start"] as const;
+type SetupStep = (typeof SETUP_STEPS)[number];
+
+function isSetupStep(value: string): value is SetupStep {
+  return (SETUP_STEPS as readonly string[]).includes(value);
+}
+
+export const createVmSetupRoutes = () => {
+  const app = new Hono<Env>();
+
+  app.post("/:step", async (c) => {
+    const ctx = c.var.meshContext;
+    try {
+      requireAuth(ctx);
+    } catch {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    const userId = getUserId(ctx);
+    if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+    let organization: ReturnType<typeof requireOrganization>;
+    try {
+      organization = requireOrganization(ctx);
+    } catch {
+      return c.json({ error: "Organization scope required" }, 403);
+    }
+
+    const step = c.req.param("step");
+    if (!step || !isSetupStep(step)) {
+      return c.json(
+        {
+          error: `step must be one of: ${SETUP_STEPS.join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const virtualMcpId = c.req.query("virtualMcpId");
+    const branch = c.req.query("branch");
+    if (!virtualMcpId || !branch) {
+      return c.json({ error: "virtualMcpId and branch are required" }, 400);
+    }
+
+    const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      return c.json({ error: "Virtual MCP not found" }, 404);
+    }
+
+    const projectRef = composeSandboxRef({
+      orgId: organization.id,
+      virtualMcpId,
+      branch,
+    });
+    const claimName = computeClaimHandle({ userId, projectRef }, branch);
+
+    const runner = await getOrInitSharedRunner();
+    if (!runner) {
+      return c.json({ error: "No sandbox runner configured" }, 503);
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await runner.proxyDaemonRequest(
+        claimName,
+        `/_decopilot_vm/setup/${step}`,
+        {
+          method: "POST",
+          headers: new Headers(),
+          body: null,
+          signal: c.req.raw.signal,
+        },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: `Daemon unreachable: ${message}` }, 502);
+    }
+
+    if (upstream.status === 404) {
+      try {
+        await upstream.body?.cancel();
+      } catch {
+        /* ignore */
+      }
+      return c.json(
+        {
+          error:
+            "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
+        },
+        410,
+      );
+    }
+
+    const body = await upstream.text();
+    const contentType =
+      upstream.headers.get("content-type") ?? "application/json";
+    return new Response(body, {
+      status: upstream.status,
+      headers: { "content-type": contentType },
+    });
+  });
+
+  return app;
+};

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type {
-  BranchStatus,
-  BranchStatusReady,
-} from "@/web/components/vm/hooks/use-vm-events";
+import type { BranchStatus, BranchStatusReady } from "./use-branch-status";
 import { selectHeaderButton } from "./panel-state";
 import type { CheckRun, PrSummary } from "./use-pr-data";
 import type { PrReviewSignals } from "./use-pr-reviews";

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -1,4 +1,4 @@
-import type { BranchStatus } from "@/web/components/vm/hooks/use-vm-events";
+import type { BranchStatus } from "./use-branch-status";
 import type { CheckRun, PrSummary } from "./use-pr-data.ts";
 import type { PrReviewSignals } from "./use-pr-reviews.ts";
 

--- a/apps/mesh/src/web/components/thread/github/use-branch-status.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branch-status.ts
@@ -1,16 +1,65 @@
 import {
   useVmEvents,
-  type BranchStatus,
+  type BranchMeta,
+  type LifecycleState,
 } from "@/web/components/vm/hooks/use-vm-events";
 
+export type BranchStatusReady = {
+  kind: "ready";
+  branch: string;
+  base: string;
+  workingTreeDirty: boolean;
+  unpushed: number;
+  aheadOfBase: number;
+  behindBase: number;
+  headSha: string;
+};
+
+export type BranchStatus =
+  | { kind: "initializing" }
+  | { kind: "cloning" }
+  | { kind: "clone-failed"; error: string }
+  | { kind: "checking-out"; to: string }
+  | { kind: "checkout-failed"; error: string }
+  | BranchStatusReady;
+
 /**
- * useBranchStatus — returns the VM daemon's latest branch-status snapshot
- * as tracked by the shared VmEventsProvider. Returns null when the VM is
- * not connected.
+ * useBranchStatus — projects the daemon's split lifecycle/branch streams
+ * into the legacy `BranchStatus` shape consumed by the GitHub panel.
  *
- * The previous version opened its own EventSource per call; the provider
- * model means consumers share one connection.
+ * The daemon now emits two separate events: `lifecycle` (phase tracking
+ * including cloning/checking-out/etc.) and `branch` (git metadata when
+ * ready). This hook unifies them so the panel can switch on a single value.
  */
 export function useBranchStatus(): BranchStatus | null {
-  return useVmEvents().branchStatus;
+  const { lifecycle, branch } = useVmEvents();
+  return deriveBranchStatus(lifecycle, branch);
+}
+
+function deriveBranchStatus(
+  lifecycle: LifecycleState,
+  branch: BranchMeta,
+): BranchStatus | null {
+  // Lifecycle drives the pre-ready states the panel cares about.
+  switch (lifecycle.phase) {
+    case "idle":
+      // Pre-config: nothing's happened yet.
+      return { kind: "initializing" };
+    case "cloning":
+      return { kind: "cloning" };
+    case "clone-failed":
+      // Daemon collapses checkout failures into clone-failed; the panel's
+      // checkout-failed branch is unreachable but kept for type stability.
+      return { kind: "clone-failed", error: lifecycle.error };
+    case "checking-out":
+      return { kind: "checking-out", to: lifecycle.to };
+  }
+
+  // Past clone/checkout — install/start phases don't belong to the GitHub
+  // panel, so we surface branch metadata once it's available.
+  if (branch.kind === "ready") return branch;
+
+  // Mid-pipeline (installing/starting/running/...) but branch hasn't been
+  // computed yet. Treat as initializing so the panel shows a loading pill.
+  return { kind: "initializing" };
 }

--- a/apps/mesh/src/web/components/vm/hooks/use-vm-events.ts
+++ b/apps/mesh/src/web/components/vm/hooks/use-vm-events.ts
@@ -8,11 +8,11 @@ import {
 } from "./vm-events-context.tsx";
 
 export type {
-  BranchStatus,
-  BranchStatusReady,
+  BranchMeta,
   ChunkHandler,
+  DaemonStatus,
+  LifecycleState,
   ReloadHandler,
-  VmStatus,
 } from "./vm-events-context.tsx";
 
 export function useVmEvents() {

--- a/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
+++ b/apps/mesh/src/web/components/vm/hooks/vm-events-context.tsx
@@ -8,9 +8,9 @@
  *   1. `event: phase` — `ClaimPhase` JSON for the pre-Ready lifecycle.
  *      Surfaces what's happening between VM_START posting a SandboxClaim
  *      and the daemon coming online (capacity wait, image pull, etc).
- *   2. `event: log/status/scripts/processes/reload/branch-status` — passthrough
- *      from the in-pod daemon's `/_decopilot_vm/events`. Same wire format the
- *      browser used to consume directly.
+ *   2. Daemon events (`event: log|lifecycle|status|tasks|scripts|branch|reload`) —
+ *      passthrough from the in-pod daemon's `/_decopilot_vm/events`. Types
+ *      come from `@decocms/sandbox/shared`.
  *
  *   3. `event: gone` — synthetic. Mesh's upstream daemon fetch returned 404
  *      (sandbox handle missing → operator-evicted on idle TTL). Mapped to
@@ -38,34 +38,15 @@ import type {
 
 export type { ClaimFailureReason, ClaimPhase };
 
-import type { UpstreamStatus } from "../upstream-status";
-export type { UpstreamStatus };
+import type {
+  BranchMeta,
+  DaemonEventName,
+  DaemonEventPayload,
+  DaemonStatus,
+  LifecycleState,
+} from "@decocms/sandbox/shared";
 
-export interface VmStatus {
-  status: UpstreamStatus;
-  port: number | null;
-  htmlSupport: boolean;
-}
-
-export interface BranchStatusReady {
-  kind: "ready";
-  branch: string;
-  base: string;
-  workingTreeDirty: boolean;
-  unpushed: number;
-  aheadOfBase: number;
-  behindBase: number;
-  /** HEAD sha (falls back to origin/<branch>). Empty if the daemon couldn't compute it. */
-  headSha: string;
-}
-
-export type BranchStatus =
-  | { kind: "initializing" }
-  | { kind: "cloning" }
-  | { kind: "clone-failed"; error: string }
-  | { kind: "checking-out"; to: string }
-  | { kind: "checkout-failed"; error: string }
-  | BranchStatusReady;
+export type { BranchMeta, DaemonStatus, LifecycleState };
 
 export type ChunkHandler = (source: string, data: string) => void;
 export type ReloadHandler = () => void;
@@ -79,15 +60,17 @@ export interface VmEventsValue {
    * present).
    */
   phase: ClaimPhase | null;
-  status: VmStatus;
+  /** Daemon's setup pipeline state. Drives retry UI. */
+  lifecycle: LifecycleState;
+  /** Daemon's operational state (running / paused / error). */
+  status: DaemonStatus;
+  /** Git metadata (branch, dirty, divergence). `unknown` until the first compute. */
+  branch: BranchMeta;
   suspended: boolean;
   /** True after a `gone` event — handle gone, reprovision via VM_START. */
   notFound: boolean;
   scripts: string[];
   activeProcesses: string[];
-  intent: { state: "running" | "paused"; reason?: string };
-  installing: boolean;
-  branchStatus: BranchStatus | null;
   getBuffer: (source: string) => string;
   hasData: (source: string) => boolean;
   subscribeChunks: (handler: ChunkHandler) => () => void;
@@ -97,14 +80,13 @@ export interface VmEventsValue {
 
 const DEFAULT_VALUE: VmEventsValue = {
   phase: null,
-  status: { status: "booting", port: null, htmlSupport: false },
+  lifecycle: { phase: "idle" },
+  status: { state: "running" },
+  branch: { kind: "unknown" },
   suspended: false,
   notFound: false,
   scripts: [],
   activeProcesses: [],
-  intent: { state: "running" },
-  installing: false,
-  branchStatus: null,
   getBuffer: () => "",
   hasData: () => false,
   subscribeChunks: () => () => {},
@@ -139,17 +121,16 @@ const SUSPENDED_AFTER_ERROR_MS = 60_000;
 const BASE_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
-const DAEMON_EVENT_TYPES = [
-  "log",
+const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
+  "lifecycle",
   "status",
-  "scripts",
-  "processes",
   "tasks",
-  "intent",
-  "phases",
+  "scripts",
+  "branch",
   "reload",
-  "branch-status",
 ] as const;
+// `log` is broadcast separately — same SSE stream, different shape.
+const LOG_EVENT = "log" as const;
 
 export function VmEventsProvider({
   virtualMcpId,
@@ -162,21 +143,13 @@ export function VmEventsProvider({
 }) {
   const { org } = useProjectContext();
   const [phase, setPhase] = useState<ClaimPhase | null>(null);
-  const [status, setStatus] = useState<VmStatus>({
-    status: "booting",
-    port: null,
-    htmlSupport: false,
-  });
+  const [lifecycle, setLifecycle] = useState<LifecycleState>({ phase: "idle" });
+  const [status, setStatus] = useState<DaemonStatus>({ state: "running" });
+  const [branchMeta, setBranchMeta] = useState<BranchMeta>({ kind: "unknown" });
   const [suspended, setSuspended] = useState(false);
   const [notFound, setNotFound] = useState(false);
   const [scripts, setScripts] = useState<string[]>([]);
   const [activeProcesses, setActiveProcesses] = useState<string[]>([]);
-  const [intent, setIntent] = useState<{
-    state: "running" | "paused";
-    reason?: string;
-  }>({ state: "running" });
-  const [installing, setInstalling] = useState(false);
-  const [branchStatus, setBranchStatus] = useState<BranchStatus | null>(null);
   // Bumped on log chunks so getBuffer/hasData consumers re-render; buffer
   // mutation alone doesn't.
   const [, setLogTick] = useState(0);
@@ -199,15 +172,14 @@ export function VmEventsProvider({
   useEffect(() => {
     // Reset on key change so stale data doesn't linger across branches.
     setPhase(null);
-    setStatus({ status: "booting", port: null, htmlSupport: false });
+    setLifecycle({ phase: "idle" });
+    setStatus({ state: "running" });
+    setBranchMeta({ kind: "unknown" });
     prevPortRef.current = null;
     setSuspended(false);
     setNotFound(false);
     setScripts([]);
     setActiveProcesses([]);
-    setIntent({ state: "running" });
-    setInstalling(false);
-    setBranchStatus(null);
     buffers.current.clear();
 
     if (!virtualMcpId || !branch) return;
@@ -239,7 +211,7 @@ export function VmEventsProvider({
       }
     };
 
-    const handlePhase = (e: MessageEvent) => {
+    const handleClaimPhase = (e: MessageEvent) => {
       try {
         const next = JSON.parse(e.data) as ClaimPhase;
         setPhase(next);
@@ -261,59 +233,81 @@ export function VmEventsProvider({
     const handleGone = () => {
       // The sandbox is gone (idle-evicted, VM_DELETE'd, or its pod terminated
       // and mesh has stopped finding the handle). Everything we've cached is
-      // about to be stale, so reset:
-      //   - phase: residual state would otherwise keep `lifecycleActive`
-      //     stuck on "Almost ready" in the booting overlay even though
-      //     nothing is starting.
-      //   - status / scripts / processes / branchStatus / log buffers: these
-      //     describe a sandbox that no longer exists. Resetting to "booting"
-      //     ensures the next provisioned sandbox goes through the boot flow.
-      // `notFound = true` then drives preview.tsx's self-heal flow when a
-      // vmEntry exists; the empty "Start Server" state when it doesn't.
+      // about to be stale, so reset.
       setNotFound(true);
       setPhase(null);
-      setStatus({ status: "booting", port: null, htmlSupport: false });
+      setLifecycle({ phase: "idle" });
+      setStatus({ state: "running" });
+      setBranchMeta({ kind: "unknown" });
       setScripts([]);
       setActiveProcesses([]);
-      setIntent({ state: "running" });
-      setInstalling(false);
-      setBranchStatus(null);
       buffers.current.clear();
     };
 
-    const handleDaemonEvent = (e: MessageEvent) => {
+    const handleLog = (e: MessageEvent) => {
       try {
-        const data = JSON.parse(e.data);
-
-        if (e.type === "log" && typeof data.data === "string") {
-          const source = data.source as string;
-          // xterm.js reads bare `\n` as "cursor down, keep column" — normalize.
-          const normalized = data.data.replace(/\r?\n/g, "\r\n");
-          getOrCreateBuffer(source).append(normalized);
-          for (const fn of chunkHandlers.current) {
-            try {
-              fn(source, normalized);
-            } catch {
-              // swallow — one broken subscriber shouldn't break others
-            }
+        const data = JSON.parse(e.data) as { source: string; data: string };
+        if (typeof data.data !== "string") return;
+        // xterm.js reads bare `\n` as "cursor down, keep column" — normalize.
+        const normalized = data.data.replace(/\r?\n/g, "\r\n");
+        getOrCreateBuffer(data.source).append(normalized);
+        for (const fn of chunkHandlers.current) {
+          try {
+            fn(data.source, normalized);
+          } catch {
+            // swallow
           }
-          setLogTick((t) => t + 1);
-        } else if (e.type === "status") {
-          const s = data.status;
-          const newPort = typeof data.port === "number" ? data.port : null;
-          const prevPort = prevPortRef.current;
-          prevPortRef.current = newPort;
-          setStatus({
-            status:
-              s === "online" || s === "offline" || s === "booting"
-                ? s
-                : "booting",
-            port: newPort,
-            htmlSupport: Boolean(data.htmlSupport),
-          });
-          // Proxy retargeted to a different active port — the iframe is stuck on
-          // whatever page it last loaded. Force-reload so it picks up the new backend.
-          if (prevPort !== null && newPort !== null && prevPort !== newPort) {
+        }
+        setLogTick((t) => t + 1);
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    const handleDaemonEvent = (e: MessageEvent) => {
+      const name = e.type as DaemonEventName;
+      try {
+        const payload = JSON.parse(e.data);
+        switch (name) {
+          case "lifecycle": {
+            const lp = payload as DaemonEventPayload<"lifecycle">;
+            setLifecycle(lp.state);
+            // Detect dev server port change (running phase carries port);
+            // reload iframe so it picks up the new backend.
+            const newPort = lp.state.phase === "running" ? lp.state.port : null;
+            const prev = prevPortRef.current;
+            prevPortRef.current = newPort;
+            if (prev !== null && newPort !== null && prev !== newPort) {
+              for (const fn of reloadHandlers.current) {
+                try {
+                  fn();
+                } catch {
+                  // swallow
+                }
+              }
+            }
+            return;
+          }
+          case "status":
+            setStatus(payload as DaemonEventPayload<"status">);
+            return;
+          case "tasks": {
+            const tp = payload as DaemonEventPayload<"tasks">;
+            // Map active task `logName`s to the activeProcesses array so the
+            // UI's Run/Restart button can render against running script tabs.
+            const active = tp.active
+              .map((j) => j.logName ?? "")
+              .filter(Boolean);
+            setActiveProcesses(active);
+            return;
+          }
+          case "scripts":
+            setScripts((payload as DaemonEventPayload<"scripts">).scripts);
+            return;
+          case "branch":
+            setBranchMeta((payload as DaemonEventPayload<"branch">).meta);
+            return;
+          case "reload":
             for (const fn of reloadHandlers.current) {
               try {
                 fn();
@@ -321,94 +315,7 @@ export function VmEventsProvider({
                 // swallow
               }
             }
-          }
-        } else if (e.type === "scripts") {
-          setScripts(data.scripts ?? []);
-        } else if (e.type === "processes") {
-          setActiveProcesses(data.active ?? []);
-        } else if (e.type === "tasks") {
-          // Daemon's task-manager surface; map to the activeProcesses array
-          // of script names so the UI's Run/Restart button can render
-          // against running script tabs. Match on `logName` — set by
-          // /exec/<name> via the spec — instead of regex-parsing `command`,
-          // which breaks for any task with trailing args (e.g. `bun run
-          // format -- --fix`).
-          const active = Array.isArray(data.active)
-            ? (data.active as Array<{ logName?: string }>)
-                .map((j) => j?.logName ?? "")
-                .filter(Boolean)
-            : [];
-          setActiveProcesses(active);
-        } else if (e.type === "intent") {
-          const next = data as {
-            state?: "running" | "paused";
-            reason?: string;
-          };
-          if (next.state === "running" || next.state === "paused") {
-            setIntent({ state: next.state, reason: next.reason });
-          }
-        } else if (e.type === "phases") {
-          const phases =
-            (
-              data as {
-                phases?: Array<{ name: string; status: string }>;
-              }
-            ).phases ?? [];
-          setInstalling(
-            phases.some((p) => p.name === "install" && p.status === "running"),
-          );
-        } else if (e.type === "reload") {
-          for (const fn of reloadHandlers.current) {
-            try {
-              fn();
-            } catch {
-              // swallow
-            }
-          }
-        } else if (e.type === "branch-status") {
-          const kind = String(data.kind ?? "initializing");
-          switch (kind) {
-            case "ready":
-              setBranchStatus({
-                kind: "ready",
-                branch: String(data.branch ?? ""),
-                base: String(data.base ?? "main"),
-                workingTreeDirty: Boolean(data.workingTreeDirty),
-                unpushed: Number(data.unpushed ?? 0),
-                aheadOfBase: Number(data.aheadOfBase ?? 0),
-                behindBase: Number(data.behindBase ?? 0),
-                headSha: String(data.headSha ?? ""),
-              });
-              break;
-            case "initializing":
-              setBranchStatus({ kind: "initializing" });
-              break;
-            case "cloning":
-              setBranchStatus({ kind: "cloning" });
-              break;
-            case "clone-failed":
-              setBranchStatus({
-                kind: "clone-failed",
-                error: String(data.error ?? ""),
-              });
-              break;
-            case "checkout-failed":
-              setBranchStatus({
-                kind: "checkout-failed",
-                error: String(data.error ?? ""),
-              });
-              break;
-            case "checking-out":
-              setBranchStatus({
-                kind: "checking-out",
-                to: String(data.to ?? ""),
-              });
-              break;
-            default:
-              console.warn("[vm-events] unknown branch-status kind:", kind);
-              setBranchStatus({ kind: "initializing" });
-              break;
-          }
+            return;
         }
       } catch {
         // ignore parse errors
@@ -437,8 +344,9 @@ export function VmEventsProvider({
         scheduleReconnect();
       };
 
-      es.addEventListener("phase", handlePhase);
+      es.addEventListener("phase", handleClaimPhase);
       es.addEventListener("gone", handleGone);
+      es.addEventListener(LOG_EVENT, handleLog);
       for (const type of DAEMON_EVENT_TYPES) {
         es.addEventListener(type, handleDaemonEvent);
       }
@@ -473,14 +381,13 @@ export function VmEventsProvider({
 
   const value: VmEventsValue = {
     phase,
+    lifecycle,
     status,
+    branch: branchMeta,
     suspended,
     notFound,
     scripts,
     activeProcesses,
-    intent,
-    installing,
-    branchStatus,
     getBuffer: (source: string) => buffers.current.get(source)?.get() ?? "",
     hasData: (source: string) =>
       (buffers.current.get(source)?.get().length ?? 0) > 0,

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -99,17 +99,24 @@ export function PreviewContent() {
     // oxlint-disable-next-line no-self-assign
     iframe.src = iframe.src;
   });
-  const hasHtmlPreview = vmEvents.status.htmlSupport;
+  // `running` lifecycle phase carries the live port + htmlSupport flag;
+  // `crashed` means the dev server stopped responding after coming up.
+  // Everything else maps to "booting" for the preview overlay.
+  const lifecyclePhase = vmEvents.lifecycle.phase;
+  const hasHtmlPreview =
+    lifecyclePhase === "running" ? vmEvents.lifecycle.htmlSupport : false;
+  const upstreamStatus: "booting" | "online" | "offline" =
+    lifecyclePhase === "running"
+      ? "online"
+      : lifecyclePhase === "crashed"
+        ? "offline"
+        : "booting";
   const suspended = vmEvents.suspended;
 
-  // Install ran, dev script is intentionally stopped (paused) — treat as paused,
-  // not booting. Otherwise on remount the booting overlay falsely flashes
-  // "Installing packages…" even though the server isn't starting.
-  const appPaused = vmEvents.intent.state === "paused";
-
-  // The daemon's status enum (booting/online/offline) is itself the
-  // "ever-responded" latch — offline means we saw a response and lost it,
-  // and htmlSupport is sticky on offline at the source.
+  // Daemon paused itself (dev script crashed) or user paused — treat as
+  // paused so the booting overlay doesn't falsely flash "Installing
+  // packages…" even though the server isn't starting.
+  const appPaused = vmEvents.status.state !== "running";
 
   // Latch the boot-overlay timer's `since` to the first time previewUrl
   // appeared, keyed on previewUrl so a new VM resets it. Rendering inline
@@ -158,8 +165,8 @@ export function PreviewContent() {
 
   const previewState = computePreviewState({
     previewUrl,
-    status: vmEvents.status.status,
-    htmlSupport: vmEvents.status.htmlSupport,
+    status: upstreamStatus,
+    htmlSupport: hasHtmlPreview,
     suspended,
     appPaused,
     vmStartPending,

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -102,9 +102,23 @@ export function PreviewContent() {
   // `running` lifecycle phase carries the live port + htmlSupport flag;
   // `crashed` means the dev server stopped responding after coming up.
   // Everything else maps to "booting" for the preview overlay.
+  //
+  // htmlSupport only lives on the `running` event — but we need it to be
+  // sticky across `running` → `crashed` so a transient drop doesn't flip a
+  // working preview to the "No web page" empty state. Latch the last seen
+  // value, keyed on previewUrl so a new VM resets it.
   const lifecyclePhase = vmEvents.lifecycle.phase;
-  const hasHtmlPreview =
-    lifecyclePhase === "running" ? vmEvents.lifecycle.htmlSupport : false;
+  const htmlSupportRef = useRef<{ url: string; value: boolean }>({
+    url: "",
+    value: false,
+  });
+  if (previewUrl && htmlSupportRef.current.url !== previewUrl) {
+    htmlSupportRef.current = { url: previewUrl, value: false };
+  }
+  if (lifecyclePhase === "running") {
+    htmlSupportRef.current.value = vmEvents.lifecycle.htmlSupport;
+  }
+  const hasHtmlPreview = htmlSupportRef.current.value;
   const upstreamStatus: "booting" | "online" | "offline" =
     lifecyclePhase === "running"
       ? "online"
@@ -113,10 +127,13 @@ export function PreviewContent() {
         : "booting";
   const suspended = vmEvents.suspended;
 
-  // Daemon paused itself (dev script crashed) or user paused — treat as
-  // paused so the booting overlay doesn't falsely flash "Installing
-  // packages…" even though the server isn't starting.
-  const appPaused = vmEvents.status.state !== "running";
+  // Only the user-pause state routes to the suspended overlay (resume
+  // affordance). The daemon's `error` state means the dev script crashed
+  // — that's a failure, surfaced via the booting overlay's retry button
+  // (gated on `lifecycle.phase ∈ {clone-failed, install-failed, start-failed}`).
+  // Lumping the two under `appPaused` would route every dev-script crash
+  // to the resume UI instead, which has no retry path.
+  const appPaused = vmEvents.status.state === "paused";
 
   // Latch the boot-overlay timer's `since` to the first time previewUrl
   // appeared, keyed on previewUrl so a new VM resets it. Rendering inline
@@ -460,6 +477,8 @@ export function PreviewContent() {
               onViewLogs={openEnv}
               claimPhase={previewUrl ? null : claimPhase}
               onRetry={retryAutoStart}
+              virtualMcpId={virtualMcpId}
+              branch={branch}
             />
           </div>
         )}

--- a/apps/mesh/src/web/components/vm/upstream-status.ts
+++ b/apps/mesh/src/web/components/vm/upstream-status.ts
@@ -1,5 +1,7 @@
 /**
- * Upstream HTTP probe status emitted by the daemon over SSE.
- * Mirrors the daemon's `UpstreamStatus` (packages/sandbox/daemon/probe.ts).
+ * Internal preview-state triplet. Originally mirrored the daemon's
+ * `UpstreamStatus`; the daemon now emits richer `LifecycleState` events
+ * instead, and `preview.tsx` projects `lifecycle.phase` into this shape
+ * for `computePreviewState`.
  */
 export type UpstreamStatus = "booting" | "online" | "offline";

--- a/apps/mesh/src/web/components/vm/vm-booting-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-booting-state.tsx
@@ -1,9 +1,38 @@
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Terminal } from "@untitledui/icons";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { GridLoader } from "@/web/components/grid-loader";
-import type { ClaimPhase } from "./hooks/vm-events-context";
+import type { ClaimPhase, LifecycleState } from "./hooks/vm-events-context";
 import { useVmEvents } from "./hooks/use-vm-events";
+
+type DaemonFailurePhase = Extract<
+  LifecycleState,
+  { phase: "clone-failed" | "install-failed" | "start-failed" }
+>;
+
+type DaemonFailureStep = "clone" | "install" | "start";
+
+const DAEMON_FAILURE_COPY: Record<
+  DaemonFailurePhase["phase"],
+  { headline: string; step: DaemonFailureStep; cta: string }
+> = {
+  "clone-failed": {
+    headline: "Clone failed",
+    step: "clone",
+    cta: "Retry clone",
+  },
+  "install-failed": {
+    headline: "Install failed",
+    step: "install",
+    cta: "Retry install",
+  },
+  "start-failed": {
+    headline: "Failed to start the dev server",
+    step: "start",
+    cta: "Retry start",
+  },
+};
 
 interface VmBootingStateProps {
   /** Wall-clock ms when the boot began — feeds the elapsed timer. */
@@ -24,6 +53,9 @@ interface VmBootingStateProps {
   claimPhase?: ClaimPhase | null;
   /** Optional retry handler shown on terminal `failed` phases. */
   onRetry?: () => void;
+  /** Identifies the sandbox for daemon-lifecycle retry POSTs. */
+  virtualMcpId?: string | null;
+  branch?: string | null;
 }
 
 const PHASES = [
@@ -94,7 +126,29 @@ export function VmBootingState({
   onViewLogs,
   claimPhase,
   onRetry,
+  virtualMcpId,
+  branch,
 }: VmBootingStateProps) {
+  const { getBuffer, lifecycle } = useVmEvents();
+
+  // Daemon-lifecycle failures take precedence over claimPhase (which is
+  // pre-Ready K8s state and shouldn't fire alongside daemon failures) and
+  // over the 3-phase animated UI.
+  if (
+    lifecycle.phase === "clone-failed" ||
+    lifecycle.phase === "install-failed" ||
+    lifecycle.phase === "start-failed"
+  ) {
+    return (
+      <DaemonLifecycleFailureView
+        phase={lifecycle}
+        virtualMcpId={virtualMcpId ?? null}
+        branch={branch ?? null}
+        onViewLogs={onViewLogs}
+      />
+    );
+  }
+
   // Lifecycle-driven pre-daemon UI takes precedence whenever the caller
   // supplies a phase. The caller (preview.tsx) decides when to drop it —
   // typically once VM_START's promise resolves and a previewUrl is in
@@ -113,7 +167,6 @@ export function VmBootingState({
   const phase = getPhaseIndex(hasSetupData, scripts, activeProcesses);
   const currentLabel = PHASES[phase]?.label ?? PHASES[0].label;
 
-  const { getBuffer } = useVmEvents();
   const lastLogLine = latestLogLine(getBuffer, activeProcesses);
 
   return (
@@ -515,4 +568,88 @@ function nodeClaimSubline(phase: ClaimPhase): string | undefined {
   if (phase.kind !== "waiting-for-capacity") return undefined;
   if (!phase.nodeClaim) return undefined;
   return `Provisioning node ${phase.nodeClaim}…`;
+}
+
+// ---- Daemon lifecycle failure UI ------------------------------------------
+
+function DaemonLifecycleFailureView({
+  phase,
+  virtualMcpId,
+  branch,
+  onViewLogs,
+}: {
+  phase: DaemonFailurePhase;
+  virtualMcpId: string | null;
+  branch: string | null;
+  onViewLogs: () => void;
+}) {
+  const { org } = useProjectContext();
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [retryError, setRetryError] = useState<string | null>(null);
+  const copy = DAEMON_FAILURE_COPY[phase.phase];
+
+  const canRetry = !!virtualMcpId && !!branch && !isRetrying;
+
+  const handleRetry = async () => {
+    if (!virtualMcpId || !branch) return;
+    setIsRetrying(true);
+    setRetryError(null);
+    try {
+      const url =
+        `/api/${encodeURIComponent(org.slug)}/vm-setup/${copy.step}` +
+        `?virtualMcpId=${encodeURIComponent(virtualMcpId)}` +
+        `&branch=${encodeURIComponent(branch)}`;
+      const res = await fetch(url, { method: "POST" });
+      if (res.ok) return;
+      if (res.status === 410) {
+        setRetryError("Sandbox is gone — it will be reprovisioned.");
+        return;
+      }
+      const body = await res.text().catch(() => "");
+      setRetryError(
+        body || `Retry failed (${res.status} ${res.statusText})`.trim(),
+      );
+    } catch (err) {
+      setRetryError(err instanceof Error ? err.message : "Retry failed");
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  return (
+    <div className="relative flex flex-col items-center justify-center w-full h-full overflow-hidden select-none gap-6 px-6">
+      <div className="flex flex-col items-center gap-2 text-center max-w-[440px]">
+        <span className="text-sm font-medium text-foreground">
+          {copy.headline}
+        </span>
+        <span className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
+          {phase.error}
+        </span>
+        {retryError && (
+          <span className="text-xs text-destructive">{retryError}</span>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={handleRetry}
+        disabled={!canRetry}
+        className={cn(
+          "rounded-md border border-foreground/15 bg-background px-3 py-1.5 text-xs font-medium transition-colors",
+          canRetry
+            ? "hover:bg-foreground/4"
+            : "opacity-50 cursor-not-allowed",
+        )}
+      >
+        {isRetrying ? "Retrying…" : copy.cta}
+      </button>
+      <button
+        type="button"
+        onClick={onViewLogs}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-200"
+      >
+        <Terminal size={11} />
+        View logs
+      </button>
+    </div>
+  );
 }

--- a/apps/mesh/src/web/components/vm/vm-booting-state.tsx
+++ b/apps/mesh/src/web/components/vm/vm-booting-state.tsx
@@ -635,9 +635,7 @@ function DaemonLifecycleFailureView({
         disabled={!canRetry}
         className={cn(
           "rounded-md border border-foreground/15 bg-background px-3 py-1.5 text-xs font-medium transition-colors",
-          canRetry
-            ? "hover:bg-foreground/4"
-            : "opacity-50 cursor-not-allowed",
+          canRetry ? "hover:bg-foreground/4" : "opacity-50 cursor-not-allowed",
         )}
       >
         {isRetrying ? "Retrying…" : copy.cta}

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -12,6 +12,7 @@ import { gitSync } from "./git/git-sync";
 import { InstallState } from "./install/install-state";
 import { LifecycleManager } from "./lifecycle/manager";
 import { readConfig } from "./persistence";
+import { createPortSniffer } from "./process/port-sniffer";
 import { TaskManager } from "./process/task-manager";
 import { PhaseManager } from "./process/phase-manager";
 import { startUpstreamProbe } from "./probe";
@@ -82,6 +83,19 @@ const TMP_DIR = join(APP_ROOT, "tmp");
 
 const broadcaster = new Broadcaster(REPLAY_BYTES);
 
+// `application.port` is what mesh told the dev script to use, but plenty of
+// frameworks (vite included) ignore PORT env and pick their own — and on the
+// host runner two sandboxes can race for the same default port, leaving the
+// loser on a fallback. Sniff the actual bind announcement from starter
+// stdout and feed THAT to the probe; the configured port stays as a
+// fallback for tools that do honor PORT.
+const portSniffer = createPortSniffer();
+const broadcastChunkRaw = broadcaster.broadcastChunk.bind(broadcaster);
+broadcaster.broadcastChunk = (source, data) => {
+  portSniffer.observe(source, data);
+  broadcastChunkRaw(source, data);
+};
+
 let currentStatus: DaemonStatus = { state: "running" };
 function setStatus(next: DaemonStatus) {
   currentStatus = next;
@@ -91,6 +105,14 @@ function setStatus(next: DaemonStatus) {
 const store = new TenantConfigStore();
 const installState = new InstallState();
 const lifecycle = new LifecycleManager({ broadcaster });
+// Drop the sniffed port whenever we leave `running` — the next dev start
+// may bind somewhere else and we need to re-sniff its announcement.
+const lifecycleTransitionRaw = lifecycle.transition.bind(lifecycle);
+lifecycle.transition = (next) => {
+  const wasRunning = lifecycle.current().phase === "running";
+  lifecycleTransitionRaw(next);
+  if (wasRunning && next.phase !== "running") portSniffer.reset();
+};
 // Per-command history for LLM context (each bash/exec spawned via TaskManager
 // is tracked as a phase). Setup pipeline phases live on `lifecycle` instead.
 const phaseManager = new PhaseManager();
@@ -151,9 +173,21 @@ store.subscribe((event) => {
 const BASELINE_GRACE_MS = 3000;
 let baselineTimer: ReturnType<typeof setTimeout> | null = null;
 const lastProbe = startUpstreamProbe({
-  getPort: () => store.read()?.application?.port ?? null,
+  getPort: () =>
+    portSniffer.current() ?? store.read()?.application?.port ?? null,
   onChange: (s) => {
+    // The probe only honors a "port is responding" verdict when we
+    // actually expect our dev script to be up — i.e. we're currently in
+    // `starting` (just spawned, waiting for first response) or already in
+    // `running`. Otherwise a sibling sandbox on the same host can
+    // resurrect us back to `running` after the orchestrator has correctly
+    // recorded `start-failed`/`crashed`, leaving the iframe pointed at
+    // some other sandbox's app. Same logic mirrored on the offline edge:
+    // only mark `crashed` when we were actually running, never as a side
+    // effect of a port that was never ours in the first place.
+    const phase = lifecycle.current().phase;
     if (s.status === "online" && s.port !== null) {
+      if (phase !== "starting" && phase !== "running") return;
       lifecycle.transition({
         phase: "running",
         port: s.port,
@@ -166,7 +200,11 @@ const lastProbe = startUpstreamProbe({
         }, BASELINE_GRACE_MS);
       }
     } else if (s.status === "offline") {
+      if (phase !== "running") return;
       lifecycle.transition({ phase: "crashed" });
+      // Dev script lost contact — next start may bind to a different port,
+      // so unlock the sniffer to re-detect on the next bind announcement.
+      portSniffer.reset();
       if (baselineTimer) {
         clearTimeout(baselineTimer);
         baselineTimer = null;
@@ -177,7 +215,14 @@ const lastProbe = startUpstreamProbe({
   onLog: (msg) => broadcaster.broadcastChunk("setup", msg),
 });
 
-const getDevPort = (): number | null => store.read()?.application?.port ?? null;
+// HTTP/WS proxy forwards to the same port the probe is HEAD-checking.
+// `application.port` is what mesh configured, but vite/etc. routinely
+// pick a fallback when the configured one is busy — using the sniffed
+// announce-port keeps the proxy aligned with what the dev script
+// actually bound to. Falls back to the configured value when nothing has
+// been sniffed yet.
+const getDevPort = (): number | null =>
+  portSniffer.current() ?? store.read()?.application?.port ?? null;
 const { appRoot, repoDir } = bootConfig;
 const fsDeps = { appRoot, repoDir };
 const readH = makeReadHandler(fsDeps);

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -1,14 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { bumpActivity, markClaimed } from "./activity";
+import { bumpActivity } from "./activity";
 import { requireToken } from "./auth";
 import { TenantConfigStore } from "./config-store";
 import { REPLAY_BYTES } from "./constants";
 import { Broadcaster } from "./events/broadcast";
+import type { DaemonStatus } from "./events/types";
 import { BranchStatusMonitor } from "./git/branch-status";
 import { gitSync } from "./git/git-sync";
 import { InstallState } from "./install/install-state";
+import { LifecycleManager } from "./lifecycle/manager";
 import { readConfig } from "./persistence";
 import { TaskManager } from "./process/task-manager";
 import { PhaseManager } from "./process/phase-manager";
@@ -33,6 +35,7 @@ import {
 } from "./routes/fs";
 import { makeHealthHandler } from "./routes/health";
 import { makeIdleHandler } from "./routes/idle";
+import { makeSetupHandler } from "./routes/setup";
 import {
   makeTasksDeleteHandler,
   makeTasksGetHandler,
@@ -79,28 +82,24 @@ const TMP_DIR = join(APP_ROOT, "tmp");
 
 const broadcaster = new Broadcaster(REPLAY_BYTES);
 
-type Intent = { state: "running" | "paused"; reason?: string };
-let currentIntent: Intent = { state: "running" };
-function setIntent(next: Intent) {
-  currentIntent = next;
-  broadcaster.broadcastEvent("intent", { type: "intent", ...next });
+let currentStatus: DaemonStatus = { state: "running" };
+function setStatus(next: DaemonStatus) {
+  currentStatus = next;
+  broadcaster.emit("status", next);
 }
 
 const store = new TenantConfigStore();
 const installState = new InstallState();
-const phaseManager = new PhaseManager({
-  onChange: (phases) =>
-    broadcaster.broadcastEvent("phases", { type: "phases", phases }),
-});
+const lifecycle = new LifecycleManager({ broadcaster });
+// Per-command history for LLM context (each bash/exec spawned via TaskManager
+// is tracked as a phase). Setup pipeline phases live on `lifecycle` instead.
+const phaseManager = new PhaseManager();
 const taskManager = new TaskManager({
   logsDir: TMP_DIR,
   phaseManager,
   broadcaster,
   onChange: () => {
-    broadcaster.broadcastEvent("tasks", {
-      type: "tasks",
-      active: getActiveTasks(),
-    });
+    broadcaster.emit("tasks", { active: getActiveTasks() });
   },
 });
 
@@ -125,33 +124,55 @@ const orchestrator = new SetupOrchestrator({
   bootConfig: { appRoot: bootConfig.appRoot, repoDir: bootConfig.repoDir },
   store,
   taskManager,
-  setIntent,
-  getIntent: () => currentIntent,
+  setStatus,
+  getStatus: () => currentStatus,
   broadcaster,
   installState,
   logsDir: TMP_DIR,
-  phaseManager,
+  lifecycle,
   branchStatus,
 });
-
-let discoveredScripts: string[] | null = null;
-
-const origEvent = broadcaster.broadcastEvent.bind(broadcaster);
-broadcaster.broadcastEvent = (event: string, data: unknown) => {
-  if (event === "scripts") {
-    discoveredScripts = (data as { scripts?: string[] }).scripts ?? [];
-  }
-  origEvent(event, data);
-};
 
 store.subscribe((event) => {
   orchestrator.handle(event.transition);
 });
 
-const lastStatus = startUpstreamProbe({
+// Probe transitions lifecycle from `starting` → `running` (dev server up)
+// and `running` → `crashed` (was online, lost contact). Pre-running phases
+// (cloning, installing, etc.) are owned by the orchestrator.
+//
+// Dirty-baseline: dev scripts often rewrite tracked files at boot (minified
+// `static/tailwind.css`, compiled CSS, lockfile drift). The first
+// `online` transition arms a noise baseline of those paths so the
+// "Save changes" button doesn't flip on for boot-time noise. The 3 s grace
+// gives common post-Ready writers (PostCSS/Tailwind JIT, Vite asset emit)
+// time to land before we snapshot. `clearBaseline` on `crashed`/restart so
+// a re-armed baseline reflects the new boot's noise.
+const BASELINE_GRACE_MS = 3000;
+let baselineTimer: ReturnType<typeof setTimeout> | null = null;
+const lastProbe = startUpstreamProbe({
   getPort: () => store.read()?.application?.port ?? null,
   onChange: (s) => {
-    broadcaster.broadcastEvent("status", { type: "status", ...s });
+    if (s.status === "online" && s.port !== null) {
+      lifecycle.transition({
+        phase: "running",
+        port: s.port,
+        htmlSupport: s.htmlSupport,
+      });
+      if (!baselineTimer) {
+        baselineTimer = setTimeout(() => {
+          baselineTimer = null;
+          branchStatus.armBaseline();
+        }, BASELINE_GRACE_MS);
+      }
+    } else if (s.status === "offline") {
+      lifecycle.transition({ phase: "crashed" });
+      if (baselineTimer) {
+        clearTimeout(baselineTimer);
+        baselineTimer = null;
+      }
+      branchStatus.clearBaseline();
+    }
   },
   onLog: (msg) => broadcaster.broadcastChunk("setup", msg),
 });
@@ -185,7 +206,8 @@ const tasksDeleteH = makeTasksDeleteHandler({ taskManager });
 const tasksStreamH = makeTasksStreamHandler({ taskManager });
 
 const scriptsHandler = makeScriptsHandler(() => {
-  if (discoveredScripts) return discoveredScripts;
+  const cached = orchestrator.getDiscoveredScripts();
+  if (cached) return cached;
   const enriched = store.read();
   const pm = enriched?.application?.packageManager?.name ?? null;
   const cwd = enriched?.application?.packageManager?.path ?? repoDir;
@@ -193,9 +215,15 @@ const scriptsHandler = makeScriptsHandler(() => {
   return discoverScripts(cwd, pm);
 });
 
+const setupCloneH = makeSetupHandler("clone", { orchestrator });
+const setupInstallH = makeSetupHandler("install", { orchestrator });
+const setupStartH = makeSetupHandler("start", { orchestrator });
+
+const isReady = () => lifecycle.current().phase === "running";
+
 const healthH = makeHealthHandler({
   config: { daemonBootId: process.env.DAEMON_BOOT_ID ?? "" },
-  getReady: () => lastStatus.status === "online",
+  getReady: isReady,
   getOrchestrator: () => ({
     running: orchestrator.isRunning(),
     pending: orchestrator.pendingCount(),
@@ -205,11 +233,11 @@ const healthH = makeHealthHandler({
 
 const eventsH = makeEventsHandler({
   broadcaster,
-  getLastStatus: () => lastStatus,
-  getDiscoveredScripts: () => discoveredScripts,
+  getLifecycle: () => lifecycle.current(),
+  getDiscoveredScripts: () => orchestrator.getDiscoveredScripts(),
   getActiveTasks,
-  getIntent: () => currentIntent,
-  getLastBranchStatus: () => branchStatus.getLast(),
+  getStatus: () => currentStatus,
+  getBranchMeta: () => branchStatus.getLast(),
 });
 
 const idleH = makeIdleHandler();
@@ -224,7 +252,7 @@ const configReadH = makeConfigReadHandler({
       running: orchestrator.isRunning(),
       pending: orchestrator.pendingCount(),
     },
-    ready: lastStatus.status === "online",
+    ready: isReady(),
   }),
   getTasks: () => phaseManager.recent(20),
 });
@@ -258,20 +286,15 @@ if (!store.read()) {
     `[daemon] boot_id=${process.env.DAEMON_BOOT_ID} ready, unclaimed — waiting for workload config`,
   );
 }
+// Reference to silence "unused" — keep for future probe-state introspection.
+void lastProbe;
 
 let firstWorkLogged = false;
 
 async function configH(req: Request): Promise<Response> {
   const { method } = req;
   if (method === "GET") return configReadH();
-  if (method === "PUT" || method === "POST") {
-    const res = await configUpdateH(req);
-    // Mark daemon as claimed on first successful config delivery so the
-    // housekeeper can distinguish warm-pool pods awaiting adoption from
-    // idle-but-active sandboxes.
-    if (res.status === 200) markClaimed();
-    return res;
-  }
+  if (method === "PUT" || method === "POST") return configUpdateH(req);
   return jsonResponse({ error: "Not found: /_decopilot_vm/config" }, 404);
 }
 
@@ -322,6 +345,12 @@ const fsH: Record<string, (req: Request) => Response | Promise<Response>> = {
   "/bash": bashH,
 };
 
+const setupH: Record<string, () => Response> = {
+  "/setup/clone": setupCloneH,
+  "/setup/install": setupInstallH,
+  "/setup/start": setupStartH,
+};
+
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE",
@@ -345,6 +374,7 @@ function vmRouteH(
 
   if (vmPath === "/config") return configH(req);
   if (vmPath.startsWith("/tasks")) return tasksRouteH(req, method, vmPath);
+  if (method === "POST" && vmPath in setupH) return setupH[vmPath]();
   if (method === "POST" && vmPath in fsH) return fsH[vmPath](req);
   if (method === "POST" && vmPath.startsWith("/exec/"))
     return execRouteH(req, vmPath);

--- a/packages/sandbox/daemon/events/broadcast.test.ts
+++ b/packages/sandbox/daemon/events/broadcast.test.ts
@@ -25,7 +25,7 @@ describe("Broadcaster", () => {
       },
     } as unknown as ReadableStreamDefaultController<Uint8Array>);
     // Must not throw.
-    b.broadcastEvent("status", { ready: true });
+    b.emit("intent", { state: "running" });
   });
 
   it("records chunks into its replay buffer", () => {

--- a/packages/sandbox/daemon/events/broadcast.ts
+++ b/packages/sandbox/daemon/events/broadcast.ts
@@ -1,5 +1,6 @@
 import { ReplayBuffer } from "./replay";
 import { sseFormat } from "./sse-format";
+import type { DaemonEventMap, DaemonEventName } from "./types";
 
 type Controller = ReadableStreamDefaultController<Uint8Array>;
 
@@ -27,15 +28,15 @@ export class Broadcaster {
     if (!data) return;
     this.replay.append(source, data);
     // Tee to stdout so `kubectl logs` / k9s show the same output that SSE
-    // subscribers see. The structured events (broadcastEvent below) stay
-    // SSE-only — they're machine-readable JSON and would be noise here.
+    // subscribers see. The structured events (emit below) stay SSE-only —
+    // they're machine-readable JSON and would be noise here.
     process.stdout.write(`[${source}] ${data}`);
     const bytes = sseFormat("log", JSON.stringify({ source, data }));
     this.fan(bytes);
   }
 
-  broadcastEvent(event: string, data: unknown): void {
-    const bytes = sseFormat(event, JSON.stringify(data));
+  emit<K extends DaemonEventName>(name: K, payload: DaemonEventMap[K]): void {
+    const bytes = sseFormat(name, JSON.stringify(payload));
     this.fan(bytes);
   }
 

--- a/packages/sandbox/daemon/events/sse.test.ts
+++ b/packages/sandbox/daemon/events/sse.test.ts
@@ -5,15 +5,11 @@ import { makeSseStream } from "./sse";
 describe("makeSseStream", () => {
   const mkDeps = (b: Broadcaster) => ({
     broadcaster: b,
-    getLastStatus: () => ({
-      status: "booting" as const,
-      port: null,
-      htmlSupport: false,
-    }),
+    getLifecycle: () => ({ phase: "idle" as const }),
     getDiscoveredScripts: () => null,
     getActiveTasks: () => [],
-    getIntent: () => ({ state: "running" as const }),
-    getLastBranchStatus: () => ({ kind: "initializing" as const }),
+    getStatus: () => ({ state: "running" as const }),
+    getBranchMeta: () => ({ kind: "unknown" as const }),
     maxClients: 10,
   });
 
@@ -27,29 +23,29 @@ describe("makeSseStream", () => {
     expect(makeSseStream(mkDeps(b))).toBeNull();
   });
 
-  it("emits status event on connect", async () => {
+  it("emits lifecycle event on connect", async () => {
     const b = new Broadcaster(100);
     const stream = makeSseStream(mkDeps(b))!;
     const reader = stream.getReader();
     const first = await reader.read();
     const text = new TextDecoder().decode(first.value);
-    expect(text).toContain("event: status");
+    expect(text).toContain("event: lifecycle");
     await reader.cancel();
   });
 
-  it("emits intent event in handshake", async () => {
+  it("emits status event in handshake", async () => {
     const b = new Broadcaster(100);
     const stream = makeSseStream(mkDeps(b))!;
     const reader = stream.getReader();
-    // Read until we see intent or run out of buffered events.
+    // Read until we see status or run out of buffered events.
     let combined = "";
     for (let i = 0; i < 20; i++) {
       const chunk = await reader.read();
       if (chunk.done) break;
       combined += new TextDecoder().decode(chunk.value);
-      if (combined.includes("event: intent")) break;
+      if (combined.includes("event: status")) break;
     }
-    expect(combined).toContain("event: intent");
+    expect(combined).toContain("event: status");
     expect(combined).toContain('"state":"running"');
     await reader.cancel();
   });

--- a/packages/sandbox/daemon/events/sse.ts
+++ b/packages/sandbox/daemon/events/sse.ts
@@ -1,25 +1,25 @@
-import type { UpstreamStatus } from "../probe";
-import type { BranchStatus } from "../types";
 import type { Broadcaster } from "./broadcast";
 import { sseFormat } from "./sse-format";
+import type {
+  ActiveTaskSummary,
+  BranchMeta,
+  DaemonEventMap,
+  DaemonEventName,
+  DaemonStatus,
+  LifecycleState,
+} from "./types";
 
 export interface SseHandshakeDeps {
   broadcaster: Broadcaster;
-  getLastStatus: () => {
-    status: UpstreamStatus;
-    port: number | null;
-    htmlSupport: boolean;
-  };
+  getLifecycle: () => LifecycleState;
   getDiscoveredScripts: () => string[] | null;
-  getActiveTasks: () => Array<{
-    id: string;
-    command: string;
-    logName?: string;
-  }>;
-  getIntent: () => { state: "running" | "paused"; reason?: string };
-  getLastBranchStatus: () => BranchStatus;
+  getActiveTasks: () => ActiveTaskSummary[];
+  getStatus: () => DaemonStatus;
+  getBranchMeta: () => BranchMeta;
   maxClients: number;
 }
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 /**
  * Returns a fresh `ReadableStream<Uint8Array>` that, on start, flushes
@@ -34,14 +34,18 @@ export function makeSseStream(
   let controller!: ReadableStreamDefaultController<Uint8Array>;
   let keepAlive: ReturnType<typeof setInterval> | null = null;
 
+  function frame<K extends DaemonEventName>(
+    name: K,
+    payload: DaemonEventMap[K],
+  ): Uint8Array {
+    return sseFormat(name, JSON.stringify(payload));
+  }
+
   return new ReadableStream<Uint8Array>({
     start(c) {
       controller = c;
 
-      const last = deps.getLastStatus();
-      c.enqueue(
-        sseFormat("status", JSON.stringify({ type: "status", ...last })),
-      );
+      c.enqueue(frame("lifecycle", { state: deps.getLifecycle() }));
 
       for (const src of deps.broadcaster.replay.sources()) {
         const buf = deps.broadcaster.replay.read(src);
@@ -53,52 +57,22 @@ export function makeSseStream(
       }
 
       const scripts = deps.getDiscoveredScripts();
-      if (scripts) {
-        c.enqueue(
-          sseFormat("scripts", JSON.stringify({ type: "scripts", scripts })),
-        );
-      }
+      if (scripts) c.enqueue(frame("scripts", { scripts }));
 
-      c.enqueue(
-        sseFormat(
-          "tasks",
-          JSON.stringify({
-            type: "tasks",
-            active: deps.getActiveTasks(),
-          }),
-        ),
-      );
-
-      c.enqueue(
-        sseFormat(
-          "intent",
-          JSON.stringify({ type: "intent", ...deps.getIntent() }),
-        ),
-      );
-
-      const lastBranch = deps.getLastBranchStatus();
-      c.enqueue(
-        sseFormat(
-          "branch-status",
-          JSON.stringify({ type: "branch-status", ...lastBranch }),
-        ),
-      );
+      c.enqueue(frame("tasks", { active: deps.getActiveTasks() }));
+      c.enqueue(frame("status", deps.getStatus()));
+      c.enqueue(frame("branch", { meta: deps.getBranchMeta() }));
 
       deps.broadcaster.register(controller);
 
       keepAlive = setInterval(() => {
         try {
-          c.enqueue(
-            sseFormat(
-              "status",
-              JSON.stringify({ type: "status", ...deps.getLastStatus() }),
-            ),
-          );
+          c.enqueue(frame("lifecycle", { state: deps.getLifecycle() }));
         } catch {
           if (keepAlive) clearInterval(keepAlive);
           deps.broadcaster.unregister(controller);
         }
-      }, 15000);
+      }, HEARTBEAT_INTERVAL_MS);
     },
 
     cancel() {

--- a/packages/sandbox/daemon/events/types.ts
+++ b/packages/sandbox/daemon/events/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Daemon event wire format. Single source of truth shared with Studio
+ * via `@decocms/sandbox/shared`.
+ *
+ * `DaemonEventMap` keys are the SSE `event:` header values; values are the
+ * payload shape JSON-serialized into the SSE `data:` field. No discriminator
+ * lives inside the payload — the wire's event header carries it.
+ */
+
+/** Where the setup pipeline is right now. Drives Studio's retry UI. */
+export type LifecycleState =
+  | { phase: "idle" }
+  | { phase: "cloning" }
+  | { phase: "checking-out"; to: string }
+  | { phase: "clone-failed"; error: string }
+  | { phase: "installing" }
+  | { phase: "install-failed"; error: string }
+  | { phase: "starting" }
+  | { phase: "running"; port: number; htmlSupport: boolean }
+  | { phase: "start-failed"; error: string }
+  /** Was running, stopped responding to the probe. */
+  | { phase: "crashed" };
+
+/** Git metadata, separate from lifecycle. `unknown` until the first compute. */
+export type BranchMeta =
+  | { kind: "unknown" }
+  | {
+      kind: "ready";
+      branch: string;
+      base: string;
+      workingTreeDirty: boolean;
+      unpushed: number;
+      aheadOfBase: number;
+      behindBase: number;
+      headSha: string;
+    };
+
+/** Active task summary surfaced for Studio's Run/Restart UI. */
+export interface ActiveTaskSummary {
+  id: string;
+  command: string;
+  logName?: string;
+}
+
+/**
+ * Daemon's overall operational state. Distinct from `LifecycleState` —
+ * lifecycle tracks pipeline progress (cloning → installing → running),
+ * status tracks whether the dev script is allowed to run and whether
+ * a side effect (e.g. unexpected crash) forced it off.
+ *
+ * `running` — proceeding normally
+ * `paused`  — user/orchestrator asked to stop progressing
+ * `error`   — daemon stopped on its own (e.g. dev script exit non-zero);
+ *             `reason` carries detail
+ */
+export interface DaemonStatus {
+  state: "running" | "paused" | "error";
+  reason?: string;
+}
+
+export interface DaemonEventMap {
+  lifecycle: { state: LifecycleState };
+  status: DaemonStatus;
+  tasks: { active: ActiveTaskSummary[] };
+  scripts: { scripts: string[] };
+  branch: { meta: BranchMeta };
+  reload: Record<string, never>;
+}
+
+export type DaemonEventName = keyof DaemonEventMap;
+export type DaemonEventPayload<K extends DaemonEventName> = DaemonEventMap[K];

--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -83,9 +83,11 @@ describe("BranchStatusMonitor", () => {
     expect(last.headSha).toMatch(/^[0-9a-f]{40}$/);
     const branchEvents = events.filter((e) => e.name === "branch");
     expect(branchEvents.length).toBe(1);
-    expect(
-      (branchEvents[0]?.payload as DaemonEventPayload<"branch">).meta.kind,
-    ).toBe("ready");
+    const first = branchEvents[0];
+    if (!first) throw new Error("missing branch event");
+    expect((first.payload as DaemonEventPayload<"branch">).meta.kind).toBe(
+      "ready",
+    );
   });
 
   it("refresh() does not re-emit identical state", () => {

--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Broadcaster } from "../events/broadcast";
+import type { DaemonEventName, DaemonEventPayload } from "../events/types";
 import { gitSync } from "./git-sync";
 import { BranchStatusMonitor } from "./branch-status";
 
@@ -24,20 +25,33 @@ function makeRepo(): { repoDir: string; cleanup: () => void } {
   };
 }
 
+/** Commit a file at `path` with `content` so it's tracked. */
+function commitFile(repoDir: string, path: string, content: string): void {
+  writeFileSync(join(repoDir, path), content);
+  gitSync(["add", path], { cwd: repoDir, asUser: false });
+  gitSync(["commit", "-m", `add ${path}`], { cwd: repoDir, asUser: false });
+}
+
 describe("BranchStatusMonitor", () => {
   let repo: ReturnType<typeof makeRepo>;
   let broadcaster: Broadcaster;
-  let events: Array<{ event: string; data: unknown }>;
+  let events: Array<{
+    name: DaemonEventName;
+    payload: DaemonEventPayload<DaemonEventName>;
+  }>;
 
   beforeEach(() => {
     repo = makeRepo();
     broadcaster = new Broadcaster(1024);
     events = [];
-    const orig = broadcaster.broadcastEvent.bind(broadcaster);
-    broadcaster.broadcastEvent = (event, data) => {
-      events.push({ event, data });
-      orig(event, data);
-    };
+    const orig = broadcaster.emit.bind(broadcaster);
+    broadcaster.emit = ((name, payload) => {
+      events.push({
+        name,
+        payload: payload as DaemonEventPayload<DaemonEventName>,
+      });
+      orig(name, payload);
+    }) as Broadcaster["emit"];
   });
 
   afterEach(() => repo.cleanup());
@@ -54,70 +68,81 @@ describe("BranchStatusMonitor", () => {
     return new BranchStatusMonitor(config, broadcaster);
   }
 
-  it("starts in 'initializing' on construction", () => {
+  it("starts as 'unknown' on construction", () => {
     const m = newMonitor();
-    expect(m.getLast()).toEqual({ kind: "initializing" });
+    expect(m.getLast()).toEqual({ kind: "unknown" });
   });
 
-  it("setPhase('cloning') broadcasts and updates last", () => {
+  it("refresh() computes git status and emits ready meta", () => {
     const m = newMonitor();
-    m.setPhase({ kind: "cloning" });
-    expect(m.getLast()).toEqual({ kind: "cloning" });
-    expect(events).toContainEqual({
-      event: "branch-status",
-      data: { type: "branch-status", kind: "cloning" },
-    });
-  });
-
-  it("setPhase('clone-failed') carries the error", () => {
-    const m = newMonitor();
-    m.setPhase({ kind: "clone-failed", error: "exit 128" });
-    expect(m.getLast()).toEqual({ kind: "clone-failed", error: "exit 128" });
-    const last = events.at(-1);
-    expect(last?.event).toBe("branch-status");
-    expect(last?.data).toEqual({
-      type: "branch-status",
-      kind: "clone-failed",
-      error: "exit 128",
-    });
-  });
-
-  it("markReady() computes git status and emits 'ready'", () => {
-    const m = newMonitor();
-    m.markReady();
+    m.refresh();
     const last = m.getLast();
     if (last?.kind !== "ready") throw new Error("expected ready");
     expect(last.branch).toBe("main");
     expect(last.workingTreeDirty).toBe(false);
     expect(last.headSha).toMatch(/^[0-9a-f]{40}$/);
-    expect(events.at(-1)?.event).toBe("branch-status");
+    const branchEvents = events.filter((e) => e.name === "branch");
+    expect(branchEvents.length).toBe(1);
+    expect(
+      (branchEvents[0]?.payload as DaemonEventPayload<"branch">).meta.kind,
+    ).toBe("ready");
   });
 
-  it("markReady() does not re-broadcast identical state", () => {
+  it("refresh() does not re-emit identical state", () => {
     const m = newMonitor();
-    m.markReady();
+    m.refresh();
     const before = events.length;
-    m.markReady();
+    m.refresh();
     expect(events.length).toBe(before);
   });
 
-  it("setPhase deduplicates identical consecutive phases", () => {
-    const m = newMonitor();
-    m.setPhase({ kind: "cloning" });
-    m.setPhase({ kind: "cloning" });
-    const cloningEvents = events.filter(
-      (e) =>
-        e.event === "branch-status" &&
-        (e.data as { kind?: string }).kind === "cloning",
-    );
-    expect(cloningEvents.length).toBe(1);
-  });
+  describe("dirty baseline", () => {
+    it("ignores baseline-dirty paths when computing workingTreeDirty", () => {
+      // Simulate: dev script regenerates a tracked file (e.g. tailwind.css).
+      commitFile(repo.repoDir, "tailwind.css", "/* original */");
+      writeFileSync(join(repo.repoDir, "tailwind.css"), "/* regenerated */");
 
-  it("setPhase overwrites a sticky 'clone-failed'", () => {
-    const m = newMonitor();
-    m.setPhase({ kind: "clone-failed", error: "x" });
-    m.setPhase({ kind: "cloning" });
-    expect(m.getLast()).toEqual({ kind: "cloning" });
+      const m = newMonitor();
+      m.armBaseline();
+      const last = m.getLast();
+      if (last?.kind !== "ready") throw new Error("expected ready");
+      expect(last.workingTreeDirty).toBe(false);
+    });
+
+    it("flips dirty=true when a non-baseline file changes", () => {
+      commitFile(repo.repoDir, "tailwind.css", "/* original */");
+      commitFile(repo.repoDir, "src.ts", "export const x = 1;");
+      writeFileSync(join(repo.repoDir, "tailwind.css"), "/* regenerated */");
+
+      const m = newMonitor();
+      m.armBaseline();
+      expect(
+        (m.getLast() as { workingTreeDirty: boolean }).workingTreeDirty,
+      ).toBe(false);
+
+      // User now edits a different file — must surface as dirty.
+      writeFileSync(join(repo.repoDir, "src.ts"), "export const x = 2;");
+      m.refresh();
+      expect(
+        (m.getLast() as { workingTreeDirty: boolean }).workingTreeDirty,
+      ).toBe(true);
+    });
+
+    it("clearBaseline() restores raw dirty reporting", () => {
+      commitFile(repo.repoDir, "tailwind.css", "/* original */");
+      writeFileSync(join(repo.repoDir, "tailwind.css"), "/* regenerated */");
+
+      const m = newMonitor();
+      m.armBaseline();
+      expect(
+        (m.getLast() as { workingTreeDirty: boolean }).workingTreeDirty,
+      ).toBe(false);
+
+      m.clearBaseline();
+      expect(
+        (m.getLast() as { workingTreeDirty: boolean }).workingTreeDirty,
+      ).toBe(true);
+    });
   });
 
   // Regression: when appRoot != repoDir AND appRoot is nested inside another
@@ -165,7 +190,7 @@ describe("BranchStatusMonitor", () => {
         dropPrivileges: false,
       } as never;
       const monitor = new BranchStatusMonitor(config, broadcaster);
-      monitor.markReady();
+      monitor.refresh();
 
       const last = monitor.getLast();
       if (last?.kind !== "ready")

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -1,44 +1,71 @@
 import fs from "node:fs";
 import type { Broadcaster } from "../events/broadcast";
-import type { BranchStatus, BranchStatusReady, Config } from "../types";
+import type { BranchMeta } from "../events/types";
+import type { Config } from "../types";
 import { gitSync as rawGitSync } from "./git-sync";
 
 const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
   rawGitSync(["-c", "safe.directory=*", ...args], opts);
 
+/**
+ * Watches `.git/` and surfaces the current `BranchMeta` (branch name, dirty,
+ * unpushed, divergence). Lifecycle phases (cloning, checking-out, …) live on
+ * `LifecycleManager`, not here — this monitor only tracks metadata once the
+ * repo is in a checkable state.
+ *
+ * Dirty-baseline: dev scripts often rewrite tracked files at boot (e.g.
+ * minified `static/tailwind.css`, compiled CSS, lockfile drift after
+ * `npm/bun install`). Those touches are not user changes, but they show up
+ * in `git status` and would flip `workingTreeDirty=true` the moment the dev
+ * server settles. To avoid false-positive "Save changes" buttons, the
+ * orchestrator calls `armBaseline()` once `lifecycle: running` stabilizes;
+ * paths in that snapshot are subtracted from subsequent dirty checks.
+ */
 export class BranchStatusMonitor {
-  private last: BranchStatus = { kind: "initializing" };
+  private last: BranchMeta = { kind: "unknown" };
   private timer: ReturnType<typeof setTimeout> | null = null;
   private watcher: ReturnType<typeof fs.watch> | null = null;
   private pollFallback: ReturnType<typeof setInterval> | null = null;
+  /** Paths reported dirty by `git status --porcelain=v1` at boot — treated as noise. */
+  private dirtyBaseline: ReadonlySet<string> | null = null;
 
   constructor(
     private readonly config: Config,
     private readonly broadcaster: Broadcaster,
   ) {}
 
-  getLast(): BranchStatus {
+  getLast(): BranchMeta {
     return this.last;
   }
 
-  /** Set a non-ready phase. Always broadcasts when the kind/payload changed. */
-  setPhase(next: Exclude<BranchStatus, BranchStatusReady>): void {
-    if (this.equal(this.last, next)) return;
-    this.last = next;
-    this.broadcast(next);
+  /**
+   * Capture the current dirty set as the noise baseline. Call once the dev
+   * server has settled (probe online → transitioned to `running`) so any
+   * boot-time file rewrites land in the baseline. Re-arming overwrites the
+   * prior snapshot. `clearBaseline()` drops it on a fresh clone/install.
+   */
+  armBaseline(): void {
+    this.dirtyBaseline = this.readDirtyPaths();
+    // Re-evaluate so the next emit reflects the new filter.
+    this.refresh();
+  }
+
+  clearBaseline(): void {
+    if (this.dirtyBaseline === null) return;
+    this.dirtyBaseline = null;
+    this.refresh();
   }
 
   /**
-   * Compute git status and enter 'ready'. Idempotent: skips broadcast when
-   * the computed status equals the last 'ready' value. Starts the .git
-   * watcher on first call.
+   * Compute git status and emit it. Idempotent — skips broadcast when the
+   * computed meta matches `last`. Starts the .git watcher on first call.
    */
-  markReady(): void {
+  refresh(): void {
     const next = this.compute();
     if (!next) return;
-    if (this.equal(this.last, next)) return;
+    if (equal(this.last, next)) return;
     this.last = next;
-    this.broadcast(next);
+    this.broadcaster.emit("branch", { meta: next });
     this.ensureWatch();
   }
 
@@ -58,24 +85,13 @@ export class BranchStatusMonitor {
     }
   }
 
-  private broadcast(s: BranchStatus): void {
-    this.broadcaster.broadcastEvent("branch-status", {
-      type: "branch-status",
-      ...s,
-    });
-  }
-
-  private equal(a: BranchStatus, b: BranchStatus): boolean {
-    return JSON.stringify(a) === JSON.stringify(b);
-  }
-
   private schedule(): void {
     if (this.timer) return;
     this.timer = setTimeout(() => {
       this.timer = null;
       // fs.watch fires meaningfully only once we're already in 'ready';
-      // ignore otherwise (orchestrator owns non-ready transitions).
-      if (this.last.kind === "ready") this.markReady();
+      // ignore otherwise (orchestrator owns pre-ready transitions).
+      if (this.last.kind === "ready") this.refresh();
     }, 250);
   }
 
@@ -91,25 +107,34 @@ export class BranchStatusMonitor {
       this.watcher.on("error", () => {});
     } catch {
       this.pollFallback = setInterval(() => {
-        if (this.last.kind === "ready") this.markReady();
+        if (this.last.kind === "ready") this.refresh();
       }, 5000);
     }
   }
 
-  private compute(): BranchStatusReady | null {
-    const run = (args: string[]) => {
-      try {
-        return gitSync(args, {
-          cwd: this.config.repoDir,
-          // Pin discovery to repoDir so a parent .git (e.g. the host's
-          // workspace tree containing .deco/sandboxes/<handle>/repo) can't
-          // hijack the lookup and report the wrong branch.
-          env: { ...process.env, GIT_CEILING_DIRECTORIES: this.config.repoDir },
-        });
-      } catch {
-        return "";
-      }
-    };
+  private runGit(args: string[]): string {
+    try {
+      return gitSync(args, {
+        cwd: this.config.repoDir,
+        // Pin discovery to repoDir so a parent .git (e.g. the host's
+        // workspace tree containing .deco/sandboxes/<handle>/repo) can't
+        // hijack the lookup and report the wrong branch.
+        env: { ...process.env, GIT_CEILING_DIRECTORIES: this.config.repoDir },
+      });
+    } catch {
+      return "";
+    }
+  }
+
+  /** Paths currently shown by porcelain v1. Empty set on clean tree or git failure. */
+  private readDirtyPaths(): Set<string> {
+    const out = this.runGit(["status", "--porcelain=v1", "-z"]);
+    if (!out) return new Set();
+    return parsePorcelainZ(out);
+  }
+
+  private compute(): Extract<BranchMeta, { kind: "ready" }> | null {
+    const run = (args: string[]) => this.runGit(args);
     const refExists = (ref: string) =>
       run(["rev-parse", "--verify", "--quiet", ref]).length > 0;
     try {
@@ -118,7 +143,11 @@ export class BranchStatusMonitor {
       let base = run(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
       if (base.startsWith("origin/")) base = base.slice("origin/".length);
       if (!base) base = "main";
-      const dirty = run(["status", "--porcelain=v1"]).length > 0;
+      const dirtyPaths = this.readDirtyPaths();
+      const baseline = this.dirtyBaseline;
+      const dirty = baseline
+        ? [...dirtyPaths].some((p) => !baseline.has(p))
+        : dirtyPaths.size > 0;
       const branchRef = refExists(`origin/${branch}`)
         ? `origin/${branch}`
         : "HEAD";
@@ -158,4 +187,34 @@ export class BranchStatusMonitor {
       return null;
     }
   }
+}
+
+function equal(a: BranchMeta, b: BranchMeta): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Parse `git status --porcelain=v1 -z` output into a set of paths.
+ * Format: each entry is `XY <path>\0`. Renames/copies (`R`/`C`) carry a
+ * second `<orig>\0` after the destination — we record both so a baseline
+ * captures whichever one a later run sees.
+ */
+function parsePorcelainZ(out: string): Set<string> {
+  const paths = new Set<string>();
+  const parts = out.split("\0");
+  for (let i = 0; i < parts.length; i++) {
+    const entry = parts[i];
+    if (!entry) continue;
+    if (entry.length < 4) continue;
+    const xy = entry.slice(0, 2);
+    const path = entry.slice(3);
+    paths.add(path);
+    // Renames/copies have an extra origin-path field.
+    if (xy[0] === "R" || xy[0] === "C") {
+      i++;
+      const orig = parts[i];
+      if (orig) paths.add(orig);
+    }
+  }
+  return paths;
 }

--- a/packages/sandbox/daemon/lifecycle/manager.ts
+++ b/packages/sandbox/daemon/lifecycle/manager.ts
@@ -1,0 +1,36 @@
+import type { Broadcaster } from "../events/broadcast";
+import type { LifecycleState } from "../events/types";
+
+export interface LifecycleManagerDeps {
+  broadcaster: Broadcaster;
+}
+
+/**
+ * Owns the daemon's setup-pipeline state. Replaces the previous split between
+ * `PhaseManager` (typed task IDs with begin/done/fail) and `BranchStatus`'s
+ * phase tracking (cloning / clone-failed / checking-out / checkout-failed).
+ *
+ * The orchestrator and probe call `transition` to advance the state; the
+ * broadcaster fans the typed `lifecycle` event to SSE subscribers, and the
+ * SSE handshake pulls `current` for late-joiners.
+ */
+export class LifecycleManager {
+  private state: LifecycleState = { phase: "idle" };
+
+  constructor(private readonly deps: LifecycleManagerDeps) {}
+
+  current(): LifecycleState {
+    return this.state;
+  }
+
+  /** Idempotent — same-shape transitions don't re-broadcast. */
+  transition(next: LifecycleState): void {
+    if (equal(this.state, next)) return;
+    this.state = next;
+    this.deps.broadcaster.emit("lifecycle", { state: next });
+  }
+}
+
+function equal(a: LifecycleState, b: LifecycleState): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/sandbox/daemon/process/port-sniffer.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.ts
@@ -1,0 +1,68 @@
+import { WELL_KNOWN_STARTERS } from "../constants";
+
+/**
+ * Most dev tools advertise their bind URL on stdout once they're up:
+ *   vite:  `Local:   http://localhost:5174/`
+ *   next:  `- Local:        http://localhost:3000`
+ *   bun:   `Listening on http://localhost:3000`
+ *   fresh: `Listening on http://0.0.0.0:8000/`
+ *
+ * The probe needs a port to HEAD-check. Mesh sets `application.port` and
+ * exports it as `PORT`, but most frameworks (vite included) ignore that
+ * env unless the project's config reads it explicitly. Worse, on the host
+ * runner two sandboxes can race for the same default port — vite then
+ * silently falls back to the next free one. That mismatch leaves the
+ * probe checking a dead port forever.
+ *
+ * The sniffer feeds the probe the port it actually saw the dev script
+ * announce. First valid match wins until `reset()`; we never overwrite a
+ * locked-in port from a later log line, so a log message that happens to
+ * contain another `http://localhost:N/` (e.g. an outbound fetch) can't
+ * retarget the probe.
+ */
+
+const URL_PATTERN = /\bhttps?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)/;
+
+/** ANSI color/cursor escape regex shared with the booting overlay. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control chars
+// oxlint-disable-next-line no-control-regex
+const ANSI = /\[[0-9;?]*[a-zA-Z]/g;
+
+export interface PortSniffer {
+  /**
+   * Inspect a log chunk. No-op when not a starter source, when a port is
+   * already locked in, or when the chunk has no recognizable bind URL.
+   */
+  observe(source: string, data: string): void;
+  /** Currently sniffed port, or null if nothing's been detected. */
+  current(): number | null;
+  /** Drop the locked-in port — the next observe() can sniff again. */
+  reset(): void;
+}
+
+export function createPortSniffer(): PortSniffer {
+  let port: number | null = null;
+  return {
+    observe(source, data) {
+      if (port !== null) return;
+      if (
+        !WELL_KNOWN_STARTERS.includes(
+          source as (typeof WELL_KNOWN_STARTERS)[number],
+        )
+      )
+        return;
+      const stripped = data.replace(ANSI, "");
+      const match = stripped.match(URL_PATTERN);
+      if (!match) return;
+      const parsed = Number(match[1]);
+      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) return;
+      port = parsed;
+    },
+    current() {
+      return port;
+    },
+    reset() {
+      port = null;
+    },
+  };
+}

--- a/packages/sandbox/daemon/routes/config.ts
+++ b/packages/sandbox/daemon/routes/config.ts
@@ -1,3 +1,4 @@
+import { markClaimed } from "../activity";
 import type { TenantConfigStore } from "../config-store";
 import type { ApplyResult } from "../config-store/types";
 import type { Phase } from "../process/phase-manager";
@@ -96,6 +97,7 @@ export function makeConfigUpdateHandler(deps: ConfigDeps) {
     }
     const { auth: _strip, ...patch } = wire;
     const result = await deps.store.apply(patch as Partial<TenantConfig>);
+    if (result.kind !== "rejected") markClaimed();
     return makeApplyResponse(deps.daemonBootId, result);
   };
 }

--- a/packages/sandbox/daemon/routes/setup.ts
+++ b/packages/sandbox/daemon/routes/setup.ts
@@ -1,0 +1,26 @@
+import type { SetupOrchestrator, Step } from "../setup/orchestrator";
+import { jsonResponse } from "./body-parser";
+
+export interface SetupRouteDeps {
+  orchestrator: SetupOrchestrator;
+}
+
+/**
+ * Retry endpoints. Each one resumes the pipeline from a named step:
+ *   - clone   → re-acquire source, then install + start
+ *   - install → reinstall deps, then start
+ *   - start   → restart the dev script
+ *
+ * Idempotent: enqueueing the same step while one is in flight is a no-op
+ * (the orchestrator coalesces). Higher-rank steps subsume lower-rank
+ * pending work.
+ */
+export function makeSetupHandler(
+  step: Step,
+  deps: SetupRouteDeps,
+): () => Response {
+  return () => {
+    deps.orchestrator.resumeFrom(step);
+    return jsonResponse({ enqueued: step });
+  };
+}

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -96,8 +96,12 @@ describe("SetupOrchestrator lifecycle integration", () => {
     try {
       const repoDir = join(dir, "repo");
       mkdirSync(repoDir);
-      // Make it look like there's already a repo (no .git yet, but cloneUrl
-      // empty means we go through the checkout branch — which will error).
+      // Empty .git so `hasGitRepo` returns true but every `git -C` op fails
+      // ("not a git repository"). This forces stepClone into the
+      // `else if (cloneUrl)` checkout branch, then makes checkoutBranch's
+      // fetch + local-checkout + create-branch all fail → throws → caught by
+      // stepClone, which transitions to clone-failed.
+      mkdirSync(join(repoDir, ".git"));
       const broadcaster = new Broadcaster(1024);
       const { lifecycle, states } = makeLifecycleSpy(broadcaster);
 
@@ -105,7 +109,12 @@ describe("SetupOrchestrator lifecycle integration", () => {
         bootConfig: { appRoot: dir, repoDir },
         store: {
           read: () => ({
-            git: { repository: { cloneUrl: "", branch: "feat/x" } },
+            git: {
+              repository: {
+                cloneUrl: "https://invalid.example.invalid/x.git",
+                branch: "feat/x",
+              },
+            },
             application: {},
           }),
           hydrate: () => {},
@@ -137,21 +146,24 @@ describe("SetupOrchestrator lifecycle integration", () => {
         to: "feat/x",
       });
 
-      const deadline = Date.now() + 5_000;
+      const deadline = Date.now() + 10_000;
       while (orchestrator.isRunning() || orchestrator.pendingCount() > 0) {
         if (Date.now() > deadline) throw new Error("orchestrator hung");
         await new Promise((r) => setTimeout(r, 50));
       }
 
-      // Empty cloneUrl + non-existent .git → falls into the "no source" path
-      // and we just expect no clone-failed (no clone happened). The test is
-      // mainly here to confirm no exceptions and lifecycle stays sane.
-      // If a checkout was attempted it would have surfaced as a clone-failed.
-      expect(states.length).toBeGreaterThanOrEqual(0);
+      const checkingOutIdx = states.findIndex(
+        (s) => s.phase === "checking-out",
+      );
+      const cloneFailedIdx = states.findIndex(
+        (s) => s.phase === "clone-failed",
+      );
+      expect(checkingOutIdx).toBeGreaterThanOrEqual(0);
+      expect(cloneFailedIdx).toBeGreaterThan(checkingOutIdx);
     } finally {
       cleanup();
     }
-  });
+  }, 15_000);
 });
 
 describe("SetupOrchestrator status transitions", () => {

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Broadcaster } from "../events/broadcast";
 import type { BranchStatusMonitor } from "../git/branch-status";
+import { LifecycleManager } from "../lifecycle/manager";
+import type { LifecycleState } from "../events/types";
 import { SetupOrchestrator } from "./orchestrator";
 
 function tempRoot(): { dir: string; cleanup: () => void } {
@@ -11,28 +13,37 @@ function tempRoot(): { dir: string; cleanup: () => void } {
   return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
-function makeMonitorSpy() {
-  const calls: Array<{ method: string; arg?: unknown }> = [];
-  const monitor = {
-    setPhase(arg: unknown) {
-      calls.push({ method: "setPhase", arg });
-    },
-    markReady() {
-      calls.push({ method: "markReady" });
-    },
+function makeMonitorStub(): BranchStatusMonitor {
+  return {
+    refresh() {},
+    getLast: () => ({ kind: "unknown" as const }),
+    stop() {},
   } as unknown as BranchStatusMonitor;
-  return { monitor, calls };
 }
 
-describe("SetupOrchestrator branch-status integration", () => {
-  it("setPhase('cloning') is called before clone, 'clone-failed' on non-zero exit", async () => {
+/** Capture every lifecycle transition the orchestrator emits. */
+function makeLifecycleSpy(broadcaster: Broadcaster) {
+  const lifecycle = new LifecycleManager({ broadcaster });
+  const states: LifecycleState[] = [];
+  const orig = lifecycle.transition.bind(lifecycle);
+  lifecycle.transition = (next) => {
+    states.push(next);
+    orig(next);
+  };
+  return { lifecycle, states };
+}
+
+describe("SetupOrchestrator lifecycle integration", () => {
+  // Test invokes real `git clone` against an unreachable host; spawnClone
+  // retries transient errors a few times before giving up, so the test runs
+  // for up to ~15s.
+  it("transitions cloning → clone-failed when clone exits non-zero", async () => {
     const { dir, cleanup } = tempRoot();
     try {
       const broadcaster = new Broadcaster(1024);
-      const { monitor, calls } = makeMonitorSpy();
+      const { lifecycle, states } = makeLifecycleSpy(broadcaster);
 
-      // Build orchestrator with a config that points to an unreachable
-      // cloneUrl so spawnClone exits non-zero quickly.
+      // cloneUrl points at an unreachable host so spawnClone exits non-zero.
       const orchestrator = new SetupOrchestrator({
         bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
         store: {
@@ -56,55 +67,45 @@ describe("SetupOrchestrator branch-status integration", () => {
           waitForLogNamesIdle: async () => {},
           onTaskExit: () => () => {},
         } as never,
-        setIntent: () => {},
-        getIntent: () => ({ state: "running" as const }),
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
         broadcaster,
         installState: { isInstalledFor: () => false } as never,
         logsDir: dir,
-        branchStatus: monitor,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
       });
 
-      orchestrator.handle({
-        kind: "bootstrap",
-        config: {} as never,
-      });
+      orchestrator.handle({ kind: "bootstrap", config: {} as never });
 
-      // Poll until the orchestrator finishes the queue (or 15s timeout)
       const deadline = Date.now() + 15_000;
       while (orchestrator.isRunning() || orchestrator.pendingCount() > 0) {
         if (Date.now() > deadline) throw new Error("orchestrator hung");
         await new Promise((r) => setTimeout(r, 50));
       }
 
-      expect(calls[0]).toEqual({
-        method: "setPhase",
-        arg: { kind: "cloning" },
-      });
-      const failed = calls.find(
-        (c) =>
-          c.method === "setPhase" &&
-          (c.arg as { kind: string })?.kind === "clone-failed",
-      );
-      expect(failed).toBeTruthy();
-      expect(calls.some((c) => c.method === "markReady")).toBe(false);
+      expect(states[0]).toEqual({ phase: "cloning" });
+      expect(states.some((s) => s.phase === "clone-failed")).toBe(true);
     } finally {
       cleanup();
     }
-  });
+  }, 20_000);
 
-  it("setPhase('checking-out') / 'checkout-failed' on branchChange error", async () => {
+  it("transitions checking-out → clone-failed when checkout fails on existing repo", async () => {
     const { dir, cleanup } = tempRoot();
     try {
-      mkdirSync(join(dir, "repo"));
-      // No git repo at appRoot, so checkout will fail
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      // Make it look like there's already a repo (no .git yet, but cloneUrl
+      // empty means we go through the checkout branch — which will error).
       const broadcaster = new Broadcaster(1024);
-      const { monitor, calls } = makeMonitorSpy();
+      const { lifecycle, states } = makeLifecycleSpy(broadcaster);
 
       const orchestrator = new SetupOrchestrator({
-        bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
+        bootConfig: { appRoot: dir, repoDir },
         store: {
           read: () => ({
-            git: { repository: { cloneUrl: "" } },
+            git: { repository: { cloneUrl: "", branch: "feat/x" } },
             application: {},
           }),
           hydrate: () => {},
@@ -121,12 +122,13 @@ describe("SetupOrchestrator branch-status integration", () => {
           waitForLogNamesIdle: async () => {},
           onTaskExit: () => () => {},
         } as never,
-        setIntent: () => {},
-        getIntent: () => ({ state: "running" as const }),
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
         broadcaster,
         installState: { isInstalledFor: () => false } as never,
         logsDir: dir,
-        branchStatus: monitor,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
       });
 
       orchestrator.handle({
@@ -141,30 +143,25 @@ describe("SetupOrchestrator branch-status integration", () => {
         await new Promise((r) => setTimeout(r, 50));
       }
 
-      expect(calls[0]).toEqual({
-        method: "setPhase",
-        arg: { kind: "checking-out", to: "feat/x" },
-      });
-      const failed = calls.find(
-        (c) =>
-          c.method === "setPhase" &&
-          (c.arg as { kind: string })?.kind === "checkout-failed",
-      );
-      expect(failed).toBeTruthy();
+      // Empty cloneUrl + non-existent .git → falls into the "no source" path
+      // and we just expect no clone-failed (no clone happened). The test is
+      // mainly here to confirm no exceptions and lifecycle stays sane.
+      // If a checkout was attempted it would have surfaced as a clone-failed.
+      expect(states.length).toBeGreaterThanOrEqual(0);
     } finally {
       cleanup();
     }
   });
 });
 
-describe("SetupOrchestrator intent transitions", () => {
-  it("flips intent to paused when a starter task exits non-zero non-intentionally", () => {
+describe("SetupOrchestrator status transitions", () => {
+  it("flips status to error when a starter task exits non-zero non-intentionally", () => {
     const { dir, cleanup } = tempRoot();
     try {
       let exitHandler: ((s: unknown) => void) | null = null;
-      const intentCalls: Array<{ state: string; reason?: string }> = [];
+      const statusCalls: Array<{ state: string; reason?: string }> = [];
       const broadcaster = new Broadcaster(1024);
-      const { monitor } = makeMonitorSpy();
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
 
       new SetupOrchestrator({
         bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
@@ -187,12 +184,13 @@ describe("SetupOrchestrator intent transitions", () => {
             return () => {};
           },
         } as never,
-        setIntent: (i) => intentCalls.push(i),
-        getIntent: () => ({ state: "running" as const }),
+        setStatus: (i) => statusCalls.push(i),
+        getStatus: () => ({ state: "running" as const }),
         broadcaster,
         installState: { isInstalledFor: () => false } as never,
         logsDir: dir,
-        branchStatus: monitor,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
       });
 
       expect(exitHandler).not.toBeNull();
@@ -203,9 +201,9 @@ describe("SetupOrchestrator intent transitions", () => {
         intentional: false,
         status: "failed",
       });
-      expect(intentCalls).toHaveLength(1);
-      expect(intentCalls[0]).toEqual({
-        state: "paused",
+      expect(statusCalls).toHaveLength(1);
+      expect(statusCalls[0]).toEqual({
+        state: "error",
         reason: "dev script exited with code 1",
       });
     } finally {
@@ -213,13 +211,13 @@ describe("SetupOrchestrator intent transitions", () => {
     }
   });
 
-  it("does NOT flip intent on intentional kill", () => {
+  it("does NOT flip status on intentional kill", () => {
     const { dir, cleanup } = tempRoot();
     try {
       let exitHandler: ((s: unknown) => void) | null = null;
-      const intentCalls: Array<{ state: string }> = [];
+      const statusCalls: Array<{ state: string }> = [];
       const broadcaster = new Broadcaster(1024);
-      const { monitor } = makeMonitorSpy();
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
 
       new SetupOrchestrator({
         bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
@@ -242,12 +240,13 @@ describe("SetupOrchestrator intent transitions", () => {
             return () => {};
           },
         } as never,
-        setIntent: (i) => intentCalls.push(i),
-        getIntent: () => ({ state: "running" as const }),
+        setStatus: (i) => statusCalls.push(i),
+        getStatus: () => ({ state: "running" as const }),
         broadcaster,
         installState: { isInstalledFor: () => false } as never,
         logsDir: dir,
-        branchStatus: monitor,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
       });
 
       exitHandler!({
@@ -257,19 +256,19 @@ describe("SetupOrchestrator intent transitions", () => {
         intentional: true,
         status: "killed",
       });
-      expect(intentCalls).toHaveLength(0);
+      expect(statusCalls).toHaveLength(0);
     } finally {
       cleanup();
     }
   });
 
-  it("does NOT flip intent for non-starter tasks", () => {
+  it("does NOT flip status for non-starter tasks", () => {
     const { dir, cleanup } = tempRoot();
     try {
       let exitHandler: ((s: unknown) => void) | null = null;
-      const intentCalls: Array<{ state: string }> = [];
+      const statusCalls: Array<{ state: string }> = [];
       const broadcaster = new Broadcaster(1024);
-      const { monitor } = makeMonitorSpy();
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
 
       new SetupOrchestrator({
         bootConfig: { appRoot: dir, repoDir: join(dir, "repo") },
@@ -292,12 +291,13 @@ describe("SetupOrchestrator intent transitions", () => {
             return () => {};
           },
         } as never,
-        setIntent: (i) => intentCalls.push(i),
-        getIntent: () => ({ state: "running" as const }),
+        setStatus: (i) => statusCalls.push(i),
+        getStatus: () => ({ state: "running" as const }),
         broadcaster,
         installState: { isInstalledFor: () => false } as never,
         logsDir: dir,
-        branchStatus: monitor,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
       });
 
       exitHandler!({
@@ -307,7 +307,7 @@ describe("SetupOrchestrator intent transitions", () => {
         intentional: false,
         status: "failed",
       });
-      expect(intentCalls).toHaveLength(0);
+      expect(statusCalls).toHaveLength(0);
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -12,14 +12,15 @@ import {
   pmRunCommand,
 } from "../constants";
 import type { Broadcaster } from "../events/broadcast";
+import type { DaemonStatus } from "../events/types";
 import type { BranchStatusMonitor } from "../git/branch-status";
 import { gitSync } from "../git/git-sync";
 import type { InstallState } from "../install/install-state";
 import { InstallState as InstallStateClass } from "../install/install-state";
+import type { LifecycleManager } from "../lifecycle/manager";
 import { LogTee } from "../process/log-tee";
 import { appLogPath, hasGitRepo, resolvePmRoot } from "../paths";
 import { discoverScripts } from "../process/script-discovery";
-import type { PhaseManager } from "../process/phase-manager";
 import type { Application, Config } from "../types";
 import { autodetectApplication } from "./autodetect";
 import { spawnClone } from "./clone";
@@ -30,32 +31,40 @@ import { installProtectedBranchHook } from "../git/protect-branch";
 
 const INSTALL_LOG_MAX_BYTES = 10 * 1024 * 1024;
 
+/**
+ * The named entry points into the setup pipeline. A step always runs
+ * forward through the pipeline (install also runs start; clone also runs
+ * install + start).
+ */
+export type Step = "clone" | "install" | "start";
+
+const STEP_RANK: Record<Step, number> = { clone: 3, install: 2, start: 1 };
+
 export interface SetupOrchestratorDeps {
   bootConfig: { appRoot: string; repoDir: string };
   store: TenantConfigStore;
   taskManager: TaskManager;
-  setIntent: (next: { state: "running" | "paused"; reason?: string }) => void;
-  getIntent: () => { state: "running" | "paused"; reason?: string };
+  setStatus: (next: DaemonStatus) => void;
+  getStatus: () => DaemonStatus;
   broadcaster: Broadcaster;
   installState: InstallState;
   /** Workspace tmp dir; install tee lives at `<logsDir>/app/install`. */
   logsDir: string;
-  /** When provided, setup phases are tracked via the phase manager. */
-  phaseManager?: PhaseManager;
+  lifecycle: LifecycleManager;
   branchStatus: BranchStatusMonitor;
 }
 
 /**
- * Reducer over `Transition` events emitted by the config store.
- *
- * Each transition maps to one async recipe. An internal FIFO queue
- * serializes runs so an in-flight install can't race a branch checkout.
- * Same-kind transitions coalesce (only the most recent matters).
+ * Drives the setup pipeline (clone → install → start) in response to config
+ * changes (`handle(transition)`) or explicit retry requests
+ * (`resumeFrom(step)`). A FIFO queue serializes runs so an in-flight install
+ * can't race a branch checkout.
  */
 export class SetupOrchestrator {
-  private readonly queue: Transition[] = [];
+  private readonly queue: Step[] = [];
   private running = false;
   private currentBranchHead: string | undefined;
+  private latestScripts: string[] | null = null;
 
   constructor(private readonly deps: SetupOrchestratorDeps) {
     this.deps.taskManager.onTaskExit((summary) => {
@@ -68,26 +77,26 @@ export class SetupOrchestrator {
         return;
       if (summary.intentional) return;
       if (summary.exitCode === 0 || summary.exitCode === null) return;
-      this.deps.setIntent({
-        state: "paused",
+      this.deps.setStatus({
+        state: "error",
         reason: `dev script exited with code ${summary.exitCode}`,
       });
     });
   }
 
-  /** Fire-and-forget enqueue. */
+  /** Config-store transition → step. Fire-and-forget. */
   handle(transition: Transition): void {
-    if (
-      transition.kind === "no-op" ||
-      transition.kind === "identity-conflict"
-    ) {
-      return;
-    }
-    this.coalesce(transition);
-    void this.drain();
+    const step = transitionToStep(transition);
+    if (!step) return;
+    this.enqueueStep(step);
   }
 
-  /** True while a transition is being applied. Surfaced on /health. */
+  /** Studio retry endpoint → resume from a named step. Fire-and-forget. */
+  resumeFrom(step: Step): void {
+    this.enqueueStep(step);
+  }
+
+  /** True while a step is being applied. Surfaced on /health. */
   isRunning(): boolean {
     return this.running;
   }
@@ -96,19 +105,22 @@ export class SetupOrchestrator {
     return this.queue.length;
   }
 
-  private coalesce(t: Transition): void {
-    // Last-of-kind wins for transitions that fully describe themselves.
-    const collapsable = new Set([
-      "branch-change",
-      "pm-change",
-      "runtime-change",
-      "port-change",
-    ]);
-    if (collapsable.has(t.kind)) {
-      const idx = this.queue.findIndex((q) => q.kind === t.kind);
-      if (idx >= 0) this.queue.splice(idx, 1);
+  /** Snapshot of the most recently discovered package-manager scripts. */
+  getDiscoveredScripts(): string[] | null {
+    return this.latestScripts;
+  }
+
+  private enqueueStep(step: Step): void {
+    // A higher-rank step subsumes lower-rank work — clone implies
+    // install + start, install implies start. So if `clone` is queued,
+    // there's no point also queuing `install` or `start`.
+    const rank = STEP_RANK[step];
+    if (this.queue.some((q) => STEP_RANK[q] >= rank)) return;
+    for (let i = this.queue.length - 1; i >= 0; i--) {
+      if (STEP_RANK[this.queue[i]] < rank) this.queue.splice(i, 1);
     }
-    this.queue.push(t);
+    this.queue.push(step);
+    void this.drain();
   }
 
   private async drain(): Promise<void> {
@@ -116,31 +128,16 @@ export class SetupOrchestrator {
     this.running = true;
     try {
       while (this.queue.length > 0) {
-        const t = this.queue.shift();
-        if (!t) break;
-        const taskId = this.deps.phaseManager?.begin(`transition:${t.kind}`);
-        this.chunk(`[orchestrator] transition: ${t.kind}\r\n`);
-        this.deps.broadcaster.broadcastEvent("transition", {
-          kind: t.kind,
-          phase: "start",
-        });
+        const step = this.queue.shift();
+        if (!step) break;
+        this.chunk(`[orchestrator] running step: ${step}\r\n`);
         try {
-          await this.run(t);
-          this.chunk(`[orchestrator] done: ${t.kind}\r\n`);
-          this.deps.broadcaster.broadcastEvent("transition", {
-            kind: t.kind,
-            phase: "done",
-          });
-          if (taskId) this.deps.phaseManager?.done(taskId);
+          await this.runStep(step);
         } catch (e) {
+          // Step methods own their own lifecycle transitions; this catch is
+          // a backstop for unexpected throws so the queue keeps draining.
           const msg = (e as Error).message;
-          this.chunk(`\r\n[orchestrator] failed: ${t.kind}: ${msg}\r\n`);
-          this.deps.broadcaster.broadcastEvent("transition", {
-            kind: t.kind,
-            phase: "failed",
-            error: msg,
-          });
-          if (taskId) this.deps.phaseManager?.fail(taskId, msg);
+          this.chunk(`\r\n[orchestrator] step ${step} crashed: ${msg}\r\n`);
         }
       }
     } finally {
@@ -148,22 +145,22 @@ export class SetupOrchestrator {
     }
   }
 
-  private async run(t: Transition): Promise<void> {
-    switch (t.kind) {
-      case "bootstrap":
-        return this.bootstrap();
-      case "branch-change":
-        return this.branchChange(t.to);
-      case "pm-change":
-      case "runtime-change":
-        return this.reinstallAndMaybeStart();
-      case "port-change":
-        return this.maybeRestartDev();
-      case "no-op":
-      case "identity-conflict":
+  private async runStep(step: Step): Promise<void> {
+    switch (step) {
+      case "clone":
+        if (!(await this.stepClone())) return;
+        if (!(await this.stepInstall())) return;
+        await this.stepStart();
         return;
-      default:
-        t satisfies never;
+      case "install":
+        await this.stopDevTask();
+        if (!(await this.stepInstall())) return;
+        await this.stepStart();
+        return;
+      case "start":
+        await this.stopDevTask();
+        await this.stepStart();
+        return;
     }
   }
 
@@ -184,14 +181,18 @@ export class SetupOrchestrator {
     this.deps.broadcaster.broadcastChunk("setup", data);
   }
 
-  private async bootstrap(): Promise<void> {
-    const initial = this.currentConfig();
-    if (!initial) return;
+  /**
+   * Acquires source: clone if no .git, otherwise checkout the configured
+   * branch. Then runs idempotent post-source-acquisition steps (git
+   * identity, protected-branch hook, fillDefaults).
+   */
+  private async stepClone(): Promise<boolean> {
+    const config = this.currentConfig();
+    if (!config) return false;
+    const cloneUrl = config.git?.repository?.cloneUrl;
 
-    const cloneUrl = initial.git?.repository?.cloneUrl;
-    if (cloneUrl && !hasGitRepo(initial.repoDir)) {
-      this.deps.branchStatus.setPhase({ kind: "cloning" });
-      const cloneTaskId = this.deps.phaseManager?.begin("clone");
+    if (cloneUrl && !hasGitRepo(config.repoDir)) {
+      this.deps.lifecycle.transition({ phase: "cloning" });
       const cloneLogPath = appLogPath(this.deps.logsDir, "clone");
       try {
         unlinkSync(cloneLogPath);
@@ -202,7 +203,7 @@ export class SetupOrchestrator {
       let code: number;
       try {
         code = await spawnClone({
-          config: initial,
+          config,
           onChunk: (_src, data) => {
             this.chunk(data);
             cloneTee.write(data);
@@ -212,45 +213,142 @@ export class SetupOrchestrator {
         cloneTee.close();
         const error = (e as Error).message;
         this.chunk(`\r\n[orchestrator] clone failed: ${error}\r\n`);
-        if (cloneTaskId) this.deps.phaseManager?.fail(cloneTaskId, error);
-        this.deps.branchStatus.setPhase({ kind: "clone-failed", error });
-        return;
+        this.deps.lifecycle.transition({ phase: "clone-failed", error });
+        return false;
       }
       cloneTee.close();
       if (code !== 0) {
-        this.chunk(`\r\n[orchestrator] clone failed (exit ${code})\r\n`);
-        if (cloneTaskId)
-          this.deps.phaseManager?.fail(cloneTaskId, `exit ${code}`);
-        this.deps.branchStatus.setPhase({
-          kind: "clone-failed",
-          error: `exit ${code}`,
-        });
-        return;
+        const error = `exit ${code}`;
+        this.chunk(`\r\n[orchestrator] clone failed (${error})\r\n`);
+        this.deps.lifecycle.transition({ phase: "clone-failed", error });
+        return false;
       }
-      if (cloneTaskId) this.deps.phaseManager?.done(cloneTaskId);
     } else if (cloneUrl) {
-      this.chunk(`[orchestrator] repo already cloned\r\n`);
+      // Repo exists. If a different branch is configured, treat that as a
+      // checkout step under the lifecycle.
+      const branch = config.git?.repository?.branch;
+      if (branch && !isSyntheticBranch(branch)) {
+        this.deps.lifecycle.transition({ phase: "checking-out", to: branch });
+        try {
+          await this.checkoutBranch(branch);
+        } catch (e) {
+          const error = (e as Error).message;
+          this.chunk(`\r\n[orchestrator] checkout failed: ${error}\r\n`);
+          this.deps.lifecycle.transition({ phase: "clone-failed", error });
+          return false;
+        }
+      } else {
+        this.chunk(`[orchestrator] repo already cloned\r\n`);
+      }
     }
 
     // Identity has to run after clone so `git config` has a repo to write
     // into — earlier order tripped posix_spawn ENOENT (it reads cwd before
     // exec, and repoDir doesn't exist until clone returns).
-    await this.gitSetup(initial);
-    await this.fillApplicationDefaults(initial.repoDir);
-    this.deps.branchStatus.markReady();
+    await this.gitSetup(config);
+    await this.fillApplicationDefaults(config.repoDir);
+    this.deps.branchStatus.refresh();
+    return true;
+  }
 
+  /**
+   * Run install. Skips when fingerprint matches (already installed for this
+   * config + branch HEAD). Returns true on success/skip, false on failure.
+   */
+  private async stepInstall(): Promise<boolean> {
+    const config = this.currentConfig();
+    if (!config) return false;
+    if (this.deps.installState.isInstalledFor(config, this.currentBranchHead)) {
+      this.broadcastDiscoveredScripts(config);
+      return true;
+    }
+    if (!config.application?.packageManager?.name) {
+      // Nothing to install — proceed to start, which will diagnose.
+      return true;
+    }
+
+    this.deps.lifecycle.transition({ phase: "installing" });
+    this.chunk(`[orchestrator] installing dependencies\r\n`);
+
+    const installLogPath = appLogPath(this.deps.logsDir, "install");
+    try {
+      unlinkSync(installLogPath);
+    } catch {
+      /* not present */
+    }
+    const installTee = new LogTee(installLogPath, INSTALL_LOG_MAX_BYTES);
+    const installPromise = spawnInstall({
+      config,
+      onChunk: (_src, data) => {
+        this.chunk(data);
+        installTee.write(data);
+      },
+    });
+    // null = no install step needed (e.g. deno auto-fetches; or no manifest
+    // present yet). Treat as success so the caller proceeds to start; mark
+    // the install fingerprint so resume doesn't retry on every boot.
+    if (!installPromise) {
+      installTee.close();
+      this.markInstallSucceeded(config);
+      return true;
+    }
+    const code = await installPromise;
+    installTee.close();
+    if (code !== 0) {
+      const error = `exit ${code}`;
+      this.chunk(`\r\n[orchestrator] install failed (${error})\r\n`);
+      this.deps.installState.mark(
+        InstallStateClass.fingerprint(config, this.currentBranchHead),
+        false,
+      );
+      this.deps.lifecycle.transition({ phase: "install-failed", error });
+      return false;
+    }
+    this.markInstallSucceeded(config);
+    return true;
+  }
+
+  /**
+   * Spawn the dev script. Probe drives the transition from `starting` to
+   * `running` once the dev server responds.
+   */
+  private async stepStart(): Promise<void> {
     const config = this.currentConfig();
     if (!config) return;
-
+    if (this.deps.getStatus().state !== "running") {
+      this.chunk(
+        `\r\n[orchestrator] skipping start: status=${this.deps.getStatus().state} (resume to retry)\r\n`,
+      );
+      return;
+    }
     if (
       !this.deps.installState.isInstalledFor(config, this.currentBranchHead)
     ) {
-      const ok = await this.runInstall();
-      if (!ok) return;
-    } else {
-      this.broadcastDiscoveredScripts(config);
+      this.chunk(
+        "\r\n[orchestrator] skipping start: install fingerprint mismatch\r\n",
+      );
+      return;
     }
-    await this.startIfReady();
+    const command = this.buildStartCommand(config);
+    if (!command) {
+      const reason = this.diagnoseNoStartCommand(config);
+      this.chunk(reason);
+      this.deps.lifecycle.transition({
+        phase: "start-failed",
+        error: reason.replace(/\r?\n/g, " ").trim(),
+      });
+      return;
+    }
+    this.deps.lifecycle.transition({ phase: "starting" });
+    await this.deps.taskManager.spawn({
+      command: command.cmd,
+      cwd: command.cwd,
+      env: buildDevEnv(config),
+      label: command.label,
+      mode: "pty",
+      logName: command.source,
+      replaceByLogName: true,
+    });
   }
 
   /**
@@ -259,7 +357,7 @@ export class SetupOrchestrator {
    * config always wins; this only patches gaps.
    *
    * Goes through `store.applyInternal` (not `apply`) so a fresh
-   * pm-change/runtime-change isn't emitted — this runs inside bootstrap,
+   * pm-change/runtime-change isn't emitted — this runs inside stepClone,
    * which already handles install+start. The `compute` callback executes
    * inside the store's serial queue, so a concurrent PUT can't race the
    * read-then-write.
@@ -293,78 +391,11 @@ export class SetupOrchestrator {
     });
   }
 
-  private async branchChange(to: string): Promise<void> {
-    await this.stopDevTask();
-    this.chunk(`[orchestrator] checking out branch: ${to}\r\n`);
-    this.deps.branchStatus.setPhase({ kind: "checking-out", to });
-    try {
-      await this.checkoutBranch(to);
-    } catch (e) {
-      const error = (e as Error).message;
-      this.chunk(`\r\n[orchestrator] branch-change failed: ${error}\r\n`);
-      this.deps.branchStatus.setPhase({ kind: "checkout-failed", error });
-      return;
-    }
-    this.refreshBranchHead();
-    this.deps.branchStatus.markReady();
-    const ok = await this.runInstall();
-    if (ok) await this.startIfReady();
-  }
-
-  private async reinstallAndMaybeStart(): Promise<void> {
-    await this.stopDevTask();
-    const ok = await this.runInstall();
-    if (ok) await this.startIfReady();
-  }
-
-  private async maybeRestartDev(): Promise<void> {
-    await this.stopDevTask();
-    await this.startIfReady();
-  }
-
   private async stopDevTask(): Promise<void> {
     for (const starter of WELL_KNOWN_STARTERS) {
       this.deps.taskManager.killByLogName(starter, { intentional: true });
     }
     await this.deps.taskManager.waitForLogNamesIdle(WELL_KNOWN_STARTERS);
-  }
-
-  /**
-   * Start the dev script iff the install fingerprint matches and we have a
-   * discovered starter script. No retry on failure — the dev process must be
-   * (re)launched by a config change (pm, runtime, branch, or port).
-   */
-  private async startIfReady(): Promise<void> {
-    const config = this.currentConfig();
-    if (!config) return;
-    if (this.deps.getIntent().state === "paused") {
-      this.chunk(
-        "\r\n[orchestrator] skipping start: intent=paused (resume to retry)\r\n",
-      );
-      return;
-    }
-    if (
-      !this.deps.installState.isInstalledFor(config, this.currentBranchHead)
-    ) {
-      this.chunk(
-        "\r\n[orchestrator] skipping start: install fingerprint mismatch\r\n",
-      );
-      return;
-    }
-    const command = this.buildStartCommand(config);
-    if (!command) {
-      this.chunk(this.diagnoseNoStartCommand(config));
-      return;
-    }
-    await this.deps.taskManager.spawn({
-      command: command.cmd,
-      cwd: command.cwd,
-      env: buildDevEnv(config),
-      label: command.label,
-      mode: "pty",
-      logName: command.source,
-      replaceByLogName: true,
-    });
   }
 
   private diagnoseNoStartCommand(config: Config): string {
@@ -411,54 +442,7 @@ export class SetupOrchestrator {
     };
   }
 
-  private async runInstall(): Promise<boolean> {
-    const config = this.currentConfig();
-    if (!config) return false;
-    if (!config.application?.packageManager?.name) return false;
-    const installTaskId = this.deps.phaseManager?.begin("install");
-    this.chunk(`[orchestrator] installing dependencies\r\n`);
-    const installLogPath = appLogPath(this.deps.logsDir, "install");
-    try {
-      unlinkSync(installLogPath);
-    } catch {
-      /* not present */
-    }
-    const installTee = new LogTee(installLogPath, INSTALL_LOG_MAX_BYTES);
-    const installPromise = spawnInstall({
-      config,
-      onChunk: (_src, data) => {
-        this.chunk(data);
-        installTee.write(data);
-      },
-    });
-    // null = no install step needed (e.g. deno auto-fetches; or no manifest
-    // present yet). Treat as success so the caller proceeds to start; mark
-    // the install fingerprint so resume doesn't retry on every boot.
-    if (!installPromise) {
-      installTee.close();
-      this.markInstallSucceeded(config);
-      if (installTaskId) this.deps.phaseManager?.done(installTaskId);
-      return true;
-    }
-    const code = await installPromise;
-    installTee.close();
-    if (code !== 0) {
-      this.chunk(`\r\n[orchestrator] install failed (exit ${code})\r\n`);
-      this.deps.installState.mark(
-        InstallStateClass.fingerprint(config, this.currentBranchHead),
-        false,
-      );
-      if (installTaskId)
-        this.deps.phaseManager?.fail(installTaskId, `exit ${code}`);
-      return false;
-    }
-    this.markInstallSucceeded(config);
-    if (installTaskId) this.deps.phaseManager?.done(installTaskId);
-    return true;
-  }
-
   private async gitSetup(config: Config): Promise<void> {
-    const gitTaskId = this.deps.phaseManager?.begin("git-setup");
     try {
       configureGitIdentity(config);
     } catch (e) {
@@ -487,7 +471,6 @@ export class SetupOrchestrator {
       }
     }
     this.refreshBranchHead();
-    if (gitTaskId) this.deps.phaseManager?.done(gitTaskId);
   }
 
   private markInstallSucceeded(config: Config): void {
@@ -511,10 +494,8 @@ export class SetupOrchestrator {
       cwd,
       config.application?.packageManager?.name ?? null,
     );
-    this.deps.broadcaster.broadcastEvent("scripts", {
-      type: "scripts",
-      scripts,
-    });
+    this.latestScripts = scripts;
+    this.deps.broadcaster.emit("scripts", { scripts });
   }
 
   private refreshBranchHead(): void {
@@ -566,5 +547,24 @@ export class SetupOrchestrator {
     this.chunk(`[orchestrator] creating new local branch: ${branch}\r\n`);
     const code = await spawnSetupStep(`${gc} checkout -b ${branch}`, onChunk);
     if (code !== 0) throw new Error(`git checkout -b ${branch} exited ${code}`);
+  }
+}
+
+function transitionToStep(t: Transition): Step | null {
+  switch (t.kind) {
+    case "bootstrap":
+    case "branch-change":
+      return "clone";
+    case "runtime-change":
+    case "pm-change":
+      return "install";
+    case "port-change":
+      return "start";
+    case "identity-conflict":
+    case "no-op":
+      return null;
+    default:
+      t satisfies never;
+      return null;
   }
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -77,10 +77,20 @@ export class SetupOrchestrator {
         return;
       if (summary.intentional) return;
       if (summary.exitCode === 0 || summary.exitCode === null) return;
-      this.deps.setStatus({
-        state: "error",
-        reason: `dev script exited with code ${summary.exitCode}`,
-      });
+      const reason = `dev script exited with code ${summary.exitCode}`;
+      this.deps.setStatus({ state: "error", reason });
+      // Lifecycle was at `starting` (post-spawn) or `running` (probe saw it
+      // up briefly). Either way the dev script is gone now; surface a
+      // terminal failure phase so the UI shows the retry button instead of
+      // sitting on the boot animation forever. If probe later overrides to
+      // `crashed`, that's also a terminal failure — both UIs treat it the
+      // same.
+      if (this.deps.lifecycle.current().phase !== "start-failed") {
+        this.deps.lifecycle.transition({
+          phase: "start-failed",
+          error: reason,
+        });
+      }
     });
   }
 
@@ -148,6 +158,10 @@ export class SetupOrchestrator {
   private async runStep(step: Step): Promise<void> {
     switch (step) {
       case "clone":
+        // A `clone` step from `branch-change` runs `git checkout -f` against
+        // the live repo; the dev server has to be down before that, otherwise
+        // the checkout fights an open file handle / writes its sources.
+        await this.stopDevTask();
         if (!(await this.stepClone())) return;
         if (!(await this.stepInstall())) return;
         await this.stepStart();

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -80,22 +80,3 @@ export interface SseFrame {
   readonly event: string;
   readonly payload: string;
 }
-
-export type BranchStatusReady = {
-  readonly kind: "ready";
-  readonly branch: string;
-  readonly base: string;
-  readonly workingTreeDirty: boolean;
-  readonly unpushed: number;
-  readonly aheadOfBase: number;
-  readonly behindBase: number;
-  readonly headSha: string;
-};
-
-export type BranchStatus =
-  | { readonly kind: "initializing" }
-  | { readonly kind: "cloning" }
-  | { readonly kind: "clone-failed"; readonly error: string }
-  | { readonly kind: "checking-out"; readonly to: string }
-  | { readonly kind: "checkout-failed"; readonly error: string }
-  | BranchStatusReady;

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {

--- a/packages/sandbox/shared.ts
+++ b/packages/sandbox/shared.ts
@@ -1,3 +1,13 @@
+export type {
+  ActiveTaskSummary,
+  BranchMeta,
+  DaemonEventMap,
+  DaemonEventName,
+  DaemonEventPayload,
+  DaemonStatus,
+  LifecycleState,
+} from "./daemon/events/types";
+
 export const PLUGIN_ID = "MCP User Sandbox";
 export const PLUGIN_DESCRIPTION =
   "Isolated per-user sandboxes for MCP tool execution";


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the sandbox daemon lifecycle into a single `lifecycle` stream, switches SSE to typed events shared with Studio, and adds browser-friendly retry endpoints. Publishes the new shared types in `@decocms/sandbox` v0.5.0.

- **New Features**
  - Added `LifecycleManager` and a single `lifecycle` event (idle/cloning/checking-out/installing/starting/running/crashed and failure variants).
  - Introduced typed SSE events via `@decocms/sandbox/shared` (`DaemonEventMap`), used across daemon and Studio.
  - Added retry endpoints: POST `/_decopilot_vm/setup/{clone,install,start}` and a Mesh proxy at POST `/api/:org/vm-setup/{clone|install|start}` for browsers.
  - `DaemonStatus` gains `error` for unexpected dev-script exits; probe now drives `running`/`crashed` and latches the actual port from logs to avoid dead probes.
  - Preview latches `htmlSupport` across `running → crashed`; overlay derives booting/online/offline from `lifecycle.phase`. `/health` ready reflects `lifecycle.phase === 'running'`.

- **Migration**
  - SSE events are now: `log|lifecycle|status|tasks|scripts|branch|reload`. Removed `intent`, `phases`, `processes`, and `branch-status`.
  - Consume shared types from `@decocms/sandbox/shared` (`LifecycleState`, `DaemonStatus`, `BranchMeta`, etc).
  - For browser retries, call `/api/:org/vm-setup/{clone|install|start}` (Mesh proxies to the daemon). Server-to-daemon remains `/_decopilot_vm/setup/{...}`.
  - Frontend updates: use `useVmEvents().lifecycle`, `status`, and `branch`. `use-branch-status` projects `lifecycle + branch` to the legacy panel shape. Preview online/offline derives from `lifecycle` (`running` → online, `crashed` → offline).

<sup>Written for commit 08f653de90c002ec7816fbdfb3ee02d066ee802a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

