### PR TITLE
fix(deps): bump @deco-cx/warp-node to 0.3.23 to fix link-tunnel HMR

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@clickhouse/client": "^1.8.1",
     "@dbos-inc/dbos-sdk": "^4.17.6",
-    "@deco-cx/warp-node": "^0.3.20",
+    "@deco-cx/warp-node": "^0.3.23",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.340.0",
+      "version": "2.343.5",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -66,7 +66,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1013.0",
         "@clickhouse/client": "^1.8.1",
         "@dbos-inc/dbos-sdk": "^4.17.6",
-        "@deco-cx/warp-node": "^0.3.20",
+        "@deco-cx/warp-node": "^0.3.23",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -655,7 +655,7 @@
 
     "@dbos-inc/dbos-sdk": ["@dbos-inc/dbos-sdk@4.17.6", "", { "dependencies": { "commander": "12.0.0", "pg": "8.11.3", "serialize-error": "8.1.0", "superjson": "^1.13.3", "ws": "^8.18.1", "yaml": "^2.8.3" }, "bin": { "dbos": "dist/src/cli/cli.js", "dbos-sdk": "dist/src/cli/cli.js" } }, "sha512-1wt9eESm1AHKnmCWG9pOrzsmroJYLiujVKldi/hlyDXeCAyYmdKRcERtEzUZgPN2zOOSNJcsdf9ItWUacSnROQ=="],
 
-    "@deco-cx/warp-node": ["@deco-cx/warp-node@0.3.20", "", { "dependencies": { "undici": "^6.21.0", "ws": "^8.18.0" } }, "sha512-rdRWrT5eMhu1zhAzliRkoQCUr2j6Dg9npUKoP4uP+rV9wIbYKSmXJbM2z/fOiy5FVvzQlpvY16ACNRIRz+UWqw=="],
+    "@deco-cx/warp-node": ["@deco-cx/warp-node@0.3.23", "", { "dependencies": { "undici": "^6.21.0", "ws": "^8.18.0" } }, "sha512-GMh6Msj62wAvc+YbmIc8FoaIZy/cGUlEwR+FbgDl/08TomJRd3jCV8Tbrb38dIAdHlkmEc5UviLAnx5rfet3OQ=="],
 
     "@deco/ui": ["@deco/ui@workspace:packages/ui"],
 


### PR DESCRIPTION
## What is this contribution about?

Bumps `@deco-cx/warp-node` from `^0.3.20` → `^0.3.23` to fix dev-server HMR through the link daemon's Warp tunnel.

0.3.20 calls `new WebSocket(new URL(reqPath, "http://127.0.0.1:<daemonPort>"))` in `handlers.client.ts` without coercing the scheme. Node's undici silently rewrites `http:` → `ws:`, so this went unnoticed in Node-hosted callers — but Bun keeps the scheme as-is and the handshake fails immediately. Since `bunx decocms link` always runs the link daemon under Bun, every WebSocket forwarded through the tunnel (Vite HMR, Next.js webpack-hmr/Turbopack HMR) died before the upgrade, so file edits in linked sandboxes never hot-reloaded. Upstream fix: deco-cx/warp-node#2, shipped in 0.3.22/0.3.23 (issue: deco-cx/warp-node#1).

## How to Test

1. `bun install` (no-op if you're already on this branch).
2. Run a new mesh release containing this commit, then `bunx decocms link@latest` (clear bunx cache if needed so the new dep resolves).
3. Open a Next.js (or Vite) preview through Studio, edit a `.tsx` file, and confirm the browser hot-reloads instead of requiring a full refresh.

## Migration Notes

None. Pure dependency bump.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (verified patched code present in `node_modules/@deco-cx/warp-node@0.3.23/dist/handlers.client.js`)
- [x] Documentation is updated (if needed) — n/a
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@deco-cx/warp-node` to 0.3.23 to restore HMR over the link tunnel when the link daemon runs under Bun. Fixes failed WebSocket upgrades that broke Vite/Next.js hot reload in Studio previews.

- **Bug Fixes**
  - Forces `ws:` for tunneled WebSocket handshakes, so Bun no longer drops the connection.
  - Dependency-only change; no breaking changes or migration steps.

<sup>Written for commit fd7f0d0a432f1754a00affe1dde6f64c83c8e876. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3455?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

