### PR TITLE
test(multi-pod): cross-pod /attach + mock-ai provider scaffolding

### DIFF
--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -26,6 +26,24 @@ services:
       retries: 5
       start_period: 5s
 
+  # Mock OpenAI-compatible AI provider. Scenarios that need to drive the
+  # decopilot dispatch pipeline (POST /messages → streamText → JetStream
+  # pump → /attach tail) point an `openai-compatible` credential at this
+  # service via `http://mock-ai:9000/v1`. No external port — only mesh
+  # pods talk to it.
+  mock-ai:
+    build:
+      context: ./mock-ai
+      dockerfile: Dockerfile
+    environment:
+      PORT: "9000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:9000/health || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
   # Migrations run once before any mesh pod starts. Pods themselves skip the
   # migration step (we override the entrypoint with a direct start command) to
   # avoid races on parallel boot.
@@ -63,6 +81,7 @@ services:
       NODE_ENV: production
       PORT: "3000"
       HOST: 0.0.0.0
+      POD_NAME: mesh-1
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
       NATS_URL: nats://nats:4222
       BETTER_AUTH_SECRET: test-secret-for-multi-pod-tests
@@ -73,6 +92,11 @@ services:
       DATA_DIR: /app/data
     ports:
       - "127.0.0.1:13001:3000"
+    # POD_NAME makes `run_owner_pod` match the compose service name
+    # ("mesh-1"), so scenarios that need to identify the dispatch owner
+    # (e.g. pod-death-dbos-replay) can map straight from a thread row
+    # to a docker compose target without an extra UUID-to-service hop.
+    # Mesh defaults this to a random UUID when unset.
     depends_on:
       postgres:
         condition: service_healthy
@@ -98,6 +122,7 @@ services:
     <<: *mesh
     environment:
       <<: *mesh-env
+      POD_NAME: mesh-2
     ports:
       - "127.0.0.1:13002:3000"
     depends_on:
@@ -114,6 +139,7 @@ services:
     <<: *mesh
     environment:
       <<: *mesh-env
+      POD_NAME: mesh-3
     ports:
       - "127.0.0.1:13003:3000"
     depends_on:

--- a/tests/multi-pod/lib/db.ts
+++ b/tests/multi-pod/lib/db.ts
@@ -1,0 +1,88 @@
+/**
+ * Direct Postgres access for scenarios that need to inspect server-side
+ * state not exposed through the public API.
+ *
+ * Use sparingly: anything observable via MCP/HTTP should be observed
+ * that way. This helper exists for the cases where the only thing we
+ * need (e.g. `threads.run_owner_pod` for targeted-kill scenarios) is
+ * deliberately internal. Shells out via `docker compose exec` so we
+ * don't have to expose a host port.
+ */
+
+const COMPOSE_FILE = new URL("../docker-compose.yml", import.meta.url).pathname;
+
+/**
+ * Run a SQL query against the cluster's postgres and return rows as an
+ * array of objects keyed by column name. Uses tuples-only output with
+ * pipe separators, so don't `SELECT` columns whose values can contain
+ * a literal "|" character.
+ */
+export async function dbQuery<T extends Record<string, string | null>>(
+  sql: string,
+): Promise<T[]> {
+  const proc = Bun.spawn(
+    [
+      "docker",
+      "compose",
+      "-f",
+      COMPOSE_FILE,
+      "exec",
+      "-T",
+      "postgres",
+      "psql",
+      "-U",
+      "postgres",
+      "-d",
+      "postgres",
+      "-A", // unaligned output (no padding)
+      "-F",
+      "|", // field separator
+      "--csv",
+      "-c",
+      sql,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`dbQuery failed (exit ${code}): ${stderr || stdout}`);
+  }
+
+  const lines = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return [];
+
+  const headers = lines[0]!.split(",");
+  return lines.slice(1).map((line) => {
+    // psql --csv quotes fields containing commas/quotes; we don't need
+    // robust parsing here because our queries select stable scalars
+    // (ids, pod ids). Strip surrounding quotes if present.
+    const cells = line.split(",").map((c) => c.replace(/^"|"$/g, ""));
+    const row: Record<string, string | null> = {};
+    headers.forEach((h, i) => {
+      const v = cells[i];
+      row[h] = v === "" || v == null ? null : v;
+    });
+    return row as T;
+  });
+}
+
+/**
+ * Convenience: look up which pod a thread's run is currently assigned to.
+ * Returns null when the thread doesn't exist or the run hasn't been
+ * claimed yet (run_owner_pod is null until RUN_STARTED fires).
+ */
+export async function getThreadRunOwnerPod(
+  threadId: string,
+): Promise<string | null> {
+  const rows = await dbQuery<{ run_owner_pod: string | null }>(
+    `SELECT run_owner_pod FROM threads WHERE id = '${threadId.replace(/'/g, "''")}'`,
+  );
+  return rows[0]?.run_owner_pod ?? null;
+}

--- a/tests/multi-pod/lib/db.ts
+++ b/tests/multi-pod/lib/db.ts
@@ -13,9 +13,11 @@ const COMPOSE_FILE = new URL("../docker-compose.yml", import.meta.url).pathname;
 
 /**
  * Run a SQL query against the cluster's postgres and return rows as an
- * array of objects keyed by column name. Uses tuples-only output with
- * pipe separators, so don't `SELECT` columns whose values can contain
- * a literal "|" character.
+ * array of objects keyed by column name. Output is RFC-4180 CSV (psql's
+ * `--csv` mode quotes fields containing commas/quotes/newlines), but our
+ * parser is intentionally naive: it splits on raw commas. So don't
+ * `SELECT` columns whose values can contain a literal "," character
+ * unless you tighten the parser too.
  */
 export async function dbQuery<T extends Record<string, string | null>>(
   sql: string,
@@ -34,9 +36,6 @@ export async function dbQuery<T extends Record<string, string | null>>(
       "postgres",
       "-d",
       "postgres",
-      "-A", // unaligned output (no padding)
-      "-F",
-      "|", // field separator
       "--csv",
       "-c",
       sql,

--- a/tests/multi-pod/lib/hooks.ts
+++ b/tests/multi-pod/lib/hooks.ts
@@ -29,8 +29,20 @@ async function restoreStoppedPods(): Promise<void> {
     ],
     { stdout: "pipe", stderr: "pipe" },
   );
-  const out = await new Response(proc.stdout).text();
-  await proc.exited;
+  const [out, err] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  // Fail loudly: if compose can't even list services (daemon down,
+  // compose file moved, etc.), silently treating it as "no pods to
+  // restore" turns the real failure into a 2-minute waitReady timeout
+  // with a misleading "mesh-1 not healthy" message.
+  if (code !== 0) {
+    throw new Error(
+      `docker compose ps failed (exit ${code}): ${err.trim() || out.trim() || "<no output>"}`,
+    );
+  }
 
   const services = new Set(ALL_PODS.map((p) => p.service as string));
   const lines = out.split("\n").filter(Boolean);

--- a/tests/multi-pod/lib/hooks.ts
+++ b/tests/multi-pod/lib/hooks.ts
@@ -1,18 +1,61 @@
 /**
  * Standard test hooks for multi-pod scenarios.
  *
- * Call `registerTestHooks()` at the top of each scenario file. It waits for
- * every mesh pod to report /health/live in `beforeAll`, ensuring the test
- * body never races against a still-booting cluster. Idempotent — if the
- * cluster was brought up out of band (e.g. `docker compose up -d` ran
- * before `bun test`), the poll resolves immediately.
+ * Call `registerTestHooks()` at the top of each scenario file. It (1)
+ * restarts any mesh pods that were left stopped by a previous scenario
+ * (the pod-death scenarios SIGKILL pods and don't currently restore
+ * them themselves) and (2) waits for every pod to report /health/live
+ * before any test body runs.
  */
 
 import { beforeAll } from "bun:test";
 import { waitReady } from "./cluster";
+import { start } from "./pod";
+import { ALL_PODS } from "./pods";
+
+const COMPOSE_FILE = new URL("../docker-compose.yml", import.meta.url).pathname;
+
+async function restoreStoppedPods(): Promise<void> {
+  const proc = Bun.spawn(
+    [
+      "docker",
+      "compose",
+      "-f",
+      COMPOSE_FILE,
+      "ps",
+      "-a",
+      "--format",
+      "{{.Service}}\t{{.State}}",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  const services = new Set(ALL_PODS.map((p) => p.service as string));
+  const lines = out.split("\n").filter(Boolean);
+  await Promise.all(
+    lines.map(async (line) => {
+      const [service, state] = line.split("\t");
+      if (
+        service &&
+        services.has(service) &&
+        state &&
+        state.toLowerCase() !== "running"
+      ) {
+        // `docker compose start` is a no-op if the container is already
+        // running — we only reach here when it's stopped/exited.
+        await start(service as never).catch(() => {
+          /* best effort; waitReady will surface a real problem */
+        });
+      }
+    }),
+  );
+}
 
 export function registerTestHooks(): void {
   beforeAll(async () => {
+    await restoreStoppedPods();
     await waitReady();
   }, 180_000);
 }

--- a/tests/multi-pod/lib/setup.ts
+++ b/tests/multi-pod/lib/setup.ts
@@ -285,7 +285,14 @@ async function mcpCall<T = unknown>(
       `${params.name} JSON-RPC error: ${json.error.message ?? JSON.stringify(json.error)}`,
     );
   }
-  if (json.result?.structuredContent) return json.result.structuredContent;
+  // Prefer structuredContent when present and non-empty. Some MCP tools
+  // ship `structuredContent: {}` alongside a populated text part — a
+  // bare truthy check would short-circuit on `{}` and the caller would
+  // see an empty object instead of the real payload.
+  const structured = json.result?.structuredContent as
+    | Record<string, unknown>
+    | undefined;
+  if (structured && Object.keys(structured).length > 0) return structured as T;
 
   const text = json.result?.content?.[0]?.text;
   if (text) {
@@ -295,5 +302,8 @@ async function mcpCall<T = unknown>(
       /* fall through */
     }
   }
-  return {} as T;
+  // Last resort: surface whatever structured payload existed (even if
+  // empty) rather than fabricating one, so callers get a faithful echo
+  // and can decide how to react.
+  return (structured ?? {}) as T;
 }

--- a/tests/multi-pod/lib/setup.ts
+++ b/tests/multi-pod/lib/setup.ts
@@ -7,6 +7,12 @@
  * recognize it — that property is exactly what makes cross-pod tests
  * possible at all.
  *
+ * `wireMockProvider(pod, session)` is an opt-in second step for scenarios
+ * that drive the decopilot dispatch pipeline. It registers an
+ * `openai-compatible` credential pointing at the in-cluster mock-ai
+ * service and pins the org's "smart" tier to it. Scenarios that don't
+ * dispatch (smoke, session-rehoming, api-key-cross-pod) skip this.
+ *
  * Each invocation creates a fresh user/org with timestamped names to
  * keep scenarios isolated; we don't reset the DB between tests.
  */
@@ -24,6 +30,17 @@ export interface Session {
   /** The unique slug used when creating the org (URL-safe). */
   orgSlug: string;
 }
+
+export interface MockProvider {
+  /** ai_provider_keys.id created for the mock-ai credential. */
+  keyId: string;
+  /** Model id the mock advertises (matches mock-ai/server.ts MODEL_ID). */
+  modelId: string;
+}
+
+/** The internal URL mesh pods use to reach the mock-ai container. */
+const MOCK_AI_INTERNAL_URL = "http://mock-ai:9000/v1";
+const MOCK_AI_MODEL_ID = "mock-model";
 
 /**
  * Sign up, create org, set active, mint API key. Everything goes through
@@ -96,16 +113,158 @@ export async function bootstrapSession(pod: PodInfo): Promise<Session> {
 
   // 4. Mint an API key via the built-in API_KEY_CREATE MCP tool. The
   // `{orgId}_self` endpoint is mesh's internal MCP namespace.
-  const apiKey = await mintApiKey(pod, cookie, orgId);
+  const apiKeyRes = await mcpCall<{ key?: string }>(pod, orgId, cookie, {
+    name: "API_KEY_CREATE",
+    arguments: {
+      name: `multi-pod-${Date.now()}`,
+      permissions: { "*": ["*"] },
+    },
+  });
+  if (!apiKeyRes.key) {
+    throw new Error(
+      `API_KEY_CREATE returned no key: ${JSON.stringify(apiKeyRes)}`,
+    );
+  }
 
-  return { cookie, apiKey, orgId, orgSlug };
+  return { cookie, apiKey: apiKeyRes.key, orgId, orgSlug };
 }
 
-async function mintApiKey(
+/**
+ * Register a credential pointing at the in-cluster mock-ai service and
+ * pin the org's "smart" tier to it. After this returns, any decopilot
+ * dispatch on this org will route through mock-ai instead of a real
+ * provider.
+ *
+ * Idempotent at the scenario level: each scenario gets a fresh org via
+ * bootstrapSession, so this always inserts a new credential.
+ */
+export async function wireMockProvider(
   pod: PodInfo,
-  cookie: string,
+  session: Session,
+): Promise<MockProvider> {
+  // 1. Create the credential. `openai-compatible` provider takes the
+  // baseUrl + apiKey as a JSON string in the `apiKey` field — that JSON
+  // is what the adapter parses at activate time (see
+  // apps/mesh/src/ai-providers/adapters/openai-compatible.ts).
+  const created = await mcpCall<{ id?: string }>(
+    pod,
+    session.orgId,
+    session.cookie,
+    {
+      name: "AI_PROVIDER_KEY_CREATE",
+      arguments: {
+        providerId: "openai-compatible",
+        label: "multi-pod-mock-ai",
+        apiKey: JSON.stringify({
+          baseUrl: MOCK_AI_INTERNAL_URL,
+          apiKey: "test-key",
+        }),
+      },
+    },
+  );
+  if (!created.id) {
+    throw new Error(
+      `AI_PROVIDER_KEY_CREATE returned no id: ${JSON.stringify(created)}`,
+    );
+  }
+
+  // 2. Pin the "smart" tier to this credential + the mock model. Other
+  // tiers stay null so any decopilot call that defaults to "smart"
+  // (which most do) routes here.
+  await mcpCall(pod, session.orgId, session.cookie, {
+    name: "ORGANIZATION_SETTINGS_UPDATE",
+    arguments: {
+      organizationId: session.orgId,
+      simple_mode: {
+        tiers: {
+          fast: null,
+          smart: { keyId: created.id, modelId: MOCK_AI_MODEL_ID },
+          thinking: null,
+          image: null,
+          web_research: null,
+        },
+      },
+    },
+  });
+
+  return { keyId: created.id, modelId: MOCK_AI_MODEL_ID };
+}
+
+/**
+ * Create a virtual MCP (agent) for the session's org. Required because
+ * COLLECTION_THREADS_CREATE rejects a thread without a real virtual MCP
+ * id — the UI creates one on the way in too. The agent has no
+ * connections; it just satisfies the FK so thread creation can succeed.
+ */
+export async function createTestAgent(
+  pod: PodInfo,
+  session: Session,
+): Promise<{ virtualMcpId: string }> {
+  const created = await mcpCall<{ item?: { id?: string }; id?: string }>(
+    pod,
+    session.orgId,
+    session.cookie,
+    {
+      name: "COLLECTION_VIRTUAL_MCP_CREATE",
+      arguments: {
+        data: {
+          title: `multi-pod-agent-${Date.now()}`,
+          connections: [],
+        },
+      },
+    },
+  );
+  const id = created.item?.id ?? created.id;
+  if (!id) {
+    throw new Error(
+      `COLLECTION_VIRTUAL_MCP_CREATE: no id in ${JSON.stringify(created)}`,
+    );
+  }
+  return { virtualMcpId: id };
+}
+
+/**
+ * Pre-create a thread row so /attach has something to look up the
+ * instant after POST /messages returns 202. Without this, /attach
+ * races against the workflow's first `prepareRun` (which is what
+ * normally inserts the thread row) and 404s.
+ */
+export async function createTestThread(
+  pod: PodInfo,
+  session: Session,
+  virtualMcpId: string,
+  threadId?: string,
+): Promise<{ threadId: string }> {
+  const id =
+    threadId ?? `thrd_test_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
+  await mcpCall(pod, session.orgId, session.cookie, {
+    name: "COLLECTION_THREADS_CREATE",
+    arguments: {
+      data: { id, virtual_mcp_id: virtualMcpId },
+    },
+  });
+  return { threadId: id };
+}
+
+interface McpEnvelope<T> {
+  result?: {
+    structuredContent?: T;
+    content?: Array<{ text?: string }>;
+  };
+  error?: { message?: string };
+}
+
+/**
+ * Generic MCP tool-call helper for the built-in `{orgId}_self` namespace.
+ * Returns the parsed structured content (or text fallback for older
+ * tools). Throws on JSON-RPC errors so tests fail loudly.
+ */
+async function mcpCall<T = unknown>(
+  pod: PodInfo,
   orgId: string,
-): Promise<string> {
+  cookie: string,
+  params: { name: string; arguments: Record<string, unknown> },
+): Promise<T> {
   const res = await postJson(
     pod,
     `/mcp/${orgId}_self`,
@@ -113,41 +272,28 @@ async function mintApiKey(
       jsonrpc: "2.0",
       id: 1,
       method: "tools/call",
-      params: {
-        name: "API_KEY_CREATE",
-        arguments: {
-          name: `multi-pod-${Date.now()}`,
-          permissions: { "*": ["*"] },
-        },
-      },
+      params,
     },
     {
       auth: { cookie },
       headers: { Accept: "application/json, text/event-stream" },
     },
   );
-  const json = (await res.json()) as {
-    result?: {
-      structuredContent?: { key?: string };
-      content?: Array<{ text?: string }>;
-    };
-    error?: unknown;
-  };
+  const json = (await res.json()) as McpEnvelope<T>;
   if (json.error) {
-    throw new Error(`API_KEY_CREATE failed: ${JSON.stringify(json.error)}`);
+    throw new Error(
+      `${params.name} JSON-RPC error: ${json.error.message ?? JSON.stringify(json.error)}`,
+    );
   }
-  const structuredKey = json.result?.structuredContent?.key;
-  if (structuredKey) return structuredKey;
+  if (json.result?.structuredContent) return json.result.structuredContent;
 
-  // Older MCP responses surface the payload as a text content part.
   const text = json.result?.content?.[0]?.text;
   if (text) {
     try {
-      const parsed = JSON.parse(text);
-      if (typeof parsed.key === "string") return parsed.key;
+      return JSON.parse(text) as T;
     } catch {
       /* fall through */
     }
   }
-  throw new Error(`API_KEY_CREATE: no key in ${JSON.stringify(json.result)}`);
+  return {} as T;
 }

--- a/tests/multi-pod/mock-ai/Dockerfile
+++ b/tests/multi-pod/mock-ai/Dockerfile
@@ -1,0 +1,7 @@
+FROM oven/bun:1-alpine
+
+WORKDIR /app
+COPY server.ts /app/server.ts
+
+EXPOSE 9000
+CMD ["bun", "run", "/app/server.ts"]

--- a/tests/multi-pod/mock-ai/server.ts
+++ b/tests/multi-pod/mock-ai/server.ts
@@ -1,0 +1,170 @@
+/**
+ * Mock OpenAI-compatible AI provider for multi-pod scenarios.
+ *
+ * Mesh's `openai-compatible` adapter (apps/mesh/src/ai-providers/adapters/
+ * openai-compatible.ts) wraps `@ai-sdk/openai` against a custom baseURL,
+ * so pointing a credential's JSON at this server is enough to drive the
+ * full decopilot dispatch pipeline (streamText → onChunk → JetStream pump
+ * → /attach tail) without burning real LLM budget.
+ *
+ * Two endpoints:
+ *   GET  /v1/models                — required by the adapter's listModels()
+ *                                    call during tier resolution
+ *   POST /v1/chat/completions      — SSE stream of OpenAI-shaped chunks
+ *
+ * Test-time control comes from the user message text — mesh doesn't
+ * propagate request headers to outbound provider calls, so we encode
+ * hints in the prompt instead. Recognized form:
+ *
+ *   "slow:<chunks>x<delayMs>"   — e.g. "slow:5x500" → 5 chunks, 500ms apart
+ *   "many:<chunks>"             — e.g. "many:20"    → 20 chunks at default 50ms
+ *
+ * Falls back to a fast default (5 chunks × 50ms ≈ 250ms total) so
+ * happy-path scenarios run quickly. Failure-injection scenarios opt
+ * into longer runs by sending the hint in their user message.
+ */
+
+const PORT = Number(process.env.PORT ?? 9000);
+const MODEL_ID = "mock-model";
+
+interface DeltaChunk {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: Array<{
+    index: 0;
+    delta: { role?: "assistant"; content?: string };
+    finish_reason: null | "stop";
+  }>;
+}
+
+function frame(payload: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function done(): Uint8Array {
+  return new TextEncoder().encode("data: [DONE]\n\n");
+}
+
+function buildChunk(
+  id: string,
+  delta: DeltaChunk["choices"][0]["delta"],
+  finish: DeltaChunk["choices"][0]["finish_reason"] = null,
+): DeltaChunk {
+  return {
+    id,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: MODEL_ID,
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  };
+}
+
+type ContentPart = { type?: string; text?: string };
+interface CompletionsBody {
+  messages?: Array<{ role: string; content?: string | ContentPart[] }>;
+}
+
+/** Flatten OpenAI content (string OR parts array) into plain text. */
+function contentToText(content: string | ContentPart[] | undefined): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  return content
+    .filter((p) => p?.type === "text" && typeof p.text === "string")
+    .map((p) => p.text)
+    .join(" ");
+}
+
+/**
+ * Walk the message array bottom-up looking for a control hint in the
+ * latest user turn. Returns {chunks, delayMs} — defaults applied for
+ * unspecified fields.
+ */
+function parseHints(body: CompletionsBody): {
+  chunks: number;
+  delayMs: number;
+} {
+  const last = body.messages
+    ?.slice()
+    .reverse()
+    .find((m) => m.role === "user");
+  const text = contentToText(last?.content);
+  if (!text) {
+    return { chunks: 5, delayMs: 50 };
+  }
+  const slow = text.match(/slow:(\d+)x(\d+)/);
+  if (slow)
+    return {
+      chunks: Math.max(1, Number(slow[1])),
+      delayMs: Math.max(0, Number(slow[2])),
+    };
+  const many = text.match(/many:(\d+)/);
+  if (many) return { chunks: Math.max(1, Number(many[1])), delayMs: 50 };
+  return { chunks: 5, delayMs: 50 };
+}
+
+async function streamCompletion(req: Request): Promise<Response> {
+  const reqBody = (await req.json().catch(() => ({}))) as CompletionsBody;
+  const { chunks: numChunks, delayMs } = parseHints(reqBody);
+  const id = `chatcmpl-${crypto.randomUUID()}`;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      // OpenAI starts every stream with a role frame; the AI SDK relies on
+      // it to attribute subsequent deltas to "assistant".
+      controller.enqueue(frame(buildChunk(id, { role: "assistant" })));
+
+      for (let i = 0; i < numChunks; i++) {
+        if (delayMs > 0) await Bun.sleep(delayMs);
+        controller.enqueue(
+          frame(buildChunk(id, { content: `chunk-${i + 1} ` })),
+        );
+      }
+
+      controller.enqueue(frame(buildChunk(id, {}, "stop")));
+      controller.enqueue(done());
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+const handler = async (req: Request): Promise<Response> => {
+  const url = new URL(req.url);
+  const path = url.pathname;
+
+  if (path === "/health") {
+    return new Response("ok");
+  }
+
+  if (path === "/v1/models" && req.method === "GET") {
+    return Response.json({
+      object: "list",
+      data: [
+        {
+          id: MODEL_ID,
+          object: "model",
+          created: 0,
+          owned_by: "mock",
+        },
+      ],
+    });
+  }
+
+  if (path === "/v1/chat/completions" && req.method === "POST") {
+    return streamCompletion(req);
+  }
+
+  return new Response(`Not found: ${req.method} ${path}`, { status: 404 });
+};
+
+Bun.serve({ port: PORT, fetch: handler });
+console.log(`[mock-ai] listening on :${PORT}`);

--- a/tests/multi-pod/scenarios/attach-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/attach-cross-pod.test.ts
@@ -10,7 +10,9 @@
  * Setup keeps the bug catchable regardless of which pod DBOS happens
  * to dispatch the workflow on:
  *
- *   1. Mock is configured to drip slowly (300ms × 5 chunks ≈ 1.5s).
+ *   1. Mock is configured to drip slowly (500ms × 5 chunks ≈ 2.5s) — see
+ *      MOCK_HINT below; this gives the test time to attach after some
+ *      chunks have already buffered in JetStream.
  *   2. POST goes to pod-1. DBOS picks an arbitrary pod to run the
  *      threadGateWorkflow step; we don't try to pin it.
  *   3. We wait ~500ms so a couple of chunks are already in JetStream.

--- a/tests/multi-pod/scenarios/attach-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/attach-cross-pod.test.ts
@@ -11,15 +11,21 @@
  * to dispatch the workflow on:
  *
  *   1. Mock is configured to drip slowly (500ms × 5 chunks ≈ 2.5s) — see
- *      MOCK_HINT below; this gives the test time to attach after some
- *      chunks have already buffered in JetStream.
+ *      MOCK_HINT below; this gives the test time to attach after chunk-1
+ *      has already buffered in JetStream.
  *   2. POST goes to pod-1. DBOS picks an arbitrary pod to run the
  *      threadGateWorkflow step; we don't try to pin it.
- *   3. We wait ~500ms so a couple of chunks are already in JetStream.
+ *   3. We open a throwaway /attach on pod-1 as a synchronization probe
+ *      and wait until *it* sees chunk-1 — deterministic signal that
+ *      the chunk is now in JetStream. A fixed sleep was racy because
+ *      a fast dispatch chain could publish chunk-1 *after* the test's
+ *      attaches opened, in which case `deliverPolicy: "new"` would
+ *      still deliver chunk-1 live and the bug wouldn't manifest.
  *   4. Two attaches open on pod-2 AND pod-3 (deliberately *not* pod-1
  *      to maximize the chance of hitting the cross-pod code path).
- *   5. Both attaches must receive at least the first chunk — the one
- *      most likely to be dropped by the `"new"` deliverPolicy bug.
+ *   5. Both attaches must receive chunk-1 — the one most likely to be
+ *      dropped by the `"new"` deliverPolicy bug, now guaranteed to be
+ *      *already in JetStream* by the time we subscribe.
  *
  * If pod-2 or pod-3 happens to be the dispatch owner, isRunning() is
  * true locally and "all" is picked the easy way — that case passes
@@ -116,15 +122,30 @@ describe("cross-pod /attach", () => {
     );
     expect(postRes.status).toBe(202);
 
-    // Let the run start streaming and buffer 1-2 chunks. If we
-    // attached immediately, the "new" deliverPolicy bug would still
-    // get the rest of the chunks and the test would pass for the
-    // wrong reason.
-    await Bun.sleep(500);
+    // Synchronization probe: open a throwaway /attach on pod-1 and
+    // wait until *it* sees chunk-1. That's a deterministic signal
+    // that chunk-1 is now in JetStream (any subscription opened from
+    // here on would have to use `deliverPolicy: "all"` to see it).
+    // A fixed sleep would be racy — if the dispatch chain (DBOS
+    // dequeue → prepareRun → streamText init) finished before the
+    // mock's first chunk-delay tick, the test attaches would still
+    // see chunk-1 live via `"new"` and the bug wouldn't manifest.
+    await collectAttachUntil(
+      PODS.MESH_1,
+      session.orgSlug,
+      threadId,
+      session.apiKey,
+      (s) => s.includes("chunk-1"),
+      15_000,
+    );
 
-    // Attach on two pods that are *not* the POST pod. Both must see
-    // the very first chunk ("chunk-1") to prove the cross-pod tail
-    // is actually replaying the buffered prefix.
+    // Now attach on the two pods that are *not* the POST pod. By the
+    // time these subscriptions open, chunk-1 is already in JetStream,
+    // so seeing it on the other side requires the deliverPolicy fix
+    // to pick "all" (or the survivor pod happens to also be the
+    // dispatch owner, in which case the local-registry fast path
+    // would catch it pre-fix too — still useful coverage for the
+    // happy path).
     const [pod2Joined, pod3Joined] = await Promise.all([
       collectAttachUntil(
         PODS.MESH_2,

--- a/tests/multi-pod/scenarios/attach-cross-pod.test.ts
+++ b/tests/multi-pod/scenarios/attach-cross-pod.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Cross-pod /attach — the headline scenario for this test framework.
+ *
+ * This directly validates the deliverPolicy fix that was merged in
+ * PR #3387: `/attach` picks `"all"` vs `"new"` based on `thread.status`
+ * from the DB, not the pod-local registry. Without the fix, a client
+ * attaching to a pod that doesn't own the run would silently miss
+ * already-buffered chunks.
+ *
+ * Setup keeps the bug catchable regardless of which pod DBOS happens
+ * to dispatch the workflow on:
+ *
+ *   1. Mock is configured to drip slowly (300ms × 5 chunks ≈ 1.5s).
+ *   2. POST goes to pod-1. DBOS picks an arbitrary pod to run the
+ *      threadGateWorkflow step; we don't try to pin it.
+ *   3. We wait ~500ms so a couple of chunks are already in JetStream.
+ *   4. Two attaches open on pod-2 AND pod-3 (deliberately *not* pod-1
+ *      to maximize the chance of hitting the cross-pod code path).
+ *   5. Both attaches must receive at least the first chunk — the one
+ *      most likely to be dropped by the `"new"` deliverPolicy bug.
+ *
+ * If pod-2 or pod-3 happens to be the dispatch owner, isRunning() is
+ * true locally and "all" is picked the easy way — that case passes
+ * pre-fix too. If pod-1 (or any non-attached pod) is the owner, the
+ * test exercises the actual cross-pod path. Over a few CI runs we get
+ * coverage of all three.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { postJson, sse } from "../lib/client";
+import { registerTestHooks } from "../lib/hooks";
+import { PODS } from "../lib/pods";
+import {
+  bootstrapSession,
+  createTestAgent,
+  createTestThread,
+  wireMockProvider,
+} from "../lib/setup";
+
+registerTestHooks();
+
+// Encoded in the prompt — mesh strips request headers before calling
+// the provider, so hints live in the message text instead. mock-ai
+// parses "slow:NxMS" to mean N chunks at M ms intervals.
+const MOCK_HINT = "slow:5x500"; // ~2.5s total run
+
+/** Collect SSE payloads from /attach until `predicate` is satisfied or
+ *  the timeout fires. Aborts the underlying request on either outcome. */
+async function collectAttachUntil(
+  pod: (typeof PODS)["MESH_2"],
+  orgSlug: string,
+  threadId: string,
+  apiKey: string,
+  predicate: (joined: string) => boolean,
+  timeoutMs: number,
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let joined = "";
+
+  try {
+    for await (const payload of sse(
+      pod,
+      `/api/${orgSlug}/decopilot/attach/${threadId}`,
+      { auth: { apiKey }, signal: controller.signal },
+    )) {
+      joined += payload;
+      if (predicate(joined)) return joined;
+    }
+  } catch (err) {
+    // AbortError on timeout is expected; rethrow anything else.
+    if (
+      err instanceof Error &&
+      err.name !== "AbortError" &&
+      !err.message.includes("aborted")
+    ) {
+      throw err;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return joined;
+}
+
+describe("cross-pod /attach", () => {
+  test("attach on non-POST pods receives buffered chunks from the live run", async () => {
+    const session = await bootstrapSession(PODS.MESH_1);
+    await wireMockProvider(PODS.MESH_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const { threadId } = await createTestThread(
+      PODS.MESH_1,
+      session,
+      virtualMcpId,
+    );
+
+    const messageBody = {
+      messages: [
+        {
+          id: crypto.randomUUID(),
+          role: "user",
+          parts: [{ type: "text", text: MOCK_HINT }],
+        },
+      ],
+      agent: { id: virtualMcpId },
+      tier: "smart",
+    };
+
+    const postRes = await postJson(
+      PODS.MESH_1,
+      `/api/${session.orgSlug}/decopilot/threads/${threadId}/messages`,
+      messageBody,
+      { auth: { apiKey: session.apiKey } },
+    );
+    expect(postRes.status).toBe(202);
+
+    // Let the run start streaming and buffer 1-2 chunks. If we
+    // attached immediately, the "new" deliverPolicy bug would still
+    // get the rest of the chunks and the test would pass for the
+    // wrong reason.
+    await Bun.sleep(500);
+
+    // Attach on two pods that are *not* the POST pod. Both must see
+    // the very first chunk ("chunk-1") to prove the cross-pod tail
+    // is actually replaying the buffered prefix.
+    const [pod2Joined, pod3Joined] = await Promise.all([
+      collectAttachUntil(
+        PODS.MESH_2,
+        session.orgSlug,
+        threadId,
+        session.apiKey,
+        (s) => s.includes("chunk-1"),
+        15_000,
+      ),
+      collectAttachUntil(
+        PODS.MESH_3,
+        session.orgSlug,
+        threadId,
+        session.apiKey,
+        (s) => s.includes("chunk-1"),
+        15_000,
+      ),
+    ]);
+
+    expect(pod2Joined).toContain("chunk-1");
+    expect(pod3Joined).toContain("chunk-1");
+  }, 30_000);
+});

--- a/tests/multi-pod/scenarios/pod-death-dbos-replay.test.ts
+++ b/tests/multi-pod/scenarios/pod-death-dbos-replay.test.ts
@@ -18,40 +18,51 @@
  *      name, so the value maps directly to a `pod.kill()` target).
  *   5. Assert one surviving /attach receives "chunk-20".
  *
- * ── Architectural finding (2026-05-17) ────────────────────────────────
+ * ── Architectural finding (2026-05-17, revised) ──────────────────────
  *
- * Running this test against the framework cluster timed out at 120s.
- * Two compounding gaps:
+ * Running this test against the framework cluster surfaces three
+ * separate, compounding gaps in the current cross-pod recovery story:
  *
- *   1. DBOS workflow replay alone can't recover the run. The recovery
- *      executor on a survivor pod re-executes `dispatchRunAndWaitStep`,
- *      which calls `dispatchRunAndWait` *without* `isResume: true`. That
- *      hits `claimRunStart` (run-reactor.ts:84) — a strict CAS that
- *      rejects re-claim from any pod other than the existing
- *      `run_owner_pod`. The dead pod still owns the row, so every
- *      replay attempt fails with `RunClaimError: ... already running on
- *      another pod`. Confirmed in mesh-1/mesh-2 logs after SIGKILL.
+ *   1. **No cross-pod DBOS recovery.** All pods boot DBOS with
+ *      `executor_id = "local"` (default; env `DBOS__VMID` is unset).
+ *      DBOS's `recoverPendingWorkflows` is filtered by executor_id, and
+ *      it only fires on `DBOS.launch()` — i.e., when a pod restarts.
+ *      The OSS SDK has no built-in scan for workflows whose executor is
+ *      dead. Surviving peers never replay a dead pod's workflows.
  *
- *   2. The heartbeat-based pod-death watcher (NatsPodHeartbeat +
- *      runRegistry.handlePodDeath, which DOES use the orphan-claim
- *      path with `isResume: true`) never fires in this cluster: the
- *      `KV_POD_HEARTBEATS` JetStream bucket is missing from NATS even
- *      though all other JS resources initialize cleanly. NATS' /jsz
- *      shows DECOPILOT_STREAMS, KV_DECOCMS_MCP_LISTS, KV_MESH_MODEL_LISTS
- *      — but no heartbeat bucket. Bucket creation appears to fail
- *      silently (app.ts:867 swallows the init error).
+ *   2. **`prepareRun` purges JetStream unconditionally** at
+ *      dispatch-run.ts:519, including on resume. Even if the heartbeat
+ *      watcher (NatsPodHeartbeat + runRegistry.handlePodDeath) does
+ *      kick in and trigger `dispatchRunAndWait(isResume: true)` on a
+ *      survivor pod, the first thing that runs nukes any chunks the
+ *      survivor watchers were mid-consumption of.
+ *
+ *   3. **NatsPodHeartbeat bucket creation is fragile**. On cold boot
+ *      `KV_POD_HEARTBEATS` sometimes isn't in NATS' jsz output even
+ *      though every other JS resource is — bucket init silently
+ *      swallows errors at app.ts:867. Re-runs eventually create it,
+ *      but it's flaky enough that you can't rely on the heartbeat
+ *      firing in the first 45s window.
  *
  * Net: permanent pod death is currently only recovered when the dead
- * pod *itself* restarts (DBOS replay on the same POD_NAME succeeds the
- * claim CAS). Same-pod-restart is a separate scenario worth adding;
- * permanent-death recovery needs either (a) the heartbeat bucket
- * initialized + watcher firing or (b) `claimRunStart` widened to allow
- * re-claim from a different pod when an external recovery executor
- * (DBOS) is the caller.
+ * pod *itself* restarts (DBOS recovery on the same POD_NAME succeeds
+ * because `claimRunStart`'s strict CAS matches). Cross-pod recovery
+ * needs:
  *
- * Un-skip this test once one of those is fixed. The test body is left
- * intact so the fix can be verified by removing the `.skip` and
- * re-running.
+ *   - per-pod `DBOS__VMID` so DBOS knows which executor owns what
+ *   - a death-detection mechanism (the existing NATS heartbeat, or
+ *     Postgres advisory locks — sub-second detection, no NATS bucket
+ *     reliability issue) that triggers recovery on a survivor
+ *   - skip `streamBuffer.purge()` when `isResume` is true
+ *
+ * The recovery itself can stay in `runRegistry.handlePodDeath`
+ * (storage-level claim + `dispatchRunAndWait(isResume: true)`) — going
+ * through DBOS's internal recoverPendingWorkflows API is possible but
+ * not exposed publicly, so it'd require importing internals.
+ *
+ * Un-skip this test once the three gaps above are addressed. The test
+ * body is left intact so the fix can be verified by removing the
+ * `.skip` and re-running.
  */
 
 import { describe, expect, test } from "bun:test";

--- a/tests/multi-pod/scenarios/pod-death-dbos-replay.test.ts
+++ b/tests/multi-pod/scenarios/pod-death-dbos-replay.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Pod-death + DBOS workflow replay.
+ *
+ * ⚠️ Currently `.skip`ped — see "Architectural finding" below.
+ *
+ * Intended scenario: when the pod owning a run dies mid-stream, recovery
+ * should resume the run on a survivor pod so /attach tails continue to
+ * receive chunks without the client reconnecting.
+ *
+ * Test shape:
+ *
+ *   1. Send a SLOW message (20 chunks × 500ms ≈ 10s window for kill).
+ *   2. Open /attach on all three pods so at least two survive the kill
+ *      no matter which pod owns the run.
+ *   3. Wait for "chunk-2" on any watcher (proof the run started).
+ *   4. Read the actual owner from `threads.run_owner_pod` and SIGKILL
+ *      that pod (POD_NAME on each compose service matches the service
+ *      name, so the value maps directly to a `pod.kill()` target).
+ *   5. Assert one surviving /attach receives "chunk-20".
+ *
+ * ── Architectural finding (2026-05-17) ────────────────────────────────
+ *
+ * Running this test against the framework cluster timed out at 120s.
+ * Two compounding gaps:
+ *
+ *   1. DBOS workflow replay alone can't recover the run. The recovery
+ *      executor on a survivor pod re-executes `dispatchRunAndWaitStep`,
+ *      which calls `dispatchRunAndWait` *without* `isResume: true`. That
+ *      hits `claimRunStart` (run-reactor.ts:84) — a strict CAS that
+ *      rejects re-claim from any pod other than the existing
+ *      `run_owner_pod`. The dead pod still owns the row, so every
+ *      replay attempt fails with `RunClaimError: ... already running on
+ *      another pod`. Confirmed in mesh-1/mesh-2 logs after SIGKILL.
+ *
+ *   2. The heartbeat-based pod-death watcher (NatsPodHeartbeat +
+ *      runRegistry.handlePodDeath, which DOES use the orphan-claim
+ *      path with `isResume: true`) never fires in this cluster: the
+ *      `KV_POD_HEARTBEATS` JetStream bucket is missing from NATS even
+ *      though all other JS resources initialize cleanly. NATS' /jsz
+ *      shows DECOPILOT_STREAMS, KV_DECOCMS_MCP_LISTS, KV_MESH_MODEL_LISTS
+ *      — but no heartbeat bucket. Bucket creation appears to fail
+ *      silently (app.ts:867 swallows the init error).
+ *
+ * Net: permanent pod death is currently only recovered when the dead
+ * pod *itself* restarts (DBOS replay on the same POD_NAME succeeds the
+ * claim CAS). Same-pod-restart is a separate scenario worth adding;
+ * permanent-death recovery needs either (a) the heartbeat bucket
+ * initialized + watcher firing or (b) `claimRunStart` widened to allow
+ * re-claim from a different pod when an external recovery executor
+ * (DBOS) is the caller.
+ *
+ * Un-skip this test once one of those is fixed. The test body is left
+ * intact so the fix can be verified by removing the `.skip` and
+ * re-running.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { postJson, sse } from "../lib/client";
+import { getThreadRunOwnerPod } from "../lib/db";
+import { registerTestHooks } from "../lib/hooks";
+import { kill } from "../lib/pod";
+import type { PodInfo, PodName } from "../lib/pods";
+import { ALL_PODS, PODS } from "../lib/pods";
+import { pollUntil } from "../lib/poll-until";
+import {
+  bootstrapSession,
+  createTestAgent,
+  createTestThread,
+  wireMockProvider,
+} from "../lib/setup";
+
+registerTestHooks();
+
+const MOCK_HINT = "slow:20x500"; // ~10s — plenty of time for kill + replay
+
+interface Watcher {
+  pod: PodInfo;
+  /** Joined SSE payloads observed so far. */
+  joined: string;
+  abort: AbortController;
+  /** Resolves when the consumer loop ends (SSE closed, aborted, error). */
+  done: Promise<void>;
+}
+
+function openAttachWatcher(
+  pod: PodInfo,
+  orgSlug: string,
+  threadId: string,
+  apiKey: string,
+): Watcher {
+  const abort = new AbortController();
+  const watcher: Watcher = {
+    pod,
+    joined: "",
+    abort,
+    done: Promise.resolve(),
+  };
+
+  watcher.done = (async () => {
+    try {
+      for await (const payload of sse(
+        pod,
+        `/api/${orgSlug}/decopilot/attach/${threadId}`,
+        { auth: { apiKey }, signal: abort.signal },
+      )) {
+        watcher.joined += payload;
+      }
+    } catch (err) {
+      // Aborts and connection drops (when the owning pod dies) are
+      // expected in this scenario — swallow them. Anything else
+      // re-throws so the test sees it. Bun's fetch surfaces the
+      // condition as either an `AbortError`, a system error with a
+      // `code` property (ECONNRESET/ECONNREFUSED), or a generic "socket
+      // connection was closed" message; cover all three.
+      const code = (err as { code?: string } | null)?.code ?? "";
+      const msg = err instanceof Error ? err.message : String(err);
+      const expectedCodes = ["ECONNRESET", "ECONNREFUSED", "ABORT_ERR"];
+      const expectedMsgs = [
+        "aborted",
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "fetch failed",
+        "socket connection was closed",
+      ];
+      const expected =
+        expectedCodes.includes(code) ||
+        expectedMsgs.some((needle) => msg.includes(needle));
+      if (!expected) throw err;
+    }
+  })();
+
+  return watcher;
+}
+
+describe("pod-death + DBOS replay", () => {
+  test.skip("killing the owning pod mid-stream still delivers the final chunk via a survivor", async () => {
+    const session = await bootstrapSession(PODS.MESH_1);
+    await wireMockProvider(PODS.MESH_1, session);
+    const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+    const { threadId } = await createTestThread(
+      PODS.MESH_1,
+      session,
+      virtualMcpId,
+    );
+
+    const messageBody = {
+      messages: [
+        {
+          id: crypto.randomUUID(),
+          role: "user",
+          parts: [{ type: "text", text: MOCK_HINT }],
+        },
+      ],
+      agent: { id: virtualMcpId },
+      tier: "smart",
+    };
+    const postRes = await postJson(
+      PODS.MESH_1,
+      `/api/${session.orgSlug}/decopilot/threads/${threadId}/messages`,
+      messageBody,
+      { auth: { apiKey: session.apiKey } },
+    );
+    expect(postRes.status).toBe(202);
+
+    // Open watchers on all three pods. Whichever pod we end up killing,
+    // the other two stay alive and at least one of them sees the run
+    // through to completion.
+    const watchers = ALL_PODS.map((pod) =>
+      openAttachWatcher(pod, session.orgSlug, threadId, session.apiKey),
+    );
+
+    // Wait until at least one watcher sees a chunk — proves the run
+    // is actually flowing before we go knock a pod over.
+    await pollUntil(
+      async () => watchers.some((w) => w.joined.includes("chunk-2")),
+      {
+        timeoutMs: 15_000,
+        intervalMs: 200,
+        label: "run-flowing-before-kill",
+      },
+    );
+
+    // Identify the dispatch owner from the DB (POD_NAME equals the
+    // compose service name, so the value here is a valid PodName).
+    const ownerRaw = await pollUntil(
+      async () => (await getThreadRunOwnerPod(threadId)) !== null,
+      {
+        timeoutMs: 5_000,
+        intervalMs: 200,
+        label: "owner-pod-claimed",
+      },
+    )
+      .then(() => getThreadRunOwnerPod(threadId))
+      .then((v) => v as PodName);
+    expect(["mesh-1", "mesh-2", "mesh-3"]).toContain(ownerRaw);
+
+    console.log(`  → run owned by ${ownerRaw}; SIGKILLing it`);
+    await kill(ownerRaw);
+
+    // Survivor watchers (everything except the killed pod) must
+    // eventually see the final chunk. We don't care which one — any
+    // single survivor receiving "chunk-20" proves the pump resumed
+    // on a replay-target pod and JetStream caught it back up.
+    const survivors = watchers.filter((w) => w.pod.service !== ownerRaw);
+    try {
+      await pollUntil(
+        async () => survivors.some((w) => w.joined.includes("chunk-20")),
+        {
+          // Generous window: DBOS workflow replay fires fast but its
+          // first claim attempt fails (the dead pod still owns the
+          // `run_owner_pod` row, claimRunStart rejects). Actual
+          // recovery comes via the heartbeat watcher's
+          // claimOrphanedRun + dispatchRunAndWait(isResume:true)
+          // backstop, which depends on the pod-death-detection
+          // interval.
+          timeoutMs: 120_000,
+          intervalMs: 500,
+          label: "final-chunk-after-replay",
+        },
+      );
+    } finally {
+      // Always close out the SSE consumers so the test process exits
+      // cleanly even on assertion failure.
+      for (const w of watchers) w.abort.abort();
+      await Promise.allSettled(watchers.map((w) => w.done));
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## What is this contribution about?

Builds out the LLM-dependent half of the multi-pod test framework added in #3391. A ~140-LOC Bun mock-ai service speaks the OpenAI streaming wire protocol so mesh's existing `openai-compatible` adapter can drive `streamText` against it — no real provider budget needed. Setup helpers gain \`wireMockProvider\`, \`createTestAgent\`, and \`createTestThread\` for the three calls every dispatch scenario needs.

The headline scenario, **\`attach-cross-pod\`**, directly validates the deliverPolicy fix from #3387: POST a slowed-down run on pod-1, attach on pods 2 and 3, assert both see the buffered prefix. Passes locally.

The second scenario, **\`pod-death-dbos-replay\`**, is fully wired but \`.skip\`ped — it surfaced a real architectural finding (see below) that needs its own follow-up to fix.

## Architectural finding (worth a separate issue)

The pod-death scenario times out at 120s. Two compounding gaps:

1. **DBOS replay alone can't recover the run.** The recovery executor re-runs \`dispatchRunAndWaitStep\` without \`isResume: true\`, which hits \`claimRunStart\`'s strict CAS. The dead pod still owns \`run_owner_pod\`, so every replay attempt fails with \`RunClaimError: ... already running on another pod\`.
2. **Heartbeat watcher (the path that WOULD handle this via \`claimOrphanedRun\` + \`isResume: true\`) never fires.** The \`KV_POD_HEARTBEATS\` JetStream bucket is missing from NATS, even though other JS resources initialize fine. Looks like bucket creation fails silently at \`app.ts:867\`.

Net: permanent pod death is currently only recovered when the dead pod *itself* restarts. The PR #3387 architectural claim ("DBOS replay covers what /attach orphan-resume used to do") is incomplete — full repro + diagnostic notes are in the test's docstring.

## How to Test

1. Start Docker Desktop.
2. \`./tests/multi-pod/run.sh\` — boots cluster, runs all scenarios, tears down.
3. Expected: \`6 pass / 1 skip / 0 fail\` across 5 files (~5s after cluster up).

For iteration: \`docker compose -f tests/multi-pod/docker-compose.yml up -d\` once, then \`bun test tests/multi-pod/scenarios/\` repeatedly.

## Migration Notes

None. Self-contained under \`tests/multi-pod/\` and the existing CI workflow picks up the new scenarios automatically.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (6/6 active scenarios pass locally)
- [ ] Documentation is updated (if needed) — none; per-file docstrings carry the structure
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mock OpenAI-compatible provider and a cross-pod /attach test to run the dispatch pipeline end-to-end across multiple pods without a real LLM, plus reliability improvements and clearer failure surfacing in the test harness.

- **New Features**
  - `mock-ai` service (OpenAI chat-completions streaming) at `http://mock-ai:9000/v1`; used by `openai-compatible`.
  - Setup helpers: `wireMockProvider`, `createTestAgent`, `createTestThread`; DB helper `getThreadRunOwnerPod`; compose `POD_NAME` mapping to target specific pods.
  - Scenarios: `attach-cross-pod` validates buffered-prefix replay across pods; `pod-death-dbos-replay` remains skipped with an updated note on three gaps (no cross-pod DBOS recovery scan, resume purges JetStream, heartbeat bucket fragility).

- **Bug Fixes**
  - `mcpCall` now prefers non-empty `structuredContent` and correctly falls back to text payloads.
  - `dbQuery` CLI/docstring synced to `--csv`; `attach-cross-pod` header timing corrected to `slow:5x500` (~2.5s).
  - `attach-cross-pod` replaces a racy sleep with a JetStream-confirmation probe to deterministically test buffered replay.
  - Test hooks auto-restore stopped pods and now fail fast when `docker compose ps` errors, avoiding misleading waitReady timeouts.

<sup>Written for commit d0b9e8a221bd7208128fd08c3a227d86ce158308. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3392?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

