### PR TITLE
fix(sandbox): align claim-handle hashLen for remote-user runner

### DIFF
--- a/apps/mesh/src/sandbox/claim-handle.test.ts
+++ b/apps/mesh/src/sandbox/claim-handle.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { computeClaimHandle } from "./claim-handle";
+
+describe("computeClaimHandle", () => {
+  const originalRunner = process.env.STUDIO_SANDBOX_RUNNER;
+
+  beforeEach(() => {
+    delete process.env.STUDIO_SANDBOX_RUNNER;
+  });
+
+  afterEach(() => {
+    if (originalRunner === undefined) {
+      delete process.env.STUDIO_SANDBOX_RUNNER;
+    } else {
+      process.env.STUDIO_SANDBOX_RUNNER = originalRunner;
+    }
+  });
+
+  it("uses hashLen=16 when runner is agent-sandbox", () => {
+    process.env.STUDIO_SANDBOX_RUNNER = "agent-sandbox";
+    const h = computeClaimHandle({ userId: "u", projectRef: "p" }, "main");
+    // computeHandle output: "<slug>-<hash>"; assert the hash segment length.
+    const hash = h.split("-").pop()!;
+    expect(hash.length).toBe(16);
+  });
+
+  it("uses hashLen=16 when runner is remote-user", () => {
+    // Same brute-force argument as agent-sandbox: the runner's preview URL
+    // is a public hostname (`<handle>.deco.host`), so the hash must be long
+    // enough to resist guessing at an unrate-limited gateway. This also
+    // keeps the cluster's claim-handle lookup in sync with what the
+    // remote-user runner stores (see remote-user/runner.ts ensure()).
+    process.env.STUDIO_SANDBOX_RUNNER = "remote-user";
+    const h = computeClaimHandle({ userId: "u", projectRef: "p" }, "main");
+    const hash = h.split("-").pop()!;
+    expect(hash.length).toBe(16);
+  });
+
+  it("uses default hashLen=5 for docker", () => {
+    process.env.STUDIO_SANDBOX_RUNNER = "docker";
+    const h = computeClaimHandle({ userId: "u", projectRef: "p" }, "main");
+    const hash = h.split("-").pop()!;
+    expect(hash.length).toBe(5);
+  });
+});

--- a/apps/mesh/src/sandbox/claim-handle.ts
+++ b/apps/mesh/src/sandbox/claim-handle.ts
@@ -6,18 +6,20 @@ import {
 
 /**
  * Compute the claim handle for a sandbox using the correct hashLen for the
- * current runner kind. agent-sandbox uses hashLen=16 (preview URLs are
- * public hostnames; shorter hashes are brute-forceable). All other runners
- * use the default hashLen=5.
+ * current runner kind. agent-sandbox and remote-user both expose preview
+ * URLs as public hostnames (`<handle>.cluster.host` and `<handle>.deco.host`
+ * respectively), so both use hashLen=16 — shorter hashes are brute-forceable
+ * at an unrate-limited gateway. Other runners (docker, host) keep their
+ * handles local, so the default hashLen=5 is fine there.
  *
  * Single source of truth — import this everywhere a claimName must match
- * what a runner stored (vm-events, vm-exec, etc.).
+ * what a runner stored (vm-events, vm-exec, etc.). The matching
+ * `hashLen=16` lives in `remote-user/runner.ts` so both sides agree by
+ * construction.
  */
 export function computeClaimHandle(id: SandboxId, branch: string): string {
   const providerKind = resolveSandboxProviderKindFromEnv();
-  return computeHandle(
-    id,
-    branch,
-    providerKind === "agent-sandbox" ? { hashLen: 16 } : {},
-  );
+  const useLongHash =
+    providerKind === "agent-sandbox" || providerKind === "remote-user";
+  return computeHandle(id, branch, useLongHash ? { hashLen: 16 } : {});
 }

--- a/packages/sandbox/server/provider/remote-user/runner.ts
+++ b/packages/sandbox/server/provider/remote-user/runner.ts
@@ -98,7 +98,12 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
   }
 
   async ensure(id: SandboxId, opts: EnsureOptions = {}): Promise<Sandbox> {
-    const handle = computeHandle(id, opts.repo?.branch);
+    // hashLen=16 mirrors agent-sandbox and the cluster's `computeClaimHandle`
+    // — `<handle>.deco.host` is a public hostname, so a short hash is
+    // brute-forceable at the deco.host gateway. If this changes, the
+    // matching constant in `apps/mesh/src/sandbox/claim-handle.ts` must
+    // change too or the cluster's state-store lookup will silently miss.
+    const handle = computeHandle(id, opts.repo?.branch, { hashLen: 16 });
 
     const cached = this.records.get(handle);
     if (cached) return this.toSandbox(cached);


### PR DESCRIPTION
## Summary

Every `preview-fetch` / `vm-events` / `vm-exec` call for a `remote-user` sandbox on staging returns 502 `{"error":"Preview not available"}`. Same root cause for all of them: a hashLen mismatch between the cluster's claim-handle lookup and what the runner actually stores.

### Evidence

Probed staging directly:

```bash
$ kubectl -n deco-mcp-mesh-stg exec deploy/deco-mcp-mesh-stg \
    -c chart-deco-studio -- printenv STUDIO_SANDBOX_RUNNER
agent-sandbox
```

```
[5xx Response] GET /api/123sa/vm/vir_fh4ge34…/deco%2Fgreen-reef/preview-fetch
  - 502: {"error":"Preview not available"}
[5xx Response] GET /api/123sa/vm/vir_5mw8woid…/deco%2Ffaint-ember/preview-fetch
  - 502: {"error":"Preview not available"}
[5xx Response] GET /api/123sa/vm/vir_lNRx-…/deco%2Fpale-mesa/preview-fetch
  - 502: {"error":"Preview not available"}
```

And in the staging Postgres:

```
sandbox_provider_kind | handle                | last_seg_len
remote-user           | green-reef-0ee90      | 5
remote-user           | pale-mesa-8dbfe       | 5
remote-user           | tender-cliff-f0fda    | 5
remote-user           | faint-ember-fb7ce     | 5
```

### Root cause

- `apps/mesh/src/sandbox/claim-handle.ts:16-23` resolves `STUDIO_SANDBOX_RUNNER` from env and picks `hashLen=16` **only when** it sees `agent-sandbox`. On staging that's true, so the lookup builds `green-reef-1234567890abcdef`.
- `packages/sandbox/server/provider/remote-user/runner.ts:101` calls `computeHandle(id, opts.repo?.branch)` with no override → default `hashLen=5` → stores `green-reef-0ee90`.
- `getByHandle("remote-user", "green-reef-1234567890abcdef")` returns null → `getPreviewUrl` returns null → handler returns the 502 (`apps/mesh/src/api/routes/vm-proxy.ts:356-359`). CF dresses the small JSON 5xx body with its branded "Bad gateway" HTML page, which is what the user-visible response looked like — but the staging log makes the underlying body clear.

The mismatch silently breaks every state-store consumer on the remote-user path; preview-fetch is just the most visible one.

### Fix

Both sides use `hashLen=16`. Same brute-force-resistance argument the existing comment cites for agent-sandbox applies verbatim to remote-user — `<handle>.deco.host` is a public hostname fronted by an unrate-limited Cloudflare Worker, so a 5-char (~30-bit) hash is meaningfully more guessable than 16 chars (~64-bit).

- `apps/mesh/src/sandbox/claim-handle.ts`: extend the long-hash path to cover `remote-user` (alongside `agent-sandbox`). Update the comment.
- `packages/sandbox/server/provider/remote-user/runner.ts:101`: pass `{ hashLen: 16 }` explicitly, with a cross-reference back to `claim-handle.ts` so a future change has a chance of noticing the coupling.

No data migration: existing `last_seg_len=5` rows on stg were already orphaned (the lookup never matched them) and will age out naturally. Production has no remote-user state to migrate yet.

## Test plan

- [x] new `apps/mesh/src/sandbox/claim-handle.test.ts`: asserts hash length 16 for both `agent-sandbox` and `remote-user`, 5 for `docker`
- [x] `bun test apps/mesh/src/sandbox packages/sandbox/server/provider/remote-user` — 22 pass, 0 fail
- [x] `bun run --cwd=apps/mesh check`, `bun run fmt` clean
- [ ] After deploy: `bunx decocms@latest auth login --target https://studio-stg.decocms.com && MESH_CLUSTER_URL=https://studio-stg.decocms.com bunx decocms@latest link`, trigger an ensure (decopilot message), then hit `/api/<org>/vm/<vmId>/<branch>/preview-fetch?path=/.decofile` — expect 200 with the decofile body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns claim-handle hash length for `remote-user` sandboxes to 16 characters so the cluster lookup matches the runner, fixing 502 "Preview not available" on preview-fetch/vm-events/vm-exec.

- **Bug Fixes**
  - `apps/mesh/src/sandbox/claim-handle.ts`: use `hashLen=16` for `remote-user` (same as `agent-sandbox`); others remain 5.
  - `packages/sandbox/server/provider/remote-user/runner.ts`: explicitly pass `{ hashLen: 16 }` in `ensure` so stored handles match the cluster lookup.
  - `apps/mesh/src/sandbox/claim-handle.test.ts`: tests for 16-char hashes on `agent-sandbox` and `remote-user`, and 5 for `docker`.

- **Migration**
  - None. Existing 5-char `remote-user` records were already unreachable and will age out.

<sup>Written for commit 5199062f15a8dd984c208614062ad92917bf61b6. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3433?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

