### PR TITLE
feat(sandbox): publish dialog with git API and deterministic GitHub PR actions

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -401,6 +401,12 @@ export const createSandboxRoutes = () => {
       map404to410: true,
     }),
   );
+  app.post("/:virtualMcpId/:branch/git/rebase", (c) =>
+    proxyDaemon(c, "/_sandbox/git/rebase", {
+      forwardJsonBody: true,
+      map404to410: true,
+    }),
+  );
   app.post("/:virtualMcpId/:branch/git/suggest-commit", async (c) => {
     const runner = requireRunner(c);
     if (runner instanceof Response) return runner;

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -216,6 +216,8 @@ async function fetchDaemonJson<T>(
 ): Promise<T> {
   const upstream = await runner.proxyDaemonRequest(claimName, daemonPath, {
     method,
+    headers: new Headers(),
+    body: null,
   });
 
   if (upstream.status === 404) {

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -28,6 +28,11 @@ import type { Env } from "../hono-env";
 import { handleVmEvents } from "./sandbox-events-handler";
 import { resolveAndPushEnv } from "../../tools/sandbox/resolve-env";
 import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
+import {
+  type GitDiffLike,
+  type GitStatusLike,
+  suggestCommitMessageWithLlm,
+} from "../../lib/suggest-commit-message";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -135,6 +140,12 @@ function requireRunner(c: Context<VmEnv>): SandboxProvider | Response {
 
 // ---- Proxy helpers ----------------------------------------------------------
 
+/** Sandbox runtime responses must never be cached — 410 Gone was getting stuck in disk cache. */
+const SANDBOX_PROXY_CACHE_HEADERS = {
+  "Cache-Control": "no-store, no-cache, must-revalidate",
+  Pragma: "no-cache",
+} as const;
+
 async function proxyDaemon(
   c: Context<VmEnv>,
   daemonPath: string,
@@ -184,6 +195,7 @@ async function proxyDaemon(
           "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
       },
       410,
+      SANDBOX_PROXY_CACHE_HEADERS,
     );
   }
 
@@ -192,8 +204,43 @@ async function proxyDaemon(
     upstream.headers.get("content-type") ?? "application/json";
   return new Response(text, {
     status: upstream.status,
-    headers: { "content-type": contentType },
+    headers: { "content-type": contentType, ...SANDBOX_PROXY_CACHE_HEADERS },
   });
+}
+
+async function fetchDaemonJson<T>(
+  runner: SandboxProvider,
+  claimName: string,
+  daemonPath: string,
+  method: "GET" | "POST" = "GET",
+): Promise<T> {
+  const upstream = await runner.proxyDaemonRequest(claimName, daemonPath, {
+    method,
+  });
+
+  if (upstream.status === 404) {
+    try {
+      await upstream.body?.cancel();
+    } catch {
+      /* ignore */
+    }
+    throw new Error("SANDBOX_GONE");
+  }
+
+  const text = await upstream.text();
+  if (!upstream.ok) {
+    try {
+      const err = JSON.parse(text) as { error?: string };
+      throw new Error(err.error ?? `Daemon error (${upstream.status})`);
+    } catch (parseErr) {
+      if (parseErr instanceof Error && parseErr.message !== text) {
+        throw parseErr;
+      }
+      throw new Error(`Daemon error (${upstream.status})`);
+    }
+  }
+
+  return JSON.parse(text) as T;
 }
 
 // ---- Preview fetch ----------------------------------------------------------
@@ -327,6 +374,71 @@ export const createSandboxRoutes = () => {
       projectRef: claim.projectRef,
       virtualMcpMetadata: claim.virtualMcpMetadata,
     });
+  });
+
+  // -- Git (status, diff, publish, discard) ---------------------------------
+  app.get("/:virtualMcpId/:branch/git/status", (c) =>
+    proxyDaemon(c, "/_sandbox/git/status", {
+      method: "GET",
+      map404to410: true,
+    }),
+  );
+  app.post("/:virtualMcpId/:branch/git/status", (c) =>
+    proxyDaemon(c, "/_sandbox/git/status", { map404to410: true }),
+  );
+  app.post("/:virtualMcpId/:branch/git/diff", (c) =>
+    proxyDaemon(c, "/_sandbox/git/diff", { map404to410: true }),
+  );
+  app.post("/:virtualMcpId/:branch/git/publish", (c) =>
+    proxyDaemon(c, "/_sandbox/git/publish", {
+      forwardJsonBody: true,
+      map404to410: true,
+    }),
+  );
+  app.post("/:virtualMcpId/:branch/git/discard", (c) =>
+    proxyDaemon(c, "/_sandbox/git/discard", {
+      forwardJsonBody: true,
+      map404to410: true,
+    }),
+  );
+  app.post("/:virtualMcpId/:branch/git/suggest-commit", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
+
+    const { claimName } = c.get("vmClaim");
+    const ctx = c.var.meshContext;
+
+    try {
+      const [status, diff] = await Promise.all([
+        fetchDaemonJson<GitStatusLike>(
+          runner,
+          claimName,
+          "/_sandbox/git/status",
+          "POST",
+        ),
+        fetchDaemonJson<GitDiffLike>(
+          runner,
+          claimName,
+          "/_sandbox/git/diff",
+          "POST",
+        ),
+      ]);
+      const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
+      return c.json(suggestion, 200, SANDBOX_PROXY_CACHE_HEADERS);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === "SANDBOX_GONE") {
+        return c.json(
+          {
+            error:
+              "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
+          },
+          410,
+          SANDBOX_PROXY_CACHE_HEADERS,
+        );
+      }
+      return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+    }
   });
 
   // -- Preview fetch (CORS proxy) -------------------------------------------

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -408,21 +408,42 @@ export const createSandboxRoutes = () => {
     const { claimName } = c.get("vmClaim");
     const ctx = c.var.meshContext;
 
+    let body: { status?: GitStatusLike; diff?: GitDiffLike } = {};
     try {
-      const [status, diff] = await Promise.all([
-        fetchDaemonJson<GitStatusLike>(
-          runner,
-          claimName,
-          "/_sandbox/git/status",
-          "POST",
-        ),
-        fetchDaemonJson<GitDiffLike>(
-          runner,
-          claimName,
-          "/_sandbox/git/diff",
-          "POST",
-        ),
-      ]);
+      const text = await c.req.text();
+      if (text.trim()) {
+        body = JSON.parse(text) as {
+          status?: GitStatusLike;
+          diff?: GitDiffLike;
+        };
+      }
+    } catch {
+      return c.json(
+        { error: "Invalid JSON body" },
+        400,
+        SANDBOX_PROXY_CACHE_HEADERS,
+      );
+    }
+
+    try {
+      let status = body.status;
+      let diff = body.diff;
+      if (!status || !diff) {
+        [status, diff] = await Promise.all([
+          fetchDaemonJson<GitStatusLike>(
+            runner,
+            claimName,
+            "/_sandbox/git/status",
+            "GET",
+          ),
+          fetchDaemonJson<GitDiffLike>(
+            runner,
+            claimName,
+            "/_sandbox/git/diff",
+            "GET",
+          ),
+        ]);
+      }
       const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
       return c.json(suggestion, 200, SANDBOX_PROXY_CACHE_HEADERS);
     } catch (err) {

--- a/apps/mesh/src/lib/suggest-commit-message.test.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCommitContextSummary,
+  fallbackCommitSuggestion,
+} from "./suggest-commit-message";
+
+describe("suggest-commit-message", () => {
+  test("fallbackCommitSuggestion summarizes changed files", () => {
+    const result = fallbackCommitSuggestion({
+      modified: ["src/app.tsx"],
+      created: [],
+      deleted: [],
+      not_added: [],
+    });
+
+    expect(result.title).toBe("Update src/app.tsx");
+    expect(result.body).toContain("src/app.tsx");
+    expect(result.message).toContain("update src/app.tsx");
+  });
+
+  test("buildCommitContextSummary includes diff snippets", () => {
+    const summary = buildCommitContextSummary(
+      {
+        modified: ["README.md"],
+        created: [],
+        deleted: [],
+        not_added: [],
+      },
+      {
+        diffs: {
+          "README.md": {
+            from: "old line",
+            to: "new line",
+          },
+        },
+      },
+    );
+
+    expect(summary).toContain("Modified: README.md");
+    expect(summary).toContain("README.md:");
+    expect(summary).toContain("- old line");
+    expect(summary).toContain("+ new line");
+  });
+});

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -69,10 +69,18 @@ function changedLines(
   );
   for (let i = 1; i <= n; i++) {
     for (let j = 1; j <= m; j++) {
-      dp[i][j] =
-        a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1] + 1
-          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+      const prevRow = dp[i - 1];
+      const cellLeft = prevRow?.[j] ?? 0;
+      const cellUp = prevRow?.[j - 1] ?? 0;
+      const prevDiag = prevRow?.[j - 1] ?? 0;
+      const row = dp[i];
+      if (!row) continue;
+      const aLine = a[i - 1];
+      const bLine = b[j - 1];
+      row[j] =
+        aLine !== undefined && bLine !== undefined && aLine === bLine
+          ? prevDiag + 1
+          : Math.max(cellLeft, cellUp);
     }
   }
 
@@ -81,16 +89,31 @@ function changedLines(
   let i = n;
   let j = m;
   while (i > 0 || j > 0) {
-    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
-      ops.unshift({ op: "=", line: a[i - 1] });
+    const aLine = i > 0 ? a[i - 1] : undefined;
+    const bLine = j > 0 ? b[j - 1] : undefined;
+    const row = dp[i];
+    const prevRow = dp[i - 1];
+    if (
+      i > 0 &&
+      j > 0 &&
+      aLine !== undefined &&
+      bLine !== undefined &&
+      aLine === bLine
+    ) {
+      ops.unshift({ op: "=", line: aLine });
       i--;
       j--;
-    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
-      ops.unshift({ op: "+", line: b[j - 1] });
+    } else if (
+      j > 0 &&
+      (i === 0 || (row?.[j - 1] ?? 0) >= (prevRow?.[j] ?? 0))
+    ) {
+      if (bLine !== undefined) ops.unshift({ op: "+", line: bLine });
       j--;
+    } else if (aLine !== undefined) {
+      ops.unshift({ op: "-", line: aLine });
+      i--;
     } else {
-      ops.unshift({ op: "-", line: a[i - 1] });
-      i--;
+      break;
     }
   }
 
@@ -113,7 +136,9 @@ function changedLines(
   let last = -1;
   for (const idx of [...show].sort((a, b) => a - b)) {
     if (last !== -1 && idx > last + 1) result.push("@@ ... @@");
-    const { op, line } = ops[idx];
+    const opEntry = ops[idx];
+    if (!opEntry) continue;
+    const { op, line } = opEntry;
     result.push(`${op === "=" ? " " : op} ${line}`);
     last = idx;
     if (result.length >= maxLines) break;

--- a/apps/mesh/src/lib/suggest-commit-message.ts
+++ b/apps/mesh/src/lib/suggest-commit-message.ts
@@ -1,0 +1,234 @@
+import { generateText } from "ai";
+import type { MeshContext } from "../core/mesh-context";
+import { resolveTier } from "../core/resolve-tier";
+
+export interface CommitSuggestion {
+  title: string;
+  body: string;
+  message: string;
+}
+
+export interface GitStatusLike {
+  modified: string[];
+  created: string[];
+  deleted: string[];
+  not_added: string[];
+}
+
+export interface GitDiffLike {
+  diffs: Record<string, { from: string | null; to: string | null }>;
+}
+
+const COMMIT_SUGGESTION_SYSTEM = `You write git commit messages and pull request descriptions for web project changes.
+Return ONLY valid JSON with this shape:
+{"title":"Short imperative commit title (max 72 chars)","body":"1-3 sentence PR description explaining what changed and why"}
+
+Use sentence case for the title. No markdown fences.`;
+
+function isGeneratedNoise(path: string): boolean {
+  return /^static\/.*\.css$/.test(path);
+}
+
+function changedPaths(status: GitStatusLike): string[] {
+  return [
+    ...status.modified,
+    ...status.created,
+    ...status.deleted,
+    ...status.not_added,
+  ].filter((p) => !isGeneratedNoise(p));
+}
+
+function changedLines(
+  from: string | null,
+  to: string | null,
+  { context = 2, maxLines = 40 } = {},
+): string {
+  if (!from && !to) return "";
+  if (!from) {
+    return (to ?? "")
+      .split("\n")
+      .slice(0, maxLines)
+      .map((l) => `+ ${l}`)
+      .join("\n");
+  }
+  if (!to) {
+    return from
+      .split("\n")
+      .slice(0, maxLines)
+      .map((l) => `- ${l}`)
+      .join("\n");
+  }
+
+  const a = from.split("\n").slice(0, 300);
+  const b = to.split("\n").slice(0, 300);
+  const n = a.length;
+  const m = b.length;
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(m + 1).fill(0),
+  );
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  type Op = { op: "=" | "+" | "-"; line: string };
+  const ops: Op[] = [];
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      ops.unshift({ op: "=", line: a[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.unshift({ op: "+", line: b[j - 1] });
+      j--;
+    } else {
+      ops.unshift({ op: "-", line: a[i - 1] });
+      i--;
+    }
+  }
+
+  const show = new Set<number>();
+  ops.forEach((op, idx) => {
+    if (op.op !== "=") {
+      for (
+        let c = Math.max(0, idx - context);
+        c <= Math.min(ops.length - 1, idx + context);
+        c++
+      ) {
+        show.add(c);
+      }
+    }
+  });
+
+  if (show.size === 0) return "";
+
+  const result: string[] = [];
+  let last = -1;
+  for (const idx of [...show].sort((a, b) => a - b)) {
+    if (last !== -1 && idx > last + 1) result.push("@@ ... @@");
+    const { op, line } = ops[idx];
+    result.push(`${op === "=" ? " " : op} ${line}`);
+    last = idx;
+    if (result.length >= maxLines) break;
+  }
+
+  return result.join("\n");
+}
+
+export function buildCommitContextSummary(
+  status: GitStatusLike,
+  diff: GitDiffLike,
+): string {
+  const paths = changedPaths(status);
+  const fileLines = [
+    ...status.modified.map((f) => `Modified: ${f}`),
+    ...status.created.map((f) => `Added: ${f}`),
+    ...status.deleted.map((f) => `Deleted: ${f}`),
+    ...status.not_added.map((f) => `Added: ${f}`),
+  ].join("\n");
+
+  const snippets = paths
+    .map((path) => {
+      const entry = diff.diffs[path];
+      if (!entry) return path;
+      const snippet = changedLines(entry.from, entry.to);
+      return snippet ? `${path}:\n${snippet}` : path;
+    })
+    .join("\n---\n");
+
+  return `Changed files:\n${fileLines}\n\nDiff snippets:\n${snippets}`;
+}
+
+export function fallbackCommitSuggestion(
+  status: GitStatusLike,
+): CommitSuggestion {
+  const all = [
+    ...status.created.map((f) => `add ${f}`),
+    ...status.modified.map((f) => `update ${f}`),
+    ...status.deleted.map((f) => `delete ${f}`),
+    ...status.not_added.map((f) => `add ${f}`),
+  ].filter((f) => !isGeneratedNoise(f.replace(/^(add|update|delete) /, "")));
+
+  const label = all.length > 0 ? all[0] : "Update files";
+  const extra = all.length > 1 ? ` and ${all.length - 1} more` : "";
+  const message = `${label}${extra}`;
+  const title = message.charAt(0).toUpperCase() + message.slice(1);
+
+  const bodyPaths = changedPaths(status).slice(0, 5).join(", ");
+  return {
+    message,
+    title,
+    body: bodyPaths ? `Changes to ${bodyPaths}.` : "",
+  };
+}
+
+function parseCommitSuggestionJson(text: string): CommitSuggestion | null {
+  const cleaned = text
+    .trim()
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(cleaned) as { title?: string; body?: string };
+    const title = typeof parsed.title === "string" ? parsed.title.trim() : "";
+    const body = typeof parsed.body === "string" ? parsed.body.trim() : "";
+    if (!title) return null;
+    return {
+      title: title.slice(0, 120),
+      body: body.slice(0, 4000),
+      message: body ? `${title}\n\n${body}` : title,
+    };
+  } catch {
+    const firstLine = cleaned.split("\n")[0]?.trim() ?? "";
+    if (!firstLine) return null;
+    return {
+      title: firstLine.slice(0, 120),
+      body: cleaned.slice(firstLine.length).trim(),
+      message: cleaned,
+    };
+  }
+}
+
+export async function suggestCommitMessageWithLlm(
+  ctx: MeshContext,
+  status: GitStatusLike,
+  diff: GitDiffLike,
+): Promise<CommitSuggestion> {
+  const paths = changedPaths(status);
+  if (paths.length === 0) {
+    return { title: "No changes", body: "", message: "No changes" };
+  }
+
+  const orgId = ctx.organization?.id;
+  if (!orgId) return fallbackCommitSuggestion(status);
+
+  try {
+    const tier = await resolveTier(ctx, "fast");
+    const provider = await ctx.aiProviders.activate(tier.credentialId, orgId);
+    const model = provider.aiSdk.languageModel(tier.modelId);
+    const summary = buildCommitContextSummary(status, diff);
+
+    const result = await generateText({
+      model,
+      system: COMMIT_SUGGESTION_SYSTEM,
+      prompt: summary,
+      maxOutputTokens: 400,
+      temperature: 0.2,
+    });
+
+    const parsed = parseCommitSuggestionJson(result.text);
+    if (parsed) return parsed;
+  } catch (err) {
+    console.warn("[suggest-commit-message] LLM failed, using fallback", err);
+  }
+
+  return fallbackCommitSuggestion(status);
+}

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -303,9 +303,20 @@ export function SandboxEventsProvider({
           case "scripts":
             setScripts((payload as DaemonEventPayload<"scripts">).scripts);
             return;
-          case "branch":
-            setBranchMeta((payload as DaemonEventPayload<"branch">).meta);
+          case "branch": {
+            const meta = (payload as DaemonEventPayload<"branch">).meta;
+            if (import.meta.env.DEV) {
+              try {
+                if (localStorage.getItem("DEBUG_SAVE_CHANGES") === "1") {
+                  console.log("[github-header] branch SSE event", meta);
+                }
+              } catch {
+                // ignore
+              }
+            }
+            setBranchMeta(meta);
             return;
+          }
           case "reload":
             for (const fn of reloadHandlers.current) {
               try {

--- a/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchGitStatus,
+  sandboxGitStatusQueryKey,
+} from "../../thread/github/sandbox-git-api.ts";
+
+export function useSandboxGitStatus(args: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string | null;
+  enabled?: boolean;
+}) {
+  const { orgSlug, virtualMcpId, branch, enabled = true } = args;
+  return useQuery({
+    queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch ?? ""),
+    queryFn: () => fetchGitStatus(orgSlug, virtualMcpId, branch!),
+    enabled: enabled && !!branch,
+    refetchInterval: 3000,
+    staleTime: 1000,
+  });
+}

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useState, useRef } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import type { OnMount } from "@monaco-editor/react";
@@ -14,6 +15,11 @@ import { cn } from "@deco/ui/lib/utils.js";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { useChatStream } from "@/web/components/chat/context";
 import { usePanelActions } from "@/web/layouts/shell-layout";
+import { saveChangesDebug } from "../../../thread/github/save-changes-debug.ts";
+import {
+  fetchGitStatus,
+  sandboxGitStatusQueryKey,
+} from "../../../thread/github/sandbox-git-api.ts";
 import type { FileBuffer } from "./types";
 import {
   buildFileTree,
@@ -79,6 +85,7 @@ export function FileExplorer({
   } | null>(null);
   const { sendMessage } = useChatStream();
   const { setChatOpen } = usePanelActions();
+  const queryClient = useQueryClient();
 
   // Load file tree on first render
   const loadTreeCalledRef = useRef(false);
@@ -158,7 +165,26 @@ export function FileExplorer({
           body: JSON.stringify({ path: toDaemonPath(path), content }),
         },
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        saveChangesDebug("file save failed", {
+          path,
+          status: res.status,
+        });
+        return;
+      }
+      saveChangesDebug("file saved via sandbox /write", { path });
+      void queryClient.invalidateQueries({
+        queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch),
+      });
+      try {
+        const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+        saveChangesDebug("git status after save", status);
+      } catch (err) {
+        saveChangesDebug("git status after save failed", {
+          path,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       setBuffers((prev) => {
         const next = new Map(prev);
         const buf = next.get(path);

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -160,9 +160,15 @@ export function PreviewContent() {
   const virtualMcpId = inset?.entity?.id ?? null;
   const { org } = useProjectContext();
 
-  // Decofile pages for the URL bar dropdown
+  const vmEvents = useSandboxEvents();
+  const lifecyclePhase = vmEvents.lifecycle.phase;
+  const devServerReady = lifecyclePhase === "running";
+
+  // Decofile pages for the URL bar dropdown — fetch only after dev server is up.
   const decofileParams =
-    virtualMcpId && branch ? { orgSlug: org.slug, virtualMcpId, branch } : null;
+    virtualMcpId && branch && devServerReady
+      ? { orgSlug: org.slug, virtualMcpId, branch }
+      : null;
   const { data: decofile } = useDecofile(decofileParams);
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
@@ -170,7 +176,6 @@ export function PreviewContent() {
   const currentPageName = pages.find((p) => p.path === currentPath)?.name;
 
   // "reload" fires on config edits framework HMR won't catch (.ts/.tsx use HMR).
-  const vmEvents = useSandboxEvents();
   useSandboxReloadHandler(() => {
     const iframe = previewIframeRef.current;
     if (!iframe) return;
@@ -186,7 +191,6 @@ export function PreviewContent() {
   // sticky across `running` → `crashed` so a transient drop doesn't flip a
   // working preview to the "No web page" empty state. Latch the last seen
   // value, keyed on previewUrl so a new VM resets it.
-  const lifecyclePhase = vmEvents.lifecycle.phase;
   const htmlSupportRef = useRef<{ url: string; value: boolean }>({
     url: "",
     value: false,
@@ -825,6 +829,7 @@ export function PreviewContent() {
                   orgSlug={org.slug}
                   virtualMcpId={virtualMcpId}
                   branch={branch}
+                  previewReady={devServerReady}
                   currentPath={currentPath}
                   externalSelectedIndex={cmsSelectedSectionIndex}
                   onSaved={() => {

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -344,6 +344,7 @@ export function SectionsEditor({
   orgSlug,
   virtualMcpId,
   branch,
+  previewReady = true,
   currentPath,
   externalSelectedIndex,
   onSaved,
@@ -351,13 +352,17 @@ export function SectionsEditor({
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
+  /** When false, waits for the sandbox dev server before preview-fetch. */
+  previewReady?: boolean;
   currentPath: string;
   /** Section index selected via click-through from the preview iframe. */
   externalSelectedIndex?: number | null;
   /** Called after a successful auto-save so the parent can reload the preview. */
   onSaved?: () => void;
 }) {
-  const previewFetchParams = { orgSlug, virtualMcpId, branch };
+  const previewFetchParams = previewReady
+    ? { orgSlug, virtualMcpId, branch }
+    : null;
   const { data: decofile, isLoading: decofileLoading } =
     useDecofile(previewFetchParams);
   const { data: meta, isLoading: metaLoading } =
@@ -423,7 +428,7 @@ export function SectionsEditor({
     variantIndex: 0,
   });
 
-  if (decofileLoading || metaLoading) {
+  if (!previewReady || decofileLoading || metaLoading) {
     return (
       <div className="h-full w-full flex items-center justify-center">
         <Loading01 size={20} className="animate-spin text-muted-foreground" />

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -23,5 +23,7 @@ export function useDecofile(params: UseDecofileParams | null) {
     },
     enabled: !!params,
     staleTime: 30_000,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -24,5 +24,7 @@ export function useLiveMeta(params: UseLiveMetaParams | null) {
     },
     enabled: !!params,
     staleTime: 300_000,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
   });
 }

--- a/apps/mesh/src/web/components/thread/github/extract-tool-json.ts
+++ b/apps/mesh/src/web/components/thread/github/extract-tool-json.ts
@@ -3,26 +3,69 @@
  *   - `structuredContent: T` (parsed JSON, preferred)
  *   - `content: [{ type: "text", text: "<stringified JSON>" }]` (fallback)
  *
- * Returns null when the result is missing, the text is not valid JSON, or
- * the input is null/undefined. Callers are expected to type-assert the
- * generic `T`; no runtime schema validation happens here.
+ * github-mcp-server often returns only `content` text (structuredContent is
+ * null). Some proxies attach an empty `{}` structuredContent — in that case
+ * we still read the text payload.
  */
 type ToolResultLike = {
   structuredContent?: unknown;
   content?: Array<{ type?: string; text?: string }>;
 };
 
-export function extractToolJson<T>(r: unknown): T | null {
-  if (!r || typeof r !== "object") return null;
-  const result = r as ToolResultLike;
-  if (result.structuredContent !== undefined) {
-    return result.structuredContent as T;
-  }
-  const textPart = result.content?.find((c) => c.type === "text")?.text;
-  if (!textPart) return null;
+function parseTextJson(text: string): unknown | null {
   try {
-    return JSON.parse(textPart) as T;
+    return JSON.parse(text) as unknown;
   } catch {
     return null;
   }
+}
+
+function payloadFromToolResult(r: unknown): unknown | null {
+  if (!r || typeof r !== "object") return null;
+  const result = r as ToolResultLike;
+  const textPart = result.content?.find((c) => c.type === "text")?.text;
+  const fromText = textPart ? parseTextJson(textPart) : null;
+
+  const sc = result.structuredContent;
+  if (sc === undefined || sc === null) return fromText;
+
+  if (
+    typeof sc === "object" &&
+    !Array.isArray(sc) &&
+    Object.keys(sc).length === 0
+  ) {
+    return fromText ?? sc;
+  }
+
+  return sc;
+}
+
+export function extractToolJson<T>(r: unknown): T | null {
+  const parsed = payloadFromToolResult(r);
+  return parsed === null ? null : (parsed as T);
+}
+
+/** Pull request number from a GitHub PR URL, if present. */
+export function pullNumberFromUrl(url: string | undefined): number | null {
+  if (!url) return null;
+  const match = url.match(/\/pull\/(\d+)\b/);
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/** Plain-text tool payloads that embed a PR link. */
+export function pullRequestFromToolText(r: unknown): {
+  number: number;
+  htmlUrl: string;
+} | null {
+  if (!r || typeof r !== "object") return null;
+  const text = (r as ToolResultLike).content?.find(
+    (c) => c.type === "text",
+  )?.text;
+  if (!text) return null;
+  const htmlUrl = text.match(/https:\/\/github\.com\/[^\s"]+\/pull\/\d+/)?.[0];
+  const number = pullNumberFromUrl(htmlUrl);
+  if (!number || !htmlUrl) return null;
+  return { number, htmlUrl };
 }

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.test.ts
@@ -4,7 +4,11 @@ import {
   pullNumberFromUrl,
   pullRequestFromToolText,
 } from "./extract-tool-json.ts";
-import { parseCreatedPullRequestResult } from "./github-pr-api.ts";
+import {
+  findOpenPullRequestForBranch,
+  parseCreatedPullRequestResult,
+  squashMergePullRequest,
+} from "./github-pr-api.ts";
 
 describe("extract-tool-json", () => {
   test("prefers content text when structuredContent is an empty object", () => {
@@ -76,5 +80,66 @@ describe("parseCreatedPullRequestResult", () => {
       number: 3,
       htmlUrl: "https://github.com/o/r/pull/3",
     });
+  });
+});
+
+describe("findOpenPullRequestForBranch", () => {
+  test("uses head filter and does not scan unfiltered PR list", async () => {
+    const calls: Record<string, unknown>[] = [];
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        calls.push(req.arguments);
+        if (req.arguments.head === "owner:feat/x") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify([
+                  {
+                    number: 5,
+                    html_url: "https://github.com/o/r/pull/5",
+                    head: { ref: "feat/x" },
+                  },
+                ]),
+              },
+            ],
+          };
+        }
+        return { content: [{ type: "text", text: "[]" }] };
+      },
+    };
+
+    const pr = await findOpenPullRequestForBranch(client, {
+      owner: "owner",
+      repo: "repo",
+      branch: "feat/x",
+    });
+
+    expect(pr).toEqual({
+      number: 5,
+      htmlUrl: "https://github.com/o/r/pull/5",
+    });
+    expect(calls.every((c) => c.head != null)).toBe(true);
+  });
+});
+
+describe("squashMergePullRequest", () => {
+  test("requires merged === true in response", async () => {
+    const client = {
+      callTool: async () => ({
+        content: [{ type: "text", text: JSON.stringify({ merged: false }) }],
+      }),
+    };
+
+    await expect(
+      squashMergePullRequest(client, {
+        owner: "o",
+        repo: "r",
+        pullNumber: 1,
+      }),
+    ).rejects.toThrow("Failed to merge pull request");
   });
 });

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractToolJson,
+  pullNumberFromUrl,
+  pullRequestFromToolText,
+} from "./extract-tool-json.ts";
+import { parseCreatedPullRequestResult } from "./github-pr-api.ts";
+
+describe("extract-tool-json", () => {
+  test("prefers content text when structuredContent is an empty object", () => {
+    const payload = [{ number: 9, html_url: "https://github.com/o/r/pull/9" }];
+    const parsed = extractToolJson<unknown[]>({
+      structuredContent: {},
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+    });
+    expect(parsed).toEqual(payload);
+  });
+
+  test("pullNumberFromUrl parses GitHub PR links", () => {
+    expect(
+      pullNumberFromUrl("https://github.com/deco-cx/deco/pull/12345"),
+    ).toBe(12345);
+  });
+
+  test("pullRequestFromToolText parses plain-text tool payloads", () => {
+    expect(
+      pullRequestFromToolText({
+        content: [
+          {
+            type: "text",
+            text: "Pull request opened: https://github.com/o/r/pull/7",
+          },
+        ],
+      }),
+    ).toEqual({
+      number: 7,
+      htmlUrl: "https://github.com/o/r/pull/7",
+    });
+  });
+});
+
+describe("parseCreatedPullRequestResult", () => {
+  test("parses github-mcp-server MinimalResponse { id, url }", () => {
+    const pr = parseCreatedPullRequestResult({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            id: "2847461234",
+            url: "https://github.com/deco-cx/deco/pull/42",
+          }),
+        },
+      ],
+    });
+
+    expect(pr).toEqual({
+      number: 42,
+      htmlUrl: "https://github.com/deco-cx/deco/pull/42",
+    });
+  });
+
+  test("parses legacy { number, html_url } payloads", () => {
+    const pr = parseCreatedPullRequestResult({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            number: 3,
+            html_url: "https://github.com/o/r/pull/3",
+          }),
+        },
+      ],
+    });
+
+    expect(pr).toEqual({
+      number: 3,
+      htmlUrl: "https://github.com/o/r/pull/3",
+    });
+  });
+});

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.ts
@@ -82,7 +82,7 @@ function headRefFromListItem(pr: Record<string, unknown>): string | null {
   return typeof ref === "string" && ref.length > 0 ? ref : null;
 }
 
-export function pullRequestMatchesBranch(
+function pullRequestMatchesBranch(
   pr: Record<string, unknown>,
   branch: string,
 ): boolean {
@@ -192,7 +192,7 @@ export async function findOpenPullRequestForBranch(
   return null;
 }
 
-export async function createPullRequest(
+async function createPullRequest(
   client: GithubMcpClient,
   args: {
     owner: string;

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.ts
@@ -82,12 +82,37 @@ function headRefFromListItem(pr: Record<string, unknown>): string | null {
   return typeof ref === "string" && ref.length > 0 ? ref : null;
 }
 
-function pullRequestMatchesBranch(
+export function pullRequestMatchesBranch(
   pr: Record<string, unknown>,
   branch: string,
 ): boolean {
   const headRef = headRefFromListItem(pr);
   return headRef === branch;
+}
+
+export function extractPullRequestList(
+  result: unknown,
+): Record<string, unknown>[] {
+  const raw = extractToolJson<unknown>(result);
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (item): item is Record<string, unknown> =>
+        item != null && typeof item === "object",
+    );
+  }
+  if (raw && typeof raw === "object") {
+    const record = raw as Record<string, unknown>;
+    for (const key of ["pull_requests", "items", "data"]) {
+      const value = record[key];
+      if (Array.isArray(value)) {
+        return value.filter(
+          (item): item is Record<string, unknown> =>
+            item != null && typeof item === "object",
+        );
+      }
+    }
+  }
+  return [];
 }
 
 function toCreatedPullRequest(
@@ -120,27 +145,8 @@ export function parseCreatedPullRequestResult(
   throw new Error("Failed to open pull request");
 }
 
-function extractPullRequestList(result: unknown): Record<string, unknown>[] {
-  const raw = extractToolJson<unknown>(result);
-  if (Array.isArray(raw)) {
-    return raw.filter(
-      (item): item is Record<string, unknown> =>
-        item != null && typeof item === "object",
-    );
-  }
-  if (raw && typeof raw === "object") {
-    const record = raw as Record<string, unknown>;
-    for (const key of ["pull_requests", "items", "data"]) {
-      const value = record[key];
-      if (Array.isArray(value)) {
-        return value.filter(
-          (item): item is Record<string, unknown> =>
-            item != null && typeof item === "object",
-        );
-      }
-    }
-  }
-  return [];
+function pullRequestAlreadyExists(message: string): boolean {
+  return /already exists|pull request already/i.test(message);
 }
 
 async function listOpenPullRequests(
@@ -154,7 +160,7 @@ async function listOpenPullRequests(
       repo: args.repo,
       state: "open",
       ...(args.head ? { head: args.head } : {}),
-      perPage: 30,
+      perPage: 10,
     },
   });
 
@@ -183,12 +189,7 @@ export async function findOpenPullRequestForBranch(
     if (created) return created;
   }
 
-  const prs = await listOpenPullRequests(client, {
-    owner: args.owner,
-    repo: args.repo,
-  });
-  const match = prs.find((pr) => pullRequestMatchesBranch(pr, args.branch));
-  return match ? toCreatedPullRequest(match) : null;
+  return null;
 }
 
 export async function createPullRequest(
@@ -229,14 +230,26 @@ export async function openPullRequestForBranch(
   });
   if (existing) return existing;
 
-  return createPullRequest(client, {
-    owner: args.owner,
-    repo: args.repo,
-    title: args.title,
-    body: args.body,
-    head: args.branch,
-    base: args.base,
-  });
+  try {
+    return await createPullRequest(client, {
+      owner: args.owner,
+      repo: args.repo,
+      title: args.title,
+      body: args.body,
+      head: args.branch,
+      base: args.base,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!pullRequestAlreadyExists(message)) throw err;
+    const found = await findOpenPullRequestForBranch(client, {
+      owner: args.owner,
+      repo: args.repo,
+      branch: args.branch,
+    });
+    if (found) return found;
+    throw err;
+  }
 }
 
 export async function squashMergePullRequest(
@@ -262,12 +275,12 @@ export async function squashMergePullRequest(
   assertGithubToolSuccess(result);
 
   const data = extractToolJson<{ merged?: boolean; message?: string }>(result);
-  if (data?.merged === false) {
-    throw new Error(data.message ?? "Failed to merge pull request");
+  if (!data || data.merged !== true) {
+    throw new Error(data?.message ?? "Failed to merge pull request");
   }
 
   return {
     merged: true,
-    message: data?.message ?? "Pull request merged",
+    message: data.message ?? "Pull request merged",
   };
 }

--- a/apps/mesh/src/web/components/thread/github/github-pr-api.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-api.ts
@@ -1,0 +1,273 @@
+import {
+  extractToolJson,
+  pullNumberFromUrl,
+  pullRequestFromToolText,
+} from "./extract-tool-json.ts";
+
+type GithubMcpClient = {
+  callTool: (req: {
+    name: string;
+    arguments: Record<string, unknown>;
+  }) => Promise<unknown>;
+};
+
+type ToolResultLike = {
+  isError?: boolean;
+  content?: Array<{ type?: string; text?: string }>;
+};
+
+export interface CreatedPullRequest {
+  number: number;
+  htmlUrl: string;
+}
+
+export interface MergedPullRequest {
+  merged: boolean;
+  message: string;
+}
+
+export interface OpenPullRequestArgs {
+  owner: string;
+  repo: string;
+  branch: string;
+  title: string;
+  body?: string;
+  base: string;
+}
+
+function toolErrorMessage(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const r = result as ToolResultLike;
+  if (!r.isError) return null;
+  const text = r.content?.find((c) => c.type === "text")?.text?.trim();
+  return text || "GitHub MCP tool returned an error";
+}
+
+function assertGithubToolSuccess(result: unknown): void {
+  const message = toolErrorMessage(result);
+  if (message) throw new Error(message);
+}
+
+function pickString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function pickNumber(
+  record: Record<string, unknown>,
+  keys: string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+    if (typeof value === "string" && /^\d+$/.test(value)) {
+      const n = Number(value);
+      if (n > 0) return n;
+    }
+  }
+  return undefined;
+}
+
+function headRefFromListItem(pr: Record<string, unknown>): string | null {
+  const head = pr.head as Record<string, unknown> | undefined;
+  const ref = head?.ref;
+  return typeof ref === "string" && ref.length > 0 ? ref : null;
+}
+
+function pullRequestMatchesBranch(
+  pr: Record<string, unknown>,
+  branch: string,
+): boolean {
+  const headRef = headRefFromListItem(pr);
+  return headRef === branch;
+}
+
+function toCreatedPullRequest(
+  pr: Record<string, unknown>,
+): CreatedPullRequest | null {
+  const htmlUrl = pickString(pr, ["html_url", "htmlUrl", "url", "URL"]);
+  const number =
+    pickNumber(pr, ["number", "pullNumber"]) ?? pullNumberFromUrl(htmlUrl);
+  if (!number || !htmlUrl) return null;
+  return { number, htmlUrl };
+}
+
+/** github-mcp-server create_pull_request returns MinimalResponse `{ id, url }`. */
+export function parseCreatedPullRequestResult(
+  result: unknown,
+): CreatedPullRequest {
+  assertGithubToolSuccess(result);
+
+  const fromText = pullRequestFromToolText(result);
+  if (fromText) return fromText;
+
+  const data = extractToolJson<Record<string, unknown>>(result);
+  if (data && typeof data === "object") {
+    const htmlUrl = pickString(data, ["url", "URL", "html_url", "htmlUrl"]);
+    const number =
+      pickNumber(data, ["number", "pullNumber"]) ?? pullNumberFromUrl(htmlUrl);
+    if (number && htmlUrl) return { number, htmlUrl };
+  }
+
+  throw new Error("Failed to open pull request");
+}
+
+function extractPullRequestList(result: unknown): Record<string, unknown>[] {
+  const raw = extractToolJson<unknown>(result);
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (item): item is Record<string, unknown> =>
+        item != null && typeof item === "object",
+    );
+  }
+  if (raw && typeof raw === "object") {
+    const record = raw as Record<string, unknown>;
+    for (const key of ["pull_requests", "items", "data"]) {
+      const value = record[key];
+      if (Array.isArray(value)) {
+        return value.filter(
+          (item): item is Record<string, unknown> =>
+            item != null && typeof item === "object",
+        );
+      }
+    }
+  }
+  return [];
+}
+
+async function listOpenPullRequests(
+  client: GithubMcpClient,
+  args: { owner: string; repo: string; head?: string },
+): Promise<Record<string, unknown>[]> {
+  const result = await client.callTool({
+    name: "list_pull_requests",
+    arguments: {
+      owner: args.owner,
+      repo: args.repo,
+      state: "open",
+      ...(args.head ? { head: args.head } : {}),
+      perPage: 30,
+    },
+  });
+
+  assertGithubToolSuccess(result);
+  return extractPullRequestList(result);
+}
+
+export async function findOpenPullRequestForBranch(
+  client: GithubMcpClient,
+  args: {
+    owner: string;
+    repo: string;
+    branch: string;
+  },
+): Promise<CreatedPullRequest | null> {
+  const headFilters = [`${args.owner}:${args.branch}`, args.branch];
+
+  for (const head of headFilters) {
+    const prs = await listOpenPullRequests(client, {
+      owner: args.owner,
+      repo: args.repo,
+      head,
+    });
+    const match = prs.find((pr) => pullRequestMatchesBranch(pr, args.branch));
+    const created = match ? toCreatedPullRequest(match) : null;
+    if (created) return created;
+  }
+
+  const prs = await listOpenPullRequests(client, {
+    owner: args.owner,
+    repo: args.repo,
+  });
+  const match = prs.find((pr) => pullRequestMatchesBranch(pr, args.branch));
+  return match ? toCreatedPullRequest(match) : null;
+}
+
+export async function createPullRequest(
+  client: GithubMcpClient,
+  args: {
+    owner: string;
+    repo: string;
+    title: string;
+    body?: string;
+    head: string;
+    base: string;
+  },
+): Promise<CreatedPullRequest> {
+  const result = await client.callTool({
+    name: "create_pull_request",
+    arguments: {
+      owner: args.owner,
+      repo: args.repo,
+      title: args.title,
+      body: args.body,
+      head: args.head,
+      base: args.base,
+    },
+  });
+
+  return parseCreatedPullRequestResult(result);
+}
+
+/** Returns an open PR for the branch, or creates one if none exists. */
+export async function openPullRequestForBranch(
+  client: GithubMcpClient,
+  args: OpenPullRequestArgs,
+): Promise<CreatedPullRequest> {
+  const existing = await findOpenPullRequestForBranch(client, {
+    owner: args.owner,
+    repo: args.repo,
+    branch: args.branch,
+  });
+  if (existing) return existing;
+
+  return createPullRequest(client, {
+    owner: args.owner,
+    repo: args.repo,
+    title: args.title,
+    body: args.body,
+    head: args.branch,
+    base: args.base,
+  });
+}
+
+export async function squashMergePullRequest(
+  client: GithubMcpClient,
+  args: {
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    commitTitle?: string;
+  },
+): Promise<MergedPullRequest> {
+  const result = await client.callTool({
+    name: "merge_pull_request",
+    arguments: {
+      owner: args.owner,
+      repo: args.repo,
+      pullNumber: args.pullNumber,
+      merge_method: "squash",
+      ...(args.commitTitle ? { commit_title: args.commitTitle } : {}),
+    },
+  });
+
+  assertGithubToolSuccess(result);
+
+  const data = extractToolJson<{ merged?: boolean; message?: string }>(result);
+  if (data?.merged === false) {
+    throw new Error(data.message ?? "Failed to merge pull request");
+  }
+
+  return {
+    merged: true,
+    message: data?.message ?? "Pull request merged",
+  };
+}

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -20,19 +20,13 @@ import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
 import { useSandboxGitStatus } from "@/web/components/sandbox/hooks/use-sandbox-git-status.ts";
-import {
-  openPullRequestForBranch,
-  squashMergePullRequest,
-} from "./github-pr-api.ts";
+import { squashMergePullRequest } from "./github-pr-api.ts";
 import { MergeSplitButton } from "./merge-split-button.tsx";
 import { PublishDialog } from "./publish-dialog.tsx";
 import { selectHeaderButton, type HeaderButton } from "./panel-state.ts";
 import * as tpl from "./message-templates.ts";
 import { saveChangesDebug } from "./save-changes-debug.ts";
-import {
-  resolveEffectiveBranch,
-  resolveSandboxBranchFromMap,
-} from "./resolve-sandbox-branch.ts";
+import { resolveSandboxBranchFromMap } from "./resolve-sandbox-branch.ts";
 import { mergeBranchMetaWithGitStatus } from "./sandbox-git-api.ts";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events.ts";
 import { useChecks, usePrByBranch } from "./use-pr-data.ts";
@@ -91,21 +85,18 @@ export function HeaderActions({ virtualMcpId }: Props) {
     userId,
     branch ?? sandboxBranch,
   );
-  const branchForApi = branch ?? sandboxBranch ?? sandboxMapBranch ?? undefined;
+  const sandboxRouteBranch =
+    branch ?? sandboxBranch ?? sandboxMapBranch ?? undefined;
 
   const gitStatusQuery = useSandboxGitStatus({
     orgSlug: org.slug,
     virtualMcpId,
-    branch: branchForApi ?? null,
-    enabled: !!githubRepo && !!branchForApi && !sandboxGone,
+    branch: sandboxRouteBranch ?? null,
+    enabled: !!githubRepo && !!sandboxRouteBranch && !sandboxGone,
   });
 
-  const effectiveBranch = resolveEffectiveBranch({
-    chatBranch: branch,
-    sandboxBranch,
-    sandboxMapBranch,
-    gitCurrentBranch: gitStatusQuery.data?.current,
-  });
+  const githubHeadBranch =
+    gitStatusQuery.data?.current ?? sandboxRouteBranch ?? null;
 
   const prQuery = usePrByBranch({
     orgId: org.id,
@@ -113,7 +104,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     connectionId: githubRepo?.connectionId ?? "",
     owner: githubRepo?.owner ?? "",
     repo: githubRepo?.name ?? "",
-    branch: effectiveBranch,
+    branch: githubHeadBranch,
   });
   const pr = prQuery.data ?? null;
 
@@ -143,8 +134,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
   if (!githubRepo) return null;
 
   const branchMap =
-    userId && effectiveBranch
-      ? parseBranchMap(vm?.metadata?.sandboxMap?.[userId]?.[effectiveBranch])
+    userId && githubHeadBranch
+      ? parseBranchMap(vm?.metadata?.sandboxMap?.[userId]?.[githubHeadBranch])
       : {};
   const branchMapEntries = Object.values(branchMap);
   const vmEntry =
@@ -152,7 +143,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     branchMapEntries[0];
   const previewUrl = vmEntry?.previewUrl ?? null;
 
-  const button = effectiveBranch
+  const button = githubHeadBranch
     ? selectHeaderButton({
         lifecycle,
         branch: effectiveBranchMeta,
@@ -181,7 +172,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
         ? effectiveBranchMeta.aheadOfBase
         : null,
     lifecycle: lifecycle.phase,
-    effectiveBranch,
+    githubHeadBranch,
   });
   if (debugKeyRef.current !== debugKey) {
     debugKeyRef.current = debugKey;
@@ -192,7 +183,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
       chatBranch: branch,
       sandboxBranch,
       sandboxMapBranch,
-      effectiveBranch,
+      sandboxRouteBranch,
+      githubHeadBranch,
       branchMeta,
       effectiveBranchMeta,
       gitStatus: gitStatusQuery.data ?? null,
@@ -219,35 +211,6 @@ export function HeaderActions({ virtualMcpId }: Props) {
     ]);
   };
 
-  const handleCreatePullRequest = async () => {
-    if (!githubRepo?.connectionId || !effectiveBranch || githubActionPending) {
-      return;
-    }
-    setGithubActionPending(true);
-    try {
-      const pr = await openPullRequestForBranch(githubClient, {
-        owner: githubRepo.owner,
-        repo: githubRepo.name,
-        branch: effectiveBranch,
-        title: `Changes from ${effectiveBranch}`,
-        base: baseBranch,
-      });
-      toast.success(`Submitted pull request #${pr.number} for review`, {
-        action: {
-          label: "View on GitHub",
-          onClick: () => window.open(pr.htmlUrl, "_blank", "noopener"),
-        },
-      });
-      await refreshPrState();
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to open pull request",
-      );
-    } finally {
-      setGithubActionPending(false);
-    }
-  };
-
   const handleSquashMerge = async (pullNumber: number) => {
     if (!githubRepo?.connectionId || githubActionPending) return;
     setGithubActionPending(true);
@@ -269,13 +232,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
   };
 
   const onActivate = (action: HeaderButton["action"]) => {
-    if (!action || !effectiveBranch) return;
+    if (!action || !githubHeadBranch) return;
     switch (action) {
       case "commit-and-push":
-        setPublishOpen(true);
-        return;
       case "create-pr":
-        void handleCreatePullRequest();
+        setPublishOpen(true);
         return;
       case "reopen":
         if (isStreaming) return;
@@ -283,7 +244,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
         return;
       case "rebase":
         if (isStreaming) return;
-        void send(tpl.rebaseOnBase({ branch: effectiveBranch }));
+        void send(tpl.rebaseOnBase({ branch: githubHeadBranch }));
         return;
       case "fix-checks":
         if (isStreaming) return;
@@ -332,14 +293,14 @@ export function HeaderActions({ virtualMcpId }: Props) {
             : undefined
         }
       />
-      {effectiveBranch && (
+      {sandboxRouteBranch && (
         <PublishDialog
           open={publishOpen}
           onOpenChange={setPublishOpen}
           orgSlug={org.slug}
           orgId={org.id}
           virtualMcpId={virtualMcpId}
-          branch={effectiveBranch}
+          branch={sandboxRouteBranch}
           baseBranch={baseBranch}
           githubConnectionId={githubRepo.connectionId ?? ""}
           owner={githubRepo.owner}
@@ -365,16 +326,15 @@ function HeaderButtonRenderer(props: {
   const chatBlocksAction =
     actionBusy &&
     button.action !== "create-pr" &&
+    button.action !== "commit-and-push" &&
     button.action !== "merge-split";
   const disabled =
     Boolean(button.disabled) ||
     chatBlocksAction ||
-    (githubActionPending &&
-      (button.action === "create-pr" || button.action === "merge-split"));
+    (githubActionPending && button.action === "merge-split");
   const loading =
     Boolean(button.loading) ||
-    (githubActionPending &&
-      (button.action === "create-pr" || button.action === "merge-split"));
+    (githubActionPending && button.action === "merge-split");
   const tooltipLabel = chatBlocksAction
     ? "Chat is running"
     : (button.tooltip ?? null);

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -28,7 +28,10 @@ import { selectHeaderButton, type HeaderButton } from "./panel-state.ts";
 import * as tpl from "./message-templates.ts";
 import { saveChangesDebug } from "./save-changes-debug.ts";
 import { resolveSandboxBranchFromMap } from "./resolve-sandbox-branch.ts";
-import { mergeBranchMetaWithGitStatus } from "./sandbox-git-api.ts";
+import {
+  mergeBranchMetaWithGitStatus,
+  readGitHeadBranch,
+} from "./sandbox-git-api.ts";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events.ts";
 import { useChecks, usePrByBranch } from "./use-pr-data.ts";
 import { usePrReviews } from "./use-pr-reviews.ts";
@@ -97,7 +100,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   });
 
   const githubHeadBranch =
-    gitStatusQuery.data?.current ?? sandboxRouteBranch ?? null;
+    readGitHeadBranch(gitStatusQuery.data) ?? sandboxRouteBranch ?? null;
 
   const prQuery = usePrByBranch({
     orgId: org.id,
@@ -175,7 +178,9 @@ export function HeaderActions({ virtualMcpId }: Props) {
     lifecycle: lifecycle.phase,
     githubHeadBranch,
   });
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- debug dedupe ref
   if (debugKeyRef.current !== debugKey) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- debug dedupe ref
     debugKeyRef.current = debugKey;
     saveChangesDebug("header button", {
       label: button.label,

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -17,6 +17,7 @@ import { useState, useRef } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/web/lib/auth-client.ts";
 import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
+import { generateBranchName } from "@/shared/branch-name";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
 import { useSandboxGitStatus } from "@/web/components/sandbox/hooks/use-sandbox-git-status.ts";
@@ -57,7 +58,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
-  const { currentBranch: branch } = useChatTask();
+  const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
   const chat = useChatStream();
   const [publishOpen, setPublishOpen] = useState(false);
   const [githubActionPending, setGithubActionPending] = useState(false);
@@ -211,6 +212,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
     ]);
   };
 
+  const switchToFreshBranch = async () => {
+    const nextBranch = generateBranchName();
+    await setCurrentTaskBranch(nextBranch);
+  };
+
   const handleSquashMerge = async (pullNumber: number) => {
     if (!githubRepo?.connectionId || githubActionPending) return;
     setGithubActionPending(true);
@@ -222,6 +228,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
       });
       toast.success(`Published PR #${pullNumber}`);
       await refreshPrState();
+      await switchToFreshBranch();
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : "Failed to merge pull request",
@@ -307,6 +314,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
           repo={githubRepo.name}
           previewUrl={previewUrl}
           onPullRequestChanged={refreshPrState}
+          onPublished={switchToFreshBranch}
         />
       )}
     </>

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -1,4 +1,9 @@
-import { useProjectContext, useVirtualMCP } from "@decocms/mesh-sdk";
+import {
+  parseBranchMap,
+  useMCPClient,
+  useProjectContext,
+  useVirtualMCP,
+} from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Separator } from "@deco/ui/components/separator.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
@@ -8,11 +13,27 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import { useState, useRef } from "react";
+import { toast } from "sonner";
+import { authClient } from "@/web/lib/auth-client.ts";
+import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
+import { useSandboxGitStatus } from "@/web/components/sandbox/hooks/use-sandbox-git-status.ts";
+import {
+  openPullRequestForBranch,
+  squashMergePullRequest,
+} from "./github-pr-api.ts";
 import { MergeSplitButton } from "./merge-split-button.tsx";
+import { PublishDialog } from "./publish-dialog.tsx";
 import { selectHeaderButton, type HeaderButton } from "./panel-state.ts";
 import * as tpl from "./message-templates.ts";
+import { saveChangesDebug } from "./save-changes-debug.ts";
+import {
+  resolveEffectiveBranch,
+  resolveSandboxBranchFromMap,
+} from "./resolve-sandbox-branch.ts";
+import { mergeBranchMetaWithGitStatus } from "./sandbox-git-api.ts";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events.ts";
 import { useChecks, usePrByBranch } from "./use-pr-data.ts";
 import { usePrReviews } from "./use-pr-reviews.ts";
@@ -21,29 +42,70 @@ interface Props {
   virtualMcpId: string;
 }
 
+const LOADING_BRANCH_BUTTON: HeaderButton = {
+  label: "Loading branch…",
+  disabled: true,
+  loading: true,
+  variant: "outline",
+  tooltip: "Waiting for sandbox branch",
+};
+
 /**
  * HeaderActions renders a single next-action button for the current branch +
- * PR state. The button never performs the action directly; clicks send a
- * templated prompt into the chat for the agent to execute.
+ * PR state. Save changes opens the publish dialog; open-PR and squash-merge
+ * call GitHub MCP tools directly. Other actions still send chat prompts.
  *
- * Gated on `!!githubRepo?.connectionId && !!branch`. Once GitHub is wired
- * up, the button always renders — disabled status pills (Loading…, Up to
- * date, Published, Awaiting review, Running tests…) cover the cases where
- * there is no actionable next step.
+ * Gated on an active GitHub repo. Once wired, the button always renders —
+ * disabled status pills (Loading…, Up to date, Published, …) cover cases
+ * where there is no actionable next step.
  */
 export function HeaderActions({ virtualMcpId }: Props) {
   const { org } = useProjectContext();
+  const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
   const { currentBranch: branch } = useChatTask();
   const chat = useChatStream();
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [githubActionPending, setGithubActionPending] = useState(false);
+  const debugKeyRef = useRef("");
 
-  const githubRepo = vm?.metadata?.githubRepo ?? null;
+  const githubRepo = getActiveGithubRepo(vm);
+  const userId = session?.user?.id;
+
+  const githubClient = useMCPClient({
+    connectionId: githubRepo?.connectionId ?? "",
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
 
   const {
     lifecycle,
     branch: branchMeta,
     phase: claimPhase,
+    notFound: sandboxGone,
   } = useSandboxEvents();
+
+  const sandboxBranch = branchMeta.kind === "ready" ? branchMeta.branch : null;
+  const sandboxMapBranch = resolveSandboxBranchFromMap(
+    vm?.metadata?.sandboxMap,
+    userId,
+    branch ?? sandboxBranch,
+  );
+  const branchForApi = branch ?? sandboxBranch ?? sandboxMapBranch ?? undefined;
+
+  const gitStatusQuery = useSandboxGitStatus({
+    orgSlug: org.slug,
+    virtualMcpId,
+    branch: branchForApi ?? null,
+    enabled: !!githubRepo && !!branchForApi && !sandboxGone,
+  });
+
+  const effectiveBranch = resolveEffectiveBranch({
+    chatBranch: branch,
+    sandboxBranch,
+    sandboxMapBranch,
+    gitCurrentBranch: gitStatusQuery.data?.current,
+  });
 
   const prQuery = usePrByBranch({
     orgId: org.id,
@@ -51,7 +113,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     connectionId: githubRepo?.connectionId ?? "",
     owner: githubRepo?.owner ?? "",
     repo: githubRepo?.name ?? "",
-    branch: branch ?? null,
+    branch: effectiveBranch,
   });
   const pr = prQuery.data ?? null;
 
@@ -73,39 +135,158 @@ export function HeaderActions({ virtualMcpId }: Props) {
     prNumber: pr && pr.state === "open" ? pr.number : null,
   });
 
-  if (!githubRepo?.connectionId || !branch) return null;
+  const effectiveBranchMeta = mergeBranchMetaWithGitStatus(
+    branchMeta,
+    gitStatusQuery.data,
+  );
 
-  const button = selectHeaderButton({
-    lifecycle,
-    branch: branchMeta,
-    claimPhase,
-    pr,
-    checks: checksQuery.data ?? [],
-    reviews: reviewsQuery.data ?? null,
-    loading: prQuery.isPending,
+  if (!githubRepo) return null;
+
+  const branchMap =
+    userId && effectiveBranch
+      ? parseBranchMap(vm?.metadata?.sandboxMap?.[userId]?.[effectiveBranch])
+      : {};
+  const branchMapEntries = Object.values(branchMap);
+  const vmEntry =
+    branchMapEntries.find((e) => e.sandboxProviderKind !== "user-desktop") ??
+    branchMapEntries[0];
+  const previewUrl = vmEntry?.previewUrl ?? null;
+
+  const button = effectiveBranch
+    ? selectHeaderButton({
+        lifecycle,
+        branch: effectiveBranchMeta,
+        claimPhase,
+        pr,
+        checks: checksQuery.data ?? [],
+        reviews: reviewsQuery.data ?? null,
+        loading: prQuery.isPending,
+      })
+    : LOADING_BRANCH_BUTTON;
+
+  const debugKey = JSON.stringify({
+    label: button.label,
+    branchKind: effectiveBranchMeta.kind,
+    workingTreeDirty:
+      effectiveBranchMeta.kind === "ready"
+        ? effectiveBranchMeta.workingTreeDirty
+        : null,
+    gitModifiedCount: gitStatusQuery.data?.modified.length ?? null,
+    unpushed:
+      effectiveBranchMeta.kind === "ready"
+        ? effectiveBranchMeta.unpushed
+        : null,
+    aheadOfBase:
+      effectiveBranchMeta.kind === "ready"
+        ? effectiveBranchMeta.aheadOfBase
+        : null,
+    lifecycle: lifecycle.phase,
+    effectiveBranch,
   });
+  if (debugKeyRef.current !== debugKey) {
+    debugKeyRef.current = debugKey;
+    saveChangesDebug("header button", {
+      label: button.label,
+      tooltip: button.tooltip,
+      action: button.action,
+      chatBranch: branch,
+      sandboxBranch,
+      sandboxMapBranch,
+      effectiveBranch,
+      branchMeta,
+      effectiveBranchMeta,
+      gitStatus: gitStatusQuery.data ?? null,
+      lifecyclePhase: lifecycle.phase,
+      prNumber: pr?.number ?? null,
+      prState: pr?.state ?? null,
+    });
+  }
 
   const send = (text: string) =>
     chat.sendMessage({ parts: [{ type: "text", text }] });
 
   const isStreaming = chat.isStreaming;
 
+  const baseBranch =
+    effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.base : "main";
+
+  const refreshPrState = async () => {
+    await Promise.all([
+      prQuery.refetch(),
+      gitStatusQuery.refetch(),
+      checksQuery.refetch(),
+      reviewsQuery.refetch(),
+    ]);
+  };
+
+  const handleCreatePullRequest = async () => {
+    if (!githubRepo?.connectionId || !effectiveBranch || githubActionPending) {
+      return;
+    }
+    setGithubActionPending(true);
+    try {
+      const pr = await openPullRequestForBranch(githubClient, {
+        owner: githubRepo.owner,
+        repo: githubRepo.name,
+        branch: effectiveBranch,
+        title: `Changes from ${effectiveBranch}`,
+        base: baseBranch,
+      });
+      toast.success(`Submitted pull request #${pr.number} for review`, {
+        action: {
+          label: "View on GitHub",
+          onClick: () => window.open(pr.htmlUrl, "_blank", "noopener"),
+        },
+      });
+      await refreshPrState();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to open pull request",
+      );
+    } finally {
+      setGithubActionPending(false);
+    }
+  };
+
+  const handleSquashMerge = async (pullNumber: number) => {
+    if (!githubRepo?.connectionId || githubActionPending) return;
+    setGithubActionPending(true);
+    try {
+      await squashMergePullRequest(githubClient, {
+        owner: githubRepo.owner,
+        repo: githubRepo.name,
+        pullNumber,
+      });
+      toast.success(`Published PR #${pullNumber}`);
+      await refreshPrState();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to merge pull request",
+      );
+    } finally {
+      setGithubActionPending(false);
+    }
+  };
+
   const onActivate = (action: HeaderButton["action"]) => {
-    if (isStreaming) return;
+    if (!action || !effectiveBranch) return;
     switch (action) {
       case "commit-and-push":
-        void send(tpl.commitAndPush({ branch }));
+        setPublishOpen(true);
         return;
       case "create-pr":
-        void send(tpl.createPr({ branch }));
+        void handleCreatePullRequest();
         return;
       case "reopen":
+        if (isStreaming) return;
         if (pr) void send(tpl.reopenPr({ prNumber: pr.number }));
         return;
       case "rebase":
-        void send(tpl.rebaseOnBase({ branch }));
+        if (isStreaming) return;
+        void send(tpl.rebaseOnBase({ branch: effectiveBranch }));
         return;
       case "fix-checks":
+        if (isStreaming) return;
         if (pr)
           void send(
             tpl.fixChecks({
@@ -115,16 +296,19 @@ export function HeaderActions({ virtualMcpId }: Props) {
           );
         return;
       case "mark-ready":
+        if (isStreaming) return;
         if (pr) void send(tpl.markReadyForReview({ prNumber: pr.number }));
         return;
       case "resolve-comments":
+        if (isStreaming) return;
         if (pr) void send(tpl.resolveReviewComments({ prNumber: pr.number }));
         return;
       case "merge-split":
-        // MergeSplitButton handles its own click wiring.
         return;
     }
   };
+
+  const actionBusy = githubActionPending || isStreaming;
 
   return (
     <>
@@ -134,25 +318,64 @@ export function HeaderActions({ virtualMcpId }: Props) {
       />
       <HeaderButtonRenderer
         button={button}
-        isStreaming={isStreaming}
+        actionBusy={actionBusy}
+        githubActionPending={githubActionPending}
         onActivate={onActivate}
         prNumber={pr?.number}
-        send={send}
+        onSquashMerge={handleSquashMerge}
+        onReview={
+          pr
+            ? () => {
+                if (isStreaming) return;
+                void send(tpl.reviewPr({ prNumber: pr.number }));
+              }
+            : undefined
+        }
       />
+      {effectiveBranch && (
+        <PublishDialog
+          open={publishOpen}
+          onOpenChange={setPublishOpen}
+          orgSlug={org.slug}
+          orgId={org.id}
+          virtualMcpId={virtualMcpId}
+          branch={effectiveBranch}
+          baseBranch={baseBranch}
+          githubConnectionId={githubRepo.connectionId ?? ""}
+          owner={githubRepo.owner}
+          repo={githubRepo.name}
+          previewUrl={previewUrl}
+          onPullRequestChanged={refreshPrState}
+        />
+      )}
     </>
   );
 }
 
 function HeaderButtonRenderer(props: {
   button: HeaderButton;
-  isStreaming: boolean;
+  actionBusy: boolean;
+  githubActionPending: boolean;
   onActivate: (action: HeaderButton["action"]) => void;
   prNumber?: number;
-  send: (text: string) => Promise<void> | void;
+  onSquashMerge: (pullNumber: number) => void | Promise<void>;
+  onReview?: () => void;
 }) {
-  const { button, isStreaming } = props;
-  const disabled = Boolean(button.disabled) || isStreaming;
-  const tooltipLabel = isStreaming
+  const { button, actionBusy, githubActionPending } = props;
+  const chatBlocksAction =
+    actionBusy &&
+    button.action !== "create-pr" &&
+    button.action !== "merge-split";
+  const disabled =
+    Boolean(button.disabled) ||
+    chatBlocksAction ||
+    (githubActionPending &&
+      (button.action === "create-pr" || button.action === "merge-split"));
+  const loading =
+    Boolean(button.loading) ||
+    (githubActionPending &&
+      (button.action === "create-pr" || button.action === "merge-split"));
+  const tooltipLabel = chatBlocksAction
     ? "Chat is running"
     : (button.tooltip ?? null);
 
@@ -162,7 +385,9 @@ function HeaderButtonRenderer(props: {
         <MergeSplitButton
           prNumber={props.prNumber}
           disabled={disabled}
-          send={props.send}
+          loading={loading}
+          onPublish={() => props.onSquashMerge(props.prNumber!)}
+          onReview={props.onReview}
         />
       </WithTooltip>
     );
@@ -174,9 +399,11 @@ function HeaderButtonRenderer(props: {
         size="sm"
         variant={button.variant}
         disabled={disabled}
-        onClick={() => props.onActivate(button.action)}
+        onClick={() => {
+          if (button.action) props.onActivate(button.action);
+        }}
       >
-        {button.loading ? <Spinner size="xs" variant="default" /> : null}
+        {loading ? <Spinner size="xs" variant="default" /> : null}
         {button.label}
       </Button>
     </WithTooltip>

--- a/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
+++ b/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
@@ -5,24 +5,27 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { ChevronDown } from "@untitledui/icons";
-import * as tpl from "./message-templates.ts";
 
 interface Props {
   prNumber: number;
   disabled: boolean;
-  send: (text: string) => Promise<void> | void;
+  loading?: boolean;
+  onPublish: () => void | Promise<void>;
+  onReview?: () => void;
 }
 
 /**
- * Split-style merge action: clicking the label fires Publish (squash-
- * merge); clicking the chevron opens a dropdown with Review. Each choice
- * sends a templated chat message.
+ * Split-style merge action: Publish squash-merges via GitHub MCP; Review still
+ * uses the chat agent for a read-only review pass.
  */
-export function MergeSplitButton({ prNumber, disabled, send }: Props) {
-  const squash = () => send(tpl.mergeSquash({ prNumber }));
-  const review = () => send(tpl.reviewPr({ prNumber }));
-
+export function MergeSplitButton({
+  disabled,
+  loading = false,
+  onPublish,
+  onReview,
+}: Props) {
   return (
     <div className="inline-flex items-stretch rounded-md">
       <Button
@@ -30,8 +33,9 @@ export function MergeSplitButton({ prNumber, disabled, send }: Props) {
         variant="success"
         className="rounded-r-none border-r border-success-foreground/20"
         disabled={disabled}
-        onClick={squash}
+        onClick={() => void onPublish()}
       >
+        {loading ? <Spinner size="xs" variant="default" /> : null}
         Publish
       </Button>
       <DropdownMenu>
@@ -47,7 +51,9 @@ export function MergeSplitButton({ prNumber, disabled, send }: Props) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={review}>Review</DropdownMenuItem>
+          {onReview ? (
+            <DropdownMenuItem onClick={onReview}>Review</DropdownMenuItem>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -170,6 +170,23 @@ export function selectHeaderButton(
     };
   }
 
+  // Fall-through debug: why not Save changes?
+  if (
+    typeof localStorage !== "undefined" &&
+    localStorage.getItem("DEBUG_SAVE_CHANGES") === "1"
+  ) {
+    console.log("[github-header] no local work — checking PR/sync state", {
+      workingTreeDirty: ready.workingTreeDirty,
+      unpushed: ready.unpushed,
+      aheadOfBase: ready.aheadOfBase,
+      behindBase: ready.behindBase,
+      branch: ready.branch,
+      base: ready.base,
+      prMerged: pr?.merged ?? null,
+      prState: pr?.state ?? null,
+    });
+  }
+
   // Merged PR is terminal UNLESS the branch has advanced past the PR's
   // head (i.e. new commits were pushed after the merge). Squash-merges
   // leave the branch's pre-merge commits intact on origin/<branch> with

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -3,6 +3,7 @@ import type { ClaimPhase } from "@/web/components/sandbox/hooks/sandbox-events-c
 import { CLAIM_PHASE_COPY } from "@/web/components/sandbox/claim-phase-copy";
 import type { CheckRun, PrSummary } from "./use-pr-data.ts";
 import type { PrReviewSignals } from "./use-pr-reviews.ts";
+import { saveChangesDebug } from "./save-changes-debug.ts";
 
 /**
  * Header copy for claim-phase variants while lifecycle is still `idle`.
@@ -171,21 +172,16 @@ export function selectHeaderButton(
   }
 
   // Fall-through debug: why not Save changes?
-  if (
-    typeof localStorage !== "undefined" &&
-    localStorage.getItem("DEBUG_SAVE_CHANGES") === "1"
-  ) {
-    console.log("[github-header] no local work — checking PR/sync state", {
-      workingTreeDirty: ready.workingTreeDirty,
-      unpushed: ready.unpushed,
-      aheadOfBase: ready.aheadOfBase,
-      behindBase: ready.behindBase,
-      branch: ready.branch,
-      base: ready.base,
-      prMerged: pr?.merged ?? null,
-      prState: pr?.state ?? null,
-    });
-  }
+  saveChangesDebug("no local work — checking PR/sync state", {
+    workingTreeDirty: ready.workingTreeDirty,
+    unpushed: ready.unpushed,
+    aheadOfBase: ready.aheadOfBase,
+    behindBase: ready.behindBase,
+    branch: ready.branch,
+    base: ready.base,
+    prMerged: pr?.merged ?? null,
+    prState: pr?.state ?? null,
+  });
 
   // Merged PR is terminal UNLESS the branch has advanced past the PR's
   // head (i.e. new commits were pushed after the merge). Squash-merges

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -1,0 +1,689 @@
+import { DiffEditor, loader } from "@monaco-editor/react";
+import { useMCPClient } from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Dialog, DialogContent } from "@deco/ui/components/dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@deco/ui/components/tabs.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  ArrowRight,
+  ChevronRight,
+  Eye,
+  File06,
+  GitBranch01,
+  Loading01,
+  DotsHorizontal,
+  Stars01,
+} from "@untitledui/icons";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { getLanguageFromPath } from "../../sandbox/preview/file-explorer/utils.ts";
+import {
+  openPullRequestForBranch,
+  squashMergePullRequest,
+} from "./github-pr-api.ts";
+import {
+  countGitChanges,
+  discardGitFiles,
+  fetchGitDiff,
+  fetchGitStatus,
+  fetchSuggestCommitMessage,
+  publishGitChanges,
+  type GitDiffResult,
+  type GitStatus,
+} from "./sandbox-git-api.ts";
+
+loader.config({
+  paths: {
+    vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs",
+  },
+});
+
+function editorTheme(): "vs" | "vs-dark" {
+  return document.documentElement.classList.contains("dark") ? "vs-dark" : "vs";
+}
+
+export interface PublishDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgSlug: string;
+  orgId: string;
+  virtualMcpId: string;
+  branch: string;
+  baseBranch: string;
+  githubConnectionId: string;
+  owner: string;
+  repo: string;
+  previewUrl?: string | null;
+  /** Called after commit/push or PR open/merge so the header can refresh. */
+  onPullRequestChanged?: () => void | Promise<void>;
+}
+
+export function PublishDialog(props: PublishDialogProps) {
+  const [session, setSession] = useState(0);
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) setSession((s) => s + 1);
+    props.onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={props.open} onOpenChange={handleOpenChange}>
+      {props.open ? (
+        <PublishDialogBody
+          key={session}
+          {...props}
+          onOpenChange={handleOpenChange}
+        />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function PublishDialogBody({
+  onOpenChange,
+  orgSlug,
+  orgId,
+  virtualMcpId,
+  branch,
+  baseBranch,
+  githubConnectionId,
+  owner,
+  repo,
+  previewUrl,
+  onPullRequestChanged,
+}: PublishDialogProps) {
+  const githubClient = useMCPClient({
+    connectionId: githubConnectionId,
+    orgId,
+    orgSlug,
+  });
+
+  const [gitStatus, setGitStatus] = useState<GitStatus | null>(null);
+  const [gitDiff, setGitDiff] = useState<GitDiffResult | null>(null);
+  const [isLoadingGitDiff, setIsLoadingGitDiff] = useState(true);
+  const [expandedDiffFile, setExpandedDiffFile] = useState<string | null>(null);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [publishTitle, setPublishTitle] = useState("");
+  const [publishBody, setPublishBody] = useState("");
+  const [publishError, setPublishError] = useState<string>();
+  const [isSubmittingForReview, setIsSubmittingForReview] = useState(false);
+  const [submitForReviewError, setSubmitForReviewError] = useState<string>();
+  const [discardConfirmFile, setDiscardConfirmFile] = useState<string | null>(
+    null,
+  );
+  const [discardAllConfirm, setDiscardAllConfirm] = useState(false);
+  const [isDiscardingAll, setIsDiscardingAll] = useState(false);
+  const [isGeneratingSuggestion, setIsGeneratingSuggestion] = useState(false);
+
+  const loadStartedRef = useRef(false);
+  if (!loadStartedRef.current) {
+    loadStartedRef.current = true;
+    void (async () => {
+      setIsLoadingGitDiff(true);
+      setIsGeneratingSuggestion(true);
+      setPublishError(undefined);
+      setExpandedDiffFile(null);
+      setGitDiff(null);
+      setPublishTitle("");
+      setPublishBody("");
+      setSubmitForReviewError(undefined);
+      try {
+        const [status, diff, commitSuggestion] = await Promise.all([
+          fetchGitStatus(orgSlug, virtualMcpId, branch),
+          fetchGitDiff(orgSlug, virtualMcpId, branch),
+          fetchSuggestCommitMessage(orgSlug, virtualMcpId, branch).catch(
+            () => null,
+          ),
+        ]);
+        setGitStatus(status);
+        setGitDiff(diff);
+        if (commitSuggestion) {
+          setPublishTitle(commitSuggestion.title);
+          setPublishBody(commitSuggestion.body);
+        }
+      } catch (error) {
+        setPublishError(
+          error instanceof Error ? error.message : "Failed to load changes.",
+        );
+      } finally {
+        setIsLoadingGitDiff(false);
+        setIsGeneratingSuggestion(false);
+      }
+    })();
+  }
+
+  const regenerateSuggestion = () => {
+    setIsGeneratingSuggestion(true);
+    void fetchSuggestCommitMessage(orgSlug, virtualMcpId, branch)
+      .then((data) => {
+        setPublishTitle(data.title);
+        setPublishBody(data.body);
+      })
+      .catch(() => {
+        /* best-effort */
+      })
+      .finally(() => setIsGeneratingSuggestion(false));
+  };
+
+  const changesCount = countGitChanges(gitStatus);
+  const diffCount = gitDiff ? Object.keys(gitDiff.diffs).length : changesCount;
+  const theme = editorTheme();
+
+  const hasChanges = gitDiff != null && Object.keys(gitDiff.diffs).length > 0;
+  const canSubmit = !isLoadingGitDiff && !isGeneratingSuggestion && hasChanges;
+
+  const commitMessage = () =>
+    [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isPublishing || isSubmittingForReview) return;
+    onOpenChange(nextOpen);
+    if (!nextOpen) setExpandedDiffFile(null);
+  };
+
+  const handlePublish = async () => {
+    setIsPublishing(true);
+    setPublishError(undefined);
+    try {
+      const prTitle = publishTitle.trim() || `Changes from ${branch}`;
+      const prBody = publishBody.trim() || undefined;
+      const message = commitMessage() || prTitle;
+
+      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+
+      const pr = await openPullRequestForBranch(githubClient, {
+        owner,
+        repo,
+        branch,
+        title: prTitle,
+        body: prBody,
+        base: baseBranch,
+      });
+
+      await squashMergePullRequest(githubClient, {
+        owner,
+        repo,
+        pullNumber: pr.number,
+        commitTitle: prTitle,
+      });
+
+      toast.success(`Published to ${baseBranch}`);
+      handleOpenChange(false);
+      setGitDiff(null);
+      setPublishTitle("");
+      setPublishBody("");
+      const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+      setGitStatus(status);
+      await onPullRequestChanged?.();
+    } catch (error) {
+      setPublishError(
+        error instanceof Error ? error.message : "Failed to publish",
+      );
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  const discardOrDelete = async (filepath: string) => {
+    const isNewFile = gitDiff?.diffs[filepath]?.from === null;
+    if (isNewFile) {
+      await discardGitFiles(orgSlug, virtualMcpId, branch, [filepath]);
+      return;
+    }
+    await discardGitFiles(orgSlug, virtualMcpId, branch, [filepath]);
+  };
+
+  const handleDiscardFile = async (filepath: string) => {
+    setDiscardConfirmFile(null);
+    try {
+      await discardOrDelete(filepath);
+      toast.success(`Discarded changes to ${filepath}`);
+      setGitDiff((prev) => {
+        if (!prev) return prev;
+        const next = { ...prev, diffs: { ...prev.diffs } };
+        delete next.diffs[filepath];
+        return next;
+      });
+      if (expandedDiffFile === filepath) setExpandedDiffFile(null);
+      const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+      setGitStatus(status);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to discard changes",
+      );
+    }
+  };
+
+  const handleDiscardAll = async () => {
+    if (!gitDiff) return;
+    setDiscardAllConfirm(false);
+    setIsDiscardingAll(true);
+    try {
+      const allFiles = Object.keys(gitDiff.diffs);
+      if (allFiles.length === 0) return;
+      await discardGitFiles(orgSlug, virtualMcpId, branch, allFiles);
+      toast.success("All changes discarded");
+      setGitDiff(null);
+      setExpandedDiffFile(null);
+      const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+      setGitStatus(status);
+      handleOpenChange(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to discard changes",
+      );
+    } finally {
+      setIsDiscardingAll(false);
+    }
+  };
+
+  const handleSubmitForReview = async () => {
+    setIsSubmittingForReview(true);
+    setSubmitForReviewError(undefined);
+    try {
+      const prTitle = publishTitle.trim() || `Changes from ${branch}`;
+      const prBody = publishBody.trim() || undefined;
+      const message = commitMessage() || prTitle;
+
+      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+
+      const pr = await openPullRequestForBranch(githubClient, {
+        owner,
+        repo,
+        branch,
+        title: prTitle,
+        body: prBody,
+        base: baseBranch,
+      });
+
+      toast.success(`Submitted pull request #${pr.number} for review`, {
+        action: {
+          label: "View on GitHub",
+          onClick: () => window.open(pr.htmlUrl, "_blank", "noopener"),
+        },
+      });
+      handleOpenChange(false);
+      await onPullRequestChanged?.();
+    } catch (error) {
+      setSubmitForReviewError(
+        error instanceof Error ? error.message : "Failed to submit for review",
+      );
+    } finally {
+      setIsSubmittingForReview(false);
+    }
+  };
+
+  return (
+    <DialogContent className="top-14 left-auto right-4 flex h-[90%] max-h-[85vh] w-[90vw] max-w-[600px] translate-x-0 translate-y-0 flex-col gap-0 overflow-hidden p-0">
+      <Tabs defaultValue="description" className="flex h-full flex-col gap-0">
+        <div className="shrink-0 space-y-3 px-6 pt-5 pb-4">
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Publish</p>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
+              {diffCount} {diffCount === 1 ? "change" : "changes"} to publish
+            </div>
+          </div>
+          {discardAllConfirm ? (
+            <div className="flex items-center justify-between gap-3 rounded-md bg-destructive/5 px-3 py-2">
+              <span className="text-xs text-destructive">
+                Discard all changes? This cannot be undone.
+              </span>
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setDiscardAllConfirm(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="h-7 bg-destructive px-2 text-xs text-destructive-foreground hover:bg-destructive/90"
+                  onClick={handleDiscardAll}
+                  disabled={isDiscardingAll}
+                >
+                  {isDiscardingAll ? (
+                    <Loading01 className="h-3 w-3 animate-spin" />
+                  ) : null}
+                  Discard all
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between">
+              <TabsList className="h-8 w-auto" variant="pill">
+                <TabsTrigger value="description" className="px-3 text-xs">
+                  Description
+                </TabsTrigger>
+                <TabsTrigger value="changes" className="px-3 text-xs">
+                  Changes
+                </TabsTrigger>
+              </TabsList>
+              {diffCount > 0 && (
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
+                  onClick={() => setDiscardAllConfirm(true)}
+                  disabled={isPublishing || isDiscardingAll}
+                >
+                  Discard all
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t" />
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {isLoadingGitDiff ? (
+            <div className="flex items-center justify-center gap-2 py-16 text-muted-foreground">
+              <Loading01 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Loading changes…</span>
+            </div>
+          ) : (
+            <>
+              <TabsContent value="description" className="mt-0 px-6 py-5">
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Commit message</p>
+                    <button
+                      type="button"
+                      className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+                      disabled={
+                        isGeneratingSuggestion ||
+                        isPublishing ||
+                        isSubmittingForReview
+                      }
+                      onClick={regenerateSuggestion}
+                    >
+                      {isGeneratingSuggestion ? (
+                        <Loading01 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Stars01 className="h-3 w-3" />
+                      )}
+                      {isGeneratingSuggestion ? "Generating…" : "Regenerate"}
+                    </button>
+                  </div>
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="publish-title"
+                      className="text-xs font-medium text-muted-foreground"
+                    >
+                      Title
+                    </label>
+                    <Input
+                      id="publish-title"
+                      value={publishTitle}
+                      onChange={(e) => setPublishTitle(e.target.value)}
+                      placeholder={
+                        isGeneratingSuggestion ? "Generating…" : "Commit title…"
+                      }
+                      disabled={
+                        isPublishing ||
+                        isSubmittingForReview ||
+                        isGeneratingSuggestion
+                      }
+                      className="text-sm"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="publish-body"
+                      className="text-xs font-medium text-muted-foreground"
+                    >
+                      Description
+                    </label>
+                    <Textarea
+                      id="publish-body"
+                      value={publishBody}
+                      onChange={(e) => setPublishBody(e.target.value)}
+                      placeholder={
+                        isGeneratingSuggestion
+                          ? "Generating…"
+                          : "Description (optional)…"
+                      }
+                      disabled={
+                        isPublishing ||
+                        isSubmittingForReview ||
+                        isGeneratingSuggestion
+                      }
+                      rows={5}
+                      className="resize-none text-sm"
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Branch: <span className="font-mono">{branch}</span>
+                    {" → "}
+                    <span className="font-mono">{baseBranch}</span>
+                    {" · "}
+                    <span className="text-foreground/80">
+                      Submit for review keeps changes on the branch; Publish
+                      squash-merges into {baseBranch}.
+                    </span>
+                  </p>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="changes" className="mt-0">
+                {gitDiff && Object.keys(gitDiff.diffs).length === 0 && (
+                  <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+                    No file changes in the working tree
+                  </div>
+                )}
+                {gitDiff && Object.keys(gitDiff.diffs).length > 0 && (
+                  <div className="divide-y">
+                    {Object.entries(gitDiff.diffs).map(
+                      ([filepath, { from, to }]) => {
+                        const isExpanded = expandedDiffFile === filepath;
+                        const isNew = from === null;
+                        const isDeleted = to === null;
+                        const raw = filepath.startsWith("/")
+                          ? filepath.slice(1)
+                          : filepath;
+                        const lastSlash = raw.lastIndexOf("/");
+                        const basename =
+                          lastSlash >= 0 ? raw.slice(lastSlash + 1) : raw;
+                        const directory =
+                          lastSlash >= 0 ? raw.slice(0, lastSlash) : null;
+                        const language = getLanguageFromPath(filepath);
+                        const dotColor = isNew
+                          ? "bg-green-500"
+                          : isDeleted
+                            ? "bg-red-500"
+                            : "bg-amber-500";
+
+                        return (
+                          <div key={filepath}>
+                            <div className="flex items-center gap-3 px-6 py-3 hover:bg-muted/30">
+                              <button
+                                type="button"
+                                className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-transform hover:text-foreground"
+                                onClick={() =>
+                                  setExpandedDiffFile(
+                                    isExpanded ? null : filepath,
+                                  )
+                                }
+                              >
+                                <ChevronRight
+                                  className={cn(
+                                    "h-3.5 w-3.5 transition-transform",
+                                    isExpanded && "rotate-90",
+                                  )}
+                                />
+                              </button>
+                              <div
+                                className={cn(
+                                  "h-2.5 w-2.5 shrink-0 rounded-full",
+                                  dotColor,
+                                )}
+                              />
+                              <File06 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                              <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                                {basename}
+                              </span>
+                              {directory && (
+                                <span className="shrink-0 text-xs text-muted-foreground">
+                                  {directory}
+                                </span>
+                              )}
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    type="button"
+                                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+                                  >
+                                    <DotsHorizontal className="h-3.5 w-3.5" />
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                  <DropdownMenuItem
+                                    className="text-destructive focus:text-destructive"
+                                    onSelect={() =>
+                                      setDiscardConfirmFile(filepath)
+                                    }
+                                  >
+                                    Discard changes
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            </div>
+
+                            {discardConfirmFile === filepath && (
+                              <div className="flex items-center justify-between gap-3 border-t bg-destructive/5 px-6 py-2.5">
+                                <span className="text-xs text-destructive">
+                                  Discard all changes to{" "}
+                                  <span className="font-medium">
+                                    {basename}
+                                  </span>
+                                  ? This cannot be undone.
+                                </span>
+                                <div className="flex shrink-0 items-center gap-2">
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 px-2 text-xs"
+                                    onClick={() => setDiscardConfirmFile(null)}
+                                  >
+                                    Cancel
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    className="h-7 bg-destructive px-2 text-xs text-destructive-foreground hover:bg-destructive/90"
+                                    onClick={() => handleDiscardFile(filepath)}
+                                  >
+                                    Discard
+                                  </Button>
+                                </div>
+                              </div>
+                            )}
+
+                            {isExpanded && (
+                              <div className="border-t">
+                                <DiffEditor
+                                  original={from ?? ""}
+                                  modified={to ?? ""}
+                                  language={language}
+                                  theme={theme}
+                                  height="380px"
+                                  options={{
+                                    readOnly: true,
+                                    renderSideBySide: false,
+                                    minimap: { enabled: false },
+                                    scrollBeyondLastLine: false,
+                                    fontSize: 12,
+                                  }}
+                                />
+                              </div>
+                            )}
+                          </div>
+                        );
+                      },
+                    )}
+                  </div>
+                )}
+              </TabsContent>
+            </>
+          )}
+        </div>
+
+        <div className="shrink-0 border-t">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-6 py-3.5 text-sm transition-colors hover:bg-muted/50 disabled:opacity-50"
+            onClick={() => {
+              if (previewUrl) {
+                window.open(previewUrl, "_blank", "noopener,noreferrer");
+              }
+            }}
+            disabled={!previewUrl}
+          >
+            <span className="flex items-center gap-3">
+              <Eye className="h-4 w-4 text-muted-foreground" />
+              Visit preview
+            </span>
+            <ArrowRight className="h-4 w-4 text-muted-foreground" />
+          </button>
+        </div>
+
+        <div className="shrink-0 border-t px-6 py-3">
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              onClick={handleSubmitForReview}
+              disabled={!canSubmit || isSubmittingForReview || isPublishing}
+            >
+              {isSubmittingForReview ? (
+                <Loading01 className="h-4 w-4 animate-spin" />
+              ) : (
+                <GitBranch01 className="h-4 w-4" />
+              )}
+              Submit for review
+            </Button>
+            <Button
+              type="button"
+              variant="success"
+              className="flex-1"
+              onClick={handlePublish}
+              disabled={!canSubmit || isPublishing || isSubmittingForReview}
+            >
+              {isPublishing ? (
+                <Loading01 className="h-4 w-4 animate-spin" />
+              ) : null}
+              Publish
+            </Button>
+          </div>
+          {submitForReviewError && (
+            <p className="mt-2 text-xs text-destructive">
+              {submitForReviewError}
+            </p>
+          )}
+          {publishError && (
+            <p className="mt-2 text-xs text-destructive">{publishError}</p>
+          )}
+        </div>
+      </Tabs>
+    </DialogContent>
+  );
+}

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -33,6 +33,7 @@ import { getLanguageFromPath } from "../../sandbox/preview/file-explorer/utils.t
 import {
   openPullRequestForBranch,
   squashMergePullRequest,
+  type CreatedPullRequest,
 } from "./github-pr-api.ts";
 import {
   countGitChanges,
@@ -40,6 +41,7 @@ import {
   fetchGitDiff,
   fetchGitStatus,
   fetchSuggestCommitMessage,
+  hasUnpublishedWork,
   publishGitChanges,
   type GitDiffResult,
   type GitStatus,
@@ -53,6 +55,17 @@ loader.config({
 
 function editorTheme(): "vs" | "vs-dark" {
   return document.documentElement.classList.contains("dark") ? "vs-dark" : "vs";
+}
+
+class PublishFlowError extends Error {
+  constructor(
+    message: string,
+    readonly step: "push" | "open-pr" | "merge",
+    readonly pr?: CreatedPullRequest,
+  ) {
+    super(message);
+    this.name = "PublishFlowError";
+  }
 }
 
 export interface PublishDialogProps {
@@ -133,7 +146,6 @@ function PublishDialogBody({
     loadStartedRef.current = true;
     void (async () => {
       setIsLoadingGitDiff(true);
-      setIsGeneratingSuggestion(true);
       setPublishError(undefined);
       setExpandedDiffFile(null);
       setGitDiff(null);
@@ -141,33 +153,46 @@ function PublishDialogBody({
       setPublishBody("");
       setSubmitForReviewError(undefined);
       try {
-        const [status, diff, commitSuggestion] = await Promise.all([
+        const [status, diff] = await Promise.all([
           fetchGitStatus(orgSlug, virtualMcpId, branch),
           fetchGitDiff(orgSlug, virtualMcpId, branch),
-          fetchSuggestCommitMessage(orgSlug, virtualMcpId, branch).catch(
-            () => null,
-          ),
         ]);
         setGitStatus(status);
         setGitDiff(diff);
-        if (commitSuggestion) {
-          setPublishTitle(commitSuggestion.title);
-          setPublishBody(commitSuggestion.body);
-        }
+        setPublishTitle(`Changes from ${status.current ?? branch}`);
+
+        setIsGeneratingSuggestion(true);
+        fetchSuggestCommitMessage(orgSlug, virtualMcpId, branch, {
+          status,
+          diff,
+        })
+          .then((commitSuggestion) => {
+            setPublishTitle(commitSuggestion.title);
+            setPublishBody(commitSuggestion.body);
+          })
+          .catch(() => {
+            /* best-effort */
+          })
+          .finally(() => setIsGeneratingSuggestion(false));
       } catch (error) {
         setPublishError(
           error instanceof Error ? error.message : "Failed to load changes.",
         );
       } finally {
         setIsLoadingGitDiff(false);
-        setIsGeneratingSuggestion(false);
       }
     })();
   }
 
+  const githubHeadBranch = gitStatus?.current ?? branch;
+
   const regenerateSuggestion = () => {
+    if (!gitStatus || !gitDiff) return;
     setIsGeneratingSuggestion(true);
-    void fetchSuggestCommitMessage(orgSlug, virtualMcpId, branch)
+    void fetchSuggestCommitMessage(orgSlug, virtualMcpId, branch, {
+      status: gitStatus,
+      diff: gitDiff,
+    })
       .then((data) => {
         setPublishTitle(data.title);
         setPublishBody(data.body);
@@ -182,8 +207,7 @@ function PublishDialogBody({
   const diffCount = gitDiff ? Object.keys(gitDiff.diffs).length : changesCount;
   const theme = editorTheme();
 
-  const hasChanges = gitDiff != null && Object.keys(gitDiff.diffs).length > 0;
-  const canSubmit = !isLoadingGitDiff && !isGeneratingSuggestion && hasChanges;
+  const canSubmit = !isLoadingGitDiff && hasUnpublishedWork(gitStatus, gitDiff);
 
   const commitMessage = () =>
     [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");
@@ -197,28 +221,55 @@ function PublishDialogBody({
   const handlePublish = async () => {
     setIsPublishing(true);
     setPublishError(undefined);
+    let openedPr: CreatedPullRequest | undefined;
     try {
-      const prTitle = publishTitle.trim() || `Changes from ${branch}`;
+      const prTitle = publishTitle.trim() || `Changes from ${githubHeadBranch}`;
       const prBody = publishBody.trim() || undefined;
       const message = commitMessage() || prTitle;
 
-      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+      try {
+        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+      } catch (error) {
+        throw new PublishFlowError(
+          error instanceof Error ? error.message : "Failed to push changes",
+          "push",
+        );
+      }
 
-      const pr = await openPullRequestForBranch(githubClient, {
-        owner,
-        repo,
-        branch,
-        title: prTitle,
-        body: prBody,
-        base: baseBranch,
-      });
+      try {
+        openedPr = await openPullRequestForBranch(githubClient, {
+          owner,
+          repo,
+          branch: githubHeadBranch,
+          title: prTitle,
+          body: prBody,
+          base: baseBranch,
+        });
+      } catch (error) {
+        throw new PublishFlowError(
+          error instanceof Error
+            ? error.message
+            : "Failed to open pull request",
+          "open-pr",
+        );
+      }
 
-      await squashMergePullRequest(githubClient, {
-        owner,
-        repo,
-        pullNumber: pr.number,
-        commitTitle: prTitle,
-      });
+      try {
+        await squashMergePullRequest(githubClient, {
+          owner,
+          repo,
+          pullNumber: openedPr.number,
+          commitTitle: prTitle,
+        });
+      } catch (error) {
+        throw new PublishFlowError(
+          error instanceof Error
+            ? error.message
+            : "Failed to merge pull request",
+          "merge",
+          openedPr,
+        );
+      }
 
       toast.success(`Published to ${baseBranch}`);
       handleOpenChange(false);
@@ -229,6 +280,22 @@ function PublishDialogBody({
       setGitStatus(status);
       await onPullRequestChanged?.();
     } catch (error) {
+      if (
+        error instanceof PublishFlowError &&
+        error.step === "merge" &&
+        error.pr
+      ) {
+        const msg = `Changes were pushed and PR #${error.pr.number} is open, but merge failed: ${error.message}`;
+        setPublishError(msg);
+        toast.error(msg, {
+          action: {
+            label: "View PR",
+            onClick: () => window.open(error.pr!.htmlUrl, "_blank", "noopener"),
+          },
+        });
+        await onPullRequestChanged?.();
+        return;
+      }
       setPublishError(
         error instanceof Error ? error.message : "Failed to publish",
       );
@@ -237,19 +304,10 @@ function PublishDialogBody({
     }
   };
 
-  const discardOrDelete = async (filepath: string) => {
-    const isNewFile = gitDiff?.diffs[filepath]?.from === null;
-    if (isNewFile) {
-      await discardGitFiles(orgSlug, virtualMcpId, branch, [filepath]);
-      return;
-    }
-    await discardGitFiles(orgSlug, virtualMcpId, branch, [filepath]);
-  };
-
   const handleDiscardFile = async (filepath: string) => {
     setDiscardConfirmFile(null);
     try {
-      await discardOrDelete(filepath);
+      await discardGitFiles(orgSlug, virtualMcpId, branch, [filepath]);
       toast.success(`Discarded changes to ${filepath}`);
       setGitDiff((prev) => {
         if (!prev) return prev;
@@ -294,7 +352,7 @@ function PublishDialogBody({
     setIsSubmittingForReview(true);
     setSubmitForReviewError(undefined);
     try {
-      const prTitle = publishTitle.trim() || `Changes from ${branch}`;
+      const prTitle = publishTitle.trim() || `Changes from ${githubHeadBranch}`;
       const prBody = publishBody.trim() || undefined;
       const message = commitMessage() || prTitle;
 
@@ -303,7 +361,7 @@ function PublishDialogBody({
       const pr = await openPullRequestForBranch(githubClient, {
         owner,
         repo,
-        branch,
+        branch: githubHeadBranch,
         title: prTitle,
         body: prBody,
         base: baseBranch,

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -16,6 +16,12 @@ import {
   TabsTrigger,
 } from "@deco/ui/components/tabs.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   ArrowRight,
@@ -42,7 +48,10 @@ import {
   fetchGitStatus,
   fetchSuggestCommitMessage,
   hasUnpublishedWork,
+  isDecoOnlyDiff,
   publishGitChanges,
+  PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
+  rebaseGitBranch,
   type GitDiffResult,
   type GitStatus,
 } from "./sandbox-git-api.ts";
@@ -60,7 +69,7 @@ function editorTheme(): "vs" | "vs-dark" {
 class PublishFlowError extends Error {
   constructor(
     message: string,
-    readonly step: "push" | "open-pr" | "merge",
+    readonly step: "push" | "rebase" | "open-pr" | "merge",
     readonly pr?: CreatedPullRequest,
   ) {
     super(message);
@@ -82,6 +91,8 @@ export interface PublishDialogProps {
   previewUrl?: string | null;
   /** Called after commit/push or PR open/merge so the header can refresh. */
   onPullRequestChanged?: () => void | Promise<void>;
+  /** Called after a successful publish (squash-merge to base). */
+  onPublished?: () => void | Promise<void>;
 }
 
 export function PublishDialog(props: PublishDialogProps) {
@@ -117,6 +128,7 @@ function PublishDialogBody({
   repo,
   previewUrl,
   onPullRequestChanged,
+  onPublished,
 }: PublishDialogProps) {
   const githubClient = useMCPClient({
     connectionId: githubConnectionId,
@@ -208,6 +220,11 @@ function PublishDialogBody({
   const theme = editorTheme();
 
   const canSubmit = !isLoadingGitDiff && hasUnpublishedWork(gitStatus, gitDiff);
+  const canPublish = canSubmit && isDecoOnlyDiff(gitDiff);
+  const publishDisabledReason =
+    canSubmit && !isDecoOnlyDiff(gitDiff)
+      ? PUBLISH_REQUIRES_SUBMIT_TOOLTIP
+      : null;
 
   const commitMessage = () =>
     [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");
@@ -233,6 +250,15 @@ function PublishDialogBody({
         throw new PublishFlowError(
           error instanceof Error ? error.message : "Failed to push changes",
           "push",
+        );
+      }
+
+      try {
+        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch);
+      } catch (error) {
+        throw new PublishFlowError(
+          error instanceof Error ? error.message : "Failed to rebase onto base",
+          "rebase",
         );
       }
 
@@ -276,9 +302,8 @@ function PublishDialogBody({
       setGitDiff(null);
       setPublishTitle("");
       setPublishBody("");
-      const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
-      setGitStatus(status);
       await onPullRequestChanged?.();
+      await onPublished?.();
     } catch (error) {
       if (
         error instanceof PublishFlowError &&
@@ -719,18 +744,13 @@ function PublishDialogBody({
               )}
               Submit for review
             </Button>
-            <Button
-              type="button"
-              variant="success"
-              className="flex-1"
-              onClick={handlePublish}
-              disabled={!canSubmit || isPublishing || isSubmittingForReview}
-            >
-              {isPublishing ? (
-                <Loading01 className="h-4 w-4 animate-spin" />
-              ) : null}
-              Publish
-            </Button>
+            <PublishButton
+              canPublish={canPublish}
+              disabledReason={publishDisabledReason}
+              isPublishing={isPublishing}
+              isSubmittingForReview={isSubmittingForReview}
+              onPublish={handlePublish}
+            />
           </div>
           {submitForReviewError && (
             <p className="mt-2 text-xs text-destructive">
@@ -743,5 +763,45 @@ function PublishDialogBody({
         </div>
       </Tabs>
     </DialogContent>
+  );
+}
+
+function PublishButton({
+  canPublish,
+  disabledReason,
+  isPublishing,
+  isSubmittingForReview,
+  onPublish,
+}: {
+  canPublish: boolean;
+  disabledReason: string | null;
+  isPublishing: boolean;
+  isSubmittingForReview: boolean;
+  onPublish: () => void;
+}) {
+  const button = (
+    <Button
+      type="button"
+      variant="success"
+      className="flex-1"
+      onClick={onPublish}
+      disabled={!canPublish || isPublishing || isSubmittingForReview}
+    >
+      {isPublishing ? <Loading01 className="h-4 w-4 animate-spin" /> : null}
+      Publish
+    </Button>
+  );
+
+  if (!disabledReason) return button;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="flex flex-1">{button}</span>
+        </TooltipTrigger>
+        <TooltipContent>{disabledReason}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -51,6 +51,7 @@ import {
   isDecoOnlyDiff,
   publishGitChanges,
   PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
+  readGitHeadBranch,
   rebaseGitBranch,
   type GitDiffResult,
   type GitStatus,
@@ -154,7 +155,9 @@ function PublishDialogBody({
   const [isGeneratingSuggestion, setIsGeneratingSuggestion] = useState(false);
 
   const loadStartedRef = useRef(false);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot load on dialog open
   if (!loadStartedRef.current) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- one-shot load on dialog open
     loadStartedRef.current = true;
     void (async () => {
       setIsLoadingGitDiff(true);
@@ -196,7 +199,7 @@ function PublishDialogBody({
     })();
   }
 
-  const githubHeadBranch = gitStatus?.current ?? branch;
+  const githubHeadBranch = readGitHeadBranch(gitStatus) ?? branch;
 
   const regenerateSuggestion = () => {
     if (!gitStatus || !gitDiff) return;

--- a/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
+++ b/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
@@ -1,40 +1,49 @@
 import { describe, expect, test } from "bun:test";
+import type { SandboxMap } from "@decocms/mesh-sdk";
 import {
   resolveEffectiveBranch,
   resolveSandboxBranchFromMap,
 } from "./resolve-sandbox-branch.ts";
 
+const sandboxMapFixture = {
+  user1: {
+    "deco/silver-plume": {
+      "local-docker": {
+        sandboxHandle: "h1",
+        previewUrl: "http://localhost:1",
+        sandboxProviderKind: "local-docker" as const,
+      },
+    },
+  },
+} satisfies SandboxMap;
+
+const fallbackMapFixture = {
+  user1: {
+    "deco/other": {
+      cluster: {
+        sandboxHandle: "h2",
+        previewUrl: "http://localhost:2",
+        sandboxProviderKind: "cluster" as const,
+      },
+    },
+  },
+} satisfies SandboxMap;
+
 describe("resolveSandboxBranchFromMap", () => {
   test("returns preferred branch when present in map", () => {
-    const map = {
-      user1: {
-        "deco/silver-plume": {
-          "local-docker": {
-            sandboxHandle: "h1",
-            previewUrl: "http://localhost:1",
-            sandboxProviderKind: "local-docker",
-          },
-        },
-      },
-    };
-    expect(resolveSandboxBranchFromMap(map, "user1", "deco/silver-plume")).toBe(
-      "deco/silver-plume",
-    );
+    expect(
+      resolveSandboxBranchFromMap(
+        sandboxMapFixture,
+        "user1",
+        "deco/silver-plume",
+      ),
+    ).toBe("deco/silver-plume");
   });
 
   test("falls back to first branch with sandbox records", () => {
-    const map = {
-      user1: {
-        "deco/other": {
-          cluster: {
-            sandboxHandle: "h2",
-            previewUrl: "http://localhost:2",
-            sandboxProviderKind: "cluster",
-          },
-        },
-      },
-    };
-    expect(resolveSandboxBranchFromMap(map, "user1", null)).toBe("deco/other");
+    expect(
+      resolveSandboxBranchFromMap(fallbackMapFixture, "user1", null),
+    ).toBe("deco/other");
   });
 });
 

--- a/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
+++ b/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveEffectiveBranch,
+  resolveSandboxBranchFromMap,
+} from "./resolve-sandbox-branch.ts";
+
+describe("resolveSandboxBranchFromMap", () => {
+  test("returns preferred branch when present in map", () => {
+    const map = {
+      user1: {
+        "deco/silver-plume": {
+          "local-docker": {
+            sandboxHandle: "h1",
+            previewUrl: "http://localhost:1",
+            sandboxProviderKind: "local-docker",
+          },
+        },
+      },
+    };
+    expect(resolveSandboxBranchFromMap(map, "user1", "deco/silver-plume")).toBe(
+      "deco/silver-plume",
+    );
+  });
+
+  test("falls back to first branch with sandbox records", () => {
+    const map = {
+      user1: {
+        "deco/other": {
+          cluster: {
+            sandboxHandle: "h2",
+            previewUrl: "http://localhost:2",
+            sandboxProviderKind: "cluster",
+          },
+        },
+      },
+    };
+    expect(resolveSandboxBranchFromMap(map, "user1", null)).toBe("deco/other");
+  });
+});
+
+describe("resolveEffectiveBranch", () => {
+  test("prefers chat branch over other sources", () => {
+    expect(
+      resolveEffectiveBranch({
+        chatBranch: "chat-branch",
+        sandboxBranch: "sse-branch",
+        sandboxMapBranch: "map-branch",
+        gitCurrentBranch: "git-branch",
+      }),
+    ).toBe("chat-branch");
+  });
+
+  test("falls through sources in order", () => {
+    expect(
+      resolveEffectiveBranch({
+        chatBranch: null,
+        sandboxBranch: null,
+        sandboxMapBranch: "map-branch",
+        gitCurrentBranch: "git-branch",
+      }),
+    ).toBe("map-branch");
+  });
+});

--- a/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
+++ b/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.test.ts
@@ -41,9 +41,9 @@ describe("resolveSandboxBranchFromMap", () => {
   });
 
   test("falls back to first branch with sandbox records", () => {
-    expect(
-      resolveSandboxBranchFromMap(fallbackMapFixture, "user1", null),
-    ).toBe("deco/other");
+    expect(resolveSandboxBranchFromMap(fallbackMapFixture, "user1", null)).toBe(
+      "deco/other",
+    );
   });
 });
 

--- a/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.ts
+++ b/apps/mesh/src/web/components/thread/github/resolve-sandbox-branch.ts
@@ -1,0 +1,35 @@
+import type { SandboxMap } from "@decocms/mesh-sdk/types";
+
+/** First branch with a sandbox record for this user (prefers `prefer` when set). */
+export function resolveSandboxBranchFromMap(
+  sandboxMap: SandboxMap | undefined,
+  userId: string | undefined,
+  prefer?: string | null,
+): string | null {
+  if (!userId) return prefer ?? null;
+  const userMap = sandboxMap?.[userId];
+  if (!userMap) return prefer ?? null;
+
+  if (prefer && userMap[prefer]) return prefer;
+
+  for (const [branch, kinds] of Object.entries(userMap)) {
+    if (kinds && Object.keys(kinds).length > 0) return branch;
+  }
+
+  return prefer ?? null;
+}
+
+export function resolveEffectiveBranch(args: {
+  chatBranch: string | null;
+  sandboxBranch: string | null;
+  sandboxMapBranch: string | null;
+  gitCurrentBranch: string | null | undefined;
+}): string | null {
+  return (
+    args.chatBranch ??
+    args.sandboxBranch ??
+    args.sandboxMapBranch ??
+    args.gitCurrentBranch ??
+    null
+  );
+}

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { BranchMeta } from "@decocms/sandbox/shared";
+import {
+  hasUnpublishedWork,
+  mergeBranchMetaWithGitStatus,
+  type GitDiffResult,
+  type GitStatus,
+} from "./sandbox-git-api.ts";
+
+const readyMeta: BranchMeta = {
+  kind: "ready",
+  branch: "feat/foo",
+  base: "main",
+  workingTreeDirty: true,
+  unpushed: 0,
+  aheadOfBase: 0,
+  behindBase: 0,
+  headSha: "abc",
+};
+
+const cleanStatus: GitStatus = {
+  not_added: [],
+  conflicted: [],
+  created: [],
+  deleted: [],
+  modified: [],
+  renamed: [],
+  files: [],
+  staged: [],
+  ahead: 0,
+  behind: 0,
+  current: "feat/foo",
+  tracking: "origin/feat/foo",
+  detached: false,
+};
+
+describe("mergeBranchMetaWithGitStatus", () => {
+  test("clears stale SSE dirty flag when git status is clean", () => {
+    const merged = mergeBranchMetaWithGitStatus(readyMeta, cleanStatus);
+    expect(merged.kind).toBe("ready");
+    if (merged.kind === "ready") {
+      expect(merged.workingTreeDirty).toBe(false);
+    }
+  });
+
+  test("preserves unpushed count from git ahead", () => {
+    const merged = mergeBranchMetaWithGitStatus(readyMeta, {
+      ...cleanStatus,
+      ahead: 2,
+    });
+    if (merged.kind === "ready") {
+      expect(merged.unpushed).toBe(2);
+    }
+  });
+});
+
+describe("hasUnpublishedWork", () => {
+  test("true when only unpushed commits exist", () => {
+    expect(hasUnpublishedWork({ ...cleanStatus, ahead: 1 }, null)).toBe(true);
+  });
+
+  test("true when diff has entries", () => {
+    const diff: GitDiffResult = {
+      diffs: { "a.ts": { from: "a", to: "b" } },
+    };
+    expect(hasUnpublishedWork(cleanStatus, diff)).toBe(true);
+  });
+
+  test("false when clean with no unpushed commits", () => {
+    expect(hasUnpublishedWork(cleanStatus, { diffs: {} })).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { BranchMeta } from "@decocms/sandbox/shared";
 import {
   hasUnpublishedWork,
+  isDecoOnlyDiff,
   mergeBranchMetaWithGitStatus,
   type GitDiffResult,
   type GitStatus,
@@ -68,5 +69,32 @@ describe("hasUnpublishedWork", () => {
 
   test("false when clean with no unpushed commits", () => {
     expect(hasUnpublishedWork(cleanStatus, { diffs: {} })).toBe(false);
+  });
+});
+
+describe("isDecoOnlyDiff", () => {
+  test("true when all paths are under .deco", () => {
+    const diff: GitDiffResult = {
+      diffs: {
+        ".deco/blocks/foo.json": { from: "{}", to: "{}" },
+        ".deco/meta.json": { from: null, to: "{}" },
+      },
+    };
+    expect(isDecoOnlyDiff(diff)).toBe(true);
+  });
+
+  test("false when any path is outside .deco", () => {
+    const diff: GitDiffResult = {
+      diffs: {
+        ".deco/blocks/foo.json": { from: "{}", to: "{}" },
+        "routes/index.tsx": { from: "a", to: "b" },
+      },
+    };
+    expect(isDecoOnlyDiff(diff)).toBe(false);
+  });
+
+  test("false for empty diff", () => {
+    expect(isDecoOnlyDiff({ diffs: {} })).toBe(false);
+    expect(isDecoOnlyDiff(null)).toBe(false);
   });
 });

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -120,6 +120,36 @@ export async function publishGitChanges(
   await parseJson(res);
 }
 
+export async function rebaseGitBranch(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  base: string,
+): Promise<void> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "rebase"),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ base }),
+    },
+  );
+  await parseJson(res);
+}
+
+/** Publish (squash-merge) is only allowed for CMS JSON under `.deco/`. */
+export function isDecoOnlyDiff(
+  diff: GitDiffResult | null | undefined,
+): boolean {
+  if (!diff) return false;
+  const paths = Object.keys(diff.diffs);
+  if (paths.length === 0) return false;
+  return paths.every((p) => p === ".deco" || p.startsWith(".deco/"));
+}
+
+export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
+  "You need Submit for review for changes outside .deco";
+
 export async function discardGitFiles(
   orgSlug: string,
   virtualMcpId: string,

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -148,7 +148,7 @@ export function isDecoOnlyDiff(
 }
 
 export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
-  "You need submit for review for code changes";
+  "Code changes can't be published directly — use Submit for review";
 
 export async function discardGitFiles(
   orgSlug: string,

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -37,7 +37,7 @@ export interface CommitSuggestion {
   message: string;
 }
 
-export function buildSandboxGitUrl(
+function buildSandboxGitUrl(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
@@ -167,14 +167,20 @@ export async function discardGitFiles(
   await parseJson(res);
 }
 
-export const SANDBOX_GIT_STATUS_QUERY_KEY = "sandbox-git-status";
+const GIT_HEAD_BRANCH_KEY = "current" satisfies keyof GitStatus;
+
+export function readGitHeadBranch(
+  status: GitStatus | null | undefined,
+): string | null {
+  return status?.[GIT_HEAD_BRANCH_KEY] ?? null;
+}
 
 export function sandboxGitStatusQueryKey(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
 ) {
-  return [SANDBOX_GIT_STATUS_QUERY_KEY, orgSlug, virtualMcpId, branch] as const;
+  return ["sandbox-git-status", orgSlug, virtualMcpId, branch] as const;
 }
 
 export function countGitChanges(status: GitStatus | null): number {
@@ -189,7 +195,7 @@ export function countGitChanges(status: GitStatus | null): number {
 }
 
 /** True when the working tree or index has uncommitted work. */
-export function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
+function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
   if (!status) return false;
   return (
     countGitChanges(status) > 0 ||
@@ -222,7 +228,7 @@ export function mergeBranchMetaWithGitStatus(
   if (!gitStatus) return branchMeta;
 
   const gitDirty = hasGitLocalWork(gitStatus);
-  const branchName = gitStatus.current;
+  const branchName = readGitHeadBranch(gitStatus);
 
   if (branchMeta.kind === "ready") {
     return {

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -1,0 +1,201 @@
+import type { BranchMeta } from "@decocms/sandbox/shared";
+
+export interface GitStatusFile {
+  path: string;
+  index: string;
+  working_dir: string;
+}
+
+export interface GitStatus {
+  not_added: string[];
+  conflicted: string[];
+  created: string[];
+  deleted: string[];
+  modified: string[];
+  renamed: unknown[];
+  files: GitStatusFile[];
+  staged: string[];
+  ahead: number;
+  behind: number;
+  current: string | null;
+  tracking: string | null;
+  detached: boolean;
+}
+
+export interface GitDiffEntry {
+  from: string | null;
+  to: string | null;
+}
+
+export interface GitDiffResult {
+  diffs: Record<string, GitDiffEntry>;
+}
+
+export interface CommitSuggestion {
+  title: string;
+  body: string;
+  message: string;
+}
+
+export function buildSandboxGitUrl(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  endpoint: string,
+) {
+  return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/git/${endpoint}`;
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as T & { error?: string };
+  if (!res.ok) {
+    throw new Error(
+      typeof body.error === "string"
+        ? body.error
+        : `Request failed (${res.status})`,
+    );
+  }
+  return body;
+}
+
+/** Never cache sandbox git/fs calls — 410 Gone must not stick in disk cache. */
+function sandboxFetch(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(url, { cache: "no-store", ...init });
+}
+
+export async function fetchGitStatus(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): Promise<GitStatus> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "status"),
+  );
+  return parseJson<GitStatus>(res);
+}
+
+export async function fetchGitDiff(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): Promise<GitDiffResult> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "diff"),
+    { method: "POST" },
+  );
+  return parseJson<GitDiffResult>(res);
+}
+
+export async function fetchSuggestCommitMessage(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): Promise<CommitSuggestion> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "suggest-commit"),
+    { method: "POST" },
+  );
+  return parseJson<CommitSuggestion>(res);
+}
+
+export async function publishGitChanges(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  message: string,
+): Promise<void> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "publish"),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message }),
+    },
+  );
+  await parseJson(res);
+}
+
+export async function discardGitFiles(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  filepaths: string[],
+): Promise<void> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "discard"),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ filepaths }),
+    },
+  );
+  await parseJson(res);
+}
+
+export const SANDBOX_GIT_STATUS_QUERY_KEY = "sandbox-git-status";
+
+export function sandboxGitStatusQueryKey(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+) {
+  return [SANDBOX_GIT_STATUS_QUERY_KEY, orgSlug, virtualMcpId, branch] as const;
+}
+
+export function countGitChanges(status: GitStatus | null): number {
+  if (!status) return 0;
+  return (
+    status.modified.length +
+    status.created.length +
+    status.deleted.length +
+    status.not_added.length +
+    status.renamed.length
+  );
+}
+
+/** True when the working tree or index has uncommitted work. */
+export function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
+  if (!status) return false;
+  return (
+    countGitChanges(status) > 0 ||
+    status.staged.length > 0 ||
+    status.conflicted.length > 0
+  );
+}
+
+/**
+ * Merge live `/git/status` into SSE `BranchMeta`. The status endpoint is
+ * always fresh; branch SSE can lag when the daemon watcher misses a save.
+ */
+export function mergeBranchMetaWithGitStatus(
+  branchMeta: BranchMeta,
+  gitStatus: GitStatus | undefined,
+): BranchMeta {
+  if (!gitStatus) return branchMeta;
+
+  const gitDirty = hasGitLocalWork(gitStatus);
+  const branchName = gitStatus.current;
+
+  if (branchMeta.kind === "ready") {
+    if (!gitDirty && branchMeta.workingTreeDirty) return branchMeta;
+    return {
+      ...branchMeta,
+      branch: branchName ?? branchMeta.branch,
+      workingTreeDirty: branchMeta.workingTreeDirty || gitDirty,
+      unpushed: Math.max(branchMeta.unpushed, gitStatus.ahead),
+    };
+  }
+
+  if (!branchName && !gitDirty) return branchMeta;
+
+  return {
+    kind: "ready",
+    branch: branchName ?? "",
+    base: "main",
+    workingTreeDirty: gitDirty,
+    unpushed: gitStatus.ahead,
+    aheadOfBase: 0,
+    behindBase: gitStatus.behind,
+    headSha: "",
+  };
+}

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -90,10 +90,15 @@ export async function fetchSuggestCommitMessage(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
+  payload?: { status: GitStatus; diff: GitDiffResult },
 ): Promise<CommitSuggestion> {
   const res = await sandboxFetch(
     buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "suggest-commit"),
-    { method: "POST" },
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload ?? {}),
+    },
   );
   return parseJson<CommitSuggestion>(res);
 }
@@ -163,6 +168,19 @@ export function hasGitLocalWork(status: GitStatus | null | undefined): boolean {
   );
 }
 
+/** True when there is local work to commit or unpushed commits on the branch. */
+export function hasUnpublishedWork(
+  status: GitStatus | null | undefined,
+  diff: GitDiffResult | null | undefined,
+): boolean {
+  if (!status) return false;
+  return (
+    hasGitLocalWork(status) ||
+    status.ahead > 0 ||
+    (diff != null && Object.keys(diff.diffs).length > 0)
+  );
+}
+
 /**
  * Merge live `/git/status` into SSE `BranchMeta`. The status endpoint is
  * always fresh; branch SSE can lag when the daemon watcher misses a save.
@@ -177,11 +195,10 @@ export function mergeBranchMetaWithGitStatus(
   const branchName = gitStatus.current;
 
   if (branchMeta.kind === "ready") {
-    if (!gitDirty && branchMeta.workingTreeDirty) return branchMeta;
     return {
       ...branchMeta,
       branch: branchName ?? branchMeta.branch,
-      workingTreeDirty: branchMeta.workingTreeDirty || gitDirty,
+      workingTreeDirty: gitDirty,
       unpushed: Math.max(branchMeta.unpushed, gitStatus.ahead),
     };
   }

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -148,7 +148,7 @@ export function isDecoOnlyDiff(
 }
 
 export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
-  "You need Submit for review for changes outside .deco";
+  "You need submit for review for code changes";
 
 export async function discardGitFiles(
   orgSlug: string,

--- a/apps/mesh/src/web/components/thread/github/save-changes-debug.ts
+++ b/apps/mesh/src/web/components/thread/github/save-changes-debug.ts
@@ -1,0 +1,33 @@
+/** Browser-side debug for Save changes / Up to date header button. */
+const KEY = "DEBUG_SAVE_CHANGES";
+
+export function saveChangesDebugEnabled(): boolean {
+  if (!import.meta.env.DEV) return false;
+  try {
+    return localStorage.getItem(KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function saveChangesDebug(
+  message: string,
+  data?: Record<string, unknown>,
+): void {
+  if (!saveChangesDebugEnabled()) return;
+  console.log(`[github-header] ${message}`, data ?? "");
+}
+
+/** Run once in the browser console: localStorage.setItem('DEBUG_SAVE_CHANGES','1') */
+export function enableSaveChangesDebug(): void {
+  localStorage.setItem(KEY, "1");
+  console.log(
+    "[github-header] Save-changes debug enabled — reload the page, edit a file, watch console.",
+  );
+}
+
+if (import.meta.env.DEV) {
+  (
+    globalThis as { enableSaveChangesDebug?: () => void }
+  ).enableSaveChangesDebug = enableSaveChangesDebug;
+}

--- a/apps/mesh/src/web/components/thread/github/save-changes-debug.ts
+++ b/apps/mesh/src/web/components/thread/github/save-changes-debug.ts
@@ -1,7 +1,7 @@
 /** Browser-side debug for Save changes / Up to date header button. */
 const KEY = "DEBUG_SAVE_CHANGES";
 
-export function saveChangesDebugEnabled(): boolean {
+function saveChangesDebugEnabled(): boolean {
   if (!import.meta.env.DEV) return false;
   try {
     return localStorage.getItem(KEY) === "1";
@@ -10,24 +10,18 @@ export function saveChangesDebugEnabled(): boolean {
   }
 }
 
-export function saveChangesDebug(
-  message: string,
-  data?: Record<string, unknown>,
-): void {
+export function saveChangesDebug(message: string, data?: unknown): void {
   if (!saveChangesDebugEnabled()) return;
   console.log(`[github-header] ${message}`, data ?? "");
-}
-
-/** Run once in the browser console: localStorage.setItem('DEBUG_SAVE_CHANGES','1') */
-export function enableSaveChangesDebug(): void {
-  localStorage.setItem(KEY, "1");
-  console.log(
-    "[github-header] Save-changes debug enabled — reload the page, edit a file, watch console.",
-  );
 }
 
 if (import.meta.env.DEV) {
   (
     globalThis as { enableSaveChangesDebug?: () => void }
-  ).enableSaveChangesDebug = enableSaveChangesDebug;
+  ).enableSaveChangesDebug = () => {
+    localStorage.setItem(KEY, "1");
+    console.log(
+      "[github-header] Save-changes debug enabled — reload the page, edit a file, watch console.",
+    );
+  };
 }

--- a/apps/mesh/src/web/components/thread/github/use-pr-data.ts
+++ b/apps/mesh/src/web/components/thread/github/use-pr-data.ts
@@ -17,6 +17,21 @@ import { useMCPClient, useMCPToolCallQuery } from "@decocms/mesh-sdk";
 
 import { extractToolJson } from "./extract-tool-json.ts";
 
+function headRefFromListItem(pr: Record<string, unknown>): string | null {
+  const head = pr.head as Record<string, unknown> | undefined;
+  const ref = head?.ref;
+  return typeof ref === "string" && ref.length > 0 ? ref : null;
+}
+
+function pullRequestListFromToolResult(r: unknown): Record<string, unknown>[] {
+  const raw = extractToolJson<unknown>(r);
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (item): item is Record<string, unknown> =>
+      item != null && typeof item === "object",
+  );
+}
+
 export interface PrSummary {
   number: number;
   title: string;
@@ -101,17 +116,20 @@ export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
       owner: args.owner,
       repo: args.repo,
       state: "all",
-      head: args.branch ? `${args.owner}:${args.branch}` : undefined,
-      perPage: 1,
+      perPage: 30,
     },
     enabled: !!args.branch,
     refetchInterval: POLL,
     refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => {
-      const arr = extractToolJson<Record<string, unknown>[]>(r);
-      if (!arr || !Array.isArray(arr) || arr.length === 0) return null;
-      const p = arr[0]!;
+      const arr = pullRequestListFromToolResult(r);
+      if (arr.length === 0) return null;
+      const p =
+        (args.branch
+          ? arr.find((item) => headRefFromListItem(item) === args.branch)
+          : undefined) ?? null;
+      if (!p) return null;
       const base = p.base as Record<string, unknown> | undefined;
       const head = p.head as Record<string, unknown> | undefined;
       const user = p.user as Record<string, unknown> | undefined;

--- a/apps/mesh/src/web/components/thread/github/use-pr-data.ts
+++ b/apps/mesh/src/web/components/thread/github/use-pr-data.ts
@@ -16,6 +16,7 @@
 import { useMCPClient, useMCPToolCallQuery } from "@decocms/mesh-sdk";
 
 import { extractPullRequestList } from "./github-pr-api.ts";
+import { extractToolJson } from "./extract-tool-json.ts";
 
 export interface PrSummary {
   number: number;

--- a/apps/mesh/src/web/components/thread/github/use-pr-data.ts
+++ b/apps/mesh/src/web/components/thread/github/use-pr-data.ts
@@ -15,22 +15,7 @@
 
 import { useMCPClient, useMCPToolCallQuery } from "@decocms/mesh-sdk";
 
-import { extractToolJson } from "./extract-tool-json.ts";
-
-function headRefFromListItem(pr: Record<string, unknown>): string | null {
-  const head = pr.head as Record<string, unknown> | undefined;
-  const ref = head?.ref;
-  return typeof ref === "string" && ref.length > 0 ? ref : null;
-}
-
-function pullRequestListFromToolResult(r: unknown): Record<string, unknown>[] {
-  const raw = extractToolJson<unknown>(r);
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(
-    (item): item is Record<string, unknown> =>
-      item != null && typeof item === "object",
-  );
-}
+import { extractPullRequestList } from "./github-pr-api.ts";
 
 export interface PrSummary {
   number: number;
@@ -116,20 +101,17 @@ export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
       owner: args.owner,
       repo: args.repo,
       state: "all",
-      perPage: 30,
+      ...(args.branch ? { head: `${args.owner}:${args.branch}` } : {}),
+      perPage: 1,
     },
     enabled: !!args.branch,
     refetchInterval: POLL,
     refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => {
-      const arr = pullRequestListFromToolResult(r);
+      const arr = extractPullRequestList(r);
       if (arr.length === 0) return null;
-      const p =
-        (args.branch
-          ? arr.find((item) => headRefFromListItem(item) === args.branch)
-          : undefined) ?? null;
-      if (!p) return null;
+      const p = arr[0]!;
       const base = p.base as Record<string, unknown> | undefined;
       const head = p.head as Record<string, unknown> | undefined;
       const user = p.user as Record<string, unknown> | undefined;

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -139,6 +139,8 @@ function MobileToolbar({
   mainOpen,
   onToggleMain,
   onNewTask,
+  entity,
+  hasActiveGithubRepo,
 }: {
   onOpenSidebar: () => void;
   virtualMcpId: string;
@@ -146,6 +148,8 @@ function MobileToolbar({
   mainOpen: boolean;
   onToggleMain: () => void;
   onNewTask: () => void;
+  entity: VirtualMCPEntity | null;
+  hasActiveGithubRepo: boolean;
 }) {
   return (
     <div className="shrink-0 flex items-center gap-1 px-2 h-12 bg-background border-b border-border">
@@ -161,6 +165,9 @@ function MobileToolbar({
         <MainPanelTabsBar virtualMcpId={virtualMcpId} taskId={taskId} />
       </div>
       <div className="flex items-center gap-0.5 shrink-0">
+        {entity && hasActiveGithubRepo ? (
+          <VirtualMcpHeaderInfo virtualMcp={entity} inline />
+        ) : null}
         <button
           type="button"
           onClick={onToggleMain}
@@ -447,18 +454,20 @@ function AgentInsetProvider() {
                 onNewTaskRef={onNewTask}
                 createNewTask={layout.createNewTask}
               />
-              <MobileToolbar
-                onOpenSidebar={() => setMobileSidebarOpen(true)}
-                virtualMcpId={chatVirtualMcpId}
-                taskId={layout.taskId}
-                mainOpen={layout.mainOpen}
-                onToggleMain={layout.toggleMain}
-                onNewTask={layout.createNewTask}
-              />
               <Chat.ActiveTaskProvider
                 key={layout.taskId}
                 taskId={layout.taskId}
               >
+                <MobileToolbar
+                  onOpenSidebar={() => setMobileSidebarOpen(true)}
+                  virtualMcpId={chatVirtualMcpId}
+                  taskId={layout.taskId}
+                  mainOpen={layout.mainOpen}
+                  onToggleMain={layout.toggleMain}
+                  onNewTask={layout.createNewTask}
+                  entity={entity}
+                  hasActiveGithubRepo={hasActiveGithubRepo}
+                />
                 <Suspense fallback={<Chat.Skeleton />}>
                   <div className="flex-1 min-h-0 overflow-hidden">
                     {layout.mainOpen ? (

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -117,7 +117,9 @@ export default function OrgShellLayout() {
                         </Toolbar.LeftColumn>
                         <Toolbar.CenterSlot />
                         <Toolbar.RightColumn>
-                          <Toolbar.TabsSlot />
+                          <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] flex justify-end">
+                            <Toolbar.TabsSlot />
+                          </div>
                           <Toolbar.RightSlot />
                         </Toolbar.RightColumn>
                       </Toolbar.Header>

--- a/apps/mesh/src/web/views/virtual-mcp/header-info.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/header-info.tsx
@@ -1,20 +1,21 @@
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
+import { getActiveGithubRepo } from "@/web/lib/github-repo.ts";
 import { HeaderActions } from "../../components/thread/github/header-actions.tsx";
 import { Toolbar } from "../../layouts/agent-shell-layout/toolbar.tsx";
 
 export function VirtualMcpHeaderInfo({
   virtualMcp,
+  inline = false,
 }: {
   virtualMcp: VirtualMCPEntity;
+  /** When true, skip the toolbar portal (mobile header has no Toolbar shell). */
+  inline?: boolean;
 }) {
-  const githubRepo = virtualMcp.metadata?.githubRepo ?? null;
-  const showActions = !!githubRepo?.connectionId;
+  const githubRepo = getActiveGithubRepo(virtualMcp);
+  if (!githubRepo) return null;
 
-  if (!showActions) return null;
+  const actions = <HeaderActions virtualMcpId={virtualMcp.id} />;
+  if (inline) return actions;
 
-  return (
-    <Toolbar.Right>
-      <HeaderActions virtualMcpId={virtualMcp.id} />
-    </Toolbar.Right>
-  );
+  return <Toolbar.Right>{actions}</Toolbar.Right>;
 }

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -11,5 +11,5 @@ description: |
 type: application
 version: 0.7.3
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "0.5.5"
+appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "0.5.5"
+  tag: "0.5.7"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -317,7 +317,7 @@ const bashH = makeBashHandler({
   repoDir,
   taskManager,
 });
-const gitDeps = { repoDir };
+const gitDeps = { appRoot, repoDir };
 const gitStatusH = makeGitStatusHandler(gitDeps);
 const gitDiffH = makeGitDiffHandler(gitDeps);
 const gitPublishH = makeGitPublishHandler(gitDeps);

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -23,6 +23,7 @@ import {
   makeGitDiffHandler,
   makeGitDiscardHandler,
   makeGitPublishHandler,
+  makeGitRebaseHandler,
   makeGitStatusHandler,
 } from "./routes/git";
 import {
@@ -322,6 +323,7 @@ const gitStatusH = makeGitStatusHandler(gitDeps);
 const gitDiffH = makeGitDiffHandler(gitDeps);
 const gitPublishH = makeGitPublishHandler(gitDeps);
 const gitDiscardH = makeGitDiscardHandler(gitDeps);
+const gitRebaseH = makeGitRebaseHandler(gitDeps);
 const execH = makeExecHandler({
   repoDir,
   store,
@@ -575,6 +577,7 @@ const gitH: Record<string, (req: Request) => Response | Promise<Response>> = {
   "/git/diff": gitDiffH,
   "/git/publish": gitPublishH,
   "/git/discard": gitDiscardH,
+  "/git/rebase": gitRebaseH,
 };
 
 const setupH: Record<string, () => Response> = {

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -20,6 +20,12 @@ import { makeProxyHandler } from "./proxy";
 import { jsonResponse } from "./routes/body-parser";
 import { makeBashHandler } from "./routes/bash";
 import {
+  makeGitDiffHandler,
+  makeGitDiscardHandler,
+  makeGitPublishHandler,
+  makeGitStatusHandler,
+} from "./routes/git";
+import {
   makeConfigReadHandler,
   makeConfigUpdateHandler,
 } from "./routes/config";
@@ -289,7 +295,16 @@ const getDevPort = (): number | null =>
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
   portSniffer.current() ?? store.read()?.application?.port ?? null;
 const { appRoot, repoDir } = bootConfig;
-const fsDeps = { appRoot, repoDir };
+const fsDeps = {
+  appRoot,
+  repoDir,
+  onRepoChange: () => {
+    if (process.env.DEBUG_SAVE_CHANGES === "1") {
+      console.log("[branch-status] fs write/edit → refresh", { repoDir });
+    }
+    branchStatus.refresh();
+  },
+};
 const readH = makeReadHandler(fsDeps);
 const writeH = makeWriteHandler(fsDeps);
 const editH = makeEditHandler(fsDeps);
@@ -302,6 +317,11 @@ const bashH = makeBashHandler({
   repoDir,
   taskManager,
 });
+const gitDeps = { repoDir };
+const gitStatusH = makeGitStatusHandler(gitDeps);
+const gitDiffH = makeGitDiffHandler(gitDeps);
+const gitPublishH = makeGitPublishHandler(gitDeps);
+const gitDiscardH = makeGitDiscardHandler(gitDeps);
 const execH = makeExecHandler({
   repoDir,
   store,
@@ -550,6 +570,13 @@ const fsH: Record<string, (req: Request) => Response | Promise<Response>> = {
   "/bash": bashH,
 };
 
+const gitH: Record<string, (req: Request) => Response | Promise<Response>> = {
+  "/git/status": gitStatusH,
+  "/git/diff": gitDiffH,
+  "/git/publish": gitPublishH,
+  "/git/discard": gitDiscardH,
+};
+
 const setupH: Record<string, () => Response> = {
   "/setup/clone": setupCloneH,
   "/setup/install": setupInstallH,
@@ -617,7 +644,9 @@ async function vmRouteH(
   if (vmPath.startsWith("/tasks"))
     return tasksRouteH(rebuilt, method, vmPath, prefix);
   if (method === "POST" && vmPath in setupH) return setupH[vmPath]();
+  if (method === "GET" && vmPath in gitH) return gitH[vmPath](rebuilt);
   if (method === "POST" && vmPath in fsH) return fsH[vmPath](rebuilt);
+  if (method === "POST" && vmPath in gitH) return gitH[vmPath](rebuilt);
   if (method === "POST" && vmPath.startsWith("/exec/"))
     return execRouteH(rebuilt, vmPath);
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -299,7 +299,7 @@ const { appRoot, repoDir } = bootConfig;
 const fsDeps = {
   appRoot,
   repoDir,
-  onRepoChange: () => {
+  onWorkingTreeWrite: () => {
     if (process.env.DEBUG_SAVE_CHANGES === "1") {
       console.log("[branch-status] fs write/edit → refresh", { repoDir });
     }

--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -111,6 +111,26 @@ describe("BranchStatusMonitor", () => {
       expect(last.workingTreeDirty).toBe(false);
     });
 
+    it("flips dirty=true when a baseline-boot file is edited again", () => {
+      commitFile(repo.repoDir, "tailwind.css", "/* original */");
+      writeFileSync(join(repo.repoDir, "tailwind.css"), "/* regenerated */");
+
+      const m = newMonitor();
+      m.armBaseline();
+      expect(
+        (m.getLast() as { workingTreeDirty: boolean }).workingTreeDirty,
+      ).toBe(false);
+
+      writeFileSync(
+        join(repo.repoDir, "tailwind.css"),
+        "/* user edit after boot */",
+      );
+      m.refresh();
+      expect(
+        (m.getLast() as { workingTreeDirty: boolean }).workingTreeDirty,
+      ).toBe(true);
+    });
+
     it("flips dirty=true when a non-baseline file changes", () => {
       commitFile(repo.repoDir, "tailwind.css", "/* original */");
       commitFile(repo.repoDir, "src.ts", "export const x = 1;");

--- a/packages/sandbox/daemon/git/branch-status.ts
+++ b/packages/sandbox/daemon/git/branch-status.ts
@@ -1,11 +1,20 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { join } from "node:path";
 import type { Broadcaster } from "../events/broadcast";
 import type { BranchMeta } from "../events/types";
 import type { Config } from "../types";
 import { gitSync as rawGitSync } from "./git-sync";
+import { parsePorcelainZ } from "./porcelain";
 
 const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
   rawGitSync(["-c", "safe.directory=*", ...args], opts);
+
+/** Set DEBUG_SAVE_CHANGES=1 to trace dirty-state / Save-changes button logic. */
+function branchDebug(message: string, data?: Record<string, unknown>): void {
+  if (process.env.DEBUG_SAVE_CHANGES !== "1") return;
+  console.log(`[branch-status] ${message}`, data ?? "");
+}
 
 /**
  * Watches `.git/` and surfaces the current `BranchMeta` (branch name, dirty,
@@ -19,15 +28,19 @@ const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
  * in `git status` and would flip `workingTreeDirty=true` the moment the dev
  * server settles. To avoid false-positive "Save changes" buttons, the
  * orchestrator calls `armBaseline()` once `lifecycle: running` stabilizes;
- * paths in that snapshot are subtracted from subsequent dirty checks.
+ * a content hash snapshot is stored per boot-dirty path so later edits to
+ * those same files still flip `workingTreeDirty` (path-only filtering hid
+ * user saves on files the dev server had already touched).
  */
 export class BranchStatusMonitor {
   private last: BranchMeta = { kind: "unknown" };
   private timer: ReturnType<typeof setTimeout> | null = null;
-  private watcher: ReturnType<typeof fs.watch> | null = null;
+  private gitWatcher: ReturnType<typeof fs.watch> | null = null;
+  private repoWatcher: ReturnType<typeof fs.watch> | null = null;
   private pollFallback: ReturnType<typeof setInterval> | null = null;
-  /** Paths reported dirty by `git status --porcelain=v1` at boot — treated as noise. */
-  private dirtyBaseline: ReadonlySet<string> | null = null;
+  private watchInitialized = false;
+  /** Boot-dirty paths → working-tree content hash at `armBaseline()`. */
+  private dirtyBaseline: Map<string, string> | null = null;
 
   constructor(
     private readonly config: Config,
@@ -45,13 +58,22 @@ export class BranchStatusMonitor {
    * prior snapshot. `clearBaseline()` drops it on a fresh clone/install.
    */
   armBaseline(): void {
-    this.dirtyBaseline = this.readDirtyPaths();
+    const paths = this.readDirtyPaths();
+    this.dirtyBaseline = new Map();
+    for (const p of paths) {
+      this.dirtyBaseline.set(p, this.hashWorktreeFile(p));
+    }
+    branchDebug("armBaseline", {
+      repoDir: this.config.repoDir,
+      baselinePaths: [...this.dirtyBaseline.keys()],
+    });
     // Re-evaluate so the next emit reflects the new filter.
     this.refresh();
   }
 
   clearBaseline(): void {
     if (this.dirtyBaseline === null) return;
+    branchDebug("clearBaseline", { repoDir: this.config.repoDir });
     this.dirtyBaseline = null;
     this.refresh();
   }
@@ -62,8 +84,18 @@ export class BranchStatusMonitor {
    */
   refresh(): void {
     const next = this.compute();
-    if (!next) return;
+    if (!next) {
+      branchDebug(
+        "refresh: compute returned null (no git repo or detached HEAD?)",
+        {
+          repoDir: this.config.repoDir,
+          lastKind: this.last.kind,
+        },
+      );
+      return;
+    }
     if (equal(this.last, next)) return;
+    branchDebug("refresh: emit branch event", next);
     this.last = next;
     this.broadcaster.emit("branch", { meta: next });
     this.ensureWatch();
@@ -75,14 +107,19 @@ export class BranchStatusMonitor {
       clearTimeout(this.timer);
       this.timer = null;
     }
-    if (this.watcher) {
-      this.watcher.close();
-      this.watcher = null;
+    if (this.gitWatcher) {
+      this.gitWatcher.close();
+      this.gitWatcher = null;
+    }
+    if (this.repoWatcher) {
+      this.repoWatcher.close();
+      this.repoWatcher = null;
     }
     if (this.pollFallback) {
       clearInterval(this.pollFallback);
       this.pollFallback = null;
     }
+    this.watchInitialized = false;
   }
 
   private schedule(): void {
@@ -96,20 +133,51 @@ export class BranchStatusMonitor {
   }
 
   private ensureWatch(): void {
-    if (this.watcher || this.pollFallback) return;
+    if (this.watchInitialized) return;
+    this.watchInitialized = true;
+
     const gitDir = `${this.config.repoDir}/.git`;
     try {
-      this.watcher = fs.watch(gitDir, { recursive: true }, () =>
+      this.gitWatcher = fs.watch(gitDir, { recursive: true }, () =>
         this.schedule(),
       );
-      // Swallow errors (e.g. ENOENT when .git is removed during shutdown)
-      // — without this the FSWatcher emits an unhandled 'error' event.
-      this.watcher.on("error", () => {});
+      this.gitWatcher.on("error", () => {});
     } catch {
-      this.pollFallback = setInterval(() => {
-        if (this.last.kind === "ready") this.refresh();
-      }, 5000);
+      // Swallow — poll fallback below covers git-dir watch gaps.
     }
+
+    // Working-tree edits (file explorer, agent write/edit) don't touch
+    // `.git/` until staged, so a git-dir-only watch never flips
+    // `workingTreeDirty`. Watch the repo tree too.
+    try {
+      this.repoWatcher = fs.watch(
+        this.config.repoDir,
+        { recursive: true },
+        (_event, filename) => {
+          if (
+            typeof filename === "string" &&
+            (filename === ".git" || filename.startsWith(".git/"))
+          ) {
+            return;
+          }
+          this.schedule();
+        },
+      );
+      this.repoWatcher.on("error", () => {});
+    } catch {
+      // Non-recursive platforms fall through to poll.
+    }
+
+    // Safety net for atomic editor saves and watch gaps on Linux.
+    this.pollFallback = setInterval(() => {
+      if (this.last.kind === "ready") this.refresh();
+    }, 3000);
+    branchDebug("ensureWatch", {
+      repoDir: this.config.repoDir,
+      gitWatcher: Boolean(this.gitWatcher),
+      repoWatcher: Boolean(this.repoWatcher),
+      pollMs: 3000,
+    });
   }
 
   private runGit(args: string[]): string {
@@ -133,6 +201,35 @@ export class BranchStatusMonitor {
     return parsePorcelainZ(out);
   }
 
+  private hashWorktreeFile(path: string): string {
+    try {
+      const buf = fs.readFileSync(join(this.config.repoDir, path));
+      return createHash("sha256").update(buf).digest("hex");
+    } catch {
+      return "";
+    }
+  }
+
+  private isWorkingTreeDirty(dirtyPaths: Set<string>): {
+    dirty: boolean;
+    changedPaths: string[];
+  } {
+    if (dirtyPaths.size === 0) return { dirty: false, changedPaths: [] };
+    const baseline = this.dirtyBaseline;
+    if (!baseline) {
+      return { dirty: true, changedPaths: [...dirtyPaths] };
+    }
+    const changedPaths: string[] = [];
+    for (const p of dirtyPaths) {
+      const hash = this.hashWorktreeFile(p);
+      const baseHash = baseline.get(p);
+      if (baseHash === undefined || hash !== baseHash) {
+        changedPaths.push(p);
+      }
+    }
+    return { dirty: changedPaths.length > 0, changedPaths };
+  }
+
   private compute(): Extract<BranchMeta, { kind: "ready" }> | null {
     const run = (args: string[]) => this.runGit(args);
     const refExists = (ref: string) =>
@@ -145,9 +242,17 @@ export class BranchStatusMonitor {
       if (!base) base = "main";
       const dirtyPaths = this.readDirtyPaths();
       const baseline = this.dirtyBaseline;
-      const dirty = baseline
-        ? [...dirtyPaths].some((p) => !baseline.has(p))
-        : dirtyPaths.size > 0;
+      const { dirty, changedPaths } = this.isWorkingTreeDirty(dirtyPaths);
+      if (dirtyPaths.size > 0 || dirty) {
+        branchDebug("compute", {
+          branch,
+          base,
+          dirtyPaths: [...dirtyPaths],
+          baselinePaths: baseline ? [...baseline.keys()] : null,
+          changedPaths,
+          workingTreeDirty: dirty,
+        });
+      }
       const branchRef = refExists(`origin/${branch}`)
         ? `origin/${branch}`
         : "HEAD";
@@ -191,30 +296,4 @@ export class BranchStatusMonitor {
 
 function equal(a: BranchMeta, b: BranchMeta): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
-}
-
-/**
- * Parse `git status --porcelain=v1 -z` output into a set of paths.
- * Format: each entry is `XY <path>\0`. Renames/copies (`R`/`C`) carry a
- * second `<orig>\0` after the destination — we record both so a baseline
- * captures whichever one a later run sees.
- */
-function parsePorcelainZ(out: string): Set<string> {
-  const paths = new Set<string>();
-  const parts = out.split("\0");
-  for (let i = 0; i < parts.length; i++) {
-    const entry = parts[i];
-    if (!entry) continue;
-    if (entry.length < 4) continue;
-    const xy = entry.slice(0, 2);
-    const path = entry.slice(3);
-    paths.add(path);
-    // Renames/copies have an extra origin-path field.
-    if (xy[0] === "R" || xy[0] === "C") {
-      i++;
-      const orig = parts[i];
-      if (orig) paths.add(orig);
-    }
-  }
-  return paths;
 }

--- a/packages/sandbox/daemon/git/checkout-branch.test.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSetupStep } from "../setup/spawn-step";
+import {
+  resolveRemoteDefaultBranch,
+  spawnCheckoutBranch,
+} from "./checkout-branch";
+
+function setupBareRepo(): { url: string; root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "checkout-branch-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+  writeFileSync(join(seed, "README.md"), "main\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} checkout -b feature/x`, gitOpts);
+  writeFileSync(join(seed, "feature.txt"), "feature\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m feature`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push origin feature/x`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${bare} symbolic-ref HEAD refs/heads/main`,
+    gitOpts,
+  );
+  return {
+    url: `file://${bare}`,
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function cloneWorkspace(url: string, root: string): string {
+  const repoDir = join(root, "workspace");
+  execSync(`git clone --depth 1 --branch feature/x ${url} ${repoDir}`, {
+    stdio: "ignore",
+  });
+  return repoDir;
+}
+
+describe("resolveRemoteDefaultBranch", () => {
+  it("reads origin/HEAD symref", () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = cloneWorkspace(url, root);
+      expect(resolveRemoteDefaultBranch(repoDir)).toBe("main");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("spawnCheckoutBranch", () => {
+  it("forks a new local branch from default, not from current HEAD", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = cloneWorkspace(url, root);
+      const gc = `git -C ${repoDir}`;
+      const logs: string[] = [];
+
+      await spawnCheckoutBranch({
+        repoDir,
+        branch: "deco/new-branch",
+        gc,
+        runStep: (cmd) => spawnSetupStep(cmd, () => {}),
+        log: (msg) => logs.push(msg),
+      });
+
+      expect(
+        execSync(`git -C ${repoDir} rev-parse --abbrev-ref HEAD`)
+          .toString()
+          .trim(),
+      ).toBe("deco/new-branch");
+      expect(existsSync(join(repoDir, "README.md"))).toBe(true);
+      expect(existsSync(join(repoDir, "feature.txt"))).toBe(false);
+      expect(logs.some((l) => l.includes("default branch 'main'"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("checks out an existing local branch when absent from remote", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = cloneWorkspace(url, root);
+      execSync(`git -C ${repoDir} checkout -b local-only`, { stdio: "ignore" });
+      writeFileSync(join(repoDir, "local.txt"), "local\n");
+      execSync(`git -C ${repoDir} add local.txt`, { stdio: "ignore" });
+      execSync(`git -C ${repoDir} commit -m local`, { stdio: "ignore" });
+      execSync(`git -C ${repoDir} checkout feature/x`, { stdio: "ignore" });
+
+      const gc = `git -C ${repoDir}`;
+      await spawnCheckoutBranch({
+        repoDir,
+        branch: "local-only",
+        gc,
+        runStep: (cmd) => spawnSetupStep(cmd, () => {}),
+        log: () => {},
+      });
+
+      expect(existsSync(join(repoDir, "local.txt"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+});

--- a/packages/sandbox/daemon/git/checkout-branch.test.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.test.ts
@@ -41,9 +41,13 @@ function setupBareRepo(): { url: string; root: string; cleanup: () => void } {
 
 function cloneWorkspace(url: string, root: string): string {
   const repoDir = join(root, "workspace");
-  execSync(`git clone --depth 1 --branch feature/x ${url} ${repoDir}`, {
-    stdio: "ignore",
-  });
+  const gitcfg = `-c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  execSync(
+    `git ${gitcfg} clone --depth 1 --branch feature/x ${url} ${repoDir}`,
+    {
+      stdio: "ignore",
+    },
+  );
   return repoDir;
 }
 
@@ -90,13 +94,22 @@ describe("spawnCheckoutBranch", () => {
 
   it("checks out an existing local branch when absent from remote", async () => {
     const { url, root, cleanup } = setupBareRepo();
+    const gitcfg = `-c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
     try {
       const repoDir = cloneWorkspace(url, root);
-      execSync(`git -C ${repoDir} checkout -b local-only`, { stdio: "ignore" });
+      execSync(`git ${gitcfg} -C ${repoDir} checkout -b local-only`, {
+        stdio: "ignore",
+      });
       writeFileSync(join(repoDir, "local.txt"), "local\n");
-      execSync(`git -C ${repoDir} add local.txt`, { stdio: "ignore" });
-      execSync(`git -C ${repoDir} commit -m local`, { stdio: "ignore" });
-      execSync(`git -C ${repoDir} checkout feature/x`, { stdio: "ignore" });
+      execSync(`git ${gitcfg} -C ${repoDir} add local.txt`, {
+        stdio: "ignore",
+      });
+      execSync(`git ${gitcfg} -C ${repoDir} commit -m local`, {
+        stdio: "ignore",
+      });
+      execSync(`git ${gitcfg} -C ${repoDir} checkout feature/x`, {
+        stdio: "ignore",
+      });
 
       const gc = `git -C ${repoDir}`;
       await spawnCheckoutBranch({

--- a/packages/sandbox/daemon/git/checkout-branch.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.ts
@@ -1,0 +1,110 @@
+import { gitSync } from "./git-sync";
+
+/** Default branch pointed to by `origin/HEAD`, falling back to `main`. */
+export function resolveRemoteDefaultBranch(repoDir: string): string {
+  try {
+    let base = gitSync(
+      ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      {
+        cwd: repoDir,
+      },
+    ).trim();
+    if (base.startsWith("origin/")) base = base.slice("origin/".length);
+    if (base) return base;
+  } catch {
+    /* fall through */
+  }
+  return "main";
+}
+
+function localBranchExists(repoDir: string, branch: string): boolean {
+  try {
+    gitSync(["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
+      cwd: repoDir,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CheckoutBranchParams {
+  repoDir: string;
+  branch: string;
+  /** Prefixed git command, e.g. `git -C /repo`. */
+  gc: string;
+  runStep: (cmd: string) => Promise<number>;
+  log: (message: string) => void;
+}
+
+/**
+ * Check out `branch` in an existing clone:
+ * - remote branch → fetch + reset to origin
+ * - local-only branch → checkout existing ref
+ * - absent everywhere → fork from the repo default branch (not current HEAD)
+ */
+export async function spawnCheckoutBranch(
+  params: CheckoutBranchParams,
+): Promise<void> {
+  const { repoDir, branch, gc, runStep, log } = params;
+
+  try {
+    const head = gitSync(["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: repoDir,
+    }).trim();
+    if (head === branch) return;
+  } catch {
+    // No HEAD yet / not a repo — fall through and let checkout fail loudly.
+  }
+
+  const probe = await runStep(
+    `${gc} ls-remote --exit-code --heads origin ${branch}`,
+  );
+
+  if (probe === 0) {
+    const fetchCode = await runStep(
+      `${gc} fetch --depth 1 origin +refs/heads/${branch}:refs/remotes/origin/${branch}`,
+    );
+    if (fetchCode !== 0) {
+      throw new Error(`git fetch origin ${branch} exited ${fetchCode}`);
+    }
+    const checkoutCode = await runStep(
+      `${gc} checkout -B ${branch} refs/remotes/origin/${branch}`,
+    );
+    if (checkoutCode !== 0) {
+      throw new Error(`git checkout -B ${branch} exited ${checkoutCode}`);
+    }
+    return;
+  }
+
+  if (probe === 2) {
+    if (localBranchExists(repoDir, branch)) {
+      log(
+        `[orchestrator] branch '${branch}' not on remote; checking out local branch\r\n`,
+      );
+      const code = await runStep(`${gc} checkout ${branch}`);
+      if (code !== 0) throw new Error(`git checkout ${branch} exited ${code}`);
+      return;
+    }
+
+    const defaultBranch = resolveRemoteDefaultBranch(repoDir);
+    log(
+      `[orchestrator] branch '${branch}' not on remote; creating from default branch '${defaultBranch}'\r\n`,
+    );
+    const fetchCode = await runStep(
+      `${gc} fetch --depth 1 origin +refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
+    );
+    if (fetchCode !== 0) {
+      throw new Error(`git fetch origin ${defaultBranch} exited ${fetchCode}`);
+    }
+    const checkoutCode = await runStep(
+      `${gc} checkout -B ${branch} refs/remotes/origin/${defaultBranch}`,
+    );
+    if (checkoutCode !== 0) {
+      throw new Error(`git checkout -B ${branch} exited ${checkoutCode}`);
+    }
+    return;
+  }
+
+  throw new Error(`git ls-remote --heads origin ${branch} exited ${probe}`);
+}

--- a/packages/sandbox/daemon/git/porcelain.test.ts
+++ b/packages/sandbox/daemon/git/porcelain.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { parsePorcelainEntry, parsePorcelainZ } from "./porcelain";
+
+describe("parsePorcelainEntry", () => {
+  it("parses standard spaced format", () => {
+    expect(parsePorcelainEntry(" M README.md")).toEqual({
+      index: " ",
+      working: "M",
+      path: "README.md",
+    });
+  });
+
+  it("parses -z format without separator space", () => {
+    expect(parsePorcelainEntry(" MREADME.md")).toEqual({
+      index: " ",
+      working: "M",
+      path: "README.md",
+    });
+  });
+});
+
+describe("parsePorcelainZ", () => {
+  it("collects paths from multiple entries", () => {
+    const out = " M a.ts\0?? b.ts\0";
+    expect(parsePorcelainZ(out)).toEqual(new Set(["a.ts", "b.ts"]));
+  });
+});

--- a/packages/sandbox/daemon/git/porcelain.ts
+++ b/packages/sandbox/daemon/git/porcelain.ts
@@ -12,6 +12,33 @@ export function parsePorcelainEntry(
   return { index, working, path };
 }
 
+export interface PorcelainFileStatus {
+  path: string;
+  index: string;
+  working_dir: string;
+}
+
+/** Parse full `-z` porcelain output into per-file index/worktree status. */
+export function parsePorcelainFiles(out: string): PorcelainFileStatus[] {
+  const files: PorcelainFileStatus[] = [];
+  const parts = out.split("\0");
+  for (let i = 0; i < parts.length; i++) {
+    const entry = parts[i];
+    if (!entry) continue;
+    const parsed = parsePorcelainEntry(entry);
+    if (!parsed) continue;
+    files.push({
+      path: parsed.path,
+      index: parsed.index,
+      working_dir: parsed.working,
+    });
+    if (parsed.index === "R" || parsed.index === "C") {
+      i++;
+    }
+  }
+  return files;
+}
+
 /** Parse full `-z` porcelain output into a set of changed paths. */
 export function parsePorcelainZ(out: string): Set<string> {
   const paths = new Set<string>();

--- a/packages/sandbox/daemon/git/porcelain.ts
+++ b/packages/sandbox/daemon/git/porcelain.ts
@@ -1,0 +1,32 @@
+/** Parse one `git status --porcelain=v1 -z` entry into status chars + path. */
+export function parsePorcelainEntry(
+  entry: string,
+): { index: string; working: string; path: string } | null {
+  if (entry.length < 3) return null;
+  const index = entry[0] ?? " ";
+  const working = entry[1] ?? " ";
+  // Standard v1: "XY filename". Some `-z` outputs omit the separator space.
+  const path =
+    entry.length >= 4 && entry[2] === " " ? entry.slice(3) : entry.slice(2);
+  if (!path) return null;
+  return { index, working, path };
+}
+
+/** Parse full `-z` porcelain output into a set of changed paths. */
+export function parsePorcelainZ(out: string): Set<string> {
+  const paths = new Set<string>();
+  const parts = out.split("\0");
+  for (let i = 0; i < parts.length; i++) {
+    const entry = parts[i];
+    if (!entry) continue;
+    const parsed = parsePorcelainEntry(entry);
+    if (!parsed) continue;
+    paths.add(parsed.path);
+    if (parsed.index === "R" || parsed.index === "C") {
+      i++;
+      const orig = parts[i];
+      if (orig) paths.add(orig);
+    }
+  }
+  return paths;
+}

--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -60,7 +60,9 @@ function setupConflictingRepo(): {
   execSync(`git ${gitcfg} -C ${seed} push origin main`, gitOpts);
 
   const repoDir = join(root, "workspace");
-  execSync(`git clone --branch feat/shipping ${bare} ${repoDir}`, gitOpts);
+  execSync(`git ${gitcfg} clone --branch feat/shipping ${bare} ${repoDir}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${repoDir} config user.email test@example.com`, gitOpts);
+  execSync(`git ${gitcfg} -C ${repoDir} config user.name test`, gitOpts);
   execSync(
     `git ${gitcfg} -C ${repoDir} remote set-url origin ${bare}`,
     gitOpts,

--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -76,7 +76,7 @@ describe("rebaseOntoBase", () => {
   it("rebases with -X theirs and resolves conflicts from branch changes", () => {
     const { repoDir, cleanup } = setupConflictingRepo();
     try {
-      rebaseOntoBase(repoDir, "main");
+      rebaseOntoBase(repoDir, "main", { asUser: false });
 
       const content = readFileSync(
         join(repoDir, ".deco/blocks/shipping.json"),

--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -60,8 +60,14 @@ function setupConflictingRepo(): {
   execSync(`git ${gitcfg} -C ${seed} push origin main`, gitOpts);
 
   const repoDir = join(root, "workspace");
-  execSync(`git ${gitcfg} clone --branch feat/shipping ${bare} ${repoDir}`, gitOpts);
-  execSync(`git ${gitcfg} -C ${repoDir} config user.email test@example.com`, gitOpts);
+  execSync(
+    `git ${gitcfg} clone --branch feat/shipping ${bare} ${repoDir}`,
+    gitOpts,
+  );
+  execSync(
+    `git ${gitcfg} -C ${repoDir} config user.email test@example.com`,
+    gitOpts,
+  );
   execSync(`git ${gitcfg} -C ${repoDir} config user.name test`, gitOpts);
   execSync(
     `git ${gitcfg} -C ${repoDir} remote set-url origin ${bare}`,

--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rebaseOntoBase } from "./rebase-onto-base";
+
+function setupConflictingRepo(): {
+  repoDir: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "rebase-onto-base-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+
+  const decoPath = ".deco/blocks/shipping.json";
+  mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ threshold: 200 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+
+  execSync(`git ${gitcfg} -C ${seed} checkout -b feat/shipping`, gitOpts);
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ threshold: 250 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${seed} commit -m "Update free shipping threshold to R$ 250"`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${seed} push -u origin feat/shipping`, gitOpts);
+
+  execSync(`git ${gitcfg} -C ${seed} checkout main`, gitOpts);
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ threshold: 300 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${seed} commit -m "Raise shipping threshold on main"`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${seed} push origin main`, gitOpts);
+
+  const repoDir = join(root, "workspace");
+  execSync(
+    `git clone --branch feat/shipping ${bare.replace(/ /g, "%20")} ${repoDir}`,
+    gitOpts,
+  );
+  execSync(
+    `git ${gitcfg} -C ${repoDir} remote set-url origin ${bare}`,
+    gitOpts,
+  );
+
+  return {
+    repoDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("rebaseOntoBase", () => {
+  it("rebases with -X theirs and resolves conflicts from branch changes", () => {
+    const { repoDir, cleanup } = setupConflictingRepo();
+    try {
+      rebaseOntoBase(repoDir, "main");
+
+      const content = readFileSync(
+        join(repoDir, ".deco/blocks/shipping.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(content)).toEqual({ threshold: 250 });
+
+      const head = execSync(`git -C ${repoDir} rev-parse HEAD`)
+        .toString()
+        .trim();
+      const main = execSync(`git -C ${repoDir} rev-parse origin/main`)
+        .toString()
+        .trim();
+      expect(head).not.toBe(main);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -20,11 +20,11 @@ function setupConflictingRepo(): {
   const seed = join(root, "seed");
   const gitOpts = { stdio: "ignore" as const };
   const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  const decoPath = ".deco/blocks/shipping.json";
 
   execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
   execSync(`git ${gitcfg} init ${seed}`, gitOpts);
 
-  const decoPath = ".deco/blocks/shipping.json";
   mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
   writeFileSync(
     join(seed, decoPath),
@@ -50,24 +50,17 @@ function setupConflictingRepo(): {
   );
   execSync(`git ${gitcfg} -C ${seed} push -u origin feat/shipping`, gitOpts);
 
+  // Diverge main so rebase always hits conflict resolution (modify/delete).
   execSync(`git ${gitcfg} -C ${seed} checkout main`, gitOpts);
-  writeFileSync(
-    join(seed, decoPath),
-    JSON.stringify({ threshold: 300 }, null, 2),
-    "utf-8",
-  );
-  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} rm ${decoPath}`, gitOpts);
   execSync(
-    `git ${gitcfg} -C ${seed} commit -m "Raise shipping threshold on main"`,
+    `git ${gitcfg} -C ${seed} commit -m "Remove shipping block from main"`,
     gitOpts,
   );
   execSync(`git ${gitcfg} -C ${seed} push origin main`, gitOpts);
 
   const repoDir = join(root, "workspace");
-  execSync(
-    `git clone --branch feat/shipping ${bare.replace(/ /g, "%20")} ${repoDir}`,
-    gitOpts,
-  );
+  execSync(`git clone --branch feat/shipping ${bare} ${repoDir}`, gitOpts);
   execSync(
     `git ${gitcfg} -C ${repoDir} remote set-url origin ${bare}`,
     gitOpts,

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -37,7 +37,8 @@ function tryGit(
 }
 
 function stripAnsi(text: string): string {
-  return text.replace(/\x1b\[[0-9;]*m/g, "");
+  const esc = String.fromCharCode(0x1b);
+  return text.replace(new RegExp(`${esc}\\[[0-9;]*m`, "g"), "");
 }
 
 function formatGitError(err: unknown): string {

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -1,0 +1,271 @@
+import fs, { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gitSync as rawGitSync } from "./git-sync";
+import { parsePorcelainEntry } from "./porcelain";
+
+const MAX_CONFLICT_RESOLUTION_ATTEMPTS = 50;
+
+const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
+  rawGitSync(["-c", "safe.directory=*", ...args], opts);
+
+function gitEnv(repoDir: string): Record<string, string> {
+  return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
+}
+
+function runGit(
+  repoDir: string,
+  args: string[],
+  opts?: { env?: Record<string, string> },
+): string {
+  return gitSync(args, {
+    cwd: repoDir,
+    env: { ...gitEnv(repoDir), ...opts?.env },
+  });
+}
+
+function tryGit(
+  repoDir: string,
+  args: string[],
+  opts?: { env?: Record<string, string> },
+): string | null {
+  try {
+    return runGit(repoDir, args, opts);
+  } catch {
+    return null;
+  }
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function formatGitError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return stripAnsi(message);
+}
+
+function isRebaseInProgress(repoDir: string): boolean {
+  return (
+    fs.existsSync(path.join(repoDir, ".git", "rebase-merge")) ||
+    fs.existsSync(path.join(repoDir, ".git", "rebase-apply"))
+  );
+}
+
+interface StatusFile {
+  path: string;
+  index: string;
+  working_dir: string;
+}
+
+function readStatusFiles(repoDir: string): StatusFile[] {
+  const porcelain = runGit(repoDir, ["status", "--porcelain=v1", "-z"]);
+  const files: StatusFile[] = [];
+  const parts = porcelain.split("\0");
+  for (let i = 0; i < parts.length; i++) {
+    const entry = parts[i];
+    if (!entry) continue;
+    const parsed = parsePorcelainEntry(entry);
+    if (!parsed) continue;
+    files.push({
+      path: parsed.path,
+      index: parsed.index,
+      working_dir: parsed.working,
+    });
+    if (parsed.index === "R" || parsed.index === "C") {
+      i++;
+    }
+  }
+  return files;
+}
+
+function getConflictedFiles(repoDir: string): string[] {
+  return readStatusFiles(repoDir)
+    .filter((f) => `${f.index}${f.working_dir}`.includes("U"))
+    .map((f) => f.path);
+}
+
+function abortRebase(repoDir: string): void {
+  if (isRebaseInProgress(repoDir)) {
+    tryGit(repoDir, ["rebase", "--abort"]);
+  }
+}
+
+let emptyHooksDir: string | null = null;
+function getEmptyHooksDir(): string {
+  if (!emptyHooksDir) {
+    emptyHooksDir = mkdtempSync(path.join(tmpdir(), "mesh-sandbox-no-hooks-"));
+  }
+  return emptyHooksDir;
+}
+
+const SKIP_HOOKS_ENV: Record<string, string> = {
+  LEFTHOOK: "0",
+  HUSKY: "0",
+};
+
+const NON_INTERACTIVE_ENV: Record<string, string> = {
+  GIT_EDITOR: "true",
+  EDITOR: "true",
+};
+
+function commitBeforeRebase(repoDir: string): void {
+  const porcelain = tryGit(repoDir, ["status", "--porcelain"]);
+  if (!porcelain?.trim()) return;
+
+  runGit(repoDir, ["add", "."]);
+  runGit(
+    repoDir,
+    [
+      "-c",
+      `core.hooksPath=${getEmptyHooksDir()}`,
+      "commit",
+      "--no-verify",
+      "-m",
+      "Before rebase",
+    ],
+    { env: SKIP_HOOKS_ENV },
+  );
+}
+
+function resolveConflictsRecursively(
+  repoDir: string,
+  wip = MAX_CONFLICT_RESOLUTION_ATTEMPTS,
+): void {
+  if (wip <= 0) {
+    abortRebase(repoDir);
+    throw new Error("Rebase conflict resolution exceeded maximum attempts");
+  }
+
+  const files = readStatusFiles(repoDir);
+  const conflicted = files.filter((f) =>
+    `${f.index}${f.working_dir}`.includes("U"),
+  );
+
+  for (const summary of conflicted) {
+    if (summary.working_dir === "D") {
+      runGit(repoDir, ["rm", summary.path]);
+    } else {
+      runGit(repoDir, ["add", summary.path]);
+    }
+  }
+
+  if (getConflictedFiles(repoDir).length !== 0) {
+    abortRebase(repoDir);
+    throw new Error("Unresolved rebase conflicts remain");
+  }
+
+  try {
+    runGit(repoDir, ["rebase", "--continue"], { env: NON_INTERACTIVE_ENV });
+  } catch (err) {
+    const message = formatGitError(err);
+    if (
+      !message.includes("CONFLICT") &&
+      getConflictedFiles(repoDir).length === 0
+    ) {
+      abortRebase(repoDir);
+      throw err;
+    }
+    resolveConflictsRecursively(repoDir, wip - 1);
+  }
+}
+
+function remoteBranchSha(repoDir: string, branch: string): string | null {
+  return tryGit(repoDir, [
+    "rev-parse",
+    "--verify",
+    `refs/remotes/origin/${branch}`,
+  ]);
+}
+
+function forcePushRebasedBranch(
+  repoDir: string,
+  branch: string,
+  leaseSha: string | null,
+): void {
+  if (leaseSha) {
+    const leaseRef = `refs/heads/${branch}:${leaseSha}`;
+    try {
+      runGit(repoDir, [
+        "push",
+        `--force-with-lease=${leaseRef}`,
+        "origin",
+        branch,
+      ]);
+      return;
+    } catch (err) {
+      const message = formatGitError(err);
+      const retriable =
+        message.includes("stale info") ||
+        message.includes("failed to push some refs");
+      if (!retriable) {
+        throw err;
+      }
+
+      runGit(repoDir, ["fetch", "origin", branch]);
+      const refreshed = remoteBranchSha(repoDir, branch);
+      if (refreshed) {
+        runGit(repoDir, [
+          "push",
+          `--force-with-lease=refs/heads/${branch}:${refreshed}`,
+          "origin",
+          branch,
+        ]);
+        return;
+      }
+    }
+  }
+
+  runGit(repoDir, ["push", "--force", "origin", branch]);
+}
+
+/**
+ * Rebase the current branch onto `origin/{base}` using the legacy deco CMS
+ * strategy: prefer branch changes on conflict (`-X theirs`), auto-resolve
+ * remaining conflicts, then force-push.
+ */
+export function rebaseOntoBase(
+  repoDir: string,
+  base: string,
+): { rebased: boolean } {
+  const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!branch || branch === "HEAD") {
+    throw new Error("Cannot rebase from a detached HEAD");
+  }
+
+  runGit(repoDir, ["fetch", "-p", "origin", base, branch]);
+  const leaseSha = remoteBranchSha(repoDir, branch);
+
+  tryGit(repoDir, [
+    "submodule",
+    "update",
+    "--init",
+    "--recursive",
+    "--depth",
+    "1",
+  ]);
+
+  const upstream = `origin/${base}`;
+  if (tryGit(repoDir, ["rev-parse", "--verify", upstream]) === null) {
+    throw new Error(`Base branch '${base}' not found on origin`);
+  }
+
+  commitBeforeRebase(repoDir);
+
+  try {
+    runGit(repoDir, ["rebase", "-X", "theirs", upstream]);
+  } catch (err) {
+    if (!isRebaseInProgress(repoDir)) {
+      throw err;
+    }
+    resolveConflictsRecursively(repoDir);
+  }
+
+  if (isRebaseInProgress(repoDir)) {
+    abortRebase(repoDir);
+    throw new Error("Rebase did not complete");
+  }
+
+  forcePushRebasedBranch(repoDir, branch, leaseSha);
+  return { rebased: true };
+}

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { gitSync as rawGitSync } from "./git-sync";
 import { parsePorcelainEntry } from "./porcelain";
+import { assertValidRemoteBranchName } from "./ref-name";
 
 const MAX_CONFLICT_RESOLUTION_ATTEMPTS = 50;
 
@@ -129,6 +130,8 @@ function commitBeforeRebase(repoDir: string): void {
       "-c",
       `core.hooksPath=${getEmptyHooksDir()}`,
       "commit",
+      // --no-verify: see publish() in routes/git.ts — removing it means surfacing
+      // hook failures clearly in the publish UI instead of opaque daemon errors.
       "--no-verify",
       "-m",
       "Before rebase",
@@ -182,6 +185,8 @@ function continueRebase(repoDir: string): void {
         `core.hooksPath=${getEmptyHooksDir()}`,
         "commit",
         "--no-edit",
+        // --no-verify: see publish() in routes/git.ts — removing it means surfacing
+        // hook failures clearly in the publish UI instead of opaque daemon errors.
         "--no-verify",
       ],
       { env: { ...env, ...SKIP_HOOKS_ENV } },
@@ -309,6 +314,8 @@ function rebaseOntoBaseInner(
   repoDir: string,
   base: string,
 ): { rebased: boolean } {
+  assertValidRemoteBranchName(base);
+
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
     throw new Error("Cannot rebase from a detached HEAD");

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -128,6 +128,49 @@ function commitBeforeRebase(repoDir: string): void {
   );
 }
 
+function resolveConflictFile(repoDir: string, summary: StatusFile): void {
+  const filePath = summary.path;
+  if (
+    summary.working_dir === "D" &&
+    !`${summary.index}${summary.working_dir}`.includes("U")
+  ) {
+    runGit(repoDir, ["rm", "-f", filePath]);
+    return;
+  }
+
+  // During rebase, `--theirs` is the commit being replayed (branch changes).
+  tryGit(repoDir, ["checkout", "--theirs", "--", filePath]);
+  runGit(repoDir, ["add", "--", filePath]);
+}
+
+function continueRebase(repoDir: string): void {
+  const env = NON_INTERACTIVE_ENV;
+  try {
+    runGit(repoDir, ["rebase", "--continue"], { env });
+  } catch (err) {
+    const message = formatGitError(err);
+    if (!message.includes("staged changes in your working tree")) {
+      throw err;
+    }
+
+    runGit(
+      repoDir,
+      [
+        "-c",
+        `core.hooksPath=${getEmptyHooksDir()}`,
+        "commit",
+        "--no-edit",
+        "--no-verify",
+      ],
+      { env: { ...env, ...SKIP_HOOKS_ENV } },
+    );
+
+    if (isRebaseInProgress(repoDir)) {
+      runGit(repoDir, ["rebase", "--continue"], { env });
+    }
+  }
+}
+
 function resolveConflictsRecursively(
   repoDir: string,
   wip = MAX_CONFLICT_RESOLUTION_ATTEMPTS,
@@ -143,11 +186,7 @@ function resolveConflictsRecursively(
   );
 
   for (const summary of conflicted) {
-    if (summary.working_dir === "D") {
-      runGit(repoDir, ["rm", summary.path]);
-    } else {
-      runGit(repoDir, ["add", summary.path]);
-    }
+    resolveConflictFile(repoDir, summary);
   }
 
   if (getConflictedFiles(repoDir).length !== 0) {
@@ -156,12 +195,13 @@ function resolveConflictsRecursively(
   }
 
   try {
-    runGit(repoDir, ["rebase", "--continue"], { env: NON_INTERACTIVE_ENV });
+    continueRebase(repoDir);
   } catch (err) {
     const message = formatGitError(err);
     if (
       !message.includes("CONFLICT") &&
-      getConflictedFiles(repoDir).length === 0
+      getConflictedFiles(repoDir).length === 0 &&
+      !isRebaseInProgress(repoDir)
     ) {
       abortRebase(repoDir);
       throw err;

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -9,6 +9,13 @@ const MAX_CONFLICT_RESOLUTION_ATTEMPTS = 50;
 const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
   rawGitSync(["-c", "safe.directory=*", ...args], opts);
 
+/** Production daemon drops to deco user; unit tests run git as the current user. */
+let rebaseGitAsUser = true;
+
+export interface RebaseOntoBaseOptions {
+  asUser?: boolean;
+}
+
 function gitEnv(repoDir: string): Record<string, string> {
   return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
 }
@@ -21,6 +28,7 @@ function runGit(
   return gitSync(args, {
     cwd: repoDir,
     env: { ...gitEnv(repoDir), ...opts?.env },
+    asUser: rebaseGitAsUser,
   });
 }
 
@@ -131,16 +139,29 @@ function commitBeforeRebase(repoDir: string): void {
 
 function resolveConflictFile(repoDir: string, summary: StatusFile): void {
   const filePath = summary.path;
+  const xy = `${summary.index}${summary.working_dir}`;
+  const abs = path.join(repoDir, filePath);
+
+  // modify/delete during rebase: keep the replayed commit version when present.
   if (
-    summary.working_dir === "D" &&
-    !`${summary.index}${summary.working_dir}`.includes("U")
+    xy.includes("U") &&
+    (summary.index === "D" || summary.working_dir === "D")
   ) {
+    if (fs.existsSync(abs)) {
+      runGit(repoDir, ["add", "--", filePath]);
+      return;
+    }
+    runGit(repoDir, ["rm", "-f", "--", filePath]);
+    return;
+  }
+
+  if (summary.working_dir === "D" && !xy.includes("U")) {
     runGit(repoDir, ["rm", "-f", filePath]);
     return;
   }
 
   // During rebase, `--theirs` is the commit being replayed (branch changes).
-  tryGit(repoDir, ["checkout", "--theirs", "--", filePath]);
+  runGit(repoDir, ["checkout", "--theirs", "--", filePath]);
   runGit(repoDir, ["add", "--", filePath]);
 }
 
@@ -199,11 +220,16 @@ function resolveConflictsRecursively(
     continueRebase(repoDir);
   } catch (err) {
     const message = formatGitError(err);
+    const remaining = getConflictedFiles(repoDir);
     if (
       !message.includes("CONFLICT") &&
-      getConflictedFiles(repoDir).length === 0 &&
+      remaining.length === 0 &&
       !isRebaseInProgress(repoDir)
     ) {
+      abortRebase(repoDir);
+      throw err;
+    }
+    if (remaining.length === 0) {
       abortRebase(repoDir);
       throw err;
     }
@@ -266,6 +292,20 @@ function forcePushRebasedBranch(
  * remaining conflicts, then force-push.
  */
 export function rebaseOntoBase(
+  repoDir: string,
+  base: string,
+  options?: RebaseOntoBaseOptions,
+): { rebased: boolean } {
+  const previousAsUser = rebaseGitAsUser;
+  rebaseGitAsUser = options?.asUser ?? true;
+  try {
+    return rebaseOntoBaseInner(repoDir, base);
+  } finally {
+    rebaseGitAsUser = previousAsUser;
+  }
+}
+
+function rebaseOntoBaseInner(
   repoDir: string,
   base: string,
 ): { rebased: boolean } {

--- a/packages/sandbox/daemon/git/ref-name.test.ts
+++ b/packages/sandbox/daemon/git/ref-name.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assertValidRemoteBranchName,
+  InvalidRemoteBranchNameError,
+} from "./ref-name";
+
+describe("assertValidRemoteBranchName", () => {
+  it("accepts common branch names", () => {
+    expect(() => assertValidRemoteBranchName("main")).not.toThrow();
+    expect(() => assertValidRemoteBranchName("feat/shipping")).not.toThrow();
+    expect(() => assertValidRemoteBranchName("release-1.0")).not.toThrow();
+  });
+
+  it("rejects git flag injection and unsafe refs", () => {
+    for (const name of [
+      "",
+      "--upload-pack=evil",
+      "-p",
+      "main..other",
+      "/main",
+      "main/",
+      "main.lock",
+      "has space",
+    ]) {
+      expect(() => assertValidRemoteBranchName(name)).toThrow(
+        InvalidRemoteBranchNameError,
+      );
+    }
+  });
+});

--- a/packages/sandbox/daemon/git/ref-name.ts
+++ b/packages/sandbox/daemon/git/ref-name.ts
@@ -1,0 +1,24 @@
+/** Git branch/ref segment safe for `git fetch origin <name>` (no flag injection). */
+const REMOTE_BRANCH_NAME = /^[a-zA-Z0-9][a-zA-Z0-9/._-]*$/;
+
+export class InvalidRemoteBranchNameError extends Error {
+  constructor(name: string) {
+    super(`Invalid base branch name: ${name}`);
+    this.name = "InvalidRemoteBranchNameError";
+  }
+}
+
+/** Validates a remote branch name before passing it as a git CLI argument. */
+export function assertValidRemoteBranchName(name: string): void {
+  if (
+    !name ||
+    name.length > 255 ||
+    name.includes("..") ||
+    name.startsWith("/") ||
+    name.endsWith("/") ||
+    name.endsWith(".lock") ||
+    !REMOTE_BRANCH_NAME.test(name)
+  ) {
+    throw new InvalidRemoteBranchNameError(name);
+  }
+}

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -23,8 +23,12 @@ export interface FsDeps {
    * bash's cwd.
    */
   repoDir: string;
-  /** Called after a successful write/edit so branch dirty state can refresh. */
-  onRepoChange?: () => void;
+  /**
+   * Called after a successful write/edit to the working tree (not a git
+   * checkout or remote change). Lets the daemon refresh branch dirty state
+   * without waiting for the `.git/` watcher poll.
+   */
+  onWorkingTreeWrite?: () => void;
 }
 
 function spawnOpts(
@@ -189,7 +193,7 @@ export function makeWriteHandler(deps: FsDeps) {
     if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, body.content, "utf-8");
-    deps.onRepoChange?.();
+    deps.onWorkingTreeWrite?.();
     return jsonResponse({
       ok: true,
       bytesWritten: Buffer.byteLength(body.content, "utf-8"),
@@ -243,7 +247,7 @@ export function makeEditHandler(deps: FsDeps) {
       ? content.replaceAll(body.old_string, body.new_string)
       : content.replace(body.old_string, body.new_string);
     fs.writeFileSync(filePath, updated, "utf-8");
-    deps.onRepoChange?.();
+    deps.onWorkingTreeWrite?.();
     return jsonResponse({
       ok: true,
       replacements: replaceAll ? count : 1,

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -23,6 +23,8 @@ export interface FsDeps {
    * bash's cwd.
    */
   repoDir: string;
+  /** Called after a successful write/edit so branch dirty state can refresh. */
+  onRepoChange?: () => void;
 }
 
 function spawnOpts(
@@ -187,6 +189,7 @@ export function makeWriteHandler(deps: FsDeps) {
     if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, body.content, "utf-8");
+    deps.onRepoChange?.();
     return jsonResponse({
       ok: true,
       bytesWritten: Buffer.byteLength(body.content, "utf-8"),
@@ -240,6 +243,7 @@ export function makeEditHandler(deps: FsDeps) {
       ? content.replaceAll(body.old_string, body.new_string)
       : content.replace(body.old_string, body.new_string);
     fs.writeFileSync(filePath, updated, "utf-8");
+    deps.onRepoChange?.();
     return jsonResponse({
       ok: true,
       replacements: replaceAll ? count : 1,

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -7,6 +7,7 @@ import {
   makeGitDiffHandler,
   makeGitDiscardHandler,
   makeGitPublishHandler,
+  makeGitRebaseHandler,
   makeGitStatusHandler,
 } from "./git";
 
@@ -148,6 +149,22 @@ describe("git routes", () => {
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({
       error: "Invalid path: ../outside-secret.txt",
+    });
+  });
+
+  it("rebase rejects invalid base branch names", async () => {
+    const { appRoot, repoDir } = initRepo();
+    const handler = makeGitRebaseHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/rebase", {
+        method: "POST",
+        body: JSON.stringify({ base: "--upload-pack=evil" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Invalid base branch name: --upload-pack=evil",
     });
   });
 });

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -1,16 +1,19 @@
 import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "bun:test";
 import { gitSync } from "../git/git-sync";
 import {
   makeGitDiffHandler,
+  makeGitDiscardHandler,
   makeGitPublishHandler,
   makeGitStatusHandler,
 } from "./git";
 
-function initRepo(): string {
-  const repoDir = mkdtempSync(join(tmpdir(), "git-route-"));
+function initRepo(): { appRoot: string; repoDir: string } {
+  const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+  const repoDir = join(appRoot, "app");
+  mkdirSync(repoDir, { recursive: true });
   gitSync(["init", "-b", "main"], { cwd: repoDir, asUser: false });
   gitSync(["config", "user.email", "test@example.com"], {
     cwd: repoDir,
@@ -20,14 +23,14 @@ function initRepo(): string {
   writeFileSync(join(repoDir, "README.md"), "hello\n");
   gitSync(["add", "README.md"], { cwd: repoDir, asUser: false });
   gitSync(["commit", "-m", "init"], { cwd: repoDir, asUser: false });
-  return repoDir;
+  return { appRoot, repoDir };
 }
 
 describe("git routes", () => {
   it("status reports modified files", async () => {
-    const repoDir = initRepo();
+    const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "README.md"), "hello world\n");
-    const handler = makeGitStatusHandler({ repoDir });
+    const handler = makeGitStatusHandler({ appRoot, repoDir });
     const res = await handler(new Request("http://x/git/status"));
     expect(res.status).toBe(200);
     const body = (await res.json()) as { modified: string[] };
@@ -35,9 +38,9 @@ describe("git routes", () => {
   });
 
   it("diff returns before/after content", async () => {
-    const repoDir = initRepo();
+    const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "README.md"), "hello world\n");
-    const handler = makeGitDiffHandler({ repoDir });
+    const handler = makeGitDiffHandler({ appRoot, repoDir });
     const res = await handler(new Request("http://x/git/diff"));
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -48,9 +51,9 @@ describe("git routes", () => {
   });
 
   it("publish commits staged changes", async () => {
-    const repoDir = initRepo();
+    const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "README.md"), "updated\n");
-    const handler = makeGitPublishHandler({ repoDir });
+    const handler = makeGitPublishHandler({ appRoot, repoDir });
     const res = await handler(
       new Request("http://x/git/publish", {
         method: "POST",
@@ -70,7 +73,7 @@ describe("git routes", () => {
   });
 
   it("publish skips failing pre-commit hooks", async () => {
-    const repoDir = initRepo();
+    const { appRoot, repoDir } = initRepo();
     const hooksDir = join(repoDir, ".git", "hooks");
     mkdirSync(hooksDir, { recursive: true });
     const hookPath = join(hooksDir, "pre-commit");
@@ -78,7 +81,7 @@ describe("git routes", () => {
     chmodSync(hookPath, 0o755);
 
     writeFileSync(join(repoDir, "README.md"), "hook-bypass\n");
-    const handler = makeGitPublishHandler({ repoDir });
+    const handler = makeGitPublishHandler({ appRoot, repoDir });
     const res = await handler(
       new Request("http://x/git/publish", {
         method: "POST",
@@ -95,5 +98,56 @@ describe("git routes", () => {
       return;
     }
     expect(res.status).toBe(200);
+  });
+
+  it("publish stages only paths with working tree changes", async () => {
+    const { appRoot, repoDir } = initRepo();
+    writeFileSync(join(repoDir, "tracked.txt"), "original\n");
+    gitSync(["add", "tracked.txt"], { cwd: repoDir, asUser: false });
+    gitSync(["commit", "-m", "add tracked"], { cwd: repoDir, asUser: false });
+
+    writeFileSync(join(repoDir, "README.md"), "updated\n");
+
+    const handler = makeGitPublishHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "only readme" }),
+      }),
+    );
+
+    if (res.status === 500) {
+      const log = gitSync(["log", "-1", "--pretty=%s"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+      expect(log.trim()).toBe("only readme");
+      const show = gitSync(["show", "--name-only", "--pretty=", "HEAD"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+      expect(show.trim()).toBe("README.md");
+      return;
+    }
+    expect(res.status).toBe(200);
+  });
+
+  it("discard rejects path traversal", async () => {
+    const { appRoot, repoDir } = initRepo();
+    const outside = join(dirname(appRoot), "outside-secret.txt");
+    writeFileSync(outside, "secret\n");
+
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: ["../outside-secret.txt"] }),
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Invalid path: ../outside-secret.txt",
+    });
   });
 });

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -1,0 +1,99 @@
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { gitSync } from "../git/git-sync";
+import {
+  makeGitDiffHandler,
+  makeGitPublishHandler,
+  makeGitStatusHandler,
+} from "./git";
+
+function initRepo(): string {
+  const repoDir = mkdtempSync(join(tmpdir(), "git-route-"));
+  gitSync(["init", "-b", "main"], { cwd: repoDir, asUser: false });
+  gitSync(["config", "user.email", "test@example.com"], {
+    cwd: repoDir,
+    asUser: false,
+  });
+  gitSync(["config", "user.name", "Test"], { cwd: repoDir, asUser: false });
+  writeFileSync(join(repoDir, "README.md"), "hello\n");
+  gitSync(["add", "README.md"], { cwd: repoDir, asUser: false });
+  gitSync(["commit", "-m", "init"], { cwd: repoDir, asUser: false });
+  return repoDir;
+}
+
+describe("git routes", () => {
+  it("status reports modified files", async () => {
+    const repoDir = initRepo();
+    writeFileSync(join(repoDir, "README.md"), "hello world\n");
+    const handler = makeGitStatusHandler({ repoDir });
+    const res = await handler(new Request("http://x/git/status"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { modified: string[] };
+    expect(body.modified).toContain("README.md");
+  });
+
+  it("diff returns before/after content", async () => {
+    const repoDir = initRepo();
+    writeFileSync(join(repoDir, "README.md"), "hello world\n");
+    const handler = makeGitDiffHandler({ repoDir });
+    const res = await handler(new Request("http://x/git/diff"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      diffs: Record<string, { from: string | null; to: string | null }>;
+    };
+    expect(body.diffs["README.md"]?.from).toContain("hello");
+    expect(body.diffs["README.md"]?.to).toContain("hello world");
+  });
+
+  it("publish commits staged changes", async () => {
+    const repoDir = initRepo();
+    writeFileSync(join(repoDir, "README.md"), "updated\n");
+    const handler = makeGitPublishHandler({ repoDir });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "update readme" }),
+      }),
+    );
+    // No remote configured in this fixture — push fails, but commit should land.
+    if (res.status === 500) {
+      const log = gitSync(["log", "-1", "--pretty=%s"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+      expect(log.trim()).toBe("update readme");
+      return;
+    }
+    expect(res.status).toBe(200);
+  });
+
+  it("publish skips failing pre-commit hooks", async () => {
+    const repoDir = initRepo();
+    const hooksDir = join(repoDir, ".git", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const hookPath = join(hooksDir, "pre-commit");
+    writeFileSync(hookPath, "#!/bin/sh\nexit 1\n");
+    chmodSync(hookPath, 0o755);
+
+    writeFileSync(join(repoDir, "README.md"), "hook-bypass\n");
+    const handler = makeGitPublishHandler({ repoDir });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "skip hooks" }),
+      }),
+    );
+
+    if (res.status === 500) {
+      const log = gitSync(["log", "-1", "--pretty=%s"], {
+        cwd: repoDir,
+        asUser: false,
+      });
+      expect(log.trim()).toBe("skip hooks");
+      return;
+    }
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { parsePorcelainFiles } from "../git/porcelain";
 import { rebaseOntoBase } from "../git/rebase-onto-base";
+import { InvalidRemoteBranchNameError } from "../git/ref-name";
 import { safePath } from "../paths";
 import { git } from "../setup/git";
 import { jsonResponse, parseJsonBody } from "./body-parser";
@@ -231,8 +232,11 @@ function publish(deps: GitDeps, message: string): { pushed: boolean } {
     const commitMsg =
       message.trim().length > 0 ? message.trim() : "Update from sandbox";
     // Sandbox repos often ship lefthook/husky hooks (deno fmt, lint, check)
-    // that need a full dev toolchain + network. Skip hooks here — CI validates
-    // on the PR after push.
+    // that need a full dev toolchain + network. Push still runs normal hooks
+    // (e.g. pre-push branch protection); only this commit skips them.
+    // --no-verify: we may want to run hooks here eventually, but removing it
+    // requires surfacing hook failures clearly in the publish UI (which step
+    // failed, logs, retry) instead of a generic daemon 500.
     runGit(
       repoDir,
       [
@@ -363,6 +367,9 @@ export function makeGitRebaseHandler(deps: GitDeps) {
     try {
       return jsonResponse(rebaseOntoBase(deps.repoDir, base));
     } catch (err) {
+      if (err instanceof InvalidRemoteBranchNameError) {
+        return jsonResponse({ error: err.message }, 400);
+      }
       return jsonResponse({ error: formatGitError(err) }, 500);
     }
   };

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,0 +1,346 @@
+import fs, { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gitSync as rawGitSync } from "../git/git-sync";
+import { parsePorcelainEntry } from "../git/porcelain";
+import { jsonResponse, parseJsonBody } from "./body-parser";
+
+export interface GitDeps {
+  repoDir: string;
+}
+
+const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
+  rawGitSync(["-c", "safe.directory=*", ...args], opts);
+
+function gitEnv(repoDir: string): Record<string, string> {
+  return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
+}
+
+function runGit(
+  repoDir: string,
+  args: string[],
+  opts?: { env?: Record<string, string> },
+): string {
+  return gitSync(args, {
+    cwd: repoDir,
+    env: { ...gitEnv(repoDir), ...opts?.env },
+  });
+}
+
+function tryGit(repoDir: string, args: string[]): string | null {
+  try {
+    return runGit(repoDir, args);
+  } catch {
+    return null;
+  }
+}
+
+export interface GitStatusFile {
+  path: string;
+  index: string;
+  working_dir: string;
+}
+
+export interface GitStatusResult {
+  not_added: string[];
+  conflicted: string[];
+  created: string[];
+  deleted: string[];
+  modified: string[];
+  renamed: unknown[];
+  files: GitStatusFile[];
+  staged: string[];
+  ahead: number;
+  behind: number;
+  current: string | null;
+  tracking: string | null;
+  detached: boolean;
+}
+
+export interface GitDiffEntry {
+  from: string | null;
+  to: string | null;
+}
+
+export interface GitDiffResult {
+  diffs: Record<string, GitDiffEntry>;
+}
+
+function parsePorcelainEntries(out: string): GitStatusFile[] {
+  const files: GitStatusFile[] = [];
+  const parts = out.split("\0");
+  for (let i = 0; i < parts.length; i++) {
+    const entry = parts[i];
+    if (!entry) continue;
+    const parsed = parsePorcelainEntry(entry);
+    if (!parsed) continue;
+    files.push({
+      path: parsed.path,
+      index: parsed.index,
+      working_dir: parsed.working,
+    });
+    if (parsed.index === "R" || parsed.index === "C") {
+      i++;
+    }
+  }
+  return files;
+}
+
+function computeStatus(repoDir: string): GitStatusResult {
+  const porcelain = runGit(repoDir, ["status", "--porcelain=v1", "-z"]);
+  const files = parsePorcelainEntries(porcelain);
+
+  const not_added: string[] = [];
+  const conflicted: string[] = [];
+  const created: string[] = [];
+  const deleted: string[] = [];
+  const modified: string[] = [];
+  const renamed: unknown[] = [];
+  const staged: string[] = [];
+
+  for (const f of files) {
+    const xy = `${f.index}${f.working_dir}`;
+    if (xy.includes("U")) conflicted.push(f.path);
+    if (f.index === "?" && f.working_dir === "?") not_added.push(f.path);
+    else if (f.index === "A" || f.working_dir === "A") created.push(f.path);
+    else if (f.index === "D" || f.working_dir === "D") deleted.push(f.path);
+    else if (f.index === "R" || f.working_dir === "R") renamed.push(f.path);
+    else modified.push(f.path);
+    if (f.index !== " " && f.index !== "?") staged.push(f.path);
+  }
+
+  const branch = tryGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const detached = branch === "HEAD";
+  const tracking = tryGit(repoDir, [
+    "rev-parse",
+    "--abbrev-ref",
+    "--symbolic-full-name",
+    "@{u}",
+  ]);
+
+  let ahead = 0;
+  let behind = 0;
+  if (tracking && !detached) {
+    const counts = tryGit(repoDir, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "@{upstream}...HEAD",
+    ]);
+    const m = counts?.match(/^(\d+)\s+(\d+)$/);
+    if (m) {
+      behind = Number(m[1]);
+      ahead = Number(m[2]);
+    }
+  }
+
+  return {
+    not_added,
+    conflicted,
+    created,
+    deleted,
+    modified,
+    renamed,
+    files,
+    staged,
+    ahead,
+    behind,
+    current: branch,
+    tracking,
+    detached,
+  };
+}
+
+function readWorkingFile(repoDir: string, filePath: string): string | null {
+  const abs = path.join(repoDir, filePath);
+  try {
+    return fs.readFileSync(abs, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function readHeadFile(repoDir: string, filePath: string): string | null {
+  return tryGit(repoDir, ["show", `HEAD:${filePath}`]);
+}
+
+function computeDiff(repoDir: string): GitDiffResult {
+  const status = computeStatus(repoDir);
+  const paths = [
+    ...new Set(status.files.map((f) => f.path).filter((p) => p.length > 0)),
+  ];
+
+  const diffs: Record<string, GitDiffEntry> = {};
+  for (const filePath of paths) {
+    const file = status.files.find((f) => f.path === filePath);
+    const index = file?.index ?? " ";
+    const working = file?.working_dir ?? " ";
+    const isDeleted = index === "D" || working === "D";
+    const isNew =
+      (index === "?" && working === "?") ||
+      index === "A" ||
+      working === "A" ||
+      (!readHeadFile(repoDir, filePath) && !isDeleted);
+
+    diffs[filePath] = {
+      from: isNew ? null : readHeadFile(repoDir, filePath),
+      to: isDeleted ? null : readWorkingFile(repoDir, filePath),
+    };
+  }
+
+  return { diffs };
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function formatGitError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return stripAnsi(message);
+}
+
+/** Empty dir passed as core.hooksPath so publish commits never run lefthook/husky. */
+let emptyHooksDir: string | null = null;
+function getEmptyHooksDir(): string {
+  if (!emptyHooksDir) {
+    emptyHooksDir = mkdtempSync(path.join(tmpdir(), "mesh-sandbox-no-hooks-"));
+  }
+  return emptyHooksDir;
+}
+
+const SKIP_HOOKS_ENV: Record<string, string> = {
+  LEFTHOOK: "0",
+  HUSKY: "0",
+};
+
+function publish(repoDir: string, message: string): { pushed: boolean } {
+  const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!branch || branch === "HEAD") {
+    throw new Error("Cannot publish from a detached HEAD");
+  }
+
+  runGit(repoDir, ["add", "-A"]);
+  const hasStagedChanges =
+    tryGit(repoDir, ["diff", "--cached", "--quiet"]) === null;
+  if (hasStagedChanges) {
+    const commitMsg =
+      message.trim().length > 0 ? message.trim() : "Update from sandbox";
+    // Sandbox repos often ship lefthook/husky hooks (deno fmt, lint, check)
+    // that need a full dev toolchain + network. Skip hooks here — CI validates
+    // on the PR after push.
+    runGit(
+      repoDir,
+      [
+        "-c",
+        `core.hooksPath=${getEmptyHooksDir()}`,
+        "commit",
+        "--no-verify",
+        "-m",
+        commitMsg,
+      ],
+      { env: SKIP_HOOKS_ENV },
+    );
+  }
+
+  runGit(repoDir, ["push", "origin", branch]);
+  return { pushed: true };
+}
+
+function discard(repoDir: string, filepaths: string[]): void {
+  const status = computeStatus(repoDir);
+  const toRestore: string[] = [];
+  const toDelete: string[] = [];
+
+  for (const fp of filepaths) {
+    const isNew =
+      status.not_added.includes(fp) ||
+      status.created.includes(fp) ||
+      readHeadFile(repoDir, fp) === null;
+    if (isNew) toDelete.push(fp);
+    else toRestore.push(fp);
+  }
+
+  if (toRestore.length > 0) {
+    runGit(repoDir, ["checkout", "--", ...toRestore]);
+  }
+  for (const fp of toDelete) {
+    const abs = path.join(repoDir, fp);
+    try {
+      fs.unlinkSync(abs);
+    } catch {
+      // ignore missing files
+    }
+  }
+}
+
+export function makeGitStatusHandler(deps: GitDeps) {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      return jsonResponse(computeStatus(deps.repoDir));
+    } catch (err) {
+      return jsonResponse(
+        { error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
+  };
+}
+
+export function makeGitDiffHandler(deps: GitDeps) {
+  return async (_req: Request): Promise<Response> => {
+    try {
+      return jsonResponse(computeDiff(deps.repoDir));
+    } catch (err) {
+      return jsonResponse(
+        { error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
+  };
+}
+
+export function makeGitPublishHandler(deps: GitDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { message?: string };
+    try {
+      body = (await parseJsonBody(req)) as { message?: string };
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    try {
+      return jsonResponse(
+        publish(
+          deps.repoDir,
+          typeof body.message === "string" ? body.message : "",
+        ),
+      );
+    } catch (err) {
+      return jsonResponse({ error: formatGitError(err) }, 500);
+    }
+  };
+}
+
+export function makeGitDiscardHandler(deps: GitDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { filepaths?: string[] };
+    try {
+      body = (await parseJsonBody(req)) as { filepaths?: string[] };
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    const filepaths = body.filepaths;
+    if (!Array.isArray(filepaths) || filepaths.length === 0) {
+      return jsonResponse({ error: "filepaths is required" }, 400);
+    }
+    try {
+      discard(deps.repoDir, filepaths);
+      return jsonResponse({ success: true });
+    } catch (err) {
+      return jsonResponse(
+        { error: err instanceof Error ? err.message : String(err) },
+        500,
+      );
+    }
+  };
+}

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -3,9 +3,11 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { gitSync as rawGitSync } from "../git/git-sync";
 import { parsePorcelainEntry } from "../git/porcelain";
+import { safePath } from "../paths";
 import { jsonResponse, parseJsonBody } from "./body-parser";
 
 export interface GitDeps {
+  appRoot: string;
   repoDir: string;
 }
 
@@ -214,13 +216,36 @@ const SKIP_HOOKS_ENV: Record<string, string> = {
   HUSKY: "0",
 };
 
-function publish(repoDir: string, message: string): { pushed: boolean } {
+function changedPathsFromStatus(status: GitStatusResult): string[] {
+  return [
+    ...new Set(status.files.map((f) => f.path).filter((p) => p.length > 0)),
+  ];
+}
+
+function resolveRepoRelativePath(deps: GitDeps, userPath: string): string {
+  const abs = safePath(deps.appRoot, deps.repoDir, userPath);
+  if (!abs) {
+    throw new Error(`Invalid path: ${userPath}`);
+  }
+  const rel = path.relative(deps.repoDir, abs);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(`Invalid path: ${userPath}`);
+  }
+  return rel;
+}
+
+function publish(deps: GitDeps, message: string): { pushed: boolean } {
+  const repoDir = deps.repoDir;
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
     throw new Error("Cannot publish from a detached HEAD");
   }
 
-  runGit(repoDir, ["add", "-A"]);
+  const status = computeStatus(repoDir);
+  const paths = changedPathsFromStatus(status);
+  if (paths.length > 0) {
+    runGit(repoDir, ["add", "--", ...paths]);
+  }
   const hasStagedChanges =
     tryGit(repoDir, ["diff", "--cached", "--quiet"]) === null;
   if (hasStagedChanges) {
@@ -247,12 +272,14 @@ function publish(repoDir: string, message: string): { pushed: boolean } {
   return { pushed: true };
 }
 
-function discard(repoDir: string, filepaths: string[]): void {
+function discard(deps: GitDeps, filepaths: string[]): void {
+  const repoDir = deps.repoDir;
+  const validated = filepaths.map((fp) => resolveRepoRelativePath(deps, fp));
   const status = computeStatus(repoDir);
   const toRestore: string[] = [];
   const toDelete: string[] = [];
 
-  for (const fp of filepaths) {
+  for (const fp of validated) {
     const isNew =
       status.not_added.includes(fp) ||
       status.created.includes(fp) ||
@@ -310,10 +337,7 @@ export function makeGitPublishHandler(deps: GitDeps) {
     }
     try {
       return jsonResponse(
-        publish(
-          deps.repoDir,
-          typeof body.message === "string" ? body.message : "",
-        ),
+        publish(deps, typeof body.message === "string" ? body.message : ""),
       );
     } catch (err) {
       return jsonResponse({ error: formatGitError(err) }, 500);
@@ -334,7 +358,7 @@ export function makeGitDiscardHandler(deps: GitDeps) {
       return jsonResponse({ error: "filepaths is required" }, 400);
     }
     try {
-      discard(deps.repoDir, filepaths);
+      discard(deps, filepaths);
       return jsonResponse({ success: true });
     } catch (err) {
       return jsonResponse(

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { gitSync as rawGitSync } from "../git/git-sync";
 import { parsePorcelainEntry } from "../git/porcelain";
 import { safePath } from "../paths";
+import { rebaseOntoBase } from "../git/rebase-onto-base";
 import { jsonResponse, parseJsonBody } from "./body-parser";
 
 export interface GitDeps {
@@ -365,6 +366,26 @@ export function makeGitDiscardHandler(deps: GitDeps) {
         { error: err instanceof Error ? err.message : String(err) },
         500,
       );
+    }
+  };
+}
+
+export function makeGitRebaseHandler(deps: GitDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: { base?: string };
+    try {
+      body = (await parseJsonBody(req)) as { base?: string };
+    } catch (e) {
+      return jsonResponse({ error: (e as Error).message }, 400);
+    }
+    const base = typeof body.base === "string" ? body.base.trim() : "";
+    if (!base) {
+      return jsonResponse({ error: "base is required" }, 400);
+    }
+    try {
+      return jsonResponse(rebaseOntoBase(deps.repoDir, base));
+    } catch (err) {
+      return jsonResponse({ error: formatGitError(err) }, 500);
     }
   };
 }

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -195,7 +195,8 @@ function computeDiff(repoDir: string): GitDiffResult {
 }
 
 function stripAnsi(text: string): string {
-  return text.replace(/\x1b\[[0-9;]*m/g, "");
+  const esc = String.fromCharCode(0x1b);
+  return text.replace(new RegExp(`${esc}\\[[0-9;]*m`, "g"), "");
 }
 
 function formatGitError(err: unknown): string {

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,19 +1,16 @@
 import fs, { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { gitSync as rawGitSync } from "../git/git-sync";
-import { parsePorcelainEntry } from "../git/porcelain";
-import { safePath } from "../paths";
+import { parsePorcelainFiles } from "../git/porcelain";
 import { rebaseOntoBase } from "../git/rebase-onto-base";
+import { safePath } from "../paths";
+import { git } from "../setup/git";
 import { jsonResponse, parseJsonBody } from "./body-parser";
 
 export interface GitDeps {
   appRoot: string;
   repoDir: string;
 }
-
-const gitSync = (args: string[], opts: Parameters<typeof rawGitSync>[1]) =>
-  rawGitSync(["-c", "safe.directory=*", ...args], opts);
 
 function gitEnv(repoDir: string): Record<string, string> {
   return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
@@ -24,7 +21,7 @@ function runGit(
   args: string[],
   opts?: { env?: Record<string, string> },
 ): string {
-  return gitSync(args, {
+  return git(args, {
     cwd: repoDir,
     env: { ...gitEnv(repoDir), ...opts?.env },
   });
@@ -69,29 +66,9 @@ export interface GitDiffResult {
   diffs: Record<string, GitDiffEntry>;
 }
 
-function parsePorcelainEntries(out: string): GitStatusFile[] {
-  const files: GitStatusFile[] = [];
-  const parts = out.split("\0");
-  for (let i = 0; i < parts.length; i++) {
-    const entry = parts[i];
-    if (!entry) continue;
-    const parsed = parsePorcelainEntry(entry);
-    if (!parsed) continue;
-    files.push({
-      path: parsed.path,
-      index: parsed.index,
-      working_dir: parsed.working,
-    });
-    if (parsed.index === "R" || parsed.index === "C") {
-      i++;
-    }
-  }
-  return files;
-}
-
 function computeStatus(repoDir: string): GitStatusResult {
   const porcelain = runGit(repoDir, ["status", "--porcelain=v1", "-z"]);
-  const files = parsePorcelainEntries(porcelain);
+  const files: GitStatusFile[] = parsePorcelainFiles(porcelain);
 
   const not_added: string[] = [];
   const conflicted: string[] = [];

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -15,6 +15,7 @@ import type { Broadcaster } from "../events/broadcast";
 import type { DaemonStatus } from "../events/types";
 import type { BranchStatusMonitor } from "../git/branch-status";
 import { gitSync } from "../git/git-sync";
+import { spawnCheckoutBranch } from "../git/checkout-branch";
 import type { InstallState } from "../install/install-state";
 import { InstallState as InstallStateClass } from "../install/install-state";
 import type { LifecycleManager } from "../lifecycle/manager";
@@ -538,63 +539,15 @@ export class SetupOrchestrator {
     const repoDir = this.deps.bootConfig.repoDir;
     if (!repoDir) return;
     const onChunk = (_src: "setup", data: string) => this.rawChunk(data);
-    // http.connectTimeout: fail fast on DNS/TCP failures (seconds).
-    // lowSpeedLimit/Time: abort if transfer rate stays below 1 B/s for 10 s.
-    // GIT_TERMINAL_PROMPT=0 + GIT_ASKPASS=true: never prompt for credentials —
-    // public repos work without auth, private-without-creds fail fast instead
-    // of hanging on a PTY-backed prompt.
     const gc = `GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=true git -c safe.directory='*' -c credential.helper= -c http.connectTimeout=10 -c http.lowSpeedLimit=1 -c http.lowSpeedTime=10 -C ${repoDir}`;
 
-    // Fresh-clone path already lands on the target branch (clone.ts uses
-    // --branch when ls-remote reports it exists). Short-circuit so gitSetup
-    // doesn't re-fetch what we just cloned.
-    try {
-      const head = gitSync(["rev-parse", "--abbrev-ref", "HEAD"], {
-        cwd: repoDir,
-      });
-      if (head === branch) return;
-    } catch {
-      // No HEAD yet / not a repo — fall through and let the checkout fail loudly.
-    }
-
-    // ls-remote --exit-code distinguishes "absent" from "broken":
-    //   0  → branch exists on origin
-    //   2  → origin reachable, no matching ref
-    //   *  → real failure (auth/DNS/TLS) — surface to caller
-    const probe = await spawnSetupStep(
-      `${gc} ls-remote --exit-code --heads origin ${branch}`,
-      onChunk,
-    );
-
-    if (probe === 0) {
-      const fetchCode = await spawnSetupStep(
-        `${gc} fetch --depth 1 origin +refs/heads/${branch}:refs/remotes/origin/${branch}`,
-        onChunk,
-      );
-      if (fetchCode !== 0)
-        throw new Error(`git fetch origin ${branch} exited ${fetchCode}`);
-      // `checkout -B` creates-or-resets, avoiding DWIM ambiguity on slash-named
-      // branches in shallow clones.
-      const checkoutCode = await spawnSetupStep(
-        `${gc} checkout -B ${branch} refs/remotes/origin/${branch}`,
-        onChunk,
-      );
-      if (checkoutCode !== 0)
-        throw new Error(`git checkout -B ${branch} exited ${checkoutCode}`);
-      return;
-    }
-
-    if (probe === 2) {
-      this.chunk(
-        `[orchestrator] branch '${branch}' not on remote; creating local branch from HEAD\r\n`,
-      );
-      const code = await spawnSetupStep(`${gc} checkout -B ${branch}`, onChunk);
-      if (code !== 0)
-        throw new Error(`git checkout -B ${branch} exited ${code}`);
-      return;
-    }
-
-    throw new Error(`git ls-remote --heads origin ${branch} exited ${probe}`);
+    await spawnCheckoutBranch({
+      repoDir,
+      branch,
+      gc,
+      runStep: (cmd) => spawnSetupStep(cmd, onChunk),
+      log: (message) => this.chunk(message),
+    });
   }
 }
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "description": "Sandbox runner for isolated per-user containerised tool execution",
   "scripts": {


### PR DESCRIPTION
## Summary
- Replace chat-based **Save changes** with a publish modal (AI commit title/body, Monaco diffs, **Submit for review**, **Publish**)
- Add sandbox daemon git routes (`status`, `diff`, `publish`, `discard`, `suggest-commit`) and mesh proxy with `Cache-Control: no-store`
- Poll live git status to fix stale SSE branch metadata; refresh dirty state on file saves
- Open/merge PRs via direct GitHub MCP calls; parse `create_pull_request` `{ id, url }` MinimalResponse correctly
- Skip pre-commit hooks on sandbox publish commits (`--no-verify`, empty hooksPath)

## Test plan
- [ ] `bun test apps/mesh/src/web/components/thread/github/github-pr-api.test.ts`
- [ ] `bun test apps/mesh/src/lib/suggest-commit-message.test.ts`
- [ ] `bun test packages/sandbox/daemon/routes/git.test.ts`
- [ ] `bun run --cwd=packages/sandbox build` then restart link daemon
- [ ] Edit file in sandbox → header shows **Save changes** → modal opens with generated commit message
- [ ] **Submit for review** commits, pushes, opens PR (first click succeeds)
- [ ] **Publish** squash-merges; header updates after PR refresh
- [ ] Header **Submit for review** hidden once open PR exists


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the chat-based “Save changes” with a publish dialog that shows Monaco diffs, suggests commit messages, and performs deterministic GitHub PR actions. Hardened publishing with a `.deco/`-only gate, a rebase onto base that prefers branch changes, validated base refs, and an automatic switch to a fresh branch from the repo default; preview data waits for the dev server.

- New Features
  - Publish modal with generated commit title/body, diffs, and actions: Submit for review (opens PR) and Publish (squash-merge).
  - Sandbox daemon git routes: status, diff, publish, discard, suggest-commit; plus live polling and dirty-state refresh on save.
  - Publish hardening: `.deco/`-only gate, rebase onto base with conflict resolution favoring branch changes (with safe fallbacks), validated base branch name, then switch to a new branch from the default branch.
  - Resolve the effective sandbox branch from chat, sandbox map, and git, with tests.

- Bug Fixes
  - Hardened git discard to repo-scoped paths; safer path handling and base-ref validation in `/git/rebase` to block flag injection.
  - Fixed “un-pushed only” submit deadlock so first Submit reliably opens a PR.
  - Tightened PR lookup and parsing: use `head` filter; prefer tool `content` text when `structuredContent` is empty; correct `{ id, url }` parsing.
  - Clarified Publish tooltip when the diff includes non-`.deco/` files, guiding users to Submit for review.
  - More accurate dirty-state: refresh on file writes and parse `git status --porcelain -z`.
  - Improved partial-failure UX and branch consistency in the publish flow.
  - Sandbox proxy responses are marked no-store to avoid cached 410s.
  - Skip pre-commit hooks on sandbox publish commits.
  - New local branches fork from the repo default (`origin/HEAD`) instead of current HEAD.
  - Defer `decofile`/live-meta fetch until the dev server is running, with retry/backoff.
  - Resolved knip/lint/typecheck issues; stabilized rebase/checkout-branch tests on CI (handle modify/delete conflicts; run test git as current user; set git identity in the rebase-onto-base fixture).
  - Renamed daemon FS write callback to `onWorkingTreeWrite` to clarify behavior and trigger immediate dirty-state refresh after edits.
  - Bumped `@decocms/sandbox` to `0.5.7`, aligned Helm image tag, and deduped git route helpers via `setup/git` and `porcelain.parsePorcelainFiles`.

<sup>Written for commit 74f38f7518a0d1ee35e4de75ee5c66b0629f5212. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

