### PR TITLE
feat(decopilot): per-thread DBOS gate for user messages

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -107,6 +107,11 @@ import {
   reconcileAutomationSchedules,
   setAutomationRuntime,
 } from "../automations";
+import {
+  setThreadGateRuntime,
+  THREAD_GATE_PARTITION_CONCURRENCY,
+  THREAD_GATE_QUEUE,
+} from "../dispatch-queue";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import { dispatchRunAndWait } from "./routes/decopilot/dispatch-run";
 import {
@@ -1168,6 +1173,15 @@ export async function createApp(options: CreateAppOptions = {}) {
     deps: { runRegistry, cancelBroadcast, streamBuffer },
   });
 
+  // Same deps shape as automations — the per-thread gate calls
+  // `dispatchRunAndWait` once the queue lets a message through. Wiring
+  // happens before `DBOS.launch()` for the same reasons.
+  setThreadGateRuntime({
+    dispatchRunFn: dispatchRunAndWait,
+    meshContextFactory: automationContextFactory,
+    deps: { runRegistry, cancelBroadcast, streamBuffer },
+  });
+
   // Must run before DBOS.launch() (which fires in index.ts after createApp).
   registerMonitoringRetentionWorkflow();
 
@@ -1823,6 +1837,14 @@ export async function createApp(options: CreateAppOptions = {}) {
     });
     await DBOS.registerQueue(AUTOMATIONS_GLOBAL_QUEUE, {
       concurrency: AUTOMATIONS_GLOBAL_CONCURRENCY,
+    });
+    // Per-thread agent-run gate. Partition key = threadId, concurrency=1,
+    // so messages on the same thread serialize behind the active run while
+    // different threads progress in parallel. Used by user-message POSTs
+    // (Phase 3) and automation fires (Phase 5).
+    await DBOS.registerQueue(THREAD_GATE_QUEUE, {
+      partitionQueue: true,
+      concurrency: THREAD_GATE_PARTITION_CONCURRENCY,
     });
     await reconcileAutomationSchedules(automationsStorage);
   };

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1166,11 +1166,11 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Stash deps for the DBOS workflow body. Safe to call before DBOS.launch():
   // it only writes a module-level pointer, no DBOS API calls.
+  // The actual dispatch (and its dispatch-run deps) lives on the thread-gate
+  // runtime now — automations hand off via `awaitThreadRun`.
   setAutomationRuntime({
     storage: automationsStorage,
-    dispatchRunFn: dispatchRunAndWait,
     meshContextFactory: automationContextFactory,
-    deps: { runRegistry, cancelBroadcast, streamBuffer },
   });
 
   // Same deps shape as automations — the per-thread gate calls

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -36,6 +36,7 @@ import { PersistedRunConfigSchema, toModelsConfig } from "./run-config";
 import { StreamRequestSchema } from "./schemas";
 import type { ChatMessage, ModelsConfig } from "./types";
 import { dispatchRun, type DispatchRunInput } from "./dispatch-run";
+import { enqueueThreadRun } from "@/dispatch-queue";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import type { SqlThreadStorage } from "@/storage/threads";
 import { getPodId } from "@/core/pod-identity";
@@ -137,18 +138,13 @@ async function resolvePerRequestModels(
 }
 
 // ============================================================================
-// Shared dispatch path: validate → dispatchAndTrack
+// Shared validate path
 // ============================================================================
-
-interface DispatchDeps {
-  runRegistry: RunRegistry;
-  streamBuffer: StreamBuffer;
-  cancelBroadcast: CancelBroadcast;
-}
 
 /**
  * Parse + permission-check an HTTP request into a `DispatchRunInput`
- * ready to hand to `dispatchAndTrack` (or directly to `dispatchRun`).
+ * ready to hand to `enqueueThreadRun` (POST /messages) or `dispatchRun`
+ * (orphan-resume).
  *
  * Pure-ish: reads `c` for the request body and auth context, but no
  * downstream side effects. Throws `HTTPException` / `TierUnavailableError`
@@ -227,39 +223,6 @@ async function validate(
   };
 }
 
-/**
- * Run an HTTP-initiated dispatch and emit the `chat_message_started`
- * posthog event for it. Pairs with `validate` for the standard
- * route-handler flow:
- *
- *   const input = await validate(c, c.req.param("threadId"));
- *   const { taskId } = await dispatchAndTrack(input, ctx, deps);
- *
- * Telemetry lives here (not inside `dispatchRun`) so orphan-resume and
- * automation paths — which call `dispatchRun` directly without a fresh
- * user message — don't double-count `chat_message_started`.
- */
-async function dispatchAndTrack(
-  input: DispatchRunInput,
-  ctx: MeshContext,
-  deps: DispatchDeps,
-): Promise<{ taskId: string }> {
-  const { taskId } = await dispatchRun(input, ctx, deps);
-  posthog.capture({
-    distinctId: input.userId,
-    event: "chat_message_started",
-    groups: { organization: input.organizationId },
-    properties: {
-      organization_id: input.organizationId,
-      agent_id: input.agent,
-      mode: input.mode,
-      thread_id: taskId,
-      credential_id: input.models.credentialId,
-    },
-  });
-  return { taskId };
-}
-
 // ============================================================================
 // Route Handler
 // ============================================================================
@@ -301,29 +264,49 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
   });
 
   // ============================================================================
-  // Messages Endpoint — fire-and-forget run creation
+  // Messages Endpoint — enqueue a run on the per-thread gate queue
   // ============================================================================
   //
   // POST /:org/decopilot/threads/:threadId/messages
   //
-  // Claims the run, starts the JetStream pump, and returns
-  // `202 { taskId }` in milliseconds. The response carries no SSE body —
-  // the client is expected to be listening on
-  // `GET /:org/decopilot/attach/:threadId` to receive the run's chunks.
+  // Enqueues the run on `threadGateWorkflow` (partition=threadId,
+  // concurrency=1) and returns `202 { taskId }` in milliseconds. The
+  // response carries no SSE body — the client is expected to be listening
+  // on `GET /:org/decopilot/attach/:threadId` to receive chunks once the
+  // workflow dequeues and dispatches.
   //
-  // Decouples message submission from the long-lived stream connection,
-  // so a slow proxy / tab close / mobile network blip on the subscribe
-  // side never affects the producer, and multiple clients can observe
-  // the same thread without coordinating.
+  // If another run on this thread is already executing, the new message
+  // queues behind it and dispatches only after that run completes.
+  //
+  // Idempotency: when the client supplies an id on the request message,
+  // the workflow ID is derived from `<threadId>:<messageId>`, so a retry
+  // of the same POST collapses onto the existing workflow handle instead
+  // of double-firing.
 
   app.post("/:org/decopilot/threads/:threadId/messages", async (c) => {
     try {
       const input = await validate(c, c.req.param("threadId"));
-      const { taskId } = await dispatchAndTrack(input, c.get("meshContext"), {
-        runRegistry,
-        streamBuffer,
-        cancelBroadcast,
-      });
+      const taskId = input.taskId;
+      if (!taskId) {
+        // validate() always sets taskId from the URL param, so this is
+        // a structural invariant rather than a user-facing error.
+        throw new HTTPException(400, { message: "threadId is required" });
+      }
+
+      const { abortSignal: _ignored, ...serializableRequest } = input;
+      const messageId =
+        input.messages[input.messages.length - 1]?.id ?? undefined;
+      const workflowID = messageId
+        ? `thread-run:${taskId}:${messageId}`
+        : undefined;
+
+      // The workflow body emits `chat_message_started` inside a DBOS step,
+      // so idempotent retries that collapse onto an existing workflowID
+      // don't double-count in PostHog. Don't add a duplicate emit here.
+      await enqueueThreadRun(
+        { threadId: taskId, request: serializableRequest },
+        { workflowID },
+      );
       return c.json({ taskId }, 202);
     } catch (err) {
       console.error("[decopilot:messages] Error", err);

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -278,10 +278,16 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
   // If another run on this thread is already executing, the new message
   // queues behind it and dispatches only after that run completes.
   //
-  // Idempotency: when the client supplies an id on the request message,
-  // the workflow ID is derived from `<threadId>:<messageId>`, so a retry
-  // of the same POST collapses onto the existing workflow handle instead
-  // of double-firing.
+  // Idempotency: a retried POST collapses onto the existing workflow
+  // handle when an idempotency signal is provided. In order of
+  // preference:
+  //   1. `X-Idempotency-Key` request header (explicit; recommended for
+  //      clients that retry).
+  //   2. Request message id (the last message's `id`, when the client
+  //      sent one).
+  // If neither is supplied, retries get a fresh workflowID and dispatch
+  // again — at-least-once semantics. Clients that care about exactly-once
+  // must send one of the two.
 
   app.post("/:org/decopilot/threads/:threadId/messages", async (c) => {
     try {
@@ -294,10 +300,11 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       }
 
       const { abortSignal: _ignored, ...serializableRequest } = input;
-      const messageId =
-        input.messages[input.messages.length - 1]?.id ?? undefined;
-      const workflowID = messageId
-        ? `thread-run:${taskId}:${messageId}`
+      const idempotencyKey =
+        c.req.header("X-Idempotency-Key") ??
+        input.messages[input.messages.length - 1]?.id;
+      const workflowID = idempotencyKey
+        ? `thread-run:${taskId}:${idempotencyKey}`
         : undefined;
 
       // The workflow body emits `chat_message_started` inside a DBOS step,

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -304,7 +304,11 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       // so idempotent retries that collapse onto an existing workflowID
       // don't double-count in PostHog. Don't add a duplicate emit here.
       await enqueueThreadRun(
-        { threadId: taskId, request: serializableRequest },
+        {
+          threadId: taskId,
+          request: serializableRequest,
+          source: "user-message",
+        },
         { workflowID },
       );
       return c.json({ taskId }, 202);

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -300,9 +300,14 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       }
 
       const { abortSignal: _ignored, ...serializableRequest } = input;
+      // Coalesce empty/whitespace-only header values to undefined so the
+      // fallback to the message id still applies. Without this, a client
+      // that sets `X-Idempotency-Key:` with an empty value would be kept
+      // as `""` by `??`, fail the truthy check below, and silently get
+      // at-least-once semantics.
+      const headerKey = c.req.header("X-Idempotency-Key")?.trim() || undefined;
       const idempotencyKey =
-        c.req.header("X-Idempotency-Key") ??
-        input.messages[input.messages.length - 1]?.id;
+        headerKey ?? input.messages[input.messages.length - 1]?.id;
       const workflowID = idempotencyKey
         ? `thread-run:${taskId}:${idempotencyKey}`
         : undefined;

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -48,7 +48,10 @@
  */
 
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
-import { awaitThreadRun } from "@/dispatch-queue";
+import {
+  awaitThreadRun,
+  type SerializableDispatchRunInput,
+} from "@/dispatch-queue";
 import { resolveTier } from "@/core/resolve-tier";
 import type { AutomationsStorage } from "@/storage/automations";
 import type { Automation } from "@/storage/types";
@@ -234,28 +237,37 @@ async function updateTriggerTimingStep(triggerId: string): Promise<void> {
   }
 }
 
-async function dispatchRunAndWaitStep(
+type BuildDispatchRequestOutcome =
+  | { ok: true; request: SerializableDispatchRunInput }
+  | { ok: false; reason: string };
+
+/**
+ * Pre-flight for the dispatch: membership pre-check + `buildStreamRequest`.
+ *
+ * Runs as a step so the request payload — including `crypto.randomUUID()`
+ * message ids — is recorded in the workflow journal and replay returns the
+ * same payload. `awaitThreadRun` is invoked from the workflow body (not
+ * here) because DBOS forbids workflow-to-workflow calls from inside a
+ * step.
+ *
+ * The membership check is intentionally repeated by the thread-gate
+ * workflow on dispatch; doing it here as well lets us early-exit before
+ * the thread-gate queue takes a slot.
+ */
+async function buildDispatchRequestStep(
   automation: Automation,
   resolvedModel: ResolvedAutomationModel,
   ctx: FireAutomationContext,
   taskId: string,
-): Promise<void> {
+): Promise<BuildDispatchRequestOutcome> {
   const rt = requireRuntime();
 
-  // Membership pre-check stays here so we can early-exit + record failure
-  // before the thread-gate queue takes a slot. `awaitThreadRun` validates
-  // membership again internally on dispatch.
   const meshCtx = await rt.meshContextFactory(
     automation.organization_id,
     automation.created_by,
   );
   if (!meshCtx) {
-    try {
-      await rt.storage.markRunFailed(taskId);
-    } catch {
-      // best-effort
-    }
-    throw new Error("creator membership lost mid-fire");
+    return { ok: false, reason: "creator membership lost mid-fire" };
   }
 
   const request = buildStreamRequest(
@@ -278,31 +290,15 @@ async function dispatchRunAndWaitStep(
   // Strip the (non-serializable, locally-built) abort signal — the
   // thread-gate workflow constructs its own from `timeoutMs`.
   const { abortSignal: _ignored, ...serializableRequest } = request;
+  return { ok: true, request: serializableRequest };
+}
 
+async function markRunFailedStep(taskId: string): Promise<void> {
+  const rt = requireRuntime();
   try {
-    // Layered queueing: this step runs under the per-automation gate
-    // (concurrency=3) and global gate (concurrency=5); awaiting the
-    // per-thread gate (concurrency=1 keyed by taskId) adds the third
-    // layer. Automation runs and user messages on the same thread now
-    // serialize through the same gate.
-    await awaitThreadRun({
-      threadId: taskId,
-      request: serializableRequest,
-      timeoutMs: rt.runTimeoutMs ?? AUTOMATIONS_RUN_TIMEOUT_MS,
-      source: "automation",
-    });
-  } catch (err) {
-    const runError = err instanceof Error ? err.message : String(err);
-    console.error(
-      `[fireAutomationWorkflow] ERROR "${automation.name}" taskId=${taskId}:`,
-      runError,
-    );
-    try {
-      await rt.storage.markRunFailed(taskId);
-    } catch {
-      // best-effort
-    }
-    throw err;
+    await rt.storage.markRunFailed(taskId);
+  } catch {
+    // best-effort
   }
 }
 
@@ -328,23 +324,50 @@ async function fireAutomationWorkflowFn(
     });
   }
 
-  // The step itself throws on dispatch failure so DBOS records the step
-  // as ERROR (good for observability). We catch at the workflow level to
-  // preserve the existing `FireAutomationOutcome` API: callers expect a
-  // resolved `{taskId, error}` outcome, not a thrown promise.
+  // Two-phase dispatch:
+  //   1. `buildDispatchRequest` step — membership pre-check + assemble the
+  //      serializable request. Recorded in the journal so replays reuse the
+  //      same message ids.
+  //   2. `awaitThreadRun` from the workflow body — calls
+  //      `DBOS.startWorkflow(threadGateWorkflow, ...)`, which is illegal
+  //      from inside a step. Errors are caught here to preserve the
+  //      `FireAutomationOutcome` API (callers expect a resolved
+  //      `{taskId, error}` outcome, not a thrown promise).
+  const built = await DBOS.runStep(
+    () =>
+      buildDispatchRequestStep(
+        prep.automation,
+        prep.resolvedModel,
+        ctx,
+        taskId,
+      ),
+    { name: "buildDispatchRequest" },
+  );
+  if (!built.ok) {
+    await DBOS.runStep(() => markRunFailedStep(taskId), {
+      name: "markRunFailed",
+    });
+    return { taskId, error: built.reason };
+  }
+
+  const rt = requireRuntime();
   try {
-    await DBOS.runStep(
-      () =>
-        dispatchRunAndWaitStep(
-          prep.automation,
-          prep.resolvedModel,
-          ctx,
-          taskId,
-        ),
-      { name: "dispatchRunAndWait" },
-    );
+    await awaitThreadRun({
+      threadId: taskId,
+      request: built.request,
+      timeoutMs: rt.runTimeoutMs ?? AUTOMATIONS_RUN_TIMEOUT_MS,
+      source: "automation",
+    });
   } catch (err) {
-    return { taskId, error: err instanceof Error ? err.message : String(err) };
+    const runError = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[fireAutomationWorkflow] ERROR "${prep.automation.name}" taskId=${taskId}:`,
+      runError,
+    );
+    await DBOS.runStep(() => markRunFailedStep(taskId), {
+      name: "markRunFailed",
+    });
+    return { taskId, error: runError };
   }
 
   return { taskId };

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -48,7 +48,7 @@
  */
 
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
-import type { DispatchRunDeps } from "@/api/routes/decopilot/dispatch-run";
+import { awaitThreadRun } from "@/dispatch-queue";
 import { resolveTier } from "@/core/resolve-tier";
 import type { AutomationsStorage } from "@/storage/automations";
 import type { Automation } from "@/storage/types";
@@ -57,11 +57,7 @@ import {
   buildStreamRequest,
   type ResolvedAutomationModel,
 } from "./build-stream-request";
-import {
-  computeNextRunAt,
-  type MeshContextFactory,
-  type DispatchRunFn,
-} from "./fire";
+import { computeNextRunAt, type MeshContextFactory } from "./fire";
 
 export const AUTOMATIONS_GATE_QUEUE = "automations-gate";
 export const AUTOMATIONS_GLOBAL_QUEUE = "automations-global";
@@ -107,12 +103,7 @@ export async function ensureOrgQueue(orgId: string): Promise<void> {
 
 export interface AutomationRuntime {
   storage: AutomationsStorage;
-  dispatchRunFn: DispatchRunFn;
   meshContextFactory: MeshContextFactory;
-  deps: Pick<
-    DispatchRunDeps,
-    "runRegistry" | "cancelBroadcast" | "streamBuffer"
-  >;
   runTimeoutMs?: number;
 }
 
@@ -248,9 +239,12 @@ async function dispatchRunAndWaitStep(
   resolvedModel: ResolvedAutomationModel,
   ctx: FireAutomationContext,
   taskId: string,
-): Promise<{ error?: string }> {
+): Promise<void> {
   const rt = requireRuntime();
 
+  // Membership pre-check stays here so we can early-exit + record failure
+  // before the thread-gate queue takes a slot. `awaitThreadRun` validates
+  // membership again internally on dispatch.
   const meshCtx = await rt.meshContextFactory(
     automation.organization_id,
     automation.created_by,
@@ -261,43 +255,42 @@ async function dispatchRunAndWaitStep(
     } catch {
       // best-effort
     }
-    return { error: "creator membership lost mid-fire" };
+    throw new Error("creator membership lost mid-fire");
   }
 
-  const timeoutMs = rt.runTimeoutMs ?? AUTOMATIONS_RUN_TIMEOUT_MS;
-  const abortController = new AbortController();
-  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+  const request = buildStreamRequest(
+    automation,
+    ctx.triggerId,
+    taskId,
+    resolvedModel,
+  );
+  if (ctx.contextMessages) {
+    request.messages = [
+      ...request.messages,
+      ...ctx.contextMessages.map((m) => ({
+        id: crypto.randomUUID(),
+        role: m.role as "user" | "assistant" | "system",
+        parts: [{ type: "text" as const, text: m.content }],
+      })),
+    ];
+  }
+
+  // Strip the (non-serializable, locally-built) abort signal — the
+  // thread-gate workflow constructs its own from `timeoutMs`.
+  const { abortSignal: _ignored, ...serializableRequest } = request;
 
   try {
-    const request = buildStreamRequest(
-      automation,
-      ctx.triggerId,
-      taskId,
-      resolvedModel,
-    );
-    if (ctx.contextMessages) {
-      request.messages = [
-        ...request.messages,
-        ...ctx.contextMessages.map((m) => ({
-          id: crypto.randomUUID(),
-          role: m.role as "user" | "assistant" | "system",
-          parts: [{ type: "text" as const, text: m.content }],
-        })),
-      ];
-    }
-    request.abortSignal = abortController.signal;
-
-    // dispatchRunAndWait resolves when the run completes (or fails).
-    // Automations need this synchronous shape so the DBOS workflow step can
-    // record the run's terminal state. With streamBuffer wired through,
-    // automation chunks publish to the per-thread JetStream subject like
-    // user-message runs, so any UI tailing the thread sees them too.
-    await rt.dispatchRunFn(request, meshCtx, {
-      runRegistry: rt.deps.runRegistry,
-      streamBuffer: rt.deps.streamBuffer,
-      cancelBroadcast: rt.deps.cancelBroadcast,
+    // Layered queueing: this step runs under the per-automation gate
+    // (concurrency=3) and global gate (concurrency=5); awaiting the
+    // per-thread gate (concurrency=1 keyed by taskId) adds the third
+    // layer. Automation runs and user messages on the same thread now
+    // serialize through the same gate.
+    await awaitThreadRun({
+      threadId: taskId,
+      request: serializableRequest,
+      timeoutMs: rt.runTimeoutMs ?? AUTOMATIONS_RUN_TIMEOUT_MS,
+      source: "automation",
     });
-    return {};
   } catch (err) {
     const runError = err instanceof Error ? err.message : String(err);
     console.error(
@@ -309,9 +302,7 @@ async function dispatchRunAndWaitStep(
     } catch {
       // best-effort
     }
-    return { error: runError };
-  } finally {
-    clearTimeout(timeout);
+    throw err;
   }
 }
 
@@ -337,13 +328,25 @@ async function fireAutomationWorkflowFn(
     });
   }
 
-  const result = await DBOS.runStep(
-    () =>
-      dispatchRunAndWaitStep(prep.automation, prep.resolvedModel, ctx, taskId),
-    { name: "dispatchRunAndWait" },
-  );
+  // The step itself throws on dispatch failure so DBOS records the step
+  // as ERROR (good for observability). We catch at the workflow level to
+  // preserve the existing `FireAutomationOutcome` API: callers expect a
+  // resolved `{taskId, error}` outcome, not a thrown promise.
+  try {
+    await DBOS.runStep(
+      () =>
+        dispatchRunAndWaitStep(
+          prep.automation,
+          prep.resolvedModel,
+          ctx,
+          taskId,
+        ),
+      { name: "dispatchRunAndWait" },
+    );
+  } catch (err) {
+    return { taskId, error: err instanceof Error ? err.message : String(err) };
+  }
 
-  if (result.error) return { taskId, error: result.error };
   return { taskId };
 }
 

--- a/apps/mesh/src/automations/fire.ts
+++ b/apps/mesh/src/automations/fire.ts
@@ -1,15 +1,5 @@
-import type {
-  DispatchRunInput,
-  DispatchRunDeps,
-} from "@/api/routes/decopilot/dispatch-run";
 import type { MeshContext } from "@/core/mesh-context";
 import { Cron } from "croner";
-
-export type DispatchRunFn = (
-  input: DispatchRunInput,
-  ctx: MeshContext,
-  deps: DispatchRunDeps,
-) => Promise<{ taskId: string }>;
 
 export type MeshContextFactory = (
   orgId: string,

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -1,4 +1,5 @@
 export {
+  awaitThreadRun,
   enqueueThreadRun,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -1,0 +1,10 @@
+export {
+  enqueueThreadRun,
+  setThreadGateRuntime,
+  THREAD_GATE_PARTITION_CONCURRENCY,
+  THREAD_GATE_QUEUE,
+  type SerializableDispatchRunInput,
+  type ThreadGateContext,
+  type ThreadGateOutcome,
+  type ThreadGateRuntime,
+} from "./thread-gate-workflow";

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import {
+  setThreadGateRuntime,
+  THREAD_GATE_PARTITION_CONCURRENCY,
+  THREAD_GATE_QUEUE,
+  type ThreadGateRuntime,
+} from "./thread-gate-workflow";
+
+describe("threadGateWorkflow plumbing", () => {
+  it("exposes the queue name and per-thread concurrency cap", () => {
+    expect(THREAD_GATE_QUEUE).toBe("thread-gate");
+    // Concurrency=1 per partition (per thread) is what gives us
+    // serialization — Phase 3 relies on this for "queue behavior".
+    expect(THREAD_GATE_PARTITION_CONCURRENCY).toBe(1);
+  });
+
+  it("setThreadGateRuntime accepts a runtime shape", () => {
+    const rt: ThreadGateRuntime = {
+      dispatchRunFn: async () => ({ taskId: "t" }),
+      meshContextFactory: async () => null,
+      deps: {
+        runRegistry: {} as ThreadGateRuntime["deps"]["runRegistry"],
+        cancelBroadcast: {} as ThreadGateRuntime["deps"]["cancelBroadcast"],
+        streamBuffer: undefined,
+      },
+    };
+    expect(() => setThreadGateRuntime(rt)).not.toThrow();
+  });
+});

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -37,12 +37,10 @@ export const THREAD_GATE_QUEUE = "thread-gate";
  */
 export const THREAD_GATE_PARTITION_CONCURRENCY = 1;
 
-const DEFAULT_RUN_TIMEOUT_MS = 5 * 60 * 1000;
-
 /**
  * Serializable subset of `DispatchRunInput`. The abort signal is the only
  * non-serializable field; the workflow step constructs its own from a
- * timeout.
+ * timeout when one is provided.
  */
 export type SerializableDispatchRunInput = Omit<
   DispatchRunInput,
@@ -54,7 +52,13 @@ export interface ThreadGateContext {
   threadId: string;
   /** Dispatch input minus the non-serializable abort signal. */
   request: SerializableDispatchRunInput;
-  /** Optional per-call timeout override (otherwise uses runtime default). */
+  /**
+   * Optional per-call timeout (ms). When set, the workflow aborts dispatch
+   * after this duration. Automations pass an explicit value; user messages
+   * leave this unset because tool-using agent loops (Claude Code, deep
+   * research, multi-step assistants) routinely run longer than any fixed
+   * cap, and were not bounded by the legacy fire-and-forget HTTP path.
+   */
   timeoutMs?: number;
   /**
    * Where the enqueue came from. Drives whether `chat_message_started`
@@ -84,7 +88,11 @@ export interface ThreadGateRuntime {
     DispatchRunDeps,
     "runRegistry" | "cancelBroadcast" | "streamBuffer"
   >;
-  /** Default per-run timeout; overridable per-enqueue via `ThreadGateContext.timeoutMs`. */
+  /**
+   * Default per-run timeout (ms). Overridable per-enqueue via
+   * `ThreadGateContext.timeoutMs`. When neither is set, no abort timer is
+   * installed.
+   */
   runTimeoutMs?: number;
 }
 
@@ -118,9 +126,17 @@ async function dispatchRunAndWaitStep(ctx: ThreadGateContext): Promise<void> {
     throw new Error("user membership lost mid-dispatch");
   }
 
-  const timeoutMs = ctx.timeoutMs ?? rt.runTimeoutMs ?? DEFAULT_RUN_TIMEOUT_MS;
+  // Abort timer is opt-in. Automations supply a 5-min cap so a runaway
+  // cron can't pin a thread slot forever; user messages leave it unset
+  // because tool-using agent loops (Claude Code, deep research,
+  // multi-step assistants) routinely outlast any fixed cap, and were not
+  // bounded by the legacy fire-and-forget HTTP path.
+  const timeoutMs = ctx.timeoutMs ?? rt.runTimeoutMs;
   const abortController = new AbortController();
-  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+  const timeoutHandle =
+    timeoutMs != null
+      ? setTimeout(() => abortController.abort(), timeoutMs)
+      : null;
 
   try {
     // Dispatch errors propagate. `dispatchRun` guarantees the run is
@@ -133,7 +149,7 @@ async function dispatchRunAndWaitStep(ctx: ThreadGateContext): Promise<void> {
       rt.deps,
     );
   } finally {
-    clearTimeout(timeout);
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
   }
 }
 
@@ -164,15 +180,60 @@ async function trackMessageStartedStep(ctx: ThreadGateContext): Promise<void> {
   });
 }
 
+/**
+ * Balances `chat_message_started` when the dispatch step throws *before*
+ * `streamText` is set up (model-permission failure, agent not found,
+ * thread-ownership check, etc. — see `prepareRun`). In-flight stream
+ * errors are already emitted by `streamText.onError` inside `dispatchRun`,
+ * so this only covers the pre-stream gap.
+ *
+ * `error_category: "setup"` keeps these distinguishable from stream-time
+ * failures (which use `classifyStreamError`).
+ */
+async function trackMessageFailedStep(
+  ctx: ThreadGateContext,
+  errorMessage: string,
+): Promise<void> {
+  if (ctx.source !== "user-message") return;
+  const { request } = ctx;
+  posthog.capture({
+    distinctId: request.userId,
+    event: "chat_message_failed",
+    groups: { organization: request.organizationId },
+    properties: {
+      organization_id: request.organizationId,
+      thread_id: request.taskId ?? ctx.threadId,
+      agent_id: request.agent,
+      model_id: request.models.thinking.id,
+      mode: request.mode,
+      error_category: "setup",
+      error_message: errorMessage,
+    },
+  });
+}
+
 async function threadGateWorkflowFn(
   ctx: ThreadGateContext,
 ): Promise<ThreadGateOutcome> {
   await DBOS.runStep(() => trackMessageStartedStep(ctx), {
     name: "trackMessageStarted",
   });
-  await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
-    name: "dispatchRunAndWait",
-  });
+  try {
+    await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
+      name: "dispatchRunAndWait",
+    });
+  } catch (err) {
+    // Setup errors (prepareRun) propagate out of `dispatchRun`; in-flight
+    // stream errors are handled inside `streamText.onError` and don't
+    // reach here. So a thrown step at this point means setup failed —
+    // emit the balancing failed event for analytics integrity. Wrapped
+    // in its own DBOS step so replay doesn't double-emit.
+    const msg = err instanceof Error ? err.message : String(err);
+    await DBOS.runStep(() => trackMessageFailedStep(ctx, msg), {
+      name: "trackMessageFailed",
+    });
+    throw err;
+  }
   return { taskId: ctx.request.taskId ?? ctx.threadId };
 }
 

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -1,0 +1,192 @@
+/**
+ * Thread Gate Workflow.
+ *
+ * Per-thread serialization for agent runs. Concurrency=1 per thread ensures
+ * messages on the same thread execute sequentially: a queued user message
+ * waits for the active run to terminate before being dispatched.
+ *
+ * The workflow body is a single `DBOS.runStep` that calls
+ * `dispatchRunAndWait`. Holding the partition slot until that step returns
+ * is what gives us "queue behavior" — DBOS won't dequeue the next message
+ * on the same thread until this run is finished.
+ *
+ * Used by user-message POSTs (later: automation fires too). Automations
+ * layer their existing per-automation and global gates above this
+ * per-thread one; user messages enter here directly.
+ *
+ * Runtime dependencies (dispatch fn, mesh-context factory, dispatch deps)
+ * are looked up via a module-level registry. App boot wires them via
+ * `setThreadGateRuntime` BEFORE `DBOS.launch()`. The workflow is registered
+ * at import time so the recovery executor can replay it after a crash.
+ */
+
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import type {
+  DispatchRunDeps,
+  DispatchRunInput,
+} from "@/api/routes/decopilot/dispatch-run";
+import type { MeshContext } from "@/core/mesh-context";
+import { posthog } from "@/posthog";
+
+export const THREAD_GATE_QUEUE = "thread-gate";
+
+/**
+ * Per-thread concurrent run cap (partition cap on the gate queue).
+ * Holding the slot until `dispatchRunAndWait` returns serializes messages
+ * on the same thread.
+ */
+export const THREAD_GATE_PARTITION_CONCURRENCY = 1;
+
+const DEFAULT_RUN_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Serializable subset of `DispatchRunInput`. The abort signal is the only
+ * non-serializable field; the workflow step constructs its own from a
+ * timeout.
+ */
+export type SerializableDispatchRunInput = Omit<
+  DispatchRunInput,
+  "abortSignal"
+>;
+
+export interface ThreadGateContext {
+  /** Stable thread identifier — also used as the queue partition key. */
+  threadId: string;
+  /** Dispatch input minus the non-serializable abort signal. */
+  request: SerializableDispatchRunInput;
+  /** Optional per-call timeout override (otherwise uses runtime default). */
+  timeoutMs?: number;
+}
+
+export type ThreadGateOutcome = { taskId: string };
+
+export type DispatchRunAndWaitFn = (
+  input: DispatchRunInput,
+  ctx: MeshContext,
+  deps: DispatchRunDeps,
+) => Promise<{ taskId: string }>;
+
+export type MeshContextFactory = (
+  orgId: string,
+  userId: string,
+) => Promise<MeshContext | null>;
+
+export interface ThreadGateRuntime {
+  dispatchRunFn: DispatchRunAndWaitFn;
+  meshContextFactory: MeshContextFactory;
+  deps: Pick<
+    DispatchRunDeps,
+    "runRegistry" | "cancelBroadcast" | "streamBuffer"
+  >;
+  /** Default per-run timeout; overridable per-enqueue via `ThreadGateContext.timeoutMs`. */
+  runTimeoutMs?: number;
+}
+
+let runtime: ThreadGateRuntime | null = null;
+
+export function setThreadGateRuntime(rt: ThreadGateRuntime): void {
+  runtime = rt;
+}
+
+function requireRuntime(): ThreadGateRuntime {
+  if (!runtime) {
+    throw new Error(
+      "[threadGate] runtime not initialized — setThreadGateRuntime() must run before workflows fire",
+    );
+  }
+  return runtime;
+}
+
+async function dispatchRunAndWaitStep(ctx: ThreadGateContext): Promise<void> {
+  const rt = requireRuntime();
+  const { request } = ctx;
+
+  const meshCtx = await rt.meshContextFactory(
+    request.organizationId,
+    request.userId,
+  );
+  if (!meshCtx) {
+    // Throw so DBOS records the step (and the workflow) as failed.
+    // Swallowing into `{error}` would mark the workflow SUCCESS and
+    // break retry / failure tooling.
+    throw new Error("user membership lost mid-dispatch");
+  }
+
+  const timeoutMs = ctx.timeoutMs ?? rt.runTimeoutMs ?? DEFAULT_RUN_TIMEOUT_MS;
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+
+  try {
+    // Dispatch errors propagate. `dispatchRun` guarantees the run is
+    // already force-finished to "failed" in the registry before throwing
+    // (see `prepareRun`), so application state stays consistent — DBOS
+    // just gets to see the failure too.
+    await rt.dispatchRunFn(
+      { ...request, abortSignal: abortController.signal },
+      meshCtx,
+      rt.deps,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * PostHog "chat_message_started" emission, wrapped in a DBOS step so it
+ * runs at most once per workflow. A retried POST that collapses onto an
+ * existing workflowID re-enters the workflow via DBOS replay; the step
+ * output is recorded in the workflow journal and the body doesn't
+ * re-execute. Without this, retries would double-count in PostHog.
+ */
+async function trackMessageStartedStep(ctx: ThreadGateContext): Promise<void> {
+  const { request } = ctx;
+  posthog.capture({
+    distinctId: request.userId,
+    event: "chat_message_started",
+    groups: { organization: request.organizationId },
+    properties: {
+      organization_id: request.organizationId,
+      agent_id: request.agent,
+      mode: request.mode,
+      thread_id: request.taskId ?? ctx.threadId,
+      credential_id: request.models.credentialId,
+    },
+  });
+}
+
+async function threadGateWorkflowFn(
+  ctx: ThreadGateContext,
+): Promise<ThreadGateOutcome> {
+  await DBOS.runStep(() => trackMessageStartedStep(ctx), {
+    name: "trackMessageStarted",
+  });
+  await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
+    name: "dispatchRunAndWait",
+  });
+  return { taskId: ctx.request.taskId ?? ctx.threadId };
+}
+
+const threadGateWorkflow = DBOS.registerWorkflow(threadGateWorkflowFn, {
+  name: "threadGateWorkflow",
+});
+
+/**
+ * Enqueue a thread run on the partitioned thread-gate queue. The partition
+ * key is the threadId, so per-thread concurrency=1 serializes runs on the
+ * same thread while different threads progress in parallel.
+ *
+ * Callers can pass `workflowID` for idempotency (e.g. a client-supplied
+ * ULID on POST /messages) — a redelivered request collapses onto the
+ * existing workflow handle instead of duplicating the run.
+ */
+export async function enqueueThreadRun(
+  ctx: ThreadGateContext,
+  opts?: { workflowID?: string },
+): Promise<{ workflowID: string }> {
+  const handle = await DBOS.startWorkflow(threadGateWorkflow, {
+    queueName: THREAD_GATE_QUEUE,
+    enqueueOptions: { queuePartitionKey: ctx.threadId },
+    workflowID: opts?.workflowID,
+  })(ctx);
+  return { workflowID: handle.workflowID };
+}

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -56,6 +56,12 @@ export interface ThreadGateContext {
   request: SerializableDispatchRunInput;
   /** Optional per-call timeout override (otherwise uses runtime default). */
   timeoutMs?: number;
+  /**
+   * Where the enqueue came from. Drives whether `chat_message_started`
+   * fires: only user-initiated POSTs count as messages — automation fires
+   * use the same gate but shouldn't pollute message-send analytics.
+   */
+  source: "user-message" | "automation";
 }
 
 export type ThreadGateOutcome = { taskId: string };
@@ -137,8 +143,12 @@ async function dispatchRunAndWaitStep(ctx: ThreadGateContext): Promise<void> {
  * existing workflowID re-enters the workflow via DBOS replay; the step
  * output is recorded in the workflow journal and the body doesn't
  * re-execute. Without this, retries would double-count in PostHog.
+ *
+ * Suppressed for automation fires — they reuse this gate but don't
+ * represent a user-initiated message.
  */
 async function trackMessageStartedStep(ctx: ThreadGateContext): Promise<void> {
+  if (ctx.source !== "user-message") return;
   const { request } = ctx;
   posthog.capture({
     distinctId: request.userId,
@@ -178,6 +188,10 @@ const threadGateWorkflow = DBOS.registerWorkflow(threadGateWorkflowFn, {
  * Callers can pass `workflowID` for idempotency (e.g. a client-supplied
  * ULID on POST /messages) — a redelivered request collapses onto the
  * existing workflow handle instead of duplicating the run.
+ *
+ * Fire-and-forget: returns the workflowID without awaiting completion.
+ * Use `awaitThreadRun` when the caller needs to block on the dispatch
+ * outcome (e.g. parent workflows that hold their own queue slot).
  */
 export async function enqueueThreadRun(
   ctx: ThreadGateContext,
@@ -189,4 +203,23 @@ export async function enqueueThreadRun(
     workflowID: opts?.workflowID,
   })(ctx);
   return { workflowID: handle.workflowID };
+}
+
+/**
+ * Enqueue and await completion. Used by callers that hold an outer
+ * workflow slot and need the dispatch outcome to advance — chiefly the
+ * automation fire path, which layers its own per-automation and global
+ * gates above this per-thread one. Failures from the inner workflow
+ * propagate so the caller's step is recorded as failed by DBOS.
+ */
+export async function awaitThreadRun(
+  ctx: ThreadGateContext,
+  opts?: { workflowID?: string },
+): Promise<ThreadGateOutcome> {
+  const handle = await DBOS.startWorkflow(threadGateWorkflow, {
+    queueName: THREAD_GATE_QUEUE,
+    enqueueOptions: { queuePartitionKey: ctx.threadId },
+    workflowID: opts?.workflowID,
+  })(ctx);
+  return await handle.getResult();
 }


### PR DESCRIPTION
## Summary

Adds a **per-thread DBOS gate** so agent runs on the same thread execute one at a time, while runs on different threads progress in parallel. Both user messages and automation fires now funnel through the same gate.

`POST /:org/decopilot/threads/:threadId/messages` enqueues onto a partitioned DBOS workflow (`threadGateWorkflow`, partition key = `threadId`, concurrency = 1) and returns `202 { taskId }` in milliseconds. A second POST while a run is in flight queues behind it and dispatches only after the active run completes. Streaming continues through `GET /:org/decopilot/attach/:threadId`.

## Changes

**`apps/mesh/src/dispatch-queue/` (new)**
- `threadGateWorkflow` — single DBOS workflow that owns the per-thread serialization. Body is two steps:
  1. `trackMessageStarted` — emits `chat_message_started` PostHog event (skipped for automation sources). Wrapped in a step so idempotent retries that collapse onto an existing workflow ID don't double-count.
  2. `dispatchRunAndWait` — invokes the configured dispatch fn; constructs its own `AbortController` (since `AbortSignal` isn't serializable across workflow boundaries). If the step throws, `trackMessageFailed` emits with `error_category: "setup"` to balance the started event.
- `enqueueThreadRun(ctx, { workflowID? })` — fire-and-forget. Used by the user-message route.
- `awaitThreadRun(ctx, { workflowID? })` — enqueue + `getResult()`. Used by automation fires that need to block on the inner run's outcome.
- Module-level `setThreadGateRuntime()` registry wires `dispatchRunFn`, `meshContextFactory`, and dispatch deps before `DBOS.launch()`.
- `THREAD_GATE_QUEUE` + `THREAD_GATE_PARTITION_CONCURRENCY` constants; queue registered in `createApp`.
- Abort timer is **opt-in**: automations pass an explicit 5 min cap so a runaway cron can't pin a thread slot; user messages leave it unset because tool-using loops (Claude Code, deep research) routinely outlast any fixed cap and weren't bounded by the legacy fire-and-forget path.

**`apps/mesh/src/api/routes/decopilot/routes.ts`**
- `POST /messages` replaces the inline `dispatchAndTrack` call with `enqueueThreadRun`. Returns `202 { taskId }`.
- Idempotency: prefers `X-Idempotency-Key` header, falls back to the last message's `id`. Combined as `workflowID = thread-run:<threadId>:<key>`. Without either, retries get a fresh workflow ID (at-least-once).
- `dispatchAndTrack` deleted; PostHog `chat_message_started` is now emitted from the workflow step.
- Orphan-resume in `/attach` continues to call `dispatchRun` directly — going through the gate would deadlock against itself.

**`apps/mesh/src/automations/dbos-workflow.ts`**
- `fireAutomationWorkflowFn` hands off to the thread gate via `awaitThreadRun` instead of calling `dispatchRunFn` directly. Existing per-automation (concurrency=3) and global (concurrency=5) gates remain layered above; the per-thread gate adds the third layer.
- Split the dispatch into two phases so DBOS rules are respected:
  - `buildDispatchRequest` **step** — membership pre-check + `buildStreamRequest`, journaled so replays reuse the same `crypto.randomUUID()` message ids.
  - `awaitThreadRun` from the **workflow body** — DBOS forbids invoking a workflow from inside a step, so this lives in the workflow context. Failures are caught at the workflow level to preserve the `FireAutomationOutcome` `{taskId, error}` shape.
- `markRunFailed` extracted into its own step so the side effect is recorded on the journal.
- `AutomationRuntime` loses `dispatchRunFn` and `deps` (now owned by the thread-gate runtime).

**`apps/mesh/src/api/app.ts`**
- Imports `setThreadGateRuntime`, `THREAD_GATE_QUEUE`, `THREAD_GATE_PARTITION_CONCURRENCY` from `@/dispatch-queue`.
- Calls `setThreadGateRuntime({ dispatchRunFn: dispatchRunAndWait, meshContextFactory, deps })` before `DBOS.launch()`.
- Registers the `thread-gate` queue with `partitionQueue: true, concurrency: 1`.

**`apps/mesh/src/automations/fire.ts`**
- Removes the now-unused `DispatchRunFn` type and `DispatchRunInput`/`DispatchRunDeps` imports.

## Telemetry semantics

- `chat_message_started` — fires from inside the workflow body (post queue-admission), once per workflow. Idempotent retries collapse onto the same workflowID and do not double-count.
- `chat_message_failed` — emitted from one of three places, never two:
  - Setup errors thrown by `prepareRun` before `streamText` starts → workflow's `trackMessageFailed` step with `error_category: "setup"`.
  - Mid-stream errors → `createUIMessageStream.onError` inside `dispatchRun` with `classifyStreamError(error)` category.
  - Automation fires are excluded from message-send analytics.

## Idempotency contract

- Header: `X-Idempotency-Key: <stable-key>` (recommended for retrying clients).
- Fallback: the last (user) message's `id`. Most chat clients already send a UUID per message.
- Without either, retries are at-least-once. Clients that need exactly-once **must** send one of the two.
- Format: `thread-run:<threadId>:<key>`. A redelivered POST gets `202` and `getResult()`-equivalent semantics inside DBOS.

## What's NOT in this PR

- Inbox UI + `GET/DELETE /threads/:id/queue` endpoints — follow-up.
- Orphan-resume continues to bypass the gate (recovery path).

## Bug fixes included on the branch

- **DBOS step/workflow invariant** (commit `ff8914bb0`): the initial automation routing crashed every fire with `Invalid call to a 'workflow' function from within a 'step' or 'transaction'` because `awaitThreadRun` was called from inside `DBOS.runStep`. Fixed by moving `awaitThreadRun` to the workflow body and splitting the prep work into a journaled step.

## Test plan

- [x] `bun run --cwd=apps/mesh check` clean (TypeScript).
- [x] `bun run fmt` clean.
- [x] `thread-gate-workflow.test.ts` covers queue plumbing (constant exports + `setThreadGateRuntime` runtime shape).
- [ ] Manual: send a user message; verify `202 { taskId }` and stream attaches via `/attach`.
- [ ] Manual: send two user messages back-to-back on the same thread; verify they serialize.
- [ ] Manual: trigger an automation fire; verify it dispatches through the thread gate without the DBOS step/workflow error.
- [ ] Manual: retry a POST with the same `X-Idempotency-Key`; verify no duplicate run / no duplicate `chat_message_started`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)