### PR TITLE
refactor(dev): track auto-spawned link daemon as a managed service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,45 +113,50 @@ jobs:
                 fi
               done)
           file_count=$(echo "$files" | wc -l)
-          echo "Running $file_count test files"
+          echo "Running $file_count test files (one bun process per file)"
           echo "$files"
-          # Bun 1.3.5 has known signal-induced crash bugs (SIGILL/exit 132 on
-          # WASM cleanup; sporadic SIGSEGV/exit 139 with "multiple threads
-          # crashing" during inter-file teardown). Both are bun-internal and
-          # not related to the tests themselves. Run once; on a signal crash,
-          # retry once before giving up.
-          set +e
-          bun test $files 2>&1 | tee /tmp/test-output.txt
-          exit_code=${PIPESTATUS[0]}
-          set -e
-          # Signal-induced exit codes (>128) on Bun 1.3.5 are spurious — retry once.
-          if [ "$exit_code" -gt 128 ]; then
-            echo "⚠️  Bun exited with signal (exit $exit_code) — retrying once"
+          # Bun 1.3.5 has known signal-induced crash bugs in WASM/JSC teardown
+          # (SIGILL/exit 132, SIGSEGV/exit 139, SIGBUS) — triggered most
+          # reliably by PGlite (WASM-backed test DB) when bun moves between
+          # test files. Running each file in its own bun process pushes the
+          # crash to process exit, where it's harmless (no further tests
+          # depend on the dead process).
+          failed_files=""
+          crashed_files=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "::group::$f"
             set +e
-            bun test $files 2>&1 | tee /tmp/test-output.txt
-            exit_code=${PIPESTATUS[0]}
+            out=$(bun test "$f" 2>&1)
+            code=$?
             set -e
-          fi
-          # Detect failures via per-test markers AND the summary line. The
-          # crash can happen before bun prints its "N fail" summary, so
-          # relying on the summary alone hides real failures.
-          if grep -qE '^\(fail\)|[1-9][0-9]* fail' /tmp/test-output.txt; then
-            echo "❌ Test failures detected in output"
+            echo "$out"
+            echo "::endgroup::"
+            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
+              failed_files="$failed_files $f"
+              continue
+            fi
+            if [ "$code" -eq 0 ]; then
+              continue
+            fi
+            # Non-zero exit with no (fail) markers. If signal-induced AND we
+            # saw a "pass" count, tests ran and bun crashed at cleanup — known
+            # Bun 1.3.5 bug, accept. Otherwise treat as real failure.
+            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '[1-9][0-9]* pass'; then
+              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
+              continue
+            fi
+            crashed_files="$crashed_files $f"
+          done <<< "$files"
+          if [ -n "$failed_files" ]; then
+            echo "❌ Test failures in:$failed_files"
             exit 1
           fi
-          if [ "$exit_code" -eq 0 ]; then
-            exit 0
+          if [ -n "$crashed_files" ]; then
+            echo "❌ Bun crashed before tests ran in:$crashed_files"
+            exit 1
           fi
-          # Bun crashed (even after retry). Only accept the crash if every
-          # input file printed its ##[group] header — otherwise tests were
-          # skipped and we must fail.
-          ran_count=$(grep -cE '^##\[group\]apps/|^##\[group\]packages/' /tmp/test-output.txt || true)
-          if [ "$exit_code" -gt 128 ] && [ "$ran_count" -ge "$file_count" ]; then
-            echo "⚠️  Bun crashed (exit $exit_code) after all $file_count test files ran — accepting"
-            exit 0
-          fi
-          echo "❌ Bun exited $exit_code; only $ran_count of $file_count test files started"
-          exit $exit_code
+          echo "✅ All $file_count test files passed"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,29 +112,46 @@ jobs:
                   echo "$f"
                 fi
               done)
-          echo "Running $(echo "$files" | wc -l) test files"
+          file_count=$(echo "$files" | wc -l)
+          echo "Running $file_count test files"
           echo "$files"
-          # Bun 1.3.5 has a known WASM cleanup bug that causes SIGILL (exit 132)
-          # after all tests complete. Capture output and check test results directly.
+          # Bun 1.3.5 has known signal-induced crash bugs (SIGILL/exit 132 on
+          # WASM cleanup; sporadic SIGSEGV/exit 139 with "multiple threads
+          # crashing" during inter-file teardown). Both are bun-internal and
+          # not related to the tests themselves. Run once; on a signal crash,
+          # retry once before giving up.
           set +e
           bun test $files 2>&1 | tee /tmp/test-output.txt
           exit_code=${PIPESTATUS[0]}
           set -e
+          # Signal-induced exit codes (>128) on Bun 1.3.5 are spurious — retry once.
+          if [ "$exit_code" -gt 128 ]; then
+            echo "⚠️  Bun exited with signal (exit $exit_code) — retrying once"
+            set +e
+            bun test $files 2>&1 | tee /tmp/test-output.txt
+            exit_code=${PIPESTATUS[0]}
+            set -e
+          fi
           # Detect failures via per-test markers AND the summary line. The
-          # SIGILL crash can happen before bun prints its "N fail" summary,
-          # so relying on the summary alone hides real failures.
+          # crash can happen before bun prints its "N fail" summary, so
+          # relying on the summary alone hides real failures.
           if grep -qE '^\(fail\)|[1-9][0-9]* fail' /tmp/test-output.txt; then
             echo "❌ Test failures detected in output"
             exit 1
           fi
-          if [ $exit_code -eq 0 ]; then
+          if [ "$exit_code" -eq 0 ]; then
             exit 0
-          elif [ $exit_code -eq 132 ]; then
-            echo "⚠️  Bun exited with SIGILL (known WASM cleanup bug) but all tests passed"
-            exit 0
-          else
-            exit $exit_code
           fi
+          # Bun crashed (even after retry). Only accept the crash if every
+          # input file printed its ##[group] header — otherwise tests were
+          # skipped and we must fail.
+          ran_count=$(grep -cE '^##\[group\]apps/|^##\[group\]packages/' /tmp/test-output.txt || true)
+          if [ "$exit_code" -gt 128 ] && [ "$ran_count" -ge "$file_count" ]; then
+            echo "⚠️  Bun crashed (exit $exit_code) after all $file_count test files ran — accepting"
+            exit 0
+          fi
+          echo "❌ Bun exited $exit_code; only $ran_count of $file_count test files started"
+          exit $exit_code
 
   build:
     runs-on: ubuntu-latest

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -180,14 +180,76 @@ export async function startDevServer(
   // Gated on --local-sandbox-provider. When set, once the cluster is up
   // on :PORT, spawn the link daemon so the dev session exercises the
   // remote-cli + desktop code paths end-to-end. The link reads its
-  // session from <dataDir>/dev-link/session.json (auto-minted by the
-  // cluster on first boot — see apps/mesh/src/auth/dev-link-session.ts).
-  const linkPort = 5174;
+  // session from <linkDataDir>/session.json (auto-minted by the cluster
+  // on first boot — see apps/mesh/src/auth/dev-link-session.ts).
+  //
+  // The link is tracked like postgres/nats: dynamic port, state file at
+  // <home>/services/link/state.json, owned-process verification on
+  // shutdown. `services down` (or our shutdown handler below) tears it
+  // down. The DATA_DIR lives OUTSIDE the mesh repo: the daemon clones
+  // user repos into `<DATA_DIR>/sandboxes/<handle>/repo`, and if that
+  // path is nested under another git repo (this one) git's parent-walk
+  // hits the outer .git, refuses to clone, and the daemon crashes
+  // mid-bootstrap. The tmpdir-rooted path keyed by workspace slug also
+  // keeps concurrent worktrees from fighting over the same sandboxes dir.
   const linkChild: Promise<Subprocess | null> = !options.localSandboxProvider
     ? Promise.resolve(null)
     : (async (): Promise<Subprocess | null> => {
+        const { ensureLink } = await import("../../services/ensure-services");
         try {
-          await waitForPort(Number(settings.port), { intervalMs: 500 });
+          const { info, proc } = await ensureLink({
+            home: settings.dataDir,
+            clusterUrl: serverUrl,
+            linkDataDir,
+            repoRoot,
+            stdio: [
+              "inherit",
+              useInherit ? "inherit" : "pipe",
+              useInherit ? "inherit" : "pipe",
+            ],
+            beforeSpawn: async () => {
+              await waitForPort(Number(settings.port), { intervalMs: 500 });
+              // The cluster's port opens the instant `Bun.serve` listens,
+              // but `bootstrapDevLinkSession` (admin user seed + API key
+              // mint) runs async after that and is what writes
+              // `session.json`. On first boot it can take many seconds
+              // (embedded pg init + migrations + seed), and the link
+              // daemon throws "No session found" immediately on a missing
+              // file. Wait for the file before spawning so we don't lose
+              // the race and leave the Sandbox spinner pinned forever.
+              const sessionPath = join(linkDataDir, "session.json");
+              const sessionWaitDeadline = Date.now() + 60_000;
+              while (!existsSync(sessionPath)) {
+                if (Date.now() > sessionWaitDeadline) {
+                  throw new Error(
+                    `dev-link session not written to ${sessionPath} within 60s`,
+                  );
+                }
+                await new Promise((r) => setTimeout(r, 500));
+              }
+            },
+          });
+          if (proc && !useInherit) {
+            pipeToLogStore(proc.stdout as ReadableStream<Uint8Array>);
+            pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
+          }
+          // Mark Sandbox ready once the link binary's HTTP server accepts
+          // connections on its port. Fire-and-forget; if the link never
+          // comes up (e.g. no admin user yet for session bootstrap), the
+          // status stays "pending" and the user sees a spinner — useful
+          // signal that something's wrong rather than silent failure.
+          void waitForPort(info.port, { intervalMs: 500 })
+            .then(() => {
+              updateService({
+                name: "Sandbox",
+                status: "ready",
+                port: info.port,
+              });
+            })
+            .catch(() => {
+              /* link never came up — leave status pending as a signal */
+            });
+          return proc;
         } catch (err) {
           addLogEntry({
             method: "",
@@ -195,98 +257,30 @@ export async function startDevServer(
             status: 0,
             duration: 0,
             timestamp: new Date(),
-            rawLine: `[link] gave up waiting for cluster on :${settings.port}: ${
+            rawLine: `[link] failed to start: ${
               err instanceof Error ? err.message : String(err)
             }`,
           });
           return null;
         }
-        // The cluster's port opens the instant `Bun.serve` listens, but
-        // `bootstrapDevLinkSession` (admin user seed + API key mint) runs
-        // async after that and is what writes `session.json`. On first boot
-        // it can take many seconds (embedded pg init + migrations + seed),
-        // and the link daemon throws "No session found" immediately on a
-        // missing file. Wait for the file before spawning so we don't lose
-        // the race and leave the Sandbox spinner pinned forever.
-        const sessionPath = join(linkDataDir, "session.json");
-        const sessionWaitDeadline = Date.now() + 60_000;
-        while (!existsSync(sessionPath)) {
-          if (Date.now() > sessionWaitDeadline) {
-            addLogEntry({
-              method: "",
-              path: "",
-              status: 0,
-              duration: 0,
-              timestamp: new Date(),
-              rawLine: `[link] gave up waiting for dev-link session at ${sessionPath} after 60s — skipping link spawn. Sandbox will stay pending.`,
-            });
-            return null;
-          }
-          await new Promise((r) => setTimeout(r, 500));
-        }
-        const proc = Bun.spawn(
-          [
-            "bun",
-            "run",
-            "--cwd=apps/mesh",
-            "src/cli.ts",
-            "link",
-            "--no-tunnel",
-            "--port",
-            String(linkPort),
-          ],
-          {
-            cwd: repoRoot,
-            env: {
-              ...process.env,
-              MESH_CLUSTER_URL: serverUrl,
-              MESH_ALLOW_LOCALHOST_LINKS: "1",
-              // DATA_DIR lives OUTSIDE the mesh repo. The daemon clones
-              // user repos into `<DATA_DIR>/sandboxes/<handle>/repo`;
-              // if that path is nested under another git repo (this one)
-              // git's parent-walk hits the outer .git, refuses to clone,
-              // and the daemon crashes mid-bootstrap. Use a tmpdir-rooted
-              // path keyed by the workspace slug so concurrent worktrees
-              // don't fight over the same sandboxes dir.
-              DATA_DIR: linkDataDir,
-              DECOCMS_HOME: linkDataDir,
-            },
-            stdio: [
-              "inherit",
-              useInherit ? "inherit" : "pipe",
-              useInherit ? "inherit" : "pipe",
-            ],
-          },
-        );
-        if (!useInherit) {
-          pipeToLogStore(proc.stdout as ReadableStream<Uint8Array>);
-          pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
-        }
-        // Mark Sandbox ready once the link binary's HTTP server accepts
-        // connections on its port. Fire-and-forget; if the link never
-        // comes up (e.g. no admin user yet for session bootstrap), the
-        // status stays "pending" and the user sees a spinner — useful
-        // signal that something's wrong rather than silent failure.
-        void waitForPort(linkPort, { intervalMs: 500 })
-          .then(() => {
-            updateService({ name: "Sandbox", status: "ready", port: linkPort });
-          })
-          .catch(() => {
-            /* link never came up — leave status pending as a signal */
-          });
-        return proc;
       })();
 
   const shutdown = async (signal: NodeJS.Signals) => {
-    // Kill the link child first — it talks to the cluster on shutdown
+    // Wait for any in-flight link spawn to settle so we don't orphan a
+    // process that gets spawned right after we've torn down everything
+    // else. On a normal shutdown the spawn has long since resolved.
+    await linkChild.catch(() => null);
+    // Stop the link first — it talks to the cluster on shutdown
     // (DELETE /api/links/me), so giving it a window before we tear down
-    // the API server reduces orphaned registry entries.
-    const link = await linkChild.catch(() => null);
-    if (link) {
+    // the API server reduces orphaned registry entries. stopLink reads
+    // the state file written by ensureLink, signals the daemon, waits
+    // for exit, then removes the state file.
+    if (options.localSandboxProvider) {
+      const { stopLink } = await import("../../services/ensure-services");
       try {
-        link.kill(signal);
+        await stopLink(settings.dataDir);
       } catch {
-        /* already gone */
+        /* best-effort */
       }
     }
     child.kill(signal);
@@ -295,13 +289,6 @@ export async function startDevServer(
     // out connecting to a dead system DB. The server has its own 55s force-
     // exit timer, so this won't hang indefinitely.
     await child.exited;
-    if (link) {
-      try {
-        await link.exited;
-      } catch {
-        /* ignore */
-      }
-    }
     if (managedServiceNames.length > 0) {
       const { stopServices } = await import("../../services/ensure-services");
       await stopServices(settings.dataDir);

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -207,6 +207,11 @@ export async function startDevServer(
               useInherit ? "inherit" : "pipe",
               useInherit ? "inherit" : "pipe",
             ],
+            onSpawn: (proc) => {
+              if (useInherit) return;
+              pipeToLogStore(proc.stdout as ReadableStream<Uint8Array>);
+              pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
+            },
             beforeSpawn: async () => {
               await waitForPort(Number(settings.port), { intervalMs: 500 });
               // The cluster's port opens the instant `Bun.serve` listens,
@@ -229,10 +234,6 @@ export async function startDevServer(
               }
             },
           });
-          if (proc && !useInherit) {
-            pipeToLogStore(proc.stdout as ReadableStream<Uint8Array>);
-            pipeToLogStore(proc.stderr as ReadableStream<Uint8Array>);
-          }
           // Mark Sandbox ready once the link binary's HTTP server accepts
           // connections on its port. Fire-and-forget; if the link never
           // comes up (e.g. no admin user yet for session bootstrap), the

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -130,8 +130,21 @@ function isProcessAlive(pid: number): boolean {
  * Verify that a PID belongs to the expected service by checking the process
  * command line. This guards against PID reuse: if the OS recycled the PID for
  * an unrelated process, we must not signal it.
+ *
+ * `mode: "comm"` matches against the executable name (`ps -o comm=`). Use this
+ * for services launched as their own binary (postgres, nats-server).
+ *
+ * `mode: "args"` matches against the full argv (`ps -o args=`). Use this when
+ * the parent process is a generic interpreter (e.g. `bun run …`) and the
+ * marker is a script path — `expectedName` is matched as a substring of the
+ * full command line, so callers can pass distinctive arg fragments like
+ * `cli.ts link`.
  */
-function isOwnedProcess(pid: number, expectedName: string): boolean {
+function isOwnedProcess(
+  pid: number,
+  expectedName: string,
+  mode: "comm" | "args" = "comm",
+): boolean {
   if (!isProcessAlive(pid)) return false;
 
   try {
@@ -148,8 +161,13 @@ function isOwnedProcess(pid: number, expectedName: string): boolean {
       return output.toLowerCase().includes(expectedName.toLowerCase());
     }
 
-    // Unix: read /proc or use ps
-    const proc = Bun.spawnSync(["ps", "-p", String(pid), "-o", "comm="]);
+    const proc = Bun.spawnSync([
+      "ps",
+      "-p",
+      String(pid),
+      "-o",
+      mode === "args" ? "args=" : "comm=",
+    ]);
     const output = new TextDecoder().decode(proc.stdout).trim().toLowerCase();
     return output.includes(expectedName.toLowerCase());
   } catch {
@@ -664,8 +682,178 @@ async function stopNats(home: string): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Link daemon (deco link, spawned via `bun run --cwd=apps/mesh src/cli.ts link`)
+// ---------------------------------------------------------------------------
+
+/**
+ * The link daemon runs as `bun run … src/cli.ts link …`, so `ps -o comm=`
+ * just shows `bun`. We match against the full argv instead — `cli.ts link`
+ * is distinctive enough to avoid PID-reuse collisions with the user's other
+ * bun processes.
+ */
+const LINK_ARGS_MARKER = "cli.ts link";
+
+export interface EnsureLinkInputs {
+  home: string;
+  /** Cluster base URL the link daemon registers against. */
+  clusterUrl: string;
+  /** DATA_DIR / DECOCMS_HOME the link inherits (sandbox clones live under here). */
+  linkDataDir: string;
+  /** Repo root — `cwd` for the spawned `bun run --cwd=apps/mesh …`. */
+  repoRoot: string;
+  /**
+   * Called only when a fresh link daemon needs to be spawned (i.e. not when
+   * an existing managed link is reused). Use this to await prerequisites
+   * like the cluster port and the dev-link session file.
+   */
+  beforeSpawn?: () => Promise<void>;
+  /** Stdio config forwarded to `Bun.spawn`. Defaults to "inherit". */
+  stdio?: Parameters<typeof Bun.spawn>[1] extends infer O
+    ? O extends { stdio?: infer S }
+      ? S
+      : never
+    : never;
+}
+
+export interface EnsureLinkResult {
+  info: ServiceInfo;
+  /** The spawned subprocess, or null when reusing an existing managed link. */
+  proc: ReturnType<typeof Bun.spawn> | null;
+}
+
+async function ensureLink(inputs: EnsureLinkInputs): Promise<EnsureLinkResult> {
+  const info: ServiceInfo = {
+    name: "Link",
+    state: "stopped",
+    pid: null,
+    port: 0,
+    owner: "none",
+  };
+
+  const existing = readState(inputs.home, "link");
+  if (existing !== null) {
+    if (isOwnedProcess(existing.pid, LINK_ARGS_MARKER, "args")) {
+      info.state = "running";
+      info.pid = existing.pid;
+      info.port = existing.port;
+      info.owner = "managed";
+      return { info, proc: null };
+    }
+    await removeState(inputs.home, "link");
+  }
+
+  if (inputs.beforeSpawn) await inputs.beforeSpawn();
+
+  const port = await findAvailablePort();
+  info.port = port;
+
+  const proc = Bun.spawn(
+    [
+      "bun",
+      "run",
+      "--cwd=apps/mesh",
+      "src/cli.ts",
+      "link",
+      "--no-tunnel",
+      "--port",
+      String(port),
+    ],
+    {
+      cwd: inputs.repoRoot,
+      env: {
+        ...process.env,
+        MESH_CLUSTER_URL: inputs.clusterUrl,
+        MESH_ALLOW_LOCALHOST_LINKS: "1",
+        DATA_DIR: inputs.linkDataDir,
+        DECOCMS_HOME: inputs.linkDataDir,
+      },
+      stdio: inputs.stdio ?? ["inherit", "inherit", "inherit"],
+    },
+  );
+
+  writeState(inputs.home, "link", {
+    pid: proc.pid,
+    port,
+    startedAt: new Date().toISOString(),
+  });
+
+  try {
+    await waitForPort(port);
+  } catch (err) {
+    // The daemon spawned but never bound its HTTP port. Leaving the process
+    // alive would leak it (caller has no handle once we throw), and leaving
+    // the state file would cause the next ensureLink to match the still-
+    // running-but-unbound process via isOwnedProcess and reuse it as
+    // "healthy", pinning Sandbox forever on the next startup.
+    try {
+      proc.kill();
+    } catch {
+      /* already gone */
+    }
+    await removeState(inputs.home, "link");
+    throw err;
+  }
+
+  info.state = "running";
+  info.pid = proc.pid;
+  info.owner = "managed";
+  return { info, proc };
+}
+
+async function stopLink(home: string): Promise<void> {
+  const state = readState(home, "link");
+  if (state === null) {
+    console.log("Link: not running");
+    return;
+  }
+
+  const { pid } = state;
+
+  if (!isProcessAlive(pid)) {
+    console.log("Link: process already dead, cleaning up state");
+    await removeState(home, "link");
+    return;
+  }
+
+  if (!isOwnedProcess(pid, LINK_ARGS_MARKER, "args")) {
+    console.log(
+      `Link: PID ${pid} no longer belongs to the link daemon (possible PID reuse), cleaning up state`,
+    );
+    await removeState(home, "link");
+    return;
+  }
+
+  console.log(`Link: stopping (PID ${pid})...`);
+
+  if (IS_WINDOWS) {
+    Bun.spawn(["taskkill", "/PID", String(pid)]);
+  } else {
+    process.kill(pid, "SIGTERM");
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < 5000 && isProcessAlive(pid)) {
+    await Bun.sleep(200);
+  }
+
+  if (isProcessAlive(pid) && isOwnedProcess(pid, LINK_ARGS_MARKER, "args")) {
+    console.log("Link: force killing...");
+    if (IS_WINDOWS) {
+      Bun.spawn(["taskkill", "/PID", String(pid), "/F"]);
+    } else {
+      process.kill(pid, "SIGKILL");
+    }
+  }
+
+  await removeState(home, "link");
+  console.log("Link stopped");
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+export { ensureLink, stopLink };
 
 function portFromUrl(url: string, fallback: number): number {
   try {
@@ -723,6 +911,9 @@ export async function ensureServices(inputs: ServiceInputs): Promise<{
 }
 
 export async function stopServices(home: string): Promise<void> {
+  // Stop the link first — it talks to the cluster (DELETE /api/links/me) on
+  // shutdown, so give it a window before pg/nats go away.
+  await stopLink(home);
   await stopPostgres(home);
   await stopNats(home);
   console.log("\nAll managed services stopped.");
@@ -764,6 +955,26 @@ async function serviceStatus(home: string): Promise<ServiceInfo[]> {
     if (natsState !== null) await removeState(home, "nats");
     services.push({
       name: "NATS",
+      state: "stopped",
+      pid: null,
+      port: 0,
+      owner: "none",
+    });
+  }
+
+  const linkState = readState(home, "link");
+  if (linkState !== null && isProcessAlive(linkState.pid)) {
+    services.push({
+      name: "Link",
+      state: "running",
+      pid: linkState.pid,
+      port: linkState.port,
+      owner: "managed",
+    });
+  } else {
+    if (linkState !== null) await removeState(home, "link");
+    services.push({
+      name: "Link",
       state: "stopped",
       pid: null,
       port: 0,

--- a/apps/mesh/src/services/ensure-services.ts
+++ b/apps/mesh/src/services/ensure-services.ts
@@ -707,6 +707,14 @@ export interface EnsureLinkInputs {
    * like the cluster port and the dev-link session file.
    */
   beforeSpawn?: () => Promise<void>;
+  /**
+   * Called synchronously after `Bun.spawn` returns and before `ensureLink`
+   * begins waiting for the port. Use this to drain `proc.stdout`/`proc.stderr`
+   * — if the link is spawned with "pipe" stdio and nothing reads from the
+   * pipes, the OS buffer fills (~16-64KB) and the daemon blocks on write
+   * before it can bind its port.
+   */
+  onSpawn?: (proc: ReturnType<typeof Bun.spawn>) => void;
   /** Stdio config forwarded to `Bun.spawn`. Defaults to "inherit". */
   stdio?: Parameters<typeof Bun.spawn>[1] extends infer O
     ? O extends { stdio?: infer S }
@@ -776,6 +784,10 @@ async function ensureLink(inputs: EnsureLinkInputs): Promise<EnsureLinkResult> {
     port,
     startedAt: new Date().toISOString(),
   });
+
+  // Drain stdio BEFORE waiting on the port — otherwise piped stdout/stderr
+  // fill the OS pipe buffer and block the daemon's writes before it binds.
+  inputs.onSpawn?.(proc);
 
   try {
     await waitForPort(port);


### PR DESCRIPTION
## What is this contribution about?

Promotes the auto-spawned `deco link` daemon (gated on `--local-sandbox-provider`) to a first-class managed service alongside postgres and NATS, so it gets a dynamic port, a `<home>/services/link/state.json` file, and owned-process verification on shutdown. `isOwnedProcess` gains a `mode: "args"` variant so interpreter-launched processes (`bun run … cli.ts link`) can be matched against argv instead of the generic `bun` executable name. `stopServices` now tears down link first so its `DELETE /api/links/me` request reaches the cluster before pg/nats go away, and `ensureLink` kills the orphaned process plus clears the state file when its post-spawn `waitForPort` times out — otherwise a stuck daemon would be reused as "healthy" on the next startup and pin Sandbox forever.

## How to Test

1. `bun run --cwd apps/mesh dev:conductor` (or any path that sets `--local-sandbox-provider`).
2. Confirm the Sandbox row in the TUI transitions from pending to ready on a dynamic port, and a `services/link/state.json` appears under your DATA_DIR.
3. Ctrl+C — verify the link logs `Link: stopping (PID …) … Link stopped` before pg/nats shut down, and the state file is removed.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the auto-spawned `deco link` daemon to a managed service with dynamic ports, state tracking, and safe shutdown to prevent orphaned processes and “stuck” Sandbox sessions. Also drains daemon stdio during spawn to avoid port-bind hangs, and hardens CI by running each test file in its own `Bun` process to isolate teardown crashes.

- **Refactors**
  - Added `ensureLink`/`stopLink` to manage the link with a dynamic port and `<home>/services/link/state.json`; included in service status.
  - Extended `isOwnedProcess` with `mode: "args"` to identify `cli.ts link`.
  - Updated `dev` to use `ensureLink`, wait for the cluster port and `<linkDataDir>/session.json`, and mark Sandbox ready when the link port opens.
  - Changed shutdown to await any in-flight spawn, stop link first (so `DELETE /api/links/me` lands), and kill + clear state on port-wait failure; cleans stale/mismatched state on startup and runs link with external DATA_DIR/DECOCMS_HOME.

- **Bug Fixes**
  - Added `onSpawn` to `ensureLink` and moved log piping in `dev` into it to drain stdout/stderr before waiting for the port; fixes boot hang and the Sandbox staying pending.
  - CI: Run each test file in its own `Bun` process to avoid `Bun 1.3.5` teardown crashes; accept signal-induced exits (>128) only when a pass count is present, and fail on `(fail)` markers or when a file crashes before tests run.

<sup>Written for commit 0109d4dad826f9db281018f832977dbf380747c7. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3465?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

