### PR TITLE
feat(web): show Claude Code model versions in selector labels

### DIFF
--- a/apps/mesh/src/web/components/chat/select-model/agent-models.test.ts
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.test.ts
@@ -73,9 +73,9 @@ describe("getAgentSections", () => {
     expect(claude.tiers.fast.modelId).toBe("claude-code:haiku");
     expect(claude.tiers.smart.modelId).toBe("claude-code:sonnet");
     expect(claude.tiers.thinking.modelId).toBe("claude-code:opus");
-    expect(claude.tiers.fast.label).toBe("Haiku");
-    expect(claude.tiers.smart.label).toBe("Sonnet");
-    expect(claude.tiers.thinking.label).toBe("Opus");
+    expect(claude.tiers.fast.label).toBe("Haiku 4.5");
+    expect(claude.tiers.smart.label).toBe("Sonnet 4.6");
+    expect(claude.tiers.thinking.label).toBe("Opus 4.7");
   });
 
   test("codex section exposes the three Codex model labels", () => {

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -103,19 +103,19 @@ const DECOPILOT_TIERS: AgentTierMap = {
 const CLAUDE_CODE_TIERS: AgentTierMap = {
   fast: {
     modelId: "claude-code:haiku",
-    label: "Haiku",
+    label: "Haiku 4.5",
     description: "Quicker responses",
     iconNode: <ClaudeCodeIcon size={16} />,
   },
   smart: {
     modelId: "claude-code:sonnet",
-    label: "Sonnet",
+    label: "Sonnet 4.6",
     description: "Balanced quality",
     iconNode: <ClaudeCodeIcon size={16} />,
   },
   thinking: {
     modelId: "claude-code:opus",
-    label: "Opus",
+    label: "Opus 4.7",
     description: "Deeper reasoning",
     iconNode: <ClaudeCodeIcon size={16} />,
   },

--- a/apps/mesh/src/web/components/chat/select-model/agent-section.test.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-section.test.tsx
@@ -73,7 +73,7 @@ describe("AgentSection", () => {
         onSelect={onSelect}
       />,
     );
-    getByText("Haiku").click();
+    getByText("Haiku 4.5").click();
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith("fast");
   });


### PR DESCRIPTION
## What is this contribution about?
The model selector showed Codex options with their versions (e.g. "GPT-5.4 Mini") but the Claude Code options were unversioned ("Haiku", "Sonnet", "Opus"). This renames the Claude Code labels to include versions: "Haiku 4.5", "Sonnet 4.6", "Opus 4.7", matching the Codex labels' format and giving users clarity on which model they're picking.

## How to Test
1. Open the desktop app and open the model selector in the chat UI.
2. Under the Claude Code section, confirm the three tiers read "Haiku 4.5", "Sonnet 4.6", and "Opus 4.7".
3. Pick each tier and confirm the selection still works.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Claude Code model versions in the chat model selector for clearer choices. Labels now read “Haiku 4.5”, “Sonnet 4.6”, and “Opus 4.7”, matching Codex formatting; selection behavior and tests updated.

<sup>Written for commit b6da80467093af3babeaba981c9c65a41ed4eff7. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3445?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

