### PR TITLE
fix(api): suppress false-positive deprecation log for /api/deco-sites/profile

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -38,7 +38,10 @@ import authRoutes from "./routes/auth";
 import { createSsoRoutes } from "./routes/org-sso";
 import { createDecopilotRoutes } from "./routes/decopilot";
 import { createDownstreamTokenRoutes } from "./routes/downstream-token";
-import { logDeprecatedRoute } from "./middleware/log-deprecated-route";
+import {
+  createLogDeprecatedRoute,
+  logDeprecatedRoute,
+} from "./middleware/log-deprecated-route";
 import { resolveOrgFromPath } from "./middleware/resolve-org-from-path";
 import { createOrgScopedApi } from "./routes/org-scoped";
 import { createVmEventsRoutes } from "./routes/vm-events";
@@ -1718,10 +1721,17 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Org-scoped deco-sites routes (GET /, POST /connection). Currently mounted
   // at /api/deco-sites with a deprecation log; the new /api/:org/deco-sites
   // mount is wired in a later task.
+  // The permanent user-scoped sub-app above shares this mount prefix, so its
+  // /profile route is excluded to prevent false-positive deprecation logs.
   const legacyDecoSitesOrg = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyDecoSitesOrg.use("*", logDeprecatedRoute);
+  legacyDecoSitesOrg.use(
+    "*",
+    createLogDeprecatedRoute({
+      permanentSiblings: new Set(["/api/deco-sites/profile"]),
+    }),
+  );
   legacyDecoSitesOrg.route("/", createDecoSitesOrgRoutes());
   app.route("/api/deco-sites", legacyDecoSitesOrg);
 

--- a/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
@@ -1,9 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
-import { logDeprecatedRoute } from "./log-deprecated-route";
+import {
+  createLogDeprecatedRoute,
+  logDeprecatedRoute,
+} from "./log-deprecated-route";
 
 type Variables = { meshContext: MeshContext };
+
+const setMeshContext = async (
+  c: import("hono").Context<{ Variables: Variables }>,
+  next: () => Promise<void>,
+) => {
+  c.set("meshContext", {
+    organization: { slug: "acme" },
+    auth: { user: { id: "user-1" } },
+  } as unknown as MeshContext);
+  await next();
+};
 
 describe("logDeprecatedRoute", () => {
   let logSpy: ReturnType<typeof spyOn>;
@@ -12,13 +26,7 @@ describe("logDeprecatedRoute", () => {
   beforeEach(() => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     app = new Hono<{ Variables: Variables }>();
-    app.use("*", async (c, next) => {
-      c.set("meshContext", {
-        organization: { slug: "acme" },
-        auth: { user: { id: "user-1" } },
-      } as unknown as MeshContext);
-      await next();
-    });
+    app.use("*", setMeshContext);
     app.use("/api/legacy/:id", logDeprecatedRoute);
     app.get("/api/legacy/:id", (c) => c.json({ ok: true }));
   });
@@ -41,6 +49,71 @@ describe("logDeprecatedRoute", () => {
         user: "user-1",
         ua: "test-agent",
       }),
+    );
+  });
+});
+
+describe("logDeprecatedRoute with sibling sub-app at same mount", () => {
+  let logSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // Reproduces the production false positive: two sub-apps mounted at the
+  // same prefix, one permanent and one legacy. A request that the permanent
+  // sub-app handles still triggers the legacy sub-app's wildcard middleware,
+  // which would otherwise log the permanent route as deprecated.
+  const buildSharedMount = (
+    mw: ReturnType<typeof createLogDeprecatedRoute>,
+  ) => {
+    const root = new Hono<{ Variables: Variables }>();
+    root.use("*", setMeshContext);
+
+    const permanent = new Hono<{ Variables: Variables }>();
+    permanent.get("/profile", (c) => c.json({ ok: true, source: "permanent" }));
+
+    const legacy = new Hono<{ Variables: Variables }>();
+    legacy.use("*", mw);
+    legacy.get("/", (c) => c.json({ ok: true, source: "legacy" }));
+
+    root.route("/api/deco-sites", permanent);
+    root.route("/api/deco-sites", legacy);
+    return root;
+  };
+
+  it("suppresses the log when the matched handler is in permanentSiblings", async () => {
+    const root = buildSharedMount(
+      createLogDeprecatedRoute({
+        permanentSiblings: new Set(["/api/deco-sites/profile"]),
+      }),
+    );
+
+    const res = await root.request("/api/deco-sites/profile", {
+      headers: { "user-agent": "test-agent" },
+    });
+    expect(res.status).toBe(200);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("still logs the legacy sub-app's own routes", async () => {
+    const root = buildSharedMount(
+      createLogDeprecatedRoute({
+        permanentSiblings: new Set(["/api/deco-sites/profile"]),
+      }),
+    );
+
+    const res = await root.request("/api/deco-sites", {
+      headers: { "user-agent": "test-agent" },
+    });
+    expect(res.status).toBe(200);
+    expect(logSpy).toHaveBeenCalledWith(
+      "deprecated route",
+      expect.objectContaining({ method: "GET" }),
     );
   });
 });

--- a/apps/mesh/src/api/middleware/log-deprecated-route.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.ts
@@ -1,6 +1,19 @@
 import type { MiddlewareHandler } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 
+type Variables = { meshContext: MeshContext };
+
+interface LogDeprecatedRouteOptions {
+  /**
+   * Hono route paths that share this sub-app's mount prefix but belong to a
+   * permanent (non-deprecated) sibling sub-app. Hono runs the wildcard
+   * middleware for every request matching the mount prefix, so without this
+   * exclusion list a permanent sibling's routes would be logged as
+   * deprecated whenever the two sub-apps are mounted at the same prefix.
+   */
+  permanentSiblings?: ReadonlySet<string>;
+}
+
 /**
  * Logs a `"deprecated route"` line for legacy route hits during the
  * org-scoped-API deprecation window.
@@ -15,28 +28,40 @@ import type { MeshContext } from "../../core/mesh-context";
  * Detection: walk `c.req.matchedRoutes` (populated by Hono after routing) for
  * a non-wildcard handler. If no real handler matched, the sub-app fell
  * through and we suppress. If the matched handler lives under
- * `/api/:org/...`, the new sub-app handled the request and we suppress.
- * Otherwise the legacy path served the request — log it.
+ * `/api/:org/...`, the new sub-app handled the request and we suppress. If
+ * the matched handler is in `permanentSiblings`, a permanent sub-app sharing
+ * this mount handled it and we suppress. Otherwise the legacy path served
+ * the request — log it.
  */
-export const logDeprecatedRoute: MiddlewareHandler<{
-  Variables: { meshContext: MeshContext };
-}> = async (c, next) => {
-  await next();
+const buildLogDeprecatedRoute =
+  (
+    options: LogDeprecatedRouteOptions = {},
+  ): MiddlewareHandler<{ Variables: Variables }> =>
+  async (c, next) => {
+    await next();
 
-  const matched = c.req.matchedRoutes ?? [];
-  const realHandler = matched.find(
-    (r) => r.method !== "ALL" && !r.path.endsWith("*"),
-  );
-  if (!realHandler || realHandler.path.startsWith("/api/:org/")) {
-    return;
-  }
+    const matched = c.req.matchedRoutes ?? [];
+    const realHandler = matched.find(
+      (r) => r.method !== "ALL" && !r.path.endsWith("*"),
+    );
+    if (!realHandler || realHandler.path.startsWith("/api/:org/")) {
+      return;
+    }
+    if (options.permanentSiblings?.has(realHandler.path)) {
+      return;
+    }
 
-  const ctx = c.get("meshContext");
-  console.log("deprecated route", {
-    route: c.req.routePath,
-    method: c.req.method,
-    org: ctx?.organization?.slug,
-    user: ctx?.auth?.user?.id,
-    ua: c.req.header("user-agent"),
-  });
-};
+    const ctx = c.get("meshContext");
+    console.log("deprecated route", {
+      route: c.req.routePath,
+      method: c.req.method,
+      org: ctx?.organization?.slug,
+      user: ctx?.auth?.user?.id,
+      ua: c.req.header("user-agent"),
+    });
+  };
+
+export const logDeprecatedRoute = buildLogDeprecatedRoute();
+
+export const createLogDeprecatedRoute = (options: LogDeprecatedRouteOptions) =>
+  buildLogDeprecatedRoute(options);


### PR DESCRIPTION
## What is this contribution about?

The permanent user-scoped `/api/deco-sites/profile` route shares the `/api/deco-sites` mount with the legacy org-scoped sub-app, so the wildcard `logDeprecatedRoute` middleware fires for `/profile` too and logs every home-page hit as a deprecated route (verified in stg: all `deprecated route` log lines were `/profile` from normal browser sessions, not real legacy usage). This PR adds a `permanentSiblings` option to the middleware (via a new `createLogDeprecatedRoute` factory) and uses it on the deco-sites legacy mount to opt `/api/deco-sites/profile` out of the log; existing `logDeprecatedRoute` call sites are unchanged.

## How to Test

1. Hit `GET /api/deco-sites/profile` as an authenticated user (e.g. open the home page).
2. Confirm no `deprecated route` line appears in the server logs for that request.
3. Hit `GET /api/deco-sites` (the legacy org-scoped route) and confirm the `deprecated route` log still fires.
4. `bun test apps/mesh/src/api/middleware/log-deprecated-route.test.ts` passes (3 tests).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses false-positive deprecation logs for /api/deco-sites/profile by excluding it from the legacy /api/deco-sites middleware. Introduces a configurable middleware factory to safely share mounts with permanent routes.

- **Bug Fixes**
  - Added createLogDeprecatedRoute({ permanentSiblings }) while keeping existing logDeprecatedRoute unchanged.
  - Applied to legacy /api/deco-sites to exclude /api/deco-sites/profile; real legacy routes still log as deprecated.
  - Expanded tests to cover shared mount behavior and prevent regressions.

<sup>Written for commit 53237ea0c2cb118dcdd8ae3db8b82caa9eb94832. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

