### PR TITLE
feat(chat): consolidate tools popover (approval level, add file, polish)

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/approval.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/approval.tsx
@@ -11,6 +11,7 @@ import {
 import { ShieldTick } from "@untitledui/icons";
 import { useState } from "react";
 import {
+  APPROVAL_LEVEL_OPTIONS,
   usePreferences,
   type ToolApprovalLevel,
 } from "@/web/hooks/use-preferences.ts";
@@ -37,14 +38,6 @@ export interface PendingApproval {
 
 const DEFAULT_DENY_REASON =
   "User denied this tool call, give other alternatives.";
-
-const APPROVAL_LEVEL_OPTIONS: {
-  value: ToolApprovalLevel;
-  label: string;
-}[] = [
-  { value: "readonly", label: "Ask before edit" },
-  { value: "auto", label: "Auto approve" },
-];
 
 // ============================================================================
 // ApprovalLevelSelect

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -487,6 +487,9 @@ export function ChatInput({
                           setConnectionsOpen(true);
                         }}
                         virtualMcpId={selectedVirtualMcp?.id ?? decopilotId}
+                        selectedModel={selectedModel}
+                        isStreaming={isStreaming}
+                        onUnsupportedFile={onUnsupportedFile}
                       />
                       {isPlanMode && (
                         <button

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -16,7 +16,6 @@ import {
   Image01,
   Lock01,
   Microphone01,
-  Plus,
   Stop,
   Upload01,
   X,
@@ -35,7 +34,6 @@ import { getSupportedFileTypesLabel, modelSupportsFiles } from "./select-model";
 import { SimpleModeTierDropdown } from "./simple-mode-tier-dropdown";
 import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers";
 import {
-  FileUploadButton,
   UnsupportedFileDialog,
   useUnsupportedFileDialog,
   processFile,
@@ -471,12 +469,6 @@ export function ChatInput({
                   <>
                     {/* Left Actions (+, Tools, active tool pills, stats) */}
                     <div className="flex items-center gap-1.5 min-w-0 shrink-0">
-                      <FileUploadButton
-                        selectedModel={selectedModel}
-                        isStreaming={isStreaming}
-                        icon={<Plus size={16} />}
-                        onUnsupportedFile={onUnsupportedFile}
-                      />
                       <ToolsPopover
                         disabled={isStreaming}
                         onOpenConnections={() => {

--- a/apps/mesh/src/web/components/chat/tiptap/file/index.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/file/index.ts
@@ -4,7 +4,6 @@ export {
 } from "./node.tsx";
 export {
   FileUploader,
-  FileUploadButton,
   UnsupportedFileDialog,
   useUnsupportedFileDialog,
   processFile,

--- a/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
@@ -6,18 +6,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { useCurrentEditor, type Editor } from "@tiptap/react";
-import { useEffect, useRef, useState, type ChangeEvent } from "react";
+import type { Editor } from "@tiptap/react";
+import { useEffect, useRef, useState } from "react";
 import { AlertTriangle, Attachment01 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
-  getAcceptedMimeTypesForModel,
   getSupportedFileTypesLabel,
   isFileTypeSupportedByModel,
   modelSupportsFiles,
@@ -223,88 +217,6 @@ export function FileUploader({
 
   // This component doesn't render anything
   return null;
-}
-
-/**
- * FileUploadButton component that renders a button with a hidden file input.
- * Uses EditorContext to access the editor instance and processFile to handle file uploads.
- */
-interface FileUploadButtonProps {
-  selectedModel: AiProviderModel | null;
-  isStreaming: boolean;
-  icon?: React.ReactNode;
-  onUnsupportedFile?: (info: UnsupportedFileInfo) => void;
-}
-
-export function FileUploadButton({
-  selectedModel,
-  isStreaming,
-  icon,
-  onUnsupportedFile,
-}: FileUploadButtonProps) {
-  const { editor } = useCurrentEditor();
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const modelSupportsFilesValue = modelSupportsFiles(selectedModel);
-
-  const handleFileSelect = async (e: ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0 || !editor) return;
-
-    const fileArray = Array.from(files);
-
-    // Get current cursor position
-    const { from } = editor.state.selection;
-    const currentPos = from;
-
-    // Process files sequentially using the shared processFile function
-    for (const file of fileArray) {
-      await processFile(
-        editor,
-        selectedModel,
-        file,
-        currentPos,
-        onUnsupportedFile,
-      );
-    }
-
-    // Reset input so same file can be selected again
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
-
-  if (!editor || !modelSupportsFilesValue) {
-    return null;
-  }
-
-  return (
-    <>
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        accept={getAcceptedMimeTypesForModel(selectedModel)}
-        className="hidden"
-        onChange={handleFileSelect}
-        disabled={isStreaming}
-      />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="text-muted-foreground/75"
-            disabled={isStreaming || !modelSupportsFilesValue}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            {icon ?? <Attachment01 size={16} />}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top">Add file</TooltipContent>
-      </Tooltip>
-    </>
-  );
 }
 
 /**

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -385,28 +385,6 @@ export function ToolsPopover({
 
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="gap-2">
-              <ShieldTick size={16} />
-              <span className="flex-1">Approvals</span>
-              <span className="text-xs text-muted-foreground">
-                {currentApprovalShort}
-              </span>
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-48 p-1.5">
-              <DropdownMenuRadioGroup
-                value={preferences.toolApprovalLevel}
-                onValueChange={handleApprovalLevelChange}
-              >
-                {APPROVAL_LEVEL_OPTIONS.map((opt) => (
-                  <DropdownMenuRadioItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger className="gap-2">
               <span className="flex size-4 items-center justify-center text-base font-medium text-muted-foreground">
                 /
               </span>
@@ -444,6 +422,28 @@ export function ToolsPopover({
                   </DropdownMenuItem>
                 ))
               )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger className="gap-2">
+              <ShieldTick size={16} />
+              <span className="flex-1">Approvals</span>
+              <span className="text-xs text-muted-foreground">
+                {currentApprovalShort}
+              </span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-48 p-1.5">
+              <DropdownMenuRadioGroup
+                value={preferences.toolApprovalLevel}
+                onValueChange={handleApprovalLevelChange}
+              >
+                {APPROVAL_LEVEL_OPTIONS.map((opt) => (
+                  <DropdownMenuRadioItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
 

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -14,6 +14,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -30,6 +32,7 @@ import {
   Link01,
   Loading01,
   Settings04,
+  ShieldTick,
 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
@@ -43,6 +46,11 @@ import { KEYS } from "@/web/lib/query-keys";
 import { useSound } from "@/web/hooks/use-sound.ts";
 import { switch005Sound } from "@deco/ui/lib/switch-005.ts";
 import { useChatPrefs } from "./context";
+import {
+  APPROVAL_LEVEL_OPTIONS,
+  usePreferences,
+  type ToolApprovalLevel,
+} from "@/web/hooks/use-preferences.ts";
 
 const FEATURED_CONNECTION_ICONS = [
   { src: "/connections/gmail.png", name: "Gmail" },
@@ -98,6 +106,28 @@ export function ToolsPopover({
   const [activePrompt, setActivePrompt] = useState<Prompt | null>(null);
 
   const { chatMode, setChatMode } = useChatPrefs();
+  const [preferences, setPreferences] = usePreferences();
+  const currentApprovalLabel =
+    APPROVAL_LEVEL_OPTIONS.find(
+      (opt) => opt.value === preferences.toolApprovalLevel,
+    )?.label ?? "Auto approve";
+
+  const handleApprovalLevelChange = (next: string) => {
+    const value = next as ToolApprovalLevel;
+    if (value === preferences.toolApprovalLevel) {
+      setOpen(false);
+      return;
+    }
+    playSwitchSound();
+    track("chat_approval_level_changed", {
+      from_level: preferences.toolApprovalLevel,
+      to_level: value,
+      source: "tools_popover",
+    });
+    setPreferences({ ...preferences, toolApprovalLevel: value });
+    setOpen(false);
+  };
+
   const isPlanMode = chatMode === "plan";
 
   const handleTogglePlanMode = () => {
@@ -264,6 +294,28 @@ export function ToolsPopover({
               <span className="text-xs text-blue-500 font-medium">On</span>
             )}
           </DropdownMenuItem>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger className="gap-2">
+              <ShieldTick size={16} />
+              <span className="flex-1">Approvals</span>
+              <span className="text-xs text-muted-foreground">
+                {currentApprovalLabel}
+              </span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-48 p-1.5">
+              <DropdownMenuRadioGroup
+                value={preferences.toolApprovalLevel}
+                onValueChange={handleApprovalLevelChange}
+              >
+                {APPROVAL_LEVEL_OPTIONS.map((opt) => (
+                  <DropdownMenuRadioItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
 
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="gap-2">

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -62,6 +62,11 @@ import {
   modelSupportsFiles,
 } from "./select-model";
 import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers";
+import { KEYBOARD_SHORTCUTS } from "@/web/lib/keyboard-shortcuts";
+
+const PLAN_MODE_SHORTCUT = KEYBOARD_SHORTCUTS.togglePlanMode.keys
+  .map((k) => (k === "Shift" ? "⇧" : k))
+  .join("");
 
 const FEATURED_CONNECTION_ICONS = [
   { src: "/connections/gmail.png", name: "Gmail" },
@@ -310,7 +315,7 @@ export function ToolsPopover({
             </span>
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-52 p-1.5">
+        <DropdownMenuContent align="start" className="w-52 p-1.5 space-y-1">
           {!supportsFiles ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -324,7 +329,7 @@ export function ToolsPopover({
                 </DropdownMenuItem>
               </TooltipTrigger>
               <TooltipContent side="right">
-                Switch to a vision-capable model to attach files
+                The selected model does not support reading files or images.
               </TooltipContent>
             </Tooltip>
           ) : (
@@ -346,9 +351,14 @@ export function ToolsPopover({
               className={cn(isPlanMode && "text-violet-500")}
             />
             <span className="flex-1">Plan mode</span>
-            {isPlanMode && (
-              <span className="text-xs text-violet-500 font-medium">On</span>
-            )}
+            <span
+              className={cn(
+                "text-xs text-muted-foreground",
+                isPlanMode && "text-violet-500 font-medium",
+              )}
+            >
+              {PLAN_MODE_SHORTCUT}
+            </span>
           </DropdownMenuItem>
 
           {/* Create image */}
@@ -428,7 +438,7 @@ export function ToolsPopover({
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="gap-2">
               <ShieldTick size={16} />
-              <span className="flex-1">Approvals</span>
+              <span className="flex-1">Approval</span>
               <span className="text-xs text-muted-foreground">
                 {currentApprovalShort}
               </span>

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -11,6 +11,11 @@ import {
 } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -31,10 +36,11 @@ import {
   Image01,
   Link01,
   Loading01,
+  Plus,
   Settings04,
   ShieldTick,
 } from "@untitledui/icons";
-import { Suspense, useState } from "react";
+import { Suspense, useRef, useState, type ChangeEvent } from "react";
 import { toast } from "sonner";
 import { track } from "@/web/lib/posthog-client";
 import {
@@ -50,6 +56,12 @@ import {
   APPROVAL_LEVEL_OPTIONS,
   usePreferences,
 } from "@/web/hooks/use-preferences.ts";
+import { processFile, type UnsupportedFileInfo } from "./tiptap/file";
+import {
+  getAcceptedMimeTypesForModel,
+  modelSupportsFiles,
+} from "./select-model";
+import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers";
 
 const FEATURED_CONNECTION_ICONS = [
   { src: "/connections/gmail.png", name: "Gmail" },
@@ -76,17 +88,54 @@ interface ToolsPopoverProps {
   disabled?: boolean;
   onOpenConnections: () => void;
   virtualMcpId: string | null;
+  selectedModel: AiProviderModel | null | undefined;
+  isStreaming: boolean;
+  onUnsupportedFile?: (info: UnsupportedFileInfo) => void;
 }
 
 export function ToolsPopover({
   disabled,
   onOpenConnections,
   virtualMcpId,
+  selectedModel,
+  isStreaming,
+  onUnsupportedFile,
 }: ToolsPopoverProps) {
   const [open, setOpen] = useState(false);
   const playSwitchSound = useSound(switch005Sound);
   const { org } = useProjectContext();
   const { editor } = useCurrentEditor();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const supportsFiles = modelSupportsFiles(selectedModel);
+  const addFileDisabled = isStreaming || !supportsFiles;
+
+  const handleAddFileClick = () => {
+    if (addFileDisabled) return;
+    setOpen(false);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileSelect = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0 || !editor) return;
+
+    const fileArray = Array.from(files);
+    const { from } = editor.state.selection;
+
+    for (const file of fileArray) {
+      await processFile(
+        editor,
+        selectedModel ?? null,
+        file,
+        from,
+        onUnsupportedFile,
+      );
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
   const client = useMCPClient({
     connectionId: virtualMcpId,
     orgId: org.id,
@@ -223,6 +272,16 @@ export function ToolsPopover({
 
   return (
     <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={getAcceptedMimeTypesForModel(selectedModel ?? null)}
+        className="hidden"
+        onChange={handleFileSelect}
+        disabled={isStreaming}
+      />
+
       <DropdownMenu
         open={open}
         onOpenChange={(next) => {
@@ -251,6 +310,32 @@ export function ToolsPopover({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-52 p-1.5">
+          {addFileDisabled && !isStreaming ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuItem
+                  aria-disabled="true"
+                  className="opacity-50 cursor-not-allowed"
+                  onSelect={(e) => e.preventDefault()}
+                >
+                  <Plus size={16} />
+                  <span className="flex-1">Add file</span>
+                </DropdownMenuItem>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                Switch to a vision-capable model to attach files
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <DropdownMenuItem
+              onClick={handleAddFileClick}
+              disabled={isStreaming}
+            >
+              <Plus size={16} />
+              <span className="flex-1">Add file</span>
+            </DropdownMenuItem>
+          )}
+
           <DropdownMenuItem
             onClick={handleTogglePlanMode}
             className={cn(isPlanMode && "text-violet-600 dark:text-violet-400")}

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -107,10 +107,9 @@ export function ToolsPopover({
   const { editor } = useCurrentEditor();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const supportsFiles = modelSupportsFiles(selectedModel);
-  const addFileDisabled = isStreaming || !supportsFiles;
 
   const handleAddFileClick = () => {
-    if (addFileDisabled) return;
+    if (!supportsFiles || isStreaming) return;
     setOpen(false);
     fileInputRef.current?.click();
   };
@@ -122,18 +121,20 @@ export function ToolsPopover({
     const fileArray = Array.from(files);
     const { from } = editor.state.selection;
 
-    for (const file of fileArray) {
-      await processFile(
-        editor,
-        selectedModel ?? null,
-        file,
-        from,
-        onUnsupportedFile,
-      );
-    }
-
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
+    try {
+      for (const file of fileArray) {
+        await processFile(
+          editor,
+          selectedModel ?? null,
+          file,
+          from,
+          onUnsupportedFile,
+        );
+      }
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
     }
   };
   const client = useMCPClient({
@@ -159,7 +160,7 @@ export function ToolsPopover({
     APPROVAL_LEVEL_OPTIONS.find(
       (opt) => opt.value === preferences.toolApprovalLevel,
     ) ?? APPROVAL_LEVEL_OPTIONS[0]!;
-  const currentApprovalLabel = currentApprovalOption.label;
+  const currentApprovalShort = currentApprovalOption.short;
 
   const handleApprovalLevelChange = (next: string) => {
     const matched = APPROVAL_LEVEL_OPTIONS.find((opt) => opt.value === next);
@@ -310,7 +311,7 @@ export function ToolsPopover({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-52 p-1.5">
-          {addFileDisabled && !isStreaming ? (
+          {!supportsFiles ? (
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuItem
@@ -387,7 +388,7 @@ export function ToolsPopover({
               <ShieldTick size={16} />
               <span className="flex-1">Approvals</span>
               <span className="text-xs text-muted-foreground">
-                {currentApprovalLabel}
+                {currentApprovalShort}
               </span>
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="w-48 p-1.5">

--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -49,7 +49,6 @@ import { useChatPrefs } from "./context";
 import {
   APPROVAL_LEVEL_OPTIONS,
   usePreferences,
-  type ToolApprovalLevel,
 } from "@/web/hooks/use-preferences.ts";
 
 const FEATURED_CONNECTION_ICONS = [
@@ -107,24 +106,27 @@ export function ToolsPopover({
 
   const { chatMode, setChatMode } = useChatPrefs();
   const [preferences, setPreferences] = usePreferences();
-  const currentApprovalLabel =
+  const currentApprovalOption =
     APPROVAL_LEVEL_OPTIONS.find(
       (opt) => opt.value === preferences.toolApprovalLevel,
-    )?.label ?? "Auto approve";
+    ) ?? APPROVAL_LEVEL_OPTIONS[0]!;
+  const currentApprovalLabel = currentApprovalOption.label;
 
   const handleApprovalLevelChange = (next: string) => {
-    const value = next as ToolApprovalLevel;
-    if (value === preferences.toolApprovalLevel) {
+    const matched = APPROVAL_LEVEL_OPTIONS.find((opt) => opt.value === next);
+    if (!matched) return;
+    if (matched.value === preferences.toolApprovalLevel) {
+      // No-op: same level re-selected, just close the popover.
       setOpen(false);
       return;
     }
     playSwitchSound();
     track("chat_approval_level_changed", {
       from_level: preferences.toolApprovalLevel,
-      to_level: value,
+      to_level: matched.value,
       source: "tools_popover",
     });
-    setPreferences({ ...preferences, toolApprovalLevel: value });
+    setPreferences({ ...preferences, toolApprovalLevel: matched.value });
     setOpen(false);
   };
 

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -21,6 +21,14 @@ const DEFAULT_PREFERENCES: Preferences = {
 
 const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];
 
+export const APPROVAL_LEVEL_OPTIONS: {
+  value: ToolApprovalLevel;
+  label: string;
+}[] = [
+  { value: "readonly", label: "Ask before edit" },
+  { value: "auto", label: "Auto approve" },
+];
+
 const VALID_THEME_MODES: ThemeMode[] = ["light", "dark", "system"];
 
 /**

--- a/apps/mesh/src/web/hooks/use-preferences.ts
+++ b/apps/mesh/src/web/hooks/use-preferences.ts
@@ -24,9 +24,10 @@ const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];
 export const APPROVAL_LEVEL_OPTIONS: {
   value: ToolApprovalLevel;
   label: string;
+  short: string;
 }[] = [
-  { value: "readonly", label: "Ask before edit" },
-  { value: "auto", label: "Auto approve" },
+  { value: "readonly", label: "Ask before edit", short: "Ask" },
+  { value: "auto", label: "Auto approve", short: "Auto" },
 ];
 
 const VALID_THEME_MODES: ThemeMode[] = ["light", "dark", "system"];

--- a/apps/mesh/src/web/lib/keyboard-shortcuts.ts
+++ b/apps/mesh/src/web/lib/keyboard-shortcuts.ts
@@ -16,7 +16,7 @@ interface ShortcutGroup {
   shortcuts: Shortcut[];
 }
 
-const KEYBOARD_SHORTCUTS = {
+export const KEYBOARD_SHORTCUTS = {
   keyboardShortcuts: { keys: [MOD, "K"], description: "Keyboard shortcuts" },
   focusChatInput: { keys: [MOD, "L"], description: "Focus chat input" },
   saveAndFormat: { keys: [MOD, "S"], description: "Save & format" },


### PR DESCRIPTION
## Summary

Makes the chat input's *Tools* popover the single entry point for everything you can attach or toggle. Two related threads land together:

### 1. Approval level in the popover
A new *Approval* submenu (radio: *Ask before edit* / *Auto approve*) lets users flip the `toolApprovalLevel` preference at any time — not just when an approval is already pending. The shared `APPROVAL_LEVEL_OPTIONS` constant moved from `approval.tsx` into `use-preferences.ts` so the popover and the existing in-prompt selector stay label-aligned. The parent row shows a compact label (*Ask* / *Auto*) via a new `short` field on each option. The submenu sits between *Prompts* and *Connections*.

Out of scope: the popover toggle does NOT bulk-accept pending approvals (that side effect stays exclusive to the in-prompt `ApprovalLevelSelect` via `onYolo`). Pending prompts stay pending until explicitly acted on.

### 2. Add file inside the popover
The standalone `+` toolbar button is gone. *Add file* is now the first item in the popover. A hidden `<input type=\"file\">` lives alongside the dropdown root so the OS file picker survives the menu closing; on click the popover closes and the picker opens, feeding selected files through the existing \`processFile\` helper. Drag-and-drop and paste are unchanged — they're handled by the separate \`FileUploader\` ProseMirror plugin.

When the selected model can't accept files, *Add file* is muted and wrapped in a tooltip: *\"The selected model does not support reading files or images.\"* (Radix's native \`disabled\` swallows hover events, so the item stays interactive with \`aria-disabled\` + an \`onSelect preventDefault\` no-op so the tooltip actually fires.) The dead \`FileUploadButton\` component and its barrel re-export are removed.

### 3. Polish pass
- *Plan mode* item now shows its keyboard shortcut next to the label.
- Vertical spacing between popover items bumped (\`space-y-1\`).
- *Approvals* renamed to *Approval*.
- Approval submenu shows a short label (*Ask* / *Auto*) on the parent row.

## Specs / plans

- \`.context/specs/2026-05-16-tool-approval-level-in-tools-popover-design.md\` + \`.context/plans/2026-05-16-tool-approval-level-in-tools-popover.md\`
- \`.context/specs/2026-05-16-add-file-in-tools-popover-design.md\` + \`.context/plans/2026-05-16-add-file-in-tools-popover.md\`

## Test plan

**Approval level**
- [ ] *Tools* → *Approval*: flip between *Ask before edit* and *Auto approve*; short label updates on the parent row.
- [ ] Trigger a non-readonly tool call with *Ask before edit* → approval prompt appears. Use the in-prompt selector to switch to *Auto approve* → next tool call runs without prompting. Re-open *Tools* → *Approval* shows *Auto*.
- [ ] Reverse: set *Auto* in the popover → flip back to *Ask before edit* via in-prompt → popover stays in sync.
- [ ] Pending-approval is unaffected: with *Ask before edit*, trigger a tool call so an approval is pending; switch to *Auto* via popover → pending prompt stays pending, only future tool calls auto-approve.
- [ ] Reload → preference persists.

**Add file**
- [ ] *Tools* → first item is *Add file*; clicking opens the native file picker; selected files attach at the cursor.
- [ ] Multi-file pick attaches each in order; re-picking the same file works (input value resets even if \`processFile\` throws).
- [ ] Switch to a non-vision model → *Add file* is muted; hover shows *\"The selected model does not support reading files or images.\"*; click is a no-op.
- [ ] Drag a file into the editor → still attaches. Paste an image from clipboard → still attaches.
- [ ] Old toolbar \`+\` button is gone.

**Polish**
- [ ] *Plan mode* item displays the keyboard shortcut chip; pressing the shortcut toggles plan mode.
- [ ] Popover items have visibly more breathing room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)