### PR TITLE
fix(sandbox): route VM proxy/events through recorded provider kind

### DIFF
--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -36,20 +36,15 @@
 
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import {
-  composeSandboxRef,
-  resolveSandboxProviderKindFromEnv,
-} from "@decocms/sandbox/provider";
+import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type {
   ClaimPhase,
+  SandboxProvider,
   SandboxProviderKind,
 } from "@decocms/sandbox/provider";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
-import {
-  getOrInitSharedRunner,
-  getSharedSandboxProvider,
-  subscribeLifecycle,
-} from "../../sandbox/lifecycle";
+import { subscribeLifecycle } from "../../sandbox/lifecycle";
+import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getUserId,
   requireAuth,
@@ -115,7 +110,31 @@ export const createVmEventsRoutes = () => {
       branch,
     });
     const claimName = computeClaimHandle({ userId, projectRef }, branch);
-    const providerKind = resolveSandboxProviderKindFromEnv();
+    const virtualMcpMetadata =
+      (virtualMcp.metadata as Record<string, unknown> | null) ?? null;
+
+    // Source of truth: vmMap. The resolver returns the provider bound for
+    // the recorded kind (or the link-or-env default when no entry exists
+    // yet), so a sandbox provisioned via `remote-user` remains addressable
+    // via `remote-user` even on a cluster whose env kind is `agent-sandbox`.
+    // The kind is needed for the stale-handle probe below — when a `gone`
+    // event must be emitted we route the state-store cleanup through the
+    // matching kind so we don't leave rows in the wrong table.
+    let runner: SandboxProvider | null;
+    let providerKind: SandboxProviderKind | null = null;
+    let resolveError: Error | null = null;
+    try {
+      const resolved = await resolveSandboxProvider(ctx, {
+        userId,
+        branch,
+        virtualMcpMetadata,
+      });
+      runner = resolved.provider;
+      providerKind = resolved.kind;
+    } catch (err) {
+      resolveError = err instanceof Error ? err : new Error(String(err));
+      runner = null;
+    }
 
     // Snapshot vmMap from the same metadata read used for the org-ownership
     // check. Used below to gate the stale-handle probe: we only run it when
@@ -125,35 +144,11 @@ export const createVmEventsRoutes = () => {
     // similar window for host/docker between `runner.ensure` returning and
     // `setVmMapEntry` writing the row). Without it, an SSE that opens during
     // that window would observe alive=false and emit a spurious `gone`.
-    const existingVmEntry = resolveVm(
-      readVmMap(virtualMcp.metadata as Record<string, unknown> | null),
-      userId,
-      branch,
-      providerKind,
-    );
-    const expectingHandle = existingVmEntry?.vmId === claimName;
-
-    // User-scoped resolution: for `remote-user` this picks the acting
-    // user's link daemon; for other kinds it falls through to the env
-    // singleton. Wrapped in a try because the remote-user path throws a
-    // typed error when no link is registered — in that case we want to
-    // emit a `failed` phase with a user-actionable message, NOT fall
-    // through to `getOrInitSharedRunner()` (which would re-throw the
-    // same error from `instantiate("remote-user")`).
-    let runner: Awaited<ReturnType<typeof getSharedSandboxProvider>> | null;
-    let resolveError: Error | null = null;
-    try {
-      runner = await getSharedSandboxProvider(ctx);
-    } catch (err) {
-      resolveError = err instanceof Error ? err : new Error(String(err));
-      // For non-remote-user kinds, try the env singleton as a last
-      // resort. For remote-user the throw IS the answer.
-      if (providerKind !== "remote-user") {
-        runner = await getOrInitSharedRunner().catch(() => null);
-      } else {
-        runner = null;
-      }
-    }
+    const existingVmEntry =
+      providerKind &&
+      resolveVm(readVmMap(virtualMcpMetadata), userId, branch, providerKind);
+    const expectingHandle =
+      !!existingVmEntry && existingVmEntry.vmId === claimName;
 
     if (!runner) {
       return streamSSE(c, async (stream) => {
@@ -193,7 +188,7 @@ export const createVmEventsRoutes = () => {
         // differs from the env's current runner, we route the stale-state
         // cleanup through the *prior* kind so we don't leave behind rows
         // in the wrong table.
-        if (expectingHandle) {
+        if (expectingHandle && providerKind) {
           const stale = await isStaleHandle(runner, claimName);
           if (stale) {
             await cleanupStaleEntry({
@@ -234,7 +229,7 @@ export const createVmEventsRoutes = () => {
 };
 
 async function isStaleHandle(
-  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>,
+  runner: SandboxProvider,
   claimName: string,
 ): Promise<boolean> {
   try {
@@ -283,7 +278,7 @@ async function isStaleHandle(
  */
 async function cleanupStaleEntry(args: {
   ctx: MeshContext;
-  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
+  runner: SandboxProvider;
   claimName: string;
   userId: string;
   projectRef: string;
@@ -331,7 +326,7 @@ async function cleanupStaleEntry(args: {
 async function emitLifecycle(args: {
   stream: import("hono/streaming").SSEStreamingApi;
   claimName: string;
-  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
+  runner: SandboxProvider;
   signal: AbortSignal;
 }): Promise<boolean> {
   const { stream, claimName, runner, signal } = args;
@@ -417,7 +412,7 @@ const PROXY_OPEN_RETRY_DELAY_MS = 500;
  */
 async function proxyDaemonEvents(args: {
   stream: import("hono/streaming").SSEStreamingApi;
-  runner: NonNullable<Awaited<ReturnType<typeof getOrInitSharedRunner>>>;
+  runner: SandboxProvider;
   claimName: string;
   signal: AbortSignal;
 }): Promise<void> {

--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -18,7 +18,6 @@ import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
-import { getOrInitSharedRunner } from "../../sandbox/lifecycle";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getUserId,
@@ -95,11 +94,12 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
   // is `agent-sandbox` / `docker`. Pre-provision callers fall through to
   // the link-or-env default policy inside `resolveSandboxProvider`.
   //
-  // On failure (e.g. env=`remote-user` but the user's link daemon is
-  // offline) we surface `null` for `remote-user`; the events handler
-  // streams a `failed` phase and other handlers 503 via `requireRunner`.
-  // For other kinds we fall back to the env singleton — the same
-  // resilience behavior the legacy code had.
+  // On failure (e.g. the recorded kind is `remote-user` but the user's
+  // link daemon is offline) we surface `null` rather than falling back
+  // to the env singleton: rebinding a `remote-user`-provisioned VM onto
+  // a different provider kind (say `agent-sandbox`) would forward traffic
+  // to a sandbox that doesn't host this VM. The events handler streams a
+  // `failed` phase from null; other handlers 503 via `requireRunner`.
   let runner: SandboxProvider | null;
   try {
     const resolved = await resolveSandboxProvider(ctx, {
@@ -109,7 +109,7 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     });
     runner = resolved.provider;
   } catch {
-    runner = await getOrInitSharedRunner().catch(() => null);
+    runner = null;
   }
 
   c.set("vmClaim", {

--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -14,20 +14,12 @@
 import { Hono, type Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import { createMiddleware } from "hono/factory";
-import {
-  composeSandboxRef,
-  resolveSandboxProviderKindFromEnv,
-} from "@decocms/sandbox/provider";
-import type {
-  SandboxProvider,
-  SandboxProviderKind,
-} from "@decocms/sandbox/provider";
+import { composeSandboxRef } from "@decocms/sandbox/provider";
+import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
-import {
-  getOrInitSharedRunner,
-  getSharedSandboxProvider,
-} from "../../sandbox/lifecycle";
+import { getOrInitSharedRunner } from "../../sandbox/lifecycle";
+import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getUserId,
   requireAuth,
@@ -94,28 +86,30 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     branch,
   });
   const claimName = computeClaimHandle({ userId, projectRef }, branch);
+  const virtualMcpMetadata =
+    (virtualMcp.metadata as Record<string, unknown>) ?? null;
 
-  // User-scoped resolution: for `remote-user` this picks the acting user's
-  // link daemon via `ctx.linkRegistry`; for `docker` / `agent-sandbox` it
-  // returns the cached env-resolved singleton. Falls back to the env
-  // singleton ONLY for non-`remote-user` kinds — for `remote-user` the
-  // throw IS the answer (no link daemon → `requireRunner`/events handler
-  // surface the 503/`failed` phase). Pattern mirrors the legacy
-  // `/api/vm-events` handler at vm-events.ts:143-156.
-  let providerKind: SandboxProviderKind | null;
-  try {
-    providerKind = resolveSandboxProviderKindFromEnv();
-  } catch {
-    providerKind = null;
-  }
+  // Source of truth: vmMap. If an entry exists for (user, branch) we use
+  // that recorded kind — a sandbox provisioned via `remote-user` must
+  // remain addressable via `remote-user` even on a cluster whose env kind
+  // is `agent-sandbox` / `docker`. Pre-provision callers fall through to
+  // the link-or-env default policy inside `resolveSandboxProvider`.
+  //
+  // On failure (e.g. env=`remote-user` but the user's link daemon is
+  // offline) we surface `null` for `remote-user`; the events handler
+  // streams a `failed` phase and other handlers 503 via `requireRunner`.
+  // For other kinds we fall back to the env singleton — the same
+  // resilience behavior the legacy code had.
   let runner: SandboxProvider | null;
   try {
-    runner = await getSharedSandboxProvider(ctx);
+    const resolved = await resolveSandboxProvider(ctx, {
+      userId,
+      branch,
+      virtualMcpMetadata,
+    });
+    runner = resolved.provider;
   } catch {
-    runner =
-      providerKind === "remote-user"
-        ? null
-        : await getOrInitSharedRunner().catch(() => null);
+    runner = await getOrInitSharedRunner().catch(() => null);
   }
 
   c.set("vmClaim", {
@@ -125,8 +119,7 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     branch,
     userId,
     projectRef,
-    virtualMcpMetadata:
-      (virtualMcp.metadata as Record<string, unknown>) ?? null,
+    virtualMcpMetadata,
   });
   return next();
 });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -37,10 +37,8 @@ import { createReadPromptTool } from "./prompts";
 import { createReadResourceTool } from "./resources";
 import { createSandboxTool, type VirtualClient } from "./sandbox";
 import { createVmTools } from "./vm-tools";
-import { getSharedSandboxProvider } from "@/sandbox/lifecycle";
+import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { ensureVm } from "@/tools/vm/start";
-import { resolveDefaultSandboxProviderKind } from "@/sandbox/resolve-default-provider-kind";
-import { resolveSandboxProviderKindFromEnv } from "@decocms/sandbox/provider";
 import { createSubtaskTool } from "./subtask";
 import { userAskTool } from "./user-ask";
 import { todoWriteTool } from "./todo-write";
@@ -154,26 +152,29 @@ async function buildAllTools(
   const vmNeedsApproval =
     toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false;
   if (vmContext) {
-    const runner = await getSharedSandboxProvider(ctx);
+    // `dispatch-run` already populated `ctx.sandboxPreference` /
+    // `ctx.linkForCurrentRun` from the resolved `DispatchTarget`, so the
+    // resolver short-circuits on those ctx hints without reading vmMap —
+    // no DB hit on the decopilot hot path. The same `kind` flows into
+    // `ensureVm` below so `runner` and the provisioned handle are
+    // guaranteed to come from the same provider.
+    const { provider: runner, kind: providerKind } =
+      await resolveSandboxProvider(ctx, {
+        userId: vmContext.userId,
+        branch: vmContext.branch,
+        virtualMcpMetadata: null,
+      });
     let cached: Promise<string> | null = null;
     const ensureHandle = () => {
       if (!cached) {
-        const userId = vmContext.userId;
-        cached = resolveDefaultSandboxProviderKind(userId, {
-          linkRegistry: ctx.linkRegistry!,
-          resolveEnvKind: resolveSandboxProviderKindFromEnv,
-        })
-          .then((sandboxProviderKind) =>
-            ensureVm(
-              {
-                virtualMcpId: vmContext.virtualMcpId,
-                branch: vmContext.branch,
-                sandboxProviderKind,
-              },
-              ctx,
-            ),
-          )
-          .then((entry) => entry.vmId);
+        cached = ensureVm(
+          {
+            virtualMcpId: vmContext.virtualMcpId,
+            branch: vmContext.branch,
+            sandboxProviderKind: providerKind,
+          },
+          ctx,
+        ).then((entry) => entry.vmId);
         // Reset on failure so the next tool call retries instead of
         // permanently caching a rejected promise.
         cached.catch(() => {

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -165,12 +165,14 @@ async function instantiate(
     case "remote-user": {
       // remote-user is never the cluster-wide default — there is no
       // ambient `LinkEntry` to bind to here. It is constructed per-run by
-      // `getSharedSandboxProvider` from `ctx.linkForCurrentRun`. Hitting
-      // this branch means VM_DELETE was called for a `remote-user` row
-      // without a live link context, which today should not happen (the
-      // remote-user provider doesn't write to `sandbox_runner_state`).
+      // `resolveSandboxProvider` (sandbox/resolve-provider.ts) from
+      // either the per-run ctx hint or the recorded vmMap kind, both of
+      // which carry the user's link. Hitting this branch means VM_DELETE
+      // was called for a `remote-user` row without a live link context,
+      // which today should not happen (the remote-user provider doesn't
+      // write to `sandbox_runner_state`).
       throw new Error(
-        "remote-user runner cannot be instantiated without a per-run LinkEntry — call getSharedSandboxProvider with ctx.linkForCurrentRun set.",
+        "remote-user runner cannot be instantiated without a per-run LinkEntry — call resolveSandboxProvider, which binds the link before constructing the provider.",
       );
     }
     default: {
@@ -180,53 +182,15 @@ async function instantiate(
   }
 }
 
-export async function getSharedSandboxProvider(
-  ctx: MeshContext,
-): Promise<SandboxProvider> {
-  // Per-run override: decopilot runs whose dispatch target is the user's
-  // desktop forward Code Sandbox tool calls to the link daemon instead of
-  // the cluster-managed runner. We build a fresh provider per call because
-  // its only state is an in-memory (handle → sandboxUrl) map and the link
-  // identity is per-run — caching across runs would mix sandboxes from
-  // different users.
-  if (
-    ctx.sandboxPreference === "remote-user" &&
-    ctx.linkForCurrentRun !== undefined
-  ) {
-    return buildRemoteUserProvider(ctx, ctx.linkForCurrentRun);
-  }
-
-  const kind = resolveSandboxProviderKindFromEnv();
-  // Auto-resolve for tools that don't go through `prepareRun` (VM_START,
-  // ensureVmForBranch, sandbox preview/event routes). When env says
-  // `remote-user`, there is no cluster-side singleton to fall back on —
-  // the provider is per-user. Resolve the acting user's link from the
-  // registry here so callers don't each have to do it.
-  if (kind === "remote-user") {
-    const userId = ctx.auth.user?.id;
-    if (!userId) {
-      throw new Error(
-        "remote-user sandbox provider requires an authenticated user — got an unauthenticated MeshContext.",
-      );
-    }
-    if (!ctx.linkRegistry) {
-      throw new Error(
-        "remote-user sandbox provider requires ctx.linkRegistry to be wired (set on MeshContextConfig).",
-      );
-    }
-    const link = await ctx.linkRegistry.get(userId);
-    if (!link) {
-      throw new Error(
-        `No link daemon registered for user "${userId}". Start one with \`deco link\` (or run \`bun run dev --local-sandbox-provider\` for dev).`,
-      );
-    }
-    return buildRemoteUserProvider(ctx, link);
-  }
-
-  return getSandboxProviderByKind(ctx, kind);
-}
-
-async function buildRemoteUserProvider(
+/**
+ * Construct a `RemoteUserSandboxProvider` bound to the given link entry.
+ * Exported so the unified resolver in `resolve-provider.ts` can build one
+ * without going through `getSharedSandboxProvider` (which requires
+ * pre-populating `ctx.sandboxPreference` / `ctx.linkForCurrentRun` as a
+ * side-effect — the resolver decides the kind from vmMap, not from those
+ * ctx fields, so the side-effect would be misleading).
+ */
+export async function buildRemoteUserProvider(
   ctx: MeshContext,
   link: NonNullable<MeshContext["linkForCurrentRun"]>,
 ): Promise<SandboxProvider> {

--- a/apps/mesh/src/sandbox/resolve-provider.test.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  EnsureOptions,
+  Sandbox,
+  SandboxId,
+  SandboxProvider,
+} from "@decocms/sandbox/provider";
+
+import type { MeshContext } from "../core/mesh-context";
+import type { LinkEntry } from "../links/protocol";
+import type { LinkRegistry } from "../links/link-registry";
+
+// Pin env kind so resolver fallback is deterministic.
+process.env.STUDIO_SANDBOX_RUNNER = "docker";
+
+async function* readyOnly() {
+  yield { kind: "ready" as const };
+}
+
+const stubDocker: SandboxProvider = {
+  kind: "docker",
+  ensure: async (_id: SandboxId, _opts?: EnsureOptions): Promise<Sandbox> => ({
+    handle: "h",
+    workdir: "/",
+    previewUrl: "https://stub",
+  }),
+  exec: async () => ({ stdout: "", stderr: "", exitCode: 0, timedOut: false }),
+  delete: async () => {},
+  alive: async () => true,
+  getPreviewUrl: async () => null,
+  proxyDaemonRequest: async () => new Response(null, { status: 204 }),
+  watchClaimLifecycle: () => readyOnly(),
+};
+
+const stubAgentSandbox: SandboxProvider = {
+  ...stubDocker,
+  kind: "agent-sandbox",
+};
+const stubRemoteUser: SandboxProvider = { ...stubDocker, kind: "remote-user" };
+
+// Mock lifecycle: dispatch on requested kind so we can assert which one was
+// picked.
+const byKindSpy = mock(
+  async (_ctx: unknown, kind: "docker" | "agent-sandbox" | "remote-user") => {
+    if (kind === "docker") return stubDocker;
+    if (kind === "agent-sandbox") return stubAgentSandbox;
+    throw new Error("unreachable — resolver builds remote-user directly");
+  },
+);
+const buildRemoteSpy = mock(async () => stubRemoteUser);
+
+mock.module("./lifecycle", () => ({
+  getSandboxProviderByKind: byKindSpy,
+  buildRemoteUserProvider: buildRemoteSpy,
+}));
+
+// Now import the resolver — its lifecycle import has been mocked.
+const { resolveSandboxProvider } = await import("./resolve-provider");
+
+function makeLink(): LinkEntry {
+  return {
+    tunnelUrl: "https://tunnel.example",
+    linkSecret: "secret",
+    capabilities: ["claude-code"],
+  } as LinkEntry;
+}
+
+function stubCtx(
+  link: LinkEntry | null,
+  hints?: {
+    sandboxPreference?: "default" | "remote-user";
+    linkForCurrentRun?: LinkEntry;
+  },
+): MeshContext {
+  const registry: LinkRegistry = {
+    get: async () => link,
+  } as unknown as LinkRegistry;
+  return {
+    linkRegistry: registry,
+    db: {} as never,
+    sandboxPreference: hints?.sandboxPreference,
+    linkForCurrentRun: hints?.linkForCurrentRun,
+  } as unknown as MeshContext;
+}
+
+describe("resolveSandboxProvider", () => {
+  test("recorded vmMap kind wins over the link-or-env default", async () => {
+    // User has a link online, so the default policy would pick `remote-user`.
+    // But vmMap records `agent-sandbox` for (user, branch) — we must honor
+    // that recorded kind so the SSE/proxy paths reach the right provider.
+    const metadata = {
+      vmMap: {
+        "u-1": {
+          "deco/foo": {
+            "agent-sandbox": {
+              vmId: "vm_xyz",
+              previewUrl: "https://p",
+              sandboxUrl: "https://p",
+              sandboxProviderKind: "agent-sandbox",
+              createdAt: 1,
+              startedWith: { packageManager: null, port: null, path: null },
+            },
+          },
+        },
+      },
+    };
+    const { provider, kind } = await resolveSandboxProvider(
+      stubCtx(makeLink()),
+      {
+        userId: "u-1",
+        branch: "deco/foo",
+        virtualMcpMetadata: metadata,
+      },
+    );
+    expect(kind).toBe("agent-sandbox");
+    expect(provider).toBe(stubAgentSandbox);
+    expect(buildRemoteSpy).not.toHaveBeenCalled();
+  });
+
+  test("link online + no vmMap entry → remote-user, bound to link", async () => {
+    const link = makeLink();
+    const { provider, kind } = await resolveSandboxProvider(stubCtx(link), {
+      userId: "u-1",
+      branch: "deco/new",
+      virtualMcpMetadata: null,
+    });
+    expect(kind).toBe("remote-user");
+    expect(provider).toBe(stubRemoteUser);
+    expect(buildRemoteSpy).toHaveBeenCalled();
+  });
+
+  test("explicit override beats both vmMap and default policy", async () => {
+    const metadata = {
+      vmMap: {
+        "u-1": {
+          "deco/foo": {
+            "remote-user": {
+              vmId: "vm_xyz",
+              previewUrl: "https://p",
+              sandboxUrl: "https://p",
+              sandboxProviderKind: "remote-user",
+              createdAt: 1,
+              startedWith: { packageManager: null, port: null, path: null },
+            },
+          },
+        },
+      },
+    };
+    const { kind } = await resolveSandboxProvider(stubCtx(makeLink()), {
+      userId: "u-1",
+      branch: "deco/foo",
+      virtualMcpMetadata: metadata,
+      explicitKind: "docker",
+    });
+    expect(kind).toBe("docker");
+  });
+
+  test("no link + no vmMap entry → env kind (docker here)", async () => {
+    const { kind } = await resolveSandboxProvider(stubCtx(null), {
+      userId: "u-1",
+      branch: "deco/fresh",
+      virtualMcpMetadata: null,
+    });
+    expect(kind).toBe("docker");
+  });
+
+  test("ctx hint (sandboxPreference=remote-user + link) short-circuits without vmMap read", async () => {
+    // dispatch-run sets these ctx fields from the resolved DispatchTarget.
+    // Resolver must honor them and skip the vmMap lookup so the decopilot
+    // hot path doesn't pay a DB hit per turn. Metadata is intentionally
+    // present and would point at a *different* recorded kind — proving
+    // the hint wins.
+    const metadata = {
+      vmMap: {
+        "u-1": {
+          "deco/foo": {
+            "agent-sandbox": {
+              vmId: "vm_xyz",
+              previewUrl: "https://p",
+              sandboxUrl: "https://p",
+              sandboxProviderKind: "agent-sandbox",
+              createdAt: 1,
+              startedWith: { packageManager: null, port: null, path: null },
+            },
+          },
+        },
+      },
+    };
+    const link = makeLink();
+    const ctx = stubCtx(null, {
+      sandboxPreference: "remote-user",
+      linkForCurrentRun: link,
+    });
+    const { kind, provider } = await resolveSandboxProvider(ctx, {
+      userId: "u-1",
+      branch: "deco/foo",
+      virtualMcpMetadata: metadata,
+    });
+    expect(kind).toBe("remote-user");
+    expect(provider).toBe(stubRemoteUser);
+  });
+
+  test("ctx hint (sandboxPreference=default) routes to env kind", async () => {
+    const ctx = stubCtx(makeLink(), { sandboxPreference: "default" });
+    const { kind } = await resolveSandboxProvider(ctx, {
+      userId: "u-1",
+      branch: "deco/foo",
+      virtualMcpMetadata: null,
+    });
+    // STUDIO_SANDBOX_RUNNER=docker pinned at top of file.
+    expect(kind).toBe("docker");
+  });
+
+  test("remote-user resolution throws when link daemon is offline", async () => {
+    // vmMap records `remote-user` but link is gone — caller (events/proxy
+    // middleware) catches this and surfaces a failed phase / 503.
+    const metadata = {
+      vmMap: {
+        "u-1": {
+          "deco/foo": {
+            "remote-user": {
+              vmId: "vm_xyz",
+              previewUrl: "https://p",
+              sandboxUrl: "https://p",
+              sandboxProviderKind: "remote-user",
+              createdAt: 1,
+              startedWith: { packageManager: null, port: null, path: null },
+            },
+          },
+        },
+      },
+    };
+    await expect(
+      resolveSandboxProvider(stubCtx(null), {
+        userId: "u-1",
+        branch: "deco/foo",
+        virtualMcpMetadata: metadata,
+      }),
+    ).rejects.toThrow(/No link daemon registered/);
+  });
+});

--- a/apps/mesh/src/sandbox/resolve-provider.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.ts
@@ -1,0 +1,150 @@
+/**
+ * Single source of truth for "which `SandboxProvider` should this request use?".
+ *
+ * Precedence (highest first):
+ *
+ *   1. **Caller override (`explicitKind`).** `VM_START` forwards
+ *      `input.sandboxProviderKind` here; `ensureVm` callers pass the kind
+ *      they already resolved. Binds the user's link for `remote-user`.
+ *
+ *   2. **Per-run dispatch hint** (`ctx.sandboxPreference` /
+ *      `ctx.linkForCurrentRun`). Set by `dispatch-run` from the resolved
+ *      `DispatchTarget`. Honoring it without a vmMap read is the whole
+ *      point: decopilot runs decided which sandbox kind to use upstream,
+ *      and any DB lookup here would just confirm what they already know.
+ *
+ *   3. **Recorded vmMap kind.** The post-provision source of truth: a
+ *      sandbox provisioned via `remote-user` stays addressable through
+ *      `remote-user` even on a cluster whose env kind is something else
+ *      (`agent-sandbox`, `docker`, …). This is what the events/proxy
+ *      route uses — no ctx hint, just the recorded entry.
+ *
+ *   4. **Default policy** (`resolveDefaultSandboxProviderKind`). Pre-
+ *      provision fall-through: live link → `remote-user`, else env kind.
+ *
+ * Returns a fully-bound `SandboxProvider` plus the resolved kind. Callers
+ * never need to set `ctx.sandboxPreference` / `ctx.linkForCurrentRun`
+ * themselves — the resolver reads them as input.
+ */
+
+import { parseBranchMap } from "@decocms/mesh-sdk";
+import {
+  resolveSandboxProviderKindFromEnv,
+  type SandboxProvider,
+  type SandboxProviderKind,
+} from "@decocms/sandbox/provider";
+
+import type { MeshContext } from "../core/mesh-context";
+import { readVmMap } from "../tools/vm/vm-map";
+import { buildRemoteUserProvider, getSandboxProviderByKind } from "./lifecycle";
+import { resolveDefaultSandboxProviderKind } from "./resolve-default-provider-kind";
+
+export interface ResolveSandboxProviderArgs {
+  /** User whose vmMap cell to read and (for `remote-user`) whose link to bind. */
+  userId: string;
+  branch: string;
+  /** Raw `virtualmcp.metadata` JSON column. May be null. */
+  virtualMcpMetadata: Record<string, unknown> | null;
+  /**
+   * Caller-provided override (e.g. `VM_START`'s `input.sandboxProviderKind`).
+   * When set, takes precedence over both the vmMap entry and the default
+   * policy. The resolver still binds the user's link for `remote-user`.
+   */
+  explicitKind?: SandboxProviderKind;
+}
+
+export interface ResolvedSandboxProvider {
+  provider: SandboxProvider;
+  /** The kind the provider was bound for. Callers persisting vmMap rows
+   *  use this so the recorded kind matches what was actually constructed. */
+  kind: SandboxProviderKind;
+}
+
+export async function resolveSandboxProvider(
+  ctx: MeshContext,
+  args: ResolveSandboxProviderArgs,
+): Promise<ResolvedSandboxProvider> {
+  const { userId, branch, virtualMcpMetadata, explicitKind } = args;
+
+  // 1. Caller override.
+  if (explicitKind) {
+    const provider = await bindProviderForKind(ctx, userId, explicitKind);
+    return { provider, kind: explicitKind };
+  }
+
+  // 2. Per-run dispatch hint. `dispatch-run` already chose; honor it
+  //    without touching vmMap. `remote-user` carries its link inline;
+  //    `default` means "use the cluster runner the env points to".
+  if (ctx.sandboxPreference === "remote-user" && ctx.linkForCurrentRun) {
+    const provider = await buildRemoteUserProvider(ctx, ctx.linkForCurrentRun);
+    return { provider, kind: "remote-user" };
+  }
+  if (ctx.sandboxPreference === "default") {
+    const kind = resolveSandboxProviderKindFromEnv();
+    const provider = await getSandboxProviderByKind(ctx, kind);
+    return { provider, kind };
+  }
+
+  // 3. Recorded vmMap kind.
+  const recorded = readRecordedKind(virtualMcpMetadata, userId, branch);
+  if (recorded) {
+    const provider = await bindProviderForKind(ctx, userId, recorded);
+    return { provider, kind: recorded };
+  }
+
+  // 4. Default policy.
+  const kind = await resolveDefaultKind(ctx, userId);
+  const provider = await bindProviderForKind(ctx, userId, kind);
+  return { provider, kind };
+}
+
+/**
+ * The first recorded kind under `vmMap[userId][branch]`. Today the cell holds
+ * at most one entry in normal usage; if multiple sibling kinds were ever
+ * persisted under the same (user, branch) we'd need an explicit preference
+ * here, but that case doesn't arise in practice and `VM_DELETE`'s explicit
+ * kind dispatch would surface a stale row before this would.
+ */
+function readRecordedKind(
+  metadata: Record<string, unknown> | null,
+  userId: string,
+  branch: string,
+): SandboxProviderKind | null {
+  const cell = readVmMap(metadata)[userId]?.[branch];
+  if (!cell) return null;
+  const parsed = parseBranchMap(cell);
+  const kinds = Object.keys(parsed) as SandboxProviderKind[];
+  return kinds[0] ?? null;
+}
+
+async function resolveDefaultKind(
+  ctx: MeshContext,
+  userId: string,
+): Promise<SandboxProviderKind> {
+  if (!ctx.linkRegistry) return resolveSandboxProviderKindFromEnv();
+  return resolveDefaultSandboxProviderKind(userId, {
+    linkRegistry: ctx.linkRegistry,
+    resolveEnvKind: resolveSandboxProviderKindFromEnv,
+  });
+}
+
+async function bindProviderForKind(
+  ctx: MeshContext,
+  userId: string,
+  kind: SandboxProviderKind,
+): Promise<SandboxProvider> {
+  if (kind !== "remote-user") return getSandboxProviderByKind(ctx, kind);
+
+  if (!ctx.linkRegistry) {
+    throw new Error(
+      "remote-user sandbox provider requires ctx.linkRegistry to be wired (set on MeshContextConfig).",
+    );
+  }
+  const link = await ctx.linkRegistry.get(userId);
+  if (!link) {
+    throw new Error(
+      `No link daemon registered for user "${userId}". Start one with \`deco link\` (or run \`bun run dev --local-sandbox-provider\` for dev).`,
+    );
+  }
+  return buildRemoteUserProvider(ctx, link);
+}

--- a/apps/mesh/src/sandbox/resolve-provider.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.ts
@@ -91,12 +91,16 @@ export async function resolveSandboxProvider(
   //    path consistently picks the one matching current intent
   //    (link online → `remote-user`, else env kind) instead of whatever
   //    `Object.keys` happens to enumerate first.
-  const recordedKinds = readRecordedKinds(virtualMcpMetadata, userId, branch);
-  if (recordedKinds.length > 0) {
+  const [firstRecorded, ...restRecorded] = readRecordedKinds(
+    virtualMcpMetadata,
+    userId,
+    branch,
+  );
+  if (firstRecorded) {
     const preferred =
-      recordedKinds.length === 1
-        ? recordedKinds[0]
-        : await pickRecordedKind(ctx, userId, recordedKinds);
+      restRecorded.length === 0
+        ? firstRecorded
+        : await pickRecordedKind(ctx, userId, firstRecorded, restRecorded);
     const provider = await bindProviderForKind(ctx, userId, preferred);
     return { provider, kind: preferred };
   }
@@ -134,11 +138,12 @@ function readRecordedKinds(
 async function pickRecordedKind(
   ctx: MeshContext,
   userId: string,
-  recorded: SandboxProviderKind[],
+  first: SandboxProviderKind,
+  rest: SandboxProviderKind[],
 ): Promise<SandboxProviderKind> {
   const preferred = await resolveDefaultKind(ctx, userId);
-  if (recorded.includes(preferred)) return preferred;
-  return recorded[0];
+  if (preferred === first || rest.includes(preferred)) return preferred;
+  return first;
 }
 
 async function resolveDefaultKind(

--- a/apps/mesh/src/sandbox/resolve-provider.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.ts
@@ -85,11 +85,20 @@ export async function resolveSandboxProvider(
     return { provider, kind };
   }
 
-  // 3. Recorded vmMap kind.
-  const recorded = readRecordedKind(virtualMcpMetadata, userId, branch);
-  if (recorded) {
-    const provider = await bindProviderForKind(ctx, userId, recorded);
-    return { provider, kind: recorded };
+  // 3. Recorded vmMap kind. Tiebreak against the default policy so that when
+  //    multiple sibling kinds were persisted (e.g. the user ran VM_START
+  //    twice with different `sandboxProviderKind` values), the events/proxy
+  //    path consistently picks the one matching current intent
+  //    (link online → `remote-user`, else env kind) instead of whatever
+  //    `Object.keys` happens to enumerate first.
+  const recordedKinds = readRecordedKinds(virtualMcpMetadata, userId, branch);
+  if (recordedKinds.length > 0) {
+    const preferred =
+      recordedKinds.length === 1
+        ? recordedKinds[0]
+        : await pickRecordedKind(ctx, userId, recordedKinds);
+    const provider = await bindProviderForKind(ctx, userId, preferred);
+    return { provider, kind: preferred };
   }
 
   // 4. Default policy.
@@ -99,22 +108,37 @@ export async function resolveSandboxProvider(
 }
 
 /**
- * The first recorded kind under `vmMap[userId][branch]`. Today the cell holds
- * at most one entry in normal usage; if multiple sibling kinds were ever
- * persisted under the same (user, branch) we'd need an explicit preference
- * here, but that case doesn't arise in practice and `VM_DELETE`'s explicit
- * kind dispatch would surface a stale row before this would.
+ * All kinds recorded under `vmMap[userId][branch]`. Multiple kinds can coexist
+ * as siblings — `VM_START` accepts an explicit `sandboxProviderKind`, and
+ * `setVmMapEntry` preserves siblings. Callers that need exactly one kind
+ * (`readRecordedKind`) tiebreak against the default policy.
  */
-function readRecordedKind(
+function readRecordedKinds(
   metadata: Record<string, unknown> | null,
   userId: string,
   branch: string,
-): SandboxProviderKind | null {
+): SandboxProviderKind[] {
   const cell = readVmMap(metadata)[userId]?.[branch];
-  if (!cell) return null;
+  if (!cell) return [];
   const parsed = parseBranchMap(cell);
-  const kinds = Object.keys(parsed) as SandboxProviderKind[];
-  return kinds[0] ?? null;
+  return Object.keys(parsed) as SandboxProviderKind[];
+}
+
+/**
+ * Picks one recorded kind when multiple siblings exist. Prefers the kind that
+ * matches the current default policy (link online → `remote-user`, else env
+ * kind); otherwise falls back to the first recorded kind. This keeps the
+ * events/proxy path deterministic across pods and matches what a fresh
+ * VM_START with no explicit kind would have used.
+ */
+async function pickRecordedKind(
+  ctx: MeshContext,
+  userId: string,
+  recorded: SandboxProviderKind[],
+): Promise<SandboxProviderKind> {
+  const preferred = await resolveDefaultKind(ctx, userId);
+  if (recorded.includes(preferred)) return preferred;
+  return recorded[0];
 }
 
 async function resolveDefaultKind(

--- a/apps/mesh/src/tools/vm/start.test.ts
+++ b/apps/mesh/src/tools/vm/start.test.ts
@@ -57,19 +57,15 @@ const mockRemoteUserRunner: SandboxProvider = {
 };
 
 mock.module("../../sandbox/lifecycle", () => ({
-  getSharedSandboxProvider: (ctx: MeshContext) => {
-    if (
-      ctx.sandboxPreference === "remote-user" &&
-      ctx.linkForCurrentRun !== undefined
-    ) {
-      return mockRemoteUserRunner;
-    }
-    return mockDockerRunner;
-  },
   getSandboxProviderByKind: (
     _ctx: unknown,
     kind: "docker" | "agent-sandbox",
   ) => (kind === "docker" ? mockDockerRunner : mockDockerRunner),
+  // The unified resolver in `resolve-provider.ts` calls
+  // `buildRemoteUserProvider` directly (no ctx side-effects), so a mock
+  // is needed for VM_START's remote-user path to construct the expected
+  // runner under test.
+  buildRemoteUserProvider: async () => mockRemoteUserRunner,
   getSharedSandboxProviderIfInit: () => mockDockerRunner,
   getOrInitSharedRunner: async () => mockDockerRunner,
   asDockerRunner: () => null,

--- a/apps/mesh/src/tools/vm/start.ts
+++ b/apps/mesh/src/tools/vm/start.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import type { VmMapEntry } from "@decocms/mesh-sdk";
 import {
   composeSandboxRef,
-  resolveSandboxProviderKindFromEnv,
+  type SandboxProvider,
   type SandboxProviderKind,
   type Workload,
 } from "@decocms/sandbox/provider";
@@ -40,13 +40,9 @@ import {
 } from "../../shared/github-runtime-detect";
 import { generateBranchName } from "../../shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
-import {
-  getSandboxProviderByKind,
-  getSharedSandboxProvider,
-} from "../../sandbox/lifecycle";
+import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { setVmMapEntry } from "./vm-map";
 import type { VirtualMCPUpdateData } from "../virtual/schema";
-import { resolveDefaultSandboxProviderKind } from "../../sandbox/resolve-default-provider-kind";
 
 type GithubRepo = {
   owner: string;
@@ -102,14 +98,19 @@ export const VM_START = defineTool({
     const earlyUserId = getUserId(ctx);
     if (!earlyUserId) throw new Error("User ID required");
 
-    const providerKind: SandboxProviderKind =
-      input.sandboxProviderKind ??
-      (ctx.linkRegistry
-        ? await resolveDefaultSandboxProviderKind(earlyUserId, {
-            linkRegistry: ctx.linkRegistry,
-            resolveEnvKind: resolveSandboxProviderKindFromEnv,
-          })
-        : resolveSandboxProviderKindFromEnv());
+    // Resolve the runner once. `resolveSandboxProvider` returns the
+    // existing kind when vmMap already has an entry for (user, branch),
+    // honors `input.sandboxProviderKind` as a caller override, and
+    // otherwise applies the link-or-env default policy. We bind the
+    // provider here so the kind we record in vmMap matches the runner
+    // that actually `ensure`d the sandbox.
+    const { provider: runner, kind: providerKind } =
+      await resolveSandboxProvider(ctx, {
+        userId: earlyUserId,
+        branch: resolvedBranch,
+        virtualMcpMetadata: null,
+        explicitKind: input.sandboxProviderKind,
+      });
 
     const {
       metadata,
@@ -137,6 +138,7 @@ export const VM_START = defineTool({
       githubRepo,
       existing,
       providerKind,
+      runner,
     });
     return {
       ...entry,
@@ -195,6 +197,17 @@ export async function ensureVm(
     return existing;
   }
 
+  // ensureVm is called from the always-on VM tools path which doesn't
+  // pre-resolve the runner. `resolveSandboxProvider` here honors the
+  // explicit kind from the caller (POST /messages already decided) and
+  // binds the user's link for `remote-user`.
+  const { provider: runner } = await resolveSandboxProvider(ctx, {
+    userId,
+    branch: input.branch,
+    virtualMcpMetadata: metadata,
+    explicitKind: providerKind,
+  });
+
   const githubRepo = (metadata as GithubRepoMeta).githubRepo ?? null;
   const { entry } = await provisionSandbox({
     ctx,
@@ -206,6 +219,7 @@ export async function ensureVm(
     githubRepo,
     existing: null,
     providerKind,
+    runner,
   });
   return entry;
 }
@@ -220,6 +234,7 @@ type StartParams = {
   githubRepo: GithubRepo | null;
   existing: VmMapEntry | null;
   providerKind: SandboxProviderKind;
+  runner: SandboxProvider;
 };
 
 async function provisionSandbox(
@@ -234,7 +249,7 @@ async function provisionSandbox(
     metadata,
     githubRepo,
     existing,
-    providerKind,
+    runner,
   } = params;
 
   let { runtime, packageManager, port, packageManagerPath } =
@@ -327,30 +342,6 @@ async function provisionSandbox(
     branch,
   });
 
-  // Dispatch to the correct runner for the resolved provider kind.
-  // - remote-user: look up the link and set ctx fields so the getSharedSandboxProvider
-  //   per-user branch fires correctly (it builds a fresh RemoteUserSandboxProvider).
-  // - all other kinds: go straight through getSandboxProviderByKind so the explicit
-  //   kind is honoured even when env says something different.
-  let runner;
-  if (providerKind === "remote-user") {
-    if (!ctx.linkRegistry) {
-      throw new Error(
-        "remote-user sandbox provider requires ctx.linkRegistry to be wired (set on MeshContextConfig).",
-      );
-    }
-    const link = await ctx.linkRegistry.get(userId);
-    if (!link) {
-      throw new Error(
-        `No link daemon registered for user "${userId}". Start one with \`deco link\` (or run \`bun run dev --local-sandbox-provider\` for dev).`,
-      );
-    }
-    ctx.sandboxPreference = "remote-user";
-    ctx.linkForCurrentRun = link;
-    runner = await getSharedSandboxProvider(ctx);
-  } else {
-    runner = await getSandboxProviderByKind(ctx, providerKind);
-  }
   const sandbox = await runner.ensure(
     { userId, projectRef },
     {

--- a/apps/mesh/src/tools/vm/stop.test.ts
+++ b/apps/mesh/src/tools/vm/stop.test.ts
@@ -37,7 +37,6 @@ function makeMockRunner(kind: SandboxProviderKind): SandboxProvider {
 }
 
 mock.module("../../sandbox/lifecycle", () => ({
-  getSharedSandboxProvider: () => makeMockRunner("docker"),
   getSandboxProviderByKind: (_ctx: unknown, kind: SandboxProviderKind) => {
     lastRequestedKind.value = kind;
     return makeMockRunner(kind);


### PR DESCRIPTION
## What is this contribution about?

VM_START records `sandboxProviderKind` in vmMap (e.g. `remote-user` when the user's link daemon is online), but the events/proxy middleware then resolved the runner via `resolveSandboxProviderKindFromEnv()` — so on a cluster running `agent-sandbox`, the SSE stream attached to the wrong lifecycle watcher and stalled at `claiming` ("Reserving sandbox") forever, never proxying the daemon's `log`/`lifecycle` events back to the browser even though the sandbox was healthy on the user's machine. The fix introduces `apps/mesh/src/sandbox/resolve-provider.ts` as the single resolver — precedence is explicit kind → per-run dispatch hint (decopilot path, zero DB read) → recorded vmMap kind → link-or-env default — and migrates VM_START, ensureVm, the unified vm-proxy middleware, the legacy vm-events route, and the decopilot built-in-tools setup onto it; `getSharedSandboxProvider` is dropped in favor of the resolver. Net −61 lines across the migrated files.

## How to Test
1. Run `bunx decocms@latest link --local-sandbox-provider` locally so the link daemon registers.
2. Open a Virtual MCP in studio.decocms.com and click Start (or trigger any decopilot tool that wants the VM).
3. Expected: the booting overlay moves off "Reserving sandbox" promptly and `[setup]` / `[lifecycle]` / `[dev]` log lines from the local daemon stream into the sandbox terminal drawer. Bonus: `write`/`read`/`exec`/`config`/`setup`/`preview-fetch` calls under `/api/:org/vm/:vmId/:branch/*` now route to the remote-user runner too.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (7 new resolver tests; broader bun test run improved 496→503 pass)
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VM event/proxy stalling by resolving the runner from the recorded vmMap kind via a unified `resolveSandboxProvider`. Removes env fallbacks, makes kind selection deterministic, and adds a type-safety fix for recorded-kind selection.

- **Bug Fixes**
  - `vm-events` and `vm-proxy` now use the recorded vmMap kind; SSE no longer stalls at “Reserving sandbox”, and stale-handle cleanup runs through the prior kind.
  - No env fallback on resolver errors; `remote-user` failures surface as null/503 instead of rebinding to `agent-sandbox`/`docker`.
  - When multiple kinds are recorded, the chosen kind follows the default policy (link online → `remote-user`, else env) and is now type-safe under `noUncheckedIndexedAccess`.

- **Refactors**
  - Introduced `resolveSandboxProvider` (explicit kind → per-run hint → recorded vmMap kind → link-or-env default) and routed VM_START/`ensureVm`, `vm-events`, `vm-proxy`, and decopilot tools through it.
  - Exported `buildRemoteUserProvider`; removed `getSharedSandboxProvider`. Decopilot path uses dispatch hints (no DB read). Added `resolve-provider.test.ts` (7 tests).

<sup>Written for commit 37c20db4f76d5d332a81c1f0dd544900ace25697. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3439?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

