### PR TITLE
feat(home): add tasks panel toggle on org home

### DIFF
--- a/apps/mesh/src/web/hooks/use-tasks-panel-state.tsx
+++ b/apps/mesh/src/web/hooks/use-tasks-panel-state.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { createContext, useContext, useEffect, useState } from "react";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useTasks } from "@/web/components/chat/task/use-task-manager";
 import { resolveTasksOpen } from "@/web/hooks/use-layout-state";
 
@@ -25,10 +25,13 @@ const TasksPanelStateContext = createContext<TasksPanelState | null>(null);
 export function TasksPanelStateProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as { tasks?: number };
+  const params = useParams({ strict: false }) as { taskId?: string };
   const { tasks } = useTasks({ owner: "all", status: "open" });
 
+  // Auto-open based on task count only when on a task route; on home the
+  // panel starts closed (user opens it via the toggle button).
   const [tasksOpen, setTasksOpen] = useState<boolean>(() =>
-    resolveTasksOpen(search.tasks, tasks.length > 0),
+    resolveTasksOpen(search.tasks, Boolean(params.taskId) && tasks.length > 0),
   );
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect

--- a/apps/mesh/src/web/layouts/org-home/index.tsx
+++ b/apps/mesh/src/web/layouts/org-home/index.tsx
@@ -8,7 +8,51 @@
  */
 
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { Menu02 } from "@untitledui/icons";
+import { useTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
+import { track } from "@/web/lib/posthog-client";
+import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import { HomePage } from "@/web/layouts/home-page";
+
+const TOGGLE_BASE =
+  "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors";
+const TOGGLE_ACTIVE = "bg-sidebar-accent text-sidebar-foreground";
+const TOGGLE_INACTIVE =
+  "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground";
+
+function HomeTasksToggle() {
+  const { tasksOpen, toggleTasks } = useTasksPanelState();
+  return (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => {
+            track("home_toolbar_toggled", {
+              button: "tasks",
+              next_state: !tasksOpen ? "open" : "closed",
+            });
+            toggleTasks();
+          }}
+          aria-pressed={tasksOpen}
+          className={cn(
+            TOGGLE_BASE,
+            tasksOpen ? TOGGLE_ACTIVE : TOGGLE_INACTIVE,
+          )}
+        >
+          <Menu02 size={16} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Tasks</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function OrgHome() {
   const isMobile = useIsMobile();
@@ -22,10 +66,17 @@ export default function OrgHome() {
   }
 
   return (
-    <div className="flex-1 min-h-0 p-1.5 overflow-hidden">
-      <div className="flex h-full flex-col bg-background overflow-hidden card-shadow rounded-[0.75rem]">
-        <HomePage />
+    <>
+      <Toolbar.Toggles>
+        <HomeTasksToggle />
+      </Toolbar.Toggles>
+      <div className="flex-1 min-h-0 pb-1 pr-1 pl-0 pt-0">
+        <div className="h-full p-0.5 pt-0.25">
+          <div className="flex flex-col h-full bg-background overflow-hidden card-shadow rounded-[0.75rem]">
+            <HomePage />
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -118,7 +118,7 @@ export default function OrgShellLayout() {
                       </Toolbar.RightColumn>
                     </Toolbar.Header>
                     <div className="flex-1 min-h-0 flex flex-row">
-                      {hasTaskRoute && <TasksPanelColumn />}
+                      <TasksPanelColumn />
                       <Suspense fallback={<RouteFallback />}>
                         <Outlet />
                       </Suspense>


### PR DESCRIPTION
## What is this contribution about?
Adds a `HomeTasksToggle` button to the org home toolbar so users can open/close the tasks panel from `/$org/`. The panel now defaults closed on home (previously auto-opened whenever any open tasks existed) and only auto-opens on task routes. The shell layout drops the `hasTaskRoute` gate around `<TasksPanelColumn />` since the column already self-hides when closed.

## How to Test
1. Navigate to `/$org/` with at least one open task — tasks panel should be closed by default.
2. Click the new toggle in the toolbar — panel opens; `?tasks=1` appears in the URL.
3. Refresh — state persists; navigate to a task route — panel remains open.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tasks panel toggle to the org home toolbar so users can open/close the panel on `/$org/`. The panel now starts closed on home and only auto-opens on task routes.

- **New Features**
  - Toolbar button to toggle the Tasks panel on home, with tooltip and tracking.
  - Syncs state to the URL via `?tasks=1`, so it persists across refresh and navigation.

- **Refactors**
  - Auto-open now checks the `taskId` route param; home no longer auto-opens based on task count.
  - Shell always renders the Tasks panel column; removed the `hasTaskRoute` gate since it self-hides when closed.

<sup>Written for commit d9a5b917440d08bb2827a6ddebc11532330b7cd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

