### PR TITLE
fix(web): keep agent/chat visible when tasks panel is open

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/tasks-workspace-layout.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/tasks-workspace-layout.tsx
@@ -54,7 +54,12 @@ export function TasksWorkspaceLayout({ children }: PropsWithChildren) {
         <TasksPanelColumnInner />
       </ResizablePanel>
       <ResizableHandle className="bg-sidebar" />
-      <ResizablePanel order={2} minSize={30} className="min-w-0 flex flex-col">
+      <ResizablePanel
+        order={2}
+        defaultSize={100 - storedTasksWidth}
+        minSize={30}
+        className="min-w-0 flex flex-row"
+      >
         {children}
       </ResizablePanel>
     </ResizablePanelGroup>


### PR DESCRIPTION
## What is this contribution about?

Fixes a regression introduced in #3460 (resizable tasks panel) where opening the Tasks panel left the entire agent/chat area blank.

Root cause (confirmed via DOM inspection): the right-side `ResizablePanel` wrapping the outlet was `flex flex-col`, putting `AgentShellLayout` on the main axis without `min-h-0`. With chat content larger than the viewport, flex's default `min-height: auto` let the child grow ~3200px (well past the 852px parent), and `overflow: hidden` on the panel clipped the chat UI out of view. Switching Panel 2 to `flex flex-row` restores cross-axis stretch (matching the pre-resizable layout) so children inherit the panel height. An explicit `defaultSize={100 - storedTasksWidth}` was also added so Panel 2 doesn't briefly start at flex-grow=1 vs Panel 1's flex-grow=18 on first mount.

## How to Test

1. Check out the branch, run `bun run dev`, open any agent task page (e.g. `/$org/$taskId`).
2. Toggle the Tasks panel open via the toolbar — the agent header, action buttons, and chat input should remain visible to the right.
3. Hard refresh (Cmd+Shift+R) with `?tasks=1` in the URL — content should appear immediately, no blank state.
4. Drag the resize handle between the tasks and main panels — width should stay within `[14%, 30%]` and persist via localStorage; agent content reflows correctly.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the agent header and chat visible when the Tasks panel is open by fixing the right-side layout and setting a stable default width. Also removes the initial layout flash on first load.

- **Bug Fixes**
  - Changed the right `ResizablePanel` to `flex flex-row` so children inherit the panel height, preventing chat from being clipped.
  - Set `defaultSize={100 - storedTasksWidth}` to align with the stored width and avoid the brief flex-grow flash on mount.

<sup>Written for commit ae7f4684ac1294b4cdbf47d5ce855cdc641e7b29. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3466?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

