### PR TITLE
fix(home): show no-provider empty state to match decopilot thread

### DIFF
--- a/apps/mesh/src/web/layouts/home-page/index.tsx
+++ b/apps/mesh/src/web/layouts/home-page/index.tsx
@@ -1,13 +1,23 @@
 import { ArrowRight } from "@untitledui/icons";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import {
+  getWellKnownDecopilotVirtualMCP,
+  useProjectContext,
+  useVirtualMCP,
+} from "@decocms/mesh-sdk";
 import { Chat } from "@/web/components/chat";
+import { useChatPrefs } from "@/web/components/chat/context";
 import { NoAiProviderEmptyState } from "@/web/components/chat/no-ai-provider-empty-state";
 import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
 import { IntegrationIcon } from "@/web/components/integration-icon";
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
+import {
+  agentHasClonableSource,
+  hasLocalCliHarness,
+} from "@/web/lib/agent-capabilities";
 import { authClient } from "@/web/lib/auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
@@ -78,11 +88,16 @@ function useIsDecoUser() {
 
 export function HomePage() {
   const { data: session } = authClient.useSession();
+  const { org } = useProjectContext();
   const [importOpen, setImportOpen] = useState(false);
   const isDecoUser = useIsDecoUser();
   const isMobile = useIsMobile();
   const allKeys = useAiProviderKeys();
   const link = useCurrentLink();
+  const { selectedVirtualMcp } = useChatPrefs();
+  const defaultAgent = getWellKnownDecopilotVirtualMCP(org.id);
+  const displayAgent = selectedVirtualMcp ?? defaultAgent;
+  const fullVm = useVirtualMCP(displayAgent.id);
   const {
     hasDecoKey,
     isZeroBalance,
@@ -91,7 +106,11 @@ export function HomePage() {
     hasOnlyDecoProvider,
   } = useDecoCredits();
 
-  if (allKeys.length === 0 && !link.online) {
+  const isClonableAgent = agentHasClonableSource(fullVm?.metadata);
+  const showProviderEmptyState =
+    allKeys.length === 0 && !(isClonableAgent && hasLocalCliHarness(link));
+
+  if (showProviderEmptyState) {
     return (
       <div className="flex-1 overflow-y-auto">
         <div className="min-h-full flex items-center justify-center px-4 py-10">


### PR DESCRIPTION
## What is this contribution about?

Aligns the home page provider-empty-state condition with `side-panel-chat.tsx` so users without cloud AI provider keys see the same `NoAiProviderEmptyState` they get when opening a decopilot thread. Previously the home page bypassed the empty state whenever any desktop link was online, but decopilot is cloud-only and a CLI link doesn't unblock it — leaving the chat input visible on the home page only to fail once the user submitted into a decopilot thread.

The new condition mirrors the thread page: `allKeys.length === 0 && !(isClonableAgent && hasLocalCliHarness(link))`. With no `selectedVirtualMcp` (the home-page default), `isClonableAgent` is false, so the empty state shows whenever cloud keys are missing.

## How to Test

1. Sign in to an org with no AI provider keys configured (and no clonable agent selected via URL).
2. Open the home page (`/$org/`) — you should now see the `NoAiProviderEmptyState` (provider grid + connect-desktop badge) instead of the chat input.
3. Add an AI provider key — the chat input returns. The existing thread-page behavior is unchanged.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the home page empty state with the decopilot thread logic. Users without cloud provider keys now see `NoAiProviderEmptyState` instead of a chat input that fails.

- **Bug Fixes**
  - Mirror thread condition: show empty state when no cloud keys and not (clonable agent with local CLI harness).
  - Choose the display agent from the selected virtual MCP or the default decopilot, then check clonability.
  - Removes false positives from an online CLI link; home now matches thread behavior.

<sup>Written for commit c38eef6e585270eddb43e78844e5a9652f20909e. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3481?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

