### PR TITLE
refactor(decopilot): unify dispatchRunAndWait on JetStream tail

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1165,7 +1165,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     storage: automationsStorage,
     dispatchRunFn: dispatchRunAndWait,
     meshContextFactory: automationContextFactory,
-    deps: { runRegistry, cancelBroadcast },
+    deps: { runRegistry, cancelBroadcast, streamBuffer },
   });
 
   // Must run before DBOS.launch() (which fires in index.ts after createApp).

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -250,13 +250,21 @@ export async function dispatchRun(
 }
 
 /**
- * Drain-to-completion: claim the run, drain `uiStream` internally until
- * the run finishes, return `{ taskId }`. The caller awaits the returned
- * promise to know the run is done.
+ * Drain-to-completion: claim the run, await the run's chunks until the
+ * `{done: true}` sentinel arrives, return `{ taskId }`. Used by callers
+ * that need to block on the agent's completion (DBOS workflow steps).
  *
- * Used by automations (DBOS workflow steps) that need to block on the
- * agent's completion. Does not require a `streamBuffer` — automations
- * don't have a subscriber to fan out to.
+ * When `deps.streamBuffer` is configured and the JetStream tail is
+ * available, the run pumps into JetStream like a normal HTTP run and this
+ * function drains the tail with `closeOnDone: true`. That gives the
+ * unification benefit: a queued user message and an automation share the
+ * same wire-level path, and any UI tailing the per-thread subject sees
+ * automation chunks too.
+ *
+ * If streamBuffer is unavailable (test mode, NATS down), falls back to
+ * reading `uiStream` directly so the function remains usable. The
+ * fallback drops chunks (no subscriber sees them) but the run still
+ * completes.
  */
 export async function dispatchRunAndWait(
   input: DispatchRunInput,
@@ -266,16 +274,48 @@ export async function dispatchRunAndWait(
   return traced(
     "decopilot.dispatchRunAndWait",
     async (rootSpan) => {
-      const { taskId, uiStream } = await prepareRun(input, ctx, deps, rootSpan);
-      const reader = uiStream.getReader();
-      try {
-        while (true) {
-          const { done } = await reader.read();
-          if (done) break;
+      const { taskId, uiStream, registrySignal } = await prepareRun(
+        input,
+        ctx,
+        deps,
+        rootSpan,
+      );
+
+      const buffer = deps.streamBuffer;
+      const tail = buffer
+        ? await buffer.createTailStream(taskId, input.abortSignal, {
+            deliverPolicy: "all",
+            closeOnDone: true,
+          })
+        : null;
+
+      if (buffer && tail) {
+        buffer.pump(uiStream, taskId, registrySignal);
+        const reader = tail.getReader();
+        try {
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        } finally {
+          reader.releaseLock();
         }
-      } finally {
-        reader.releaseLock();
+      } else {
+        // Fallback: no JetStream tail available — drain uiStream directly.
+        // Preserves the previous behavior for test environments and any
+        // deployment without NATS. No chunks are observable to tailers in
+        // this mode.
+        const reader = uiStream.getReader();
+        try {
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        } finally {
+          reader.releaseLock();
+        }
       }
+
       return { taskId };
     },
     dispatchRunSpanAttrs(input),

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -282,9 +282,16 @@ export async function dispatchRunAndWait(
       );
 
       const buffer = deps.streamBuffer;
+      // `deliverPolicy: "new"` here, not "all". The subscription is set
+      // up before `pump()` runs, so every chunk for *this* run lands in
+      // the "new" window. Replaying "all" could surface a stale
+      // `{done:true}` left on the subject by an earlier run that shared
+      // the same `taskId` (DBOS crash-recovery replay; later, user
+      // messages reusing the per-thread subject) and close the tail
+      // before this run produces any output.
       const tail = buffer
         ? await buffer.createTailStream(taskId, input.abortSignal, {
-            deliverPolicy: "all",
+            deliverPolicy: "new",
             closeOnDone: true,
           })
         : null;

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -260,6 +260,28 @@ describe("NatsStreamBuffer", () => {
       expect(stream).toBeNull();
     });
 
+    it("closes on the {done} sentinel when closeOnDone is set", async () => {
+      // Used by `dispatchRunAndWait` to block on a single run's completion.
+      // The default cross-run behavior must NOT apply here.
+      const { sub, push } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+
+      const stream = await buffer.createTailStream("task-1", undefined, {
+        closeOnDone: true,
+      });
+
+      push(encodeMsg({ p: "chunk-1" }));
+      push(encodeMsg({ p: "chunk-2" }));
+      push(encodeMsg({ done: true }));
+      // Any chunk published after `done` must not be observed by this
+      // subscriber — the stream is already terminating.
+      push(encodeMsg({ p: "after-done" }));
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual(["chunk-1", "chunk-2"]);
+      expect(sub.unsubscribe).toHaveBeenCalled();
+    });
+
     it("swallows the {done} sentinel and keeps tailing across runs", async () => {
       // Subscribe-model behavior: one connection covers multiple runs in
       // the thread. The producer's {done} marker between runs must not

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -162,6 +162,7 @@ export class NatsStreamBuffer implements StreamBuffer {
     signal?: AbortSignal,
     opts?: {
       deliverPolicy?: "all" | "new";
+      closeOnDone?: boolean;
     },
   ): Promise<ReadableStream | null> {
     const js = this.js;
@@ -169,6 +170,7 @@ export class NatsStreamBuffer implements StreamBuffer {
 
     const deliverPolicy =
       opts?.deliverPolicy === "new" ? DeliverPolicy.New : DeliverPolicy.All;
+    const closeOnDone = opts?.closeOnDone ?? false;
     const subj = streamSubject(taskId);
 
     let sub;
@@ -221,6 +223,11 @@ export class NatsStreamBuffer implements StreamBuffer {
           try {
             const data = JSON.parse(decoder.decode(msg.data));
             if (data.done) {
+              if (closeOnDone) {
+                cleanup();
+                controller.close();
+                return;
+              }
               // A run ended, but the subscription stays open for the next
               // run on this thread. Clients detect run boundaries from the
               // AI-SDK `{type: "finish"}` chunk in the data stream, not

--- a/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
@@ -50,12 +50,17 @@ export interface StreamBuffer {
    *   chunks published after the subscription is established (use when the
    *   thread is idle and we don't want to replay any stale tail of a
    *   recently-completed run).
+   * - `closeOnDone` (default `false`): when true, close the stream as soon
+   *   as a `{done: true}` sentinel arrives. Use for callers that want to
+   *   block on a single run (e.g. `dispatchRunAndWait`). Default `false`
+   *   preserves the cross-run continuation needed by `/attach`.
    */
   createTailStream(
     taskId: string,
     signal?: AbortSignal,
     opts?: {
       deliverPolicy?: "all" | "new";
+      closeOnDone?: boolean;
     },
   ): Promise<ReadableStream | null>;
 

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -109,7 +109,10 @@ export interface AutomationRuntime {
   storage: AutomationsStorage;
   dispatchRunFn: DispatchRunFn;
   meshContextFactory: MeshContextFactory;
-  deps: Pick<DispatchRunDeps, "runRegistry" | "cancelBroadcast">;
+  deps: Pick<
+    DispatchRunDeps,
+    "runRegistry" | "cancelBroadcast" | "streamBuffer"
+  >;
   runTimeoutMs?: number;
 }
 
@@ -284,12 +287,14 @@ async function dispatchRunAndWaitStep(
     }
     request.abortSignal = abortController.signal;
 
-    // dispatchRunAndWait drains uiStream internally and resolves when the run
-    // completes (or fails). Automations need this synchronous shape so
-    // the DBOS workflow step can record the run's terminal state.
+    // dispatchRunAndWait resolves when the run completes (or fails).
+    // Automations need this synchronous shape so the DBOS workflow step can
+    // record the run's terminal state. With streamBuffer wired through,
+    // automation chunks publish to the per-thread JetStream subject like
+    // user-message runs, so any UI tailing the thread sees them too.
     await rt.dispatchRunFn(request, meshCtx, {
       runRegistry: rt.deps.runRegistry,
-      streamBuffer: undefined,
+      streamBuffer: rt.deps.streamBuffer,
       cancelBroadcast: rt.deps.cancelBroadcast,
     });
     return {};


### PR DESCRIPTION
## Summary

- `dispatchRunAndWait` now pumps to JetStream and drains the per-thread tail (new `closeOnDone` option on `createTailStream`) instead of reading `uiStream` directly. Fallback to direct drain when streamBuffer is unavailable (test mode, no NATS).
- `streamBuffer` is now plumbed through `AutomationRuntime`, so automation chunks publish to the same per-thread JetStream subject user-message runs use. Any client tailing `/attach` for an automation thread sees its chunks live.
- No caller behavior changes — `dispatchRunAndWait` still blocks until the run terminates; this just unifies the wire-level path.

Sets the stage for routing user messages through a per-thread DBOS gate (follow-up PR).

## Test plan

- [x] `bun run check` clean across all workspaces
- [x] 384 decopilot + automation tests pass (new test for `closeOnDone` added)
- [x] Manual: user message + automation both streamed correctly end-to-end (verified on the parent branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `dispatchRunAndWait` on the per-thread JetStream tail so automation and user-message runs share the same path. Uses a new `closeOnDone` option to block until `{done: true}`, and falls back to draining `uiStream` when `streamBuffer`/NATS is unavailable. Also plumbs `streamBuffer` through `AutomationRuntime` so automation chunks publish to the per-thread subject and are visible to `/attach`.

- **Bug Fixes**
  - When tailing for `dispatchRunAndWait`, use `deliverPolicy: "new"` to ignore stale `{done: true}` from previous runs and prevent premature tail closure.

<sup>Written for commit 5c648100c1a0cd671c5140d3e266c8231ad3a292. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3375?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

