### PR TITLE
fix(chat-model-selector): single-harness UI tweaks + 'on desktop' rename

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-model-popover.tsx
+++ b/apps/mesh/src/web/components/chat/agent-model-popover.tsx
@@ -22,17 +22,28 @@ export function AgentModelPopover({
   lockedAgent,
   onSelect,
 }: Props) {
+  const single = sections.length === 1;
+  // Always resolve a default selection so one tier is always highlighted —
+  // when activeAgent doesn't match a rendered section, fall back to the
+  // first section so the popover never opens with nothing "On".
+  const resolvedActiveAgent =
+    sections.find((s) => s.kind === activeAgent)?.kind ??
+    sections[0]?.kind ??
+    null;
+
   return (
-    <div className="flex flex-col gap-1 p-1.5 w-72">
+    <div className="flex flex-col gap-1 w-72">
       {sections.map((section) => {
         const disabled = lockedAgent !== null && lockedAgent !== section.kind;
-        const selectedTier = activeAgent === section.kind ? activeTier : null;
+        const selectedTier =
+          resolvedActiveAgent === section.kind ? activeTier : null;
         return (
           <AgentSection
             key={section.kind}
             section={section}
             selectedTier={selectedTier}
             disabled={disabled}
+            hideHeader={single}
             onSelect={(tier) => onSelect(section.kind, tier)}
           />
         );

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -31,7 +31,7 @@ export interface AgentSection {
   kind: AgentKind;
   title: string;
   /** True for laptop-CLI agents (Claude Code, Codex). Drives the green
-   *  band + " · on this laptop" suffix in the popover, and the green
+   *  band + " · on desktop" suffix in the popover, and the green
    *  ring on the closed chat-input trigger. */
   isLocal: boolean;
   tiers: AgentTierMap;

--- a/apps/mesh/src/web/components/chat/select-model/agent-section.test.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-section.test.tsx
@@ -30,7 +30,7 @@ describe("AgentSection", () => {
     expect(header?.className).not.toMatch(/text-success/);
   });
 
-  test("local CLI section header uses text-success and · on this laptop suffix", () => {
+  test("local CLI section header uses text-success and · on desktop suffix", () => {
     const { container, getByText } = render(
       <AgentSection
         section={claude}
@@ -43,7 +43,7 @@ describe("AgentSection", () => {
       "[data-testid=agent-section-header]",
     );
     expect(header?.className).toMatch(/text-success/);
-    expect(getByText(/Claude Code · on this laptop/)).toBeInTheDocument();
+    expect(getByText(/Claude Code · on desktop/)).toBeInTheDocument();
   });
 
   test("disabled section sets aria-disabled and stops onSelect from firing", () => {

--- a/apps/mesh/src/web/components/chat/select-model/agent-section.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-section.tsx
@@ -9,6 +9,7 @@ interface Props {
   section: AgentSectionData;
   selectedTier: ChatTier | null;
   disabled: boolean;
+  hideHeader?: boolean;
   onSelect: (tier: ChatTier) => void;
 }
 
@@ -16,6 +17,7 @@ export function AgentSection({
   section,
   selectedTier,
   disabled,
+  hideHeader,
   onSelect,
 }: Props) {
   const localBand = section.isLocal && !disabled ? "bg-success/5" : "";
@@ -25,25 +27,26 @@ export function AgentSection({
       data-testid="agent-section"
       aria-disabled={disabled || undefined}
       className={cn(
-        "rounded-md p-1",
+        "p-1 flex flex-col gap-0.5",
+        section.isLocal ? "rounded-none" : "rounded-md",
         localBand,
         disabled && "opacity-40 pointer-events-none",
       )}
     >
-      <div
-        data-testid="agent-section-header"
-        className={cn(
-          "flex items-center justify-between px-2 py-1 text-xs font-medium",
-          section.isLocal ? "text-success" : "text-muted-foreground",
-        )}
-      >
-        <span>
-          {section.isLocal
-            ? `${section.title} · on this laptop`
-            : section.title}
-        </span>
-        {disabled && <Lock01 size={12} className="opacity-60" />}
-      </div>
+      {!hideHeader && (
+        <div
+          data-testid="agent-section-header"
+          className={cn(
+            "flex items-center justify-between px-2 py-1 text-xs font-medium",
+            section.isLocal ? "text-success" : "text-muted-foreground",
+          )}
+        >
+          <span>
+            {section.isLocal ? `${section.title} · on desktop` : section.title}
+          </span>
+          {disabled && <Lock01 size={12} className="opacity-60" />}
+        </div>
+      )}
 
       {TIER_ORDER.map((tier) => {
         const entry = section.tiers[tier];


### PR DESCRIPTION
## Summary
- Hide the section header in the chat-input model popover when only one harness is rendered — single-harness users no longer see a redundant group label.
- Always resolve a default highlighted tier so the popover never opens with nothing marked "On".
- Square off the local (green) section background and add small vertical gap between tier rows; drop the popover's outer padding.
- Rename the "· on this laptop" suffix to "· on desktop" in the label, the matching test, and the JSDoc.

## Test plan
- [x] \`bun test apps/mesh/src/web/components/chat/select-model/agent-section.test.tsx apps/mesh/src/web/components/chat/agent-model-popover.test.tsx\` — 9/9 passing
- [ ] Open the chat input with a single available harness; confirm no group label renders
- [ ] Open with multiple harnesses; confirm the green local-section band is square-cornered and labelled "· on desktop"
- [ ] Confirm a tier row is always highlighted "On" when the popover opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the chat model selector popover to reduce visual noise and prevent blank states. It hides the header when only one harness is shown, always highlights a default tier, squares the local section with tighter spacing (no outer padding), and renames the suffix to "· on desktop".

<sup>Written for commit c09a7768e25b29e8a4e5b0fe4b9e417ef5e6cf9e. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3429?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

