### PR TITLE
fix(decopilot): default to "ephemeral" branch + rename laptop → desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ You can also define outcomes declaratively and let Studio work backward to deriv
 
 Token spend per connection — OpenRouter, Perplexity, Firecrawl, all of it. Latency, errors, bottlenecks. One dashboard.
 
-### From your laptop to your org
+### From your desktop to your org
 
 | | |
 |---|---|
-| **Local** | `bunx decocms` on your laptop. Embedded PostgreSQL. Private. |
+| **Local** | `bunx decocms` on your desktop. Embedded PostgreSQL. Private. |
 | **Cloud** | Log in to studio.decocms.com. Control local projects from any browser. |
 | **Team** | Invite people. Roles. Shared connections. Cost attribution. |
 | **Enterprise** | Self-hosted. Your infra. Your rules. |

--- a/apps/mesh/src/ai-providers/adapters/claude-code-models.ts
+++ b/apps/mesh/src/ai-providers/adapters/claude-code-models.ts
@@ -1,7 +1,7 @@
 import type { ModelInfo } from "../types";
 
 /**
- * Browser-safe model list for the Claude Code laptop harness. Lives apart
+ * Browser-safe model list for the Claude Code desktop harness. Lives apart
  * from `claude-code.ts` because that file re-exports `createClaudeCodeModel`
  * from `../../harnesses/claude-code`, which transitively pulls
  * `ai-sdk-provider-claude-code` (and Node's `crypto`) into any bundle that

--- a/apps/mesh/src/ai-providers/adapters/codex-models.ts
+++ b/apps/mesh/src/ai-providers/adapters/codex-models.ts
@@ -1,7 +1,7 @@
 import type { ModelInfo } from "../types";
 
 /**
- * Browser-safe model list for the Codex laptop harness. Lives apart from
+ * Browser-safe model list for the Codex desktop harness. Lives apart from
  * `codex.ts` because that file re-exports `createCodexModel` from
  * `../../harnesses/codex`, which transitively pulls Node-only crypto
  * code into any bundle that imports it. The chat model selector only

--- a/apps/mesh/src/ai-providers/agent-tiers.ts
+++ b/apps/mesh/src/ai-providers/agent-tiers.ts
@@ -2,12 +2,12 @@ import type { HarnessId } from "../harnesses";
 import type { ChatTier } from "@/tools/organization/schema";
 
 /**
- * Per-agent (laptop-CLI harness) tier → model mapping.
+ * Per-agent (desktop-CLI harness) tier → model mapping.
  *
  * Lives in the server-safe `ai-providers/` folder so both the cluster's
  * dispatch path (`resolvePerRequestModels`) and the web `agent-models.ts`
  * can read it. The cluster never has an `ai_provider_keys` row for these
- * harnesses — capability and credential live on the user's laptop link.
+ * harnesses — capability and credential live on the user's desktop link.
  */
 export interface AgentTierEntry {
   modelId: string;
@@ -35,7 +35,7 @@ function getAgentTiers(agent: HarnessId): AgentTierMap | null {
   return null;
 }
 
-/** Returns the model the laptop harness should run for the given tier,
+/** Returns the model the desktop harness should run for the given tier,
  *  or `null` when the harness is Decopilot (uses the AI provider path). */
 export function resolveAgentTier(
   agent: HarnessId,

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -193,7 +193,7 @@ function lookupResumeSessionRef(
  *   - `"local"` — `getInternalUrl()` (loopback; the harness runs inside
  *     the cluster pod alongside the API).
  *   - `"remote-cli"` — `getPublicUrl()` (the harness runs on the user's
- *     laptop and dials the cluster back over the public network — or, in
+ *     desktop and dials the cluster back over the public network — or, in
  *     dev mode, localhost via `MESH_ALLOW_LOCALHOST_LINKS=1`).
  */
 const MCP_KEY_TTL_SECONDS = 3600;
@@ -275,9 +275,9 @@ export interface DispatchRunInput {
    * body. When omitted, falls back to deriving from the credential's
    * provider id (legacy behavior; still correct for Decopilot).
    *
-   * Necessary because the laptop-CLI harnesses no longer have an
+   * Necessary because the desktop-CLI harnesses no longer have an
    * `ai_provider_keys` row to drive the credential→harness lookup —
-   * their `credentialId` is the sentinel `laptop:<harness>`.
+   * their `credentialId` is the sentinel `desktop:<harness>`.
    */
   harnessId?: HarnessId | null;
 }
@@ -434,7 +434,7 @@ async function prepareRun(
     const credentialKey = await ctx.storage.aiProviderKeys
       .findById(input.models.credentialId, input.organizationId)
       .catch(() => null);
-    // Prefer the pre-resolved pin from POST /messages (covers laptop-CLI
+    // Prefer the pre-resolved pin from POST /messages (covers desktop-CLI
     // harnesses whose synthetic credentialId doesn't match any row);
     // fall back to deriving from the credential's provider id for legacy
     // callers (e.g. older automation paths) that don't set `harnessId`.
@@ -799,7 +799,7 @@ async function prepareRun(
         // claude-code cwd resolution: with the `host` runner gone, the
         // cluster never has a local on-disk workdir to point the CLI at,
         // so the harness falls back to its own ambient cwd. Remote-user
-        // dispatch runs the harness inside the laptop daemon, where the
+        // dispatch runs the harness inside the desktop daemon, where the
         // daemon is spawned with workdir = sandbox path; remote-cli runs
         // claude-code in-process on the user's machine (no resolver
         // needed). Production runners (docker, agent-sandbox, freestyle)

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -177,8 +177,8 @@ async function tryResolveTier(ctx: MeshContext, tier: SimpleModeTier) {
  *   `image` and `web_research` tiers — when present they enable the
  *   `generate_image` and `web_search` built-in tools.
  *
- * - **Laptop-CLI harnesses (`claude-code`, `codex`):** the model lives
- *   on the user's laptop, not in any AI provider key. We synthesize the
+ * - **Desktop-CLI harnesses (`claude-code`, `codex`):** the model lives
+ *   on the user's desktop, not in any AI provider key. We synthesize the
  *   ModelsConfig from the agent's hardcoded tier map (`agent-tiers.ts`).
  *   The `credentialId` is a sentinel — the harness reads `models.thinking.id`
  *   to know which CLI sub-command to invoke and ignores the credential.
@@ -204,7 +204,7 @@ async function resolvePerRequestModels(
       );
     }
     return {
-      credentialId: `laptop:${harnessId}`,
+      credentialId: `desktop:${harnessId}`,
       thinking: {
         id: entry.modelId,
         title: entry.label,
@@ -425,12 +425,15 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         existingThread = null;
       }
 
-      const branch = existingThread?.branch ?? input.branch ?? null;
-      if (!branch) {
-        throw new HTTPException(400, {
-          message: "thread has no branch pinned",
-        });
-      }
+      // Fall back to the "ephemeral" synthetic branch when neither the
+      // thread row nor the request body pins one. Synthetic branches
+      // (see packages/sandbox/daemon/constants.ts:isSyntheticBranch) are
+      // accepted by the daemon as vmMap routing keys but never checked
+      // out — exactly the right semantics for Decopilot threads on
+      // agents with no clonable repo, where the branch is purely an
+      // isolation key.
+      const branch = existingThread?.branch ?? input.branch ?? "ephemeral";
+      const branchWasDefaulted = !existingThread?.branch && !input.branch;
 
       // Determine the pinned (kind, harness). If the thread row has them,
       // use those. Otherwise this is the first message — derive defaults and
@@ -448,7 +451,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       let pinnedHarness = (existingThread?.harness_id ??
         null) as HarnessId | null;
 
-      if (!pinnedKind || !pinnedHarness) {
+      if (!pinnedKind || !pinnedHarness || branchWasDefaulted) {
         pinnedKind =
           pinnedKind ??
           input.sandboxProviderKind ??
@@ -463,6 +466,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
             await ctx.storage.threads?.update?.(taskId, {
               sandbox_provider_kind: pinnedKind,
               harness_id: pinnedHarness,
+              ...(branchWasDefaulted ? { branch } : {}),
             });
           } catch (err) {
             console.warn(

--- a/apps/mesh/src/auth/dev-link-session.ts
+++ b/apps/mesh/src/auth/dev-link-session.ts
@@ -1,6 +1,6 @@
 /**
  * Dev-only helper to bootstrap an OAuth-ish session file for the
- * laptop-side link daemon when it auto-spawns out of `bun run dev`.
+ * desktop-side link daemon when it auto-spawns out of `bun run dev`.
  *
  * In production the link reads a real OAuth session minted by
  * `decocms auth login`. Locally we have no such login flow — the dev

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -85,7 +85,7 @@ Usage:
   deco services <up|down|status>     Manage services (Postgres, NATS)
   deco init <directory>              Scaffold a new MCP app
   deco auth <login|whoami|logout>    Manage CLI authentication
-  deco link [options]                Start the laptop-side link daemon
+  deco link [options]                Start the desktop-side link daemon
   deco completion [shell]            Install shell completions
 
 Server Options:

--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -1,5 +1,5 @@
 /**
- * `deco link` — the laptop-side link daemon command.
+ * `deco link` — the desktop-side link daemon command.
  *
  * Boots a local Bun.serve on `--port` (default 5174), opens a Warp
  * tunnel to deco.host so the cluster can reach it, registers with the

--- a/apps/mesh/src/core/harness-context.ts
+++ b/apps/mesh/src/core/harness-context.ts
@@ -1,5 +1,5 @@
 /**
- * `HarnessContext` is defined in `apps/mesh/src/harnesses` so the laptop
+ * `HarnessContext` is defined in `apps/mesh/src/harnesses` so the desktop
  * link daemon can construct one without depending on cluster modules.
  * This file re-exports it for cluster-side consumers that still import
  * via the historical `@/core/harness-context` path.

--- a/apps/mesh/src/core/server-constants.ts
+++ b/apps/mesh/src/core/server-constants.ts
@@ -37,7 +37,7 @@ export function getInternalUrl(): string {
  * Used when minting URLs that need to be resolvable from outside the
  * cluster — e.g. the MCP endpoint URL handed to a remote link daemon
  * (Phase 9 remote harness dispatch), which talks back to the cluster
- * over HTTP from the user's laptop.
+ * over HTTP from the user's desktop.
  *
  * In dev mode (`MESH_ALLOW_LOCALHOST_LINKS=1`) we deliberately advertise
  * a localhost URL so a link daemon running on the same machine can dial

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -220,7 +220,7 @@ async function threadGateWorkflowFn(
   });
   try {
     // The dispatch step is non-retriable for v1. If a pod dies mid-stream,
-    // the laptop daemon (if remote-cli) keeps running, and a DBOS replay
+    // the desktop daemon (if remote-cli) keeps running, and a DBOS replay
     // would open a second concurrent dispatch against the same workdir —
     // racing on git state and tool output. Marking the step non-retriable
     // converts pod death into a clean "run failed" rather than a corruption

--- a/apps/mesh/src/harnesses/claude-code/index.ts
+++ b/apps/mesh/src/harnesses/claude-code/index.ts
@@ -15,7 +15,7 @@
  * `processLocal.resolveCwd` callback that mapped to the `host` runner's
  * `localWorkdir(handle)`. That runner has been retired; the cluster no
  * longer supplies a resolver, and this harness falls through to
- * `process.cwd()` on the laptop daemon (spawned with workdir = sandbox
+ * `process.cwd()` on the desktop daemon (spawned with workdir = sandbox
  * path) or to `undefined` (SDK default) inside the cluster.
  *
  * Behavior parity with stream-core: the inline call at lines 888–906
@@ -47,7 +47,7 @@ import { createUsageAccumulator } from "../usage-accumulator";
  * agent → SDK default cwd) or no userId is available (defensive).
  *
  * Otherwise:
- *   - Laptop daemon (no `processLocal`): the sandbox daemon is spawned
+ *   - Desktop daemon (no `processLocal`): the sandbox daemon is spawned
  *     with `cwd = <appRoot>`, but the cloned repo lives at
  *     `<appRoot>/repo` (see `packages/sandbox/daemon/entry.ts` — it
  *     joins APP_ROOT with "repo" to form `repoDir`). Prefer the env

--- a/apps/mesh/src/harnesses/decopilot/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/index.ts
@@ -46,7 +46,7 @@ import type { PendingImage } from "./built-in-tools";
 
 /** Narrowed view of `HarnessStreamInput.processLocal` for the cluster
  *  decopilot harness. The package types those structurally-deep fields
- *  as `unknown` so the package stays portable to the laptop daemon; the
+ *  as `unknown` so the package stays portable to the desktop daemon; the
  *  cluster knows it builds richer values and narrows here at the
  *  harness boundary. */
 interface ClusterProcessLocal {
@@ -83,7 +83,7 @@ export const decopilotHarnessFactory: HarnessFactory = {
     // ctx field reads only happen on a real MeshContext value. The widening
     // cast here is a TS-level erasure; the defensive check below catches a
     // narrow HarnessContext smuggled in via misuse (e.g. a non-decopilot
-    // caller mistakenly invoking this factory on the laptop).
+    // caller mistakenly invoking this factory on the desktop).
     //
     // `storage` and `db` are required fields on MeshContext but absent
     // from HarnessContext, so their presence reliably distinguishes the

--- a/apps/mesh/src/harnesses/index.ts
+++ b/apps/mesh/src/harnesses/index.ts
@@ -6,7 +6,7 @@ import { registerHarnessFactory } from "./registry";
 // Side-effect registration. Importing this module wires up the three
 // in-tree harnesses. Out-of-tree harnesses register themselves the same way.
 //
-// CLI harnesses (claude-code, codex) are also imported by the laptop link
+// CLI harnesses (claude-code, codex) are also imported by the desktop link
 // daemon; decopilot pulls in cluster-only modules (RunRegistry, run-stream,
 // mesh tools) and is only usable on the cluster side.
 registerHarnessFactory(decopilotHarnessFactory);

--- a/apps/mesh/src/harnesses/remote-dispatch.ts
+++ b/apps/mesh/src/harnesses/remote-dispatch.ts
@@ -20,7 +20,7 @@
  * `/_sandbox/<handle>/*` (that route was deleted with the per-daemon-tunnel
  * migration).
  *
- * Handle vs runId: for remote-cli (whole-harness dispatch), the laptop
+ * Handle vs runId: for remote-cli (whole-harness dispatch), the desktop
  * spins up an ephemeral per-run sandbox; the handle == `input.runId`.
  * This differs from the remote-user provider path (Task 5.1), where the
  * handle is `computeHandle(sandboxId, branch)` because the sandbox is
@@ -29,7 +29,7 @@
  * directly.
  *
  * Cancellation: on consumer abort, fires a DELETE to the runs endpoint
- * independent of SSE close so the laptop can abort its CLI subprocess
+ * independent of SSE close so the desktop can abort its CLI subprocess
  * promptly even if the response stream is still draining.
  */
 import type { UIMessageChunk } from "ai";
@@ -151,7 +151,7 @@ export interface RemoteDispatchDeps {
 export type RemoteDispatchLink = Pick<LinkEntry, "tunnelUrl" | "linkSecret">;
 
 /**
- * Ensure the laptop link has a sandbox registered at `handle` before the
+ * Ensure the desktop link has a sandbox registered at `handle` before the
  * cluster fires `remoteDispatch`. The link's `POST /api/sandboxes`
  * spawns (or reuses) a daemon for `handle` and returns the daemon's
  * `sandboxUrl` — a per-daemon tunnel (`https://<handle>.deco.host` in

--- a/apps/mesh/src/harnesses/types.ts
+++ b/apps/mesh/src/harnesses/types.ts
@@ -5,7 +5,7 @@ import type { UIMessage, UIMessageChunk, UIMessageStreamWriter } from "ai";
  *
  * These types intentionally avoid importing from cluster-only paths
  * (`@/core/*`, `@/storage/*`, `@/api/*`, etc.) so this file stays portable
- * into the laptop daemon's bundle. The cluster-side shapes (`ChatMessage`
+ * into the desktop daemon's bundle. The cluster-side shapes (`ChatMessage`
  * with metadata + tools, full `MeshContext`, decopilot-only
  * `HarnessProcessLocal` internals) flow in via structural compatibility:
  * the cluster passes its richer types where the harness expects a
@@ -167,7 +167,7 @@ export interface HarnessStreamInput {
   // ===== Tool gateway =====
   /** MCP endpoint the harness should connect to. In-process (decopilot,
    *  cluster-side claude-code/codex) uses `getInternalUrl()/mcp/virtual-mcp/<agentId>`;
-   *  remote-cli (laptop daemon dispatch) uses the cluster's public URL.
+   *  remote-cli (desktop daemon dispatch) uses the cluster's public URL.
    *  The Bearer token is a 1h-TTL temp key — `expiresAt` carries its
    *  absolute deadline so remote daemons can refresh proactively. */
   mcp: {
@@ -241,7 +241,7 @@ export interface Harness {
  *  cluster-side code path on `HarnessStreamInput.processLocal` (today,
  *  only decopilot does this).
  *
- *  The laptop's daemon constructs a HarnessContext directly to invoke
+ *  The desktop's daemon constructs a HarnessContext directly to invoke
  *  `claudeCodeHarnessFactory.create()` / `codexHarnessFactory.create()`
  *  without depending on cluster-only modules.
  *

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -256,7 +256,7 @@ if (settings.localMode) {
         void seeded;
         // When the cluster is in dev mode (MESH_ALLOW_LOCALHOST_LINKS=1
         // set by `bun run dev`), bootstrap an API-key-backed session for
-        // the laptop-side link binary that `bun run dev` auto-spawns.
+        // the desktop-side link binary that `bun run dev` auto-spawns.
         // The link reads it from `<DATA_DIR>/dev-link/session.json` and
         // presents the API key as a Bearer token to POST /api/links.
         if (process.env.MESH_ALLOW_LOCALHOST_LINKS === "1") {

--- a/apps/mesh/src/link-daemon/capabilities.ts
+++ b/apps/mesh/src/link-daemon/capabilities.ts
@@ -3,7 +3,7 @@ import type { Capability } from "@/links/protocol";
 /**
  * Detected once at daemon startup. The result rides the existing
  * `capabilities: Capability[]` field on the registration payload, so the
- * cluster sees an accurate view of what this laptop can actually run.
+ * cluster sees an accurate view of what this desktop can actually run.
  *
  * `decopilot-sandbox` is unconditional — the daemon process IS the sandbox
  * host, so it can always serve that capability.

--- a/apps/mesh/src/link-daemon/control-plane.test.ts
+++ b/apps/mesh/src/link-daemon/control-plane.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { signRequest } from "@/links/protocol";
 import { makeControlPlaneHandler } from "./control-plane";
-import { createLaptopSandboxProvider } from "./sandbox-provider";
+import { createDesktopSandboxProvider } from "./sandbox-provider";
 
 const SECRET = "test-link-secret";
 
 function buildHandler() {
   let portCounter = 30000;
-  const provider = createLaptopSandboxProvider({
+  const provider = createDesktopSandboxProvider({
     dataDir: "/tmp/link-cp-test",
     spawnDaemon: () => ({ port: 0, kill: () => {} }),
     postConfig: async () => {},

--- a/apps/mesh/src/link-daemon/control-plane.ts
+++ b/apps/mesh/src/link-daemon/control-plane.ts
@@ -7,7 +7,7 @@
  *
  * Browser preview + cluster→daemon RPCs are NOT served here anymore —
  * each daemon has its own warp tunnel (<handle>.deco.host) opened by
- * the laptop provider at ensureSandbox time. The cluster reads the
+ * the desktop provider at ensureSandbox time. The cluster reads the
  * URL from the link's response, persists it in sandbox_runner_state,
  * and talks to the daemon directly.
  *
@@ -19,10 +19,10 @@
  */
 
 import { verifyRequest } from "@/links/protocol";
-import type { LaptopSandboxProvider, RepoRef } from "./sandbox-provider";
+import type { DesktopSandboxProvider, RepoRef } from "./sandbox-provider";
 
 export interface ControlPlaneDeps {
-  provider: LaptopSandboxProvider;
+  provider: DesktopSandboxProvider;
   linkSecret: string;
   seenNonce: (nonce: string) => boolean;
   recordNonce: (nonce: string) => void;

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -1,5 +1,5 @@
 /**
- * Laptop-side link daemon.
+ * Desktop-side link daemon.
  *
  * Boots a local Bun.serve, opens a Warp tunnel (unless `noTunnel`),
  * registers with the cluster's `/api/links` to receive a `linkSecret`,
@@ -23,7 +23,7 @@ import { makeControlPlaneHandler } from "./control-plane";
 import { loadOrCreateMachineId } from "./machine-id";
 import { registerWithCluster, startHeartbeatLoop } from "./registration";
 import {
-  createLaptopSandboxProvider,
+  createDesktopSandboxProvider,
   type SpawnResult,
 } from "./sandbox-provider";
 import { readSession } from "./session";
@@ -170,7 +170,7 @@ export async function startLinkDaemon(
     await waitForDaemonReady(`http://127.0.0.1:${port}`);
   };
 
-  const provider = createLaptopSandboxProvider({
+  const provider = createDesktopSandboxProvider({
     dataDir: opts.dataDir,
     spawnDaemon: spawnSandboxDaemon,
     postConfig: postSandboxConfig,

--- a/apps/mesh/src/link-daemon/machine-id.ts
+++ b/apps/mesh/src/link-daemon/machine-id.ts
@@ -1,7 +1,7 @@
 /**
  * Machine-id is the stable identifier the link daemon presents at
  * registration. It lives at `<dataDir>/.deco/link/machine-id` and is
- * generated once per laptop.
+ * generated once per desktop.
  *
  * The cluster keys its `LinkRegistry` by the OAuth userSub, NOT by this
  * machineId — but it stores the value so it can detect "another machine

--- a/apps/mesh/src/link-daemon/sandbox-provider.test.ts
+++ b/apps/mesh/src/link-daemon/sandbox-provider.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createLaptopSandboxProvider } from "./sandbox-provider";
+import { createDesktopSandboxProvider } from "./sandbox-provider";
 
 function fakeDaemonSpawner() {
   return {
@@ -19,12 +19,12 @@ function tmpDataDir(): string {
   return mkdtempSync(join(tmpdir(), "link-prov-"));
 }
 
-describe("laptop sandbox provider", () => {
+describe("desktop sandbox provider", () => {
   it("creates a sandbox and returns sandboxUrl", async () => {
     const dataDir = tmpDataDir();
     try {
       let portCounter = 30000;
-      const provider = createLaptopSandboxProvider({
+      const provider = createDesktopSandboxProvider({
         dataDir,
         spawnDaemon: () => fakeDaemonSpawner(),
         postConfig: async () => {},
@@ -51,7 +51,7 @@ describe("laptop sandbox provider", () => {
     try {
       let spawnCount = 0;
       let portCounter = 30000;
-      const provider = createLaptopSandboxProvider({
+      const provider = createDesktopSandboxProvider({
         dataDir,
         spawnDaemon: () => {
           spawnCount++;
@@ -75,7 +75,7 @@ describe("laptop sandbox provider", () => {
     try {
       let spawnCount = 0;
       let portCounter = 30000;
-      const provider = createLaptopSandboxProvider({
+      const provider = createDesktopSandboxProvider({
         dataDir,
         spawnDaemon: () => {
           spawnCount++;
@@ -107,11 +107,11 @@ describe("laptop sandbox provider", () => {
   });
 });
 
-describe("LaptopSandboxProvider tunnel lifecycle", () => {
+describe("DesktopSandboxProvider tunnel lifecycle", () => {
   it("opens a tunnel after postConfig and returns the public URL", async () => {
     const tunnelHandles: Array<{ subDomain: string }> = [];
 
-    const provider = createLaptopSandboxProvider({
+    const provider = createDesktopSandboxProvider({
       dataDir: "/tmp/test",
       spawnDaemon: async ({ port }) => ({ port, kill: () => {} }),
       postConfig: async () => {},
@@ -140,7 +140,7 @@ describe("LaptopSandboxProvider tunnel lifecycle", () => {
   });
 
   it("falls back to 127.0.0.1 URL when openDaemonTunnel returns null", async () => {
-    const provider = createLaptopSandboxProvider({
+    const provider = createDesktopSandboxProvider({
       dataDir: "/tmp/test",
       spawnDaemon: async ({ port }) => ({ port, kill: () => {} }),
       postConfig: async () => {},
@@ -160,7 +160,7 @@ describe("LaptopSandboxProvider tunnel lifecycle", () => {
 
   it("closes the tunnel on deleteSandbox", async () => {
     const closes: string[] = [];
-    const provider = createLaptopSandboxProvider({
+    const provider = createDesktopSandboxProvider({
       dataDir: "/tmp/test",
       spawnDaemon: async ({ port }) => ({ port, kill: () => {} }),
       postConfig: async () => {},
@@ -187,7 +187,7 @@ describe("LaptopSandboxProvider tunnel lifecycle", () => {
       exitResolver = r;
     });
 
-    const provider = createLaptopSandboxProvider({
+    const provider = createDesktopSandboxProvider({
       dataDir: "/tmp/test",
       spawnDaemon: async ({ port }) => ({
         port,

--- a/apps/mesh/src/link-daemon/sandbox-provider.ts
+++ b/apps/mesh/src/link-daemon/sandbox-provider.ts
@@ -1,5 +1,5 @@
 /**
- * LaptopSandboxProvider — owns per-handle sandbox daemons on the user's
+ * DesktopSandboxProvider — owns per-handle sandbox daemons on the user's
  * machine. Each `ensureSandbox` call either returns an existing
  * (handle, port) pair or spawns a fresh daemon process, posts the
  * initial tenant config, waits for `/health`, and tracks it for LRU
@@ -59,7 +59,7 @@ export interface SandboxState {
   activeDispatchCount: number;
 }
 
-export interface LaptopSandboxProvider {
+export interface DesktopSandboxProvider {
   ensureSandbox(
     input: EnsureSandboxInput,
   ): Promise<{ sandboxUrl: string; port: number }>;
@@ -79,7 +79,7 @@ export interface OpenTunnelDeps {
   localAddr: string;
 }
 
-export interface LaptopSandboxProviderDeps {
+export interface DesktopSandboxProviderDeps {
   dataDir: string;
   spawnDaemon: (args: {
     workdir: string;
@@ -104,9 +104,9 @@ export interface LaptopSandboxProviderDeps {
   maxSandboxes?: number;
 }
 
-export function createLaptopSandboxProvider(
-  deps: LaptopSandboxProviderDeps,
-): LaptopSandboxProvider {
+export function createDesktopSandboxProvider(
+  deps: DesktopSandboxProviderDeps,
+): DesktopSandboxProvider {
   const cap = deps.maxSandboxes ?? 20;
   const sandboxes = new Map<string, SandboxState>();
   const pickPort = deps.pickPort ?? allocateEphemeralPort;

--- a/apps/mesh/src/links/resolve-dispatch-target.ts
+++ b/apps/mesh/src/links/resolve-dispatch-target.ts
@@ -5,7 +5,7 @@
  * The VM entry's `sandboxProviderKind` is the single source of truth:
  *   - cloud kind (docker/freestyle/agent-sandbox) → cluster default sandbox
  *   - `remote-user` + decopilot → cluster decopilot, sandbox tools tunneled
- *   - `remote-user` + claude-code/codex → whole stream dispatched to the laptop
+ *   - `remote-user` + claude-code/codex → whole stream dispatched to the desktop
  *
  * Link health is checked only for `remote-user` VMs. Offline/missing-capability
  * paths return an `error` target which `POST /messages` surfaces as 409.

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -184,7 +184,7 @@ export async function getSharedSandboxProvider(
   ctx: MeshContext,
 ): Promise<SandboxProvider> {
   // Per-run override: decopilot runs whose dispatch target is the user's
-  // laptop forward Code Sandbox tool calls to the link daemon instead of
+  // desktop forward Code Sandbox tool calls to the link daemon instead of
   // the cluster-managed runner. We build a fresh provider per call because
   // its only state is an in-memory (handle → sandboxUrl) map and the link
   // identity is per-run — caching across runs would mix sandboxes from

--- a/apps/mesh/src/tools/links/get-current.ts
+++ b/apps/mesh/src/tools/links/get-current.ts
@@ -6,7 +6,7 @@ import { requireAuth } from "../../core/mesh-context";
 export const LINK_CURRENT_GET = defineTool({
   name: "LINK_CURRENT_GET",
   description:
-    "Return the calling user's currently registered laptop link, or `online: false` if no link is registered or the TTL has expired. The `linkSecret` is never returned.",
+    "Return the calling user's currently registered desktop link, or `online: false` if no link is registered or the TTL has expired. The `linkSecret` is never returned.",
   inputSchema: z.object({}),
   outputSchema: z.object({
     online: z.boolean(),

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -905,7 +905,7 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "LINK_CURRENT_GET",
     description:
-      "Return the calling user's current laptop link status (online/offline, capabilities)",
+      "Return the calling user's current desktop link status (online/offline, capabilities)",
     category: "Links",
   },
 ];

--- a/apps/mesh/src/web/components/chat/agent-model-popover.tsx
+++ b/apps/mesh/src/web/components/chat/agent-model-popover.tsx
@@ -32,7 +32,7 @@ export function AgentModelPopover({
     null;
 
   return (
-    <div className="flex flex-col gap-1 w-72">
+    <div className="flex flex-col gap-1 w-72 max-h-[var(--radix-popover-content-available-height)] overflow-y-auto">
       {sections.map((section) => {
         const disabled = lockedAgent !== null && lockedAgent !== section.kind;
         const selectedTier =

--- a/apps/mesh/src/web/components/chat/agent-model-trigger.tsx
+++ b/apps/mesh/src/web/components/chat/agent-model-trigger.tsx
@@ -47,9 +47,9 @@ function optionForAgent(kind: AgentKind) {
     case "decopilot":
       return "decopilot" as const;
     case "claude-code":
-      return "claude-code-laptop" as const;
+      return "claude-code-desktop" as const;
     case "codex":
-      return "codex-laptop" as const;
+      return "codex-desktop" as const;
   }
 }
 
@@ -67,7 +67,7 @@ function agentKindFromHarness(
 /**
  * Trigger pill in the chat input that opens the merged sectioned
  * popover (Decopilot + Claude Code + Codex). When the active agent is
- * a laptop-CLI variant the pill turns `text-success` + `bg-success/10`
+ * a desktop-CLI variant the pill turns `text-success` + `bg-success/10`
  * to mirror the "Desktop connected" affordance in
  * `NoAiProviderEmptyState`. The popover handles agent + tier writes
  * atomically.

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -509,7 +509,7 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   };
 
   // Effective option: the user's pick filtered through what the current
-  // agent can actually run. Laptop-CLI options (Claude Code / Codex /
+  // agent can actually run. Desktop-CLI options (Claude Code / Codex /
   // Decopilot desktop) need a git branch to check out on the user's
   // desktop; if the user picked a desktop variant but the current agent
   // has no clonable source (Decopilot-only / ephemeral), this falls back

--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -31,15 +31,15 @@ export function visibleCapabilities(caps: readonly Capability[]): string[] {
     .filter((label): label is string => Boolean(label));
 }
 
-interface ConnectLaptopDialogProps {
+interface ConnectDesktopDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export function ConnectLaptopDialog({
+export function ConnectDesktopDialog({
   open,
   onOpenChange,
-}: ConnectLaptopDialogProps) {
+}: ConnectDesktopDialogProps) {
   const link = useCurrentLink();
   const [copied, setCopied] = useState(false);
 

--- a/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/no-ai-provider-empty-state.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, Laptop01, Zap } from "@untitledui/icons";
+import { Check, Monitor01, Zap } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ConnectProviderDialog } from "@/web/views/settings/ai-providers/connect-provider-dialog";
 import {
@@ -23,9 +23,9 @@ import { unwrapToolResult } from "@/web/lib/unwrap-tool-result";
 import { useQuery } from "@tanstack/react-query";
 import type { BrandContext } from "@/storage/types";
 import {
-  ConnectLaptopDialog,
+  ConnectDesktopDialog,
   visibleCapabilities,
-} from "./connect-laptop-dialog";
+} from "./connect-desktop-dialog";
 
 interface NoAiProviderEmptyStateProps {
   title?: string;
@@ -92,7 +92,7 @@ export function NoAiProviderEmptyState({
   const [pendingProvider, setPendingProvider] =
     useState<ProviderSelection | null>(null);
   const [gridOpen, setGridOpen] = useState(false);
-  const [laptopOpen, setLaptopOpen] = useState(false);
+  const [desktopOpen, setDesktopOpen] = useState(false);
   const link = useCurrentLink();
 
   const aiProviders = useAiProviders();
@@ -165,7 +165,7 @@ export function NoAiProviderEmptyState({
         <SettingsCard>
           {link.online ? (
             <SettingsCardItem
-              onClick={() => setLaptopOpen(true)}
+              onClick={() => setDesktopOpen(true)}
               icon={
                 <div className="size-8 rounded-md bg-success/10 flex items-center justify-center text-success">
                   <Check size={16} />
@@ -181,8 +181,8 @@ export function NoAiProviderEmptyState({
             />
           ) : (
             <SettingsCardItem
-              onClick={() => setLaptopOpen(true)}
-              icon={<Laptop01 size={16} />}
+              onClick={() => setDesktopOpen(true)}
+              icon={<Monitor01 size={16} />}
               title="Connect your desktop"
               description="Use Claude Code, Codex, or your local files via the link CLI."
             />
@@ -201,7 +201,7 @@ export function NoAiProviderEmptyState({
         initialProvider={pendingProvider ?? undefined}
       />
 
-      <ConnectLaptopDialog open={laptopOpen} onOpenChange={setLaptopOpen} />
+      <ConnectDesktopDialog open={desktopOpen} onOpenChange={setDesktopOpen} />
     </div>
   );
 }

--- a/apps/mesh/src/web/components/chat/pills/agent-options.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.ts
@@ -1,7 +1,7 @@
 import type { HarnessId } from "@/harnesses";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 
-export type AgentOption = "decopilot" | "claude-code-laptop" | "codex-laptop";
+export type AgentOption = "decopilot" | "claude-code-desktop" | "codex-desktop";
 
 export interface AgentPins {
   harness: HarnessId;
@@ -16,6 +16,6 @@ export interface AgentPins {
  */
 export const AGENT_OPTION_PINS: Record<AgentOption, AgentPins> = {
   decopilot: { harness: "decopilot", sandbox: null },
-  "claude-code-laptop": { harness: "claude-code", sandbox: "remote-user" },
-  "codex-laptop": { harness: "codex", sandbox: "remote-user" },
+  "claude-code-desktop": { harness: "claude-code", sandbox: "remote-user" },
+  "codex-desktop": { harness: "codex", sandbox: "remote-user" },
 };

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -30,7 +30,7 @@ export type AgentTierMap = Record<ChatTier, AgentTierEntry>;
 export interface AgentSection {
   kind: AgentKind;
   title: string;
-  /** True for laptop-CLI agents (Claude Code, Codex). Drives the green
+  /** True for desktop-CLI agents (Claude Code, Codex). Drives the green
    *  band + " · on desktop" suffix in the popover, and the green
    *  ring on the closed chat-input trigger. */
   isLocal: boolean;
@@ -115,9 +115,9 @@ export interface AgentModelSet {
 }
 
 /**
- * Returns the laptop-CLI model set for an agent, or null for Decopilot
+ * Returns the desktop-CLI model set for an agent, or null for Decopilot
  * (which still uses the standard provider-key path on the settings page).
- * Kept for the settings flow that mounts `LaptopCliModelSelectorBody`.
+ * Kept for the settings flow that mounts `DesktopCliModelSelectorBody`.
  */
 export function getAgentModelSet(agent: HarnessId): AgentModelSet | null {
   if (agent === "claude-code") {
@@ -147,7 +147,7 @@ const SECTION_ORDER: AgentKind[] = ["decopilot", "claude-code", "codex"];
 /**
  * Pure eligibility function for the merged chat-input popover. Returns
  * sections in stable `SECTION_ORDER`. Mirrors the gates that
- * `computeAgentOptions` used to enforce, minus `decopilot-laptop`.
+ * `computeAgentOptions` used to enforce, minus `decopilot-desktop`.
  *
  * Gates:
  *   decopilot   → hasAnyKey

--- a/apps/mesh/src/web/components/chat/select-model/desktop-cli.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/desktop-cli.tsx
@@ -3,7 +3,7 @@ import type { ChatTier } from "@/tools/organization/schema";
 import type { AgentModelSet } from "./agent-models";
 import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers";
 
-interface LaptopCliModelSelectorProps {
+interface DesktopCliModelSelectorProps {
   modelSet: AgentModelSet;
   selectedModelId: string | null;
   onSelect: (model: AiProviderModel) => void;
@@ -15,11 +15,11 @@ const TIER_ROWS: Array<{ tier: ChatTier; description: string }> = [
   { tier: "thinking", description: "Deeper reasoning" },
 ];
 
-export function LaptopCliModelSelectorBody({
+export function DesktopCliModelSelectorBody({
   modelSet,
   selectedModelId,
   onSelect,
-}: LaptopCliModelSelectorProps) {
+}: DesktopCliModelSelectorProps) {
   const lookup = Object.fromEntries(modelSet.models.map((m) => [m.modelId, m]));
 
   return (

--- a/apps/mesh/src/web/components/chat/select-model/index.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/index.tsx
@@ -4,7 +4,7 @@ import {
   DecopilotModelSelectorBody,
   DecopilotModelSelectorStandalone,
 } from "./decopilot";
-import { LaptopCliModelSelectorBody } from "./laptop-cli";
+import { DesktopCliModelSelectorBody } from "./desktop-cli";
 import { getAgentModelSet } from "./agent-models";
 import { useChatPrefs } from "../context";
 import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers";
@@ -30,7 +30,7 @@ export function ModelSelectorBody({ onClose, agent }: BodyProps) {
   }
 
   return (
-    <LaptopCliModelSelectorBody
+    <DesktopCliModelSelectorBody
       modelSet={cli}
       selectedModelId={
         prefs.selectedModel?.modelId ?? cli.tiers[prefs.simpleModeTier].modelId
@@ -60,7 +60,7 @@ export function ModelSelectorStandaloneBody({
   const cli = agent ? getAgentModelSet(agent) : null;
   if (!cli) return <DecopilotModelSelectorStandalone {...rest} />;
   return (
-    <LaptopCliModelSelectorBody
+    <DesktopCliModelSelectorBody
       modelSet={cli}
       selectedModelId={rest.selectedModel?.modelId ?? cli.tiers.smart.modelId}
       onSelect={(model) => {

--- a/apps/mesh/src/web/components/chat/side-panel-chat.tsx
+++ b/apps/mesh/src/web/components/chat/side-panel-chat.tsx
@@ -107,7 +107,7 @@ function ChatPanelContent() {
   const link = useCurrentLink();
 
   // Clonable agents (Start Website + GitHub-imported) can route through
-  // a laptop CLI harness when one is online, so the no-provider gate
+  // a desktop CLI harness when one is online, so the no-provider gate
   // only fires for them if neither a cloud provider nor a local CLI is
   // available.
   const isClonableAgent = agentHasClonableSource(fullVm?.metadata);

--- a/deploy/helm/sandbox-env/examples/values-kind.yaml
+++ b/deploy/helm/sandbox-env/examples/values-kind.yaml
@@ -12,7 +12,7 @@ image:
   tag: local
   pullPolicy: Never
 
-# ── modest sandbox limits for laptop kind ──────────────────────────────
+# ── modest sandbox limits for desktop kind ──────────────────────────────
 # Bump back up when stress-testing.
 resources:
   requests:

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -17,7 +17,7 @@
 #        waitForDaemonReady) on every code-execution. This path uses
 #        portforward unconditionally — see runner.ts:openForwarder. It
 #        works the same whether mesh runs in-cluster or on a developer's
-#        laptop, and routes through the apiserver so we don't have to
+#        desktop, and routes through the apiserver so we don't have to
 #        open daemon ingress on 9000 to mesh's pod selector.
 #   In production we *could* switch path 2 to in-cluster Service DNS and
 #   drop portforward from this Role; the daemon already enforces its own

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -27,7 +27,7 @@ The host app calls `resolveSandboxProviderKindFromEnv()` to pick the runner. Sin
 
 1. `STUDIO_SANDBOX_RUNNER` is honored if set (one of `docker`,
    `agent-sandbox`, `remote-user`).
-2. Otherwise the runner defaults to `remote-user` (the laptop-side
+2. Otherwise the runner defaults to `remote-user` (the desktop-side
    `deco link` daemon — auto-spawned by `bun run dev --local-sandbox-provider`
    in local dev, and the supported topology for single-machine self-hosts
    running the link side-by-side).

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -88,7 +88,7 @@ const bootConfig = {
   // HMAC secret used to authenticate the cluster's harness-dispatch
   // calls (POST /_decopilot_vm/dispatch + DELETE /_decopilot_vm/runs/:id).
   // Equals the link's `linkSecret` from the cluster's `LinkRegistry`.
-  // Spawned by the `deco link` daemon for the laptop case; absent on legacy
+  // Spawned by the `deco link` daemon for the desktop case; absent on legacy
   // cluster-side runner daemons that don't accept remote harness
   // dispatch — in that case the dispatch routes refuse all requests
   // (HMAC verification with an empty secret never matches a valid

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -66,7 +66,7 @@ const activeRuns = new Map<string, AbortController>();
 /** Recently-cancelled runIds. A dispatch that arrives within
  *  `TOMBSTONE_MS` of a cancel is rejected with 410 Gone — this resolves
  *  the cancel-before-dispatch race that otherwise leaves an orphan
- *  harness running on the laptop. */
+ *  harness running on the desktop. */
 const tombstones = new Map<string, number>();
 
 /** Test-visible hook to reset module state between tests. The harness

--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -1,7 +1,7 @@
 /**
  * Shared daemon spawn / executable resolution.
  *
- * Used by the `deco link` daemon (laptop-side, where the link binary
+ * Used by the `deco link` daemon (desktop-side, where the link binary
  * fronts the sandbox daemon for the cluster's remote-harness dispatcher).
  *
  * In dev (source tree present), spawn `bun run <daemon/entry.ts>` so the

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -73,7 +73,7 @@ const RUNNER_KINDS: ReadonlySet<SandboxProviderKind> = new Set([
 /**
  * Single resolution rule:
  *   - explicit STUDIO_SANDBOX_RUNNER wins (validated against the kind set);
- *   - otherwise default to "remote-user" (the laptop-side link daemon —
+ *   - otherwise default to "remote-user" (the desktop-side link daemon —
  *     auto-spawned by `bun run dev` in local dev, and the supported
  *     topology for single-machine self-hosts running the link side-by-side).
  *

--- a/packages/sandbox/server/provider/remote-user/runner.ts
+++ b/packages/sandbox/server/provider/remote-user/runner.ts
@@ -1,7 +1,7 @@
 /**
  * remote-user sandbox provider — cluster-side stub that forwards every
  * `SandboxProvider` call to a per-user `link` binary running on the
- * developer's laptop. The link exposes:
+ * developer's desktop. The link exposes:
  *
  *   - `<tunnelUrl>/api/sandboxes`                 (POST: ensure, DELETE/<h>: tear down)
  *   - `<sandboxUrl>/_decopilot_vm/*`              (exec + daemon proxy passthrough)
@@ -20,7 +20,7 @@
  * miss. The `records` map becomes an advisory in-process cache; the state
  * store is the canonical lookup.
  *
- * `localWorkdir` returns null — the workdir lives on the laptop and is never
+ * `localWorkdir` returns null — the workdir lives on the desktop and is never
  * referenced by cluster code. `watchClaimLifecycle` emits a single synthetic
  * `ready` phase, matching host/docker semantics — by the time `ensure`
  * resolves the link has already brought the daemon up.
@@ -264,11 +264,11 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * Workdir lives on the laptop; cluster code never references it. Returning
+   * Workdir lives on the desktop; cluster code never references it. Returning
    * null lets dispatch-run fall through to its default (`process.cwd()`),
    * which is fine because cluster-side dispatch for `remote-user` is the
    * decopilot Code Sandbox tool path — the harness itself runs on the
-   * laptop, where `localWorkdir` IS meaningful (different provider).
+   * desktop, where `localWorkdir` IS meaningful (different provider).
    */
   async localWorkdir(_handle: string): Promise<string | null> {
     return null;


### PR DESCRIPTION
## What is this contribution about?

Fixes the multi-pod `attach-cross-pod` CI failure and the default Decopilot chat 400 (`thread has no branch pinned`) introduced by #3417 — when neither the thread row nor the request body pins a branch, default to the `"ephemeral"` synthetic branch (already recognized by `isSyntheticBranch` in `packages/sandbox/daemon/constants.ts` and never `git checkout`'d) and persist it onto the thread row so subsequent messages share the same `vmMap` entry. Also renames the "laptop-CLI" concept to "desktop-CLI" across the codebase — types (`LaptopSandboxProvider`, `LaptopCli…`, `ConnectLaptop…`), file renames, `AgentOption` literals (`claude-code-laptop` → `claude-code-desktop`, same for codex), the `laptop:<harness>` credential sentinel, the `Laptop01` icon (→ `Monitor01`), and prose mentions in comments / READMEs / helm YAML (migrations 084/088 left untouched as shipped history). Finally, constrains the merged chat-model popover to `max-h-[var(--radix-popover-content-available-height)] overflow-y-auto` so it scrolls when the viewport can't fit all three sections × three tiers.

## Screenshots/Demonstration

Before: popover overflowed the top of the viewport on small screens (Fast/Smart unreachable). After: the picker fits the available space and scrolls when needed.

## How to Test

1. Open a Decopilot chat on an agent with no GitHub repo connected (e.g. the default Decopilot) and send a message — it should dispatch without `400 thread has no branch pinned`; the thread row should end up with `branch = "ephemeral"`.
2. Shrink the browser window vertically and click the model trigger pill — the popover should render Decopilot + Claude Code + Codex sections with an inner scrollbar instead of clipping off-screen.
3. Re-run the `multi-pod` CI job — `tests/multi-pod/scenarios/attach-cross-pod.test.ts` should pass.

## Migration Notes

None — `"ephemeral"` is already a first-class synthetic branch on the daemon side. The `AgentOption` localStorage rename will silently migrate any stored `claude-code-laptop` / `codex-laptop` value to `null` on next load (same pattern PR #3417 used when it removed `decopilot-laptop`).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default Decopilot threads to the synthetic "ephemeral" branch when no branch is pinned, fixing 400s on first message and the multi‑pod attach‑cross‑pod CI failure. Also rename the laptop‑CLI concept to desktop‑CLI across the codebase and make the merged model picker scroll on small screens.

- **Bug Fixes**
  - `POST /decopilot/threads/:id/messages`: fall back to `"ephemeral"` when neither the thread nor request pins a branch; persist it to the thread so subsequent messages hit the same vmMap entry.
  - Model picker: constrain height with `max-h-[var(--radix-popover-content-available-height)]` and `overflow-y-auto` to prevent off‑screen overflow.

- **Refactors**
  - Rename laptop → desktop throughout: `LaptopSandboxProvider` → `DesktopSandboxProvider`, `ConnectLaptopDialog` → `ConnectDesktopDialog`, icon `Laptop01` → `Monitor01`, CLI/help/docs/tests.
  - Update agent options and credential sentinels: `claude-code-laptop` → `claude-code-desktop`, `codex-laptop` → `codex-desktop`; `credentialId` from `laptop:<harness>` → `desktop:<harness>`.

<sup>Written for commit ae2ccd7092d90aecf9577d9feb1b6e87d75037b5. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3432?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

