### PR TITLE
fix(sandbox/daemon): resolve branch via ls-remote before cloning

### DIFF
--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Config } from "../types";
+import { spawnClone } from "./clone";
+
+/**
+ * Creates a bare "origin" git repo with two branches:
+ *   - main      → contains README.md
+ *   - feature/x → contains README.md + feature.txt (branched from main+1)
+ *
+ * Returned `url` is a `file://` URL safe to use as a clone source.
+ */
+function setupBareRepo(): { url: string; root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "clonetest-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+  writeFileSync(join(seed, "README.md"), "hello\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} checkout -b feature/x`, gitOpts);
+  writeFileSync(join(seed, "feature.txt"), "feature\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m feature`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push origin feature/x`, gitOpts);
+  // Make `main` the default branch the bare repo's HEAD points at, so a clone
+  // without --branch lands on main.
+  execSync(
+    `git ${gitcfg} -C ${bare} symbolic-ref HEAD refs/heads/main`,
+    gitOpts,
+  );
+  return {
+    url: `file://${bare}`,
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function currentBranch(repoDir: string): string {
+  return execSync(`git -C ${repoDir} rev-parse --abbrev-ref HEAD`)
+    .toString()
+    .trim();
+}
+
+function makeConfig(
+  repoDir: string,
+  cloneUrl: string,
+  branch?: string,
+): Config {
+  return {
+    git: {
+      repository: { cloneUrl, ...(branch ? { branch } : {}) },
+    },
+    application: {},
+    repoDir,
+  } as unknown as Config;
+}
+
+describe("spawnClone", () => {
+  it("clones the target branch directly when it exists on remote", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url, "feature/x"),
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      expect(currentBranch(repoDir)).toBe("feature/x");
+      // The clone landed on feature/x — the file unique to that branch is present.
+      expect(existsSync(join(repoDir, "feature.txt"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("clones default and forks a local branch when target is missing on remote", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url, "feature/new"),
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      // Local branch was created from default (main); feature/x's exclusive
+      // file should NOT be present, README.md (from main) should be.
+      expect(currentBranch(repoDir)).toBe("feature/new");
+      expect(existsSync(join(repoDir, "README.md"))).toBe(true);
+      expect(existsSync(join(repoDir, "feature.txt"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("clones the default branch when no branch is specified", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url),
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      expect(currentBranch(repoDir)).toBe("main");
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("fails with a non-zero exit when ls-remote cannot reach the remote", async () => {
+    const { root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      // file:// URL pointing at a path that doesn't exist — ls-remote returns
+      // a fatal error (not exit 2), so spawnClone must surface a non-zero
+      // exit code instead of silently falling through to a local fork.
+      const code = await spawnClone({
+        config: makeConfig(
+          repoDir,
+          "file:///nonexistent/path/to/repo.git",
+          "feature/x",
+        ),
+        onChunk: () => {},
+      });
+      expect(code).not.toBe(0);
+      expect(existsSync(repoDir)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("clones into a non-empty dir without .git via init+fetch", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      mkdirSync(repoDir);
+      // Pre-populate with a non-.git file — mimics .decocms/daemon.json being
+      // written before the first clone. spawnClone must fall back to
+      // init + fetch + checkout instead of `git clone`.
+      writeFileSync(join(repoDir, "marker.txt"), "preexisting\n");
+      const code = await spawnClone({
+        config: makeConfig(repoDir, url, "feature/x"),
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      expect(currentBranch(repoDir)).toBe("feature/x");
+      expect(existsSync(join(repoDir, "marker.txt"))).toBe(true);
+      expect(existsSync(join(repoDir, "feature.txt"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+});

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync } from "node:fs";
+import { isSyntheticBranch } from "../constants";
 import type { Config } from "../types";
 import { spawnSetupStep } from "./spawn-step";
 
@@ -90,6 +91,12 @@ async function runNetworkStep(cmd: string, deps: CloneDeps): Promise<number> {
   return 1;
 }
 
+// `git ls-remote --exit-code` returns 2 when the remote was reachable but no
+// matching ref was found. Any other non-zero exit is a real failure (auth,
+// DNS, TLS, …) that we surface to the caller instead of silently falling
+// through to a fork-from-default fallback.
+const LS_REMOTE_NO_MATCH = 2;
+
 /** Resolves to exit code (0 on success). Emits chunks via `onChunk`. */
 export async function spawnClone(deps: CloneDeps): Promise<number> {
   const { config } = deps;
@@ -105,8 +112,44 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
     return 1;
   }
 
-  const gc = `git -c safe.directory='*' -c credential.helper=`;
+  const gc = `git -c safe.directory='*' -c credential.helper= -c http.connectTimeout=10 -c http.lowSpeedLimit=1 -c http.lowSpeedTime=10`;
   const dir = config.repoDir;
+
+  const requestedBranch = config.git?.repository?.branch;
+  const branch =
+    requestedBranch && !isSyntheticBranch(requestedBranch)
+      ? requestedBranch
+      : null;
+
+  // Decide which branch to put the working tree on. `ls-remote --exit-code`
+  // gives deterministic semantics that replace the old silent "try fetch,
+  // fall through on any failure" probe:
+  //   0   → branch exists on origin → clone it directly with --branch
+  //   2   → origin reachable but branch absent → clone default, fork locally
+  //   any → real failure → surface to caller
+  let branchOnRemote: string | null = null;
+  let branchToForkLocally: string | null = null;
+  if (branch) {
+    const probe = await runNetworkStep(
+      `${gc} ls-remote --exit-code --heads ${cloneUrl} ${branch}`,
+      deps,
+    );
+    if (probe === 0) {
+      branchOnRemote = branch;
+    } else if (probe === LS_REMOTE_NO_MATCH) {
+      deps.onChunk(
+        "setup",
+        `[clone] branch '${branch}' not on remote; cloning default and forking locally\r\n`,
+      );
+      branchToForkLocally = branch;
+    } else {
+      deps.onChunk(
+        "setup",
+        `\r\n[clone] ls-remote failed (exit ${probe}); aborting clone\r\n`,
+      );
+      return probe;
+    }
+  }
 
   // When repoDir already has files (e.g. .decocms/daemon.json written before
   // the first clone) but no .git, `git clone` would fail with "already exists
@@ -121,13 +164,35 @@ export async function spawnClone(deps: CloneDeps): Promise<number> {
       const code = await runStep(step, deps);
       if (code !== 0) return code;
     }
+    const fetchRef = branchOnRemote
+      ? `+refs/heads/${branchOnRemote}:refs/remotes/origin/${branchOnRemote}`
+      : "HEAD";
     const fetchCode = await runNetworkStep(
-      `${gc} -C ${dir} fetch --depth 1 origin HEAD`,
+      `${gc} -C ${dir} fetch --depth 1 origin ${fetchRef}`,
       deps,
     );
     if (fetchCode !== 0) return fetchCode;
-    return runStep(`${gc} -C ${dir} checkout FETCH_HEAD`, deps);
+    const checkoutCmd = branchOnRemote
+      ? `${gc} -C ${dir} checkout -B ${branchOnRemote} refs/remotes/origin/${branchOnRemote}`
+      : `${gc} -C ${dir} checkout FETCH_HEAD`;
+    const checkoutCode = await runStep(checkoutCmd, deps);
+    if (checkoutCode !== 0) return checkoutCode;
+    if (branchToForkLocally) {
+      return runStep(
+        `${gc} -C ${dir} checkout -B ${branchToForkLocally}`,
+        deps,
+      );
+    }
+    return 0;
   }
 
-  return runNetworkStep(`${gc} clone --depth 1 ${cloneUrl} ${dir}`, deps);
+  const cloneCmd = branchOnRemote
+    ? `${gc} clone --depth 1 --branch ${branchOnRemote} ${cloneUrl} ${dir}`
+    : `${gc} clone --depth 1 ${cloneUrl} ${dir}`;
+  const cloneCode = await runNetworkStep(cloneCmd, deps);
+  if (cloneCode !== 0) return cloneCode;
+  if (branchToForkLocally) {
+    return runStep(`${gc} -C ${dir} checkout -B ${branchToForkLocally}`, deps);
+  }
+  return 0;
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -537,37 +537,60 @@ export class SetupOrchestrator {
     const repoDir = this.deps.bootConfig.repoDir;
     if (!repoDir) return;
     const onChunk = (_src: "setup", data: string) => this.rawChunk(data);
-    const silent = (_src: "setup", _data: string) => {};
     // http.connectTimeout: fail fast on DNS/TCP failures (seconds).
     // lowSpeedLimit/Time: abort if transfer rate stays below 1 B/s for 10 s.
     const gc = `git -c safe.directory='*' -c http.connectTimeout=10 -c http.lowSpeedLimit=1 -c http.lowSpeedTime=10 -C ${repoDir}`;
 
-    // Silent probe — failure is expected when branch doesn't exist on remote yet.
-    // After a successful fetch, refs/remotes/origin/<branch> exists and
-    // `checkout -f` will auto-create the local tracking branch from it, so a
-    // second `fetch origin branch:branch` is not needed.
+    // Fresh-clone path already lands on the target branch (clone.ts uses
+    // --branch when ls-remote reports it exists). Short-circuit so gitSetup
+    // doesn't re-fetch what we just cloned.
+    try {
+      const head = gitSync(["rev-parse", "--abbrev-ref", "HEAD"], {
+        cwd: repoDir,
+      });
+      if (head === branch) return;
+    } catch {
+      // No HEAD yet / not a repo — fall through and let the checkout fail loudly.
+    }
+
+    // ls-remote --exit-code distinguishes "absent" from "broken":
+    //   0  → branch exists on origin
+    //   2  → origin reachable, no matching ref
+    //   *  → real failure (auth/DNS/TLS) — surface to caller
     const probe = await spawnSetupStep(
-      `${gc} fetch origin +refs/heads/${branch}:refs/remotes/origin/${branch}`,
-      silent,
+      `${gc} ls-remote --exit-code --heads origin ${branch}`,
+      onChunk,
     );
 
     if (probe === 0) {
-      const code = await spawnSetupStep(`${gc} checkout -f ${branch}`, onChunk);
-      if (code !== 0)
-        throw new Error(`git checkout -f ${branch} exited ${code}`);
+      const fetchCode = await spawnSetupStep(
+        `${gc} fetch --depth 1 origin +refs/heads/${branch}:refs/remotes/origin/${branch}`,
+        onChunk,
+      );
+      if (fetchCode !== 0)
+        throw new Error(`git fetch origin ${branch} exited ${fetchCode}`);
+      // `checkout -B` creates-or-resets, avoiding DWIM ambiguity on slash-named
+      // branches in shallow clones.
+      const checkoutCode = await spawnSetupStep(
+        `${gc} checkout -B ${branch} refs/remotes/origin/${branch}`,
+        onChunk,
+      );
+      if (checkoutCode !== 0)
+        throw new Error(`git checkout -B ${branch} exited ${checkoutCode}`);
       return;
     }
 
-    // Branch not on remote — try local checkout (silent; might fail), then create.
-    this.chunk(
-      `[orchestrator] branch not found on remote, checking out locally\r\n`,
-    );
-    if ((await spawnSetupStep(`${gc} checkout -f ${branch}`, silent)) === 0)
+    if (probe === 2) {
+      this.chunk(
+        `[orchestrator] branch '${branch}' not on remote; creating local branch from HEAD\r\n`,
+      );
+      const code = await spawnSetupStep(`${gc} checkout -B ${branch}`, onChunk);
+      if (code !== 0)
+        throw new Error(`git checkout -B ${branch} exited ${code}`);
       return;
+    }
 
-    this.chunk(`[orchestrator] creating new local branch: ${branch}\r\n`);
-    const code = await spawnSetupStep(`${gc} checkout -b ${branch}`, onChunk);
-    if (code !== 0) throw new Error(`git checkout -b ${branch} exited ${code}`);
+    throw new Error(`git ls-remote --heads origin ${branch} exited ${probe}`);
   }
 }
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## What is this contribution about?

The daemon's clone+checkout flow was producing `error: pathspec '<branch>' did not match any file(s) known to git` on boots where the branch genuinely existed upstream. Root cause: the daemon cloned the remote default, then ran a **silent** `fetch + checkout -f` probe whose failure modes (auth, DNS, shallow-clone DWIM quirks) were swallowed, leaving the failed `git checkout` to surface a misleading "pathspec" error.

This PR replaces that probe-then-fallback dance with `git ls-remote --exit-code --heads`, which has deterministic exit codes — `0` (exists), `2` (reachable but absent), anything else (real failure). Based on the result we either clone with `--branch` directly (one round trip, no follow-up fetch), fork from default locally with `checkout -B`, or surface the real exit code. `checkoutBranch` in the orchestrator gets the same treatment plus a HEAD short-circuit so post-clone re-entry from `gitSetup` doesn't redo the network call.

## How to Test

1. `bun test packages/sandbox/daemon/setup/clone.test.ts` — 5 new tests against a local bare repo cover: branch exists upstream → cloned directly; branch missing upstream → forked locally from default; no branch specified → default clone; ls-remote can't reach remote → non-zero exit; pre-populated repoDir without `.git` → init+fetch path.
2. `bun test packages/sandbox/daemon/setup/orchestrator.test.ts` — existing lifecycle tests still pass; the failure-path test now produces the new (clearer) error `git ls-remote --heads origin <branch> exited 128`.
3. End-to-end: boot a daemon against any cloneUrl with `git.repository.branch` set to a branch that exists upstream → should land on that branch directly, no spurious pathspec error in logs.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed) — N/A
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes branch checkout failures by resolving the target branch with git ls-remote before cloning. Clones now land on the right branch (or fork locally) and failures surface clear, actionable errors instead of “pathspec” noise.

- **Bug Fixes**
  - Replace silent fetch+checkout probe with `git ls-remote --exit-code --heads` (0=exists, 2=absent, other=failure).
  - Clone flow: use `--branch` when upstream exists; otherwise clone default and `checkout -B` to fork locally. Handles non-empty dirs via init+fetch.
  - Orchestrator: short-circuits when HEAD already matches; uses `ls-remote`, depth-1 fetch with explicit refspec, and `checkout -B` from `refs/remotes/origin/<branch>`; fails loudly on real errors.
  - Tests: add coverage for upstream-present, upstream-absent, no-branch, unreachable remote, and non-empty dir paths. Existing lifecycle tests still pass with clearer errors.

<sup>Written for commit d2fa964747d9bc89730d208527ee971f29026e00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

