### PR TITLE
feat(preview): enhance lifecycle failure handling in preview state

### DIFF
--- a/apps/mesh/src/web/components/vm/preview/preview-state.test.ts
+++ b/apps/mesh/src/web/components/vm/preview/preview-state.test.ts
@@ -10,6 +10,8 @@ const base: PreviewStateInput = {
   appPaused: false,
   vmStartPending: false,
   lastStartError: null,
+  lifecycleFailure: null,
+  lifecycleFailureError: null,
   claimPhase: null,
   notFound: false,
   userStopped: false,
@@ -167,5 +169,73 @@ describe("computePreviewState", () => {
         suspended: true,
       }),
     ).toEqual({ kind: "suspended" });
+  });
+
+  test("lifecycle start-failed → dev-script-failed", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        lifecycleFailure: "start-failed",
+        lifecycleFailureError: "dev script exited with code 1",
+      }),
+    ).toEqual({
+      kind: "dev-script-failed",
+      failure: "start-failed",
+      error: "dev script exited with code 1",
+    });
+  });
+
+  test("lifecycle install-failed → dev-script-failed", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        lifecycleFailure: "install-failed",
+        lifecycleFailureError: "exit 1",
+      }),
+    ).toEqual({
+      kind: "dev-script-failed",
+      failure: "install-failed",
+      error: "exit 1",
+    });
+  });
+
+  test("lifecycle failure with null error uses default reason", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        lifecycleFailure: "start-failed",
+        lifecycleFailureError: null,
+      }),
+    ).toEqual({
+      kind: "dev-script-failed",
+      failure: "start-failed",
+      error: "Sandbox start-failed",
+    });
+  });
+
+  test("lastStartError still wins over lifecycleFailure", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        lastStartError: "boom",
+        lifecycleFailure: "start-failed",
+        lifecycleFailureError: "dev script exited with code 1",
+      }),
+    ).toEqual({ kind: "errored", error: "boom" });
+  });
+
+  test("lifecycleFailure wins over suspended", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        suspended: true,
+        lifecycleFailure: "start-failed",
+        lifecycleFailureError: "dev script exited with code 1",
+      }),
+    ).toEqual({
+      kind: "dev-script-failed",
+      failure: "start-failed",
+      error: "dev script exited with code 1",
+    });
   });
 });

--- a/apps/mesh/src/web/components/vm/preview/preview-state.ts
+++ b/apps/mesh/src/web/components/vm/preview/preview-state.ts
@@ -4,7 +4,7 @@
  * DOM/auth/SSE scaffolding.
  *
  * Priority order (highest first):
- *   errored → suspended → starting-now → no-html → iframe → never-started
+ *   errored → dev-script-failed → suspended → starting-now → no-html → iframe → never-started
  *
  * `status === "online" || "offline"` is the "ever-responded" latch:
  * once the daemon has seen the upstream answer, the iframe stays mounted
@@ -19,6 +19,16 @@
 export type UpstreamStatus = "booting" | "online" | "offline";
 export type ClaimPhaseLike = { kind: string };
 
+/**
+ * Terminal daemon setup-pipeline failures. Distinct from `lastStartError`
+ * (the VM_START mutation rejection) — these come from the daemon AFTER it
+ * came online, e.g. `bun run dev` exiting with a non-zero code.
+ */
+export type LifecycleFailure =
+  | "clone-failed"
+  | "install-failed"
+  | "start-failed";
+
 export interface PreviewStateInput {
   previewUrl: string | null;
   status: UpstreamStatus;
@@ -27,6 +37,8 @@ export interface PreviewStateInput {
   appPaused: boolean;
   vmStartPending: boolean;
   lastStartError: string | null;
+  lifecycleFailure: LifecycleFailure | null;
+  lifecycleFailureError: string | null;
   claimPhase: ClaimPhaseLike | null;
   notFound: boolean;
   userStopped: boolean;
@@ -36,6 +48,7 @@ export type PreviewState =
   | { kind: "never-started" }
   | { kind: "starting-now" }
   | { kind: "errored"; error: string }
+  | { kind: "dev-script-failed"; failure: LifecycleFailure; error: string }
   | { kind: "suspended" }
   | { kind: "crashed"; previewUrl: string }
   | { kind: "no-html"; previewUrl: string }
@@ -44,6 +57,13 @@ export type PreviewState =
 export function computePreviewState(input: PreviewStateInput): PreviewState {
   if (input.lastStartError) {
     return { kind: "errored", error: input.lastStartError };
+  }
+  if (input.lifecycleFailure) {
+    return {
+      kind: "dev-script-failed",
+      failure: input.lifecycleFailure,
+      error: input.lifecycleFailureError ?? `Sandbox ${input.lifecycleFailure}`,
+    };
   }
   if (input.suspended || input.appPaused) {
     return { kind: "suspended" };

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -286,6 +286,16 @@ export function PreviewContent() {
     !appPaused &&
     (claimPhase?.kind === "ready" || lifecyclePhase !== "idle");
 
+  // `visual` and `cms` drop out of the toggle options when the iframe is
+  // gone (they require a live dev server to inject overlays into). Fall
+  // back to `preview` for the toggle binding + overlay renders so the
+  // toggle never carries a value not in its option list.
+  const effectiveViewMode: PreviewViewMode =
+    previewState.kind !== "iframe" &&
+    (viewMode === "visual" || viewMode === "cms")
+      ? "preview"
+      : viewMode;
+
   // ref-latest pattern: effects below depend only on upstream signals, not
   // on this closure's churning captures (branch, mutation, setter).
   const triggerStart = (reason: "auto-start" | "self-heal") => {
@@ -610,7 +620,7 @@ export function PreviewContent() {
               so the user can drop into code mode after a dev-script crash. */}
           <div className="flex shrink-0 items-center gap-1">
             <ViewModeToggle
-              value={viewMode}
+              value={effectiveViewMode}
               onValueChange={handleViewModeChange}
               options={viewModeOptions}
               size="sm"
@@ -989,13 +999,13 @@ export function PreviewContent() {
             </div>
           )}
 
-          {viewMode === "visual" && !visualElement && (
+          {effectiveViewMode === "visual" && !visualElement && (
             <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
               <CursorClick01 size={12} />
               Click any element to ask the AI
             </div>
           )}
-          {viewMode === "visual" && visualElement && (
+          {effectiveViewMode === "visual" && visualElement && (
             <VisualEditorPrompt
               element={visualElement}
               onDismiss={() => setVisualElement(null)}

--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -57,7 +57,11 @@ import {
   vmUserStop,
   type VmStartArgs,
 } from "../hooks/use-vm-start";
-import { computePreviewState, type PreviewState } from "./preview-state";
+import {
+  computePreviewState,
+  type LifecycleFailure,
+  type PreviewState,
+} from "./preview-state";
 import { VmStateCard } from "./state-card";
 import { derivePhaseProgress } from "./derive-phase-progress";
 import {
@@ -239,6 +243,22 @@ export function PreviewContent() {
   const userStopped =
     !!virtualMcpId && !!branch && vmUserStop.isStopped(virtualMcpId, branch);
 
+  // Terminal lifecycle failures from the daemon (clone/install/dev script
+  // exited non-zero). Distinct from `lastStartError`, which is a VM_START
+  // mutation rejection — these come from the daemon AFTER it came online.
+  // The daemon also flips status.state to "error", but lifecycle.phase
+  // carries which step failed, which the card uses to pick a log source.
+  const lifecycleFailure: LifecycleFailure | null =
+    lifecyclePhase === "start-failed" ||
+    lifecyclePhase === "install-failed" ||
+    lifecyclePhase === "clone-failed"
+      ? lifecyclePhase
+      : null;
+  const lifecycleFailureError =
+    lifecycleFailure && "error" in vmEvents.lifecycle
+      ? (vmEvents.lifecycle.error ?? null)
+      : null;
+
   const previewState = computePreviewState({
     previewUrl,
     status: upstreamStatus,
@@ -247,10 +267,24 @@ export function PreviewContent() {
     appPaused,
     vmStartPending,
     lastStartError,
+    lifecycleFailure,
+    lifecycleFailureError,
     claimPhase,
     notFound: vmEvents.notFound,
     userStopped,
   });
+
+  // Daemon is reachable independent of the dev script: ready claim, handle
+  // still present, not user-stopped/suspended. Gates surfaces (FileExplorer,
+  // terminal) that talk to the daemon's HTTP API and don't need a dev server.
+  const daemonReady =
+    !!virtualMcpId &&
+    !!branch &&
+    !vmEvents.notFound &&
+    !userStopped &&
+    !suspended &&
+    !appPaused &&
+    (claimPhase?.kind === "ready" || lifecyclePhase !== "idle");
 
   // ref-latest pattern: effects below depend only on upstream signals, not
   // on this closure's churning captures (branch, mutation, setter).
@@ -542,14 +576,21 @@ export function PreviewContent() {
     }
   })();
 
+  // visual + cms require a live iframe (they inject overlays into the dev
+  // server); when the iframe isn't up we still offer preview + code so the
+  // user can browse files after a dev-script crash.
   const viewModeOptions: ViewModeOption<PreviewViewMode>[] = [
     { value: "preview", icon: <Monitor04 size={14} />, tooltip: "Interactive" },
-    {
-      value: "visual",
-      icon: <CursorClick01 size={14} />,
-      tooltip: "Visual editor",
-    },
-    ...(pages.length > 0
+    ...(previewState.kind === "iframe"
+      ? [
+          {
+            value: "visual" as PreviewViewMode,
+            icon: <CursorClick01 size={14} />,
+            tooltip: "Visual editor",
+          },
+        ]
+      : []),
+    ...(previewState.kind === "iframe" && pages.length > 0
       ? [
           {
             value: "cms" as PreviewViewMode,
@@ -563,209 +604,217 @@ export function PreviewContent() {
 
   return (
     <div className="flex flex-col w-full h-full">
-      {previewState.kind === "iframe" && (
+      {daemonReady && (
         <div className="flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
-          {/* Group 1: view mode toggle */}
+          {/* Group 1: view mode toggle. Always visible when the daemon is up
+              so the user can drop into code mode after a dev-script crash. */}
           <div className="flex shrink-0 items-center gap-1">
-            {hasHtmlPreview && (
-              <ViewModeToggle
-                value={viewMode}
-                onValueChange={handleViewModeChange}
-                options={viewModeOptions}
-                size="sm"
-                className="shrink-0 bg-foreground/4.5"
-              />
-            )}
+            <ViewModeToggle
+              value={viewMode}
+              onValueChange={handleViewModeChange}
+              options={viewModeOptions}
+              size="sm"
+              className="shrink-0 bg-foreground/4.5"
+            />
           </div>
 
-          {/* Group 2: nav + url (hidden in code mode) */}
-          <div
-            className={cn(
-              "flex min-w-0 flex-1 items-center gap-0.5",
-              viewMode === "code" && "hidden",
-            )}
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() =>
-                    previewIframeRef.current?.contentWindow?.history.back()
-                  }
-                >
-                  <ArrowLeft size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Back</TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() =>
-                    previewIframeRef.current?.contentWindow?.history.forward()
-                  }
-                >
-                  <ArrowRight size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Forward</TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" onClick={handleRefresh}>
-                  <RefreshCw01 size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Refresh</TooltipContent>
-            </Tooltip>
-
-            <div ref={pagesContainerRef} className="relative min-w-0 flex-1">
-              <button
-                type="button"
-                className="flex h-8 w-full min-w-0 items-center gap-1 rounded-md bg-background px-2 transition-colors duration-200 hover:bg-accent"
-                onClick={() => setPagesOpen((prev) => !prev)}
+          {/* Groups 2+3 only render when the iframe is live — they read
+              `previewState.previewUrl` and steer the iframe directly. */}
+          {previewState.kind === "iframe" && (
+            <>
+              {/* Group 2: nav + url (hidden in code mode) */}
+              <div
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-0.5",
+                  viewMode === "code" && "hidden",
+                )}
               >
-                <span className="min-w-0 flex-1 truncate text-left text-[12px] text-foreground/88">
-                  {previewLabel}
-                </span>
-                {currentPageName && (
-                  <span className="shrink-0 text-[12px] text-muted-foreground">
-                    {currentPageName}
-                  </span>
-                )}
-                {pages.length > 0 && (
-                  <ChevronDown
-                    size={12}
-                    className={cn(
-                      "shrink-0 text-muted-foreground transition-transform",
-                      pagesOpen && "rotate-180",
-                    )}
-                  />
-                )}
-              </button>
-
-              {pagesOpen && pages.length > 0 && (
-                <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
-                  <div className="px-2 pt-2 pb-1">
-                    <input
-                      type="text"
-                      value={pagesSearch}
-                      onChange={(e) => setPagesSearch(e.target.value)}
-                      placeholder="Search pages..."
-                      className="w-full rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
-                      autoFocus
-                    />
-                  </div>
-                  <ScrollArea className="max-h-[60vh]">
-                    <div className="p-1.5">
-                      {pages
-                        .filter((page) => {
-                          if (!pagesSearch) return true;
-                          const q = pagesSearch.toLowerCase();
-                          return (
-                            page.name.toLowerCase().includes(q) ||
-                            page.path.toLowerCase().includes(q)
-                          );
-                        })
-                        .map((page) => (
-                          <button
-                            key={page.key}
-                            type="button"
-                            className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                            onClick={() => {
-                              setPagesOpen(false);
-                              setPagesSearch("");
-                              setCurrentPath(page.path);
-                              // Navigate the iframe
-                              const iframe = previewIframeRef.current;
-                              if (iframe && previewUrl) {
-                                iframe.src = new URL(
-                                  page.path,
-                                  previewUrl,
-                                ).href;
-                              }
-                            }}
-                          >
-                            <span className="min-w-0 flex-1 truncate font-medium">
-                              {page.name}
-                            </span>
-                            <span className="shrink-0 text-xs text-muted-foreground">
-                              {page.path}
-                            </span>
-                          </button>
-                        ))}
-                      {pagesSearch &&
-                        pages.every((page) => {
-                          const q = pagesSearch.toLowerCase();
-                          return (
-                            !page.name.toLowerCase().includes(q) &&
-                            !page.path.toLowerCase().includes(q)
-                          );
-                        }) && (
-                          <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                            No pages match "{pagesSearch}"
-                          </div>
-                        )}
-                    </div>
-                  </ScrollArea>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Group 3: open in new tab + more actions (hidden in code mode) */}
-          <div
-            className={cn(
-              "flex shrink-0 items-center gap-0.5",
-              viewMode === "code" && "hidden",
-            )}
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => {
-                    let url = previewState.previewUrl;
-                    if (url && currentPath && currentPath !== "/") {
-                      try {
-                        const parsed = new URL(url);
-                        parsed.pathname = currentPath;
-                        url = parsed.href;
-                      } catch {
-                        // keep original url
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() =>
+                        previewIframeRef.current?.contentWindow?.history.back()
                       }
-                    }
-                    window.open(url, "_blank", "noopener");
-                  }}
-                >
-                  <LinkExternal01 size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open in new tab</TooltipContent>
-            </Tooltip>
+                    >
+                      <ArrowLeft size={14} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Back</TooltipContent>
+                </Tooltip>
 
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon">
-                  <DotsHorizontal size={14} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={handleHardReload}>
-                  Hard Reload
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleCopyUrl}>
-                  Copy Current URL
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() =>
+                        previewIframeRef.current?.contentWindow?.history.forward()
+                      }
+                    >
+                      <ArrowRight size={14} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Forward</TooltipContent>
+                </Tooltip>
+
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" onClick={handleRefresh}>
+                      <RefreshCw01 size={14} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Refresh</TooltipContent>
+                </Tooltip>
+
+                <div
+                  ref={pagesContainerRef}
+                  className="relative min-w-0 flex-1"
+                >
+                  <button
+                    type="button"
+                    className="flex h-8 w-full min-w-0 items-center gap-1 rounded-md bg-background px-2 transition-colors duration-200 hover:bg-accent"
+                    onClick={() => setPagesOpen((prev) => !prev)}
+                  >
+                    <span className="min-w-0 flex-1 truncate text-left text-[12px] text-foreground/88">
+                      {previewLabel}
+                    </span>
+                    {currentPageName && (
+                      <span className="shrink-0 text-[12px] text-muted-foreground">
+                        {currentPageName}
+                      </span>
+                    )}
+                    {pages.length > 0 && (
+                      <ChevronDown
+                        size={12}
+                        className={cn(
+                          "shrink-0 text-muted-foreground transition-transform",
+                          pagesOpen && "rotate-180",
+                        )}
+                      />
+                    )}
+                  </button>
+
+                  {pagesOpen && pages.length > 0 && (
+                    <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
+                      <div className="px-2 pt-2 pb-1">
+                        <input
+                          type="text"
+                          value={pagesSearch}
+                          onChange={(e) => setPagesSearch(e.target.value)}
+                          placeholder="Search pages..."
+                          className="w-full rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
+                          autoFocus
+                        />
+                      </div>
+                      <ScrollArea className="max-h-[60vh]">
+                        <div className="p-1.5">
+                          {pages
+                            .filter((page) => {
+                              if (!pagesSearch) return true;
+                              const q = pagesSearch.toLowerCase();
+                              return (
+                                page.name.toLowerCase().includes(q) ||
+                                page.path.toLowerCase().includes(q)
+                              );
+                            })
+                            .map((page) => (
+                              <button
+                                key={page.key}
+                                type="button"
+                                className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                onClick={() => {
+                                  setPagesOpen(false);
+                                  setPagesSearch("");
+                                  setCurrentPath(page.path);
+                                  // Navigate the iframe
+                                  const iframe = previewIframeRef.current;
+                                  if (iframe && previewUrl) {
+                                    iframe.src = new URL(
+                                      page.path,
+                                      previewUrl,
+                                    ).href;
+                                  }
+                                }}
+                              >
+                                <span className="min-w-0 flex-1 truncate font-medium">
+                                  {page.name}
+                                </span>
+                                <span className="shrink-0 text-xs text-muted-foreground">
+                                  {page.path}
+                                </span>
+                              </button>
+                            ))}
+                          {pagesSearch &&
+                            pages.every((page) => {
+                              const q = pagesSearch.toLowerCase();
+                              return (
+                                !page.name.toLowerCase().includes(q) &&
+                                !page.path.toLowerCase().includes(q)
+                              );
+                            }) && (
+                              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                                No pages match "{pagesSearch}"
+                              </div>
+                            )}
+                        </div>
+                      </ScrollArea>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Group 3: open in new tab + more actions (hidden in code mode) */}
+              <div
+                className={cn(
+                  "flex shrink-0 items-center gap-0.5",
+                  viewMode === "code" && "hidden",
+                )}
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        let url = previewState.previewUrl;
+                        if (url && currentPath && currentPath !== "/") {
+                          try {
+                            const parsed = new URL(url);
+                            parsed.pathname = currentPath;
+                            url = parsed.href;
+                          } catch {
+                            // keep original url
+                          }
+                        }
+                        window.open(url, "_blank", "noopener");
+                      }}
+                    >
+                      <LinkExternal01 size={14} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Open in new tab</TooltipContent>
+                </Tooltip>
+
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <DotsHorizontal size={14} />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={handleHardReload}>
+                      Hard Reload
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleCopyUrl}>
+                      Copy Current URL
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </>
+          )}
         </div>
       )}
 
@@ -891,6 +940,28 @@ export function PreviewContent() {
             </div>
           )}
 
+          {/* Dev-script (or install/clone) exited after the daemon came up.
+              Card overlay is suppressed in `code` mode so the user can drop
+              into the FileExplorer to debug what went wrong. */}
+          {previewState.kind === "dev-script-failed" && viewMode !== "code" && (
+            <div className="absolute inset-0 z-40">
+              <VmStateCard
+                kind="dev-script-failed"
+                progress={progress}
+                logSource={
+                  previewState.failure === "start-failed" ? "dev" : "setup"
+                }
+                errorLine={
+                  previewState.error.split("\n")[0] ?? "Dev script exited"
+                }
+                onRetry={retryAutoStart}
+                onOpenTerminal={openDrawer}
+                onBrowseFiles={() => setViewMode("code")}
+                drawerOpen={drawerOpenEffective}
+              />
+            </div>
+          )}
+
           {previewState.kind === "suspended" && (
             <div className="absolute inset-0 z-30">
               <VmStateCard kind="suspended" onResume={retryAutoStart} />
@@ -930,30 +1001,30 @@ export function PreviewContent() {
               onDismiss={() => setVisualElement(null)}
             />
           )}
-          {/* File explorer (code mode) */}
-          {viewMode === "code" &&
-            previewState.kind === "iframe" &&
-            virtualMcpId &&
-            branch && (
-              <div className="absolute inset-0 z-10 bg-background">
-                <Suspense
-                  fallback={
-                    <div className="h-full flex items-center justify-center">
-                      <Loading01
-                        size={20}
-                        className="animate-spin text-muted-foreground"
-                      />
-                    </div>
-                  }
-                >
-                  <FileExplorer
-                    orgSlug={org.slug}
-                    virtualMcpId={virtualMcpId}
-                    branch={branch}
-                  />
-                </Suspense>
-              </div>
-            )}
+          {/* File explorer (code mode). Gated on daemon-ready, NOT on the
+              dev server: the daemon's FS endpoints (/read, /glob, …) keep
+              serving even when the dev script has crashed, so the user can
+              still browse files to debug a `start-failed`. */}
+          {viewMode === "code" && daemonReady && virtualMcpId && branch && (
+            <div className="absolute inset-0 z-10 bg-background">
+              <Suspense
+                fallback={
+                  <div className="h-full flex items-center justify-center">
+                    <Loading01
+                      size={20}
+                      className="animate-spin text-muted-foreground"
+                    />
+                  </div>
+                }
+              >
+                <FileExplorer
+                  orgSlug={org.slug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                />
+              </Suspense>
+            </div>
+          )}
 
           {previewState.kind === "iframe" && (
             <iframe

--- a/apps/mesh/src/web/components/vm/preview/state-card-helpers.ts
+++ b/apps/mesh/src/web/components/vm/preview/state-card-helpers.ts
@@ -34,6 +34,8 @@ export function headlineFor(kind: StateCardKind): string {
       return "Starting your sandbox";
     case "errored":
       return "Sandbox failed to start";
+    case "dev-script-failed":
+      return "Dev script exited";
     case "suspended":
       return "Sandbox is paused";
     case "crashed":

--- a/apps/mesh/src/web/components/vm/preview/state-card-types.ts
+++ b/apps/mesh/src/web/components/vm/preview/state-card-types.ts
@@ -2,5 +2,6 @@ export type StateCardKind =
   | "never-started"
   | "starting-now"
   | "errored"
+  | "dev-script-failed"
   | "suspended"
   | "crashed";

--- a/apps/mesh/src/web/components/vm/preview/state-card.tsx
+++ b/apps/mesh/src/web/components/vm/preview/state-card.tsx
@@ -2,6 +2,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   AlertTriangle,
+  Code02,
   Monitor04,
   PauseCircle,
   Play,
@@ -35,6 +36,17 @@ export type VmStateCardProps =
       /** Drawer-open hides the inline peek (mutually exclusive surfaces). */
       drawerOpen: boolean;
     }
+  | {
+      kind: "dev-script-failed";
+      progress: PhaseProgress;
+      logSource: string;
+      errorLine: string;
+      onRetry: () => void;
+      onOpenTerminal: () => void;
+      onBrowseFiles: () => void;
+      /** Drawer-open hides the inline peek (mutually exclusive surfaces). */
+      drawerOpen: boolean;
+    }
   | { kind: "suspended"; onResume: () => void }
   | { kind: "crashed"; onOpenTerminal: () => void };
 
@@ -56,12 +68,11 @@ export function VmStateCard(props: VmStateCardProps) {
         <Glyph kind={props.kind} />
         <Headline kind={props.kind} />
         <Subline {...props} />
-        {props.kind === "errored" && (
+        {(props.kind === "errored" || props.kind === "dev-script-failed") && (
           <PhaseStripView progress={props.progress} />
         )}
-        {props.kind === "errored" && !props.drawerOpen && (
-          <LogPeek source={props.logSource} />
-        )}
+        {(props.kind === "errored" || props.kind === "dev-script-failed") &&
+          !props.drawerOpen && <LogPeek source={props.logSource} />}
         <Footer {...props} />
       </div>
     </div>
@@ -78,6 +89,8 @@ function Glyph({ kind }: { kind: NonBootingKind }) {
     case "never-started":
       return <Monitor04 className={cn(cls, "text-muted-foreground/60")} />;
     case "errored":
+      return <AlertTriangle className={cn(cls, "text-destructive")} />;
+    case "dev-script-failed":
       return <AlertTriangle className={cn(cls, "text-destructive")} />;
     case "suspended":
       return <PauseCircle className={cn(cls, "text-blue-500")} />;
@@ -99,6 +112,15 @@ function Subline(props: Exclude<VmStateCardProps, { kind: "starting-now" }>) {
         </p>
       );
     case "errored":
+      return (
+        <p
+          role="alert"
+          className="max-w-sm break-words text-sm text-destructive/80"
+        >
+          {props.errorLine}
+        </p>
+      );
+    case "dev-script-failed":
       return (
         <p
           role="alert"
@@ -195,6 +217,20 @@ function Footer(props: Exclude<VmStateCardProps, { kind: "starting-now" }>) {
         <Button size="sm" onClick={props.onRetry} className="mt-2">
           <RefreshCw01 className="size-4" /> Retry
         </Button>
+      );
+    case "dev-script-failed":
+      return (
+        <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+          <Button size="sm" onClick={props.onRetry}>
+            <RefreshCw01 className="size-4" /> Retry
+          </Button>
+          <Button size="sm" variant="outline" onClick={props.onBrowseFiles}>
+            <Code02 className="size-4" /> Browse files
+          </Button>
+          <Button size="sm" variant="outline" onClick={props.onOpenTerminal}>
+            <Terminal className="size-4" /> View logs
+          </Button>
+        </div>
       );
     case "suspended":
       return (

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.339.4",
+      "version": "2.340.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },

--- a/packages/sandbox/daemon/loopback.ts
+++ b/packages/sandbox/daemon/loopback.ts
@@ -22,18 +22,39 @@ export type LoopbackHost = "::1" | "127.0.0.1";
 function canConnect(host: LoopbackHost, port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const sock = connect({ host, port });
+    let connected = false;
     let done = false;
     const finish = (ok: boolean) => {
       if (done) return;
       done = true;
       clearTimeout(timer);
       try {
-        sock.destroy();
+        if (connected) {
+          // Two things have to happen for a clean FIN close:
+          //   1. We send FIN on our write side (`sock.end()`).
+          //   2. We READ whatever upstream sends back. Otherwise unread
+          //      bytes pile up in our OS receive buffer, and when the
+          //      socket finally closes, the kernel sends RST instead of
+          //      FIN (BSD/Linux behavior — discarding unread data is
+          //      signaled with RST).
+          // Vite's HTTP server replies to our empty connection with a 400.
+          // Without the drain below, that 400 stays unread, the close RSTs
+          // Vite, and Vite (on Node 24) exits the process on the unhandled
+          // socket `error` event.
+          sock.on("data", () => {});
+          sock.on("error", () => {});
+          sock.end();
+        } else {
+          sock.destroy();
+        }
       } catch {}
       resolve(ok);
     };
     const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
-    sock.once("connect", () => finish(true));
+    sock.once("connect", () => {
+      connected = true;
+      finish(true);
+    });
     sock.once("error", () => finish(false));
   });
 }

--- a/packages/sandbox/daemon/probe.ts
+++ b/packages/sandbox/daemon/probe.ts
@@ -86,15 +86,22 @@ async function head(
   port: number,
   timeoutMs: number,
 ): Promise<HeadResult | null> {
+  // Explicit AbortController + clearTimeout instead of AbortSignal.timeout().
+  // The latter keeps the timer alive past a successful fetch, and a late abort
+  // can poison a connection in Bun's keep-alive pool.
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
   try {
     const res = await fetchLoopback(port, "/", {
       method: "HEAD",
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: ac.signal,
     });
     const ct = (res.headers.get("content-type") ?? "").toLowerCase();
     return { status: res.status, isHtml: ct.includes("text/html") };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/sandbox/daemon/ws-proxy.ts
+++ b/packages/sandbox/daemon/ws-proxy.ts
@@ -7,14 +7,29 @@
  * triggers a full-page reload as recovery — the user sees the page load
  * then immediately reload, in a loop.
  *
- * On upgrade we stash the upstream port, path/query, and the client's
- * negotiated subprotocols in ws.data, then open the upstream WS on the
- * `open` callback and bridge frames in both directions. Subprotocols
- * (`vite-hmr`, `vite-ping`, …) are forwarded — Vite ignores connections
- * that drop them. The upstream loopback (IPv4 vs IPv6) is picked by a
- * TCP probe before connecting, so a mid-handshake failure never silently
- * retries on the other family.
+ * Implementation notes:
+ *
+ * We CANNOT use Bun's global `WebSocket` or the `ws` npm package as the
+ * client to upstream. Bun shims `ws` to its native WebSocket, and Bun's
+ * WebSocket client closes its TCP socket with RST instead of FIN. Vite
+ * on Node 24 emits an unhandled `error` event on the receiving socket
+ * when it sees that RST, which exits the dev-server process.
+ *
+ * Instead we hand-roll the upstream side using `node:http.request` with
+ * upgrade headers. The 'upgrade' event hands us the raw TCP socket post-
+ * handshake; we then implement WebSocket framing inline to bridge bytes
+ * between Bun.serve's already-decoded messages and the raw upstream
+ * socket. Closing that socket goes through Node's standard FIN path —
+ * no RST.
+ *
+ * Subprotocols (`vite-hmr`, `vite-ping`, …) are forwarded — Vite ignores
+ * connections that drop them. The upstream loopback (IPv4 vs IPv6) is
+ * picked by a TCP probe before connecting, so a mid-handshake failure
+ * never silently retries on the other family.
  */
+import { randomBytes } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import type { Socket } from "node:net";
 import type { ServerWebSocket } from "bun";
 import { bracketHost, pickLoopback } from "./loopback";
 
@@ -33,7 +48,8 @@ export interface WsProxyData {
   pathQuery: string;
   /** Subprotocols the client advertised on the upgrade request. */
   protocols: string[] | undefined;
-  upstream: WebSocket | null;
+  /** Raw TCP socket to upstream after the WS handshake, or null pre-handshake. */
+  upstream: Socket | null;
   /** Frames received from the client before the upstream handshake completes. */
   pending: (string | ArrayBuffer | Uint8Array)[];
 }
@@ -82,10 +98,9 @@ export function makeWsUpgrader(
     message(ws: ServerWebSocket<WsProxyData>, message: string | Buffer): void {
       opts.onClientMessage?.();
       const upstream = ws.data.upstream;
-      const frame = typeof message === "string" ? message : message.buffer;
-      if (upstream && upstream.readyState === WebSocket.OPEN) {
+      if (upstream && !upstream.destroyed) {
         try {
-          upstream.send(frame as never);
+          upstream.write(encodeFrame(message, /* isClient */ true));
         } catch {}
         return;
       }
@@ -95,16 +110,21 @@ export function makeWsUpgrader(
           ws.close(1011, "ws-proxy backlog overflow");
         } catch {}
         try {
-          ws.data.upstream?.close();
+          ws.data.upstream?.end();
         } catch {}
         return;
       }
-      ws.data.pending.push(frame as ArrayBuffer | string);
+      ws.data.pending.push(message as ArrayBuffer | string);
     },
 
     close(ws: ServerWebSocket<WsProxyData>): void {
+      const sock = ws.data.upstream;
+      if (!sock || sock.destroyed) return;
       try {
-        ws.data.upstream?.close();
+        sock.write(encodeFrame(Buffer.alloc(0), true, /* opcode */ 0x8)); // close frame
+      } catch {}
+      try {
+        sock.end();
       } catch {}
     },
   };
@@ -124,32 +144,184 @@ async function connectUpstream(
     } catch {}
     return;
   }
-  const target = `ws://${bracketHost(host)}:${port}${ws.data.pathQuery}`;
-  const upstream = new WebSocket(target, ws.data.protocols);
-  upstream.binaryType = "arraybuffer";
-  ws.data.upstream = upstream;
-
-  upstream.addEventListener("open", () => {
+  const wsKey = randomBytes(16).toString("base64");
+  const headers: Record<string, string> = {
+    Host: `${bracketHost(host)}:${port}`,
+    Upgrade: "websocket",
+    Connection: "Upgrade",
+    "Sec-WebSocket-Key": wsKey,
+    "Sec-WebSocket-Version": "13",
+  };
+  if (ws.data.protocols && ws.data.protocols.length > 0) {
+    headers["Sec-WebSocket-Protocol"] = ws.data.protocols.join(", ");
+  }
+  const req = httpRequest({
+    host,
+    port,
+    path: ws.data.pathQuery,
+    method: "GET",
+    headers,
+  });
+  req.on("error", () => {
+    try {
+      ws.close();
+    } catch {}
+  });
+  req.on("response", () => {
+    // Vite refused the upgrade — close the client.
+    try {
+      ws.close();
+    } catch {}
+  });
+  req.on("upgrade", (_res, socket) => {
+    ws.data.upstream = socket;
+    // Server frames (upstream → client) are never masked. Decode and forward.
+    const decoder = createFrameDecoder((opcode, payload) => {
+      try {
+        if (opcode === 0x1) {
+          ws.send(payload.toString("utf8"));
+        } else if (opcode === 0x2) {
+          ws.send(payload);
+        } else if (opcode === 0x8) {
+          // close
+          try {
+            ws.close();
+          } catch {}
+        }
+        // ping/pong: Bun.serve handles its side; ignore upstream's.
+      } catch {}
+    });
+    socket.on("data", (chunk: Buffer) => decoder(chunk));
+    socket.on("close", () => {
+      try {
+        ws.close();
+      } catch {}
+    });
+    socket.on("error", () => {
+      try {
+        ws.close();
+      } catch {}
+    });
+    // Flush any frames that arrived from the client before handshake completed.
     for (const frame of ws.data.pending) {
       try {
-        upstream.send(frame as never);
+        socket.write(encodeFrame(frame, true));
       } catch {}
     }
     ws.data.pending.length = 0;
   });
-  upstream.addEventListener("message", (e) => {
-    try {
-      ws.send(e.data as never);
-    } catch {}
-  });
-  upstream.addEventListener("close", () => {
-    try {
-      ws.close();
-    } catch {}
-  });
-  upstream.addEventListener("error", () => {
-    try {
-      ws.close();
-    } catch {}
-  });
+  req.end();
+}
+
+/**
+ * Encode a WebSocket data frame. `isClient=true` masks the payload (required
+ * for client→server frames per RFC 6455 §5.3). Default opcode is text/binary
+ * derived from the payload type; pass `opcode` to override (e.g. 0x8 for close).
+ */
+function encodeFrame(
+  payload: string | Buffer | ArrayBuffer | Uint8Array,
+  isClient: boolean,
+  opcode?: number,
+): Buffer {
+  let payloadBuf: Buffer;
+  let inferredOpcode: number;
+  if (typeof payload === "string") {
+    payloadBuf = Buffer.from(payload, "utf8");
+    inferredOpcode = 0x1;
+  } else if (payload instanceof ArrayBuffer) {
+    payloadBuf = Buffer.from(payload);
+    inferredOpcode = 0x2;
+  } else if (Buffer.isBuffer(payload)) {
+    payloadBuf = payload;
+    inferredOpcode = 0x2;
+  } else {
+    payloadBuf = Buffer.from(payload as Uint8Array);
+    inferredOpcode = 0x2;
+  }
+  const op = opcode ?? inferredOpcode;
+  const len = payloadBuf.length;
+
+  const header: number[] = [];
+  header.push(0x80 | (op & 0x0f)); // FIN=1, opcode
+
+  const maskBit = isClient ? 0x80 : 0x00;
+  if (len < 126) {
+    header.push(maskBit | len);
+  } else if (len < 65536) {
+    header.push(maskBit | 126, (len >> 8) & 0xff, len & 0xff);
+  } else {
+    // 64-bit length. JS integers are safe up to 2^53; high 32 bits are 0
+    // for any payload size we'll ever see.
+    header.push(maskBit | 127, 0, 0, 0, 0);
+    header.push(
+      (len >>> 24) & 0xff,
+      (len >>> 16) & 0xff,
+      (len >>> 8) & 0xff,
+      len & 0xff,
+    );
+  }
+
+  if (isClient) {
+    const mask = randomBytes(4);
+    const masked = Buffer.alloc(len);
+    for (let i = 0; i < len; i++) masked[i] = payloadBuf[i] ^ mask[i & 3];
+    return Buffer.concat([Buffer.from(header), mask, masked]);
+  }
+  return Buffer.concat([Buffer.from(header), payloadBuf]);
+}
+
+/**
+ * Stateful WS frame decoder for incoming server frames (unmasked). Returns a
+ * function that takes a chunk of bytes and invokes `onFrame` once per complete
+ * frame. Buffers partial frames across chunks.
+ *
+ * Only handles non-fragmented frames in practice — Vite's HMR sends each
+ * message as a single frame with FIN=1. Continuation frames would be dropped
+ * (good enough for the use case; HMR doesn't use them).
+ */
+function createFrameDecoder(
+  onFrame: (opcode: number, payload: Buffer) => void,
+): (chunk: Buffer) => void {
+  let buf: Buffer = Buffer.alloc(0);
+  return (chunk: Buffer) => {
+    buf = buf.length === 0 ? chunk : Buffer.concat([buf, chunk]);
+    while (true) {
+      if (buf.length < 2) return;
+      const b0 = buf[0];
+      const b1 = buf[1];
+      const opcode = b0 & 0x0f;
+      const masked = (b1 & 0x80) !== 0;
+      let payloadLen = b1 & 0x7f;
+      let offset = 2;
+      if (payloadLen === 126) {
+        if (buf.length < offset + 2) return;
+        payloadLen = (buf[offset] << 8) | buf[offset + 1];
+        offset += 2;
+      } else if (payloadLen === 127) {
+        if (buf.length < offset + 8) return;
+        // Skip high 32 bits (must be 0 for any realistic payload).
+        const lo =
+          buf[offset + 4] * 0x1000000 +
+          ((buf[offset + 5] << 16) | (buf[offset + 6] << 8) | buf[offset + 7]);
+        payloadLen = lo;
+        offset += 8;
+      }
+      let maskKey: Buffer | null = null;
+      if (masked) {
+        if (buf.length < offset + 4) return;
+        maskKey = buf.subarray(offset, offset + 4);
+        offset += 4;
+      }
+      if (buf.length < offset + payloadLen) return;
+      let payload = buf.subarray(offset, offset + payloadLen);
+      if (maskKey) {
+        const unmasked = Buffer.alloc(payloadLen);
+        for (let i = 0; i < payloadLen; i++)
+          unmasked[i] = payload[i] ^ maskKey[i & 3];
+        payload = unmasked;
+      }
+      buf = buf.subarray(offset + payloadLen);
+      onFrame(opcode, payload);
+    }
+  };
 }

--- a/packages/sandbox/daemon/ws-proxy.ts
+++ b/packages/sandbox/daemon/ws-proxy.ts
@@ -173,7 +173,7 @@ async function connectUpstream(
       ws.close();
     } catch {}
   });
-  req.on("upgrade", (_res, socket) => {
+  req.on("upgrade", (_res, socket, head: Buffer) => {
     ws.data.upstream = socket;
     // Server frames (upstream → client) are never masked. Decode and forward.
     const decoder = createFrameDecoder((opcode, payload) => {
@@ -183,7 +183,6 @@ async function connectUpstream(
         } else if (opcode === 0x2) {
           ws.send(payload);
         } else if (opcode === 0x8) {
-          // close
           try {
             ws.close();
           } catch {}
@@ -191,6 +190,10 @@ async function connectUpstream(
         // ping/pong: Bun.serve handles its side; ignore upstream's.
       } catch {}
     });
+    // `head` carries any bytes that arrived in the same TCP segment as the
+    // upgrade response — feed them through the decoder before attaching the
+    // socket data listener, otherwise the first upstream frame is dropped.
+    if (head.length > 0) decoder(head);
     socket.on("data", (chunk: Buffer) => decoder(chunk));
     socket.on("close", () => {
       try {


### PR DESCRIPTION
- Added new lifecycle failure states to `PreviewStateInput` and updated `computePreviewState` to handle "dev-script-failed" scenarios.
- Introduced tests for various lifecycle failure cases in `preview-state.test.ts`.
- Updated UI components to reflect new lifecycle failure states, including state card and view mode options.
- Bumped version to 2.340.0 in `bun.lock`.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new preview state for dev-script lifecycle failures with a recovery UI, and hardens the WS proxy and probes to stop Vite crashes and preview reload loops. Also keeps the toolbar stable and view mode valid when the iframe is down.

- **New Features**
  - Introduced `dev-script-failed` state when `clone/install/start` fails, with error details and tests.
  - UI: new state card (Retry, View logs, Browse files); gate `visual`/`cms` to a live iframe; add `effectiveViewMode` to fall back to `preview` when the iframe isn’t available; keep Code mode and the top toolbar available when the daemon is up.
  - Extended `PreviewStateInput` with `lifecycleFailure` and `lifecycleFailureError`.

- **Bug Fixes**
  - Replaced upstream WS client with Node HTTP upgrade + manual WS framing in `ws-proxy`; forwards subprotocols, buffers early frames, and closes cleanly to prevent Vite exits.
  - Loopback TCP probe now drains and FIN-closes sockets to avoid RSTs that could crash the dev server.
  - HEAD probe uses an `AbortController` with a manual timeout to prevent late aborts from poisoning keep-alive connections.

<sup>Written for commit ce44ed8e193c657f1217b862b92fa1c7fb71bc35. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

