### PR TITLE
fix(settings): back button returns to pre-settings location

### DIFF
--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -245,9 +245,22 @@ const orgIndexRoute = createRoute({
 // SETTINGS LAYOUT (/$org/settings)
 // ============================================
 
+const SETTINGS_ENTERED_FROM_KEY = "mesh.settingsEnteredFrom";
+
 const settingsLayout = createRoute({
   getParentRoute: () => orgLayout,
   path: "/settings",
+  beforeLoad: () => {
+    // Record the URL the user was on right before entering /settings, so the
+    // toolbar back button can return there even when the in-settings history
+    // has accumulated extra entries (e.g. /settings → /settings/general
+    // redirect → /settings/connections → detail).
+    if (typeof window === "undefined") return;
+    const current = window.location.pathname + window.location.search;
+    if (!current.includes("/settings")) {
+      sessionStorage.setItem(SETTINGS_ENTERED_FROM_KEY, current);
+    }
+  },
   component: lazyRouteComponent(() => import("./layouts/settings-layout.tsx")),
 });
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -249,17 +249,6 @@ const orgIndexRoute = createRoute({
 const settingsLayout = createRoute({
   getParentRoute: () => orgLayout,
   path: "/settings",
-  beforeLoad: () => {
-    // Record the URL the user was on right before entering /settings, so the
-    // toolbar back button can return there even when the in-settings history
-    // has accumulated extra entries (e.g. /settings → /settings/general
-    // redirect → /settings/connections → detail).
-    if (typeof window === "undefined") return;
-    const current = window.location.pathname + window.location.search;
-    if (!current.includes("/settings")) {
-      sessionStorage.setItem(SESSIONSTORAGE_KEYS.settingsEnteredFrom, current);
-    }
-  },
   component: lazyRouteComponent(() => import("./layouts/settings-layout.tsx")),
 });
 
@@ -626,6 +615,24 @@ declare module "@tanstack/react-router" {
     router: typeof router;
   }
 }
+
+// Capture the URL the user was on right before entering /settings, so the
+// settings toolbar's back button can return there even when in-settings
+// history has accumulated extra entries (e.g. /settings → redirect to
+// /settings/general → /settings/connections → detail). We store the
+// fromLocation only on the boundary cross from non-settings → settings;
+// internal /settings → /settings nav doesn't overwrite it.
+router.subscribe("onBeforeNavigate", ({ fromLocation, toLocation }) => {
+  const enteringSettings = toLocation.pathname.includes("/settings");
+  if (!enteringSettings) return;
+  const fromPath = fromLocation?.pathname ?? "";
+  if (fromPath.includes("/settings")) return;
+  if (!fromLocation) return;
+  sessionStorage.setItem(
+    SESSIONSTORAGE_KEYS.settingsEnteredFrom,
+    fromLocation.href,
+  );
+});
 
 const rootElement = document.getElementById("root")!;
 

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -20,6 +20,7 @@ import "../../index.css";
 
 import { authClient } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { SESSIONSTORAGE_KEYS } from "@/web/lib/sessionstorage-keys";
 
 import { sourcePlugins } from "./plugins.ts";
 import type {
@@ -245,8 +246,6 @@ const orgIndexRoute = createRoute({
 // SETTINGS LAYOUT (/$org/settings)
 // ============================================
 
-const SETTINGS_ENTERED_FROM_KEY = "mesh.settingsEnteredFrom";
-
 const settingsLayout = createRoute({
   getParentRoute: () => orgLayout,
   path: "/settings",
@@ -258,7 +257,7 @@ const settingsLayout = createRoute({
     if (typeof window === "undefined") return;
     const current = window.location.pathname + window.location.search;
     if (!current.includes("/settings")) {
-      sessionStorage.setItem(SETTINGS_ENTERED_FROM_KEY, current);
+      sessionStorage.setItem(SESSIONSTORAGE_KEYS.settingsEnteredFrom, current);
     }
   },
   component: lazyRouteComponent(() => import("./layouts/settings-layout.tsx")),

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -47,6 +47,7 @@ import { pluginSettingsSidebarItems } from "@/web/index";
 import { useStatusSounds } from "../hooks/use-status-sounds";
 import { authClient } from "@/web/lib/auth-client";
 import { track } from "@/web/lib/posthog-client";
+import { SESSIONSTORAGE_KEYS } from "@/web/lib/sessionstorage-keys";
 
 interface SettingsNavItem {
   key: string;
@@ -381,8 +382,6 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
 // Settings toolbar — back/forward navigation only (no panel toggles)
 // ---------------------------------------------------------------------------
 
-const SETTINGS_ENTERED_FROM_KEY = "mesh.settingsEnteredFrom";
-
 function SettingsToolbar() {
   const { org } = useParams({ from: "/shell/$org" });
   const navigate = useNavigate();
@@ -392,9 +391,11 @@ function SettingsToolbar() {
     // settingsLayout.beforeLoad). Falls back to the org home if that signal
     // isn't available — never leave the user stranded inside /settings.
     if (typeof window !== "undefined") {
-      const from = sessionStorage.getItem(SETTINGS_ENTERED_FROM_KEY);
+      const from = sessionStorage.getItem(
+        SESSIONSTORAGE_KEYS.settingsEnteredFrom,
+      );
       if (from && !from.includes("/settings")) {
-        sessionStorage.removeItem(SETTINGS_ENTERED_FROM_KEY);
+        sessionStorage.removeItem(SESSIONSTORAGE_KEYS.settingsEnteredFrom);
         navigate({ to: from });
         return;
       }

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -3,6 +3,7 @@ import {
   Link,
   useRouterState,
   useParams,
+  useNavigate,
 } from "@tanstack/react-router";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -380,13 +381,33 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
 // Settings toolbar — back/forward navigation only (no panel toggles)
 // ---------------------------------------------------------------------------
 
+const SETTINGS_ENTERED_FROM_KEY = "mesh.settingsEnteredFrom";
+
 function SettingsToolbar() {
+  const { org } = useParams({ from: "/shell/$org" });
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    // Prefer the URL the user was on before entering /settings (recorded in
+    // settingsLayout.beforeLoad). Falls back to the org home if that signal
+    // isn't available — never leave the user stranded inside /settings.
+    if (typeof window !== "undefined") {
+      const from = sessionStorage.getItem(SETTINGS_ENTERED_FROM_KEY);
+      if (from && !from.includes("/settings")) {
+        sessionStorage.removeItem(SETTINGS_ENTERED_FROM_KEY);
+        navigate({ to: from });
+        return;
+      }
+    }
+    navigate({ to: "/$org", params: { org } });
+  };
+
   return (
     <div className="shrink-0 flex items-center justify-between pl-1 pr-2 h-10">
       <div className="flex items-center gap-0.5 min-w-0">
         <button
           type="button"
-          onClick={() => window.history.back()}
+          onClick={handleBack}
           className="flex size-7 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground transition-colors"
           title="Go back"
         >

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -4,6 +4,7 @@ import {
   useRouterState,
   useParams,
   useNavigate,
+  useRouter,
 } from "@tanstack/react-router";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -385,20 +386,20 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
 function SettingsToolbar() {
   const { org } = useParams({ from: "/shell/$org" });
   const navigate = useNavigate();
+  const router = useRouter();
 
   const handleBack = () => {
-    // Prefer the URL the user was on before entering /settings (recorded in
-    // settingsLayout.beforeLoad). Falls back to the org home if that signal
-    // isn't available — never leave the user stranded inside /settings.
-    if (typeof window !== "undefined") {
-      const from = sessionStorage.getItem(
-        SESSIONSTORAGE_KEYS.settingsEnteredFrom,
-      );
-      if (from && !from.includes("/settings")) {
-        sessionStorage.removeItem(SESSIONSTORAGE_KEYS.settingsEnteredFrom);
-        navigate({ to: from });
-        return;
-      }
+    // Prefer the URL the user was on before entering /settings (recorded by
+    // the router.onBeforeNavigate subscription in web/index.tsx). Falls back
+    // to the org home if that signal is missing — never leave the user
+    // stranded inside /settings.
+    const from = sessionStorage.getItem(
+      SESSIONSTORAGE_KEYS.settingsEnteredFrom,
+    );
+    if (from && !from.includes("/settings")) {
+      sessionStorage.removeItem(SESSIONSTORAGE_KEYS.settingsEnteredFrom);
+      router.history.push(from);
+      return;
     }
     navigate({ to: "/$org", params: { org } });
   };

--- a/apps/mesh/src/web/lib/sessionstorage-keys.ts
+++ b/apps/mesh/src/web/lib/sessionstorage-keys.ts
@@ -1,0 +1,3 @@
+export const SESSIONSTORAGE_KEYS = {
+  settingsEnteredFrom: "mesh.settingsEnteredFrom",
+} as const;


### PR DESCRIPTION
## Summary
- The settings toolbar back button (`apps/mesh/src/web/layouts/settings-layout.tsx`) called `window.history.back()` — walking exactly one history entry.
- When extra entries land in history (e.g. footer `Settings` button → `/settings` → redirect to `/settings/general` → click `Connections` → `/settings/connections` → pick one → detail), pressing back strands the user inside `/settings` instead of returning them to the chat (or whatever page they came from).
- Even on the dialog path (`chat → connection-detail`), if any intermediate effect pushes a search-param normalization without `replace: true`, the same drift happens.

## Fix
- `apps/mesh/src/web/index.tsx`: add a `beforeLoad` to `settingsLayout` that records the previous URL into `sessionStorage["mesh.settingsEnteredFrom"]` — but only when the prior location is **outside** `/settings`, so internal nav doesn't overwrite the original entry point.
- `apps/mesh/src/web/layouts/settings-layout.tsx`: replace `window.history.back()` in `SettingsToolbar` with a TanStack Router `navigate` that prefers the recorded `from`, clears the key after use, and falls back to the org home (`/$org`) when the signal is missing — so the user is never stranded inside settings.

Forward button is unchanged (`window.history.forward()`).

## Test plan
- [ ] Path A — chat → connections sidebar dialog → pick a connection → back → returns to chat (not `/settings/general`)
- [ ] Path B — chat → footer Settings → Connections → pick one → back → returns to chat
- [ ] Refresh on a settings sub-route, then click back → falls back to `/$org` (org home), no broken state
- [ ] `bun run check` passes
- [ ] `bun run fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings back button so it returns to the page you were on before entering Settings, even after navigating within Settings. Prevents getting stuck inside `/settings`, with a safe fallback to the org home.

- **Bug Fixes**
  - Capture the pre-Settings URL via `@tanstack/react-router` `router.subscribe('onBeforeNavigate')` in `apps/mesh/src/web/index.tsx` when crossing from outside `/settings`; store `fromLocation.href` in `sessionStorage`, and have the back button in `apps/mesh/src/web/layouts/settings-layout.tsx` use `router.history.push` to that URL, clear it, or fall back to `/$org`.
  - Centralize the storage key in `apps/mesh/src/web/lib/sessionstorage-keys.ts` as `SESSIONSTORAGE_KEYS` and use it in both places.

<sup>Written for commit 20aaaa0b736faef88850fb1be0c44d7b19c0cfcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

