### PR TITLE
feat(decopilot): add outputBytes to tool metadata and UI components

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -248,6 +248,7 @@ export async function toolsFromMCP(
         execute: async (input, callOptions) => {
           const startTime = performance.now();
           let isError = false;
+          let outputBytes: number | undefined;
           try {
             // Resolve any mesh-storage: URIs in tool arguments to fresh
             // presigned URLs before forwarding to the MCP client.
@@ -269,6 +270,14 @@ export async function toolsFromMCP(
               },
             );
             isError = Boolean((result as { isError?: boolean })?.isError);
+            // Measure the size of what the model will see as the tool
+            // result. JSON.stringify can throw on circular refs; swallow
+            // and leave outputBytes undefined in that case.
+            try {
+              outputBytes = Buffer.byteLength(JSON.stringify(result), "utf8");
+            } catch {
+              outputBytes = undefined;
+            }
             return result as unknown as CallToolResult;
           } catch (err) {
             isError = true;
@@ -283,6 +292,7 @@ export async function toolsFromMCP(
                   _meta,
                   annotations,
                   latencyMs,
+                  outputBytes,
                 },
               });
             }

--- a/apps/mesh/src/api/routes/decopilot/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/types.ts
@@ -29,6 +29,8 @@ export type ChatMessage = UIMessage<
     "tool-metadata": {
       annotations?: NonNullable<ToolDefinition["annotations"]>;
       latencyMs?: number;
+      /** UTF-8 byte length of the JSON-serialized tool result. */
+      outputBytes?: number;
     };
     "tool-subtask-metadata": {
       usage: UsageStats;

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -414,6 +414,7 @@ function MessagePart({
           part={part}
           annotations={getMeta(part.toolCallId)?.annotations}
           latency={getMeta(part.toolCallId)?.latencySeconds}
+          outputBytes={getMeta(part.toolCallId)?.outputBytes}
           isLastMessage={isLastMessage}
           toolMeta={getMeta(part.toolCallId)?._meta}
         />
@@ -489,6 +490,7 @@ function MessagePart({
             part={fallback}
             annotations={meta?.annotations}
             latency={meta?.latencySeconds}
+            outputBytes={meta?.outputBytes}
             isLastMessage={isLastMessage}
             toolMeta={meta?._meta}
           />

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/generic.tsx
@@ -62,6 +62,8 @@ interface GenericToolCallPartProps {
   annotations?: ToolDefinition["annotations"];
   /** Latency in seconds from data-tool-metadata part */
   latency?: number;
+  /** UTF-8 byte length of the JSON-serialized tool result. */
+  outputBytes?: number;
   /** Whether this part belongs to the last (most recent) assistant message */
   isLastMessage?: boolean;
   /** Tool _meta from data-tool-metadata part */
@@ -126,6 +128,43 @@ function AnnotationBadges({
   );
 }
 
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) {
+    const kb = n / 1024;
+    return kb < 10 ? `${kb.toFixed(1)} KB` : `${Math.round(kb)} KB`;
+  }
+  const mb = n / (1024 * 1024);
+  return mb < 10 ? `${mb.toFixed(1)} MB` : `${Math.round(mb)} MB`;
+}
+
+function formatLatency(seconds: number): string {
+  if (seconds < 1) return `${Math.round(seconds * 1000)}ms`;
+  if (seconds < 10) return `${seconds.toFixed(1)}s`;
+  return `${Math.round(seconds)}s`;
+}
+
+function LatencyBytesBadge({
+  latency,
+  outputBytes,
+}: {
+  latency?: number;
+  outputBytes?: number;
+}) {
+  const hasLatency = typeof latency === "number" && latency > 0;
+  const hasBytes = typeof outputBytes === "number" && outputBytes >= 0;
+  if (!hasLatency && !hasBytes) return null;
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[11px] font-mono tabular-nums text-muted-foreground/60 px-1 leading-none">
+      {hasLatency && <span>{formatLatency(latency!)}</span>}
+      {hasLatency && hasBytes && (
+        <span className="text-muted-foreground/30">·</span>
+      )}
+      {hasBytes && <span>{formatBytes(outputBytes!)}</span>}
+    </span>
+  );
+}
+
 /** Returns a short status hint shown on the summary line */
 function getSummary(
   state: string,
@@ -172,6 +211,7 @@ export function GenericToolCallPart({
   part,
   annotations,
   latency,
+  outputBytes,
   isLastMessage,
   toolMeta,
 }: GenericToolCallPartProps) {
@@ -328,7 +368,10 @@ export function GenericToolCallPart({
         })()}
         iconDestructive={isCancelled}
         trailing={
-          <AnnotationBadges annotations={annotations} toolMeta={toolMeta} />
+          <>
+            <AnnotationBadges annotations={annotations} toolMeta={toolMeta} />
+            <LatencyBytesBadge latency={latency} outputBytes={outputBytes} />
+          </>
         }
         title={friendlyName}
         latency={latency}

--- a/apps/mesh/src/web/components/chat/message/use-filter-parts.ts
+++ b/apps/mesh/src/web/components/chat/message/use-filter-parts.ts
@@ -13,6 +13,8 @@ export interface ToolMetadata {
   annotations?: NonNullable<ToolDefinition["annotations"]>;
   /** Latency in seconds (converted from ms for UI) */
   latencySeconds?: number;
+  /** UTF-8 byte length of the JSON-serialized tool result. */
+  outputBytes?: number;
   _meta?: ToolDefinition["_meta"];
 }
 
@@ -76,6 +78,7 @@ export function useFilterParts(message: ChatMessage | null) {
             data: {
               annotations?: unknown;
               latencyMs?: number;
+              outputBytes?: number;
               _meta?: unknown;
             };
           }
@@ -91,6 +94,13 @@ export function useFilterParts(message: ChatMessage | null) {
           Number.isFinite(data.latencyMs)
         ) {
           meta.latencySeconds = data.latencyMs / 1000;
+        }
+        if (
+          typeof data.outputBytes === "number" &&
+          Number.isFinite(data.outputBytes) &&
+          data.outputBytes >= 0
+        ) {
+          meta.outputBytes = data.outputBytes;
         }
         if (data._meta && typeof data._meta === "object") {
           meta._meta = data._meta as ToolDefinition["_meta"];
@@ -158,6 +168,15 @@ export function useFilterParts(message: ChatMessage | null) {
         continue;
       }
 
+      // Skip invisible data-* parts (they're consumed above into the
+      // dataParts maps and the MessagePart switch returns null for them).
+      // Including them in renderOrder would let them claim
+      // `isLastVisiblePart` and steal the message-bottom usage stats from
+      // the real last visible part.
+      if (p.type.startsWith("data-")) {
+        continue;
+      }
+
       stepParts.push({ index: i });
     }
 
@@ -168,6 +187,10 @@ export function useFilterParts(message: ChatMessage | null) {
   return {
     reasoningGroups,
     renderOrder,
-    dataParts: { toolMetadata, toolSubtaskMetadata, webSearchStreaming },
+    dataParts: {
+      toolMetadata,
+      toolSubtaskMetadata,
+      webSearchStreaming,
+    },
   };
 }


### PR DESCRIPTION
- Introduced outputBytes to track the UTF-8 byte length of JSON-serialized tool results in tool metadata.
- Updated relevant UI components to display outputBytes alongside latency information.
- Enhanced error handling for outputBytes calculation in toolsFromMCP function.
- Adjusted data filtering logic to accommodate new outputBytes property in message parts.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `outputBytes` to tool metadata and show it in the chat UI next to latency. This reveals the UTF-8 size of each tool result to help spot large responses.

- **New Features**
  - Compute and store `outputBytes` for each tool call on the server (UTF-8 length of the JSON result; safe if serialization fails).
  - Display `outputBytes` beside latency with compact units; wired through `useFilterParts`, `assistant`, and `GenericToolCallPart`.

- **Bug Fixes**
  - Exclude invisible `data-*` parts from render order so they don’t take last-message stats.

<sup>Written for commit adbe7099267cd53975f04cd1e2aaffb05606e590. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3456?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

