### PR TITLE
fix(ui): resolve Open in panel tool lookup and args race condition

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -191,7 +191,7 @@ export function GenericToolCallPart({
 
   const { setChatOpen } = usePanelActions();
   const { taskId } = useChatTask();
-  const { addOrReplace } = useTaskExpandedTools(taskId);
+  const { addOrReplaceEager } = useTaskExpandedTools(taskId);
   const navigate = useNavigate();
 
   const connectionId =
@@ -231,7 +231,7 @@ export function GenericToolCallPart({
       "input" in part && part.input && typeof part.input === "object"
         ? (part.input as Record<string, unknown>)
         : {};
-    addOrReplace({
+    addOrReplaceEager({
       toolName: rawToolName,
       appId: connectionId,
       args,

--- a/apps/mesh/src/web/hooks/use-task-expanded-tools.ts
+++ b/apps/mesh/src/web/hooks/use-task-expanded-tools.ts
@@ -110,8 +110,35 @@ export function useTaskExpandedTools(taskId: string) {
     },
   });
 
+  /**
+   * Synchronously patches the query cache and then fires the server mutation.
+   * Use this when code that runs immediately after (e.g. a navigate() call)
+   * needs the expanded_tools data to already be in the cache.
+   */
+  const addOrReplaceEager = (tool: Omit<ThreadExpandedTool, "expandedAt">) => {
+    const key = KEYS.ensureTask(org.id, taskId);
+    const previous = queryClient.getQueryData<Task | null>(key);
+    const currentTools: ThreadExpandedTool[] =
+      previous?.metadata?.expanded_tools ?? [];
+    const nextTools = currentTools.filter((t) => t.toolName !== tool.toolName);
+    nextTools.push({ ...tool, expandedAt: new Date().toISOString() });
+    queryClient.setQueryData<Task | null>(key, (prev) =>
+      prev
+        ? {
+            ...prev,
+            metadata: {
+              ...(prev.metadata ?? {}),
+              expanded_tools: nextTools,
+            },
+          }
+        : prev,
+    );
+    mutation.mutate(tool);
+  };
+
   return {
     addOrReplace: mutation.mutate,
+    addOrReplaceEager,
     isPending: mutation.isPending,
   };
 }

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -7,7 +7,7 @@ import {
   useProjectContext,
   useMCPClient,
   useMCPToolsList,
-  useMCPToolCall,
+  useMCPToolCallQuery,
 } from "@decocms/mesh-sdk";
 import type {
   McpUiDisplayMode,
@@ -57,7 +57,7 @@ function AppRenderer({
     return "fullscreen";
   };
   const toolInput = args ?? EMPTY_TOOL_INPUT;
-  const { data: toolResult } = useMCPToolCall({
+  const { data: toolResult } = useMCPToolCallQuery({
     client,
     toolName: tool.name,
     toolArguments: toolInput,
@@ -120,7 +120,24 @@ export function AppViewContent({
 
   const decodedToolName = stripMcpServerPrefix(decodeURIComponent(toolName));
 
-  const tool = toolsResult.tools.find((t) => t.name === decodedToolName);
+  // Try exact match first. If that fails, the decoded name may be the original
+  // (un-namespaced) tool name while the tools list has gateway-namespaced names
+  // (e.g. "render_html" vs "conn-abc_render_html"), or vice versa. Fall back to
+  // matching by the base name with the gateway namespace stripped from both sides.
+  const tool =
+    toolsResult.tools.find((t) => t.name === decodedToolName) ??
+    toolsResult.tools.find((t) => {
+      const clientId = getGatewayClientId(t._meta);
+      if (!clientId) return false;
+      // Case 1: decoded name is the base name, tool list has namespaced names
+      const baseName = stripToolNamespace(t.name, clientId);
+      if (baseName === decodedToolName) return true;
+      // Case 2: decoded name has namespace prefix, tool list has base names
+      const decodedBase = stripToolNamespace(decodedToolName, clientId);
+      if (decodedBase !== decodedToolName && t.name === decodedBase)
+        return true;
+      return false;
+    });
 
   const resourceURI = tool?._meta ? getUIResourceUri(tool._meta) : undefined;
 

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -7,7 +7,7 @@ import {
   useProjectContext,
   useMCPClient,
   useMCPToolsList,
-  useMCPToolCallQuery,
+  useMCPToolCall,
 } from "@decocms/mesh-sdk";
 import type {
   McpUiDisplayMode,
@@ -57,7 +57,7 @@ function AppRenderer({
     return "fullscreen";
   };
   const toolInput = args ?? EMPTY_TOOL_INPUT;
-  const { data: toolResult } = useMCPToolCallQuery({
+  const { data: toolResult } = useMCPToolCall({
     client,
     toolName: tool.name,
     toolArguments: toolInput,


### PR DESCRIPTION
## Summary
- Fix tool name mismatch in panel view: added fallback matching that strips gateway namespace prefixes when exact match fails (e.g. `render_html` vs `conn-abc_render_html`)
- Fix args race condition: switched from `useMCPToolCall` (suspense) to `useMCPToolCallQuery` (non-suspense) so the panel doesn't crash when args haven't arrived from the optimistic cache update yet

## Test plan
- [ ] Open a chat, trigger a tool with UI (e.g. `render_html`), click "Open in panel" — should render correctly
- [ ] Verify pinned views from virtual MCP metadata still work (tools with/without args)
- [ ] Verify agent-declared tabs (`layoutTabs`) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Open in panel” so the right tool renders and the panel stays stable. Adds namespace-agnostic tool matching and eagerly caches args before navigation to avoid races.

- **Bug Fixes**
  - Tool lookup: fallback matches by stripping `mcp__<server>__` and gateway prefixes (e.g. `conn-abc_`) on both sides when exact match fails.
  - Args race: added `addOrReplaceEager()` in `useTaskExpandedTools` to sync-patch the query cache before `navigate()`, and use it in the open flow so args are present on first render. Restores `useMCPToolCall` (suspense) now that the cache is correct.

<sup>Written for commit 779d086f3d3660bdededbf6ee2719a90940f5c3b. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3444?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

