### PR TITLE
fix(automations): enforce 5-minute minimum on minute-interval input

### DIFF
--- a/apps/mesh/src/web/components/automations/trigger-card.tsx
+++ b/apps/mesh/src/web/components/automations/trigger-card.tsx
@@ -92,7 +92,9 @@ export function TriggerCard({
 
   const handleCountSave = async (newCount: number) => {
     if (!interval) return;
-    const clamped = Math.max(1, newCount);
+    const minCount = interval.unit === "minutes" ? 5 : 1;
+    const clamped = Math.max(minCount, newCount);
+    if (clamped !== newCount) setCount(clamped);
     const newCron = buildCronFromInterval(clamped, interval.unit);
     if (newCron === trigger.cron_expression) return;
     try {
@@ -125,7 +127,7 @@ export function TriggerCard({
             <span className="text-sm text-muted-foreground">Every</span>
             <input
               type="number"
-              min={1}
+              min={interval.unit === "minutes" ? 5 : 1}
               value={count}
               onChange={(e) => setCount(parseInt(e.target.value) || 1)}
               onBlur={() => handleCountSave(count)}


### PR DESCRIPTION
## What is this contribution about?
The automation trigger UI lets users type any number for a cron interval, but the backend rejects anything below 300s (5 minutes). This makes the input's `min` attribute and the on-blur clamp respect that 5-minute floor — but only when the unit is "minutes". Hours/days/weeks keep `min=1` since their smallest step already exceeds the API limit.

## Screenshots/Demonstration
N/A — minor input validation change.

## How to Test
1. Open an automation with a cron trigger set to "Every N minutes".
2. Try to type `1` in the count input and blur — value should clamp to `5`.
3. Switch to hours/days/weeks — input min stays at `1`.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a 5-minute minimum for the "Every N minutes" automation trigger to match backend limits and prevent invalid saves. Other units keep a minimum of 1.

- **Bug Fixes**
  - Clamp minutes input to 5 on blur and update the field if lower.
  - Set dynamic `min` attribute: 5 for minutes, 1 for hours/days/weeks.

<sup>Written for commit 255d93dd79be197380f86ecb8c6161a96ed00dab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

