### PR TITLE
feat(web): make tasks panel resizable

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/tasks-panel-column.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/tasks-panel-column.tsx
@@ -1,33 +1,24 @@
 /**
- * TasksPanelColumn — fixed-width left column hosting the org-wide TasksPanel.
+ * TasksPanelColumn — left column hosting the org-wide TasksPanel.
  *
  * Lives outside the agent-scoped Suspense so it stays mounted across
  * virtualMcpId switches. Default open state follows the count of tasks +
- * automations; user-driven `?tasks=0|1` overrides the default.
+ * automations; user-driven `?tasks=0|1` overrides the default. Width is
+ * managed by the surrounding ResizablePanel in TasksWorkspaceLayout.
  */
 
 import { Suspense } from "react";
-import { useTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
 import { TasksPanel } from "@/web/layouts/tasks-panel";
 
-const TASKS_COLUMN_WIDTH_PX = 280;
-
-function TasksPanelColumnInner() {
-  const { tasksOpen } = useTasksPanelState();
-
-  if (!tasksOpen) return null;
-
+export function TasksPanelColumnInner() {
   return (
-    <aside
-      className="shrink-0 h-full bg-sidebar pb-1"
-      style={{ width: `${TASKS_COLUMN_WIDTH_PX}px` }}
-    >
+    <div className="h-full bg-sidebar pb-1">
       <div className="h-full p-0.5 pt-0.25">
         <div className="h-full bg-background rounded-[0.75rem] overflow-hidden card-shadow">
           <TasksPanel />
         </div>
       </div>
-    </aside>
+    </div>
   );
 }
 

--- a/apps/mesh/src/web/layouts/agent-shell-layout/tasks-panel-column.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/tasks-panel-column.tsx
@@ -7,7 +7,6 @@
  * managed by the surrounding ResizablePanel in TasksWorkspaceLayout.
  */
 
-import { Suspense } from "react";
 import { TasksPanel } from "@/web/layouts/tasks-panel";
 
 export function TasksPanelColumnInner() {
@@ -19,13 +18,5 @@ export function TasksPanelColumnInner() {
         </div>
       </div>
     </div>
-  );
-}
-
-export function TasksPanelColumn() {
-  return (
-    <Suspense fallback={null}>
-      <TasksPanelColumnInner />
-    </Suspense>
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/tasks-workspace-layout.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/tasks-workspace-layout.tsx
@@ -1,0 +1,62 @@
+/**
+ * TasksWorkspaceLayout — wraps the TasksPanelColumn + main outlet in a
+ * horizontal ResizablePanelGroup so the Tasks column width is user-resizable.
+ *
+ * When `tasksOpen` is false the Tasks panel is removed entirely (same
+ * behavior as before) and only `children` is rendered, so no resize handle
+ * is shown.
+ */
+
+import { useTransition, type PropsWithChildren } from "react";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/web/components/resizable";
+import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { useTasksPanelState } from "@/web/hooks/use-tasks-panel-state";
+import { TasksPanelColumnInner } from "@/web/layouts/agent-shell-layout/tasks-panel-column";
+
+const DEFAULT_TASKS_PANEL_SIZE = 18;
+const MIN_TASKS_PANEL_SIZE = 14;
+const MAX_TASKS_PANEL_SIZE = 30;
+
+export function TasksWorkspaceLayout({ children }: PropsWithChildren) {
+  const { tasksOpen } = useTasksPanelState();
+  const [storedTasksWidth, setTasksWidth] = useLocalStorage(
+    LOCALSTORAGE_KEYS.tasksPanelWidth(),
+    DEFAULT_TASKS_PANEL_SIZE,
+  );
+  const [_isPending, startTransition] = useTransition();
+
+  if (!tasksOpen) {
+    return <>{children}</>;
+  }
+
+  const handleResize = (size: number) =>
+    startTransition(() => {
+      if (size >= MIN_TASKS_PANEL_SIZE && size <= MAX_TASKS_PANEL_SIZE) {
+        setTasksWidth(size);
+      }
+    });
+
+  return (
+    <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
+      <ResizablePanel
+        order={1}
+        defaultSize={storedTasksWidth}
+        minSize={MIN_TASKS_PANEL_SIZE}
+        maxSize={MAX_TASKS_PANEL_SIZE}
+        onResize={handleResize}
+        className="overflow-hidden"
+      >
+        <TasksPanelColumnInner />
+      </ResizablePanel>
+      <ResizableHandle className="bg-sidebar" />
+      <ResizablePanel order={2} minSize={30} className="min-w-0 flex flex-col">
+        {children}
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -24,7 +24,7 @@ import { ThreadManagerProvider } from "@/web/components/chat/store/hooks";
 import { TasksPanelStateProvider } from "@/web/hooks/use-tasks-panel-state";
 import { LinkedDesktopIndicator } from "@/web/components/header/linked-desktop-indicator";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
-import { TasksPanelColumn } from "@/web/layouts/agent-shell-layout/tasks-panel-column";
+import { TasksWorkspaceLayout } from "@/web/layouts/agent-shell-layout/tasks-workspace-layout";
 import { TasksPanel } from "@/web/layouts/tasks-panel";
 
 function RouteFallback() {
@@ -122,10 +122,11 @@ export default function OrgShellLayout() {
                         </Toolbar.RightColumn>
                       </Toolbar.Header>
                       <div className="flex-1 min-h-0 flex flex-row">
-                        <TasksPanelColumn />
-                        <Suspense fallback={<RouteFallback />}>
-                          <Outlet />
-                        </Suspense>
+                        <TasksWorkspaceLayout>
+                          <Suspense fallback={<RouteFallback />}>
+                            <Outlet />
+                          </Suspense>
+                        </TasksWorkspaceLayout>
                       </div>
                     </Toolbar>
                   )}

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -23,6 +23,7 @@ export const LOCALSTORAGE_KEYS = {
   assistantChatActiveTask: (locator: ProjectLocator) =>
     `mesh:assistant-chat:active-task:${locator}`,
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,
+  tasksPanelWidth: () => `mesh:tasks-panel:width`,
   sidebarOpen: () => `mesh:sidebar-open`,
   orgHomeQuickstart: (org: string) => `mesh:org-home:quickstart:${org}`,
   storeShowStdio: () => `mesh:store:show-stdio`,


### PR DESCRIPTION
## What is this contribution about?
The Tasks sidebar on the org shell was a fixed 280px column. This PR wraps the Tasks column and the main outlet in a horizontal `ResizablePanelGroup`, so users can drag the divider to resize the Tasks panel. The chosen width is persisted to localStorage under a new `tasksPanelWidth` key, with min/max bounds (≈220px–470px) to keep the layout sensible. Mobile layout and the open/close toggle behavior are unchanged.

## Screenshots/Demonstration
N/A — drag the right edge of the Tasks column to resize.

## How to Test
1. Run \`bun run dev\` and open a workspace on desktop.
2. Drag the divider on the right edge of the Tasks panel — the column should resize smoothly and the main area should follow.
3. Reload the page — the chosen width should persist.
4. Close the Tasks panel (\`?tasks=0\` or the toggle) and reopen it — it should restore to the last chosen width and the resize divider should disappear when closed.
5. Inside a chat route, confirm the inner Chat/Main resizable still works independently.

## Migration Notes
N/A.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Tasks sidebar resizable in the org shell. Users can drag the divider to adjust width, which persists across reloads; mobile and open/close behavior stay the same.

- **New Features**
  - Added `TasksWorkspaceLayout` that wraps the Tasks panel and main outlet in a horizontal `ResizablePanelGroup`.
  - Persisted width to `localStorage` via `LOCALSTORAGE_KEYS.tasksPanelWidth()`, with sensible min/max bounds.
  - Hid the resize handle when the Tasks panel is closed; restores the last width when reopened.
  - Kept the inner chat/main resizer working independently; moved width control out of `TasksPanelColumn` and removed its unused export to satisfy `knip`.

<sup>Written for commit 5615dc2922d69414b3b16803212d71b2e08fb0b4. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3460?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

