### PR TITLE
fix(web): model selector + ai-provider dialog UI nits

### DIFF
--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -45,6 +45,40 @@ const CLAUDE_CODE_LOGO =
 const CODEX_LOGO =
   "https://decoims.com/decocms/9170ffd4-b9cc-4661-ad8f-ae2eea019e00/codex.svg";
 
+const ClaudeCodeIcon = ({ size = 16 }: { size?: number }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M13 12L18.5 5M7.63965 3L12.5 12L13.6865 3M4.48381 6.71679L11.9872 12M3 12L11.9872 12.473M12.2244 13.177L7 20M4.84194 16.8682L11.2824 12.9758M11.5 21L12.665 13.177M21 14L13.1846 12.668M21 10.5788L13 12.3223M16.779 19.646L12.8876 13.3772M19.3566 18.207L13.313 12.9893" />
+  </svg>
+);
+
+const CodexIcon = ({ size = 16 }: { size?: number }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    fill="currentColor"
+    fillRule="evenodd"
+    aria-hidden="true"
+  >
+    <path
+      clipRule="evenodd"
+      d="M8.086.457a6.105 6.105 0 013.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 00.107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 01-.18 1.631.167.167 0 00.04.155 5.982 5.982 0 011.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 01-2.934 1.851.162.162 0 00-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 00-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 01-2.595-.622 6.058 6.058 0 01-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 01-.495-1.283 6.11 6.11 0 01-.017-3.064.166.166 0 00.008-.074.115.115 0 00-.037-.064 5.958 5.958 0 01-1.38-2.202 5.196 5.196 0 01-.333-1.589 6.915 6.915 0 01.188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 00.087-.087A6.016 6.016 0 015.635 2.31C6.315 1.464 7.132.846 8.086.457zm-.804 7.85a.848.848 0 00-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 001.46.864l1.94-3.272a.849.849 0 00.007-.854l-1.94-3.393zm5.446 6.24a.849.849 0 000 1.695h4.848a.849.849 0 000-1.696h-4.848z"
+    />
+  </svg>
+);
+
 const DECOPILOT_TIERS: AgentTierMap = {
   fast: {
     modelId: null,
@@ -71,19 +105,19 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
     modelId: "claude-code:haiku",
     label: "Haiku",
     description: "Quicker responses",
-    iconUrl: CLAUDE_CODE_LOGO,
+    iconNode: <ClaudeCodeIcon size={16} />,
   },
   smart: {
     modelId: "claude-code:sonnet",
     label: "Sonnet",
     description: "Balanced quality",
-    iconUrl: CLAUDE_CODE_LOGO,
+    iconNode: <ClaudeCodeIcon size={16} />,
   },
   thinking: {
     modelId: "claude-code:opus",
     label: "Opus",
     description: "Deeper reasoning",
-    iconUrl: CLAUDE_CODE_LOGO,
+    iconNode: <ClaudeCodeIcon size={16} />,
   },
 };
 
@@ -92,19 +126,19 @@ const CODEX_TIERS: AgentTierMap = {
     modelId: "codex:gpt-5.4-mini",
     label: "GPT-5.4 Mini",
     description: "Quicker responses",
-    iconUrl: CODEX_LOGO,
+    iconNode: <CodexIcon size={16} />,
   },
   smart: {
     modelId: "codex:gpt-5.3-codex",
     label: "GPT-5.3 Codex",
     description: "Balanced quality",
-    iconUrl: CODEX_LOGO,
+    iconNode: <CodexIcon size={16} />,
   },
   thinking: {
     modelId: "codex:gpt-5.5",
     label: "GPT-5.5",
     description: "Deeper reasoning",
-    iconUrl: CODEX_LOGO,
+    iconNode: <CodexIcon size={16} />,
   },
 };
 

--- a/apps/mesh/src/web/components/chat/select-model/agent-section.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-section.tsx
@@ -58,8 +58,9 @@ export function AgentSection({
             disabled={disabled}
             onClick={() => onSelect(tier)}
             className={cn(
-              "flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent",
-              isSelected && "bg-accent",
+              "flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm",
+              section.isLocal ? "hover:bg-success/10" : "hover:bg-accent",
+              isSelected && (section.isLocal ? "bg-success/15" : "bg-accent"),
             )}
           >
             {entry.iconNode ? (

--- a/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
@@ -311,7 +311,7 @@ export function ConnectProviderDialog({
 
   return (
     <Dialog open={state.kind !== "closed"} onOpenChange={(o) => !o && close()}>
-      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center gap-2">
             {showBack && (


### PR DESCRIPTION
## What is this contribution about?
A few UI polish passes on the chat-input model selector and the AI provider connect dialog:
- Claude Code and Codex tier icons in the model selector now inherit `currentColor` (inline SVG) so their stroke color matches Decopilot's bolt/stars/atom icons instead of staying full-color.
- Selected/hover rows in the "on desktop" sections use success-tinted shades (`bg-success/15` selected, `bg-success/10` hover) so the green band stays cohesive.
- The AI provider connect dialog (used in settings and the no-provider empty state) now uses a single narrow `sm:max-w-md` width across grid/form/OAuth/provision states, so going back from the OpenRouter OAuth-pending screen no longer expands the dialog into a wide grid view.

## Screenshots/Demonstration
N/A — visual nits; see linked Conductor workspace.

## How to Test
1. Open the chat input model selector with desktop linked and verify Claude Code / Codex icons render in the same muted-foreground stroke as Decopilot's icons; selected/hover rows in those sections show green tints.
2. From settings → AI Providers, click "Show all", then OpenRouter, then the back arrow — dialog stays at the same narrow width throughout.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the chat model selector and AI provider connect dialog for a more consistent UI: unified tier icon styling, green-tinted selection on desktop-linked rows, and a stable narrow dialog width across states.

- **Bug Fixes**
  - Model selector: Inlined Claude Code and Codex icons to use currentColor, matching Decopilot icon styling.
  - Model selector: Applied success-tinted hover/selected backgrounds for desktop-linked sections.
  - Provider dialog: Standardized width to `sm:max-w-md` across grid/form/OAuth/provision states to stop width jumps when navigating back from `OpenRouter` OAuth pending.

<sup>Written for commit f8dfb25e294884db4c688f89b69b37716e8b79d0. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

