### PR TITLE
feat(mesh): implement studio pack backfill for organizations

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -129,6 +129,7 @@ import {
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,
 } from "../dispatch-queue";
+import { backfillStudioPackForAllOrgs } from "../auth/install-studio-pack-workflow";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import { dispatchRunAndWait } from "./routes/decopilot/dispatch-run";
 import {
@@ -2008,6 +2009,13 @@ export async function createApp(options: CreateAppOptions = {}) {
       concurrency: THREAD_GATE_PARTITION_CONCURRENCY,
     });
     await reconcileAutomationSchedules(automationsStorage);
+
+    // Fire-and-forget backfill of studio pack agents for every org. Safe
+    // to skip awaiting — the workflow IDs are deterministic per-org, so
+    // replicas/workers all enqueueing in parallel collapse via OAOO.
+    backfillStudioPackForAllOrgs().catch((err) => {
+      console.error("[studio-pack-backfill] failed:", err);
+    });
   };
 
   return Object.assign(app, { markShuttingDown, shutdown, initDbos });

--- a/apps/mesh/src/api/routes/suggested-actions.ts
+++ b/apps/mesh/src/api/routes/suggested-actions.ts
@@ -22,7 +22,7 @@ import { Hono } from "hono";
 import { isBrandContextSetup, isDecopilot } from "@decocms/mesh-sdk";
 import type { MeshContext } from "@/core/mesh-context";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
-import { findStudioPackAgentByMcpId } from "@/tools/virtual/studio-pack";
+import { STUDIO_PACK_AGENTS } from "@/tools/virtual/studio-pack";
 
 type Variables = {
   meshContext: MeshContext;
@@ -51,6 +51,15 @@ export function createSuggestedActionsRoutes() {
 
     const mine = c.req.query("mine") !== "false";
 
+    const studioPackAgentIds = STUDIO_PACK_AGENTS.map((a) => a.getId(orgId));
+    const existingStudioPack = await mesh.storage.virtualMcps.listByIds(
+      orgId,
+      studioPackAgentIds,
+    );
+    const existingStudioPackIds = new Set(existingStudioPack.map((a) => a.id));
+    const isHandledByChecklist = (virtualMcpId: string | null | undefined) =>
+      !!virtualMcpId && existingStudioPackIds.has(virtualMcpId);
+
     // Over-fetch so we still hit `limit` real rows after dropping Studio
     // Pack threads (handled by the checklist endpoint). Storage layer
     // already orders by last-message created_at DESC.
@@ -65,11 +74,7 @@ export function createSuggestedActionsRoutes() {
     // (they pass null), so we key off the title prefix written by both
     // createAutomationRunThread and createToolCallRunThread.
     const primary = assistantLast
-      .filter(
-        (r) =>
-          !r.thread.virtual_mcp_id ||
-          findStudioPackAgentByMcpId(r.thread.virtual_mcp_id) === null,
-      )
+      .filter((r) => !isHandledByChecklist(r.thread.virtual_mcp_id))
       .map((r) => ({
         ...r,
         fromState: describeFromThreadState(r.lastMessage.parts),
@@ -89,11 +94,7 @@ export function createSuggestedActionsRoutes() {
         lastMessageRole: "user",
       });
       const fallback = userLast
-        .filter(
-          (r) =>
-            !r.thread.virtual_mcp_id ||
-            findStudioPackAgentByMcpId(r.thread.virtual_mcp_id) === null,
-        )
+        .filter((r) => !isHandledByChecklist(r.thread.virtual_mcp_id))
         .map((r) => ({ ...r, fromState: null as string | null }));
       rows = [...primary, ...fallback.slice(0, limit - primary.length)];
     }

--- a/apps/mesh/src/auth/install-studio-pack-workflow.ts
+++ b/apps/mesh/src/auth/install-studio-pack-workflow.ts
@@ -79,3 +79,29 @@ export async function enqueueInstallStudioPack(
     workflowID: `install-studio-pack:${input.orgId}`,
   })(input);
 }
+
+export async function backfillStudioPackForAllOrgs(): Promise<void> {
+  const database = getDb();
+  const rows = await database.db
+    .selectFrom("member")
+    .select(["organizationId", "userId"])
+    .orderBy("createdAt", "asc")
+    .execute();
+
+  const orgToUser = new Map<string, string>();
+  for (const r of rows) {
+    if (!orgToUser.has(r.organizationId)) {
+      orgToUser.set(r.organizationId, r.userId);
+    }
+  }
+
+  await Promise.all(
+    Array.from(orgToUser).map(async ([orgId, createdBy]) => {
+      try {
+        await enqueueInstallStudioPack({ orgId, createdBy });
+      } catch (err) {
+        console.error("[studio-pack-backfill] enqueue failed", { orgId }, err);
+      }
+    }),
+  );
+}


### PR DESCRIPTION
- Added a new function `backfillStudioPackForAllOrgs` to enqueue installation of studio packs for all organizations based on their members.
- Updated `createApp` to trigger the backfill process in a fire-and-forget manner, ensuring it runs concurrently without blocking the main application flow.
- Enhanced the suggested actions route to utilize studio pack agent IDs for improved task handling, refining the filtering logic to check against existing studio packs.

This update improves the onboarding experience for new organizations by ensuring they have the necessary studio packs installed automatically.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically backfills Studio Pack agents for all organizations and improves suggested actions filtering to hide checklist-handled threads. This smooths org onboarding without blocking app startup.

- **New Features**
  - Added `backfillStudioPackForAllOrgs` to enqueue Studio Pack installs per org using the first member; deterministic workflow IDs ensure OAOO across workers.
  - Triggers backfill in `createApp` as fire-and-forget so startup remains non-blocking.

- **Refactors**
  - Suggested actions now uses `STUDIO_PACK_AGENTS` IDs with `virtualMcps.listByIds` to detect existing packs and filter them out.
  - Replaced `findStudioPackAgentByMcpId`, reducing duplicate suggestions from checklist-managed threads.

<sup>Written for commit 00e263ad2f3b03087afda9ab5ad70cde7f88f693. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3474?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

