### PR TITLE
feat(chat): reserve scroll padding for highlight stack

### DIFF
--- a/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
+++ b/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
@@ -33,8 +33,6 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 
-export { isCreditError } from "./is-credit-error";
-
 const QUICK_AMOUNTS = {
   usd: [
     { dollars: 10, label: "Starter" },

--- a/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
+++ b/apps/mesh/src/web/components/chat/credits-exhausted-banner.tsx
@@ -33,14 +33,7 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 
-/**
- * Detect credit/payment errors.
- * The backend prefixes these with `[CREDITS]` so detection is deterministic.
- */
-export function isCreditError(error: Error | null): boolean {
-  if (!error) return false;
-  return error.message.startsWith("[CREDITS]");
-}
+export { isCreditError } from "./is-credit-error";
 
 const QUICK_AMOUNTS = {
   usd: [

--- a/apps/mesh/src/web/components/chat/highlight/approval.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/approval.tsx
@@ -17,23 +17,14 @@ import {
   usePreferences,
   type ToolApprovalLevel,
 } from "@/web/hooks/use-preferences.ts";
-import { stripMcpServerPrefix } from "@/web/lib/tool-namespace";
-import { toTitleCase } from "../message/parts/tool-call-part/utils.tsx";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { PaginatedFormFooterLeft } from "./common/paginated-form-footer";
 import { useMultiPartDecisionForm } from "./common/use-multipart-decision-form";
-
-// ============================================================================
-// Types
-// ============================================================================
-
-export interface PendingApproval {
-  approvalId: string;
-  toolCallId: string;
-  toolName: string;
-  friendlyName: string;
-  input: unknown;
-}
+import { type PendingApproval } from "./extract-pending-approvals";
+export {
+  extractPendingApprovals,
+  type PendingApproval,
+} from "./extract-pending-approvals";
 
 // ============================================================================
 // Constants
@@ -416,46 +407,4 @@ export function ApprovalHighlight({
       onRespond={onRespond}
     />
   );
-}
-
-// ============================================================================
-// Utility: extract pending approvals from message parts
-// ============================================================================
-
-export function extractPendingApprovals(
-  parts: Array<{
-    type: string;
-    state?: string;
-    approval?: { id: string };
-    toolCallId?: string;
-    toolName?: string;
-    input?: unknown;
-  }>,
-): PendingApproval[] {
-  const result: PendingApproval[] = [];
-  for (const part of parts) {
-    if (
-      "state" in part &&
-      part.state === "approval-requested" &&
-      "approval" in part &&
-      part.approval?.id &&
-      "toolCallId" in part &&
-      part.toolCallId
-    ) {
-      const toolName =
-        "toolName" in part && typeof part.toolName === "string"
-          ? part.toolName
-          : part.type.startsWith("tool-")
-            ? part.type.replace("tool-", "")
-            : "Tool";
-      result.push({
-        approvalId: part.approval.id,
-        toolCallId: part.toolCallId,
-        toolName,
-        friendlyName: toTitleCase(stripMcpServerPrefix(toolName)),
-        input: part.input,
-      });
-    }
-  }
-  return result;
 }

--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -56,6 +56,18 @@ export interface CollapsibleHighlightProps {
   onClose?: () => void;
 }
 
+/**
+ * Collapsed height of a single highlight card in pixels, including the
+ * `mb-2` gap below it. Equals chip row (`px-3 py-2` + `text-sm` line ≈ 36px)
+ * + `mb-2` (8px) = 44px. Used by `useHighlightCount` consumers to reserve
+ * exactly enough scroll padding so that when every highlight is collapsed,
+ * the last message can be scrolled flush against the top of the stack.
+ *
+ * If the chip row's vertical padding or font size changes, update this
+ * value (or measure with devtools and round up).
+ */
+export const HIGHLIGHT_COLLAPSED_HEIGHT_PX = 44;
+
 // Tint is applied via an ::after pseudo-element instead of a `bg-*` utility so
 // it layers over `bg-background` rather than colliding with it under twMerge
 // (which would otherwise strip the solid background and leave the card

--- a/apps/mesh/src/web/components/chat/highlight/extract-pending-approvals.ts
+++ b/apps/mesh/src/web/components/chat/highlight/extract-pending-approvals.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure extraction helper for pending approvals from assistant message parts.
+ *
+ * Extracted as a pure .ts module so it can be imported by bun:test code
+ * without dragging in @deco/ui transitively via approval.tsx.
+ */
+
+import { stripMcpServerPrefix } from "@/web/lib/tool-namespace";
+import { toTitleCase } from "../message/parts/tool-call-part/utils.tsx";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PendingApproval {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  friendlyName: string;
+  input: unknown;
+}
+
+// ============================================================================
+// Utility: extract pending approvals from message parts
+// ============================================================================
+
+export function extractPendingApprovals(
+  parts: Array<{
+    type: string;
+    state?: string;
+    approval?: { id: string };
+    toolCallId?: string;
+    toolName?: string;
+    input?: unknown;
+  }>,
+): PendingApproval[] {
+  const result: PendingApproval[] = [];
+  for (const part of parts) {
+    if (
+      "state" in part &&
+      part.state === "approval-requested" &&
+      "approval" in part &&
+      part.approval?.id &&
+      "toolCallId" in part &&
+      part.toolCallId
+    ) {
+      const toolName =
+        "toolName" in part && typeof part.toolName === "string"
+          ? part.toolName
+          : part.type.startsWith("tool-")
+            ? part.type.replace("tool-", "")
+            : "Tool";
+      result.push({
+        approvalId: part.approval.id,
+        toolCallId: part.toolCallId,
+        toolName,
+        friendlyName: toTitleCase(stripMcpServerPrefix(toolName)),
+        input: part.input,
+      });
+    }
+  }
+  return result;
+}

--- a/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts
+++ b/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure extraction helper for pending propose_plan parts from assistant messages.
+ *
+ * Extracted as a pure .ts module so it can be imported by bun:test code
+ * without dragging in @deco/ui transitively via propose-plan.tsx.
+ */
+
+import type { ChatMessage } from "../types.ts";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PendingPlan {
+  toolCallId: string;
+  plan: string;
+  state: string;
+}
+
+// ============================================================================
+// Utility: extract pending propose_plan parts from message
+// ============================================================================
+
+export function extractPendingPlans(
+  parts: ChatMessage["parts"],
+): PendingPlan[] {
+  const result: PendingPlan[] = [];
+
+  for (const part of parts) {
+    if (
+      "type" in part &&
+      (part as { type: string }).type === "tool-propose_plan" &&
+      "state" in part &&
+      (part as { state: string }).state === "input-available" &&
+      "toolCallId" in part &&
+      "input" in part
+    ) {
+      const input = (part as { input: { plan: string } }).input;
+      result.push({
+        toolCallId: (part as { toolCallId: string }).toolCallId,
+        plan: input.plan,
+        state: (part as { state: string }).state,
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -131,14 +131,6 @@ export function ChatHighlight() {
   const userAskParts = assistantParts.filter(
     (part) => part.type === "tool-user_ask",
   );
-  // Coerce to boolean — `.length` is a number, and concurrent JSX renders
-  // `{0 && <X/>}` as the literal text "0" (unlike the prior priority cascade,
-  // where `if (0) { return … }` was control flow). After every user_ask
-  // resolves to `output-available`, the unfiltered count is 0, which would
-  // otherwise stamp a stray "0" between the highlight stack and the input.
-  const isWaitingForUserInput = !!userAskParts.filter(
-    (p) => p.state !== "output-available",
-  ).length;
   const pendingPlans = extractPendingPlans(assistantParts);
   const pendingApprovals = extractPendingApprovals(
     assistantParts as Array<{
@@ -264,7 +256,7 @@ export function ChatHighlight() {
           onRespond={handleApprovalRespond}
         />
       )}
-      {pendingPlans.length > 0 && (
+      {flags.hasPlans && (
         <ProposePlanHighlight
           key={planKey}
           plans={pendingPlans}
@@ -273,7 +265,7 @@ export function ChatHighlight() {
           onDismiss={handlePlanDismiss}
         />
       )}
-      {isWaitingForUserInput && (
+      {flags.isWaitingForUserInput && (
         <UserAskQuestionHighlight
           key={userAskKey}
           userAskParts={userAskParts}

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -12,10 +12,8 @@ import { ProposePlanHighlight, extractPendingPlans } from "./propose-plan";
 import { UserAskQuestionHighlight } from "./user-ask-question";
 import { TodosHighlight } from "./todos";
 import { CollapsibleHighlight } from "./collapsible-highlight";
-import {
-  CreditsExhaustedBanner,
-  isCreditError,
-} from "../credits-exhausted-banner";
+import { CreditsExhaustedBanner } from "../credits-exhausted-banner";
+import { useHighlightFlags } from "./use-highlight-count";
 import type { UserAskToolPart } from "../types";
 
 // ============================================================================
@@ -102,7 +100,6 @@ export function ChatHighlight() {
     clearFinishReason,
     messages,
     isStreaming,
-    isWaitingForApprovals,
     submit,
     sendMessage,
   } = useChatStream();
@@ -229,30 +226,13 @@ export function ChatHighlight() {
   // closest to the chat input. Credit-exhausted errors are a modal,
   // handled by an early return outside the stack.
 
-  if (!isStreaming && error && isCreditError(error)) {
+  const flags = useHighlightFlags();
+
+  if (flags.isCreditExhausted) {
     return <CreditsExhaustedBanner onDismiss={clearError} />;
   }
 
-  const showError = !isStreaming && !!error;
-  const hasApprovals =
-    pendingApprovals.length > 0 || (isStreaming && isWaitingForApprovals);
-  // `user_ask` and `propose_plan` are client-side tools (no `execute`), so
-  // the model emitting one terminates the step loop with
-  // `finishReason: "tool-calls"`. Same for tools paused on
-  // `approval-requested`. Those are expected handoffs, not stuck loops —
-  // the matching cards (UserAskQuestion / ProposePlan / Approval) already
-  // tell the user what to do, so suppress the duplicate warning. Mirrors
-  // the backend's `resolveThreadStatus` (status.ts) which maps the same
-  // shape to `requires_action`.
-  const isToolCallsWaitingOnClient =
-    finishReason === "tool-calls" &&
-    (isWaitingForUserInput || hasApprovals || pendingPlans.length > 0);
-  const showWarning =
-    !isStreaming &&
-    !!finishReason &&
-    finishReason !== "stop" &&
-    !isToolCallsWaitingOnClient &&
-    !showError;
+  const { showError, showWarning, hasApprovals } = flags;
   const userAskKey = userAskParts.map((p) => p.toolCallId).join("|");
   const planKey = pendingPlans[0]?.toolCallId ?? "";
   const approvalKey = pendingApprovals.map((a) => a.approvalId).join("|");

--- a/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
@@ -4,17 +4,11 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Check, ClipboardCheck } from "@untitledui/icons";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { MessageTextPart } from "../message/parts/text-part.tsx";
-import type { ChatMessage } from "../types.ts";
-
-// ============================================================================
-// Types
-// ============================================================================
-
-export interface PendingPlan {
-  toolCallId: string;
-  plan: string;
-  state: string;
-}
+import { type PendingPlan } from "./extract-pending-plans";
+export {
+  extractPendingPlans,
+  type PendingPlan,
+} from "./extract-pending-plans";
 
 // ============================================================================
 // ProposePlanPrompt - Plan card with approve/reject buttons
@@ -124,34 +118,4 @@ export function ProposePlanHighlight({
       onDismiss={onDismiss}
     />
   );
-}
-
-// ============================================================================
-// Utility: extract pending propose_plan parts from message
-// ============================================================================
-
-export function extractPendingPlans(
-  parts: ChatMessage["parts"],
-): PendingPlan[] {
-  const result: PendingPlan[] = [];
-
-  for (const part of parts) {
-    if (
-      "type" in part &&
-      (part as { type: string }).type === "tool-propose_plan" &&
-      "state" in part &&
-      (part as { state: string }).state === "input-available" &&
-      "toolCallId" in part &&
-      "input" in part
-    ) {
-      const input = (part as { input: { plan: string } }).input;
-      result.push({
-        toolCallId: (part as { toolCallId: string }).toolCallId,
-        plan: input.plan,
-        state: (part as { state: string }).state,
-      });
-    }
-  }
-
-  return result;
 }

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import { deriveHighlightFlags } from "./use-highlight-count";
+
+const noFlags = {
+  isCreditExhausted: false,
+  hasTodos: false,
+  showError: false,
+  showWarning: false,
+  hasApprovals: false,
+  hasPlans: false,
+  isWaitingForUserInput: false,
+} as const;
+
+const baseInput = {
+  messages: [] as UIMessage[],
+  error: null as Error | null,
+  finishReason: null as string | null,
+  isStreaming: false,
+  isWaitingForApprovals: false,
+};
+
+describe("deriveHighlightFlags", () => {
+  test("empty state → all flags false", () => {
+    expect(deriveHighlightFlags(baseInput)).toEqual(noFlags);
+  });
+
+  test("error while not streaming → showError true", () => {
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        error: new Error("boom"),
+      }),
+    ).toEqual({ ...noFlags, showError: true });
+  });
+
+  test("error while streaming → showError false", () => {
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        error: new Error("boom"),
+        isStreaming: true,
+      }),
+    ).toEqual(noFlags);
+  });
+
+  test("credit error → isCreditExhausted true, all other flags false", () => {
+    // isCreditError checks for `[CREDITS]` prefix in the error message.
+    const err = new Error("[CREDITS] insufficient credits");
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        error: err,
+      }),
+    ).toEqual({ ...noFlags, isCreditExhausted: true });
+  });
+
+  test("finishReason 'length' (not streaming, no error) → showWarning true", () => {
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        finishReason: "length",
+      }),
+    ).toEqual({ ...noFlags, showWarning: true });
+  });
+
+  test("finishReason 'stop' → showWarning false (normal completion)", () => {
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        finishReason: "stop",
+      }),
+    ).toEqual(noFlags);
+  });
+
+  test("finishReason 'tool-calls' with pending user_ask → showWarning suppressed", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-user_ask",
+            toolCallId: "c1",
+            state: "input-available",
+            input: { question: "?" },
+          },
+        ],
+      } as unknown as UIMessage,
+    ];
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        finishReason: "tool-calls",
+        messages,
+      }),
+    ).toEqual({ ...noFlags, isWaitingForUserInput: true });
+  });
+
+  test("todos present → hasTodos true", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-todo_write",
+            toolCallId: "c1",
+            state: "input-available",
+            input: {
+              todos: [
+                {
+                  content: "A",
+                  activeForm: "Doing A",
+                  status: "pending" as const,
+                },
+              ],
+            },
+          },
+        ],
+      } as unknown as UIMessage,
+    ];
+    expect(deriveHighlightFlags({ ...baseInput, messages })).toEqual({
+      ...noFlags,
+      hasTodos: true,
+    });
+  });
+
+  test("streaming + isWaitingForApprovals → hasApprovals true", () => {
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        isStreaming: true,
+        isWaitingForApprovals: true,
+      }),
+    ).toEqual({ ...noFlags, hasApprovals: true });
+  });
+});

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
@@ -9,18 +9,13 @@
  * The credit-exhausted case is special: it renders as a modal `Dialog`
  * outside the stack, so it does NOT count toward `n`. The `isCreditExhausted`
  * flag is exposed for `ChatHighlight` to handle the early return.
- *
- * NOTE: The pure extraction helpers (extractPendingApprovals,
- * extractPendingPlans, isCreditError) are intentionally inlined here rather
- * than imported from their respective UI modules (approval.tsx,
- * propose-plan.tsx, credits-exhausted-banner.tsx). Those files pull in heavy
- * React UI components whose transitive dependencies (e.g. @deco/ui) are not
- * available in the bun test environment. The logic is identical to the
- * source-of-truth implementations in those files.
  */
 
 import type { UIMessage } from "ai";
 import { deriveCurrentTodos } from "./derive-current-todos";
+import { extractPendingApprovals } from "./extract-pending-approvals";
+import { extractPendingPlans } from "./extract-pending-plans";
+import { isCreditError } from "../is-credit-error";
 
 export interface HighlightFlags {
   isCreditExhausted: boolean;
@@ -50,52 +45,6 @@ const EMPTY_FLAGS: HighlightFlags = {
   isWaitingForUserInput: false,
 };
 
-// ---------------------------------------------------------------------------
-// Inlined pure helpers — identical logic to the source files, but without the
-// React/UI imports that would break the bun test environment.
-// ---------------------------------------------------------------------------
-
-/** Mirror of isCreditError in credits-exhausted-banner.tsx */
-function isCreditError(error: Error | null): boolean {
-  if (!error) return false;
-  return error.message.startsWith("[CREDITS]");
-}
-
-type LoosePart = {
-  type: string;
-  state?: string;
-  approval?: { id: string };
-  toolCallId?: string;
-  toolName?: string;
-  input?: unknown;
-};
-
-/** Mirror of extractPendingApprovals in approval.tsx */
-function extractPendingApprovals(parts: LoosePart[]): LoosePart[] {
-  return parts.filter(
-    (part) =>
-      "state" in part &&
-      part.state === "approval-requested" &&
-      "approval" in part &&
-      part.approval?.id &&
-      "toolCallId" in part &&
-      part.toolCallId,
-  );
-}
-
-/** Mirror of extractPendingPlans in propose-plan.tsx */
-function extractPendingPlans(parts: LoosePart[]): LoosePart[] {
-  return parts.filter(
-    (part) =>
-      part.type === "tool-propose_plan" &&
-      part.state === "input-available" &&
-      "toolCallId" in part &&
-      "input" in part,
-  );
-}
-
-// ---------------------------------------------------------------------------
-
 export function deriveHighlightFlags(
   input: DeriveHighlightFlagsInput,
 ): HighlightFlags {
@@ -111,6 +60,14 @@ export function deriveHighlightFlags(
   const assistantParts =
     lastMessage?.role === "assistant" ? lastMessage.parts : [];
 
+  type LoosePart = {
+    type: string;
+    state?: string;
+    approval?: { id: string };
+    toolCallId?: string;
+    toolName?: string;
+    input?: unknown;
+  };
   const looseParts = assistantParts as LoosePart[];
   const userAskParts = looseParts.filter(
     (part) => part.type === "tool-user_ask",
@@ -119,7 +76,9 @@ export function deriveHighlightFlags(
     (p) => p.state !== "output-available",
   ).length;
 
-  const pendingPlans = extractPendingPlans(looseParts);
+  const pendingPlans = extractPendingPlans(
+    assistantParts as Parameters<typeof extractPendingPlans>[0],
+  );
   const pendingApprovals = extractPendingApprovals(looseParts);
 
   const todos = deriveCurrentTodos(messages);

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
@@ -16,6 +16,7 @@ import { deriveCurrentTodos } from "./derive-current-todos";
 import { extractPendingApprovals } from "./extract-pending-approvals";
 import { extractPendingPlans } from "./extract-pending-plans";
 import { isCreditError } from "../is-credit-error";
+import { useChatStream } from "../context";
 
 export interface HighlightFlags {
   isCreditExhausted: boolean;
@@ -111,4 +112,42 @@ export function deriveHighlightFlags(
     hasPlans,
     isWaitingForUserInput,
   };
+}
+
+/**
+ * Reads the current `useChatStream()` state and returns the highlight flags.
+ * Use this in any component under `ChatProvider` that needs to react to
+ * which highlights are rendered.
+ */
+export function useHighlightFlags(): HighlightFlags {
+  const { messages, error, finishReason, isStreaming, isWaitingForApprovals } =
+    useChatStream();
+
+  return deriveHighlightFlags({
+    messages,
+    error: error ?? null,
+    finishReason: finishReason ?? null,
+    isStreaming,
+    isWaitingForApprovals,
+  });
+}
+
+/**
+ * Counts how many `CollapsibleHighlight` cards are currently rendered in
+ * the stack (excludes the credit-exhausted modal). Multiply by
+ * `HIGHLIGHT_COLLAPSED_HEIGHT_PX` to get the bottom padding needed on the
+ * messages scroll area so that, when every card is collapsed, the last
+ * message can be scrolled flush against the top of the stack.
+ */
+export function useHighlightCount(): number {
+  const flags = useHighlightFlags();
+  if (flags.isCreditExhausted) return 0;
+  return (
+    Number(flags.hasTodos) +
+    Number(flags.showError) +
+    Number(flags.showWarning) +
+    Number(flags.hasApprovals) +
+    Number(flags.hasPlans) +
+    Number(flags.isWaitingForUserInput)
+  );
 }

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
@@ -1,0 +1,155 @@
+/**
+ * Derives whether each `CollapsibleHighlight` card in the chat stack should
+ * render, plus a count of how many are visible. Both `ChatHighlight` (the
+ * stack itself) and `ChatMessages` (the scrollable area above the input)
+ * call this so that the scroll area can reserve `n × HIGHLIGHT_COLLAPSED_HEIGHT_PX`
+ * of bottom padding — enough room that, when every card is collapsed, the
+ * last message can be scrolled flush with the top of the stack.
+ *
+ * The credit-exhausted case is special: it renders as a modal `Dialog`
+ * outside the stack, so it does NOT count toward `n`. The `isCreditExhausted`
+ * flag is exposed for `ChatHighlight` to handle the early return.
+ *
+ * NOTE: The pure extraction helpers (extractPendingApprovals,
+ * extractPendingPlans, isCreditError) are intentionally inlined here rather
+ * than imported from their respective UI modules (approval.tsx,
+ * propose-plan.tsx, credits-exhausted-banner.tsx). Those files pull in heavy
+ * React UI components whose transitive dependencies (e.g. @deco/ui) are not
+ * available in the bun test environment. The logic is identical to the
+ * source-of-truth implementations in those files.
+ */
+
+import type { UIMessage } from "ai";
+import { deriveCurrentTodos } from "./derive-current-todos";
+
+export interface HighlightFlags {
+  isCreditExhausted: boolean;
+  hasTodos: boolean;
+  showError: boolean;
+  showWarning: boolean;
+  hasApprovals: boolean;
+  hasPlans: boolean;
+  isWaitingForUserInput: boolean;
+}
+
+export interface DeriveHighlightFlagsInput {
+  messages: UIMessage[];
+  error: Error | null;
+  finishReason: string | null;
+  isStreaming: boolean;
+  isWaitingForApprovals: boolean;
+}
+
+const EMPTY_FLAGS: HighlightFlags = {
+  isCreditExhausted: false,
+  hasTodos: false,
+  showError: false,
+  showWarning: false,
+  hasApprovals: false,
+  hasPlans: false,
+  isWaitingForUserInput: false,
+};
+
+// ---------------------------------------------------------------------------
+// Inlined pure helpers — identical logic to the source files, but without the
+// React/UI imports that would break the bun test environment.
+// ---------------------------------------------------------------------------
+
+/** Mirror of isCreditError in credits-exhausted-banner.tsx */
+function isCreditError(error: Error | null): boolean {
+  if (!error) return false;
+  return error.message.startsWith("[CREDITS]");
+}
+
+type LoosePart = {
+  type: string;
+  state?: string;
+  approval?: { id: string };
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+};
+
+/** Mirror of extractPendingApprovals in approval.tsx */
+function extractPendingApprovals(parts: LoosePart[]): LoosePart[] {
+  return parts.filter(
+    (part) =>
+      "state" in part &&
+      part.state === "approval-requested" &&
+      "approval" in part &&
+      part.approval?.id &&
+      "toolCallId" in part &&
+      part.toolCallId,
+  );
+}
+
+/** Mirror of extractPendingPlans in propose-plan.tsx */
+function extractPendingPlans(parts: LoosePart[]): LoosePart[] {
+  return parts.filter(
+    (part) =>
+      part.type === "tool-propose_plan" &&
+      part.state === "input-available" &&
+      "toolCallId" in part &&
+      "input" in part,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+export function deriveHighlightFlags(
+  input: DeriveHighlightFlagsInput,
+): HighlightFlags {
+  const { messages, error, finishReason, isStreaming, isWaitingForApprovals } =
+    input;
+
+  // Credit-exhausted is a modal, not a stacked card.
+  if (!isStreaming && error && isCreditError(error)) {
+    return { ...EMPTY_FLAGS, isCreditExhausted: true };
+  }
+
+  const lastMessage = messages.at(-1);
+  const assistantParts =
+    lastMessage?.role === "assistant" ? lastMessage.parts : [];
+
+  const looseParts = assistantParts as LoosePart[];
+  const userAskParts = looseParts.filter(
+    (part) => part.type === "tool-user_ask",
+  );
+  const isWaitingForUserInput = !!userAskParts.filter(
+    (p) => p.state !== "output-available",
+  ).length;
+
+  const pendingPlans = extractPendingPlans(looseParts);
+  const pendingApprovals = extractPendingApprovals(looseParts);
+
+  const todos = deriveCurrentTodos(messages);
+
+  const showError = !isStreaming && !!error;
+  const hasApprovals =
+    pendingApprovals.length > 0 || (isStreaming && isWaitingForApprovals);
+  const hasPlans = pendingPlans.length > 0;
+
+  // Matches the suppression logic in ChatHighlight: `tool-calls` is the
+  // expected handoff when the model emits user_ask/propose_plan/approval,
+  // so the matching card already covers the situation — suppress the
+  // duplicate warning.
+  const isToolCallsWaitingOnClient =
+    finishReason === "tool-calls" &&
+    (isWaitingForUserInput || hasApprovals || hasPlans);
+  const showWarning =
+    !isStreaming &&
+    !!finishReason &&
+    finishReason !== "stop" &&
+    !isToolCallsWaitingOnClient &&
+    !showError;
+
+  return {
+    isCreditExhausted: false,
+    hasTodos: todos.length > 0,
+    showError,
+    showWarning,
+    hasApprovals,
+    hasPlans,
+    isWaitingForUserInput,
+  };
+}

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -57,12 +57,12 @@ function ChatMessages() {
   const lastMessagePair = messagePairs.at(-1);
   const highlightCount = useHighlightCount();
 
-  // Reserve `n × h + 32px` of bottom padding so that, when every highlight
+  // Reserve `n × h + 16px` of bottom padding so that, when every highlight
   // is collapsed, the last message sits a comfortable gap above the top of
-  // the highlight stack. The 32px baseline keeps the last message off the
+  // the highlight stack. The 16px baseline keeps the last message off the
   // bottom edge even when no highlights are rendered. Expanded highlights
   // still cover content — the affordance is "collapse to read".
-  const paddingBottom = highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 32;
+  const paddingBottom = highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 16;
 
   return (
     <div

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -59,13 +59,10 @@ function ChatMessages() {
 
   // Reserve `n × h + 32px` of bottom padding so that, when every highlight
   // is collapsed, the last message sits a comfortable gap above the top of
-  // the highlight stack. The extra 32px is a breathing-room buffer so the
-  // last message doesn't sit flush against the card. Expanded highlights
+  // the highlight stack. The 32px baseline keeps the last message off the
+  // bottom edge even when no highlights are rendered. Expanded highlights
   // still cover content — the affordance is "collapse to read".
-  const paddingBottom =
-    highlightCount > 0
-      ? highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 32
-      : 0;
+  const paddingBottom = highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 32;
 
   return (
     <div

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -57,13 +57,15 @@ function ChatMessages() {
   const lastMessagePair = messagePairs.at(-1);
   const highlightCount = useHighlightCount();
 
-  // Reserve `n × h + 8px` of bottom padding so that, when every highlight
+  // Reserve `n × h + 16px` of bottom padding so that, when every highlight
   // is collapsed, the last message sits a comfortable gap above the top of
-  // the highlight stack. The extra 8px is a breathing-room buffer so the
+  // the highlight stack. The extra 16px is a breathing-room buffer so the
   // last message doesn't sit flush against the card. Expanded highlights
   // still cover content — the affordance is "collapse to read".
   const paddingBottom =
-    highlightCount > 0 ? highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 8 : 0;
+    highlightCount > 0
+      ? highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 16
+      : 0;
 
   return (
     <div

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -57,11 +57,13 @@ function ChatMessages() {
   const lastMessagePair = messagePairs.at(-1);
   const highlightCount = useHighlightCount();
 
-  // Reserve exactly `n × h` of bottom padding so that, when every highlight
-  // is collapsed, the last message can be scrolled flush with the top of
-  // the highlight stack. Expanded highlights still cover content — the
-  // affordance is "collapse to read".
-  const paddingBottom = highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX;
+  // Reserve `n × h + 8px` of bottom padding so that, when every highlight
+  // is collapsed, the last message sits a comfortable gap above the top of
+  // the highlight stack. The extra 8px is a breathing-room buffer so the
+  // last message doesn't sit flush against the card. Expanded highlights
+  // still cover content — the affordance is "collapse to read".
+  const paddingBottom =
+    highlightCount > 0 ? highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 8 : 0;
 
   return (
     <div

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -57,14 +57,14 @@ function ChatMessages() {
   const lastMessagePair = messagePairs.at(-1);
   const highlightCount = useHighlightCount();
 
-  // Reserve `n × h + 16px` of bottom padding so that, when every highlight
+  // Reserve `n × h + 32px` of bottom padding so that, when every highlight
   // is collapsed, the last message sits a comfortable gap above the top of
-  // the highlight stack. The extra 16px is a breathing-room buffer so the
+  // the highlight stack. The extra 32px is a breathing-room buffer so the
   // last message doesn't sit flush against the card. Expanded highlights
   // still cover content — the affordance is "collapse to read".
   const paddingBottom =
     highlightCount > 0
-      ? highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 16
+      ? highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX + 32
       : 0;
 
   return (

--- a/apps/mesh/src/web/components/chat/index.tsx
+++ b/apps/mesh/src/web/components/chat/index.tsx
@@ -4,6 +4,8 @@ import { ActiveTaskProvider, ChatProvider, useChatStream } from "./context";
 
 export { useChatTask } from "./context";
 import { IceBreakers } from "./ice-breakers";
+import { HIGHLIGHT_COLLAPSED_HEIGHT_PX } from "./highlight/collapsible-highlight";
+import { useHighlightCount } from "./highlight/use-highlight-count";
 import { ChatInput } from "./input";
 import { MessagePair, useMessagePairs } from "./message/pair.tsx";
 import { NoAiProviderEmptyState } from "./no-ai-provider-empty-state";
@@ -53,24 +55,19 @@ function ChatMessages() {
   const { messages, status } = useChatStream();
   const messagePairs = useMessagePairs(messages);
   const lastMessagePair = messagePairs.at(-1);
+  const highlightCount = useHighlightCount();
 
-  const isStreaming = status === "submitted" || status === "streaming";
-  const lastMessage = messages.at(-1);
-  const hasActiveUserAsk =
-    !isStreaming &&
-    lastMessage?.role === "assistant" &&
-    lastMessage.parts
-      .filter((p) => p.type === "tool-user_ask")
-      .some((p) => p.state === "input-available");
-  const hasActivePendingApprovals =
-    !isStreaming &&
-    lastMessage?.role === "assistant" &&
-    lastMessage.parts.some(
-      (p) => "state" in p && p.state === "approval-requested",
-    );
+  // Reserve exactly `n × h` of bottom padding so that, when every highlight
+  // is collapsed, the last message can be scrolled flush with the top of
+  // the highlight stack. Expanded highlights still cover content — the
+  // affordance is "collapse to read".
+  const paddingBottom = highlightCount * HIGHLIGHT_COLLAPSED_HEIGHT_PX;
 
   return (
-    <div className="w-full min-w-0 max-w-full overflow-y-auto h-full overflow-x-hidden">
+    <div
+      className="w-full min-w-0 max-w-full overflow-y-auto h-full overflow-x-hidden"
+      style={{ paddingBottom }}
+    >
       <div className="flex flex-col min-w-0 max-w-2xl mx-auto w-full">
         {messagePairs.slice(0, -1).map((pair, index) => (
           <MessagePair
@@ -82,12 +79,7 @@ function ChatMessages() {
         ))}
       </div>
       {lastMessagePair && (
-        <div
-          className={cn(
-            "min-h-full min-w-0 max-w-2xl mx-auto w-full",
-            (hasActiveUserAsk || hasActivePendingApprovals) && "pb-60",
-          )}
-        >
+        <div className="min-h-full min-w-0 max-w-2xl mx-auto w-full">
           <MessagePair
             key={`pair-${lastMessagePair?.user.id}`}
             pair={lastMessagePair}

--- a/apps/mesh/src/web/components/chat/is-credit-error.ts
+++ b/apps/mesh/src/web/components/chat/is-credit-error.ts
@@ -1,0 +1,11 @@
+/**
+ * Detect credit/payment errors.
+ * The backend prefixes these with `[CREDITS]` so detection is deterministic.
+ *
+ * Extracted as a pure .ts module so it can be imported by bun:test code
+ * without dragging in @deco/ui transitively.
+ */
+export function isCreditError(error: Error | null): boolean {
+  if (!error) return false;
+  return error.message.startsWith("[CREDITS]");
+}


### PR DESCRIPTION
## What is this contribution about?

The `ChatHighlight` stack is absolutely positioned above the chat input, so message text used to scroll behind it and visually collide. The old mitigation (`pb-60` on the last message pair) only handled user-ask and pending-approval and over-reserved 240px. This PR replaces that with a formula `paddingBottom = n × HIGHLIGHT_COLLAPSED_HEIGHT_PX + 16` applied to the messages scroll container, where `n` is the number of mounted highlight cards (todos, status, plan, approval, user-ask). When every highlight is collapsed, the last message clears the stack with a small breathing-room buffer; expanded highlights still cover content — the affordance is "collapse to read." Highlight gating is now sourced from a single shared `useHighlightFlags` hook, with three pure helpers (`isCreditError`, `extractPendingApprovals`, `extractPendingPlans`) extracted to `.ts` modules so the new logic is unit-testable without dragging `@deco/ui` through `bun:test`.

## Screenshots/Demonstration

> _Manual verification still pending — see "How to Test."_

## How to Test

1. `bun run dev` and open a chat.
2. Trigger each highlight type one at a time: todos (any plan-style task), status warning (induce a non-`stop` finish reason), propose-plan, user-ask, approval.
3. Scroll the messages list to the bottom and confirm the last message clears the collapsed highlight stack with ~16px buffer.
4. Stack two highlights (e.g. todos + warning) — confirm two card heights are reserved.
5. Inspect a collapsed `CollapsibleHighlight` in DevTools; if its height + `mb-2` differs from 44px by more than ~2px, update `HIGHLIGHT_COLLAPSED_HEIGHT_PX` in `collapsible-highlight.tsx`.
6. Verify the credits-exhausted modal still renders (no padding gap).

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (automated: 46/46 unit tests, typecheck, lint, format pass; manual verification pending)
- [ ] Documentation is updated (if needed) — N/A
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent messages from scrolling under the highlight stack by reserving bottom padding based on how many highlights are mounted. Replaces the `pb-60` hack with `n × HIGHLIGHT_COLLAPSED_HEIGHT_PX + 16` for a clean, predictable layout.

- New Features
  - Add `useHighlightFlags` and `useHighlightCount` to drive rendering and scroll padding.
  - Reserve padding for each mounted highlight (todos, error, warning, approvals, plans, user_ask); collapsed cards clear the last message with a 16px buffer. Export `HIGHLIGHT_COLLAPSED_HEIGHT_PX = 44`; credit-exhausted is a modal and excluded.

- Refactors
  - Implement `deriveHighlightFlags` pure helper with unit tests; extract `isCreditError`, `extractPendingApprovals`, and `extractPendingPlans` to `.ts` modules for testability.
  - Unify highlight gating in `ChatHighlight` via `useHighlightFlags`; remove duplicated logic and the `pb-60` workaround; drop dead `isCreditError` re-export.

<sup>Written for commit 3eb91530fe1f1c781de46b497b6e6c1d43288c78. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3402?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

