### PR TITLE
feat(home): add QA Agent builtin template

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.test.ts
@@ -3,7 +3,7 @@
  * resolution.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "@/core/mesh-context";
 import type { Capability } from "@/links/protocol";
@@ -105,6 +105,12 @@ describe("computeIdempotencyKey", () => {
 // mocked implementations. Other tests in this file don't import the route
 // factory, so the mocks don't bleed into them.
 
+// Capture the real implementations BEFORE mocking so we can restore them in
+// afterAll. Bun's mock.module is module-global within a shard, and
+// model-permissions.test.ts (same shard) imports the real module — without
+// restoration the stub here causes that file's tests to fail.
+const realModelPermissions = await import("./model-permissions");
+
 mock.module("@/core/resolve-tier", () => ({
   resolveTier: async () => ({
     credentialId: "cred_local",
@@ -123,6 +129,10 @@ mock.module("./model-permissions", () => ({
 mock.module("@/dispatch-queue", () => ({
   enqueueThreadRun: async () => ({ workflowID: "wf_test" }),
 }));
+
+afterAll(() => {
+  mock.module("./model-permissions", () => realModelPermissions);
+});
 
 // `./helpers` is mocked minimally — only `ensureOrganization` is exercised
 // on the 409 path, and the real one already works against our stub context.

--- a/apps/mesh/src/web/components/home/agents-list.tsx
+++ b/apps/mesh/src/web/components/home/agents-list.tsx
@@ -33,6 +33,7 @@ import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.t
 import { SiteDiagnosticsRecruitModal } from "@/web/components/home/site-diagnostics-recruit-modal.tsx";
 import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-modal.tsx";
 import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
+import { QaAgentRecruitModal } from "@/web/components/home/qa-agent-recruit-modal.tsx";
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
 import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recruit-modal.tsx";
 import { SelfHealingRepoFlow } from "@/web/components/self-healing-repo/self-healing-repo-flow.tsx";
@@ -199,6 +200,7 @@ type RecruitModalKey =
   | "diagnostics"
   | "ai-image"
   | "ai-research"
+  | "qa-agent"
   | "lean-canvas"
   | "studio-pack"
   | "self-healing";
@@ -212,6 +214,7 @@ type HomeTile =
         | "site-diagnostics"
         | "ai-image"
         | "ai-research"
+        | "qa-agent"
         | "lean-canvas"
         | "studio-pack"
         | "self-healing-storefront";
@@ -249,6 +252,7 @@ function AgentsListContent() {
   const [diagnosticsModalOpen, setDiagnosticsModalOpen] = useState(false);
   const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
   const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
+  const [qaAgentModalOpen, setQaAgentModalOpen] = useState(false);
   const [leanCanvasModalOpen, setLeanCanvasModalOpen] = useState(false);
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
   const [selfHealingOpen, setSelfHealingOpen] = useState(false);
@@ -266,6 +270,9 @@ function AgentsListContent() {
   )!;
   const aiResearchAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "ai-research",
+  )!;
+  const qaAgentTemplate = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "qa-agent",
   )!;
   const leanCanvasAgent = WELL_KNOWN_AGENT_TEMPLATES.find(
     (t) => t.id === "lean-canvas",
@@ -291,6 +298,11 @@ function AgentsListContent() {
     virtualMcps,
     aiResearchAgent.id,
     aiResearchAgent.title,
+  );
+  const existingQaAgent = findExistingForTemplate(
+    virtualMcps,
+    qaAgentTemplate.id,
+    qaAgentTemplate.title,
   );
   const existingLeanCanvas = findExistingForTemplate(
     virtualMcps,
@@ -401,6 +413,23 @@ function AgentsListContent() {
         onClick: "ai-research",
       };
     }
+    if (id === qaAgentTemplate.id) {
+      if (existingQaAgent) {
+        return {
+          key: existingQaAgent.id,
+          kind: "existing",
+          templateId: "qa-agent",
+          agent: existingQaAgent,
+        };
+      }
+      return {
+        key: id,
+        kind: "template-recruit",
+        templateId: "qa-agent",
+        agent: qaAgentTemplate,
+        onClick: "qa-agent",
+      };
+    }
     const custom = virtualMcps.find(
       (a): a is typeof a & { id: string } =>
         a.id !== null && a.id === id && !isDecopilot(a.id),
@@ -434,6 +463,7 @@ function AgentsListContent() {
       siteDiagnosticsAgent.id,
       aiImageAgent.id,
       aiResearchAgent.id,
+      qaAgentTemplate.id,
     ];
     const templateTiles = templateIds
       .map(resolveTile)
@@ -449,7 +479,8 @@ function AgentsListContent() {
         (a) =>
           a.id !== existingDiagnostics?.id &&
           a.id !== existingAiImage?.id &&
-          a.id !== existingAiResearch?.id,
+          a.id !== existingAiResearch?.id &&
+          a.id !== existingQaAgent?.id,
       )
       .sort((a, b) => {
         const aIdx = recentIds.indexOf(a.id);
@@ -485,6 +516,7 @@ function AgentsListContent() {
         diagnostics: () => setDiagnosticsModalOpen(true),
         "ai-image": () => setAiImageModalOpen(true),
         "ai-research": () => setAiResearchModalOpen(true),
+        "qa-agent": () => setQaAgentModalOpen(true),
         "lean-canvas": () => setLeanCanvasModalOpen(true),
         "studio-pack": () => setStudioPackModalOpen(true),
         "self-healing": () => setSelfHealingOpen(true),
@@ -547,6 +579,12 @@ function AgentsListContent() {
         open={aiResearchModalOpen}
         onOpenChange={setAiResearchModalOpen}
         existingAgent={existingAiResearch}
+      />
+
+      <QaAgentRecruitModal
+        open={qaAgentModalOpen}
+        onOpenChange={setQaAgentModalOpen}
+        existingAgent={existingQaAgent}
       />
 
       <LeanCanvasRecruitModal

--- a/apps/mesh/src/web/components/home/qa-agent-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/qa-agent-recruit-modal.tsx
@@ -148,7 +148,7 @@ export function QaAgentRecruitModal({
         connectionId = matchingConnection.id;
       } else {
         const connection = await connectionActions.create.mutateAsync({
-          title: template.title,
+          title: "QA mcp",
           description: "Autonomous QA agent driven by Playwright.",
           icon: template.icon,
           connection_type: "HTTP",

--- a/apps/mesh/src/web/components/home/qa-agent-recruit-modal.tsx
+++ b/apps/mesh/src/web/components/home/qa-agent-recruit-modal.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@deco/ui/components/drawer.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import {
+  SELF_MCP_ALIAS_ID,
+  WELL_KNOWN_AGENT_TEMPLATES,
+  useConnectionActions,
+  useMCPClient,
+  useMCPToolCallMutation,
+  useProjectContext,
+  useVirtualMCPActions,
+} from "@decocms/mesh-sdk";
+import type { CollectionListOutput } from "@decocms/bindings/collections";
+import type { ConnectionEntity } from "@decocms/mesh-sdk";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { track } from "@/web/lib/posthog-client";
+import { QA_AGENT_SYSTEM_PROMPT } from "./qa-agent-system-prompt";
+
+const QA_MCP_APP_ID = "deco/qa-mcp";
+const QA_MCP_URL = "https://qa-mcp.deco-cx.workers.dev/api/mcp";
+const QA_MCP_APP_NAME = "qa-mcp";
+
+interface QaAgentRecruitModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existingAgent?: { id: string } | null;
+}
+
+const CAPABILITIES = [
+  "Drives a real browser (Playwright) via primitive tools",
+  "Goal-driven planning with self-loop detection",
+  "Validates e-commerce flows: PLP → PDP → cart → checkout",
+  "Honest verdicts: objective_met, blocked, or exhausted",
+  "Respects a per-run budget (50 primitive calls)",
+];
+
+function RecruitContent({
+  onRecruit,
+  isRecruiting,
+}: {
+  onRecruit: () => void;
+  isRecruiting: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-muted-foreground">
+        Add an autonomous QA agent that drives a real browser to test your
+        site's critical user flows end-to-end.
+      </p>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">Capabilities</p>
+        <ul className="space-y-1.5">
+          {CAPABILITIES.map((cap) => (
+            <li
+              key={cap}
+              className="text-sm text-muted-foreground flex items-start gap-2"
+            >
+              <span className="text-emerald-500 mt-0.5 shrink-0">+</span>
+              {cap}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <Button
+        onClick={onRecruit}
+        disabled={isRecruiting}
+        className="w-full cursor-pointer"
+      >
+        {isRecruiting ? "Setting up..." : "Add QA Agent"}
+      </Button>
+    </div>
+  );
+}
+
+export function QaAgentRecruitModal({
+  open,
+  onOpenChange,
+  existingAgent,
+}: QaAgentRecruitModalProps) {
+  const isMobile = useIsMobile();
+  const { org } = useProjectContext();
+  const navigateToAgent = useNavigateToAgent();
+  const connectionActions = useConnectionActions();
+  const virtualMcpActions = useVirtualMCPActions();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const connectionQuery = useMCPToolCallMutation({ client });
+  const [isRecruiting, setIsRecruiting] = useState(false);
+
+  const template = WELL_KNOWN_AGENT_TEMPLATES.find((t) => t.id === "qa-agent")!;
+
+  const headerIcon = (
+    <IntegrationIcon icon={template.icon} name={template.title} size="sm" />
+  );
+
+  const handleRecruit = async () => {
+    if (existingAgent) {
+      onOpenChange(false);
+      navigateToAgent(existingAgent.id);
+      return;
+    }
+
+    setIsRecruiting(true);
+    try {
+      const existingConnectionResult = await connectionQuery.mutateAsync({
+        name: "COLLECTION_CONNECTIONS_LIST",
+        arguments: {
+          where: {
+            field: ["app_id"],
+            operator: "eq",
+            value: QA_MCP_APP_ID,
+          },
+          limit: 1,
+          offset: 0,
+        },
+      });
+
+      let connectionId: string;
+      const existingConnections = (
+        existingConnectionResult as {
+          structuredContent?: CollectionListOutput<ConnectionEntity>;
+        }
+      )?.structuredContent?.items;
+
+      const matchingConnection = existingConnections?.find(
+        (c) => c.app_id === QA_MCP_APP_ID,
+      );
+
+      if (matchingConnection) {
+        connectionId = matchingConnection.id;
+      } else {
+        const connection = await connectionActions.create.mutateAsync({
+          title: template.title,
+          description: "Autonomous QA agent driven by Playwright.",
+          icon: template.icon,
+          connection_type: "HTTP",
+          connection_url: QA_MCP_URL,
+          app_name: QA_MCP_APP_NAME,
+          app_id: QA_MCP_APP_ID,
+          metadata: {
+            type: "qa-agent",
+            source: "store",
+            registry_item_id: QA_MCP_APP_ID,
+            verified: false,
+          },
+        });
+        connectionId = connection.id;
+      }
+
+      const virtualMcp = await virtualMcpActions.create.mutateAsync({
+        title: template.title,
+        description:
+          "Drive a real browser to test critical user flows end-to-end.",
+        icon: template.icon,
+        status: "active",
+        connections: [
+          {
+            connection_id: connectionId,
+            selected_tools: null,
+            selected_resources: null,
+            selected_prompts: null,
+          },
+        ],
+        metadata: {
+          type: "qa-agent",
+          instructions: QA_AGENT_SYSTEM_PROMPT,
+        },
+      });
+
+      track("agent_recruit_confirmed", {
+        template_id: "qa-agent",
+        agent_id: virtualMcp.id!,
+      });
+      onOpenChange(false);
+      navigateToAgent(virtualMcp.id!);
+    } catch (error) {
+      track("agent_recruit_failed", {
+        template_id: "qa-agent",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      console.error("Failed to create QA Agent:", error);
+    } finally {
+      setIsRecruiting(false);
+    }
+  };
+
+  const title = `Add ${template.title}`;
+
+  return isMobile ? (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="h-[70dvh]">
+        <DrawerHeader className="px-4 pt-4 pb-4 shrink-0">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DrawerTitle className="text-xl font-semibold">{title}</DrawerTitle>
+          </div>
+        </DrawerHeader>
+        <div className="flex flex-col flex-1 min-h-0 px-4 pb-8">
+          <RecruitContent
+            onRecruit={handleRecruit}
+            isRecruiting={isRecruiting}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  ) : (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px] p-8">
+        <DialogHeader className="mb-4">
+          <div className="flex items-center gap-3">
+            {headerIcon}
+            <DialogTitle className="text-xl font-semibold">{title}</DialogTitle>
+          </div>
+        </DialogHeader>
+        <RecruitContent onRecruit={handleRecruit} isRecruiting={isRecruiting} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/home/qa-agent-system-prompt.ts
+++ b/apps/mesh/src/web/components/home/qa-agent-system-prompt.ts
@@ -1,0 +1,53 @@
+export const QA_AGENT_SYSTEM_PROMPT = `You are a QA testing agent. You drive a real browser via the QA MCP's primitive tools (start_run, click, fill, snapshot, navigate, end_run, etc.) and validate site behavior end-to-end.
+
+# Core operating principles
+
+## Read runState every turn
+Every primitive response includes \`runState\`:
+- \`stepCount\` — primitives called so far in this run
+- \`recentActions\` — compact summaries of the last 8 actions
+- \`budgetRemaining\` — how many primitive calls remain before the hard cap (50)
+- \`warning\` — appears at 70% of the budget; wrap up
+
+When \`budgetRemaining\` hits 0, the MCP refuses further primitives. Always call \`end_run\` before that, never "try one more thing".
+
+## Detect your own loops via recentActions
+Scan \`runState.recentActions\` every turn. If the SAME (tool, target) — e.g. \`click(e5)\` — OR the SAME tight cycle — e.g. \`click → snapshot → scroll → click\` — appears 3+ times WITHOUT visible state progress (URL didn't change, expected element flag didn't flip, cart count didn't move), YOU ARE LOOPING. Stop and call \`end_run\` with summary starting \`"blocked: <one-line reason>"\`. This is correct triage, not failure.
+
+## Trust the MCP, not your visual memory
+- \`belowFold: N\` does NOT mean "can't click" — the MCP handles below-fold elements with a force-click + dispatchEvent fallback. Click directly.
+- \`result: "timeout"\` does NOT always mean failure — animations and HTMX swaps frequently report timeout while the click actually succeeded. Re-snapshot and check whether the expected change happened.
+- \`failureReason\` (when set) tells you precisely what blocked the action: \`occluded\` (overlay on top — dismiss it first), \`disabled\` (do whatever enables the target first), \`not_found\` (snapshot stale, re-snapshot).
+- **Empty-name anchors with an \`<img>\` child ARE product card links**. Product cards on most storefronts render as \`<a href="…/p">\` wrapping just an image, with no aria-label. In the snapshot they appear as \`<a>\` with \`name: ""\` (or the SKU code as name, like \`"363995_10077_10-REGATA-…"\`), an \`href\` ending in \`/p\` or containing \`/produto/\`. The MCP boosts these to the top of the snapshot. **Click them by ref to enter the PDP — an empty \`name\` does NOT mean "not a link".**
+- **The MCP boosts size selectors and cart-add CTAs** (\`Incluir na mochila\`, \`Adicionar à sacola\`, \`eu quero\`, \`Add to cart\`, etc.) into the top of the snapshot so they survive the element cap. If you don't see one of them, it's much more likely the page hasn't hydrated yet (call \`wait_for_load\`) than that it's missing.
+
+## After every navigation: wait_for_load
+JS-heavy storefronts hydrate asynchronously. After \`start_run\`, after \`navigate\`, after any click that triggers navigation — call \`wait_for_load\` before reading the next snapshot. Otherwise you'll see "only nav links" and waste turns assuming the page is broken.
+
+## Recognize hover-gated UI and skip honestly
+Some storefronts hide secondary controls (PLP quick-add chips, "compre junto" cross-sell, recommendation tooltips) BEHIND a \`:hover\` CSS state — they only render when a real mouse hovers the element. The MCP does NOT currently expose a \`hover\` primitive, so those elements are genuinely unreachable from here.
+
+**How to detect**: if a snapshot shows only "image + title + price" per product card (no size chips, no inline cart-add) AFTER \`wait_for_load\`, the storefront is hover-gating those controls. They will not appear from scrolling or repeated snapshots — they're CSS-hidden until pointer-enter fires.
+
+**How to react**: STOP trying. Don't loop trying to make them appear. Either skip the hover-gated path entirely (note it in the summary with a one-line reason like \`"PLP quick-add not testable — hover-gated, MCP lacks hover primitive"\`), or fall back to a path that doesn't require hover (e.g. enter the PDP via the card anchor instead of using inline quick-add).
+
+## Three valid end_run verdicts
+Embed in your \`summary\`:
+- \`objective_met\` — you completed the test as specified. Honestly skipping a path that's unreachable for a documented technical reason (e.g. hover-gated UI + no hover primitive) still counts as \`objective_met\` as long as you noted the skip and ran the rest.
+- \`blocked\` — concrete obstacle (auth wall, every variant OOS, CAPTCHA, real-payment gate, same recovery strategy failed 3+ times).
+- \`exhausted\` — ran the test as far as it could go but the final state is ambiguous. Use this when "blocked" feels too strong but the objective wasn't truly met.
+
+# What NOT to do
+
+- **Don't skip mandatory steps in a pill's test plan.** When a pill says "1. start_run, 2. dismiss banner, 3. find shelf, 4. click card → PDP, 5. select size, 6. add to cart, …", every numbered step is mandatory unless explicitly tagged \`(optional)\`. If you observe that step 5 (select size) can ALSO be done from the listing page without entering the PDP, that's BONUS information — NOT a license to drop step 4. Mandatory steps run in declared order; bonus paths run AFTER, not INSTEAD OF.
+- **Don't confuse wishlist with cart-add.** \`Adicionar aos desejos\` / \`Adicionar aos favoritos\` / \`Add to wishlist\` / \`Favoritar\` / \`Lista de desejos\` are WISHLIST buttons, not cart-add. They share the \`Adicionar…\` verb prefix with the real cart-add and usually render right next to it on PDPs. The discriminator is the SECOND noun: \`sacola/mochila/carrinho/bolsa/cart/bag\` → cart-add; \`desejos/favoritos/wishlist\` → wishlist. Read the whole name, not just the verb.
+- **Don't pick the verbose carousel button when a bare-name size picker exists.** Storefronts often expose two elements per size: a verbose \`<button aria-label="show M size">\` (an image-carousel control that swaps the product photo — does NOT select a SKU for cart) and a bare-name \`<label>M</label>\` or \`<button>M</button>\` (the real SKU picker that updates the cart). When both are in the snapshot, click the bare-name one. If only the verbose one exists and clicking it doesn't flip the cart-add from \`disabled: true → false\`, the storefront's size picker is unreachable from DOM-only automation — record a bug and end blocked.
+- **Don't construct product/PDP/cart URLs by guessing from page text.** Click a real anchor or use a known cart path (\`/cart\`, \`/sacola\`, \`/carrinho\`, \`/checkout/\`, \`/bag\`).
+- **Don't enter real PII, real credit cards, or real emails.** Use \`test+qa@example.com\` style.
+- **Don't complete a purchase.** Stop at the checkout page.
+- **Don't invent refs.** Only use refs from the latest snapshot.
+- **Don't trust the header cart icon as your only verification** — icon-only buttons often have no label. Verify cart-add by navigating to the cart page (\`/sacola\` / \`/carrinho\` / \`/cart\` / \`/checkout/\`).
+- **Don't end_run while the cart count and your summary disagree.** If the cart shows N items but your summary describes M < N additions, you missed an interaction — go back and reconstruct it (which path added the missing item?) before calling \`end_run\`.
+
+# What's already in the MCP pills
+When the user clicks a pill like "Run E-commerce Checkout Flow", the MCP sends you a detailed test plan with step-by-step instructions, including the e-commerce vocab (shelf, PDP, SKU, cart, checkout), main-product-vs-cross-sell rules, verification protocols, and bug-detection criteria. Follow the pill content closely — it's the specific test plan. These Instructions complement it with the universal behavior expected across ALL workflows.`;

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -83,6 +83,7 @@ import { StudioPackRecruitModal } from "@/web/components/home/studio-pack-recrui
 import { LeanCanvasRecruitModal } from "@/web/components/home/lean-canvas-recruit-modal.tsx";
 import { AiImageRecruitModal } from "@/web/components/home/ai-image-recruit-modal.tsx";
 import { AiResearchRecruitModal } from "@/web/components/home/ai-research-recruit-modal.tsx";
+import { QaAgentRecruitModal } from "@/web/components/home/qa-agent-recruit-modal.tsx";
 import { useThreadActions } from "@/web/components/chat/store/hooks";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
 import { useNavigateToAgentThread } from "@/web/hooks/use-navigate-to-agent-thread";
@@ -362,6 +363,7 @@ function PinAgentPopoverContent({
   onOpenStudioPackModal,
   onOpenAiImageModal,
   onOpenAiResearchModal,
+  onOpenQaAgentModal,
 }: {
   onClose: () => void;
   onOpenImportDeco: () => void;
@@ -372,6 +374,7 @@ function PinAgentPopoverContent({
   onOpenStudioPackModal: () => void;
   onOpenAiImageModal: () => void;
   onOpenAiResearchModal: () => void;
+  onOpenQaAgentModal: () => void;
 }) {
   const [search, setSearch] = useState("");
   const allAgents = useVirtualMCPs();
@@ -449,6 +452,17 @@ function PinAgentPopoverContent({
       )
     : undefined;
 
+  const qaAgentTemplate = WELL_KNOWN_AGENT_TEMPLATES.find(
+    (t) => t.id === "qa-agent",
+  );
+  const existingQaAgent = qaAgentTemplate
+    ? allAgents.find(
+        (a) =>
+          (a as { metadata?: { type?: string } }).metadata?.type ===
+          qaAgentTemplate.id,
+      )
+    : undefined;
+
   const handleSelect = (agent: VirtualMCPEntity) => {
     if (!isPinned(agent.id)) {
       pin(agent.id);
@@ -488,6 +502,12 @@ function PinAgentPopoverContent({
         navigateToAgent(existingAiResearch.id);
       } else {
         onOpenAiResearchModal();
+      }
+    } else if (templateId === "qa-agent") {
+      if (existingQaAgent) {
+        navigateToAgent(existingQaAgent.id);
+      } else {
+        onOpenQaAgentModal();
       }
     } else if (templateId === "studio-pack") {
       onOpenStudioPackModal();
@@ -678,6 +698,7 @@ function PinAgentPopover() {
   const [studioPackModalOpen, setStudioPackModalOpen] = useState(false);
   const [aiImageModalOpen, setAiImageModalOpen] = useState(false);
   const [aiResearchModalOpen, setAiResearchModalOpen] = useState(false);
+  const [qaAgentModalOpen, setQaAgentModalOpen] = useState(false);
   const isMobile = useIsMobile();
   const { setOpenMobile } = useSidebar();
 
@@ -710,6 +731,7 @@ function PinAgentPopover() {
         onOpenStudioPackModal={() => setStudioPackModalOpen(true)}
         onOpenAiImageModal={() => setAiImageModalOpen(true)}
         onOpenAiResearchModal={() => setAiResearchModalOpen(true)}
+        onOpenQaAgentModal={() => setQaAgentModalOpen(true)}
       />
     </Suspense>
   );
@@ -797,6 +819,10 @@ function PinAgentPopover() {
       <AiResearchRecruitModal
         open={aiResearchModalOpen}
         onOpenChange={setAiResearchModalOpen}
+      />
+      <QaAgentRecruitModal
+        open={qaAgentModalOpen}
+        onOpenChange={setQaAgentModalOpen}
       />
     </>
   );

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -353,6 +353,12 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
     icon: "icon://SearchMd?color=green",
     type: "builtin-agent" as const,
   },
+  {
+    id: "qa-agent",
+    title: "QA Agent",
+    icon: "icon://CheckCircle?color=green",
+    type: "builtin-agent" as const,
+  },
 ] as const;
 
 export type WellKnownAgentTemplate =

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -356,7 +356,7 @@ export const WELL_KNOWN_AGENT_TEMPLATES = [
   {
     id: "qa-agent",
     title: "QA Agent",
-    icon: "icon://CheckCircle?color=green",
+    icon: "icon://ActivityHeart?color=green",
     type: "builtin-agent" as const,
   },
 ] as const;


### PR DESCRIPTION
## What is this contribution about?
Adds a **QA Agent** tile to the home page (alongside Web Researcher, Image Creator, etc.). One click recruits a virtual MCP wired to the `deco/qa-mcp` HTTP server (`https://qa-mcp.deco-cx.workers.dev/api/mcp`) and seeds it with a curated system prompt that teaches the agent how to drive a real browser via QA MCP primitives (`start_run`, `click`, `snapshot`, `wait_for_load`, `end_run`, …) end-to-end. Follows the existing `site-diagnostics` recruit pattern but without `configSchema` collection — the MCP handles its own credentials server-side.

## How to Test
1. `bun run dev` and open the home page.
2. Click the **QA Agent** tile → recruit modal opens with capabilities list + "Add QA Agent" button.
3. Click "Add QA Agent" → expect navigation to the new agent view.
4. List tools in the chat → confirm QA MCP primitives appear; try "open https://example.com and snapshot the page".
5. Click the tile again → should short-circuit to the existing agent instead of recreating it.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a QA Agent tile to the home page and wires it into the sidebar popover; it recruits a virtual MCP wired to `deco/qa-mcp` with an end-to-end browser QA prompt. One click sets it up; if it already exists, we navigate to it.

- New Features
  - Added "QA Agent" to `WELL_KNOWN_AGENT_TEMPLATES` and the home grid.
  - Recruit modal with capabilities and an "Add QA Agent" action.
  - Creates or reuses an HTTP connection to the QA MCP and spins up a virtual MCP preloaded with QA instructions.
  - Uses the ActivityHeart icon; the HTTP connection is titled "QA mcp".
  - Subsequent clicks open the existing agent; tracks recruit success/failure and navigates to the agent view.
  - No `configSchema`; credentials handled server-side by the MCP.

- Bug Fixes
  - Sidebar "Browse agents" popover now handles the QA Agent (opens recruit modal or reuses existing) and no longer navigates to a broken "Virtual MCP not found" URL.
  - Restored the real `model-permissions` module after mocking in decopilot route tests to prevent cross-file test failures.

<sup>Written for commit f1094a4b6903a7a7fb584a91ef41d8cc91862a36. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3458?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

