### PR TITLE
refactor(sandbox): rename remote-user provider kind to desktop

### DIFF
--- a/apps/mesh/migrations/084-drop-host-sandbox-rows.ts
+++ b/apps/mesh/migrations/084-drop-host-sandbox-rows.ts
@@ -6,7 +6,7 @@
  * sandbox daemon as a child of the mesh process. It has been retired in
  * favor of the laptop-side `deco link` daemon (auto-spawned by
  * `bun run dev --local-sandbox-provider`), which exercises the same
- * remote-cli + remote-user code paths production uses.
+ * remote-cli + desktop code paths production uses.
  *
  * Any `runner_kind = 'host'` rows left in dev databases are orphaned
  * pointers to daemon PIDs/ports that no longer exist; the new code path

--- a/apps/mesh/migrations/089-rename-remote-user-to-desktop.test.ts
+++ b/apps/mesh/migrations/089-rename-remote-user-to-desktop.test.ts
@@ -1,14 +1,16 @@
 /**
- * Integration test for migration 082.
+ * Integration test for migration 089: vmMap kind-key + sandboxProviderKind
+ * rename from `remote-user` to `desktop`.
  *
- * Migrations 080 and 081 silently no-op'd against the wrong table name. This
- * test pins down that 082 actually rewrites the data on a `connections` row
- * (where virtual MCPs live) and that re-running is a no-op — so a fresh
- * install never regresses to the v1 shape, and a partial-prior-run state
- * converges on a single re-run.
+ * Mirrors the 087 pattern: writes to `connections` rows (where virtual
+ * MCPs live as `connection_type='VIRTUAL'`), runs the migration directly,
+ * asserts the resulting `metadata` JSON shape, and confirms re-running is a
+ * no-op. Runner-state and thread updates are exercised by the integration
+ * suite where those tables are seeded — the migration test focuses on the
+ * JSONB rewrites because that's where the logic is non-trivial.
  */
 
-import { beforeEach, afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { sql } from "kysely";
 import {
   closeTestDatabase,
@@ -19,7 +21,7 @@ import {
   createTestSchema,
   seedCommonTestFixtures,
 } from "../src/storage/test-helpers";
-import { up as up087 } from "./087-fix-vm-map-rekey";
+import { up as up089 } from "./089-rename-remote-user-to-desktop";
 
 const USER = "user_test";
 const ORG = "org_test";
@@ -46,8 +48,6 @@ async function insertVirtualConnection(
   metadata: Record<string, unknown>,
 ): Promise<void> {
   const now = new Date().toISOString();
-  // `connection_url` is NOT NULL even for VIRTUAL connections; tests use
-  // an inert placeholder URL since the migration only touches `metadata`.
   await sql`
     INSERT INTO connections (
       id, organization_id, created_by, title, connection_type,
@@ -60,7 +60,7 @@ async function insertVirtualConnection(
   `.execute(database.db);
 }
 
-describe("migration 082 — fix vmMap rekey", () => {
+describe("migration 089 — rename remote-user → desktop", () => {
   let database: TestDatabase;
 
   beforeEach(async () => {
@@ -73,24 +73,26 @@ describe("migration 082 — fix vmMap rekey", () => {
     await closeTestDatabase(database);
   });
 
-  it("wraps a v1 bare entry under its sandboxProviderKind", async () => {
-    await insertVirtualConnection(database, "vir_v1_kind", {
+  it("renames the inner 'remote-user' kind key to 'desktop'", async () => {
+    await insertVirtualConnection(database, "vir_kind_key", {
       vmMap: {
         [USER]: {
           "deco/branch-a": {
-            vmId: "vm-a",
-            previewUrl: "http://x/preview",
-            sandboxProviderKind: "desktop",
-            createdAt: 1779000000000,
+            "remote-user": {
+              vmId: "vm-a",
+              previewUrl: "http://x/preview",
+              sandboxProviderKind: "remote-user",
+              createdAt: 1779000000000,
+            },
           },
         },
       },
     });
 
     // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
-    await up087(database.db as any);
+    await up089(database.db as any);
 
-    const meta = await getMetadata(database, "vir_v1_kind");
+    const meta = await getMetadata(database, "vir_kind_key");
     expect(meta).toEqual({
       vmMap: {
         [USER]: {
@@ -107,92 +109,55 @@ describe("migration 082 — fix vmMap rekey", () => {
     });
   });
 
-  it("falls back to runnerKind, then docker, when sandboxProviderKind is absent", async () => {
-    await insertVirtualConnection(database, "vir_v1_runner", {
+  it("rewrites sandboxProviderKind field value even when key already migrated", async () => {
+    // Edge case: the outer key matches the new name but the inner
+    // sandboxProviderKind field still carries the old value (would happen
+    // if writer was upgraded mid-flight and the row was written halfway).
+    await insertVirtualConnection(database, "vir_field_only", {
       vmMap: {
         [USER]: {
-          "deco/branch-runner": {
-            vmId: "vm-r",
-            previewUrl: null,
-            runnerKind: "agent-sandbox",
-            createdAt: 1779000000001,
-          },
-          "deco/branch-default": {
-            vmId: "vm-d",
-            previewUrl: null,
+          "deco/branch-b": {
+            desktop: {
+              vmId: "vm-b",
+              previewUrl: null,
+              sandboxProviderKind: "remote-user",
+              createdAt: 1779000000001,
+            },
           },
         },
       },
     });
 
     // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
-    await up087(database.db as any);
+    await up089(database.db as any);
 
-    const meta = (await getMetadata(database, "vir_v1_runner")) as {
+    const meta = (await getMetadata(database, "vir_field_only")) as {
       vmMap: Record<string, Record<string, Record<string, unknown>>>;
     };
-    const userBranches = meta.vmMap[USER]!;
-    // The runnerKind branch was wrapped under "agent-sandbox" AND its inner
-    // entry's `runnerKind` key was renamed to `sandboxProviderKind`.
-    const runnerBranch = userBranches["deco/branch-runner"]!;
-    expect(Object.keys(runnerBranch)).toEqual(["agent-sandbox"]);
-    expect(runnerBranch["agent-sandbox"]).toEqual({
-      vmId: "vm-r",
+    const branch = meta.vmMap[USER]!["deco/branch-b"]!;
+    expect(branch.desktop).toEqual({
+      vmId: "vm-b",
       previewUrl: null,
-      sandboxProviderKind: "agent-sandbox",
+      sandboxProviderKind: "desktop",
       createdAt: 1779000000001,
     });
-    // The bare-default branch (no kind hint) was wrapped under "docker".
-    expect(Object.keys(userBranches["deco/branch-default"]!)).toEqual([
-      "docker",
-    ]);
   });
 
-  it("renames runnerKind → sandboxProviderKind on already-v2 inner entries", async () => {
-    await insertVirtualConnection(database, "vir_v2_runner", {
+  it("leaves other kinds (docker, agent-sandbox) untouched", async () => {
+    await insertVirtualConnection(database, "vir_other_kinds", {
       vmMap: {
         [USER]: {
           "deco/branch-c": {
-            "agent-sandbox": {
-              vmId: "vm-c",
+            docker: {
+              vmId: "vm-d",
               previewUrl: null,
-              runnerKind: "agent-sandbox",
+              sandboxProviderKind: "docker",
               createdAt: 1779000000002,
             },
-          },
-        },
-      },
-    });
-
-    // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
-    await up087(database.db as any);
-
-    const meta = await getMetadata(database, "vir_v2_runner");
-    expect(meta).toEqual({
-      vmMap: {
-        [USER]: {
-          "deco/branch-c": {
             "agent-sandbox": {
-              vmId: "vm-c",
+              vmId: "vm-as",
               previewUrl: null,
               sandboxProviderKind: "agent-sandbox",
-              createdAt: 1779000000002,
-            },
-          },
-        },
-      },
-    });
-  });
-
-  it("is idempotent — re-running on a clean row makes no change", async () => {
-    await insertVirtualConnection(database, "vir_idem", {
-      vmMap: {
-        [USER]: {
-          "deco/branch-i": {
-            desktop: {
-              vmId: "vm-i",
-              previewUrl: null,
-              sandboxProviderKind: "desktop",
               createdAt: 1779000000003,
             },
           },
@@ -201,10 +166,52 @@ describe("migration 082 — fix vmMap rekey", () => {
     });
 
     // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
-    await up087(database.db as any);
+    await up089(database.db as any);
+
+    const meta = await getMetadata(database, "vir_other_kinds");
+    expect(meta).toEqual({
+      vmMap: {
+        [USER]: {
+          "deco/branch-c": {
+            docker: {
+              vmId: "vm-d",
+              previewUrl: null,
+              sandboxProviderKind: "docker",
+              createdAt: 1779000000002,
+            },
+            "agent-sandbox": {
+              vmId: "vm-as",
+              previewUrl: null,
+              sandboxProviderKind: "agent-sandbox",
+              createdAt: 1779000000003,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("is idempotent — re-running on already-migrated row makes no change", async () => {
+    await insertVirtualConnection(database, "vir_idem", {
+      vmMap: {
+        [USER]: {
+          "deco/branch-i": {
+            desktop: {
+              vmId: "vm-i",
+              previewUrl: null,
+              sandboxProviderKind: "desktop",
+              createdAt: 1779000000004,
+            },
+          },
+        },
+      },
+    });
+
+    // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
+    await up089(database.db as any);
     const after1 = await getMetadata(database, "vir_idem");
     // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
-    await up087(database.db as any);
+    await up089(database.db as any);
     const after2 = await getMetadata(database, "vir_idem");
 
     expect(after2).toEqual(after1);
@@ -216,7 +223,7 @@ describe("migration 082 — fix vmMap rekey", () => {
     });
 
     // biome-ignore lint/suspicious/noExplicitAny: migration accepts the test Kysely instance
-    await up087(database.db as any);
+    await up089(database.db as any);
 
     const meta = await getMetadata(database, "vir_no_map");
     expect(meta).toEqual({ instructions: "hello" });

--- a/apps/mesh/migrations/089-rename-remote-user-to-desktop.ts
+++ b/apps/mesh/migrations/089-rename-remote-user-to-desktop.ts
@@ -1,0 +1,152 @@
+/**
+ * Migration 089: Rename the `remote-user` SandboxProviderKind value to
+ * `desktop`. The runner's behaviour is unchanged — only the discriminant
+ * string moves. See packages/sandbox/server/provider/desktop/ for the
+ * renamed runner.
+ *
+ * Three rewrite passes, all idempotent:
+ *
+ *  (1) sandbox_runner_state.sandbox_provider_kind = 'remote-user'
+ *      → 'desktop'. Trivial column update.
+ *
+ *  (2) Connections (where virtualmcps live as connection_type='VIRTUAL'):
+ *      rename the inner key `vmMap[user][branch]['remote-user']` →
+ *      `vmMap[user][branch]['desktop']`. This is the 3-level v2 shape
+ *      established by migration 087.
+ *
+ *  (3) Same rows: rewrite the `sandboxProviderKind` field value inside
+ *      every vmMap inner entry from `'remote-user'` → `'desktop'`. This
+ *      catches entries where the field doesn't match the key (shouldn't
+ *      happen in steady state, but defensively normalized) and any
+ *      pre-v2 legacy rows that 087 left as bare entries under a renamed
+ *      kind.
+ *
+ * mesh-sdk's `parseBranchMap` / `parseVmMapEntry` continue to tolerate the
+ * legacy `'remote-user'` value/key on read until this migration has run
+ * everywhere — see packages/mesh-sdk/src/types/virtual-mcp.ts.
+ */
+
+import { sql, type Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // (1) Runner state rows.
+  await sql`
+    UPDATE sandbox_runner_state
+    SET sandbox_provider_kind = 'desktop'
+    WHERE sandbox_provider_kind = 'remote-user'
+  `.execute(db);
+
+  // (2) Rename the inner kind key in vmMap. Guard with a WHERE that only
+  // touches rows containing at least one `remote-user` inner key so the
+  // rewrite is a no-op on already-renamed databases.
+  await sql`
+    UPDATE connections c
+    SET metadata = (
+      jsonb_set(
+        c.metadata::jsonb,
+        '{vmMap}',
+        (
+          SELECT jsonb_object_agg(
+            user_key,
+            COALESCE(
+              (
+                SELECT jsonb_object_agg(
+                  branch_key,
+                  COALESCE(
+                    (
+                      SELECT jsonb_object_agg(
+                        CASE WHEN kind_key = 'remote-user' THEN 'desktop' ELSE kind_key END,
+                        inner_entry
+                      )
+                      FROM jsonb_each(branch_entry) AS kinds(kind_key, inner_entry)
+                    ),
+                    '{}'::jsonb
+                  )
+                )
+                FROM jsonb_each(user_map) AS branches(branch_key, branch_entry)
+              ),
+              '{}'::jsonb
+            )
+          )
+          FROM jsonb_each(c.metadata::jsonb -> 'vmMap') AS users(user_key, user_map)
+        )
+      )
+    )::text
+    WHERE c.connection_type = 'VIRTUAL'
+      AND c.metadata IS NOT NULL
+      AND c.metadata::jsonb ? 'vmMap'
+      AND EXISTS (
+        SELECT 1
+        FROM jsonb_each(c.metadata::jsonb -> 'vmMap') AS users(user_key, user_map)
+        JOIN jsonb_each(user_map) AS branches(branch_key, branch_entry) ON true
+        JOIN jsonb_each(branch_entry) AS kinds(kind_key, inner_entry) ON true
+        WHERE kind_key = 'remote-user'
+      );
+  `.execute(db);
+
+  // (3) Rewrite the sandboxProviderKind field value inside each inner
+  // entry. Same guard as (2): only touch rows that still carry the legacy
+  // value somewhere.
+  await sql`
+    UPDATE connections c
+    SET metadata = (
+      jsonb_set(
+        c.metadata::jsonb,
+        '{vmMap}',
+        (
+          SELECT jsonb_object_agg(
+            user_key,
+            COALESCE(
+              (
+                SELECT jsonb_object_agg(
+                  branch_key,
+                  COALESCE(
+                    (
+                      SELECT jsonb_object_agg(
+                        kind_key,
+                        CASE
+                          WHEN inner_entry->>'sandboxProviderKind' = 'remote-user'
+                            THEN jsonb_set(inner_entry, '{sandboxProviderKind}', '"desktop"'::jsonb)
+                          ELSE inner_entry
+                        END
+                      )
+                      FROM jsonb_each(branch_entry) AS kinds(kind_key, inner_entry)
+                    ),
+                    '{}'::jsonb
+                  )
+                )
+                FROM jsonb_each(user_map) AS branches(branch_key, branch_entry)
+              ),
+              '{}'::jsonb
+            )
+          )
+          FROM jsonb_each(c.metadata::jsonb -> 'vmMap') AS users(user_key, user_map)
+        )
+      )
+    )::text
+    WHERE c.connection_type = 'VIRTUAL'
+      AND c.metadata IS NOT NULL
+      AND c.metadata::jsonb ? 'vmMap'
+      AND EXISTS (
+        SELECT 1
+        FROM jsonb_each(c.metadata::jsonb -> 'vmMap') AS users(user_key, user_map)
+        JOIN jsonb_each(user_map) AS branches(branch_key, branch_entry) ON true
+        JOIN jsonb_each(branch_entry) AS kinds(kind_key, inner_entry) ON true
+        WHERE inner_entry->>'sandboxProviderKind' = 'remote-user'
+      );
+  `.execute(db);
+
+  // Pin any threads that recorded the old kind to the new name so dispatch
+  // resolution doesn't bounce through the tolerant readers forever.
+  await sql`
+    UPDATE threads
+    SET sandbox_provider_kind = 'desktop'
+    WHERE sandbox_provider_kind = 'remote-user'
+  `.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // No-op. The old value `'remote-user'` is no longer recognized by the
+  // runtime (the SandboxProviderKind union dropped it). Rolling forward
+  // would mean reverting code too, so a DB rollback alone is never useful.
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -87,6 +87,7 @@ import * as migration085renamerunnerkindd from "./085-rename-runner-kind.ts";
 import * as migration086threadpinsandvmmaprekey from "./086-thread-pins-and-vm-map-rekey.ts";
 import * as migration087fixvmmaprekey from "./087-fix-vm-map-rekey.ts";
 import * as migration088purgecliactivatekeys from "./088-purge-cli-activate-keys.ts";
+import * as migration089renameremoteusertodesktop from "./089-rename-remote-user-to-desktop.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -191,6 +192,7 @@ const migrations: Record<string, Migration> = {
   "086-thread-pins-and-vm-map-rekey": migration086threadpinsandvmmaprekey,
   "087-fix-vm-map-rekey": migration087fixvmmaprekey,
   "088-purge-cli-activate-keys": migration088purgecliactivatekeys,
+  "089-rename-remote-user-to-desktop": migration089renameremoteusertodesktop,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -460,7 +460,7 @@ async function prepareRun(
     }
 
     // Stash the resolved target on the context so downstream consumers
-    // (Phase 5's remote-user sandbox provider, Phase 6's remote-cli
+    // (Phase 5's desktop sandbox provider, Phase 6's remote-cli
     // dispatch) can read it without re-querying the registry.
     if (target.kind === "local") {
       ctx.sandboxPreference = target.sandbox;
@@ -822,8 +822,8 @@ async function prepareRun(
         //     tunnel that the cluster talks to directly (no link
         //     reverse-proxy hop). Without ensure() first there's no
         //     sandboxUrl to dispatch against.
-        //   - `local` (default OR remote-user) — runs in-cluster.
-        //     `remote-user` only changes where the sandbox tool calls go;
+        //   - `local` (default OR desktop) — runs in-cluster.
+        //     `desktop` only changes where the sandbox tool calls go;
         //     the harness still runs here.
         let harnessChunks;
         if (target.kind === "remote-cli") {

--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -133,7 +133,7 @@ mock.module("@/dispatch-queue", () => ({
 // eagerly provisions a sandbox — that happens lazily inside the built-in
 // tools layer on the first VM-tool call. We only need to stub the kind
 // resolver; each test pins it via the module-level `vmKindForTest`.
-type VmKind = "docker" | "agent-sandbox" | "remote-user";
+type VmKind = "docker" | "agent-sandbox" | "desktop";
 let vmKindForTest: VmKind = "docker";
 
 mock.module("@/sandbox/resolve-default-provider-kind", () => ({
@@ -274,8 +274,8 @@ describe("POST /messages — VM-based dispatch", () => {
     temperature: 0.5,
   };
 
-  test("VM with remote-user kind + no online link → 409 link_offline", async () => {
-    const { app } = buildApp({ vmKind: "remote-user", linkOnline: false });
+  test("VM with desktop kind + no online link → 409 link_offline", async () => {
+    const { app } = buildApp({ vmKind: "desktop", linkOnline: false });
     const res = await app.request(
       `/api/org_1/decopilot/threads/${THREAD_ID}/messages`,
       {
@@ -290,9 +290,9 @@ describe("POST /messages — VM-based dispatch", () => {
     expect(body.code).toBe("link_offline");
   });
 
-  test("VM with remote-user kind + link missing capability → 409 capability_missing", async () => {
+  test("VM with desktop kind + link missing capability → 409 capability_missing", async () => {
     const { app, seedLink } = buildApp({
-      vmKind: "remote-user",
+      vmKind: "desktop",
       linkOnline: true,
       linkCapabilities: ["decopilot-sandbox"],
     });
@@ -354,7 +354,7 @@ describe("POST /messages — first-message pinning", () => {
 
   test("first message with explicit pins persists them and uses them", async () => {
     const { app, seedLink, threadUpdateSpy } = buildApp({
-      vmKind: "remote-user",
+      vmKind: "desktop",
       linkOnline: true,
       threadPins: { sandbox_provider_kind: null, harness_id: null },
     });
@@ -366,7 +366,7 @@ describe("POST /messages — first-message pinning", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           ...validBody,
-          sandboxProviderKind: "remote-user",
+          sandboxProviderKind: "desktop",
           harnessId: "claude-code",
         }),
       },
@@ -375,7 +375,7 @@ describe("POST /messages — first-message pinning", () => {
     expect(threadUpdateSpy).toHaveBeenCalledWith(
       THREAD_ID,
       expect.objectContaining({
-        sandbox_provider_kind: "remote-user",
+        sandbox_provider_kind: "desktop",
         harness_id: "claude-code",
       }),
     );
@@ -383,7 +383,7 @@ describe("POST /messages — first-message pinning", () => {
 
   test("first message without explicit pins derives defaults and persists", async () => {
     const { app, seedLink, threadUpdateSpy } = buildApp({
-      vmKind: "remote-user",
+      vmKind: "desktop",
       linkOnline: true,
       threadPins: { sandbox_provider_kind: null, harness_id: null },
     });
@@ -398,26 +398,26 @@ describe("POST /messages — first-message pinning", () => {
     );
     expect(res.status).toBe(202);
     // link is online → resolveDefaultSandboxProviderKind returns vmKindForTest
-    // which is "remote-user"
+    // which is "desktop"
     expect(threadUpdateSpy).toHaveBeenCalledWith(
       THREAD_ID,
       expect.objectContaining({
-        sandbox_provider_kind: "remote-user",
+        sandbox_provider_kind: "desktop",
       }),
     );
   });
 
   test("subsequent message ignores request pins and uses thread row", async () => {
-    // Thread is pinned to (remote-user, claude-code). The request body sends
+    // Thread is pinned to (desktop, claude-code). The request body sends
     // harnessId: "decopilot" which would require the decopilot-sandbox
     // capability. If the route mistakenly uses the body's harnessId, the link
     // check fails with 409 capability_missing. Using the pinned harness
     // (claude-code) instead → the link's claude-code capability matches → 202.
     const { app, seedLink, threadUpdateSpy } = buildApp({
-      vmKind: "remote-user",
+      vmKind: "desktop",
       linkOnline: true,
       threadPins: {
-        sandbox_provider_kind: "remote-user",
+        sandbox_provider_kind: "desktop",
         harness_id: "claude-code",
       },
     });
@@ -429,7 +429,7 @@ describe("POST /messages — first-message pinning", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           ...validBody,
-          sandboxProviderKind: "docker", // should be ignored — thread row has remote-user
+          sandboxProviderKind: "docker", // should be ignored — thread row has desktop
           harnessId: "decopilot", // should be ignored — thread row has claude-code
         }),
       },

--- a/apps/mesh/src/api/routes/decopilot/schemas.ts
+++ b/apps/mesh/src/api/routes/decopilot/schemas.ts
@@ -44,7 +44,7 @@ const baseStreamRequestSchema = z.object({
   branch: z.string().nullish(),
   toolApprovalLevel: z.enum(["auto", "readonly"]).default("auto"),
   sandboxProviderKind: z
-    .enum(["docker", "agent-sandbox", "remote-user"])
+    .enum(["docker", "agent-sandbox", "desktop"])
     .nullish()
     .describe(
       "Pinned on first message. Subsequent messages ignore this field (the thread row carries the pinned value).",

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -115,8 +115,8 @@ export const createVmEventsRoutes = () => {
 
     // Source of truth: vmMap. The resolver returns the provider bound for
     // the recorded kind (or the link-or-env default when no entry exists
-    // yet), so a sandbox provisioned via `remote-user` remains addressable
-    // via `remote-user` even on a cluster whose env kind is `agent-sandbox`.
+    // yet), so a sandbox provisioned via `desktop` remains addressable
+    // via `desktop` even on a cluster whose env kind is `agent-sandbox`.
     // The kind is needed for the stale-handle probe below — when a `gone`
     // event must be emitted we route the state-store cleanup through the
     // matching kind so we don't leave rows in the wrong table.

--- a/apps/mesh/src/api/routes/vm-proxy.ts
+++ b/apps/mesh/src/api/routes/vm-proxy.ts
@@ -89,14 +89,14 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     (virtualMcp.metadata as Record<string, unknown>) ?? null;
 
   // Source of truth: vmMap. If an entry exists for (user, branch) we use
-  // that recorded kind — a sandbox provisioned via `remote-user` must
-  // remain addressable via `remote-user` even on a cluster whose env kind
+  // that recorded kind — a sandbox provisioned via `desktop` must
+  // remain addressable via `desktop` even on a cluster whose env kind
   // is `agent-sandbox` / `docker`. Pre-provision callers fall through to
   // the link-or-env default policy inside `resolveSandboxProvider`.
   //
-  // On failure (e.g. the recorded kind is `remote-user` but the user's
+  // On failure (e.g. the recorded kind is `desktop` but the user's
   // link daemon is offline) we surface `null` rather than falling back
-  // to the env singleton: rebinding a `remote-user`-provisioned VM onto
+  // to the env singleton: rebinding a `desktop`-provisioned VM onto
   // a different provider kind (say `agent-sandbox`) would forward traffic
   // to a sandbox that doesn't host this VM. The events handler streams a
   // `failed` phase from null; other handlers 503 via `requireRunner`.

--- a/apps/mesh/src/cli.ts
+++ b/apps/mesh/src/cli.ts
@@ -101,7 +101,7 @@ Server Options:
 Dev Options:
   --vite-port <port>            Vite dev server port (default: 4000)
   --base-url <url>              Base URL for the server
-  --local-sandbox-provider      Auto-spawn the local link daemon (remote-user sandbox provider)
+  --local-sandbox-provider      Auto-spawn the local link daemon (desktop sandbox provider)
 
 Auth Options:
   --target <url>        Decocms target (default: https://studio.decocms.com)

--- a/apps/mesh/src/cli/cli-store.ts
+++ b/apps/mesh/src/cli/cli-store.ts
@@ -90,7 +90,7 @@ export function setDevMode(opts: { localSandboxProvider?: boolean } = {}) {
       { name: "Vite", status: "pending", port: 0 },
       // Auto-spawned by `bun run dev --local-sandbox-provider` after the
       // cluster is up — see apps/mesh/src/cli/commands/dev.ts. The
-      // remote-user sandbox provider routes through this. Marked ready
+      // desktop sandbox provider routes through this. Marked ready
       // once the link binary's HTTP server begins accepting connections.
       ...(opts.localSandboxProvider
         ? [{ name: "Sandbox", status: "pending" as const, port: 0 }]

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -29,7 +29,7 @@ export interface DevOptions {
   noTui?: boolean;
   localMode: boolean;
   /** When true, auto-spawn the link daemon (`deco link`) so the
-   *  remote-user sandbox provider has a live target. Default false —
+   *  desktop sandbox provider has a live target. Default false —
    *  `dev:conductor` opts in. */
   localSandboxProvider: boolean;
 }
@@ -179,7 +179,7 @@ export async function startDevServer(
   // ── Auto-spawn `deco link --no-tunnel` (opt-in) ───────────────────
   // Gated on --local-sandbox-provider. When set, once the cluster is up
   // on :PORT, spawn the link daemon so the dev session exercises the
-  // remote-cli + remote-user code paths end-to-end. The link reads its
+  // remote-cli + desktop code paths end-to-end. The link reads its
   // session from <dataDir>/dev-link/session.json (auto-minted by the
   // cluster on first boot — see apps/mesh/src/auth/dev-link-session.ts).
   const linkPort = 5174;

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -113,7 +113,7 @@ export interface MeshContextConfig {
   eventBus: EventBus;
   modelListCache?: ModelListCache;
   memberRoleCache?: MemberRoleCache;
-  /** Required for remote-user sandbox auto-resolution; tests may omit. */
+  /** Required for desktop sandbox auto-resolution; tests may omit. */
   linkRegistry?: LinkRegistry;
 }
 

--- a/apps/mesh/src/core/mesh-context.ts
+++ b/apps/mesh/src/core/mesh-context.ts
@@ -403,19 +403,19 @@ export interface MeshContext extends HarnessContext {
    * Sandbox dispatch preference for the in-flight run, populated by
    * `prepareRun` from the resolved `DispatchTarget`:
    *   - `"default"` — cluster sandbox (today's behavior).
-   *   - `"remote-user"` — decopilot still runs in the cluster, but its
+   *   - `"desktop"` — decopilot still runs in the cluster, but its
    *     Code Sandbox tool calls are forwarded to the user's link daemon.
    * Unset for non-decopilot harnesses (`remote-cli` runs never enter the
    * sandbox tool path on the cluster side).
    */
-  sandboxPreference?: "default" | "remote-user";
+  sandboxPreference?: "default" | "desktop";
 
   /**
    * Link entry for the user this run is dispatched on behalf of, if any.
    * Set by `prepareRun` when the resolved `DispatchTarget` references a
-   * link (either `local/remote-user` or `remote-cli`). The remote-user
-   * sandbox provider reads this to know which daemon URL + secret to talk
-   * to without re-querying the registry. Unset for `local/default` runs.
+   * link (either `local/desktop` or `remote-cli`). The desktop sandbox
+   * provider reads this to know which daemon URL + secret to talk to
+   * without re-querying the registry. Unset for `local/default` runs.
    */
   linkForCurrentRun?: LinkEntry;
 

--- a/apps/mesh/src/harnesses/remote-dispatch.ts
+++ b/apps/mesh/src/harnesses/remote-dispatch.ts
@@ -22,7 +22,7 @@
  *
  * Handle vs runId: for remote-cli (whole-harness dispatch), the desktop
  * spins up an ephemeral per-run sandbox; the handle == `input.runId`.
- * This differs from the remote-user provider path (Task 5.1), where the
+ * This differs from the desktop provider path (Task 5.1), where the
  * handle is `computeHandle(sandboxId, branch)` because the sandbox is
  * long-lived and shared across runs. The daemon's cancel route
  * (`/_decopilot_vm/runs/<runId>`) confirms this — it matches on runId
@@ -162,7 +162,7 @@ export type RemoteDispatchLink = Pick<LinkEntry, "tunnelUrl" | "linkSecret">;
  *
  * Used by `remote-cli` dispatch where the handle equals `input.runId` —
  * a fresh, ephemeral per-run sandbox. We do NOT go through the
- * `remote-user` SandboxProvider here because that provider derives its
+ * `desktop` SandboxProvider here because that provider derives its
  * handle via `computeHandle(sandboxId, branch)`, which would diverge
  * from the runId-keyed flow `remoteDispatch` uses.
  *

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -119,7 +119,7 @@ const previewProxyDeps = {
 };
 
 // Boot/dev wiring for the Docker runner. The boot sweep + local ingress
-// are Docker-only — other runners (freestyle, agent-sandbox, remote-user)
+// are Docker-only — other runners (agent-sandbox, desktop)
 // either don't run on this machine or expose previews via their own
 // publicly-reachable URLs.
 const { resolveSandboxProviderKindFromEnv } = await import(

--- a/apps/mesh/src/link-daemon/sandbox-provider.ts
+++ b/apps/mesh/src/link-daemon/sandbox-provider.ts
@@ -112,7 +112,7 @@ export function createDesktopSandboxProvider(
   const pickPort = deps.pickPort ?? allocateEphemeralPort;
 
   // In-flight ensureSandbox promises, keyed by handle. The cluster
-  // creates a fresh `RemoteUserSandboxProvider` for every request
+  // creates a fresh `DesktopSandboxProvider` for every request
   // (its `records` map is per-instance), so several concurrent
   // VM_START / preview / proxyDaemonRequest paths can race here
   // before any of them gets a chance to populate `sandboxes`. Without

--- a/apps/mesh/src/links/resolve-dispatch-target.test.ts
+++ b/apps/mesh/src/links/resolve-dispatch-target.test.ts
@@ -25,24 +25,24 @@ describe("resolveDispatchTarget", () => {
     if (t.kind === "local") expect(t.sandbox).toBe("default");
   });
 
-  test("remote-user + decopilot + link online → local/remote-user", async () => {
+  test("desktop + decopilot + link online → local/desktop", async () => {
     const t = await resolveDispatchTarget(
       {
         harnessId: "decopilot",
-        sandboxProviderKind: "remote-user",
+        sandboxProviderKind: "desktop",
         userId: "u",
       },
       { linkRegistry: stubRegistry(linkOnline()) },
     );
     expect(t.kind).toBe("local");
-    if (t.kind === "local") expect(t.sandbox).toBe("remote-user");
+    if (t.kind === "local") expect(t.sandbox).toBe("desktop");
   });
 
-  test("remote-user + claude-code + link online → remote-cli", async () => {
+  test("desktop + claude-code + link online → remote-cli", async () => {
     const t = await resolveDispatchTarget(
       {
         harnessId: "claude-code",
-        sandboxProviderKind: "remote-user",
+        sandboxProviderKind: "desktop",
         userId: "u",
       },
       { linkRegistry: stubRegistry(linkOnline()) },
@@ -50,19 +50,19 @@ describe("resolveDispatchTarget", () => {
     expect(t.kind).toBe("remote-cli");
   });
 
-  test("remote-user + codex + link online → remote-cli", async () => {
+  test("desktop + codex + link online → remote-cli", async () => {
     const t = await resolveDispatchTarget(
-      { harnessId: "codex", sandboxProviderKind: "remote-user", userId: "u" },
+      { harnessId: "codex", sandboxProviderKind: "desktop", userId: "u" },
       { linkRegistry: stubRegistry(linkOnline()) },
     );
     expect(t.kind).toBe("remote-cli");
   });
 
-  test("remote-user + link offline → error/link_offline", async () => {
+  test("desktop + link offline → error/link_offline", async () => {
     const t = await resolveDispatchTarget(
       {
         harnessId: "claude-code",
-        sandboxProviderKind: "remote-user",
+        sandboxProviderKind: "desktop",
         userId: "u",
       },
       { linkRegistry: stubRegistry(null) },
@@ -71,11 +71,11 @@ describe("resolveDispatchTarget", () => {
     if (t.kind === "error") expect(t.reason).toBe("link_offline");
   });
 
-  test("remote-user + link missing capability → error/capability_missing", async () => {
+  test("desktop + link missing capability → error/capability_missing", async () => {
     const t = await resolveDispatchTarget(
       {
         harnessId: "claude-code",
-        sandboxProviderKind: "remote-user",
+        sandboxProviderKind: "desktop",
         userId: "u",
       },
       { linkRegistry: stubRegistry(linkOnline(["decopilot-sandbox"])) },

--- a/apps/mesh/src/links/resolve-dispatch-target.ts
+++ b/apps/mesh/src/links/resolve-dispatch-target.ts
@@ -3,11 +3,11 @@
  * provider kind pinned for this (thread, virtualMcpId, branch).
  *
  * `sandboxProviderKind` is the single source of truth:
- *   - cloud kind (docker/freestyle/agent-sandbox) → cluster default sandbox
- *   - `remote-user` + decopilot → cluster decopilot, sandbox tools tunneled
- *   - `remote-user` + claude-code/codex → whole stream dispatched to the desktop
+ *   - cloud kind (docker/agent-sandbox) → cluster default sandbox
+ *   - `desktop` + decopilot → cluster decopilot, sandbox tools tunneled
+ *   - `desktop` + claude-code/codex → whole stream dispatched to the desktop
  *
- * Link health is checked only for `remote-user`. Offline/missing-capability
+ * Link health is checked only for `desktop`. Offline/missing-capability
  * paths return an `error` target which `POST /messages` surfaces as 409.
  *
  * Takes the kind directly (not a `VmMapEntry`) so the POST handler can
@@ -26,7 +26,7 @@ export type DispatchTarget =
       reason: "link_offline" | "capability_missing";
       activeCapabilities?: string[];
     }
-  | { kind: "local"; sandbox: "default" | "remote-user"; link?: LinkEntry }
+  | { kind: "local"; sandbox: "default" | "desktop"; link?: LinkEntry }
   | { kind: "remote-cli"; link: LinkEntry };
 
 interface Input {
@@ -52,7 +52,7 @@ export async function resolveDispatchTarget(
 ): Promise<DispatchTarget> {
   const kind = input.sandboxProviderKind;
 
-  if (kind !== "remote-user") {
+  if (kind !== "desktop") {
     return { kind: "local", sandbox: "default" };
   }
 
@@ -69,7 +69,7 @@ export async function resolveDispatchTarget(
   }
 
   if (input.harnessId === "decopilot") {
-    return { kind: "local", sandbox: "remote-user", link };
+    return { kind: "local", sandbox: "desktop", link };
   }
   return { kind: "remote-cli", link };
 }

--- a/apps/mesh/src/sandbox/claim-handle.test.ts
+++ b/apps/mesh/src/sandbox/claim-handle.test.ts
@@ -24,13 +24,13 @@ describe("computeClaimHandle", () => {
     expect(hash.length).toBe(16);
   });
 
-  it("uses hashLen=16 when runner is remote-user", () => {
+  it("uses hashLen=16 when runner is desktop", () => {
     // Same brute-force argument as agent-sandbox: the runner's preview URL
     // is a public hostname (`<handle>.deco.host`), so the hash must be long
     // enough to resist guessing at an unrate-limited gateway. This also
     // keeps the cluster's claim-handle lookup in sync with what the
-    // remote-user runner stores (see remote-user/runner.ts ensure()).
-    process.env.STUDIO_SANDBOX_RUNNER = "remote-user";
+    // desktop runner stores (see desktop/runner.ts ensure()).
+    process.env.STUDIO_SANDBOX_RUNNER = "desktop";
     const h = computeClaimHandle({ userId: "u", projectRef: "p" }, "main");
     const hash = h.split("-").pop()!;
     expect(hash.length).toBe(16);

--- a/apps/mesh/src/sandbox/claim-handle.ts
+++ b/apps/mesh/src/sandbox/claim-handle.ts
@@ -6,20 +6,20 @@ import {
 
 /**
  * Compute the claim handle for a sandbox using the correct hashLen for the
- * current runner kind. agent-sandbox and remote-user both expose preview
+ * current runner kind. agent-sandbox and desktop both expose preview
  * URLs as public hostnames (`<handle>.cluster.host` and `<handle>.deco.host`
  * respectively), so both use hashLen=16 — shorter hashes are brute-forceable
- * at an unrate-limited gateway. Other runners (docker, host) keep their
+ * at an unrate-limited gateway. Other runners (docker) keep their
  * handles local, so the default hashLen=5 is fine there.
  *
  * Single source of truth — import this everywhere a claimName must match
  * what a runner stored (vm-events, vm-exec, etc.). The matching
- * `hashLen=16` lives in `remote-user/runner.ts` so both sides agree by
+ * `hashLen=16` lives in `desktop/runner.ts` so both sides agree by
  * construction.
  */
 export function computeClaimHandle(id: SandboxId, branch: string): string {
   const providerKind = resolveSandboxProviderKindFromEnv();
   const useLongHash =
-    providerKind === "agent-sandbox" || providerKind === "remote-user";
+    providerKind === "agent-sandbox" || providerKind === "desktop";
   return computeHandle(id, branch, useLongHash ? { hashLen: 16 } : {});
 }

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -162,17 +162,17 @@ async function instantiate(
         meter,
       });
     }
-    case "remote-user": {
-      // remote-user is never the cluster-wide default — there is no
+    case "desktop": {
+      // desktop is never the cluster-wide default — there is no
       // ambient `LinkEntry` to bind to here. It is constructed per-run by
       // `resolveSandboxProvider` (sandbox/resolve-provider.ts) from
       // either the per-run ctx hint or the recorded vmMap kind, both of
       // which carry the user's link. Hitting this branch means VM_DELETE
-      // was called for a `remote-user` row without a live link context,
-      // which today should not happen (the remote-user provider doesn't
+      // was called for a `desktop` row without a live link context,
+      // which today should not happen (the desktop provider doesn't
       // write to `sandbox_runner_state`).
       throw new Error(
-        "remote-user runner cannot be instantiated without a per-run LinkEntry — call resolveSandboxProvider, which binds the link before constructing the provider.",
+        "desktop runner cannot be instantiated without a per-run LinkEntry — call resolveSandboxProvider, which binds the link before constructing the provider.",
       );
     }
     default: {
@@ -183,22 +183,22 @@ async function instantiate(
 }
 
 /**
- * Construct a `RemoteUserSandboxProvider` bound to the given link entry.
+ * Construct a `DesktopSandboxProvider` bound to the given link entry.
  * Exported so the unified resolver in `resolve-provider.ts` can build one
  * without going through `getSharedSandboxProvider` (which requires
  * pre-populating `ctx.sandboxPreference` / `ctx.linkForCurrentRun` as a
  * side-effect — the resolver decides the kind from vmMap, not from those
  * ctx fields, so the side-effect would be misleading).
  */
-export async function buildRemoteUserProvider(
+export async function buildDesktopProvider(
   ctx: MeshContext,
   link: NonNullable<MeshContext["linkForCurrentRun"]>,
 ): Promise<SandboxProvider> {
-  const { RemoteUserSandboxProvider } = await import(
-    "@decocms/sandbox/provider/remote-user"
+  const { DesktopSandboxProvider } = await import(
+    "@decocms/sandbox/provider/desktop"
   );
   const stateStore = new KyselySandboxProviderStateStore(ctx.db);
-  return new RemoteUserSandboxProvider({
+  return new DesktopSandboxProvider({
     link: { tunnelUrl: link.tunnelUrl, linkSecret: link.linkSecret },
     stateStore,
   });

--- a/apps/mesh/src/sandbox/resolve-default-provider-kind.test.ts
+++ b/apps/mesh/src/sandbox/resolve-default-provider-kind.test.ts
@@ -17,12 +17,12 @@ function stubRegistry(link: LinkEntry | null): LinkRegistry {
 }
 
 describe("resolveDefaultSandboxProviderKind", () => {
-  test("returns remote-user when the user's link is online", async () => {
+  test("returns desktop when the user's link is online", async () => {
     const kind = await resolveDefaultSandboxProviderKind("u-1", {
       linkRegistry: stubRegistry(linkOnline()),
       resolveEnvKind: () => "docker",
     });
-    expect(kind).toBe("remote-user");
+    expect(kind).toBe("desktop");
   });
 
   test("falls back to env kind when no link is registered", async () => {

--- a/apps/mesh/src/sandbox/resolve-default-provider-kind.ts
+++ b/apps/mesh/src/sandbox/resolve-default-provider-kind.ts
@@ -3,8 +3,8 @@
  * caller hasn't explicitly chosen one.
  *
  * Policy:
- *   - link online for this user → "remote-user"
- *   - otherwise → whatever the env's cluster runner is (docker/freestyle/agent-sandbox)
+ *   - link online for this user → "desktop"
+ *   - otherwise → whatever the env's cluster runner is (docker/agent-sandbox)
  *
  * The link probe is the same one `resolveDispatchTarget` uses, so manual VM
  * start (from the branch picker) and auto-start (from VmEventsBridge) agree.
@@ -22,6 +22,6 @@ export async function resolveDefaultSandboxProviderKind(
   deps: ResolveDefaultDeps,
 ): Promise<SandboxProviderKind> {
   const link = await deps.linkRegistry.get(userId);
-  if (link) return "remote-user";
+  if (link) return "desktop";
   return deps.resolveEnvKind();
 }

--- a/apps/mesh/src/sandbox/resolve-provider.test.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.test.ts
@@ -36,22 +36,22 @@ const stubAgentSandbox: SandboxProvider = {
   ...stubDocker,
   kind: "agent-sandbox",
 };
-const stubRemoteUser: SandboxProvider = { ...stubDocker, kind: "remote-user" };
+const stubDesktop: SandboxProvider = { ...stubDocker, kind: "desktop" };
 
 // Mock lifecycle: dispatch on requested kind so we can assert which one was
 // picked.
 const byKindSpy = mock(
-  async (_ctx: unknown, kind: "docker" | "agent-sandbox" | "remote-user") => {
+  async (_ctx: unknown, kind: "docker" | "agent-sandbox" | "desktop") => {
     if (kind === "docker") return stubDocker;
     if (kind === "agent-sandbox") return stubAgentSandbox;
-    throw new Error("unreachable — resolver builds remote-user directly");
+    throw new Error("unreachable — resolver builds desktop directly");
   },
 );
-const buildRemoteSpy = mock(async () => stubRemoteUser);
+const buildDesktopSpy = mock(async () => stubDesktop);
 
 mock.module("./lifecycle", () => ({
   getSandboxProviderByKind: byKindSpy,
-  buildRemoteUserProvider: buildRemoteSpy,
+  buildDesktopProvider: buildDesktopSpy,
 }));
 
 // Now import the resolver — its lifecycle import has been mocked.
@@ -68,7 +68,7 @@ function makeLink(): LinkEntry {
 function stubCtx(
   link: LinkEntry | null,
   hints?: {
-    sandboxPreference?: "default" | "remote-user";
+    sandboxPreference?: "default" | "desktop";
     linkForCurrentRun?: LinkEntry;
   },
 ): MeshContext {
@@ -85,7 +85,7 @@ function stubCtx(
 
 describe("resolveSandboxProvider", () => {
   test("recorded vmMap kind wins over the link-or-env default", async () => {
-    // User has a link online, so the default policy would pick `remote-user`.
+    // User has a link online, so the default policy would pick `desktop`.
     // But vmMap records `agent-sandbox` for (user, branch) — we must honor
     // that recorded kind so the SSE/proxy paths reach the right provider.
     const metadata = {
@@ -114,19 +114,19 @@ describe("resolveSandboxProvider", () => {
     );
     expect(kind).toBe("agent-sandbox");
     expect(provider).toBe(stubAgentSandbox);
-    expect(buildRemoteSpy).not.toHaveBeenCalled();
+    expect(buildDesktopSpy).not.toHaveBeenCalled();
   });
 
-  test("link online + no vmMap entry → remote-user, bound to link", async () => {
+  test("link online + no vmMap entry → desktop, bound to link", async () => {
     const link = makeLink();
     const { provider, kind } = await resolveSandboxProvider(stubCtx(link), {
       userId: "u-1",
       branch: "deco/new",
       virtualMcpMetadata: null,
     });
-    expect(kind).toBe("remote-user");
-    expect(provider).toBe(stubRemoteUser);
-    expect(buildRemoteSpy).toHaveBeenCalled();
+    expect(kind).toBe("desktop");
+    expect(provider).toBe(stubDesktop);
+    expect(buildDesktopSpy).toHaveBeenCalled();
   });
 
   test("explicit override beats both vmMap and default policy", async () => {
@@ -134,11 +134,11 @@ describe("resolveSandboxProvider", () => {
       vmMap: {
         "u-1": {
           "deco/foo": {
-            "remote-user": {
+            desktop: {
               vmId: "vm_xyz",
               previewUrl: "https://p",
               sandboxUrl: "https://p",
-              sandboxProviderKind: "remote-user",
+              sandboxProviderKind: "desktop",
               createdAt: 1,
               startedWith: { packageManager: null, port: null, path: null },
             },
@@ -164,7 +164,7 @@ describe("resolveSandboxProvider", () => {
     expect(kind).toBe("docker");
   });
 
-  test("ctx hint (sandboxPreference=remote-user + link) short-circuits without vmMap read", async () => {
+  test("ctx hint (sandboxPreference=desktop + link) short-circuits without vmMap read", async () => {
     // dispatch-run sets these ctx fields from the resolved DispatchTarget.
     // Resolver must honor them and skip the vmMap lookup so the decopilot
     // hot path doesn't pay a DB hit per turn. Metadata is intentionally
@@ -188,7 +188,7 @@ describe("resolveSandboxProvider", () => {
     };
     const link = makeLink();
     const ctx = stubCtx(null, {
-      sandboxPreference: "remote-user",
+      sandboxPreference: "desktop",
       linkForCurrentRun: link,
     });
     const { kind, provider } = await resolveSandboxProvider(ctx, {
@@ -196,8 +196,8 @@ describe("resolveSandboxProvider", () => {
       branch: "deco/foo",
       virtualMcpMetadata: metadata,
     });
-    expect(kind).toBe("remote-user");
-    expect(provider).toBe(stubRemoteUser);
+    expect(kind).toBe("desktop");
+    expect(provider).toBe(stubDesktop);
   });
 
   test("ctx hint (sandboxPreference=default) routes to env kind", async () => {
@@ -211,18 +211,18 @@ describe("resolveSandboxProvider", () => {
     expect(kind).toBe("docker");
   });
 
-  test("remote-user resolution throws when link daemon is offline", async () => {
-    // vmMap records `remote-user` but link is gone — caller (events/proxy
+  test("desktop resolution throws when link daemon is offline", async () => {
+    // vmMap records `desktop` but link is gone — caller (events/proxy
     // middleware) catches this and surfaces a failed phase / 503.
     const metadata = {
       vmMap: {
         "u-1": {
           "deco/foo": {
-            "remote-user": {
+            desktop: {
               vmId: "vm_xyz",
               previewUrl: "https://p",
               sandboxUrl: "https://p",
-              sandboxProviderKind: "remote-user",
+              sandboxProviderKind: "desktop",
               createdAt: 1,
               startedWith: { packageManager: null, port: null, path: null },
             },

--- a/apps/mesh/src/sandbox/resolve-provider.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.ts
@@ -5,7 +5,7 @@
  *
  *   1. **Caller override (`explicitKind`).** `VM_START` forwards
  *      `input.sandboxProviderKind` here; `ensureVm` callers pass the kind
- *      they already resolved. Binds the user's link for `remote-user`.
+ *      they already resolved. Binds the user's link for `desktop`.
  *
  *   2. **Per-run dispatch hint** (`ctx.sandboxPreference` /
  *      `ctx.linkForCurrentRun`). Set by `dispatch-run` from the resolved
@@ -14,13 +14,13 @@
  *      and any DB lookup here would just confirm what they already know.
  *
  *   3. **Recorded vmMap kind.** The post-provision source of truth: a
- *      sandbox provisioned via `remote-user` stays addressable through
- *      `remote-user` even on a cluster whose env kind is something else
+ *      sandbox provisioned via `desktop` stays addressable through
+ *      `desktop` even on a cluster whose env kind is something else
  *      (`agent-sandbox`, `docker`, …). This is what the events/proxy
  *      route uses — no ctx hint, just the recorded entry.
  *
  *   4. **Default policy** (`resolveDefaultSandboxProviderKind`). Pre-
- *      provision fall-through: live link → `remote-user`, else env kind.
+ *      provision fall-through: live link → `desktop`, else env kind.
  *
  * Returns a fully-bound `SandboxProvider` plus the resolved kind. Callers
  * never need to set `ctx.sandboxPreference` / `ctx.linkForCurrentRun`
@@ -36,11 +36,11 @@ import {
 
 import type { MeshContext } from "../core/mesh-context";
 import { readVmMap } from "../tools/vm/vm-map";
-import { buildRemoteUserProvider, getSandboxProviderByKind } from "./lifecycle";
+import { buildDesktopProvider, getSandboxProviderByKind } from "./lifecycle";
 import { resolveDefaultSandboxProviderKind } from "./resolve-default-provider-kind";
 
 export interface ResolveSandboxProviderArgs {
-  /** User whose vmMap cell to read and (for `remote-user`) whose link to bind. */
+  /** User whose vmMap cell to read and (for `desktop`) whose link to bind. */
   userId: string;
   branch: string;
   /** Raw `virtualmcp.metadata` JSON column. May be null. */
@@ -48,7 +48,7 @@ export interface ResolveSandboxProviderArgs {
   /**
    * Caller-provided override (e.g. `VM_START`'s `input.sandboxProviderKind`).
    * When set, takes precedence over both the vmMap entry and the default
-   * policy. The resolver still binds the user's link for `remote-user`.
+   * policy. The resolver still binds the user's link for `desktop`.
    */
   explicitKind?: SandboxProviderKind;
 }
@@ -73,11 +73,11 @@ export async function resolveSandboxProvider(
   }
 
   // 2. Per-run dispatch hint. `dispatch-run` already chose; honor it
-  //    without touching vmMap. `remote-user` carries its link inline;
+  //    without touching vmMap. `desktop` carries its link inline;
   //    `default` means "use the cluster runner the env points to".
-  if (ctx.sandboxPreference === "remote-user" && ctx.linkForCurrentRun) {
-    const provider = await buildRemoteUserProvider(ctx, ctx.linkForCurrentRun);
-    return { provider, kind: "remote-user" };
+  if (ctx.sandboxPreference === "desktop" && ctx.linkForCurrentRun) {
+    const provider = await buildDesktopProvider(ctx, ctx.linkForCurrentRun);
+    return { provider, kind: "desktop" };
   }
   if (ctx.sandboxPreference === "default") {
     const kind = resolveSandboxProviderKindFromEnv();
@@ -89,7 +89,7 @@ export async function resolveSandboxProvider(
   //    multiple sibling kinds were persisted (e.g. the user ran VM_START
   //    twice with different `sandboxProviderKind` values), the events/proxy
   //    path consistently picks the one matching current intent
-  //    (link online → `remote-user`, else env kind) instead of whatever
+  //    (link online → `desktop`, else env kind) instead of whatever
   //    `Object.keys` happens to enumerate first.
   const [firstRecorded, ...restRecorded] = readRecordedKinds(
     virtualMcpMetadata,
@@ -130,7 +130,7 @@ function readRecordedKinds(
 
 /**
  * Picks one recorded kind when multiple siblings exist. Prefers the kind that
- * matches the current default policy (link online → `remote-user`, else env
+ * matches the current default policy (link online → `desktop`, else env
  * kind); otherwise falls back to the first recorded kind. This keeps the
  * events/proxy path deterministic across pods and matches what a fresh
  * VM_START with no explicit kind would have used.
@@ -162,11 +162,11 @@ async function bindProviderForKind(
   userId: string,
   kind: SandboxProviderKind,
 ): Promise<SandboxProvider> {
-  if (kind !== "remote-user") return getSandboxProviderByKind(ctx, kind);
+  if (kind !== "desktop") return getSandboxProviderByKind(ctx, kind);
 
   if (!ctx.linkRegistry) {
     throw new Error(
-      "remote-user sandbox provider requires ctx.linkRegistry to be wired (set on MeshContextConfig).",
+      "desktop sandbox provider requires ctx.linkRegistry to be wired (set on MeshContextConfig).",
     );
   }
   const link = await ctx.linkRegistry.get(userId);
@@ -175,5 +175,5 @@ async function bindProviderForKind(
       `No link daemon registered for user "${userId}". Start one with \`deco link\` (or run \`bun run dev --local-sandbox-provider\` for dev).`,
     );
   }
-  return buildRemoteUserProvider(ctx, link);
+  return buildDesktopProvider(ctx, link);
 }

--- a/apps/mesh/src/tools/thread/schema.ts
+++ b/apps/mesh/src/tools/thread/schema.ts
@@ -91,7 +91,7 @@ export const ThreadEntitySchema = z.object({
     .nullable()
     .optional()
     .describe(
-      "Pinned on first message; identifies which VM to dispatch to (e.g. 'docker', 'freestyle', 'agent-sandbox', 'remote-user').",
+      "Pinned on first message; identifies which VM to dispatch to (e.g. 'docker', 'agent-sandbox', 'desktop').",
     ),
   harness_id: z
     .string()

--- a/apps/mesh/src/tools/vm/start.test.ts
+++ b/apps/mesh/src/tools/vm/start.test.ts
@@ -43,13 +43,13 @@ const mockDockerRunner: SandboxProvider = {
   watchClaimLifecycle: () => readyOnly(),
 };
 
-const mockRemoteUserDelete = mock(async (_handle: string) => {});
+const mockDesktopDelete = mock(async (_handle: string) => {});
 
-const mockRemoteUserRunner: SandboxProvider = {
-  kind: "remote-user",
+const mockDesktopRunner: SandboxProvider = {
+  kind: "desktop",
   ensure: (id, opts) => mockEnsure(id, opts),
   exec: async () => ({ stdout: "", stderr: "", exitCode: 0, timedOut: false }),
-  delete: (handle) => mockRemoteUserDelete(handle),
+  delete: (handle) => mockDesktopDelete(handle),
   alive: async () => true,
   getPreviewUrl: async () => "https://stub.preview/",
   proxyDaemonRequest: async () => new Response(null, { status: 204 }),
@@ -62,10 +62,10 @@ mock.module("../../sandbox/lifecycle", () => ({
     kind: "docker" | "agent-sandbox",
   ) => (kind === "docker" ? mockDockerRunner : mockDockerRunner),
   // The unified resolver in `resolve-provider.ts` calls
-  // `buildRemoteUserProvider` directly (no ctx side-effects), so a mock
-  // is needed for VM_START's remote-user path to construct the expected
+  // `buildDesktopProvider` directly (no ctx side-effects), so a mock
+  // is needed for VM_START's desktop path to construct the expected
   // runner under test.
-  buildRemoteUserProvider: async () => mockRemoteUserRunner,
+  buildDesktopProvider: async () => mockDesktopRunner,
   getSharedSandboxProviderIfInit: () => mockDockerRunner,
   getOrInitSharedRunner: async () => mockDockerRunner,
   asDockerRunner: () => null,
@@ -275,10 +275,10 @@ describe("VM_START", () => {
     mockEnsure.mockReset();
     mockDockerDelete.mockReset();
     mockAgentSandboxDelete.mockReset();
-    mockRemoteUserDelete.mockReset();
+    mockDesktopDelete.mockReset();
     mockDockerDelete.mockImplementation(async () => {});
     mockAgentSandboxDelete.mockImplementation(async () => {});
-    mockRemoteUserDelete.mockImplementation(async () => {});
+    mockDesktopDelete.mockImplementation(async () => {});
     mockTokenGet.mockReset();
     mockEnsure.mockImplementation(async () => ({
       handle: "vm_xyz",
@@ -560,7 +560,7 @@ describe("VM_START", () => {
     expect(opts.repo?.cloneUrl).not.toContain("ghu_stale_token");
   });
 
-  it("provisions a new remote-user VM even when a docker entry exists under the same branch — kinds are siblings", async () => {
+  it("provisions a new desktop VM even when a docker entry exists under the same branch — kinds are siblings", async () => {
     // With kind-in-key, different kinds coexist — no teardown occurs.
     const dockerEntry: VmMapEntry = {
       vmId: "vm_docker_existing",
@@ -577,7 +577,7 @@ describe("VM_START", () => {
       },
     };
     const virtualMcp = makeVirtualMcp(ORG_ID, metadata);
-    // Link registry with online link so resolveDefaultSandboxProviderKind picks remote-user
+    // Link registry with online link so resolveDefaultSandboxProviderKind picks desktop
     const linkRegistry: LinkRegistry = {
       get: async (_userId: string) => ({
         machineId: "machine_1",
@@ -593,7 +593,7 @@ describe("VM_START", () => {
     };
     const ctx = makeCtx({ virtualMcp, linkRegistry });
 
-    // Link is online → kind resolves to remote-user; no docker entry for remote-user → provision a new one
+    // Link is online → kind resolves to desktop; no docker entry for desktop → provision a new one
     const result = await VM_START.handler(
       { virtualMcpId: VMCP_ID, branch: BRANCH },
       ctx,
@@ -602,7 +602,7 @@ describe("VM_START", () => {
     // No teardown of the docker entry (kinds are siblings)
     expect(mockDockerDelete).not.toHaveBeenCalled();
     expect(mockEnsure).toHaveBeenCalledTimes(1);
-    expect(result.sandboxProviderKind).toBe("remote-user");
+    expect(result.sandboxProviderKind).toBe("desktop");
     expect(result.isNewVm).toBe(true);
   });
 
@@ -643,7 +643,7 @@ describe("VM_START", () => {
     createdAt: new Date().toISOString(),
   };
 
-  it("VM_START with no sandboxProviderKind picks remote-user when the link is online", async () => {
+  it("VM_START with no sandboxProviderKind picks desktop when the link is online", async () => {
     const linkRegistry: LinkRegistry = {
       get: async (_userId: string) => STUB_LINK,
       put: async () => {},
@@ -658,14 +658,14 @@ describe("VM_START", () => {
       ctx,
     );
 
-    expect(result.sandboxProviderKind).toBe("remote-user");
+    expect(result.sandboxProviderKind).toBe("desktop");
     const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
     const updated = (updateCall[2] as { metadata: { vmMap: VmMap } }).metadata;
     // 3-level key: vmMap[userId][branch][kind]
     const stored = (
       updated.vmMap[USER_ID]?.[BRANCH] as Record<string, unknown>
-    )?.["remote-user"] as VmMapEntry | undefined;
-    expect(stored?.sandboxProviderKind).toBe("remote-user");
+    )?.["desktop"] as VmMapEntry | undefined;
+    expect(stored?.sandboxProviderKind).toBe("desktop");
   });
 
   it("VM_START with no sandboxProviderKind picks env kind when no link", async () => {
@@ -695,7 +695,7 @@ describe("VM_START", () => {
   });
 
   it("VM_START with explicit sandboxProviderKind ignores defaults", async () => {
-    // Link is online, env is "docker" — but explicit "docker" must win (and remote-user would also be overrideable).
+    // Link is online, env is "docker" — but explicit "docker" must win (and desktop would also be overrideable).
     const linkRegistry: LinkRegistry = {
       get: async (_userId: string) => STUB_LINK,
       put: async () => {},

--- a/apps/mesh/src/tools/vm/start.ts
+++ b/apps/mesh/src/tools/vm/start.ts
@@ -75,10 +75,10 @@ export const VM_START = defineTool({
         "Optional git branch to check out. When omitted the handler generates `deco/<adjective>-<noun>` and uses it. The resolved branch is returned in the response so callers can persist it.",
       ),
     sandboxProviderKind: z
-      .enum(["docker", "agent-sandbox", "remote-user"])
+      .enum(["docker", "agent-sandbox", "desktop"])
       .optional()
       .describe(
-        "Explicit runtime choice. When omitted, defaults to `remote-user` if the acting user's link daemon is online, else the cluster env kind.",
+        "Explicit runtime choice. When omitted, defaults to `desktop` if the acting user's link daemon is online, else the cluster env kind.",
       ),
   }),
   outputSchema: z.object({
@@ -86,7 +86,7 @@ export const VM_START = defineTool({
     vmId: z.string(),
     branch: z.string(),
     isNewVm: z.boolean(),
-    sandboxProviderKind: z.enum(["docker", "agent-sandbox", "remote-user"]),
+    sandboxProviderKind: z.enum(["docker", "agent-sandbox", "desktop"]),
   }),
 
   handler: async (input, ctx) => {
@@ -200,7 +200,7 @@ export async function ensureVm(
   // ensureVm is called from the always-on VM tools path which doesn't
   // pre-resolve the runner. `resolveSandboxProvider` here honors the
   // explicit kind from the caller (POST /messages already decided) and
-  // binds the user's link for `remote-user`.
+  // binds the user's link for `desktop`.
   const { provider: runner } = await resolveSandboxProvider(ctx, {
     userId,
     branch: input.branch,
@@ -378,7 +378,7 @@ async function provisionSandbox(
   const entry: VmMapEntry = {
     vmId: sandbox.handle,
     previewUrl: sandbox.previewUrl,
-    sandboxUrl: sandbox.previewUrl, // for remote-user the two are equal
+    sandboxUrl: sandbox.previewUrl, // for desktop the two are equal
     sandboxProviderKind: runner.kind,
     createdAt,
     startedWith: {

--- a/apps/mesh/src/tools/vm/stop.test.ts
+++ b/apps/mesh/src/tools/vm/stop.test.ts
@@ -239,10 +239,10 @@ describe("VM_DELETE", () => {
     }
   });
 
-  it("coalesces legacy 'host' kind input to 'remote-user'", async () => {
+  it("coalesces legacy 'host' kind input to 'desktop'", async () => {
     // Use a docker entry as a stand-in — what matters is the dispatch kind.
     const metadata: Metadata = {
-      vmMap: makeVmMap("user-1", BRANCH, "remote-user", DOCKER_ENTRY),
+      vmMap: makeVmMap("user-1", BRANCH, "desktop", DOCKER_ENTRY),
     };
     const virtualMcp = makeVirtualMcp("org_1", metadata);
     const ctx = makeCtx({ virtualMcp });
@@ -258,7 +258,7 @@ describe("VM_DELETE", () => {
       ctx,
     );
 
-    expect(lastRequestedKind.value).toBe("remote-user");
+    expect(lastRequestedKind.value).toBe("desktop");
   });
 
   it("skips runner.delete and DB update when no vmMap entry for (user, branch, kind)", async () => {

--- a/apps/mesh/src/tools/vm/stop.ts
+++ b/apps/mesh/src/tools/vm/stop.ts
@@ -29,7 +29,7 @@ export const VM_DELETE = defineTool({
       .min(1)
       .describe("Branch whose vm should be deleted (vmMap[userId][branch])"),
     sandboxProviderKind: z
-      .enum(["docker", "agent-sandbox", "remote-user"])
+      .enum(["docker", "agent-sandbox", "desktop"])
       .describe(
         "Kind of sandbox provider the VM was started with. Used to locate the correct 3-level vmMap entry.",
       ),
@@ -43,7 +43,7 @@ export const VM_DELETE = defineTool({
     // the dev-mode replacement so the stop path doesn't crash.
     const rawKind = input.sandboxProviderKind as string;
     const kind: SandboxProviderKind =
-      rawKind === "host" ? "remote-user" : (rawKind as SandboxProviderKind);
+      rawKind === "host" ? "desktop" : (rawKind as SandboxProviderKind);
 
     let vmEntry: Awaited<ReturnType<typeof requireVmEntry>>;
     try {

--- a/apps/mesh/src/web/components/chat/agent-model-trigger.tsx
+++ b/apps/mesh/src/web/components/chat/agent-model-trigger.tsx
@@ -57,9 +57,9 @@ function agentKindFromHarness(
   agent: HarnessId | null,
   sandboxKind: SandboxProviderKind | null,
 ): AgentKind | null {
-  if (agent === "claude-code" && sandboxKind === "remote-user")
+  if (agent === "claude-code" && sandboxKind === "desktop")
     return "claude-code";
-  if (agent === "codex" && sandboxKind === "remote-user") return "codex";
+  if (agent === "codex" && sandboxKind === "desktop") return "codex";
   if (agent === "decopilot") return "decopilot";
   return null;
 }
@@ -106,7 +106,7 @@ export function AgentModelTrigger({
       startVm.mutate({
         virtualMcpId,
         branch: currentBranch,
-        sandboxProviderKind: "remote-user" as const,
+        sandboxProviderKind: "desktop" as const,
       });
     }
     track("agent_model_selected", { agent: kind, tier: nextTier });

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -522,7 +522,7 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
     pendingAgentOption === null
       ? null
       : !hasClonableSource &&
-          AGENT_OPTION_PINS[pendingAgentOption].sandbox === "remote-user"
+          AGENT_OPTION_PINS[pendingAgentOption].sandbox === "desktop"
         ? "decopilot"
         : pendingAgentOption;
 

--- a/apps/mesh/src/web/components/chat/pills/agent-options.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.ts
@@ -16,6 +16,6 @@ export interface AgentPins {
  */
 export const AGENT_OPTION_PINS: Record<AgentOption, AgentPins> = {
   decopilot: { harness: "decopilot", sandbox: null },
-  "claude-code-desktop": { harness: "claude-code", sandbox: "remote-user" },
-  "codex-desktop": { harness: "codex", sandbox: "remote-user" },
+  "claude-code-desktop": { harness: "claude-code", sandbox: "desktop" },
+  "codex-desktop": { harness: "codex", sandbox: "desktop" },
 };

--- a/apps/mesh/src/web/components/chat/task/types.ts
+++ b/apps/mesh/src/web/components/chat/task/types.ts
@@ -21,7 +21,7 @@ export interface Task {
   trigger_id?: string | null;
   /** Git branch associated with this thread, when the vMCP is GitHub-linked. */
   branch?: string | null;
-  /** Sandbox provider kind pinned on first message (e.g. "docker", "freestyle", "remote-user"). */
+  /** Sandbox provider kind pinned on first message (e.g. "docker", "agent-sandbox", "desktop"). */
   sandbox_provider_kind?: string | null;
   /** Harness id pinned on first message (e.g. "claude-code", "codex", "decopilot"). */
   harness_id?: string | null;

--- a/apps/mesh/src/web/components/vm/hooks/use-vm-start.ts
+++ b/apps/mesh/src/web/components/vm/hooks/use-vm-start.ts
@@ -29,10 +29,10 @@ export interface VmStartArgs {
   branch?: string;
   /**
    * Optional explicit sandbox provider kind. When omitted the server picks
-   * via resolveDefaultSandboxProviderKind (link-online ⇒ remote-user, else
+   * via resolveDefaultSandboxProviderKind (link-online ⇒ desktop, else
    * the env kind). Used by the v2 RunnerPill to materialize a specific kind.
    */
-  sandboxProviderKind?: "docker" | "agent-sandbox" | "remote-user";
+  sandboxProviderKind?: "docker" | "agent-sandbox" | "desktop";
 }
 
 export interface VmStartResult {
@@ -40,7 +40,7 @@ export interface VmStartResult {
   vmId: string;
   branch: string;
   isNewVm: boolean;
-  sandboxProviderKind?: "docker" | "agent-sandbox" | "remote-user";
+  sandboxProviderKind?: "docker" | "agent-sandbox" | "desktop";
 }
 
 const inflightStarts = new Map<string, Promise<VmStartResult>>();

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -137,7 +137,7 @@ export function PreviewContent() {
 
   // vmMap[userId][branch][sandboxProviderKind] -> { vmId, previewUrl, ... }
   // Use parseBranchMap to handle both legacy 2-level and current 3-level shapes.
-  // For the preview surface we pick the first non-remote-user entry (cloud VMs
+  // For the preview surface we pick the first non-desktop entry (cloud VMs
   // have an accessible previewUrl), falling back to the first entry of any kind.
   // There is typically only one entry per branch in normal usage.
   const userId = session?.user?.id;
@@ -146,7 +146,7 @@ export function PreviewContent() {
     userId && branch ? parseBranchMap(metadata?.vmMap?.[userId]?.[branch]) : {};
   const branchMapEntries = Object.values(branchMap);
   const vmEntry =
-    branchMapEntries.find((e) => e.sandboxProviderKind !== "remote-user") ??
+    branchMapEntries.find((e) => e.sandboxProviderKind !== "desktop") ??
     branchMapEntries[0];
   const previewUrl = vmEntry?.previewUrl ?? null;
 

--- a/packages/mesh-sdk/src/types/virtual-mcp.test.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.test.ts
@@ -124,23 +124,23 @@ describe("parseBranchMap tolerant reader", () => {
   test("parses 3-level (kind-keyed) map", () => {
     const result = parseBranchMap({
       docker: { vmId: "v1", previewUrl: null, sandboxProviderKind: "docker" },
-      "remote-user": {
+      desktop: {
         vmId: "v2",
         previewUrl: null,
-        sandboxProviderKind: "remote-user",
+        sandboxProviderKind: "desktop",
       },
     });
     expect(result.docker?.vmId).toBe("v1");
-    expect(result["remote-user"]?.vmId).toBe("v2");
+    expect(result.desktop?.vmId).toBe("v2");
   });
 
   test("wraps 2-level legacy entry under its sandboxProviderKind", () => {
     const result = parseBranchMap({
       vmId: "v-legacy",
       previewUrl: null,
-      sandboxProviderKind: "remote-user",
+      sandboxProviderKind: "desktop",
     });
-    expect(result["remote-user"]?.vmId).toBe("v-legacy");
+    expect(result.desktop?.vmId).toBe("v-legacy");
     expect(result.docker).toBeUndefined();
   });
 
@@ -180,9 +180,9 @@ describe("parseVmMapEntry tolerant reader", () => {
     const result = parseVmMapEntry({
       vmId: "v1",
       previewUrl: null,
-      runnerKind: "remote-user",
+      runnerKind: "desktop",
     });
-    expect(result.sandboxProviderKind).toBe("remote-user");
+    expect(result.sandboxProviderKind).toBe("desktop");
     expect(
       (result as unknown as { runnerKind?: unknown }).runnerKind,
     ).toBeUndefined();
@@ -193,8 +193,8 @@ describe("parseVmMapEntry tolerant reader", () => {
       vmId: "v1",
       previewUrl: null,
       runnerKind: "docker",
-      sandboxProviderKind: "remote-user",
+      sandboxProviderKind: "desktop",
     });
-    expect(result.sandboxProviderKind).toBe("remote-user");
+    expect(result.sandboxProviderKind).toBe("desktop");
   });
 });

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -235,13 +235,13 @@ export const VmMapEntrySchema = z.object({
     .nullable()
     .optional()
     .describe(
-      "Daemon's public URL — what cluster→daemon RPCs target. Equal to previewUrl for remote-user; null/absent for runners that route through cluster ingress (docker, agent-sandbox).",
+      "Daemon's public URL — what cluster→daemon RPCs target. Equal to previewUrl for desktop; null/absent for runners that route through cluster ingress (docker, agent-sandbox).",
     ),
   sandboxProviderKind: z
     // Legacy values ("freestyle", "host") are tolerated on read for
     // pre-removal vmMap entries; writers use one of the active kinds.
     // The tolerant readers (parseVmMapEntry, parseBranchMap) normalize.
-    .enum(["docker", "agent-sandbox", "remote-user", "freestyle", "host"])
+    .enum(["docker", "agent-sandbox", "desktop", "freestyle", "host"])
     .optional(),
   createdAt: z
     .number()
@@ -300,7 +300,7 @@ export function parseVmMapEntry(raw: unknown): VmMapEntry {
 }
 
 /** The active sandbox provider kinds (excludes legacy "freestyle", "host"). */
-type SandboxProviderKind = "docker" | "agent-sandbox" | "remote-user";
+type SandboxProviderKind = "docker" | "agent-sandbox" | "desktop";
 
 /**
  * Tolerant reader at the branch-map level.
@@ -326,7 +326,7 @@ export function parseBranchMap(
     // runners no longer exist; rows from before the removal still parse.
     const raw = entry.sandboxProviderKind;
     const kind: SandboxProviderKind =
-      raw === "docker" || raw === "agent-sandbox" || raw === "remote-user"
+      raw === "docker" || raw === "agent-sandbox" || raw === "desktop"
         ? raw
         : "docker";
     return { [kind]: entry };

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -26,8 +26,8 @@ Three runner backends live behind the common `SandboxProvider` interface
 The host app calls `resolveSandboxProviderKindFromEnv()` to pick the runner. Single rule:
 
 1. `STUDIO_SANDBOX_RUNNER` is honored if set (one of `docker`,
-   `agent-sandbox`, `remote-user`).
-2. Otherwise the runner defaults to `remote-user` (the desktop-side
+   `agent-sandbox`, `desktop`).
+2. Otherwise the runner defaults to `desktop` (the desktop-side
    `deco link` daemon — auto-spawned by `bun run dev --local-sandbox-provider`
    in local dev, and the supported topology for single-machine self-hosts
    running the link side-by-side).
@@ -36,7 +36,7 @@ Preconditions:
 
 - `agent-sandbox` is opt-in only — never auto-selected.
 - The retired `host` runner kind is rejected. Local dev now exercises
-  `remote-user` against the auto-spawned link binary, matching the
+  `desktop` against the auto-spawned link binary, matching the
   production code path.
 
 ## URL shape
@@ -67,7 +67,7 @@ for this, you can remove them — they're no longer needed.
 ## Environment
 
 - `STUDIO_SANDBOX_RUNNER` — pin the runner: `docker`,
-  `agent-sandbox`, or `remote-user`. Defaults to `remote-user`. Setting
+  `agent-sandbox`, or `desktop`. Defaults to `desktop`. Setting
   it explicitly is required for production deploys; auto-detection of
   Docker has been removed.
 - `STUDIO_SANDBOX_IMAGE` — override the Docker runner image

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -14,7 +14,7 @@
     "./provider": "./server/provider/index.ts",
     "./provider/agent-sandbox": "./server/provider/agent-sandbox/index.ts",
     "./daemon-spawn": "./server/daemon-spawn.ts",
-    "./provider/remote-user": "./server/provider/remote-user/index.ts",
+    "./provider/desktop": "./server/provider/desktop/index.ts",
     "./daemon-client": "./server/daemon-client.ts",
     "./daemon/routes/dispatch": "./daemon/routes/dispatch.ts"
   },

--- a/packages/sandbox/server/provider/desktop/index.ts
+++ b/packages/sandbox/server/provider/desktop/index.ts
@@ -1,0 +1,2 @@
+export { DesktopSandboxProvider, createDesktopProvider } from "./runner";
+export type { DesktopLinkRef, DesktopProviderOptions } from "./runner";

--- a/packages/sandbox/server/provider/desktop/runner.test.ts
+++ b/packages/sandbox/server/provider/desktop/runner.test.ts
@@ -6,7 +6,7 @@ import {
   verifyRequest,
 } from "../../../../../apps/mesh/src/links/protocol/hmac";
 import type { RunnerStateStoreOps } from "../state-store";
-import { RemoteUserSandboxProvider } from "./runner";
+import { DesktopSandboxProvider } from "./runner";
 
 const TUNNEL = "https://link-x.deco.host";
 const SECRET = "this-is-the-stored-hash-acting-as-the-signing-key";
@@ -134,12 +134,12 @@ function makeFakeStateStore(): RunnerStateStoreOps & {
   };
 }
 
-describe("RemoteUserSandboxProvider.ensure", () => {
+describe("DesktopSandboxProvider.ensure", () => {
   it("POSTs /api/sandboxes with HMAC headers and returns a Sandbox", async () => {
     const { fetch, calls } = makeFakeFetch(() =>
       jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/handle-abc` }),
     );
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -177,7 +177,7 @@ describe("RemoteUserSandboxProvider.ensure", () => {
     const { fetch, calls } = makeFakeFetch(() =>
       jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/handle-abc` }),
     );
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -195,17 +195,17 @@ describe("RemoteUserSandboxProvider.ensure", () => {
     const { fetch } = makeFakeFetch(
       () => new Response("nope", { status: 500 }),
     );
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
     expect(provider.ensure({ userId: "u", projectRef: "p" })).rejects.toThrow(
-      /remote-user ensure failed: 500/,
+      /desktop ensure failed: 500/,
     );
   });
 });
 
-describe("RemoteUserSandboxProvider.exec", () => {
+describe("DesktopSandboxProvider.exec", () => {
   it("proxies to <sandboxUrl>/_decopilot_vm/exec with HMAC headers", async () => {
     const { fetch, calls } = makeFakeFetch((call) => {
       if (call.url.endsWith("/api/sandboxes")) {
@@ -218,7 +218,7 @@ describe("RemoteUserSandboxProvider.exec", () => {
         timedOut: false,
       });
     });
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -236,7 +236,7 @@ describe("RemoteUserSandboxProvider.exec", () => {
 
   it("throws on unknown handle", async () => {
     const { fetch } = makeFakeFetch(() => jsonResponse({}));
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -246,14 +246,14 @@ describe("RemoteUserSandboxProvider.exec", () => {
   });
 });
 
-describe("RemoteUserSandboxProvider.delete", () => {
+describe("DesktopSandboxProvider.delete", () => {
   it("calls DELETE /api/sandboxes/<handle>", async () => {
     const { fetch, calls } = makeFakeFetch((call) => {
       if (call.method === "POST")
         return jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/h-1` });
       return new Response(null, { status: 204 });
     });
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -271,7 +271,7 @@ describe("RemoteUserSandboxProvider.delete", () => {
     const { fetch: deadFetch } = makeFakeFetch(
       () => new Response(null, { status: 404 }),
     );
-    const probeOnly = new RemoteUserSandboxProvider({
+    const probeOnly = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: deadFetch,
     });
@@ -284,7 +284,7 @@ describe("RemoteUserSandboxProvider.delete", () => {
         return jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/h-1` });
       return new Response("not found", { status: 404 });
     });
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -294,7 +294,7 @@ describe("RemoteUserSandboxProvider.delete", () => {
   });
 });
 
-describe("RemoteUserSandboxProvider.alive", () => {
+describe("DesktopSandboxProvider.alive", () => {
   it("returns true after ensure() populated the in-process records cache", async () => {
     // ensure() populates `records`, so alive() reuses it without hitting
     // the state store. Probe URL is `<sandboxUrl>/health`, unsigned.
@@ -303,7 +303,7 @@ describe("RemoteUserSandboxProvider.alive", () => {
         return jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/alive-1` });
       return new Response("", { status: 200 });
     });
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -316,7 +316,7 @@ describe("RemoteUserSandboxProvider.alive", () => {
 
   it("returns false when there is no cached record and no state store", async () => {
     const { fetch } = makeFakeFetch(() => new Response(null, { status: 404 }));
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -324,7 +324,7 @@ describe("RemoteUserSandboxProvider.alive", () => {
   });
 });
 
-describe("RemoteUserSandboxProvider.proxyDaemonRequest", () => {
+describe("DesktopSandboxProvider.proxyDaemonRequest", () => {
   it("forwards to <sandboxUrl><path> with HMAC", async () => {
     const { fetch, calls } = makeFakeFetch((call) => {
       if (call.url.endsWith("/api/sandboxes"))
@@ -334,7 +334,7 @@ describe("RemoteUserSandboxProvider.proxyDaemonRequest", () => {
         headers: { "content-type": "application/json" },
       });
     });
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -362,7 +362,7 @@ describe("RemoteUserSandboxProvider.proxyDaemonRequest", () => {
     const { fetch, calls } = makeFakeFetch(
       () => new Response("", { status: 200 }),
     );
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -380,10 +380,10 @@ describe("RemoteUserSandboxProvider.proxyDaemonRequest", () => {
   });
 });
 
-describe("RemoteUserSandboxProvider misc surface", () => {
+describe("DesktopSandboxProvider misc surface", () => {
   it("localWorkdir + getPreviewUrl return null when no record is known", async () => {
     const { fetch } = makeFakeFetch(() => jsonResponse({}));
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -393,7 +393,7 @@ describe("RemoteUserSandboxProvider misc surface", () => {
 
   it("watchClaimLifecycle yields a single ready phase", async () => {
     const { fetch } = makeFakeFetch(() => jsonResponse({}));
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
     });
@@ -407,14 +407,14 @@ describe("RemoteUserSandboxProvider misc surface", () => {
   it("rejects construction without tunnelUrl or linkSecret", () => {
     expect(
       () =>
-        new RemoteUserSandboxProvider({
+        new DesktopSandboxProvider({
           // @ts-expect-error - intentional
           link: { tunnelUrl: "", linkSecret: "x" },
         }),
     ).toThrow();
     expect(
       () =>
-        new RemoteUserSandboxProvider({
+        new DesktopSandboxProvider({
           // @ts-expect-error - intentional
           link: { tunnelUrl: TUNNEL, linkSecret: "" },
         }),
@@ -422,27 +422,27 @@ describe("RemoteUserSandboxProvider misc surface", () => {
   });
 });
 
-describe("RemoteUserSandboxProvider + state store", () => {
+describe("DesktopSandboxProvider + state store", () => {
   it("persists {handle, sandboxUrl} on ensure", async () => {
     const { fetch } = makeFakeFetch(() =>
       jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/persisted` }),
     );
     const stateStore = makeFakeStateStore();
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
       stateStore,
     });
 
     const sandbox = await provider.ensure({ userId: "u", projectRef: "p" });
-    const row = await stateStore.getByHandle("remote-user", sandbox.handle);
+    const row = await stateStore.getByHandle("desktop", sandbox.handle);
     expect(row).not.toBeNull();
     expect(row?.state.sandboxUrl).toBe(`${TUNNEL}/_sandbox/persisted`);
   });
 
   it("alive() probes sandboxUrl from state store on cache miss", async () => {
     const stateStore = makeFakeStateStore();
-    await stateStore.put({ userId: "u", projectRef: "p" }, "remote-user", {
+    await stateStore.put({ userId: "u", projectRef: "p" }, "desktop", {
       handle: "fresh-handle",
       state: {
         handle: "fresh-handle",
@@ -452,7 +452,7 @@ describe("RemoteUserSandboxProvider + state store", () => {
     const { fetch, calls } = makeFakeFetch(
       () => new Response("", { status: 200 }),
     );
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
       stateStore,
@@ -464,7 +464,7 @@ describe("RemoteUserSandboxProvider + state store", () => {
 
   it("proxyDaemonRequest forwards to sandboxUrl from state store on cache miss", async () => {
     const stateStore = makeFakeStateStore();
-    await stateStore.put({ userId: "u", projectRef: "p" }, "remote-user", {
+    await stateStore.put({ userId: "u", projectRef: "p" }, "desktop", {
       handle: "proxy-handle",
       state: {
         handle: "proxy-handle",
@@ -474,7 +474,7 @@ describe("RemoteUserSandboxProvider + state store", () => {
     const { fetch, calls } = makeFakeFetch(
       () => new Response("{}", { status: 200 }),
     );
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
       stateStore,
@@ -495,7 +495,7 @@ describe("RemoteUserSandboxProvider + state store", () => {
   it("alive() returns false when state store has no row", async () => {
     const stateStore = makeFakeStateStore();
     const { fetch } = makeFakeFetch(() => new Response("", { status: 200 }));
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
       stateStore,
@@ -510,7 +510,7 @@ describe("RemoteUserSandboxProvider + state store", () => {
         return jsonResponse({ sandboxUrl: `${TUNNEL}/_sandbox/del` });
       return new Response(null, { status: 204 });
     });
-    const provider = new RemoteUserSandboxProvider({
+    const provider = new DesktopSandboxProvider({
       link: { tunnelUrl: TUNNEL, linkSecret: SECRET },
       fetchImpl: fetch,
       stateStore,

--- a/packages/sandbox/server/provider/desktop/runner.ts
+++ b/packages/sandbox/server/provider/desktop/runner.ts
@@ -1,5 +1,5 @@
 /**
- * remote-user sandbox provider — cluster-side stub that forwards every
+ * desktop sandbox provider — cluster-side stub that forwards every
  * `SandboxProvider` call to a per-user `link` binary running on the
  * developer's desktop. The link exposes:
  *
@@ -13,7 +13,7 @@
  * against `DAEMON_LINK_SECRET` (set up by Task 1). HMAC requires symmetric
  * key material; v2 will encrypt at rest with a cluster KMS key.
  *
- * The cluster builds a fresh `RemoteUserSandboxProvider` per request, so the
+ * The cluster builds a fresh `DesktopSandboxProvider` per request, so the
  * in-memory `records` map is almost always empty. To remain functional across
  * cluster pod boundaries we mirror docker's pattern: take a `stateStore` in
  * the constructor, persist `{handle, sandboxUrl}` on ensure, hydrate on cache
@@ -22,7 +22,7 @@
  *
  * `localWorkdir` returns null — the workdir lives on the desktop and is never
  * referenced by cluster code. `watchClaimLifecycle` emits a single synthetic
- * `ready` phase, matching host/docker semantics — by the time `ensure`
+ * `ready` phase, matching docker semantics — by the time `ensure`
  * resolves the link has already brought the daemon up.
  */
 
@@ -40,7 +40,7 @@ import type {
   SandboxProvider,
 } from "../types";
 
-const RUNNER_KIND = "remote-user" as const;
+const RUNNER_KIND = "desktop" as const;
 
 /**
  * Subset of `LinkEntry` the provider actually needs. The dispatch path passes
@@ -48,7 +48,7 @@ const RUNNER_KIND = "remote-user" as const;
  * structurally compatible so tests can fake it without inventing a
  * `createdAt` timestamp.
  */
-export interface RemoteUserLinkRef {
+export interface DesktopLinkRef {
   tunnelUrl: string;
   /**
    * HMAC signing key — the raw bearer secret stored in `LinkEntry`. Both
@@ -57,8 +57,8 @@ export interface RemoteUserLinkRef {
   linkSecret: string;
 }
 
-export interface RemoteUserProviderOptions {
-  link: RemoteUserLinkRef;
+export interface DesktopProviderOptions {
+  link: DesktopLinkRef;
   /** @internal test seam */
   fetchImpl?: typeof fetch;
   /**
@@ -77,20 +77,20 @@ interface RemoteRecord {
   sandboxUrl: string;
 }
 
-export class RemoteUserSandboxProvider implements SandboxProvider {
+export class DesktopSandboxProvider implements SandboxProvider {
   readonly kind = RUNNER_KIND;
 
-  private readonly link: RemoteUserLinkRef;
+  private readonly link: DesktopLinkRef;
   private readonly fetcher: typeof fetch;
   private readonly stateStore: RunnerStateStoreOps | null;
   private readonly records = new Map<string, RemoteRecord>();
 
-  constructor(opts: RemoteUserProviderOptions) {
+  constructor(opts: DesktopProviderOptions) {
     if (!opts.link?.tunnelUrl) {
-      throw new Error("RemoteUserSandboxProvider requires link.tunnelUrl");
+      throw new Error("DesktopSandboxProvider requires link.tunnelUrl");
     }
     if (!opts.link?.linkSecret) {
-      throw new Error("RemoteUserSandboxProvider requires link.linkSecret");
+      throw new Error("DesktopSandboxProvider requires link.linkSecret");
     }
     this.link = opts.link;
     this.fetcher = opts.fetchImpl ?? fetch;
@@ -127,13 +127,13 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
     if (!res.ok) {
       const detail = await safeReadText(res);
       throw new Error(
-        `remote-user ensure failed: ${res.status}${detail ? ` ${detail}` : ""}`,
+        `desktop ensure failed: ${res.status}${detail ? ` ${detail}` : ""}`,
       );
     }
     const body = (await res.json()) as { sandboxUrl?: unknown };
     if (typeof body.sandboxUrl !== "string") {
       throw new Error(
-        "remote-user ensure: link did not return a sandboxUrl string",
+        "desktop ensure: link did not return a sandboxUrl string",
       );
     }
     const rec: RemoteRecord = { handle, sandboxUrl: body.sandboxUrl };
@@ -151,7 +151,7 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
     const rec = await this.resolveRecord(handle);
     if (!rec) {
       throw new Error(
-        `remote-user provider: unknown handle "${handle}" — was ensure() called?`,
+        `desktop provider: unknown handle "${handle}" — was ensure() called?`,
       );
     }
     const bodyString = JSON.stringify(input);
@@ -170,7 +170,7 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
     if (!res.ok) {
       const detail = await safeReadText(res);
       throw new Error(
-        `remote-user exec failed: ${res.status}${detail ? ` ${detail}` : ""}`,
+        `desktop exec failed: ${res.status}${detail ? ` ${detail}` : ""}`,
       );
     }
     return (await res.json()) as ExecOutput;
@@ -256,7 +256,7 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
     if (!res.ok && res.status !== 404) {
       const detail = await safeReadText(res);
       throw new Error(
-        `remote-user delete failed: ${res.status}${detail ? ` ${detail}` : ""}`,
+        `desktop delete failed: ${res.status}${detail ? ` ${detail}` : ""}`,
       );
     }
     // Hint to dead-code: rec read only for symmetry / future logging.
@@ -271,7 +271,7 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
   /**
    * Workdir lives on the desktop; cluster code never references it. Returning
    * null lets dispatch-run fall through to its default (`process.cwd()`),
-   * which is fine because cluster-side dispatch for `remote-user` is the
+   * which is fine because cluster-side dispatch for `desktop` is the
    * decopilot Code Sandbox tool path — the harness itself runs on the
    * desktop, where `localWorkdir` IS meaningful (different provider).
    */
@@ -351,12 +351,12 @@ export class RemoteUserSandboxProvider implements SandboxProvider {
  * Backwards-compatible factory matching the shape Phase 5 was originally
  * sketched against in the plan. Construct via `new` is the canonical form;
  * this exists so callers don't have to update if they're already importing
- * `createRemoteUserProvider`.
+ * `createDesktopProvider`.
  */
-export function createRemoteUserProvider(
-  opts: RemoteUserProviderOptions,
-): RemoteUserSandboxProvider {
-  return new RemoteUserSandboxProvider(opts);
+export function createDesktopProvider(
+  opts: DesktopProviderOptions,
+): DesktopSandboxProvider {
+  return new DesktopSandboxProvider(opts);
 }
 
 // ---- Module-private helpers --------------------------------------------------

--- a/packages/sandbox/server/provider/index.test.ts
+++ b/packages/sandbox/server/provider/index.test.ts
@@ -10,8 +10,8 @@ describe("resolveSandboxProviderKindFromEnv", () => {
     process.env = { ...ORIG };
   });
 
-  it("defaults to 'remote-user' when nothing is configured", () => {
-    expect(resolveSandboxProviderKindFromEnv()).toBe("remote-user");
+  it("defaults to 'desktop' when nothing is configured", () => {
+    expect(resolveSandboxProviderKindFromEnv()).toBe("desktop");
   });
 
   it("honors explicit STUDIO_SANDBOX_RUNNER=docker", () => {

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -1,7 +1,7 @@
 /**
  * Public surface. Ships `DockerSandboxProvider` only via the default entry;
  * agent-sandbox sits behind its own subpath export (./provider/agent-sandbox)
- * because its SDK is heavy and not every deploy needs it. `remote-user` is
+ * because its SDK is heavy and not every deploy needs it. `desktop` is
  * constructed per-run from the acting user's link entry.
  */
 
@@ -67,13 +67,13 @@ export function createDockerProvider(
 const RUNNER_KINDS: ReadonlySet<SandboxProviderKind> = new Set([
   "docker",
   "agent-sandbox",
-  "remote-user",
+  "desktop",
 ]);
 
 /**
  * Single resolution rule:
  *   - explicit STUDIO_SANDBOX_RUNNER wins (validated against the kind set);
- *   - otherwise default to "remote-user" (the desktop-side link daemon —
+ *   - otherwise default to "desktop" (the user's desktop link daemon —
  *     auto-spawned by `bun run dev` in local dev, and the supported
  *     topology for single-machine self-hosts running the link side-by-side).
  *
@@ -83,12 +83,10 @@ const RUNNER_KINDS: ReadonlySet<SandboxProviderKind> = new Set([
  */
 export function resolveSandboxProviderKindFromEnv(): SandboxProviderKind {
   const raw = process.env.STUDIO_SANDBOX_RUNNER;
-  const kind = (
-    raw && raw.length > 0 ? raw : "remote-user"
-  ) as SandboxProviderKind;
+  const kind = (raw && raw.length > 0 ? raw : "desktop") as SandboxProviderKind;
   if (!RUNNER_KINDS.has(kind)) {
     throw new Error(
-      `Unknown STUDIO_SANDBOX_RUNNER="${raw}" — expected "docker", "agent-sandbox", or "remote-user".`,
+      `Unknown STUDIO_SANDBOX_RUNNER="${raw}" — expected "docker", "agent-sandbox", or "desktop".`,
     );
   }
   return kind;

--- a/packages/sandbox/server/provider/remote-user/index.ts
+++ b/packages/sandbox/server/provider/remote-user/index.ts
@@ -1,8 +1,0 @@
-export {
-  RemoteUserSandboxProvider,
-  createRemoteUserProvider,
-} from "./runner";
-export type {
-  RemoteUserLinkRef,
-  RemoteUserProviderOptions,
-} from "./runner";

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -102,7 +102,7 @@ export interface ProxyRequestInit {
  * Persisted on `vmMap` and `sandbox_runner_state.sandbox_provider_kind`.
  * When widening, keep `VmMapEntry.sandboxProviderKind` in sync.
  */
-export type SandboxProviderKind = "docker" | "agent-sandbox" | "remote-user";
+export type SandboxProviderKind = "docker" | "agent-sandbox" | "desktop";
 
 export interface SandboxProvider {
   readonly kind: SandboxProviderKind;

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
       DATA_DIR: /app/data
       # Pin the sandbox runner so POST /decopilot/messages doesn't default
-      # to "remote-user" — there's no link daemon in this cluster, and
+      # to "desktop" — there's no link daemon in this cluster, and
       # resolveDispatchTarget would 409 with link_offline. "docker" makes
       # resolveDispatchTarget short-circuit to the local cluster default;
       # no sandbox is actually provisioned because ensureVm is lazy


### PR DESCRIPTION
## What is this contribution about?

Renames the `remote-user` `SandboxProviderKind` to `desktop` across the entire codebase — the type union, the directory (`packages/sandbox/server/provider/remote-user/` → `desktop/`), every identifier (`RemoteUserSandboxProvider` → `DesktopSandboxProvider`, `createRemoteUserProvider`, `RemoteUserLinkRef`, `RemoteUserProviderOptions`, `buildRemoteUserProvider`), every literal string (env values, Zod enums, vmMap keys, chat agent options), and all docs/comments/tests. The new name is honest about what the runner actually is — a sandbox on the user's desktop, reached via the link daemon — and avoids the misleading "remote" framing from the cluster's perspective.

Migration 089 forward-renames persisted data in three places: `sandbox_runner_state.sandbox_provider_kind` column, `threads.sandbox_provider_kind` column, and the `connections.metadata.vmMap[user][branch][kind]` JSON (both the outer key and the inner `sandboxProviderKind` field). All three SQL passes are idempotent. No legacy-coalesce paths or tolerant-reader fallbacks remain in application code — once 089 runs, only the new name is recognized.

## How to Test

1. Check out the branch and run `bun run dev` — local dev still auto-spawns the link daemon and routes through it as before.
2. `bun run check` and `bun run lint` pass clean.
3. `bun test apps/mesh/migrations/089-rename-remote-user-to-desktop.test.ts` verifies the JSONB rewrites are idempotent and leave other kinds alone.
4. Confirm `STUDIO_SANDBOX_RUNNER=desktop` is the new env value (default when unset); `STUDIO_SANDBOX_RUNNER=remote-user` is now rejected by `resolveSandboxProviderKindFromEnv`.

## Migration Notes

**Migration 089** runs on boot and must be applied to any deployed DB that received writes from `origin/main` — those DBs hold `'remote-user'` values in three locations. The migration is forward-only (no `down`) because the new `SandboxProviderKind` union no longer recognizes `'remote-user'`; rolling back the code would also require manually reverting the DB.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (README, schema comments)
- [ ] No breaking changes — **the env value `STUDIO_SANDBOX_RUNNER=remote-user` and any external callers passing `sandboxProviderKind: "remote-user"` to `VM_START`/`VM_DELETE` will now error. Anything outside this repo that pinned that literal needs an update.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the sandbox provider kind from `remote-user` to `desktop` across code and data. Behavior is unchanged; the new name better reflects a desktop-hosted sandbox and is now the default when unset.

- **Refactors**
  - Renamed identifiers and paths: `RemoteUserSandboxProvider` → `DesktopSandboxProvider`, `createRemoteUserProvider` → `createDesktopProvider`, `RemoteUserLinkRef` → `DesktopLinkRef`, `RemoteUserProviderOptions` → `DesktopProviderOptions`; module path moved to `packages/sandbox/server/provider/desktop/`.
  - Updated enums, literals, comments, tests, and UI to use `desktop` (e.g., zod schemas, vmMap keys, chat pins, CLI help).
  - `resolveSandboxProviderKindFromEnv()` now defaults to `desktop`; `STUDIO_SANDBOX_RUNNER=remote-user` is rejected.
  - Public import path updated in `packages/sandbox`: use `@decocms/sandbox/provider/desktop`.

- **Migration**
  - Added Migration 089 to rewrite persisted `'remote-user'` → `'desktop'`:
    - `sandbox_runner_state.sandbox_provider_kind`
    - `threads.sandbox_provider_kind`
    - `connections.metadata.vmMap[user][branch][kind]` and inner `sandboxProviderKind`
  - Idempotent and forward-only; application code only recognizes `desktop`.
  - Adoption:
    - Run migrations on boot for any DBs that saw writes with the old value.
    - Set `STUDIO_SANDBOX_RUNNER=desktop` (or omit to use the default).
    - Update any external callers sending `"sandboxProviderKind": "remote-user"` to send `"desktop"` instead.

<sup>Written for commit 2365a45cde015e3c5df761d82637dca8ac0bc266. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3440?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

