### PR TITLE
fix(dev): wait for dev-link session before spawning link daemon

### DIFF
--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -5,6 +5,7 @@
  * buildSettings(). Spawns dev servers and reports progress via the CLI
  * store so the Ink UI can update live.
  */
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "path";
 import type { Subprocess } from "bun";
@@ -199,6 +200,29 @@ export async function startDevServer(
             }`,
           });
           return null;
+        }
+        // The cluster's port opens the instant `Bun.serve` listens, but
+        // `bootstrapDevLinkSession` (admin user seed + API key mint) runs
+        // async after that and is what writes `session.json`. On first boot
+        // it can take many seconds (embedded pg init + migrations + seed),
+        // and the link daemon throws "No session found" immediately on a
+        // missing file. Wait for the file before spawning so we don't lose
+        // the race and leave the Sandbox spinner pinned forever.
+        const sessionPath = join(linkDataDir, "session.json");
+        const sessionWaitDeadline = Date.now() + 60_000;
+        while (!existsSync(sessionPath)) {
+          if (Date.now() > sessionWaitDeadline) {
+            addLogEntry({
+              method: "",
+              path: "",
+              status: 0,
+              duration: 0,
+              timestamp: new Date(),
+              rawLine: `[link] gave up waiting for dev-link session at ${sessionPath} after 60s — skipping link spawn. Sandbox will stay pending.`,
+            });
+            return null;
+          }
+          await new Promise((r) => setTimeout(r, 500));
         }
         const proc = Bun.spawn(
           [

--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -375,7 +375,9 @@ function ConnectionInspectorViewWithConnection({
     await queryClient.invalidateQueries({
       queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
     });
-    await queryClient.invalidateQueries({ queryKey: ["mcp", "client"] });
+    await queryClient.invalidateQueries({
+      queryKey: KEYS.mcpClientPrefix(),
+    });
 
     toast.success("Authentication successful");
   };

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -49,6 +49,13 @@ export const KEYS = {
   mcpTools: (url: string, token?: string | null) =>
     ["mcp", "tools", url, token] as const,
 
+  // Prefix for all mesh-sdk mcp-client queries (mcpClient, mcpToolsList,
+  // mcpResourcesList, mcpPromptsList, mcpReadResource, mcpGetPrompt,
+  // mcpToolCall — all start with ["mcp", "client", ...]). Use with
+  // invalidateQueries to blow away every cached client query at once,
+  // e.g. after an MCP connection re-authenticates.
+  mcpClientPrefix: () => ["mcp", "client"] as const,
+
   organizationSettings: (organizationId: string) =>
     ["organization-settings", organizationId] as const,
 


### PR DESCRIPTION
## What is this contribution about?

On first boot of `bun run dev:conductor`, the TUI Sandbox spinner never resolves. The cluster's port opens the instant `Bun.serve` listens, but `bootstrapDevLinkSession` (admin user seed + API-key mint that writes `session.json`) runs async after that and can take many seconds on a cold workspace (embedded pg init + migrations + seed). The link daemon was being spawned the moment the cluster port came up, immediately threw \"No session found\" from `readSession`, and exited — leaving `waitForPort(linkPort)` polling forever (it has no timeout), so the Sandbox status never flipped to ready. This PR makes the dev launcher also wait for `<TMPDIR>/decocms-dev-link-<slug>/session.json` to appear before spawning `deco link`, with a 60s deadline that logs a clear reason if bootstrap genuinely fails (e.g. no admin user can be seeded) instead of hanging silently.

## How to Test
1. `rm -rf \"\$TMPDIR/decocms-dev-link-<slug>\"` to simulate a first boot for the current workspace.
2. `bun run dev:conductor`.
3. Expected: Sandbox row in the TUI transitions from pending to ready once the link daemon comes up, instead of spinning forever.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Sandbox spinner from hanging on first boot by waiting for the dev-link `session.json` before starting the link daemon. Also centralizes MCP client query keys with `KEYS.mcpClientPrefix()` for consistent cache invalidation.

- **Bug Fixes**
  - Polls for `<TMPDIR>/decocms-dev-link-<slug>/session.json` every 500ms before spawning `deco link`.
  - If the file doesn’t appear within 60s, logs the reason and skips spawn, avoiding the “No session found” crash and an endless `waitForPort(linkPort)` loop.

- **Refactors**
  - Adds `KEYS.mcpClientPrefix()` and uses it in connection details to invalidate all `["mcp","client",…]` queries, matching the query-key constants rule.

<sup>Written for commit 010df894accb5f275cdd999ddb5a657b0757df10. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3431?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

