### PR TITLE
fix(sandbox-operator): set namespace PSA enforce to privileged

### DIFF
--- a/deploy/helm/sandbox-operator/Chart.yaml
+++ b/deploy/helm/sandbox-operator/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   live in this chart — see deploy/helm/sandbox-env for those.
 type: application
 # Chart version is independent of upstream agent-sandbox. Bump on any change.
-version: 0.1.1
+version: 0.1.2
 # Tracks the upstream agent-sandbox release pinned by vendor.sh.
 appVersion: "0.4.5"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml
+++ b/deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml
@@ -3,18 +3,23 @@
 # Contains: controller Deployments, RBAC, Namespace, Service, ServiceAccount.
 #
 # LOCAL EDIT — preserve when re-running vendor.sh:
-#   PodSecurity admission labels added to the Namespace below. `baseline`
-#   is enforced (operator controller pod runs without an explicit
-#   securityContext; `restricted` would block it until that's patched).
-#   `restricted` is set as warn/audit so violations from sandbox pods or
-#   the controller surface in audit logs without rejecting admission.
-#   When the operator's pod spec hardens to `restricted`, flip enforce.
+#   PodSecurity admission labels added to the Namespace below. `enforce`
+#   is `privileged` because the sandbox-env chart (>= 0.7.0) adds a
+#   `setup-netpol` init container that holds NET_ADMIN to program iptables
+#   in the pod netns before user code starts. `baseline` rejects NET_ADMIN
+#   at admission time, so sandbox pod creates fail with PodSecurity
+#   violations and the operator's reconcile loop never converges.
+#   The real security boundary is the main sandbox container's pod spec
+#   (drops ALL caps, RO rootfs, hostUsers remap, no SA token) — not the
+#   namespace label. `restricted` stays on warn/audit so any regression
+#   in that pod-level posture (here or in the controller) surfaces in
+#   audit logs without rejecting admission.
 kind: Namespace
 apiVersion: v1
 metadata:
   name: agent-sandbox-system
   labels:
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: latest

--- a/deploy/helm/sandbox-operator/vendor.sh
+++ b/deploy/helm/sandbox-operator/vendor.sh
@@ -170,11 +170,14 @@ fi
 
 # Inject PodSecurity admission labels into the agent-sandbox-system Namespace.
 #
-# Upstream ships a bare Namespace; we enforce `baseline` and warn/audit on
-# `restricted` so violations from sandbox pods or the controller surface in
-# audit logs without rejecting admission. When the operator's pod spec
-# hardens to restricted, flip enforce. See README + the LOCAL EDIT comment
-# in HEADER_TMPL below.
+# Upstream ships a bare Namespace; we enforce `privileged` because the
+# sandbox-env chart (>= 0.7.0) adds a `setup-netpol` init container that
+# holds NET_ADMIN to program iptables — `baseline` would reject it at
+# admission. The real security boundary lives in the sandbox-env pod
+# spec (drops ALL caps on the main container, RO rootfs, hostUsers
+# remap, no SA token). warn/audit stay on `restricted` so any regression
+# in that pod-level posture surfaces in audit logs without rejecting
+# admission. See README + the LOCAL EDIT comment in HEADER_TMPL below.
 log "injecting PodSecurity admission labels into agent-sandbox-system Namespace"
 awk '
   function flush(   i, is_target, has_kind, name_line, indent) {
@@ -202,7 +205,7 @@ awk '
         match(buf[i], /^[[:space:]]*/)
         indent = substr(buf[i], RSTART, RLENGTH)
         print indent "labels:"
-        print indent "  pod-security.kubernetes.io/enforce: baseline"
+        print indent "  pod-security.kubernetes.io/enforce: privileged"
         print indent "  pod-security.kubernetes.io/enforce-version: latest"
         print indent "  pod-security.kubernetes.io/warn: restricted"
         print indent "  pod-security.kubernetes.io/warn-version: latest"
@@ -219,7 +222,7 @@ awk '
 ' "${WORK}/manifest.yaml" > "${WORK}/manifest.patched.yaml"
 sed -i.bak -e '$d' "${WORK}/manifest.patched.yaml" && rm "${WORK}/manifest.patched.yaml.bak"
 mv "${WORK}/manifest.patched.yaml" "${WORK}/manifest.yaml"
-if ! grep -q '^[[:space:]]*pod-security.kubernetes.io/enforce:[[:space:]]*baseline[[:space:]]*$' "${WORK}/manifest.yaml"; then
+if ! grep -q '^[[:space:]]*pod-security.kubernetes.io/enforce:[[:space:]]*privileged[[:space:]]*$' "${WORK}/manifest.yaml"; then
   err "post-patch: PodSecurity labels were not injected into the Namespace doc"
   err "  upstream may have moved the Namespace into extensions.yaml or changed its name;"
   err "  inspect ${WORK}/manifest.yaml and update the awk patch in this script"
@@ -277,12 +280,17 @@ HEADER_TMPL="# Vendored from ${REPO} ${UPSTREAM_VERSION} via vendor.sh.
 # Contains: controller Deployments, RBAC, Namespace, Service, ServiceAccount.
 #
 # LOCAL EDIT — preserve when re-running vendor.sh:
-#   PodSecurity admission labels added to the Namespace below. \`baseline\`
-#   is enforced (operator controller pod runs without an explicit
-#   securityContext; \`restricted\` would block it until that's patched).
-#   \`restricted\` is set as warn/audit so violations from sandbox pods or
-#   the controller surface in audit logs without rejecting admission.
-#   When the operator's pod spec hardens to \`restricted\`, flip enforce.
+#   PodSecurity admission labels added to the Namespace below. \`enforce\`
+#   is \`privileged\` because the sandbox-env chart (>= 0.7.0) adds a
+#   \`setup-netpol\` init container that holds NET_ADMIN to program iptables
+#   in the pod netns before user code starts. \`baseline\` rejects NET_ADMIN
+#   at admission time, so sandbox pod creates fail with PodSecurity
+#   violations and the operator's reconcile loop never converges.
+#   The real security boundary is the main sandbox container's pod spec
+#   (drops ALL caps, RO rootfs, hostUsers remap, no SA token) — not the
+#   namespace label. \`restricted\` stays on warn/audit so any regression
+#   in that pod-level posture (here or in the controller) surfaces in
+#   audit logs without rejecting admission.
 "
 
 printf "%s" "${HEADER_CRDS}" > "${CRDS_FILE}"


### PR DESCRIPTION
## Summary

- Flips `pod-security.kubernetes.io/enforce` on the `agent-sandbox-system` namespace from `baseline` to `privileged`.
- Bumps `sandbox-operator` chart `0.1.1` → `0.1.2`.

## Why

PR #3321 added a `setup-netpol` init container to `sandbox-env` (chart >= 0.7.0) that holds `NET_ADMIN` to program iptables in the pod netns before user code starts. The `agent-sandbox-system` namespace was enforcing PSA `baseline`, which rejects `NET_ADMIN` at admission. Result: after the chart bump every sandbox pod create from the operator failed with a PodSecurity violation and the reconcile loop never converged.

Observed live on EKS staging right after bumping `sandbox-env` to `0.7.0`:

```
pods "studio-sandbox-stg-dtzpg" is forbidden: violates PodSecurity "baseline:latest":
non-default capabilities (container "setup-netpol" must not include "NET_ADMIN"
in securityContext.capabilities.add)
```

## Why `privileged` and not something tighter

PSA is namespace-scoped with three levels (`privileged` / `baseline` / `restricted`) and no built-in way to allow `NET_ADMIN` only on a specific init container. Tighter alternatives I considered:

| Option | Trade-off |
|---|---|
| Kyverno/OPA policy targeting just `setup-netpol` | Stricter, but adds a cluster-level dependency this chart can't assume. |
| PSA `AdmissionConfiguration` exemption for the operator SA | Cluster-API-server config, not chart-portable. |
| Different firewall mechanism (no NET_ADMIN) | iptables/nftables both require NET_ADMIN. CNI-based alternatives bring back the v1.3.x VPC CNI NP-agent conntrack bug that motivated #3321 in the first place. |

`privileged` is the simplest fix that stays portable across stock K8s clusters.

## Why this is acceptable security-wise

- The **real security boundary** is the main sandbox container's pod spec: `capabilities.drop: [ALL]`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `hostUsers: true` (userns remap), `automountServiceAccountToken: false`. Unchanged.
- `NET_ADMIN` on the init container **does not leak to the main container** — Linux capabilities are per-container in K8s. The init container exits before the main container starts.
- The iptables firewall the init container installs blocks all egress to RFC1918 / IMDS / link-local. Even a privileged sandbox pod can't reach in-cluster services.
- `warn` / `audit` stay at `restricted`, so any regression in the pod-level posture (here or in `sandbox-env`) surfaces in audit logs without rejecting admission.

The trade-off this does make: namespace PSA was a backstop catching mis-specs in this namespace. With `privileged` that backstop is gone — chart code review and audit logs are now the controls.

## Test plan

- [x] Verified failing path on live EKS staging (controller log excerpt above).
- [ ] After merge + chart publish: bump `sandbox-operator` `targetRevision` in `argo-deploy-mesh` to `0.1.2`, watch `agent-sandbox-system` namespace label flip, watch operator successfully create a `studio-sandbox-stg-*` pod with `setup-netpol` init container completing.
- [ ] Re-run the NATS reachability probe from inside the new pod — should be REJECTED by the iptables OUTPUT rules (the original motivation for the netinit work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the `agent-sandbox-system` namespace PSA enforce level to `privileged` so sandbox pods with the `setup-netpol` init container (needs `NET_ADMIN`) are admitted again. This fixes pod creation failures introduced by `sandbox-env >= 0.7.0`.

- **Bug Fixes**
  - Set `pod-security.kubernetes.io/enforce: privileged` on `agent-sandbox-system`; keep warn/audit at `restricted`.
  - Updated `vendor.sh` to inject `enforce=privileged` and adjust checks so regenerated manifests match HEAD.

- **Dependencies**
  - Bump `sandbox-operator` chart to `0.1.2`.

<sup>Written for commit 4d59845592cb584c1dceccc2e25cfd6e4d78ad83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

