### PR TITLE
fix(chat): isolate subtask agent fetch in Suspense to prevent chat suspension

### DIFF
--- a/apps/mesh/src/web/components/chat/context-panel.tsx
+++ b/apps/mesh/src/web/components/chat/context-panel.tsx
@@ -12,7 +12,7 @@ import { calculateUsageStats } from "@/web/lib/usage-utils";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { useChatStream, useChatTask, useChatPrefs } from "./context";
 import type { ChatMessage, SubtaskToolPart } from "./types";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
 // ============================================================================
 // Helpers
@@ -141,21 +141,18 @@ function ContextBreakdownBar({
 // SubtaskRow — resolves agent via single-item fetch
 // ============================================================================
 
-function SubtaskRow({ part }: { part: SubtaskToolPart }) {
-  const agentId = part.input?.agent_id;
+function SubtaskAgentInfo({
+  agentId,
+  isError,
+}: {
+  agentId: string | undefined;
+  isError: boolean;
+}) {
   const agent = useVirtualMCP(agentId);
   const agentTitle = agent?.title ?? "Subtask";
   const agentIcon = agent?.icon ?? null;
-  const isRunning =
-    part.state === "input-streaming" ||
-    part.state === "input-available" ||
-    (part.state === "output-available" &&
-      (part as { preliminary?: boolean }).preliminary === true);
-  const isError = part.state === "output-error";
-  const isApproval = part.state === "approval-requested";
-
   return (
-    <div className="flex items-center gap-2 text-xs min-w-0">
+    <>
       <IntegrationIcon
         icon={agentIcon}
         name={agentTitle}
@@ -170,6 +167,46 @@ function SubtaskRow({ part }: { part: SubtaskToolPart }) {
       >
         {agentTitle}
       </span>
+    </>
+  );
+}
+
+function SubtaskAgentInfoFallback({ isError }: { isError: boolean }) {
+  return (
+    <>
+      <IntegrationIcon
+        icon={null}
+        name="Subtask"
+        size="xs"
+        className="size-6 rounded-md shrink-0"
+      />
+      <span
+        className={cn(
+          "shrink-0 font-medium",
+          isError ? "text-destructive" : "text-foreground",
+        )}
+      >
+        Subtask
+      </span>
+    </>
+  );
+}
+
+function SubtaskRow({ part }: { part: SubtaskToolPart }) {
+  const agentId = part.input?.agent_id;
+  const isRunning =
+    part.state === "input-streaming" ||
+    part.state === "input-available" ||
+    (part.state === "output-available" &&
+      (part as { preliminary?: boolean }).preliminary === true);
+  const isError = part.state === "output-error";
+  const isApproval = part.state === "approval-requested";
+
+  return (
+    <div className="flex items-center gap-2 text-xs min-w-0">
+      <Suspense fallback={<SubtaskAgentInfoFallback isError={isError} />}>
+        <SubtaskAgentInfo agentId={agentId} isError={isError} />
+      </Suspense>
       {part.input?.prompt && (
         <>
           <span className="text-muted-foreground/50">·</span>

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -7,7 +7,7 @@ import {
   Tool02,
 } from "@untitledui/icons";
 import type { ToolUIPart } from "ai";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, Suspense, useEffect, useState } from "react";
 import { ToolCallShell } from "./parts/tool-call-part/common.tsx";
 import type { ChatMessage } from "../types.ts";
 import { MessageStatsBar } from "../usage-stats.tsx";
@@ -18,6 +18,7 @@ import {
   WebSearchPart,
   ProposePlanPart,
   SubtaskPart,
+  SubtaskPartFallback,
   UserAskPart,
 } from "./parts/tool-call-part/index.ts";
 import { SmartAutoScroll } from "./smart-auto-scroll.tsx";
@@ -438,15 +439,19 @@ function MessagePart({
           streamingText={dataParts.webSearchStreaming.get(part.toolCallId)}
         />
       );
-    case "tool-subtask":
+    case "tool-subtask": {
+      const subtaskProps = {
+        part,
+        subtaskMeta: getSubtaskMeta(part.toolCallId),
+        annotations: getMeta(part.toolCallId)?.annotations,
+        latency: getMeta(part.toolCallId)?.latencySeconds,
+      };
       return (
-        <SubtaskPart
-          part={part}
-          subtaskMeta={getSubtaskMeta(part.toolCallId)}
-          annotations={getMeta(part.toolCallId)?.annotations}
-          latency={getMeta(part.toolCallId)?.latencySeconds}
-        />
+        <Suspense fallback={<SubtaskPartFallback {...subtaskProps} />}>
+          <SubtaskPart {...subtaskProps} />
+        </Suspense>
       );
+    }
     case "text":
       return (
         <MessageTextPart

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
@@ -2,5 +2,5 @@ export { GenericToolCallPart } from "./generic.tsx";
 export { GenerateImagePart } from "./generate-image.tsx";
 export { WebSearchPart } from "./web-search.tsx";
 export { UserAskPart } from "./user-ask.tsx";
-export { SubtaskPart } from "./subtask.tsx";
+export { SubtaskPart, SubtaskPartFallback } from "./subtask.tsx";
 export { ProposePlanPart } from "./propose-plan.tsx";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -19,8 +19,16 @@ interface SubtaskPartProps {
   latency?: number;
 }
 
-export function SubtaskPart({ part, subtaskMeta, latency }: SubtaskPartProps) {
-  // State computation
+/**
+ * Derives ToolCallShell config from a SubtaskToolPart — no agent data needed.
+ * Shared between SubtaskPart (loaded) and SubtaskPartFallback (Suspense fallback),
+ * so the two render identical shells aside from the agent-dependent title/icon.
+ */
+function useSubtaskShellConfig({
+  part,
+  subtaskMeta,
+  latency,
+}: SubtaskPartProps) {
   const isInputStreaming =
     part.state === "input-streaming" || part.state === "input-available";
   const isOutputStreaming =
@@ -28,7 +36,6 @@ export function SubtaskPart({ part, subtaskMeta, latency }: SubtaskPartProps) {
   const isComplete = part.state === "output-available" && !part.preliminary;
   const isError = part.state === "output-error";
 
-  // Derive UI state for ToolCallShell
   // Approval-requested parts render as idle inline (approval UI is in the highlight above input)
   const rawState = getEffectiveState(
     part.state,
@@ -36,27 +43,16 @@ export function SubtaskPart({ part, subtaskMeta, latency }: SubtaskPartProps) {
   );
   const effectiveState = rawState === "approval" ? "idle" : rawState;
 
-  // Agent lookup (single-item fetch, no full list needed)
-  const agentId = part.input?.agent_id;
-  const agent = useVirtualMCP(agentId);
+  const fallbackTitle: string = isInputStreaming
+    ? "Starting subtask..."
+    : isOutputStreaming
+      ? "Subtask running..."
+      : isComplete
+        ? "Subtask completed"
+        : isError
+          ? "Subtask failed"
+          : "Subtask";
 
-  // Usage extraction from data part
-  const usage = subtaskMeta?.usage;
-
-  // Title: agent name or fallback status
-  const title: string = agent?.title
-    ? agent.title
-    : isInputStreaming
-      ? "Starting subtask..."
-      : isOutputStreaming
-        ? "Subtask running..."
-        : isComplete
-          ? "Subtask completed"
-          : isError
-            ? "Subtask failed"
-            : "Subtask";
-
-  // Summary: the task prompt (what this subtask was asked to do)
   const prompt = part.input?.prompt ?? "";
   const summary =
     part.state === "approval-requested"
@@ -65,32 +61,66 @@ export function SubtaskPart({ part, subtaskMeta, latency }: SubtaskPartProps) {
         ? prompt.slice(0, 120) + "…"
         : prompt;
 
-  // Detail (expanded content)
   const response = isError
     ? getToolPartErrorText(part)
     : (extractTextFromOutput(part.output) ?? "No output available");
   const detail = `# Task\n${part.input?.prompt ?? "No prompt provided"}\n\n# ${isError ? "Error" : "Result"}\n${response}`;
 
-  // Icon
-  const icon = (
-    <IntegrationIcon
-      icon={agent?.icon}
-      name={agent?.title ?? "Subtask"}
-      size="2xs"
-      className="rounded-xs"
-      fallbackIcon={<Users03 />}
+  return {
+    fallbackTitle,
+    summary,
+    usage: subtaskMeta?.usage,
+    latency,
+    detail,
+    state: effectiveState,
+  };
+}
+
+/**
+ * Suspense fallback for SubtaskPart. Renders the exact same ToolCallShell shape
+ * as the loaded view (so no CLS) — just with a default icon and a status-derived
+ * title instead of the agent's icon and name.
+ */
+export function SubtaskPartFallback(props: SubtaskPartProps) {
+  const { fallbackTitle, ...shell } = useSubtaskShellConfig(props);
+  return (
+    <ToolCallShell
+      icon={
+        <IntegrationIcon
+          icon={undefined}
+          name="Subtask"
+          size="2xs"
+          className="rounded-xs"
+          fallbackIcon={<Users03 />}
+        />
+      }
+      title={fallbackTitle}
+      {...shell}
     />
   );
+}
+
+/**
+ * Suspends on the agent fetch (useVirtualMCP). MUST be wrapped in
+ * <Suspense fallback={<SubtaskPartFallback ... />}> by the caller.
+ */
+export function SubtaskPart(props: SubtaskPartProps) {
+  const { fallbackTitle, ...shell } = useSubtaskShellConfig(props);
+  const agent = useVirtualMCP(props.part.input?.agent_id);
 
   return (
     <ToolCallShell
-      icon={icon}
-      title={title}
-      summary={summary}
-      usage={usage}
-      latency={latency}
-      detail={detail}
-      state={effectiveState}
+      icon={
+        <IntegrationIcon
+          icon={agent?.icon}
+          name={agent?.title ?? "Subtask"}
+          size="2xs"
+          className="rounded-xs"
+          fallbackIcon={<Users03 />}
+        />
+      }
+      title={agent?.title ?? fallbackTitle}
+      {...shell}
     />
   );
 }


### PR DESCRIPTION
## What is this contribution about?

When a subtask tool call appeared in the chat with a not-yet-cached `agent_id`, the chat panel would fall back to its skeleton state. Both `SubtaskRow` (in the context panel) and `SubtaskPart` (in the message tree) called `useVirtualMCP` at the top level, and their thrown promises propagated past the message tree all the way up to the panel-level `<Suspense>` in `side-panel-chat.tsx`. This wraps each agent fetch in a local Suspense boundary with a CLS-free fallback that renders the same shell shape (status icon, prompt, etc. stay visible — only the agent icon + name swap when the fetch resolves).

## Screenshots/Demonstration

No visual change in the steady state — the subtask rows and message parts render identically once loaded. The difference is during the brief agent fetch: previously the whole chat panel went to skeleton; now only the icon + name show a placeholder while the rest of the row/shell stays mounted.

## How to Test

1. Open a chat that triggers a subtask (e.g. delegate to an agent whose details aren't already cached, like opening a fresh page and asking the agent to delegate to another agent).
2. Watch the chat as the subtask tool call appears.
3. Expected: the chat continues rendering normally; the subtask shell appears immediately with a status title ("Subtask running…") and default icon, then swaps to the agent's name + icon. The chat panel should not blank out to the skeleton.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the chat panel from flashing to the skeleton when a subtask’s `agent_id` isn’t cached by isolating the agent fetch in local `<Suspense>` boundaries with a no-CLS fallback. Only the agent icon/name placeholder loads; the subtask shell and chat remain visible.

- **Bug Fixes**
  - Context panel: `SubtaskRow` now wraps `useVirtualMCP` in a local `<Suspense>` via `SubtaskAgentInfo` and `SubtaskAgentInfoFallback`.
  - Message tree: `SubtaskPart` suspends only its agent fetch; new `SubtaskPartFallback` and shared `useSubtaskShellConfig` keep `ToolCallShell` layout identical. `assistant.tsx` wraps `SubtaskPart` in `<Suspense>`.

<sup>Written for commit 0061423a16565db769228546ac77a548d756c3aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

