### PR TITLE
feat(chat): add minimize toggle to user-ask highlight card

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/card.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/card.tsx
@@ -1,5 +1,9 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { ArrowLeft, ArrowRight } from "@untitledui/icons";
+import { ArrowLeft, ArrowRight, ChevronDown } from "@untitledui/icons";
+import { useState } from "react";
+
+// ease-in-out-cubic — on-screen morph per animation guide
+const EASE = "cubic-bezier(0.645, 0.045, 0.355, 1)";
 
 // ============================================================================
 // Pagination - "← 1 of 4 →" control
@@ -66,6 +70,7 @@ export interface HighlightCardProps {
   footerLeft?: React.ReactNode;
   footerRight: React.ReactNode;
   className?: string;
+  minimizable?: boolean;
 }
 
 export function HighlightCard({
@@ -74,29 +79,70 @@ export function HighlightCard({
   footerLeft,
   footerRight,
   className,
+  minimizable,
 }: HighlightCardProps) {
+  const [minimized, setMinimized] = useState(false);
+
   return (
     <div
       className={cn(
-        "flex flex-col rounded-xl bg-background border shadow-md w-[calc(100%-16px)] max-w-[584px] mx-auto mb-[-16px]",
+        "flex flex-col rounded-xl bg-background border shadow-md w-[calc(100%-16px)] max-w-[584px] mx-auto",
         className ?? "border-border",
       )}
+      style={{
+        marginBottom: minimized ? "8px" : "-16px",
+        transition: `margin-bottom 180ms ${EASE}`,
+      }}
     >
       {/* Header */}
-      <div className="flex items-center gap-2 p-4">
-        <p className="flex-1 text-base font-medium text-foreground min-w-0">
+      <div className="flex items-start gap-2 px-4 pt-4 pb-5">
+        <p className={cn("flex-1 text-base font-medium text-foreground min-w-0", minimized && "truncate")}>
           {title}
         </p>
+        {minimizable && (
+          <button
+            type="button"
+            onClick={() => setMinimized((v) => !v)}
+            className="shrink-0 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            aria-label={minimized ? "Expand question" : "Minimize question"}
+          >
+            <ChevronDown
+              size={18}
+              style={{
+                transform: minimized ? "rotate(0deg)" : "rotate(180deg)",
+                transition: `transform 180ms ${EASE}`,
+              }}
+            />
+          </button>
+        )}
       </div>
 
-      {/* Options / Content */}
-      <div className="overflow-clip pb-4">{children}</div>
+      {/* Collapsible body — grid trick animates height without knowing it */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateRows: minimized ? "0fr" : "1fr",
+          transition: `grid-template-rows 180ms ${EASE}`,
+        }}
+      >
+        <div style={{ overflow: "hidden", minHeight: 0 }}>
+          <div
+            style={{
+              opacity: minimized ? 0 : 1,
+              transition: `opacity 120ms ${EASE}`,
+            }}
+          >
+            {/* Options / Content */}
+            <div className="overflow-clip pb-4">{children}</div>
 
-      {/* Footer with border-t */}
-      <div className="border-t border-border px-3 py-3 pb-6">
-        <div className="flex items-center justify-between">
-          <div>{footerLeft}</div>
-          <div className="flex items-center gap-2">{footerRight}</div>
+            {/* Footer with border-t */}
+            <div className="border-t border-border px-3 py-3 pb-6">
+              <div className="flex items-center justify-between">
+                <div>{footerLeft}</div>
+                <div className="flex items-center gap-2">{footerRight}</div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/mesh/src/web/components/chat/highlight/card.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/card.tsx
@@ -96,7 +96,12 @@ export function HighlightCard({
     >
       {/* Header */}
       <div className="flex items-start gap-2 px-4 pt-4 pb-5">
-        <p className={cn("flex-1 text-base font-medium text-foreground min-w-0", minimized && "truncate")}>
+        <p
+          className={cn(
+            "flex-1 text-base font-medium text-foreground min-w-0",
+            minimized && "truncate",
+          )}
+        >
           {title}
         </p>
         {minimizable && (

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
@@ -434,6 +434,7 @@ function UserAskPrompt({ parts, onSubmit }: UserAskPromptProps) {
           <HighlightCard
             title={part.input?.prompt ?? "Question"}
             footerRight={footerButtons}
+            minimizable
           >
             <QuestionInput
               input={part.input as UserAskInput}
@@ -461,6 +462,7 @@ function UserAskPrompt({ parts, onSubmit }: UserAskPromptProps) {
                 title={part.input?.prompt ?? "Question"}
                 footerLeft={pagination}
                 footerRight={footerButtons}
+                minimizable
               >
                 <QuestionInput
                   input={part.input as UserAskInput}


### PR DESCRIPTION
## What is this contribution about?

Adds a collapse/expand toggle to the user-ask highlight card so users can minimize it to read the chat without skipping or answering the question. Clicking the chevron collapses the card to just its title bar; clicking again restores it.

## Screenshots/Demonstration

- Minimized state: card collapses to a single title row with truncated text and a gap above the chat input
- Expanded state: full card with question inputs and action buttons, title wraps freely

## How to Test

1. Trigger a `user_ask` tool call from an agent
2. Click the chevron (↑) in the top-right of the card — card should animate closed, title truncates to one line
3. Click the chevron (↓) again — card animates open, title wraps normally
4. Verify Skip/Submit still work normally when expanded

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapse/expand toggle to the user-ask highlight card so users can hide the form and keep reading the chat, then reopen it when ready. Skip/Submit behavior is unchanged.

- **New Features**
  - Added minimize/expand with chevron + ARIA; enabled on user-ask cards.
  - Animated collapse via CSS grid; chevron rotates; content fades; title truncates when minimized.
  - Adjusted bottom spacing to keep room above the chat input when minimized.

- **Bug Fixes**
  - Fixed Biome formatting on the HighlightCard title `className`.

<sup>Written for commit 20de04ee62ac0ef168d938e51feb8b9e3e6d4cf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

