### PR TITLE
feat(chat): permission-gated "Edit default models" link in tier dropdown

### DIFF
--- a/apps/mesh/src/cli/lib/port-wait.test.ts
+++ b/apps/mesh/src/cli/lib/port-wait.test.ts
@@ -82,7 +82,11 @@ describe("waitForPort", () => {
     const port = await ephemeralPort();
     const promise = waitForPort(port, { intervalMs: 20 });
     setTimeout(() => {
-      void listenOn("127.0.0.1", port);
+      // If something else grabbed the port in the TOCTOU window, waitForPort
+      // will still detect the listener — suppress EADDRINUSE so the test passes.
+      listenOn("127.0.0.1", port).catch((err: NodeJS.ErrnoException) => {
+        if (err.code !== "EADDRINUSE") throw err;
+      });
     }, 60);
     expect(await promise).toBe("127.0.0.1");
   });

--- a/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
+++ b/apps/mesh/src/web/components/chat/simple-mode-tier-dropdown.tsx
@@ -3,9 +3,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
-import { Atom01, Lightning01, Stars01 } from "@untitledui/icons";
+import { Atom01, Lightning01, Settings02, Stars01 } from "@untitledui/icons";
+import { useNavigate } from "@tanstack/react-router";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useCanManageAiProviders } from "@/web/hooks/use-can-manage-ai-providers";
 
 export type SimpleModeTier = "fast" | "smart" | "thinking";
 
@@ -41,6 +45,10 @@ export function SimpleModeTierDropdown({
     SIMPLE_MODE_TIER_OPTIONS.find((o) => o.value === tier) ??
     SIMPLE_MODE_TIER_OPTIONS[1]!;
   const Icon = current.Icon;
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const canManageAiProviders = useCanManageAiProviders();
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -72,6 +80,22 @@ export function SimpleModeTierDropdown({
               )}
             </DropdownMenuItem>
           ),
+        )}
+        {canManageAiProviders && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() =>
+                navigate({
+                  to: "/$org/settings/ai-providers",
+                  params: { org: org.slug },
+                })
+              }
+            >
+              <Settings02 size={16} className="text-muted-foreground" />
+              <span>Edit default models</span>
+            </DropdownMenuItem>
+          </>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/mesh/src/web/hooks/use-can-manage-ai-providers.ts
+++ b/apps/mesh/src/web/hooks/use-can-manage-ai-providers.ts
@@ -1,0 +1,62 @@
+import { authClient } from "@/web/lib/auth-client";
+import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+const AI_PROVIDER_SELF_PERMISSIONS = [
+  "AI_PROVIDER_KEY_CREATE",
+  "AI_PROVIDER_KEY_UPDATE",
+  "AI_PROVIDER_KEY_DELETE",
+];
+
+export function useCanManageAiProviders(): boolean {
+  const { data: session } = authClient.useSession();
+  const { locator } = useProjectContext();
+  const orgAuth = useOrgAuthClient();
+  const userId = session?.user?.id;
+
+  const { data: membersData } = useQuery({
+    queryKey: KEYS.members(locator),
+    queryFn: () => orgAuth.organization.listMembers(),
+    enabled: !!userId,
+  });
+
+  const { data: rolesData } = useQuery({
+    queryKey: KEYS.organizationRoles(locator),
+    queryFn: async () => {
+      const result = await orgAuth.organization.listRoles();
+      return result?.data ?? [];
+    },
+    enabled: !!userId,
+  });
+
+  if (!userId || !membersData?.data) return false;
+
+  const members =
+    (membersData.data as { members?: Array<{ userId: string; role: string }> })
+      .members ?? [];
+  const currentMember = members.find((m) => m.userId === userId);
+  if (!currentMember) return false;
+
+  const { role } = currentMember;
+
+  if (role === "admin" || role === "owner") return true;
+
+  if (Array.isArray(rolesData)) {
+    const memberRole = (
+      rolesData as Array<{
+        role: string;
+        permission?: Record<string, string[]>;
+      }>
+    ).find((r) => r.role === role);
+    if (memberRole?.permission) {
+      const selfPerms: string[] = memberRole.permission["self"] ?? [];
+      if (selfPerms.includes("*")) return true;
+      if (AI_PROVIDER_SELF_PERMISSIONS.some((p) => selfPerms.includes(p)))
+        return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## What is this contribution about?

Adds an \"Edit default models\" shortcut item at the bottom of the Fast/Smart/Thinking tier dropdown in chat. The item navigates to `/$org/settings/ai-providers` and is only visible to users who have AI provider management access (admin, owner, or custom role with `AI_PROVIDER_KEY_CREATE/UPDATE/DELETE` in their self-permissions).

A new `useCanManageAiProviders` hook encapsulates the permission check: it fetches the current user's org membership role and, for custom roles, inspects the role's permission object to see if any AI provider key tools are granted.

## Screenshots/Demonstration

The \"Edit default models\" item appears below a separator after the Fast/Smart/Thinking options, only for users with the appropriate permission.

## How to Test

1. Log in as an **admin or owner** and open the tier dropdown in chat — the \"Edit default models\" item should appear at the bottom.
2. Click it — should navigate to `Settings > AI Providers`.
3. Log in as a **regular user** (role: `user`) — the item should not appear.
4. Assign a custom role with `AI_PROVIDER_KEY_CREATE` in its self-permissions — the item should reappear for that user.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permission-gated "Edit default models" link to the chat tier dropdown. Also fixes a flaky `waitForPort` test in CI.

- **New Features**
  - Permission-gated menu item with `Settings02`; navigates via `@tanstack/react-router` to `/$org/settings/ai-providers`.
  - New `useCanManageAiProviders` checks admin/owner or self-perms (`AI_PROVIDER_KEY_CREATE/UPDATE/DELETE`).

<sup>Written for commit d79efe83241183e7dacccf49eea09af2d31774ee. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3394?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

