### PR TITLE
chore(helm): bump chart version to 0.7.0

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: A Helm chart for deco Studio self-hosted deployment
 type: application
-version: 0.6.6
+version: 0.7.0
 appVersion: "latest"
 
 dependencies:


### PR DESCRIPTION
Bumps the Helm chart version from `0.6.6` to `0.7.0`.

This release includes opt-in ExternalSecret support (merged in #3418), which is a backward-compatible new feature — a minor version bump per SemVer.

## Changes in this chart version

- `externalsecret.yaml`: new template — creates a namespace-scoped `SecretStore` + `ExternalSecret` when `externalSecret.enabled=true`, pulling all keys from AWS Secrets Manager via `dataFrom.extract`
- `secret.yaml`: skips inline Secret creation when `externalSecret.enabled=true`
- `_helpers.tpl`: added `chart-deco-studio.validateExternalSecret` — fails fast on misconfiguration (missing `secretPath`, conflict with `secret.secretName`)
- `validations.yaml`: wires in the new validation
- `values.yaml`: new `externalSecret` block (`enabled: false` by default — zero impact on existing deployments)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Helm chart to 0.7.0 to release opt-in ExternalSecret support for AWS Secrets Manager. Disabled by default and backward compatible.

- **New Features**
  - Opt-in `externalSecret` support (`externalSecret.enabled=true`) creating a namespace `SecretStore` and `ExternalSecret`.
  - Validation to catch misconfig (e.g., missing `secretPath` or conflicting `secret.secretName`) and skip inline Secret when ExternalSecret is enabled.

<sup>Written for commit 5b6e6d7be8bb6ec2462cf583067bf95fa81f8170. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3420?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

