### PR TITLE
feat(chat): AI-powered thread quick actions (starter suggestions)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -35,8 +35,9 @@ import {
 import { PersistedRunConfigSchema, toModelsConfig } from "./run-config";
 import { StreamRequestSchema } from "./schemas";
 import type { ChatMessage, ModelsConfig } from "./types";
-import { streamCore } from "./stream-core";
+import { streamCore, createLanguageModel } from "./stream-core";
 import { RunClaimError } from "./run-reactor";
+import { genSuggestions } from "./suggestions-generator";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import type { SqlThreadStorage } from "@/storage/threads";
 import { getPodId } from "@/core/pod-identity";
@@ -592,6 +593,65 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       if (err instanceof HTTPException) throw err;
       console.error("[decopilot:attach] Error", err);
       return c.body(null, 500);
+    }
+  });
+
+  // ============================================================================
+  // Agent Suggestions Endpoint — generates 3 starter questions for an agent
+  // ============================================================================
+
+  app.post("/:org/decopilot/agent-suggestions", async (c) => {
+    try {
+      const ctx = c.get("meshContext");
+      const organization = ensureOrganization(c);
+
+      const { virtualMcpId } = await c.req.json();
+      if (typeof virtualMcpId !== "string") {
+        return c.json({ error: "virtualMcpId required" }, 400);
+      }
+
+      const [virtualMcp, models] = await Promise.all([
+        ctx.storage.virtualMcps.findById(virtualMcpId, organization.id),
+        resolvePerRequestModels(ctx, undefined).catch(() => null),
+      ]);
+
+      if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+        return c.json({ error: "Agent not found" }, 404);
+      }
+
+      const agentDescription = [
+        virtualMcp.metadata?.instructions,
+        virtualMcp.description,
+        virtualMcp.title,
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+
+      if (!models) {
+        return c.json({ suggestions: [] });
+      }
+
+      const provider = await ctx.aiProviders
+        .activate(models.credentialId, organization.id)
+        .catch(() => null);
+
+      if (!provider) {
+        return c.json({ suggestions: [] });
+      }
+
+      const suggestions = await genSuggestions({
+        abortSignal: c.req.raw.signal,
+        model: createLanguageModel(provider, models.fast ?? models.thinking),
+        agentDescription,
+      });
+
+      return c.json({ suggestions: suggestions ?? [] });
+    } catch (err) {
+      if (err instanceof HTTPException) {
+        return c.json({ error: err.message }, err.status);
+      }
+      console.error("[decopilot:agent-suggestions] Error", err);
+      return c.json({ suggestions: [] });
     }
   });
 

--- a/apps/mesh/src/api/routes/decopilot/suggestions-generator.ts
+++ b/apps/mesh/src/api/routes/decopilot/suggestions-generator.ts
@@ -1,0 +1,73 @@
+/**
+ * Agent Suggestions Generator
+ *
+ * Generates 3 starter questions for an agent based on its system prompt,
+ * using the same LLM approach as title generation.
+ */
+
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { generateText } from "ai";
+
+const SUGGESTIONS_GENERATOR_PROMPT = `Given the following description or instructions for an AI agent, generate 3 short, specific starter questions or requests a user might ask.
+
+Rules:
+- Make them specific to this agent's domain, not generic
+- Each suggestion under 70 characters
+- Use action form: "Can you...?" or direct imperative
+- Sentence case only (capitalize first word and proper nouns)
+- Return JSON: {"suggestions": ["...", "...", "..."]}
+
+Good example for a Site Diagnostics agent:
+{"suggestions": ["Can you audit my website performance?", "Run an SEO analysis on my page", "Check my Core Web Vitals score"]}
+
+Good example for a Code Review agent:
+{"suggestions": ["Review my latest pull request", "Can you check for security issues?", "Help me refactor this function"]}`;
+
+export async function genSuggestions(config: {
+  abortSignal: AbortSignal;
+  model: LanguageModelV3;
+  agentDescription: string;
+}): Promise<string[] | null> {
+  const { abortSignal, model, agentDescription } = config;
+
+  try {
+    const result = await generateText({
+      model,
+      system: SUGGESTIONS_GENERATOR_PROMPT,
+      messages: [{ role: "user", content: agentDescription }],
+      maxOutputTokens: 200,
+      temperature: 0.3,
+      abortSignal,
+    });
+
+    const cleaned = result.text
+      .trim()
+      .replace(/^```(?:json)?\s*\n?/i, "")
+      .replace(/\n?```\s*$/, "")
+      .trim();
+
+    const parsed = JSON.parse(cleaned);
+    const suggestions = parsed.suggestions;
+
+    if (
+      !Array.isArray(suggestions) ||
+      !suggestions.every((s) => typeof s === "string")
+    ) {
+      return null;
+    }
+
+    return suggestions.slice(0, 3).map((s: string) =>
+      s
+        .replace(/^["']|["']$/g, "")
+        .replace(/[.!?]$/, "")
+        .slice(0, 80)
+        .trim(),
+    );
+  } catch (error) {
+    const err = error as Error;
+    if (err.name !== "AbortError") {
+      console.error("[decopilot:suggestions] Failed to generate:", err.message);
+    }
+    return null;
+  }
+}

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -7,6 +7,7 @@ import { IceBreakers } from "./ice-breakers";
 import { ChatInput } from "./input";
 import { MessagePair, useMessagePairs } from "./message/pair.tsx";
 import { NoAiProviderEmptyState } from "./no-ai-provider-empty-state";
+import { AfterMessageSuggestions } from "./thread-suggestions";
 import { CreditsEmptyState } from "./credits-empty-state";
 import { CreditsExhaustedBanner } from "./credits-exhausted-banner";
 import { CreditsEyebrow, NoCreditsEyebrow } from "./credits-eyebrow";
@@ -69,6 +70,12 @@ function ChatMessages() {
       (p) => "state" in p && p.state === "approval-requested",
     );
 
+  const showSuggestions =
+    !isStreaming &&
+    !hasActiveUserAsk &&
+    !hasActivePendingApprovals &&
+    lastMessagePair?.assistant != null;
+
   return (
     <div className="w-full min-w-0 max-w-full overflow-y-auto h-full overflow-x-hidden">
       <div className="flex flex-col min-w-0 max-w-2xl mx-auto w-full">
@@ -94,6 +101,9 @@ function ChatMessages() {
             isLastPair={true}
             status={status}
           />
+          {showSuggestions && (
+            <AfterMessageSuggestions className="px-4 pb-6 pt-2" />
+          )}
         </div>
       )}
     </div>

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -18,12 +18,16 @@ import { BranchPicker } from "../thread/github/branch-picker.tsx";
 
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
+import { ThreadSuggestions } from "./thread-suggestions";
+import { useAgentSuggestions } from "@/web/hooks/use-agent-suggestions";
+import type { TiptapDoc } from "./types";
 
 // ---------- Default sidebar empty state ----------
 
 function SidebarEmptyState() {
   const { org } = useProjectContext();
   const { selectedVirtualMcp } = useChatPrefs();
+  const { sendMessage } = useChatStream();
   const { data: session } = authClient.useSession();
   const { currentBranch, setCurrentTaskBranch } = useChatTask();
 
@@ -35,41 +39,59 @@ function SidebarEmptyState() {
   const githubRepo = fullVm?.metadata?.githubRepo ?? null;
   const showBranchPicker = !!githubRepo?.connectionId && !!userId;
 
+  const suggestions = useAgentSuggestions(displayAgent.id);
+
+  const handleSuggestionSelect = async (text: string) => {
+    const doc: TiptapDoc = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+    };
+    await sendMessage(doc);
+  };
+
   return (
-    <div className="h-full w-full flex flex-col items-center justify-center gap-6 px-4">
-      <div className="flex flex-col items-center justify-center gap-2 md:gap-4 text-center">
-        <IntegrationIcon
-          icon={displayAgent.icon}
-          name={displayAgent.title}
-          size="lg"
-          fallbackIcon={<Users03 size={32} />}
-          className="size-10 min-w-10 md:size-[60px]! md:min-w-[60px] rounded-xl md:rounded-[18px]!"
-        />
-        <h3 className="text-base md:text-xl font-medium text-foreground">
-          {displayAgent.title}
-        </h3>
-        <div className="text-muted-foreground text-center text-base max-w-md line-clamp-2">
-          {displayAgent.description ??
-            "Ask anything about configuring model providers or using MCP Mesh."}
-        </div>
-        {showBranchPicker && (
-          <div className="mt-2">
-            <BranchPicker
-              orgId={org.id}
-              orgSlug={org.slug}
-              userId={userId}
-              connectionId={githubRepo.connectionId!}
-              owner={githubRepo.owner}
-              repo={githubRepo.name}
-              vmMap={fullVm?.metadata?.vmMap}
-              value={currentBranch ?? undefined}
-              onChange={setCurrentTaskBranch}
-            />
+    <div className="h-full w-full flex flex-col px-4 max-w-2xl mx-auto">
+      <div className="flex-1 flex flex-col items-center justify-center gap-6">
+        <div className="flex flex-col items-center justify-center gap-2 md:gap-4 text-center">
+          <IntegrationIcon
+            icon={displayAgent.icon}
+            name={displayAgent.title}
+            size="lg"
+            fallbackIcon={<Users03 size={32} />}
+            className="size-10 min-w-10 md:size-[60px]! md:min-w-[60px] rounded-xl md:rounded-[18px]!"
+          />
+          <h3 className="text-base md:text-xl font-medium text-foreground">
+            {displayAgent.title}
+          </h3>
+          <div className="text-muted-foreground text-center text-base max-w-md line-clamp-2">
+            {displayAgent.description ??
+              "Ask anything about configuring model providers or using MCP Mesh."}
           </div>
-        )}
+          {showBranchPicker && (
+            <div className="mt-2">
+              <BranchPicker
+                orgId={org.id}
+                orgSlug={org.slug}
+                userId={userId}
+                connectionId={githubRepo.connectionId!}
+                owner={githubRepo.owner}
+                repo={githubRepo.name}
+                vmMap={fullVm?.metadata?.vmMap}
+                value={currentBranch ?? undefined}
+                onChange={setCurrentTaskBranch}
+              />
+            </div>
+          )}
+        </div>
+        <div className="w-full">
+          <Chat.IceBreakers />
+        </div>
       </div>
-      <div className="w-full max-w-3xl mx-auto">
-        <Chat.IceBreakers />
+      <div className="w-full pb-4">
+        <ThreadSuggestions
+          suggestions={suggestions}
+          onSelect={handleSuggestionSelect}
+        />
       </div>
     </div>
   );

--- a/apps/mesh/src/web/components/chat/thread-suggestions.tsx
+++ b/apps/mesh/src/web/components/chat/thread-suggestions.tsx
@@ -1,0 +1,78 @@
+import { CornerDownRight } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useChatPrefs, useChatStream } from "./context";
+import { useAgentSuggestions } from "@/web/hooks/use-agent-suggestions";
+import type { TiptapDoc } from "./types";
+
+// ── UI ─────────────────────────────────────────────────────────────────────
+
+interface ThreadSuggestionsProps {
+  suggestions: string[];
+  onSelect: (text: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ThreadSuggestions({
+  suggestions,
+  onSelect,
+  disabled,
+  className,
+}: ThreadSuggestionsProps) {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div className={cn("flex flex-col items-start gap-2", className)}>
+      {suggestions.map((suggestion) => (
+        <button
+          key={suggestion}
+          type="button"
+          disabled={disabled}
+          onClick={() => onSelect(suggestion)}
+          className={cn(
+            "flex items-center gap-2 px-4 py-2.5 rounded-full",
+            "bg-muted text-muted-foreground text-sm font-medium",
+            "transition-colors hover:bg-muted/70 hover:text-foreground",
+            disabled && "opacity-50 cursor-not-allowed",
+          )}
+        >
+          <CornerDownRight size={14} className="shrink-0" />
+          <span>{suggestion}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ── After-message container ────────────────────────────────────────────────
+
+function useSuggestionSend() {
+  const { sendMessage, isStreaming } = useChatStream();
+
+  const send = async (text: string) => {
+    const doc: TiptapDoc = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+    };
+    await sendMessage(doc);
+  };
+
+  return { send, disabled: isStreaming };
+}
+
+export function AfterMessageSuggestions({ className }: { className?: string }) {
+  const { selectedVirtualMcp } = useChatPrefs();
+  const { send, disabled } = useSuggestionSend();
+  const suggestions = useAgentSuggestions(selectedVirtualMcp?.id);
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <ThreadSuggestions
+      suggestions={suggestions}
+      onSelect={send}
+      disabled={disabled}
+      className={className}
+    />
+  );
+}

--- a/apps/mesh/src/web/components/chat/thread-suggestions.tsx
+++ b/apps/mesh/src/web/components/chat/thread-suggestions.tsx
@@ -23,16 +23,19 @@ export function ThreadSuggestions({
 
   return (
     <div className={cn("flex flex-col items-start gap-2", className)}>
-      {suggestions.map((suggestion) => (
+      {suggestions.map((suggestion, index) => (
         <button
           key={suggestion}
           type="button"
           disabled={disabled}
           onClick={() => onSelect(suggestion)}
+          style={{ animationDelay: `${index * 60}ms` }}
           className={cn(
             "flex items-center gap-2 px-4 py-2.5 rounded-full",
             "bg-muted text-muted-foreground text-sm font-medium",
             "transition-colors hover:bg-muted/70 hover:text-foreground",
+            "animate-in fade-in-0 slide-in-from-bottom-1 duration-200 ease-out",
+            "motion-reduce:animate-none",
             disabled && "opacity-50 cursor-not-allowed",
           )}
         >

--- a/apps/mesh/src/web/hooks/use-agent-suggestions.ts
+++ b/apps/mesh/src/web/hooks/use-agent-suggestions.ts
@@ -1,0 +1,36 @@
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "../lib/query-keys";
+
+export function useAgentSuggestions(
+  virtualMcpId: string | null | undefined,
+): string[] {
+  const { org } = useProjectContext();
+  const id = virtualMcpId ?? null;
+
+  const { data } = useQuery({
+    queryKey: KEYS.agentSuggestions(org.id, id),
+    enabled: !!id,
+    staleTime: Infinity,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    queryFn: async (): Promise<string[]> => {
+      const response = await fetch(
+        `/api/${org.slug}/decopilot/agent-suggestions`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ virtualMcpId: id }),
+        },
+      );
+      if (!response.ok) return [];
+      const json = (await response.json()) as { suggestions?: string[] };
+      return Array.isArray(json.suggestions) ? json.suggestions : [];
+    },
+  });
+
+  return data ?? [];
+}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -300,6 +300,10 @@ export const KEYS = {
   aiProviderCredits: (orgId: string, keyId: string) =>
     ["ai-provider-credits", orgId, keyId] as const,
 
+  // Agent starter suggestions (scoped by org + virtualMcpId)
+  agentSuggestions: (orgId: string, virtualMcpId: string | null) =>
+    ["agent-suggestions", orgId, virtualMcpId ?? "default"] as const,
+
   // Organization SSO
   orgSsoConfig: (organizationId: string) =>
     ["org-sso-config", organizationId] as const,


### PR DESCRIPTION
## What is this contribution about?

Adds contextual starter suggestions to the chat UI — 3 short, agent-specific questions generated by the configured LLM based on the agent's description and instructions. Suggestions appear in the empty-state sidebar before the first message and as quick-action chips after each assistant response.

**New pieces:**
- `POST /api/:org/decopilot/agent-suggestions` — endpoint that calls the LLM to generate suggestions
- `suggestions-generator.ts` — LLM utility (same pattern as title generation)
- `thread-suggestions.tsx` — `ThreadSuggestions` (base UI) and `AfterMessageSuggestions` (post-message variant)
- `use-agent-suggestions.ts` — React Query hook, fetches once and caches indefinitely per agent

## Screenshots/Demonstration
> UI shows pill-style suggestion chips with a CornerDownRight icon; clicking one sends the message immediately.

## How to Test
1. Open an agent chat with a configured AI provider
2. On the empty state, starter suggestions should appear below the ice breakers
3. After the agent replies, the same suggestions should appear below the last message
4. Clicking a suggestion sends it as a new message
5. Suggestions are not shown while the agent is streaming or has a pending approval

## Migration Notes
No migrations needed.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent‑specific starter suggestions to the chat to speed up first asks and follow‑ups. Three short prompts are generated from the agent description and shown in the empty state and after each assistant reply; clicking one sends it. Suggestions now animate in with a subtle, staggered fade‑in.

- New Features
  - API: `POST /api/:org/decopilot/agent-suggestions` generates 3 suggestions from the configured model and agent description; returns an empty list when models/provider are unavailable. Uses `suggestions-generator.ts`.
  - UI: `ThreadSuggestions` and `AfterMessageSuggestions` render pill chips in the sidebar (below ice breakers) and below the last message; hidden while streaming or when approvals are pending. Adds 200ms fade-in + slide-up animation, staggered by 60ms, respecting reduced motion.
  - Data: `use-agent-suggestions` React Query hook fetches once and caches indefinitely per agent; added query key in `query-keys.ts`.

<sup>Written for commit 4fc96efcc68bab93e40c5f9dcb9a2c6a5f0a6355. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

