### PR TITLE
fix(vm): show Preview tab on clonable vMCPs without GitHub connection

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
@@ -1,17 +1,17 @@
 import { PreviewContent } from "@/web/components/sandbox/preview/preview";
-import { agentHasConnectedGithub } from "@/web/lib/agent-capabilities";
+import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { AlertCircle } from "@untitledui/icons";
 
 export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
   const entity = useVirtualMCP(virtualMcpId);
-  const hasConnectedGithub = agentHasConnectedGithub(entity);
+  const hasClonableSource = agentHasClonableSource(entity?.metadata);
 
-  if (!hasConnectedGithub) {
+  if (!hasClonableSource) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground p-6">
         <AlertCircle size={24} className="text-muted-foreground/60" />
-        <div>No repository connected.</div>
+        <div>No source to preview.</div>
         <div className="text-xs text-muted-foreground/80">
           Connect a GitHub repository from the Connections tab to enable
           Preview.

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -21,7 +21,10 @@ import {
   useVirtualMCP,
 } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
-import { agentHasConnectedGithub } from "@/web/lib/agent-capabilities";
+import {
+  agentHasClonableSource,
+  agentHasConnectedGithub,
+} from "@/web/lib/agent-capabilities";
 import { useChatTask } from "@/web/components/chat/index";
 import { useThreadManager } from "@/web/components/chat/store/hooks";
 import type {
@@ -155,6 +158,7 @@ export function useMainPanelTabs(ctx: {
   const pinnedViews = entityUI?.pinnedViews ?? [];
   const expandedTools: ThreadExpandedTool[] = metadata?.expanded_tools ?? [];
   const hasActiveGithubRepo = agentHasConnectedGithub(entity);
+  const hasClonableSource = agentHasClonableSource(entity?.metadata);
   const connections = useConnections({ includeVirtual: true });
 
   const { activeTab, mainOpen } = resolveActiveTabAndOpen({
@@ -174,8 +178,10 @@ export function useMainPanelTabs(ctx: {
   // work tabs (Preview, git) come first so they're closest to the panel;
   // Settings + Automations stay anchored at the right.
   const systemTabs: Array<{ id: string; title: string }> = [];
-  if (hasActiveGithubRepo) {
+  if (hasClonableSource) {
     systemTabs.push({ id: "preview", title: "Preview" });
+  }
+  if (hasActiveGithubRepo) {
     systemTabs.push({ id: "git", title: currentBranch ?? "git" });
   }
   systemTabs.push({ id: "settings", title: "Settings" });

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -205,7 +205,7 @@ export function SettingsSidebar() {
 
   return (
     <Sidebar variant="sidebar">
-      <SidebarContent className="flex flex-col flex-1 mt-2 px-2 pb-2 gap-0">
+      <SidebarContent className="flex flex-col flex-1 mt-2 px-2 pb-2 gap-0 overflow-y-auto">
         {/* Back to org */}
         <SidebarGroup className="pt-0 pr-0 pb-3 md:pb-3 pl-0">
           <SidebarGroupContent>


### PR DESCRIPTION
## What is this contribution about?

Preview was gated on `agentHasConnectedGithub` in the same `if` block as the git tab, so template-clone vMCPs (Start Website, etc.) — which have `metadata.githubRepo.url` but no authenticated GitHub connection — lost the Preview tab when the git tab was removed. This switches Preview's gate to `agentHasClonableSource` so any vMCP with a clonable source gets a Preview tab; git tab still requires a connected GitHub identity. The inner `PreviewTab` empty-state predicate is realigned to match.

## How to Test

1. Open a Start Website / template-clone vMCP (no GitHub connection).
2. Confirm the **Preview** tab appears in the main panel and renders `PreviewContent`.
3. Open a vMCP with a connected GitHub repo — Preview **and** the branch/git tab both appear.
4. Open a decopilot-only vMCP (no `githubRepo.url`) — neither tab appears.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing Preview tab for template-clone vMCPs by gating Preview on a clonable source instead of a connected GitHub repo. The Git tab still requires a connected GitHub identity, and the settings sidebar now scrolls to avoid overlapping the version footer.

- **Bug Fixes**
  - Switched Preview gating from `agentHasConnectedGithub` to `agentHasClonableSource` in main tabs and `PreviewTab`.
  - Updated empty state copy to “No source to preview.”
  - Made `SidebarContent` scrollable to prevent overlap on short viewports.

<sup>Written for commit dae4e78f619f4ac1ed421f5c80fc88857231039b. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3472?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

