### PR TITLE
refactor(sandbox): drop redundant .deco segment from DATA_DIR paths

### DIFF
--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -124,8 +124,8 @@ export async function startDevServer(
   // Pre-compute the link's data dir so the cluster's `bootstrapDevLinkSession`
   // can write `session.json` to the exact path the link will read. The dir
   // lives in tmpdir — NOT under settings.dataDir, which is inside the
-  // mesh repo. Sandbox clones go into `<DATA_DIR>/.deco/link/sandboxes/<handle>/repo`;
-  // when that parent is itself a git repo (e.g. `~/code/mesh/.deco/...`)
+  // mesh repo. Sandbox clones go into `<DATA_DIR>/link/sandboxes/<handle>/repo`;
+  // when that parent is itself a git repo (e.g. `~/code/mesh/...`)
   // git's parent-walk hits the outer .git, refuses to clone, and the
   // daemon crashes mid-bootstrap. Keying by workspace slug isolates
   // concurrent worktrees.
@@ -242,7 +242,7 @@ export async function startDevServer(
               MESH_CLUSTER_URL: serverUrl,
               MESH_ALLOW_LOCALHOST_LINKS: "1",
               // DATA_DIR lives OUTSIDE the mesh repo. The daemon clones
-              // user repos into `<DATA_DIR>/.deco/link/sandboxes/<handle>/repo`;
+              // user repos into `<DATA_DIR>/link/sandboxes/<handle>/repo`;
               // if that path is nested under another git repo (this one)
               // git's parent-walk hits the outer .git, refuses to clone,
               // and the daemon crashes mid-bootstrap. Use a tmpdir-rooted

--- a/apps/mesh/src/harnesses/remote-dispatch.ts
+++ b/apps/mesh/src/harnesses/remote-dispatch.ts
@@ -167,7 +167,7 @@ export type RemoteDispatchLink = Pick<LinkEntry, "tunnelUrl" | "linkSecret">;
  * from the runId-keyed flow `remoteDispatch` uses.
  *
  * No `repo` is sent: ephemeral CLI runs operate on an empty workdir
- * the link auto-creates at `<dataDir>/.deco/link/sandboxes/<handle>/`.
+ * the link auto-creates at `<dataDir>/link/sandboxes/<handle>/`.
  *
  * Idempotent on the link side — repeated POSTs with the same handle
  * return the existing sandbox unchanged.

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -7,7 +7,7 @@
  * reverse proxy). On stop (SIGINT/SIGTERM or `handle.stop()`) it
  * gracefully deregisters, kills any sandboxes, and closes the tunnel.
  *
- * The OAuth session is read from `<dataDir>/.deco/session.json` (the
+ * The OAuth session is read from `<dataDir>/session.json` (the
  * format `deco auth login` writes).
  */
 

--- a/apps/mesh/src/link-daemon/machine-id.ts
+++ b/apps/mesh/src/link-daemon/machine-id.ts
@@ -1,6 +1,6 @@
 /**
  * Machine-id is the stable identifier the link daemon presents at
- * registration. It lives at `<dataDir>/.deco/link/machine-id` and is
+ * registration. It lives at `<dataDir>/link/machine-id` and is
  * generated once per desktop.
  *
  * The cluster keys its `LinkRegistry` by the OAuth userSub, NOT by this
@@ -15,7 +15,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 function machineIdPath(dataDir: string): string {
-  return join(dataDir, ".deco", "link", "machine-id");
+  return join(dataDir, "link", "machine-id");
 }
 
 export async function loadOrCreateMachineId(dataDir: string): Promise<string> {

--- a/apps/mesh/src/link-daemon/sandbox-provider.ts
+++ b/apps/mesh/src/link-daemon/sandbox-provider.ts
@@ -148,13 +148,7 @@ export function createDesktopSandboxProvider(
     input: EnsureSandboxInput,
   ): Promise<{ sandboxUrl: string; port: number }> => {
     evictIfNeeded();
-    const workdir = join(
-      deps.dataDir,
-      ".deco",
-      "link",
-      "sandboxes",
-      input.handle,
-    );
+    const workdir = join(deps.dataDir, "link", "sandboxes", input.handle);
     await mkdir(workdir, { recursive: true });
     // Two ephemeral ports per sandbox: one for the daemon's HTTP/proxy
     // (port) and one for the dev script the orchestrator will spawn

--- a/apps/mesh/src/link-daemon/session.ts
+++ b/apps/mesh/src/link-daemon/session.ts
@@ -1,5 +1,5 @@
 /**
- * Read the OAuth session from `<dataDir>/.deco/session.json`, matching
+ * Read the OAuth session from `<dataDir>/session.json`, matching
  * the shape `decocms auth login` writes (see
  * `apps/mesh/src/cli/lib/session.ts`). Reading is read-only on the
  * link side — minting a new session must go through the `decocms`

--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -148,7 +148,7 @@ describe("BranchStatusMonitor", () => {
   });
 
   // Regression: when appRoot != repoDir AND appRoot is nested inside another
-  // git worktree (e.g. host runner: <project>/.deco/sandboxes/<handle>/repo
+  // git worktree (e.g. host runner: <project>/link/sandboxes/<handle>/repo
   // sits under the project's own .git), git's parent-directory walk used to
   // hijack the lookup and report the outer repo's branch. The monitor must
   // resolve git from repoDir and refuse to escape it.

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -117,7 +117,7 @@ export class BranchStatusMonitor {
       return gitSync(args, {
         cwd: this.config.repoDir,
         // Pin discovery to repoDir so a parent .git (e.g. the host's
-        // workspace tree containing .deco/sandboxes/<handle>/repo) can't
+        // workspace tree containing link/sandboxes/<handle>/repo) can't
         // hijack the lookup and report the wrong branch.
         env: { ...process.env, GIT_CEILING_DIRECTORIES: this.config.repoDir },
       });

--- a/packages/sandbox/server/daemon-spawn.ts
+++ b/packages/sandbox/server/daemon-spawn.ts
@@ -10,7 +10,7 @@
  * In production (the link binary, or `bunx decocms@latest`), the source
  * TS path resolves to a nonexistent `<bunx-cache>/.../daemon/entry.ts` —
  * we materialize the embedded bundle (loaded lazily from
- * `daemon-asset.ts`) into `<homeDir>/.deco/cache/sandbox-daemon-<hash>.js`
+ * `daemon-asset.ts`) into `<homeDir>/cache/sandbox-daemon-<hash>.js`
  * and spawn that.
  *
  * `node-pty` is a runtime dep of the daemon. Its install location lives
@@ -67,7 +67,7 @@ export async function materializeDaemonBundle(
     .update(DAEMON_BUNDLE)
     .digest("hex")
     .slice(0, 16);
-  const cacheDir = join(homeDir, ".deco", "cache");
+  const cacheDir = join(homeDir, "cache");
   const cachePath = join(cacheDir, `sandbox-daemon-${hash}.js`);
   if (existsSync(cachePath)) return cachePath;
   await mkdir(cacheDir, { recursive: true });


### PR DESCRIPTION
## What is this contribution about?

The link-daemon was hardcoding an extra `.deco` path segment underneath `DATA_DIR`, producing redundant paths like `~/deco/.deco/link/sandboxes/...` when running `bunx decocms link` (DATA_DIR already defaults to `~/deco`). This treats DATA_DIR as the leaf data directory and removes the extra segment in three places: sandbox workdirs (`$DATA_DIR/link/sandboxes/<handle>`), the machine-id file (`$DATA_DIR/link/machine-id`), and the materialized daemon bundle cache (`$DATA_DIR/cache/`). Comments and docstrings across `link-daemon/`, `cli/commands/dev.ts`, `harnesses/remote-dispatch.ts`, and `packages/sandbox/daemon/git/branch-status.{ts,test.ts}` were updated to match — `session.json` was already at the DATA_DIR root, matching what `decocms auth login` writes, so no change was needed there.

## How to Test

1. `DATA_DIR=/tmp/decocms-link-test bunx decocms link --no-tunnel` (or run via `decocms dev --local-sandbox-provider`)
2. Trigger a sandbox spawn (any path that hits `ensureSandbox`)
3. Expected: clone lands at `/tmp/decocms-link-test/link/sandboxes/<handle>/repo` (no `.deco` between DATA_DIR and `link/`), and `/tmp/decocms-link-test/link/machine-id` exists

## Migration Notes

Existing installs will leave stale data under `<DATA_DIR>/.deco/link/...` and `<DATA_DIR>/.deco/cache/`. The link daemon will repopulate fresh state at the new paths on next run; the old directories can be deleted manually. Machine-id will be regenerated, which the cluster tolerates (it's keyed on user sub, not machine-id).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (typecheck + 18 affected tests pass)
- [x] Documentation is updated (comments/docstrings reflect new paths)
- [x] No breaking changes (modulo stale local data on existing installs — see Migration Notes)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the redundant `.deco` path segment so the link daemon treats the data directory as the leaf directory. This avoids paths like `~/deco/.deco/...` and places sandboxes, machine-id, and the daemon cache under the correct roots.

- **Refactors**
  - Sandbox workdirs now at `$DATA_DIR/link/sandboxes/<handle>/repo`
  - Machine ID now at `$DATA_DIR/link/machine-id`
  - Daemon bundle now materialized at `$HOME/cache/sandbox-daemon-<hash>.js`

- **Migration**
  - Old data under `$DATA_DIR/.deco/link/...` and `$HOME/.deco/cache/` is stale and can be deleted; new paths are created automatically on next run.
  - Machine ID will be regenerated; this is safe (registry keys on user, not machine).

<sup>Written for commit 78b90799d2a64022f038337a631a27c7db919686. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3443?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

