### PR TITLE
test(multi-pod): scaffold framework for multi-pod scenarios

### DIFF
--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -4,6 +4,26 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    # Multi-pod tests are slow (~7-10 min cold image build + serialized
+    # boot + scenarios). Only run on PRs that change code the framework
+    # actually exercises — server-side mesh, dispatch/automations, storage
+    # schema, or the test infra itself. UI/docs/plugin PRs skip.
+    paths:
+      - "apps/mesh/src/api/**"
+      - "apps/mesh/src/auth/**"
+      - "apps/mesh/src/core/**"
+      - "apps/mesh/src/storage/**"
+      - "apps/mesh/src/dispatch-queue/**"
+      - "apps/mesh/src/event-bus/**"
+      - "apps/mesh/src/automations/**"
+      - "apps/mesh/src/database/**"
+      - "apps/mesh/src/index.ts"
+      - "apps/mesh/migrations/**"
+      - "packages/runtime/**"
+      - "packages/bindings/**"
+      - "tests/multi-pod/**"
+      - ".github/workflows/multi-pod.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -1,0 +1,46 @@
+name: Multi-Pod Tests
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  multi-pod:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Install dependencies
+        run: bun install
+
+      # No --wait here: the one-shot `migrate` service exits 0 once schemas
+      # are created and `--wait` mis-classifies that as a failure. The test
+      # suite's beforeAll hook (lib/hooks.ts → cluster.waitReady) polls
+      # /health/live on each mesh pod instead.
+      - name: Start cluster
+        run: docker compose -f tests/multi-pod/docker-compose.yml up -d --build
+
+      - name: Run multi-pod scenarios
+        run: bun test tests/multi-pod/scenarios/ --serial --timeout 900000
+
+      - name: Dump mesh logs
+        if: failure()
+        run: docker compose -f tests/multi-pod/docker-compose.yml logs mesh-1 mesh-2 mesh-3
+
+      - name: Dump infra logs
+        if: failure()
+        run: docker compose -f tests/multi-pod/docker-compose.yml logs postgres nats migrate
+
+      - name: Tear down cluster
+        if: always()
+        run: docker compose -f tests/multi-pod/docker-compose.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ studio-demo/
 .worktrees
 .claude/worktrees
 
+# Claude runtime state (loop schedule lock, etc.)
+.claude/*.lock
+
 # Playwright
 apps/mesh/test-results/
 apps/mesh/playwright-report/

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -45,7 +45,12 @@ services:
     build:
       context: ../../
       dockerfile: tests/resilience/Dockerfile.studio
-    restart: unless-stopped
+    # No restart policy — tests need explicit start/stop control. With
+    # `unless-stopped`, `docker kill` is auto-restarted within seconds,
+    # which would defeat any pod-death scenario (the SIGKILL'd pod would
+    # come back before the assertion fires). A genuine boot crash is
+    # surfaced via the healthcheck, not papered over by a restart.
+    restart: "no"
     working_dir: /app/apps/mesh
     # Bypass the Dockerfile entrypoint (which runs `bun run migrate` before
     # exec'ing the CLI) AND pass `--skip-migrations` so the CLI's own boot
@@ -82,12 +87,28 @@ services:
       start_period: 60s
       retries: 20
 
+  # mesh-2 and mesh-3 wait for the previous pod to be healthy before
+  # starting. This serializes *first-boot* DBOS migrations: even with
+  # mesh's own --skip-migrations, DBOS still runs its system-schema
+  # migrations on `DBOS.launch()` and three parallel boots race on
+  # inserts into `dbos.dbos_migrations` (unique-constraint violations
+  # crash pods 2/3). Once the schema exists, subsequent boots are
+  # idempotent — restarting a single pod mid-test stays fast.
   mesh-2:
     <<: *mesh
     environment:
       <<: *mesh-env
     ports:
       - "127.0.0.1:13002:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      mesh-1:
+        condition: service_healthy
 
   mesh-3:
     <<: *mesh
@@ -95,3 +116,12 @@ services:
       <<: *mesh-env
     ports:
       - "127.0.0.1:13003:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      mesh-2:
+        condition: service_healthy

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -1,0 +1,89 @@
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  nats:
+    image: nats:2.10.22
+    command: -js -m 8222
+    healthcheck:
+      test: ["CMD", "nats-server", "--help"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+  # Migrations run once before any mesh pod starts. Pods themselves skip the
+  # migration step (we override the entrypoint with a direct start command) to
+  # avoid races on parallel boot.
+  migrate:
+    build:
+      context: ../../
+      dockerfile: tests/resilience/Dockerfile.studio
+    working_dir: /app/apps/mesh
+    command: ["bun", "run", "migrate"]
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  mesh-1: &mesh
+    build:
+      context: ../../
+      dockerfile: tests/resilience/Dockerfile.studio
+    restart: unless-stopped
+    working_dir: /app/apps/mesh
+    # Bypass the Dockerfile entrypoint (which runs migrations again) and start
+    # the server directly. Migrations are guaranteed done by the `migrate`
+    # dependency below.
+    command: ["bun", "run", "src/cli.ts", "--no-tui"]
+    environment: &mesh-env
+      NODE_ENV: production
+      PORT: "3000"
+      HOST: 0.0.0.0
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+      NATS_URL: nats://nats:4222
+      BETTER_AUTH_SECRET: test-secret-for-multi-pod-tests
+      BETTER_AUTH_URL: http://localhost:3000
+      BASE_URL: http://localhost:3000
+      DECOCMS_LOCAL_MODE: "true"
+      ENCRYPTION_KEY: test-encryption-key-32chars-long!
+      DATA_DIR: /app/data
+    ports:
+      - "127.0.0.1:13001:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "bun -e \"const r = await fetch('http://localhost:3000/health/live'); if(!r.ok) process.exit(1)\""]
+      interval: 5s
+      timeout: 5s
+      start_period: 60s
+      retries: 20
+
+  mesh-2:
+    <<: *mesh
+    environment:
+      <<: *mesh-env
+    ports:
+      - "127.0.0.1:13002:3000"
+
+  mesh-3:
+    <<: *mesh
+    environment:
+      <<: *mesh-env
+    ports:
+      - "127.0.0.1:13003:3000"

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -12,10 +12,15 @@ services:
       retries: 10
 
   nats:
-    image: nats:2.10.22
+    # Alpine variant so the healthcheck can shell out to wget; the scratch-
+    # based `nats:2.10.22` ships only the nats-server binary, which is why
+    # the resilience suite settled for `nats-server --help` (which passes
+    # even when the server isn't serving). The monitoring port `-m 8222`
+    # exposes `/healthz` for a real readiness check.
+    image: nats:2.10.22-alpine
     command: -js -m 8222
     healthcheck:
-      test: ["CMD", "nats-server", "--help"]
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:8222/healthz || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -42,10 +47,13 @@ services:
       dockerfile: tests/resilience/Dockerfile.studio
     restart: unless-stopped
     working_dir: /app/apps/mesh
-    # Bypass the Dockerfile entrypoint (which runs migrations again) and start
-    # the server directly. Migrations are guaranteed done by the `migrate`
-    # dependency below.
-    command: ["bun", "run", "src/cli.ts", "--no-tui"]
+    # Bypass the Dockerfile entrypoint (which runs `bun run migrate` before
+    # exec'ing the CLI) AND pass `--skip-migrations` so the CLI's own boot
+    # migration is suppressed too. Without the flag each of the three pods
+    # would race on the migration step independently of the `migrate`
+    # service. The `migrate` service is the single source of truth for
+    # schema state; pods read-only at boot.
+    command: ["bun", "run", "src/cli.ts", "--no-tui", "--skip-migrations"]
     environment: &mesh-env
       NODE_ENV: production
       PORT: "3000"

--- a/tests/multi-pod/lib/client.ts
+++ b/tests/multi-pod/lib/client.ts
@@ -1,0 +1,147 @@
+/**
+ * Pod-pinned HTTP client.
+ *
+ * Every helper takes a `PodInfo` so tests can target a specific pod (no LB,
+ * no sticky sessions, no guesswork). Auth is passed per call rather than
+ * stored on the client — most multi-pod scenarios share one auth context
+ * across multiple pod targets, so the client itself stays auth-agnostic.
+ *
+ * Origin header: mesh's Better Auth requires it to match BETTER_AUTH_URL
+ * (http://localhost:3000 in compose). We send that origin regardless of
+ * which host port we hit — all pods share the same BETTER_AUTH_URL.
+ */
+
+import type { PodInfo } from "./pods";
+
+const ORIGIN = "http://localhost:3000";
+
+export interface Auth {
+  apiKey?: string;
+  cookie?: string;
+}
+
+export interface FetchOpts extends RequestInit {
+  auth?: Auth;
+}
+
+/** Low-level: `fetch` against a specific pod, auth applied. */
+export async function fetchOn(
+  pod: PodInfo,
+  path: string,
+  opts?: FetchOpts,
+): Promise<Response> {
+  const { auth, headers: extraHeaders, ...init } = opts ?? {};
+
+  const headers = new Headers(extraHeaders);
+  if (!headers.has("Origin")) headers.set("Origin", ORIGIN);
+  if (auth?.apiKey) headers.set("Authorization", `Bearer ${auth.apiKey}`);
+  if (auth?.cookie) headers.set("Cookie", auth.cookie);
+
+  return fetch(`${pod.baseUrl}${path}`, { ...init, headers });
+}
+
+/** POST + JSON body convenience. Throws on non-2xx so tests fail loudly. */
+export async function postJson(
+  pod: PodInfo,
+  path: string,
+  body: unknown,
+  opts?: FetchOpts,
+): Promise<Response> {
+  const headers = new Headers(opts?.headers);
+  headers.set("Content-Type", "application/json");
+
+  const res = await fetchOn(pod, path, {
+    ...opts,
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "<unreadable>");
+    throw new Error(
+      `POST ${pod.service} ${path} → HTTP ${res.status}: ${text}`,
+    );
+  }
+  return res;
+}
+
+/** GET + JSON convenience. */
+export async function getJson<T = unknown>(
+  pod: PodInfo,
+  path: string,
+  opts?: FetchOpts,
+): Promise<T> {
+  const res = await fetchOn(pod, path, opts);
+  if (!res.ok) {
+    const text = await res.text().catch(() => "<unreadable>");
+    throw new Error(`GET ${pod.service} ${path} → HTTP ${res.status}: ${text}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Extract session cookies from a Set-Cookie response. Better Auth replies
+ * with multiple cookies (session token + CSRF token); we collapse them into
+ * a single `name=value; name=value` header value ready to re-send.
+ */
+export function extractSessionCookie(res: Response): string {
+  const setCookies = res.headers.getSetCookie?.() ?? [];
+  return setCookies
+    .map((c) => c.split(";")[0].trim())
+    .filter(Boolean)
+    .join("; ");
+}
+
+/**
+ * Open an SSE stream and yield each `data:` payload until the response
+ * ends or the abort signal fires. The /attach endpoint emits AI-SDK UI
+ * message chunks as SSE; the consumer typically only cares about
+ * specific `type` values (e.g. "text-delta") and aborts once it's
+ * collected enough.
+ */
+export async function* sse(
+  pod: PodInfo,
+  path: string,
+  opts?: FetchOpts,
+): AsyncGenerator<string, void, unknown> {
+  const headers = new Headers(opts?.headers);
+  headers.set("Accept", "text/event-stream");
+
+  const res = await fetchOn(pod, path, { ...opts, headers });
+  if (!res.ok || !res.body) {
+    const text = res.ok
+      ? "<no body>"
+      : await res.text().catch(() => "<unreadable>");
+    throw new Error(
+      `SSE GET ${pod.service} ${path} → HTTP ${res.status}: ${text}`,
+    );
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE frames are delimited by a blank line ("\n\n"). Each frame may
+      // span multiple "data: ..." lines; we concat them and yield once.
+      let sepIdx: number;
+      while ((sepIdx = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, sepIdx);
+        buffer = buffer.slice(sepIdx + 2);
+        const payload = frame
+          .split("\n")
+          .filter((l) => l.startsWith("data:"))
+          .map((l) => l.slice(5).trimStart())
+          .join("\n");
+        if (payload) yield payload;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/tests/multi-pod/lib/cluster.ts
+++ b/tests/multi-pod/lib/cluster.ts
@@ -22,9 +22,17 @@ async function compose(...args: string[]): Promise<void> {
   }
 }
 
-/** Bring the cluster up and wait until all mesh pods report /health/live. */
+/**
+ * Bring the cluster up and wait until all mesh pods report /health/live.
+ *
+ * We don't pass `--wait` to docker compose because the one-shot `migrate`
+ * service (`Exited 0` once schemas are created) is mis-classified as a
+ * failure by `--wait` and exits non-zero. The `waitReady()` poll below
+ * is the source of truth for readiness instead — same approach as
+ * `run.sh`.
+ */
 export async function up(): Promise<void> {
-  await compose("up", "-d", "--build", "--wait");
+  await compose("up", "-d", "--build");
   await waitReady();
 }
 

--- a/tests/multi-pod/lib/cluster.ts
+++ b/tests/multi-pod/lib/cluster.ts
@@ -1,0 +1,55 @@
+/**
+ * Cluster lifecycle for multi-pod tests.
+ *
+ * Wraps `docker compose` so test files don't have to know about it. The
+ * usual flow is run.sh-managed (bring cluster up before tests, tear down
+ * after), but `up()` / `down()` are exposed for ad-hoc local debugging.
+ */
+
+import { pollUntil } from "./poll-until";
+import { ALL_PODS } from "./pods";
+
+const COMPOSE_FILE = new URL("../docker-compose.yml", import.meta.url).pathname;
+
+async function compose(...args: string[]): Promise<void> {
+  const proc = Bun.spawn(["docker", "compose", "-f", COMPOSE_FILE, ...args], {
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`docker compose ${args.join(" ")} exited ${code}`);
+  }
+}
+
+/** Bring the cluster up and wait until all mesh pods report /health/live. */
+export async function up(): Promise<void> {
+  await compose("up", "-d", "--build", "--wait");
+  await waitReady();
+}
+
+/** `docker compose down -v` — destroys volumes too. */
+export async function down(): Promise<void> {
+  await compose("down", "-v");
+}
+
+/** Poll /health/live on each pod until all respond 200. */
+export async function waitReady(timeoutMs = 120_000): Promise<void> {
+  await Promise.all(
+    ALL_PODS.map((pod) =>
+      pollUntil(
+        async () => {
+          const res = await fetch(`${pod.baseUrl}/health/live`).catch(
+            () => null,
+          );
+          return res?.ok ?? false;
+        },
+        {
+          timeoutMs,
+          intervalMs: 1000,
+          label: `wait-ready:${pod.service}`,
+        },
+      ),
+    ),
+  );
+}

--- a/tests/multi-pod/lib/hooks.ts
+++ b/tests/multi-pod/lib/hooks.ts
@@ -1,0 +1,18 @@
+/**
+ * Standard test hooks for multi-pod scenarios.
+ *
+ * Call `registerTestHooks()` at the top of each scenario file. It waits for
+ * every mesh pod to report /health/live in `beforeAll`, ensuring the test
+ * body never races against a still-booting cluster. Idempotent — if the
+ * cluster was brought up out of band (e.g. `docker compose up -d` ran
+ * before `bun test`), the poll resolves immediately.
+ */
+
+import { beforeAll } from "bun:test";
+import { waitReady } from "./cluster";
+
+export function registerTestHooks(): void {
+  beforeAll(async () => {
+    await waitReady();
+  }, 180_000);
+}

--- a/tests/multi-pod/lib/pod.ts
+++ b/tests/multi-pod/lib/pod.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-pod control via docker compose. Tests use these to simulate pod
+ * death, restart, or to inspect logs for assertions.
+ *
+ * Failure-injection helpers (kill, stop, restart) operate on the compose
+ * service name (e.g. "mesh-1"); the test never speaks Docker directly.
+ */
+
+import type { PodName } from "./pods";
+
+const COMPOSE_FILE = new URL("../docker-compose.yml", import.meta.url).pathname;
+
+async function compose(...args: string[]): Promise<string> {
+  const proc = Bun.spawn(["docker", "compose", "-f", COMPOSE_FILE, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(
+      `docker compose ${args.join(" ")} exited ${code}: ${stderr || stdout}`,
+    );
+  }
+  return stdout;
+}
+
+/**
+ * SIGKILL the pod. Simulates abrupt host loss — no graceful shutdown, no
+ * Hono cleanup hooks, no DBOS deregister. Use this for the "did DBOS
+ * recovery work" scenarios.
+ */
+export async function kill(pod: PodName): Promise<void> {
+  await compose("kill", "-s", "SIGKILL", pod);
+}
+
+/** SIGTERM, allowing the pod to drain. Closer to a rolling-deploy stop. */
+export async function stop(pod: PodName): Promise<void> {
+  await compose("stop", pod);
+}
+
+/** Bring a stopped/killed pod back up. */
+export async function start(pod: PodName): Promise<void> {
+  await compose("start", pod);
+}
+
+/**
+ * Return the pod's full container logs since boot. Useful for asserting
+ * "after pod B died, pod A's logs mention picking up the workflow".
+ */
+export async function logs(pod: PodName): Promise<string> {
+  return compose("logs", "--no-color", pod);
+}
+
+/** Polling-friendly: does the pod's log output contain this substring? */
+export async function logsContain(
+  pod: PodName,
+  needle: string,
+): Promise<boolean> {
+  const out = await logs(pod);
+  return out.includes(needle);
+}

--- a/tests/multi-pod/lib/pods.ts
+++ b/tests/multi-pod/lib/pods.ts
@@ -1,0 +1,30 @@
+/**
+ * Pod registry for multi-pod tests.
+ *
+ * One source of truth for which mesh services exist, what their compose
+ * service names are, and which host port they expose. Tests pick a pod by
+ * name (`PODS.MESH_1`) and `client.ts` / `pod.ts` look up the port or
+ * service from this map.
+ *
+ * Keep in sync with `docker-compose.yml` — adding a pod means appending it
+ * here and to the compose file.
+ */
+
+export type PodName = "mesh-1" | "mesh-2" | "mesh-3";
+
+export interface PodInfo {
+  /** Compose service name (used by docker compose CLI). */
+  service: PodName;
+  /** Host port that maps to the pod's internal 3000. */
+  port: number;
+  /** Base URL the test process uses to reach this pod. */
+  baseUrl: string;
+}
+
+export const PODS: Record<string, PodInfo> = {
+  MESH_1: { service: "mesh-1", port: 13001, baseUrl: "http://127.0.0.1:13001" },
+  MESH_2: { service: "mesh-2", port: 13002, baseUrl: "http://127.0.0.1:13002" },
+  MESH_3: { service: "mesh-3", port: 13003, baseUrl: "http://127.0.0.1:13003" },
+} as const;
+
+export const ALL_PODS: PodInfo[] = Object.values(PODS);

--- a/tests/multi-pod/lib/poll-until.ts
+++ b/tests/multi-pod/lib/poll-until.ts
@@ -1,0 +1,35 @@
+/**
+ * Poll a condition until it returns truthy or the deadline passes.
+ *
+ * The distributed-systems analogue of `expect(x).toBe(y)` — in a multi-pod
+ * setup, assertions are "this becomes true within N seconds", not "this is
+ * true right now". Wrap every cross-pod assertion in pollUntil and you stop
+ * writing setTimeout-littered tests.
+ */
+export async function pollUntil(
+  condition: () => Promise<boolean>,
+  opts: { timeoutMs: number; intervalMs?: number; label?: string },
+): Promise<void> {
+  const { timeoutMs, intervalMs = 1000, label = "pollUntil" } = opts;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      if (await condition()) {
+        return;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await Bun.sleep(Math.min(intervalMs, remaining));
+  }
+
+  const base = `[${label}] Condition not met within ${timeoutMs}ms (polled every ${intervalMs}ms)`;
+  const cause =
+    lastError instanceof Error ? lastError.message : String(lastError ?? "");
+  throw new Error(cause ? `${base}: ${cause}` : base);
+}

--- a/tests/multi-pod/lib/setup.ts
+++ b/tests/multi-pod/lib/setup.ts
@@ -1,0 +1,153 @@
+/**
+ * Multi-pod test bootstrap.
+ *
+ * `bootstrapSession(pod)` is a one-shot: signs up a user, creates an org,
+ * mints an API key. Returns auth artifacts that scenarios pass to the
+ * `client.ts` helpers. The session lives in shared Postgres, so all pods
+ * recognize it — that property is exactly what makes cross-pod tests
+ * possible at all.
+ *
+ * Each invocation creates a fresh user/org with timestamped names to
+ * keep scenarios isolated; we don't reset the DB between tests.
+ */
+
+import { extractSessionCookie, fetchOn, postJson } from "./client";
+import type { PodInfo } from "./pods";
+
+export interface Session {
+  /** Better Auth session cookie, name=value style, ready to re-send. */
+  cookie: string;
+  /** API key minted via API_KEY_CREATE (Bearer-style). */
+  apiKey: string;
+  /** Slug-based org id created for this session. */
+  orgId: string;
+  /** The unique slug used when creating the org (URL-safe). */
+  orgSlug: string;
+}
+
+/**
+ * Sign up, create org, set active, mint API key. Everything goes through
+ * `pod` — but the resulting session is recognized cluster-wide because
+ * Better Auth + the API-key table live in shared Postgres.
+ */
+export async function bootstrapSession(pod: PodInfo): Promise<Session> {
+  const stamp = Date.now();
+  const email = `multi-pod-${stamp}@test.local`;
+  const password = "multi-pod-password-2026!";
+  const orgSlug = `multi-pod-${stamp}`;
+
+  // 1. Sign up — most paths return the session cookie inline.
+  const signUpRes = await fetchOn(pod, "/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password, name: "Multi-Pod Test" }),
+  });
+  if (!signUpRes.ok) {
+    const body = await signUpRes.text().catch(() => "<unreadable>");
+    throw new Error(`signUp → HTTP ${signUpRes.status}: ${body}`);
+  }
+  let cookie = extractSessionCookie(signUpRes);
+
+  // Fall back to explicit sign-in if sign-up didn't set cookies (some
+  // Better Auth flows return 200 without one for the verification path).
+  if (!cookie) {
+    const signInRes = await fetchOn(pod, "/api/auth/sign-in/email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!signInRes.ok) {
+      const body = await signInRes.text().catch(() => "<unreadable>");
+      throw new Error(`signIn → HTTP ${signInRes.status}: ${body}`);
+    }
+    cookie = extractSessionCookie(signInRes);
+  }
+  if (!cookie) throw new Error("bootstrapSession: no session cookie");
+
+  // 2. Create org. Better Auth returns the org row; we want its id.
+  const createOrgRes = await postJson(
+    pod,
+    "/api/auth/organization/create",
+    { name: "Multi-Pod Test Org", slug: orgSlug },
+    { auth: { cookie } },
+  );
+  const orgJson = (await createOrgRes.json()) as {
+    id?: string;
+    organizationId?: string;
+  };
+  const orgId = orgJson.id ?? orgJson.organizationId;
+  if (!orgId) throw new Error(`createOrg: no id in ${JSON.stringify(orgJson)}`);
+
+  // 3. Set active so subsequent calls (esp. MCP) resolve the org without a
+  // selector header.
+  await postJson(
+    pod,
+    "/api/auth/organization/set-active",
+    { organizationId: orgId },
+    { auth: { cookie } },
+  );
+
+  // Re-extract cookies in case set-active rotated them.
+  const refreshRes = await fetchOn(pod, "/api/auth/get-session", {
+    auth: { cookie },
+  });
+  const refreshed = extractSessionCookie(refreshRes);
+  if (refreshed) cookie = refreshed;
+
+  // 4. Mint an API key via the built-in API_KEY_CREATE MCP tool. The
+  // `{orgId}_self` endpoint is mesh's internal MCP namespace.
+  const apiKey = await mintApiKey(pod, cookie, orgId);
+
+  return { cookie, apiKey, orgId, orgSlug };
+}
+
+async function mintApiKey(
+  pod: PodInfo,
+  cookie: string,
+  orgId: string,
+): Promise<string> {
+  const res = await postJson(
+    pod,
+    `/mcp/${orgId}_self`,
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "API_KEY_CREATE",
+        arguments: {
+          name: `multi-pod-${Date.now()}`,
+          permissions: { "*": ["*"] },
+        },
+      },
+    },
+    {
+      auth: { cookie },
+      headers: { Accept: "application/json, text/event-stream" },
+    },
+  );
+  const json = (await res.json()) as {
+    result?: {
+      structuredContent?: { key?: string };
+      content?: Array<{ text?: string }>;
+    };
+    error?: unknown;
+  };
+  if (json.error) {
+    throw new Error(`API_KEY_CREATE failed: ${JSON.stringify(json.error)}`);
+  }
+  const structuredKey = json.result?.structuredContent?.key;
+  if (structuredKey) return structuredKey;
+
+  // Older MCP responses surface the payload as a text content part.
+  const text = json.result?.content?.[0]?.text;
+  if (text) {
+    try {
+      const parsed = JSON.parse(text);
+      if (typeof parsed.key === "string") return parsed.key;
+    } catch {
+      /* fall through */
+    }
+  }
+  throw new Error(`API_KEY_CREATE: no key in ${JSON.stringify(json.result)}`);
+}

--- a/tests/multi-pod/run.sh
+++ b/tests/multi-pod/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+
+trap 'docker compose -f "$COMPOSE_FILE" down -v' EXIT INT TERM
+
+# Bring everything up. We don't use --wait because the `migrate` service is a
+# one-shot that exits 0 once schemas are created; --wait mis-classifies that
+# as a failure. Instead, the test suite's setup hooks poll each pod's
+# /health/live before scenarios run (see lib/cluster.ts:waitReady).
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+bun test "$SCRIPT_DIR/scenarios/" --serial --timeout 900000

--- a/tests/multi-pod/scenarios/api-key-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/api-key-cross-pod.test.ts
@@ -1,0 +1,88 @@
+/**
+ * API-key cross-pod — proves Bearer-token auth is shared cluster-wide.
+ *
+ * The cluster-smoke scenario covers cookie-based session lookup. Decopilot
+ * endpoints (POST /messages, GET /attach) authenticate via API key in
+ * production, which is a different code path — Bearer header → API-key
+ * table lookup, not Cookie header → session table lookup. This scenario
+ * pins down that path before any decopilot scenario relies on it.
+ *
+ * The call we make is `COLLECTION_THREADS_LIST` over the built-in MCP
+ * endpoint at `/mcp/{orgId}_self`. It's a read-only tool that needs no
+ * fixture state (returns an empty list for a fresh org), so the test is
+ * stable and order-independent.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { postJson } from "../lib/client";
+import { registerTestHooks } from "../lib/hooks";
+import { ALL_PODS, PODS } from "../lib/pods";
+import { bootstrapSession } from "../lib/setup";
+
+registerTestHooks();
+
+interface McpEnvelope<T> {
+  result?: {
+    structuredContent?: T;
+    content?: Array<{ text?: string }>;
+  };
+  error?: { message?: string };
+}
+
+interface ListThreadsResult {
+  items?: unknown[];
+  total?: number;
+}
+
+async function listThreads(
+  pod: (typeof ALL_PODS)[number],
+  orgId: string,
+  apiKey: string,
+): Promise<ListThreadsResult> {
+  const res = await postJson(
+    pod,
+    `/mcp/${orgId}_self`,
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "COLLECTION_THREADS_LIST",
+        arguments: { limit: 10 },
+      },
+    },
+    {
+      auth: { apiKey },
+      headers: { Accept: "application/json, text/event-stream" },
+    },
+  );
+  const json = (await res.json()) as McpEnvelope<ListThreadsResult>;
+  if (json.error) {
+    throw new Error(
+      `${pod.service}: COLLECTION_THREADS_LIST failed: ${json.error.message}`,
+    );
+  }
+  // Newer MCP responses use structuredContent; older paths fall back to
+  // the text content envelope. Cover both.
+  const structured = json.result?.structuredContent;
+  if (structured) return structured;
+  const text = json.result?.content?.[0]?.text;
+  return text ? (JSON.parse(text) as ListThreadsResult) : {};
+}
+
+describe("API key cross-pod", () => {
+  test("API key minted on pod-1 authenticates on every pod", async () => {
+    const { orgId, apiKey } = await bootstrapSession(PODS.MESH_1);
+
+    // The same Bearer key should resolve to the same org on every pod,
+    // because API-key lookups go through the shared API-key table — not
+    // any pod-local registry.
+    for (const pod of ALL_PODS) {
+      const result = await listThreads(pod, orgId, apiKey);
+      // A freshly-minted org has no threads. We don't assert items is
+      // *exactly* empty (avoids coupling to whether any boot-time seeding
+      // ever lands) — just that the call succeeded and the shape matches.
+      expect(Array.isArray(result.items ?? [])).toBe(true);
+    }
+  });
+});

--- a/tests/multi-pod/scenarios/cluster-smoke.test.ts
+++ b/tests/multi-pod/scenarios/cluster-smoke.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Cluster smoke test — proves the multi-pod framework actually works.
+ *
+ * Three assertions, each one rules out a class of "did I wire it right"
+ * failure before we trust any higher-level scenario:
+ *
+ *   1. All three pods respond to /health/live independently.
+ *      → compose works, ports map, mesh boots, migrations ran once.
+ *
+ *   2. /health/ready agrees on the *same* nats and postgres dependencies.
+ *      → all pods see the same shared infra (not three independent stacks).
+ *
+ *   3. A session bootstrapped against pod 1 is recognized by pod 2 and 3.
+ *      → Better Auth's session store lives in shared Postgres, which is
+ *      what makes any cross-pod scenario possible in the first place.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getJson, fetchOn } from "../lib/client";
+import { registerTestHooks } from "../lib/hooks";
+import { ALL_PODS, PODS } from "../lib/pods";
+import { bootstrapSession } from "../lib/setup";
+
+registerTestHooks();
+
+interface HealthReady {
+  status: string;
+  services?: Record<string, { status: string }>;
+}
+
+describe("cluster smoke", () => {
+  test("every pod responds to /health/live", async () => {
+    for (const pod of ALL_PODS) {
+      const res = await fetchOn(pod, "/health/live");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test("every pod reports postgres and nats up via /health/ready", async () => {
+    for (const pod of ALL_PODS) {
+      const health = await getJson<HealthReady>(pod, "/health/ready");
+      expect(health.services?.postgres?.status).toBe("up");
+      expect(health.services?.nats?.status).toBe("up");
+    }
+  });
+
+  test("session created on pod-1 is recognized on pod-2 and pod-3", async () => {
+    const session = await bootstrapSession(PODS.MESH_1);
+
+    for (const pod of [PODS.MESH_2, PODS.MESH_3]) {
+      const res = await fetchOn(pod, "/api/auth/get-session", {
+        auth: { cookie: session.cookie },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user?: { id?: string } } | null;
+      // The session endpoint returns the user when authenticated; absence
+      // would mean each pod has its own session store (the bug we're
+      // guarding against).
+      expect(body?.user?.id).toBeTruthy();
+    }
+  });
+});

--- a/tests/multi-pod/scenarios/session-rehoming.test.ts
+++ b/tests/multi-pod/scenarios/session-rehoming.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Session rehoming — proves Better Auth session *invalidation* propagates
+ * cluster-wide, not just creation.
+ *
+ * The cluster-smoke scenario already verifies a new session is visible on
+ * all pods. This one closes the other half of the contract: signing out on
+ * one pod must invalidate the cookie everywhere within a bounded window.
+ * If that ever drifts (e.g. someone caches sessions in-memory per pod),
+ * a signed-out user could still send requests through a different pod —
+ * exactly the kind of bug that hides in single-pod tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { fetchOn, postJson } from "../lib/client";
+import { registerTestHooks } from "../lib/hooks";
+import { ALL_PODS, PODS } from "../lib/pods";
+import { pollUntil } from "../lib/poll-until";
+import { bootstrapSession } from "../lib/setup";
+
+registerTestHooks();
+
+interface SessionResponse {
+  user?: { id?: string } | null;
+}
+
+async function getSessionUserId(
+  pod: (typeof ALL_PODS)[number],
+  cookie: string,
+): Promise<string | undefined> {
+  const res = await fetchOn(pod, "/api/auth/get-session", {
+    auth: { cookie },
+  });
+  if (!res.ok) return undefined;
+  const body = (await res.json()) as SessionResponse | null;
+  return body?.user?.id;
+}
+
+describe("session rehoming", () => {
+  test("sign-out on pod-2 invalidates the cookie on every pod", async () => {
+    const session = await bootstrapSession(PODS.MESH_1);
+
+    // Baseline: cookie is valid on all three pods. If this fails, the
+    // smoke test would already have flagged it — but we want a fresh
+    // baseline since this scenario creates its own session.
+    for (const pod of ALL_PODS) {
+      const userId = await getSessionUserId(pod, session.cookie);
+      expect(userId).toBeTruthy();
+    }
+
+    // Sign out on a *different* pod than the one we signed up against.
+    // That's the load-bearing assertion: the invalidation isn't local to
+    // the pod that minted the session.
+    await postJson(
+      PODS.MESH_2,
+      "/api/auth/sign-out",
+      {},
+      { auth: { cookie: session.cookie } },
+    );
+
+    // Better Auth deletes the session row synchronously, so a poll
+    // shouldn't really be needed — but using pollUntil leaves room for
+    // any future caching layer without rewriting the test, and surfaces
+    // a clearer error message if a pod ever lags.
+    for (const pod of ALL_PODS) {
+      await pollUntil(
+        async () => (await getSessionUserId(pod, session.cookie)) === undefined,
+        {
+          timeoutMs: 5_000,
+          intervalMs: 250,
+          label: `${pod.service}:cookie-invalidated`,
+        },
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What is this contribution about?

Studio currently has no way to test multi-pod behavior. Bugs that only surface across pods — cross-pod \`/attach\`, DBOS workflow replay after pod death, NATS partition tolerance, session rehoming — can't be reproduced with \`bun run dev\` (single process) and aren't covered by the existing single-pod resilience suite. This PR adds a Docker-Compose-based framework that runs three mesh pods against shared Postgres + NATS, plus pod-pinned HTTP/SSE clients, per-pod \`kill\`/\`restart\` controls, a session-bootstrap helper, and a polling helper for distributed assertions.

A \`cluster-smoke\` scenario proves the foundation: each pod responds to \`/health/live\` and \`/health/ready\` independently, and a session created on pod-1 is recognized by pod-2 and pod-3. If any of those failed, every higher-level scenario would be untrustworthy. Migrations run once via a separate \`migrate\` service so the three mesh pods don't race; pods skip migration in their entrypoint. No scenarios that need an LLM yet — those will land in a follow-up PR after we agree on a mock-AI-provider strategy.

## How to Test

1. Start Docker Desktop.
2. \`./tests/multi-pod/run.sh\` — builds the studio image (~5 min cold, cached after), brings up postgres + nats + 3 mesh pods, runs the smoke scenario, tears everything down.
3. Expected: \`3 pass / 0 fail\`. Cluster tears down on exit even if a test fails.

For iteration: \`docker compose -f tests/multi-pod/docker-compose.yml up -d --build\` once, then \`bun test tests/multi-pod/scenarios/\` repeatedly; the \`registerTestHooks()\` in each scenario waits for \`/health/live\` so it's race-free.

## Migration Notes

None. Self-contained under \`tests/multi-pod/\`; doesn't change any application code.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (3/3 smoke assertions pass locally)
- [ ] Documentation is updated (if needed) — none yet; comments in each file explain the structure
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Docker Compose multi-pod test framework (3 mesh pods on shared Postgres + NATS) with smoke and cross-pod auth scenarios, pod-pinned clients, failure injection, distributed assertions, and CI to run on `main` and path-filtered PRs that touch mesh server code. Orchestration is hardened with a real NATS `/healthz`, a one-shot `migrate`, serialized first boot, and no auto-restart to make pod-death tests reliable.

- New Features
  - 3-pod cluster via Docker Compose with a one-shot `migrate`; mesh pods run with `--skip-migrations`. Runner: `tests/multi-pod/run.sh`; CI: `.github/workflows/multi-pod.yml` (runs on push to `main`, on PRs that modify server-side code via path filter, and `workflow_dispatch`; dumps logs on failure).
  - Pod-pinned HTTP/SSE client with per-request auth; per-pod controls (`kill`/`stop`/`start`) and logs for failure injection.
  - Session bootstrap (sign up → org → API key) on shared Postgres; scenarios: `cluster-smoke`, `api-key-cross-pod` (Bearer path), and `session-rehoming` (cookie invalidation propagates).

- Bug Fixes
  - NATS healthcheck uses monitoring `/healthz` on `nats:2.10.22-alpine` to avoid false positives.
  - Startup hardened: serialized first boot (`mesh-2` waits on `mesh-1`, `mesh-3` on `mesh-2`), disabled Docker auto-restart (`restart: "no"`), and dropped `docker compose --wait` in favor of `/health/live` polling.
  - Ignore `.claude/*.lock` to prevent accidental commits of local runtime locks.

<sup>Written for commit b04ff27cc7cc8e2fb1beb3fb76666ffc7884e31a. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3391?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

