### PR TITLE
fix(decopilot): keep attach replay open across silent gaps

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -1,6 +1,81 @@
 import { describe, it, expect, mock } from "bun:test";
 import { NatsStreamBuffer } from "./nats-stream-buffer";
 
+type DeferredMsg = { data: Uint8Array };
+
+function createControlledSubscription() {
+  const queue: Array<{ done: false; value: DeferredMsg } | { done: true }> = [];
+  const waiters: Array<
+    (
+      v: { done: false; value: DeferredMsg } | { done: true; value: undefined },
+    ) => void
+  > = [];
+
+  const push = (value: DeferredMsg) => {
+    const next = waiters.shift();
+    if (next) next({ done: false, value });
+    else queue.push({ done: false, value });
+  };
+
+  const end = () => {
+    const next = waiters.shift();
+    if (next) next({ done: true, value: undefined });
+    else queue.push({ done: true });
+  };
+
+  const sub = {
+    unsubscribe: mock(() => {}),
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<
+          { done: false; value: DeferredMsg } | { done: true; value: undefined }
+        > {
+          const queued = queue.shift();
+          if (queued) {
+            if (queued.done) {
+              return Promise.resolve({ done: true, value: undefined });
+            }
+            return Promise.resolve(queued);
+          }
+          return new Promise((resolve) => waiters.push(resolve));
+        },
+        return(): Promise<{ done: true; value: undefined }> {
+          waiters.splice(0).forEach((w) => w({ done: true, value: undefined }));
+          return Promise.resolve({ done: true, value: undefined });
+        },
+      };
+    },
+  };
+
+  return { sub, push, end };
+}
+
+function bufferWith(subscribeFn: () => Promise<unknown>) {
+  const mockJs = { subscribe: mockOf(subscribeFn) };
+  const buffer = new NatsStreamBuffer({
+    getConnection: () => ({}) as never,
+    getJetStream: () => mockJs as never,
+  });
+  // Bypass init() — inject the JetStream client directly.
+  (buffer as unknown as { js: unknown }).js = mockJs;
+  return buffer;
+}
+
+function mockOf<T extends (...args: never[]) => unknown>(fn: T): T {
+  return mock(fn) as unknown as T;
+}
+
+async function readAll(stream: ReadableStream): Promise<unknown[]> {
+  const reader = stream.getReader();
+  const out: unknown[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out.push(value);
+  }
+  return out;
+}
+
 describe("NatsStreamBuffer", () => {
   it("purge is a no-op when jsm is not initialized (no throw)", () => {
     const buffer = new NatsStreamBuffer({
@@ -76,5 +151,116 @@ describe("NatsStreamBuffer", () => {
     await buffer.init();
 
     expect(streamAddMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe("createReplayStream", () => {
+    function encodeMsg(payload: unknown): DeferredMsg {
+      return { data: new TextEncoder().encode(JSON.stringify(payload)) };
+    }
+
+    it("returns null when JetStream is unavailable", async () => {
+      const buffer = new NatsStreamBuffer({
+        getConnection: () => null,
+        getJetStream: () => null,
+      });
+      const result = await buffer.createReplayStream("task-1");
+      expect(result).toBeNull();
+    });
+
+    it("yields buffered chunks and closes on done marker", async () => {
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+
+      const stream = await buffer.createReplayStream("task-1");
+      expect(stream).not.toBeNull();
+
+      push(encodeMsg({ p: "chunk-1" }));
+      push(encodeMsg({ p: "chunk-2" }));
+      push(encodeMsg({ done: true }));
+      end();
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual(["chunk-1", "chunk-2"]);
+      expect(sub.unsubscribe).toHaveBeenCalled();
+    });
+
+    it("stays open across long silent gaps between chunks", async () => {
+      // Regression: previously a 30s pull timeout would close the SSE
+      // stream prematurely with [DONE] when the producer (e.g. deep
+      // research polling Gemini) went silent between progress chunks.
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+
+      const stream = await buffer.createReplayStream("task-1");
+      const reader = stream!.getReader();
+
+      push(encodeMsg({ p: "before-gap" }));
+      const first = await reader.read();
+      expect(first.done).toBe(false);
+      expect(first.value).toBe("before-gap");
+
+      // Simulate a long silent period. The pull is now awaiting iter.next()
+      // with no incoming messages. Kick off the next read and confirm it
+      // does NOT resolve while the subscription is idle.
+      let secondResolved = false;
+      const secondP = reader.read().then((r) => {
+        secondResolved = true;
+        return r;
+      });
+
+      // Yield to the event loop and a short timer; nothing should resolve.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(secondResolved).toBe(false);
+
+      // After the gap, a new chunk arrives — it must flow through.
+      push(encodeMsg({ p: "after-gap" }));
+      const second = await secondP;
+      expect(second.done).toBe(false);
+      expect(second.value).toBe("after-gap");
+
+      push(encodeMsg({ done: true }));
+      end();
+      const tail = await reader.read();
+      expect(tail.done).toBe(true);
+    });
+
+    it("skips malformed messages and continues", async () => {
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+
+      const stream = await buffer.createReplayStream("task-1");
+
+      // Malformed JSON between two valid chunks.
+      push(encodeMsg({ p: "ok-1" }));
+      push({ data: new TextEncoder().encode("not-json{{{") });
+      push(encodeMsg({ p: "ok-2" }));
+      push(encodeMsg({ done: true }));
+      end();
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual(["ok-1", "ok-2"]);
+    });
+
+    it("cleans up when consumer cancels", async () => {
+      const { sub, push } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+
+      const stream = await buffer.createReplayStream("task-1");
+      const reader = stream!.getReader();
+
+      push(encodeMsg({ p: "first" }));
+      await reader.read();
+
+      await reader.cancel();
+      expect(sub.unsubscribe).toHaveBeenCalled();
+    });
+
+    it("returns null when subscribe throws", async () => {
+      const buffer = bufferWith(() =>
+        Promise.reject(new Error("subscribe failed")),
+      );
+      const stream = await buffer.createReplayStream("task-1");
+      expect(stream).toBeNull();
+    });
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -26,7 +26,6 @@ const SUBJECT_PREFIX = "decopilot.stream";
 const MAX_AGE_NS = 5 * 60 * 1_000_000_000; // 5 min
 const MAX_BYTES = 500 * 1024 * 1024; // 500 MB
 const MAX_MSGS_PER_SUBJECT = 20_000; // ~20K chunks per thread
-const PULL_TIMEOUT_MS = 30_000;
 
 function assertSafeSubjectToken(id: string): void {
   if (/[.*>\s]/.test(id)) throw new Error("Invalid NATS subject token");
@@ -184,17 +183,7 @@ export class NatsStreamBuffer implements StreamBuffer {
     return new ReadableStream({
       async pull(controller) {
         while (true) {
-          let timer: ReturnType<typeof setTimeout> | undefined;
-          const result = await Promise.race([
-            iter.next(),
-            new Promise<{ done: true; value: undefined }>((r) => {
-              timer = setTimeout(
-                () => r({ done: true, value: undefined }),
-                PULL_TIMEOUT_MS,
-              );
-            }),
-          ]);
-          clearTimeout(timer);
+          const result = await iter.next();
           if (result.done) {
             cleanup();
             controller.close();


### PR DESCRIPTION
## Summary

The JetStream replay stream backing `GET /api/<org>/decopilot/attach/:threadId` raced `iter.next()` against a 30s pull timeout and treated both as `done: true`, closing the SSE stream with `[DONE]` whenever the producer went silent for half a minute.

This is particularly bad for **deep research**: the original run buffers `start → start-step → tool-input-start → tool-input-delta → tool-input-available` in the first second, then the `web_search` tool polls Gemini for **minutes** with no transcript progress. Any `/attach` that lands during a silent window replays the buffered chunks and then closes prematurely, leaving the UI showing a research skeleton forever even though the run is still alive server-side.

Observed in prod on `v2.312.5`:

```
data: {"type":"start", ...}
data: {"type":"start-step"}
data: {"type":"tool-input-start","toolCallId":"...","toolName":"web_search", ...}
data: {"type":"tool-input-delta", ...}
data: {"type":"tool-input-available","input":{"query":"..."}, ...}
: keepalive
: keepalive
data: [DONE]      ← stream closes ~30s after last buffered chunk; run keeps going server-side
```

The client treats `[DONE]` as a clean completion, so the PR #3334 auto-resume (which only fires on `TypeError`) doesn't kick in. The thread sits in `in_progress` until the 30-minute reaper fires.

## The fix

Drop the timeout race in `createReplayStream` and just `await iter.next()` directly.

- Proxy idle-cuts are already handled by `wrapWithSseKeepalive` (15s `: keepalive\n\n` comments).
- Real termination is handled by the `{done: true}` flush marker that `relay()` publishes, and by the NATS subscription's own lifecycle when the consumer cancels.
- The timeout was a paranoid hedge against a hung subscription, but it had no correct case — every time it fired, it was wrong.

## Test plan

- [x] Added regression test `stays open across long silent gaps between chunks` — kicks off a `reader.read()` while the subscription is idle, asserts it does **not** resolve, then pushes a chunk and asserts it flows through.
- [x] Added coverage for the other replay paths: buffered chunks + done marker, malformed-message skip, consumer cancel, subscribe-throws.
- [x] `bun test apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts` — 10/10 pass.
- [x] `bun run --cwd apps/mesh check` clean.
- [x] `bun run lint` clean.
- [x] `bun run fmt`.

## Follow-up (not in this PR)

A defense-in-depth fix on the client: `useStreamManager` could add a fourth resume trigger that fires when `chat.status` settles into anything-not-streaming while `threadStatus` is still `in_progress` AND there's no terminal assistant message. Today's three triggers (mount, `decopilot.step`, `TypeError`) don't cover the "clean but premature `[DONE]`" failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Decopilot attach replay streams open across long silent gaps by removing a faulty 30s pull-timeout race. Prevents premature `[DONE]` and stuck research UIs during long tool runs.

- **Bug Fixes**
  - Removed the 30s timeout race in `createReplayStream`; now we just await `iter.next()`.
  - Real termination relies on `{done: true}` flush markers and NATS subscription lifecycle; idle periods are covered by `wrapWithSseKeepalive`.
  - Added tests for long-gap behavior, buffered+done flow, malformed-message skip, consumer cancel, and subscribe errors.

<sup>Written for commit 32a8dbbb4457851fe46318142c8d097d5b2da9ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

