### PR TITLE
feat(sandbox): add file explorer (code editor) view mode to preview panel

### DIFF
--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -197,6 +197,9 @@ export const createVmRoutes = () => {
   app.post("/:vmId/:branch/read", (c) =>
     proxyDaemon(c, "/_decopilot_vm/read", { forwardJsonBody: true }),
   );
+  app.post("/:vmId/:branch/glob", (c) =>
+    proxyDaemon(c, "/_decopilot_vm/glob", { forwardJsonBody: true }),
+  );
 
   // -- Script exec/kill -----------------------------------------------------
   app.post("/:vmId/:branch/exec/:script", (c) => {

--- a/apps/mesh/src/web/components/vm/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/vm/preview/file-explorer/file-explorer.tsx
@@ -12,6 +12,8 @@ import {
 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.js";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { useChatStream } from "@/web/components/chat/context";
+import { usePanelActions } from "@/web/layouts/shell-layout";
 import type { FileBuffer } from "./types";
 import {
   buildFileTree,
@@ -67,6 +69,16 @@ export function FileExplorer({
 
   // Editor ref for save
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+
+  // Ask AI inline prompt state
+  const [askAi, setAskAi] = useState<{
+    filePath: string;
+    lineStart: number;
+    lineEnd: number;
+    selectedCode: string;
+  } | null>(null);
+  const { sendMessage } = useChatStream();
+  const { setChatOpen } = usePanelActions();
 
   // Load file tree on first render
   const loadTreeCalledRef = useRef(false);
@@ -230,7 +242,48 @@ export function FileExplorer({
       const value = editor.getValue();
       await saveFile(selectedFile, value);
     });
+
+    // Ctrl+K / Cmd+K to open "Ask the AI" prompt
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK, () => {
+      const selection = editor.getSelection();
+      const model = editor.getModel();
+      if (!selection || !model || !selectedFile) return;
+      const selectedCode = model.getValueInRange(selection);
+      setAskAi({
+        filePath: selectedFile,
+        lineStart: selection.startLineNumber,
+        lineEnd: selection.endLineNumber,
+        selectedCode,
+      });
+    });
   };
+
+  function handleAskAiSend(prompt: string) {
+    if (!askAi) return;
+    const lines = [
+      `The user selected code in the file explorer and asked: **"${prompt.trim()}"**`,
+      "",
+      `**File:** \`${askAi.filePath}\``,
+      `**Lines:** ${askAi.lineStart}–${askAi.lineEnd}`,
+    ];
+    if (askAi.selectedCode) {
+      const lang = getLanguageFromPath(askAi.filePath);
+      lines.push(
+        "",
+        "**Selected code:**",
+        "```" + lang,
+        askAi.selectedCode,
+        "```",
+      );
+    }
+    lines.push(
+      "",
+      "Please read the source file, locate the code, and apply the requested change.",
+    );
+    setChatOpen(true);
+    sendMessage({ parts: [{ type: "text", text: lines.join("\n") }] });
+    setAskAi(null);
+  }
 
   if (loading && !treeLoaded) {
     return (
@@ -328,7 +381,7 @@ export function FileExplorer({
       </div>
 
       {/* Editor area */}
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="relative flex-1 flex flex-col overflow-hidden">
         {/* Tab bar */}
         {openTabs.length > 0 && (
           <div className="flex items-center border-b overflow-x-auto shrink-0">
@@ -375,6 +428,62 @@ export function FileExplorer({
                 </div>
               );
             })}
+          </div>
+        )}
+
+        {/* Ask AI inline prompt */}
+        {askAi && (
+          <div
+            className="absolute top-0 left-1/2 -translate-x-1/2 z-20 mt-2"
+            style={{ width: "360px" }}
+          >
+            <form
+              className="flex w-full items-center gap-1.5 rounded-xl border border-border bg-background/95 px-3 py-1.5 shadow-lg backdrop-blur"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const form = e.currentTarget;
+                const input = form.elements.namedItem(
+                  "askAiInput",
+                ) as HTMLInputElement;
+                if (input.value.trim()) {
+                  handleAskAiSend(input.value);
+                }
+              }}
+            >
+              <input
+                name="askAiInput"
+                autoFocus
+                type="text"
+                placeholder="Ask the AI..."
+                className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                onKeyDown={(e) => {
+                  e.stopPropagation();
+                  if (e.key === "Escape") setAskAi(null);
+                }}
+              />
+              <button
+                type="submit"
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-opacity"
+                title="Send"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 10 10"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <title>Send</title>
+                  <path
+                    d="M5 9V1M1 5l4-4 4 4"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </form>
           </div>
         )}
 

--- a/apps/mesh/src/web/components/vm/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/vm/preview/file-explorer/file-explorer.tsx
@@ -1,0 +1,458 @@
+import { useState, useRef } from "react";
+import Editor, { loader } from "@monaco-editor/react";
+import type { OnMount } from "@monaco-editor/react";
+import {
+  ChevronDown,
+  ChevronRight,
+  File06,
+  FolderClosed,
+  Loading01,
+  SearchSm,
+  XClose,
+} from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import type { FileBuffer } from "./types";
+import {
+  buildFileTree,
+  flattenTree,
+  getAncestorDirectories,
+  getLanguageFromPath,
+  stripLineNumbers,
+} from "./utils";
+
+// Configure Monaco CDN (shared with workflow editor)
+loader.config({
+  paths: {
+    vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs",
+  },
+});
+
+interface FileExplorerProps {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+function buildApiUrl(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  endpoint: string,
+) {
+  return `/api/${orgSlug}/vm/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${endpoint}`;
+}
+
+/** The daemon expects relative paths (no leading slash). */
+function toDaemonPath(treePath: string) {
+  return treePath.startsWith("/") ? treePath.slice(1) : treePath;
+}
+
+export function FileExplorer({
+  orgSlug,
+  virtualMcpId,
+  branch,
+}: FileExplorerProps) {
+  // File tree state
+  const [files, setFiles] = useState<string[]>([]);
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [openTabs, setOpenTabs] = useState<string[]>([]);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [treeLoaded, setTreeLoaded] = useState(false);
+
+  // File buffers: path -> { savedContent, editorValue, loaded }
+  const [buffers, setBuffers] = useState<Map<string, FileBuffer>>(new Map());
+
+  // Editor ref for save
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+
+  // Load file tree on first render
+  const loadTreeCalledRef = useRef(false);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot fetch trigger
+  if (!loadTreeCalledRef.current) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot fetch trigger
+    loadTreeCalledRef.current = true;
+    fetchFileTree();
+  }
+
+  async function fetchFileTree() {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        buildApiUrl(orgSlug, virtualMcpId, branch, "glob"),
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ pattern: "**/*" }),
+        },
+      );
+      if (!res.ok) return;
+      const data = (await res.json()) as { files?: string[] };
+      setFiles(data.files ?? []);
+      setTreeLoaded(true);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadFileContent(path: string) {
+    const existing = buffers.get(path);
+    if (existing?.loaded) return;
+
+    setBuffers((prev) => {
+      const next = new Map(prev);
+      next.set(path, { savedContent: "", editorValue: "", loaded: false });
+      return next;
+    });
+
+    try {
+      const res = await fetch(
+        buildApiUrl(orgSlug, virtualMcpId, branch, "read"),
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ path: toDaemonPath(path) }),
+        },
+      );
+      if (!res.ok) return;
+      const data = (await res.json()) as {
+        kind?: string;
+        content?: string;
+      };
+      const content = stripLineNumbers(data.content ?? "");
+      setBuffers((prev) => {
+        const next = new Map(prev);
+        next.set(path, {
+          savedContent: content,
+          editorValue: content,
+          loaded: true,
+        });
+        return next;
+      });
+    } catch {
+      // Failed to load — leave buffer empty
+    }
+  }
+
+  async function saveFile(path: string, content: string) {
+    try {
+      const res = await fetch(
+        buildApiUrl(orgSlug, virtualMcpId, branch, "write"),
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ path: toDaemonPath(path), content }),
+        },
+      );
+      if (!res.ok) return;
+      setBuffers((prev) => {
+        const next = new Map(prev);
+        const buf = next.get(path);
+        if (buf) {
+          next.set(path, { ...buf, savedContent: content });
+        }
+        return next;
+      });
+    } catch {
+      // Save failed silently
+    }
+  }
+
+  function openFile(path: string) {
+    setSelectedFile(path);
+    if (!openTabs.includes(path)) {
+      setOpenTabs((prev) => [...prev, path]);
+    }
+    loadFileContent(path);
+  }
+
+  function closeTab(path: string) {
+    setOpenTabs((prev) => {
+      const next = prev.filter((t) => t !== path);
+      if (selectedFile === path) {
+        setSelectedFile(next[next.length - 1] ?? null);
+      }
+      return next;
+    });
+    setBuffers((prev) => {
+      const next = new Map(prev);
+      next.delete(path);
+      return next;
+    });
+  }
+
+  function toggleDir(path: string) {
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }
+
+  function handleFileClick(path: string) {
+    // Auto-expand ancestor directories
+    const ancestors = getAncestorDirectories(path);
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      for (const a of ancestors) next.add(a);
+      return next;
+    });
+    openFile(path);
+  }
+
+  const tree = buildFileTree(files);
+  const flatNodes = flattenTree(tree, expandedDirs);
+
+  // Filter by search
+  const filteredNodes = search
+    ? flatNodes.filter((row) =>
+        row.node.name.toLowerCase().includes(search.toLowerCase()),
+      )
+    : flatNodes;
+
+  const currentBuffer = selectedFile ? buffers.get(selectedFile) : null;
+  const isDirty =
+    currentBuffer?.loaded &&
+    currentBuffer.editorValue !== currentBuffer.savedContent;
+
+  const handleEditorMount: OnMount = (editor, monaco) => {
+    editorRef.current = editor;
+
+    // Ctrl+S / Cmd+S to save
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, async () => {
+      if (!selectedFile) return;
+      const value = editor.getValue();
+      await saveFile(selectedFile, value);
+    });
+  };
+
+  if (loading && !treeLoaded) {
+    return (
+      <div className="flex items-center justify-center h-full w-full">
+        <Loading01 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full overflow-hidden">
+      {/* File tree sidebar */}
+      <div className="w-64 shrink-0 border-r flex flex-col overflow-hidden">
+        {/* Search */}
+        <div className="p-2 border-b">
+          <div className="relative">
+            <SearchSm
+              size={14}
+              className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search files..."
+              className="w-full rounded-md border border-input bg-transparent pl-7 pr-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
+            />
+          </div>
+        </div>
+
+        {/* Tree */}
+        <ScrollArea className="flex-1">
+          <div className="py-1">
+            {filteredNodes.map((row) => {
+              const { node, depth } = row;
+              const isDir = node.kind === "directory";
+              const isExpanded = expandedDirs.has(node.path);
+              const isSelected = selectedFile === node.path;
+
+              return (
+                <button
+                  key={node.path}
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center gap-1 px-2 py-1 text-left text-xs hover:bg-accent transition-colors",
+                    isSelected && "bg-accent",
+                  )}
+                  style={{ paddingLeft: `${depth * 12 + 8}px` }}
+                  onClick={() => {
+                    if (isDir) {
+                      toggleDir(node.path);
+                    } else {
+                      handleFileClick(node.path);
+                    }
+                  }}
+                >
+                  {isDir ? (
+                    <>
+                      {isExpanded ? (
+                        <ChevronDown
+                          size={12}
+                          className="shrink-0 text-muted-foreground"
+                        />
+                      ) : (
+                        <ChevronRight
+                          size={12}
+                          className="shrink-0 text-muted-foreground"
+                        />
+                      )}
+                      <FolderClosed
+                        size={14}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <span className="w-3 shrink-0" />
+                      <File06
+                        size={14}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                    </>
+                  )}
+                  <span className="truncate">{node.name}</span>
+                </button>
+              );
+            })}
+            {treeLoaded && filteredNodes.length === 0 && (
+              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                {search ? `No files match "${search}"` : "No files found"}
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+
+      {/* Editor area */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* Tab bar */}
+        {openTabs.length > 0 && (
+          <div className="flex items-center border-b overflow-x-auto shrink-0">
+            {openTabs.map((tab) => {
+              const tabBuffer = buffers.get(tab);
+              const tabDirty =
+                tabBuffer?.loaded &&
+                tabBuffer.editorValue !== tabBuffer.savedContent;
+              const isActive = selectedFile === tab;
+              const name = tab.split("/").pop() ?? tab;
+
+              return (
+                <div
+                  key={tab}
+                  className={cn(
+                    "flex items-center gap-1 px-3 py-1.5 text-xs border-r cursor-pointer transition-colors",
+                    isActive
+                      ? "bg-background text-foreground"
+                      : "bg-muted/50 text-muted-foreground hover:bg-accent",
+                  )}
+                  onClick={() => {
+                    setSelectedFile(tab);
+                    loadFileContent(tab);
+                  }}
+                  onKeyDown={() => {}}
+                  role="tab"
+                  tabIndex={0}
+                  aria-selected={isActive}
+                >
+                  <span className="truncate max-w-32">{name}</span>
+                  {tabDirty && (
+                    <span className="w-1.5 h-1.5 rounded-full bg-foreground/60 shrink-0" />
+                  )}
+                  <button
+                    type="button"
+                    className="ml-1 rounded p-0.5 hover:bg-accent-foreground/10"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      closeTab(tab);
+                    }}
+                  >
+                    <XClose size={12} />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Monaco editor */}
+        <div className="flex-1 overflow-hidden">
+          {selectedFile && currentBuffer?.loaded ? (
+            <Editor
+              key={selectedFile}
+              language={getLanguageFromPath(selectedFile)}
+              theme={
+                document.documentElement.classList.contains("dark")
+                  ? "vs-dark"
+                  : "light"
+              }
+              value={currentBuffer.editorValue}
+              path={selectedFile}
+              onChange={(value) => {
+                const path = selectedFile;
+                if (!path) return;
+                setBuffers((prev) => {
+                  const next = new Map(prev);
+                  const buf = next.get(path);
+                  if (buf) {
+                    next.set(path, { ...buf, editorValue: value ?? "" });
+                  }
+                  return next;
+                });
+              }}
+              onMount={handleEditorMount}
+              loading={
+                <div className="flex items-center justify-center h-full w-full">
+                  <Loading01
+                    size={20}
+                    className="animate-spin text-muted-foreground"
+                  />
+                </div>
+              }
+              options={{
+                fontSize: 13,
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                lineNumbersMinChars: 2,
+                wordWrap: "on",
+                minimap: { enabled: false },
+                padding: { top: 12, bottom: 12 },
+                scrollbar: {
+                  vertical: "auto",
+                  horizontal: "auto",
+                  verticalScrollbarSize: 8,
+                  horizontalScrollbarSize: 8,
+                },
+              }}
+            />
+          ) : selectedFile && !currentBuffer?.loaded ? (
+            <div className="flex items-center justify-center h-full w-full">
+              <Loading01
+                size={20}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-full w-full text-sm text-muted-foreground">
+              Select a file to edit
+            </div>
+          )}
+        </div>
+
+        {/* Status bar */}
+        {selectedFile && (
+          <div className="flex items-center justify-between px-3 py-1 border-t text-[11px] text-muted-foreground shrink-0">
+            <span className="truncate">{selectedFile}</span>
+            <span>
+              {isDirty ? "Modified" : "Saved"} &middot;{" "}
+              {getLanguageFromPath(selectedFile)}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/vm/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/vm/preview/file-explorer/file-explorer.tsx
@@ -174,6 +174,7 @@ export function FileExplorer({
 
   function openFile(path: string) {
     setSelectedFile(path);
+    setAskAi(null);
     if (!openTabs.includes(path)) {
       setOpenTabs((prev) => [...prev, path]);
     }
@@ -268,13 +269,8 @@ export function FileExplorer({
     ];
     if (askAi.selectedCode) {
       const lang = getLanguageFromPath(askAi.filePath);
-      lines.push(
-        "",
-        "**Selected code:**",
-        "```" + lang,
-        askAi.selectedCode,
-        "```",
-      );
+      const safeCode = askAi.selectedCode.replace(/```/g, "`` `");
+      lines.push("", "**Selected code:**", "```" + lang, safeCode, "```");
     }
     lines.push(
       "",

--- a/apps/mesh/src/web/components/vm/preview/file-explorer/types.ts
+++ b/apps/mesh/src/web/components/vm/preview/file-explorer/types.ts
@@ -1,0 +1,17 @@
+export type TreeNode = {
+  name: string;
+  path: string;
+  kind: "directory" | "file";
+  children: TreeNode[];
+};
+
+export type FlatNode = {
+  node: TreeNode;
+  depth: number;
+};
+
+export type FileBuffer = {
+  savedContent: string;
+  editorValue: string;
+  loaded: boolean;
+};

--- a/apps/mesh/src/web/components/vm/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/vm/preview/file-explorer/utils.ts
@@ -1,16 +1,11 @@
 import type { FlatNode, TreeNode } from "./types";
 
-export function normalizePath(path: string) {
+function normalizePath(path: string) {
   if (!path.trim()) {
     return "/";
   }
   const normalized = path.startsWith("/") ? path : `/${path}`;
   return normalized.replace(/\/+/g, "/");
-}
-
-export function getBasename(path: string) {
-  const normalized = normalizePath(path);
-  return normalized.split("/").filter(Boolean).pop() ?? "/";
 }
 
 export function getLanguageFromPath(filepath: string | null) {

--- a/apps/mesh/src/web/components/vm/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/vm/preview/file-explorer/utils.ts
@@ -1,0 +1,137 @@
+import type { FlatNode, TreeNode } from "./types";
+
+export function normalizePath(path: string) {
+  if (!path.trim()) {
+    return "/";
+  }
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return normalized.replace(/\/+/g, "/");
+}
+
+export function getBasename(path: string) {
+  const normalized = normalizePath(path);
+  return normalized.split("/").filter(Boolean).pop() ?? "/";
+}
+
+export function getLanguageFromPath(filepath: string | null) {
+  if (!filepath) return "plaintext";
+
+  const n = filepath.toLowerCase();
+
+  if (n.endsWith(".tsx") || n.endsWith(".ts")) return "typescript";
+  if (
+    n.endsWith(".jsx") ||
+    n.endsWith(".js") ||
+    n.endsWith(".mjs") ||
+    n.endsWith(".cjs")
+  )
+    return "javascript";
+  if (n.endsWith(".json")) return "json";
+  if (n.endsWith(".md") || n.endsWith(".mdx")) return "markdown";
+  if (n.endsWith(".css")) return "css";
+  if (n.endsWith(".scss")) return "scss";
+  if (n.endsWith(".html")) return "html";
+  if (n.endsWith(".yaml") || n.endsWith(".yml")) return "yaml";
+  if (n.endsWith(".xml") || n.endsWith(".svg")) return "xml";
+  if (n.endsWith(".py")) return "python";
+  if (n.endsWith(".sql")) return "sql";
+  if (n.endsWith(".sh")) return "shell";
+
+  return "plaintext";
+}
+
+export function getAncestorDirectories(filepath: string) {
+  const parts = normalizePath(filepath).split("/").filter(Boolean);
+  const directories = ["/"];
+  let current = "";
+
+  for (const part of parts.slice(0, -1)) {
+    current += `/${part}`;
+    directories.push(current);
+  }
+
+  return directories;
+}
+
+export function buildFileTree(files: string[]): TreeNode[] {
+  const root: TreeNode = {
+    name: "/",
+    path: "/",
+    kind: "directory",
+    children: [],
+  };
+
+  for (const rawFile of files) {
+    const file = normalizePath(rawFile);
+    const parts = file.split("/").filter(Boolean);
+    let current = root;
+    let currentPath = "";
+
+    parts.forEach((part, index) => {
+      currentPath += `/${part}`;
+      const isFile = index === parts.length - 1;
+      let child = current.children.find((entry) => entry.name === part);
+
+      if (!child) {
+        child = {
+          name: part,
+          path: currentPath,
+          kind: isFile ? "file" : "directory",
+          children: [],
+        };
+        current.children.push(child);
+      }
+
+      current = child;
+    });
+  }
+
+  const sortNodes = (nodes: TreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    for (const node of nodes) {
+      if (node.children.length > 0) sortNodes(node.children);
+    }
+  };
+
+  sortNodes(root.children);
+  return root.children;
+}
+
+export function flattenTree(
+  nodes: TreeNode[],
+  expandedDirectories: Set<string>,
+  depth = 0,
+): FlatNode[] {
+  const rows: FlatNode[] = [];
+
+  for (const node of nodes) {
+    rows.push({ node, depth });
+
+    if (
+      node.kind === "directory" &&
+      node.children.length > 0 &&
+      expandedDirectories.has(node.path)
+    ) {
+      rows.push(...flattenTree(node.children, expandedDirectories, depth + 1));
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Strip the line-number prefix from the daemon's read endpoint.
+ * The daemon returns content in `"1\tcontent\n2\tcontent"` format.
+ */
+export function stripLineNumbers(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => {
+      const match = line.match(/^\d+\t(.*)/);
+      return match ? match[1] : line;
+    })
+    .join("\n");
+}

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -12,6 +12,7 @@ import {
   ArrowLeft,
   ArrowRight,
   ChevronDown,
+  Code02,
   CursorClick01,
   DotsHorizontal,
   TextInput,
@@ -73,6 +74,12 @@ const SectionsEditor = lazy(() =>
   })),
 );
 
+const FileExplorer = lazy(() =>
+  import("./file-explorer/file-explorer").then((m) => ({
+    default: m.FileExplorer,
+  })),
+);
+
 /** Delay before reloading the preview iframe after a save, giving the dev server time to pick up file changes. */
 const DEV_SERVER_SETTLE_MS = 500;
 
@@ -92,18 +99,16 @@ function drawerStatusFromPreview(
   return "idle";
 }
 
-type PreviewViewMode = "preview" | "visual";
+type PreviewViewMode = "preview" | "visual" | "code";
 
-const VIEW_MODE_OPTIONS: [
-  ViewModeOption<PreviewViewMode>,
-  ViewModeOption<PreviewViewMode>,
-] = [
+const VIEW_MODE_OPTIONS: ViewModeOption<PreviewViewMode>[] = [
   { value: "preview", icon: <Monitor04 size={14} />, tooltip: "Interactive" },
   {
     value: "visual",
     icon: <CursorClick01 size={14} />,
     tooltip: "Visual Editor",
   },
+  { value: "code", icon: <Code02 size={14} />, tooltip: "Code Editor" },
 ];
 
 export function PreviewContent() {
@@ -533,8 +538,13 @@ export function PreviewContent() {
             )}
           </div>
 
-          {/* Group 2: nav + url */}
-          <div className="flex min-w-0 flex-1 items-center gap-0.5">
+          {/* Group 2: nav + url (hidden in code mode) */}
+          <div
+            className={cn(
+              "flex min-w-0 flex-1 items-center gap-0.5",
+              viewMode === "code" && "hidden",
+            )}
+          >
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -663,8 +673,13 @@ export function PreviewContent() {
             </div>
           </div>
 
-          {/* Group 3: open in new tab + more actions */}
-          <div className="flex shrink-0 items-center gap-0.5">
+          {/* Group 3: open in new tab + more actions (hidden in code mode) */}
+          <div
+            className={cn(
+              "flex shrink-0 items-center gap-0.5",
+              viewMode === "code" && "hidden",
+            )}
+          >
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -842,6 +857,31 @@ export function PreviewContent() {
               onDismiss={() => setVisualElement(null)}
             />
           )}
+          {/* File explorer (code mode) */}
+          {viewMode === "code" &&
+            previewState.kind === "iframe" &&
+            virtualMcpId &&
+            branch && (
+              <div className="absolute inset-0 z-10 bg-background">
+                <Suspense
+                  fallback={
+                    <div className="h-full flex items-center justify-center">
+                      <Loading01
+                        size={20}
+                        className="animate-spin text-muted-foreground"
+                      />
+                    </div>
+                  }
+                >
+                  <FileExplorer
+                    orgSlug={org.slug}
+                    virtualMcpId={virtualMcpId}
+                    branch={branch}
+                  />
+                </Suspense>
+              </div>
+            )}
+
           {previewState.kind === "iframe" && (
             <iframe
               // Key on previewUrl: `src` mutations don't reliably refetch in all
@@ -849,7 +889,10 @@ export function PreviewContent() {
               key={previewState.previewUrl}
               ref={previewIframeRef}
               src={previewState.previewUrl}
-              className="w-full h-full border-0"
+              className={cn(
+                "w-full h-full border-0",
+                viewMode === "code" && "invisible",
+              )}
               title="Dev Server Preview"
               tabIndex={sectionsOpen ? -1 : undefined}
               onLoad={() => {

--- a/packages/ui/src/components/view-mode-toggle.tsx
+++ b/packages/ui/src/components/view-mode-toggle.tsx
@@ -19,7 +19,7 @@ type ViewModeSize = "sm" | "md" | "lg";
 interface ViewModeToggleProps<T extends string = string> {
   value: T;
   onValueChange: (value: T) => void;
-  options: [ViewModeOption<T>, ViewModeOption<T>];
+  options: ViewModeOption<T>[];
   size?: ViewModeSize;
   fullWidth?: boolean;
   className?: string;
@@ -48,20 +48,19 @@ export function ViewModeToggle<T extends string = string>({
   fullWidth = false,
   className,
 }: ViewModeToggleProps<T>) {
-  const firstRef = useRef<HTMLButtonElement>(null);
-  const secondRef = useRef<HTMLButtonElement>(null);
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
   const [indicatorPosition, setIndicatorPosition] = useState({
     left: 0,
     width: 0,
     opacity: 0,
   });
 
-  const updateIndicator = (ref: React.RefObject<HTMLButtonElement | null>) => {
-    if (!ref.current) return;
-    const { offsetLeft, offsetWidth } = ref.current;
+  const updateIndicator = (index: number) => {
+    const el = refs.current[index];
+    if (!el) return;
     setIndicatorPosition({
-      left: offsetLeft,
-      width: offsetWidth,
+      left: el.offsetLeft,
+      width: el.offsetWidth,
       opacity: 1,
     });
   };
@@ -69,8 +68,8 @@ export function ViewModeToggle<T extends string = string>({
   // Initialize indicator position based on current value
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
-    const ref = value === options[0].value ? firstRef : secondRef;
-    updateIndicator(ref);
+    const idx = options.findIndex((o) => o.value === value);
+    if (idx >= 0) updateIndicator(idx);
   }, [value, options]);
 
   const config = sizeConfig[size];
@@ -78,10 +77,11 @@ export function ViewModeToggle<T extends string = string>({
   return (
     <div className={cn("relative flex gap-0 bg-muted rounded-lg", className)}>
       {options.map((option, i) => {
-        const ref = i === 0 ? firstRef : secondRef;
         const btn = (
           <button
-            ref={ref}
+            ref={(el) => {
+              refs.current[i] = el;
+            }}
             key={option.value}
             type="button"
             onClick={() => onValueChange(option.value)}


### PR DESCRIPTION

<img width="3024" height="1724" alt="image" src="https://github.com/user-attachments/assets/806dcdbc-c5ff-473e-bf6f-c5366f4df674" />

## Summary

- **Generalized `ViewModeToggle`** to support N options (was hardcoded for exactly 2), enabling the new third "Code" tab
- **Added `glob` proxy endpoint** to `vm-proxy.ts` for listing sandbox files
- **Created `FileExplorer` component** with file tree sidebar, Monaco code editor, tabbed editing, search, dirty indicators, and Ctrl+S/Cmd+S save
- **Updated preview panel** to lazy-load the file explorer in "code" mode while keeping the iframe mounted (invisible) for HMR state preservation

## Test plan

- [ ] Start a sandbox, verify the 3-option toggle (Interactive / Visual Editor / Code Editor) renders correctly
- [ ] Switch to "Code" view mode — file tree should load and display project files
- [ ] Select a file — content loads in Monaco editor with correct syntax highlighting
- [ ] Edit a file, verify dirty indicator (dot) appears on the tab
- [ ] Save with Ctrl+S / Cmd+S — verify "Modified" status changes to "Saved"
- [ ] Switch back to "Interactive" mode — iframe should reflect saved changes
- [ ] Close tabs via X button, verify last-tab-close shows "Select a file to edit"
- [ ] Search files in the sidebar filter input
- [ ] Verify URL bar and nav buttons are hidden in code mode, visible in other modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new "Code" view mode to the sandbox preview with a file explorer and Monaco editor for in-browser editing. The preview iframe stays mounted (hidden) to preserve HMR, and the view toggle now supports three options.

- **New Features**
  - File explorer with tree, search, tabbed `@monaco-editor/react` editor, dirty dots, and Ctrl/Cmd+S save (loaded via CDN).
  - New `glob` VM proxy endpoint to list project files; uses existing read/write APIs for load/save.
  - Lazy-loads the code editor; hides nav/URL controls in code mode while keeping the iframe mounted.
  - Inline editor prompt (Cmd/Ctrl+K) that sends selected code, file path, and line range to chat.

- **Bug Fixes**
  - Dismiss the inline prompt when switching files and escape triple backticks in selections to prevent markdown issues.
  - Remove unused exports from file explorer utils.

<sup>Written for commit 7eb1885d970426dbc4b8b5b2512270df0a0ec6fc. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3424?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



