### PR TITLE
feat(web): replace infinite splash with org-access-gate screens

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,11 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       NATS_URL: nats://localhost:4222
+      # Better Auth's per-endpoint signup limiter kicks in after a handful of
+      # /sign-up/email POSTs in a short window. Our e2e specs do multiple
+      # signups per run; without this they get 429s and only pass on retry,
+      # which masks real regressions as "flaky".
+      DISABLE_RATE_LIMIT: "true"
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ studio-demo/
 # Playwright
 apps/mesh/test-results/
 apps/mesh/playwright-report/
+apps/mesh/screenshots/
 
 # Generated docs (root-level only, not apps/docs/). Use /docs/* not /docs
 # so we can un-ignore specific subdirs below — git won't traverse into an

--- a/apps/mesh/e2e/fixtures/auth.ts
+++ b/apps/mesh/e2e/fixtures/auth.ts
@@ -4,11 +4,11 @@ import { type Page } from "@playwright/test";
  * Generates a unique test user for each test run.
  * Using a timestamp suffix avoids conflicts between parallel runs or re-runs.
  */
-function generateTestUser() {
-  const suffix = Date.now();
+function generateTestUser(overrides?: { email?: string }) {
+  const suffix = Date.now() + Math.floor(Math.random() * 1000);
   return {
     name: `Test User ${suffix}`,
-    email: `test-${suffix}@playwright.local`,
+    email: overrides?.email ?? `test-${suffix}@playwright.local`,
     password: "Playwright123!",
   };
 }
@@ -16,15 +16,26 @@ function generateTestUser() {
 /**
  * Signs up a new user via the login page form.
  * Returns the user credentials and waits for the home page to load.
+ * Pass `email` to sign up with a specific address (e.g. to match a pending
+ * invitation seeded earlier in the test).
  */
-export async function signUp(page: Page) {
-  const user = generateTestUser();
+export async function signUp(page: Page, options?: { email?: string }) {
+  const user = generateTestUser(options);
 
   await page.goto("/login");
 
-  // Wait for the name input — the form is in sign-up mode by default in a fresh context.
-  // The button has aria-hidden when the form is empty, so fill fields first then click.
-  await page.getByPlaceholder("Your name").waitFor({ state: "visible" });
+  // The form remembers its last mode via localStorage and may render as
+  // sign-in after cookie wipes; flip to sign-up if the "Your name" field
+  // isn't already showing. Single-shot wait so the happy path stays fast.
+  const nameField = page.getByPlaceholder("Your name");
+  const inSignupMode = await nameField
+    .waitFor({ state: "visible", timeout: 2000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!inSignupMode) {
+    await page.getByRole("button", { name: "Sign up" }).click();
+    await nameField.waitFor({ state: "visible" });
+  }
   await page.getByPlaceholder("Your name").fill(user.name);
   await page.getByPlaceholder("you@example.com").fill(user.email);
   await page.getByPlaceholder("••••••••").fill(user.password);

--- a/apps/mesh/e2e/tests/org-access-gate.spec.ts
+++ b/apps/mesh/e2e/tests/org-access-gate.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+import { signUp } from "../fixtures/auth";
+
+/**
+ * Regression for the "infinite loading" shell when visiting /:org you don't
+ * belong to. Covers the three concrete branches the gate must show:
+ *   - org slug doesn't exist  → "Organization not found"
+ *   - pending invitation       → "You've been invited" + accept flow
+ *   - (auto-domain-join needs domain seeding that's awkward via the UI,
+ *      so the integration test in apps/mesh/src/api/routes/auth.test.ts
+ *      covers it end-to-end against the real DB.)
+ */
+test.describe("Org access gate", () => {
+  test("shows the not-found screen when the org slug doesn't exist", async ({
+    page,
+  }) => {
+    await signUp(page);
+    // Wait for the post-signup redirect off /login so we know auth is established.
+    await page.waitForURL(
+      (url) => {
+        const slug = url.pathname.split("/")[1];
+        return !!slug && slug !== "login" && slug !== "api";
+      },
+      { timeout: 15_000 },
+    );
+
+    // Pick a slug that almost certainly doesn't exist.
+    const fakeSlug = `definitely-not-a-real-org-${Date.now()}`;
+    await page.goto(`/${fakeSlug}/`);
+
+    await expect(
+      page.getByRole("heading", { name: "Organization not found" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: "Go to home" }),
+    ).toBeVisible();
+    await page.screenshot({ path: "screenshots/not-found.png", fullPage: true });
+  });
+
+  test("shows the no-access screen for an existing org the user isn't in", async ({
+    page,
+    context,
+  }) => {
+    // User A — creates their own org (auto-created at signup).
+    await signUp(page);
+    await page.waitForURL(
+      (url) => {
+        const slug = url.pathname.split("/")[1];
+        return !!slug && slug !== "login" && slug !== "api";
+      },
+      { timeout: 15_000 },
+    );
+    const orgASlug = new URL(page.url()).pathname.split("/")[1];
+
+    // Sign out by clearing the session cookie so we can sign up as a second user.
+    await context.clearCookies();
+
+    // User B — fresh signup, no membership in org A.
+    await signUp(page);
+    await page.waitForURL(
+      (url) => {
+        const slug = url.pathname.split("/")[1];
+        return !!slug && slug !== "login" && slug !== "api";
+      },
+      { timeout: 15_000 },
+    );
+
+    // Navigate to org A — user B has no invite, no auto-join, so should see
+    // the no-access screen rather than hang on the splash.
+    await page.goto(`/${orgASlug}/`);
+    await expect(page.getByRole("heading", { name: "No access" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.screenshot({ path: "screenshots/no-access.png", fullPage: true });
+  });
+
+  test("shows the pending-invite screen and accepting it lands in the org", async ({
+    page,
+    context,
+  }) => {
+    // User A — creates org A.
+    await signUp(page);
+    await page.waitForURL(
+      (url) => {
+        const slug = url.pathname.split("/")[1];
+        return !!slug && slug !== "login" && slug !== "api";
+      },
+      { timeout: 15_000 },
+    );
+    const orgASlug = new URL(page.url()).pathname.split("/")[1];
+
+    // Pre-mint the address we'll invite + sign up B with, so they match.
+    const bEmail = `invitee-${Date.now()}@playwright.local`;
+
+    // Invite B via the members settings page.
+    await page.goto(`/${orgASlug}/settings/members`);
+    await page.getByRole("button", { name: "Invite Member" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Invite members" }),
+    ).toBeVisible();
+    await page.getByPlaceholder(/Enter email addresses/i).fill(bEmail);
+    // Default role ("user") is already selected; submit.
+    await page.getByRole("button", { name: /^Invite \d+ Member/ }).click();
+    // Wait for the dialog to close (success path).
+    await expect(
+      page.getByRole("heading", { name: "Invite members" }),
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Swap principals: clear cookies and sign up B with the invited email.
+    await context.clearCookies();
+    await signUp(page, { email: bEmail });
+    await page.waitForURL(
+      (url) => {
+        const slug = url.pathname.split("/")[1];
+        return !!slug && slug !== "login" && slug !== "api";
+      },
+      { timeout: 15_000 },
+    );
+
+    // B navigates to org A — should see the pending-invite screen, not hang.
+    await page.goto(`/${orgASlug}/`);
+    await expect(page.getByText(/You.*been invited to/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.screenshot({
+      path: "screenshots/pending-invite.png",
+      fullPage: true,
+    });
+
+    // Accepting redirects B into org A.
+    await page.getByRole("button", { name: "Accept invitation" }).click();
+    await page.waitForURL(new RegExp(`/${orgASlug}(/|$)`), {
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/mesh/e2e/tests/org-access-gate.spec.ts
+++ b/apps/mesh/e2e/tests/org-access-gate.spec.ts
@@ -34,7 +34,10 @@ test.describe("Org access gate", () => {
     await expect(
       page.getByRole("button", { name: "Go to home" }),
     ).toBeVisible();
-    await page.screenshot({ path: "screenshots/not-found.png", fullPage: true });
+    await page.screenshot({
+      path: "screenshots/not-found.png",
+      fullPage: true,
+    });
   });
 
   test("shows the no-access screen for an existing org the user isn't in", async ({
@@ -71,7 +74,10 @@ test.describe("Org access gate", () => {
     await expect(page.getByRole("heading", { name: "No access" })).toBeVisible({
       timeout: 10_000,
     });
-    await page.screenshot({ path: "screenshots/no-access.png", fullPage: true });
+    await page.screenshot({
+      path: "screenshots/no-access.png",
+      fullPage: true,
+    });
   });
 
   test("shows the pending-invite screen and accepting it lands in the org", async ({

--- a/apps/mesh/src/api/routes/auth.test.ts
+++ b/apps/mesh/src/api/routes/auth.test.ts
@@ -1,0 +1,305 @@
+/**
+ * HTTP integration tests for the custom auth routes — specifically the
+ * /org-access-status/:slug endpoint that drives the shell layout's
+ * "you visited an org you don't belong to" branch.
+ *
+ * Each test exercises a distinct status branch:
+ *   - not-found:        unknown slug
+ *   - member:           caller is already in the org
+ *   - pending-invite:   caller has a non-expired invitation
+ *   - auto-domain-join: org claims the caller's verified email domain
+ *   - no-access:        none of the above
+ *   - 401:              unauthenticated
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { sql } from "kysely";
+import { auth } from "../../auth";
+import { __setDbForTesting } from "../../database";
+import {
+  closeTestDatabase,
+  createTestDatabase,
+  type TestDatabase,
+} from "../../database/test-db";
+import type { EventBus } from "../../event-bus";
+import {
+  createTestSchema,
+  seedCommonTestFixtures,
+} from "../../storage/test-helpers";
+import { createApp } from "../app";
+
+function createMockEventBus(): EventBus {
+  return {
+    start: async () => {},
+    stop: () => {},
+    isRunning: () => false,
+    publish: async () => ({}) as never,
+    subscribe: async () => ({}) as never,
+    unsubscribe: async () => ({ success: true }),
+    listSubscriptions: async () => [],
+    getSubscription: async () => null,
+    getEvent: async () => null,
+    cancelEvent: async () => ({ success: true }),
+    ackEvent: async () => ({ success: true }),
+    syncSubscriptions: async () => ({
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      unchanged: 0,
+      subscriptions: [],
+    }),
+  };
+}
+
+/**
+ * Convenience: stub the session that the endpoint reads via
+ * `auth.api.getSession({ headers })`. Pass `null` to simulate unauthenticated.
+ */
+function mockSession(
+  user: { id: string; email: string; emailVerified: boolean } | null,
+) {
+  vi.spyOn(auth.api, "getSession").mockResolvedValue(
+    user ? ({ user } as never) : null,
+  );
+}
+
+describe("GET /api/auth/custom/org-access-status/:slug", () => {
+  let database: TestDatabase;
+  let app: Awaited<ReturnType<typeof createApp>>;
+
+  beforeEach(async () => {
+    database = await createTestDatabase();
+    await createTestSchema(database.db);
+    await seedCommonTestFixtures(database.db);
+
+    // The endpoint queries through `getDb()` directly — point the singleton
+    // at the test DB so production query paths run against PGlite.
+    __setDbForTesting(database);
+
+    const now = new Date().toISOString();
+
+    // user_1 is already seeded (unverified). Add a verified corporate user
+    // and a verified user whose org owns no domain (used by the no-access
+    // and auto-join tests).
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES ('user_alpha', 'alpha@acme.test', 1, 'Alpha', ${now}, ${now}),
+             ('user_outsider', 'outsider@example.com', 1, 'Outsider', ${now}, ${now})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+
+    // user_1 IS a member of org_1 (lets us test the "member" branch).
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES ('mem_1', 'user_1', 'org_1', 'member', ${now})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+
+    app = await createApp({ database, eventBus: createMockEventBus() });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    __setDbForTesting(null);
+    await closeTestDatabase(database);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockSession(null);
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns not-found for an unknown slug", async () => {
+    mockSession({
+      id: "user_1",
+      email: "user_1@test.com",
+      emailVerified: true,
+    });
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/auth/custom/org-access-status/this-org-doesnt-exist",
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "not-found" });
+  });
+
+  it("returns member when the user already belongs to the org", async () => {
+    mockSession({
+      id: "user_1",
+      email: "user_1@test.com",
+      emailVerified: true,
+    });
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_1"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      organization: { slug: string };
+    };
+    expect(body.status).toBe("member");
+    expect(body.organization.slug).toBe("org_1");
+  });
+
+  it("returns pending-invite when an invitation matches the caller + org", async () => {
+    mockSession({
+      id: "user_outsider",
+      email: "outsider@example.com",
+      emailVerified: true,
+    });
+
+    // The endpoint reads invites via `auth.api.listUserInvitations`. Stub it
+    // rather than wiring the full Better Auth adapter for one row — the
+    // endpoint only cares about (organizationId, status, expiresAt).
+    const futureExpiry = new Date(Date.now() + 60_000).toISOString();
+    vi.spyOn(auth.api, "listUserInvitations").mockResolvedValue([
+      {
+        id: "invite_abc",
+        organizationId: "org_456",
+        status: "pending",
+        expiresAt: futureExpiry,
+        // Extra fields the endpoint doesn't look at — kept for type fidelity.
+        email: "outsider@example.com",
+        role: "member",
+        inviterId: "user_1",
+      },
+    ] as never);
+
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_456"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      invitation: { id: string };
+      organization: { slug: string };
+    };
+    expect(body.status).toBe("pending-invite");
+    expect(body.invitation.id).toBe("invite_abc");
+    expect(body.organization.slug).toBe("org_456");
+  });
+
+  it("ignores expired invitations and falls through to no-access", async () => {
+    mockSession({
+      id: "user_outsider",
+      email: "outsider@example.com",
+      emailVerified: true,
+    });
+
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+    vi.spyOn(auth.api, "listUserInvitations").mockResolvedValue([
+      {
+        id: "invite_expired",
+        organizationId: "org_456",
+        status: "pending",
+        expiresAt: pastExpiry,
+        email: "outsider@example.com",
+        role: "member",
+        inviterId: "user_1",
+      },
+    ] as never);
+
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_456"),
+    );
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("no-access");
+  });
+
+  it("returns auto-domain-join when the org claims the caller's verified domain", async () => {
+    mockSession({
+      id: "user_alpha",
+      email: "alpha@acme.test",
+      emailVerified: true,
+    });
+    // No matching invitations.
+    vi.spyOn(auth.api, "listUserInvitations").mockResolvedValue([] as never);
+
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO organization_domains
+        (organization_id, domain, auto_join_enabled, created_at, updated_at)
+      VALUES ('org_456', 'acme.test', true, ${now}, ${now})
+    `.execute(database.db);
+
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_456"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      organization: { domain?: string; slug: string };
+    };
+    expect(body.status).toBe("auto-domain-join");
+    expect(body.organization.slug).toBe("org_456");
+    expect(body.organization.domain).toBe("acme.test");
+  });
+
+  it("does NOT auto-domain-join when auto_join_enabled is false", async () => {
+    mockSession({
+      id: "user_alpha",
+      email: "alpha@acme.test",
+      emailVerified: true,
+    });
+    vi.spyOn(auth.api, "listUserInvitations").mockResolvedValue([] as never);
+
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO organization_domains
+        (organization_id, domain, auto_join_enabled, created_at, updated_at)
+      VALUES ('org_456', 'acme.test', false, ${now}, ${now})
+    `.execute(database.db);
+
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_456"),
+    );
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("no-access");
+  });
+
+  it("does NOT auto-domain-join for unverified email even if domain matches", async () => {
+    mockSession({
+      id: "user_alpha",
+      email: "alpha@acme.test",
+      emailVerified: false,
+    });
+    vi.spyOn(auth.api, "listUserInvitations").mockResolvedValue([] as never);
+
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO organization_domains
+        (organization_id, domain, auto_join_enabled, created_at, updated_at)
+      VALUES ('org_456', 'acme.test', true, ${now}, ${now})
+    `.execute(database.db);
+
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_456"),
+    );
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("no-access");
+  });
+
+  it("returns no-access when the user is neither a member nor invited nor auto-join-eligible", async () => {
+    mockSession({
+      id: "user_outsider",
+      email: "outsider@example.com",
+      emailVerified: true,
+    });
+    vi.spyOn(auth.api, "listUserInvitations").mockResolvedValue([] as never);
+
+    const res = await app.fetch(
+      new Request("http://test/api/auth/custom/org-access-status/org_456"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      organization: { slug: string };
+    };
+    expect(body.status).toBe("no-access");
+    expect(body.organization.slug).toBe("org_456");
+  });
+});

--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -601,4 +601,112 @@ app.post("/domain-setup", async (c) => {
   }
 });
 
+/**
+ * Org Access Status Endpoint (authenticated)
+ *
+ * For the shell layout's "you visited /:org/... but aren't a member" branch.
+ * Resolves an org by slug and tells the frontend which screen to render:
+ *
+ *   member            — user is already a member (shell should re-fetch)
+ *   pending-invite    — there's a pending invitation for this email
+ *   auto-domain-join  — the org has auto_join_enabled for the user's verified domain
+ *   no-access         — none of the above
+ *   not-found         — slug doesn't resolve
+ *
+ * Route: GET /api/auth/custom/org-access-status/:slug
+ */
+app.get("/org-access-status/:slug", async (c) => {
+  const slug = c.req.param("slug");
+  const session = (await auth.api.getSession({
+    headers: c.req.raw.headers,
+  })) as {
+    user?: { id: string; email: string; emailVerified: boolean };
+  } | null;
+  if (!session?.user) {
+    return c.json({ success: false, error: "Authentication required" }, 401);
+  }
+
+  const db = getDb().db;
+
+  const org = await db
+    .selectFrom("organization")
+    .select(["id", "name", "slug", "logo"])
+    .where("slug", "=", slug)
+    .executeTakeFirst();
+
+  if (!org) {
+    return c.json({ status: "not-found" as const });
+  }
+
+  const orgPayload = {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    logo: org.logo,
+  };
+
+  const membership = await db
+    .selectFrom("member")
+    .select(["id"])
+    .where("userId", "=", session.user.id)
+    .where("organizationId", "=", org.id)
+    .executeTakeFirst();
+
+  if (membership) {
+    return c.json({ status: "member" as const, organization: orgPayload });
+  }
+
+  // Pending invite for this user's email targeting this org?
+  try {
+    const invitations = (await auth.api.listUserInvitations({
+      headers: c.req.raw.headers,
+    })) as Array<{
+      id: string;
+      organizationId: string;
+      status: string;
+      expiresAt: string | Date;
+    }>;
+    const now = Date.now();
+    const match = invitations.find(
+      (inv) =>
+        inv.organizationId === org.id &&
+        inv.status === "pending" &&
+        new Date(inv.expiresAt).getTime() > now,
+    );
+    if (match) {
+      return c.json({
+        status: "pending-invite" as const,
+        invitation: { id: match.id },
+        organization: orgPayload,
+      });
+    }
+  } catch (error) {
+    // listUserInvitations can fail for unverified emails or transient DB
+    // issues — fall through to the auto-domain-join / no-access checks
+    // rather than failing the whole status lookup.
+    console.error("[Auth] listUserInvitations failed:", error);
+  }
+
+  // Auto domain join: org claimed user's domain with auto_join_enabled.
+  if (session.user.emailVerified) {
+    const emailDomain = session.user.email?.split("@")[1]?.toLowerCase();
+    if (emailDomain && !GENERIC_EMAIL_DOMAINS.has(emailDomain)) {
+      const domainRecord = await new OrganizationDomainStorage(
+        db,
+      ).getByOrganizationId(org.id);
+      if (
+        domainRecord?.autoJoinEnabled &&
+        domainRecord.domain === emailDomain
+      ) {
+        return c.json({
+          status: "auto-domain-join" as const,
+          organization: { ...orgPayload, domain: emailDomain },
+        });
+      }
+    }
+  }
+
+  return c.json({ status: "no-access" as const, organization: orgPayload });
+});
+
 export default app;

--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -147,3 +147,12 @@ export function getDb(): MeshDatabase {
   }
   return dbInstance;
 }
+
+/**
+ * Test-only: override the lazy `getDb()` singleton with a specific instance
+ * (typically the PGlite-backed one from `createTestDatabase`). Pass `null` in
+ * afterEach to clear. Production code paths must never call this.
+ */
+export function __setDbForTesting(db: MeshDatabase | null): void {
+  dbInstance = db;
+}

--- a/apps/mesh/src/web/components/auto-domain-join-screen.tsx
+++ b/apps/mesh/src/web/components/auto-domain-join-screen.tsx
@@ -1,0 +1,84 @@
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Building02 } from "@untitledui/icons";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export interface AutoDomainJoinScreenProps {
+  orgName: string;
+  orgSlug: string;
+  orgLogo: string | null;
+  domain: string;
+}
+
+export function AutoDomainJoinScreen({
+  orgName,
+  orgSlug,
+  orgLogo,
+  domain,
+}: AutoDomainJoinScreenProps) {
+  const [isJoining, setIsJoining] = useState(false);
+
+  const handleJoin = async () => {
+    setIsJoining(true);
+    try {
+      const res = await fetch("/api/auth/custom/domain-join", {
+        method: "POST",
+        credentials: "include",
+      });
+      const data = (await res.json()) as {
+        success?: boolean;
+        slug?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.success) {
+        toast.error(data.error ?? "Failed to join organization");
+        setIsJoining(false);
+        return;
+      }
+      window.location.href = `/${data.slug ?? orgSlug}`;
+    } catch {
+      toast.error("Failed to join organization");
+      setIsJoining(false);
+    }
+  };
+
+  const handleGoHome = () => {
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
+        {orgLogo ? (
+          <Avatar
+            url={orgLogo}
+            fallback={orgName.charAt(0).toUpperCase()}
+            shape="square"
+            size="base"
+            className="h-12 w-12"
+          />
+        ) : (
+          <div className="bg-primary/10 p-3 rounded-full">
+            <Building02 className="h-6 w-6 text-primary" />
+          </div>
+        )}
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium">Join {orgName}?</h3>
+          <p className="text-sm text-muted-foreground">
+            Anyone with an <strong>@{domain}</strong> email can join this
+            organization.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 w-full">
+          <Button onClick={handleJoin} disabled={isJoining}>
+            {isJoining ? "Joining…" : `Enter ${orgName}`}
+          </Button>
+          <Button variant="ghost" onClick={handleGoHome} disabled={isJoining}>
+            Go to home
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/auto-domain-join-screen.tsx
+++ b/apps/mesh/src/web/components/auto-domain-join-screen.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Building02 } from "@untitledui/icons";
-import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 export interface AutoDomainJoinScreenProps {
@@ -17,11 +17,8 @@ export function AutoDomainJoinScreen({
   orgLogo,
   domain,
 }: AutoDomainJoinScreenProps) {
-  const [isJoining, setIsJoining] = useState(false);
-
-  const handleJoin = async () => {
-    setIsJoining(true);
-    try {
+  const joinMutation = useMutation({
+    mutationFn: async () => {
       const res = await fetch("/api/auth/custom/domain-join", {
         method: "POST",
         credentials: "include",
@@ -32,16 +29,19 @@ export function AutoDomainJoinScreen({
         error?: string;
       };
       if (!res.ok || !data.success) {
-        toast.error(data.error ?? "Failed to join organization");
-        setIsJoining(false);
-        return;
+        throw new Error(data.error ?? "Failed to join organization");
       }
+      return data;
+    },
+    onSuccess: (data) => {
       window.location.href = `/${data.slug ?? orgSlug}`;
-    } catch {
-      toast.error("Failed to join organization");
-      setIsJoining(false);
-    }
-  };
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to join organization",
+      );
+    },
+  });
 
   const handleGoHome = () => {
     window.location.href = "/";
@@ -71,10 +71,17 @@ export function AutoDomainJoinScreen({
           </p>
         </div>
         <div className="flex flex-col gap-2 w-full">
-          <Button onClick={handleJoin} disabled={isJoining}>
-            {isJoining ? "Joining…" : `Enter ${orgName}`}
+          <Button
+            onClick={() => joinMutation.mutate()}
+            disabled={joinMutation.isPending}
+          >
+            {joinMutation.isPending ? "Joining…" : `Enter ${orgName}`}
           </Button>
-          <Button variant="ghost" onClick={handleGoHome} disabled={isJoining}>
+          <Button
+            variant="ghost"
+            onClick={handleGoHome}
+            disabled={joinMutation.isPending}
+          >
             Go to home
           </Button>
         </div>

--- a/apps/mesh/src/web/components/no-access-screen.tsx
+++ b/apps/mesh/src/web/components/no-access-screen.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { Lock01, SearchLg } from "@untitledui/icons";
+
+export interface NoAccessScreenProps {
+  orgSlug: string;
+  orgName?: string;
+  reason: "no-access" | "not-found";
+}
+
+export function NoAccessScreen({
+  orgSlug,
+  orgName,
+  reason,
+}: NoAccessScreenProps) {
+  const handleGoHome = () => {
+    window.location.href = "/";
+  };
+
+  const isNotFound = reason === "not-found";
+  const Icon = isNotFound ? SearchLg : Lock01;
+  const title = isNotFound ? "Organization not found" : "No access";
+  const body = isNotFound ? (
+    <>
+      We couldn&apos;t find an organization called <strong>{orgSlug}</strong>.
+    </>
+  ) : (
+    <>
+      You don&apos;t have access to <strong>{orgName ?? orgSlug}</strong>. Ask
+      an admin to invite you.
+    </>
+  );
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
+        <div className="bg-muted p-3 rounded-full">
+          <Icon className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium">{title}</h3>
+          <p className="text-sm text-muted-foreground">{body}</p>
+        </div>
+        <Button onClick={handleGoHome}>Go to home</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/org-access-gate.tsx
+++ b/apps/mesh/src/web/components/org-access-gate.tsx
@@ -1,0 +1,55 @@
+import { AutoDomainJoinScreen } from "@/web/components/auto-domain-join-screen";
+import { NoAccessScreen } from "@/web/components/no-access-screen";
+import { PendingInviteScreen } from "@/web/components/pending-invite-screen";
+import { useOrgAccessStatus } from "@/web/hooks/use-org-access-status";
+
+/**
+ * Renders the right "you can't enter here yet" screen when the shell layout's
+ * activeOrg fetch comes back null. Hits /api/auth/custom/org-access-status to
+ * differentiate no-access vs pending-invite vs auto-domain-join vs not-found.
+ */
+export function OrgAccessGate({ orgSlug }: { orgSlug: string }) {
+  const { data } = useOrgAccessStatus(orgSlug);
+
+  if (data.status === "not-found") {
+    return <NoAccessScreen orgSlug={orgSlug} reason="not-found" />;
+  }
+
+  if (data.status === "pending-invite") {
+    return (
+      <PendingInviteScreen
+        invitationId={data.invitation.id}
+        orgName={data.organization.name}
+        orgSlug={data.organization.slug}
+        orgLogo={data.organization.logo}
+      />
+    );
+  }
+
+  if (data.status === "auto-domain-join") {
+    return (
+      <AutoDomainJoinScreen
+        orgName={data.organization.name}
+        orgSlug={data.organization.slug}
+        orgLogo={data.organization.logo}
+        domain={data.organization.domain ?? ""}
+      />
+    );
+  }
+
+  // "member" shouldn't normally hit this branch (shell would have rendered
+  // already), but if it does, send the user to a fresh load so the shell can
+  // pick up the membership. Otherwise fall through to no-access.
+  if (data.status === "member") {
+    window.location.reload();
+    return null;
+  }
+
+  return (
+    <NoAccessScreen
+      orgSlug={orgSlug}
+      orgName={data.organization.name}
+      reason="no-access"
+    />
+  );
+}

--- a/apps/mesh/src/web/components/pending-invite-screen.tsx
+++ b/apps/mesh/src/web/components/pending-invite-screen.tsx
@@ -1,0 +1,100 @@
+import { authClient } from "@/web/lib/auth-client";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Mail01 } from "@untitledui/icons";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export interface PendingInviteScreenProps {
+  invitationId: string;
+  orgName: string;
+  orgSlug: string;
+  orgLogo: string | null;
+}
+
+export function PendingInviteScreen({
+  invitationId,
+  orgName,
+  orgSlug,
+  orgLogo,
+}: PendingInviteScreenProps) {
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [isRejecting, setIsRejecting] = useState(false);
+
+  const handleAccept = async () => {
+    setIsAccepting(true);
+    try {
+      const result = await authClient.organization.acceptInvitation({
+        invitationId,
+      });
+      if (result.error) {
+        toast.error(result.error.message);
+        setIsAccepting(false);
+        return;
+      }
+      window.location.href = `/${orgSlug}`;
+    } catch {
+      toast.error("Failed to accept invitation");
+      setIsAccepting(false);
+    }
+  };
+
+  const handleReject = async () => {
+    setIsRejecting(true);
+    try {
+      const result = await authClient.organization.rejectInvitation({
+        invitationId,
+      });
+      if (result.error) {
+        toast.error(result.error.message);
+        setIsRejecting(false);
+        return;
+      }
+      toast.success("Invitation declined");
+      window.location.href = "/";
+    } catch {
+      toast.error("Failed to decline invitation");
+      setIsRejecting(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
+        {orgLogo ? (
+          <Avatar
+            url={orgLogo}
+            fallback={orgName.charAt(0).toUpperCase()}
+            shape="square"
+            size="base"
+            className="h-12 w-12"
+          />
+        ) : (
+          <div className="bg-primary/10 p-3 rounded-full">
+            <Mail01 className="h-6 w-6 text-primary" />
+          </div>
+        )}
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium">
+            You&apos;ve been invited to <strong>{orgName}</strong>
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Accept the invitation to join this organization.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 w-full">
+          <Button onClick={handleAccept} disabled={isAccepting || isRejecting}>
+            {isAccepting ? "Accepting…" : "Accept invitation"}
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={handleReject}
+            disabled={isAccepting || isRejecting}
+          >
+            {isRejecting ? "Declining…" : "Decline"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/pending-invite-screen.tsx
+++ b/apps/mesh/src/web/components/pending-invite-screen.tsx
@@ -2,7 +2,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Mail01 } from "@untitledui/icons";
-import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 export interface PendingInviteScreenProps {
@@ -18,45 +18,44 @@ export function PendingInviteScreen({
   orgSlug,
   orgLogo,
 }: PendingInviteScreenProps) {
-  const [isAccepting, setIsAccepting] = useState(false);
-  const [isRejecting, setIsRejecting] = useState(false);
-
-  const handleAccept = async () => {
-    setIsAccepting(true);
-    try {
+  const acceptMutation = useMutation({
+    mutationFn: async () => {
       const result = await authClient.organization.acceptInvitation({
         invitationId,
       });
-      if (result.error) {
-        toast.error(result.error.message);
-        setIsAccepting(false);
-        return;
-      }
+      if (result.error) throw new Error(result.error.message);
+      return result.data;
+    },
+    onSuccess: () => {
       window.location.href = `/${orgSlug}`;
-    } catch {
-      toast.error("Failed to accept invitation");
-      setIsAccepting(false);
-    }
-  };
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to accept invitation",
+      );
+    },
+  });
 
-  const handleReject = async () => {
-    setIsRejecting(true);
-    try {
+  const rejectMutation = useMutation({
+    mutationFn: async () => {
       const result = await authClient.organization.rejectInvitation({
         invitationId,
       });
-      if (result.error) {
-        toast.error(result.error.message);
-        setIsRejecting(false);
-        return;
-      }
+      if (result.error) throw new Error(result.error.message);
+      return result.data;
+    },
+    onSuccess: () => {
       toast.success("Invitation declined");
       window.location.href = "/";
-    } catch {
-      toast.error("Failed to decline invitation");
-      setIsRejecting(false);
-    }
-  };
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to decline invitation",
+      );
+    },
+  });
+
+  const isBusy = acceptMutation.isPending || rejectMutation.isPending;
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background">
@@ -83,15 +82,15 @@ export function PendingInviteScreen({
           </p>
         </div>
         <div className="flex flex-col gap-2 w-full">
-          <Button onClick={handleAccept} disabled={isAccepting || isRejecting}>
-            {isAccepting ? "Accepting…" : "Accept invitation"}
+          <Button onClick={() => acceptMutation.mutate()} disabled={isBusy}>
+            {acceptMutation.isPending ? "Accepting…" : "Accept invitation"}
           </Button>
           <Button
             variant="ghost"
-            onClick={handleReject}
-            disabled={isAccepting || isRejecting}
+            onClick={() => rejectMutation.mutate()}
+            disabled={isBusy}
           >
-            {isRejecting ? "Declining…" : "Decline"}
+            {rejectMutation.isPending ? "Declining…" : "Decline"}
           </Button>
         </div>
       </div>

--- a/apps/mesh/src/web/hooks/use-org-access-status.ts
+++ b/apps/mesh/src/web/hooks/use-org-access-status.ts
@@ -1,0 +1,38 @@
+import { KEYS } from "@/web/lib/query-keys";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export interface OrgAccessStatusOrg {
+  id: string;
+  name: string;
+  slug: string;
+  logo: string | null;
+  domain?: string;
+}
+
+export type OrgAccessStatus =
+  | { status: "member"; organization: OrgAccessStatusOrg }
+  | {
+      status: "pending-invite";
+      invitation: { id: string };
+      organization: OrgAccessStatusOrg;
+    }
+  | { status: "auto-domain-join"; organization: OrgAccessStatusOrg }
+  | { status: "no-access"; organization: OrgAccessStatusOrg }
+  | { status: "not-found" };
+
+export function useOrgAccessStatus(slug: string) {
+  return useSuspenseQuery({
+    queryKey: KEYS.orgAccessStatus(slug),
+    queryFn: async (): Promise<OrgAccessStatus> => {
+      const res = await fetch(
+        `/api/auth/custom/org-access-status/${encodeURIComponent(slug)}`,
+        { credentials: "include" },
+      );
+      if (!res.ok) {
+        throw new Error(`org-access-status failed (${res.status})`);
+      }
+      return (await res.json()) as OrgAccessStatus;
+    },
+    refetchOnWindowFocus: false,
+  });
+}

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { OrgAccessGate } from "@/web/components/org-access-gate";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { KeyboardShortcutsDialog } from "@/web/components/keyboard-shortcuts-dialog";
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
@@ -234,7 +235,15 @@ function ShellLayoutContent() {
   const { data: ssoStatus } = useOrgSsoStatus(orgId, orgSlug);
 
   if (!activeOrg) {
-    return <SplashScreen />;
+    // Not a member: figure out which screen to show (no-access / pending
+    // invite / auto-domain-join / not-found). Wrapped in Suspense so the
+    // brief access-status fetch shows the splash instead of throwing back to
+    // the parent suspense boundary.
+    return (
+      <Suspense fallback={<SplashScreen />}>
+        <OrgAccessGate orgSlug={org!} />
+      </Suspense>
+    );
   }
 
   const isArchivedOrg =

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -63,6 +63,9 @@ export const KEYS = {
   activeOrganization: (org: string | undefined) =>
     ["activeOrganization", org] as const,
 
+  // Org access status (for /:org gate — pending invite / auto-join / no access)
+  orgAccessStatus: (slug: string) => ["org-access-status", slug] as const,
+
   // Models list (scoped by organization)
   modelsList: (orgId: string) => ["models-list", orgId] as const,
 


### PR DESCRIPTION
## Summary
- Visiting `/:org` for an org you aren't in now renders one of **no-access**, **pending-invite**, or **auto-domain-join** instead of hanging on `<SplashScreen/>` forever.
- New `GET /api/auth/custom/org-access-status/:slug` consolidates the membership / invite / domain checks so the shell layout makes a single call.
- Pending-invite reuses Better Auth's `acceptInvitation` / `rejectInvitation`; auto-domain-join reuses the existing `POST /api/auth/custom/domain-join`.

## Test plan
- [x] `bun test apps/mesh/src/api/routes/auth.test.ts` — 9 HTTP integration tests covering the 5 status branches + edge cases (expired invite, `auto_join_enabled=false`, unverified email)
- [x] `bun run --cwd=apps/mesh test:e2e -- org-access-gate` — Playwright covers **not-found**, **no-access**, and **pending-invite + accept** end-to-end
- [x] `bun run check`, `bun run lint`, `bun run fmt`
- [ ] Manual: visit an org URL you don't belong to and confirm the right screen appears (and accept-invite redirects you in)

## Screens
Screenshots captured by the Playwright run are in `apps/mesh/screenshots/` (gitignored).

## Out of scope
- Auto-domain-join is HTTP-tested but not Playwright-tested: the signup hook auto-joins corporate users, so the screen is unreachable from a fresh signup flow.
- The legacy `useEffect`-style sign-out flow inside `inbox.tsx` is untouched; the new `<PendingInviteScreen/>` duplicates a small bit of accept/reject logic on purpose (different surface, different copy).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the infinite splash on unauthorized org routes with clear access gate screens and a single status endpoint. Actions for invites and auto-join now use `@tanstack/react-query` mutations for a smoother flow.

- **New Features**
  - Added `GET /api/auth/custom/org-access-status/:slug` to consolidate membership, invitation, and domain checks.
  - Shell now renders `<OrgAccessGate>` (Suspense-wrapped) when `activeOrg` is null instead of hanging on `<SplashScreen />`.
  - Screens: no-access (go-home CTA), pending-invite (accept/decline via `authClient.organization.acceptInvitation` / `rejectInvitation`), auto-domain-join (enter via `POST /api/auth/custom/domain-join`).
  - Hook `use-org-access-status` with query key `org-access-status` for fetching status.
  - Tests: 9 HTTP integration tests; Playwright E2E for not-found, no-access, and pending-invite. CI sets `DISABLE_RATE_LIMIT=true` to avoid signup 429s and the signup helper is more robust. Screenshots saved under `apps/mesh/screenshots/` (gitignored).

- **Refactors**
  - Switched pending-invite and auto-domain-join actions to `useMutation` from `@tanstack/react-query`.

<sup>Written for commit 9bee43a8b1c3a2af152a82654db6dd46ca40da28. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3441?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

