### PR TITLE
fix(virtual-mcp): allow Preview as default main view for clonable agents

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -96,7 +96,10 @@ import {
 } from "./types";
 import { VirtualMCPShareModal } from "./virtual-mcp-share-modal";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
-import { agentHasConnectedGithub } from "@/web/lib/agent-capabilities";
+import {
+  agentHasClonableSource,
+  agentHasConnectedGithub,
+} from "@/web/lib/agent-capabilities";
 import { FIXED_SYSTEM_TABS } from "@/web/layouts/main-panel-tabs/tab-id";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
 import { EnvVarsField } from "@/web/components/sandbox/runtime-card/env-vars-field";
@@ -857,20 +860,20 @@ function LayoutTabContent({
   const noInteractiveTools =
     connectionsWithTools && connectionsData.length === 0;
 
-  // Check if virtual MCP has a connected GitHub repo (requires real auth, enables preview/terminal)
-  const hasGithubRepo = agentHasConnectedGithub(virtualMcp);
+  // Preview is available whenever the agent has a clonable source —
+  // either a Start Website template or a connected GitHub repo — matching
+  // the gating in `use-main-panel-tabs.ts`.
+  const hasClonableSource = agentHasClonableSource(virtualMcp?.metadata);
 
   // Build options for the default main view selector.
   // Order mirrors the right-panel tab order in the unified chat layout:
   // Chat (no main panel), then fixed system tabs, then pinned ext-apps.
-  // Terminal and Preview are gated behind a connected GitHub repo,
-  // matching the gating in main-panel-tabs/index.tsx.
   const defaultMainOptions: { value: string; label: string }[] = [
     { value: "chat", label: "Chat" },
     { value: "settings", label: "Settings" },
     { value: "automations", label: "Automations" },
   ];
-  if (hasGithubRepo) {
+  if (hasClonableSource) {
     defaultMainOptions.push({ value: "preview", label: "Preview" });
   }
   for (const pv of pinnedViews) {


### PR DESCRIPTION
## What is this contribution about?
The Layout settings card in the virtual-MCP detail view only offered **Preview** as a default main view when the agent had a connected GitHub repo. Start Website agents have a clonable source without a connected GitHub identity, so the Preview tab appeared in the right-panel tabs but could not be picked as the default. This swaps the gating predicate from `agentHasConnectedGithub` to `agentHasClonableSource`, matching the gating already used in `use-main-panel-tabs.ts`.

## Screenshots/Demonstration
N/A — selector now lists "Preview" for Start Website agents (no GitHub connection required).

## How to Test
1. Create an agent via "Start Website" (clonable template, no GitHub connection).
2. Open the agent's Settings → Layout card.
3. Open the "Main view" select — **Preview** should be available.
4. Pick **Preview**, reopen the agent: the preview tab is the default main view.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Preview to be set as the default main view for clonable agents by gating on a clonable source instead of a connected GitHub repo. Fixes Start Website agents where Preview was shown but not selectable.

- **Bug Fixes**
  - Switched Layout settings predicate from agentHasConnectedGithub to agentHasClonableSource to match `use-main-panel-tabs.ts`.

<sup>Written for commit 7d20947753fee7e4bb7cbfa56582ed27a1deec47. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3485?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

