### PR TITLE
feat(vm/preview): replace provision orb with 8x6 capacity-rack visual

### DIFF
--- a/apps/mesh/src/web/components/vm/preview/booting-visual.tsx
+++ b/apps/mesh/src/web/components/vm/preview/booting-visual.tsx
@@ -5,6 +5,11 @@ import type { ClaimPhase } from "../hooks/vm-events-context";
 import { CLAIM_PHASE_COPY } from "../claim-phase-copy";
 import type { PhaseKey, PhaseProgress } from "./derive-phase-progress";
 import { activePhaseIndex } from "./state-card-helpers";
+import {
+  RACK_SCAN_DELAYS,
+  RACK_SCAN_PERIOD_SEC,
+  RESERVED_SLOT_INDEX,
+} from "./provision-rack";
 
 /**
  * The starting-now booting visual: a GridLoader pill with a phase-aware
@@ -102,6 +107,11 @@ export function BootingVisual({ progress, claimPhase }: BootingVisualProps) {
           0%, 100% { opacity: 0.5; }
           50% { opacity: 1; }
         }
+        @keyframes vm-rack-scan {
+          0%, 100% { opacity: 0; }
+          8% { opacity: 1; }
+          22% { opacity: 0; }
+        }
       `}</style>
     </div>
   );
@@ -162,36 +172,50 @@ function BrowserChrome({ showUrl = false }: { showUrl?: boolean }) {
   );
 }
 
-/** Phase 0: pulsing central orb with a constellation of breathing dots. */
+/**
+ * Phase 0: 4×3 capacity rack. A chart-1 scanner highlight sweeps across
+ * 11 muted tiles while one persistent chart-1 tile sits at
+ * RESERVED_SLOT_INDEX, reading as "your sandbox slot is claimed."
+ */
 function ProvisionContent() {
-  // Stable pseudo-random delays for the 8 outer dots.
-  const dotDelays = [0.0, 0.3, 0.6, 0.9, 1.2, 1.5, 0.4, 1.0];
   return (
     <div className="flex h-full flex-col">
       <BrowserChrome />
-      <div className="relative flex flex-1 items-center justify-center">
-        {dotDelays.map((delay, i) => {
-          const angle = (i * Math.PI * 2) / dotDelays.length;
-          const radius = 80; // px
-          const x = Math.cos(angle) * radius;
-          const y = Math.sin(angle) * radius;
-          return (
-            <div
-              key={i}
-              className={cn("absolute size-2 rounded-full", MUTED_2)}
-              style={{
-                transform: `translate(${x}px, ${y}px)`,
-                animation: `vm-breathe 3s ease-in-out ${delay}s infinite`,
-              }}
-            />
-          );
-        })}
-        <div
-          className="size-12 rounded-full bg-chart-1/[0.10]"
-          style={{
-            animation: "vm-breathe 2.4s ease-in-out infinite",
-          }}
-        />
+      <div className="flex flex-1 items-center justify-center px-8 py-5">
+        <div className="grid w-full grid-cols-4 grid-rows-3 gap-3">
+          {RACK_SCAN_DELAYS.map((delay, i) => {
+            if (i === RESERVED_SLOT_INDEX) {
+              return (
+                <div
+                  key={i}
+                  className="aspect-square rounded-md bg-chart-1/[0.55]"
+                  style={{
+                    animation: "vm-breathe 2.4s ease-in-out infinite",
+                  }}
+                />
+              );
+            }
+            // `delay` is `number | null`; the `null` entry sits at RESERVED_SLOT_INDEX,
+            // which the early-return above already handled — so on this branch it's
+            // always a number. Narrow with an assertion rather than a `?? 0` fallback
+            // (which would silently substitute 0 for a case that cannot occur).
+            const scanDelay = delay as number;
+            return (
+              <div
+                key={i}
+                className={cn("relative aspect-square rounded-md", MUTED_2)}
+              >
+                <div
+                  className="absolute inset-0 rounded-md bg-chart-1/40 opacity-0"
+                  style={{
+                    animation: `vm-rack-scan ${RACK_SCAN_PERIOD_SEC}s ease-in-out infinite`,
+                    animationDelay: `${scanDelay}s`,
+                  }}
+                />
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/apps/mesh/src/web/components/vm/preview/booting-visual.tsx
+++ b/apps/mesh/src/web/components/vm/preview/booting-visual.tsx
@@ -72,7 +72,7 @@ export function BootingVisual({ progress, claimPhase }: BootingVisualProps) {
   const headline = pillHeadline(progress, claimPhase);
 
   return (
-    <div className="relative flex w-full flex-col items-center justify-center gap-8 select-none [clip-path:inset(0_0_-200px_0)]">
+    <div className="relative flex w-full flex-col items-center justify-center gap-12 select-none [clip-path:inset(0_0_-200px_0)]">
       <div className="flex items-center gap-2 rounded-full border border-foreground/10 bg-background px-3.5 py-1.5 shadow-[0_4px_20px_-4px_rgb(0_0_0_/_0.12)]">
         <GridLoader />
         <span
@@ -173,22 +173,28 @@ function BrowserChrome({ showUrl = false }: { showUrl?: boolean }) {
 }
 
 /**
- * Phase 0: 4×3 capacity rack. A chart-1 scanner highlight sweeps across
- * 11 muted tiles while one persistent chart-1 tile sits at
+ * Phase 0: 8×6 capacity rack. A chart-1 scanner highlight sweeps across
+ * the muted tiles while one persistent chart-1 tile sits at
  * RESERVED_SLOT_INDEX, reading as "your sandbox slot is claimed."
+ *
+ * Padding (`px-8 py-5`) and gap (`gap-2`) match `InstallContent` so the
+ * provision and install grids share the same outer rhythm. Tiles are
+ * sized by the grid (no `aspect-square`) so 48 cells fit cleanly inside
+ * the card's 4/3 aspect — the 8/6 grid ratio matches the card's 4/3, so
+ * tiles come out close to square.
  */
 function ProvisionContent() {
   return (
     <div className="flex h-full flex-col">
       <BrowserChrome />
-      <div className="flex flex-1 items-center justify-center px-8 py-5">
-        <div className="grid w-full grid-cols-4 grid-rows-3 gap-3">
+      <div className="flex flex-1 px-8 py-5">
+        <div className="grid h-full w-full grid-cols-8 grid-rows-6 gap-2">
           {RACK_SCAN_DELAYS.map((delay, i) => {
             if (i === RESERVED_SLOT_INDEX) {
               return (
                 <div
                   key={i}
-                  className="aspect-square rounded-md bg-chart-1/[0.55]"
+                  className="rounded-md bg-chart-1/[0.55]"
                   style={{
                     animation: "vm-breathe 2.4s ease-in-out infinite",
                   }}
@@ -201,10 +207,7 @@ function ProvisionContent() {
             // (which would silently substitute 0 for a case that cannot occur).
             const scanDelay = delay as number;
             return (
-              <div
-                key={i}
-                className={cn("relative aspect-square rounded-md", MUTED_2)}
-              >
+              <div key={i} className={cn("relative rounded-md", MUTED_2)}>
                 <div
                   className="absolute inset-0 rounded-md bg-chart-1/40 opacity-0"
                   style={{

--- a/apps/mesh/src/web/components/vm/preview/booting-visual.tsx
+++ b/apps/mesh/src/web/components/vm/preview/booting-visual.tsx
@@ -72,7 +72,7 @@ export function BootingVisual({ progress, claimPhase }: BootingVisualProps) {
   const headline = pillHeadline(progress, claimPhase);
 
   return (
-    <div className="relative flex w-full flex-col items-center justify-center gap-12 select-none [clip-path:inset(0_0_-200px_0)]">
+    <div className="relative flex w-full flex-col items-center justify-center gap-12 select-none [clip-path:inset(-24px_0_-200px_0)]">
       <div className="flex items-center gap-2 rounded-full border border-foreground/10 bg-background px-3.5 py-1.5 shadow-[0_4px_20px_-4px_rgb(0_0_0_/_0.12)]">
         <GridLoader />
         <span

--- a/apps/mesh/src/web/components/vm/preview/provision-rack.test.ts
+++ b/apps/mesh/src/web/components/vm/preview/provision-rack.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "bun:test";
+import {
+  RACK_SCAN_DELAYS,
+  RACK_SCAN_PERIOD_SEC,
+  RACK_SLOT_COUNT,
+  RESERVED_SLOT_INDEX,
+} from "./provision-rack";
+
+test("RACK_SLOT_COUNT is 12 (4×3 grid)", () => {
+  expect(RACK_SLOT_COUNT).toBe(12);
+});
+
+test("RESERVED_SLOT_INDEX is within the grid", () => {
+  expect(RESERVED_SLOT_INDEX).toBeGreaterThanOrEqual(0);
+  expect(RESERVED_SLOT_INDEX).toBeLessThan(RACK_SLOT_COUNT);
+});
+
+test("RACK_SCAN_DELAYS has one entry per slot, null at reserved index", () => {
+  expect(RACK_SCAN_DELAYS).toHaveLength(RACK_SLOT_COUNT);
+  expect(RACK_SCAN_DELAYS[RESERVED_SLOT_INDEX]).toBeNull();
+});
+
+test("non-reserved tiles get strictly increasing delays starting at 0", () => {
+  const nonNull = RACK_SCAN_DELAYS.filter((d): d is number => d !== null);
+  expect(nonNull).toHaveLength(RACK_SLOT_COUNT - 1);
+  expect(nonNull[0]).toBe(0);
+  for (let i = 1; i < nonNull.length; i++) {
+    expect(nonNull[i]).toBeGreaterThan(nonNull[i - 1] as number);
+  }
+});
+
+test("delays are evenly spaced across the scan period", () => {
+  const nonNull = RACK_SCAN_DELAYS.filter((d): d is number => d !== null);
+  const step = RACK_SCAN_PERIOD_SEC / (RACK_SLOT_COUNT - 1);
+  nonNull.forEach((delay, i) => {
+    expect(delay).toBeCloseTo(i * step, 5);
+  });
+});

--- a/apps/mesh/src/web/components/vm/preview/provision-rack.test.ts
+++ b/apps/mesh/src/web/components/vm/preview/provision-rack.test.ts
@@ -6,8 +6,8 @@ import {
   RESERVED_SLOT_INDEX,
 } from "./provision-rack";
 
-test("RACK_SLOT_COUNT is 12 (4×3 grid)", () => {
-  expect(RACK_SLOT_COUNT).toBe(12);
+test("RACK_SLOT_COUNT is 48 (8×6 grid)", () => {
+  expect(RACK_SLOT_COUNT).toBe(48);
 });
 
 test("RESERVED_SLOT_INDEX is within the grid", () => {

--- a/apps/mesh/src/web/components/vm/preview/provision-rack.ts
+++ b/apps/mesh/src/web/components/vm/preview/provision-rack.ts
@@ -1,19 +1,20 @@
 /**
  * Geometry and animation choreography for the "Reserving sandbox" booting
- * card's 4×3 capacity-rack visual. Pure data — no React imports — so it can
+ * card's 8×6 capacity-rack visual. Pure data — no React imports — so it can
  * be unit-tested in isolation.
  *
  * Spec: .context/specs/2026-05-13-provision-card-rack-redesign-design.md
  */
 
-/** Total tiles in the 4 cols × 3 rows rack. */
-export const RACK_SLOT_COUNT = 12;
+/** Total tiles in the 8 cols × 6 rows rack. */
+export const RACK_SLOT_COUNT = 48;
 
 /**
- * Zero-based index of the persistently chart-1 "reserved" tile. Index 6 is
- * row 2, col 3 in a 4-column grid — centered horizontally, middle row.
+ * Zero-based index of the persistently chart-1 "reserved" tile. Index 28 is
+ * row 3, col 4 in an 8-column grid — just past the visual center, anchoring
+ * the eye slightly below and right of dead-middle.
  */
-export const RESERVED_SLOT_INDEX = 6;
+export const RESERVED_SLOT_INDEX = 28;
 
 /** Loop period of the scanner sweep, in seconds. */
 export const RACK_SCAN_PERIOD_SEC = 3;
@@ -23,7 +24,7 @@ export const RACK_SCAN_PERIOD_SEC = 3;
  * for the reserved tile (which does not participate in the sweep).
  *
  * Indexed by tile position 0..RACK_SLOT_COUNT-1. The reserved slot is
- * skipped from scan order, so the remaining 11 tiles receive delays evenly
+ * skipped from scan order, so the remaining tiles receive delays evenly
  * spaced across one RACK_SCAN_PERIOD_SEC loop, producing a chart-1
  * highlight that travels left→right, top→bottom across the rack.
  */

--- a/apps/mesh/src/web/components/vm/preview/provision-rack.ts
+++ b/apps/mesh/src/web/components/vm/preview/provision-rack.ts
@@ -1,0 +1,42 @@
+/**
+ * Geometry and animation choreography for the "Reserving sandbox" booting
+ * card's 4×3 capacity-rack visual. Pure data — no React imports — so it can
+ * be unit-tested in isolation.
+ *
+ * Spec: .context/specs/2026-05-13-provision-card-rack-redesign-design.md
+ */
+
+/** Total tiles in the 4 cols × 3 rows rack. */
+export const RACK_SLOT_COUNT = 12;
+
+/**
+ * Zero-based index of the persistently chart-1 "reserved" tile. Index 6 is
+ * row 2, col 3 in a 4-column grid — centered horizontally, middle row.
+ */
+export const RESERVED_SLOT_INDEX = 6;
+
+/** Loop period of the scanner sweep, in seconds. */
+export const RACK_SCAN_PERIOD_SEC = 3;
+
+/**
+ * Per-tile `animation-delay` for the scanner sweep, in seconds, or `null`
+ * for the reserved tile (which does not participate in the sweep).
+ *
+ * Indexed by tile position 0..RACK_SLOT_COUNT-1. The reserved slot is
+ * skipped from scan order, so the remaining 11 tiles receive delays evenly
+ * spaced across one RACK_SCAN_PERIOD_SEC loop, producing a chart-1
+ * highlight that travels left→right, top→bottom across the rack.
+ */
+export const RACK_SCAN_DELAYS: ReadonlyArray<number | null> = (() => {
+  const out: (number | null)[] = [];
+  let scanOrder = 0;
+  for (let i = 0; i < RACK_SLOT_COUNT; i++) {
+    if (i === RESERVED_SLOT_INDEX) {
+      out.push(null);
+    } else {
+      out.push((scanOrder / (RACK_SLOT_COUNT - 1)) * RACK_SCAN_PERIOD_SEC);
+      scanOrder++;
+    }
+  }
+  return out;
+})();


### PR DESCRIPTION
## What is this contribution about?

Redesigns the **Reserving sandbox** booting card. The old visual (a pulsing chart-1 orb surrounded by 8 orbiting dots — a "planetary system") is replaced with an **8×6 capacity-rack grid**: 47 muted tiles continuously swept by a chart-1 scanner highlight plus one persistent chart-1 "reserved" tile, reading as *your sandbox slot got claimed.* Tile geometry and animation timing live in a new pure-data helper module (`provision-rack.ts`) with unit-test coverage; the JSX wires those constants into the existing `ProvisionContent` component. Two small layout fixes ride along: pill-to-card spacing bumped from `gap-8` to `gap-12` so long `ClaimPhase` labels (e.g. *waiting-for-capacity*) clear the upcoming-card peek, and the container's `clip-path` top inset relaxed from `0` to `-24px` so the pill's drop-shadow halo isn't cut off.

## Screenshots/Demonstration

To view: `bun run dev`, trigger any sandbox start, watch the **Reserving sandbox** phase. The active card now shows a dense rack of small rectangles with a chart-1 scan line crawling left→right, top→bottom every ~3s, with a single chart-1 tile breathing at the center.

## How to Test

1. `bun run dev` and trigger a sandbox start (or use any flow that boots the VM preview).
2. While the runner is in the **provision** phase, confirm the rack visual: 8 cols × 6 rows, one chart-1 tile centered (row 4, col 5), chart-1 scanner sweeping the rest, pill headline floating above with full shadow halo.
3. Cycle through long `ClaimPhase` sub-labels (*waiting-for-capacity*, *starting-container*, *warming-daemon*) and confirm none of them visually overlap the cards.
4. Run `bun test apps/mesh/src/web/components/vm/preview/provision-rack.test.ts` — 5 pass / 0 fail.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed) — JSDoc inline in `provision-rack.ts` and `ProvisionContent`
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the “Reserving sandbox” orb with an 8×6 capacity-rack grid featuring a sweeping scanner and a persistent reserved tile to clearly show a claimed slot. Includes a small layout tweak and a test-covered helper module.

- **New Features**
  - New `provision-rack.ts` exporting `RACK_SLOT_COUNT`, `RESERVED_SLOT_INDEX`, `RACK_SCAN_PERIOD_SEC`, and `RACK_SCAN_DELAYS`; used by `ProvisionContent` to render the rack and scan animation.
  - Added `provision-rack.test.ts` to validate geometry and delay sequencing.
  - Increased pill-to-card spacing to `gap-12`; aligned padding and tightened grid gap for consistency.

- **Bug Fixes**
  - Unclipped the pill’s shadow by relaxing the container `clip-path` top inset.

<sup>Written for commit a29cc4886273876214e08236660c2c053702366d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

