### PR TITLE
fix(monitoring): surface backend errors instead of rendering zeros

### DIFF
--- a/apps/mesh/src/storage/monitoring-sql.ts
+++ b/apps/mesh/src/storage/monitoring-sql.ts
@@ -982,7 +982,7 @@ LIMIT 1000`;
           continue;
         }
         console.error("queryMetricTimeseries failed:", err);
-        return emptyResult;
+        throw new Error("Monitoring stats unavailable", { cause: err });
       }
     }
 
@@ -1228,7 +1228,7 @@ ORDER BY bucket ASC, tool_name ASC`;
           continue;
         }
         console.error("queryMetricTopToolsTimeseries failed:", err);
-        return emptyResult;
+        throw new Error("Monitoring stats unavailable", { cause: err });
       }
     }
 

--- a/apps/mesh/src/web/components/monitoring/hooks.ts
+++ b/apps/mesh/src/web/components/monitoring/hooks.ts
@@ -1,9 +1,10 @@
 import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,
-  useMCPToolCall,
   useProjectContext,
 } from "@decocms/mesh-sdk";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { useQuery } from "@tanstack/react-query";
 
 /** Connection ID used for all LLM calls emitted by Decopilot. Must match server-side DECOPILOT_CONNECTION_ID. */
 const DECOPILOT_CONNECTION_ID = "decopilot";
@@ -26,6 +27,54 @@ interface MonitoringStatsParams extends MonitoringMetricFilters {
   endDate: string;
 }
 
+/**
+ * MCP tools can return a successful HTTP response with `isError: true` in the
+ * body. React Query treats that as success, so we promote it to a thrown error
+ * here — that way `isError`/`error` on the hook reflect tool failures.
+ */
+async function callMonitoringTool<TData>(
+  client: Client,
+  toolArguments: Record<string, unknown>,
+): Promise<TData> {
+  const result = (await client.callTool({
+    name: "MONITORING_STATS",
+    arguments: toolArguments,
+  })) as {
+    isError?: boolean;
+    structuredContent?: unknown;
+  };
+
+  if (result.isError) {
+    throw new Error("MONITORING_STATS tool returned an error");
+  }
+
+  return (result.structuredContent ?? result) as TData;
+}
+
+interface MonitoringStatsResult {
+  totalCalls: number;
+  totalErrors: number;
+  avgDurationMs: number;
+  p50DurationMs: number;
+  p95DurationMs: number;
+  connectionBreakdown: Array<{
+    connectionId: string;
+    calls: number;
+    errors: number;
+    errorRate: number;
+    avgDurationMs: number;
+  }>;
+  timeseries: Array<{
+    timestamp: string;
+    calls: number;
+    errors: number;
+    errorRate: number;
+    avg: number;
+    p50: number;
+    p95: number;
+  }>;
+}
+
 export function useMonitoringStats(
   params: MonitoringStatsParams,
   queryOptions?: MonitoringQueryOptions,
@@ -37,43 +86,26 @@ export function useMonitoringStats(
     orgSlug: org.slug,
   });
 
-  return useMCPToolCall<{
-    totalCalls: number;
-    totalErrors: number;
-    avgDurationMs: number;
-    p50DurationMs: number;
-    p95DurationMs: number;
-    connectionBreakdown: Array<{
-      connectionId: string;
-      calls: number;
-      errors: number;
-      errorRate: number;
-      avgDurationMs: number;
-    }>;
-    timeseries: Array<{
-      timestamp: string;
-      calls: number;
-      errors: number;
-      errorRate: number;
-      avg: number;
-      p50: number;
-      p95: number;
-    }>;
-  }>({
-    client,
-    toolName: "MONITORING_STATS",
-    toolArguments: {
-      ...params,
-      excludeConnectionIds: [
-        DECOPILOT_CONNECTION_ID,
-        ...(params.excludeConnectionIds ?? []),
-      ],
-    },
+  const toolArguments = {
+    ...params,
+    excludeConnectionIds: [
+      DECOPILOT_CONNECTION_ID,
+      ...(params.excludeConnectionIds ?? []),
+    ],
+  };
+
+  return useQuery<MonitoringStatsResult, Error>({
+    queryKey: [
+      "MONITORING_STATS",
+      org.id,
+      "tool-calls",
+      JSON.stringify(toolArguments),
+    ],
+    queryFn: () =>
+      callMonitoringTool<MonitoringStatsResult>(client, toolArguments),
     staleTime: 30_000,
+    retry: false,
     ...queryOptions,
-    select: (result) =>
-      ((result as { structuredContent?: unknown }).structuredContent ??
-        result) as any,
   });
 }
 
@@ -81,6 +113,14 @@ interface MonitoringLlmStatsParams {
   interval: string;
   startDate: string;
   endDate: string;
+}
+
+interface MonitoringLlmStatsResult extends MonitoringStatsResult {
+  topTools: Array<{
+    toolName: string;
+    connectionId: string | null;
+    calls: number;
+  }>;
 }
 
 /**
@@ -101,45 +141,23 @@ export function useMonitoringLlmStats(
     orgSlug: org.slug,
   });
 
-  return useMCPToolCall<{
-    totalCalls: number;
-    totalErrors: number;
-    avgDurationMs: number;
-    p50DurationMs: number;
-    p95DurationMs: number;
-    connectionBreakdown: Array<{
-      connectionId: string;
-      calls: number;
-      errors: number;
-      errorRate: number;
-      avgDurationMs: number;
-    }>;
-    topTools: Array<{
-      toolName: string;
-      connectionId: string | null;
-      calls: number;
-    }>;
-    timeseries: Array<{
-      timestamp: string;
-      calls: number;
-      errors: number;
-      errorRate: number;
-      avg: number;
-      p50: number;
-      p95: number;
-    }>;
-  }>({
-    client,
-    toolName: "MONITORING_STATS",
-    toolArguments: {
-      ...params,
-      connectionIds: [DECOPILOT_CONNECTION_ID],
-      topN: 5,
-    },
+  const toolArguments = {
+    ...params,
+    connectionIds: [DECOPILOT_CONNECTION_ID],
+    topN: 5,
+  };
+
+  return useQuery<MonitoringLlmStatsResult, Error>({
+    queryKey: [
+      "MONITORING_STATS",
+      org.id,
+      "llm",
+      JSON.stringify(toolArguments),
+    ],
+    queryFn: () =>
+      callMonitoringTool<MonitoringLlmStatsResult>(client, toolArguments),
     staleTime: 30_000,
+    retry: false,
     ...queryOptions,
-    select: (result) =>
-      ((result as { structuredContent?: unknown }).structuredContent ??
-        result) as any,
   });
 }

--- a/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
@@ -7,6 +7,11 @@ import { useState } from "react";
 import type { useConnections } from "@decocms/mesh-sdk";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@deco/ui/components/alert.tsx";
 import { Card } from "@deco/ui/components/card.tsx";
 import {
   Select,
@@ -16,7 +21,7 @@ import {
   SelectValue,
 } from "@deco/ui/components/select.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { Container } from "@untitledui/icons";
+import { AlertTriangle, Container } from "@untitledui/icons";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import {
   KPIChart,
@@ -230,7 +235,7 @@ export function OverviewTabContent({
   const interval = getIntervalFromRange(displayDateRange);
   const refetchInterval = isStreaming ? streamingRefetchInterval : false;
 
-  const { data: serverStats } = useMonitoringStats(
+  const { data: serverStats, isError: serverStatsError } = useMonitoringStats(
     {
       interval,
       startDate: displayDateRange.startDate.toISOString(),
@@ -243,7 +248,7 @@ export function OverviewTabContent({
     { refetchInterval },
   );
 
-  const { data: llmStats } = useMonitoringLlmStats(
+  const { data: llmStats, isError: llmStatsError } = useMonitoringLlmStats(
     {
       interval,
       startDate: displayDateRange.startDate.toISOString(),
@@ -251,6 +256,8 @@ export function OverviewTabContent({
     },
     { refetchInterval },
   );
+
+  const hasError = serverStatsError || llmStatsError;
 
   const stats: MonitoringStatsData = serverStats
     ? {
@@ -299,6 +306,19 @@ export function OverviewTabContent({
 
   return (
     <div className="flex flex-col gap-4 px-4 md:px-10 pt-2 pb-6 max-w-[1200px] mx-auto w-full overflow-auto">
+      {hasError && (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <div className="flex flex-col gap-1">
+            <AlertTitle>Failed to load monitoring data</AlertTitle>
+            <AlertDescription>
+              We couldn't fetch your monitoring stats right now. Please try
+              again later.
+            </AlertDescription>
+          </div>
+        </Alert>
+      )}
+
       {/* Row 1: Tool Calls — full width */}
       <MonitoringMetricCard
         title="Tool Calls"


### PR DESCRIPTION
## What is this contribution about?

The monitoring overview was silently rendering zeros across every card (Tool Calls, Latency, Errors, AI Usage) when ClickHouse reads failed — most recently caused by a credential issue in prod, which produced `queryMetricTopToolsTimeseries failed: Authentication failed` in the server logs while the UI just showed a quiet \"0\". This PR makes the failure observable end-to-end without leaking backend detail to the client: the storage layer (`monitoring-sql.ts`) now throws a sanitized `Monitoring stats unavailable` on the final-source catch (keeping the rollup→raw fallback and the original error in `cause` for logs/OTel), the monitoring hooks were rewritten with `useQuery` plus a helper that promotes MCP `isError` responses into thrown query errors (the SDK's `useMCPToolCall` was a suspense query that bubbled to the page-level `ErrorBoundary` and hid the tabs), and the Overview tab renders a generic destructive `Alert` banner at the top when either query fails.

## How to Test

1. With local `bun run dev` running, temporarily make `DuckDBEngine.query` in `apps/mesh/src/monitoring/query-engine.ts` throw at the start of the `try` block (e.g. `throw new Error(\"simulated failure\")`).
2. Open the Monitoring → Overview page. You should see the red \"Failed to load monitoring data\" banner at the top, cards rendered with 0s underneath, and the Overview/Audit/Threads tabs still visible/clickable (Audit and Threads keep working).
3. Revert the throw — the banner disappears and the dashboard renders real data again.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface backend monitoring failures instead of silently showing zeros. Errors are now sanitized and displayed as a non-blocking alert while the dashboard remains usable.

- **Bug Fixes**
  - Storage: throw sanitized "Monitoring stats unavailable" on final fallback in `monitoring-sql.ts` (original error preserved in `cause` for logs/OTel).
  - Hooks: replaced `useMCPToolCall` with `useQuery` from `@tanstack/react-query` and added a helper that throws when MCP responses set `isError`.
  - UI: show a destructive `Alert` on the Overview when either query fails; tabs and cards still render.
  - Stability: disabled automatic retries for these queries to avoid loops on auth/config failures.

<sup>Written for commit 8df970dbf9682b85b38542fe10e2496847bb9c24. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3488?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

