### PR TITLE
feat(chat/highlight): replace chevron toggle with X close button

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -2,32 +2,23 @@
  * CollapsibleHighlight — the shared shell for every banner in the chat
  * highlight slot (todos, question, plan, approval, error, warning).
  *
- * One always-visible chip row (icon + label + optional count + caret),
- * one expandable body containing the substantive content (form fields,
- * plan markdown, todo list, etc.), and an optional footer row.
+ * One chip row (icon + label + optional count + close button), the
+ * substantive body content (form fields, plan markdown, todo list,
+ * etc.), and an optional footer row.
  *
- * Open/close state is local. Each banner instance gets its own state;
- * the parent passes a stable `key` so React remounts on identity change
- * (a new question, a new approval batch, a new plan) and the new instance
- * starts at `defaultExpanded`. Stable identity = stable state across
- * re-renders.
+ * Dismiss state is local to this instance. Clicking the X unrenders
+ * the entire card; the parent passes a stable `key` so React remounts
+ * on identity change (a new question, a new approval batch, a new
+ * plan) and the dismissal resets. Stable identity = stable state
+ * across re-renders.
  *
- * The body is rendered into the DOM unconditionally — the collapse uses
- * a grid-template-rows trick that animates height without measuring,
- * which also preserves form state, scroll position, and selected tab
- * across collapse/expand cycles.
- *
- * Visual styling (paddings, animation curve, rotating chevron, etc.)
- * is borrowed from rafavalls' HighlightCard so we stay aligned with the
- * design system; the single-component architecture is ours.
+ * The `defaultExpanded` prop is retained for API compatibility but no
+ * longer affects rendering — the body always renders.
  */
 
 import { useState, type ReactNode } from "react";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { ChevronDown } from "@untitledui/icons";
-
-// ease-in-out-cubic — on-screen morph per animation guide
-const EASE = "cubic-bezier(0.645, 0.045, 0.355, 1)";
+import { X } from "@untitledui/icons";
 
 export type HighlightVariant = "default" | "error" | "warning";
 
@@ -78,10 +69,11 @@ export function CollapsibleHighlight({
   footerLeft,
   footerRight,
   children,
-  defaultExpanded,
   variant = "default",
 }: CollapsibleHighlightProps) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [closed, setClosed] = useState(false);
+
+  if (closed) return null;
 
   return (
     <div
@@ -94,17 +86,9 @@ export function CollapsibleHighlight({
         VARIANT_OVERLAY[variant],
       )}
     >
-      <button
-        type="button"
+      <div
         data-testid="collapsible-highlight-chip"
-        aria-expanded={expanded}
-        onClick={() => setExpanded((prev) => !prev)}
-        className={cn(
-          "flex items-center gap-2 w-full px-3 py-2 text-sm text-left",
-          "hover:bg-accent/50 transition-colors rounded-t-xl",
-          expanded && "rounded-b-none",
-          !expanded && "rounded-b-xl",
-        )}
+        className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left rounded-t-xl"
       >
         <span className={cn("shrink-0", VARIANT_ICON_COLOR[variant])}>
           {icon}
@@ -115,67 +99,48 @@ export function CollapsibleHighlight({
             {count}
           </span>
         ) : null}
-        <span
-          aria-hidden="true"
-          className="text-muted-foreground shrink-0 flex items-center justify-center"
+        <button
+          type="button"
+          data-testid="collapsible-highlight-close"
+          onClick={() => setClosed(true)}
+          aria-label="Close"
+          title="Close"
+          className="text-muted-foreground hover:text-foreground transition-colors shrink-0 flex items-center justify-center -mr-1 p-1 rounded-md hover:bg-accent/50"
         >
-          <ChevronDown
-            size={16}
-            style={{
-              transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
-              transition: `transform 180ms ${EASE}`,
-            }}
-          />
-        </span>
-      </button>
+          <X size={16} />
+        </button>
+      </div>
 
-      {/* Collapsible body — grid trick animates height without measuring */}
-      <div
-        data-testid="collapsible-highlight-body"
-        style={{
-          display: "grid",
-          gridTemplateRows: expanded ? "1fr" : "0fr",
-          transition: `grid-template-rows 180ms ${EASE}`,
-        }}
-      >
-        <div style={{ overflow: "hidden", minHeight: 0 }}>
-          <div
-            style={{
-              opacity: expanded ? 1 : 0,
-              transition: `opacity 120ms ${EASE}`,
-            }}
-          >
-            {title ? (
-              <div className="flex items-start gap-2 px-4 pt-4 pb-5 border-t border-dashed border-border/60">
-                <p className="flex-1 text-base font-medium text-foreground min-w-0">
-                  {title}
-                </p>
-              </div>
-            ) : (
-              <div className="border-t border-dashed border-border/60" />
-            )}
-
-            {/* When a title is present, the title block's `pt-4` already
-                provides the 16px gap from the dashed divider to the first
-                body element. When no title is present (e.g. TodosHighlight),
-                the children must carry that top padding themselves so every
-                card has the same chip → body distance. */}
-            {children ? (
-              <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
-                {children}
-              </div>
-            ) : null}
-
-            {footerLeft || footerRight ? (
-              <div className="border-t border-border px-3 py-3 pb-6">
-                <div className="flex items-center justify-between">
-                  <div>{footerLeft}</div>
-                  <div className="flex items-center gap-2">{footerRight}</div>
-                </div>
-              </div>
-            ) : null}
+      <div data-testid="collapsible-highlight-body">
+        {title ? (
+          <div className="flex items-start gap-2 px-4 pt-4 pb-5 border-t border-dashed border-border/60">
+            <p className="flex-1 text-base font-medium text-foreground min-w-0">
+              {title}
+            </p>
           </div>
-        </div>
+        ) : (
+          <div className="border-t border-dashed border-border/60" />
+        )}
+
+        {/* When a title is present, the title block's `pt-4` already
+            provides the 16px gap from the dashed divider to the first
+            body element. When no title is present (e.g. TodosHighlight),
+            the children must carry that top padding themselves so every
+            card has the same chip → body distance. */}
+        {children ? (
+          <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
+            {children}
+          </div>
+        ) : null}
+
+        {footerLeft || footerRight ? (
+          <div className="border-t border-border px-3 py-3 pb-6">
+            <div className="flex items-center justify-between">
+              <div>{footerLeft}</div>
+              <div className="flex items-center gap-2">{footerRight}</div>
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -2,23 +2,34 @@
  * CollapsibleHighlight — the shared shell for every banner in the chat
  * highlight slot (todos, question, plan, approval, error, warning).
  *
- * One chip row (icon + label + optional count + close button), the
- * substantive body content (form fields, plan markdown, todo list,
- * etc.), and an optional footer row.
+ * One always-visible chip row (icon + label + optional count + close
+ * button), one expandable body containing the substantive content
+ * (form fields, plan markdown, todo list, etc.), and an optional
+ * footer row.
  *
- * Dismiss state is local to this instance. Clicking the X unrenders
- * the entire card; the parent passes a stable `key` so React remounts
- * on identity change (a new question, a new approval batch, a new
- * plan) and the dismissal resets. Stable identity = stable state
- * across re-renders.
+ * Two pieces of local state, both held per-instance:
+ *  - `expanded`: clicking anywhere on the chip row (except the X)
+ *    toggles the body open/closed. Initial value comes from
+ *    `defaultExpanded`.
+ *  - `closed`: clicking the X dismisses the whole card. When true the
+ *    component returns `null`.
  *
- * The `defaultExpanded` prop is retained for API compatibility but no
- * longer affects rendering — the body always renders.
+ * Parents pass a stable `key` so React remounts on identity change
+ * (a new question, a new approval batch, a new plan); both states
+ * reset on remount.
+ *
+ * The body is rendered into the DOM unconditionally — the collapse
+ * uses a grid-template-rows trick that animates height without
+ * measuring, which also preserves form state, scroll position, and
+ * selected tab across collapse/expand cycles.
  */
 
 import { useState, type ReactNode } from "react";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { X } from "@untitledui/icons";
+import { ChevronDown, X } from "@untitledui/icons";
+
+// ease-in-out-cubic — on-screen morph per animation guide
+const EASE = "cubic-bezier(0.645, 0.045, 0.355, 1)";
 
 export type HighlightVariant = "default" | "error" | "warning";
 
@@ -69,8 +80,10 @@ export function CollapsibleHighlight({
   footerLeft,
   footerRight,
   children,
+  defaultExpanded,
   variant = "default",
 }: CollapsibleHighlightProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const [closed, setClosed] = useState(false);
 
   if (closed) return null;
@@ -86,9 +99,17 @@ export function CollapsibleHighlight({
         VARIANT_OVERLAY[variant],
       )}
     >
-      <div
+      <button
+        type="button"
         data-testid="collapsible-highlight-chip"
-        className="flex items-center gap-2 w-full px-3 py-2 text-sm text-left rounded-t-xl"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+        className={cn(
+          "flex items-center gap-2 w-full px-3 py-2 text-sm text-left",
+          "hover:bg-accent/50 transition-colors rounded-t-xl",
+          expanded && "rounded-b-none",
+          !expanded && "rounded-b-xl",
+        )}
       >
         <span className={cn("shrink-0", VARIANT_ICON_COLOR[variant])}>
           {icon}
@@ -99,48 +120,95 @@ export function CollapsibleHighlight({
             {count}
           </span>
         ) : null}
-        <button
-          type="button"
+        <span
+          aria-hidden="true"
+          className="text-muted-foreground shrink-0 flex items-center justify-center"
+        >
+          <ChevronDown
+            size={16}
+            style={{
+              transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+              transition: `transform 180ms ${EASE}`,
+            }}
+          />
+        </span>
+        {/*
+          Rendered as a nested <span role="button"> rather than a real
+          <button> because the outer chip is already a <button> and
+          nesting interactive elements is invalid HTML. stopPropagation
+          on click + keydown keeps the chip's expand/collapse from
+          firing when the user dismisses the card.
+        */}
+        <span
+          role="button"
+          tabIndex={0}
           data-testid="collapsible-highlight-close"
-          onClick={() => setClosed(true)}
           aria-label="Close"
           title="Close"
-          className="text-muted-foreground hover:text-foreground transition-colors shrink-0 flex items-center justify-center -mr-1 p-1 rounded-md hover:bg-accent/50"
+          onClick={(e) => {
+            e.stopPropagation();
+            setClosed(true);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              e.stopPropagation();
+              setClosed(true);
+            }
+          }}
+          className="text-muted-foreground hover:text-foreground transition-colors shrink-0 flex items-center justify-center -mr-1 ml-1 p-1 rounded-md hover:bg-accent"
         >
           <X size={16} />
-        </button>
-      </div>
+        </span>
+      </button>
 
-      <div data-testid="collapsible-highlight-body">
-        {title ? (
-          <div className="flex items-start gap-2 px-4 pt-4 pb-5 border-t border-dashed border-border/60">
-            <p className="flex-1 text-base font-medium text-foreground min-w-0">
-              {title}
-            </p>
-          </div>
-        ) : (
-          <div className="border-t border-dashed border-border/60" />
-        )}
+      {/* Collapsible body — grid trick animates height without measuring */}
+      <div
+        data-testid="collapsible-highlight-body"
+        style={{
+          display: "grid",
+          gridTemplateRows: expanded ? "1fr" : "0fr",
+          transition: `grid-template-rows 180ms ${EASE}`,
+        }}
+      >
+        <div style={{ overflow: "hidden", minHeight: 0 }}>
+          <div
+            style={{
+              opacity: expanded ? 1 : 0,
+              transition: `opacity 120ms ${EASE}`,
+            }}
+          >
+            {title ? (
+              <div className="flex items-start gap-2 px-4 pt-4 pb-5 border-t border-dashed border-border/60">
+                <p className="flex-1 text-base font-medium text-foreground min-w-0">
+                  {title}
+                </p>
+              </div>
+            ) : (
+              <div className="border-t border-dashed border-border/60" />
+            )}
 
-        {/* When a title is present, the title block's `pt-4` already
-            provides the 16px gap from the dashed divider to the first
-            body element. When no title is present (e.g. TodosHighlight),
-            the children must carry that top padding themselves so every
-            card has the same chip → body distance. */}
-        {children ? (
-          <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
-            {children}
-          </div>
-        ) : null}
+            {/* When a title is present, the title block's `pt-4` already
+                provides the 16px gap from the dashed divider to the first
+                body element. When no title is present (e.g. TodosHighlight),
+                the children must carry that top padding themselves so every
+                card has the same chip → body distance. */}
+            {children ? (
+              <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
+                {children}
+              </div>
+            ) : null}
 
-        {footerLeft || footerRight ? (
-          <div className="border-t border-border px-3 py-3 pb-6">
-            <div className="flex items-center justify-between">
-              <div>{footerLeft}</div>
-              <div className="flex items-center gap-2">{footerRight}</div>
-            </div>
+            {footerLeft || footerRight ? (
+              <div className="border-t border-border px-3 py-3 pb-6">
+                <div className="flex items-center justify-between">
+                  <div>{footerLeft}</div>
+                  <div className="flex items-center gap-2">{footerRight}</div>
+                </div>
+              </div>
+            ) : null}
           </div>
-        ) : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What is this contribution about?
The highlight cards rendered above the chat input previously used an up/down chevron to toggle an expand/collapse animation on the card body. This PR replaces the chevron with an X close button that fully dismisses the card. Dismissal is tracked with local `useState` inside `CollapsibleHighlight`; when set, the component returns `null`. Stable parent `key`s (`userAskKey`, `planKey`, `approvalKey`) already remount the card on identity change, so the dismissal resets when a new question / plan / approval arrives. The body always renders now — the collapse animation and `defaultExpanded` toggle behavior were removed (the prop is kept on the interface for API compatibility but is a no-op).

## Screenshots/Demonstration
N/A — small UI affordance change; verify locally per steps below.

## How to Test
1. Run `bun run dev` and open a chat.
2. Trigger any highlight card (e.g. ask the agent a clarifying question, propose a plan, or cause an error/warning).
3. The chip row should show an X button on the right instead of a chevron.
4. Clicking the X removes the card from view. Triggering a new highlight (new question / new plan / new error) re-renders a fresh card.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the chevron-only toggle with an X close button and restored expand/collapse on highlight cards. Clicking the chip toggles the body; clicking X dismisses the card until a new question/plan/approval mounts.

- **New Features**
  - Chip row toggles expand/collapse again (chevron rotates, body animates) and respects `defaultExpanded`.
  - X close button dismisses the card via local state; remount on new question/plan/approval resets it.
  - Close control is a span with role="button" (Enter/Space supported) that stops propagation; includes an accessible label and `data-testid`.

<sup>Written for commit 898db8be140809d0a6f1ada0266324c43d8ab1b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

