### PR TITLE
chore(helm): bump chart version to 0.7.1

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "latest"
 
 dependencies:


### PR DESCRIPTION
Bumps chart to `0.7.1` to publish the fix from #3421 under a distinct version.

The fix allows `externalSecret.enabled=true` as a valid source for `DATABASE_URL` when `database.engine=postgresql`, preventing a false-positive validation failure at helm template time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps Helm chart `chart-deco-studio` to version 0.7.1 to publish the validation fix for `DATABASE_URL` sources. This version allows `externalSecret.enabled=true` with `database.engine=postgresql`, preventing a false-positive failure during `helm template`.

<sup>Written for commit 2f2ecec2cf5a60c882321f1c434f05bcf152976c. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3423?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

