### PR TITLE
fix(mesh): make DBOS sslmode=verify-full explicit

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -29,10 +29,15 @@ const { DBOS } = await import("@dbos-inc/dbos-sdk");
 // DBOS uses its own pg client (separate from mesh's pool), so the `sslmode`
 // must travel in the URL. RDS's pg_hba.conf rejects unencrypted connections
 // with `no pg_hba.conf entry for host ... no encryption` when this is missing.
+// Use `verify-full` explicitly: pg-connection-string v2 silently upgrades
+// `require` to `verify-full`, but v3 / pg v9 will drop that upgrade and treat
+// `require` as encrypt-without-verification (libpq semantics).
 function withSslmode(url: string, ssl: boolean): string {
   if (!ssl) return url;
   const u = new URL(url);
-  if (!u.searchParams.has("sslmode")) u.searchParams.set("sslmode", "require");
+  if (!u.searchParams.has("sslmode")) {
+    u.searchParams.set("sslmode", "verify-full");
+  }
   return u.toString();
 }
 DBOS.setConfig({


### PR DESCRIPTION
## What is this contribution about?

`pg-connection-string` v2 silently upgrades `sslmode=require` (and `prefer`/`verify-ca`) to `verify-full`, and emits a deprecation warning on every DBOS startup. In v3 / pg v9 that upgrade goes away — `require` will mean encrypt-without-verification (libpq semantics), silently weakening TLS.

This pins the DBOS `systemDatabaseUrl` to explicit `sslmode=verify-full`, locking in today's wire behavior and silencing the warning. Verified against production: the prod RDS (`rds-mcp-mesh`, sa-east-1) uses `rds-ca-rsa2048-g1`, which is present in the CA bundle mounted via `NODE_EXTRA_CA_CERTS`; current pods are already running effectively under `verify-full` via the silent upgrade, so this change is a no-op on the wire.

## How to Test
1. Boot the server with `DATABASE_PG_SSL=true` against an RDS-compatible Postgres
2. Confirm DBOS init no longer logs the `pg-connection-string` SSL deprecation warning
3. Confirm the server still connects successfully

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set `sslmode=verify-full` for DBOS Postgres connections when SSL is enabled. This keeps strict TLS verification, removes the `pg-connection-string` warning, and avoids weaker TLS after future upgrades.

- **Bug Fixes**
  - Set `sslmode=verify-full` in DBOS `systemDatabaseUrl` when missing.
  - Preserves current behavior (v2 silently upgraded `require`) and prevents weaker TLS in `pg-connection-string` v3 / pg v9.
  - Silences the startup deprecation warning from `pg-connection-string`.

<sup>Written for commit 4749509aa05fdeaf9e5387f8d249cf2e4a31de3d. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3467?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

