### PR TITLE
fix(chat): scroll no-AI-provider empty state when content exceeds viewport

### DIFF
--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -43,7 +43,7 @@ function ChatMain({
 
 function ChatEmptyState({ children }: PropsWithChildren) {
   return (
-    <div className="h-full w-full flex items-center justify-center max-w-2xl mx-auto">
+    <div className="min-h-full shrink-0 w-full flex items-center justify-center max-w-2xl mx-auto py-10">
       {children}
     </div>
   );

--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -91,8 +91,10 @@ export function HomePage() {
 
   if (allKeys.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center px-4 py-10">
-        <NoAiProviderEmptyState />
+      <div className="flex-1 overflow-y-auto">
+        <div className="min-h-full flex items-center justify-center px-4 py-10">
+          <NoAiProviderEmptyState />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What is this contribution about?

The "no AI provider" empty state (badge + heading + provider grid) was getting clipped at the top and bottom when its content exceeded the available panel height, with no way to scroll to the hidden content. This happened in both the side panel chat (`Chat.EmptyState`) and the home page route. Both wrappers used `h-full` + `flex items-center justify-center`, which pinned the element to the parent's height and pushed overflowing content equally above and below — unreachable. Switched both to `min-h-full` (plus `shrink-0` on the chat case to defeat its `flex flex-col` parent collapsing it) so the wrapper grows with its content and the existing `overflow-y-auto` parent becomes scrollable. Also added `py-10` to the chat empty state for breathing room.

## How to Test

1. Sign into an org that has no AI provider keys configured.
2. Open an agent page where the side panel chat renders the empty state (e.g. `/<org>/<agent>?main=instructions`), and resize the window so the panel height is small enough that the provider grid exceeds the visible area.
3. Confirm the heading and badge are visible at the top, the provider grid scrolls naturally, and nothing is clipped. The home page route (`/<org>/`) when no providers are set should behave the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clipping and enables scrolling for the “no AI provider” empty state in chat and home when content exceeds the viewport.

- **Bug Fixes**
  - Chat: switch wrapper from `h-full` to `min-h-full` + `shrink-0`, add `py-10` so content expands and the parent’s `overflow-y-auto` scrolls.
  - Home: add an `overflow-y-auto` wrapper and set inner container to `min-h-full` with centered layout and padding.

<sup>Written for commit 8d1678cc49a8c7809b8f485cb10f818c21a9d0c4. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3379?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

