### PR TITLE
fix(sandbox): stop base64-encoding proxy body and fix open-in-new-tab path

### DIFF
--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -113,8 +113,6 @@ async function proxyDaemon(
   daemonPath: string,
   opts?: {
     method?: "GET" | "POST" | "PUT";
-    /** When true, base64-encode the raw request body (Cloudflare WAF bypass). */
-    encodeBody?: boolean;
     forwardJsonBody?: boolean;
     signal?: AbortSignal;
     /** Map 404 to 410 (sandbox needs re-provision). */
@@ -129,11 +127,7 @@ async function proxyDaemon(
   let body: string | null = null;
   const headers = new Headers();
 
-  if (opts?.encodeBody) {
-    const rawBody = await c.req.text();
-    body = Buffer.from(rawBody, "utf-8").toString("base64");
-    headers.set("content-type", "application/json");
-  } else if (opts?.forwardJsonBody) {
+  if (opts?.forwardJsonBody) {
     body = await c.req.text();
     headers.set("content-type", "application/json");
   }
@@ -198,10 +192,10 @@ export const createVmRoutes = () => {
 
   // -- File write/read (base64-encoded body) --------------------------------
   app.post("/:vmId/:branch/write", (c) =>
-    proxyDaemon(c, "/_decopilot_vm/write", { encodeBody: true }),
+    proxyDaemon(c, "/_decopilot_vm/write", { forwardJsonBody: true }),
   );
   app.post("/:vmId/:branch/read", (c) =>
-    proxyDaemon(c, "/_decopilot_vm/read", { encodeBody: true }),
+    proxyDaemon(c, "/_decopilot_vm/read", { forwardJsonBody: true }),
   );
 
   // -- Script exec/kill -----------------------------------------------------

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -670,9 +670,19 @@ export function PreviewContent() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() =>
-                    window.open(previewState.previewUrl, "_blank", "noopener")
-                  }
+                  onClick={() => {
+                    let url = previewState.previewUrl;
+                    if (url && currentPath && currentPath !== "/") {
+                      try {
+                        const parsed = new URL(url);
+                        parsed.pathname = currentPath;
+                        url = parsed.href;
+                      } catch {
+                        // keep original url
+                      }
+                    }
+                    window.open(url, "_blank", "noopener");
+                  }}
                 >
                   <LinkExternal01 size={14} />
                 </Button>


### PR DESCRIPTION
## Summary
- **Fix sections-editor save error**: The freestyle runner removal (`8ac97c6c5`) changed the daemon body parser from base64-decoded JSON to plain `req.json()`, but `vm-proxy.ts` still base64-encoded the body for `/write` and `/read` routes, causing "Failed to parse body: Failed to parse JSON" on every save
- **Fix "Open in new tab" button**: Now includes the current pathname (e.g. `/institucional/sobre-nos`) instead of always opening the base preview URL

## Test plan
- [ ] Open sections editor, edit a section form field — save should succeed without "Failed to parse body" error
- [ ] Navigate to a subpage in the preview iframe, click "Open in new tab" — new tab should open with the current path, not the root URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sections-editor saves by sending plain JSON to the VM daemon, and updates “Open in new tab” to include the current preview path.

- **Bug Fixes**
  - `vm-proxy`: stop base64-encoding bodies for `/write` and `/read`; forward JSON with `content-type: application/json` to match the daemon parser and remove “Failed to parse body” errors.
  - Preview: “Open in new tab” now preserves the current pathname; falls back to the base URL if parsing fails.

<sup>Written for commit 855dfaeb3570a97bfd4dc9a747692750abf88e0f. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3419?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

