### PR TITLE
fix(web): stop archived threads from resurrecting in the tasks panel

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-model-popover.test.tsx
+++ b/apps/mesh/src/web/components/chat/agent-model-popover.test.tsx
@@ -58,7 +58,7 @@ describe("AgentModelPopover", () => {
         onSelect={onSelect}
       />,
     );
-    getByText("Haiku").click();
+    getByText("Haiku 4.5").click();
     expect(onSelect).toHaveBeenCalledWith("claude-code", "fast");
   });
 

--- a/apps/mesh/src/web/components/chat/agent-model-trigger.test.tsx
+++ b/apps/mesh/src/web/components/chat/agent-model-trigger.test.tsx
@@ -67,7 +67,7 @@ describe("AgentModelTriggerPure", () => {
         onSelect={() => {}}
       />,
     );
-    expect(getByText("Opus")).toBeInTheDocument();
+    expect(getByText("Opus 4.7")).toBeInTheDocument();
   });
 
   test("label reflects the active Decopilot tier label (Smart)", () => {

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -87,7 +87,7 @@ function statusToString(s: ConnStatus): ChatStreamContextValue["status"] {
 }
 
 import { useChatNavigation } from "./hooks/use-chat-navigation";
-import { useThreadActions, useThreadManager, useThreads } from "./store/hooks";
+import { useThreadActions, useThreadManager } from "./store/hooks";
 import { derivePartsFromTiptapDoc } from "./derive-parts";
 import type { VirtualMCPInfo } from "./select-virtual-mcp";
 import type { ChatMessage, ChatMode, Metadata } from "./types";
@@ -586,8 +586,9 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
 
 export function ChatContextProvider({
   virtualMcpId,
+  task,
   children,
-}: PropsWithChildren<{ virtualMcpId: string }>) {
+}: PropsWithChildren<{ virtualMcpId: string; task: Task | null }>) {
   const { locator } = useProjectContext();
   const { data: session } = authClient.useSession();
   const user = session?.user ?? null;
@@ -603,8 +604,6 @@ export function ChatContextProvider({
   const [preferences] = usePreferences();
   const { markTaskRead } = useTaskReadState();
 
-  // Resolve the active thread directly from the manager's snapshot by id.
-  const { threads: allThreads } = useThreads();
   const threadActions = useThreadActions();
 
   // taskId always comes from the URL (seeded by router's validateSearch)
@@ -627,9 +626,12 @@ export function ChatContextProvider({
     });
   };
 
-  const activeTask = effectiveTaskId
-    ? (allThreads.find((t) => t.id === effectiveTaskId) ?? null)
-    : null;
+  // The active task row is resolved by the route layout via `useEnsureTask`
+  // and threaded in as a prop, so this provider doesn't need to read the
+  // panel-visible threads slot. Guard against transient prop/URL skew during
+  // navigation by only honoring the prop when ids match.
+  const activeTask =
+    effectiveTaskId && task?.id === effectiveTaskId ? task : null;
   const currentBranch = activeTask?.branch ?? null;
   const isBranchLocked = !!activeTask?.branch;
 

--- a/apps/mesh/src/web/components/chat/store/thread-manager-store.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-manager-store.test.ts
@@ -443,8 +443,11 @@ describe("ThreadManagerStore.fetchThread", () => {
     const row = await store.fetchThread("t-archived");
     expect(row?.id).toBe("t-archived");
     expect(row?.title).toBe("Old thread");
-    // Row should be merged into the local list.
-    expect(store.threads.get().some((t) => t.id === "t-archived")).toBe(true);
+    // fetchThread is a pure read: the row is returned to the caller but
+    // NOT inserted into the panel-visible threads slot. Otherwise an
+    // archived row (or an in-flight just-hidden row, before its UPDATE
+    // commits server-side) could resurrect itself in the panel cache.
+    expect(store.threads.get().some((t) => t.id === "t-archived")).toBe(false);
     store.dispose();
   });
 

--- a/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
@@ -343,14 +343,15 @@ export class ThreadManagerStore {
   }
 
   /**
-   * Resolve a thread by id. Checks the loaded `threads` slot first; falls
-   * back to a `COLLECTION_THREADS_GET` MCP call when the row isn't in the
-   * loaded set (e.g., direct link to an older thread past page 0 or to an
-   * archived thread). Returns null if the thread doesn't exist server-side
-   * or the MCP call fails.
+   * Resolve a thread by id without mutating the `threads` slot. Checks the
+   * loaded set first to skip a round-trip; otherwise issues
+   * `COLLECTION_THREADS_GET`. Returns null if the thread doesn't exist
+   * server-side or the MCP call fails.
    *
-   * Resolved rows are merged into the local list so subsequent lookups hit
-   * the fast path.
+   * The `threads` slot represents threads loaded for the panel (filtered
+   * server-side by `hidden: false`); merging arbitrary by-id GET results
+   * into it would resurrect archived rows in the panel cache, so this
+   * method intentionally returns the row without inserting.
    */
   async fetchThread(id: string): Promise<Task | null> {
     if (!id) return null;
@@ -365,17 +366,7 @@ export class ThreadManagerStore {
       if ((result as { isError?: boolean }).isError) return null;
       const payload = ((result as { structuredContent?: unknown })
         .structuredContent ?? result) as { item?: Task | null };
-      const row = payload.item ?? null;
-      if (row) {
-        // Merge into the local list so future lookups are local. The row may
-        // already be present if a concurrent event arrived between the
-        // find() above and this fetch; dedupe by id.
-        this.threads.update((list) => {
-          if (list.some((t) => t.id === row.id)) return list;
-          return [row, ...list];
-        });
-      }
-      return row;
+      return payload.item ?? null;
     } catch {
       return null;
     }

--- a/apps/mesh/src/web/hooks/use-ensure-task.ts
+++ b/apps/mesh/src/web/hooks/use-ensure-task.ts
@@ -19,8 +19,10 @@
  * Fetch path: when the store doesn't know the id AND the watcher has moved
  * past `loading`, call `manager.fetchThread(id)` first. This handles
  * direct links to threads beyond page 0 or archived threads without firing
- * a spurious CREATE. `fetchThread` merges the found row into the loaded list
- * so subsequent lookups hit the fast path and `chat-context` also sees the row.
+ * a spurious CREATE. `fetchThread` is a pure read — the resolved row is held
+ * in this hook's local state and passed downstream via the `task` prop on
+ * `Chat.Provider`, so archived/by-id GET results never pollute the
+ * panel-visible `threads` slot.
  *
  * Slow path (create): only fires when `fetchThread` returns null (the row
  * genuinely doesn't exist server-side). `COLLECTION_THREADS_CREATE` is
@@ -105,8 +107,6 @@ export function useEnsureTask(id: string, virtualMcpId: string): State {
 
   if (!id) return { status: "ready", task: null };
   if (localHit) return { status: "ready", task: localHit };
-  // fetchedTask is a Task when fetchThread returned a row (already in local list
-  // via merge, but localHit above may not have updated yet in the same render).
   if (fetchedTask && typeof fetchedTask === "object") {
     return { status: "ready", task: fetchedTask };
   }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -433,7 +433,11 @@ function AgentInsetProvider() {
     return (
       <InsetContext value={insetContextValue}>
         <div className="flex flex-col flex-1 bg-background min-h-0">
-          <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
+          <Chat.Provider
+            key={chatVirtualMcpId}
+            virtualMcpId={chatVirtualMcpId}
+            task={ensureState.status === "ready" ? ensureState.task : null}
+          >
             <VmEventsBridge
               virtualMcpId={virtualMcpId}
               hasActiveGithubRepo={hasActiveGithubRepo}
@@ -509,7 +513,11 @@ function AgentInsetProvider() {
           />
         </Toolbar.Toggles>
 
-        <Chat.Provider key={chatVirtualMcpId} virtualMcpId={chatVirtualMcpId}>
+        <Chat.Provider
+          key={chatVirtualMcpId}
+          virtualMcpId={chatVirtualMcpId}
+          task={ensureState.status === "ready" ? ensureState.task : null}
+        >
           <Toolbar.Tabs>
             <MainPanelTabsBar
               virtualMcpId={virtualMcpId}


### PR DESCRIPTION
## What is this contribution about?

When archiving the active task from the tasks panel, the row briefly disappeared and then re-appeared. Root cause: `ThreadManagerStore.fetchThread` was a by-id GET that also wrote its result into the panel-visible `threads` slot — when `useEnsureTask` re-rendered after the optimistic hide (localHit gone), it fired `COLLECTION_THREADS_GET` for the just-archived id, raced the in-flight `COLLECTION_THREADS_UPDATE`, and merged the row back into the panel cache. This refactor separates the two responsibilities: `fetchThread` is now a pure read, and `ChatContextProvider` receives the active task via a new `task` prop sourced from `useEnsureTask` in the route layout, so the panel slot is only ever touched by paths that respect its `hidden: false` invariant.

## Screenshots/Demonstration

Verified in browser: archive active task (3→2, stays at 2), archive non-active task (2→1, stays at 1), deep-link to an archived task (chat renders, archived row stays out of panel). No console errors.

## How to Test

1. Open the tasks panel with several tasks.
2. Archive the currently active task. Panel count should decrement and stay decremented; URL redirects to the next task.
3. Archive a non-active task. Panel count decrements, URL unchanged.
4. Open a URL pointing directly at an archived task. The chat view should still render with the archived task's branch/title, but the archived row must NOT appear in the panel list.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`bun run check`, `bun run lint`, `bun test apps/mesh/src/web/components/chat/store/`, manual browser verification)
- [x] No breaking changes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where archived tasks briefly reappeared in the tasks panel. By-id fetches no longer mutate the panel list, and the active task is passed into `Chat.Provider` via a new `task` prop. Also updates agent model selector tests to match the new labels.

- **Bug Fixes**
  - Made `ThreadManagerStore.fetchThread` a pure read (no writes to `threads`).
  - Resolved the active task in the route with `useEnsureTask` and passed it to `ChatContextProvider` as `task`; the provider no longer reads from the panel list.
  - Preserves the panel’s `hidden: false` invariant; deep-links to archived tasks still render without repopulating the panel.
  - Updated `AgentModelPopover` and `AgentModelTrigger` tests to expect the new tier labels (e.g., "Haiku 4.5", "Opus 4.7").

<sup>Written for commit 53f5b52b6a239c992d9d21328f09a99c7754e6b9. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

