### PR TITLE
refactor(secrets): extract secretInfoSchema to a separate file and up…

### DIFF
--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -25,6 +25,8 @@ import {
 } from "../../core/mesh-context";
 import type { Env } from "../hono-env";
 import { handleVmEvents } from "./vm-events-handler";
+import { resolveAndPushEnv } from "../../tools/vm/resolve-env";
+import type { RuntimeConfigMeta } from "../../tools/vm/helpers";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -230,13 +232,43 @@ export const createVmRoutes = () => {
   );
 
   // -- Setup retry ----------------------------------------------------------
-  app.post("/:vmId/:branch/setup/:step", (c) => {
+  app.post("/:vmId/:branch/setup/:step", async (c) => {
     const step = c.req.param("step");
     if (!step || !isSetupStep(step)) {
       return c.json(
         { error: `step must be one of: ${SETUP_STEPS.join(", ")}` },
         400,
       );
+    }
+    // On "start", refresh the daemon's env from the virtual MCP's current
+    // `metadata.runtime.env`. The dev script inherits env at spawn time, so
+    // edits made after the last VM_START don't reach a running process
+    // unless we push the freshly-resolved env to /config before the
+    // orchestrator restarts it.
+    if (step === "start") {
+      const claim = c.get("vmClaim");
+      if (claim.runner) {
+        const organization = requireOrganization(c.var.meshContext);
+        const entries =
+          (claim.virtualMcpMetadata as RuntimeConfigMeta | null)?.runtime
+            ?.env ?? null;
+        try {
+          await resolveAndPushEnv({
+            ctx: c.var.meshContext,
+            runner: claim.runner,
+            handle: claim.claimName,
+            orgId: organization.id,
+            userId: claim.userId,
+            entries,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return c.json(
+            { error: `Failed to push env to daemon: ${message}` },
+            502,
+          );
+        }
+      }
     }
     return proxyDaemon(c, `/_decopilot_vm/setup/${step}`, {
       signal: c.req.raw.signal,

--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -26,7 +26,7 @@ import {
 import type { Env } from "../hono-env";
 import { handleVmEvents } from "./vm-events-handler";
 import { resolveAndPushEnv } from "../../tools/vm/resolve-env";
-import type { RuntimeConfigMeta } from "../../tools/vm/helpers";
+import { readValidatedRuntimeEnv } from "../../tools/vm/helpers";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -249,9 +249,7 @@ export const createVmRoutes = () => {
       const claim = c.get("vmClaim");
       if (claim.runner) {
         const organization = requireOrganization(c.var.meshContext);
-        const entries =
-          (claim.virtualMcpMetadata as RuntimeConfigMeta | null)?.runtime
-            ?.env ?? null;
+        const entries = readValidatedRuntimeEnv(claim.virtualMcpMetadata);
         try {
           await resolveAndPushEnv({
             ctx: c.var.meshContext,

--- a/apps/mesh/src/tools/secrets/create.ts
+++ b/apps/mesh/src/tools/secrets/create.ts
@@ -1,18 +1,7 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/mesh-context";
-
-const secretInfoSchema = z.object({
-  id: z.string(),
-  scope: z.enum(["user", "organization"]),
-  userId: z.string().nullable(),
-  name: z.string(),
-  description: z.string().nullable(),
-  createdBy: z.string(),
-  createdAt: z.string(),
-  updatedBy: z.string(),
-  updatedAt: z.string(),
-});
+import { secretInfoSchema } from "./schema";
 
 export const SECRET_CREATE = defineTool({
   name: "SECRET_CREATE",

--- a/apps/mesh/src/tools/secrets/list.ts
+++ b/apps/mesh/src/tools/secrets/list.ts
@@ -1,18 +1,7 @@
 import z from "zod";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/mesh-context";
-
-const secretInfoSchema = z.object({
-  id: z.string(),
-  scope: z.enum(["user", "organization"]),
-  userId: z.string().nullable(),
-  name: z.string(),
-  description: z.string().nullable(),
-  createdBy: z.string(),
-  createdAt: z.string(),
-  updatedBy: z.string(),
-  updatedAt: z.string(),
-});
+import { secretInfoSchema } from "./schema";
 
 export const SECRET_LIST = defineTool({
   name: "SECRET_LIST",

--- a/apps/mesh/src/tools/secrets/schema.ts
+++ b/apps/mesh/src/tools/secrets/schema.ts
@@ -1,0 +1,20 @@
+import z from "zod";
+
+/**
+ * Public-facing secret metadata. Values are never returned by any tool — the
+ * encrypted_value column is intentionally omitted. Shared across SECRET_CREATE
+ * and SECRET_LIST so the wire contract can't drift between them.
+ */
+export const secretInfoSchema = z.object({
+  id: z.string(),
+  scope: z.enum(["user", "organization"]),
+  userId: z.string().nullable(),
+  name: z.string(),
+  description: z.string().nullable(),
+  createdBy: z.string(),
+  createdAt: z.string(),
+  updatedBy: z.string(),
+  updatedAt: z.string(),
+});
+
+export type SecretInfoOutput = z.infer<typeof secretInfoSchema>;

--- a/apps/mesh/src/tools/vm/helpers.ts
+++ b/apps/mesh/src/tools/vm/helpers.ts
@@ -6,7 +6,11 @@
  * - Runtime detection logic (resolveRuntimeConfig)
  */
 
-import type { RuntimeEnvEntry, VmMapEntry } from "@decocms/mesh-sdk";
+import {
+  ENV_VAR_KEY_RE,
+  type RuntimeEnvEntry,
+  type VmMapEntry,
+} from "@decocms/mesh-sdk";
 
 import {
   requireAuth,
@@ -47,7 +51,7 @@ export function readValidatedRuntimeEnv(
   for (const item of env) {
     if (!item || typeof item !== "object") continue;
     const e = item as Record<string, unknown>;
-    if (typeof e.key !== "string" || e.key.length === 0) continue;
+    if (typeof e.key !== "string" || !ENV_VAR_KEY_RE.test(e.key)) continue;
     if (e.kind === "literal" && typeof e.value === "string") {
       out.push({ key: e.key, kind: "literal", value: e.value });
       continue;

--- a/apps/mesh/src/tools/vm/helpers.ts
+++ b/apps/mesh/src/tools/vm/helpers.ts
@@ -28,6 +28,42 @@ export type RuntimeConfigMeta = {
 };
 
 /**
+ * Defensive reader for `metadata.runtime.env`. The DB column is JSON, so
+ * the static cast to `RuntimeConfigMeta` can't be trusted — older rows or
+ * hand-edited metadata may carry a non-array `env`, malformed entries, or
+ * the wrong types under the discriminator. Returns only entries that
+ * match the wire contract; everything else is silently dropped so a bad
+ * row can't crash `resolveAndPushEnv`'s `for...of`.
+ */
+export function readValidatedRuntimeEnv(
+  metadata: Record<string, unknown> | null | undefined,
+): RuntimeEnvEntry[] | null {
+  if (!metadata) return null;
+  const runtime = (metadata as { runtime?: unknown }).runtime;
+  if (!runtime || typeof runtime !== "object") return null;
+  const env = (runtime as { env?: unknown }).env;
+  if (!Array.isArray(env)) return null;
+  const out: RuntimeEnvEntry[] = [];
+  for (const item of env) {
+    if (!item || typeof item !== "object") continue;
+    const e = item as Record<string, unknown>;
+    if (typeof e.key !== "string" || e.key.length === 0) continue;
+    if (e.kind === "literal" && typeof e.value === "string") {
+      out.push({ key: e.key, kind: "literal", value: e.value });
+      continue;
+    }
+    if (
+      e.kind === "secret" &&
+      typeof e.secretId === "string" &&
+      e.secretId.length > 0
+    ) {
+      out.push({ key: e.key, kind: "secret", secretId: e.secretId });
+    }
+  }
+  return out.length === 0 ? null : out;
+}
+
+/**
  * Extracts common auth + lookup boilerplate shared by all VM tools.
  * Validates auth, checks access, fetches and validates the Virtual MCP,
  * and returns the metadata and vmMap entry for the current user on the

--- a/apps/mesh/src/web/components/vm/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/vm/runtime-card/env-vars-field.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { Suspense, useReducer, useRef, useState } from "react";
 import type {
   Control,
   FieldPath,
@@ -125,16 +125,18 @@ interface RunningSandboxNoticeProps<T extends FieldValues> {
  * Banner shown above the env list when:
  *   (a) the caller already has a sandbox provisioned for this agent
  *       (vmMap has an entry under their userId), and
- *   (b) the env array changed since the page loaded.
+ *   (b) the env array changed since the last push to the daemon.
  *
- * The push to the daemon happens on VM_START's `resolveAndPushEnv`, but a
- * daemon already running a dev script won't pick up new env until that
- * process restarts. The notice tells the user that, and the button POSTs
- * /setup/start for each of their branches to recycle the dev script.
+ * The push to the daemon happens server-side on /setup/start (which
+ * resolves secrets + PUTs /config before proxying to the daemon's
+ * orchestrator). A daemon already running a dev script won't pick up new
+ * env until that process restarts, so this notice + button recycle the
+ * dev script for each of the caller's branches.
  *
- * Baseline is captured on mount via a ref — autosave running between
- * keystrokes does NOT clear the banner; the user has to actually restart
- * (or reload the page after a manual restart) to clear it.
+ * Baseline is held in a ref initialized from the same `useWatch` value
+ * that `current` reads. That guarantees they match on first render —
+ * without this, getValues vs useWatch could diverge before subscriptions
+ * settled and the banner surfaced before the user touched anything.
  */
 function RunningSandboxNotice<T extends FieldValues>({
   control,
@@ -148,13 +150,16 @@ function RunningSandboxNotice<T extends FieldValues>({
   const fieldPath = "metadata.runtime.env" as FieldPath<T>;
   const vmMapPath = "metadata.vmMap" as FieldPath<T>;
 
-  // Baseline is held in component state (not a ref) so a successful restart
-  // can re-baseline and trigger a re-render that hides the banner.
-  const [baseline, setBaseline] = useState(() =>
-    JSON.stringify(form.getValues(fieldPath) ?? []),
-  );
   const current = useWatch({ control, name: fieldPath });
-  const envChanged = JSON.stringify(current ?? []) !== baseline;
+  // Drop in-progress rows (no key / invalid key / secret without secretId)
+  // before comparing. Adding an empty row via "+ Add env var" or starting
+  // to type a key wouldn't otherwise be sent to the daemon by autosave,
+  // so it shouldn't surface a restart banner either.
+  const currentStr = JSON.stringify(normalizeEnvForCompare(current));
+
+  const baselineRef = useRef(currentStr);
+  const [, bumpBaseline] = useReducer((x: number) => x + 1, 0);
+  const envChanged = currentStr !== baselineRef.current;
 
   const vmMap = form.getValues(vmMapPath) as
     | Record<string, Record<string, unknown>>
@@ -181,8 +186,8 @@ function RunningSandboxNotice<T extends FieldValues>({
     setRestarting(false);
     const failed = results.filter((r) => r.status === "rejected").length;
     if (failed === 0) {
-      // Match baseline so the banner self-clears; further edits surface it again.
-      setBaseline(JSON.stringify(form.getValues(fieldPath) ?? []));
+      baselineRef.current = currentStr;
+      bumpBaseline();
       toast.success(
         userBranches.length === 1
           ? "Restarted dev with new env"
@@ -851,6 +856,32 @@ function SaveAsSecretDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+// Mirrors `stripIncompleteEnvEntries` in views/virtual-mcp/index.tsx so the
+// banner's notion of "changed" matches what autosave actually sends.
+function normalizeEnvForCompare(value: unknown): unknown[] {
+  if (!Array.isArray(value)) return [];
+  const out: unknown[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as {
+      key?: string;
+      kind?: string;
+      value?: string;
+      secretId?: string;
+    };
+    const key = (e.key ?? "").trim();
+    if (!key || !ENV_VAR_KEY_RE.test(key)) continue;
+    if (e.kind === "literal") {
+      out.push({ key, kind: "literal", value: e.value ?? "" });
+      continue;
+    }
+    if (e.kind === "secret" && e.secretId) {
+      out.push({ key, kind: "secret", secretId: e.secretId });
+    }
+  }
+  return out;
 }
 
 function sanitizeSecretName(envKey: string): string {

--- a/apps/mesh/src/web/components/vm/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/vm/runtime-card/env-vars-field.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useReducer, useRef, useState } from "react";
+import { Suspense, useState } from "react";
 import type {
   Control,
   FieldPath,
@@ -133,10 +133,9 @@ interface RunningSandboxNoticeProps<T extends FieldValues> {
  * env until that process restarts, so this notice + button recycle the
  * dev script for each of the caller's branches.
  *
- * Baseline is held in a ref initialized from the same `useWatch` value
- * that `current` reads. That guarantees they match on first render —
- * without this, getValues vs useWatch could diverge before subscriptions
- * settled and the banner surfaced before the user touched anything.
+ * Both baseline and `current` are passed through `normalizeEnvForCompare`
+ * so in-progress rows (no key, invalid key, secret without secretId) —
+ * which autosave already strips — never count as a real change.
  */
 function RunningSandboxNotice<T extends FieldValues>({
   control,
@@ -150,16 +149,12 @@ function RunningSandboxNotice<T extends FieldValues>({
   const fieldPath = "metadata.runtime.env" as FieldPath<T>;
   const vmMapPath = "metadata.vmMap" as FieldPath<T>;
 
+  const [baseline, setBaseline] = useState(() =>
+    JSON.stringify(normalizeEnvForCompare(form.getValues(fieldPath))),
+  );
   const current = useWatch({ control, name: fieldPath });
-  // Drop in-progress rows (no key / invalid key / secret without secretId)
-  // before comparing. Adding an empty row via "+ Add env var" or starting
-  // to type a key wouldn't otherwise be sent to the daemon by autosave,
-  // so it shouldn't surface a restart banner either.
   const currentStr = JSON.stringify(normalizeEnvForCompare(current));
-
-  const baselineRef = useRef(currentStr);
-  const [, bumpBaseline] = useReducer((x: number) => x + 1, 0);
-  const envChanged = currentStr !== baselineRef.current;
+  const envChanged = currentStr !== baseline;
 
   const vmMap = form.getValues(vmMapPath) as
     | Record<string, Record<string, unknown>>
@@ -186,8 +181,7 @@ function RunningSandboxNotice<T extends FieldValues>({
     setRestarting(false);
     const failed = results.filter((r) => r.status === "rejected").length;
     if (failed === 0) {
-      baselineRef.current = currentStr;
-      bumpBaseline();
+      setBaseline(currentStr);
       toast.success(
         userBranches.length === 1
           ? "Restarted dev with new env"

--- a/apps/mesh/src/web/components/vm/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/vm/runtime-card/env-vars-field.tsx
@@ -7,6 +7,7 @@ import type {
 } from "react-hook-form";
 import { Controller, useFieldArray, useWatch } from "react-hook-form";
 import { toast } from "sonner";
+import { ENV_VAR_KEY_RE } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   Dialog,
@@ -56,7 +57,6 @@ import {
   useSecrets,
 } from "@/web/hooks/use-secrets";
 
-const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const SECRET_NAME_RE = /^[A-Za-z0-9_.-]+$/;
 
 export interface EnvVarsFieldProps<T extends FieldValues> {
@@ -488,24 +488,41 @@ function EnvRow<T extends FieldValues>({
         <Controller
           control={control}
           name={keyName}
-          render={({ field }) => (
-            <Input
-              {...field}
-              value={(field.value as string | undefined) ?? ""}
-              placeholder="KEY"
-              spellCheck={false}
-              autoComplete="off"
-              autoCapitalize="off"
-              autoCorrect="off"
-              className="font-mono"
-              aria-label={`Env var ${index + 1} key`}
-              onBlur={(e) => {
-                const v = e.target.value.trim();
-                field.onChange(v);
-                field.onBlur();
-              }}
-            />
-          )}
+          render={({ field }) => {
+            const v = ((field.value as string | undefined) ?? "").trim();
+            const invalid = v.length > 0 && !ENV_VAR_KEY_RE.test(v);
+            return (
+              <div className="space-y-1">
+                <Input
+                  {...field}
+                  value={(field.value as string | undefined) ?? ""}
+                  placeholder="KEY"
+                  spellCheck={false}
+                  autoComplete="off"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  className={cn(
+                    "font-mono",
+                    invalid &&
+                      "border-destructive focus-visible:ring-destructive",
+                  )}
+                  aria-invalid={invalid}
+                  aria-label={`Env var ${index + 1} key`}
+                  onBlur={(e) => {
+                    const next = e.target.value.trim();
+                    field.onChange(next);
+                    field.onBlur();
+                  }}
+                />
+                {invalid ? (
+                  <p className="text-[11px] text-destructive">
+                    Letters, digits, underscores. Must start with a letter or
+                    underscore.
+                  </p>
+                ) : null}
+              </div>
+            );
+          }}
         />
       </div>
 
@@ -842,5 +859,5 @@ function sanitizeSecretName(envKey: string): string {
   // Env keys already constrain to [A-Za-z_][A-Za-z0-9_]*, which is a subset
   // of the secret-name charset — pass-through is safe and gives users a
   // predictable default.
-  return ENV_KEY_RE.test(stripped) ? stripped : "";
+  return ENV_VAR_KEY_RE.test(stripped) ? stripped : "";
 }

--- a/apps/mesh/src/web/views/settings/secrets.tsx
+++ b/apps/mesh/src/web/views/settings/secrets.tsx
@@ -119,6 +119,14 @@ function CreateSecretDialog({ open, onOpenChange }: CreateSecretDialogProps) {
     setDescription("");
   }
 
+  // Single close path so Cancel and Radix's outside-click/Escape both clear
+  // the form. Calling onOpenChange(false) directly skips the wrapper below,
+  // because Radix only fires its onOpenChange when *it* initiates the close.
+  function handleClose() {
+    reset();
+    onOpenChange(false);
+  }
+
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
     if (!name.trim() || !value) return;
@@ -130,8 +138,7 @@ function CreateSecretDialog({ open, onOpenChange }: CreateSecretDialogProps) {
         description: description.trim() || undefined,
       });
       toast.success(`Secret "${name.trim()}" created`);
-      reset();
-      onOpenChange(false);
+      handleClose();
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to create secret",
@@ -143,8 +150,8 @@ function CreateSecretDialog({ open, onOpenChange }: CreateSecretDialogProps) {
     <Dialog
       open={open}
       onOpenChange={(o) => {
-        if (!o) reset();
-        onOpenChange(o);
+        if (!o) handleClose();
+        else onOpenChange(o);
       }}
     >
       <DialogContent className="sm:max-w-lg">
@@ -218,7 +225,7 @@ function CreateSecretDialog({ open, onOpenChange }: CreateSecretDialogProps) {
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={handleClose}
               disabled={createSecret.isPending}
             >
               Cancel

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -55,6 +55,7 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   type ConnectionEntity,
+  ENV_VAR_KEY_RE,
   SELF_MCP_ALIAS_ID,
   StudioPackAgentId,
   useConnection,
@@ -182,9 +183,12 @@ function editSessionReducer(
 }
 
 /**
- * Drops in-progress env rows (empty key, or kind=secret with empty secretId)
- * from the payload sent on autosave. Keeps the partial row in form state so
- * the user can keep typing — the next save will include it once it's valid.
+ * Drops in-progress / invalid env rows from the autosave payload. A row is
+ * stripped when: key is empty, key fails the shell-portable regex, or it's a
+ * secret-kind row with no secretId. The partial/invalid row stays in form
+ * state so the user can keep editing; the server-side Zod schema would
+ * reject these anyway and we'd surface a noisy validation error on every
+ * keystroke without this filter.
  */
 function stripIncompleteEnvEntries(
   data: VirtualMcpFormData,
@@ -194,7 +198,7 @@ function stripIncompleteEnvEntries(
   const cleaned = env.filter((entry) => {
     if (!entry || typeof entry !== "object") return false;
     const key = ((entry as { key?: string }).key ?? "").trim();
-    if (!key) return false;
+    if (!key || !ENV_VAR_KEY_RE.test(key)) return false;
     if (entry.kind === "literal") return true;
     if (entry.kind === "secret") {
       return Boolean((entry as { secretId?: string }).secretId);
@@ -1527,7 +1531,7 @@ Define step-by-step how the agent should handle requests.
                       size="sm"
                       onClick={handleTestAgent}
                     >
-                      <Play size={14} className="!size-[14px]" />
+                      <Play size={14} className="size-[14px]!" />
                       Test Agent
                     </Button>
                     <Button

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -122,6 +122,7 @@ export {
   type VmMapEntry,
   type RuntimeMetadata,
   type RuntimeEnvEntry,
+  ENV_VAR_KEY_RE,
   type GithubRepo,
   // Decopilot event types
   THREAD_STATUSES,

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -34,6 +34,7 @@ export {
   type VmMapEntry,
   type RuntimeMetadata,
   type RuntimeEnvEntry,
+  ENV_VAR_KEY_RE,
 } from "./virtual-mcp";
 
 export {

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -116,6 +116,19 @@ const VirtualMcpUISchema = z.object({
 export type VirtualMcpUI = z.infer<typeof VirtualMcpUISchema>;
 
 /**
+ * Shell-portable env var name: must start with a letter or underscore and
+ * contain only letters, digits, and underscores. Same shape parse-dotenv
+ * enforces on imports. Single source of truth — the form editor and the
+ * paste flow both validate against this.
+ */
+export const ENV_VAR_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const envVarKey = z.string().min(1).regex(ENV_VAR_KEY_RE, {
+  message:
+    "Env var key must start with a letter or underscore and contain only letters, digits, and underscores.",
+});
+
+/**
  * One env var declaration on a virtual MCP. Literal values live inline in
  * metadata; secret values store a stable secretId that mesh resolves against
  * the credential vault on every VM_START. The env var KEY is independent of
@@ -124,12 +137,12 @@ export type VirtualMcpUI = z.infer<typeof VirtualMcpUISchema>;
  */
 const RuntimeEnvEntrySchema = z.discriminatedUnion("kind", [
   z.object({
-    key: z.string().min(1),
+    key: envVarKey,
     kind: z.literal("literal"),
     value: z.string(),
   }),
   z.object({
-    key: z.string().min(1),
+    key: envVarKey,
     kind: z.literal("secret"),
     secretId: z.string().min(1),
   }),


### PR DESCRIPTION
…date references

- Moved the secretInfoSchema definition from create.ts and list.ts to a new schema.ts file for better organization and reusability.
- Updated imports in create.ts and list.ts to reference the new schema location.
- Enhanced the EnvVarsField component to utilize the ENV_VAR_KEY_RE regex for validating environment variable keys.
- Improved the CreateSecretDialog component by consolidating the reset logic into a single handleClose function for better maintainability.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `secretInfoSchema` into a shared module and tightened env var handling: one regex source for keys via `@decocms/mesh-sdk`, pushing the current env to the daemon on VM start, and a restart banner that reflects the last push.

- **Refactors**
  - Moved `secretInfoSchema` to `apps/mesh/src/tools/secrets/schema.ts`; updated imports; added `SecretInfoOutput`.
  - Added `readValidatedRuntimeEnv` to drop malformed entries using `ENV_VAR_KEY_RE`; used by setup before pushing env.
  - Consolidated Create Secret dialog close/reset; restart banner compares normalized env and re-baselines after successful restarts.

- **New Features**
  - Introduced and exported `ENV_VAR_KEY_RE` in `packages/mesh-sdk`; enforced in Zod `RuntimeEnvEntry`; UI validates keys with inline errors and filters invalid rows on autosave.
  - On `POST /:vmId/:branch/setup/start`, resolve secrets and push current env to the daemon; return 502 with a clear error if the push fails.

<sup>Written for commit bdf8ffbc5b67a206b35eaf99d2396aac8bfc9054. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3427?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

