### PR TITLE
feat(todos): animated checkbox design + hide from chat tool parts

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -14,6 +14,86 @@
   }
 }
 
+@layer components {
+  /* Animated todo checkbox — stroke-dasharray technique from checkbox source */
+  .todo-cb {
+    --ts1: 300ms;
+    --ts2: 600ms;
+    --size: 15px;
+    --tick: var(--primary-foreground);
+    --border-col: var(--border);
+    --active-col: var(--primary);
+    position: relative;
+    pointer-events: none;
+    width: var(--size);
+    height: var(--size);
+    flex-shrink: 0;
+    border-radius: 3px;
+    transition:
+      box-shadow var(--ts1),
+      background var(--ts1);
+    box-shadow: inset 0 0 0 1.5px var(--b, var(--border-col));
+  }
+
+  .todo-cb svg {
+    fill: none;
+    stroke: var(--active-col);
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    stroke-dasharray: var(--a, 86.12);
+    stroke-dashoffset: var(--o, 86.12);
+    transition:
+      stroke-dasharray var(--ts2),
+      stroke-dashoffset var(--ts2);
+  }
+
+  .todo-cb[data-checked="true"] {
+    background: var(--active-col);
+    --b: var(--active-col);
+    transition-delay: 0.4s;
+  }
+
+  .todo-cb[data-checked="true"] svg {
+    --a: 16 86.12;
+    --o: 102.22;
+    animation-name: todo-cb-fill;
+    animation-delay: var(--ts1);
+    animation-fill-mode: forwards;
+    animation-timing-function: ease;
+    animation-duration: var(--ts2);
+  }
+
+  .todo-cb[data-progress="true"] {
+    --b: var(--active-col);
+    animation: todo-cb-pulse 1.4s ease-in-out infinite;
+  }
+
+  @keyframes todo-cb-fill {
+    0% {
+      stroke: var(--active-col);
+    }
+    100% {
+      stroke: var(--tick);
+    }
+  }
+
+  @keyframes todo-cb-pulse {
+    0%,
+    100% {
+      box-shadow: inset 0 0 0 1.5px var(--active-col);
+    }
+    50% {
+      box-shadow: inset 0 0 0 1.5px
+        color-mix(in oklch, var(--active-col) 30%, transparent);
+    }
+  }
+}
+
 @layer utilities {
   .shimmer {
     background-image: linear-gradient(

--- a/apps/mesh/src/web/components/chat/highlight/todos.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/todos.tsx
@@ -1,15 +1,3 @@
-/**
- * TodosHighlight — collapsed chip + expanded list for the per-thread todo
- * list maintained by the model via `todo_write`.
- *
- * Reads the same UIMessage stream the chat renders; no API call of its
- * own. Renders nothing when the list is empty.
- *
- * Defaults to collapsed (only banner that does) — todos are passive
- * status, not an active prompt. Wraps `CollapsibleHighlight` so the
- * chip + body share a single card with consistent chrome.
- */
-
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { Todo } from "@/api/routes/decopilot/built-in-tools/todo-write";
 import { useChatStream } from "../context";
@@ -26,14 +14,14 @@ export function TodosHighlight() {
 
   return (
     <CollapsibleHighlight
-      icon={<StatusMark status={label.icon} />}
+      icon={<ChipStatusIcon status={label.icon} />}
       label={label.activity}
       count={label.progress}
       defaultExpanded={false}
     >
       <ul
         data-testid="todos-list"
-        className="flex flex-col gap-1.5 px-4 max-h-[40vh] overflow-y-auto"
+        className="flex flex-col px-2 max-h-[40vh] overflow-y-auto"
       >
         {/* key=i is safe: todo_write rewrites the full list atomically; no stable id exists */}
         {todos.map((todo, i) => (
@@ -48,24 +36,69 @@ function TodoRow({ todo }: { todo: Todo }) {
   const isCompleted = todo.status === "completed";
   const isInProgress = todo.status === "in_progress";
   const label = isInProgress ? todo.activeForm : todo.content;
+
   return (
-    <li
-      className={cn(
-        "flex items-start gap-2 text-sm",
-        isCompleted && "text-muted-foreground line-through opacity-70",
-      )}
-    >
-      <StatusMark status={todo.status} />
-      <span className="leading-snug">{label}</span>
+    <li className="flex items-start gap-2.5 px-2 py-1.5 rounded-lg hover:bg-accent/50 transition-colors">
+      <TodoCheckbox status={todo.status} />
+      <span
+        className={cn(
+          "relative text-sm leading-snug pt-px select-none",
+          isCompleted && "text-muted-foreground",
+        )}
+      >
+        {label}
+        <span
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            left: 0,
+            top: "50%",
+            height: "1px",
+            background: "currentColor",
+            width: isCompleted ? "100%" : "0%",
+            transition: isCompleted
+              ? "width 300ms ease 200ms"
+              : "width 150ms ease",
+          }}
+        />
+      </span>
     </li>
   );
 }
 
-function StatusMark({ status }: { status: ChipIcon }) {
+function TodoCheckbox({ status }: { status: Todo["status"] }) {
+  return (
+    <div
+      className="todo-cb mt-0.5"
+      data-checked={status === "completed" ? "true" : undefined}
+      data-progress={status === "in_progress" ? "true" : undefined}
+      aria-hidden="true"
+    >
+      <svg viewBox="0 0 21 21">
+        <path d="M5,10.75 L8.5,14.25 L19.4,2.3 C18.8333333,1.43333333 18.0333333,1 17,1 L4,1 C2.35,1 1,2.35 1,4 L1,17 C1,18.65 2.35,20 4,20 L17,20 C18.65,20 20,18.65 20,17 L20,7.99769186" />
+      </svg>
+    </div>
+  );
+}
+
+function ChipStatusIcon({ status }: { status: ChipIcon }) {
   if (status === "completed") {
     return (
-      <span aria-label="completed" className="mt-0.5 shrink-0">
-        ✓
+      <span
+        aria-label="completed"
+        className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-sm bg-primary"
+      >
+        <svg
+          viewBox="0 0 10 8"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-2 h-2 text-primary-foreground"
+          style={{ strokeWidth: 2 }}
+        >
+          <path d="M1 4l2.5 2.5L9 1" />
+        </svg>
       </span>
     );
   }
@@ -73,14 +106,14 @@ function StatusMark({ status }: { status: ChipIcon }) {
     return (
       <span
         aria-label="in progress"
-        className="mt-0.5 inline-block w-2 h-2 rounded-full bg-primary animate-pulse shrink-0"
+        className="inline-block w-2 h-2 rounded-full bg-primary animate-pulse shrink-0"
       />
     );
   }
   return (
     <span
       aria-label="pending"
-      className="mt-0.5 inline-block w-2 h-2 rounded-full border border-muted-foreground shrink-0"
+      className="inline-block w-3.5 h-3.5 rounded-sm border-[1.5px] border-muted-foreground/50 shrink-0"
     />
   );
 }

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -213,7 +213,10 @@ function collapsedCounts(
       const type = parts[item.index]?.type;
       if (type === "text") {
         messages++;
-      } else if (type === "dynamic-tool" || type?.startsWith("tool-")) {
+      } else if (
+        (type === "dynamic-tool" || type?.startsWith("tool-")) &&
+        type !== "tool-todo_write"
+      ) {
         toolCalls++;
       }
     }
@@ -415,6 +418,8 @@ function MessagePart({
           toolMeta={getMeta(part.toolCallId)?._meta}
         />
       );
+    case "tool-todo_write":
+      return null;
     case "tool-user_ask":
       return (
         <UserAskPart


### PR DESCRIPTION
## What is this contribution about?

Redesigns the todo list UI with an animated SVG checkbox (stroke-dasharray draw-in on completion, animated strikethrough, pulsing border for in-progress items) using pure CSS — no `useEffect`, React 19 compliant. Also hides `todo_write` tool calls from the chat message parts so only the `TodosHighlight` banner surfaces todo state, matching the `user_ask` pattern.

## Screenshots/Demonstration

> Animated checkbox draws in when a todo completes, strikethrough animates across the label, and in-progress items show a pulsing border. The "N tool calls" collapsed header no longer counts `todo_write` calls.

## How to Test

1. Start a multi-step chat that triggers `todo_write`
2. Verify no "Todo Write" entries appear in the collapsed tool-calls list
3. Expand the todos highlight — confirm animated checkboxes, strikethrough on completed items, and pulsing border on in-progress items

## Migration Notes

None.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an animated checkbox UI for todos and hides `todo_write` tool calls from the chat stream. This keeps chat focused while the Todos highlight surfaces state.

- New Features
  - Animated todo checkbox: CSS-only SVG tick, pulsing border for in-progress, and delayed strikethrough on completion. No `useEffect`; React 19 friendly.
  - Chat behavior: Excludes `tool-todo_write` from collapsed counts and rendering, so only `TodosHighlight` shows todo state (consistent with `user_ask`).

<sup>Written for commit 88e9d13565e9c6f567aeb2b2e254b1442aca3831. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

