### PR TITLE
chore(helm): update chart description to reflect ExternalSecret support

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: chart-deco-studio
-description: A Helm chart for deco Studio self-hosted deployment
+description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
 version: 0.7.0
 appVersion: "latest"


### PR DESCRIPTION
Updates `Chart.yaml` description to document the three supported secret modes.

This also retriggeres `publish-chart.yml` to republish `0.7.0` with the postgres validation fix from #3421 included (that PR only touched `_helpers.tpl`, so the publish workflow did not fire).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Helm chart description to list supported secret sources: inline values, external secretName, and AWS Secrets Manager via ExternalSecret. Also retriggers the chart publish for v0.7.0 so the latest Postgres validation fix is included.

<sup>Written for commit 6d0b0ca00caf93dfd8a51c33a27432e7515f9c3b. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3422?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

