### PR TITLE
feat(chat): click prompt chip in editor to edit its arguments

### DIFF
--- a/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
+++ b/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
@@ -32,6 +32,8 @@ interface PromptArgsDialogProps {
   prompt: Prompt | null;
   setPrompt: (prompt: Prompt | null) => void;
   onSubmit: (values: PromptArgumentValues) => Promise<void>;
+  /** Pre-fill the form (e.g., when editing an existing prompt chip). */
+  defaultValues?: PromptArgumentValues;
 }
 
 function buildArgumentSchema(prompt: Prompt) {
@@ -44,10 +46,13 @@ function buildArgumentSchema(prompt: Prompt) {
   return z.object(shape);
 }
 
-function buildDefaultValues(prompt: Prompt): PromptArgumentValues {
+function buildDefaultValues(
+  prompt: Prompt,
+  overrides?: PromptArgumentValues,
+): PromptArgumentValues {
   const defaults: PromptArgumentValues = {};
   for (const arg of prompt.arguments ?? []) {
-    defaults[arg.name] = "";
+    defaults[arg.name] = overrides?.[arg.name] ?? "";
   }
   return defaults;
 }
@@ -56,13 +61,14 @@ export function PromptArgsDialog({
   prompt,
   setPrompt,
   onSubmit,
+  defaultValues,
 }: PromptArgsDialogProps) {
   const id = useId();
   const schema = prompt ? buildArgumentSchema(prompt) : z.object({});
   const resolver = zodResolver(schema as any);
   const form = useForm<PromptArgumentValues>({
     resolver: resolver as unknown as Resolver<PromptArgumentValues>,
-    defaultValues: prompt ? buildDefaultValues(prompt) : {},
+    defaultValues: prompt ? buildDefaultValues(prompt, defaultValues) : {},
     mode: "onChange",
   });
 

--- a/apps/mesh/src/web/components/chat/ice-breakers.tsx
+++ b/apps/mesh/src/web/components/chat/ice-breakers.tsx
@@ -396,6 +396,8 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
             ),
             metadata: result.messages,
             char: "/",
+            kind: "prompt",
+            args,
           }),
         ],
       });

--- a/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
@@ -155,10 +155,15 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
   const requestEditRef = useRef<(req: EditMentionRequest) => void>(() => {});
   requestEditRef.current = async (req: EditMentionRequest) => {
     if (!client) return;
-    const prompts = await fetchPrompts(queryClient, promptsQueryKey, client);
-    const prompt = prompts.find((p) => p.name === req.promptId);
-    if (!prompt?.arguments || prompt.arguments.length === 0) return;
-    setEditingMention({ ...req, prompt });
+    try {
+      const prompts = await fetchPrompts(queryClient, promptsQueryKey, client);
+      const prompt = prompts.find((p) => p.name === req.promptId);
+      if (!prompt?.arguments || prompt.arguments.length === 0) return;
+      setEditingMention({ ...req, prompt });
+    } catch (error) {
+      console.error("[slash] Failed to load prompt for editing:", error);
+      toast.error("Failed to load prompt. Please try again.");
+    }
   };
   // Reassign the storage dispatcher on every render so that if SlashMention
   // remounts (Suspense, route change), the new instance's ref is used instead

--- a/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
@@ -31,7 +31,15 @@ import {
   PromptArgsDialog,
   type PromptArgumentValues,
 } from "../dialog-prompt-arguments.tsx";
-import { BaseItem, insertMention, OnSelectProps, Suggestion } from "./mention";
+import {
+  BaseItem,
+  createMentionDoc,
+  getMentionStorage,
+  insertMention,
+  OnSelectProps,
+  Suggestion,
+  type EditMentionRequest,
+} from "./mention";
 import { track } from "@/web/lib/posthog-client";
 
 interface SlashMentionProps {
@@ -54,6 +62,14 @@ interface PromptSelectContext {
   item: SlashItem;
 }
 
+interface EditingMention {
+  promptId: string;
+  promptName: string;
+  args: Record<string, string>;
+  pos: number;
+  prompt: Prompt;
+}
+
 async function fetchAndInsertPrompt(
   editor: Editor,
   range: Range,
@@ -70,6 +86,8 @@ async function fetchAndInsertPrompt(
       name: stripToolNamespace(promptName, clientId),
       metadata: result.messages,
       char: "/",
+      kind: "prompt",
+      args: values,
     });
   } catch (error) {
     console.error("[slash] Failed to fetch prompt:", error);
@@ -91,6 +109,7 @@ async function fetchAndInsertResource(
       name: resourceUri,
       metadata: result.contents,
       char: "/",
+      kind: "resource",
     });
   } catch (error) {
     console.error("[slash] Failed to fetch resource:", error);
@@ -126,6 +145,29 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
   const [activePrompt, setActivePrompt] = useState<PromptSelectContext | null>(
     null,
   );
+  const [editingMention, setEditingMention] = useState<EditingMention | null>(
+    null,
+  );
+
+  // Bridge for chip clicks → edit dialog. The storage on the MentionNode
+  // extension is read by `MentionNodeView`; we dispatch through a ref so the
+  // stored callback always uses the latest closure without needing useEffect.
+  const requestEditRef = useRef<(req: EditMentionRequest) => void>(() => {});
+  requestEditRef.current = async (req: EditMentionRequest) => {
+    if (!client) return;
+    const prompts = await fetchPrompts(queryClient, promptsQueryKey, client);
+    const prompt = prompts.find((p) => p.name === req.promptId);
+    if (!prompt?.arguments || prompt.arguments.length === 0) return;
+    setEditingMention({ ...req, prompt });
+  };
+  // Reassign the storage dispatcher on every render so that if SlashMention
+  // remounts (Suspense, route change), the new instance's ref is used instead
+  // of the stale one from the previous mount. The closure simply forwards to
+  // the latest `requestEditRef.current`.
+  const mentionStorage = getMentionStorage(editor);
+  if (mentionStorage) {
+    mentionStorage.onEditChip = (req) => requestEditRef.current(req);
+  }
 
   // Track picker open → close outcome so we can measure abandonment.
   const pickerOpenedAtRef = useRef<number | null>(null);
@@ -174,6 +216,44 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
       values,
     );
     setActivePrompt(null);
+  };
+
+  const handleEditDialogSubmit = async (newValues: PromptArgumentValues) => {
+    if (!editingMention || !client) return;
+    try {
+      const result = await getPrompt(
+        client,
+        editingMention.promptId,
+        newValues,
+      );
+      const clientId = getGatewayClientId(editingMention.prompt._meta);
+      editor
+        .chain()
+        .focus()
+        .setNodeSelection(editingMention.pos)
+        .deleteSelection()
+        .insertContentAt(
+          editingMention.pos,
+          createMentionDoc({
+            id: editingMention.promptId,
+            name: stripToolNamespace(editingMention.promptId, clientId),
+            metadata: result.messages,
+            char: "/",
+            kind: "prompt",
+            args: newValues,
+          }),
+        )
+        .run();
+      track("chat_picker_item_selected", {
+        picker: "/edit",
+        item_kind: "prompt",
+        item_name: editingMention.promptId,
+      });
+    } catch (error) {
+      console.error("[slash] Failed to update prompt:", error);
+      toast.error("Failed to update prompt. Please try again.");
+    }
+    setEditingMention(null);
   };
 
   const fetchItems = async (props: { query: string }): Promise<SlashItem[]> => {
@@ -270,6 +350,17 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
         prompt={dialogPrompt}
         setPrompt={() => setActivePrompt(null)}
         onSubmit={handleDialogSubmit}
+      />
+      <PromptArgsDialog
+        key={
+          editingMention
+            ? `edit-${editingMention.promptId}-${editingMention.pos}`
+            : "edit-idle"
+        }
+        prompt={editingMention?.prompt ?? null}
+        setPrompt={() => setEditingMention(null)}
+        onSubmit={handleEditDialogSubmit}
+        defaultValues={editingMention?.args}
       />
     </>
   );

--- a/apps/mesh/src/web/components/chat/tiptap/mention/index.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/index.ts
@@ -1,3 +1,11 @@
 export type { BaseItem, OnSelectProps } from "./hooks.ts";
-export { insertMention, MentionNode } from "./node.tsx";
+export {
+  createMentionDoc,
+  getMentionStorage,
+  insertMention,
+  MentionNode,
+  type EditMentionRequest,
+  type MentionAttrs,
+  type MentionStorage,
+} from "./node.tsx";
 export { Suggestion } from "./suggestion.tsx";

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -22,6 +22,31 @@ export interface MentionAttrs<T = unknown> {
   metadata: T;
   /** Character that triggered the mention ("/" prompts+resources, "@" agents) */
   char?: "/" | "@";
+  /** Discriminator for "/" mentions; "@" mentions are always agents. */
+  kind?: "prompt" | "resource";
+  /** Argument values the user typed in PromptArgsDialog. Only meaningful for prompt mentions. */
+  args?: Record<string, string>;
+}
+
+// ============================================================================
+// Edit Bridge (chip click → SlashMention dialog)
+// ============================================================================
+
+export interface EditMentionRequest {
+  promptId: string;
+  promptName: string;
+  args: Record<string, string>;
+  pos: number;
+}
+
+export interface MentionStorage {
+  onEditChip: ((req: EditMentionRequest) => void) | null;
+}
+
+export function getMentionStorage(editor: Editor): MentionStorage | undefined {
+  return (editor.storage as unknown as Record<string, unknown>).mention as
+    | MentionStorage
+    | undefined;
 }
 
 // ============================================================================
@@ -61,23 +86,47 @@ export function createMentionDoc<T>(attrs: MentionAttrs<T>): JSONContent {
 // ============================================================================
 
 function MentionNodeView(props: NodeViewProps) {
-  const { node, selected, view } = props;
-  const { name, char } = node.attrs as MentionAttrs;
+  const { node, selected, view, editor, getPos } = props;
+  const { name, char, kind, id, args } = node.attrs as MentionAttrs;
 
   const isSelected = selected && view.editable;
   const isAgent = char === "@";
+  // Clickable when editable AND it's a "/" mention that's either a known
+  // prompt or a legacy chip without `kind` (we'll re-verify in the handler).
+  const isClickable = view.editable && char === "/" && kind !== "resource";
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!isClickable) return;
+    const storage = getMentionStorage(editor);
+    const onEdit = storage?.onEditChip;
+    if (!onEdit) return;
+    if (typeof getPos !== "function") return;
+    const pos = getPos();
+    if (typeof pos !== "number") return;
+    e.preventDefault();
+    e.stopPropagation();
+    onEdit({
+      promptId: id,
+      promptName: name,
+      args: args ?? {},
+      pos,
+    });
+  };
 
   return (
     <NodeViewWrapper
+      onClick={handleClick}
       className={cn(
         "px-1 py-1 rounded",
         "inline-flex items-center gap-1",
-        "cursor-default select-none",
+        isClickable ? "cursor-pointer" : "cursor-default",
+        "select-none",
         "text-xs font-light",
         isAgent
           ? "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400"
           : "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
         isSelected && "outline-2 outline-blue-300 outline-offset-0",
+        isClickable && "hover:brightness-95",
         "capitalize",
       )}
     >
@@ -97,6 +146,12 @@ export const MentionNode = Node.create({
   group: "inline",
   inline: true,
   atom: true,
+
+  addStorage(): MentionStorage {
+    return {
+      onEditChip: null,
+    };
+  },
 
   addAttributes() {
     return {
@@ -138,6 +193,28 @@ export const MentionNode = Node.create({
           return { "data-metadata": JSON.stringify(attributes.metadata) };
         },
       },
+      kind: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-kind") || null,
+        renderHTML: (attributes) => {
+          if (!attributes.kind) return {};
+          return { "data-kind": attributes.kind };
+        },
+      },
+      args: {
+        default: null,
+        parseHTML: (element) => {
+          try {
+            return JSON.parse(element.getAttribute("data-args") || "null");
+          } catch {
+            return null;
+          }
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.args) return {};
+          return { "data-args": JSON.stringify(attributes.args) };
+        },
+      },
     };
   },
 
@@ -167,6 +244,12 @@ export const MentionNode = Node.create({
     }
     if (node.attrs.metadata) {
       attrs["data-metadata"] = JSON.stringify(node.attrs.metadata);
+    }
+    if (node.attrs.kind) {
+      attrs["data-kind"] = node.attrs.kind;
+    }
+    if (node.attrs.args) {
+      attrs["data-args"] = JSON.stringify(node.attrs.args);
     }
 
     return ["span", { ...HTMLAttributes, ...attrs }];

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -136,6 +136,8 @@ export function ToolsPopover({
         name: stripToolNamespace(prompt.name, clientId),
         metadata: result.messages,
         char: "/",
+        kind: "prompt",
+        args: values,
       });
     } catch {
       toast.error("Failed to load prompt. Please try again.");


### PR DESCRIPTION
## What is this contribution about?
Slash-prompt chips in the Tiptap editor (e.g. `/Predict And Apply` in the automation Instructions field, or in chat) are now clickable. Clicking a prompt chip re-opens `PromptArgsDialog` pre-filled with the values the user originally typed and, on submit, replaces the chip in place with refreshed metadata. Mention nodes now persist `kind` ("prompt" | "resource") and `args` so the edit flow knows what to pre-fill and can ignore non-editable chips.

## Screenshots/Demonstration
N/A — pure UX wiring on existing components.

## How to Test
1. `bun run dev`, open an automation that has a slash-prompt with arguments (e.g. `/Predict And Apply`) in its Instructions.
2. Click the orange chip. The arguments modal should open with the previous values pre-filled.
3. Change a value, confirm — the chip stays in place and autosaves. Reload to verify persistence.
4. Resources (`/`-mentions with `kind: "resource"`) and `@` agent chips should remain non-clickable.

## Migration Notes
Backward compatible: existing chips in the DB have no `kind`/`args`. They are still clickable; the dialog opens with empty values on first edit, and from then on the args are stored.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slash-prompt chips are now clickable to edit arguments in place via `PromptArgsDialog`; submit refreshes the chip. Resource and `@` chips remain non-clickable; backward compatible (old chips open blank on first edit).

- **New Features**
  - Prompt chips open `PromptArgsDialog` pre-filled; submit replaces the chip in place with refreshed metadata.
  - Mention nodes persist `kind` (`"prompt"` | `"resource"`) and `args`; only prompt chips are clickable.
  - `PromptArgsDialog` accepts `defaultValues`; added click-to-edit bridge from `MentionNode` to `SlashMention`. Ice breakers and tools popover now set `kind` and `args` on insert.

- **Bug Fixes**
  - Wrapped prompt lookup in the edit-on-click flow with try/catch and toast error to avoid unhandled rejections when loading prompts fails.

<sup>Written for commit b279797d99b1747521ead45b4fbff9a4b7aa61cc. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3384?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

