### PR TITLE
fix(decopilot): defer ensureVm() so POST /messages doesn't require a sandbox

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -128,18 +128,13 @@ mock.module("@/dispatch-queue", () => ({
 // on the 409 path, and the real one already works against our stub context.
 // We do NOT mock the module, to keep the rest of the imports intact.
 
-// `ensureVm` is stubbed so tests don't try to provision real sandboxes.
-// The stub returns a vmMap entry with the sandboxProviderKind requested by each
-// test scenario via the module-level `vmKindForTest` variable.
+// The POST handler resolves the sandbox provider kind to feed
+// `resolveDispatchTarget` and to persist on the thread row, but no longer
+// eagerly provisions a sandbox — that happens lazily inside the built-in
+// tools layer on the first VM-tool call. We only need to stub the kind
+// resolver; each test pins it via the module-level `vmKindForTest`.
 type VmKind = "docker" | "agent-sandbox" | "remote-user";
 let vmKindForTest: VmKind = "docker";
-mock.module("@/tools/vm/start", () => ({
-  ensureVm: async () => ({
-    vmId: "vm_test",
-    previewUrl: null,
-    sandboxProviderKind: vmKindForTest,
-  }),
-}));
 
 mock.module("@/sandbox/resolve-default-provider-kind", () => ({
   resolveDefaultSandboxProviderKind: async () => vmKindForTest,

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -42,7 +42,6 @@ import { enqueueThreadRun } from "@/dispatch-queue";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import type { LinkRegistry } from "../../../links/link-registry";
 import { resolveDispatchTarget } from "../../../links/resolve-dispatch-target";
-import { ensureVm } from "@/tools/vm/start";
 import {
   resolveSandboxProviderKindFromEnv,
   type SandboxProviderKind,
@@ -477,17 +476,21 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         }
       }
 
-      const vm = await ensureVm(
-        {
-          virtualMcpId: input.agent.id,
-          branch,
-          sandboxProviderKind: pinnedKind,
-        },
-        ctx,
-      );
-
+      // `resolveDispatchTarget` only needs the resolved `sandboxProviderKind`
+      // — we pass it directly instead of provisioning a VM here. VM
+      // provisioning happens lazily inside the built-in tools layer
+      // (`apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts`'s
+      // `ensureHandle`) on the first VM-tool invocation. Eagerly calling
+      // `ensureVm` at POST time used to fail in environments without a
+      // link daemon for the user even when the run never touches the
+      // sandbox (e.g. CI multi-pod tests that drive only the mock AI
+      // provider).
       const target = await resolveDispatchTarget(
-        { harnessId: pinnedHarness, vm, userId: input.userId },
+        {
+          harnessId: pinnedHarness,
+          sandboxProviderKind: pinnedKind,
+          userId: input.userId,
+        },
         { linkRegistry },
       );
       if (target.kind === "error") {

--- a/apps/mesh/src/links/resolve-dispatch-target.test.ts
+++ b/apps/mesh/src/links/resolve-dispatch-target.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { resolveDispatchTarget } from "./resolve-dispatch-target";
-import type { VmMapEntry } from "@decocms/mesh-sdk";
 import type { LinkRegistry } from "./link-registry";
 import type { LinkEntry } from "./protocol";
 
@@ -16,65 +15,69 @@ const linkOnline = (
 const stubRegistry = (link: LinkEntry | null): LinkRegistry =>
   ({ get: async () => link }) as unknown as LinkRegistry;
 
-const cloudVm = (
-  kind: "docker" | "freestyle" | "agent-sandbox" = "docker",
-): VmMapEntry =>
-  ({ vmId: "v", previewUrl: null, sandboxProviderKind: kind }) as VmMapEntry;
-
-const localVm = (): VmMapEntry =>
-  ({
-    vmId: "v",
-    previewUrl: null,
-    sandboxProviderKind: "remote-user",
-  }) as VmMapEntry;
-
 describe("resolveDispatchTarget", () => {
-  test("cloud VM + any harness → local/default", async () => {
+  test("cloud kind + any harness → local/default", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "claude-code", vm: cloudVm(), userId: "u" },
+      { harnessId: "claude-code", sandboxProviderKind: "docker", userId: "u" },
       { linkRegistry: stubRegistry(null) },
     );
     expect(t.kind).toBe("local");
     if (t.kind === "local") expect(t.sandbox).toBe("default");
   });
 
-  test("remote-user VM + decopilot + link online → local/remote-user", async () => {
+  test("remote-user + decopilot + link online → local/remote-user", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "decopilot", vm: localVm(), userId: "u" },
+      {
+        harnessId: "decopilot",
+        sandboxProviderKind: "remote-user",
+        userId: "u",
+      },
       { linkRegistry: stubRegistry(linkOnline()) },
     );
     expect(t.kind).toBe("local");
     if (t.kind === "local") expect(t.sandbox).toBe("remote-user");
   });
 
-  test("remote-user VM + claude-code + link online → remote-cli", async () => {
+  test("remote-user + claude-code + link online → remote-cli", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "claude-code", vm: localVm(), userId: "u" },
+      {
+        harnessId: "claude-code",
+        sandboxProviderKind: "remote-user",
+        userId: "u",
+      },
       { linkRegistry: stubRegistry(linkOnline()) },
     );
     expect(t.kind).toBe("remote-cli");
   });
 
-  test("remote-user VM + codex + link online → remote-cli", async () => {
+  test("remote-user + codex + link online → remote-cli", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "codex", vm: localVm(), userId: "u" },
+      { harnessId: "codex", sandboxProviderKind: "remote-user", userId: "u" },
       { linkRegistry: stubRegistry(linkOnline()) },
     );
     expect(t.kind).toBe("remote-cli");
   });
 
-  test("remote-user VM + link offline → error/link_offline", async () => {
+  test("remote-user + link offline → error/link_offline", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "claude-code", vm: localVm(), userId: "u" },
+      {
+        harnessId: "claude-code",
+        sandboxProviderKind: "remote-user",
+        userId: "u",
+      },
       { linkRegistry: stubRegistry(null) },
     );
     expect(t.kind).toBe("error");
     if (t.kind === "error") expect(t.reason).toBe("link_offline");
   });
 
-  test("remote-user VM + link missing capability → error/capability_missing", async () => {
+  test("remote-user + link missing capability → error/capability_missing", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "claude-code", vm: localVm(), userId: "u" },
+      {
+        harnessId: "claude-code",
+        sandboxProviderKind: "remote-user",
+        userId: "u",
+      },
       { linkRegistry: stubRegistry(linkOnline(["decopilot-sandbox"])) },
     );
     expect(t.kind).toBe("error");

--- a/apps/mesh/src/links/resolve-dispatch-target.ts
+++ b/apps/mesh/src/links/resolve-dispatch-target.ts
@@ -1,16 +1,21 @@
 /**
- * Resolve where a dispatch should execute, from the harness and the VM entry
- * the user has selected for this (virtualMcpId, branch).
+ * Resolve where a dispatch should execute, from the harness and the sandbox
+ * provider kind pinned for this (thread, virtualMcpId, branch).
  *
- * The VM entry's `sandboxProviderKind` is the single source of truth:
+ * `sandboxProviderKind` is the single source of truth:
  *   - cloud kind (docker/freestyle/agent-sandbox) → cluster default sandbox
  *   - `remote-user` + decopilot → cluster decopilot, sandbox tools tunneled
  *   - `remote-user` + claude-code/codex → whole stream dispatched to the desktop
  *
- * Link health is checked only for `remote-user` VMs. Offline/missing-capability
+ * Link health is checked only for `remote-user`. Offline/missing-capability
  * paths return an `error` target which `POST /messages` surfaces as 409.
+ *
+ * Takes the kind directly (not a `VmMapEntry`) so the POST handler can
+ * decide where to dispatch without eagerly provisioning a sandbox — VM
+ * provisioning is deferred to the built-in tools layer, which already
+ * resolves the handle lazily on first VM-tool invocation.
  */
-import type { VmMapEntry } from "@decocms/mesh-sdk";
+import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 import type { Capability, LinkEntry } from "./protocol";
 import type { LinkRegistry } from "./link-registry";
 import type { HarnessId } from "../harnesses";
@@ -26,7 +31,7 @@ export type DispatchTarget =
 
 interface Input {
   harnessId: HarnessId;
-  vm: VmMapEntry;
+  sandboxProviderKind: SandboxProviderKind;
   userId: string;
 }
 
@@ -45,7 +50,7 @@ export async function resolveDispatchTarget(
   input: Input,
   deps: Deps,
 ): Promise<DispatchTarget> {
-  const kind = input.vm.sandboxProviderKind;
+  const kind = input.sandboxProviderKind;
 
   if (kind !== "remote-user") {
     return { kind: "local", sandbox: "default" };


### PR DESCRIPTION
## What is this contribution about?

Fixes the multi-pod CI failure (`tests/multi-pod/scenarios/attach-cross-pod.test.ts` → 500 `"No link daemon registered for user ..."` on POST `/api/:org/decopilot/threads/:id/messages`). PR #3417 added an eager `ensureVm()` to that handler, which provisions a sandbox via `resolveDefaultSandboxProviderKind` → defaults to `"remote-user"` when no link is registered AND `STUDIO_SANDBOX_RUNNER` is unset (the multi-pod compose), then throws inside `provisionSandbox` because there is no link daemon. Since `resolveDispatchTarget` only ever read `vm.sandboxProviderKind` off the returned entry, this refactors it to take the kind directly and drops the eager `ensureVm` call from the POST handler — the built-in tools layer already provisions the sandbox lazily on the first VM-tool invocation (`ensureHandle` in `apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts`), so runs that never touch a VM-backed tool no longer pay the provisioning cost (or its hard prerequisites).

## How to Test

1. Re-run the `Multi-Pod Tests` workflow on this branch — `attach-cross-pod.test.ts` should pass.
2. `cd apps/mesh && bun test src/links/resolve-dispatch-target.test.ts src/api/routes/decopilot/routes.test.ts` — all 18 tests pass.
3. Open Decopilot locally with `bun run dev`, send a message that triggers `bash`/`read`/`write` — the VM is provisioned on first tool call (unchanged behavior).

## Migration Notes

None — `resolveDispatchTarget` is internal to mesh and has one production caller.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers VM provisioning for Decopilot so `POST /api/:org/decopilot/threads/:id/messages` no longer requires a sandbox, fixing 500s in multi-pod CI without a link daemon. Dispatch target is now resolved from the sandbox provider kind, and the VM is created lazily on first tool use.

- **Bug Fixes**
  - Prevent 500 "No link daemon registered…" by removing eager `ensureVm()` in `POST /messages`.
  - Multi-pod CI path works again; runs that never use VM-backed tools skip provisioning.

- **Refactors**
  - `resolveDispatchTarget` now takes `sandboxProviderKind` instead of a VM entry and avoids provisioning.
  - Route handler resolves and persists the kind, and tests were updated to stub kind resolution instead of `ensureVm`.

<sup>Written for commit 8fa7d10d8e81efed66e381867c22d94f35c96a9a. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3434?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

