### PR TITLE
ci(release-mesh): bump studio-stg image in deco-apps-cd

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -302,15 +302,17 @@ jobs:
           echo "Triggered ArgoCD deployment with image tag \`${{ needs.prepare.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
-  # GitOps: commit the new mesh version into deco-apps-cd so ArgoCD rolls it
-  # out. Only STAGING (deco-studio-stg) is bumped automatically — it is
-  # auto-sync. Prod (deco-studio) is manual-sync and promoted deliberately,
-  # so it is never bumped here.
+  # GitOps: commit the new mesh version into deco-apps-cd so ArgoCD picks it up.
+  # Both staging (deco-studio-stg) and prod (deco-studio) image tags are bumped.
+  # IMPORTANT: this only updates the desired version in git — it does NOT deploy
+  # prod. deco-studio-stg is auto-sync (rolls out immediately); deco-studio is
+  # manual-sync, so prod just shows OutOfSync until someone Syncs it deliberately
+  # (the promotion gate is preserved).
   # Requires the GH_APP_ID / GH_APP_PRIVATE_KEY app (write to deco-apps-cd) —
   # the same GitHub App the admin CI uses.
   # ---------------------------------------------------------------------------
-  bump-staging:
-    name: Bump staging in deco-apps-cd
+  bump-deco-apps-cd:
+    name: Bump image in deco-apps-cd
     needs: [prepare, merge-docker]
     if: |
       always() &&
@@ -326,7 +328,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: decocms
           repositories: deco-apps-cd
-      - name: Bump studio-stg mesh image
+      - name: Bump mesh image (stg + prod)
         env:
           GH_TOKEN: ${{ steps.cd-token.outputs.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -335,13 +337,14 @@ jobs:
           git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/decocms/deco-apps-cd.git" cd-repo
           cd cd-repo
           yq -i ".studio.image.tag = \"${VERSION}\"" apps/deco-studio-stg/values.yaml
+          yq -i ".studio.image.tag = \"${VERSION}\"" apps/deco-studio/values.yaml
           if git diff --quiet; then
-            echo "studio-stg already at ${VERSION}, nothing to commit"
+            echo "already at ${VERSION}, nothing to commit"
             exit 0
           fi
           git config user.name "deco-studio-ci[bot]"
           git config user.email "deco-studio-ci[bot]@users.noreply.github.com"
-          git commit -am "chore(studio-stg): bump mesh image to ${VERSION}"
+          git commit -am "chore(studio): bump mesh image to ${VERSION} (stg + prod)"
           git push
-          echo "### Staging bump" >> $GITHUB_STEP_SUMMARY
-          echo "Committed \`studio.image.tag=${VERSION}\` to deco-apps-cd (deco-studio-stg)" >> $GITHUB_STEP_SUMMARY
+          echo "### deco-apps-cd bump" >> $GITHUB_STEP_SUMMARY
+          echo "Committed \`studio.image.tag=${VERSION}\` (stg rolls out; prod awaits manual Sync)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -314,10 +314,16 @@ jobs:
   bump-deco-apps-cd:
     name: Bump image in deco-apps-cd
     needs: [prepare, merge-docker]
+    # Only bump when a VALID image for this version exists: either it was
+    # already published (image-exists == 'true', so merge-docker is skipped),
+    # or it was just built and merged successfully. A skipped merge-docker due
+    # to a failed build must NOT bump (no image was published).
     if: |
       always() &&
-      (needs.prepare.outputs.version-changed == 'true' || needs.prepare.outputs.image-exists == 'false') &&
-      (needs.merge-docker.result == 'success' || needs.merge-docker.result == 'skipped')
+      (
+        needs.prepare.outputs.image-exists == 'true' ||
+        needs.merge-docker.result == 'success'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Generate token for deco-apps-cd

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -300,3 +300,48 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployment" >> $GITHUB_STEP_SUMMARY
           echo "Triggered ArgoCD deployment with image tag \`${{ needs.prepare.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+
+  # ---------------------------------------------------------------------------
+  # GitOps: commit the new mesh version into deco-apps-cd so ArgoCD rolls it
+  # out. Only STAGING (deco-studio-stg) is bumped automatically — it is
+  # auto-sync. Prod (deco-studio) is manual-sync and promoted deliberately,
+  # so it is never bumped here.
+  # Requires the GH_APP_ID / GH_APP_PRIVATE_KEY app (write to deco-apps-cd) —
+  # the same GitHub App the admin CI uses.
+  # ---------------------------------------------------------------------------
+  bump-staging:
+    name: Bump staging in deco-apps-cd
+    needs: [prepare, merge-docker]
+    if: |
+      always() &&
+      (needs.prepare.outputs.version-changed == 'true' || needs.prepare.outputs.image-exists == 'false') &&
+      (needs.merge-docker.result == 'success' || needs.merge-docker.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token for deco-apps-cd
+        id: cd-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: decocms
+          repositories: deco-apps-cd
+      - name: Bump studio-stg mesh image
+        env:
+          GH_TOKEN: ${{ steps.cd-token.outputs.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/decocms/deco-apps-cd.git" cd-repo
+          cd cd-repo
+          yq -i ".studio.image.tag = \"${VERSION}\"" apps/deco-studio-stg/values.yaml
+          if git diff --quiet; then
+            echo "studio-stg already at ${VERSION}, nothing to commit"
+            exit 0
+          fi
+          git config user.name "deco-studio-ci[bot]"
+          git config user.email "deco-studio-ci[bot]@users.noreply.github.com"
+          git commit -am "chore(studio-stg): bump mesh image to ${VERSION}"
+          git push
+          echo "### Staging bump" >> $GITHUB_STEP_SUMMARY
+          echo "Committed \`studio.image.tag=${VERSION}\` to deco-apps-cd (deco-studio-stg)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

After the mesh image is built/published, commit the new `studio.image.tag` into `deco-apps-cd/apps/deco-studio-stg/values.yaml` so ArgoCD rolls **staging** out automatically (GitOps — same pattern as the admin CI bumping its version into deco-apps-cd).

- **Staging only** (`deco-studio-stg`, auto-sync) is bumped automatically.
- **Prod** (`deco-studio`) is manual-sync and promoted deliberately (cutover-gated) — **not** touched by CI.
- New `bump-staging` job; uses `actions/create-github-app-token` with the same GitHub App as the admin CI.

## ⚠️ Prerequisite

The repo needs the `GH_APP_ID` / `GH_APP_PRIVATE_KEY` secrets for a GitHub App with **write access to `decocms/deco-apps-cd`** (the same app admin CI uses — if org-level, already available). Without them the `bump-staging` job fails at token generation.

## Notes

- The legacy `argo-deploy-mesh` dispatch step is left as-is (fires only on manual `deploy_to_production` runs); remove once that repo is decommissioned. "Otimizar os builds depois" conforme combinado.

## Test plan
- [ ] Merge a change under `apps/mesh/**` → new version → `bump-staging` commits to deco-apps-cd → deco-studio-stg rolls the new image

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically bumps the mesh image tag in `decocms/deco-apps-cd` for staging and prod only when a valid image exists. Staging auto-rolls out; prod only updates the desired version and waits for a manual Sync.

- **New Features**
  - Adds `bump-deco-apps-cd` job to update `studio.image.tag` in `apps/deco-studio-stg/values.yaml` and `apps/deco-studio/values.yaml` via `actions/create-github-app-token`.
  - Bumps only if the image already exists or `merge-docker` succeeded; no-ops if the tag is unchanged.
  - Keeps the legacy `argo-deploy-mesh` dispatch for manual production deploys.

- **Migration**
  - Add `GH_APP_ID` and `GH_APP_PRIVATE_KEY` secrets for a GitHub App with write access to `decocms/deco-apps-cd`.

<sup>Written for commit fc83c7c354846365f3c299eaf35d149347bc4265. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3487?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

