### PR TITLE
feat(decopilot): pending-message inbox above the chat input

### DIFF
--- a/apps/mesh/migrations/078-queued-messages.ts
+++ b/apps/mesh/migrations/078-queued-messages.ts
@@ -1,0 +1,46 @@
+/**
+ * Queued messages — pending agent runs awaiting dispatch on the per-thread
+ * gate queue.
+ *
+ * Row lifecycle:
+ * - Inserted with status='queued' at POST /messages, before the workflow is
+ *   enqueued. Holds the message text so the inbox UI can render pending
+ *   bubbles above the input.
+ * - On DELETE /messages/:id, the row is atomically transitioned to
+ *   'cancelled' (CAS). The workflow consumer checks this on dequeue and
+ *   skips dispatch if the row is gone or cancelled.
+ * - The workflow consumer deletes the row at the start of dispatch (the
+ *   message is now "running" — it appears in the chat as the streaming
+ *   response, not in the inbox).
+ *
+ * No 'running' / 'consumed' states persisted — the workflow journal is the
+ * source of truth for in-flight work, this table only tracks the inbox.
+ */
+
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("queued_messages")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("thread_id", "text", (col) => col.notNull())
+    .addColumn("organization_id", "text", (col) => col.notNull())
+    .addColumn("user_id", "text", (col) => col.notNull())
+    .addColumn("content", "text", (col) => col.notNull())
+    .addColumn("status", "text", (col) => col.notNull().defaultTo("queued"))
+    .addColumn("workflow_id", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo("now()"),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("queued_messages_thread_id_created_at_idx")
+    .on("queued_messages")
+    .columns(["thread_id", "created_at"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("queued_messages").execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -76,6 +76,7 @@ import * as migration074sandboxrunnerstatehandlenonunique from "./074-sandbox-ru
 import * as migration075threadinflightasyncjobs from "./075-thread-inflight-async-jobs.ts";
 import * as migration076automationsdropagentjson from "./076-automations-drop-agent-json.ts";
 import * as migration077tieronlymodelselection from "./077-tier-only-model-selection.ts";
+import * as migration078queuedmessages from "./078-queued-messages.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -167,6 +168,7 @@ const migrations: Record<string, Migration> = {
   "075-thread-inflight-async-jobs": migration075threadinflightasyncjobs,
   "076-automations-drop-agent-json": migration076automationsdropagentjson,
   "077-tier-only-model-selection": migration077tieronlymodelselection,
+  "078-queued-messages": migration078queuedmessages,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -91,6 +91,7 @@ import type { StreamBuffer } from "./routes/decopilot/stream-buffer";
 import { NatsStreamBuffer } from "./routes/decopilot/nats-stream-buffer";
 import { RunRegistry } from "./routes/decopilot/run-registry";
 import type { RunReactorDeps } from "./routes/decopilot/run-reactor";
+import { SqlQueuedMessagesStorage } from "../storage/queued-messages";
 import { SqlThreadStorage } from "../storage/threads";
 import type { Thread } from "../storage/types";
 import { registerMonitoringRetentionWorkflow } from "../monitoring/dbos-retention-workflow";
@@ -759,6 +760,7 @@ export async function createApp(options: CreateAppOptions = {}) {
         })();
       },
       createTailStream: async () => null,
+      publish: () => {},
       purge: () => {},
       teardown: () => {},
     };
@@ -1176,9 +1178,11 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Same deps shape as automations — the per-thread gate calls
   // `dispatchRunAndWait` once the queue lets a message through. Wiring
   // happens before `DBOS.launch()` for the same reasons.
+  const queuedMessagesStorage = new SqlQueuedMessagesStorage(database.db);
   setThreadGateRuntime({
     dispatchRunFn: dispatchRunAndWait,
     meshContextFactory: automationContextFactory,
+    queuedMessagesStorage,
     deps: { runRegistry, cancelBroadcast, streamBuffer },
   });
 
@@ -1557,6 +1561,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     streamBuffer,
     runRegistry,
     threadStorage,
+    queuedMessagesStorage,
   });
   app.route("/api", decopilotRoutes);
 

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -107,6 +107,18 @@ export class NatsStreamBuffer implements StreamBuffer {
     this.jsm = jsm;
   }
 
+  publish(taskId: string, chunk: unknown): void {
+    const js = this.js;
+    if (!js) return;
+    const subj = streamSubject(taskId);
+    const tracker = createPublishTracker(taskId);
+    tracker.publish(
+      js,
+      subj,
+      this.encoder.encode(JSON.stringify({ p: chunk })),
+    );
+  }
+
   pump(
     stream: ReadableStream,
     taskId: string,

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -39,6 +39,7 @@ import { dispatchRun, type DispatchRunInput } from "./dispatch-run";
 import { enqueueThreadRun } from "@/dispatch-queue";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import type { SqlThreadStorage } from "@/storage/threads";
+import type { QueuedMessagesStorage } from "@/storage/queued-messages";
 import { getPodId } from "@/core/pod-identity";
 
 // ============================================================================
@@ -224,6 +225,28 @@ async function validate(
 }
 
 /**
+ * Pull the user-visible text out of a ChatMessage for inbox rendering. The
+ * AI-SDK UI parts have many types; we only render the text payload(s) here
+ * — file attachments, tool calls, etc. don't apply to a pending message.
+ */
+function extractMessageText(message: ChatMessage): string {
+  const texts: string[] = [];
+  for (const part of message.parts) {
+    if (
+      typeof part === "object" &&
+      part !== null &&
+      "type" in part &&
+      part.type === "text" &&
+      "text" in part &&
+      typeof (part as { text: unknown }).text === "string"
+    ) {
+      texts.push((part as { text: string }).text);
+    }
+  }
+  return texts.join("\n");
+}
+
+/**
  * Emit the `chat_message_started` posthog event for an enqueued run.
  * Telemetry lives here (not inside `dispatchRun`) so orphan-resume and
  * automation paths — which don't represent a fresh user message — don't
@@ -253,10 +276,17 @@ export interface DecopilotDeps {
   streamBuffer: StreamBuffer;
   runRegistry: RunRegistry;
   threadStorage: SqlThreadStorage;
+  queuedMessagesStorage: QueuedMessagesStorage;
 }
 
 export function createDecopilotRoutes(deps: DecopilotDeps) {
-  const { cancelBroadcast, streamBuffer, runRegistry, threadStorage } = deps;
+  const {
+    cancelBroadcast,
+    streamBuffer,
+    runRegistry,
+    threadStorage,
+    queuedMessagesStorage,
+  } = deps;
   const app = new Hono<{ Variables: { meshContext: MeshContext } }>();
 
   // ============================================================================
@@ -297,7 +327,9 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
   // workflow dequeues and dispatches.
   //
   // If another run on this thread is already executing, the new message
-  // queues behind it and dispatches only after that run completes.
+  // queues behind it and dispatches only after that run completes. Clients
+  // see queued messages via the inbox endpoint and can cancel them by
+  // taskId before they dequeue.
   //
   // Idempotency: when the client supplies an id on the request message,
   // the workflow ID is derived from `<threadId>:<messageId>`, so a retry
@@ -315,18 +347,51 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       }
 
       const { abortSignal: _ignored, ...serializableRequest } = input;
-      const messageId =
-        input.messages[input.messages.length - 1]?.id ?? undefined;
-      const workflowID = messageId
-        ? `thread-run:${taskId}:${messageId}`
-        : undefined;
+      const userMessage = input.messages[input.messages.length - 1];
+      const queuedMessageId = userMessage?.id ?? crypto.randomUUID();
+      const workflowID = `thread-run:${taskId}:${queuedMessageId}`;
+
+      // Insert the inbox row BEFORE enqueueing. If two clients race the
+      // same `(threadId, messageId)` (retry), the second insert fails on
+      // PK conflict and we treat that as idempotent — the workflow
+      // workflowID dedupes the run on the DBOS side too.
+      try {
+        await queuedMessagesStorage.insert({
+          id: queuedMessageId,
+          threadId: taskId,
+          organizationId: input.organizationId,
+          userId: input.userId,
+          content: userMessage ? extractMessageText(userMessage) : "",
+          workflowId: workflowID,
+        });
+        streamBuffer.publish(taskId, {
+          type: "data-queue-enqueued",
+          data: {
+            type: "queue-enqueued",
+            taskId: queuedMessageId,
+            content: userMessage ? extractMessageText(userMessage) : "",
+            createdAt: new Date().toISOString(),
+          },
+        });
+      } catch (insertErr) {
+        // Likely a PK conflict on retry; we still enqueue (DBOS will
+        // collapse the duplicate workflow handle by workflowID).
+        console.warn(
+          "[decopilot:messages] queued_messages insert failed, continuing",
+          insertErr,
+        );
+      }
 
       await enqueueThreadRun(
-        { threadId: taskId, request: serializableRequest },
+        {
+          threadId: taskId,
+          queuedMessageId,
+          request: serializableRequest,
+        },
         { workflowID },
       );
       trackMessageStarted(input, taskId);
-      return c.json({ taskId }, 202);
+      return c.json({ taskId, queuedMessageId }, 202);
     } catch (err) {
       console.error("[decopilot:messages] Error", err);
       if (err instanceof TierUnavailableError) {
@@ -342,6 +407,74 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       );
     }
   });
+
+  // ============================================================================
+  // Inbox Endpoints — list / cancel pending messages on the thread-gate queue
+  // ============================================================================
+  //
+  // GET /:org/decopilot/threads/:threadId/queue
+  //   Returns messages that were submitted on this thread and haven't yet
+  //   been picked up by the dispatcher. Used by the chat UI to render
+  //   pending bubbles above the input on tab open (initial snapshot);
+  //   subsequent state changes flow as `data-queue-*` events on /attach.
+  //
+  // DELETE /:org/decopilot/threads/:threadId/queue/:messageId
+  //   Cancels a queued message. Atomic CAS queued→cancelled, so a message
+  //   that has already started dispatching can't be cancelled this way —
+  //   use the existing `POST /cancel/:threadId` to stop an in-flight run.
+
+  app.get("/:org/decopilot/threads/:threadId/queue", async (c) => {
+    try {
+      const { thread, organization } = await validateThreadAccess(c);
+      const rows = await queuedMessagesStorage.listByThread(
+        thread.id,
+        organization.id,
+      );
+      return c.json({
+        items: rows.map((r) => ({
+          id: r.id,
+          threadId: r.threadId,
+          content: r.content,
+          createdAt: r.createdAt.toISOString(),
+        })),
+      });
+    } catch (err) {
+      console.error("[decopilot:queue:list] Error", err);
+      if (err instanceof HTTPException) {
+        return c.json({ error: err.message }, err.status);
+      }
+      return c.json({ error: "Internal error" }, 500);
+    }
+  });
+
+  app.delete(
+    "/:org/decopilot/threads/:threadId/queue/:messageId",
+    async (c) => {
+      try {
+        const { thread, organization } = await validateThreadOwnership(c);
+        const messageId = c.req.param("messageId");
+        const cancelled = await queuedMessagesStorage.cancel(
+          messageId,
+          organization.id,
+        );
+        if (!cancelled) {
+          // Either already dispatched (claim won the race) or unknown id.
+          return c.json({ cancelled: false }, 404);
+        }
+        streamBuffer.publish(thread.id, {
+          type: "data-queue-cancelled",
+          data: { type: "queue-cancelled", taskId: messageId },
+        });
+        return c.json({ cancelled: true });
+      } catch (err) {
+        console.error("[decopilot:queue:cancel] Error", err);
+        if (err instanceof HTTPException) {
+          return c.json({ error: err.message }, err.status);
+        }
+        return c.json({ error: "Internal error" }, 500);
+      }
+    },
+  );
 
   // ============================================================================
   // Cancel Endpoint — cancel ongoing run (local or via NATS to owning pod)

--- a/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
@@ -36,6 +36,16 @@ export interface StreamBuffer {
   ): void;
 
   /**
+   * Publish a single chunk onto the per-task subject. Used for out-of-band
+   * events (e.g. queue state transitions) that need to interleave with the
+   * run's UI stream without going through the pump.
+   *
+   * Fire-and-forget: publish errors are logged and dropped, same as `pump`.
+   * No-op when JetStream isn't configured.
+   */
+  publish(taskId: string, chunk: unknown): void;
+
+  /**
    * Subscribe to the per-task subject and stream chunks as a ReadableStream.
    * Returns null when JetStream is unavailable.
    *

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
@@ -18,6 +18,12 @@ describe("threadGateWorkflow plumbing", () => {
     const rt: ThreadGateRuntime = {
       dispatchRunFn: async () => ({ taskId: "t" }),
       meshContextFactory: async () => null,
+      queuedMessagesStorage: {
+        insert: async () => ({}) as never,
+        listByThread: async () => [],
+        cancel: async () => null,
+        claim: async () => "missing",
+      },
       deps: {
         runRegistry: {} as ThreadGateRuntime["deps"]["runRegistry"],
         cancelBroadcast: {} as ThreadGateRuntime["deps"]["cancelBroadcast"],

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -10,12 +10,13 @@
  * is what gives us "queue behavior" — DBOS won't dequeue the next message
  * on the same thread until this run is finished.
  *
- * Used by user-message POSTs (later: automation fires too). Automations
- * layer their existing per-automation and global gates above this
- * per-thread one; user messages enter here directly.
+ * Used by both user-message POSTs and automation fires (after Phase 5 of
+ * the queue unification). Automations layer their existing per-automation
+ * and global gates above this per-thread one; user messages enter here
+ * directly.
  *
- * Runtime dependencies (dispatch fn, mesh-context factory, dispatch deps)
- * are looked up via a module-level registry. App boot wires them via
+ * Runtime dependencies (storage, dispatch fn, mesh-context factory, dispatch
+ * deps) are looked up via a module-level registry. App boot wires them via
  * `setThreadGateRuntime` BEFORE `DBOS.launch()`. The workflow is registered
  * at import time so the recovery executor can replay it after a crash.
  */
@@ -26,6 +27,7 @@ import type {
   DispatchRunInput,
 } from "@/api/routes/decopilot/dispatch-run";
 import type { MeshContext } from "@/core/mesh-context";
+import type { QueuedMessagesStorage } from "@/storage/queued-messages";
 
 export const THREAD_GATE_QUEUE = "thread-gate";
 
@@ -51,6 +53,12 @@ export type SerializableDispatchRunInput = Omit<
 export interface ThreadGateContext {
   /** Stable thread identifier — also used as the queue partition key. */
   threadId: string;
+  /**
+   * Per-message id (== `queued_messages.id`). Distinct from `threadId`
+   * because a thread can have multiple queued messages. Used to claim /
+   * cancel the right row at dispatch time.
+   */
+  queuedMessageId: string;
   /** Dispatch input minus the non-serializable abort signal. */
   request: SerializableDispatchRunInput;
   /** Optional per-call timeout override (otherwise uses runtime default). */
@@ -75,6 +83,7 @@ export type MeshContextFactory = (
 export interface ThreadGateRuntime {
   dispatchRunFn: DispatchRunAndWaitFn;
   meshContextFactory: MeshContextFactory;
+  queuedMessagesStorage: QueuedMessagesStorage;
   deps: Pick<
     DispatchRunDeps,
     "runRegistry" | "cancelBroadcast" | "streamBuffer"
@@ -97,6 +106,52 @@ function requireRuntime(): ThreadGateRuntime {
   }
   return runtime;
 }
+
+/**
+ * Pre-flight claim. The row was inserted by `POST /messages` before
+ * enqueueing — atomically transition it (delete) now so a concurrent
+ * `DELETE /messages/:id` (cancel) loses the race rather than us dispatching
+ * a cancelled message.
+ *
+ * See `QueuedMessagesStorage.claim` for the tri-state return semantics
+ * (replay-safe).
+ */
+async function claimStep(
+  ctx: ThreadGateContext,
+): Promise<"claimed" | "cancelled" | "missing"> {
+  const rt = requireRuntime();
+  return await rt.queuedMessagesStorage.claim(ctx.queuedMessageId);
+}
+
+/**
+ * Emit a queue-state event onto the per-thread JetStream subject. Tail
+ * subscribers (`/attach`) see this interleaved with run chunks and update
+ * the inbox UI in real time.
+ *
+ * The chunk shape mirrors AI-SDK v5 typed data parts so the existing tail
+ * decoder can pass it through unchanged — the UI listens for these `type`
+ * values to add / remove pending message bubbles above the input.
+ */
+function emitQueueEvent(
+  threadId: string,
+  chunk:
+    | {
+        type: "queue-enqueued";
+        taskId: string;
+        content: string;
+        createdAt: string;
+      }
+    | { type: "queue-dequeued"; taskId: string }
+    | { type: "queue-cancelled"; taskId: string },
+): void {
+  const rt = runtime;
+  if (!rt) return;
+  const buffer = rt.deps.streamBuffer;
+  if (!buffer) return;
+  buffer.publish(threadId, { type: `data-${chunk.type}`, data: chunk });
+}
+
+export { emitQueueEvent };
 
 async function dispatchRunAndWaitStep(
   ctx: ThreadGateContext,
@@ -133,10 +188,30 @@ async function dispatchRunAndWaitStep(
 async function threadGateWorkflowFn(
   ctx: ThreadGateContext,
 ): Promise<ThreadGateOutcome> {
+  const taskId = ctx.request.taskId ?? ctx.threadId;
+
+  const claim = await DBOS.runStep(() => claimStep(ctx), {
+    name: "claimQueuedMessage",
+  });
+  if (claim === "cancelled") {
+    // taskId on queue events identifies the inbox row, not the thread,
+    // so the UI removes the right bubble. The thread id is encoded in
+    // the JetStream subject already.
+    emitQueueEvent(ctx.threadId, {
+      type: "queue-cancelled",
+      taskId: ctx.queuedMessageId,
+    });
+    return { taskId, error: "cancelled" };
+  }
+
+  emitQueueEvent(ctx.threadId, {
+    type: "queue-dequeued",
+    taskId: ctx.queuedMessageId,
+  });
+
   const result = await DBOS.runStep(() => dispatchRunAndWaitStep(ctx), {
     name: "dispatchRunAndWait",
   });
-  const taskId = ctx.request.taskId ?? ctx.threadId;
   if (result.error) return { taskId, error: result.error };
   return { taskId };
 }

--- a/apps/mesh/src/storage/queued-messages.ts
+++ b/apps/mesh/src/storage/queued-messages.ts
@@ -1,0 +1,150 @@
+/**
+ * Queued messages — pending agent runs awaiting dispatch on the per-thread
+ * gate queue.
+ *
+ * Powers the chat inbox: messages the user submitted while a run was already
+ * active. The workflow consumer claims a row at dispatch time (`claim`)
+ * which atomically deletes it, so the table only ever holds rows that
+ * haven't been picked up yet. Cancel marks `status='cancelled'` so the
+ * workflow consumer skips dispatch when it dequeues.
+ */
+
+import type { Kysely } from "kysely";
+import type { Database, QueuedMessage, QueuedMessageStatus } from "./types";
+
+export interface InsertQueuedMessageInput {
+  id: string;
+  threadId: string;
+  organizationId: string;
+  userId: string;
+  content: string;
+  workflowId: string;
+}
+
+function mapRow(row: {
+  id: string;
+  thread_id: string;
+  organization_id: string;
+  user_id: string;
+  content: string;
+  status: string;
+  workflow_id: string;
+  created_at: Date;
+}): QueuedMessage {
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    organizationId: row.organization_id,
+    userId: row.user_id,
+    content: row.content,
+    status: row.status as QueuedMessageStatus,
+    workflowId: row.workflow_id,
+    createdAt: row.created_at,
+  };
+}
+
+export interface QueuedMessagesStorage {
+  insert(input: InsertQueuedMessageInput): Promise<QueuedMessage>;
+  /**
+   * List rows for a thread, scoped to an org. Returns queued AND cancelled
+   * rows — cancelled rows are short-lived (consumer GCs them at dequeue)
+   * but the list endpoint excludes them for the inbox UI.
+   */
+  listByThread(
+    threadId: string,
+    organizationId: string,
+  ): Promise<QueuedMessage[]>;
+  /**
+   * Atomic CAS queued→cancelled. Returns the row when the transition
+   * succeeded, or null when the row was already gone (consumed) or already
+   * cancelled. Used by `DELETE /messages/:id`.
+   */
+  cancel(id: string, organizationId: string): Promise<QueuedMessage | null>;
+  /**
+   * Atomic claim. Used by the workflow consumer to decide whether to
+   * dispatch.
+   *
+   * - `"claimed"` — row existed with status='queued', deleted by this call.
+   *   Dispatch should proceed.
+   * - `"cancelled"` — row exists with status='cancelled'. User invoked
+   *   `DELETE /messages/:id`; skip dispatch.
+   * - `"missing"` — row does not exist. Treated as a DBOS replay-safety
+   *   case: a prior attempt of this workflow already deleted the row, and
+   *   we're re-running the claim step. Dispatch should proceed.
+   *
+   * Replay safety is the reason `claim` returns three states instead of a
+   * boolean: a DELETE that commits but doesn't get its result recorded
+   * (worker crash between the SQL ack and the DBOS step ack) must not
+   * cause the replay to skip dispatch.
+   */
+  claim(id: string): Promise<"claimed" | "cancelled" | "missing">;
+}
+
+export class SqlQueuedMessagesStorage implements QueuedMessagesStorage {
+  constructor(private readonly db: Kysely<Database>) {}
+
+  async insert(input: InsertQueuedMessageInput): Promise<QueuedMessage> {
+    const row = await this.db
+      .insertInto("queued_messages")
+      .values({
+        id: input.id,
+        thread_id: input.threadId,
+        organization_id: input.organizationId,
+        user_id: input.userId,
+        content: input.content,
+        status: "queued",
+        workflow_id: input.workflowId,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return mapRow(row);
+  }
+
+  async listByThread(
+    threadId: string,
+    organizationId: string,
+  ): Promise<QueuedMessage[]> {
+    const rows = await this.db
+      .selectFrom("queued_messages")
+      .selectAll()
+      .where("thread_id", "=", threadId)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "queued")
+      .orderBy("created_at", "asc")
+      .execute();
+    return rows.map(mapRow);
+  }
+
+  async cancel(
+    id: string,
+    organizationId: string,
+  ): Promise<QueuedMessage | null> {
+    const row = await this.db
+      .updateTable("queued_messages")
+      .set({ status: "cancelled" })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "queued")
+      .returningAll()
+      .executeTakeFirst();
+    return row ? mapRow(row) : null;
+  }
+
+  async claim(id: string): Promise<"claimed" | "cancelled" | "missing"> {
+    const deleted = await this.db
+      .deleteFrom("queued_messages")
+      .where("id", "=", id)
+      .where("status", "=", "queued")
+      .returning("id")
+      .executeTakeFirst();
+    if (deleted) return "claimed";
+
+    const remaining = await this.db
+      .selectFrom("queued_messages")
+      .select("status")
+      .where("id", "=", id)
+      .executeTakeFirst();
+    if (!remaining) return "missing";
+    return remaining.status === "cancelled" ? "cancelled" : "claimed";
+  }
+}

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1017,6 +1017,34 @@ export interface SandboxRunnerStateTable {
 }
 
 // ============================================================================
+// Queued Messages Table Definition
+// ============================================================================
+
+export type QueuedMessageStatus = "queued" | "cancelled";
+
+export interface QueuedMessageTable {
+  id: string;
+  thread_id: string;
+  organization_id: string;
+  user_id: string;
+  content: string;
+  status: QueuedMessageStatus;
+  workflow_id: string;
+  created_at: ColumnType<Date, Date | string | undefined, never>;
+}
+
+export interface QueuedMessage {
+  id: string;
+  threadId: string;
+  organizationId: string;
+  userId: string;
+  content: string;
+  status: QueuedMessageStatus;
+  workflowId: string;
+  createdAt: Date;
+}
+
+// ============================================================================
 // Organization Domain Table Definition
 // ============================================================================
 
@@ -1163,4 +1191,7 @@ export interface Database {
   organization_domains: OrganizationDomainTable;
 
   sandbox_runner_state: SandboxRunnerStateTable;
+
+  // Pending agent runs awaiting dispatch on the per-thread gate queue
+  queued_messages: QueuedMessageTable;
 }

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -67,6 +67,11 @@ const openedChats = new Set<string>();
 
 import { useChatNavigation } from "./hooks/use-chat-navigation";
 import { useStreamManager } from "./hooks/use-stream-manager";
+import {
+  decodeQueueChunk,
+  useThreadQueue,
+  type QueuedItem,
+} from "./hooks/use-thread-queue";
 import { useTaskActions } from "../../hooks/use-tasks";
 import { useTaskManager, type TaskOwnerFilter } from "./task";
 import { useTaskMessages } from "./task/use-task-manager";
@@ -103,6 +108,10 @@ export interface ChatStreamContextValue {
   isChatEmpty: boolean;
   isWaitingForApprovals: boolean;
   isRunInProgress: boolean;
+  /** Messages on this thread that are queued behind the active run. */
+  queuedMessages: QueuedItem[];
+  /** Cancel a queued message before the dispatcher picks it up. */
+  cancelQueuedMessage: (id: string) => Promise<void>;
 }
 
 export interface ChatTaskContextValue {
@@ -969,6 +978,11 @@ export function ActiveTaskProvider({
   const onToolCall = useInvalidateCollectionsOnToolCall();
   const queryClient = useQueryClient();
 
+  // Inbox of pending messages on this thread. `apply` is called from the
+  // chat's `onData` below for every `data-queue-*` chunk that arrives on
+  // /attach, so the bubble list stays in sync with the dispatcher.
+  const queue = useThreadQueue(org.slug, taskId);
+
   // Subscribe model: persistent /attach + POST /messages. No useChat.
   const chat = useThreadChat<ChatMessage>({
     threadId: taskId,
@@ -1019,7 +1033,10 @@ export function ActiveTaskProvider({
           title,
           updated_at: new Date().toISOString(),
         });
+        return;
       }
+      const queueEvent = decodeQueueChunk(chunk);
+      if (queueEvent) queue.apply(queueEvent);
     },
   });
 
@@ -1195,6 +1212,8 @@ export function ActiveTaskProvider({
     isChatEmpty,
     isWaitingForApprovals: isWaitingForApprovals ?? false,
     isRunInProgress,
+    queuedMessages: queue.items,
+    cancelQueuedMessage: queue.cancel,
   };
 
   return (

--- a/apps/mesh/src/web/components/chat/hooks/use-thread-queue.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-thread-queue.ts
@@ -1,0 +1,132 @@
+/**
+ * useThreadQueue — inbox of pending agent runs for one thread.
+ *
+ * Fetches the initial snapshot from `GET /:org/decopilot/threads/:id/queue`,
+ * then applies delta events from `useThreadChat`'s onData callback. The
+ * apply function is exposed so the chat consumer can forward
+ * `data-queue-*` chunks coming off the persistent /attach stream into this
+ * cache — no extra subscription needed.
+ *
+ * Cancel does an optimistic remove + `DELETE /:org/decopilot/threads/:id/queue/:messageId`;
+ * the matching `data-queue-cancelled` event arriving on /attach is a no-op
+ * because the row is already gone from the cache.
+ */
+
+import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+export interface QueuedItem {
+  id: string;
+  threadId: string;
+  content: string;
+  createdAt: string;
+}
+
+interface QueueQueryData {
+  items: QueuedItem[];
+}
+
+export type QueueEvent =
+  | {
+      type: "queue-enqueued";
+      taskId: string;
+      content: string;
+      createdAt: string;
+    }
+  | { type: "queue-dequeued"; taskId: string }
+  | { type: "queue-cancelled"; taskId: string };
+
+export function useThreadQueue(
+  orgSlug: string,
+  threadId: string,
+): {
+  items: QueuedItem[];
+  cancel: (id: string) => Promise<void>;
+  apply: (event: QueueEvent) => void;
+} {
+  const qc = useQueryClient();
+  const key = KEYS.threadQueue(orgSlug, threadId);
+
+  const { data } = useQuery({
+    queryKey: key,
+    enabled: !!threadId,
+    queryFn: async (): Promise<QueueQueryData> => {
+      const resp = await fetch(
+        `/api/${encodeURIComponent(orgSlug)}/decopilot/threads/${encodeURIComponent(threadId)}/queue`,
+        { credentials: "include" },
+      );
+      if (!resp.ok) return { items: [] };
+      return (await resp.json()) as QueueQueryData;
+    },
+  });
+
+  const cancel = async (id: string): Promise<void> => {
+    qc.setQueryData<QueueQueryData>(key, (curr) =>
+      curr ? { items: curr.items.filter((i) => i.id !== id) } : curr,
+    );
+    try {
+      const resp = await fetch(
+        `/api/${encodeURIComponent(orgSlug)}/decopilot/threads/${encodeURIComponent(threadId)}/queue/${encodeURIComponent(id)}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!resp.ok && resp.status !== 404) {
+        // Cancel raced with the dispatcher (claim won) or some other
+        // transient issue. Refetch to converge on the server's truth.
+        qc.invalidateQueries({ queryKey: key });
+      }
+    } catch {
+      qc.invalidateQueries({ queryKey: key });
+    }
+  };
+
+  const apply = (event: QueueEvent): void => {
+    qc.setQueryData<QueueQueryData>(key, (curr) => {
+      const items = curr?.items ?? [];
+      if (event.type === "queue-enqueued") {
+        if (items.some((i) => i.id === event.taskId)) return curr ?? { items };
+        return {
+          items: [
+            ...items,
+            {
+              id: event.taskId,
+              threadId,
+              content: event.content,
+              createdAt: event.createdAt,
+            },
+          ],
+        };
+      }
+      return { items: items.filter((i) => i.id !== event.taskId) };
+    });
+  };
+
+  return {
+    items: data?.items ?? [],
+    cancel,
+    apply,
+  };
+}
+
+/**
+ * Decoder for `data-queue-*` chunks coming off the /attach stream. Returns
+ * a `QueueEvent` when the chunk is a queue update, or null otherwise.
+ * Call from the chat consumer's `onData` callback and feed the result into
+ * `apply` from `useThreadQueue`.
+ */
+export function decodeQueueChunk(chunk: {
+  type: string;
+  data?: unknown;
+}): QueueEvent | null {
+  if (!chunk.type.startsWith("data-queue-")) return null;
+  const data = chunk.data;
+  if (typeof data !== "object" || data === null) return null;
+  const evt = data as { type?: string };
+  switch (evt.type) {
+    case "queue-enqueued":
+    case "queue-dequeued":
+    case "queue-cancelled":
+      return evt as QueueEvent;
+    default:
+      return null;
+  }
+}

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -58,6 +58,7 @@ import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dial
 import { ConnectionsBanner } from "./connections-banner";
 import { useVoiceInput } from "@/web/hooks/use-voice-input.ts";
 import { VoiceWaveform } from "./voice-input";
+import { QueuedMessages } from "./queued-messages";
 
 // ============================================================================
 // useWindowFileDrop - Reusable hook for window-level file drag & drop
@@ -352,20 +353,25 @@ export function ChatInput({
 
   const playClickSound = useSound(question004Sound);
 
-  const canSubmit =
-    !isStreaming && !isModelsLoading && !isTiptapDocEmpty(tiptapDoc);
+  // `canSubmit` no longer requires `!isStreaming`: typing while a run is
+  // active enqueues onto the thread-gate queue. The submit button stays
+  // visible as a send button when there's text, even mid-stream — only
+  // when the composer is empty does it morph into a stop button.
+  const canSubmit = !isModelsLoading && !isTiptapDocEmpty(tiptapDoc);
 
-  const showStopOrCancel = isStreaming || isRunInProgress;
+  const hasInput = !isTiptapDocEmpty(tiptapDoc);
+  const showStopOrCancel = (isStreaming || isRunInProgress) && !hasInput;
 
   const handleSubmit = (e?: FormEvent) => {
     e?.preventDefault();
-    if (isStreaming) {
+    // Empty composer + a run in progress → the button is in stop mode,
+    // so trigger cancel of the active run.
+    if (!canSubmit && (isStreaming || isRunInProgress)) {
       track("chat_message_stopped", { thread_id: taskId });
       stop();
-    } else if (isRunInProgress) {
-      track("chat_message_stopped", { thread_id: taskId });
-      stop();
-    } else if (canSubmit && tiptapDoc) {
+      return;
+    }
+    if (canSubmit && tiptapDoc) {
       track("chat_message_sent", {
         thread_id: taskId || null,
         mode: chatMode,
@@ -398,6 +404,17 @@ export function ChatInput({
   return (
     <>
       <div className="flex flex-col w-full justify-end">
+        {/* Pending messages bubbles — only shown on threads that have a stream
+            context (i.e. not on the home composer). Cancellation goes through
+            the chat stream context's cancelQueuedMessage. */}
+        {stream && stream.queuedMessages.length > 0 && (
+          <QueuedMessages
+            items={stream.queuedMessages}
+            onCancel={(id: string) => void stream.cancelQueuedMessage(id)}
+            className="mb-2"
+          />
+        )}
+
         <div className="relative rounded-2xl w-full flex flex-col">
           {/* Muted background for connections banner - peeks through form's bottom radius */}
           {showConnectionsBanner && (
@@ -413,7 +430,11 @@ export function ChatInput({
             key={taskId}
             tiptapDoc={tiptapDoc}
             setTiptapDoc={setTiptapDoc}
-            disabled={isStreaming}
+            // Editor stays enabled while a run is in flight so messages
+            // can be typed and submitted to the thread-gate queue. The
+            // submit button itself still morphs to "stop" when the
+            // composer is empty, so the active run can be cancelled.
+            disabled={false}
             enterToSubmit={true}
             onSubmit={handleSubmit}
           >
@@ -431,7 +452,7 @@ export function ChatInput({
               <div className="group/input relative flex flex-col gap-2 flex-1">
                 <TiptapInput
                   ref={tiptapRef}
-                  disabled={isStreaming || voice.status === "recording"}
+                  disabled={voice.status === "recording"}
                   virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
                   showFileUploader={true}
                   selectedModel={selectedModel}

--- a/apps/mesh/src/web/components/chat/queued-messages.tsx
+++ b/apps/mesh/src/web/components/chat/queued-messages.tsx
@@ -1,0 +1,56 @@
+/**
+ * Pending message bubbles shown above the input — one per row in the
+ * thread's gate queue, ordered oldest → newest. Clicking the X cancels
+ * the message before the dispatcher claims it; once dispatch starts the
+ * row is gone from this list (it'll surface as the streaming response in
+ * the chat instead).
+ *
+ * Pure presentational — state lives in `useThreadQueue`.
+ */
+
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { X } from "@untitledui/icons";
+import type { QueuedItem } from "./hooks/use-thread-queue";
+
+interface QueuedMessagesProps {
+  items: QueuedItem[];
+  onCancel: (id: string) => void;
+  className?: string;
+}
+
+export function QueuedMessages({
+  items,
+  onCancel,
+  className,
+}: QueuedMessagesProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className={cn(
+            "group flex items-center gap-2 rounded-lg border border-dashed",
+            "bg-muted/40 px-3 py-2 text-sm text-muted-foreground",
+          )}
+        >
+          <span className="flex-1 truncate" title={item.content}>
+            {item.content || "(no text)"}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 shrink-0 p-0 opacity-60 hover:opacity-100"
+            onClick={() => onCancel(item.id)}
+            aria-label="Remove queued message"
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -179,6 +179,8 @@ export const KEYS = {
   threadSandbox: (orgKey: string, taskId: string | undefined) =>
     ["thread-sandbox", "v2", orgKey, taskId] as const,
   threadOutputs: (threadId: string) => ["thread-outputs", threadId] as const,
+  threadQueue: (orgSlug: string, threadId: string) =>
+    ["thread-queue", orgSlug, threadId] as const,
 
   // Virtual MCP tools (for tool definition lookup in chat)
   // null virtualMcpId means default virtual MCP


### PR DESCRIPTION
## Summary

Visible queue management on top of the per-thread DBOS gate from #3376.

**Backend**
- `queued_messages` table (migration 078) — pending rows inserted on POST, atomically claimed by the workflow on dispatch. `claim()` is replay-safe (tri-state: claimed / cancelled / missing).
- `GET /:org/decopilot/threads/:id/queue` for initial snapshot + `DELETE /:org/decopilot/threads/:id/queue/:messageId` for cancel (atomic CAS).
- `streamBuffer.publish()` for emitting `data-queue-*` events onto the per-thread JetStream subject — tail subscribers see them interleaved with run chunks.

**Frontend**
- `useThreadQueue` hook (react-query backed) — fetches initial snapshot, exposes `apply(event)` so `useThreadChat`'s `onData` can forward `data-queue-*` chunks as deltas.
- `<QueuedMessages>` renders pending bubbles above the input with an X to cancel.
- Chat input no longer disabled mid-stream — typing enqueues onto the gate. The submit button is a stop button only when the composer is empty.

Built on top of #3376 (target branch for now; rebases to `main` after the stack merges).

## Known UX gap (not in this PR)

`useThreadChat.sendMessage` optimistically adds the user message to local chat state, so while a message is queued it shows both as a chat bubble and as a pending bubble. Likely fix: suppress the optimistic add while a run is already in-flight, or hide chat history entries that are still in the queue. Worth a separate design pass before deciding.

## Test plan

- [x] `bun run check` clean across all workspaces
- [x] 504 tests pass (decopilot + dispatch-queue + automations + storage)
- [ ] Manual: queue two messages on the same thread mid-stream and confirm:
  - both render as pending bubbles
  - clicking X cancels before dispatch
  - the second dispatches after the first finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pending-message inbox above the chat input so users can see and cancel queued messages while a run is in progress. Typing during a stream now enqueues to the per-thread gate instead of disabling the input.

- **New Features**
  - Backend: `queued_messages` table with replay-safe `claim()`; queue events published via `streamBuffer.publish` as `data-queue-*`.
  - API: `GET /:org/decopilot/threads/:threadId/queue` and `DELETE /:org/decopilot/threads/:threadId/queue/:messageId`.
  - POST response: returns `{ taskId, queuedMessageId }` for idempotency/cancel.
  - Frontend: `useThreadQueue` hook (+ `decodeQueueChunk`) to sync inbox via deltas.
  - UI: `<QueuedMessages>` renders pending bubbles with cancel.
  - Input: editor stays enabled mid-stream; send enqueues; button shows stop only when the composer is empty.

- **Migration**
  - Run DB migration `078-queued-messages`.

<sup>Written for commit f2a5fb3a5187b4d5d91ba8b9b8f50a1750fefef8. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

