### PR TITLE
feat(pwa): paint into Window Controls Overlay title-bar strip

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -7,10 +7,66 @@
   }
   body {
     @apply bg-background text-foreground;
-    padding-top: env(titlebar-area-height, 0);
   }
   svg {
     stroke-width: 1.75;
+  }
+}
+
+/* Window Controls Overlay (installed PWA on Chromium):
+   - lift the toolbar out of flow and pin it to the title-bar strip
+   - reserve space on the shell root for the now-floating bar
+   - shrink the toolbar's children so they fit the (smaller) WCO strip
+   - make the strip background draggable; opt buttons back to clickable
+   - hide elements that duplicate browser chrome (e.g. app logo)
+
+   These rules live outside @layer base so they win against Tailwind's
+   utility classes (h-12, pl-1, pr-2, size-7, etc.) which would otherwise
+   cascade later and beat them. */
+@media (display-mode: window-controls-overlay) {
+  .app-shell-root {
+    padding-top: env(titlebar-area-height, 0);
+  }
+  .app-titlebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 50;
+    height: env(titlebar-area-height, 3rem);
+    padding-top: 0;
+    padding-left: env(titlebar-area-x, 0px);
+    padding-right: calc(
+      100vw -
+      env(titlebar-area-x, 0px) -
+      env(titlebar-area-width, 100vw)
+    );
+  }
+  /* Make interactive controls in the title-bar a tad more compact so they
+     match the typical macOS title-bar height (~28-32px). */
+  .app-titlebar button,
+  .app-titlebar [role="button"] {
+    width: 1.375rem;
+    height: 1.375rem;
+  }
+  .app-titlebar svg {
+    width: 14px;
+    height: 14px;
+  }
+  .wco-drag {
+    -webkit-app-region: drag;
+    app-region: drag;
+  }
+  .wco-drag button,
+  .wco-drag a,
+  .wco-drag input,
+  .wco-drag [role="button"],
+  .wco-no-drag {
+    -webkit-app-region: no-drag;
+    app-region: no-drag;
+  }
+  .wco-hide {
+    display: none !important;
   }
 }
 

--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -15,17 +15,20 @@
 
 /* Window Controls Overlay (installed PWA on Chromium):
    - lift the toolbar out of flow and pin it to the title-bar strip
-   - reserve space on the shell root for the now-floating bar
-   - shrink the toolbar's children so they fit the (smaller) WCO strip
+   - reserve matching space on the shell root for the now-floating bar
    - make the strip background draggable; opt buttons back to clickable
    - hide elements that duplicate browser chrome (e.g. app logo)
 
    These rules live outside @layer base so they win against Tailwind's
-   utility classes (h-12, pl-1, pr-2, size-7, etc.) which would otherwise
-   cascade later and beat them. */
+   utility classes (h-12, pl-1, pr-2, etc.) which would otherwise cascade
+   later and beat them. */
 @media (display-mode: window-controls-overlay) {
+  /* The bar uses the OS title-bar height but never less than 2rem (32px) so
+     size-7 icon buttons and h-8 tab buttons keep their natural sizing without
+     overflowing. macOS's WCO strip is ~28-32px so this is usually a no-op on
+     Mac; the floor only matters on platforms with skinnier WCO strips. */
   .app-shell-root {
-    padding-top: env(titlebar-area-height, 0);
+    padding-top: max(env(titlebar-area-height, 0), 2rem);
   }
   .app-titlebar {
     position: fixed;
@@ -33,7 +36,7 @@
     left: 0;
     right: 0;
     z-index: 50;
-    height: env(titlebar-area-height, 3rem);
+    height: max(env(titlebar-area-height, 3rem), 2rem);
     padding-top: 0;
     padding-left: env(titlebar-area-x, 0px);
     padding-right: calc(
@@ -41,17 +44,6 @@
       env(titlebar-area-x, 0px) -
       env(titlebar-area-width, 100vw)
     );
-  }
-  /* Make interactive controls in the title-bar a tad more compact so they
-     match the typical macOS title-bar height (~28-32px). */
-  .app-titlebar button,
-  .app-titlebar [role="button"] {
-    width: 1.375rem;
-    height: 1.375rem;
-  }
-  .app-titlebar svg {
-    width: 14px;
-    height: 14px;
   }
   .wco-drag {
     -webkit-app-region: drag;

--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -1,14 +1,21 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="theme-color" content="#f6f4ed" />
     <script>
       // Apply dark mode class before first paint to prevent flash
       (function() {
         try {
           var p = JSON.parse(localStorage.getItem("mesh:user:preferences") || "{}");
           var theme = p.theme || "system";
-          if (theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+          var isDark = theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (isDark) {
             document.documentElement.classList.add("dark");
+            // Also pre-set <meta name="theme-color"> so the PWA title-bar (WCO)
+            // doesn't flash light before the React runtime syncs it from --sidebar.
+            // Value approximates dark --sidebar: oklch(0.155 0.005 60).
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute("content", "#272524");
           }
         } catch(e) {}
       })();
@@ -26,7 +33,6 @@
     <meta name="twitter:image" content="/og-image.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#f6f4ed" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/mesh/index.html
+++ b/apps/mesh/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:image" content="/og-image.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#D0EC1A" />
+    <meta name="theme-color" content="#f6f4ed" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/mesh/public/manifest.webmanifest
+++ b/apps/mesh/public/manifest.webmanifest
@@ -7,7 +7,7 @@
   "display": "standalone",
   "display_override": ["window-controls-overlay"],
   "background_color": "#ffffff",
-  "theme_color": "#D0EC1A",
+  "theme_color": "#f6f4ed",
   "icons": [
     {
       "src": "/favicon.svg",

--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -25,7 +25,7 @@ function SidebarLogoHeader() {
   const darkSrc = typeof logo === "string" ? logo : logo.dark;
 
   return (
-    <SidebarHeader className="flex items-center justify-center shrink-0 px-2 pb-0">
+    <SidebarHeader className="wco-hide flex items-center justify-center shrink-0 px-2 pb-0">
       <div className="flex w-full aspect-square items-center justify-center">
         <img
           src={lightSrc}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
@@ -60,9 +60,15 @@ export function Toolbar({ children }: { children?: ReactNode }) {
   );
 }
 
+/**
+ * The header occupies the WCO title-bar strip when the app is installed as a
+ * PWA. `env(titlebar-area-*)` resolves to non-zero values only inside that
+ * mode; in a regular browser tab the fallbacks (0 left/right, 3rem height)
+ * give the standard h-12 toolbar.
+ */
 function ToolbarHeader({ children }: { children?: ReactNode }) {
   return (
-    <div className="shrink-0 grid grid-cols-3 items-center pl-1 pr-2 pt-0.25 h-12">
+    <div className="app-titlebar wco-drag shrink-0 grid grid-cols-3 items-center pl-1 pr-2 pt-0.25 h-12 bg-sidebar">
       {children}
     </div>
   );

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -81,7 +81,7 @@ export default function OrgShellLayout() {
   return (
     <ThreadManagerProvider>
       <SidebarProvider defaultOpen={false}>
-        <div className="flex flex-col h-dvh overflow-hidden">
+        <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
           <SidebarLayout
             className="flex-1 bg-sidebar"
             style={

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -104,9 +104,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       if (!raw) return;
       const ctx = document.createElement("canvas").getContext("2d");
       if (!ctx) return;
-      if (!CSS.supports("color", raw)) return;
+      // Canvas rejects invalid values silently (keeps the prior fillStyle), so
+      // seed with a sentinel we can detect. CSS.supports("color", x) is too
+      // lax — it accepts CSS-wide keywords (inherit, unset, …) that fillStyle
+      // does not parse, which would leave the meta tag stuck on the sentinel.
+      ctx.fillStyle = "#010203";
+      const sentinel = ctx.fillStyle as string;
       ctx.fillStyle = raw;
-      meta.content = ctx.fillStyle as string;
+      const normalised = ctx.fillStyle as string;
+      if (normalised === sentinel) return;
+      meta.content = normalised;
     };
 
     if (preferences.theme === "dark") {

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -104,14 +104,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       if (!raw) return;
       const ctx = document.createElement("canvas").getContext("2d");
       if (!ctx) return;
-      // Canvas rejects invalid values silently (keeps the prior fillStyle),
-      // so seed with a sentinel we can detect.
-      ctx.fillStyle = "#000";
+      if (!CSS.supports("color", raw)) return;
       ctx.fillStyle = raw;
-      const normalised = ctx.fillStyle as string;
-      if (normalised && normalised !== "#000000") {
-        meta.content = normalised;
-      }
+      meta.content = ctx.fillStyle as string;
     };
 
     if (preferences.theme === "dark") {

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -88,19 +88,50 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useLayoutEffect(() => {
     const root = document.documentElement;
 
+    // Keep <meta name="theme-color"> in sync with the resolved theme so the
+    // PWA title-bar (Window Controls Overlay) matches the app chrome. We
+    // read --sidebar from documentElement (which may be oklch) and round-trip
+    // through canvas's fillStyle setter — the setter normalises any valid CSS
+    // color to canonical hex/rgb format, which is exactly what the meta tag
+    // accepts. Runs *after* the dark class toggle so the var resolves to the
+    // right value for the active theme.
+    const applyMeta = () => {
+      const meta = document.querySelector<HTMLMetaElement>(
+        'meta[name="theme-color"]',
+      );
+      if (!meta) return;
+      const raw = getComputedStyle(root).getPropertyValue("--sidebar").trim();
+      if (!raw) return;
+      const ctx = document.createElement("canvas").getContext("2d");
+      if (!ctx) return;
+      // Canvas rejects invalid values silently (keeps the prior fillStyle),
+      // so seed with a sentinel we can detect.
+      ctx.fillStyle = "#000";
+      ctx.fillStyle = raw;
+      const normalised = ctx.fillStyle as string;
+      if (normalised && normalised !== "#000000") {
+        meta.content = normalised;
+      }
+    };
+
     if (preferences.theme === "dark") {
       root.classList.add("dark");
+      applyMeta();
       return;
     }
 
     if (preferences.theme === "light") {
       root.classList.remove("dark");
+      applyMeta();
       return;
     }
 
     // System mode: follow OS preference and listen for changes
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const apply = (dark: boolean) => root.classList.toggle("dark", dark);
+    const apply = (dark: boolean) => {
+      root.classList.toggle("dark", dark);
+      applyMeta();
+    };
 
     apply(mq.matches);
 


### PR DESCRIPTION
## What is this contribution about?

The installed PWA was rendering an empty lime band above the app — `theme_color: #D0EC1A` painting through an unused `env(titlebar-area-height)` body shim left over from a half-done WCO setup. This PR finishes the integration: the existing top toolbar is now pinned to the title-bar strip with `position: fixed` + `env(titlebar-area-*)` padding to dodge the macOS traffic lights and Chrome's right-side controls, `-webkit-app-region: drag/no-drag` regions are wired so the bar drags the window but buttons stay clickable, and the sidebar's deco logo is hidden under `display-mode: window-controls-overlay` (it would otherwise sit behind the traffic lights). `<meta name="theme-color">` is kept in sync with the active `--sidebar` token at runtime via a canvas-normalised color probe, so light and dark themes both match `bg-sidebar` exactly. All WCO rules live outside `@layer base` so they win against Tailwind utilities; in a regular browser tab or non-WCO PWA mode the DOM and styles are byte-identical to before this branch.

## Screenshots/Demonstration

Before: a lime-green band above the entire UI in the installed PWA.
After: a compact title-bar strip containing the toolbar's nav/toggles/tabs/right-actions, sized to macOS's native title-bar height, with the strip background matching the rest of the sidebar.

## How to Test

1. `bun run dev`, install the app as a PWA from `http://pwa-green-bar.localhost` (or your local URL).
2. Open the installed PWA — the title-bar strip should contain the back/forward/toggles/tabs/right-actions, with no empty colored band; dragging the strip background should move the window, clicking buttons should not.
3. Toggle theme between light/dark/system — the strip color should track `bg-sidebar` in each.
4. Open the same URL in a regular browser tab — layout should look identical to `main` (toolbar in its original h-12 position, sidebar logo visible).

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Window Controls Overlay by moving the toolbar into the title-bar strip and removing the lime band. The strip matches `bg-sidebar` in light/dark, pre-paints `<meta name="theme-color">` to avoid dark-mode flash, and keeps a 32px minimum height; non-WCO views are unchanged.

- New Features
  - Pin the toolbar to the WCO strip via `env(titlebar-area-*)`, reserve space on `.app-shell-root`, and make the strip draggable with no-drag on controls.
  - Sync `<meta name="theme-color">` to computed `--sidebar` at runtime and hide the sidebar logo in WCO. Rules live outside `@layer base` to override Tailwind only in WCO.

- Bug Fixes
  - Floor the WCO title-bar at 32px so right-side buttons and tabs fit.
  - Prevent dark-mode flash and handle edge-case colors by pre-setting `theme-color` before first paint and normalizing with a canvas `fillStyle` sentinel (replaces the earlier `CSS.supports` check).

<sup>Written for commit 397f470c8b098ebf71575aae209e18b70cd73a52. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3483?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

