### PR TITLE
fix(decopilot): auto-resume chat on mid-stream connection cuts

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1054,10 +1054,10 @@ export function ActiveTaskProvider({
     messages.length > 0;
 
   // Stream manager (SSE + resume) — task-scoped.
-  // The `onResumeSuccess` clears `chatError` so the "network error" banner
-  // disappears once a silent resume picks the stream back up. Without this,
-  // a single transient disconnect leaves a sticky banner even after the
-  // resumed run finishes successfully.
+  // Owns every "should we resume?" decision: mount, watch-SSE step events,
+  // and mid-stream connection cuts on the chat fetch itself. The
+  // `onResumeSuccess` clears `chatError` so the "network error" banner
+  // disappears once a silent resume picks the stream back up.
   useStreamManager(taskId, chat, thread?.status, () => setChatError(null));
 
   // sendMessage — captures context at call time

--- a/apps/mesh/src/web/components/chat/hooks/use-stream-manager.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-stream-manager.ts
@@ -1,7 +1,21 @@
 /**
  * useStreamManager — task-scoped SSE subscription + stream resume logic.
  *
- * Listens for SSE events on the active task and resumes disconnected streams.
+ * Owns every decision about *when* to call `chat.resumeStream()`. Three
+ * triggers feed in:
+ *
+ *   1. Mount / task switch with a server-side in-flight run
+ *   2. `decopilot.step` events on the org-wide watch SSE (the run made
+ *      progress server-side — pick the stream back up to render it)
+ *   3. `chat.status` transitioning to "error" when the cause looks like a
+ *      mid-stream connection cut (proxy idle/duration timeout, TCP RST,
+ *      mid-byte UTF-8 truncation). The watch SSE is on a separate socket
+ *      and may be in reconnect at the same moment, so we can't rely on
+ *      it to deliver the next step event in a timely way.
+ *
+ * All three go through the same `tryResumeStream` gate (in-flight guard +
+ * retry cap + active-chat check), so concurrent triggers can't fire two
+ * /attach requests for the same task.
  */
 
 import { useRef, useSyncExternalStore } from "react";
@@ -14,12 +28,40 @@ import type { ChatMessage } from "../types";
 
 const MAX_RESUME_RETRIES = 3;
 
+/**
+ * Discriminates "the wire broke" from "the server told us something is
+ * wrong". The browser's fetch / Web Streams APIs throw `TypeError` for
+ * every transport-level failure (TCP RST mid-stream, mid-byte UTF-8
+ * truncation by `TextDecoderStream`, network unreachable, ...). The AI
+ * SDK funnels server-emitted error chunks through `new Error(chunkText)`
+ * and HTTP-error responses through `new Error(responseText)` — both plain
+ * `Error`, not `TypeError`. AbortError is filtered by the AI SDK before
+ * `chat.error` is populated, so explicit user stops never land here.
+ *
+ * Keeping this as an `instanceof` check (vs. matching browser-specific
+ * message strings like "network error" / "Error in input stream" / "Load
+ * failed") makes the discriminator browser-agnostic and avoids a
+ * message-catalog that has to be kept in sync with browser releases.
+ *
+ * Auto-retrying app-level errors would be actively harmful: the credits
+ * banner keys off the `[CREDITS]` prefix from `sanitizeStreamError`, and
+ * if we cleared and re-set `chatError` while resuming through buffered
+ * chunks the user would see it flicker on-and-off instead of staying
+ * stable with the inline top-up.
+ */
+function isTransientStreamError(error: Error): boolean {
+  return error instanceof TypeError;
+}
+
+const isRunInProgressStatus = (s: ThreadDisplayStatus | undefined): boolean =>
+  s === "in_progress" || s === "expired";
+
 export function useStreamManager(
   threadId: string,
   chat: UseChatHelpers<ChatMessage>,
   threadStatus: ThreadDisplayStatus | undefined,
   onResumeSuccess?: () => void,
-) {
+): void {
   const { locator, org } = useProjectContext();
   const queryClient = useQueryClient();
 
@@ -153,4 +195,23 @@ export function useStreamManager(
       }
     },
   });
+
+  // Detect `chat.status` transitioning *into* "error" with a transient-looking
+  // cause while the server still says the run is in-flight, and fire a resume.
+  // Detection happens in render (compare current vs. ref-tracked previous);
+  // the resume itself is deferred to a microtask so React's commit completes
+  // before we kick off another fetch. Reading status from the ref keeps the
+  // detection idempotent across re-renders — only true status *transitions*
+  // queue a resume, not every render while status === "error".
+  const prevChatStatusRef = useRef(chat.status);
+  if (
+    prevChatStatusRef.current !== "error" &&
+    chat.status === "error" &&
+    chat.error &&
+    isTransientStreamError(chat.error) &&
+    isRunInProgressStatus(threadStatus)
+  ) {
+    queueMicrotask(() => tryResumeStreamRef.current("on-stream-error"));
+  }
+  prevChatStatusRef.current = chat.status;
 }


### PR DESCRIPTION
## What is this contribution about?

When an upstream proxy cuts the chat stream mid-flight (e.g. a 120s hard-duration cap, which SSE heartbeats can't defeat), `chat.status` goes to `"error"` and stays there until the user refreshes. The pre-existing auto-resume in `useStreamManager` only fired from `decopilot.step` events on the org-wide watch SSE (which must itself reconnect after the same proxy cut it) or from component mount — neither of which is timely on a mid-stream cut.

This PR adds a third resume trigger inside `useStreamManager`: detect `chat.status` transitioning into `"error"` with a transport-level cause while the server still reports the run as in-flight, and fire `tryResumeStream("on-stream-error")`. Detection is a prev-status ref comparison in render; the resume itself is deferred via `queueMicrotask` so React commits before another fetch starts. Goes through the existing `tryResumeStream` gate — same in-flight guard, retry cap, and active-chat check as the other triggers, so concurrent triggers can't fire two `/attach` requests for the same task. The hook's public surface is unchanged.

## How to Test

1. `bun test apps/mesh/src/web/components/chat apps/mesh/src/api/routes/decopilot` — 335 passing.
2. `bun run check`, `bun run lint`, `bun run fmt:check` — clean.
3. In a deploy with an aggressive proxy duration cap: start a long chat, wait for the proxy to RST the connection mid-stream. The browser console should show `[chat] Error ...` followed by `[chat] resumeStream (on-stream-error)`, and the stream should pick back up via `/decopilot/attach/:threadId` without the user refreshing.
4. Click Stop on an active chat — should NOT trigger a resume (AbortError is filtered by the AI SDK before reaching chat.error).
5. Trigger a credits/auth error path — should NOT trigger a resume (those don't match the transient pattern).

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed) — N/A
- [x] No breaking changes