### PR TITLE
fix(toolbar): even spacing for header toggles and desktop icon

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
@@ -137,10 +137,7 @@ function ToolbarTabs({ children }: { children: ReactNode }) {
 function ToolbarTogglesSlot() {
   const { setTogglesEl } = useToolbarCtx();
   return (
-    <div
-      ref={setTogglesEl}
-      className="flex items-center gap-0.5 shrink-0 ml-0.5"
-    />
+    <div ref={setTogglesEl} className="flex items-center gap-0.5 shrink-0" />
   );
 }
 


### PR DESCRIPTION
## What is this contribution about?
The `Toolbar.TogglesSlot` wrapper had an extra `ml-0.5` that made its left side 4px from the back/forward chevrons while the right side stayed at 2px, so the desktop icon next to it didn't share the same rhythm as the tasks/chat buttons. Dropping the `ml-0.5` lets the parent `LeftColumn`'s `gap-0.5` apply uniformly, so all header buttons sit 2px apart.

## How to Test
1. Open any org page on desktop.
2. Inspect the header left column: back, forward, tasks, chat, desktop.
3. All adjacent buttons should now be 2px apart with no visual hiccup around the toggles group.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uneven spacing in the header toolbar by removing the extra left margin on the toggles slot, so back/forward, tasks, chat, and desktop buttons are evenly spaced at 2px.

<sup>Written for commit f8f43f4dc20fa4c150f7691d7c601cb82979e971. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3471?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

