### PR TITLE
feat(dbos): add opt-in DBOS Conductor support

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -173,7 +173,13 @@ if (ingressEligible) {
 // import chain). Launch DBOS afterwards so the registry is sealed before
 // the executor starts dequeueing workflows.
 const app = await createApp();
-await DBOS.launch();
+// Conductor opt-in via env (SDK defaults conductorURL to wss://cloud.dbos.dev/...).
+const conductorKey = process.env.DBOS_CONDUCTOR_KEY?.trim();
+const conductorURL = process.env.DBOS_CONDUCTOR_URL?.trim();
+await DBOS.launch({
+  ...(conductorKey ? { conductorKey } : {}),
+  ...(conductorKey && conductorURL ? { conductorURL } : {}),
+});
 // Post-launch DBOS setup (queue registration, schedule reconciliation).
 // Must run after launch because registerQueue / listSchedules require an
 // initialized executor.

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: A Helm chart for deco Studio self-hosted deployment
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -176,6 +176,14 @@ Validate OTel collector/S3 configuration.
 {{- if and .Values.otel.collector.enabled (not .Values.otel.enabled) }}
 {{- fail "chart-deco-studio: otel.collector.enabled=true requires otel.enabled=true" -}}
 {{- end }}
+{{- if and .Values.dbosConductor .Values.dbosConductor.enabled }}
+{{- if and .Values.secret.secretName (not .Values.dbosConductor.existingSecret) }}
+{{- fail "chart-deco-studio: when secret.secretName is set, dbosConductor.existingSecret must also be set (the chart-managed Secret is skipped, so DBOS_CONDUCTOR_KEY has nowhere to live otherwise)" -}}
+{{- end }}
+{{- if and .Values.dbosConductor.key .Values.dbosConductor.existingSecret }}
+{{- fail "chart-deco-studio: dbosConductor.key and dbosConductor.existingSecret are mutually exclusive" -}}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -92,6 +92,17 @@ spec:
               value: {{ include "chart-deco-studio.otelAttributes" . | quote }}
             {{- end }}
             {{- end }}
+            {{- if and .Values.dbosConductor .Values.dbosConductor.enabled }}
+            - name: DBOS_CONDUCTOR_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dbosConductor.existingSecret | default (include "chart-deco-studio.secretName" .) }}
+                  key: {{ .Values.dbosConductor.existingSecretKey | default "DBOS_CONDUCTOR_KEY" }}
+            {{- with .Values.dbosConductor.url }}
+            - name: DBOS_CONDUCTOR_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/studio/templates/secret.yaml
+++ b/deploy/helm/studio/templates/secret.yaml
@@ -54,4 +54,7 @@ stringData:
   {{- with .Values.secret.AUTH_SSO_GOOGLE_CLIENT_SECRET }}
   AUTH_SSO_GOOGLE_CLIENT_SECRET: {{ . | quote }}
   {{- end }}
+  {{- if and .Values.dbosConductor .Values.dbosConductor.enabled (not .Values.dbosConductor.existingSecret) }}
+  DBOS_CONDUCTOR_KEY: {{ required "chart-deco-studio: dbosConductor.key is required when dbosConductor.enabled=true and dbosConductor.existingSecret is empty" .Values.dbosConductor.key | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -231,6 +231,24 @@ nats:
           size: 10Gi
           storageClassName: ""  # empty = use cluster default StorageClass
 
+# DBOS Conductor — opt-in management service for DBOS workflows.
+# https://docs.dbos.dev/production/conductor
+# When enabled, the app dials wss:// to the conductor URL for workflow
+# recovery, observability, and retention. Disconnects don't affect the
+# request path. Requires outbound egress to the conductor URL.
+dbosConductor:
+  enabled: false
+  # Inline API key — written into the chart-managed Secret as DBOS_CONDUCTOR_KEY.
+  # Leave empty when supplying the key via existingSecret.
+  key: ""
+  # Optional WS URL override. SDK default: wss://cloud.dbos.dev/conductor/v1alpha1
+  url: ""
+  # Pre-existing Secret with the conductor key. When set, the chart skips
+  # writing the key and references this Secret instead. Mutually exclusive
+  # with `key`.
+  existingSecret: ""
+  existingSecretKey: "DBOS_CONDUCTOR_KEY"
+
 # Additional environment variables (merged with existing envs)
 env: []
 # env:


### PR DESCRIPTION
## Summary
- Wire `DBOS_CONDUCTOR_KEY` / `DBOS_CONDUCTOR_URL` env vars into `DBOS.launch()` in `apps/mesh/src/index.ts`. When unset, behavior is unchanged.
- Add a `dbosConductor` block to `deploy/helm/studio/`: opt-in (`enabled: false` by default), supports either an inline `key` (written into the chart-managed Secret) or a pre-existing Secret via `existingSecret` / `existingSecretKey`.
- Helm validations reject misconfigured combinations (enabled w/o key or existingSecret; both key and existingSecret set; `secret.secretName` set without `dbosConductor.existingSecret` — since the chart-managed Secret is skipped in that case).

## Context
[DBOS Conductor](https://docs.dbos.dev/production/conductor) is an out-of-band management service that dials over WebSocket to provide workflow recovery across executors, observability dashboards, and retention. Conductor is **not on the request path** — disconnects don't affect serving traffic; the SDK reconnects in the background.

The smallest viable deployment shape is "managed Conductor": no extra K8s manifests needed, just an outbound `wss://` connection and an API key from DBOS Cloud. This PR is exactly that.

A self-hosted Conductor deployment (Conductor + Console + their own Postgres) is a much larger lift and is intentionally **not** included here. If/when we want it, `dbosConductor.url` already accepts a custom endpoint.

## Test plan
- [x] `helm template` with default values: no `DBOS_CONDUCTOR_*` env vars rendered, no behavior change.
- [x] `helm template` with `dbosConductor.enabled=true --set dbosConductor.key=…`: `DBOS_CONDUCTOR_KEY` written into chart-managed Secret and referenced via `secretKeyRef` in the Deployment.
- [x] `helm template` with `dbosConductor.existingSecret=…`: `DBOS_CONDUCTOR_KEY` not written into chart-managed Secret; Deployment references the external Secret.
- [x] `helm template` validation failures: enabled without key, both key+existingSecret, `secret.secretName` set without `existingSecret` — all fail with clear messages.
- [x] `tsc --noEmit` clean on `apps/mesh`.
- [ ] Smoke test against a real DBOS Cloud account in a non-prod namespace before flipping `enabled: true` on any environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in DBOS Conductor integration. When enabled, the app dials Conductor for workflow recovery, observability, and retention; default behavior is unchanged.

- **New Features**
  - Wire `DBOS_CONDUCTOR_KEY` and optional `DBOS_CONDUCTOR_URL` into `DBOS.launch()` (only passed when a key is set).
  - Helm: add `dbosConductor` block (enabled=false by default) with `key`, `url`, `existingSecret`, and `existingSecretKey`.
  - Deployment injects `DBOS_CONDUCTOR_KEY/URL`; chart-managed Secret stores the key when provided inline.
  - Helm validations prevent invalid combos (enabled without key/secret, key+existingSecret together, or `secret.secretName` without `dbosConductor.existingSecret`).
  - Bump Helm chart version to 0.6.5.

- **Migration**
  - To enable via Helm: set `dbosConductor.enabled=true` and either `dbosConductor.key=<api-key>` or `dbosConductor.existingSecret=<name>`.
  - Optionally set `dbosConductor.url` to override the SDK’s default conductor URL.

<sup>Written for commit 5384b2e38ea9c5ee40aad55d4c6d9399a8b78b55. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3408?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

