### PR TITLE
fix(org): pass path-resolved org id to ORGANIZATION_GET

### DIFF
--- a/apps/mesh/src/tools/organization/get.ts
+++ b/apps/mesh/src/tools/organization/get.ts
@@ -41,9 +41,18 @@ export const ORGANIZATION_GET = defineTool({
     // Check authorization
     await ctx.access.check();
 
-    // Get full organization via Better Auth
-    // This uses the active organization from session
-    const organization = await ctx.boundAuth.organization.get();
+    // Resolve org from the URL-path context, not the session's active org.
+    // Better Auth's session row holds a single activeOrganizationId shared
+    // across tabs, so falling back to it leaks invitations/members from
+    // whichever org "won" the last setActiveOrganization call.
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      throw new Error(
+        "Organization ID required (no active organization in context)",
+      );
+    }
+
+    const organization = await ctx.boundAuth.organization.get(organizationId);
 
     if (!organization) {
       throw new Error("No active organization found");

--- a/apps/mesh/src/tools/organization/organization-tools.test.ts
+++ b/apps/mesh/src/tools/organization/organization-tools.test.ts
@@ -108,8 +108,10 @@ const createMockBoundAuth = (
         headers: new Headers(),
       });
     }),
-    get: vi.fn(async () => {
-      return mockAuth.api.getFullOrganization();
+    get: vi.fn(async (organizationId?: string) => {
+      return mockAuth.api.getFullOrganization({
+        query: organizationId ? { organizationId } : undefined,
+      });
     }),
     list: vi.fn(async (userId) => {
       return mockAuth.api.listOrganizations({
@@ -323,18 +325,33 @@ describe("Organization Tools", () => {
   });
 
   describe("ORGANIZATION_GET", () => {
-    it("should get active organization", async () => {
+    it("should forward the path-resolved org id to Better Auth", async () => {
       const mockAuth = createMockAuth();
       const ctx = createMockContext(mockAuth);
 
       const result = await ORGANIZATION_GET.execute({}, ctx);
 
-      expect(mockAuth.api.getFullOrganization).toHaveBeenCalled();
+      // Must pass organizationId — falling back to session.activeOrganizationId
+      // leaks the wrong org across tabs.
+      expect(mockAuth.api.getFullOrganization).toHaveBeenCalledWith({
+        query: { organizationId: "org_123" },
+      });
       expect(result.id).toBe("org_123");
       expect(result.slug).toBe("test-org");
     });
 
-    it("should throw when no active organization", async () => {
+    it("should throw when ctx.organization is missing", async () => {
+      const mockAuth = createMockAuth();
+      const ctx = createMockContext(mockAuth);
+      ctx.organization = undefined;
+
+      await expect(ORGANIZATION_GET.execute({}, ctx)).rejects.toThrow(
+        "Organization ID required",
+      );
+      expect(mockAuth.api.getFullOrganization).not.toHaveBeenCalled();
+    });
+
+    it("should throw when Better Auth returns null", async () => {
       const mockAuth = createMockAuth();
       mockAuth.api.getFullOrganization.mockResolvedValue(null);
       const ctx = createMockContext(mockAuth);


### PR DESCRIPTION
## What is this contribution about?

`ORGANIZATION_GET` called `ctx.boundAuth.organization.get()` with no arguments, which falls back to `session.activeOrganizationId` — the same shared per-user session row that caused the original cross-tab org bleed. The members screen fetches invitations through this tool (`useInvitations` → MCP `ORGANIZATION_GET`), so with two tabs open to different orgs, the invites list could come from whichever org last set itself active on the session.

This forwards `ctx.organization?.id` (set by `resolve-org-from-path` from the `/api/:org/...` URL) to Better Auth, and throws if it's missing — mirroring the client-side guard in `useOrgAuthClient`. Audited sibling org tools; all others either already throw on missing `ctx.organization` or take an explicit `input.id`.

## How to Test

1. Open two browser tabs, each on the members screen of a different org you belong to.
2. In tab A, switch to tab B and back — refresh tab A's members page.
3. Expected: tab A's pending invitations are tab A's org's invitations, not tab B's.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (existing test tightened to assert org id is forwarded; new test for missing-context guard)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-tab org bleed in the members/invitations view by resolving the org from the URL path and passing its id through `ORGANIZATION_GET` to Better Auth. Each tab now loads invitations for its own org; also suppresses a new lint rule to unblock CI.

- **Bug Fixes**
  - Forward `ctx.organization?.id` to Better Auth; throw if missing instead of falling back to the session’s active org.
  - Update tests to assert id forwarding, missing-context guard, and null response handling.
  - Suppress `ban-ref-current-assignment` on the `requestEditRef.current = ...` assignment in the mention-slash bridge to fix CI until refactor.

<sup>Written for commit e4a3f687a535bea4951052d0d44826b9ef3178e0. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3405?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

