### PR TITLE
fix(chat): drop async-research stub when live message covers the tool call

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection-replay.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection-replay.test.ts
@@ -191,6 +191,166 @@ describe("UI message stream replay (web_search)", () => {
     expect(String(combined?.message ?? "")).toContain(TOOL_CALL_ID);
   });
 
+  test("reattach mid-research with stub seed: web_search completes and follow-up steps fold cleanly", async () => {
+    // The customer scenario: proxy cuts SSE every ~2 minutes. On
+    // reattach, the client refetches the DB (which now contains the
+    // `msg_async_stub_<toolCallId>` row written at markPolling time)
+    // and starts a fresh foldSubStream seeded with that stub. The
+    // JetStream subject's 5-minute retention has aged out the original
+    // `start` / `start-step` / `tool-input-*` chunks, so the new
+    // SSE response begins with `data-web-search` and proceeds straight
+    // to `tool-output-available` (web_search done), then a chain of
+    // follow-up tool calls, then a text answer, then `finish`.
+    //
+    // Production symptom: the UI gets stuck on the web_search loading
+    // skeleton even though the stream completes cleanly. A page
+    // refresh fixes it (loadInitialPage replaces the stub with the
+    // fully-populated assistant row).
+    //
+    // This test exercises the reader exactly as foldSubStream does:
+    // seed = the persisted stub, no `start` chunk, the rest of the
+    // run. If the final emitted message has the tool-web_search part
+    // in `output-available` state plus the follow-up text, the SDK
+    // reader path is fine and the bug lives in our wrapper (most
+    // likely in how messages reconcile after refetch). If it doesn't,
+    // we've reproduced the bug at the SDK layer.
+    const STUB_ID = "msg_async_stub_" + TOOL_CALL_ID;
+    const FOLLOWUP_TOOL_CALL_ID = "tc_followup_1";
+    const FINAL_TEXT = "Aqui está o relatório final.";
+
+    const stubSeed: UIMessage = {
+      id: STUB_ID,
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-web_search",
+          toolCallId: TOOL_CALL_ID,
+          state: "input-available",
+          input: { query: QUERY },
+        },
+      ],
+    } as unknown as UIMessage;
+
+    // Chunks the client sees on this reattach: no start, no start-step
+    // for the web_search step (those aged out of JetStream). Mirrors
+    // the production capture in
+    // .context/attachments/.../pasted_text_2026-05-22_15-20-03.txt.
+    const reattachChunks: UIMessageChunk[] = [
+      // Late progress chunks (text now non-empty as the report streams in)
+      {
+        type: "data-web-search",
+        id: TOOL_CALL_ID,
+        data: { text: REPORT.slice(0, 30) },
+      } as UIMessageChunk,
+      {
+        type: "data-web-search",
+        id: TOOL_CALL_ID,
+        data: { text: REPORT },
+      } as UIMessageChunk,
+      // web_search finishes
+      {
+        type: "data-tool-metadata",
+        id: TOOL_CALL_ID,
+        data: { latencyMs: 482_000 },
+      } as UIMessageChunk,
+      {
+        type: "tool-output-available",
+        toolCallId: TOOL_CALL_ID,
+        output: { success: true, content: REPORT, query: QUERY },
+      },
+      { type: "finish-step" },
+      { type: "message-metadata", messageMetadata: {} } as UIMessageChunk,
+      // Next step in the agent loop — follow-up tool call
+      { type: "start-step" },
+      {
+        type: "tool-input-start",
+        toolCallId: FOLLOWUP_TOOL_CALL_ID,
+        toolName: "DECO_SLIDES_CREATE",
+      },
+      {
+        type: "tool-input-delta",
+        toolCallId: FOLLOWUP_TOOL_CALL_ID,
+        inputTextDelta: JSON.stringify({ title: "Relatório" }),
+      },
+      {
+        type: "tool-input-available",
+        toolCallId: FOLLOWUP_TOOL_CALL_ID,
+        toolName: "DECO_SLIDES_CREATE",
+        input: { title: "Relatório" },
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: FOLLOWUP_TOOL_CALL_ID,
+        output: { id: "slides_1" },
+      },
+      { type: "finish-step" },
+      { type: "message-metadata", messageMetadata: {} } as UIMessageChunk,
+      // Final synthesis step — text deltas
+      { type: "start-step" },
+      { type: "text-start", id: "txt_1" } as UIMessageChunk,
+      {
+        type: "text-delta",
+        id: "txt_1",
+        delta: FINAL_TEXT,
+      } as UIMessageChunk,
+      { type: "text-end", id: "txt_1" } as UIMessageChunk,
+      { type: "finish-step" },
+      { type: "message-metadata", messageMetadata: {} } as UIMessageChunk,
+      { type: "finish" },
+    ];
+
+    const errors: unknown[] = [];
+    const iter = readUIMessageStream({
+      message: stubSeed,
+      stream: streamOf(reattachChunks),
+      onError: (e) => errors.push(e),
+    });
+
+    const { messages, error } = await drain(iter);
+    expect(error).toBeNull();
+    expect(errors).toEqual([]);
+
+    const final = messages.at(-1);
+    expect(final).toBeDefined();
+    // Should keep the stub's id (we seeded with it, and no `start`
+    // chunk arrived to rewrite it).
+    expect(final!.id).toBe(STUB_ID);
+
+    // The web_search tool part must have transitioned to output-available.
+    const webSearchPart = final!.parts.find(
+      (p) =>
+        typeof p === "object" &&
+        p !== null &&
+        "type" in p &&
+        (p as { type: string }).type === "tool-web_search",
+    ) as { state: string; output?: { content?: string } } | undefined;
+    expect(webSearchPart).toBeDefined();
+    expect(webSearchPart!.state).toBe("output-available");
+    expect(webSearchPart!.output?.content).toBe(REPORT);
+
+    // The follow-up tool call should be present and finished too.
+    const followupPart = final!.parts.find(
+      (p) =>
+        typeof p === "object" &&
+        p !== null &&
+        "type" in p &&
+        (p as { type: string }).type === "tool-DECO_SLIDES_CREATE",
+    ) as { state: string } | undefined;
+    expect(followupPart).toBeDefined();
+    expect(followupPart!.state).toBe("output-available");
+
+    // And the final synthesis text must have streamed in.
+    const textPart = final!.parts.find(
+      (p) =>
+        typeof p === "object" &&
+        p !== null &&
+        "type" in p &&
+        (p as { type: string }).type === "text",
+    ) as { text: string } | undefined;
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toContain(FINAL_TEXT);
+  });
+
   test("refresh AT completion with seed-from-DB containing tool-input recovers", async () => {
     // The fix-path: if we persist the tool-input-available part to
     // the DB when the row goes to 'polling', the client's

--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   __resetRegistry,
+  dropRedundantStubs,
   getOrOpenStream,
   mergeAndSort,
   type RequestOptions,
@@ -706,6 +707,69 @@ describe("mergeAndSort", () => {
       "u-1",
       "msg_A",
     ]);
+  });
+});
+
+// ─── async-research stub dedup ───────────────────────────────────────────────
+
+describe("dropRedundantStubs", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  const assistantMsg = (id: string, parts: any[] = []) =>
+    ({
+      id,
+      role: "assistant",
+      parts,
+      created_at: "2026-01-01T00:00:00Z",
+      // biome-ignore lint/suspicious/noExplicitAny: test helper
+    }) as any;
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
+  const userMsg = { id: "u1", role: "user", parts: [] } as any;
+  const TC = "tc_abc";
+
+  const stub = assistantMsg("msg_async_stub_" + TC, [
+    { type: "tool-web_search", toolCallId: TC, state: "input-available" },
+  ]);
+  const live = assistantMsg("msg_live", [
+    { type: "tool-web_search", toolCallId: TC, state: "output-available" },
+    { type: "text", text: "answer" },
+  ]);
+
+  test("drops stub when a live assistant message covers the toolCallId", () => {
+    const out = dropRedundantStubs([userMsg, stub, live]);
+    expect(out.map((m) => m.id)).toEqual(["u1", "msg_live"]);
+  });
+
+  test("keeps stub when no live message covers its toolCallId", () => {
+    const out = dropRedundantStubs([userMsg, stub]);
+    expect(out.map((m) => m.id)).toEqual(["u1", "msg_async_stub_" + TC]);
+  });
+
+  test("keeps stub when the live message covers a DIFFERENT toolCallId", () => {
+    const otherLive = assistantMsg("msg_live2", [
+      {
+        type: "tool-web_search",
+        toolCallId: "tc_other",
+        state: "input-available",
+      },
+    ]);
+    const out = dropRedundantStubs([userMsg, stub, otherLive]);
+    expect(out.map((m) => m.id).sort()).toEqual(
+      ["msg_async_stub_" + TC, "msg_live2", "u1"].sort(),
+    );
+  });
+
+  test("noop when there are no stubs (cheap fast path)", () => {
+    const out = dropRedundantStubs([userMsg, live]);
+    expect(out).toBe(out); // (sanity that it returns a list)
+    expect(out.map((m) => m.id)).toEqual(["u1", "msg_live"]);
+  });
+
+  test("mergeAndSort applies the dedup automatically", () => {
+    // Production scenario: refetch returns the persisted stub; the
+    // in-memory live message has the same tool-web_search part from
+    // the prior connection's fold. After mergeAndSort the stub is gone.
+    const out = mergeAndSort([live], [stub]);
+    expect(out.map((m) => m.id)).toEqual(["msg_live"]);
   });
 });
 

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -809,8 +809,12 @@ export class ThreadConnection {
     for await (const msg of iter) {
       last = msg;
       // Replace-by-id in place — the AI SDK reader emits the cumulative
-      // message each chunk; we mirror that into `messages`.
-      this.messages.update((curr) => upsertById(curr, msg));
+      // message each chunk; we mirror that into `messages`. `dropRedundantStubs`
+      // hides the persisted `msg_async_stub_*` row once the live message
+      // carries the same `tool-web_search` part (which happens on the
+      // first tool-input chunk), so we never render the stub alongside
+      // the real assistant turn on a reattach.
+      this.messages.update((curr) => dropRedundantStubs(upsertById(curr, msg)));
       if (this.status.get().kind !== "streaming") {
         this.status.set({ kind: "streaming" });
       }
@@ -848,6 +852,71 @@ function upsertById(list: UIMessage[], msg: UIMessage): UIMessage[] {
   return next;
 }
 
+const ASYNC_STUB_ID_PREFIX = "msg_async_stub_";
+
+/**
+ * Drop `msg_async_stub_<toolCallId>` rows when another assistant message
+ * already carries the matching `tool-web_search` part.
+ *
+ * The stub is inserted by the server at `markPolling` time (see
+ * `apps/mesh/src/storage/async-research-jobs.ts`) so a browser refresh
+ * during the long polling window has something to seed
+ * `readUIMessageStream` against — without it, the SDK throws
+ * "No tool invocation found" when the eventual `tool-output-available`
+ * chunk arrives.
+ *
+ * The collateral was that on a proxy-driven SSE reattach (customer's
+ * infra cuts every ~2 min), the client ends up with TWO assistant
+ * messages for the same turn: the persisted stub (refetched from the
+ * DB after the cut) and the in-memory AI-SDK message built from the
+ * first connection's chunks. The fold writes to the in-memory one,
+ * the stub stays frozen on its `input-available` state, and the UI
+ * shows what looks like a stuck loading skeleton next to the actual
+ * (correct) content. Refreshing the page hides this because
+ * `markCompleted` has already deleted the stub by then.
+ *
+ * Once the live assistant row carries the same `tool-web_search`
+ * part, the stub is redundant. Filtering it out at the
+ * write-to-`messages` boundary keeps it from ever rendering as a
+ * phantom turn.
+ */
+export function dropRedundantStubs(messages: UIMessage[]): UIMessage[] {
+  let hasStub = false;
+  for (const m of messages) {
+    if (m.id.startsWith(ASYNC_STUB_ID_PREFIX)) {
+      hasStub = true;
+      break;
+    }
+  }
+  if (!hasStub) return messages;
+
+  // Tool-call ids covered by NON-stub assistant messages. A stub whose
+  // suffix matches one of these is redundant.
+  const covered = new Set<string>();
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    if (m.id.startsWith(ASYNC_STUB_ID_PREFIX)) continue;
+    for (const p of m.parts) {
+      if (
+        p &&
+        typeof p === "object" &&
+        "type" in p &&
+        (p as { type: string }).type === "tool-web_search" &&
+        "toolCallId" in p
+      ) {
+        covered.add((p as { toolCallId: string }).toolCallId);
+      }
+    }
+  }
+  if (covered.size === 0) return messages;
+
+  return messages.filter((m) => {
+    if (!m.id.startsWith(ASYNC_STUB_ID_PREFIX)) return true;
+    const toolCallId = m.id.slice(ASYNC_STUB_ID_PREFIX.length);
+    return !covered.has(toolCallId);
+  });
+}
+
 /**
  * Merge `incoming` rows into `prev` (upsert by id), then sort the result
  * ascending by `(created_at, id)`. The id tiebreaker mirrors
@@ -872,7 +941,7 @@ export function mergeAndSort(
     if (ta !== tb) return ta - tb;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
-  return merged;
+  return dropRedundantStubs(merged);
 }
 
 /**


### PR DESCRIPTION
## Summary

Frontend-only fix for a UX regression on long deep-research runs over flaky proxies (the customer's infra cuts SSE every ~2 min). After a reattach, two assistant messages for the same turn could coexist in the rendered list — the persisted \`msg_async_stub_<toolCallId>\` row and the in-memory AI-SDK message — and the stub stayed frozen on its \`input-available\` state, rendering as a phantom \"Researching…\" skeleton next to the actual completed content. Page refresh hid it because \`markCompleted\` had already deleted the stub from the DB by then.

## Root cause

On reattach:

1. \`forceCloseSubStream(true)\` aborts the prior fold; the in-memory \`message_X\` (no \`created_at\`) stays in \`messages\`.
2. \`refetchLatestPage()\` pulls the stub from the DB. \`mergeAndSort\` upserts by id and sorts by \`created_at\` — \`message_X\` (no \`created_at\` → \`+Infinity\`) sorts last, so \`messages.at(-1)\` is \`message_X\`, not the stub.
3. The new fold uses \`message_X\` as the seed and correctly streams \`tool-output-available\` + follow-up tools + final text into it.
4. The stub is **never touched** — it stays in the list, rendering its loading skeleton.

A focused test that runs the customer's exact reattach SSE through \`readUIMessageStream\` with a stub-shaped seed passes cleanly — the SDK reader is fine; the bug is in our wrapper's message reconciliation.

## Fix

\`dropRedundantStubs\` in \`thread-connection.ts\` filters \`msg_async_stub_<toolCallId>\` rows when ANOTHER assistant message in the list already carries a \`tool-web_search\` part with the matching \`toolCallId\`. Applied in two places:

- \`mergeAndSort\` — catches all refetch paths (initial page, refetch-on-reconnect, fetch-older).
- The fold's \`upsertById\` call in \`foldSubStream\` — catches the stub the instant the live message gains the \`tool-web_search\` part from chunks, before any visible stale render.

Early-return when no stubs exist, so the cost on the vast majority of updates is one boolean check.

## Follow-up (not in this PR)

The architecturally correct fix is to **unify the stub id with the AI SDK's messageId** — predetermine \`messageId\` server-side and use it both as the stub's id and as the AI SDK stream's \`messageId\`. Then they're the same row from minute one and \`mergeAndSort\`'s upsert-by-id naturally handles everything. That's a bigger change touching \`dispatch-run.ts\` + AI SDK plumbing and worth doing as a planned follow-up; this PR unblocks the customer in the meantime.

## Test plan

- [x] 5 new unit tests for \`dropRedundantStubs\` (covers drop-when-covered, keep-when-not, keep-with-different-toolCallId, no-stub fast path, and \`mergeAndSort\` integration).
- [x] Regression scenario added to \`thread-connection-replay.test.ts\` that replays the customer's exact SSE shape (no \`start\` chunk at the front, since JetStream's 5-min retention would have aged it out on a 15-min run with proxy cuts every 2 min) through \`readUIMessageStream\` with a stub-shaped seed — confirms the SDK reader path is correct.
- [x] \`bun test\` for the two changed test files: 43/43 pass.
- [x] \`bun run check\` clean for the touched files (pre-existing typecheck errors in unrelated \`agent-section.test.tsx\` / \`agent-model-trigger.test.tsx\` exist on \`main\` and are unaffected by this PR).
- [x] \`bun run fmt\` no fixes applied.
- [x] \`bun run knip\` clean.
- [ ] Manual: customer to verify on next long research run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops async-research stubs when a live assistant message already covers the same tool call, fixing the phantom “Researching…” skeleton after SSE reconnects. Dedup runs on merge and during streaming so the stub never renders.

- **Bug Fixes**
  - Added `dropRedundantStubs` to remove `msg_async_stub_<toolCallId>` if a non-stub assistant has a matching `tool-web_search` part.
  - Applied in `mergeAndSort` and the fold’s `upsertById` path to catch refetch and live updates.
  - Fast path when no stubs exist to keep updates cheap.
  - Added 5 unit tests and a replay regression test matching the customer’s SSE trace.

<sup>Written for commit 078c0b280d7b16fffe1c4fa9e691b1da2c32c0cd. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3452?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

