### PR TITLE
test(decopilot): restore module mocks so siblings see real impls

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -3,13 +3,28 @@
  * resolution.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "@/core/mesh-context";
 import type { Capability } from "@/links/protocol";
 import { createInMemoryLinkRegistry } from "../../../links/link-registry";
 import { computeIdempotencyKey } from "./routes";
 import type { ChatMessage } from "./types";
+
+// Capture the REAL implementations of every module we mock below so we
+// can put them back in `afterAll`. Static imports are hoisted to the
+// top of the module and evaluated before the `mock.module()` calls
+// further down, so these references point at the originals. Without
+// these the mocks installed by this file persist for the entire shard
+// and break sibling tests (e.g. model-permissions.test.ts, which
+// imports `./model-permissions` and ends up reading our stub instead
+// of the real functions).
+const _realModelPermissions = await import("./model-permissions");
+const _realResolveTier = await import("@/core/resolve-tier");
+const _realDispatchQueue = await import("@/dispatch-queue");
+const _realResolveDefaultSandboxProviderKind = await import(
+  "@/sandbox/resolve-default-provider-kind"
+);
 
 describe("computeIdempotencyKey", () => {
   test("returns undefined for no message", () => {
@@ -440,4 +455,20 @@ describe("POST /messages — first-message pinning", () => {
     // Pins were already set — no update should be written.
     expect(threadUpdateSpy).not.toHaveBeenCalled();
   });
+});
+
+// Restore the originals at the end of the shard. Bun's `mock.module()`
+// replaces the module registry process-wide, so without re-pointing
+// these modules back to their real implementations any sibling test
+// file that runs after us in the same `bun test ...` invocation
+// continues to see our stubs. See the captured `_real*` namespaces at
+// the top of this file.
+afterAll(() => {
+  mock.module("./model-permissions", () => _realModelPermissions);
+  mock.module("@/core/resolve-tier", () => _realResolveTier);
+  mock.module("@/dispatch-queue", () => _realDispatchQueue);
+  mock.module(
+    "@/sandbox/resolve-default-provider-kind",
+    () => _realResolveDefaultSandboxProviderKind,
+  );
 });


### PR DESCRIPTION
## What is this contribution about?

`apps/mesh/src/api/routes/decopilot/routes.test.ts` uses Bun's `mock.module()` to stub `./model-permissions`, `@/core/resolve-tier`, `@/dispatch-queue`, and `@/sandbox/resolve-default-provider-kind`, but Bun replaces these in the module registry **process-wide** and the file never restored them. When CI shard 0 ran `routes.test.ts` before `model-permissions.test.ts` in the same `bun test` invocation, the latter imported the stub `() => true` for `checkModelPermission` and `() => ({})` for `parseModelsToMap`, failing every "should deny" / object-shape assertion (13 failures). This was a pre-existing main failure — see run `26306333156` on main where shard 0 failed with the same 13 tests.

The fix captures the real module references via top-level `await import(...)` (a snapshot, unlike `import * as` which is a live view that would update with the mock) before the `mock.module()` calls, then re-installs them in `afterAll`.

## How to Test

1. Run shard 0 in the same order CI uses: `bun test apps/mesh/src/api/routes/decopilot/routes.test.ts apps/mesh/src/api/routes/decopilot/conversation.test.ts apps/mesh/src/api/routes/decopilot/model-permissions.test.ts`.
2. Before this PR: 13 failures in `model-permissions.test.ts`. After: 47/47 pass.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore real module implementations after Bun `mock.module()` in `routes.test.ts` to stop process‑wide mock leakage and fix shard 0 test failures. Sibling tests now import real functions instead of stubs.

- **Bug Fixes**
  - Capture real modules via top‑level `await import(...)` for `./model-permissions`, `@/core/resolve-tier`, `@/dispatch-queue`, `@/sandbox/resolve-default-provider-kind`.
  - Reinstall originals in `afterAll` with `mock.module(...)`.
  - Verified in CI order: previously 13 failures in `model-permissions.test.ts`; now all pass.

<sup>Written for commit 99a220b45cea667652db658d07eb0f8eed501f22. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3454?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

