### PR TITLE
fix(ai-providers): sync codex model catalog and add tier defaults

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/codex.ts
+++ b/apps/mesh/src/ai-providers/adapters/codex.ts
@@ -8,9 +8,20 @@ const CODEX_LOGO =
 export const CODEX_MODELS: ModelInfo[] = [
   {
     providerId: "codex",
+    modelId: "codex:gpt-5.5",
+    title: "GPT-5.5",
+    description:
+      "Frontier model for complex coding, research, and real-world work",
+    capabilities: ["text", "reasoning"],
+    logo: CODEX_LOGO,
+    limits: null,
+    costs: null,
+  },
+  {
+    providerId: "codex",
     modelId: "codex:gpt-5.4",
     title: "GPT-5.4",
-    description: "Latest frontier agentic coding model",
+    description: "Strong model for everyday coding",
     capabilities: ["text", "reasoning"],
     logo: CODEX_LOGO,
     limits: null,
@@ -20,7 +31,8 @@ export const CODEX_MODELS: ModelInfo[] = [
     providerId: "codex",
     modelId: "codex:gpt-5.4-mini",
     title: "GPT-5.4 Mini",
-    description: "Latest frontier agentic coding model",
+    description:
+      "Small, fast, and cost-efficient model for simpler coding tasks",
     capabilities: ["text", "reasoning"],
     logo: CODEX_LOGO,
     limits: null,
@@ -30,7 +42,7 @@ export const CODEX_MODELS: ModelInfo[] = [
     providerId: "codex",
     modelId: "codex:gpt-5.3-codex",
     title: "GPT-5.3 Codex",
-    description: "Frontier Codex-optimized agentic coding model",
+    description: "Coding-optimized model",
     capabilities: ["text", "reasoning"],
     logo: CODEX_LOGO,
     limits: null,
@@ -38,30 +50,10 @@ export const CODEX_MODELS: ModelInfo[] = [
   },
   {
     providerId: "codex",
-    modelId: "codex:gpt-5.2-codex",
-    title: "GPT-5.2 Codex",
+    modelId: "codex:gpt-5.2",
+    title: "GPT-5.2",
     description: "Optimized for professional work and long-running agents",
     capabilities: ["text", "reasoning"],
-    logo: CODEX_LOGO,
-    limits: null,
-    costs: null,
-  },
-  {
-    providerId: "codex",
-    modelId: "codex:gpt-5.1-codex-max",
-    title: "GPT-5.1 Codex Max",
-    description: "Deep and fast reasoning",
-    capabilities: ["text", "reasoning"],
-    logo: CODEX_LOGO,
-    limits: null,
-    costs: null,
-  },
-  {
-    providerId: "codex",
-    modelId: "codex:gpt-5.1-codex-mini",
-    title: "GPT-5.1 Codex Mini",
-    description: "Cheaper, faster, but less capable",
-    capabilities: ["text"],
     logo: CODEX_LOGO,
     limits: null,
     costs: null,
@@ -70,12 +62,11 @@ export const CODEX_MODELS: ModelInfo[] = [
 
 /** Map composite model IDs to SDK model names. */
 const CODEX_SDK_MODELS: Record<string, string> = {
+  "codex:gpt-5.5": "gpt-5.5",
   "codex:gpt-5.4": "gpt-5.4",
   "codex:gpt-5.4-mini": "gpt-5.4-mini",
   "codex:gpt-5.3-codex": "gpt-5.3-codex",
-  "codex:gpt-5.2-codex": "gpt-5.2-codex",
-  "codex:gpt-5.1-codex-max": "gpt-5.1-codex-max",
-  "codex:gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
+  "codex:gpt-5.2": "gpt-5.2",
 };
 
 /** Resolve a composite codex model ID to the SDK model name. */

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -31,6 +31,7 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       "claude-code:opus",
       "claude-code:haiku",
     ],
+    codex: ["codex:gpt-5.4"],
   };
 
 /**
@@ -48,6 +49,7 @@ export const FAST_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
   deco: ["qwen/qwen3.5-flash", "anthropic/claude-haiku"],
   google: ["gemini-2.5-flash", "gemini-3-flash"],
   "claude-code": ["claude-code:haiku", "claude-code:sonnet"],
+  codex: ["codex:gpt-5.4-mini"],
 };
 
 /**
@@ -78,6 +80,7 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
   ],
   google: ["gemini-3-pro", "gemini-3-flash"],
   "claude-code": ["claude-code:sonnet"],
+  codex: ["codex:gpt-5.4"],
 };
 
 /**
@@ -100,6 +103,7 @@ export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
     ],
     google: ["gemini-3-pro"],
     "claude-code": ["claude-code:opus", "claude-code:sonnet"],
+    codex: ["codex:gpt-5.5"],
   };
 
 /**


### PR DESCRIPTION
## Summary

- **Sync the Codex model catalog** with what the `codex` CLI itself advertises (per the official model-selection menu): adds `gpt-5.5`, renames `gpt-5.2-codex` → `gpt-5.2`, and drops the legacy `gpt-5.1-codex-max` / `gpt-5.1-codex-mini` entries. Descriptions also updated to match the CLI copy.
- **Add Codex to the simple-mode tier defaults** so chat/automations work out-of-the-box for orgs whose only connected provider is Codex:
  - `fast` → `codex:gpt-5.4-mini`
  - `smart` → `codex:gpt-5.4`
  - `thinking` → `codex:gpt-5.5`
  - default (single-pick) → `codex:gpt-5.4`

Previously, an org with only a Codex CLI key connected got `TierUnavailableError` from `resolveTier` because none of the tier preference maps had a `codex` entry.

## Files

- `apps/mesh/src/ai-providers/adapters/codex.ts` — `CODEX_MODELS` and `CODEX_SDK_MODELS` rewritten
- `packages/mesh-sdk/src/lib/default-model.ts` — `codex` added to `DEFAULT_MODEL_PREFERENCES`, `FAST_MODEL_PREFERENCES`, `SMART_MODEL_PREFERENCES`, `THINKING_MODEL_PREFERENCES`

## Test plan

- [x] `bun run check` passes
- [x] `bun run fmt` clean
- [ ] Manual: connect only a Codex CLI key, open chat, confirm the simple-mode dropdown shows fast/smart/thinking populated with the right Codex models
- [ ] Manual: confirm `gpt-5.5` is selectable from the model picker and a generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the `codex` model catalog with the CLI and adds `codex` defaults to simple-mode tiers so orgs using only `codex` work out of the box and no longer hit TierUnavailableError.

- **New Features**
  - Catalog: added `gpt-5.5`, renamed `gpt-5.2-codex` → `gpt-5.2`, removed `gpt-5.1-codex-max`/`mini`, aligned descriptions, and updated SDK mapping.
  - Tier defaults: `fast` → `codex:gpt-5.4-mini`, `smart` → `codex:gpt-5.4`, `thinking` → `codex:gpt-5.5`, default → `codex:gpt-5.4`.

<sup>Written for commit 0d8bb5f2281affc6b3777aa8a515c6946a5a6f67. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3386?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

