### PR TITLE
fix(sandbox): scrub legacy freestyle entries from vmMap

### DIFF
--- a/apps/mesh/migrations/079-strip-legacy-freestyle-vm-map-entries.ts
+++ b/apps/mesh/migrations/079-strip-legacy-freestyle-vm-map-entries.ts
@@ -1,0 +1,96 @@
+/**
+ * Scrub legacy vmMap entries with retired runnerKinds.
+ *
+ * PR #3411 (`refactor(sandbox): remove freestyle runner`) narrowed
+ * `RunnerKind` from `"host" | "docker" | "agent-sandbox" | "freestyle"` to
+ * `"host" | "docker" | "agent-sandbox"` and tightened the `VmMapEntrySchema`
+ * accordingly. VMs started before the cutover left
+ * `connections.metadata.vmMap[userId][branch].runnerKind = "freestyle"`
+ * rows in the DB. `COLLECTION_VIRTUAL_MCP_LIST` validates its output
+ * against the new schema, so those rows now make the whole list call
+ * fail with `MCP error -32602: Output validation error`.
+ *
+ * The freestyle runner is gone, so the freestyle entries can never be
+ * resumed or torn down — match PR #3411's "skip teardown" intent by
+ * deleting them. User buckets that become empty are dropped too, since
+ * `readVmMap` treats a missing user the same as an empty one.
+ *
+ * Defined-by-omission entries (no `runnerKind` field at all) are left
+ * alone: the schema accepts them via `.optional()`.
+ */
+import { type Kysely, sql } from "kysely";
+
+const VALID_RUNNER_KINDS = new Set(["host", "docker", "agent-sandbox"]);
+
+type VmEntry = { runnerKind?: unknown } & Record<string, unknown>;
+type UserMap = Record<string, VmEntry>;
+type VmMap = Record<string, UserMap>;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const result = await sql<{ id: string; metadata: string | null }>`
+    SELECT id, metadata FROM "connections"
+    WHERE connection_type = 'VIRTUAL'
+      AND metadata IS NOT NULL
+      AND metadata LIKE '%vmMap%'
+  `.execute(db);
+
+  for (const row of result.rows) {
+    if (!row.metadata) continue;
+
+    let meta: Record<string, unknown>;
+    try {
+      meta = JSON.parse(row.metadata);
+    } catch {
+      continue;
+    }
+
+    const vmMap = meta.vmMap;
+    if (!vmMap || typeof vmMap !== "object") continue;
+
+    let changed = false;
+    const nextVmMap: VmMap = {};
+
+    for (const [userId, userMap] of Object.entries(vmMap as VmMap)) {
+      if (!userMap || typeof userMap !== "object") {
+        changed = true;
+        continue;
+      }
+
+      const nextUserMap: UserMap = {};
+      for (const [branch, entry] of Object.entries(userMap)) {
+        if (!entry || typeof entry !== "object") {
+          changed = true;
+          continue;
+        }
+        const kind = (entry as VmEntry).runnerKind;
+        if (kind !== undefined && !VALID_RUNNER_KINDS.has(kind as string)) {
+          changed = true;
+          continue;
+        }
+        nextUserMap[branch] = entry;
+      }
+
+      if (Object.keys(nextUserMap).length > 0) {
+        nextVmMap[userId] = nextUserMap;
+      } else {
+        changed = true;
+      }
+    }
+
+    if (!changed) continue;
+
+    meta.vmMap = nextVmMap;
+    const updated = JSON.stringify(meta);
+
+    await sql`
+      UPDATE "connections"
+      SET metadata = ${updated}
+      WHERE id = ${row.id}
+    `.execute(db);
+  }
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // No-op: the deleted entries pointed at a runner that no longer exists,
+  // so there is nothing meaningful to restore.
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -77,6 +77,7 @@ import * as migration075threadinflightasyncjobs from "./075-thread-inflight-asyn
 import * as migration076automationsdropagentjson from "./076-automations-drop-agent-json.ts";
 import * as migration077tieronlymodelselection from "./077-tier-only-model-selection.ts";
 import * as migration078automationtoolcallkind from "./078-automation-tool-call-kind.ts";
+import * as migration079striplegacyfreestylevmmapentries from "./079-strip-legacy-freestyle-vm-map-entries.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -169,6 +170,8 @@ const migrations: Record<string, Migration> = {
   "076-automations-drop-agent-json": migration076automationsdropagentjson,
   "077-tier-only-model-selection": migration077tieronlymodelselection,
   "078-automation-tool-call-kind": migration078automationtoolcallkind,
+  "079-strip-legacy-freestyle-vm-map-entries":
+    migration079striplegacyfreestylevmmapentries,
 };
 
 export default migrations;


### PR DESCRIPTION
## What is this contribution about?

PR #3411 (`refactor(sandbox): remove freestyle runner`) narrowed `RunnerKind` to `host | docker | agent-sandbox`, but legacy VMs started under the old runner still have `connections.metadata.vmMap[user][branch].runnerKind = "freestyle"` persisted. `COLLECTION_VIRTUAL_MCP_LIST` now fails output validation against the tightened `VmMapEntrySchema`, returning `MCP error -32602` and breaking the VM list UI. This migration walks every VIRTUAL connection's `vmMap`, drops entries whose `runnerKind` is outside the new enum, prunes empty user buckets, and leaves entries with no `runnerKind` untouched (the schema makes the field `.optional()`, matching PR #3411's "skip teardown" intent for pre-runnerKind entries).

## How to Test

1. Seed a VIRTUAL connection whose `metadata.vmMap[someUser][someBranch].runnerKind = "freestyle"` (or just reproduce against a DB that already has them).
2. Call `COLLECTION_VIRTUAL_MCP_LIST` — confirm it fails with the validation error described above.
3. Run `bun run --cwd=apps/mesh migrate`.
4. Call `COLLECTION_VIRTUAL_MCP_LIST` again — expected: no validation error, and the offending freestyle entries are gone from the row's metadata. Entries with valid runnerKinds and entries with no runnerKind at all are preserved.

## Migration Notes

Adds `apps/mesh/migrations/079-strip-legacy-freestyle-vm-map-entries.ts`. Run with `bun run --cwd=apps/mesh migrate`. `down()` is intentionally a no-op — the deleted entries pointed at a runner that no longer exists in the code.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs legacy `freestyle` entries from VIRTUAL connection `vmMap` to fix validation errors and restore the VM list UI. Adds a migration that removes invalid `runnerKind` records and prunes empty buckets while preserving entries with no `runnerKind`.

- **Bug Fixes**
  - Drop `vmMap` entries where `runnerKind` is not `host`, `docker`, or `agent-sandbox` to satisfy `VmMapEntrySchema` and stop `MCP -32602` in `COLLECTION_VIRTUAL_MCP_LIST`.
  - Prune empty user buckets; keep entries missing `runnerKind`.

- **Migration**
  - Added `apps/mesh/migrations/079-strip-legacy-freestyle-vm-map-entries.ts` and wired it in `apps/mesh/migrations/index.ts`.
  - Run with: `bun run --cwd=apps/mesh migrate`. `down()` is a no-op.

<sup>Written for commit bc15151ac032b556a17379a3881b6392a2fb6b47. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

