### PR TITLE
feat(chat-input): container-responsive bottom row + chat panel min-width

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -440,7 +440,7 @@ export function ChatInput({
               </div>
 
               {/* Bottom Actions Row */}
-              <div className="flex items-center justify-between p-2.5 gap-1">
+              <div className="@container/chat-bottom flex items-center justify-between p-2.5 gap-1">
                 {voice.status === "recording" ? (
                   <>
                     {/* Spacer */}
@@ -500,10 +500,13 @@ export function ChatInput({
                             });
                             setChatMode("default");
                           }}
+                          title="Plan mode"
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          Plan mode
+                          <span className="hidden @[480px]/chat-bottom:inline">
+                            Plan mode
+                          </span>
                           <X
                             size={14}
                             className="shrink-0 hidden group-hover:block group-disabled:hidden"
@@ -523,10 +526,11 @@ export function ChatInput({
                             });
                             setChatMode("default");
                           }}
+                          title="Create image"
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="max-w-[120px] truncate">
+                          <span className="hidden @[480px]/chat-bottom:inline max-w-[120px] truncate">
                             Create image
                           </span>
                           <X
@@ -548,10 +552,11 @@ export function ChatInput({
                             });
                             setChatMode("default");
                           }}
+                          title="Web search"
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="max-w-[120px] truncate">
+                          <span className="hidden @[480px]/chat-bottom:inline max-w-[120px] truncate">
                             Web search
                           </span>
                           <X

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -505,7 +505,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-32 @[484px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-32 @[488px]/chat-bottom:opacity-100">
                             Plan mode
                           </span>
                           <X
@@ -532,7 +532,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-[120px] @[484px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-[120px] @[488px]/chat-bottom:opacity-100">
                             Create image
                           </span>
                           <X
@@ -559,7 +559,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-[120px] @[484px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-[120px] @[488px]/chat-bottom:opacity-100">
                             Web search
                           </span>
                           <X

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -505,7 +505,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          <span className="hidden @[480px]/chat-bottom:inline">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-32 @[480px]/chat-bottom:opacity-100">
                             Plan mode
                           </span>
                           <X
@@ -532,7 +532,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="hidden @[480px]/chat-bottom:inline max-w-[120px] truncate">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-[120px] @[480px]/chat-bottom:opacity-100">
                             Create image
                           </span>
                           <X
@@ -559,7 +559,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="hidden @[480px]/chat-bottom:inline max-w-[120px] truncate">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-[120px] @[480px]/chat-bottom:opacity-100">
                             Web search
                           </span>
                           <X

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -505,7 +505,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-32 @[488px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[496px]/chat-bottom:max-w-32 @[496px]/chat-bottom:opacity-100">
                             Plan mode
                           </span>
                           <X
@@ -532,7 +532,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-[120px] @[488px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[496px]/chat-bottom:max-w-[120px] @[496px]/chat-bottom:opacity-100">
                             Create image
                           </span>
                           <X
@@ -559,7 +559,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-[120px] @[488px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[496px]/chat-bottom:max-w-[120px] @[496px]/chat-bottom:opacity-100">
                             Web search
                           </span>
                           <X

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -501,6 +501,7 @@ export function ChatInput({
                             setChatMode("default");
                           }}
                           title="Plan mode"
+                          aria-label="Plan mode"
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
@@ -527,6 +528,7 @@ export function ChatInput({
                             setChatMode("default");
                           }}
                           title="Create image"
+                          aria-label="Create image"
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
@@ -553,6 +555,7 @@ export function ChatInput({
                             setChatMode("default");
                           }}
                           title="Web search"
+                          aria-label="Web search"
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -505,7 +505,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-violet-600 dark:text-violet-400 hover:bg-violet-500/10 group whitespace-nowrap animate-in fade-in duration-200"
                         >
                           <BookOpen01 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-32 @[480px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-32 @[484px]/chat-bottom:opacity-100">
                             Plan mode
                           </span>
                           <X
@@ -532,7 +532,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-pink-600 dark:text-pink-400 hover:bg-pink-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Image01 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-[120px] @[480px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-[120px] @[484px]/chat-bottom:opacity-100">
                             Create image
                           </span>
                           <X
@@ -559,7 +559,7 @@ export function ChatInput({
                           className="flex items-center gap-1.5 h-8 rounded-lg px-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-500/10 group whitespace-nowrap animate-in fade-in duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
                         >
                           <Globe02 size={14} className="shrink-0" />
-                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-[120px] @[480px]/chat-bottom:opacity-100">
+                          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-[120px] @[484px]/chat-bottom:opacity-100">
                             Web search
                           </span>
                           <X

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -48,10 +48,13 @@ export function SimpleModeTierDropdown({
           type="button"
           variant="ghost"
           size="default"
+          title={current.label}
           className="text-muted-foreground hover:text-foreground"
         >
           <Icon size={14} />
-          <span className="hidden sm:inline">{current.label}</span>
+          <span className="hidden @[480px]/chat-bottom:inline">
+            {current.label}
+          </span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-52 p-1.5">

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -49,6 +49,7 @@ export function SimpleModeTierDropdown({
           variant="ghost"
           size="default"
           title={current.label}
+          aria-label={current.label}
           className="text-muted-foreground hover:text-foreground"
         >
           <Icon size={14} />

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -53,7 +53,7 @@ export function SimpleModeTierDropdown({
           className="text-muted-foreground hover:text-foreground"
         >
           <Icon size={14} />
-          <span className="hidden @[480px]/chat-bottom:inline">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-24 @[480px]/chat-bottom:opacity-100">
             {current.label}
           </span>
         </Button>

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -53,7 +53,7 @@ export function SimpleModeTierDropdown({
           className="text-muted-foreground hover:text-foreground"
         >
           <Icon size={14} />
-          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-24 @[480px]/chat-bottom:opacity-100">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-24 @[484px]/chat-bottom:opacity-100">
             {current.label}
           </span>
         </Button>

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -53,7 +53,7 @@ export function SimpleModeTierDropdown({
           className="text-muted-foreground hover:text-foreground"
         >
           <Icon size={14} />
-          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-24 @[488px]/chat-bottom:opacity-100">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[496px]/chat-bottom:max-w-24 @[496px]/chat-bottom:opacity-100">
             {current.label}
           </span>
         </Button>

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -53,7 +53,7 @@ export function SimpleModeTierDropdown({
           className="text-muted-foreground hover:text-foreground"
         >
           <Icon size={14} />
-          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-24 @[484px]/chat-bottom:opacity-100">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-24 @[488px]/chat-bottom:opacity-100">
             {current.label}
           </span>
         </Button>

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -213,7 +213,7 @@ export function ToolsPopover({
             className="text-muted-foreground hover:text-foreground"
           >
             <Settings04 size={14} />
-            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-24 @[488px]/chat-bottom:opacity-100">
+            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[496px]/chat-bottom:max-w-24 @[496px]/chat-bottom:opacity-100">
               Tools
             </span>
           </Button>

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -213,7 +213,7 @@ export function ToolsPopover({
             className="text-muted-foreground hover:text-foreground"
           >
             <Settings04 size={14} />
-            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-24 @[480px]/chat-bottom:opacity-100">
+            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-24 @[484px]/chat-bottom:opacity-100">
               Tools
             </span>
           </Button>

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -209,6 +209,7 @@ export function ToolsPopover({
             size="default"
             disabled={disabled}
             title="Tools"
+            aria-label="Tools"
             className="text-muted-foreground hover:text-foreground"
           >
             <Settings04 size={14} />

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -208,10 +208,11 @@ export function ToolsPopover({
             variant="ghost"
             size="default"
             disabled={disabled}
+            title="Tools"
             className="text-muted-foreground hover:text-foreground"
           >
             <Settings04 size={14} />
-            <span className="hidden sm:inline">Tools</span>
+            <span className="hidden @[480px]/chat-bottom:inline">Tools</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-52 p-1.5">

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -213,7 +213,9 @@ export function ToolsPopover({
             className="text-muted-foreground hover:text-foreground"
           >
             <Settings04 size={14} />
-            <span className="hidden @[480px]/chat-bottom:inline">Tools</span>
+            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-24 @[480px]/chat-bottom:opacity-100">
+              Tools
+            </span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-52 p-1.5">

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -213,7 +213,7 @@ export function ToolsPopover({
             className="text-muted-foreground hover:text-foreground"
           >
             <Settings04 size={14} />
-            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-24 @[484px]/chat-bottom:opacity-100">
+            <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-24 @[488px]/chat-bottom:opacity-100">
               Tools
             </span>
           </Button>

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -215,7 +215,7 @@ export function SessionStats({
               )}
             />
           </svg>
-          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-32 @[480px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-32 @[484px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
             {pct.toFixed(0)}%{cost > 0 ? ` · $${cost.toFixed(2)}` : ""}
           </span>
         </button>

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -215,7 +215,7 @@ export function SessionStats({
               )}
             />
           </svg>
-          <span className="hidden @[480px]/chat-bottom:inline text-[11px] font-mono tabular-nums">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[480px]/chat-bottom:max-w-32 @[480px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
             {pct.toFixed(0)}%{cost > 0 ? ` · $${cost.toFixed(2)}` : ""}
           </span>
         </button>

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -180,6 +180,7 @@ export function SessionStats({
         <button
           type="button"
           onClick={onOpenContextPanel}
+          aria-label={`Context usage: ${pct.toFixed(0)}%${cost > 0 ? `, $${cost.toFixed(2)}` : ""}`}
           className={cn(
             "flex items-center gap-1.5 text-muted-foreground hover:text-foreground h-6 px-1 shrink-0",
             onOpenContextPanel ? "cursor-pointer" : "cursor-default",
@@ -214,7 +215,7 @@ export function SessionStats({
               )}
             />
           </svg>
-          <span className="text-[11px] font-mono tabular-nums">
+          <span className="hidden @[480px]/chat-bottom:inline text-[11px] font-mono tabular-nums">
             {pct.toFixed(0)}%{cost > 0 ? ` · $${cost.toFixed(2)}` : ""}
           </span>
         </button>

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -215,7 +215,7 @@ export function SessionStats({
               )}
             />
           </svg>
-          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[484px]/chat-bottom:max-w-32 @[484px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-32 @[488px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
             {pct.toFixed(0)}%{cost > 0 ? ` · $${cost.toFixed(2)}` : ""}
           </span>
         </button>

--- a/apps/mesh/src/web/components/chat/usage-stats.tsx
+++ b/apps/mesh/src/web/components/chat/usage-stats.tsx
@@ -215,7 +215,7 @@ export function SessionStats({
               )}
             />
           </svg>
-          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[488px]/chat-bottom:max-w-32 @[488px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
+          <span className="inline-block overflow-hidden whitespace-nowrap max-w-0 opacity-0 transition-[max-width,opacity] duration-200 ease-out @[496px]/chat-bottom:max-w-32 @[496px]/chat-bottom:opacity-100 text-[11px] font-mono tabular-nums">
             {pct.toFixed(0)}%{cost > 0 ? ` · $${cost.toFixed(2)}` : ""}
           </span>
         </button>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -28,7 +28,8 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 function PersistentChatPanel({
   children,
   defaultSize,
-}: PropsWithChildren<{ defaultSize: number }>) {
+  chatOpen,
+}: PropsWithChildren<{ defaultSize: number; chatOpen: boolean }>) {
   const [_isPending, startTransition] = useTransition();
   const [storedChatPanelWidth, setChatPanelWidth] = useLocalStorage(
     LOCALSTORAGE_KEYS.decoChatPanelWidth(),
@@ -48,7 +49,10 @@ function PersistentChatPanel({
       minSize={20}
       collapsible={true}
       collapsedSize={0}
-      className="min-w-0 overflow-hidden bg-sidebar"
+      className={cn(
+        "overflow-hidden bg-sidebar",
+        chatOpen ? "min-w-[328px]" : "min-w-0",
+      )}
       onResize={handleResize}
       order={1}
     >
@@ -102,7 +106,7 @@ export function ChatMainPanelGroup({
       className="flex-1 min-h-0 pb-1 pr-1 pl-0 pt-0"
       style={{ overflow: "visible" }}
     >
-      <PersistentChatPanel defaultSize={sizes.chat}>
+      <PersistentChatPanel defaultSize={sizes.chat} chatOpen={chatOpen}>
         <div className="h-full p-0.5 pt-0.25">
           <div className="h-full bg-background rounded-[0.75rem] overflow-hidden card-shadow">
             {chatContent ?? <ChatCenterPanel />}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -51,7 +51,7 @@ function PersistentChatPanel({
       collapsedSize={0}
       className={cn(
         "overflow-hidden bg-sidebar",
-        chatOpen ? "min-w-[328px]" : "min-w-0",
+        chatOpen ? "min-w-[348px]" : "min-w-0",
       )}
       onResize={handleResize}
       order={1}


### PR DESCRIPTION
## What is this contribution about?

The chat-input bottom row (Tools, tier dropdown, Plan/Image/Web pills, context ring) used `hidden sm:inline` to collapse labels — but `sm:` is a viewport breakpoint, so a wide viewport with a narrow chat panel still showed the text and overflowed the container. This PR migrates those labels to a Tailwind v4 named container query (`@container/chat-bottom` + `@[496px]/chat-bottom:`), so labels collapse based on the chat panel's actual width and glide in/out via `max-width` + `opacity` over 200ms. Buttons gained `aria-label` (alongside `title`) so the icon-only state has a real accessible name for screen readers. As a complementary fix, `PersistentChatPanel` (the `react-resizable-panels` wrapper) now enforces a 348px CSS `min-width` while chat is open — `minSize` is percentage-based and would otherwise let small viewports shrink the panel below the width its bottom row is designed for; we drop the min-width when chat is toggled closed so the library can still collapse to 0.

## Screenshots/Demonstration

Drag the right-side panel open until the chat column squeezes — the labels (Tools, Smart/Fast/Thinking, any active mode pill, and the context % text) fade and slide to icon-only together at 496px of chat-panel width. Drag the chat-main divider all the way left — the chat panel stops at 348px instead of percentage-based 20%.

## How to Test

1. `bun run dev` and open any chat.
2. With a wide chat panel, verify Tools / tier / context % / any active pill all show their text labels.
3. Open the right context panel (or drag the chat-main divider) to narrow the chat column. As it crosses 496px, the labels animate to icon-only and the bottom row stops overflowing.
4. Hover an icon-only button — `title` tooltip shows the label. Verify (e.g., via DevTools Accessibility tree) that each button reports an accessible name.
5. Drag the chat-main divider all the way left — chat panel floors at 348px and won't shrink further. Toggle chat closed via the existing button — panel still collapses to 0.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the chat input’s bottom row responsive to the chat panel width using Tailwind v4 container queries. Labels collapse to icons under 496px to prevent overflow, and the chat panel now keeps a 348px min width when open.

- **New Features**
  - Use `@container/chat-bottom` + `@[496px]/chat-bottom:` so Tools, tier, Plan/Image/Web pills, and SessionStats text collapse based on panel width.
  - Animate label collapse with `max-width` + `opacity` over 200ms.
  - Add `aria-label` to bottom-row buttons and SessionStats for accessible names; keep `title` for hover tooltips.
  - Enforce CSS `min-width: 348px` on the `react-resizable-panels` chat panel while `chatOpen`; allow collapse to 0 when closed.
  - Fix overflow when the viewport is wide but the chat panel is narrow.

<sup>Written for commit 61e1bef3fd7243b9cfcdd824d8e860172f3e3654. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

