### PR TITLE
fix(api): suppress /api/deco-sites/profile false-positive deprecation log

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -38,10 +38,7 @@ import authRoutes from "./routes/auth";
 import { createSsoRoutes } from "./routes/org-sso";
 import { createDecopilotRoutes } from "./routes/decopilot";
 import { createDownstreamTokenRoutes } from "./routes/downstream-token";
-import {
-  createLogDeprecatedRoute,
-  logDeprecatedRoute,
-} from "./middleware/log-deprecated-route";
+import { logDeprecatedRoute } from "./middleware/log-deprecated-route";
 import { resolveOrgFromPath } from "./middleware/resolve-org-from-path";
 import { createOrgScopedApi } from "./routes/org-scoped";
 import { createVmEventsRoutes } from "./routes/vm-events";
@@ -1721,17 +1718,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Org-scoped deco-sites routes (GET /, POST /connection). Currently mounted
   // at /api/deco-sites with a deprecation log; the new /api/:org/deco-sites
   // mount is wired in a later task.
-  // The permanent user-scoped sub-app above shares this mount prefix, so its
-  // /profile route is excluded to prevent false-positive deprecation logs.
   const legacyDecoSitesOrg = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyDecoSitesOrg.use(
-    "*",
-    createLogDeprecatedRoute({
-      permanentSiblings: new Set(["/api/deco-sites/profile"]),
-    }),
-  );
+  legacyDecoSitesOrg.use("*", logDeprecatedRoute);
   legacyDecoSitesOrg.route("/", createDecoSitesOrgRoutes());
   app.route("/api/deco-sites", legacyDecoSitesOrg);
 

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -38,7 +38,10 @@ import authRoutes from "./routes/auth";
 import { createSsoRoutes } from "./routes/org-sso";
 import { createDecopilotRoutes } from "./routes/decopilot";
 import { createDownstreamTokenRoutes } from "./routes/downstream-token";
-import { logDeprecatedRoute } from "./middleware/log-deprecated-route";
+import {
+  createLogDeprecatedRoute,
+  logDeprecatedRoute,
+} from "./middleware/log-deprecated-route";
 import { resolveOrgFromPath } from "./middleware/resolve-org-from-path";
 import { createOrgScopedApi } from "./routes/org-scoped";
 import { createVmEventsRoutes } from "./routes/vm-events";
@@ -1549,7 +1552,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyOrgSso = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyOrgSso.use("*", logDeprecatedRoute);
+  legacyOrgSso.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api/org-sso" }),
+  );
   legacyOrgSso.route("/", createSsoRoutes());
   app.route("/api/org-sso", legacyOrgSso);
 
@@ -1608,20 +1614,20 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Virtual MCP / Agent routes (must be before proxy to match /mcp/gateway and /mcp/virtual-mcp before /mcp/:connectionId)
   // /mcp/gateway/:virtualMcpId (backward compat) or /mcp/virtual-mcp/:virtualMcpId
   const legacyVirtualMcp = new Hono<Env>();
-  legacyVirtualMcp.use("*", logDeprecatedRoute);
+  legacyVirtualMcp.use("*", createLogDeprecatedRoute({ mountPath: "/mcp" }));
   legacyVirtualMcp.route("/", createVirtualMcpRoutes());
   app.route("/mcp", legacyVirtualMcp);
 
   // Self MCP routes (at /mcp/self) - exposes all management tools
   const legacySelf = new Hono<Env>();
-  legacySelf.use("*", logDeprecatedRoute);
+  legacySelf.use("*", createLogDeprecatedRoute({ mountPath: "/mcp/self" }));
   legacySelf.route("/", createSelfRoutes());
   app.route("/mcp/self", legacySelf);
 
   // MCP Proxy routes (connection-specific)
   // Note: SELF MCP ({org}_self) is handled by proxy.ts with special case detection
   const legacyProxy = new Hono<Env>();
-  legacyProxy.use("*", logDeprecatedRoute);
+  legacyProxy.use("*", createLogDeprecatedRoute({ mountPath: "/mcp" }));
   legacyProxy.route("/", createProxyRoutes());
   app.route("/mcp", legacyProxy);
 
@@ -1652,7 +1658,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyThreadOutputsRoutes = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyThreadOutputsRoutes.use("*", logDeprecatedRoute);
+  legacyThreadOutputsRoutes.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api" }),
+  );
   legacyThreadOutputsRoutes.route("/", createThreadOutputsRoutes());
   app.route("/api", legacyThreadOutputsRoutes);
 
@@ -1665,7 +1674,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyTriggerCallback = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyTriggerCallback.use("*", logDeprecatedRoute);
+  legacyTriggerCallback.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api" }),
+  );
   legacyTriggerCallback.route(
     "/",
     createTriggerCallbackRoutes({
@@ -1682,7 +1694,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyKVRoutes = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyKVRoutes.use("*", logDeprecatedRoute);
+  legacyKVRoutes.use("*", createLogDeprecatedRoute({ mountPath: "/api" }));
   legacyKVRoutes.route("/", createKVRoutes({ kvStorage }));
   app.route("/api", legacyKVRoutes);
 
@@ -1706,7 +1718,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyDownstreamTokenRoutes = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyDownstreamTokenRoutes.use("*", logDeprecatedRoute);
+  legacyDownstreamTokenRoutes.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api" }),
+  );
   legacyDownstreamTokenRoutes.route("/", createDownstreamTokenRoutes());
   app.route("/api", legacyDownstreamTokenRoutes);
 
@@ -1721,7 +1736,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyDecoSitesOrg = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyDecoSitesOrg.use("*", logDeprecatedRoute);
+  legacyDecoSitesOrg.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api/deco-sites" }),
+  );
   legacyDecoSitesOrg.route("/", createDecoSitesOrgRoutes());
   app.route("/api/deco-sites", legacyDecoSitesOrg);
 
@@ -1734,7 +1752,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   const legacyVmEvents = new Hono<{
     Variables: { meshContext: MeshContext };
   }>();
-  legacyVmEvents.use("*", logDeprecatedRoute);
+  legacyVmEvents.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api/vm-events" }),
+  );
   legacyVmEvents.route("/", createVmEventsRoutes());
   app.route("/api/vm-events", legacyVmEvents);
 

--- a/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
@@ -1,23 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
-import {
-  createLogDeprecatedRoute,
-  logDeprecatedRoute,
-} from "./log-deprecated-route";
+import { logDeprecatedRoute } from "./log-deprecated-route";
 
 type Variables = { meshContext: MeshContext };
-
-const setMeshContext = async (
-  c: import("hono").Context<{ Variables: Variables }>,
-  next: () => Promise<void>,
-) => {
-  c.set("meshContext", {
-    organization: { slug: "acme" },
-    auth: { user: { id: "user-1" } },
-  } as unknown as MeshContext);
-  await next();
-};
 
 describe("logDeprecatedRoute", () => {
   let logSpy: ReturnType<typeof spyOn>;
@@ -26,7 +12,13 @@ describe("logDeprecatedRoute", () => {
   beforeEach(() => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     app = new Hono<{ Variables: Variables }>();
-    app.use("*", setMeshContext);
+    app.use("*", async (c, next) => {
+      c.set("meshContext", {
+        organization: { slug: "acme" },
+        auth: { user: { id: "user-1" } },
+      } as unknown as MeshContext);
+      await next();
+    });
     app.use("/api/legacy/:id", logDeprecatedRoute);
     app.get("/api/legacy/:id", (c) => c.json({ ok: true }));
   });
@@ -49,71 +41,6 @@ describe("logDeprecatedRoute", () => {
         user: "user-1",
         ua: "test-agent",
       }),
-    );
-  });
-});
-
-describe("logDeprecatedRoute with sibling sub-app at same mount", () => {
-  let logSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    logSpy = spyOn(console, "log").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    logSpy.mockRestore();
-  });
-
-  // Reproduces the production false positive: two sub-apps mounted at the
-  // same prefix, one permanent and one legacy. A request that the permanent
-  // sub-app handles still triggers the legacy sub-app's wildcard middleware,
-  // which would otherwise log the permanent route as deprecated.
-  const buildSharedMount = (
-    mw: ReturnType<typeof createLogDeprecatedRoute>,
-  ) => {
-    const root = new Hono<{ Variables: Variables }>();
-    root.use("*", setMeshContext);
-
-    const permanent = new Hono<{ Variables: Variables }>();
-    permanent.get("/profile", (c) => c.json({ ok: true, source: "permanent" }));
-
-    const legacy = new Hono<{ Variables: Variables }>();
-    legacy.use("*", mw);
-    legacy.get("/", (c) => c.json({ ok: true, source: "legacy" }));
-
-    root.route("/api/deco-sites", permanent);
-    root.route("/api/deco-sites", legacy);
-    return root;
-  };
-
-  it("suppresses the log when the matched handler is in permanentSiblings", async () => {
-    const root = buildSharedMount(
-      createLogDeprecatedRoute({
-        permanentSiblings: new Set(["/api/deco-sites/profile"]),
-      }),
-    );
-
-    const res = await root.request("/api/deco-sites/profile", {
-      headers: { "user-agent": "test-agent" },
-    });
-    expect(res.status).toBe(200);
-    expect(logSpy).not.toHaveBeenCalled();
-  });
-
-  it("still logs the legacy sub-app's own routes", async () => {
-    const root = buildSharedMount(
-      createLogDeprecatedRoute({
-        permanentSiblings: new Set(["/api/deco-sites/profile"]),
-      }),
-    );
-
-    const res = await root.request("/api/deco-sites", {
-      headers: { "user-agent": "test-agent" },
-    });
-    expect(res.status).toBe(200);
-    expect(logSpy).toHaveBeenCalledWith(
-      "deprecated route",
-      expect.objectContaining({ method: "GET" }),
     );
   });
 });

--- a/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
@@ -1,9 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
-import { logDeprecatedRoute } from "./log-deprecated-route";
+import {
+  createLogDeprecatedRoute,
+  logDeprecatedRoute,
+} from "./log-deprecated-route";
 
 type Variables = { meshContext: MeshContext };
+
+const setMeshContext = async (
+  c: import("hono").Context<{ Variables: Variables }>,
+  next: () => Promise<void>,
+) => {
+  c.set("meshContext", {
+    organization: { slug: "acme" },
+    auth: { user: { id: "user-1" } },
+  } as unknown as MeshContext);
+  await next();
+};
 
 describe("logDeprecatedRoute", () => {
   let logSpy: ReturnType<typeof spyOn>;
@@ -12,13 +26,7 @@ describe("logDeprecatedRoute", () => {
   beforeEach(() => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     app = new Hono<{ Variables: Variables }>();
-    app.use("*", async (c, next) => {
-      c.set("meshContext", {
-        organization: { slug: "acme" },
-        auth: { user: { id: "user-1" } },
-      } as unknown as MeshContext);
-      await next();
-    });
+    app.use("*", setMeshContext);
     app.use("/api/legacy/:id", logDeprecatedRoute);
     app.get("/api/legacy/:id", (c) => c.json({ ok: true }));
   });
@@ -27,8 +35,8 @@ describe("logDeprecatedRoute", () => {
     logSpy.mockRestore();
   });
 
-  it("logs the call and continues", async () => {
-    const res = await app.request("/api/legacy/abc", {
+  it("logs the route metadata when a legacy path is hit", async () => {
+    const res = await app.request("/api/legacy/123", {
       headers: { "user-agent": "test-agent" },
     });
     expect(res.status).toBe(200);
@@ -41,6 +49,151 @@ describe("logDeprecatedRoute", () => {
         user: "user-1",
         ua: "test-agent",
       }),
+    );
+  });
+});
+
+// These tests exercise the suppression logic directly by stubbing
+// `c.req.matchedRoutes` to mirror what Hono populates in production. We
+// can't recreate the full prod routing tree in a unit test (the ordering of
+// sub-app mounts plus root-app middleware affects which wildcard handlers
+// fire), so we test the middleware's decision logic against the exact
+// matchedRoutes shape captured from a real production request to
+// `/api/deco-sites/profile`.
+describe("createLogDeprecatedRoute suppression logic", () => {
+  let logSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  const buildStubContext = (
+    matchedRoutes: Array<{
+      method: string;
+      path: string;
+      basePath: string;
+    }>,
+  ) => {
+    // Mirror Hono's `c.req.routePath` for the matched real handler (the
+    // first non-wildcard non-ALL entry), since that's what production logs.
+    const realHandler = matchedRoutes.find(
+      (r) => r.method !== "ALL" && !r.path.endsWith("*"),
+    );
+    return {
+      req: {
+        matchedRoutes,
+        routePath: realHandler?.path ?? "/",
+        method: realHandler?.method ?? "GET",
+        path: realHandler?.path ?? "/",
+        url: `http://test${realHandler?.path ?? "/"}`,
+        header: () => "test-agent",
+      },
+      get: (key: string) =>
+        key === "meshContext"
+          ? {
+              organization: { slug: "acme" },
+              auth: { user: { id: "user-1" } },
+            }
+          : undefined,
+    };
+  };
+
+  // Captured from a real prod trace of GET /api/deco-sites/profile while
+  // `legacyDecoSitesOrg`'s wildcard middleware fired alongside the user
+  // sub-app's `/profile` handler. Both sub-apps are mounted at
+  // `/api/deco-sites`, so basePath is identical for both — which is why the
+  // basePath check alone isn't sufficient and we need `permanentSiblings`.
+  const PROD_PROFILE_MATCHED_ROUTES = [
+    { method: "ALL", path: "/api/deco-sites/*", basePath: "/api/deco-sites" },
+    {
+      method: "GET",
+      path: "/api/deco-sites/profile",
+      basePath: "/api/deco-sites",
+    },
+    { method: "ALL", path: "/api/deco-sites/*", basePath: "/api/deco-sites" },
+    { method: "ALL", path: "/api/deco-sites/*", basePath: "/api/deco-sites" },
+  ];
+
+  it("suppresses the prod /api/deco-sites/profile log via PERMANENT_ROUTES (mountPath-equipped mw)", async () => {
+    const mw = createLogDeprecatedRoute({ mountPath: "/api/deco-sites" });
+    // biome-ignore lint/suspicious/noExplicitAny: stubbed minimal context
+    await mw(
+      buildStubContext(PROD_PROFILE_MATCHED_ROUTES) as any,
+      async () => {},
+    );
+    expect(logSpy).not.toHaveBeenCalledWith(
+      "deprecated route",
+      expect.anything(),
+    );
+  });
+
+  it("suppresses the prod /api/deco-sites/profile log via PERMANENT_ROUTES (root-mounted mw with no options)", async () => {
+    // Regression guard for the bug seen in production after the prior fix:
+    // legacyWellKnownProtectedResource is mounted at `/` with the no-options
+    // logDeprecatedRoute, which fires for every request and would otherwise
+    // log the user sub-app's `/profile` handler as deprecated.
+    // biome-ignore lint/suspicious/noExplicitAny: stubbed minimal context
+    await logDeprecatedRoute(
+      buildStubContext(PROD_PROFILE_MATCHED_ROUTES) as any,
+      async () => {},
+    );
+    expect(logSpy).not.toHaveBeenCalledWith(
+      "deprecated route",
+      expect.anything(),
+    );
+  });
+
+  it("suppresses when the responding handler is in a different sub-app (basePath mismatch)", async () => {
+    const mw = createLogDeprecatedRoute({ mountPath: "/api" });
+    const matched = [
+      { method: "ALL", path: "/api/*", basePath: "/api" },
+      {
+        method: "GET",
+        path: "/api/deco-sites/profile",
+        basePath: "/api/deco-sites",
+      },
+    ];
+    // biome-ignore lint/suspicious/noExplicitAny: stubbed minimal context
+    await mw(buildStubContext(matched) as any, async () => {});
+    expect(logSpy).not.toHaveBeenCalledWith(
+      "deprecated route",
+      expect.anything(),
+    );
+  });
+
+  it("suppresses when the responding handler lives under /api/:org/", async () => {
+    const mw = createLogDeprecatedRoute({ mountPath: "/api" });
+    const matched = [
+      { method: "ALL", path: "/api/*", basePath: "/api" },
+      {
+        method: "GET",
+        path: "/api/:org/connections",
+        basePath: "/api/:org",
+      },
+    ];
+    // biome-ignore lint/suspicious/noExplicitAny: stubbed minimal context
+    await mw(buildStubContext(matched) as any, async () => {});
+    expect(logSpy).not.toHaveBeenCalledWith(
+      "deprecated route",
+      expect.anything(),
+    );
+  });
+
+  it("logs when the responding handler belongs to this sub-app", async () => {
+    const mw = createLogDeprecatedRoute({ mountPath: "/api" });
+    const matched = [
+      { method: "ALL", path: "/api/*", basePath: "/api" },
+      { method: "GET", path: "/api/kv/:key", basePath: "/api" },
+    ];
+    // biome-ignore lint/suspicious/noExplicitAny: stubbed minimal context
+    await mw(buildStubContext(matched) as any, async () => {});
+    expect(logSpy).toHaveBeenCalledWith(
+      "deprecated route",
+      expect.objectContaining({ route: "/api/kv/:key" }),
     );
   });
 });

--- a/apps/mesh/src/api/middleware/log-deprecated-route.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.ts
@@ -1,19 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 
-type Variables = { meshContext: MeshContext };
-
-interface LogDeprecatedRouteOptions {
-  /**
-   * Hono route paths that share this sub-app's mount prefix but belong to a
-   * permanent (non-deprecated) sibling sub-app. Hono runs the wildcard
-   * middleware for every request matching the mount prefix, so without this
-   * exclusion list a permanent sibling's routes would be logged as
-   * deprecated whenever the two sub-apps are mounted at the same prefix.
-   */
-  permanentSiblings?: ReadonlySet<string>;
-}
-
 /**
  * Logs a `"deprecated route"` line for legacy route hits during the
  * org-scoped-API deprecation window.
@@ -28,40 +15,28 @@ interface LogDeprecatedRouteOptions {
  * Detection: walk `c.req.matchedRoutes` (populated by Hono after routing) for
  * a non-wildcard handler. If no real handler matched, the sub-app fell
  * through and we suppress. If the matched handler lives under
- * `/api/:org/...`, the new sub-app handled the request and we suppress. If
- * the matched handler is in `permanentSiblings`, a permanent sub-app sharing
- * this mount handled it and we suppress. Otherwise the legacy path served
- * the request — log it.
+ * `/api/:org/...`, the new sub-app handled the request and we suppress.
+ * Otherwise the legacy path served the request — log it.
  */
-const buildLogDeprecatedRoute =
-  (
-    options: LogDeprecatedRouteOptions = {},
-  ): MiddlewareHandler<{ Variables: Variables }> =>
-  async (c, next) => {
-    await next();
+export const logDeprecatedRoute: MiddlewareHandler<{
+  Variables: { meshContext: MeshContext };
+}> = async (c, next) => {
+  await next();
 
-    const matched = c.req.matchedRoutes ?? [];
-    const realHandler = matched.find(
-      (r) => r.method !== "ALL" && !r.path.endsWith("*"),
-    );
-    if (!realHandler || realHandler.path.startsWith("/api/:org/")) {
-      return;
-    }
-    if (options.permanentSiblings?.has(realHandler.path)) {
-      return;
-    }
+  const matched = c.req.matchedRoutes ?? [];
+  const realHandler = matched.find(
+    (r) => r.method !== "ALL" && !r.path.endsWith("*"),
+  );
+  if (!realHandler || realHandler.path.startsWith("/api/:org/")) {
+    return;
+  }
 
-    const ctx = c.get("meshContext");
-    console.log("deprecated route", {
-      route: c.req.routePath,
-      method: c.req.method,
-      org: ctx?.organization?.slug,
-      user: ctx?.auth?.user?.id,
-      ua: c.req.header("user-agent"),
-    });
-  };
-
-export const logDeprecatedRoute = buildLogDeprecatedRoute();
-
-export const createLogDeprecatedRoute = (options: LogDeprecatedRouteOptions) =>
-  buildLogDeprecatedRoute(options);
+  const ctx = c.get("meshContext");
+  console.log("deprecated route", {
+    route: c.req.routePath,
+    method: c.req.method,
+    org: ctx?.organization?.slug,
+    user: ctx?.auth?.user?.id,
+    ua: c.req.header("user-agent"),
+  });
+};

--- a/apps/mesh/src/api/middleware/log-deprecated-route.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.ts
@@ -1,42 +1,85 @@
 import type { MiddlewareHandler } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 
+type Variables = { meshContext: MeshContext };
+
+/**
+ * Permanent (non-deprecated) routes that any legacy deprecation middleware
+ * may incorrectly attribute to itself. Hono mounts multiple legacy sub-apps
+ * at broad prefixes (e.g. `/`, `/api`); each one's wildcard middleware fires
+ * for every request matching the prefix and inspects `c.req.matchedRoutes`,
+ * so a permanent sibling's handler can be misidentified as the deprecated
+ * route. Suppress those globally here rather than threading per-mount
+ * allowlists through every legacy registration.
+ *
+ * Add a path here when a permanent route shows up in production deprecation
+ * logs.
+ */
+const PERMANENT_ROUTES: ReadonlySet<string> = new Set([
+  "/api/deco-sites/profile",
+]);
+
+interface LogDeprecatedRouteOptions {
+  /**
+   * Mount path of the legacy sub-app this middleware is attached to.
+   *
+   * Hono runs `use("*", ...)` for every request whose URL prefix-matches the
+   * sub-app's mount, even when a sibling sub-app at a longer-prefix mount
+   * actually serves the response. Suppress when the responding handler's
+   * `basePath` doesn't match this mount path — that means a sibling at a
+   * different prefix served it.
+   *
+   * For permanent siblings mounted at the SAME prefix (where basePath
+   * cannot distinguish them), add the path to `PERMANENT_ROUTES` above
+   * instead.
+   */
+  mountPath?: string;
+}
+
 /**
  * Logs a `"deprecated route"` line for legacy route hits during the
  * org-scoped-API deprecation window.
- *
- * The middleware is attached via `app.use("*", logDeprecatedRoute)` on each
- * legacy sub-app, which Hono treats as a path-prefix middleware. That
- * wildcard fires on every request whose URL prefix-matches the parent mount —
- * including hits to the new `/api/:org/*` mount that shares the `/api`
- * prefix. Without a guard, every new-path call would emit a spurious
- * deprecation log.
- *
- * Detection: walk `c.req.matchedRoutes` (populated by Hono after routing) for
- * a non-wildcard handler. If no real handler matched, the sub-app fell
- * through and we suppress. If the matched handler lives under
- * `/api/:org/...`, the new sub-app handled the request and we suppress.
- * Otherwise the legacy path served the request — log it.
  */
-export const logDeprecatedRoute: MiddlewareHandler<{
-  Variables: { meshContext: MeshContext };
-}> = async (c, next) => {
-  await next();
+const buildLogDeprecatedRoute =
+  (
+    options: LogDeprecatedRouteOptions = {},
+  ): MiddlewareHandler<{ Variables: Variables }> =>
+  async (c, next) => {
+    await next();
 
-  const matched = c.req.matchedRoutes ?? [];
-  const realHandler = matched.find(
-    (r) => r.method !== "ALL" && !r.path.endsWith("*"),
-  );
-  if (!realHandler || realHandler.path.startsWith("/api/:org/")) {
-    return;
-  }
+    const matched = c.req.matchedRoutes ?? [];
+    const realHandler = matched.find(
+      (r) => r.method !== "ALL" && !r.path.endsWith("*"),
+    );
+    if (!realHandler) return;
 
-  const ctx = c.get("meshContext");
-  console.log("deprecated route", {
-    route: c.req.routePath,
-    method: c.req.method,
-    org: ctx?.organization?.slug,
-    user: ctx?.auth?.user?.id,
-    ua: c.req.header("user-agent"),
-  });
-};
+    // Globally permanent routes — never log these regardless of which legacy
+    // sub-app's wildcard fired.
+    if (PERMANENT_ROUTES.has(realHandler.path)) return;
+
+    // Suppress when the responding handler lives in the org-scoped sub-app.
+    // Belt-and-suspenders for mounts without `mountPath` (e.g. sub-apps
+    // mounted at `/` where basePath alone can't distinguish siblings).
+    if (realHandler.path.startsWith("/api/:org/")) return;
+
+    if (
+      options.mountPath !== undefined &&
+      realHandler.basePath !== options.mountPath
+    ) {
+      return;
+    }
+
+    const ctx = c.get("meshContext");
+    console.log("deprecated route", {
+      route: c.req.routePath,
+      method: c.req.method,
+      org: ctx?.organization?.slug,
+      user: ctx?.auth?.user?.id,
+      ua: c.req.header("user-agent"),
+    });
+  };
+
+export const logDeprecatedRoute = buildLogDeprecatedRoute();
+
+export const createLogDeprecatedRoute = (options: LogDeprecatedRouteOptions) =>
+  buildLogDeprecatedRoute(options);

--- a/apps/mesh/src/api/routes/dev-only.ts
+++ b/apps/mesh/src/api/routes/dev-only.ts
@@ -19,7 +19,7 @@
 import { Hono } from "hono";
 import type { Context, MiddlewareHandler } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
-import { logDeprecatedRoute } from "../middleware/log-deprecated-route";
+import { createLogDeprecatedRoute } from "../middleware/log-deprecated-route";
 import { createDevAssetsRoutes } from "./dev-assets";
 import devAssetsMcpRoutes, {
   callDevAssetsTool,
@@ -86,7 +86,10 @@ export function mountDevRoutes(
   // /api/:org/dev-assets/* mount is wired in a later task.
   // These are public but use signed URLs for security.
   const legacyDevAssets = new Hono();
-  legacyDevAssets.use("*", logDeprecatedRoute);
+  legacyDevAssets.use(
+    "*",
+    createLogDeprecatedRoute({ mountPath: "/api/dev-assets" }),
+  );
   legacyDevAssets.route("/", createDevAssetsRoutes({ orgFromPath: false }));
   app.route("/api/dev-assets", legacyDevAssets);
 }


### PR DESCRIPTION
## What is this contribution about?

The previous attempt at fixing the spurious `deprecated route { route: "/api/deco-sites/profile", ... }` log (#3330) targeted only `legacyDecoSitesOrg`'s wildcard middleware — but production traces showed the false positive also leaks from other legacy sub-apps mounted at broader prefixes (`/`, `/api`). Each sub-app's `use("*", ...)` fires for every prefix-matching request and walks `c.req.matchedRoutes`, mis-attributing a permanent sibling's handler (the user-scoped `GET /api/deco-sites/profile`) as deprecated. This PR reverts the prior partial fix and replaces it with two complementary guards: a module-level `PERMANENT_ROUTES` allowlist that every legacy mw consults (suppresses any future false positive regardless of which mount fires), and a new `createLogDeprecatedRoute({ mountPath })` factory that uses `realHandler.basePath` to suppress when a sibling sub-app at a different prefix served the request — wired through every sub-app legacy mount in `app.ts` and `dev-only.ts`. The prior unit test was bogus (didn't actually exercise the leaking middleware in any configuration); replaced with stub-context tests driven by the exact `matchedRoutes` shape captured from a real prod trace, plus a regression guard for the root-mounted no-options middleware that triggered the latest leak.

## How to Test

1. Sign in to a non-deco.cx user account and load any page that triggers `GET /api/deco-sites/profile` (e.g. the org dashboard).
2. Tail the mesh server logs.
3. Expected: no `deprecated route { route: "/api/deco-sites/profile", ... }` line appears. Legitimate legacy hits (e.g. `GET /api/connections/...`) still log.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`bun test apps/mesh/src/api/middleware/log-deprecated-route.test.ts apps/mesh/src/api/integration-org-scoped.test.ts` — 19/19 pass)
- [x] No documentation changes needed
- [x] No breaking changes (deprecation-log-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses false-positive “deprecated route” logs for `GET /api/deco-sites/profile` by guarding legacy middleware across all mounts, so only true legacy routes are logged. This general fix replaces the prior partial approach and keeps legitimate legacy hits intact.

- **Bug Fixes**
  - Added `PERMANENT_ROUTES` allowlist (includes `/api/deco-sites/profile`) used by all legacy deprecation middleware.
  - Introduced `createLogDeprecatedRoute({ mountPath })` to compare `basePath` and ignore requests served by sibling sub-apps.
  - Replaced plain `logDeprecatedRoute` with the mount-aware version across legacy mounts in `app.ts` and `dev-only.ts`.
  - Updated tests to use prod-shaped `matchedRoutes`, added regression for root-mounted middleware, and verified legacy routes still log.

<sup>Written for commit 53ff64a1048dbd0e7e2de34c592b5365d8e136ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

