### PR TITLE
fix(monitoring): fix table borders and layout in threads and audit tabs

### DIFF
--- a/apps/mesh/src/web/components/monitoring/log-row.tsx
+++ b/apps/mesh/src/web/components/monitoring/log-row.tsx
@@ -56,7 +56,7 @@ export function LogRow({
   return (
     <TableRow
       ref={lastLogRef}
-      className="h-14 md:h-16 transition-colors cursor-pointer hover:bg-muted/40"
+      className="h-14 md:h-16 transition-colors cursor-pointer hover:bg-muted/40 border-b-0"
       onClick={onClick}
     >
       {/* Connection Icon */}

--- a/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
@@ -176,8 +176,8 @@ function MonitoringLogsTableContent({
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-      <div className="flex-1 overflow-auto min-w-0">
+    <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex-1 min-w-0">
         <div className="min-w-[600px] md:min-w-0">
           <Table className="w-full border-collapse">
             <TableHeader className="border-b-0 z-20">
@@ -470,7 +470,7 @@ export function AuditTabContent({
   return (
     <div className="flex-1 flex flex-col overflow-auto min-w-0">
       <div className="mx-auto w-full max-w-[1200px] px-4 md:px-10 flex flex-col flex-1 min-h-0">
-        <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+        <div className="flex-1 flex flex-col min-w-0">
           <MonitoringLogsTable
             connectionIds={connectionIds}
             virtualMcpIds={virtualMcpIds}

--- a/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
@@ -177,7 +177,7 @@ function MonitoringLogsTableContent({
 
   return (
     <div className="flex-1 flex flex-col min-w-0">
-      <div className="flex-1 min-w-0">
+      <div className="flex-1 min-w-0 pt-1">
         <div className="min-w-[600px] md:min-w-0">
           <Table className="w-full border-collapse">
             <TableHeader className="border-b-0 z-20">

--- a/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/audit.tsx
@@ -178,7 +178,7 @@ function MonitoringLogsTableContent({
   return (
     <div className="flex-1 flex flex-col overflow-hidden min-w-0">
       <div className="flex-1 overflow-auto min-w-0">
-        <div className="min-w-[600px] md:min-w-0 bg-background">
+        <div className="min-w-[600px] md:min-w-0">
           <Table className="w-full border-collapse">
             <TableHeader className="border-b-0 z-20">
               <TableRow className="h-9 hover:bg-transparent border-b border-border">

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
@@ -816,8 +816,8 @@ export function ThreadsTabContent({
   return (
     <div className="flex-1 flex flex-col overflow-auto min-w-0">
       <div className="mx-auto w-full max-w-[1200px] px-4 md:px-10 flex flex-col flex-1 min-h-0">
-        <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-          <div className="flex-1 overflow-auto min-w-0">
+        <div className="flex-1 flex flex-col min-w-0">
+          <div className="flex-1 min-w-0">
             <div className="min-w-0">
               {isLoading ? (
                 <div className="flex flex-1 items-center justify-center py-20">

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
@@ -307,7 +307,7 @@ function ThreadRow({
   return (
     <TableRow
       ref={lastRowRef}
-      className="h-14 md:h-16 cursor-pointer hover:bg-muted/40 transition-colors"
+      className="h-14 md:h-16 cursor-pointer hover:bg-muted/40 transition-colors border-b-0"
       onClick={onClick}
     >
       <TableCell className="min-w-0 pr-2 pl-4 md:pr-4">
@@ -814,79 +814,83 @@ export function ThreadsTabContent({
     );
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+    <div className="flex-1 flex flex-col overflow-auto min-w-0">
       <div className="mx-auto w-full max-w-[1200px] px-4 md:px-10 flex flex-col flex-1 min-h-0">
-        <div className="flex-1 overflow-auto">
-          {isLoading ? (
-            <div className="flex flex-1 items-center justify-center py-20">
-              <span className="text-sm text-muted-foreground">
-                Loading\u2026
-              </span>
-            </div>
-          ) : visibleThreads.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center py-20">
-              <EmptyState
-                title={
-                  hasActiveFilters
-                    ? "No matching threads"
-                    : "No threads in this time range"
-                }
-                description={
-                  hasActiveFilters
-                    ? "Try adjusting your filters or search query."
-                    : "Try expanding the time range to see older threads."
-                }
-              />
-            </div>
-          ) : (
-            <>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="pl-4 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
-                      Title
-                    </TableHead>
-                    <TableHead className="w-36 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
-                      Agent
-                    </TableHead>
-                    <TableHead className="w-28 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
-                      User
-                    </TableHead>
-                    <TableHead className="w-24 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
-                      Status
-                    </TableHead>
-                    <TableHead className="w-32 px-3 pr-5 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
-                      Date
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {visibleThreads.map((thread, idx) => (
-                    <ThreadRow
-                      key={thread.id}
-                      thread={thread}
-                      members={membersData}
-                      connections={allConnections}
-                      virtualMcps={allVirtualMcps}
-                      onClick={() => setSelectedThreadIndex(idx)}
-                      lastRowRef={
-                        idx === visibleThreads.length - 1
-                          ? (lastRowRef as (
-                              node: HTMLTableRowElement | null,
-                            ) => void)
-                          : undefined
-                      }
-                    />
-                  ))}
-                </TableBody>
-              </Table>
-              {isFetchingNextPage && (
-                <div className="py-4 text-center text-sm text-muted-foreground">
-                  Loading more...
+        <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+          <div className="flex-1 overflow-auto min-w-0">
+            <div className="min-w-0">
+              {isLoading ? (
+                <div className="flex flex-1 items-center justify-center py-20">
+                  <span className="text-sm text-muted-foreground">
+                    Loading\u2026
+                  </span>
                 </div>
+              ) : visibleThreads.length === 0 ? (
+                <div className="flex flex-1 items-center justify-center py-20">
+                  <EmptyState
+                    title={
+                      hasActiveFilters
+                        ? "No matching threads"
+                        : "No threads in this time range"
+                    }
+                    description={
+                      hasActiveFilters
+                        ? "Try adjusting your filters or search query."
+                        : "Try expanding the time range to see older threads."
+                    }
+                  />
+                </div>
+              ) : (
+                <>
+                  <Table className="w-full border-collapse">
+                    <TableHeader className="border-b-0 z-20">
+                      <TableRow className="h-9 hover:bg-transparent border-b border-border">
+                        <TableHead className="pl-4 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                          Title
+                        </TableHead>
+                        <TableHead className="w-36 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                          Agent
+                        </TableHead>
+                        <TableHead className="w-28 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                          User
+                        </TableHead>
+                        <TableHead className="w-24 px-3 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                          Status
+                        </TableHead>
+                        <TableHead className="w-32 px-3 pr-5 text-xs font-mono font-normal text-muted-foreground uppercase tracking-wide">
+                          Date
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {visibleThreads.map((thread, idx) => (
+                        <ThreadRow
+                          key={thread.id}
+                          thread={thread}
+                          members={membersData}
+                          connections={allConnections}
+                          virtualMcps={allVirtualMcps}
+                          onClick={() => setSelectedThreadIndex(idx)}
+                          lastRowRef={
+                            idx === visibleThreads.length - 1
+                              ? (lastRowRef as (
+                                  node: HTMLTableRowElement | null,
+                                ) => void)
+                              : undefined
+                          }
+                        />
+                      ))}
+                    </TableBody>
+                  </Table>
+                  {isFetchingNextPage && (
+                    <div className="py-4 text-center text-sm text-muted-foreground">
+                      Loading more...
+                    </div>
+                  )}
+                </>
               )}
-            </>
-          )}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
@@ -817,7 +817,7 @@ export function ThreadsTabContent({
     <div className="flex-1 flex flex-col overflow-auto min-w-0">
       <div className="mx-auto w-full max-w-[1200px] px-4 md:px-10 flex flex-col flex-1 min-h-0">
         <div className="flex-1 flex flex-col min-w-0">
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 pt-1">
             <div className="min-w-0">
               {isLoading ? (
                 <div className="flex flex-1 items-center justify-center py-20">


### PR DESCRIPTION
## What is this contribution about?

Fixes visual issues in the monitoring threads and audit tabs: removes duplicate row borders by adding `border-b-0` to table rows, removes `overflow-hidden` from container divs that was clipping content, and restructures the threads table layout to match the audit tab's layout pattern.

## Screenshots/Demonstration

> UI changes to the monitoring threads and audit tables — borders and scroll behavior fixes.

## How to Test

1. Open the monitoring page and navigate to the Threads tab
2. Verify table rows no longer show double/extra borders
3. Switch to the Audit tab and confirm layout matches threads tab
4. Scroll through both tables to confirm content is not clipped

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed table borders and layout in Monitoring Threads and Audit tabs to remove double row dividers and clipping. Threads now uses the same card-style table, spacing, and scrolling as Audit.

- **Bug Fixes**
  - Removed `overflow-hidden` and adjusted scroll wrappers to prevent clipping and enable scrolling.
  - Added `border-b-0` to data rows in `LogRow` and `ThreadRow` to eliminate duplicate borders.
  - Standardized the Threads table to the Audit layout (max-width wrapper, padding including `pt-1`, `border-collapse`, consistent header/row styles).

<sup>Written for commit b1c4c6ce41338ac4389416cf67decaab0afa3d9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

