### PR TITLE
feat(helm/studio): add opt-in ExternalSecret support for AWS Secrets Manager

### DIFF
--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -179,6 +179,18 @@ Validate OTel collector/S3 configuration.
 {{- end }}
 
 {{/*
+Validates ExternalSecret configuration.
+*/}}
+{{- define "chart-deco-studio.validateExternalSecret" -}}
+{{- if and .Values.externalSecret.enabled .Values.secret.secretName }}
+{{- fail "chart-deco-studio: externalSecret.enabled=true and secret.secretName are mutually exclusive — remove secret.secretName when using ExternalSecret" -}}
+{{- end }}
+{{- if and .Values.externalSecret.enabled (not .Values.externalSecret.secretPath) }}
+{{- fail "chart-deco-studio: externalSecret.secretPath is required when externalSecret.enabled=true" -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Formats OTEL headers map as key=value,key2=value2 format.
 */}}
 {{- define "chart-deco-studio.otelHeaders" -}}

--- a/deploy/helm/studio/templates/externalsecret.yaml
+++ b/deploy/helm/studio/templates/externalsecret.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.externalSecret.enabled }}
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: {{ .Values.externalSecret.secretStoreName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart-deco-studio.labels" . | nindent 4 }}
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: {{ .Values.externalSecret.provider.aws.region }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart-deco-studio.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStoreName }}
+    kind: SecretStore
+  target:
+    name: {{ include "chart-deco-studio.secretName" . }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: {{ required "externalSecret.secretPath is required when externalSecret.enabled=true" .Values.externalSecret.secretPath }}
+{{- end }}

--- a/deploy/helm/studio/templates/externalsecret.yaml
+++ b/deploy/helm/studio/templates/externalsecret.yaml
@@ -26,10 +26,10 @@ spec:
     name: {{ .Values.externalSecret.secretStoreName }}
     kind: SecretStore
   target:
-    name: {{ include "chart-deco-studio.secretName" . }}
+    name: {{ include "chart-deco-studio.fullname" . }}-secrets
     creationPolicy: Owner
     deletionPolicy: Retain
   dataFrom:
     - extract:
-        key: {{ required "externalSecret.secretPath is required when externalSecret.enabled=true" .Values.externalSecret.secretPath }}
+        key: {{ .Values.externalSecret.secretPath }}
 {{- end }}

--- a/deploy/helm/studio/templates/secret.yaml
+++ b/deploy/helm/studio/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secret.secretName }}
+{{- if and (not .Values.secret.secretName) (not .Values.externalSecret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/studio/templates/validations.yaml
+++ b/deploy/helm/studio/templates/validations.yaml
@@ -3,4 +3,5 @@ This file only runs chart-level validations and renders no resources.
 */ -}}
 {{- include "chart-deco-studio.validate" . -}}
 {{- include "chart-deco-studio.validateOtel" . -}}
+{{- include "chart-deco-studio.validateExternalSecret" . -}}
 

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -74,6 +74,20 @@ secret:
   # Generate with: openssl rand -base64 32
   ENCRYPTION_KEY: ""
 
+# ExternalSecret — pull all values from AWS Secrets Manager via external-secrets operator.
+# When enabled, creates a namespace-scoped SecretStore and an ExternalSecret using dataFrom
+# so every key in the SM JSON becomes an env var automatically.
+# Requires: external-secrets operator installed on the cluster.
+# Incompatible with: secret.secretName (both reference the same target Secret name).
+externalSecret:
+  enabled: false
+  # secretPath: ""  # Required when enabled. SM secret key path.
+  secretStoreName: "aws-secrets-manager"
+  refreshInterval: "1h"
+  provider:
+    aws:
+      region: "sa-east-1"
+
 volumes: []
 # - name: foo
 #   secret:


### PR DESCRIPTION
## Summary

- New template `templates/externalsecret.yaml`: when `externalSecret.enabled=true`, creates a namespace-scoped `SecretStore` and an `ExternalSecret` using `dataFrom` — imports all keys from the Secrets Manager JSON at once, no per-key listing required
- `templates/secret.yaml`: updated condition to skip inline Secret creation when `externalSecret.enabled=true`
- `values.yaml`: new `externalSecret` block, disabled by default (`enabled: false`)

**Backward compatible** — existing deployments are unaffected unless `externalSecret.enabled=true` is explicitly set.

## Usage

```yaml
externalSecret:
  enabled: true
  secretPath: "your/secret/path"
  secretStoreName: "aws-secrets-manager"
  refreshInterval: "1h"
  provider:
    aws:
      region: "us-east-1"
```

## Test plan

- [ ] Deploy with `externalSecret.enabled=true` and verify the `ExternalSecret` syncs and the Secret is created correctly
- [ ] Verify that deploys without `externalSecret.enabled` continue to work as before