### PR TITLE
fix(chat): keep highlight card opaque when variant tint applied

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -56,10 +56,16 @@ export interface CollapsibleHighlightProps {
   onClose?: () => void;
 }
 
+// Tint is applied via an ::after pseudo-element instead of a `bg-*` utility so
+// it layers over `bg-background` rather than colliding with it under twMerge
+// (which would otherwise strip the solid background and leave the card
+// translucent).
 const VARIANT_OVERLAY: Record<HighlightVariant, string> = {
   default: "",
-  error: "bg-destructive/5",
-  warning: "bg-amber-500/5",
+  error:
+    "after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-destructive/5 after:pointer-events-none",
+  warning:
+    "after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-amber-500/5 after:pointer-events-none",
 };
 
 const VARIANT_BORDER: Record<HighlightVariant, string> = {
@@ -101,7 +107,7 @@ export function CollapsibleHighlight({
       data-testid="collapsible-highlight"
       data-variant={variant}
       className={cn(
-        "flex flex-col rounded-xl bg-background border shadow-md",
+        "relative flex flex-col rounded-xl bg-background border shadow-md",
         "w-[calc(100%-16px)] max-w-[640px] mx-auto mb-2",
         VARIANT_BORDER[variant],
         VARIANT_OVERLAY[variant],


### PR DESCRIPTION
## What is this contribution about?

Error and warning highlight cards above the chat input were rendering translucent. `CollapsibleHighlight` combines `bg-background` with a variant tint (`bg-destructive/5` or `bg-amber-500/5`) through `cn()` → `twMerge`, and twMerge dedupes conflicting `bg-*` utilities — so the solid background got stripped and only the 5%-alpha tint survived, letting messages bleed through.

This PR applies the tint via an `::after` pseudo-element (`relative` parent + `after:absolute after:inset-0 after:bg-…/5 after:pointer-events-none`) so it layers on top of `bg-background` instead of colliding with it. The `default` variant is unchanged.

## Screenshots/Demonstration

Before: error/warning highlights appeared semi-transparent over chat content. After: highlights render on a solid background with the colored tint layered on top.

## How to Test

1. Trigger an error in the chat (e.g. submit when an error path is hit) so the red \"Error occurred\" highlight appears above the chat input.
2. Trigger a warning (e.g. a non-stop \`finishReason\` like \`length\`).
3. Expected: both cards have a solid opaque background with a subtle red/amber tint; no underlying chat content shows through.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes translucent error/warning highlight cards by layering the tint with an ::after overlay so the solid background stays opaque. Prevents chat messages from bleeding through.

- **Bug Fixes**
  - Apply tint via `::after` overlay (`after:bg-destructive/5` or `after:bg-amber-500/5`) with a `relative` parent.
  - Add `after:rounded-xl` and `after:pointer-events-none` to match shape and avoid intercepting clicks.
  - Default variant unchanged.

<sup>Written for commit 05f1241ef6bc046b181acf08e47cba4f90ebd05d. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3380?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

