### PR TITLE
fix(link): lowercase userSub when composing link tunnel host

### DIFF
--- a/apps/mesh/src/link-daemon/tunnel.test.ts
+++ b/apps/mesh/src/link-daemon/tunnel.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { computeLinkSubDomain } from "./tunnel";
+
+describe("computeLinkSubDomain", () => {
+  it("lowercases mixed-case userSubs", () => {
+    // Better Auth subs are case-sensitive nanoids, but hostnames are
+    // case-insensitive and the WHATWG URL parser lowercases the host on
+    // the wire. The Warp DO behind deco.host keys its registration map
+    // by the `domain` field passed in the register message — if we send
+    // it mixed-case while the public HTTP request arrives lowercase,
+    // every dispatch 503s with "No registration for domain". The
+    // cluster's `expectedTunnelDomain` does the same in
+    // `apps/mesh/src/links/routes.ts`.
+    expect(computeLinkSubDomain("ycoiLjsJJ87qAKNeANPPpb7UDoCKdqoy")).toBe(
+      "link-ycoiljsjj87qakneanpppb7udockdqoy.deco.host",
+    );
+  });
+
+  it("is idempotent for already-lowercase userSubs", () => {
+    expect(computeLinkSubDomain("abc123")).toBe("link-abc123.deco.host");
+  });
+});

--- a/apps/mesh/src/link-daemon/tunnel.ts
+++ b/apps/mesh/src/link-daemon/tunnel.ts
@@ -77,7 +77,16 @@ export async function openTunnel(
  * the cluster's `expectedTunnelDomain(userSub)` in
  * `apps/mesh/src/links/routes.ts` — both sides derive the host from the
  * authenticated userSub independently.
+ *
+ * userSub is lowercased because hostnames are case-insensitive (RFC 3986
+ * §3.2.2) but Better Auth subs are case-sensitive nanoids. WHATWG URL
+ * parsing lowercases the host on the wire, so a mixed-case sub
+ * registered as `domain` in the Warp protocol won't match the lowercase
+ * Host header on incoming HTTP requests — the deco.host DO's
+ * `hostToClientId` map misses and returns 503 "No registration for
+ * domain". Lowercase here keeps the application-layer registration in
+ * sync with what the transport actually sees.
  */
 export function computeLinkSubDomain(userSub: string): string {
-  return `link-${userSub}.deco.host`;
+  return `link-${userSub.toLowerCase()}.deco.host`;
 }

--- a/apps/mesh/src/links/routes.test.ts
+++ b/apps/mesh/src/links/routes.test.ts
@@ -78,6 +78,33 @@ describe("POST /api/links", () => {
     expect(res.status).toBe(426);
   });
 
+  it("derives a lowercase tunnelUrl from a mixed-case userSub", async () => {
+    // hostnames are case-insensitive but Better Auth subs are case-sensitive
+    // nanoids — the cluster and the daemon both lowercase the sub when
+    // composing the deco.host hostname so the Warp DO's registration map
+    // (keyed by `domain`) matches the lookup (keyed by the lowercase Host
+    // header). Without this every mixed-case sub 503s on dispatch.
+    const { app, registry } = buildApp(false);
+    const res = await app.request("/api/links", {
+      method: "POST",
+      body: JSON.stringify({
+        machineId: "m1",
+        cliVersion: "1.0.0",
+        protocolVersion: 1,
+        capabilities: ["claude-code"],
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-test-sub": "ycoiLjsJJ87qAKNeANPPpb7UDoCKdqoy",
+      },
+    });
+    expect(res.status).toBe(200);
+    const stored = await registry.get("ycoiLjsJJ87qAKNeANPPpb7UDoCKdqoy");
+    expect(stored?.tunnelUrl).toBe(
+      "https://link-ycoiljsjj87qakneanpppb7udockdqoy.deco.host",
+    );
+  });
+
   it("rejects 409 when another machineId is active", async () => {
     const { app } = buildApp();
     const first = await app.request("/api/links", {

--- a/apps/mesh/src/links/routes.ts
+++ b/apps/mesh/src/links/routes.ts
@@ -53,7 +53,16 @@ export interface LinksRoutesDeps<E extends Env = Env> {
 }
 
 function expectedTunnelDomain(userSub: string): string {
-  return `https://link-${userSub}.deco.host`;
+  // Lowercase the sub because hostnames are case-insensitive but Better
+  // Auth subs are case-sensitive nanoids. The Warp DO behind deco.host
+  // keys its `hostToClientId` map by the literal `domain` field the
+  // client sent in the register message, while HTTP forwarding looks up
+  // by the request's Host header — which the WHATWG URL parser lowercased
+  // on the wire. Without this, every sub containing uppercase letters
+  // gets a permanent 503 "No registration for domain" on dispatch. The
+  // daemon does the same in `computeLinkSubDomain`; both sides must
+  // agree.
+  return `https://link-${userSub.toLowerCase()}.deco.host`;
 }
 
 function timingSafeEqualStrings(a: string, b: string): boolean {


### PR DESCRIPTION
## Summary

Mixed-case Better Auth user subs (e.g. `ycoiLjsJJ87qAKNeANPPpb7UDoCKdqoy`) caused every `deco link` tunnel to silently 503 on the first dispatch. The daemon reported `Tunnel open: …` but the cluster-side fetch came back as:

```
remote-user ensure failed: 503 No registration for domain and/or remote service not available
```

Hostnames are case-insensitive per RFC 3986 §3.2.2, and the WHATWG URL parser lowercases the host on the wire. The Warp DO behind `*.deco.host` keys its `hostToClientId` map by the **literal `domain`** field the client sent in the `register` WS message, while HTTP forwarding looks up by the **lowercase Host header** on incoming requests. The two never matched for subs containing uppercase characters.

Proof from the Cloudflare Worker log:

```
Daemon advertised : link-ycoiLjsJJ87qAKNeANPPpb7UDoCKdqoy.deco.host
CF Worker received: link-ycoiljsjj87qakneanpppb7udockdqoy.deco.host
```

This PR lowercases the sub on both sides — `computeLinkSubDomain` in `apps/mesh/src/link-daemon/tunnel.ts` (what the daemon registers with Warp) and `expectedTunnelDomain` in `apps/mesh/src/links/routes.ts` (what the cluster stores in `linkRegistry` and dispatches to). Both must agree because each computes the URL from the raw `userSub` independently.

`userSub` itself stays case-sensitive everywhere it actually matters (registry key, `X-Mesh-User-Sub` HMAC header, Better Auth session) — only the hostname embedding changes.

There's a parallel one-line bug in `deco-cx/warp` itself (the server should lowercase before storing/looking up in `hostToClientId` — defense in depth per RFC 3986). Worth a follow-up PR there, but fixing mesh alone unblocks every user immediately.

## Test plan

- [x] `bun test apps/mesh/src/link-daemon apps/mesh/src/links` — 67 pass, including:
  - new `tunnel.test.ts`: asserts `computeLinkSubDomain("Mixed…Case") → "link-mixed…case.deco.host"`
  - new case in `routes.test.ts`: registers with a mixed-case `userSub` against the prod path (`allowLocalhostLinks: false`) and asserts the stored `tunnelUrl` is fully lowercase
- [x] `bun run --cwd=apps/mesh check` — clean
- [x] `bun run fmt` — clean
- [ ] After deploy, run `bunx decocms auth login --target https://studio-stg.decocms.com && MESH_CLUSTER_URL=https://studio-stg.decocms.com bunx decocms link`, then dispatch a tool that triggers `RemoteUserSandboxProvider.ensure()` — should return 200 instead of 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowercase the Better Auth `userSub` when composing link tunnel hostnames on the daemon and cluster. This fixes 503 “No registration for domain” errors for users with mixed‑case subs.

- **Bug Fixes**
  - Daemon: `computeLinkSubDomain(userSub)` lowercases before building `link-<sub>.deco.host`; Cluster: `expectedTunnelDomain(userSub)` does the same for stored/dispatch URLs.
  - Added tests for mixed-case subs; `userSub` remains case-sensitive for registry keys and HMAC headers.

<sup>Written for commit 51b1bef692bf9e3a111a025c33ac832fc11d74cc. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

