### PR TITLE
fix(multi-pod): pin STUDIO_SANDBOX_RUNNER=docker to unblock attach-cross-pod

### DIFF
--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -90,6 +90,13 @@ services:
       DECOCMS_LOCAL_MODE: "true"
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
       DATA_DIR: /app/data
+      # Pin the sandbox runner so POST /decopilot/messages doesn't default
+      # to "remote-user" — there's no link daemon in this cluster, and
+      # resolveDispatchTarget would 409 with link_offline. "docker" makes
+      # resolveDispatchTarget short-circuit to the local cluster default;
+      # no sandbox is actually provisioned because ensureVm is lazy
+      # (built-in-tools/index.ts) and the mock-ai test never emits tool calls.
+      STUDIO_SANDBOX_RUNNER: docker
     ports:
       - "127.0.0.1:13001:3000"
     # POD_NAME makes `run_owner_pod` match the compose service name


### PR DESCRIPTION
## What is this contribution about?

Fixes the `attach-cross-pod` multi-pod CI failure where `POST /api/:org/decopilot/threads/:id/messages` returned `409 link_unavailable / link_offline` (see [failing job](https://github.com/decocms/studio/actions/runs/26260933794/job/77293975289)).

Root cause: `tests/multi-pod/docker-compose.yml` didn't set `STUDIO_SANDBOX_RUNNER`, so `resolveSandboxProviderKindFromEnv()` defaulted to `"remote-user"`. With no link daemon registered in CI, `resolveDispatchTarget` rejected the request before it could enqueue. PR #3434 removed the eager `ensureVm()` (which had been 500-ing) but the dispatch check that gates on link presence stayed, so the symptom shifted from 500 → 409 without fully fixing the test.

Pinning `STUDIO_SANDBOX_RUNNER=docker` on the mesh services makes `resolveDispatchTarget` short-circuit to the local cluster default (no link check), and no real sandbox is provisioned because `ensureVm` is lazy (`built-in-tools/index.ts:159-184`) and the mock-AI scenario never emits tool calls.

## How to Test

1. Start Docker Desktop.
2. Run `./tests/multi-pod/run.sh`.
3. `attach-cross-pod` should pass (along with the rest of the suite).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `STUDIO_SANDBOX_RUNNER=docker` in `tests/multi-pod/docker-compose.yml` to fix `attach-cross-pod` failing with 409 `link_offline` on `POST /api/:org/decopilot/threads/:id/messages`. This forces local dispatch and avoids any sandbox provisioning since `ensureVm` is lazy.

- **Bug Fixes**
  - Unset runner defaulted to "remote-user", triggering a link check and 409 in CI. Setting it to `docker` short-circuits to the local cluster and unblocks the test.

<sup>Written for commit baf57c5e2e40991827b43321a8d040c8288a53a7. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3436?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

