### PR TITLE
refactor(decopilot): drop /attach orphan-resume; collapse to pure tail

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1289,10 +1289,11 @@ export async function createApp(options: CreateAppOptions = {}) {
 
     // Pod-death recovery: a different pod's run was claimed by us. Drain
     // synchronously to know when the run completes server-side. We
-    // deliberately don't pass a streamBuffer here — clients reconnecting
-    // via /attach trigger their own pump via the user-initiated
-    // orphan-resume path in routes.ts; this background recovery is only
-    // for the case where no client is currently attached.
+    // deliberately don't pass a streamBuffer here — this background
+    // recovery is the safety net for threads no DBOS replay or attached
+    // client picks up; clients reconnecting via /attach see the run via
+    // the workflow's own JetStream pump on the pod that DBOS replayed it
+    // onto.
     await dispatchRunAndWait(
       {
         messages: [],
@@ -1556,7 +1557,6 @@ export async function createApp(options: CreateAppOptions = {}) {
     cancelBroadcast,
     streamBuffer,
     runRegistry,
-    threadStorage,
   });
   app.route("/api", decopilotRoutes);
 

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1,20 +1,16 @@
 /**
  * Dispatch Run
  *
- * The agent loop, decoupled from any transport. Two public entry points:
- *
- *   dispatchRun(input, ctx, deps)
- *     Fire-and-forget. Claims the run, starts the JetStream pump, returns
- *     `{ taskId }`. Subscribers receive chunks via
- *     `streamBuffer.createTailStream(taskId)` (the `/attach` endpoint).
- *     Requires `deps.streamBuffer`. Used by every HTTP route that
- *     initiates work.
+ * The agent loop, decoupled from any transport.
  *
  *   dispatchRunAndWait(input, ctx, deps)
- *     Same lifecycle, but drains `uiStream` internally until the run
- *     terminates and resolves once it's done. Used by automation paths
- *     (DBOS workflow steps, pod-death recovery) that need to await
- *     completion. Does not require a `streamBuffer`.
+ *     Claims the run, drains `uiStream` internally until the run
+ *     terminates, and resolves once it's done. Used by every entry point
+ *     that initiates work (the per-thread DBOS workflow step that backs
+ *     POST /messages, automation fires, pod-death recovery). When a
+ *     `streamBuffer` is configured the run also pumps into JetStream so
+ *     `/attach` tails see chunks live; without one the run still
+ *     completes but its chunks are dropped.
  */
 
 import type { MeshContext } from "@/core/mesh-context";
@@ -209,44 +205,6 @@ function dispatchRunSpanAttrs(input: DispatchRunInput): Record<string, string> {
     "decopilot.user.id": input.userId,
     "decopilot.thread.id": input.taskId ?? "",
   };
-}
-
-/**
- * Fire-and-forget: claim the run, start the JetStream pump, return
- * `{ taskId }`. Subscribers receive chunks via
- * `streamBuffer.createTailStream` (the `/attach` endpoint). Requires
- * `deps.streamBuffer` to be configured; routes that need an SSE response
- * call `createTailStream` themselves after this returns.
- *
- * Used by every HTTP route that initiates work (`POST /messages`,
- * `/attach` orphan-resume, the deprecated `POST /stream`).
- */
-export async function dispatchRun(
-  input: DispatchRunInput,
-  ctx: MeshContext,
-  deps: DispatchRunDeps,
-): Promise<DispatchRunResult> {
-  const buffer = deps.streamBuffer;
-  if (!buffer) {
-    throw new Error(
-      "dispatchRun: deps.streamBuffer is required for HTTP-initiated runs. " +
-        "Use dispatchRunAndWait for automation flows that need to await completion.",
-    );
-  }
-  return traced(
-    "decopilot.dispatchRun",
-    async (rootSpan) => {
-      const { taskId, uiStream, registrySignal } = await prepareRun(
-        input,
-        ctx,
-        deps,
-        rootSpan,
-      );
-      buffer.pump(uiStream, taskId, registrySignal);
-      return { taskId };
-    },
-    dispatchRunSpanAttrs(input),
-  );
 }
 
 /**
@@ -1759,15 +1717,10 @@ async function prepareRun(
       },
     });
 
-    // Setup complete — hand the uiStream back to the dispatch variant.
-    // The caller (`dispatchRun` or `dispatchRunAndWait`) picks the
-    // consumption strategy:
-    //   - `dispatchRun` → `streamBuffer.pump(uiStream, taskId, registrySignal)`
-    //     fans the chunks out via JetStream so /attach subscribers can tail
-    //     them across runs and across tabs.
-    //   - `dispatchRunAndWait` → drains `uiStream` directly with a reader
-    //     loop and resolves when the run finishes. Used by automations
-    //     that need to await completion.
+    // Setup complete — hand the uiStream back to dispatchRunAndWait,
+    // which drains it with a reader loop and (when a streamBuffer is
+    // configured) also pumps the chunks into JetStream so /attach
+    // subscribers can tail them across runs and across tabs.
     return {
       taskId: mem.thread.id,
       uiStream,

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -359,7 +359,7 @@ async function prepareRun(
     const windowSize = input.windowSize ?? DEFAULT_WINDOW_SIZE;
 
     if (!input.taskId) {
-      throw new Error("dispatchRun: taskId is required");
+      throw new Error("dispatchRunAndWait: taskId is required");
     }
 
     // 2. Load entities and create/load memory in parallel

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -380,10 +380,11 @@ async function prepareRun(
     ]);
 
     // Diagnostic (resume only): record whether the provider activated and
-    // whether the optional model slots are present. Paired with the log in
-    // routes.ts:/attach orphan-resume; together they pinpoint whether tool
-    // dropout on resume is a persistence-side or provider-activation issue.
-    // Drop once the resume-tool-dropout issue is root-caused.
+    // whether the optional model slots are present. `isResume` is only set
+    // by the heartbeat-watcher pod-death recovery in app.ts now, so this
+    // log helps pinpoint whether tool dropout on resume is a
+    // persistence-side or provider-activation issue. Drop once the
+    // resume-tool-dropout issue is root-caused.
     if (input.isResume) {
       console.log("[decopilot:stream] resume — runtime state", {
         taskId: input.taskId,

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -2,10 +2,10 @@
  * NATS JetStream Stream Buffer
  *
  * The per-task JetStream subject is the source of truth for a run's UI
- * stream. The producer (`dispatchRun`) calls `pump()` once; tail consumers
- * (every HTTP response, including the initial `/stream`) call
- * `createTailStream()`. The pump is decoupled from any consumer, so an
- * HTTP cancel never stalls the producer or drops chunks.
+ * stream. The producer (`dispatchRunAndWait`) calls `pump()` once; tail
+ * consumers (every `/attach` HTTP response) call `createTailStream()`. The
+ * pump is decoupled from any consumer, so an HTTP cancel never stalls the
+ * producer or drops chunks.
  *
  * - Per-subject message limit (20K chunks per thread) prevents one thread
  *   from starving others.

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -400,9 +400,15 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
 
   app.get("/:org/decopilot/attach/:threadId", async (c) => {
     try {
-      const { taskId } = await validateThreadAccess(c);
+      const { taskId, thread } = await validateThreadAccess(c);
 
-      const deliverPolicy = runRegistry.isRunning(taskId) ? "all" : "new";
+      // Use the DB's view, not pod-local registry state. A client attached
+      // to a non-owner pod (any multi-pod deployment, including mid-deploy
+      // and after a DBOS replay rehome) needs `"all"` to catch chunks the
+      // owning pod has already pumped to the shared JetStream subject.
+      // The buffer is purged on terminal events (run-reactor), so `"all"`
+      // only ever replays the current in-flight run.
+      const deliverPolicy = thread.status === "in_progress" ? "all" : "new";
       const tailChunkStream = await streamBuffer.createTailStream(
         taskId,
         c.req.raw.signal,

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -32,14 +32,11 @@ import {
   fetchModelPermissions,
   parseModelsToMap,
 } from "./model-permissions";
-import { PersistedRunConfigSchema, toModelsConfig } from "./run-config";
 import { StreamRequestSchema } from "./schemas";
 import type { ChatMessage, ModelsConfig } from "./types";
-import { dispatchRun, type DispatchRunInput } from "./dispatch-run";
+import type { DispatchRunInput } from "./dispatch-run";
 import { enqueueThreadRun } from "@/dispatch-queue";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
-import type { SqlThreadStorage } from "@/storage/threads";
-import { getPodId } from "@/core/pod-identity";
 
 // ============================================================================
 // Request Validation
@@ -143,8 +140,7 @@ async function resolvePerRequestModels(
 
 /**
  * Parse + permission-check an HTTP request into a `DispatchRunInput`
- * ready to hand to `enqueueThreadRun` (POST /messages) or `dispatchRun`
- * (orphan-resume).
+ * ready to hand to `enqueueThreadRun` (POST /messages).
  *
  * Pure-ish: reads `c` for the request body and auth context, but no
  * downstream side effects. Throws `HTTPException` / `TierUnavailableError`
@@ -231,11 +227,10 @@ export interface DecopilotDeps {
   cancelBroadcast: CancelBroadcast;
   streamBuffer: StreamBuffer;
   runRegistry: RunRegistry;
-  threadStorage: SqlThreadStorage;
 }
 
 export function createDecopilotRoutes(deps: DecopilotDeps) {
-  const { cancelBroadcast, streamBuffer, runRegistry, threadStorage } = deps;
+  const { cancelBroadcast, streamBuffer, runRegistry } = deps;
   const app = new Hono<{ Variables: { meshContext: MeshContext } }>();
 
   // ============================================================================
@@ -388,153 +383,56 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
   });
 
   // ============================================================================
-  // Attach Endpoint — replay JetStream-buffered stream for late-joining clients
+  // Attach Endpoint — tail the per-thread JetStream subject
   // ============================================================================
+  //
+  // Pure watch endpoint. The persistent connection stays open across runs —
+  // JetStream-level `{done}` sentinels are skipped on the server, and
+  // clients detect run boundaries from the AI-SDK `{type: "finish"}` chunk
+  // in the stream. One open /attach per (tab, thread) covers every run.
+  //
+  // Recovery for in-flight runs whose owning pod died is handled out of
+  // band: the thread-gate workflow step is restarted by the DBOS recovery
+  // executor on a healthy pod, and the heartbeat watcher in `app.ts`
+  // resurrects orphaned runs explicitly. Either way, chunks land back on
+  // this thread's JetStream subject and the existing /attach tail picks
+  // them up — no client-triggered resume is needed here.
 
   app.get("/:org/decopilot/attach/:threadId", async (c) => {
     try {
-      const { taskId, thread, organization } = await validateThreadAccess(c);
+      const { taskId } = await validateThreadAccess(c);
 
-      const activeRun = runRegistry.isRunning(taskId);
-
-      // The persistent connection stays open across runs — JetStream-level
-      // `{done}` sentinels are skipped on the server, and clients detect
-      // run boundaries from the AI-SDK `{type: "finish"}` chunk in the
-      // stream. One open /attach per (tab, thread) covers every run.
-      const serveTail = async (deliverPolicy: "all" | "new") => {
-        const tailChunkStream = await streamBuffer.createTailStream(
-          taskId,
-          c.req.raw.signal,
-          { deliverPolicy },
-        );
-        if (!tailChunkStream) {
-          return c.body(null, 204);
-        }
-
-        const tailStream = createUIMessageStream({
-          execute: async ({ writer }) => {
-            const reader = tailChunkStream.getReader();
-            try {
-              while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                writer.write(value);
-              }
-            } finally {
-              reader.releaseLock();
-            }
-          },
-        });
-
-        return wrapWithSseKeepalive(
-          createUIMessageStreamResponse({
-            stream: tailStream,
-            consumeSseStream: consumeStream,
-          }),
-        );
-      };
-
-      // ── Fast path: run is active on this pod → tail JetStream ──
-      if (activeRun) {
-        return await serveTail("all");
-      }
-
-      // ── Orphan resume path ──
-      const ctx = c.get("meshContext");
-      const userId = ctx.auth?.user?.id;
-
-      // Not in_progress → no run to resume. Attach anyway from "new" so
-      // the client picks up the next POST /messages on this thread
-      // without having to reconnect.
-      if (thread.status !== "in_progress") {
-        return await serveTail("new");
-      }
-
-      // Only the thread owner can trigger orphan resume
-      if (thread.created_by !== userId) {
-        return c.body(null, 204);
-      }
-
-      // No persisted config → can't resume; force-fail so user can retry
-      if (!thread.run_config) {
-        await threadStorage.forceFailIfInProgress(taskId, organization.id);
-        return c.body(null, 204);
-      }
-
-      // Validate stored config (schema drift protection)
-      const parsed = PersistedRunConfigSchema.safeParse(thread.run_config);
-      if (!parsed.success) {
-        await threadStorage.forceFailIfInProgress(taskId, organization.id);
-        return c.body(null, 204);
-      }
-      const config = parsed.data;
-
-      // Diagnostic: report which optional model slots survived persistence.
-      // Helps trace cases where a resumed run loses conditional tools like
-      // `web_search` / `generate_image` (gated by `models.deepResearch` and
-      // `models.image` in built-in-tools/index.ts). Drop once the
-      // resume-tool-dropout issue is root-caused.
-      console.log("[decopilot:attach] orphan resume — persisted config", {
+      const deliverPolicy = runRegistry.isRunning(taskId) ? "all" : "new";
+      const tailChunkStream = await streamBuffer.createTailStream(
         taskId,
-        thinkingModelId: config.models.thinking.id,
-        hasFast: !!config.models.fast,
-        hasCoding: !!config.models.coding,
-        hasImage: !!config.models.image,
-        hasDeepResearch: !!config.models.deepResearch,
-        mode: config.mode,
+        c.req.raw.signal,
+        { deliverPolicy },
+      );
+      if (!tailChunkStream) {
+        return c.body(null, 204);
+      }
+
+      const tailStream = createUIMessageStream({
+        execute: async ({ writer }) => {
+          const reader = tailChunkStream.getReader();
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              writer.write(value);
+            }
+          } finally {
+            reader.releaseLock();
+          }
+        },
       });
 
-      // Re-check model permissions with CURRENT user role
-      const allowedModels = await fetchModelPermissions(
-        ctx.db,
-        organization.id,
-        ctx.auth.user?.role,
+      return wrapWithSseKeepalive(
+        createUIMessageStreamResponse({
+          stream: tailStream,
+          consumeSseStream: consumeStream,
+        }),
       );
-      if (
-        allowedModels !== undefined &&
-        !checkModelPermission(
-          allowedModels,
-          config.models.credentialId,
-          config.models.thinking.id,
-        )
-      ) {
-        throw new HTTPException(403, {
-          message: "Model not allowed for your role",
-        });
-      }
-
-      // Atomic CAS claim — succeeds for null or stale run_owner_pod
-      const claimed = await threadStorage.claimOrphanedRun(
-        taskId,
-        organization.id,
-        getPodId(),
-      );
-      if (!claimed) {
-        return c.body(null, 204);
-      }
-
-      // Resume the run — identity from auth context, NOT stored config.
-      // Fire-and-forget: the resumed run pumps into JetStream, and the
-      // tail subscription created below is what we serve to this request.
-      await dispatchRun(
-        {
-          messages: [],
-          models: toModelsConfig(config.models),
-          agent: config.agent,
-          temperature: config.temperature,
-          toolApprovalLevel: config.toolApprovalLevel,
-          mode: config.mode,
-          organizationId: organization.id,
-          userId,
-          taskId,
-          windowSize: config.windowSize,
-          isResume: true,
-        },
-        ctx,
-        { runRegistry, streamBuffer, cancelBroadcast },
-      );
-
-      return await serveTail("all");
     } catch (err) {
       if (err instanceof HTTPException) throw err;
       console.error("[decopilot:attach] Error", err);

--- a/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/stream-buffer.ts
@@ -2,12 +2,11 @@
  * Stream Buffer Interface
  *
  * Abstraction for treating a NATS JetStream subject as the single source
- * of truth for a run's UI stream. The producer (`dispatchRun`) pumps chunks
- * into JetStream via `pump()`; every HTTP response — both initial `/stream`
- * and any `/attach` — reads from JetStream via `createTailStream()`. The
- * producer's lifetime is bound to the run registry, not to any HTTP
- * consumer, so a proxy/idle/tab-close on the consumer side never stalls or
- * drops chunks.
+ * of truth for a run's UI stream. The producer (`dispatchRunAndWait`) pumps
+ * chunks into JetStream via `pump()`; every `/attach` HTTP response reads
+ * from JetStream via `createTailStream()`. The producer's lifetime is bound
+ * to the run registry, not to any HTTP consumer, so a proxy/idle/tab-close
+ * on the consumer side never stalls or drops chunks.
  */
 
 /**

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -2,7 +2,7 @@
  * Build Stream Request
  *
  * Converts a stored Automation row into a DispatchRunInput suitable for passing
- * to dispatchRun(). The caller is expected to resolve the automation's tier via
+ * to dispatchRunAndWait(). The caller is expected to resolve the automation's tier via
  * resolveTier() first; the resolved model is passed in here. The automation's
  * stored `models` JSON is no longer read for credential or model info — after
  * migration 077 it carries only `{ tier }`.

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -84,7 +84,7 @@ export const AUTOMATIONS_GATE_PARTITION_CONCURRENCY = 3;
 /**
  * Global concurrent fire cap across the entire cluster. Set conservatively to
  * keep the pg pool from being exhausted by tool fan-out inside each fire's
- * dispatchRun call. Bump when `databasePoolMax` is bumped.
+ * dispatchRunAndWait call. Bump when `databasePoolMax` is bumped.
  */
 export const AUTOMATIONS_GLOBAL_CONCURRENCY = 5;
 const AUTOMATIONS_RUN_TIMEOUT_MS = 5 * 60 * 1000;

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -139,10 +139,10 @@ async function dispatchRunAndWaitStep(ctx: ThreadGateContext): Promise<void> {
       : null;
 
   try {
-    // Dispatch errors propagate. `dispatchRun` guarantees the run is
-    // already force-finished to "failed" in the registry before throwing
-    // (see `prepareRun`), so application state stays consistent — DBOS
-    // just gets to see the failure too.
+    // Dispatch errors propagate. `dispatchRunAndWait` guarantees the run
+    // is already force-finished to "failed" in the registry before
+    // throwing (see `prepareRun`), so application state stays consistent
+    // — DBOS just gets to see the failure too.
     await rt.dispatchRunFn(
       { ...request, abortSignal: abortController.signal },
       meshCtx,
@@ -184,7 +184,7 @@ async function trackMessageStartedStep(ctx: ThreadGateContext): Promise<void> {
  * Balances `chat_message_started` when the dispatch step throws *before*
  * `streamText` is set up (model-permission failure, agent not found,
  * thread-ownership check, etc. — see `prepareRun`). In-flight stream
- * errors are already emitted by `streamText.onError` inside `dispatchRun`,
+ * errors are already emitted by `streamText.onError` inside `dispatchRunAndWait`,
  * so this only covers the pre-stream gap.
  *
  * `error_category: "setup"` keeps these distinguishable from stream-time
@@ -223,7 +223,7 @@ async function threadGateWorkflowFn(
       name: "dispatchRunAndWait",
     });
   } catch (err) {
-    // Setup errors (prepareRun) propagate out of `dispatchRun`; in-flight
+    // Setup errors (prepareRun) propagate out of `dispatchRunAndWait`; in-flight
     // stream errors are handled inside `streamText.onError` and don't
     // reach here. So a thrown step at this point means setup failed —
     // emit the balancing failed event for analytics integrity. Wrapped


### PR DESCRIPTION
## What is this contribution about?

Pre-PR-#3376, `POST /messages` dispatched runs directly, so a pod death mid-run left orphan threads that only the next `/attach` could resurrect — hence the orphan-resume code path in `/attach` (`routes.ts:442-537`). Now every user message lives inside a `threadGateWorkflow` DBOS step, and the recovery executor replays it on a healthy pod with `streamBuffer` wired in — chunks land back on the per-thread JetStream subject and the existing `/attach` tail picks them up. The heartbeat watcher in `app.ts` stays as a backstop. This PR strips the now-vestigial client-triggered resume, removes the dead fire-and-forget `dispatchRun` export (only the orphan-resume called it), and drops `threadStorage` from `DecopilotDeps`. Net -150 lines; no behavior change for the happy path.

## How to Test

1. `bun run dev`, open a thread, send a message, confirm the stream renders normally and reconnecting via the page-refresh `/attach` tail works.
2. Run `bun test apps/mesh/src/api/routes/decopilot/` — 350/350 pass.
3. Pod-death scenario (optional, requires multi-pod setup against shared Postgres + NATS): kill the pod owning an in-flight run mid-stream and confirm a client tailing `/attach` continues to receive chunks (DBOS replays the workflow step on another pod, which re-pumps into the same JetStream subject).

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the client-triggered orphan-resume from `/attach` and collapsed the endpoint to a pure JetStream tail. All runs now go through the per-thread DBOS `threadGateWorkflow` via `dispatchRunAndWait`, which pumps to JetStream when `streamBuffer` is present.

- **Refactors**
  - Dropped `/attach` orphan-resume; endpoint now only tails the per-thread JetStream subject and serves SSE.
  - Removed fire-and-forget `dispatchRun`; all producers use `dispatchRunAndWait` (drains and pumps when configured).
  - Recovery relies on DBOS replay and the heartbeat watcher; chunks return to JetStream and existing `/attach` tails pick them up.
  - Removed `threadStorage` from `DecopilotDeps` and cleaned up docs/comments to reference `dispatchRunAndWait`.

- **Bug Fixes**
  - `/attach` now sets `deliverPolicy` from DB `thread.status` (cluster-wide) instead of pod-local `isRunning`, preventing missed chunks in multi-pod setups.
  - Corrected a stale `dispatchRun` reference in `prepareRun` error messaging to `dispatchRunAndWait`.

<sup>Written for commit 0cf93de1ae2871530040e218e768efb852b122d3. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

