### PR TITLE
fix(chat): guard tiptap editor.view access in slash mention

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts
@@ -128,12 +128,17 @@ function useMenuNavigation<T>({
   // Attach keyboard listener to editor
   // eslint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
-    const dom = editor.view.dom;
+    if (editor?.isDestroyed) return undefined;
 
-    // Guard against editor being destroyed
-    if (editor?.isDestroyed || !dom) {
+    let dom: HTMLElement;
+    try {
+      dom = editor.view.dom;
+    } catch {
+      // Editor view not mounted yet (or already torn down). Bail; the effect
+      // will re-run when the editor reference changes.
       return undefined;
     }
+    if (!dom) return undefined;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const currentItems = itemsRef.current;


### PR DESCRIPTION
## Summary
- `useMenuNavigation` (slash mention) read `editor.view.dom` before the `editor.isDestroyed` guard. TipTap's `Editor.view` getter throws `[tiptap error]: The editor view is not available...` when the editor is destroyed or not yet mounted, making the underlying guard unreachable.
- This race fired during navigation transitions (back from settings, opening a new chat), tripping `ChunkErrorBoundary` in a remount loop — producing the infinite-loading-chat symptom and the recurring error in `connections → back`.

## Fix
In `apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts`, hoist the `editor.isDestroyed` check above any `editor.view` access and wrap the `editor.view.dom` read in `try/catch` (covers both destroyed and not-yet-mounted, which throw the same error). On either condition the effect no-ops; React reruns it once `editor` settles.

## Test plan
- [ ] `bun run dev`, open a new chat / new thread — no error, chat loads
- [ ] Connections → pick a connection → click back — returns to previous view without throwing
- [ ] `bun run check` passes
- [ ] `bun run fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `editor.view.dom` access in the slash-mention handler with an early `editor.isDestroyed` check and a try/catch around `editor.view`. This prevents view errors, fixing the infinite-loading chat and crashes during navigation (new chat and back from connections/settings).

<sup>Written for commit 8d4f78dc9882c3499bd2cc7c97165a38056d079e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

