### PR TITLE
Daemon broadcast

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -91,9 +91,9 @@ const broadcaster = new Broadcaster(REPLAY_BYTES);
 // fallback for tools that do honor PORT.
 const portSniffer = createPortSniffer();
 const broadcastChunkRaw = broadcaster.broadcastChunk.bind(broadcaster);
-broadcaster.broadcastChunk = (source, data) => {
+broadcaster.broadcastChunk = (source, data, opts) => {
   portSniffer.observe(source, data);
-  broadcastChunkRaw(source, data);
+  broadcastChunkRaw(source, data, opts);
 };
 
 let currentStatus: DaemonStatus = { state: "running" };
@@ -109,9 +109,13 @@ const lifecycle = new LifecycleManager({ broadcaster });
 // may bind somewhere else and we need to re-sniff its announcement.
 const lifecycleTransitionRaw = lifecycle.transition.bind(lifecycle);
 lifecycle.transition = (next) => {
-  const wasRunning = lifecycle.current().phase === "running";
+  const prev = lifecycle.current().phase;
+  const wasRunning = prev === "running";
   lifecycleTransitionRaw(next);
   if (wasRunning && next.phase !== "running") portSniffer.reset();
+  if (prev !== next.phase) {
+    console.log(`[lifecycle] ${prev} → ${next.phase}`);
+  }
 };
 // Per-command history for LLM context (each bash/exec spawned via TaskManager
 // is tracked as a phase). Setup pipeline phases live on `lifecycle` instead.
@@ -123,6 +127,14 @@ const taskManager = new TaskManager({
   onChange: () => {
     broadcaster.emit("tasks", { active: getActiveTasks() });
   },
+});
+
+// Per-chunk task output is silenced in pod logs (see broadcaster opt-out);
+// surface exits explicitly so an operator can see "dev exited 1" without
+// the firehose of stdout that preceded it.
+taskManager.onTaskExit((s) => {
+  const label = s.logName ?? s.id;
+  console.log(`[task] ${label} ${s.status} (exit=${s.exitCode})`);
 });
 
 function getActiveTasks() {

--- a/packages/sandbox/daemon/events/broadcast.ts
+++ b/packages/sandbox/daemon/events/broadcast.ts
@@ -4,6 +4,10 @@ import type { DaemonEventMap, DaemonEventName } from "./types";
 
 type Controller = ReadableStreamDefaultController<Uint8Array>;
 
+// Force tee for every chunk regardless of caller opt-out. Lets an operator
+// crank a pod up to the full firehose without a code change.
+const VERBOSE = process.env.DAEMON_LOG_VERBOSE === "1";
+
 export class Broadcaster {
   readonly replay: ReplayBuffer;
   private readonly clients = new Set<Controller>();
@@ -24,13 +28,16 @@ export class Broadcaster {
     return this.clients.size;
   }
 
-  broadcastChunk(source: string, data: string): void {
+  broadcastChunk(source: string, data: string, opts?: { tee?: boolean }): void {
     if (!data) return;
     this.replay.append(source, data);
-    // Tee to stdout so `kubectl logs` / k9s show the same output that SSE
-    // subscribers see. The structured events (emit below) stay SSE-only —
-    // they're machine-readable JSON and would be noise here.
-    process.stdout.write(`[${source}] ${data}`);
+    // Tee to stdout so `kubectl logs` / k9s see control-plane messages
+    // (orchestrator status, daemon, lifecycle). Raw subprocess streams pass
+    // `tee: false` to keep pod logs readable — they remain on SSE + replay
+    // + the per-task LogTee on disk.
+    if (VERBOSE || opts?.tee !== false) {
+      process.stdout.write(`[${source}] ${data}`);
+    }
     const bytes = sseFormat("log", JSON.stringify({ source, data }));
     this.fan(bytes);
   }

--- a/packages/sandbox/daemon/process/log-tee.ts
+++ b/packages/sandbox/daemon/process/log-tee.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   openSync,
   statSync,
+  unlinkSync,
   writeSync,
 } from "node:fs";
 import { dirname } from "node:path";
@@ -11,9 +12,11 @@ import { dirname } from "node:path";
 /**
  * Append-mode tee to a single log file. Each chunk is flushed to the
  * kernel via writeSync; fsync only happens on close to keep per-chunk
- * overhead low. Hard size cap protects against runaway output — once we
- * exceed `maxBytes`, subsequent writes are dropped (with a single
- * truncation marker emitted) until the tee is closed.
+ * overhead low. Hard size cap is enforced by **rotation**: when a write
+ * would exceed `maxBytes`, the file is unlinked and reopened fresh with a
+ * `[log rotated at N bytes]` marker. This keeps per-log disk bounded at
+ * roughly `maxBytes` even for long-lived tasks that restart many times
+ * (e.g. a dev script crash-looping inside a pod).
  *
  * Open the tee lazily: callers can defer creating the file until the
  * first write so empty logs don't litter the disk.
@@ -21,7 +24,7 @@ import { dirname } from "node:path";
 export class LogTee {
   private fd: number | null = null;
   private written = 0;
-  private truncated = false;
+  private rotatedOnce = false;
 
   constructor(
     private readonly path: string,
@@ -30,32 +33,9 @@ export class LogTee {
 
   write(data: string): void {
     if (data.length === 0) return;
-    if (this.truncated) return;
     const buf = Buffer.from(data, "utf-8");
     if (this.written + buf.length > this.maxBytes) {
-      this.truncated = true;
-      const remain = Math.max(0, this.maxBytes - this.written);
-      if (remain > 0 && this.openIfNeeded()) {
-        try {
-          writeSync(this.fd as number, buf, 0, remain);
-          this.written += remain;
-        } catch {
-          /* unrecoverable; leave truncated as-is */
-        }
-      }
-      const marker = Buffer.from(
-        `\n[log truncated at ${this.maxBytes} bytes]\n`,
-        "utf-8",
-      );
-      if (this.openIfNeeded()) {
-        try {
-          writeSync(this.fd as number, marker);
-        } catch {
-          /* ignore */
-        }
-      }
-      this.close();
-      return;
+      this.rotate();
     }
     if (!this.openIfNeeded()) return;
     try {
@@ -63,6 +43,28 @@ export class LogTee {
       this.written += buf.length;
     } catch {
       /* swallow — log writes must never crash the daemon */
+    }
+  }
+
+  private rotate(): void {
+    this.close();
+    try {
+      unlinkSync(this.path);
+    } catch {
+      /* ignore — already gone or never existed */
+    }
+    this.written = 0;
+    this.rotatedOnce = true;
+    if (!this.openIfNeeded()) return;
+    const marker = Buffer.from(
+      `[log rotated at ${this.maxBytes} bytes]\n`,
+      "utf-8",
+    );
+    try {
+      writeSync(this.fd as number, marker);
+      this.written = marker.length;
+    } catch {
+      /* ignore */
     }
   }
 
@@ -83,7 +85,7 @@ export class LogTee {
   }
 
   isTruncated(): boolean {
-    return this.truncated;
+    return this.rotatedOnce;
   }
 
   bytesWritten(): number {

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -114,7 +114,11 @@ export interface TaskManagerDeps {
    * line (`$ <label>`) is also broadcast on spawn.
    */
   broadcaster?: {
-    broadcastChunk: (source: string, data: string) => void;
+    broadcastChunk: (
+      source: string,
+      data: string,
+      opts?: { tee?: boolean },
+    ) => void;
   };
 }
 
@@ -556,7 +560,13 @@ export class TaskManager {
       }
     }
     if (task.spec.logName) {
-      this.deps.broadcaster?.broadcastChunk(task.spec.logName, chunk.data);
+      // tee: false — subprocess output stays on SSE + replay + on-disk
+      // LogTee; the header line written at spawn time already went to
+      // pod logs, so an operator can correlate later exit events back to
+      // the command without the noise of every line in between.
+      this.deps.broadcaster?.broadcastChunk(task.spec.logName, chunk.data, {
+        tee: false,
+      });
     }
   }
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -195,6 +195,13 @@ export class SetupOrchestrator {
     this.deps.broadcaster.broadcastChunk("setup", data);
   }
 
+  // Raw subprocess output (clone/install/checkout). Skips the stdout tee so
+  // pod logs aren't drowned in progress bars; still goes to SSE + replay +
+  // the per-step LogTee on disk.
+  private rawChunk(data: string): void {
+    this.deps.broadcaster.broadcastChunk("setup", data, { tee: false });
+  }
+
   /**
    * Acquires source: clone if no .git, otherwise checkout the configured
    * branch. Then runs idempotent post-source-acquisition steps (git
@@ -219,7 +226,7 @@ export class SetupOrchestrator {
         code = await spawnClone({
           config,
           onChunk: (_src, data) => {
-            this.chunk(data);
+            this.rawChunk(data);
             cloneTee.write(data);
           },
         });
@@ -294,7 +301,7 @@ export class SetupOrchestrator {
     const installPromise = spawnInstall({
       config,
       onChunk: (_src, data) => {
-        this.chunk(data);
+        this.rawChunk(data);
         installTee.write(data);
       },
     });
@@ -529,7 +536,7 @@ export class SetupOrchestrator {
   private async checkoutBranch(branch: string): Promise<void> {
     const repoDir = this.deps.bootConfig.repoDir;
     if (!repoDir) return;
-    const onChunk = (_src: "setup", data: string) => this.chunk(data);
+    const onChunk = (_src: "setup", data: string) => this.rawChunk(data);
     const silent = (_src: "setup", _data: string) => {};
     // http.connectTimeout: fail fast on DNS/TCP failures (seconds).
     // lowSpeedLimit/Time: abort if transfer rate stays below 1 B/s for 10 s.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve daemon observability while keeping pod logs readable by default. Adds selective stdout teeing, explicit lifecycle and task-exit logs, and rotates per-task log files instead of truncating.

- **New Features**
  - Added `broadcastChunk(source, data, { tee?: boolean })`; `DAEMON_LOG_VERBOSE=1` forces tee of all chunks.
  - Orchestrator and `TaskManager` mark raw subprocess output with `{ tee: false }`; full output still goes to SSE/replay and on-disk `LogTee`.
  - Lifecycle transitions now log `[lifecycle] prev → next`; port sniffer reset on leaving "running" stays intact.
  - `TaskManager` logs exits: `[task] <label> <status> (exit=<code>)` for quick operator context.
  - `LogTee` now rotates at `maxBytes` with `[log rotated at N bytes]` marker, keeping per-log disk bounded for long-lived tasks.

<sup>Written for commit 9d3621b5653204cb368226700970b5177644a335. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

