### PR TITLE
fix(web): remove back/forward buttons from preview toolbar

### DIFF
--- a/apps/mesh/src/web/components/vm/preview/preview.tsx
+++ b/apps/mesh/src/web/components/vm/preview/preview.tsx
@@ -10,8 +10,6 @@ import {
 } from "@decocms/mesh-sdk";
 
 import {
-  ArrowLeft,
-  ArrowRight,
   ChevronDown,
   Code02,
   CursorClick01,
@@ -639,36 +637,6 @@ export function PreviewContent() {
                   viewMode === "code" && "hidden",
                 )}
               >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() =>
-                        previewIframeRef.current?.contentWindow?.history.back()
-                      }
-                    >
-                      <ArrowLeft size={14} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Back</TooltipContent>
-                </Tooltip>
-
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() =>
-                        previewIframeRef.current?.contentWindow?.history.forward()
-                      }
-                    >
-                      <ArrowRight size={14} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Forward</TooltipContent>
-                </Tooltip>
-
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button variant="ghost" size="icon" onClick={handleRefresh}>


### PR DESCRIPTION
## Summary
- The back/forward buttons in the preview toolbar accessed `iframe.contentWindow.history`, which throws a `SecurityError` on cross-origin iframes
- Since the preview iframe always runs on a different origin from the app, these buttons never worked
- Remove them entirely instead of adding a try/catch workaround

## Test plan
- [ ] Verify the preview toolbar no longer shows back/forward arrow buttons
- [ ] Verify refresh, open-in-new-tab, and other toolbar actions still work
- [ ] No `SecurityError` in the console when interacting with the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Back/Forward buttons from the preview toolbar. They used `iframe.contentWindow.history` on a cross‑origin preview, which always throws a SecurityError, so removing them stops console errors and simplifies the UI while keeping refresh and open-in-new-tab actions.

<sup>Written for commit 5e60697abce726af300382164d5660410cbf724c. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3464?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

