### PR TITLE
fix(chat): remove duplicate close button and report action from error highlight

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -52,6 +52,8 @@ export interface CollapsibleHighlightProps {
   defaultExpanded: boolean;
   /** Drives translucent overlay for status banners. */
   variant?: HighlightVariant;
+  /** Called when the close (X) button is clicked, after local dismissal. */
+  onClose?: () => void;
 }
 
 const VARIANT_OVERLAY: Record<HighlightVariant, string> = {
@@ -82,9 +84,15 @@ export function CollapsibleHighlight({
   children,
   defaultExpanded,
   variant = "default",
+  onClose,
 }: CollapsibleHighlightProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [closed, setClosed] = useState(false);
+
+  const handleClose = () => {
+    setClosed(true);
+    onClose?.();
+  };
 
   if (closed) return null;
 
@@ -147,13 +155,13 @@ export function CollapsibleHighlight({
           title="Close"
           onClick={(e) => {
             e.stopPropagation();
-            setClosed(true);
+            handleClose();
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
               e.stopPropagation();
-              setClosed(true);
+              handleClose();
             }
           }}
           className="text-muted-foreground hover:text-foreground transition-colors shrink-0 flex items-center justify-center -mr-1 ml-1 p-1 rounded-md hover:bg-accent"

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@deco/ui/components/button.tsx";
-import { AlertCircle, AlertTriangle, X } from "@untitledui/icons";
+import { AlertCircle, AlertTriangle } from "@untitledui/icons";
 import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { useChatStream, useChatTask } from "../context";
 import { ApprovalHighlight, extractPendingApprovals } from "./approval";
@@ -57,47 +57,27 @@ function StatusHighlight(props: StatusHighlightProps) {
       title={message}
       defaultExpanded={true}
       variant={variant}
+      onClose={onDismiss}
       footerRight={
-        <>
-          {isError ? (
-            <>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={props.onFixInChat}
-                className="h-7 text-xs"
-              >
-                Fix in chat
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled
-                className="h-7 text-xs"
-              >
-                Report
-              </Button>
-            </>
-          ) : (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={props.onContinue}
-              className="h-7 text-xs"
-            >
-              Continue
-            </Button>
-          )}
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="text-muted-foreground hover:text-foreground transition-colors shrink-0 ml-1"
-            title="Dismiss"
-            aria-label="Dismiss"
+        isError ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={props.onFixInChat}
+            className="h-7 text-xs"
           >
-            <X size={14} />
-          </button>
-        </>
+            Fix in chat
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={props.onContinue}
+            className="h-7 text-xs"
+          >
+            Continue
+          </Button>
+        )
       }
     >
       {null}


### PR DESCRIPTION
## What is this contribution about?
The error banner above the chat input rendered two close (X) buttons — one in the card header and another in the footer next to the action buttons. The footer X has been removed, and the header X is now wired through a new `onClose` prop on `CollapsibleHighlight` so dismissing the banner still clears the underlying `error` / `finishReason` state. The disabled "Report" button has also been dropped since the action is not yet available.

## Screenshots/Demonstration
Before: error banner showed `Fix in chat`, disabled `Report`, and a redundant `X` in the footer in addition to the header `X`.
After: error banner shows only `Fix in chat` in the footer; a single `X` in the header dismisses the banner and clears the error.

## How to Test
1. Trigger an error in the chat (e.g. send a message with no model configured for the selected tier).
2. Confirm only one close (X) button appears, in the top-right of the banner.
3. Click the X — the banner disappears and a subsequent error correctly reappears.
4. Confirm the "Report" button is no longer rendered.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate close (X) in the chat error banner and dropped the unused "Report" action. The banner now has a single header X; dismissing it clears the underlying error/finishReason state.

- **Bug Fixes**
  - Added `onClose` to `CollapsibleHighlight` and wired the header X to it.
  - Simplified footer actions: errors show "Fix in chat"; non-errors show "Continue".

<sup>Written for commit 29c22eb463ef5d7da93b850c667cc75d446c7a15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

