### PR TITLE
fix(user-ask): persist 'Something else' draft across option selections

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/get-user-ask-response.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/get-user-ask-response.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getUserAskResponse } from "./get-user-ask-response";
+
+describe("getUserAskResponse", () => {
+  test("returns empty string for undefined value", () => {
+    expect(getUserAskResponse(undefined)).toBe("");
+  });
+
+  test("returns response for text/confirm shape", () => {
+    expect(getUserAskResponse({ response: "hello" })).toBe("hello");
+    expect(getUserAskResponse({ response: "" })).toBe("");
+  });
+
+  test("returns option when a predefined choice is selected", () => {
+    expect(getUserAskResponse({ option: "Option 1", draft: "" })).toBe(
+      "Option 1",
+    );
+  });
+
+  test("prefers option over draft when both are present", () => {
+    expect(getUserAskResponse({ option: "Option 1", draft: "foo" })).toBe(
+      "Option 1",
+    );
+  });
+
+  test("returns draft when option is null", () => {
+    expect(getUserAskResponse({ option: null, draft: "foo" })).toBe("foo");
+  });
+
+  test("returns empty string when option is null and draft is empty", () => {
+    expect(getUserAskResponse({ option: null, draft: "" })).toBe("");
+  });
+});

--- a/apps/mesh/src/web/components/chat/highlight/get-user-ask-response.ts
+++ b/apps/mesh/src/web/components/chat/highlight/get-user-ask-response.ts
@@ -1,0 +1,24 @@
+/**
+ * Form value shape for a single user-ask question.
+ *
+ * - text/confirm questions store `{ response }`
+ * - choice questions store `{ option, draft }` where `option` is the
+ *   currently selected predefined option (or null), and `draft` is the
+ *   user's typed "Something else..." text (persisted across option
+ *   selections).
+ */
+export type UserAskQuestionValue =
+  | { response: string }
+  | { option: string | null; draft: string };
+
+/**
+ * Derive the response string that gets submitted for a question.
+ * For choice questions, prefer the selected option; fall back to the draft.
+ */
+export function getUserAskResponse(
+  value: UserAskQuestionValue | undefined,
+): string {
+  if (!value) return "";
+  if ("response" in value) return value.response;
+  return value.option ?? value.draft;
+}

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
@@ -11,8 +11,17 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Edit02, MessageQuestionCircle } from "@untitledui/icons";
 import { useEffect, useRef, useState } from "react";
-import { type Control, type FieldValues, useForm } from "react-hook-form";
+import {
+  type Control,
+  type FieldValues,
+  useController,
+  useForm,
+} from "react-hook-form";
 import type { UserAskToolPart } from "../types";
+import {
+  getUserAskResponse,
+  type UserAskQuestionValue,
+} from "./get-user-ask-response";
 import { Pagination } from "./pagination";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { buildCombinedSchema } from "./user-ask-schemas";
@@ -20,8 +29,13 @@ import { buildCombinedSchema } from "./user-ask-schemas";
 /** Inferred from UserAskToolPart so we don't import the backend module directly. */
 type UserAskInput = NonNullable<UserAskToolPart["input"]>;
 
-// Type for the combined form values: { [toolCallId]: { response: string } }
-type CombinedFormValues = Record<string, { response: string }>;
+// A loose shape — each question's value is one of the UserAskQuestionValue
+// variants. We use a loose record type here because react-hook-form's generic
+// inference doesn't play well with discriminated unions at nested paths.
+type CombinedFormValues = Record<
+  string,
+  { response?: string; option?: string | null; draft?: string }
+>;
 
 // Shared props for all question input field components
 interface FieldInputProps {
@@ -103,112 +117,97 @@ function ChoiceInput({
   name,
   options,
 }: FieldInputProps & { options: string[] }) {
-  const [isCustom, setIsCustom] = useState(false);
-  const customInputRef = useRef<HTMLInputElement>(null);
-  const fieldRef = useRef<{ onChange: (v: string) => void } | null>(null);
+  const { field: optionField } = useController({
+    control,
+    name: `${name}.option`,
+    defaultValue: null,
+  });
+  const { field: draftField } = useController({
+    control,
+    name: `${name}.draft`,
+    defaultValue: "",
+  });
+
+  const optionValue = optionField.value as string | null;
+  const draftValue = (draftField.value as string | undefined) ?? "";
 
   useNumberKeyShortcut(options.length, (index) => {
-    fieldRef.current?.onChange(options[index] ?? "");
-    setIsCustom(false);
+    const option = options[index];
+    if (option != null) optionField.onChange(option);
   });
 
   if (options.length === 0) return null;
 
+  const isCustomActive = optionValue === null;
+
   return (
-    <FormField
-      control={control}
-      name={name}
-      render={({ field }) => {
-        fieldRef.current = field;
-        const isCustomValue =
-          isCustom || (!!field.value && !options.includes(field.value));
-
-        return (
-          <FormItem>
-            <FormControl>
-              <div
-                className="flex flex-col px-2"
-                role="group"
-                aria-label="Choice options"
+    <FormItem>
+      <FormControl>
+        <div
+          className="flex flex-col px-2"
+          role="group"
+          aria-label="Choice options"
+        >
+          {options.map((option, index) => {
+            const isSelected = optionValue === option;
+            return (
+              <button
+                key={`${index}-${option}`}
+                type="button"
+                onClick={() => optionField.onChange(option)}
+                className={cn(
+                  "flex items-center gap-3 px-2 py-3 rounded-lg text-left transition-colors w-full",
+                  isSelected && "bg-accent/50",
+                  !isSelected && "hover:bg-accent/30",
+                )}
+                aria-label={`Select ${option}`}
               >
-                {options.map((option, index) => {
-                  const isSelected = field.value === option;
-                  return (
-                    <button
-                      key={`${index}-${option}`}
-                      type="button"
-                      onClick={() => {
-                        field.onChange(option ?? "");
-                        setIsCustom(false);
-                      }}
-                      className={cn(
-                        "flex items-center gap-3 px-2 py-3 rounded-lg text-left transition-colors w-full",
-                        isSelected && "bg-accent/50",
-                        !isSelected && "hover:bg-accent/30",
-                      )}
-                      aria-label={`Select ${option}`}
-                    >
-                      <span
-                        className={cn(
-                          "flex items-center justify-center size-6 rounded-md text-sm shrink-0",
-                          isSelected
-                            ? "bg-chart-1 text-white"
-                            : "bg-muted text-foreground",
-                        )}
-                      >
-                        {index + 1}
-                      </span>
-                      <span className="text-sm text-foreground truncate">
-                        {option}
-                      </span>
-                    </button>
-                  );
-                })}
-
-                {/* "Something else..." — this IS the input */}
-                <div
+                <span
                   className={cn(
-                    "flex items-center gap-3 px-2 py-3 rounded-lg transition-colors w-full cursor-text",
-                    isCustomValue && "bg-accent/50",
-                    !isCustomValue && "hover:bg-accent/30",
+                    "flex items-center justify-center size-6 rounded-md text-sm shrink-0",
+                    isSelected
+                      ? "bg-chart-1 text-white"
+                      : "bg-muted text-foreground",
                   )}
-                  onClick={() => {
-                    setIsCustom(true);
-                    // Clear value if it was a predefined option
-                    if (options.includes(field.value)) {
-                      field.onChange("");
-                    }
-                    // Focus the hidden input
-                    setTimeout(() => customInputRef.current?.focus(), 0);
-                  }}
                 >
-                  <span className="flex items-center justify-center size-6 rounded-md bg-muted shrink-0">
-                    <Edit02 size={16} className="text-muted-foreground" />
-                  </span>
-                  {isCustomValue ? (
-                    <input
-                      ref={customInputRef}
-                      type="text"
-                      value={field.value}
-                      onChange={(e) => field.onChange(e.target.value)}
-                      placeholder="Something else..."
-                      autoFocus
-                      aria-label="Custom choice input"
-                      className="flex-1 text-sm bg-transparent outline-none placeholder:text-foreground/25 text-foreground min-w-0"
-                    />
-                  ) : (
-                    <span className="text-sm text-foreground/25">
-                      Something else...
-                    </span>
-                  )}
-                </div>
-              </div>
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        );
-      }}
-    />
+                  {index + 1}
+                </span>
+                <span className="text-sm text-foreground truncate">
+                  {option}
+                </span>
+              </button>
+            );
+          })}
+
+          <label
+            className={cn(
+              "flex items-center gap-3 px-2 py-3 rounded-lg transition-colors w-full cursor-text",
+              isCustomActive && "bg-accent/50",
+              !isCustomActive && "hover:bg-accent/30",
+            )}
+          >
+            <span className="flex items-center justify-center size-6 rounded-md bg-muted shrink-0">
+              <Edit02 size={16} className="text-muted-foreground" />
+            </span>
+            <input
+              type="text"
+              value={isCustomActive ? draftValue : ""}
+              onChange={(e) => {
+                draftField.onChange(e.target.value);
+                if (optionValue !== null) optionField.onChange(null);
+              }}
+              onFocus={() => {
+                if (optionValue !== null) optionField.onChange(null);
+              }}
+              placeholder="Something else..."
+              aria-label="Custom choice input"
+              className="flex-1 text-sm bg-transparent outline-none placeholder:text-foreground/25 text-foreground min-w-0"
+            />
+          </label>
+        </div>
+      </FormControl>
+      <FormMessage />
+    </FormItem>
   );
 }
 
@@ -286,25 +285,29 @@ function ConfirmInput({ control, name }: FieldInputProps) {
 interface QuestionInputProps {
   input: UserAskInput;
   control: Control<FieldValues>;
-  name: string;
+  toolCallId: string;
 }
 
-function QuestionInput({ input, control, name }: QuestionInputProps) {
+function QuestionInput({ input, control, toolCallId }: QuestionInputProps) {
   switch (input.type) {
     case "text":
       return (
-        <TextInput control={control} name={name} placeholder={input.default} />
+        <TextInput
+          control={control}
+          name={`${toolCallId}.response`}
+          placeholder={input.default}
+        />
       );
     case "choice":
       return (
         <ChoiceInput
           control={control}
-          name={name}
+          name={toolCallId}
           options={(input.options?.filter(Boolean) ?? []) as string[]}
         />
       );
     case "confirm":
-      return <ConfirmInput control={control} name={name} />;
+      return <ConfirmInput control={control} name={`${toolCallId}.response`} />;
     default:
       return null;
   }
@@ -332,37 +335,55 @@ function UserAskPrompt({ parts, onSubmit }: UserAskPromptProps) {
   const form = useForm<CombinedFormValues>({
     resolver: zodResolver(schema) as never,
     defaultValues: Object.fromEntries(
-      parts.map((p) => [p.toolCallId, { response: "" }]),
+      parts.map((p) => {
+        const input = p.input as UserAskInput | undefined;
+        if (input?.type === "choice") {
+          return [p.toolCallId, { option: null, draft: "" }];
+        }
+        return [p.toolCallId, { response: "" }];
+      }),
     ),
   });
 
   const values = form.watch();
   const currentIndex = parts.findIndex((p) => p.toolCallId === activeTab);
-  const currentAnswered = !!values[activeTab]?.response;
-  const allAnswered = parts.every((p) => !!values[p.toolCallId]?.response);
+  const currentAnswered = !!getUserAskResponse(
+    values[activeTab] as UserAskQuestionValue | undefined,
+  );
+  const allAnswered = parts.every(
+    (p) =>
+      !!getUserAskResponse(
+        values[p.toolCallId] as UserAskQuestionValue | undefined,
+      ),
+  );
 
   const submitAll = (data: CombinedFormValues) => {
     for (const part of parts) {
-      const response = data[part.toolCallId]?.response;
+      const response = getUserAskResponse(
+        data[part.toolCallId] as UserAskQuestionValue | undefined,
+      );
       if (response) {
         onSubmit(part, response);
       }
     }
   };
 
-  /** Find the first unanswered part (excluding current), or null if all filled. */
   const findNextUnanswered = (formValues: CombinedFormValues) =>
     parts.find(
-      (p) => !formValues[p.toolCallId]?.response && p.toolCallId !== activeTab,
+      (p) =>
+        !getUserAskResponse(
+          formValues[p.toolCallId] as UserAskQuestionValue | undefined,
+        ) && p.toolCallId !== activeTab,
     ) ?? null;
 
-  /**
-   * Shared logic for both Skip and the primary button:
-   * if all questions are answered → submit the form, otherwise go to next unanswered tab.
-   */
   const advanceOrSubmit = () => {
     const latest = form.getValues();
-    const everyAnswered = parts.every((p) => !!latest[p.toolCallId]?.response);
+    const everyAnswered = parts.every(
+      (p) =>
+        !!getUserAskResponse(
+          latest[p.toolCallId] as UserAskQuestionValue | undefined,
+        ),
+    );
     if (everyAnswered) {
       form.handleSubmit(submitAll)();
     } else {
@@ -372,9 +393,14 @@ function UserAskPrompt({ parts, onSubmit }: UserAskPromptProps) {
   };
 
   const handleSkip = () => {
-    // Fill the current question with the skip sentence
-    form.setValue(`${activeTab}.response`, "user has skip this question");
-    // Then advance or submit
+    const activePart = parts.find((p) => p.toolCallId === activeTab);
+    const skipText = "user has skip this question";
+    if (activePart?.input?.type === "choice") {
+      form.setValue(`${activeTab}.option` as never, null as never);
+      form.setValue(`${activeTab}.draft` as never, skipText as never);
+    } else {
+      form.setValue(`${activeTab}.response` as never, skipText as never);
+    }
     advanceOrSubmit();
   };
 
@@ -442,7 +468,7 @@ function UserAskPrompt({ parts, onSubmit }: UserAskPromptProps) {
             <QuestionInput
               input={part.input as UserAskInput}
               control={form.control}
-              name={`${part.toolCallId}.response`}
+              toolCallId={part.toolCallId}
             />
           </CollapsibleHighlight>
         </form>
@@ -473,7 +499,7 @@ function UserAskPrompt({ parts, onSubmit }: UserAskPromptProps) {
                 <QuestionInput
                   input={part.input as UserAskInput}
                   control={form.control}
-                  name={`${part.toolCallId}.response`}
+                  toolCallId={part.toolCallId}
                 />
               </TabsContent>
             ))}

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-schemas.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-schemas.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { buildCombinedSchema } from "./user-ask-schemas";
+
+const choicePart = {
+  toolCallId: "q1",
+  input: {
+    type: "choice" as const,
+    prompt: "Pick one",
+    options: ["A", "B"],
+  },
+};
+
+const textPart = {
+  toolCallId: "q2",
+  input: { type: "text" as const, prompt: "Type something" },
+};
+
+const confirmPart = {
+  toolCallId: "q3",
+  input: { type: "confirm" as const, prompt: "OK?" },
+};
+
+describe("buildCombinedSchema — choice", () => {
+  test("accepts a value with a non-null option", () => {
+    const schema = buildCombinedSchema([choicePart]);
+    const result = schema.safeParse({
+      q1: { option: "A", draft: "" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a value with non-empty draft and null option", () => {
+    const schema = buildCombinedSchema([choicePart]);
+    const result = schema.safeParse({
+      q1: { option: null, draft: "foo" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a value with null option and empty draft", () => {
+    const schema = buildCombinedSchema([choicePart]);
+    const result = schema.safeParse({
+      q1: { option: null, draft: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("preserves draft when option is set (round-trip)", () => {
+    const schema = buildCombinedSchema([choicePart]);
+    const value = { q1: { option: "A", draft: "foo" } };
+    const parsed = schema.parse(value);
+    expect(parsed.q1).toEqual({ option: "A", draft: "foo" });
+  });
+});
+
+describe("buildCombinedSchema — text and confirm unchanged", () => {
+  test("text requires a non-empty response", () => {
+    const schema = buildCombinedSchema([textPart]);
+    expect(schema.safeParse({ q2: { response: "" } }).success).toBe(false);
+    expect(schema.safeParse({ q2: { response: "hi" } }).success).toBe(true);
+  });
+
+  test("confirm only accepts yes/no", () => {
+    const schema = buildCombinedSchema([confirmPart]);
+    expect(schema.safeParse({ q3: { response: "maybe" } }).success).toBe(false);
+    expect(schema.safeParse({ q3: { response: "yes" } }).success).toBe(true);
+    expect(schema.safeParse({ q3: { response: "no" } }).success).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-schemas.ts
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-schemas.ts
@@ -8,9 +8,14 @@ const textResponseSchema = z.object({
   response: z.string().min(1, "Response is required"),
 });
 
-const choiceResponseSchema = z.object({
-  response: z.string().min(1, "Please select or enter an option"),
-});
+const choiceResponseSchema = z
+  .object({
+    option: z.string().nullable(),
+    draft: z.string(),
+  })
+  .refine((v) => (v.option ?? v.draft).length > 0, {
+    message: "Please select or enter an option",
+  });
 
 const confirmResponseSchema = z.object({
   response: z.enum(["yes", "no"]),


### PR DESCRIPTION
## Summary

- Fix bug where typing in the choice question's "Something else..." input was wiped when the user clicked a predefined option.
- Move the custom draft into form state (`{ option, draft }` per choice question) so it persists across selections and is restored on focus (mouse, keyboard tab, mobile tap).
- Refactor `ChoiceInput` to be deterministic — no `useState`, `useRef`, `setTimeout`, `customInputRef`, or conditional `<input>`/`<span>` swap. Single source of truth lives in react-hook-form.

## How it works

A choice question's form value changes from `{ response: string }` to `{ option: string | null; draft: string }`. A new `getUserAskResponse()` helper derives the submitted response (`option ?? draft`). The parent uses it uniformly for "is answered" checks, submit, and skip. Text and confirm questions keep their existing shape.

Visual rule (declarative): the input shows `draft` when `option === null`, otherwise `""`. Picking an option leaves `draft` untouched in form state. Focusing the input flips `option` back to `null`, restoring the draft.

## Test plan

- [x] `bun run fmt:check` clean
- [x] `bun run check` clean across all workspaces
- [x] `bun run lint` 0 warnings / 0 errors
- [x] `bun test apps/mesh/src/web/components/chat/highlight/` — 22/22 pass (helper + schema unit tests added)
- [ ] Manual browser verification of the choice question flow:
  - [ ] Type "foo" → click an option → click back into input → "foo" reappears
  - [ ] Keyboard tab into the input restores the draft
  - [ ] Mobile tap restores the draft
  - [ ] Number-key shortcuts 1–9 still pick options
  - [ ] Skip on a choice question submits "user has skip this question"
  - [ ] Submit with an option selected sends the option (not the draft)
  - [ ] Submit with no option but non-empty draft sends the draft

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the "Something else..." draft in choice questions and drive `ChoiceInput` from form state for predictable behavior. Submissions now use `getUserAskResponse` to send the selected option or the draft.

- **Bug Fixes**
  - Draft text no longer clears when picking an option; focusing the input restores it.
  - Submit sends the selected option, otherwise the draft; Skip fills "user has skip this question".

- **Refactors**
  - Choice value now stores `{ option: string | null; draft: string }`; added `getUserAskResponse` to derive the submitted value.
  - Rewrote `ChoiceInput` to use `react-hook-form` only (no local state/refs/timeouts); number-key shortcuts still work.
  - Updated `zod` schema and added unit tests for schema and helper.

<sup>Written for commit d78d37da5a8b9f16c0d11aaefd12e67ac878a7ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

