### PR TITLE
fix(web): allow code editor through starting-now overlay

### DIFF
--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -925,15 +925,16 @@ export function PreviewContent() {
             </div>
           )}
 
-          {previewState.kind === "starting-now" && (
-            <div className="absolute inset-0 z-30">
-              <VmStateCard
-                kind="starting-now"
-                progress={progress}
-                claimPhase={claimPhase}
-              />
-            </div>
-          )}
+          {previewState.kind === "starting-now" &&
+            !(viewMode === "code" && daemonReady) && (
+              <div className="absolute inset-0 z-30">
+                <VmStateCard
+                  kind="starting-now"
+                  progress={progress}
+                  claimPhase={claimPhase}
+                />
+              </div>
+            )}
 
           {previewState.kind === "errored" && (
             <div className="absolute inset-0 z-40">


### PR DESCRIPTION
## Summary
- The "Starting your preview" overlay (`z-30`) was blocking the file explorer (`z-10`) even when the user clicked the code editor toggle and the daemon was already reachable
- Applied the same suppression pattern used for `dev-script-failed`: hide the overlay when `viewMode === "code" && daemonReady`
- This lets users browse files to debug issues while the dev server is still starting or has failed without reporting a `lifecycleFailure`

## Test plan
- [ ] Start a sandbox, let the daemon come up, but have the dev script fail (e.g. bad config)
- [ ] Click the code editor toggle in the toolbar
- [ ] Verify the file explorer is visible and not blocked by the "Starting your preview" overlay
- [ ] Verify the overlay still shows normally in preview mode while starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "Starting your preview" overlay in code view when the daemon is ready, so the code editor and file explorer remain usable while the dev server starts or after a script fails.

- **Bug Fixes**
  - Suppress the overlay when `viewMode === "code" && daemonReady`, matching the `dev-script-failed` behavior.
  - Overlay still shows in preview mode and other states.

<sup>Written for commit 207426614a65bd395421cb68bb0ff48a3e9703b4. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

