### PR TITLE
fix(github): progressively search remote branches

### DIFF
--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type UIEvent, useRef, useState } from "react";
 import type { VmMap } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -47,8 +47,20 @@ export function BranchPicker({
   onChange,
 }: Props) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [isSearchingRemote, setIsSearchingRemote] = useState(false);
+  const searchRequestId = useRef(0);
 
-  const { yours, others, isLoading, isError } = useBranches({
+  const {
+    yours,
+    others,
+    isLoading,
+    isError,
+    hasMore,
+    isFetchingMore,
+    fetchMore,
+    fetchUntilMatch,
+  } = useBranches({
     orgId,
     orgSlug,
     userId,
@@ -65,6 +77,34 @@ export function BranchPicker({
   };
 
   const label = value ?? "Select branch…";
+  const handleSearchChange = (nextSearch: string) => {
+    setSearch(nextSearch);
+    searchRequestId.current += 1;
+
+    const requestId = searchRequestId.current;
+    const trimmedSearch = nextSearch.trim();
+    if (!trimmedSearch) {
+      setIsSearchingRemote(false);
+      return;
+    }
+
+    setIsSearchingRemote(true);
+    void fetchUntilMatch(trimmedSearch).finally(() => {
+      if (requestId === searchRequestId.current) {
+        setIsSearchingRemote(false);
+      }
+    });
+  };
+
+  const onListScroll = (event: UIEvent<HTMLDivElement>) => {
+    const target = event.currentTarget;
+    const distanceFromBottom =
+      target.scrollHeight - target.scrollTop - target.clientHeight;
+
+    if (distanceFromBottom < 48) {
+      fetchMore();
+    }
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -83,8 +123,12 @@ export function BranchPicker({
         align="start"
       >
         <Command>
-          <div className="flex items-center border-b pr-2 [&>[data-slot=command-input-wrapper]]:flex-1 [&>[data-slot=command-input-wrapper]]:border-b-0">
-            <CommandInput placeholder="Search branches…" />
+          <div className="*:data-[slot=command-input-wrapper]:flex-1 *:data-[slot=command-input-wrapper]:border-b-0 flex items-center border-b pr-2">
+            <CommandInput
+              placeholder="Search loaded branches…"
+              value={search}
+              onValueChange={handleSearchChange}
+            />
             <Button
               variant="outline"
               size="sm"
@@ -94,19 +138,20 @@ export function BranchPicker({
               New
             </Button>
           </div>
-          <CommandList>
+          <CommandList onScroll={onListScroll}>
             {isError && (
               <div className="p-3 text-xs text-muted-foreground">
                 Couldn't load branches from GitHub. You can still pick from your
                 branches.
               </div>
             )}
-            {!isError &&
-              !isLoading &&
-              yours.length === 0 &&
-              others.length === 0 && (
-                <CommandEmpty>No branches found.</CommandEmpty>
-              )}
+            {!isError && !isLoading && (
+              <CommandEmpty>
+                {hasMore
+                  ? "Looking through more branches..."
+                  : "No branches found."}
+              </CommandEmpty>
+            )}
             {yours.length > 0 && (
               <CommandGroup heading="Your branches">
                 {yours.map((b) => (
@@ -142,6 +187,26 @@ export function BranchPicker({
                   ))}
                 </CommandGroup>
               </>
+            )}
+            {hasMore && (
+              <div className="border-t p-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-full text-xs"
+                  disabled={isFetchingMore}
+                  onClick={fetchMore}
+                >
+                  {isFetchingMore || isSearchingRemote
+                    ? "Loading more…"
+                    : "Load more branches"}
+                </Button>
+              </div>
+            )}
+            {!hasMore && others.length > 0 && (
+              <div className="border-t p-2 text-center text-xs text-muted-foreground">
+                All loaded
+              </div>
             )}
           </CommandList>
         </Command>

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -89,7 +89,10 @@ export function BranchPicker({
     }
 
     setIsSearchingRemote(true);
-    void fetchUntilMatch(trimmedSearch).finally(() => {
+    void fetchUntilMatch(
+      trimmedSearch,
+      () => requestId === searchRequestId.current,
+    ).finally(() => {
       if (requestId === searchRequestId.current) {
         setIsSearchingRemote(false);
       }

--- a/apps/mesh/src/web/components/thread/github/use-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branches.ts
@@ -16,7 +16,10 @@ export interface UseBranchesResult {
   hasMore: boolean;
   isFetchingMore: boolean;
   fetchMore: () => void;
-  fetchUntilMatch: (search: string) => Promise<void>;
+  fetchUntilMatch: (
+    search: string,
+    shouldContinue?: () => boolean,
+  ) => Promise<void>;
 }
 
 interface UseBranchesArgs {
@@ -69,6 +72,18 @@ function pageHasBranchMatch(
         !excludedNames.has(branch.name) &&
         branch.name.toLowerCase().includes(normalizedSearch),
     ),
+  );
+}
+
+function branchNamesHaveMatch(
+  branchNames: Set<string>,
+  search: string,
+): boolean {
+  const normalizedSearch = search.trim().toLowerCase();
+  if (!normalizedSearch) return true;
+
+  return [...branchNames].some((branchName) =>
+    branchName.toLowerCase().includes(normalizedSearch),
   );
 }
 
@@ -195,17 +210,28 @@ export function useBranches({
 
   const defaultBase =
     data?.pages.find((page) => page.default_branch)?.default_branch ?? null;
-  const fetchUntilMatch = async (search: string) => {
-    if (yourBranchNames.has(search) || isFetchingNextPage) {
+  const fetchUntilMatch = async (
+    search: string,
+    shouldContinue = () => true,
+  ) => {
+    if (
+      !shouldContinue() ||
+      branchNamesHaveMatch(yourBranchNames, search) ||
+      isFetchingNextPage
+    ) {
       return;
     }
 
     let pages = data?.pages ?? [];
     while (
+      shouldContinue() &&
       !pageHasBranchMatch(pages, search, yourBranchNames) &&
       (pages.at(-1)?.branches.length ?? BRANCHES_PER_PAGE) >= BRANCHES_PER_PAGE
     ) {
       const result = await fetchNextPage();
+      if (!shouldContinue()) {
+        break;
+      }
       const nextPages = result.data?.pages ?? pages;
       if (nextPages.length === pages.length) {
         break;

--- a/apps/mesh/src/web/components/thread/github/use-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branches.ts
@@ -1,8 +1,5 @@
-import {
-  type VmMap,
-  useMCPClient,
-  useMCPToolCallQuery,
-} from "@decocms/mesh-sdk";
+import { type VmMap, useMCPClient } from "@decocms/mesh-sdk";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 export interface Branch {
   name: string;
@@ -16,6 +13,10 @@ export interface UseBranchesResult {
   defaultBase: string | null;
   isLoading: boolean;
   isError: boolean;
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  fetchMore: () => void;
+  fetchUntilMatch: (search: string) => Promise<void>;
 }
 
 interface UseBranchesArgs {
@@ -44,6 +45,32 @@ type RawBranchesResponse =
       branches?: RawBranch[];
       default_branch?: string;
     };
+
+interface BranchesPage {
+  branches: RawBranch[];
+  default_branch: string | null;
+  page: number;
+}
+
+const BRANCHES_PER_PAGE = 100;
+
+function pageHasBranchMatch(
+  pages: BranchesPage[] | undefined,
+  search: string,
+  excludedNames: Set<string>,
+): boolean {
+  const normalizedSearch = search.trim().toLowerCase();
+  if (!normalizedSearch) return true;
+
+  return (pages ?? []).some((page) =>
+    page.branches.some(
+      (branch) =>
+        typeof branch.name === "string" &&
+        !excludedNames.has(branch.name) &&
+        branch.name.toLowerCase().includes(normalizedSearch),
+    ),
+  );
+}
 
 /**
  * github-mcp-server may return either:
@@ -93,25 +120,64 @@ export function useBranches({
     orgSlug,
   });
 
-  const { data, isLoading, isError } = useMCPToolCallQuery<RawBranchesResponse>(
-    {
-      client,
-      toolName: "list_branches",
-      toolArguments: { owner, repo },
-      enabled: enabled && !!connectionId && !!owner && !!repo,
-      staleTime: 30_000,
-      select: (r) => extractBranches(r),
+  const {
+    data,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery<BranchesPage>({
+    queryKey: ["github-branches", orgId, orgSlug, connectionId, owner, repo],
+    enabled: enabled && !!connectionId && !!owner && !!repo,
+    staleTime: 30_000,
+    retry: false,
+    initialPageParam: 1,
+    queryFn: async ({ pageParam, signal }) => {
+      const page = Number(pageParam);
+      const result = await client.callTool(
+        {
+          name: "list_branches",
+          arguments: { owner, repo, page, perPage: BRANCHES_PER_PAGE },
+        },
+        undefined,
+        { signal },
+      );
+      const parsed = extractBranches(result);
+      const branches = Array.isArray(parsed) ? parsed : (parsed.branches ?? []);
+
+      return {
+        branches,
+        default_branch: Array.isArray(parsed)
+          ? null
+          : (parsed.default_branch ?? null),
+        page,
+      };
     },
-  );
+    getNextPageParam: (lastPage) => {
+      if (lastPage.branches.length < BRANCHES_PER_PAGE) {
+        return undefined;
+      }
+
+      return lastPage.page + 1;
+    },
+  });
 
   const yourBranchNames = new Set(Object.keys(vmMap?.[userId] ?? {}));
   const yours: Branch[] = [...yourBranchNames]
     .sort()
     .map((name) => ({ name, source: "yours" as const }));
 
-  const rawBranches: RawBranch[] = Array.isArray(data)
-    ? data
-    : (data?.branches ?? []);
+  const branchesByName = new Map<string, RawBranch>();
+  for (const page of data?.pages ?? []) {
+    for (const branch of page.branches) {
+      if (typeof branch.name === "string") {
+        branchesByName.set(branch.name, branch);
+      }
+    }
+  }
+
+  const rawBranches: RawBranch[] = [...branchesByName.values()];
 
   const others: Branch[] = rawBranches
     .filter(
@@ -127,9 +193,26 @@ export function useBranches({
           : (b.commit?.author?.login ?? null),
     }));
 
-  const defaultBase = Array.isArray(data)
-    ? null
-    : (data?.default_branch ?? null);
+  const defaultBase =
+    data?.pages.find((page) => page.default_branch)?.default_branch ?? null;
+  const fetchUntilMatch = async (search: string) => {
+    if (yourBranchNames.has(search) || isFetchingNextPage) {
+      return;
+    }
+
+    let pages = data?.pages ?? [];
+    while (
+      !pageHasBranchMatch(pages, search, yourBranchNames) &&
+      (pages.at(-1)?.branches.length ?? BRANCHES_PER_PAGE) >= BRANCHES_PER_PAGE
+    ) {
+      const result = await fetchNextPage();
+      const nextPages = result.data?.pages ?? pages;
+      if (nextPages.length === pages.length) {
+        break;
+      }
+      pages = nextPages;
+    }
+  };
 
   return {
     yours,
@@ -137,5 +220,13 @@ export function useBranches({
     defaultBase,
     isLoading,
     isError,
+    hasMore: hasNextPage ?? false,
+    isFetchingMore: isFetchingNextPage,
+    fetchMore: () => {
+      if (hasNextPage && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    },
+    fetchUntilMatch,
   };
 }

--- a/apps/mesh/src/web/components/thread/github/use-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branches.ts
@@ -1,4 +1,4 @@
-import { type VmMap, useMCPClient } from "@decocms/mesh-sdk";
+import { KEYS, type VmMap, useMCPClient } from "@decocms/mesh-sdk";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 export interface Branch {
@@ -143,7 +143,7 @@ export function useBranches({
     isFetchingNextPage,
     fetchNextPage,
   } = useInfiniteQuery<BranchesPage>({
-    queryKey: ["github-branches", orgId, orgSlug, connectionId, owner, repo],
+    queryKey: KEYS.githubBranches(orgId, orgSlug, connectionId, owner, repo),
     enabled: enabled && !!connectionId && !!owner && !!repo,
     staleTime: 30_000,
     retry: false,

--- a/packages/mesh-sdk/src/lib/query-keys.ts
+++ b/packages/mesh-sdk/src/lib/query-keys.ts
@@ -149,6 +149,13 @@ export const KEYS = {
     owner: string | null | undefined,
     repo: string | null | undefined,
   ) => ["github-readme", owner, repo] as const,
+  githubBranches: (
+    orgId: string,
+    orgSlug: string,
+    connectionId: string | null | undefined,
+    owner: string,
+    repo: string,
+  ) => ["github-branches", orgId, orgSlug, connectionId, owner, repo] as const,
 
   // Monitoring queries
   monitoringStats: () => ["monitoring", "stats"] as const,


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the GitHub Branch Picker progressively search remote branches and load more results on demand. Users can find branches beyond the first page with smooth scrolling and a clear loading state.

- **New Features**
  - Progressive search keeps fetching pages until a match, with cancel-on-typing to avoid stale results.
  - Infinite pagination with “Load more” and auto-fetch near list bottom.
  - Dynamic empty state (“Looking through more branches…”) and “All loaded” indicator.

- **Refactors**
  - Switched to `useInfiniteQuery` from `@tanstack/react-query` for paginated `list_branches` via `@decocms/mesh-sdk`’s `useMCPClient`.
  - Added `KEYS.githubBranches` in `@decocms/mesh-sdk` and used it for query keys.
  - Deduplicates branches across pages and preserves `default_branch`.
  - Exposes `hasMore`, `isFetchingMore`, `fetchMore`, and `fetchUntilMatch(search, shouldContinue)` from `useBranches`.

<sup>Written for commit 554c0a5f5b36cdc6b20cf31bad486635a5ba7fb2. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3395?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

