### PR TITLE
chore(sandbox): bump to 0.5.5 + align sandbox-env chart image tag

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-version: 0.7.2
+version: 0.7.3
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "0.4.8"
+appVersion: "0.5.5"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "0.2.1"
+  tag: "0.5.5"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## What is this contribution about?

Releases a new \`studio-sandbox\` image (\`0.5.5\`) and bumps the \`sandbox-env\` Helm chart so warm-pool sandboxes pick up the dual-serve daemon routes shipped in #3463 (\`/_sandbox/*\` + legacy \`/_decopilot_vm/*\`).

Without this bump, post-rename mesh (staging is already on \`2.347.0\`/\`2.348.0\`) calls \`POST /_sandbox/config\` against deployed \`studio-sandbox:0.5.4\` daemons that only know the legacy prefix, so the request falls through to the daemon's catch-all proxy and returns \`503 "No dev server running"\` HTML — sandboxes cannot start.

## How to Test

1. Wait for the \`release-studio-sandbox\` workflow to publish \`ghcr.io/decocms/studio/studio-sandbox:0.5.5\`.
2. Sync the \`sandbox-env\` chart in staging (and prod).
3. \`kubectl -n agent-sandbox-system delete pod -l app.kubernetes.io/name=studio-sandbox-stg\` (and \`-prod\`) to recycle the warm pool onto \`0.5.5\`.
4. Open a sandbox preview from staging mesh — expected: dev server boots normally instead of the \`503\` "No dev server" page.

## Migration Notes

Chart version bumped to \`0.7.3\`; \`appVersion\` and \`image.tag\` aligned to \`0.5.5\`. Deploys must roll the chart out before the warm-pool pods will use the new image.

## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working (post-deploy verification needed)
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `studio-sandbox` 0.5.5 and align the `sandbox-env` chart so warm‑pool sandboxes pull the new image with dual-serve routes (`/_sandbox/*` + legacy `/_decopilot_vm/*`). This prevents 503s when the mesh calls `POST /_sandbox/config`.

- **Dependencies**
  - Bump `@decocms/sandbox` to 0.5.5; `sandbox-env` chart to 0.7.3; set `appVersion` and `image.tag` to 0.5.5.

- **Migration**
  - Roll out the updated `sandbox-env` chart to staging and prod.
  - Recycle warm‑pool pods to pull `0.5.5` and apply the change.

<sup>Written for commit fccbdc57bf1ae82341c2e318a3feb0a683334f59. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3468?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

