### PR TITLE
fix(chat): guard tiptap editor.view against destroyed/unmounted editor

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts
@@ -128,12 +128,17 @@ function useMenuNavigation<T>({
   // Attach keyboard listener to editor
   // eslint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
-    const dom = editor.view.dom;
+    if (editor?.isDestroyed) return undefined;
 
-    // Guard against editor being destroyed
-    if (editor?.isDestroyed || !dom) {
+    let dom: HTMLElement;
+    try {
+      dom = editor.view.dom;
+    } catch {
+      // Editor view not mounted yet (or already torn down). Bail; the effect
+      // will re-run when the editor reference changes.
       return undefined;
     }
+    if (!dom) return undefined;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const currentItems = itemsRef.current;


### PR DESCRIPTION
## What is this contribution about?

Fixes a TipTap crash that bubbled up to `ChunkErrorBoundary` and left the chat in an infinite loading state. The `useMenuNavigation` effect in `mention/hooks.ts` accessed `editor.view.dom` *before* the destroyed-editor guard — TipTap throws `[tiptap error]: The editor view is not available. Cannot access view['dom']. The editor may not be mounted yet.` when the editor is destroyed or its `EditorView` hasn't been created yet, so the guard underneath was unreachable. This raced during navigation transitions (e.g. opening a new chat/thread, navigating back from a connection's settings page). The fix hoists the `editor.isDestroyed` check above any `editor.view` access and wraps the read in a `try/catch` to also tolerate the not-yet-mounted state.

## How to Test

1. `bun run dev` and open the app.
2. Open a new chat / new thread — chat should open immediately, no console error, no boundary reset.
3. Open a chat → click a Connection from the sidebar dialog → click back from the connection page — should return without the TipTap error.
4. Type `/` and `@` in the chat input — pickers still open and respond to ↑/↓/Enter/Esc.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`bun run check` and `bun run fmt` pass)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent chat crashes by guarding TipTap editor.view.dom access in `useMenuNavigation` when the editor is destroyed or not yet mounted. This removes the ChunkErrorBoundary reset and infinite loading during navigation (opening a new chat or returning from a connection’s settings).

<sup>Written for commit 5f69b7ee5382d11aad332410155fd282b4529a78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

