### PR TITLE
fix(helm): allow externalSecret as valid DATABASE_URL source in postgres validation

### DIFF
--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -116,7 +116,7 @@ Global validations to ensure scaling requirements are met.
 {{- if and .Values.autoscaling.enabled (not (or $distributed $usesPostgres)) }}
 {{- fail "chart-deco-studio: autoscaling.enabled=true exige storage distribuído (persistence.distributed=true ou accessMode=ReadWriteMany) ou database.engine=postgresql" -}}
 {{- end }}
-{{- if and $usesPostgres (not .Values.database.url) (not .Values.secret.secretName) }}
+{{- if and $usesPostgres (not .Values.database.url) (not .Values.secret.secretName) (not .Values.externalSecret.enabled) }}
 {{- fail "chart-deco-studio: defina database.url quando database.engine=postgresql ou use secret.secretName para fornecer DATABASE_URL via Secret" -}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Problem

When `database.engine=postgresql` and `externalSecret.enabled=true`, the chart fails at render time:

```
chart-deco-studio: defina database.url quando database.engine=postgresql ou use secret.secretName para fornecer DATABASE_URL via Secret
```

The validation only accepted `database.url` or `secret.secretName` as valid sources for `DATABASE_URL`, ignoring the case where the value comes from AWS Secrets Manager via ExternalSecret.

## Fix

Added `externalSecret.enabled` as a third valid source. The check now passes when any of these is set:
- `database.url`
- `secret.secretName`
- `externalSecret.enabled: true`

Republishes chart `0.7.0` with the fix included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Helm chart validation to accept `externalSecret.enabled` as a valid `DATABASE_URL` source when `database.engine=postgresql`, preventing render failures for ExternalSecret setups (e.g., AWS Secrets Manager). The chart now renders without requiring `database.url` or `secret.secretName` when ExternalSecret is used.

<sup>Written for commit 78d378322177437c03df9dd2200ee31e5c4bd5fe. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3421?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

