### PR TITLE
fix(preview): proxy decofile and live-meta fetches server-side to avoid CORS

### DIFF
--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -20,6 +20,7 @@ import { createVirtualMcpRoutes } from "./virtual-mcp";
 import { createVmEventsRoutes } from "./vm-events";
 import { createVmExecRoutes } from "./vm-exec";
 import { createVmFileRoutes } from "./vm-file";
+import { createVmPreviewFetchRoutes } from "./vm-preview-fetch";
 import { createVmSetupRoutes } from "./vm-setup";
 
 interface OrgScopedDeps {
@@ -68,6 +69,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/vm-events", createVmEventsRoutes()); // /api/:org/vm-events
   app.route("/vm-exec", createVmExecRoutes()); // /api/:org/vm-exec/{exec,kill}/:script
   app.route("/vm-file", createVmFileRoutes()); // /api/:org/vm-file/{write,read}
+  app.route("/vm-preview-fetch", createVmPreviewFetchRoutes()); // /api/:org/vm-preview-fetch?path=...
   app.route("/vm-setup", createVmSetupRoutes()); // /api/:org/vm-setup/:step
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites
   app.route("/sso", createSsoRoutes()); // /api/:org/sso/* (renamed from /api/org-sso)

--- a/apps/mesh/src/api/routes/vm-preview-fetch.ts
+++ b/apps/mesh/src/api/routes/vm-preview-fetch.ts
@@ -1,0 +1,99 @@
+/**
+ * Browser-facing proxy for fetching resources from the sandbox preview.
+ *
+ * The studio UI (origin A) needs to read `.decofile` and `/live/_meta` from
+ * the preview daemon (origin B). Direct client-side fetches fail due to CORS.
+ * This route authenticates the user and proxies the GET request server-side,
+ * following the same auth + claim + proxy pattern as `vm-file.ts`.
+ */
+
+import { Hono, type Context } from "hono";
+import { composeSandboxRef } from "@decocms/sandbox/runner";
+import { computeClaimHandle } from "../../sandbox/claim-handle";
+import { getOrInitSharedRunner } from "../../sandbox/lifecycle";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "../../core/mesh-context";
+import type { Env } from "../hono-env";
+
+/** Allowed preview paths that can be fetched through this proxy. */
+const ALLOWED_PATHS = new Set(["/.decofile", "/live/_meta"]);
+
+async function proxyPreviewGet(c: Context<Env>) {
+  const ctx = c.var.meshContext;
+  try {
+    requireAuth(ctx);
+  } catch {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  const userId = getUserId(ctx);
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  let organization: ReturnType<typeof requireOrganization>;
+  try {
+    organization = requireOrganization(ctx);
+  } catch {
+    return c.json({ error: "Organization scope required" }, 403);
+  }
+
+  const virtualMcpId = c.req.query("virtualMcpId");
+  const branch = c.req.query("branch");
+  const path = c.req.query("path");
+  if (!virtualMcpId || !branch || !path) {
+    return c.json(
+      { error: "virtualMcpId, branch, and path are required" },
+      400,
+    );
+  }
+
+  if (!ALLOWED_PATHS.has(path)) {
+    return c.json({ error: "Path not allowed" }, 403);
+  }
+
+  const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
+  if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+    return c.json({ error: "Virtual MCP not found" }, 404);
+  }
+
+  const projectRef = composeSandboxRef({
+    orgId: organization.id,
+    virtualMcpId,
+    branch,
+  });
+  const claimName = computeClaimHandle({ userId, projectRef }, branch);
+
+  const runner = await getOrInitSharedRunner();
+  if (!runner) {
+    return c.json({ error: "No sandbox runner configured" }, 503);
+  }
+
+  const previewUrl = await runner.getPreviewUrl(claimName);
+  if (!previewUrl) {
+    return c.json({ error: "Preview not available" }, 502);
+  }
+
+  const base = previewUrl.replace(/\/+$/, "");
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${base}${path}`);
+  } catch {
+    return c.json({ error: "Preview unreachable" }, 502);
+  }
+
+  const text = await upstream.text();
+  return new Response(text, {
+    status: upstream.status,
+    headers: {
+      "content-type":
+        upstream.headers.get("content-type") ?? "application/json",
+    },
+  });
+}
+
+export const createVmPreviewFetchRoutes = () => {
+  const app = new Hono<Env>();
+  app.get("/", proxyPreviewGet);
+  return app;
+};

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -341,14 +341,12 @@ function unwrapSection(
  * Changes auto-save after a debounce.
  */
 export function SectionsEditor({
-  previewUrl,
   orgSlug,
   virtualMcpId,
   branch,
   currentPath,
   onSaved,
 }: {
-  previewUrl: string;
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
@@ -356,9 +354,11 @@ export function SectionsEditor({
   /** Called after a successful auto-save so the parent can reload the preview. */
   onSaved?: () => void;
 }) {
+  const previewFetchParams = { orgSlug, virtualMcpId, branch };
   const { data: decofile, isLoading: decofileLoading } =
-    useDecofile(previewUrl);
-  const { data: meta, isLoading: metaLoading } = useLiveMeta(previewUrl);
+    useDecofile(previewFetchParams);
+  const { data: meta, isLoading: metaLoading } =
+    useLiveMeta(previewFetchParams);
 
   const [selectedSectionIndex, setSelectedSectionIndex] = useState<
     number | null
@@ -388,7 +388,7 @@ export function SectionsEditor({
     setRuleResolveType(null);
   }
 
-  const saveBlock = useSaveBlock({ previewUrl, orgSlug, virtualMcpId, branch });
+  const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pageDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -1,15 +1,31 @@
 import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
 
-export function useDecofile(previewUrl: string | null) {
+interface UseDecofileParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+export function useDecofile(params: UseDecofileParams | null) {
+  const key = params
+    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
+    : "";
   return useQuery({
-    queryKey: KEYS.decofile(previewUrl ?? ""),
+    queryKey: KEYS.decofile(key),
     queryFn: async () => {
-      const res = await fetch(`${previewUrl}/.decofile`);
+      const search = new URLSearchParams({
+        virtualMcpId: params!.virtualMcpId,
+        branch: params!.branch,
+        path: "/.decofile",
+      });
+      const res = await fetch(
+        `/api/${params!.orgSlug}/vm-preview-fetch?${search.toString()}`,
+      );
       if (!res.ok) throw new Error(`Failed to fetch decofile: ${res.status}`);
       return (await res.json()) as Record<string, unknown>;
     },
-    enabled: !!previewUrl,
+    enabled: !!params,
     staleTime: 30_000,
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -2,15 +2,31 @@ import { useQuery } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
 import type { LiveMeta } from "./resolve-schema";
 
-export function useLiveMeta(previewUrl: string | null) {
+interface UseLiveMetaParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+export function useLiveMeta(params: UseLiveMetaParams | null) {
+  const key = params
+    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
+    : "";
   return useQuery({
-    queryKey: KEYS.liveMeta(previewUrl ?? ""),
+    queryKey: KEYS.liveMeta(key),
     queryFn: async () => {
-      const res = await fetch(`${previewUrl}/live/_meta`);
+      const search = new URLSearchParams({
+        virtualMcpId: params!.virtualMcpId,
+        branch: params!.branch,
+        path: "/live/_meta",
+      });
+      const res = await fetch(
+        `/api/${params!.orgSlug}/vm-preview-fetch?${search.toString()}`,
+      );
       if (!res.ok) throw new Error(`Failed to fetch live meta: ${res.status}`);
       return (await res.json()) as LiveMeta;
     },
-    enabled: !!previewUrl,
+    enabled: !!params,
     staleTime: 300_000,
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -2,14 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
 
 interface UseSaveBlockParams {
-  previewUrl: string;
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
 }
 
 export function useSaveBlock({
-  previewUrl,
   orgSlug,
   virtualMcpId,
   branch,
@@ -44,8 +42,9 @@ export function useSaveBlock({
       return res.json();
     },
     onSuccess: () => {
+      const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
       queryClient.invalidateQueries({
-        queryKey: KEYS.decofile(previewUrl),
+        queryKey: KEYS.decofile(cacheKey),
       });
     },
   });

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -143,9 +143,7 @@ export function PreviewContent() {
 
   // Decofile pages for the URL bar dropdown
   const decofileParams =
-    virtualMcpId && branch
-      ? { orgSlug: org.slug, virtualMcpId, branch }
-      : null;
+    virtualMcpId && branch ? { orgSlug: org.slug, virtualMcpId, branch } : null;
   const { data: decofile } = useDecofile(decofileParams);
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -138,8 +138,15 @@ export function PreviewContent() {
     userId && branch ? metadata?.vmMap?.[userId]?.[branch] : undefined;
   const previewUrl = vmEntry?.previewUrl ?? null;
 
+  const virtualMcpId = inset?.entity?.id ?? null;
+  const { org } = useProjectContext();
+
   // Decofile pages for the URL bar dropdown
-  const { data: decofile } = useDecofile(previewUrl);
+  const decofileParams =
+    virtualMcpId && branch
+      ? { orgSlug: org.slug, virtualMcpId, branch }
+      : null;
+  const { data: decofile } = useDecofile(decofileParams);
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
     : [];
@@ -197,8 +204,6 @@ export function PreviewContent() {
   //   auto-start: once per taskId
   //   self-heal:  once per dead vmId (don't loop on repeat 404s; new vmId OK)
   // A shared ref would conflate them.
-  const virtualMcpId = inset?.entity?.id ?? null;
-  const { org } = useProjectContext();
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: inset?.entity?.organization_id ?? "",
@@ -711,7 +716,6 @@ export function PreviewContent() {
               }
             >
               <SectionsEditor
-                previewUrl={previewUrl}
                 orgSlug={org.slug}
                 virtualMcpId={virtualMcpId}
                 branch={branch}


### PR DESCRIPTION
## Summary
- Add `vm-preview-fetch` server-side proxy route (`GET /api/:org/vm-preview-fetch`) that authenticates the user and fetches `/.decofile` and `/live/_meta` from the sandbox preview internally, avoiding CORS errors
- Path allowlist (`/.decofile`, `/live/_meta`) prevents SSRF — only these two paths can be proxied
- Update `useDecofile`, `useLiveMeta`, and `useSaveBlock` hooks to use the proxy instead of direct cross-origin fetches
- Also fixes double-slash issue when `previewUrl` ended with `/`

## Test plan
- [ ] Start a sandbox preview via the sections editor
- [ ] Verify decofile loads without CORS errors in the browser console
- [ ] Verify live meta (schema form) loads correctly
- [ ] Verify auto-save still works and invalidates the decofile cache
- [ ] Verify the pages dropdown in the URL bar still populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxies preview fetches for `/.decofile` and `/live/_meta` through the server to remove CORS errors and eliminate trailing-slash double slashes.

- **Bug Fixes**
  - Added `GET /api/:org/vm-preview-fetch` to securely proxy preview requests after auth; allowlisted to `/.decofile` and `/live/_meta`.
  - Normalizes preview URLs in the proxy to avoid double slashes.
  - Updated `useDecofile` and `useLiveMeta` to use the proxy with a stable cache key (`orgSlug/virtualMcpId/branch`).
  - Updated `useSaveBlock` to invalidate the decofile cache using the new key; hooked up `SectionsEditor` and preview so pages dropdown and auto-save work without CORS.

- **Migration**
  - `SectionsEditor` no longer accepts `previewUrl`. Remove it and pass `orgSlug`, `virtualMcpId`, and `branch`.

<sup>Written for commit 727e33a7ffd67ff547f8672ff12f6483558c5678. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3404?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

