### PR TITLE
fix(github-picker): show reconnect action on GitHub accounts error

### DIFF
--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -20,6 +20,7 @@ import {
   useProjectContext,
   useMCPClient,
   useConnections,
+  authenticateMcp,
   SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
@@ -544,6 +545,7 @@ function InstallationPicker({
     orgId,
     orgSlug,
   });
+  const [isReconnecting, setIsReconnecting] = useState(false);
 
   const installationsQuery = useQuery({
     queryKey: KEYS.githubUserOrgs(orgId, connectionId),
@@ -562,6 +564,55 @@ function InstallationPicker({
     },
   });
 
+  const handleReconnect = async () => {
+    setIsReconnecting(true);
+    try {
+      const { token, tokenInfo, error } = await authenticateMcp({
+        connectionId,
+        orgSlug,
+        scope: "offline_access",
+      });
+      if (error || !token) {
+        toast.error(`Authentication failed: ${error ?? "No token received"}`);
+        return;
+      }
+      if (tokenInfo) {
+        try {
+          const response = await fetch(
+            `/api/${orgSlug}/connections/${connectionId}/oauth-token`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              credentials: "include",
+              body: JSON.stringify({
+                accessToken: tokenInfo.accessToken,
+                refreshToken: tokenInfo.refreshToken,
+                expiresIn: tokenInfo.expiresIn,
+                scope: tokenInfo.scope,
+                clientId: tokenInfo.clientId,
+                clientSecret: tokenInfo.clientSecret,
+                tokenEndpoint: tokenInfo.tokenEndpoint,
+              }),
+            },
+          );
+          if (!response.ok) {
+            console.error("Failed to save OAuth token:", await response.text());
+          }
+        } catch {
+          // Token saved via primary method failed, but auth succeeded
+        }
+      }
+      await installationsQuery.refetch();
+    } catch (err) {
+      toast.error(
+        "Reconnection failed: " +
+          (err instanceof Error ? err.message : "Unknown error"),
+      );
+    } finally {
+      setIsReconnecting(false);
+    }
+  };
+
   if (installationsQuery.isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">
@@ -572,10 +623,36 @@ function InstallationPicker({
 
   if (installationsQuery.isError) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <p className="text-sm text-destructive">
-          Failed to load GitHub accounts
-        </p>
+      <div className="flex flex-col items-center gap-4 px-6 py-10">
+        <div className="size-10 rounded-full bg-destructive/10 flex items-center justify-center">
+          <GitHubIcon className="size-5 text-destructive" />
+        </div>
+        <div className="flex flex-col items-center gap-1 text-center">
+          <p className="text-sm font-medium">Failed to load GitHub accounts</p>
+          <p className="text-xs text-muted-foreground max-w-[260px] leading-relaxed">
+            Your GitHub connection may need to be re-authenticated. Reconnect to
+            grant access again.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleReconnect}
+            disabled={isReconnecting}
+            className="text-xs font-medium text-foreground border border-border rounded-md px-3 py-1.5 hover:bg-accent transition-colors disabled:opacity-50 flex items-center gap-1.5"
+          >
+            {isReconnecting && <Loading01 size={12} className="animate-spin" />}
+            {isReconnecting ? "Reconnecting..." : "Reconnect GitHub"}
+          </button>
+          <button
+            type="button"
+            onClick={() => installationsQuery.refetch()}
+            disabled={isReconnecting}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            Retry
+          </button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- When the GitHub import modal fails to load accounts (e.g. expired OAuth token), it now shows a proper error state with a **"Reconnect GitHub"** button that triggers re-authentication, instead of just a plain red error message
- Adds a **"Retry"** fallback for transient errors that don't require re-auth
- Matches the existing `AutoInstallGitHubUI` error design for visual consistency

## Test plan
- [ ] Open the GitHub import modal with an expired/invalid GitHub OAuth token
- [ ] Verify the error state shows the GitHub icon, helpful message, and reconnect button
- [ ] Click "Reconnect GitHub" and verify the OAuth flow opens
- [ ] After successful re-auth, verify the installations list loads
- [ ] Click "Retry" and verify it refetches without triggering OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows an actionable error state in the GitHub import modal when accounts fail to load, with a “Reconnect GitHub” flow and a “Retry” option to recover without manual steps. Improves UX for expired/invalid OAuth tokens and matches the existing error design.

- **Bug Fixes**
  - Added reconnect flow using `authenticateMcp`, persists tokens via the connection OAuth endpoint, then refetches installations.
  - Added “Retry” to refetch without re-auth.
  - Updated error UI with GitHub icon and reconnect progress state.

<sup>Written for commit 7b52b87470401c050cb923f169d4e2d8b6543e5e. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3403?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

