### PR TITLE
chore(dev): auto-spawn local sandbox provider in `bun run dev`

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -18,6 +18,7 @@ const child = Bun.spawn(
     "run",
     join(repoRoot, "apps/mesh/src/cli.ts"),
     "dev",
+    "--local-sandbox-provider",
     ...process.argv.slice(2),
   ],
   {


### PR DESCRIPTION
## What is this contribution about?
Pass `--local-sandbox-provider` from `scripts/dev.ts` so plain `bun run dev` auto-spawns the `deco link` daemon (port 5174) once the cluster is up — matching the behavior `bun run dev:conductor` already had. Previously the Sandbox panel sat pending in `bun run dev` because no provider was registered.

## How to Test
1. Run `bun run dev` from the repo root.
2. Wait for the cluster to come up.
3. Expected: the link daemon is spawned automatically and the Sandbox provider appears as ready (no need for `--local-sandbox-provider` or `dev:conductor`).

## Migration Notes
N/A.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-start the local Sandbox provider when running `bun run dev`. We pass `--local-sandbox-provider` from `scripts/dev.ts` so the `deco link` daemon launches with the cluster, matching `bun run dev:conductor`, and the Sandbox panel no longer stays pending.

<sup>Written for commit 879c4d29874bcaf51269c95fa8cdff903c01fdd8. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3442?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

