### PR TITLE
Improve CMS section editor navigation

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -1,8 +1,27 @@
+import { useState } from "react";
+import { DotsGrid, DotsHorizontal, Plus, Trash01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
-import { Plus, Trash01 } from "@untitledui/icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
 import type { FieldProps } from "./field-props";
-import { SchemaForm } from "../schema-form";
-import { renderField } from "../schema-form";
+import { SchemaForm, renderField } from "../schema-form";
+
+function getItemLabel(item: unknown, index: number): string {
+  if (typeof item === "string") return item || `Item ${index + 1}`;
+  if (typeof item === "number" || typeof item === "boolean")
+    return String(item);
+  if (item && typeof item === "object" && !Array.isArray(item)) {
+    const obj = item as Record<string, unknown>;
+    for (const key of ["name", "label", "title", "text", "href", "id"]) {
+      if (typeof obj[key] === "string" && obj[key]) return obj[key] as string;
+    }
+  }
+  return `Item ${index + 1}`;
+}
 
 export function ArrayField({
   schema,
@@ -10,9 +29,12 @@ export function ArrayField({
   onChange,
   path,
   label,
+  breadcrumbPath = [],
+  onBreadcrumbChange,
 }: FieldProps) {
   const items = Array.isArray(value) ? value : [];
   const itemSchema = schema.items;
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   const addItem = () => {
     const t = itemSchema?.type;
@@ -28,63 +50,141 @@ export function ArrayField({
               : t === "array"
                 ? []
                 : "";
-    onChange([...items, defaultVal]);
+    const next = [...items, defaultVal];
+    onChange(next);
+    const nextIndex = next.length - 1;
+    setSelectedIndex(nextIndex);
+    onBreadcrumbChange?.([
+      ...breadcrumbPath,
+      getItemLabel(defaultVal, nextIndex),
+    ]);
   };
 
   const removeItem = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
+    if (selectedIndex === index) {
+      setSelectedIndex(null);
+      onBreadcrumbChange?.(breadcrumbPath);
+    }
   };
 
   const updateItem = (index: number, val: unknown) => {
     const next = [...items];
     next[index] = val;
     onChange(next);
+    if (selectedIndex === index) {
+      onBreadcrumbChange?.([...breadcrumbPath, getItemLabel(val, index)]);
+    }
   };
+
+  if (selectedIndex !== null && selectedIndex < items.length) {
+    const item = items[selectedIndex];
+    const itemBreadcrumbPath = [
+      ...breadcrumbPath,
+      getItemLabel(item, selectedIndex),
+    ];
+    return (
+      <div className="space-y-4">
+        {itemSchema?.type === "object" && itemSchema.properties ? (
+          <SchemaForm
+            schema={itemSchema}
+            value={item}
+            onChange={(val) => updateItem(selectedIndex, val)}
+            basePath={`${path}.${selectedIndex}`}
+            breadcrumbPath={itemBreadcrumbPath}
+            onBreadcrumbChange={onBreadcrumbChange}
+          />
+        ) : itemSchema ? (
+          renderField({
+            schema: itemSchema,
+            value: item,
+            onChange: (val) => updateItem(selectedIndex, val),
+            path: `${path}.${selectedIndex}`,
+            label: itemSchema.title ?? `Item ${selectedIndex + 1}`,
+            breadcrumbPath: itemBreadcrumbPath,
+            onBreadcrumbChange,
+          })
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium">{label}</span>
-        <Button type="button" variant="outline" size="sm" onClick={addItem}>
-          <Plus size={14} />
-          Add
-        </Button>
-      </div>
-      {schema.description && (
-        <p className="text-xs text-muted-foreground">{schema.description}</p>
-      )}
-      {items.map((item, i) => (
-        <div key={`${path}.${i}`} className="border rounded-md p-3 relative">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="absolute top-1 right-1 h-7 w-7 p-0"
-            onClick={() => removeItem(i)}
-          >
-            <Trash01 size={14} />
-          </Button>
-          {itemSchema?.type === "object" && itemSchema.properties ? (
-            <SchemaForm
-              schema={itemSchema}
-              value={item}
-              onChange={(val) => updateItem(i, val)}
-              basePath={`${path}.${i}`}
-            />
-          ) : itemSchema ? (
-            renderField({
-              schema: itemSchema,
-              value: item,
-              onChange: (val) => updateItem(i, val),
-              path: `${path}.${i}`,
-              label: itemSchema.title ?? `Item ${i + 1}`,
-            })
-          ) : null}
+      <div className="min-w-0 space-y-0.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 truncate text-sm font-medium">{label}</span>
+          {items.length > 0 && (
+            <span className="rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+              {items.length}
+            </span>
+          )}
         </div>
-      ))}
-      {items.length === 0 && (
-        <p className="text-xs text-muted-foreground py-2">No items yet.</p>
+        {schema.description && (
+          <p className="break-words text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
+
+      {items.length > 0 && (
+        <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
+          {items.map((item, i) => (
+            <div
+              key={`${path}.${i}`}
+              className="group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground"
+            >
+              <DotsGrid className="size-3.5 shrink-0 cursor-grab text-muted-foreground/40" />
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedIndex(i);
+                  onBreadcrumbChange?.([
+                    ...breadcrumbPath,
+                    getItemLabel(item, i),
+                  ]);
+                }}
+                className="min-w-0 flex-1 truncate text-left text-sm"
+                title={getItemLabel(item, i)}
+              >
+                {getItemLabel(item, i)}
+              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Open actions for ${getItemLabel(item, i)}`}
+                    className="size-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <DotsHorizontal size={14} />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => removeItem(i)}
+                  >
+                    <Trash01 size={14} />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          ))}
+        </div>
       )}
+
+      <button
+        type="button"
+        onClick={addItem}
+        className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-border/60 py-2.5 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-muted/30"
+      >
+        <Plus size={14} />
+        Add item
+      </button>
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/boolean-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/boolean-field.tsx
@@ -12,11 +12,13 @@ export function BooleanField({
   const checked = typeof value === "boolean" ? value : false;
 
   return (
-    <div className="flex items-center justify-between gap-2 py-1">
-      <div>
+    <div className="flex items-center justify-between gap-3">
+      <div className="space-y-0.5">
         <Label htmlFor={path}>{label}</Label>
         {schema.description && (
-          <p className="text-xs text-muted-foreground">{schema.description}</p>
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
         )}
       </div>
       <Switch

--- a/apps/mesh/src/web/components/sections-editor/fields/enum-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/enum-field.tsx
@@ -19,20 +19,23 @@ export function EnumField({
   const strValue = value != null ? String(value) : "";
 
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={path}>{label}</Label>
-      {schema.description && (
-        <p className="text-xs text-muted-foreground">{schema.description}</p>
-      )}
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={path}>{label}</Label>
+        {schema.description && (
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
       <Select
         value={strValue}
         onValueChange={(v) => {
-          // Map the string back to the original enum value to preserve type
           const original = options.find((opt) => String(opt) === v);
           onChange(original !== undefined ? original : v);
         }}
       >
-        <SelectTrigger>
+        <SelectTrigger className="h-10">
           <SelectValue placeholder="Select..." />
         </SelectTrigger>
         <SelectContent>

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -6,4 +6,6 @@ export interface FieldProps {
   onChange: (value: unknown) => void;
   path: string;
   label: string;
+  breadcrumbPath?: string[];
+  onBreadcrumbChange?: (path: string[]) => void;
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -12,31 +12,36 @@ export function ImageField({
   const strValue = typeof value === "string" ? value : "";
 
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={path}>{label}</Label>
-      {schema.description && (
-        <p className="text-xs text-muted-foreground">{schema.description}</p>
-      )}
-      <div className="flex gap-2 items-start">
-        <Input
-          id={path}
-          type="url"
-          value={strValue}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder="https://..."
-          className="flex-1"
-        />
-        {strValue && (
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={path}>{label}</Label>
+        {schema.description && (
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
+      {strValue && (
+        <div className="overflow-hidden rounded-lg border border-border/50 bg-muted/30">
           <img
             src={strValue}
             alt={label}
-            className="h-10 w-10 rounded border object-cover shrink-0"
+            className="max-h-32 w-full object-cover"
             onError={(e) => {
-              (e.target as HTMLImageElement).style.display = "none";
+              (e.target as HTMLImageElement).parentElement!.style.display =
+                "none";
             }}
           />
-        )}
-      </div>
+        </div>
+      )}
+      <Input
+        id={path}
+        type="url"
+        value={strValue}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="https://..."
+        className="h-10"
+      />
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/number-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/number-field.tsx
@@ -12,11 +12,15 @@ export function NumberField({
   const numValue = typeof value === "number" ? value : "";
 
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={path}>{label}</Label>
-      {schema.description && (
-        <p className="text-xs text-muted-foreground">{schema.description}</p>
-      )}
+    <div className="space-y-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={path}>{label}</Label>
+        {schema.description && (
+          <p className="text-xs leading-normal text-muted-foreground">
+            {schema.description}
+          </p>
+        )}
+      </div>
       <Input
         id={path}
         type="number"
@@ -25,6 +29,7 @@ export function NumberField({
           const v = e.target.value;
           onChange(v === "" ? undefined : Number(v));
         }}
+        className="h-10"
       />
     </div>
   );

--- a/apps/mesh/src/web/components/sections-editor/fields/object-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/object-field.tsx
@@ -9,6 +9,8 @@ export function ObjectField({
   onChange,
   path,
   label,
+  breadcrumbPath,
+  onBreadcrumbChange,
 }: FieldProps) {
   const [open, setOpen] = useState(false);
   const objValue =
@@ -18,23 +20,50 @@ export function ObjectField({
 
   if (!schema.properties) return null;
 
+  const contentId = `${path}-fields`;
+  const nestedBreadcrumbPath = [...(breadcrumbPath ?? []), label];
+
+  const handleToggle = () => {
+    const nextOpen = !open;
+    setOpen(nextOpen);
+    onBreadcrumbChange?.(
+      nextOpen ? nestedBreadcrumbPath : (breadcrumbPath ?? []),
+    );
+  };
+
   return (
-    <div className="border rounded-md">
+    <div className="min-w-0 space-y-2">
       <button
         type="button"
-        onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 w-full px-3 py-2 text-sm font-medium text-left hover:bg-muted/50"
+        aria-expanded={open}
+        aria-controls={contentId}
+        onClick={handleToggle}
+        className="group flex w-full min-w-0 items-center gap-2 rounded-md py-1.5 pr-2 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
       >
-        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-        {label}
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors group-hover:text-accent-foreground">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+        <span className="min-w-0 truncate text-sm font-medium">{label}</span>
       </button>
+
+      {schema.description && (
+        <p className="break-words pl-9 text-xs leading-normal text-muted-foreground">
+          {schema.description}
+        </p>
+      )}
+
       {open && (
-        <div className="px-3 pb-3">
+        <div
+          id={contentId}
+          className="ml-3 min-w-0 border-l border-border/80 pl-5"
+        >
           <SchemaForm
             schema={schema}
             value={objValue}
             onChange={onChange}
             basePath={path}
+            breadcrumbPath={nestedBreadcrumbPath}
+            onBreadcrumbChange={onBreadcrumbChange}
           />
         </div>
       )}

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -3,6 +3,27 @@ import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import type { FieldProps } from "./field-props";
 
+function FieldLabel({
+  htmlFor,
+  label,
+  description,
+}: {
+  htmlFor: string;
+  label: string;
+  description?: string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {description && (
+        <p className="text-xs leading-normal text-muted-foreground">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export function StringField({
   schema,
   value,
@@ -20,11 +41,12 @@ export function StringField({
     format === "markdown"
   ) {
     return (
-      <div className="space-y-1.5">
-        <Label htmlFor={path}>{label}</Label>
-        {schema.description && (
-          <p className="text-xs text-muted-foreground">{schema.description}</p>
-        )}
+      <div className="space-y-2">
+        <FieldLabel
+          htmlFor={path}
+          label={label}
+          description={schema.description}
+        />
         <Textarea
           id={path}
           value={strValue}
@@ -37,21 +59,25 @@ export function StringField({
 
   if (format === "color-input") {
     return (
-      <div className="space-y-1.5">
-        <Label htmlFor={path}>{label}</Label>
-        <div className="flex gap-2 items-center">
+      <div className="space-y-2">
+        <FieldLabel
+          htmlFor={path}
+          label={label}
+          description={schema.description}
+        />
+        <div className="flex items-center gap-2">
           <input
             type="color"
             value={strValue || "#000000"}
             onChange={(e) => onChange(e.target.value)}
-            className="h-8 w-8 rounded border cursor-pointer"
+            className="h-10 w-10 cursor-pointer rounded-lg border border-border bg-background p-1"
           />
           <Input
             id={path}
             value={strValue}
             onChange={(e) => onChange(e.target.value)}
             placeholder="#000000"
-            className="flex-1"
+            className="h-10 flex-1"
           />
         </div>
       </div>
@@ -59,11 +85,12 @@ export function StringField({
   }
 
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={path}>{label}</Label>
-      {schema.description && (
-        <p className="text-xs text-muted-foreground">{schema.description}</p>
-      )}
+    <div className="space-y-2">
+      <FieldLabel
+        htmlFor={path}
+        label={label}
+        description={schema.description}
+      />
       <Input
         id={path}
         type={format === "url" ? "url" : "text"}
@@ -72,6 +99,7 @@ export function StringField({
         placeholder={
           schema.default != null ? String(schema.default) : undefined
         }
+        className="h-10"
       />
     </div>
   );

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -135,11 +135,15 @@ export function SchemaForm({
   value,
   onChange,
   basePath,
+  breadcrumbPath = [],
+  onBreadcrumbChange,
 }: {
   schema: SchemaProperty;
   value: unknown;
   onChange: (value: unknown) => void;
   basePath: string;
+  breadcrumbPath?: string[];
+  onBreadcrumbChange?: (path: string[]) => void;
 }) {
   const properties = schema.properties;
   if (!properties) return null;
@@ -164,7 +168,7 @@ export function SchemaForm({
   };
 
   return (
-    <div className="space-y-4">
+    <div className="min-w-0 space-y-6">
       {keys.map((key) => {
         const propSchema = properties[key];
         if (!propSchema) return null;
@@ -177,6 +181,8 @@ export function SchemaForm({
           onChange: (val) => updateField(key, val),
           path: fieldPath,
           label,
+          breadcrumbPath,
+          onBreadcrumbChange,
         });
       })}
     </div>

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { ArrowLeft, Loading01 } from "@untitledui/icons";
+import { ChevronRight, Loading01 } from "@untitledui/icons";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import { toast } from "sonner";
@@ -345,12 +345,15 @@ export function SectionsEditor({
   virtualMcpId,
   branch,
   currentPath,
+  externalSelectedIndex,
   onSaved,
 }: {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
   currentPath: string;
+  /** Section index selected via click-through from the preview iframe. */
+  externalSelectedIndex?: number | null;
   /** Called after a successful auto-save so the parent can reload the preview. */
   onSaved?: () => void;
 }) {
@@ -370,11 +373,16 @@ export function SectionsEditor({
     null,
   );
   const [activeVariantIndex, setActiveVariantIndex] = useState(0);
+  const [prevExternalIdx, setPrevExternalIdx] = useState<
+    number | null | undefined
+  >(undefined);
   const [ruleFormValue, setRuleFormValue] = useState<Record<
     string,
     unknown
   > | null>(null);
   const [ruleResolveType, setRuleResolveType] = useState<string | null>(null);
+  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  const [formResetKey, setFormResetKey] = useState(0);
 
   // Reset form state when the active page changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -386,6 +394,8 @@ export function SectionsEditor({
     setActiveVariantIndex(0);
     setRuleFormValue(null);
     setRuleResolveType(null);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
   }
 
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
@@ -458,6 +468,29 @@ export function SectionsEditor({
     pageVariants,
     variantIndex: safeVariantIndex,
   };
+
+  // Auto-select section when parent signals a click-through from the preview.
+  if (
+    externalSelectedIndex !== undefined &&
+    externalSelectedIndex !== prevExternalIdx
+  ) {
+    setPrevExternalIdx(externalSelectedIndex ?? null);
+    if (typeof externalSelectedIndex === "number") {
+      const rawSection = rawSections[externalSelectedIndex];
+      const parsed = parsedSections[externalSelectedIndex];
+      if (rawSection && parsed) {
+        const unwrapped = unwrapSection(rawSection, parsed, decofile);
+        setSelectedSectionIndex(externalSelectedIndex);
+        if (!unwrapped) {
+          setFormValue(null);
+          setActiveResolveType(null);
+        } else {
+          setFormValue(unwrapped.data);
+          setActiveResolveType(unwrapped.resolveType);
+        }
+      }
+    }
+  }
 
   const activeSchema =
     activeResolveType && meta ? resolveSchema(activeResolveType, meta) : null;
@@ -569,6 +602,8 @@ export function SectionsEditor({
 
   const handleSelectSection = (index: number) => {
     setSelectedSectionIndex(index);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
     const rawSection = rawSections[index];
     const parsed = parsedSections[index];
     if (!rawSection || !parsed) return;
@@ -736,24 +771,70 @@ export function SectionsEditor({
       : null;
 
   const isEditing = activeSchema && formValue && selectedParsed;
+  const editingBreadcrumbs = isEditing
+    ? [activePage.name, selectedParsed.label, ...fieldBreadcrumbs]
+    : [];
+  const exitSectionEditing = () => {
+    setSelectedSectionIndex(null);
+    setFormValue(null);
+    setActiveResolveType(null);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+  };
+  const handleBreadcrumbClick = (index: number) => {
+    if (index === 0) {
+      exitSectionEditing();
+      return;
+    }
+
+    if (index === 1) {
+      setFieldBreadcrumbs([]);
+      setFormResetKey((key) => key + 1);
+      return;
+    }
+
+    setFieldBreadcrumbs(fieldBreadcrumbs.slice(0, index - 1));
+  };
 
   return (
     <div className="flex flex-col h-full">
       {/* Page header */}
       <div className="px-3 py-2.5 border-b shrink-0">
         {isEditing ? (
-          <button
-            type="button"
-            onClick={() => {
-              setSelectedSectionIndex(null);
-              setFormValue(null);
-              setActiveResolveType(null);
-            }}
-            className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <ArrowLeft className="h-3.5 w-3.5" />
-            <span>{activePage.name}</span>
-          </button>
+          <div className="flex min-w-0 items-center overflow-hidden">
+            <nav
+              aria-label="Editing breadcrumb"
+              className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
+            >
+              {editingBreadcrumbs.map((crumb, index) => {
+                const isLast = index === editingBreadcrumbs.length - 1;
+
+                return (
+                  <span
+                    key={`${crumb}-${index}`}
+                    className="flex min-w-0 items-center gap-1 overflow-hidden"
+                  >
+                    {index > 0 && (
+                      <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleBreadcrumbClick(index)}
+                      title={crumb}
+                      className={cn(
+                        "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                        isLast
+                          ? "font-medium text-foreground"
+                          : "text-muted-foreground",
+                      )}
+                    >
+                      {crumb}
+                    </button>
+                  </span>
+                );
+              })}
+            </nav>
+          </div>
         ) : (
           <PageHeaderInputs
             pageKey={activePageKey!}
@@ -776,6 +857,7 @@ export function SectionsEditor({
                 setSelectedSectionIndex(null);
                 setFormValue(null);
                 setActiveResolveType(null);
+                setFieldBreadcrumbs([]);
                 const variantRule = pageVariants[i]?.rule;
                 const variantRuleRt =
                   (variantRule?.__resolveType as string) ?? "";
@@ -804,14 +886,14 @@ export function SectionsEditor({
       {isEditing ? (
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-4">
-            <h2 className="text-sm font-semibold mb-4">
-              {selectedParsed.label}
-            </h2>
             <SchemaForm
+              key={formResetKey}
               schema={activeSchema}
               value={formValue}
               onChange={handleFormChange}
               basePath=""
+              breadcrumbPath={[]}
+              onBreadcrumbChange={setFieldBreadcrumbs}
             />
           </div>
         </ScrollArea>
@@ -820,8 +902,8 @@ export function SectionsEditor({
           {/* Variant rule editor */}
           {hasMultipleVariants && ruleResolveType !== null && (
             <div className="px-3 py-3 border-b space-y-2">
-              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Rule
+              <span className="text-xs font-medium text-muted-foreground">
+                Variant rule
               </span>
               <MatcherPicker
                 currentRt={ruleResolveType}

--- a/apps/mesh/src/web/components/vm/preview/cms-editor-script.ts
+++ b/apps/mesh/src/web/components/vm/preview/cms-editor-script.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+export const CmsEditorPayloadSchema = z.object({
+  sectionIndex: z.number(),
+  manifestKey: z.string(),
+});
+
+export type CmsEditorPayload = z.infer<typeof CmsEditorPayloadSchema>;
+
+/**
+ * Self-contained script injected into the preview iframe for CMS mode.
+ * Highlights full sections (elements with data-manifest-key) on hover
+ * and posts the section's DOM index back to the parent on click.
+ */
+export const CMS_EDITOR_SCRIPT = `(function() {
+  if (window.__cmsEditorActive) return;
+  window.__cmsEditorActive = true;
+
+  var highlight = document.createElement("div");
+  highlight.style.cssText = "position:fixed;pointer-events:none;outline:2px solid #06b6d4;background:rgba(6,182,212,0.06);border-radius:2px;z-index:2147483647;display:none;";
+  document.body.appendChild(highlight);
+
+  var badge = document.createElement("div");
+  badge.style.cssText = "position:fixed;pointer-events:none;background:#06b6d4;color:white;font:11px/1 monospace;padding:2px 6px;border-radius:2px;z-index:2147483647;display:none;white-space:nowrap;max-width:240px;overflow:hidden;text-overflow:ellipsis;";
+  document.body.appendChild(badge);
+
+  var findSection = function(el) {
+    var node = el;
+    while (node && node !== document.body) {
+      if (node.hasAttribute && node.hasAttribute("data-manifest-key")) return node;
+      node = node.parentElement;
+    }
+    return null;
+  };
+
+  var getAllSections = function() {
+    return Array.from(document.querySelectorAll("[data-manifest-key]"));
+  };
+
+  var lastSection = null;
+  var rafPending = false;
+
+  var moveHandler = function(e) {
+    if (rafPending) return;
+    rafPending = true;
+    var target = e.target;
+    requestAnimationFrame(function() {
+      rafPending = false;
+      if (!target || target === highlight || target === badge) return;
+      var section = findSection(target);
+      if (section === lastSection) return;
+      lastSection = section;
+      if (!section) {
+        highlight.style.display = "none";
+        badge.style.display = "none";
+        return;
+      }
+      var r = section.getBoundingClientRect();
+      highlight.style.display = "block";
+      highlight.style.top = r.top + "px";
+      highlight.style.left = r.left + "px";
+      highlight.style.width = r.width + "px";
+      highlight.style.height = r.height + "px";
+      badge.textContent = section.getAttribute("data-manifest-key") || "section";
+      badge.style.display = "block";
+      badge.style.top = Math.max(0, r.top - 20) + "px";
+      badge.style.left = r.left + "px";
+    });
+  };
+  document.addEventListener("mousemove", moveHandler, true);
+
+  var outHandler = function(e) {
+    if (!e.relatedTarget || e.relatedTarget === document.documentElement) {
+      highlight.style.display = "none";
+      badge.style.display = "none";
+      lastSection = null;
+    }
+  };
+  document.addEventListener("mouseout", outHandler, true);
+
+  var clickHandler = function(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    var target = e.target;
+    if (!target || target === highlight || target === badge) return;
+    var section = findSection(target);
+    if (!section) return;
+
+    var sections = getAllSections();
+    var sectionIndex = sections.indexOf(section);
+    var manifestKey = section.getAttribute("data-manifest-key") || "";
+
+    highlight.style.outline = "2px solid #06b6d4";
+    highlight.style.background = "rgba(6,182,212,0.18)";
+    setTimeout(function() {
+      highlight.style.background = "rgba(6,182,212,0.06)";
+    }, 400);
+
+    window.parent.postMessage({
+      type: "cms-editor::section-clicked",
+      payload: { sectionIndex: sectionIndex, manifestKey: manifestKey }
+    }, "*");
+  };
+  document.addEventListener("click", clickHandler, true);
+
+  window.addEventListener("message", function(e) {
+    if (e.data && e.data.type === "cms-editor::deactivate") {
+      highlight.remove();
+      badge.remove();
+      document.removeEventListener("mousemove", moveHandler, true);
+      document.removeEventListener("mouseout", outHandler, true);
+      document.removeEventListener("click", clickHandler, true);
+      window.__cmsEditorActive = false;
+    }
+  });
+})();`;

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -15,8 +15,8 @@ import {
   Code02,
   CursorClick01,
   DotsHorizontal,
-  TextInput,
   LinkExternal01,
+  TextInput,
   Loading01,
   Monitor04,
   RefreshCw01,
@@ -47,6 +47,7 @@ import {
   VisualEditorPayloadSchema,
   type VisualEditorPayload,
 } from "./visual-editor-script";
+import { CMS_EDITOR_SCRIPT, CmsEditorPayloadSchema } from "./cms-editor-script";
 import { VisualEditorPrompt } from "./visual-editor-prompt";
 import { useVmEvents, useVmReloadHandler } from "../hooks/use-vm-events";
 import {
@@ -99,17 +100,7 @@ function drawerStatusFromPreview(
   return "idle";
 }
 
-type PreviewViewMode = "preview" | "visual" | "code";
-
-const VIEW_MODE_OPTIONS: ViewModeOption<PreviewViewMode>[] = [
-  { value: "preview", icon: <Monitor04 size={14} />, tooltip: "Interactive" },
-  {
-    value: "visual",
-    icon: <CursorClick01 size={14} />,
-    tooltip: "Visual Editor",
-  },
-  { value: "code", icon: <Code02 size={14} />, tooltip: "Code Editor" },
-];
+type PreviewViewMode = "preview" | "visual" | "cms" | "code";
 
 export function PreviewContent() {
   const inset = useInsetContext();
@@ -123,7 +114,14 @@ export function PreviewContent() {
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
 
   // Sections editor panel
-  const [sectionsOpen, setSectionsOpen] = useState(false);
+  const sectionsOpen = viewMode === "cms";
+  const [cmsSelectedSectionIndex, setCmsSelectedSectionIndex] = useState<
+    number | null
+  >(null);
+  const [panelWidth, setPanelWidth] = useState(384);
+  const isResizingRef = useRef(false);
+  const resizeStartXRef = useRef(0);
+  const resizeStartWidthRef = useRef(0);
   // Tracks the last focused element outside the iframe so we can restore it
   // when the iframe reload steals focus.
   const focusBeforeIframeRef = useRef<HTMLElement | null>(null);
@@ -153,6 +151,7 @@ export function PreviewContent() {
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
     : [];
+  const currentPageName = pages.find((p) => p.path === currentPath)?.name;
 
   // "reload" fires on config edits framework HMR won't catch (.ts/.tsx use HMR).
   const vmEvents = useVmEvents();
@@ -388,10 +387,13 @@ export function PreviewContent() {
     }
     const handler = (e: MessageEvent) => {
       if (e.origin !== allowedOrigin) return;
-      if (e.data?.type !== "visual-editor::element-clicked") return;
-      const result = VisualEditorPayloadSchema.safeParse(e.data.payload);
-      if (result.success) {
-        setVisualElement(result.data);
+      if (e.data?.type === "visual-editor::element-clicked") {
+        const result = VisualEditorPayloadSchema.safeParse(e.data.payload);
+        if (result.success) setVisualElement(result.data);
+      } else if (e.data?.type === "cms-editor::section-clicked") {
+        const result = CmsEditorPayloadSchema.safeParse(e.data.payload);
+        if (result.success)
+          setCmsSelectedSectionIndex(result.data.sectionIndex);
       }
     };
     window.addEventListener("message", handler);
@@ -466,14 +468,30 @@ export function PreviewContent() {
     win.postMessage({ type: "visual-editor::deactivate" }, "*");
   };
 
+  const injectCmsEditor = () => {
+    const win = previewIframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage(
+      { type: "visual-editor::activate", script: CMS_EDITOR_SCRIPT },
+      "*",
+    );
+  };
+
+  const deactivateCmsEditor = () => {
+    const win = previewIframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage({ type: "cms-editor::deactivate" }, "*");
+  };
+
   const handleViewModeChange = (mode: PreviewViewMode) => {
+    const prev = viewMode;
     setViewMode(mode);
     setVisualElement(null);
-    if (mode === "visual") {
-      injectVisualEditor();
-    } else {
-      deactivateVisualEditor();
-    }
+    if (mode !== "cms") setCmsSelectedSectionIndex(null);
+    if (prev === "visual") deactivateVisualEditor();
+    if (prev === "cms") deactivateCmsEditor();
+    if (mode === "visual") injectVisualEditor();
+    if (mode === "cms") injectCmsEditor();
   };
 
   const handleRefresh = () => {
@@ -507,34 +525,39 @@ export function PreviewContent() {
     }
   })();
 
+  const viewModeOptions: ViewModeOption<PreviewViewMode>[] = [
+    { value: "preview", icon: <Monitor04 size={14} />, tooltip: "Interactive" },
+    {
+      value: "visual",
+      icon: <CursorClick01 size={14} />,
+      tooltip: "Visual editor",
+    },
+    ...(pages.length > 0
+      ? [
+          {
+            value: "cms" as PreviewViewMode,
+            icon: <TextInput size={14} />,
+            tooltip: "Sections editor",
+          },
+        ]
+      : []),
+    { value: "code", icon: <Code02 size={14} />, tooltip: "Code editor" },
+  ];
+
   return (
     <div className="flex flex-col w-full h-full">
       {previewState.kind === "iframe" && (
         <div className="flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
-          {/* Group 1: view mode toggle + sections */}
+          {/* Group 1: view mode toggle */}
           <div className="flex shrink-0 items-center gap-1">
             {hasHtmlPreview && (
               <ViewModeToggle
                 value={viewMode}
                 onValueChange={handleViewModeChange}
-                options={VIEW_MODE_OPTIONS}
+                options={viewModeOptions}
                 size="sm"
                 className="shrink-0 bg-foreground/4.5"
               />
-            )}
-            {pages.length > 0 && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant={sectionsOpen ? "secondary" : "ghost"}
-                    size="icon"
-                    onClick={() => setSectionsOpen((prev) => !prev)}
-                  >
-                    <TextInput size={14} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Sections Editor</TooltipContent>
-              </Tooltip>
             )}
           </div>
 
@@ -593,6 +616,11 @@ export function PreviewContent() {
                 <span className="min-w-0 flex-1 truncate text-left text-[12px] text-foreground/88">
                   {previewLabel}
                 </span>
+                {currentPageName && (
+                  <span className="shrink-0 text-[12px] text-muted-foreground">
+                    {currentPageName}
+                  </span>
+                )}
                 {pages.length > 0 && (
                   <ChevronDown
                     size={12}
@@ -727,54 +755,82 @@ export function PreviewContent() {
       <div className="flex-1 flex overflow-hidden">
         {/* Sections editor side panel (left) */}
         {sectionsOpen && previewUrl && branch && virtualMcpId && (
-          <div className="w-96 shrink-0 border-r overflow-hidden">
-            <Suspense
-              fallback={
-                <div className="h-full flex items-center justify-center">
-                  <Loading01
-                    size={20}
-                    className="animate-spin text-muted-foreground"
-                  />
-                </div>
-              }
+          <>
+            <div
+              className="shrink-0 border-r overflow-hidden"
+              style={{ width: panelWidth }}
             >
-              <SectionsEditor
-                orgSlug={org.slug}
-                virtualMcpId={virtualMcpId}
-                branch={branch}
-                currentPath={currentPath}
-                onSaved={() => {
-                  setTimeout(() => {
-                    const iframe = previewIframeRef.current;
-                    if (!iframe) return;
-                    // Prevent iframe from stealing focus during reload
-                    const focused =
-                      document.activeElement as HTMLElement | null;
-                    const prevTabIndex = iframe.tabIndex;
-                    iframe.tabIndex = -1;
-                    iframe.style.pointerEvents = "none";
-                    iframe.blur();
-                    try {
-                      iframe.contentWindow?.location.reload();
-                    } catch {
-                      // Cross-origin fallback
-                      // biome-ignore lint/correctness/noSelfAssign: reloads the iframe
-                      // oxlint-disable-next-line no-self-assign
-                      iframe.src = iframe.src;
-                    }
-                    const restore = () => {
-                      iframe.tabIndex = prevTabIndex;
-                      iframe.style.pointerEvents = "";
-                      focused?.focus();
-                      iframe.removeEventListener("load", restore);
-                    };
-                    iframe.addEventListener("load", restore);
-                    setTimeout(restore, 3000);
-                  }, DEV_SERVER_SETTLE_MS);
-                }}
-              />
-            </Suspense>
-          </div>
+              <Suspense
+                fallback={
+                  <div className="h-full flex items-center justify-center">
+                    <Loading01
+                      size={20}
+                      className="animate-spin text-muted-foreground"
+                    />
+                  </div>
+                }
+              >
+                <SectionsEditor
+                  orgSlug={org.slug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  currentPath={currentPath}
+                  externalSelectedIndex={cmsSelectedSectionIndex}
+                  onSaved={() => {
+                    setTimeout(() => {
+                      const iframe = previewIframeRef.current;
+                      if (!iframe) return;
+                      // Prevent iframe from stealing focus during reload
+                      const focused =
+                        document.activeElement as HTMLElement | null;
+                      const prevTabIndex = iframe.tabIndex;
+                      iframe.tabIndex = -1;
+                      iframe.style.pointerEvents = "none";
+                      iframe.blur();
+                      try {
+                        iframe.contentWindow?.location.reload();
+                      } catch {
+                        // Cross-origin fallback
+                        // biome-ignore lint/correctness/noSelfAssign: reloads the iframe
+                        // oxlint-disable-next-line no-self-assign
+                        iframe.src = iframe.src;
+                      }
+                      const restore = () => {
+                        iframe.tabIndex = prevTabIndex;
+                        iframe.style.pointerEvents = "";
+                        focused?.focus();
+                        iframe.removeEventListener("load", restore);
+                      };
+                      iframe.addEventListener("load", restore);
+                      setTimeout(restore, 3000);
+                    }, DEV_SERVER_SETTLE_MS);
+                  }}
+                />
+              </Suspense>
+            </div>
+            <div
+              className="w-1 shrink-0 cursor-col-resize bg-transparent hover:bg-border transition-colors"
+              onPointerDown={(e) => {
+                isResizingRef.current = true;
+                resizeStartXRef.current = e.clientX;
+                resizeStartWidthRef.current = panelWidth;
+                e.currentTarget.setPointerCapture(e.pointerId);
+              }}
+              onPointerMove={(e) => {
+                if (!isResizingRef.current) return;
+                const delta = e.clientX - resizeStartXRef.current;
+                setPanelWidth(
+                  Math.max(
+                    240,
+                    Math.min(640, resizeStartWidthRef.current + delta),
+                  ),
+                );
+              }}
+              onPointerUp={() => {
+                isResizingRef.current = false;
+              }}
+            />
+          </>
         )}
 
         <div className="flex-1 relative overflow-hidden">
@@ -913,9 +969,8 @@ export function PreviewContent() {
                 } catch {
                   // Cross-origin — can't read, keep current value
                 }
-                if (viewMode === "visual") {
-                  injectVisualEditor();
-                }
+                if (viewMode === "visual") injectVisualEditor();
+                if (viewMode === "cms") injectCmsEditor();
               }}
             />
           )}

--- a/packages/sandbox/daemon/process/pty-spawn.ts
+++ b/packages/sandbox/daemon/process/pty-spawn.ts
@@ -28,6 +28,7 @@
  */
 
 import fs from "node:fs";
+import { spawn as nodeSpawn } from "node:child_process";
 import { spawn as ptySpawn } from "node-pty";
 
 export interface PtyHandle {
@@ -110,7 +111,16 @@ export function spawnPty(opts: PtySpawnOpts): PtyHandle {
       }
     }
   }
-  if (lastErr) throw lastErr;
+  if (lastErr) {
+    // node-pty prebuilt binaries may not run on very new OS versions (e.g.
+    // macOS 26 / Darwin 25+). Fall back to a plain child_process.spawn so
+    // setup steps (clone/install) still work — color/progress output is lost
+    // but all data and exit-code semantics are preserved.
+    if ((lastErr as Error).message?.includes("posix_spawnp")) {
+      return spawnFallback(opts);
+    }
+    throw lastErr;
+  }
 
   const pid = raw.pid;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -214,6 +224,64 @@ export function spawnPty(opts: PtySpawnOpts): PtyHandle {
     },
     kill(signal) {
       raw.kill(signal);
+    },
+  };
+}
+
+function spawnFallback(opts: PtySpawnOpts): PtyHandle {
+  const baseEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (typeof v === "string") baseEnv[k] = v;
+  }
+  const overrideEnv: Record<string, string> = {};
+  if (opts.env) {
+    for (const [k, v] of Object.entries(opts.env)) {
+      if (typeof v === "string") overrideEnv[k] = v;
+    }
+  }
+
+  const spawnOpts: Parameters<typeof nodeSpawn>[2] = {
+    cwd: opts.cwd ?? process.cwd(),
+    env: { TERM: "xterm-256color", ...baseEnv, ...overrideEnv },
+    ...(typeof opts.uid === "number" ? { uid: opts.uid } : {}),
+    ...(typeof opts.gid === "number" ? { gid: opts.gid } : {}),
+  };
+
+  const child = nodeSpawn("sh", ["-c", opts.cmd], spawnOpts);
+  const dataListeners: Array<(data: string) => void> = [];
+  const exitListeners: Array<(exitCode: number) => void> = [];
+
+  const emit = (chunk: Buffer | string) => {
+    const str = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    for (const l of dataListeners) l(str);
+  };
+  child.stdout?.on("data", emit);
+  child.stderr?.on("data", emit);
+
+  child.on("exit", (code, signal) => {
+    // Map signal name to number via kill -l convention (best-effort).
+    const sigMap: Record<string, number> = {
+      SIGHUP: 1,
+      SIGINT: 2,
+      SIGQUIT: 3,
+      SIGKILL: 9,
+      SIGTERM: 15,
+    };
+    const sigNum = signal ? (sigMap[signal] ?? 1) : 0;
+    const exitCode = sigNum > 0 ? 128 + sigNum : (code ?? 0);
+    for (const l of exitListeners) l(exitCode);
+  });
+
+  return {
+    pid: child.pid ?? -1,
+    onData: (cb) => {
+      dataListeners.push(cb);
+    },
+    onExit: (cb) => {
+      exitListeners.push(cb);
+    },
+    kill: (signal) => {
+      child.kill((signal ?? "SIGHUP") as NodeJS.Signals);
     },
   };
 }

--- a/packages/ui/src/components/view-mode-toggle.tsx
+++ b/packages/ui/src/components/view-mode-toggle.tsx
@@ -19,7 +19,7 @@ type ViewModeSize = "sm" | "md" | "lg";
 interface ViewModeToggleProps<T extends string = string> {
   value: T;
   onValueChange: (value: T) => void;
-  options: ViewModeOption<T>[];
+  options: Array<ViewModeOption<T>>;
   size?: ViewModeSize;
   fullWidth?: boolean;
   className?: string;
@@ -48,28 +48,24 @@ export function ViewModeToggle<T extends string = string>({
   fullWidth = false,
   className,
 }: ViewModeToggleProps<T>) {
-  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+  const buttonRefsRef = useRef<(HTMLButtonElement | null)[]>([]);
   const [indicatorPosition, setIndicatorPosition] = useState({
     left: 0,
     width: 0,
     opacity: 0,
   });
 
-  const updateIndicator = (index: number) => {
-    const el = refs.current[index];
+  // Initialize indicator position based on current value
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    const idx = options.findIndex((o) => o.value === value);
+    const el = buttonRefsRef.current[idx];
     if (!el) return;
     setIndicatorPosition({
       left: el.offsetLeft,
       width: el.offsetWidth,
       opacity: 1,
     });
-  };
-
-  // Initialize indicator position based on current value
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect
-  useEffect(() => {
-    const idx = options.findIndex((o) => o.value === value);
-    if (idx >= 0) updateIndicator(idx);
   }, [value, options]);
 
   const config = sizeConfig[size];
@@ -80,7 +76,7 @@ export function ViewModeToggle<T extends string = string>({
         const btn = (
           <button
             ref={(el) => {
-              refs.current[i] = el;
+              buttonRefsRef.current[i] = el;
             }}
             key={option.value}
             type="button"


### PR DESCRIPTION
## What is this contribution about?
This updates the CMS sections editor with a clearer breadcrumb-driven navigation model, drill-in array editing, inline object disclosure styling, and width-safe form rows. It also adds CMS preview section picking, allows the shared view-mode toggle to support more than two modes, and falls back to child_process spawning when node-pty cannot start on newer macOS/Darwin environments.

## Screenshots/Demonstration
UI changes affect the preview CMS sections editor and were reviewed from the attached Conductor screenshots during implementation.

## How to Test
1. Run `bun run fmt`.
2. Run `bun run check`.
3. Open a preview with editable sections, switch to the sections editor, click sections/items/nested objects, and confirm breadcrumbs navigate without duplicated body titles or horizontal overflow.

## Migration Notes
No database migrations or configuration changes required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the CMS sections editor with breadcrumb-driven drill-in editing and a resizable side panel. Adds a new CMS view mode that highlights full sections in the preview and selects them on click, plus a safe fallback when `node-pty` fails on newer macOS.

- **New Features**
  - Breadcrumb header shows page > section > nested field path; crumbs are clickable to step back.
  - Drill-in editing for arrays/objects with labeled item list, inline actions, count badges, and consistent field UI (labels/descriptions, 40px inputs, better image preview and color input).
  - New “CMS” view in `ViewModeToggle`: opens the sections panel, injects a preview highlighter for `[data-manifest-key]`, and syncs click-to-select with the editor; panel is resizable by drag.

- **Bug Fixes**
  - Fall back to `child_process.spawn` when `node-pty` fails with newer Darwin versions, preserving setup flows.
  - Prevent duplicated titles and horizontal overflow in the sections editor UI.

<sup>Written for commit 7d7a9ef91a73c76ca27fe185c9e055ad10b57906. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3410?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

