### PR TITLE
feat(profile): add profile picture upload and fix avatar refresh bug

### DIFF
--- a/apps/mesh/src/web/views/settings/profile-preferences.tsx
+++ b/apps/mesh/src/web/views/settings/profile-preferences.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@deco/ui/components/input.tsx";
 import { Moon01, Monitor01, Play, Sun } from "@untitledui/icons";
 import { Controller, useForm } from "react-hook-form";
+import { useRef, useState } from "react";
 import { authClient } from "@/web/lib/auth-client";
 import {
   usePreferences,
@@ -36,10 +37,61 @@ interface ProfileFormValues {
   name: string;
 }
 
+function ProfileAvatarUpload({
+  value,
+  name,
+  isUpdating,
+  onUpload,
+}: {
+  value?: string;
+  name?: string;
+  isUpdating: boolean;
+  onUpload: (dataUrl: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 2 * 1024 * 1024) {
+      toast.error("Image must be smaller than 2MB");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onerror = () => toast.error("Failed to read image");
+    reader.onloadend = () => {
+      if (reader.result) onUpload(reader.result as string);
+      if (inputRef.current) inputRef.current.value = "";
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => inputRef.current?.click()}
+      disabled={isUpdating}
+      className="rounded-full overflow-hidden hover:ring-2 hover:ring-border transition-all disabled:opacity-50"
+      aria-label="Upload profile picture"
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFile}
+        className="hidden"
+        disabled={isUpdating}
+      />
+      <Avatar url={value} fallback={name ?? "U"} shape="circle" size="base" />
+    </button>
+  );
+}
+
 function ProfileSection() {
   const { data: session, isPending } = authClient.useSession();
   const user = session?.user;
   const userImage = (user as { image?: string } | undefined)?.image;
+  const [isUpdatingImage, setIsUpdatingImage] = useState(false);
 
   const form = useForm<ProfileFormValues>({
     values: { name: user?.name ?? "" },
@@ -75,6 +127,19 @@ function ProfileSection() {
     },
   });
 
+  const handleImageUpload = async (dataUrl: string) => {
+    setIsUpdatingImage(true);
+    try {
+      await authClient.updateUser({ image: dataUrl });
+      track("profile_updated", { fields: ["image"] });
+      toast.success("Profile picture updated");
+    } catch {
+      toast.error("Failed to update profile picture");
+    } finally {
+      setIsUpdatingImage(false);
+    }
+  };
+
   if (isPending) return null;
 
   return (
@@ -82,12 +147,13 @@ function ProfileSection() {
       <SettingsCard>
         <SettingsCardItem
           title="Avatar"
+          description="Click to upload a new picture"
           action={
-            <Avatar
-              url={userImage}
-              fallback={user?.name ?? "U"}
-              shape="circle"
-              size="base"
+            <ProfileAvatarUpload
+              value={userImage}
+              name={user?.name}
+              isUpdating={isUpdatingImage}
+              onUpload={handleImageUpload}
             />
           }
         />

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -6,7 +6,7 @@ import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { cn } from "../lib/utils.ts";
 import { User01 } from "@untitledui/icons";
 import { cva, type VariantProps } from "class-variance-authority";
-import { type HTMLAttributes, type ReactNode, useMemo, useState } from "react";
+import { type HTMLAttributes, type ReactNode, useMemo } from "react";
 
 // Export basic primitives for backward compatibility
 function AvatarRoot({
@@ -201,7 +201,6 @@ function UnifiedAvatar({
   muted = false,
   ...props
 }: BaseAvatarProps) {
-  const [isError, setIsError] = useState(false);
   const fallbackContent = useMemo(() => {
     if (typeof fallback === "string") {
       const trimmed = fallback.trim();
@@ -239,20 +238,20 @@ function UnifiedAvatar({
         </div>
       ) : (
         <>
-          {url && !isError && (
+          {url && (
             <AvatarImage
               src={url}
               loading="lazy"
               alt="Avatar"
               className={cn(avatarImageVariants({ objectFit }))}
-              onError={() => setIsError(true)}
             />
           )}
-          {(!url || isError) && (
-            <AvatarFallback className={cn(fallbackColor, "rounded-none")}>
-              {fallbackContent}
-            </AvatarFallback>
-          )}
+          <AvatarFallback
+            className={cn(fallbackColor, "rounded-none")}
+            delayMs={url ? 600 : 0}
+          >
+            {fallbackContent}
+          </AvatarFallback>
         </>
       )}
     </AvatarRoot>


### PR DESCRIPTION
## What is this contribution about?

Users couldn't change their profile picture (no UI existed) and uploaded images sometimes wouldn't render due to a stale error state in the Avatar component. This PR adds an upload UI to **Settings → Profile & Preferences** that reuses the org-logo pattern (base64 data URL + `authClient.updateUser({ image })`) and fixes the Avatar component to rely on Radix's built-in image loading status instead of a manual `isError` flag that never reset on URL changes.

## How to Test

1. Go to **Settings → Profile & Preferences**
2. Click your avatar — file picker opens
3. Pick an image under 2MB → toast confirms and the avatar updates immediately
4. Re-upload a different image — the new picture should render (previously, if any URL failed once, subsequent uploads would stay on the initials fallback)

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds profile picture upload in Settings and fixes avatar refresh so new images render after failures. Improves reliability and makes it easy to update your avatar.

- **New Features**
  - Click your avatar in Settings → Profile & Preferences to upload an image (max 2MB).
  - File is read as a base64 data URL and saved via `authClient.updateUser({ image })`; shows success/error toasts and disables while updating.

- **Bug Fixes**
  - Avatar now uses `@radix-ui/react-avatar` loading state instead of a manual error flag.
  - New image URLs render correctly after a previous load failure; fallback shows with a small delay for smoother transitions.

<sup>Written for commit 80acfe0341c7ba799271b3715a666982f51fe5d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

