### PR TITLE
fix(chat): keep highlight tint behind banner buttons

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -60,12 +60,16 @@ export interface CollapsibleHighlightProps {
 // it layers over `bg-background` rather than colliding with it under twMerge
 // (which would otherwise strip the solid background and leave the card
 // translucent).
+// `isolate` on the card creates a stacking context so `after:-z-10` keeps the
+// tint behind every child (including buttons with their own backgrounds).
+// Without it, the absolutely-positioned ::after layers on top of static
+// siblings and bleeds red/amber through `bg-background` buttons.
 const VARIANT_OVERLAY: Record<HighlightVariant, string> = {
   default: "",
   error:
-    "after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-destructive/5 after:pointer-events-none",
+    "isolate after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-destructive/5 after:pointer-events-none after:-z-10",
   warning:
-    "after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-amber-500/5 after:pointer-events-none",
+    "isolate after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-amber-500/5 after:pointer-events-none after:-z-10",
 };
 
 const VARIANT_BORDER: Record<HighlightVariant, string> = {


### PR DESCRIPTION
## What is this contribution about?
The "Fix in chat" outline button on the error highlight banner was rendering with a red background because the card's `::after` tint overlay was stacking above the static-positioned children. Added `isolate` to the card and `after:-z-10` to the pseudo so the destructive/warning tint stays behind every child (buttons, footer, chip), keeping outline buttons looking like normal outline buttons.

## How to Test
1. Trigger an error in a chat (e.g. force a tool/model failure).
2. Confirm the error banner shows with its red tint.
3. Verify the "Fix in chat" button has a normal outline-button background, not a red wash.
4. Repeat for a warning banner (e.g. `tool-calls` finish reason) and confirm the "Continue" outline button is unaffected by the amber tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the destructive/warning tint overlay behind highlight banner content so outline buttons (e.g., "Fix in chat" and "Continue") no longer appear tinted. Adds `isolate` to the card container and `after:-z-10` to the `::after` overlay to create a stacking context and place the tint behind all children.

<sup>Written for commit 83f7c03f976e3474392dad0848925f7ef0f3f7cb. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3390?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

