### PR TITLE
Tlgimenes/todo clear on fetch

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/todo-write.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/todo-write.test.ts
@@ -44,9 +44,9 @@ describe("todoWriteTool", () => {
     expect(TodoWriteInputSchema.safeParse({ todos: [] }).success).toBe(true);
   });
 
-  test("description tells the model not to call todo_write to read the list", () => {
+  test("description tells the model how to read its current state", () => {
     expect(todoWriteTool.description).toMatch(
-      /current[- ]?todos|do not call.*to read|always visible/i,
+      /your last call|prior tool-call|true one-shots/i,
     );
   });
 

--- a/apps/mesh/src/api/routes/decopilot/built-in-tools/todo-write.ts
+++ b/apps/mesh/src/api/routes/decopilot/built-in-tools/todo-write.ts
@@ -4,7 +4,8 @@
  * Claude-Code-style TodoWrite: the model rewrites the full todo list on
  * every call. There is no incremental create/update/delete. The list's
  * source of truth is the most recent todo_write tool-call message in the
- * thread; see `todo-write-context.ts` for the reader (`readCurrentTodos`).
+ * thread; only the most recent call survives the cross-turn message
+ * loader (`keepLastTodoWrite` in `todo-write-context.ts`).
  */
 
 import { tool, zodSchema } from "ai";
@@ -34,10 +35,10 @@ export type TodoWriteInput = z.infer<typeof TodoWriteInputSchema>;
 
 const description =
   "Plan and track multi-step work. Call with the FULL todo list every time — this replaces the prior list. " +
-  "Use whenever a task has 3+ distinct steps. Mark exactly one todo `in_progress` at a time. " +
+  "Call at the start of every multi-step request. Skip only for true one-shots (a single tool call or a direct answer). " +
+  "Mark exactly one todo `in_progress` at a time. " +
   "Flip a todo to `in_progress` before starting it and to `completed` the moment it finishes — do not batch completions. " +
-  "For trivial (<3 step) work, do not call this tool at all. " +
-  "The current list is always visible to you in the `<current-todos>` system block — do not call this tool to read the list back.";
+  "Your prior tool-call inputs are your current state — read your last call to see where you are.";
 
 export const todoWriteTool = tool({
   description,

--- a/apps/mesh/src/api/routes/decopilot/constants.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.test.ts
@@ -6,8 +6,8 @@ describe("buildTodoWritePrompt", () => {
     expect(buildTodoWritePrompt()).toContain("todo_write");
   });
 
-  test("specifies the 3+ step threshold", () => {
-    expect(buildTodoWritePrompt()).toMatch(/3\+|three or more/i);
+  test("instructs to call it at the start of every multi-step request", () => {
+    expect(buildTodoWritePrompt()).toMatch(/multi-step|every multi-step/i);
   });
 
   test("specifies the single-in-progress constraint", () => {
@@ -20,9 +20,9 @@ describe("buildTodoWritePrompt", () => {
     );
   });
 
-  test("tells the model the current list is always visible", () => {
+  test("tells the model to re-read its last call for current state", () => {
     expect(buildTodoWritePrompt()).toMatch(
-      /current[- ]?todos|always visible|always present in the system/i,
+      /most recent|last call|re-read/i,
     );
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/constants.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.test.ts
@@ -21,8 +21,6 @@ describe("buildTodoWritePrompt", () => {
   });
 
   test("tells the model to re-read its last call for current state", () => {
-    expect(buildTodoWritePrompt()).toMatch(
-      /most recent|last call|re-read/i,
-    );
+    expect(buildTodoWritePrompt()).toMatch(/most recent|last call|re-read/i);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -41,8 +41,11 @@ Follow this workflow for every request:
 1. **Understand intent** — ask clarifying questions (via user_ask) if
    the request is ambiguous.
 2. **Set a goal** — state what you will accomplish in one sentence.
-3. **Plan** — for multi-step tasks (3+ tool calls), outline the steps
-   and wait for user confirmation. For simple tasks, act immediately.
+3. **Plan** — before executing, call \`todo_write\` to record the steps
+   you intend to take. Keep it updated as you work: flip a todo to
+   \`in_progress\` before starting it, \`completed\` the moment it
+   finishes. Skip only for true one-shots (a single tool call or a
+   direct answer).
 4. **Execute** — use the capabilities listed in the sections below. If a
    needed capability is missing, explain that to the user and suggest
    what would unblock the request (e.g. installing a connection).
@@ -83,19 +86,18 @@ export function buildTodoWritePrompt(): string {
   return `<todo-write>
 You have a \`todo_write\` tool for planning and tracking multi-step work.
 
-- Use it whenever a task has 3+ distinct steps.
+- Call it at the start of every multi-step request (see \`<workflow>\`).
+  Skip only for true one-shots (a single tool call or a direct answer).
 - Mark exactly one todo \`in_progress\` at any time.
 - Update the list as you work: flip a todo to \`in_progress\` before
   starting it, \`completed\` the moment it finishes. Do not batch
   completions.
 - Rewrite the entire list every call — there is no incremental update.
-- For trivial (<3 step) work, do not call the tool at all.
 - \`content\` is imperative ("Implement X"); \`activeForm\` is
   present-continuous ("Implementing X") and shown in the user's UI
   while the todo is in progress.
-- The current list is always visible to you in the \`<current-todos>\`
-  system block. Do not call \`todo_write\` to read the list back — call
-  it only to add, update, or complete a todo.
+- Your most recent \`todo_write\` call is your current state — re-read
+  your last call to see where you are.
 </todo-write>`;
 }
 

--- a/apps/mesh/src/api/routes/decopilot/conversation.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/conversation.test.ts
@@ -319,8 +319,8 @@ describe("denyPendingApprovals", () => {
   });
 });
 
-describe("processConversation — todo_write stripping", () => {
-  test("strips todo_write tool-call/result parts from LLM messages but keeps them in originalMessages", async () => {
+describe("processConversation — todo_write trimming", () => {
+  test("keeps the most recent todo_write tool-call when there is only one", async () => {
     const messages: ChatMessage[] = [
       {
         id: "u1",
@@ -360,14 +360,18 @@ describe("processConversation — todo_write stripping", () => {
       models: { connectionId: "c", thinking: { id: "m" } } as never,
     });
 
-    // The LLM-bound `messages` must not contain any todo_write parts.
+    // The LLM-bound `messages` must contain exactly one todo_write tool-call part
+    // (the latest call survives). The AI SDK also emits a matching tool-result
+    // part, so we count only tool-call typed parts to count invocations.
     const allParts = result.messages.flatMap((m) =>
       Array.isArray((m as { content?: unknown }).content)
         ? (m as { content: { type?: unknown; toolName?: unknown }[] }).content
         : [],
     );
-    const todoWriteParts = allParts.filter((p) => p.toolName === "todo_write");
-    expect(todoWriteParts).toHaveLength(0);
+    const todoWriteCallParts = allParts.filter(
+      (p) => p.toolName === "todo_write" && p.type === "tool-call",
+    );
+    expect(todoWriteCallParts).toHaveLength(1);
 
     // The originalMessages preserve everything (used by title gen + audit).
     const originalAssistant = result.originalMessages.find(
@@ -378,5 +382,96 @@ describe("processConversation — todo_write stripping", () => {
       originalAssistant!.parts as { type?: string }[]
     ).some((p) => p.type === "tool-todo_write");
     expect(originalHasTodoWrite).toBe(true);
+  });
+
+  test("keeps only the latest todo_write call/result when multiple exist", async () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "u1",
+        role: "user",
+        parts: [{ type: "text", text: "make a plan" }],
+      } as unknown as ChatMessage,
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-todo_write",
+            state: "output-available",
+            toolCallId: "tw1",
+            input: {
+              todos: [
+                {
+                  content: "v1",
+                  status: "pending",
+                  activeForm: "doing v1",
+                },
+              ],
+            },
+            output: { ok: true, count: 1 },
+          },
+        ],
+      } as unknown as ChatMessage,
+      {
+        id: "u2",
+        role: "user",
+        parts: [{ type: "text", text: "continue" }],
+      } as unknown as ChatMessage,
+      {
+        id: "a2",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-todo_write",
+            state: "output-available",
+            toolCallId: "tw2",
+            input: {
+              todos: [
+                {
+                  content: "v2",
+                  status: "in_progress",
+                  activeForm: "doing v2",
+                },
+              ],
+            },
+            output: { ok: true, count: 1 },
+          },
+        ],
+      } as unknown as ChatMessage,
+      {
+        id: "u3",
+        role: "user",
+        parts: [{ type: "text", text: "done?" }],
+      } as unknown as ChatMessage,
+    ];
+
+    const result = await processConversation(messages, {
+      windowSize: 50,
+      models: { connectionId: "c", thinking: { id: "m" } } as never,
+    });
+
+    // The LLM-bound `messages` must contain exactly one todo_write tool-call part.
+    // The AI SDK also emits a matching tool-result part, so we count only
+    // tool-call typed parts to count invocations.
+    const allParts = result.messages.flatMap((m) =>
+      Array.isArray((m as { content?: unknown }).content)
+        ? (m as { content: { type?: unknown; toolName?: unknown; toolCallId?: unknown }[] }).content
+        : [],
+    );
+    const todoWriteCallParts = allParts.filter(
+      (p) => p.toolName === "todo_write" && p.type === "tool-call",
+    );
+    expect(todoWriteCallParts).toHaveLength(1);
+
+    // The surviving todo_write tool-call part must be the latest one (tw2).
+    expect(todoWriteCallParts[0]!.toolCallId).toBe("tw2");
+
+    // The originalMessages retain both tool-todo_write parts.
+    const originalTodoWriteCount = result.originalMessages.flatMap((m) =>
+      (m.parts as { type?: string }[]).filter(
+        (p) => p.type === "tool-todo_write",
+      ),
+    ).length;
+    expect(originalTodoWriteCount).toBe(2);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/conversation.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/conversation.test.ts
@@ -455,7 +455,15 @@ describe("processConversation — todo_write trimming", () => {
     // tool-call typed parts to count invocations.
     const allParts = result.messages.flatMap((m) =>
       Array.isArray((m as { content?: unknown }).content)
-        ? (m as { content: { type?: unknown; toolName?: unknown; toolCallId?: unknown }[] }).content
+        ? (
+            m as {
+              content: {
+                type?: unknown;
+                toolName?: unknown;
+                toolCallId?: unknown;
+              }[];
+            }
+          ).content
         : [],
     );
     const todoWriteCallParts = allParts.filter(

--- a/apps/mesh/src/api/routes/decopilot/conversation.ts
+++ b/apps/mesh/src/api/routes/decopilot/conversation.ts
@@ -16,8 +16,7 @@ import {
 import type { ChatMessage } from "./types";
 import type { Memory } from "./memory";
 import { ThreadMessage } from "@/storage/types";
-import { readCurrentTodos, stripTodoWriteParts } from "./todo-write-context";
-import type { Todo } from "./built-in-tools/todo-write";
+import { keepLastTodoWrite } from "./todo-write-context";
 
 /**
  * Split request messages into system and the single request message.
@@ -35,13 +34,6 @@ export function splitRequestMessages(messages: ChatMessage[]): {
 export interface ProcessedConversation {
   systemMessages: SystemModelMessage[];
   messages: ReturnType<typeof pruneMessages>;
-  /**
-   * The current todo list, read from the pre-strip ModelMessage stream.
-   * Exposed so `stream-core` can inject the `<current-todos>` system
-   * tail without re-traversing the messages. Empty list if no
-   * `todo_write` call has been made yet.
-   */
-  currentTodos: Todo[];
   originalMessages: ChatMessage[];
 }
 
@@ -171,20 +163,12 @@ export async function processConversation(
     messages: nonSystemModelMessages,
   } = splitMessages(modelMessages);
 
-  // Snapshot the live todo list from the pre-strip ModelMessage stream
-  // so the caller can rebuild <current-todos> without redoing the scan.
-  const currentTodos = readCurrentTodos(nonSystemModelMessages);
-
-  // Strip todo_write tool-call/result parts. The live todo list has
-  // already been captured a few lines above via `readCurrentTodos` and
-  // is returned to the caller as `currentTodos`; stream-core embeds it
-  // into the frozen <current-todos> system tail (see `system-prompt`)
-  // and `prepareStep` re-derives the live snapshot per agent-loop step
-  // (see `stream-core` — same strip + inject pipeline, intra-loop).
-  // Older todo_write inputs are pure redundancy — the state is encoded
-  // in the injected block, and the message-stream representation never
-  // benefited from Anthropic prompt caching (no cacheControl on messages).
-  const todoStrippedMessages = stripTodoWriteParts(nonSystemModelMessages);
+  // Keep only the most recent `todo_write` tool-call/result pair. The
+  // agent reads its current todo state directly from its own most-recent
+  // tool call in the visible stream; older calls are pure context bloat
+  // and are pruned here. The intra-loop strip+inject is gone — the agent
+  // loop sees its own todo_write calls live, with no manipulation.
+  const todoTrimmedMessages = keepLastTodoWrite(nonSystemModelMessages);
 
   // Strip reasoning from all previous assistant messages.
   // pruneMessages removes reasoning content parts, but leaves message-level
@@ -196,7 +180,7 @@ export async function processConversation(
   // We strip both reasoning parts AND all provider metadata from assistant
   // messages to prevent this.
   const prunedModelMessages = pruneMessages({
-    messages: todoStrippedMessages,
+    messages: todoTrimmedMessages,
     reasoning: "all",
     emptyMessages: "remove",
     toolCalls: "none",
@@ -257,7 +241,6 @@ export async function processConversation(
   return {
     systemMessages: systemModelMessages,
     messages: cleanedModelMessages,
-    currentTodos,
     originalMessages: validUIMessages,
   };
 }

--- a/apps/mesh/src/api/routes/decopilot/stream-core.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-core.ts
@@ -20,7 +20,6 @@ import { SpanStatusCode } from "@opentelemetry/api";
 import {
   type ToolSet,
   createUIMessageStream,
-  pruneMessages,
   stepCountIs,
   streamText,
 } from "ai";
@@ -33,8 +32,7 @@ import {
   emptyCacheAccumulator,
   OPENROUTER_CACHE_PROVIDER_OPTIONS,
 } from "./cache-instrumentation";
-import { buildCurrentTodosPrompt, buildSystemMessages } from "./system-prompt";
-import { readCurrentTodos, stripTodoWriteParts } from "./todo-write-context";
+import { buildSystemMessages } from "./system-prompt";
 import {
   buildConnectionsBlock,
   type ConnectionsBlockTool,
@@ -761,7 +759,6 @@ async function streamCoreInner(
         const {
           systemMessages: processedSystemMessages,
           messages: processedMessages,
-          currentTodos,
           originalMessages,
         } = await processConversation(materializedMessages, {
           windowSize,
@@ -949,7 +946,6 @@ async function streamCoreInner(
         const systemPromptMessages = buildSystemMessages(
           systemPrompts,
           new Date(),
-          currentTodos,
         );
 
         let result;
@@ -1027,36 +1023,11 @@ async function streamCoreInner(
                         ];
                       }
 
-                      // Intra-loop todo_write strip + inject. We read the current
-                      // todos from the PRE-strip stream so the latest write wins,
-                      // then strip every todo_write call/result, prune any empties
-                      // the strip leaves behind, and append the freshest snapshot
-                      // as a synthetic user message. The model never sees prior
-                      // todo_write tool-calls; the only signal for the live state
-                      // is this trailing <current-todos> block.
-                      //
-                      // The frozen <current-todos> in the system prefix (computed
-                      // once at request entry) becomes stale as the loop progresses
-                      // — we deliberately do not refresh it there because the
-                      // system prefix has to stay byte-stable for Anthropic prompt
-                      // caching. The trailing user message is uncached and updated
-                      // every step.
-                      const liveTodos = readCurrentTodos(withImages);
-                      const strippedMessages = pruneMessages({
-                        messages: stripTodoWriteParts(withImages),
-                        emptyMessages: "remove",
-                      });
-                      const todosBlock = buildCurrentTodosPrompt(liveTodos);
-                      const messagesForStep =
-                        todosBlock !== null
-                          ? [
-                              ...strippedMessages,
-                              {
-                                role: "user" as const,
-                                content: todosBlock,
-                              },
-                            ]
-                          : strippedMessages;
+                      // The agent sees its own todo_write tool calls live inside
+                      // the loop — no per-step manipulation. Cross-turn pruning
+                      // (keeping only the latest todo_write) happens once at
+                      // HTTP-request entry in `processConversation`.
+                      const messagesForStep = withImages;
 
                       const hasEnableTool = connectionsBlockTools.length > 0;
                       let activeToolNames = [

--- a/apps/mesh/src/api/routes/decopilot/system-prompt.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/system-prompt.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { Todo } from "./built-in-tools/todo-write";
 import { buildBasePlatformPrompt } from "./constants";
 import {
   buildCurrentContextPrompt,
-  buildCurrentTodosPrompt,
   buildSystemMessages,
 } from "./system-prompt";
 
@@ -95,122 +93,5 @@ describe("buildSystemMessages", () => {
     expect(out).toHaveLength(1);
     expect(out[0]!.content).toContain("<current-context>");
     expect(out[0]!.providerOptions?.anthropic?.cacheControl).toBeFalsy();
-  });
-});
-
-describe("buildCurrentTodosPrompt", () => {
-  test("returns null for empty todo list", () => {
-    expect(buildCurrentTodosPrompt([])).toBeNull();
-  });
-
-  test("renders a single pending todo with content", () => {
-    const todos: Todo[] = [
-      {
-        content: "Implement login",
-        status: "pending",
-        activeForm: "Implementing login",
-      },
-    ];
-    const block = buildCurrentTodosPrompt(todos);
-    expect(block).toContain("<current-todos>");
-    expect(block).toContain("</current-todos>");
-    expect(block).toContain("[pending] Implement login");
-  });
-
-  test("renders an in_progress todo with activeForm (not content)", () => {
-    const todos: Todo[] = [
-      {
-        content: "Run tests",
-        status: "in_progress",
-        activeForm: "Running tests",
-      },
-    ];
-    const block = buildCurrentTodosPrompt(todos);
-    expect(block).toContain("[in_progress] Running tests");
-    expect(block).not.toContain("Run tests");
-  });
-
-  test("renders completed todos with content (not activeForm)", () => {
-    const todos: Todo[] = [
-      {
-        content: "Wrote docs",
-        status: "completed",
-        activeForm: "Writing docs",
-      },
-    ];
-    const block = buildCurrentTodosPrompt(todos);
-    expect(block).toContain("[completed] Wrote docs");
-  });
-
-  test("renders a full mixed list in order", () => {
-    const todos: Todo[] = [
-      { content: "Done item", status: "completed", activeForm: "Doing done" },
-      {
-        content: "Active item",
-        status: "in_progress",
-        activeForm: "Doing active",
-      },
-      {
-        content: "Pending item",
-        status: "pending",
-        activeForm: "Doing pending",
-      },
-    ];
-    const block = buildCurrentTodosPrompt(todos)!;
-    const lines = block.split("\n");
-    expect(lines).toEqual([
-      "<current-todos>",
-      "- [completed] Done item",
-      "- [in_progress] Doing active",
-      "- [pending] Pending item",
-      "</current-todos>",
-    ]);
-  });
-});
-
-describe("buildSystemMessages — current todos tail", () => {
-  const now = new Date("2026-05-12T10:00:00Z");
-
-  test("appends no extra system message when todos is empty", () => {
-    const out = buildSystemMessages(["base", "agent"], now, []);
-    // 2 parts + 1 <current-context> tail = 3 messages
-    expect(out).toHaveLength(3);
-    // The last message is <current-context>, NOT <current-todos>.
-    expect(out[2]!.content).toContain("<current-context>");
-    expect(out[2]!.content).not.toContain("<current-todos>");
-  });
-
-  test("appends <current-todos> after <current-context> when todos non-empty", () => {
-    const out = buildSystemMessages(["base", "agent"], now, [
-      { content: "x", status: "pending", activeForm: "doing x" },
-    ]);
-    // 2 parts + <current-context> + <current-todos> = 4 messages
-    expect(out).toHaveLength(4);
-    expect(out[2]!.content).toContain("<current-context>");
-    expect(out[3]!.content).toContain("<current-todos>");
-    expect(out[3]!.content).toContain("[pending] x");
-  });
-
-  test("the new <current-todos> tail message has NO cache markers", () => {
-    const out = buildSystemMessages(["base", "agent"], now, [
-      { content: "x", status: "pending", activeForm: "doing x" },
-    ]);
-    expect(out[3]!.providerOptions).toBeUndefined();
-  });
-
-  test("cache markers on BP1/BP2 are unchanged when todos non-empty", () => {
-    const out = buildSystemMessages(["base", "agent"], now, [
-      { content: "x", status: "pending", activeForm: "doing x" },
-    ]);
-    // parts.length === 2, so bp1Idx = 0, bp2Idx = 1 — both get markers.
-    expect(out[0]!.providerOptions).toEqual({
-      anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } },
-    });
-    expect(out[1]!.providerOptions).toEqual({
-      anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } },
-    });
-    // <current-context> and <current-todos> tails both unmarked.
-    expect(out[2]!.providerOptions).toBeUndefined();
-    expect(out[3]!.providerOptions).toBeUndefined();
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/system-prompt.ts
+++ b/apps/mesh/src/api/routes/decopilot/system-prompt.ts
@@ -18,7 +18,6 @@
  * markers propagate through OpenRouter routes too.
  */
 
-import type { Todo } from "./built-in-tools/todo-write";
 import { EPHEMERAL_5M } from "./cache-instrumentation";
 
 export interface SystemMessage {
@@ -46,21 +45,6 @@ Current time: ${iso.slice(11, 16)} UTC
 </current-context>`;
 }
 
-/**
- * Per-request, non-cached system prompt block carrying the current
- * todo list. Returns null when the list is empty so the caller can
- * skip the append entirely. Lives alongside <current-context> in the
- * non-cached system tail — never wrapped in cache markers.
- */
-export function buildCurrentTodosPrompt(todos: readonly Todo[]): string | null {
-  if (todos.length === 0) return null;
-  const lines = todos.map((t) => {
-    const label = t.status === "in_progress" ? t.activeForm : t.content;
-    return `- [${t.status}] ${label}`;
-  });
-  return `<current-todos>\n${lines.join("\n")}\n</current-todos>`;
-}
-
 const EPHEMERAL_5M_PROVIDER_OPTIONS = {
   anthropic: { cacheControl: EPHEMERAL_5M },
 };
@@ -85,7 +69,6 @@ const EPHEMERAL_5M_PROVIDER_OPTIONS = {
 export function buildSystemMessages(
   parts: string[],
   now: Date,
-  todos: readonly Todo[] = [],
 ): SystemMessage[] {
   const out: SystemMessage[] = [];
   const bp2Idx = parts.length - 1;
@@ -102,12 +85,5 @@ export function buildSystemMessages(
     role: "system",
     content: buildCurrentContextPrompt(now),
   });
-  const todosBlock = buildCurrentTodosPrompt(todos);
-  if (todosBlock !== null) {
-    out.push({
-      role: "system",
-      content: todosBlock,
-    });
-  }
   return out;
 }

--- a/apps/mesh/src/api/routes/decopilot/todo-write-context.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/todo-write-context.test.ts
@@ -1,17 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { ModelMessage } from "ai";
-import { readCurrentTodos, stripTodoWriteParts } from "./todo-write-context";
+import { keepLastTodoWrite } from "./todo-write-context";
 
-// -----------------------------
-// readCurrentTodos
-// -----------------------------
-
-describe("readCurrentTodos", () => {
+describe("keepLastTodoWrite", () => {
   test("empty input → []", () => {
-    expect(readCurrentTodos([])).toEqual([]);
+    expect(keepLastTodoWrite([])).toEqual([]);
   });
 
-  test("no assistant todo_write tool-call → []", () => {
+  test("no todo_write parts → input returned by reference", () => {
     const messages: ModelMessage[] = [
       { role: "user", content: "hi" },
       {
@@ -19,17 +15,11 @@ describe("readCurrentTodos", () => {
         content: [{ type: "text", text: "hello" }],
       },
     ];
-    expect(readCurrentTodos(messages)).toEqual([]);
+    const out = keepLastTodoWrite(messages);
+    expect(out).toBe(messages);
   });
 
-  test("single todo_write tool-call → parsed todos", () => {
-    const todos = [
-      {
-        content: "Write tests",
-        activeForm: "Writing tests",
-        status: "pending" as const,
-      },
-    ];
+  test("single todo_write call + matching result → preserved", () => {
     const messages: ModelMessage[] = [
       {
         role: "assistant",
@@ -37,137 +27,39 @@ describe("readCurrentTodos", () => {
           { type: "text", text: "planning" },
           {
             type: "tool-call",
-            toolCallId: "c1",
-            toolName: "todo_write",
-            input: { todos },
-          },
-        ],
-      },
-    ];
-    expect(readCurrentTodos(messages)).toEqual(todos);
-  });
-
-  test("multiple todo_write tool-calls → latest wins", () => {
-    const older = [
-      { content: "A", activeForm: "Doing A", status: "pending" as const },
-    ];
-    const newer = [
-      { content: "A", activeForm: "Doing A", status: "in_progress" as const },
-      { content: "B", activeForm: "Doing B", status: "pending" as const },
-    ];
-    const messages: ModelMessage[] = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "c1",
-            toolName: "todo_write",
-            input: { todos: older },
-          },
-        ],
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "c2",
-            toolName: "todo_write",
-            input: { todos: newer },
-          },
-        ],
-      },
-    ];
-    expect(readCurrentTodos(messages)).toEqual(newer);
-  });
-
-  test("malformed latest input → fall through to older valid call", () => {
-    const older = [
-      { content: "A", activeForm: "Doing A", status: "pending" as const },
-    ];
-    const messages: ModelMessage[] = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "c1",
-            toolName: "todo_write",
-            input: { todos: older },
-          },
-        ],
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "c2",
-            toolName: "todo_write",
-            input: { todos: "not-an-array" },
-          },
-        ],
-      },
-    ];
-    expect(readCurrentTodos(messages)).toEqual(older);
-  });
-
-  test("tool-call on tool message (not assistant) is ignored", () => {
-    const messages: ModelMessage[] = [
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "c1",
-            toolName: "todo_write",
-            output: { type: "json", value: { ok: true, count: 1 } },
-          },
-        ],
-      },
-    ];
-    expect(readCurrentTodos(messages)).toEqual([]);
-  });
-});
-
-// -----------------------------
-// stripTodoWriteParts — preserved behavior from strip-todo-writes.test.ts
-// -----------------------------
-
-describe("stripTodoWriteParts", () => {
-  test("empty input → []", () => {
-    expect(stripTodoWriteParts([])).toEqual([]);
-  });
-
-  test("messages without todo_write are unchanged", () => {
-    const messages: ModelMessage[] = [
-      { role: "user", content: "hi" },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "hello" }],
-      },
-    ];
-    expect(stripTodoWriteParts(messages)).toEqual(messages);
-  });
-
-  test("removes a todo_write tool-call and its result, leaves siblings intact", () => {
-    const messages: ModelMessage[] = [
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "step 1" },
-          {
-            type: "tool-call",
-            toolCallId: "tw",
+            toolCallId: "tw1",
             toolName: "todo_write",
             input: { todos: [] },
           },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tw1",
+            toolName: "todo_write",
+            output: { type: "json", value: { ok: true, count: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = keepLastTodoWrite(messages);
+    expect((out[0] as { content: unknown[] }).content).toHaveLength(2);
+    expect((out[1] as { content: unknown[] }).content).toHaveLength(1);
+  });
+
+  test("multiple todo_write calls → only the latest call AND its result survive", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
           {
             type: "tool-call",
-            toolCallId: "bash",
-            toolName: "bash",
-            input: { command: "ls" },
+            toolCallId: "tw1",
+            toolName: "todo_write",
+            input: { todos: [] },
           },
         ],
       },
@@ -176,22 +68,107 @@ describe("stripTodoWriteParts", () => {
         content: [
           {
             type: "tool-result",
-            toolCallId: "tw",
+            toolCallId: "tw1",
             toolName: "todo_write",
             output: { type: "json", value: { ok: true, count: 0 } },
           },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "step 2" },
+          {
+            type: "tool-call",
+            toolCallId: "tw2",
+            toolName: "todo_write",
+            input: { todos: [] },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
           {
             type: "tool-result",
-            toolCallId: "bash",
-            toolName: "bash",
-            output: { type: "json", value: { stdout: "" } },
+            toolCallId: "tw2",
+            toolName: "todo_write",
+            output: { type: "json", value: { ok: true, count: 0 } },
           },
         ],
       },
     ];
-    const result = stripTodoWriteParts(messages);
-    expect((result[0] as { content: unknown[] }).content).toHaveLength(2);
-    expect((result[1] as { content: unknown[] }).content).toHaveLength(1);
+    const out = keepLastTodoWrite(messages);
+    // First assistant: tw1 call dropped → content empty.
+    expect((out[0] as { content: unknown[] }).content).toEqual([]);
+    // First tool: tw1 result dropped → content empty.
+    expect((out[1] as { content: unknown[] }).content).toEqual([]);
+    // Second assistant: text kept, tw2 call kept.
+    expect((out[2] as { content: unknown[] }).content).toHaveLength(2);
+    // Second tool: tw2 result kept.
+    expect((out[3] as { content: unknown[] }).content).toHaveLength(1);
+  });
+
+  test("latest todo_write call has no matching result → just the call survives", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tw_orphan",
+            toolName: "todo_write",
+            input: { todos: [] },
+          },
+        ],
+      },
+    ];
+    const out = keepLastTodoWrite(messages);
+    expect((out[0] as { content: unknown[] }).content).toHaveLength(1);
+  });
+
+  test("non-todo_write tool calls and text are untouched", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "running ls" },
+          {
+            type: "tool-call",
+            toolCallId: "b1",
+            toolName: "bash",
+            input: { command: "ls" },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "tw1",
+            toolName: "todo_write",
+            input: { todos: [] },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "b1",
+            toolName: "bash",
+            output: { type: "json", value: { stdout: "" } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tw1",
+            toolName: "todo_write",
+            output: { type: "json", value: { ok: true, count: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = keepLastTodoWrite(messages);
+    // All parts kept since tw1 is the latest.
+    expect((out[0] as { content: unknown[] }).content).toHaveLength(3);
+    expect((out[1] as { content: unknown[] }).content).toHaveLength(2);
   });
 
   test("does not mutate input", () => {
@@ -201,7 +178,18 @@ describe("stripTodoWriteParts", () => {
         content: [
           {
             type: "tool-call",
-            toolCallId: "tw",
+            toolCallId: "tw1",
+            toolName: "todo_write",
+            input: { todos: [] },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tw2",
             toolName: "todo_write",
             input: { todos: [] },
           },
@@ -209,7 +197,7 @@ describe("stripTodoWriteParts", () => {
       },
     ];
     const before = JSON.stringify(messages);
-    stripTodoWriteParts(messages);
+    keepLastTodoWrite(messages);
     expect(JSON.stringify(messages)).toBe(before);
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/todo-write-context.ts
+++ b/apps/mesh/src/api/routes/decopilot/todo-write-context.ts
@@ -1,73 +1,94 @@
 /**
  * `todo_write` context helpers.
  *
- * Two ModelMessage-level operations used both at HTTP-request entry
- * (cross-turn, via `processConversation`) and inside the agent loop
- * (intra-loop, via `prepareStep`):
+ * One ModelMessage-level operation used at HTTP-request entry
+ * (cross-turn, via `processConversation`):
  *
- *   • `stripTodoWriteParts` — remove every `todo_write` tool-call and
- *     matching tool-result part from a `ModelMessage[]`, returning a
- *     new array. Empty messages produced by stripping are left as
+ *   • `keepLastTodoWrite` — given a `ModelMessage[]`, keep only the
+ *     most recent `todo_write` tool-call (by occurrence order) and
+ *     its matching tool-result (by `toolCallId`); remove every older
+ *     `todo_write` call/result. Non-`todo_write` parts are left
+ *     untouched. Empty messages produced by stripping are left as
  *     `content: []` and cleaned up downstream by `pruneMessages`.
  *
- *   • `readCurrentTodos` — scan a `ModelMessage[]` backwards for the
- *     most recent assistant `tool-call` with `toolName: "todo_write"`
- *     and return its parsed todo list. Malformed latest inputs fall
- *     through to older valid calls. Used to rebuild `<current-todos>`
- *     each agent-loop step from the pre-strip stream.
+ * The intra-loop strip+inject is gone: the agent sees its own
+ * `todo_write` tool calls live inside the agent loop. Across turns,
+ * historical `todo_write` calls are pruned to keep the context lean.
  *
- * Single source of truth: do not add another implementation. The
- * frontend chip's UIMessage reader lives separately in
+ * The frontend chip's UIMessage reader lives separately in
  * `web/components/chat/highlight/derive-current-todos.ts` because the
  * UI part shape (`type: "tool-todo_write"`) differs from the model
- * part shape (`type: "tool-call", toolName: "todo_write"`).
+ * part shape (`type: "tool-call", toolName: "todo_write"`). It is
+ * unaffected by this module.
  */
 
 import type { ModelMessage } from "ai";
-import { type Todo, TodoWriteInputSchema } from "./built-in-tools/todo-write";
 
 const TODO_WRITE_TOOL_NAME = "todo_write";
 
 interface PartLike {
   type?: unknown;
   toolName?: unknown;
-  input?: unknown;
+  toolCallId?: unknown;
 }
 
-export function stripTodoWriteParts(
+function isTodoWriteCallPart(part: PartLike): part is PartLike & {
+  type: "tool-call";
+  toolCallId: string;
+} {
+  return (
+    part.type === "tool-call" &&
+    part.toolName === TODO_WRITE_TOOL_NAME &&
+    typeof part.toolCallId === "string"
+  );
+}
+
+function isTodoWriteResultPart(part: PartLike): part is PartLike & {
+  type: "tool-result";
+  toolCallId: string;
+} {
+  return (
+    part.type === "tool-result" &&
+    part.toolName === TODO_WRITE_TOOL_NAME &&
+    typeof part.toolCallId === "string"
+  );
+}
+
+export function keepLastTodoWrite(
   messages: readonly ModelMessage[],
 ): ModelMessage[] {
+  // Pass 1: find the toolCallId of the latest todo_write tool-call.
+  let latestCallId: string | null = null;
+  for (let i = messages.length - 1; i >= 0 && latestCallId === null; i--) {
+    const msg = messages[i]!;
+    const content = (msg as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (let j = content.length - 1; j >= 0; j--) {
+      const part = content[j] as PartLike;
+      if (isTodoWriteCallPart(part)) {
+        latestCallId = part.toolCallId;
+        break;
+      }
+    }
+  }
+
+  if (latestCallId === null) {
+    // Nothing to do — no todo_write calls exist.
+    return messages as ModelMessage[];
+  }
+
+  const survivorId = latestCallId;
   return messages.map((msg) => {
     const content = (msg as { content?: unknown }).content;
     if (!Array.isArray(content)) return msg;
 
     const filtered = (content as PartLike[]).filter((part) => {
-      const isTodoWriteCall =
-        part.type === "tool-call" && part.toolName === TODO_WRITE_TOOL_NAME;
-      const isTodoWriteResult =
-        part.type === "tool-result" && part.toolName === TODO_WRITE_TOOL_NAME;
-      return !isTodoWriteCall && !isTodoWriteResult;
+      if (isTodoWriteCallPart(part)) return part.toolCallId === survivorId;
+      if (isTodoWriteResultPart(part)) return part.toolCallId === survivorId;
+      return true;
     });
 
     if (filtered.length === content.length) return msg;
     return { ...msg, content: filtered } as ModelMessage;
   });
-}
-
-export function readCurrentTodos(messages: readonly ModelMessage[]): Todo[] {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]!;
-    if (msg.role !== "assistant") continue;
-    const content = (msg as { content?: unknown }).content;
-    if (!Array.isArray(content)) continue;
-    for (let j = content.length - 1; j >= 0; j--) {
-      const part = content[j] as PartLike;
-      if (part.type !== "tool-call") continue;
-      if (part.toolName !== TODO_WRITE_TOOL_NAME) continue;
-      const parsed = TodoWriteInputSchema.safeParse(part.input);
-      if (parsed.success) return parsed.data.todos;
-      // Latest call had malformed input; fall through to older calls.
-    }
-  }
-  return [];
 }

--- a/apps/mesh/src/web/components/chat/highlight/derive-current-todos.ts
+++ b/apps/mesh/src/web/components/chat/highlight/derive-current-todos.ts
@@ -7,10 +7,11 @@
  * we only trust `input-available` and `output-available` states so we
  * never read mid-stream partial input.
  *
- * This is the UI-shape twin of the backend's
- * `readCurrentTodos(ModelMessage[])` in
- * `api/routes/decopilot/todo-write-context.ts`. They cannot share an
- * implementation because the part shapes differ.
+ * This is the UI-shape counterpart of the backend's todo_write
+ * handling in `api/routes/decopilot/todo-write-context.ts`. They cannot
+ * share an implementation because the part shapes differ — UIMessages
+ * carry todo_write as `type: "tool-todo_write"`, ModelMessages as
+ * `type: "tool-call", toolName: "todo_write"`.
  */
 
 import type { UIMessage } from "ai";


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep only the latest `todo_write` call/result in the model context and remove the `<current-todos>` system block and intra-loop strip+inject. The agent now calls `todo_write` at the start of every multi-step request and reads its state from its last call.

- **Refactors**
  - Replaced `stripTodoWriteParts` with `keepLastTodoWrite` to retain only the most recent `todo_write` call/result; older ones are pruned.
  - Removed `readCurrentTodos`, the `currentTodos` plumbing, the `<current-todos>` system block, and the per-step inject in `stream-core`.
  - Updated `buildSystemMessages` and deleted `buildCurrentTodosPrompt`; simplified related tests.
  - Revised tool and prompt copy: call `todo_write` at the start of multi-step work; skip only true one-shots; read state from the last call.

<sup>Written for commit bb749d0bce2ac6a7a0bc31462443ea5d1b9ee2a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

