### PR TITLE
fix(connection): refresh MCP data after successful OAuth

### DIFF
--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -375,6 +375,7 @@ function ConnectionInspectorViewWithConnection({
     await queryClient.invalidateQueries({
       queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
     });
+    await queryClient.invalidateQueries({ queryKey: ["mcp", "client"] });
 
     toast.success("Authentication successful");
   };


### PR DESCRIPTION
## Summary
After a successful OAuth handshake on the connection settings page, invalidate the MCP client queries (prefix `["mcp", "client"]`) so the tools, prompts, and resources lists refetch and reflect the newly authenticated state — no manual page reload needed.

## Why
Previously the "Authentication successful" toast appeared, but the tools/prompts/resources lists kept rendering the unauthenticated (empty) state because their React Query cache was never invalidated. The cached data stayed "fresh", so the hooks never refetched.

These lists are fetched by the mesh-sdk hooks (`useMCPToolsListQuery`, `useMCPPromptsListQuery`, `useMCPResourcesListQuery`), all keyed under the prefix `["mcp", "client", <client>, ...]`. Invalidating that prefix forces an immediate refetch of all three without a full page reload (preserving scroll and client state).

## Before
<img width="800" height="450" alt="ezgif-15b25bd082fdf7b0" src="https://github.com/user-attachments/assets/f3f95b0f-8e1d-4982-b972-d044e6c45f9f" />


## After
<img width="800" height="450" alt="ezgif-14e215f073d2c381" src="https://github.com/user-attachments/assets/190c1939-24af-4930-9953-8ac70e97e2d1" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the connection settings view immediately after successful OAuth by invalidating `isMCPAuthenticated` and `["mcp","client"]` queries, so the authenticated state and tools, prompts, and resources update without a page reload. Removes the need to manually refresh after the success toast.

<sup>Written for commit 52bb7d4c208ea0c53d7bb63309b0d6cb48b0c2c4. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3398?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



