### PR TITLE
feat(automations): click-to-edit prompt arguments in instructions

### DIFF
--- a/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
+++ b/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
@@ -32,6 +32,10 @@ interface PromptArgsDialogProps {
   prompt: Prompt | null;
   setPrompt: (prompt: Prompt | null) => void;
   onSubmit: (values: PromptArgumentValues) => Promise<void>;
+  /** Prefill the form with these values (e.g. when editing an existing
+   * mention). Keys that don't match the current prompt's arguments are
+   * dropped silently. */
+  defaultValues?: PromptArgumentValues;
 }
 
 function buildArgumentSchema(prompt: Prompt) {
@@ -44,10 +48,13 @@ function buildArgumentSchema(prompt: Prompt) {
   return z.object(shape);
 }
 
-function buildDefaultValues(prompt: Prompt): PromptArgumentValues {
+function buildDefaultValues(
+  prompt: Prompt,
+  preset?: PromptArgumentValues,
+): PromptArgumentValues {
   const defaults: PromptArgumentValues = {};
   for (const arg of prompt.arguments ?? []) {
-    defaults[arg.name] = "";
+    defaults[arg.name] = preset?.[arg.name] ?? "";
   }
   return defaults;
 }
@@ -56,15 +63,17 @@ export function PromptArgsDialog({
   prompt,
   setPrompt,
   onSubmit,
+  defaultValues,
 }: PromptArgsDialogProps) {
   const id = useId();
   const schema = prompt ? buildArgumentSchema(prompt) : z.object({});
   const resolver = zodResolver(schema as any);
   const form = useForm<PromptArgumentValues>({
     resolver: resolver as unknown as Resolver<PromptArgumentValues>,
-    defaultValues: prompt ? buildDefaultValues(prompt) : {},
+    defaultValues: prompt ? buildDefaultValues(prompt, defaultValues) : {},
     mode: "onChange",
   });
+  const isEditing = !!defaultValues;
 
   const argumentsList = prompt?.arguments ?? [];
 
@@ -163,6 +172,8 @@ export function PromptArgsDialog({
                     <Spinner size="xs" />
                     Loading...
                   </span>
+                ) : isEditing ? (
+                  "Save"
                 ) : (
                   "Use prompt"
                 )}

--- a/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
@@ -25,13 +25,20 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Editor, Range } from "@tiptap/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   PromptArgsDialog,
   type PromptArgumentValues,
 } from "../dialog-prompt-arguments.tsx";
-import { BaseItem, insertMention, OnSelectProps, Suggestion } from "./mention";
+import {
+  BaseItem,
+  insertMention,
+  MENTION_EDIT_EVENT,
+  type MentionEditEventDetail,
+  OnSelectProps,
+  Suggestion,
+} from "./mention";
 import { track } from "@/web/lib/posthog-client";
 
 interface SlashMentionProps {
@@ -49,10 +56,14 @@ interface SlashItem extends BaseItem {
   _meta?: Prompt["_meta"];
 }
 
-interface PromptSelectContext {
-  range: Range;
-  item: SlashItem;
-}
+type ActivePromptContext =
+  | { mode: "create"; range: Range; item: SlashItem }
+  | {
+      mode: "edit";
+      pos: number;
+      item: SlashItem;
+      values: PromptArgumentValues;
+    };
 
 async function fetchAndInsertPrompt(
   editor: Editor,
@@ -70,10 +81,46 @@ async function fetchAndInsertPrompt(
       name: stripToolNamespace(promptName, clientId),
       metadata: result.messages,
       char: "/",
+      values:
+        values && Object.keys(values).length > 0
+          ? (values as Record<string, string>)
+          : undefined,
     });
   } catch (error) {
     console.error("[slash] Failed to fetch prompt:", error);
     toast.error("Failed to load prompt. Please try again.");
+  }
+}
+
+async function fetchAndUpdatePrompt(
+  editor: Editor,
+  pos: number,
+  client: Client,
+  promptName: string,
+  values: PromptArgumentValues,
+) {
+  try {
+    const result = await getPrompt(client, promptName, values);
+    editor
+      .chain()
+      .focus()
+      .command(({ tr }) => {
+        const node = tr.doc.nodeAt(pos);
+        if (!node || node.type.name !== "mention") return false;
+        tr.setNodeMarkup(pos, undefined, {
+          ...node.attrs,
+          metadata: result.messages,
+          values:
+            Object.keys(values).length > 0
+              ? (values as Record<string, string>)
+              : undefined,
+        });
+        return true;
+      })
+      .run();
+  } catch (error) {
+    console.error("[slash] Failed to update prompt:", error);
+    toast.error("Failed to update prompt. Please try again.");
   }
 }
 
@@ -123,7 +170,7 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
     virtualMcpId ?? "default",
   ] as const;
 
-  const [activePrompt, setActivePrompt] = useState<PromptSelectContext | null>(
+  const [activePrompt, setActivePrompt] = useState<ActivePromptContext | null>(
     null,
   );
 
@@ -147,7 +194,7 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
     if (item.kind === "prompt") {
       // If prompt has arguments, open dialog
       if (item.arguments && item.arguments.length > 0) {
-        setActivePrompt({ range, item });
+        setActivePrompt({ mode: "create", range, item });
         return;
       }
       const clientId = getGatewayClientId(item._meta);
@@ -163,18 +210,87 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
   const handleDialogSubmit = async (values: PromptArgumentValues) => {
     if (!activePrompt || !client) return;
 
-    const { range, item } = activePrompt;
-    const clientId = getGatewayClientId(item._meta);
-    await fetchAndInsertPrompt(
-      editor,
-      range,
-      client,
-      item.name,
-      clientId,
-      values,
-    );
+    if (activePrompt.mode === "create") {
+      const { range, item } = activePrompt;
+      const clientId = getGatewayClientId(item._meta);
+      await fetchAndInsertPrompt(
+        editor,
+        range,
+        client,
+        item.name,
+        clientId,
+        values,
+      );
+    } else {
+      const { pos, item } = activePrompt;
+      await fetchAndUpdatePrompt(editor, pos, client, item.name, values);
+    }
     setActivePrompt(null);
   };
+
+  // Listen for click-to-edit events dispatched by MentionNodeView. Use a ref
+  // so the registered listener always reads the latest dependencies without
+  // re-attaching on every render.
+  const openEditDialogRef = useRef<
+    (detail: MentionEditEventDetail) => Promise<void>
+  >(async () => {});
+  openEditDialogRef.current = async ({ pos, attrs }) => {
+    if (!client) return;
+    const promptName = attrs.id || attrs.name;
+    if (!promptName) return;
+
+    let prompts =
+      queryClient.getQueryData<ListPromptsResult>(promptsQueryKey)?.prompts;
+    if (!prompts) {
+      try {
+        const result = await queryClient.fetchQuery({
+          queryKey: promptsQueryKey,
+          queryFn: () => listPrompts(client),
+          staleTime: 60000,
+        });
+        prompts = result.prompts;
+      } catch {
+        toast.error("Failed to load prompts.");
+        return;
+      }
+    }
+
+    const prompt = prompts?.find((p) => p.name === promptName);
+    if (!prompt) {
+      toast.error("Prompt not available.");
+      return;
+    }
+
+    const item: SlashItem = {
+      name: prompt.name,
+      title: prompt.title,
+      description: prompt.description,
+      icon: promptToConnectionRef.current.get(prompt.name)?.icon ?? null,
+      kind: "prompt",
+      arguments: prompt.arguments,
+      _meta: prompt._meta,
+    };
+
+    setActivePrompt({
+      mode: "edit",
+      pos,
+      item,
+      values: (attrs.values as PromptArgumentValues) ?? {},
+    });
+  };
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    const dom = editor?.view?.dom;
+    if (!dom) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<MentionEditEventDetail>).detail;
+      if (!detail) return;
+      void openEditDialogRef.current(detail);
+    };
+    dom.addEventListener(MENTION_EDIT_EVENT, handler);
+    return () => dom.removeEventListener(MENTION_EDIT_EVENT, handler);
+  }, [editor]);
 
   const fetchItems = async (props: { query: string }): Promise<SlashItem[]> => {
     const { query } = props;
@@ -238,6 +354,18 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
         } as Prompt)
       : null;
 
+  const dialogDefaultValues =
+    activePrompt?.mode === "edit" ? activePrompt.values : undefined;
+
+  // Remount the dialog whenever the active prompt or prefilled values change
+  // so react-hook-form re-initializes with the right defaults. (The form only
+  // resets defaultValues at mount.)
+  const dialogKey = activePrompt
+    ? `${activePrompt.mode}-${activePrompt.item.name}-${
+        activePrompt.mode === "edit" ? `edit-${activePrompt.pos}` : "create"
+      }`
+    : "none";
+
   return (
     <>
       <Suggestion<SlashItem>
@@ -267,9 +395,11 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
         }}
       />
       <PromptArgsDialog
+        key={dialogKey}
         prompt={dialogPrompt}
         setPrompt={() => setActivePrompt(null)}
         onSubmit={handleDialogSubmit}
+        defaultValues={dialogDefaultValues}
       />
     </>
   );

--- a/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
@@ -56,11 +56,54 @@ interface SlashItem extends BaseItem {
   _meta?: Prompt["_meta"];
 }
 
+interface PositionTracker {
+  /** Returns the position remapped through every doc change since the tracker
+   * was created. */
+  get: () => number;
+  dispose: () => void;
+}
+
+/**
+ * Captures a ProseMirror position and keeps it up-to-date as the document
+ * changes. The caller must invoke `dispose()` when done (e.g. on dialog
+ * submit/close) to avoid leaking a transaction listener.
+ *
+ * Needed because click → fetchQuery → setActivePrompt → user submits dialog
+ * is an async sequence; any keystrokes in the editor between click and submit
+ * would shift the original position and cause `setNodeMarkup` to silently no-op
+ * when the captured pos no longer points at the original mention.
+ */
+function createPositionTracker(
+  editor: Editor,
+  initialPos: number,
+): PositionTracker {
+  let pos = initialPos;
+  const onTransaction = ({
+    transaction,
+  }: {
+    transaction: {
+      docChanged: boolean;
+      mapping: { map: (p: number) => number };
+    };
+  }) => {
+    if (transaction.docChanged) {
+      pos = transaction.mapping.map(pos);
+    }
+  };
+  editor.on("transaction", onTransaction);
+  return {
+    get: () => pos,
+    dispose: () => {
+      editor.off("transaction", onTransaction);
+    },
+  };
+}
+
 type ActivePromptContext =
   | { mode: "create"; range: Range; item: SlashItem }
   | {
       mode: "edit";
-      pos: number;
+      posTracker: PositionTracker;
       item: SlashItem;
       values: PromptArgumentValues;
     };
@@ -94,19 +137,27 @@ async function fetchAndInsertPrompt(
 
 async function fetchAndUpdatePrompt(
   editor: Editor,
-  pos: number,
+  getLivePos: () => number,
   client: Client,
   promptName: string,
   values: PromptArgumentValues,
 ) {
   try {
     const result = await getPrompt(client, promptName, values);
+    let applied = false;
     editor
       .chain()
       .focus()
       .command(({ tr }) => {
+        const pos = getLivePos();
         const node = tr.doc.nodeAt(pos);
-        if (!node || node.type.name !== "mention") return false;
+        if (
+          !node ||
+          node.type.name !== "mention" ||
+          node.attrs.id !== promptName
+        ) {
+          return false;
+        }
         tr.setNodeMarkup(pos, undefined, {
           ...node.attrs,
           metadata: result.messages,
@@ -115,9 +166,13 @@ async function fetchAndUpdatePrompt(
               ? (values as Record<string, string>)
               : undefined,
         });
+        applied = true;
         return true;
       })
       .run();
+    if (!applied) {
+      toast.error("The mention was removed before changes could be saved.");
+    }
   } catch (error) {
     console.error("[slash] Failed to update prompt:", error);
     toast.error("Failed to update prompt. Please try again.");
@@ -207,6 +262,16 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
     }
   };
 
+  const closeDialog = () => {
+    if (activePrompt?.mode === "edit") {
+      activePrompt.posTracker.dispose();
+    }
+    setActivePrompt(null);
+  };
+
+  // PromptArgsDialog calls `setPrompt(null)` (→ `closeDialog`) after submit, so
+  // we don't clear `activePrompt` or dispose the tracker here — the close path
+  // owns cleanup, including on cancel.
   const handleDialogSubmit = async (values: PromptArgumentValues) => {
     if (!activePrompt || !client) return;
 
@@ -222,10 +287,15 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
         values,
       );
     } else {
-      const { pos, item } = activePrompt;
-      await fetchAndUpdatePrompt(editor, pos, client, item.name, values);
+      const { posTracker, item } = activePrompt;
+      await fetchAndUpdatePrompt(
+        editor,
+        posTracker.get,
+        client,
+        item.name,
+        values,
+      );
     }
-    setActivePrompt(null);
   };
 
   // Listen for click-to-edit events dispatched by MentionNodeView. Use a ref
@@ -239,44 +309,55 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
     const promptName = attrs.id || attrs.name;
     if (!promptName) return;
 
-    let prompts =
-      queryClient.getQueryData<ListPromptsResult>(promptsQueryKey)?.prompts;
-    if (!prompts) {
-      try {
-        const result = await queryClient.fetchQuery({
-          queryKey: promptsQueryKey,
-          queryFn: () => listPrompts(client),
-          staleTime: 60000,
-        });
-        prompts = result.prompts;
-      } catch {
-        toast.error("Failed to load prompts.");
+    // Start tracking immediately so any typing during the async prompt lookup
+    // is mapped through to the live document position.
+    const posTracker = createPositionTracker(editor, pos);
+
+    try {
+      let prompts =
+        queryClient.getQueryData<ListPromptsResult>(promptsQueryKey)?.prompts;
+      if (!prompts) {
+        try {
+          const result = await queryClient.fetchQuery({
+            queryKey: promptsQueryKey,
+            queryFn: () => listPrompts(client),
+            staleTime: 60000,
+          });
+          prompts = result.prompts;
+        } catch {
+          toast.error("Failed to load prompts.");
+          posTracker.dispose();
+          return;
+        }
+      }
+
+      const prompt = prompts?.find((p) => p.name === promptName);
+      if (!prompt) {
+        toast.error("Prompt not available.");
+        posTracker.dispose();
         return;
       }
+
+      const item: SlashItem = {
+        name: prompt.name,
+        title: prompt.title,
+        description: prompt.description,
+        icon: promptToConnectionRef.current.get(prompt.name)?.icon ?? null,
+        kind: "prompt",
+        arguments: prompt.arguments,
+        _meta: prompt._meta,
+      };
+
+      setActivePrompt({
+        mode: "edit",
+        posTracker,
+        item,
+        values: (attrs.values as PromptArgumentValues) ?? {},
+      });
+    } catch (error) {
+      posTracker.dispose();
+      throw error;
     }
-
-    const prompt = prompts?.find((p) => p.name === promptName);
-    if (!prompt) {
-      toast.error("Prompt not available.");
-      return;
-    }
-
-    const item: SlashItem = {
-      name: prompt.name,
-      title: prompt.title,
-      description: prompt.description,
-      icon: promptToConnectionRef.current.get(prompt.name)?.icon ?? null,
-      kind: "prompt",
-      arguments: prompt.arguments,
-      _meta: prompt._meta,
-    };
-
-    setActivePrompt({
-      mode: "edit",
-      pos,
-      item,
-      values: (attrs.values as PromptArgumentValues) ?? {},
-    });
   };
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
@@ -361,9 +442,7 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
   // so react-hook-form re-initializes with the right defaults. (The form only
   // resets defaultValues at mount.)
   const dialogKey = activePrompt
-    ? `${activePrompt.mode}-${activePrompt.item.name}-${
-        activePrompt.mode === "edit" ? `edit-${activePrompt.pos}` : "create"
-      }`
+    ? `${activePrompt.mode}-${activePrompt.item.name}`
     : "none";
 
   return (
@@ -397,7 +476,7 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
       <PromptArgsDialog
         key={dialogKey}
         prompt={dialogPrompt}
-        setPrompt={() => setActivePrompt(null)}
+        setPrompt={closeDialog}
         onSubmit={handleDialogSubmit}
         defaultValues={dialogDefaultValues}
       />

--- a/apps/mesh/src/web/components/chat/tiptap/mention/index.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/index.ts
@@ -1,3 +1,9 @@
 export type { BaseItem, OnSelectProps } from "./hooks.ts";
-export { insertMention, MentionNode } from "./node.tsx";
+export {
+  insertMention,
+  MENTION_EDIT_EVENT,
+  MentionNode,
+  type MentionAttrs,
+  type MentionEditEventDetail,
+} from "./node.tsx";
 export { Suggestion } from "./suggestion.tsx";

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -22,6 +22,10 @@ export interface MentionAttrs<T = unknown> {
   metadata: T;
   /** Character that triggered the mention ("/" prompts+resources, "@" agents) */
   char?: "/" | "@";
+  /** Original prompt argument values used to render this mention. Present only
+   * for slash-prompt mentions whose prompt declared arguments — enables
+   * click-to-edit. */
+  values?: Record<string, string>;
 }
 
 // ============================================================================
@@ -60,19 +64,48 @@ export function createMentionDoc<T>(attrs: MentionAttrs<T>): JSONContent {
 // React Node View Component
 // ============================================================================
 
+export const MENTION_EDIT_EVENT = "mention:edit";
+
+export interface MentionEditEventDetail {
+  pos: number;
+  attrs: MentionAttrs;
+}
+
 function MentionNodeView(props: NodeViewProps) {
-  const { node, selected, view } = props;
-  const { name, char } = node.attrs as MentionAttrs;
+  const { node, selected, view, getPos } = props;
+  const { name, char, values } = node.attrs as MentionAttrs;
 
   const isSelected = selected && view.editable;
   const isAgent = char === "@";
+  const isEditablePrompt =
+    char === "/" &&
+    view.editable &&
+    !!values &&
+    typeof values === "object" &&
+    Object.keys(values).length > 0;
+
+  const handleClick = () => {
+    if (!isEditablePrompt) return;
+    const pos = typeof getPos === "function" ? getPos() : null;
+    if (typeof pos !== "number") return;
+    view.dom.dispatchEvent(
+      new CustomEvent<MentionEditEventDetail>(MENTION_EDIT_EVENT, {
+        detail: { pos, attrs: node.attrs as MentionAttrs },
+        bubbles: true,
+      }),
+    );
+  };
 
   return (
     <NodeViewWrapper
+      onClick={isEditablePrompt ? handleClick : undefined}
       className={cn(
         "px-1 py-1 rounded",
         "inline-flex items-center gap-1",
-        "cursor-default select-none",
+        isEditablePrompt
+          ? "cursor-pointer hover:ring-2 hover:ring-amber-300 dark:hover:ring-amber-600"
+          : "cursor-default",
+        "select-none",
         "text-xs font-light",
         isAgent
           ? "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400"
@@ -138,6 +171,20 @@ export const MentionNode = Node.create({
           return { "data-metadata": JSON.stringify(attributes.metadata) };
         },
       },
+      values: {
+        default: null,
+        parseHTML: (element) => {
+          try {
+            return JSON.parse(element.getAttribute("data-values") || "null");
+          } catch {
+            return null;
+          }
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.values) return {};
+          return { "data-values": JSON.stringify(attributes.values) };
+        },
+      },
     };
   },
 
@@ -167,6 +214,9 @@ export const MentionNode = Node.create({
     }
     if (node.attrs.metadata) {
       attrs["data-metadata"] = JSON.stringify(node.attrs.metadata);
+    }
+    if (node.attrs.values) {
+      attrs["data-values"] = JSON.stringify(node.attrs.values);
     }
 
     return ["span", { ...HTMLAttributes, ...attrs }];


### PR DESCRIPTION
## What is this contribution about?
Lets users click a slash-prompt pill (e.g. `/Predict And Apply`) inside an Automation's Instructions field and reopen its arguments dialog prefilled with the previously submitted values. Today, fixing a typo in those values requires deleting the pill and re-inserting it because the user-supplied arguments are discarded after `getPrompt` is called — only the rendered MCP messages are persisted.

The mention node now also stores the input `values` alongside `metadata`, exposes a click handler that dispatches a `mention:edit` DOM event when the prompt has values, and `SlashMention` listens for it to reopen `PromptArgsDialog` in edit mode. On save, the existing node is updated in place via `setNodeMarkup` (no duplicate pill). If the prompt's argument schema drifted on the MCP since insertion, matching names prefill and new fields stay blank.

## How to Test
1. Open an automation and add an instruction prompt that takes arguments (e.g. `/predict & apply`); fill in a value and confirm the pill renders.
2. Click the pill — the dialog should reopen prefilled with the value you submitted; change it, hit "Save", and confirm the pill stays in place.
3. Reload the page and click the pill again — the new value should still be prefilled.
4. Confirm prompts without arguments are not clickable, and read-only message history still renders normally.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Click a slash-prompt pill in Automation Instructions to edit its arguments with prefilled values and update it in place; no delete/reinsert, and MCP messages stay in sync.

- **New Features**
  - Persist prompt argument `values` on the mention node (as `data-values`) and reopen via `mention:edit`.
  - Edit mode pre-fills values and shows "Save".
  - On save, update the node in place via `setNodeMarkup` and refresh from `getPrompt` (no duplicate pill).
  - Handle schema drift: prefill matching names; new fields blank; prompts without args stay non-clickable; read-only history unchanged.

- **Bug Fixes**
  - Remap the mention’s position across editor transactions during the async dialog flow; if the mention disappears before submit, show a toast instead of silently no-oping.

<sup>Written for commit ede1bb538878fc772a63bd8eca7df70cc8055909. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

