### PR TITLE
chore(decopilot): log persisted-config + provider state on resume

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -516,6 +516,21 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       }
       const config = parsed.data;
 
+      // Diagnostic: report which optional model slots survived persistence.
+      // Helps trace cases where a resumed run loses conditional tools like
+      // `web_search` / `generate_image` (gated by `models.deepResearch` and
+      // `models.image` in built-in-tools/index.ts). Drop once the
+      // resume-tool-dropout issue is root-caused.
+      console.log("[decopilot:attach] orphan resume — persisted config", {
+        taskId,
+        thinkingModelId: config.models.thinking.id,
+        hasFast: !!config.models.fast,
+        hasCoding: !!config.models.coding,
+        hasImage: !!config.models.image,
+        hasDeepResearch: !!config.models.deepResearch,
+        mode: config.mode,
+      });
+
       // Re-check model permissions with CURRENT user role
       const allowedModels = await fetchModelPermissions(
         ctx.db,

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -272,6 +272,22 @@ async function streamCoreInner(
       }),
     ]);
 
+    // Diagnostic (resume only): record whether the provider activated and
+    // whether the optional model slots are present. Paired with the log in
+    // routes.ts:/attach orphan-resume; together they pinpoint whether tool
+    // dropout on resume is a persistence-side or provider-activation issue.
+    // Drop once the resume-tool-dropout issue is root-caused.
+    if (input.isResume) {
+      console.log("[decopilot:stream] resume — runtime state", {
+        taskId: input.taskId,
+        isCliAgent,
+        providerActivated: !!provider,
+        thinkingModelId: input.models.thinking.id,
+        hasImage: !!input.models.image,
+        hasDeepResearch: !!input.models.deepResearch,
+      });
+    }
+
     taskId = mem.thread.id;
     ctx.metadata.threadId = mem.thread.id;
     rootSpan.setAttribute("decopilot.thread.id", mem.thread.id);


### PR DESCRIPTION
## What is this contribution about?

Adds two temporary diagnostic logs to pinpoint the resume-tool-dropout case — a customer report where a resumed run lost the `web_search` and `generate_image` tools (`tools: 136 → 134` between the initial `/decopilot/stream` and the subsequent `/decopilot/attach/:threadId`). Both tools are gated by `provider && models.X` in `built-in-tools/index.ts`, but we couldn't determine whether the dropout came from the persisted run_config losing those model slots or from `aiProviders.activate` returning falsy on resume — the terminal-status reactor clears `run_config` once the run completes, erasing the forensics.

The `/attach` log reports which optional slots survived persistence; the `streamCore` log (resume only) reports whether the provider activated. Together they isolate which side of the boundary failed. Logs are scoped to resume-only and inexpensive (one structured log per resume event). Remove once root-caused.

## How to Test

1. `bun test apps/mesh/src/api/routes/decopilot/` — 269 passing.
2. `bun run check` and `bun run lint` — both clean.
3. In a deploy, force a resume (kill mid-stream, refocus tab) and confirm the logs appear with the right shape:
   - `[decopilot:attach] orphan resume — persisted config { taskId, hasDeepResearch, hasImage, ... }`
   - `[decopilot:stream] resume — runtime state { taskId, providerActivated, hasDeepResearch, ... }`

## Migration Notes

None. Pure logging.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed) — N/A
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add resume-only diagnostic logs to Decopilot to trace why tools disappear after a resume. We log which optional model slots survived persistence on `/decopilot/attach/:threadId` and whether the provider activated on resume in `streamCore`, so we can tell if the dropout is from persistence or provider activation.

<sup>Written for commit 00708a461b506f01bf69545279c46987b1df8d7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

