### PR TITLE
feat(deco-sites): auto-provision file-config on deco-site import

### DIFF
--- a/apps/mesh/src/api/routes/deco-sites.test.ts
+++ b/apps/mesh/src/api/routes/deco-sites.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { MeshContext } from "../../core/mesh-context";
+import type { FileConfigInfo } from "../../storage/types";
+import {
+  provisionDecoAssetsCredentials,
+  provisionDecoAssetsFileConfig,
+} from "./deco-sites";
+
+const originalFetch = globalThis.fetch;
+
+function fetchOk(body: unknown): typeof globalThis.fetch {
+  return mock(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+function fetchFail(status: number, body = ""): typeof globalThis.fetch {
+  return mock(() =>
+    Promise.resolve(new Response(body, { status })),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+function makeCtx(existing: FileConfigInfo[] = []): {
+  ctx: MeshContext;
+  createCalls: Array<Record<string, unknown>>;
+} {
+  const createCalls: Array<Record<string, unknown>> = [];
+  const orgFileConfigs = {
+    list: async (_orgId: string) => existing,
+    create: async (input: Record<string, unknown>) => {
+      createCalls.push(input);
+      return {} as FileConfigInfo;
+    },
+  };
+  const ctx = {
+    storage: { orgFileConfigs },
+  } as unknown as MeshContext;
+  return { ctx, createCalls };
+}
+
+describe("provisionDecoAssetsCredentials", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns credentials on 200", async () => {
+    globalThis.fetch = fetchOk({
+      accessKeyId: "GOOG1ETEST",
+      secretAccessKey: "secretvalue",
+    });
+    const result = await provisionDecoAssetsCredentials("acme", "api-key");
+    expect(result).toEqual({
+      accessKeyId: "GOOG1ETEST",
+      secretAccessKey: "secretvalue",
+    });
+  });
+
+  test("returns null on non-2xx", async () => {
+    globalThis.fetch = fetchFail(401, "Unauthorized");
+    const result = await provisionDecoAssetsCredentials("acme", "api-key");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on malformed response", async () => {
+    globalThis.fetch = fetchOk({ accessKeyId: "GOOG1E" }); // missing secret
+    const result = await provisionDecoAssetsCredentials("acme", "api-key");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when fetch throws", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("network down")),
+    ) as unknown as typeof globalThis.fetch;
+    const result = await provisionDecoAssetsCredentials("acme", "api-key");
+    expect(result).toBeNull();
+  });
+});
+
+describe("provisionDecoAssetsFileConfig", () => {
+  let restoreFetch: () => void;
+
+  beforeEach(() => {
+    restoreFetch = () => {
+      globalThis.fetch = originalFetch;
+    };
+  });
+  afterEach(() => restoreFetch());
+
+  test("creates a file config with the expected shape", async () => {
+    globalThis.fetch = fetchOk({
+      accessKeyId: "GOOG1ETEST",
+      secretAccessKey: "secretvalue",
+    });
+    const { ctx, createCalls } = makeCtx();
+
+    await provisionDecoAssetsFileConfig({
+      ctx,
+      orgId: "org_1",
+      userId: "user_1",
+      siteName: "acme",
+      serviceAccountApiKey: "api-key",
+    });
+
+    expect(createCalls).toHaveLength(1);
+    const created = createCalls[0]!;
+    expect(created).toMatchObject({
+      organizationId: "org_1",
+      createdBy: "user_1",
+      name: "deco-assets-acme",
+      bucket: "deco-assets",
+      region: "auto",
+      endpoint: "https://storage.googleapis.com",
+      forcePathStyle: true,
+      prefix: "acme/",
+      publicUrlBase: "https://decoims.com",
+      credentials: {
+        accessKeyId: "GOOG1ETEST",
+        secretAccessKey: "secretvalue",
+      },
+    });
+  });
+
+  test("is idempotent: skips when a file config with the same name already exists", async () => {
+    const fetchSpy = fetchOk({
+      accessKeyId: "GOOG1ETEST",
+      secretAccessKey: "secretvalue",
+    });
+    globalThis.fetch = fetchSpy;
+    const { ctx, createCalls } = makeCtx([
+      {
+        id: "fcfg_existing",
+        organizationId: "org_1",
+        name: "deco-assets-acme",
+        description: null,
+        bucket: "deco-assets",
+        region: "auto",
+        endpoint: "https://storage.googleapis.com",
+        forcePathStyle: true,
+        prefix: "acme/",
+        publicUrlBase: "https://decoims.com",
+        createdBy: "user_1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedBy: "user_1",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await provisionDecoAssetsFileConfig({
+      ctx,
+      orgId: "org_1",
+      userId: "user_1",
+      siteName: "acme",
+      serviceAccountApiKey: "api-key",
+    });
+
+    expect(createCalls).toHaveLength(0);
+    // No HTTP call either — we short-circuit before hitting admin.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("name match is case-insensitive (matches DB unique index)", async () => {
+    globalThis.fetch = fetchOk({
+      accessKeyId: "X",
+      secretAccessKey: "Y",
+    });
+    const { ctx, createCalls } = makeCtx([
+      {
+        id: "fcfg_existing",
+        organizationId: "org_1",
+        name: "DECO-ASSETS-ACME",
+        description: null,
+        bucket: "deco-assets",
+        region: "auto",
+        endpoint: "https://storage.googleapis.com",
+        forcePathStyle: true,
+        prefix: "acme/",
+        publicUrlBase: "https://decoims.com",
+        createdBy: "user_1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedBy: "user_1",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await provisionDecoAssetsFileConfig({
+      ctx,
+      orgId: "org_1",
+      userId: "user_1",
+      siteName: "acme",
+      serviceAccountApiKey: "api-key",
+    });
+
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test("does not create when credentials provisioning fails", async () => {
+    globalThis.fetch = fetchFail(403, "Forbidden");
+    const { ctx, createCalls } = makeCtx();
+
+    await provisionDecoAssetsFileConfig({
+      ctx,
+      orgId: "org_1",
+      userId: "user_1",
+      siteName: "acme",
+      serviceAccountApiKey: "api-key",
+    });
+
+    expect(createCalls).toHaveLength(0);
+  });
+});

--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -283,6 +283,125 @@ const requireAuth = async (
 };
 
 const ADMIN_MCP = "https://sites-admin-mcp.decocache.com/api/mcp";
+const ADMIN_API = "https://admin.deco.cx";
+
+/**
+ * Bucket layout that deco-sites/admin's provisionTenantS3Credentials
+ * sets up: a single `deco-assets` bucket on GCS (path-style S3 interop),
+ * one managed folder per site under `<siteName>/`, served through the
+ * `decoims.com` image CDN. Mirrors what the legacy admin's media widget
+ * already reads from — see `clients/gcsTenantCredentials.ts` in admin.
+ */
+const DECO_ASSETS_BUCKET = "deco-assets";
+const DECO_ASSETS_ENDPOINT = "https://storage.googleapis.com";
+const DECOIMS_CDN = "https://decoims.com";
+const FILE_CONFIG_NAME_PREFIX = "deco-assets-";
+
+interface TenantS3Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+}
+
+/**
+ * Calls `POST admin.deco.cx/api/<site>/s3-credentials` as the team's
+ * service account. The endpoint provisions (idempotently) a GCP service
+ * account, IAM-binds it to the site's managed folder, and mints a fresh
+ * HMAC key — see deco-sites/admin#3223 / #3235 for the auth contract.
+ * Returns null on any failure so callers can fall back to best-effort
+ * behaviour (the deco-sites import itself shouldn't fail just because
+ * storage couldn't be provisioned).
+ */
+export async function provisionDecoAssetsCredentials(
+  siteName: string,
+  serviceAccountApiKey: string,
+): Promise<TenantS3Credentials | null> {
+  try {
+    const res = await fetch(
+      `${ADMIN_API}/api/${encodeURIComponent(siteName)}/s3-credentials`,
+      {
+        method: "POST",
+        headers: { "x-api-key": serviceAccountApiKey },
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(
+        `[deco-sites] s3-credentials failed (${res.status}) for site=${siteName}: ${body.slice(0, 200)}`,
+      );
+      return null;
+    }
+    const data = (await res.json()) as {
+      accessKeyId?: string;
+      secretAccessKey?: string;
+    };
+    if (!data.accessKeyId || !data.secretAccessKey) {
+      console.error(
+        `[deco-sites] s3-credentials returned malformed response for site=${siteName}`,
+      );
+      return null;
+    }
+    return {
+      accessKeyId: data.accessKeyId,
+      secretAccessKey: data.secretAccessKey,
+    };
+  } catch (err) {
+    console.error(
+      `[deco-sites] s3-credentials request errored for site=${siteName}:`,
+      err,
+    );
+    return null;
+  }
+}
+
+/**
+ * Create a FILE_CONFIG row pointing at the per-site managed folder
+ * inside `gs://deco-assets`, served through `https://decoims.com`. If a
+ * config with the same name already exists in this org (re-import of
+ * the same site), no-op — credentials there may have been rotated by
+ * the user. Caller treats this as best-effort.
+ */
+export async function provisionDecoAssetsFileConfig(params: {
+  ctx: MeshContext;
+  orgId: string;
+  userId: string;
+  siteName: string;
+  serviceAccountApiKey: string;
+}): Promise<void> {
+  const { ctx, orgId, userId, siteName, serviceAccountApiKey } = params;
+  const configName = `${FILE_CONFIG_NAME_PREFIX}${siteName}`;
+
+  const existing = await ctx.storage.orgFileConfigs.list(orgId);
+  if (existing.some((c) => c.name.toLowerCase() === configName.toLowerCase())) {
+    console.log(
+      `[deco-sites] file-config "${configName}" already exists for org=${orgId}, skipping`,
+    );
+    return;
+  }
+
+  const creds = await provisionDecoAssetsCredentials(
+    siteName,
+    serviceAccountApiKey,
+  );
+  if (!creds) return;
+
+  await ctx.storage.orgFileConfigs.create({
+    organizationId: orgId,
+    name: configName,
+    description: `deco-assets storage for site "${siteName}". Provisioned during deco.cx import.`,
+    bucket: DECO_ASSETS_BUCKET,
+    region: "auto",
+    endpoint: DECO_ASSETS_ENDPOINT,
+    forcePathStyle: true,
+    prefix: `${siteName}/`,
+    publicUrlBase: DECOIMS_CDN,
+    credentials: creds,
+    createdBy: userId,
+  });
+  console.log(
+    `[deco-sites] file-config "${configName}" provisioned for org=${orgId}`,
+  );
+}
 
 async function fetchFaviconAsDataUrl(domain: string): Promise<string | null> {
   try {
@@ -531,6 +650,24 @@ export const createDecoSitesOrgRoutes = () => {
         app_id: null,
         tools,
         configuration_scopes,
+      });
+
+      // Best-effort: provision a FILE_CONFIG pointing at the site's
+      // deco-assets folder so the sections-editor file picker can list
+      // and upload images right after import. Any failure here is
+      // logged and swallowed — the deco.cx connection itself is
+      // already created and useful on its own.
+      await provisionDecoAssetsFileConfig({
+        ctx,
+        orgId,
+        userId,
+        siteName,
+        serviceAccountApiKey: apiKey,
+      }).catch((err) => {
+        console.error(
+          `[deco-sites] file-config provisioning failed for site=${siteName}:`,
+          err,
+        );
       });
 
       return c.json({ connId: connection.id, icon: faviconIcon });


### PR DESCRIPTION
## Summary

When a user imports a deco.cx site into a Studio org, also auto-provision a `FILE_CONFIG` pointing at that site's managed folder inside `gs://deco-assets`. The sections-editor file picker is then immediately usable for the imported site — no manual *Settings → Files* round-trip.

## What happens during import (`POST /api/deco-sites/connection`)

After the existing connection + service-account creation:

1. **Call `admin.deco.cx/api/<site>/s3-credentials`** with the team service account's api key (`x-api-key`). The endpoint (deco-sites/admin) provisions a GCP service account, IAM-binds it to the site's managed folder inside `gs://deco-assets`, and mints a fresh HMAC key.

2. **Insert a `FILE_CONFIG`** named `deco-assets-<siteName>` with:
   - `bucket=deco-assets`
   - `region=auto`
   - `endpoint=https://storage.googleapis.com`
   - `forcePathStyle=true`
   - `prefix=<siteName>/`
   - `publicUrlBase=https://decoims.com`

## Properties

- **Idempotent**: if a file-config with the same name already exists for this org (re-import of the same site), no-op. Credentials the user rotated manually aren't overwritten.
- **Best-effort**: any failure (admin down, IAM propagation lag, HMAC quota exceeded, etc.) is logged and swallowed — the deco.cx connection itself is already created and useful on its own. The user can re-trigger by re-importing.

## Dependency

Requires deco-sites/admin#3235 (new `allowRequestCheckTeamAdmin` on `/api/[site]/s3-credentials`) to be merged. Until then the call returns 401 and the import flow continues normally without a file-config.

## Test plan

- [ ] With admin#3235 merged, import a deco.cx site → confirm a `FILE_CONFIG` named `deco-assets-<site>` appears under *Settings → Files*.
- [ ] Open a section with an image field on that site → picker lists existing assets under the site's folder.
- [ ] Upload through the picker → file appears at `decoims.com/<site>/.../<uuid>-<name>`.
- [ ] Re-import the same site → no duplicate file-config (skipped with log line).
- [ ] Temporarily simulate admin returning 401 → import still succeeds, no file-config created, log line emitted.
- [ ] `bun test apps/mesh/src/api/routes/deco-sites.test.ts` (8 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-provisions a `FILE_CONFIG` when importing a deco.cx site so the sections-editor file picker works immediately. Runs during `POST /api/deco-sites/connection`, removing the need for a manual Settings → Files step.

- **New Features**
  - After connection/service-account setup, call `admin.deco.cx/api/<site>/s3-credentials` with the team service account `x-api-key` to mint HMAC credentials.
  - Create `FILE_CONFIG` named `deco-assets-<siteName>` pointing to `deco-assets` with `endpoint=https://storage.googleapis.com`, `prefix=<siteName>/`, and `publicUrlBase=https://decoims.com`.
  - Idempotent: skip if a same-named config exists (case-insensitive). Credentials aren’t overwritten.
  - Best-effort: failures are logged; the import still completes.

- **Dependencies**
  - Requires `deco-sites/admin#3235` to accept team service accounts on `/api/[site]/s3-credentials`. Until merged, this step returns 401 and is skipped.

<sup>Written for commit f19361ae66769b166fbe7a2f04b231a52a991d66. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3486?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

