### PR TITLE
feat(sections-editor): section list actions and drag reorder polish

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
@@ -1,11 +1,10 @@
+import { WELL_KNOWN_STARTERS } from "@decocms/sandbox/shared";
 import { useRef, useState } from "react";
 import { Play } from "@untitledui/icons";
 import { toast } from "sonner";
 import { useSandboxEvents } from "../../hooks/use-sandbox-events";
 import { DEFAULT_TAB, DrawerToolbar, type DrawerStatus } from "./toolbar";
 import { SandboxTerminal } from "./terminal";
-
-const WELL_KNOWN_STARTERS = ["dev", "start"];
 
 export interface PreviewDrawerProps {
   vmId: string | null;

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -830,6 +830,7 @@ export function PreviewContent() {
                   virtualMcpId={virtualMcpId}
                   branch={branch}
                   previewReady={devServerReady}
+                  previewUrl={previewUrl}
                   currentPath={currentPath}
                   externalSelectedIndex={cmsSelectedSectionIndex}
                   onSaved={() => {

--- a/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
@@ -1,0 +1,239 @@
+import { useRef, useState, type RefObject } from "react";
+import { LayoutAlt01, SearchMd } from "@untitledui/icons";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { SectionCatalogEntry } from "./section-catalog";
+import { buildSectionPreviewUrl } from "./section-preview-url";
+
+const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
+
+function useLazyPreviewVisible(scrollRootRef: RefObject<HTMLElement | null>) {
+  const loadedRef = useRef(false);
+  const [loaded, setLoaded] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const desiredNodeRef = useRef<HTMLDivElement | null>(null);
+  const scrollRootRefMirror = useRef(scrollRootRef);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- mirror latest scroll root for stable observer callback
+  scrollRootRefMirror.current = scrollRootRef;
+
+  const [ref] = useState<(node: HTMLDivElement | null) => void>(() => {
+    return (node: HTMLDivElement | null) => {
+      desiredNodeRef.current = node;
+
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+
+      if (!node || loadedRef.current) return;
+
+      queueMicrotask(() => {
+        if (desiredNodeRef.current !== node || loadedRef.current) return;
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            if (!entries[0]?.isIntersecting || loadedRef.current) return;
+            loadedRef.current = true;
+            setLoaded(true);
+            observer.disconnect();
+            observerRef.current = null;
+          },
+          {
+            root: scrollRootRefMirror.current.current,
+            rootMargin: "160px 0px",
+          },
+        );
+
+        observer.observe(node);
+        observerRef.current = observer;
+      });
+    };
+  });
+
+  return { ref, loaded };
+}
+
+function LazySectionPreview({
+  previewUrl,
+  title,
+  scrollRootRef,
+}: {
+  previewUrl: string;
+  title: string;
+  scrollRootRef: RefObject<HTMLElement | null>;
+}) {
+  const { ref, loaded } = useLazyPreviewVisible(scrollRootRef);
+  const [iframeLoaded, setIframeLoaded] = useState(false);
+
+  return (
+    <div
+      ref={ref}
+      className="relative aspect-[16/10] w-full overflow-hidden bg-muted/40"
+    >
+      {!loaded ? (
+        <div className="flex h-full items-center justify-center">
+          <LayoutAlt01 className="h-8 w-8 text-muted-foreground/30" />
+        </div>
+      ) : (
+        <>
+          {!iframeLoaded && (
+            <div className="absolute inset-0 flex items-center justify-center bg-muted/40">
+              <LayoutAlt01 className="h-8 w-8 animate-pulse text-muted-foreground/40" />
+            </div>
+          )}
+          <iframe
+            src={previewUrl}
+            title={`Preview ${title}`}
+            className="pointer-events-none h-[200%] w-[200%] origin-top-left scale-50 border-0 bg-white"
+            tabIndex={-1}
+            onLoad={() => setIframeLoaded(true)}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function SectionGalleryCard({
+  entry,
+  previewUrl,
+  scrollRootRef,
+  onSelect,
+}: {
+  entry: SectionCatalogEntry;
+  previewUrl: string;
+  scrollRootRef: RefObject<HTMLElement | null>;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "group flex flex-col overflow-hidden rounded-lg border bg-card text-left transition-colors",
+        "hover:border-primary/40 hover:bg-accent/30",
+        entry.isSavedBlock &&
+          "border-[oklch(0.7278_0.151_289/0.35)] hover:bg-[oklch(0.7278_0.151_289/0.08)]",
+      )}
+    >
+      <LazySectionPreview
+        previewUrl={previewUrl}
+        title={entry.title}
+        scrollRootRef={scrollRootRef}
+      />
+      <div className="flex items-center gap-2 border-t px-3 py-2.5">
+        <LayoutAlt01
+          className="h-4 w-4 shrink-0"
+          style={
+            entry.isSavedBlock
+              ? { color: GLOBAL_SECTION_ICON_COLOR }
+              : undefined
+          }
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{entry.title}</p>
+          {entry.description && (
+            <p className="truncate text-xs text-muted-foreground">
+              {entry.description}
+            </p>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function AddSectionModal({
+  open,
+  onOpenChange,
+  sections,
+  previewBaseUrl,
+  livePageResolveType,
+  siteTheme,
+  onSelect,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sections: SectionCatalogEntry[];
+  previewBaseUrl: string;
+  livePageResolveType: string;
+  siteTheme?: Record<string, unknown>;
+  onSelect: (entry: SectionCatalogEntry) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const [prevOpen, setPrevOpen] = useState(open);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setSearch("");
+  }
+
+  const query = search.trim().toLowerCase();
+  const filtered = query
+    ? sections.filter(
+        (entry) =>
+          entry.title.toLowerCase().includes(query) ||
+          entry.resolveType.toLowerCase().includes(query) ||
+          entry.description?.toLowerCase().includes(query),
+      )
+    : sections;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        closeButtonClassName="top-3 right-3"
+        className="flex h-[90vh] max-h-[90vh] w-[96vw] max-w-[96vw] sm:max-w-[96vw] flex-col gap-0 overflow-hidden p-0"
+      >
+        <DialogHeader className="shrink-0 border-b px-4 py-3 text-left">
+          <DialogTitle>Add section</DialogTitle>
+          <div className="relative pt-2">
+            <SearchMd
+              size={14}
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search sections..."
+              className="h-9 pl-8"
+            />
+          </div>
+        </DialogHeader>
+
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+          <div className="p-4">
+            {filtered.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                No sections found.
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {filtered.map((entry) => (
+                  <SectionGalleryCard
+                    key={entry.resolveType}
+                    entry={entry}
+                    scrollRootRef={scrollRef}
+                    previewUrl={buildSectionPreviewUrl(
+                      previewBaseUrl,
+                      livePageResolveType,
+                      entry.previewBlock,
+                      siteTheme,
+                    )}
+                    onSelect={() => onSelect(entry)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
@@ -16,6 +16,7 @@ import {
 import type { LiveMeta } from "./resolve-schema";
 import { buildSectionPreviewUrl } from "./section-preview-url";
 import {
+  onPreviewIframeSlotAvailable,
   releasePreviewIframeSlot,
   tryAcquirePreviewIframeSlot,
 } from "./preview-iframe-pool";
@@ -29,11 +30,28 @@ function useLazyPreviewVisible(
   const [iframeActive, setIframeActive] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const desiredNodeRef = useRef<HTMLDivElement | null>(null);
+  const slotWaitUnsubRef = useRef<(() => void) | null>(null);
   const scrollRootRefMirror = useRef(scrollRootRef);
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- mirror latest scroll root for stable observer callback
   scrollRootRefMirror.current = scrollRootRef;
 
   const [ref] = useState<(node: HTMLDivElement | null) => void>(() => {
+    const clearSlotWait = () => {
+      slotWaitUnsubRef.current?.();
+      slotWaitUnsubRef.current = null;
+    };
+
+    const tryActivateSlot = () => {
+      if (slotHeldRef.current) return true;
+      if (tryAcquirePreviewIframeSlot(slotId)) {
+        slotHeldRef.current = true;
+        setIframeActive(true);
+        clearSlotWait();
+        return true;
+      }
+      return false;
+    };
+
     return (node: HTMLDivElement | null) => {
       desiredNodeRef.current = node;
 
@@ -41,6 +59,7 @@ function useLazyPreviewVisible(
         observerRef.current.disconnect();
         observerRef.current = null;
       }
+      clearSlotWait();
 
       if (!node) {
         if (slotHeldRef.current) {
@@ -58,13 +77,17 @@ function useLazyPreviewVisible(
           (entries) => {
             const intersecting = entries[0]?.isIntersecting ?? false;
             if (intersecting) {
-              if (!slotHeldRef.current && tryAcquirePreviewIframeSlot(slotId)) {
-                slotHeldRef.current = true;
-                setIframeActive(true);
+              if (!tryActivateSlot() && !slotWaitUnsubRef.current) {
+                slotWaitUnsubRef.current = onPreviewIframeSlotAvailable(() => {
+                  if (desiredNodeRef.current === node) {
+                    tryActivateSlot();
+                  }
+                });
               }
               return;
             }
 
+            clearSlotWait();
             if (slotHeldRef.current) {
               releasePreviewIframeSlot(slotId);
               slotHeldRef.current = false;

--- a/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/add-section-modal.tsx
@@ -8,14 +8,25 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
-import type { SectionCatalogEntry } from "./section-catalog";
+import {
+  extractSectionCatalog,
+  findLivePageResolveType,
+  findSiteThemeBlock,
+} from "./section-catalog";
+import type { LiveMeta } from "./resolve-schema";
 import { buildSectionPreviewUrl } from "./section-preview-url";
+import {
+  releasePreviewIframeSlot,
+  tryAcquirePreviewIframeSlot,
+} from "./preview-iframe-pool";
+import { GLOBAL_SECTION_ICON_COLOR } from "./section-types";
 
-const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
-
-function useLazyPreviewVisible(scrollRootRef: RefObject<HTMLElement | null>) {
-  const loadedRef = useRef(false);
-  const [loaded, setLoaded] = useState(false);
+function useLazyPreviewVisible(
+  scrollRootRef: RefObject<HTMLElement | null>,
+  slotId: string,
+) {
+  const slotHeldRef = useRef(false);
+  const [iframeActive, setIframeActive] = useState(false);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const desiredNodeRef = useRef<HTMLDivElement | null>(null);
   const scrollRootRefMirror = useRef(scrollRootRef);
@@ -31,18 +42,34 @@ function useLazyPreviewVisible(scrollRootRef: RefObject<HTMLElement | null>) {
         observerRef.current = null;
       }
 
-      if (!node || loadedRef.current) return;
+      if (!node) {
+        if (slotHeldRef.current) {
+          releasePreviewIframeSlot(slotId);
+          slotHeldRef.current = false;
+          setIframeActive(false);
+        }
+        return;
+      }
 
       queueMicrotask(() => {
-        if (desiredNodeRef.current !== node || loadedRef.current) return;
+        if (desiredNodeRef.current !== node) return;
 
         const observer = new IntersectionObserver(
           (entries) => {
-            if (!entries[0]?.isIntersecting || loadedRef.current) return;
-            loadedRef.current = true;
-            setLoaded(true);
-            observer.disconnect();
-            observerRef.current = null;
+            const intersecting = entries[0]?.isIntersecting ?? false;
+            if (intersecting) {
+              if (!slotHeldRef.current && tryAcquirePreviewIframeSlot(slotId)) {
+                slotHeldRef.current = true;
+                setIframeActive(true);
+              }
+              return;
+            }
+
+            if (slotHeldRef.current) {
+              releasePreviewIframeSlot(slotId);
+              slotHeldRef.current = false;
+              setIframeActive(false);
+            }
           },
           {
             root: scrollRootRefMirror.current.current,
@@ -56,19 +83,21 @@ function useLazyPreviewVisible(scrollRootRef: RefObject<HTMLElement | null>) {
     };
   });
 
-  return { ref, loaded };
+  return { ref, iframeActive };
 }
 
 function LazySectionPreview({
   previewUrl,
   title,
   scrollRootRef,
+  slotId,
 }: {
   previewUrl: string;
   title: string;
   scrollRootRef: RefObject<HTMLElement | null>;
+  slotId: string;
 }) {
-  const { ref, loaded } = useLazyPreviewVisible(scrollRootRef);
+  const { ref, iframeActive } = useLazyPreviewVisible(scrollRootRef, slotId);
   const [iframeLoaded, setIframeLoaded] = useState(false);
 
   return (
@@ -76,7 +105,7 @@ function LazySectionPreview({
       ref={ref}
       className="relative aspect-[16/10] w-full overflow-hidden bg-muted/40"
     >
-      {!loaded ? (
+      {!iframeActive ? (
         <div className="flex h-full items-center justify-center">
           <LayoutAlt01 className="h-8 w-8 text-muted-foreground/30" />
         </div>
@@ -90,6 +119,8 @@ function LazySectionPreview({
           <iframe
             src={previewUrl}
             title={`Preview ${title}`}
+            sandbox="allow-scripts allow-same-origin"
+            referrerPolicy="no-referrer"
             className="pointer-events-none h-[200%] w-[200%] origin-top-left scale-50 border-0 bg-white"
             tabIndex={-1}
             onLoad={() => setIframeLoaded(true)}
@@ -106,7 +137,7 @@ function SectionGalleryCard({
   scrollRootRef,
   onSelect,
 }: {
-  entry: SectionCatalogEntry;
+  entry: ReturnType<typeof extractSectionCatalog>[number];
   previewUrl: string;
   scrollRootRef: RefObject<HTMLElement | null>;
   onSelect: () => void;
@@ -126,6 +157,7 @@ function SectionGalleryCard({
         previewUrl={previewUrl}
         title={entry.title}
         scrollRootRef={scrollRootRef}
+        slotId={entry.resolveType}
       />
       <div className="flex items-center gap-2 border-t px-3 py-2.5">
         <LayoutAlt01
@@ -152,19 +184,17 @@ function SectionGalleryCard({
 export function AddSectionModal({
   open,
   onOpenChange,
-  sections,
+  meta,
+  decofile,
   previewBaseUrl,
-  livePageResolveType,
-  siteTheme,
   onSelect,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  sections: SectionCatalogEntry[];
+  meta: LiveMeta | null | undefined;
+  decofile: Record<string, unknown> | null | undefined;
   previewBaseUrl: string;
-  livePageResolveType: string;
-  siteTheme?: Record<string, unknown>;
-  onSelect: (entry: SectionCatalogEntry) => void;
+  onSelect: (entry: ReturnType<typeof extractSectionCatalog>[number]) => void;
 }) {
   const [search, setSearch] = useState("");
   const [prevOpen, setPrevOpen] = useState(open);
@@ -173,6 +203,26 @@ export function AddSectionModal({
   if (open !== prevOpen) {
     setPrevOpen(open);
     if (open) setSearch("");
+  }
+
+  const sections =
+    open && meta && decofile ? extractSectionCatalog(meta, decofile) : [];
+  const livePageResolveType = meta ? findLivePageResolveType(meta) : "";
+  const siteTheme = decofile ? findSiteThemeBlock(decofile) : undefined;
+
+  const previewUrls = new Map<string, string>();
+  if (open && livePageResolveType) {
+    for (const entry of sections) {
+      previewUrls.set(
+        entry.resolveType,
+        buildSectionPreviewUrl(
+          previewBaseUrl,
+          livePageResolveType,
+          entry.previewBlock,
+          siteTheme,
+        ),
+      );
+    }
   }
 
   const query = search.trim().toLowerCase();
@@ -220,12 +270,15 @@ export function AddSectionModal({
                     key={entry.resolveType}
                     entry={entry}
                     scrollRootRef={scrollRef}
-                    previewUrl={buildSectionPreviewUrl(
-                      previewBaseUrl,
-                      livePageResolveType,
-                      entry.previewBlock,
-                      siteTheme,
-                    )}
+                    previewUrl={
+                      previewUrls.get(entry.resolveType) ??
+                      buildSectionPreviewUrl(
+                        previewBaseUrl,
+                        livePageResolveType,
+                        entry.previewBlock,
+                        siteTheme,
+                      )
+                    }
                     onSelect={() => onSelect(entry)}
                   />
                 ))}

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
@@ -54,5 +54,6 @@ describe("block-type-utils", () => {
       true,
     );
     expect(isAutoPreviewBlockKey("Header")).toBe(false);
+    expect(isAutoPreviewBlockKey("%")).toBe(false);
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isAutoPreviewBlockKey,
+  isManifestSectionResolveType,
+  isSavedBlockResolveType,
+  parseSavedBlockSchemaTitle,
+} from "./block-type-utils";
+import type { LiveMeta } from "./resolve-schema";
+
+const meta: LiveMeta = {
+  manifest: {
+    blocks: {
+      sections: {
+        "site/sections/Header/Header.tsx": { $ref: "#/definitions/Header" },
+      },
+      loaders: {
+        "vtex/loaders/legacy/productList.ts": {
+          $ref: "#/definitions/ProductList",
+        },
+      },
+    },
+  },
+  schema: {},
+};
+
+describe("block-type-utils", () => {
+  it("parseSavedBlockSchemaTitle extracts block id and module path", () => {
+    expect(
+      parseSavedBlockSchemaTitle("#site/sections/Header/Header.tsx@Header"),
+    ).toEqual({
+      moduleResolveType: "site/sections/Header/Header.tsx",
+      blockId: "Header",
+    });
+  });
+
+  it("isManifestSectionResolveType distinguishes sections from loaders", () => {
+    expect(
+      isManifestSectionResolveType(meta, "site/sections/Header/Header.tsx"),
+    ).toBe(true);
+    expect(
+      isManifestSectionResolveType(meta, "vtex/loaders/legacy/productList.ts"),
+    ).toBe(false);
+  });
+
+  it("isSavedBlockResolveType detects block id references", () => {
+    expect(isSavedBlockResolveType("Header")).toBe(true);
+    expect(isSavedBlockResolveType("site/sections/Header/Header.tsx")).toBe(
+      false,
+    );
+  });
+
+  it("isAutoPreviewBlockKey detects generated preview stubs", () => {
+    expect(isAutoPreviewBlockKey("Preview%20%2Fsections%2FFooter.tsx")).toBe(
+      true,
+    );
+    expect(isAutoPreviewBlockKey("Header")).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
@@ -12,7 +12,7 @@ export function parseSavedBlockSchemaTitle(
   };
 }
 
-export function getManifestBlockType(
+function getManifestBlockType(
   meta: LiveMeta,
   resolveType: string,
 ): string | null {

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
@@ -1,0 +1,42 @@
+import type { LiveMeta } from "./resolve-schema";
+
+/** Saved block union titles: `#site/sections/Foo.tsx@BlockId`. */
+export function parseSavedBlockSchemaTitle(
+  title: string,
+): { blockId: string; moduleResolveType: string } | null {
+  if (!title.startsWith("#") || !title.includes("@")) return null;
+  const atIndex = title.indexOf("@");
+  return {
+    moduleResolveType: title.slice(1, atIndex),
+    blockId: title.slice(atIndex + 1),
+  };
+}
+
+export function getManifestBlockType(
+  meta: LiveMeta,
+  resolveType: string,
+): string | null {
+  const blocks = meta.manifest?.blocks ?? {};
+  for (const [blockType, blockMap] of Object.entries(blocks)) {
+    if (resolveType in blockMap) return blockType;
+  }
+  return null;
+}
+
+export function isManifestSectionResolveType(
+  meta: LiveMeta,
+  resolveType: string,
+): boolean {
+  const blockType = getManifestBlockType(meta, resolveType);
+  return blockType !== null && blockType.includes("sections");
+}
+
+/** Block id reference (no module path) — e.g. `Header`, not `site/sections/Header.tsx`. */
+export function isSavedBlockResolveType(resolveType: string): boolean {
+  return !resolveType.includes("/");
+}
+
+/** Auto-generated preview stubs under `.deco/blocks/Preview …`. */
+export function isAutoPreviewBlockKey(blockKey: string): boolean {
+  return decodeURIComponent(blockKey).startsWith("Preview ");
+}

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
@@ -38,5 +38,9 @@ export function isSavedBlockResolveType(resolveType: string): boolean {
 
 /** Auto-generated preview stubs under `.deco/blocks/Preview …`. */
 export function isAutoPreviewBlockKey(blockKey: string): boolean {
-  return decodeURIComponent(blockKey).startsWith("Preview ");
+  try {
+    return decodeURIComponent(blockKey).startsWith("Preview ");
+  } catch {
+    return blockKey.startsWith("Preview ");
+  }
 }

--- a/apps/mesh/src/web/components/sections-editor/make-reusable-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/make-reusable-modal.tsx
@@ -1,0 +1,100 @@
+import { useState, type FormEvent } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Loading01 } from "@untitledui/icons";
+
+export function MakeReusableModal({
+  open,
+  onOpenChange,
+  defaultBlockId = "",
+  isPending = false,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultBlockId?: string;
+  isPending?: boolean;
+  onSubmit: (blockId: string) => void | Promise<void>;
+}) {
+  const [blockId, setBlockId] = useState(defaultBlockId);
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setBlockId(defaultBlockId);
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && !isPending) {
+      onOpenChange(false);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = blockId.trim();
+    if (!trimmed || isPending) return;
+    await onSubmit(trimmed);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Save as global</DialogTitle>
+            <DialogDescription>
+              Save this section as a global block so it can be reused on other
+              pages.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="py-4 space-y-2">
+            <label htmlFor="block-id" className="text-sm font-medium">
+              Block name
+            </label>
+            <Input
+              id="block-id"
+              value={blockId}
+              onChange={(e) => setBlockId(e.target.value)}
+              placeholder="MyNewBlock"
+              autoFocus
+              disabled={isPending}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!blockId.trim() || isPending}>
+              {isPending ? (
+                <>
+                  <Loading01 size={14} className="animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                "Save"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/matcher-icons.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-icons.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { resolveMatcherIconName } from "./matcher-icons";
+import { resolveBlockSchemaMetadata } from "./resolve-schema";
+import type { LiveMeta } from "./resolve-schema";
+
+describe("matcher-icons", () => {
+  it("resolveMatcherIconName maps known matchers and admin schema icons", () => {
+    expect(resolveMatcherIconName("website/matchers/device.ts")).toBe(
+      "Phone02",
+    );
+    expect(resolveMatcherIconName("website/matchers/date.ts")).toBe("Calendar");
+    expect(
+      resolveMatcherIconName("website/matchers/custom.ts", "device-mobile"),
+    ).toBe("Phone02");
+    expect(
+      resolveMatcherIconName("website/matchers/custom.ts", "Calendar"),
+    ).toBe("Calendar");
+  });
+
+  it("resolveBlockSchemaMetadata reads icon/title/description from live meta", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          "website/matchers": {
+            "website/matchers/device.ts": {
+              $ref: "#/definitions/DeviceMatcher",
+            },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          DeviceMatcher: {
+            title: "By Device",
+            description: "Target users by device type",
+            icon: "device-mobile",
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveBlockSchemaMetadata("website/matchers/device.ts", meta),
+    ).toEqual({
+      title: "By Device",
+      description: "Target users by device type",
+      icon: "device-mobile",
+    });
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
@@ -1,4 +1,5 @@
 import { FilterLines } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
 import type { ComponentType, SVGProps } from "react";
 import { getIconComponent } from "../agent-icon";
 
@@ -90,7 +91,11 @@ export function MatcherIcon({
 
   return (
     <div
-      className={`flex ${boxClass} shrink-0 items-center justify-center rounded-full bg-muted ${className ?? ""}`}
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full bg-muted",
+        boxClass,
+        className,
+      )}
     >
       <Icon size={iconSize} className="text-muted-foreground" />
     </div>

--- a/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
@@ -71,7 +71,7 @@ export function resolveMatcherIconName(
   return "FilterLines";
 }
 
-export function getMatcherIconComponent(iconName: string): IconComponent {
+function getMatcherIconComponent(iconName: string): IconComponent {
   return getIconComponent(iconName) ?? FilterLines;
 }
 

--- a/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
@@ -1,5 +1,5 @@
 import { FilterLines } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.js";
+import { cn } from "@deco/ui/lib/utils.ts";
 import type { ComponentType, SVGProps } from "react";
 import { getIconComponent } from "../agent-icon";
 

--- a/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-icons.tsx
@@ -1,0 +1,98 @@
+import { FilterLines } from "@untitledui/icons";
+import type { ComponentType, SVGProps } from "react";
+import { getIconComponent } from "../agent-icon";
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement> & { size?: number }>;
+
+const KNOWN_MATCHER_ICON_BY_RESOLVE_TYPE: Array<[RegExp, string]> = [
+  [/always|matchalways/i, "Users03"],
+  [/device|matchdevice/i, "Phone02"],
+  [/date|matchdate/i, "Calendar"],
+  [/random|matchrandom/i, "Shuffle01"],
+  [/host|matchhost/i, "Globe02"],
+  [/location|matchlocation/i, "MarkerPin01"],
+  [/pathname/i, "Link03"],
+  [/cron|matchcron/i, "Clock"],
+  [/multi|matchmulti/i, "FilterLines"],
+  [/never|matchnever/i, "EyeOff"],
+  [/environment|matchenvironment/i, "Cloud01"],
+  [/eq\.ts|\/eq$/i, "Brackets"],
+  [/user|requser|isdecouser/i, "User01"],
+  [/site|template/i, "LayoutAlt01"],
+];
+
+/** Admin schema icon ids → @untitledui/icons component names. */
+const SCHEMA_ICON_TO_UNTITLED: Record<string, string> = {
+  "device-mobile": "Phone02",
+  "device-desktop": "Monitor01",
+  "device-tablet": "Tablet01",
+  "calendar-event": "Calendar",
+  "calendar-month": "Calendar",
+  clock: "Clock",
+  "current-location": "MarkerPin01",
+  "map-2": "MarkerPin01",
+  "world-search": "Globe02",
+  shuffle: "Shuffle01",
+  filter: "FilterLines",
+  "eye-off": "EyeOff",
+  flask: "Beaker02",
+  link: "Link03",
+  "git-merge": "GitBranch01",
+  users: "Users03",
+  flag: "Flag01",
+  "cloud-storm": "Cloud01",
+  campaign: "Announcement01",
+  experiment: "Beaker02",
+  language: "Globe02",
+  "hand-click": "CursorClick01",
+};
+
+function isUntitledIconName(name: string): boolean {
+  return getIconComponent(name) !== undefined;
+}
+
+export function resolveMatcherIconName(
+  resolveType: string,
+  schemaIcon?: string,
+): string {
+  if (schemaIcon) {
+    if (isUntitledIconName(schemaIcon)) return schemaIcon;
+
+    const mapped = SCHEMA_ICON_TO_UNTITLED[schemaIcon];
+    if (mapped && isUntitledIconName(mapped)) return mapped;
+  }
+
+  for (const [pattern, iconName] of KNOWN_MATCHER_ICON_BY_RESOLVE_TYPE) {
+    if (pattern.test(resolveType) && isUntitledIconName(iconName)) {
+      return iconName;
+    }
+  }
+
+  return "FilterLines";
+}
+
+export function getMatcherIconComponent(iconName: string): IconComponent {
+  return getIconComponent(iconName) ?? FilterLines;
+}
+
+export function MatcherIcon({
+  iconName,
+  size = "md",
+  className,
+}: {
+  iconName: string;
+  size?: "sm" | "md";
+  className?: string;
+}) {
+  const Icon = getMatcherIconComponent(iconName);
+  const boxClass = size === "sm" ? "size-7" : "size-9";
+  const iconSize = size === "sm" ? 16 : 18;
+
+  return (
+    <div
+      className={`flex ${boxClass} shrink-0 items-center justify-center rounded-full bg-muted ${className ?? ""}`}
+    >
+      <Icon size={iconSize} className="text-muted-foreground" />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@deco/ui/components/command.tsx";
 import { resolveBlockSchemaMetadata, type LiveMeta } from "./resolve-schema";
 import { MatcherIcon, resolveMatcherIconName } from "./matcher-icons";
+import { labelFromResolveType } from "./section-types";
 
 export interface MatcherEntry {
   resolveType: string;
@@ -20,17 +21,6 @@ export interface MatcherEntry {
 }
 
 const ALWAYS_MATCHER_ICON = "Users03";
-
-function titleFromResolveType(resolveType: string): string {
-  const segments = resolveType.split("/");
-  const filename = segments[segments.length - 1] ?? resolveType;
-  return (
-    filename
-      .replace(/\.(tsx?|jsx?)$/, "")
-      .replace(/[-_]/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase()) || resolveType
-  );
-}
 
 /**
  * Extract the list of available matcher block types from live meta.
@@ -52,7 +42,7 @@ export function extractMatchers(meta: LiveMeta): MatcherEntry[] {
 
       result.push({
         resolveType,
-        title: metadata.title ?? titleFromResolveType(resolveType),
+        title: metadata.title ?? labelFromResolveType(resolveType),
         description: metadata.description,
         iconName: resolveMatcherIconName(resolveType, metadata.icon),
       });

--- a/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
@@ -9,12 +9,27 @@ import {
   CommandItem,
   CommandEmpty,
 } from "@deco/ui/components/command.tsx";
-import type { LiveMeta } from "./resolve-schema";
+import { resolveBlockSchemaMetadata, type LiveMeta } from "./resolve-schema";
+import { MatcherIcon, resolveMatcherIconName } from "./matcher-icons";
 
 export interface MatcherEntry {
   resolveType: string;
   title: string;
   description?: string;
+  iconName: string;
+}
+
+const ALWAYS_MATCHER_ICON = "Users03";
+
+function titleFromResolveType(resolveType: string): string {
+  const segments = resolveType.split("/");
+  const filename = segments[segments.length - 1] ?? resolveType;
+  return (
+    filename
+      .replace(/\.(tsx?|jsx?)$/, "")
+      .replace(/[-_]/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase()) || resolveType
+  );
 }
 
 /**
@@ -25,21 +40,38 @@ export interface MatcherEntry {
 export function extractMatchers(meta: LiveMeta): MatcherEntry[] {
   const blocks = meta.manifest?.blocks ?? {};
   const result: MatcherEntry[] = [];
+
   for (const [blockType, blockMap] of Object.entries(blocks)) {
     if (!blockType.includes("matchers")) continue;
+
     for (const resolveType of Object.keys(blockMap)) {
       // Skip "always" — it's hardcoded as the first option in the picker
       if (resolveType.includes("always")) continue;
-      const segments = resolveType.split("/");
-      const filename = segments[segments.length - 1] ?? resolveType;
-      const title = filename
-        .replace(/\.(tsx?|jsx?)$/, "")
-        .replace(/[-_]/g, " ")
-        .replace(/\b\w/g, (c) => c.toUpperCase());
-      result.push({ resolveType, title });
+
+      const metadata = resolveBlockSchemaMetadata(resolveType, meta);
+
+      result.push({
+        resolveType,
+        title: metadata.title ?? titleFromResolveType(resolveType),
+        description: metadata.description,
+        iconName: resolveMatcherIconName(resolveType, metadata.icon),
+      });
     }
   }
+
   return result;
+}
+
+function resolveCurrentMatcherIcon(
+  currentRt: string,
+  matchers: MatcherEntry[],
+): string {
+  if (!currentRt) return ALWAYS_MATCHER_ICON;
+
+  const match = matchers.find((matcher) => matcher.resolveType === currentRt);
+  if (match) return match.iconName;
+
+  return resolveMatcherIconName(currentRt);
 }
 
 /**
@@ -57,6 +89,7 @@ export function MatcherPicker({
   onSelect: (resolveType: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const currentIconName = resolveCurrentMatcherIcon(currentRt, matchers);
 
   const handleSelect = (rt: string) => {
     onSelect(rt);
@@ -70,6 +103,7 @@ export function MatcherPicker({
         onClick={() => setOpen(true)}
         className="flex h-9 w-full items-center gap-2 rounded-md border border-input bg-transparent px-3 text-left text-sm shadow-xs transition-colors hover:bg-accent/40"
       >
+        <MatcherIcon iconName={currentIconName} size="sm" />
         <span className="flex-1 truncate">{currentLabel}</span>
         <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       </button>
@@ -90,6 +124,7 @@ export function MatcherPicker({
               onSelect={() => handleSelect("")}
               className={cn("gap-2.5", !currentRt && "bg-accent/60")}
             >
+              <MatcherIcon iconName={ALWAYS_MATCHER_ICON} size="sm" />
               <div className="flex min-w-0 flex-1 flex-col">
                 <span className="text-sm">Always</span>
                 <span className="text-xs text-muted-foreground">
@@ -97,21 +132,22 @@ export function MatcherPicker({
                 </span>
               </div>
             </CommandItem>
-            {matchers.map((m) => (
+            {matchers.map((matcher) => (
               <CommandItem
-                key={m.resolveType}
-                value={`${m.title} ${m.resolveType} ${m.description ?? ""}`}
-                onSelect={() => handleSelect(m.resolveType)}
+                key={matcher.resolveType}
+                value={`${matcher.title} ${matcher.resolveType} ${matcher.description ?? ""}`}
+                onSelect={() => handleSelect(matcher.resolveType)}
                 className={cn(
                   "gap-2.5",
-                  currentRt === m.resolveType && "bg-accent/60",
+                  currentRt === matcher.resolveType && "bg-accent/60",
                 )}
               >
+                <MatcherIcon iconName={matcher.iconName} size="sm" />
                 <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="text-sm">{m.title}</span>
-                  {m.description && (
+                  <span className="text-sm">{matcher.title}</span>
+                  {matcher.description && (
                     <span className="truncate text-xs text-muted-foreground">
-                      {m.description}
+                      {matcher.description}
                     </span>
                   )}
                 </div>

--- a/apps/mesh/src/web/components/sections-editor/page-sections.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildPageDataWithSections,
+  suggestBlockId,
+  validateBlockId,
+} from "./page-sections";
+
+describe("page-sections", () => {
+  it("buildPageDataWithSections replaces a flat sections array", () => {
+    const decofile = {
+      Home: {
+        name: "Home",
+        sections: [{ __resolveType: "site/sections/Hero.tsx" }],
+      },
+    };
+    const updated = [{ __resolveType: "Header" }];
+
+    expect(
+      buildPageDataWithSections(decofile, "Home", updated, 0, [
+        { label: "Default", sections: updated },
+      ]).sections,
+    ).toEqual(updated);
+  });
+
+  it("buildPageDataWithSections updates a multivariate page variant", () => {
+    const decofile = {
+      Home: {
+        sections: {
+          variants: [
+            {
+              rule: { __resolveType: "website/matchers/always.ts" },
+              value: [{ __resolveType: "A" }],
+            },
+            {
+              rule: {
+                __resolveType: "website/matchers/device.ts",
+                mobile: true,
+              },
+              value: [{ __resolveType: "B" }],
+            },
+          ],
+        },
+      },
+    };
+    const pageVariants = [
+      { label: "Default", sections: [{ __resolveType: "A" }] },
+      { label: "Mobile", sections: [{ __resolveType: "B" }] },
+    ];
+    const updated = [{ __resolveType: "MobileHero" }];
+
+    const result = buildPageDataWithSections(
+      decofile,
+      "Home",
+      updated,
+      1,
+      pageVariants,
+    ) as {
+      sections: {
+        variants: Array<{ value: unknown }>;
+      };
+    };
+
+    expect(result.sections.variants[1]?.value).toEqual(updated);
+    expect(result.sections.variants[0]?.value).toEqual([
+      { __resolveType: "A" },
+    ]);
+  });
+
+  it("validateBlockId rejects invalid and duplicate ids", () => {
+    const decofile = { Header: { __resolveType: "site/sections/Header.tsx" } };
+
+    expect(validateBlockId("", decofile)).toBe("Block name is required.");
+    expect(validateBlockId("site/sections/Hero", decofile)).toContain(
+      "slashes",
+    );
+    expect(validateBlockId("Header", decofile)).toContain("already exists");
+    expect(validateBlockId("1Hero", decofile)).toContain(
+      "Must start with a letter",
+    );
+    expect(validateBlockId("MyNewBlock", decofile)).toBeNull();
+  });
+
+  it("suggestBlockId sanitizes labels", () => {
+    expect(suggestBlockId("Hero")).toBe("Hero");
+    expect(suggestBlockId("Variants of Hero")).toBe("VariantsofHero");
+    expect(suggestBlockId("FAQ Section")).toBe("FAQSection");
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/page-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.ts
@@ -63,7 +63,7 @@ export function validateBlockId(
   if (trimmed.includes("/")) {
     return "Block name cannot contain slashes.";
   }
-  if (trimmed in decofile) {
+  if (Object.hasOwn(decofile, trimmed)) {
     return "A block with this name already exists.";
   }
   if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmed)) {

--- a/apps/mesh/src/web/components/sections-editor/page-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.ts
@@ -1,12 +1,4 @@
-interface RawSection {
-  __resolveType: string;
-  section?: { __resolveType?: string; [key: string]: unknown };
-  variants?: Array<{
-    value?: Record<string, unknown>;
-    rule?: Record<string, unknown>;
-  }>;
-  [key: string]: unknown;
-}
+import type { RawSection } from "./section-types";
 
 interface PageVariant {
   label: string;

--- a/apps/mesh/src/web/components/sections-editor/page-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.ts
@@ -1,0 +1,81 @@
+interface RawSection {
+  __resolveType: string;
+  section?: { __resolveType?: string; [key: string]: unknown };
+  variants?: Array<{
+    value?: Record<string, unknown>;
+    rule?: Record<string, unknown>;
+  }>;
+  [key: string]: unknown;
+}
+
+interface PageVariant {
+  label: string;
+  sections: RawSection[];
+  rule?: Record<string, unknown>;
+}
+
+export function buildPageDataWithSections(
+  decofile: Record<string, unknown>,
+  pageKey: string,
+  updatedSections: RawSection[],
+  variantIndex: number,
+  pageVariants: PageVariant[],
+): Record<string, unknown> {
+  const fullPageData = {
+    ...(decofile[pageKey] as Record<string, unknown>),
+  };
+
+  if (pageVariants.length > 1) {
+    const currentSections = fullPageData.sections as Record<string, unknown>;
+    const variants = [
+      ...((currentSections?.variants as Array<Record<string, unknown>>) ?? []),
+    ];
+    if (variants[variantIndex]) {
+      variants[variantIndex] = {
+        ...variants[variantIndex],
+        value: updatedSections,
+      };
+    }
+    fullPageData.sections = { ...currentSections, variants };
+  } else {
+    fullPageData.sections = updatedSections;
+  }
+
+  return fullPageData;
+}
+
+export function cloneSection(section: RawSection): RawSection {
+  return structuredClone(section);
+}
+
+export function canMakeSectionReusable(section: {
+  isSavedBlock?: boolean;
+  isMultivariate?: boolean;
+}): boolean {
+  return !section.isSavedBlock && !section.isMultivariate;
+}
+
+export function suggestBlockId(label: string): string {
+  const cleaned = label.replace(/[^A-Za-z0-9_-]/g, "");
+  if (/^[A-Za-z]/.test(cleaned)) return cleaned;
+  if (cleaned) return `Block${cleaned}`;
+  return "";
+}
+
+export function validateBlockId(
+  blockId: string,
+  decofile: Record<string, unknown>,
+): string | null {
+  const trimmed = blockId.trim();
+  if (!trimmed) return "Block name is required.";
+  if (trimmed.includes("/")) {
+    return "Block name cannot contain slashes.";
+  }
+  if (trimmed in decofile) {
+    return "A block with this name already exists.";
+  }
+  if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmed)) {
+    return "Use letters, numbers, hyphens, or underscores. Must start with a letter.";
+  }
+  return null;
+}

--- a/apps/mesh/src/web/components/sections-editor/parse-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/parse-sections.ts
@@ -1,0 +1,126 @@
+import { isLazyResolveType } from "./section-lazy";
+import { labelFromResolveType, type RawSection } from "./section-types";
+
+export interface ParsedSection {
+  index: number;
+  resolveType: string;
+  label: string;
+  isLazy?: boolean;
+  isHidden?: boolean;
+  isSavedBlock?: boolean;
+  isMultivariate?: boolean;
+}
+
+/**
+ * Parse raw decofile sections into display-ready entries with
+ * isLazy / isHidden / isSavedBlock / isMultivariate flags.
+ * Mirrors admin-mcp's `parseSectionsFromArray()`.
+ */
+export function parseSections(
+  rawSections: RawSection[],
+  decofile: Record<string, unknown>,
+): ParsedSection[] {
+  return rawSections.map((s, idx) => {
+    const rt = s.__resolveType ?? "";
+    const isLazy = isLazyResolveType(rt);
+
+    if (!isLazy && rt !== "" && !rt.includes("/") && rt in decofile) {
+      const resolvedBlock = decofile[rt] as Record<string, unknown> | undefined;
+      const label =
+        (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
+        rt.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) ||
+        `Section ${idx + 1}`;
+      return {
+        index: idx,
+        resolveType: rt,
+        label,
+        isLazy: false,
+        isSavedBlock: true,
+      };
+    }
+
+    const innerSection = isLazy
+      ? (s.section as RawSection | undefined)
+      : undefined;
+    const mvRt = isLazy ? (innerSection?.__resolveType ?? "") : rt;
+
+    if (mvRt.includes("flags/multivariate")) {
+      const mvObj = (isLazy ? innerSection : s) as RawSection;
+      const rawVariants = Array.isArray(mvObj?.variants) ? mvObj.variants : [];
+
+      const NEVER_TYPES = ["website/matchers/never.ts"];
+      if (
+        rawVariants.length === 1 &&
+        NEVER_TYPES.includes(
+          (rawVariants[0]?.rule?.__resolveType as string) ?? "",
+        )
+      ) {
+        const innerValue = (rawVariants[0]?.value ?? {}) as Record<
+          string,
+          unknown
+        >;
+        let innerRt = (innerValue.__resolveType as string) ?? "";
+        const innerIsLazy = isLazyResolveType(innerRt);
+        if (innerIsLazy) {
+          const nested = innerValue.section as
+            | Record<string, unknown>
+            | undefined;
+          innerRt = (nested?.__resolveType as string) ?? innerRt;
+        }
+        return {
+          index: idx,
+          resolveType: rt,
+          label: labelFromResolveType(innerRt) || `Section ${idx + 1}`,
+          isHidden: true,
+          isLazy: innerIsLazy,
+        };
+      }
+
+      const firstValueRt = (
+        rawVariants[0]?.value as Record<string, unknown> | undefined
+      )?.__resolveType as string | undefined;
+      const sectionLabel = firstValueRt
+        ? labelFromResolveType(firstValueRt)
+        : "Section";
+      return {
+        index: idx,
+        resolveType: rt,
+        label: `Variants of ${sectionLabel}`,
+        isMultivariate: true,
+        isLazy,
+      };
+    }
+
+    const effectiveRt = isLazy ? (s.section?.__resolveType ?? rt) : rt;
+    if (
+      isLazy &&
+      effectiveRt !== "" &&
+      !effectiveRt.includes("/") &&
+      effectiveRt in decofile
+    ) {
+      const resolvedBlock = decofile[effectiveRt] as
+        | Record<string, unknown>
+        | undefined;
+      const label =
+        (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
+        effectiveRt
+          .replace(/[-_]/g, " ")
+          .replace(/\b\w/g, (c) => c.toUpperCase()) ||
+        `Section ${idx + 1}`;
+      return {
+        index: idx,
+        resolveType: rt,
+        label,
+        isLazy: true,
+        isSavedBlock: true,
+      };
+    }
+
+    return {
+      index: idx,
+      resolveType: rt,
+      label: labelFromResolveType(effectiveRt) || `Section ${idx + 1}`,
+      isLazy,
+    };
+  });
+}

--- a/apps/mesh/src/web/components/sections-editor/preview-iframe-pool.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-iframe-pool.ts
@@ -1,6 +1,13 @@
 const MAX_CONCURRENT_PREVIEW_IFRAMES = 12;
 
 const active = new Set<string>();
+const waiters = new Set<() => void>();
+
+function notifyWaiters(): void {
+  for (const waiter of waiters) {
+    waiter();
+  }
+}
 
 export function tryAcquirePreviewIframeSlot(id: string): boolean {
   if (active.has(id)) return true;
@@ -10,5 +17,13 @@ export function tryAcquirePreviewIframeSlot(id: string): boolean {
 }
 
 export function releasePreviewIframeSlot(id: string): void {
-  active.delete(id);
+  if (!active.delete(id)) return;
+  notifyWaiters();
+}
+
+export function onPreviewIframeSlotAvailable(callback: () => void): () => void {
+  waiters.add(callback);
+  return () => {
+    waiters.delete(callback);
+  };
 }

--- a/apps/mesh/src/web/components/sections-editor/preview-iframe-pool.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-iframe-pool.ts
@@ -1,0 +1,14 @@
+const MAX_CONCURRENT_PREVIEW_IFRAMES = 12;
+
+const active = new Set<string>();
+
+export function tryAcquirePreviewIframeSlot(id: string): boolean {
+  if (active.has(id)) return true;
+  if (active.size >= MAX_CONCURRENT_PREVIEW_IFRAMES) return false;
+  active.add(id);
+  return true;
+}
+
+export function releasePreviewIframeSlot(id: string): void {
+  active.delete(id);
+}

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -1,3 +1,5 @@
+import { parseSavedBlockSchemaTitle } from "./block-type-utils";
+
 /**
  * Schema resolution for /live/_meta JSON Schemas.
  *
@@ -258,7 +260,17 @@ export function resolveSchema(
           for (const branch of nonNull) {
             const def = resolveRef(branch.$ref as string);
             let rt: string | undefined;
-            if (Array.isArray(def.allOf)) {
+            let title: string | undefined;
+
+            if (typeof def.title === "string") {
+              const saved = parseSavedBlockSchemaTitle(def.title);
+              if (saved) {
+                rt = saved.blockId;
+                title = saved.blockId;
+              }
+            }
+
+            if (!rt && Array.isArray(def.allOf)) {
               for (const part of def.allOf as RawSchema[]) {
                 const props = (part.properties ?? {}) as RawSchema;
                 const rtProp = (props.__resolveType ?? {}) as RawSchema;
@@ -275,13 +287,14 @@ export function resolveSchema(
             anyOfRefs.push({
               resolveType: rt,
               title:
-                typeof def.title === "string"
+                title ??
+                (typeof def.title === "string" && !def.title.startsWith("#")
                   ? def.title
                   : (rt
                       .split("/")
                       .pop()
                       ?.replace(/\.tsx?$/, "")
-                      .replace(/[-_]/g, " ") ?? rt),
+                      .replace(/[-_]/g, " ") ?? rt)),
               description:
                 typeof def.description === "string"
                   ? def.description
@@ -398,5 +411,52 @@ export function resolveSchema(
     type: "object",
     title: typeof merged.title === "string" ? merged.title : undefined,
     properties,
+  };
+}
+
+export interface BlockSchemaMetadata {
+  title?: string;
+  description?: string;
+  icon?: string;
+}
+
+/**
+ * Read block schema metadata (title, description, icon) from live meta.
+ * Mirrors admin's getSchemaIcon / getSchemaTitle / getSchemaDescription.
+ */
+export function resolveBlockSchemaMetadata(
+  resolveType: string,
+  meta: LiveMeta,
+): BlockSchemaMetadata {
+  const globalSchema = meta.schema ?? {};
+  const allBlockTypes = meta.manifest?.blocks ?? {};
+
+  let blockSchema: RawSchema = {};
+  for (const blockTypeMap of Object.values(allBlockTypes)) {
+    if (blockTypeMap[resolveType]) {
+      blockSchema = blockTypeMap[resolveType] as RawSchema;
+      break;
+    }
+  }
+
+  const defs = (globalSchema.$defs ?? globalSchema.definitions ?? {}) as Record<
+    string,
+    RawSchema
+  >;
+
+  const resolved =
+    typeof blockSchema.$ref === "string"
+      ? (defs[blockSchema.$ref.split("/").pop() ?? ""] ?? {})
+      : { ...globalSchema, ...blockSchema };
+
+  const icon = (resolved as { icon?: string }).icon;
+
+  return {
+    title: typeof resolved.title === "string" ? resolved.title : undefined,
+    description:
+      typeof resolved.description === "string"
+        ? resolved.description
+        : undefined,
+    icon: typeof icon === "string" ? icon : undefined,
   };
 }

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -439,7 +439,8 @@ export function resolveBlockSchemaMetadata(
     }
   }
 
-  const defs = (globalSchema.$defs ?? globalSchema.definitions ?? {}) as Record<
+  const merged: RawSchema = { ...globalSchema, ...blockSchema };
+  const defs = (merged.$defs ?? merged.definitions ?? {}) as Record<
     string,
     RawSchema
   >;

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "bun:test";
+import {
+  extractSectionCatalog,
+  findLivePageResolveType,
+  findSiteThemeBlock,
+} from "./section-catalog";
+import {
+  buildSectionPreviewUrl,
+  encodePreviewProps,
+} from "./section-preview-url";
+import type { LiveMeta } from "./resolve-schema";
+
+describe("section-preview-url", () => {
+  it("encodePreviewProps matches admin encodeProps", () => {
+    const json = JSON.stringify({ sections: [{ __resolveType: "preview" }] });
+    expect(encodePreviewProps(json)).toBe(btoa(encodeURIComponent(json)));
+  });
+
+  it("buildSectionPreviewUrl targets live previews with preview block props", () => {
+    const url = buildSectionPreviewUrl(
+      "https://abc.preview.example.com/current-page",
+      "website/pages/Page.tsx",
+      "site/sections/Hero.tsx",
+    );
+
+    expect(url).toContain("https://abc.preview.example.com/live/previews/");
+    expect(url).toContain("website%2Fpages%2FPage.tsx");
+    expect(url).toContain("props=");
+  });
+
+  it("buildSectionPreviewUrl appends site theme like admin", () => {
+    const theme = { __resolveType: "Deco" };
+    const url = buildSectionPreviewUrl(
+      "https://abc.preview.example.com/",
+      "website/pages/Page.tsx",
+      "Header",
+      theme,
+    );
+    const propsParam = new URL(url).searchParams.get("props");
+    expect(propsParam).toBeTruthy();
+    const decoded = JSON.parse(decodeURIComponent(atob(propsParam!))) as {
+      sections: unknown[];
+    };
+    expect(decoded.sections).toHaveLength(2);
+    expect(decoded.sections[0]).toEqual({
+      __resolveType: "preview",
+      block: "Header",
+    });
+    expect(decoded.sections[1]).toEqual(theme);
+  });
+});
+
+describe("section-catalog", () => {
+  it("findLivePageResolveType prefers manifest page blocks", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+        },
+      },
+      schema: {},
+    };
+
+    expect(findLivePageResolveType(meta)).toBe("website/pages/Page.tsx");
+  });
+
+  it("findSiteThemeBlock reads theme from site block", () => {
+    expect(
+      findSiteThemeBlock({
+        site: { theme: { __resolveType: "Deco" } },
+      }),
+    ).toEqual({ __resolveType: "Deco" });
+  });
+
+  it("extractSectionCatalog merges manifest sections, schema refs, and saved blocks", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+          sections: {
+            "site/sections/Hero.tsx": { $ref: "#/definitions/Hero" },
+            "site/sections/Footer/Footer.tsx": {
+              $ref: "#/definitions/FooterSection",
+            },
+            "site/sections/Header/Header.tsx": {
+              $ref: "#/definitions/HeaderSection",
+            },
+          },
+          loaders: {
+            "vtex/loaders/legacy/productList.ts": {
+              $ref: "#/definitions/ProductList",
+            },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          Page: {
+            type: "object",
+            properties: {
+              sections: {
+                type: "array",
+                items: {
+                  anyOf: [{ $ref: "#/definitions/HeroSection" }],
+                },
+              },
+            },
+          },
+          HeroSection: {
+            allOf: [
+              {
+                properties: {
+                  __resolveType: {
+                    enum: ["site/sections/Hero.tsx"],
+                  },
+                },
+              },
+            ],
+            title: "Hero",
+          },
+          Hero: {
+            title: "Hero",
+            description: "Hero section",
+          },
+          FooterSection: {
+            title: "Footer",
+          },
+        },
+      },
+    };
+
+    const decofile = {
+      Header: {
+        __resolveType: "site/sections/Header/Header.tsx",
+        title: "Header",
+      },
+      "Product List Loader": {
+        __resolveType: "vtex/loaders/legacy/productList.ts",
+      },
+      "Preview /sections/Footer.tsx": {
+        __resolveType: "site/sections/Footer/Footer.tsx",
+      },
+      "pages-home": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/",
+      },
+    };
+
+    const catalog = extractSectionCatalog(meta, decofile);
+    const resolveTypes = catalog.map((entry) => entry.resolveType);
+
+    expect(resolveTypes).toContain("site/sections/Hero.tsx");
+    expect(resolveTypes).toContain("site/sections/Footer/Footer.tsx");
+    expect(resolveTypes).toContain("Header");
+    expect(resolveTypes).not.toContain("Product List Loader");
+    expect(resolveTypes).not.toContain("Preview /sections/Footer.tsx");
+  });
+
+  it("extractSectionCatalog includes manifest sections even when page anyOf is populated", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+          sections: {
+            "site/sections/Hero.tsx": { $ref: "#/definitions/Hero" },
+            "site/sections/Benefits.tsx": { $ref: "#/definitions/Benefits" },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          Page: {
+            type: "object",
+            properties: {
+              sections: {
+                type: "array",
+                items: {
+                  anyOf: [{ $ref: "#/definitions/HeroSection" }],
+                },
+              },
+            },
+          },
+          HeroSection: {
+            allOf: [
+              {
+                properties: {
+                  __resolveType: {
+                    enum: ["site/sections/Hero.tsx"],
+                  },
+                },
+              },
+            ],
+            title: "Hero",
+          },
+          Hero: { title: "Hero" },
+          Benefits: { title: "Benefits" },
+        },
+      },
+    };
+
+    const catalog = extractSectionCatalog(meta, {});
+    expect(catalog.map((entry) => entry.resolveType)).toContain(
+      "site/sections/Benefits.tsx",
+    );
+  });
+
+  it("extractSectionCatalog excludes Theme sections", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          pages: {
+            "website/pages/Page.tsx": { $ref: "#/definitions/Page" },
+          },
+          sections: {
+            "site/sections/Theme/Theme.tsx": { $ref: "#/definitions/Theme" },
+            "site/sections/Hero.tsx": { $ref: "#/definitions/Hero" },
+            "site/sections/Header/Header.tsx": {
+              $ref: "#/definitions/HeaderSection",
+            },
+          },
+        },
+      },
+      schema: { definitions: { Theme: {}, Hero: {}, HeaderSection: {} } },
+    };
+
+    const decofile = {
+      Deco: { __resolveType: "site/sections/Theme/Theme.tsx" },
+      Header: { __resolveType: "site/sections/Header/Header.tsx" },
+    };
+
+    const catalog = extractSectionCatalog(meta, decofile);
+    const resolveTypes = catalog.map((entry) => entry.resolveType);
+
+    expect(resolveTypes).not.toContain("site/sections/Theme/Theme.tsx");
+    expect(resolveTypes).not.toContain("Deco");
+    expect(resolveTypes).toContain("site/sections/Hero.tsx");
+    expect(resolveTypes).toContain("Header");
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.ts
@@ -10,6 +10,7 @@ import {
   type LiveMeta,
   type SchemaProperty,
 } from "./resolve-schema";
+import { labelFromResolveType } from "./section-types";
 
 export interface SectionCatalogEntry {
   resolveType: string;
@@ -30,17 +31,6 @@ const PAGE_BLOCK_RESOLVE_TYPES = new Set<string>(LIVE_PAGE_RESOLVE_TYPES);
 const EXCLUDED_SECTION_RESOLVE_TYPES = new Set([
   "site/sections/Theme/Theme.tsx",
 ]);
-
-function labelFromResolveType(rt: string): string {
-  const segments = rt.split("/");
-  const filename = segments[segments.length - 1] ?? rt;
-  return (
-    filename
-      .replace(/\.(tsx?|jsx?)$/, "")
-      .replace(/[-_]/g, " ")
-      .replace(/\b\w/g, (c) => c.toUpperCase()) || rt
-  );
-}
 
 function shouldSkipSectionResolveType(resolveType: string): boolean {
   if (EXCLUDED_SECTION_RESOLVE_TYPES.has(resolveType)) return true;

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.ts
@@ -1,0 +1,210 @@
+import {
+  isAutoPreviewBlockKey,
+  isManifestSectionResolveType,
+  isSavedBlockResolveType,
+} from "./block-type-utils";
+import { isLazyResolveType } from "./section-lazy";
+import {
+  resolveBlockSchemaMetadata,
+  resolveSchema,
+  type LiveMeta,
+  type SchemaProperty,
+} from "./resolve-schema";
+
+export interface SectionCatalogEntry {
+  resolveType: string;
+  title: string;
+  description?: string;
+  previewBlock: string;
+  isSavedBlock: boolean;
+}
+
+const LIVE_PAGE_RESOLVE_TYPES = [
+  "website/pages/Page.tsx",
+  "$live/pages/LivePage.tsx",
+] as const;
+
+const PAGE_BLOCK_RESOLVE_TYPES = new Set<string>(LIVE_PAGE_RESOLVE_TYPES);
+
+/** Theme sections belong in site settings, not the page section picker. */
+const EXCLUDED_SECTION_RESOLVE_TYPES = new Set([
+  "site/sections/Theme/Theme.tsx",
+]);
+
+function labelFromResolveType(rt: string): string {
+  const segments = rt.split("/");
+  const filename = segments[segments.length - 1] ?? rt;
+  return (
+    filename
+      .replace(/\.(tsx?|jsx?)$/, "")
+      .replace(/[-_]/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase()) || rt
+  );
+}
+
+function shouldSkipSectionResolveType(resolveType: string): boolean {
+  if (EXCLUDED_SECTION_RESOLVE_TYPES.has(resolveType)) return true;
+  if (isLazyResolveType(resolveType)) return true;
+  if (resolveType.toLowerCase().includes("preview")) return true;
+  return false;
+}
+
+export function findLivePageResolveType(meta: LiveMeta): string {
+  const blocks = meta.manifest?.blocks ?? {};
+  for (const blockMap of Object.values(blocks)) {
+    for (const resolveType of Object.keys(blockMap)) {
+      if (PAGE_BLOCK_RESOLVE_TYPES.has(resolveType)) {
+        return resolveType;
+      }
+    }
+  }
+  return LIVE_PAGE_RESOLVE_TYPES[0];
+}
+
+function collectAnyOfRefsFromSchema(
+  schema: SchemaProperty | null | undefined,
+): Array<{ resolveType: string; title: string; description?: string }> {
+  if (!schema) return [];
+  if (schema.anyOfRefs?.length) return schema.anyOfRefs;
+  if (schema.items) return collectAnyOfRefsFromSchema(schema.items);
+  if (schema.properties) {
+    for (const child of Object.values(schema.properties)) {
+      const refs = collectAnyOfRefsFromSchema(child);
+      if (refs.length > 0) return refs;
+    }
+  }
+  return [];
+}
+
+function listManifestSections(meta: LiveMeta): SectionCatalogEntry[] {
+  const blocks = meta.manifest?.blocks ?? {};
+  const entries: SectionCatalogEntry[] = [];
+
+  for (const [blockType, blockMap] of Object.entries(blocks)) {
+    if (!blockType.includes("sections")) continue;
+
+    for (const resolveType of Object.keys(blockMap)) {
+      if (shouldSkipSectionResolveType(resolveType)) continue;
+
+      const metadata = resolveBlockSchemaMetadata(resolveType, meta);
+      entries.push({
+        resolveType,
+        title: metadata.title ?? labelFromResolveType(resolveType),
+        description: metadata.description,
+        previewBlock: resolveType,
+        isSavedBlock: false,
+      });
+    }
+  }
+
+  return entries;
+}
+
+function listSavedSectionBlocks(
+  meta: LiveMeta,
+  decofile: Record<string, unknown>,
+): SectionCatalogEntry[] {
+  const entries: SectionCatalogEntry[] = [];
+
+  for (const [key, val] of Object.entries(decofile)) {
+    if (key.includes("/")) continue;
+    if (isAutoPreviewBlockKey(key)) continue;
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+
+    const obj = val as Record<string, unknown>;
+    const rt = obj.__resolveType;
+    if (typeof rt !== "string") continue;
+    if (PAGE_BLOCK_RESOLVE_TYPES.has(rt)) continue;
+    if (typeof obj.path === "string") continue;
+    if (shouldSkipSectionResolveType(rt)) continue;
+    if (!isManifestSectionResolveType(meta, rt)) continue;
+
+    entries.push({
+      resolveType: key,
+      title: key,
+      description: typeof obj.name === "string" ? obj.name : undefined,
+      previewBlock: key,
+      isSavedBlock: true,
+    });
+  }
+
+  return entries;
+}
+
+function catalogEntryFromSchemaRef(
+  meta: LiveMeta,
+  ref: { resolveType: string; title: string; description?: string },
+): SectionCatalogEntry {
+  const isSaved = isSavedBlockResolveType(ref.resolveType);
+  const metadata = isSaved
+    ? {}
+    : resolveBlockSchemaMetadata(ref.resolveType, meta);
+
+  return {
+    resolveType: ref.resolveType,
+    title: ref.title || metadata.title || labelFromResolveType(ref.resolveType),
+    description: ref.description ?? metadata.description,
+    // Saved blocks preview by block id so the runtime resolver loads `.deco/blocks/{id}.json`.
+    previewBlock: ref.resolveType,
+    isSavedBlock: isSaved,
+  };
+}
+
+/**
+ * Lists sections that can be inserted into a page.
+ * Merges manifest sections, page schema anyOf refs, and saved global blocks.
+ */
+export function extractSectionCatalog(
+  meta: LiveMeta,
+  decofile: Record<string, unknown>,
+): SectionCatalogEntry[] {
+  const livePageRt = findLivePageResolveType(meta);
+  const pageSchema = resolveSchema(livePageRt, meta);
+  const refs = collectAnyOfRefsFromSchema(pageSchema?.properties?.sections);
+
+  const byResolveType = new Map<string, SectionCatalogEntry>();
+
+  const addEntry = (entry: SectionCatalogEntry) => {
+    if (shouldSkipSectionResolveType(entry.resolveType)) return;
+    if (isSavedBlockResolveType(entry.resolveType)) {
+      if (!isAutoPreviewBlockKey(entry.resolveType)) {
+        byResolveType.set(entry.resolveType, entry);
+      }
+      return;
+    }
+    if (!isManifestSectionResolveType(meta, entry.resolveType)) return;
+    if (!byResolveType.has(entry.resolveType)) {
+      byResolveType.set(entry.resolveType, entry);
+    }
+  };
+
+  for (const entry of listManifestSections(meta)) {
+    addEntry(entry);
+  }
+
+  for (const ref of refs) {
+    addEntry(catalogEntryFromSchemaRef(meta, ref));
+  }
+
+  for (const entry of listSavedSectionBlocks(meta, decofile)) {
+    addEntry(entry);
+  }
+
+  return [...byResolveType.values()].sort((a, b) =>
+    a.title.localeCompare(b.title),
+  );
+}
+
+/** Site theme block from decofile — included in section previews like admin. */
+export function findSiteThemeBlock(
+  decofile: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const site = decofile.site;
+  if (!site || typeof site !== "object" || Array.isArray(site))
+    return undefined;
+  const theme = (site as Record<string, unknown>).theme;
+  if (!theme || typeof theme !== "object" || Array.isArray(theme)) {
+    return undefined;
+  }
+  return theme as Record<string, unknown>;
+}

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.ts
@@ -58,10 +58,15 @@ function collectAnyOfRefsFromSchema(
   if (schema.anyOfRefs?.length) return schema.anyOfRefs;
   if (schema.items) return collectAnyOfRefsFromSchema(schema.items);
   if (schema.properties) {
+    const refs: Array<{
+      resolveType: string;
+      title: string;
+      description?: string;
+    }> = [];
     for (const child of Object.values(schema.properties)) {
-      const refs = collectAnyOfRefsFromSchema(child);
-      if (refs.length > 0) return refs;
+      refs.push(...collectAnyOfRefsFromSchema(child));
     }
+    return refs;
   }
   return [];
 }

--- a/apps/mesh/src/web/components/sections-editor/section-lazy.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-lazy.ts
@@ -1,0 +1,8 @@
+const LAZY_SUFFIXES = [
+  "website/sections/Rendering/Lazy.tsx",
+  "website/sections/Rendering/SingleDeferred.tsx",
+];
+
+export function isLazyResolveType(rt: string): boolean {
+  return LAZY_SUFFIXES.some((suffix) => rt.endsWith(suffix));
+}

--- a/apps/mesh/src/web/components/sections-editor/section-list.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-list.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { parseSections } from "./parse-sections";
+
+describe("parseSections", () => {
+  it("labels inline manifest sections from resolve type path", () => {
+    const parsed = parseSections(
+      [{ __resolveType: "site/sections/Hero/Hero.tsx" }],
+      {},
+    );
+    expect(parsed[0]?.label).toBe("Hero");
+    expect(parsed[0]?.isSavedBlock).toBeUndefined();
+  });
+
+  it("detects saved block references from decofile", () => {
+    const parsed = parseSections([{ __resolveType: "Header" }], {
+      Header: {
+        __resolveType: "site/sections/Header/Header.tsx",
+        name: "Site Header",
+      },
+    });
+    expect(parsed[0]?.isSavedBlock).toBe(true);
+    expect(parsed[0]?.label).toBe("Site Header");
+  });
+
+  it("detects lazy-wrapped saved blocks", () => {
+    const parsed = parseSections(
+      [
+        {
+          __resolveType: "website/sections/Rendering/Lazy.tsx",
+          section: { __resolveType: "Header" },
+        },
+      ],
+      {
+        Header: { __resolveType: "site/sections/Header/Header.tsx" },
+      },
+    );
+    expect(parsed[0]?.isSavedBlock).toBe(true);
+    expect(parsed[0]?.isLazy).toBe(true);
+  });
+
+  it("detects multivariate sections", () => {
+    const parsed = parseSections(
+      [
+        {
+          __resolveType: "website/flags/multivariate/section.ts",
+          variants: [
+            {
+              value: { __resolveType: "site/sections/Footer/Footer.tsx" },
+              rule: { __resolveType: "website/matchers/always.ts" },
+            },
+          ],
+        },
+      ],
+      {},
+    );
+    expect(parsed[0]?.isMultivariate).toBe(true);
+    expect(parsed[0]?.label).toContain("Footer");
+  });
+
+  it("marks never-matcher single variants as hidden", () => {
+    const parsed = parseSections(
+      [
+        {
+          __resolveType: "website/flags/multivariate/section.ts",
+          variants: [
+            {
+              value: { __resolveType: "site/sections/Hero/Hero.tsx" },
+              rule: { __resolveType: "website/matchers/never.ts" },
+            },
+          ],
+        },
+      ],
+      {},
+    );
+    expect(parsed[0]?.isHidden).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -1,26 +1,67 @@
+import { useRef, useState } from "react";
 import { cn } from "@deco/ui/lib/utils.js";
-import { DotsGrid, Eye, EyeOff, LayoutAlt01, Zap } from "@untitledui/icons";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
+  Copy01,
+  DotsGrid,
+  DotsHorizontal,
+  Eye,
+  EyeOff,
+  LayoutAlt01,
+  Trash01,
+  Zap,
+} from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
 import {
   DndContext,
+  DragOverlay,
   closestCenter,
   PointerSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext,
+  arrayMove,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { canMakeSectionReusable } from "./page-sections";
+
+const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
+const GLOBAL_SECTION_ROW_CLASS =
+  "text-[oklch(0.45_0.15_289)] hover:bg-[oklch(0.7278_0.151_289/0.12)] dark:text-[oklch(0.78_0.15_289)] dark:hover:bg-[oklch(0.7278_0.151_289/0.15)]";
+const GLOBAL_SECTION_MENU_ITEM_CLASS =
+  "text-[oklch(0.45_0.15_289)] focus:bg-[oklch(0.7278_0.151_289/0.12)] focus:text-[oklch(0.45_0.15_289)] dark:text-[oklch(0.78_0.15_289)] dark:focus:bg-[oklch(0.7278_0.151_289/0.15)] dark:focus:text-[oklch(0.78_0.15_289)] [&_svg]:!text-[oklch(0.7278_0.151_289)]";
+
+interface SectionEntry {
+  id: string;
+  section: ParsedSection;
+}
+
+function createEntries(sections: ParsedSection[]): SectionEntry[] {
+  return sections.map((section, index) => ({
+    id: crypto.randomUUID(),
+    section: { ...section, index },
+  }));
+}
+
+function remapEntryIndices(entries: SectionEntry[]): SectionEntry[] {
+  return entries.map((entry, index) => ({
+    ...entry,
+    section: { ...entry.section, index },
+  }));
+}
 
 // ─── types ─────────────────────────────────────────────────────────────────────
 
@@ -181,69 +222,18 @@ export function parseSections(
   });
 }
 
-// ─── sortable item ──────────────────────────────────────────────────────────────
-
-function SortableSectionItem({
-  section,
-  selected,
-  onSelect,
-}: {
-  section: ParsedSection;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: String(section.index) });
-
-  const style = {
-    transform: CSS.Transform.toString(
-      transform ? { ...transform, x: 0 } : null,
-    ),
-    transition,
-    opacity: isDragging ? 0.5 : undefined,
-    zIndex: isDragging ? 100 : undefined,
-  };
-
+function SectionRowContent({ section }: { section: ParsedSection }) {
   const saved = section.isSavedBlock === true;
   const multivariate = section.isMultivariate === true;
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      onClick={onSelect}
-      className={cn(
-        "group flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-2.5 transition-colors active:cursor-grabbing",
-        selected
-          ? "bg-accent text-accent-foreground"
-          : saved
-            ? "text-[oklch(0.45_0.15_289)] hover:bg-[oklch(0.7278_0.151_289/0.12)] dark:text-[oklch(0.78_0.15_289)] dark:hover:bg-[oklch(0.7278_0.151_289/0.15)]"
-            : multivariate
-              ? "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]"
-              : "text-foreground/80 hover:bg-accent hover:text-accent-foreground",
-      )}
-      {...attributes}
-      {...listeners}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        listeners?.onKeyDown?.(e);
-        if (e.key === "Enter" || e.key === " ") onSelect();
-      }}
-    >
+    <>
       <DotsGrid className="h-4 w-4 shrink-0 text-muted-foreground/40" />
-
       <LayoutAlt01
         className="h-4 w-4 shrink-0"
         style={
           saved
-            ? { color: "oklch(0.7278 0.151 289)" }
+            ? { color: GLOBAL_SECTION_ICON_COLOR }
             : multivariate
               ? { color: "oklch(0.65 0.15 160)" }
               : undefined
@@ -251,47 +241,145 @@ function SortableSectionItem({
       />
       <span
         className={cn(
-          "flex-1 truncate text-sm font-medium",
+          "min-w-0 flex-1 truncate text-sm font-medium",
           section.isHidden && "line-through opacity-50",
         )}
       >
         {section.label}
       </span>
-
-      {/* Hidden toggle */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={cn(
-              "shrink-0 rounded p-1 transition-colors",
-              section.isHidden
-                ? "text-muted-foreground"
-                : "text-muted-foreground/60 opacity-0 group-hover:opacity-100",
-            )}
-          >
-            {section.isHidden ? (
-              <EyeOff className="h-3.5 w-3.5" />
-            ) : (
-              <Eye className="h-3.5 w-3.5" />
-            )}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          {section.isHidden ? "Hidden section" : "Visible"}
-        </TooltipContent>
-      </Tooltip>
-
-      {/* Lazy indicator */}
-      {section.isLazy && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="shrink-0 rounded p-1 text-yellow-500">
-              <Zap className="h-3.5 w-3.5" />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="top">Lazy loaded</TooltipContent>
-        </Tooltip>
+      {section.isHidden ? (
+        <EyeOff className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      ) : (
+        <Eye className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60 opacity-0 group-hover:opacity-100" />
       )}
+      {section.isLazy && (
+        <Zap className="h-3.5 w-3.5 shrink-0 text-yellow-500" />
+      )}
+    </>
+  );
+}
+
+function sectionRowClassName(section: ParsedSection, selected: boolean) {
+  const saved = section.isSavedBlock === true;
+  const multivariate = section.isMultivariate === true;
+
+  return cn(
+    "group flex select-none items-center gap-2 rounded-md px-2 py-2.5",
+    selected
+      ? "bg-accent text-accent-foreground"
+      : saved
+        ? GLOBAL_SECTION_ROW_CLASS
+        : multivariate
+          ? "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]"
+          : "text-foreground/80 hover:bg-accent hover:text-accent-foreground",
+  );
+}
+
+// ─── sortable item ──────────────────────────────────────────────────────────────
+
+function SortableSectionItem({
+  section,
+  sortableId,
+  selected,
+  onSelect,
+  onDelete,
+  onDuplicate,
+  onMakeReusable,
+}: {
+  section: ParsedSection;
+  sortableId: string;
+  selected: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+  onMakeReusable: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useSortable({
+      id: sortableId,
+      animateLayoutChanges: () => false,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(
+      transform ? { ...transform, x: 0 } : null,
+    ),
+    opacity: isDragging ? 0 : undefined,
+  };
+
+  const enableMakeReusable = canMakeSectionReusable(section);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className={cn(
+        "touch-none transition-colors",
+        isDragging ? "cursor-grabbing" : "cursor-pointer",
+        sectionRowClassName(section, selected),
+      )}
+    >
+      <SectionRowContent section={section} />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Open actions for ${section.label}`}
+            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <DotsHorizontal size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {enableMakeReusable && (
+            <DropdownMenuItem
+              className={GLOBAL_SECTION_MENU_ITEM_CLASS}
+              onClick={(e) => {
+                e.stopPropagation();
+                onMakeReusable();
+              }}
+            >
+              <LayoutAlt01 size={14} />
+              Save as global
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              onDuplicate();
+            }}
+          >
+            <Copy01 size={14} />
+            Duplicate
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -299,37 +387,85 @@ function SortableSectionItem({
 // ─── component ─────────────────────────────────────────────────────────────────
 
 export function SectionList({
+  listKey,
   sections,
   selectedIndex,
   onSelect,
   onReorder,
+  onDelete,
+  onDuplicate,
+  onMakeReusable,
 }: {
+  listKey: string;
   sections: ParsedSection[];
   selectedIndex: number | null;
   onSelect: (index: number) => void;
   onReorder?: (fromIndex: number, toIndex: number) => void;
+  onDelete: (index: number) => void;
+  onDuplicate: (index: number) => void;
+  onMakeReusable: (index: number) => void;
 }) {
+  const [entries, setEntries] = useState<SectionEntry[]>(() =>
+    createEntries(sections),
+  );
+  const [activeEntry, setActiveEntry] = useState<SectionEntry | null>(null);
+  const [prevListKey, setPrevListKey] = useState(listKey);
+  const [prevSectionCount, setPrevSectionCount] = useState(sections.length);
+  const suppressClickRef = useRef(false);
+
+  if (prevListKey !== listKey) {
+    setPrevListKey(listKey);
+    setPrevSectionCount(sections.length);
+    setEntries(createEntries(sections));
+  } else if (prevSectionCount !== sections.length) {
+    setPrevSectionCount(sections.length);
+    setEntries(createEntries(sections));
+  }
+
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
   );
 
-  const sortableIds = sections.map((s) => String(s.index));
+  const entryIds = entries.map((entry) => entry.id);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const id = String(event.active.id);
+    setActiveEntry(entries.find((entry) => entry.id === id) ?? null);
+  };
 
   const handleDragEnd = (event: DragEndEvent) => {
+    setActiveEntry(null);
+
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
-    const oldIndex = sortableIds.indexOf(String(active.id));
-    const newIndex = sortableIds.indexOf(String(over.id));
+    const oldIndex = entryIds.indexOf(String(active.id));
+    const newIndex = entryIds.indexOf(String(over.id));
     if (oldIndex === -1 || newIndex === -1) return;
 
+    setEntries((current) =>
+      remapEntryIndices(arrayMove([...current], oldIndex, newIndex)),
+    );
+    suppressClickRef.current = true;
+    requestAnimationFrame(() => {
+      suppressClickRef.current = false;
+    });
     onReorder?.(oldIndex, newIndex);
   };
 
-  if (sections.length === 0) {
+  const handleDragCancel = () => {
+    setActiveEntry(null);
+  };
+
+  const handleSelect = (index: number) => {
+    if (suppressClickRef.current) return;
+    onSelect(index);
+  };
+
+  if (entries.length === 0) {
     return (
       <p className="text-xs text-muted-foreground px-2 py-3">
         No sections in this page.
@@ -338,26 +474,47 @@ export function SectionList({
   }
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragEnd={handleDragEnd}
-    >
-      <SortableContext
-        items={sortableIds}
-        strategy={verticalListSortingStrategy}
+    <div className={activeEntry ? "cursor-grabbing" : undefined}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
       >
-        <div className="space-y-1">
-          {sections.map((section) => (
-            <SortableSectionItem
-              key={`${section.resolveType}-${section.index}`}
-              section={section}
-              selected={selectedIndex === section.index}
-              onSelect={() => onSelect(section.index)}
-            />
-          ))}
-        </div>
-      </SortableContext>
-    </DndContext>
+        <SortableContext
+          items={entryIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-1">
+            {entries.map((entry) => (
+              <SortableSectionItem
+                key={entry.id}
+                sortableId={entry.id}
+                section={entry.section}
+                selected={selectedIndex === entry.section.index}
+                onSelect={() => handleSelect(entry.section.index)}
+                onDelete={() => onDelete(entry.section.index)}
+                onDuplicate={() => onDuplicate(entry.section.index)}
+                onMakeReusable={() => onMakeReusable(entry.section.index)}
+              />
+            ))}
+          </div>
+        </SortableContext>
+
+        <DragOverlay dropAnimation={null}>
+          {activeEntry ? (
+            <div
+              className={cn(
+                "cursor-grabbing shadow-lg ring-1 ring-border/60",
+                sectionRowClassName(activeEntry.section, false),
+              )}
+            >
+              <SectionRowContent section={activeEntry.section} />
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -38,8 +38,15 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { canMakeSectionReusable } from "./page-sections";
+import {
+  GLOBAL_SECTION_ICON_COLOR,
+  sectionsDisplayKey,
+  type RawSection,
+} from "./section-types";
+import { parseSections, type ParsedSection } from "./parse-sections";
 
-const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
+export { parseSections, type ParsedSection, type RawSection };
+
 const GLOBAL_SECTION_ROW_CLASS =
   "text-[oklch(0.45_0.15_289)] hover:bg-[oklch(0.7278_0.151_289/0.12)] dark:text-[oklch(0.78_0.15_289)] dark:hover:bg-[oklch(0.7278_0.151_289/0.15)]";
 const GLOBAL_SECTION_MENU_ITEM_CLASS =
@@ -62,158 +69,6 @@ function remapEntryIndices(entries: SectionEntry[]): SectionEntry[] {
     ...entry,
     section: { ...entry.section, index },
   }));
-}
-
-// ─── types ─────────────────────────────────────────────────────────────────────
-
-export interface ParsedSection {
-  index: number;
-  resolveType: string;
-  label: string;
-  isLazy?: boolean;
-  isHidden?: boolean;
-  isSavedBlock?: boolean;
-  isMultivariate?: boolean;
-}
-
-interface RawSection {
-  __resolveType: string;
-  section?: { __resolveType?: string };
-  variants?: Array<{
-    value?: Record<string, unknown>;
-    rule?: Record<string, unknown>;
-  }>;
-  [key: string]: unknown;
-}
-
-import { isLazyResolveType } from "./section-lazy";
-
-export { isLazyResolveType } from "./section-lazy";
-
-function labelFromResolveType(rt: string): string {
-  const parts = rt.split("/");
-  const filename = parts[parts.length - 1] ?? rt;
-  return filename.replace(/\.(tsx|ts|jsx|js)$/, "") || rt;
-}
-
-/**
- * Parse raw decofile sections into display-ready entries with
- * isLazy / isHidden / isSavedBlock / isMultivariate flags.
- * Mirrors admin-mcp's `parseSectionsFromArray()`.
- */
-export function parseSections(
-  rawSections: RawSection[],
-  decofile: Record<string, unknown>,
-): ParsedSection[] {
-  return rawSections.map((s, idx) => {
-    const rt = s.__resolveType ?? "";
-    const isLazy = isLazyResolveType(rt);
-
-    // ── Saved block (named block ref — no "/" in resolveType) ────────
-    if (!isLazy && rt !== "" && !rt.includes("/") && rt in decofile) {
-      const resolvedBlock = decofile[rt] as Record<string, unknown> | undefined;
-      const label =
-        (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
-        rt.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) ||
-        `Section ${idx + 1}`;
-      return {
-        index: idx,
-        resolveType: rt,
-        label,
-        isLazy: false,
-        isSavedBlock: true,
-      };
-    }
-
-    // ── Multivariate detection ──────────────────────────────────────
-    const innerSection = isLazy
-      ? (s.section as RawSection | undefined)
-      : undefined;
-    const mvRt = isLazy ? (innerSection?.__resolveType ?? "") : rt;
-
-    if (mvRt.includes("flags/multivariate")) {
-      const mvObj = (isLazy ? innerSection : s) as RawSection;
-      const rawVariants = Array.isArray(mvObj?.variants) ? mvObj.variants : [];
-
-      // ── Hidden: single variant with "never" matcher ───────────────
-      const NEVER_TYPES = ["website/matchers/never.ts"];
-      if (
-        rawVariants.length === 1 &&
-        NEVER_TYPES.includes(
-          (rawVariants[0]?.rule?.__resolveType as string) ?? "",
-        )
-      ) {
-        const innerValue = (rawVariants[0]?.value ?? {}) as Record<
-          string,
-          unknown
-        >;
-        let innerRt = (innerValue.__resolveType as string) ?? "";
-        const innerIsLazy = isLazyResolveType(innerRt);
-        if (innerIsLazy) {
-          const nested = innerValue.section as
-            | Record<string, unknown>
-            | undefined;
-          innerRt = (nested?.__resolveType as string) ?? innerRt;
-        }
-        return {
-          index: idx,
-          resolveType: rt,
-          label: labelFromResolveType(innerRt) || `Section ${idx + 1}`,
-          isHidden: true,
-          isLazy: innerIsLazy,
-        };
-      }
-
-      // Regular multivariate
-      const firstValueRt = (
-        rawVariants[0]?.value as Record<string, unknown> | undefined
-      )?.__resolveType as string | undefined;
-      const sectionLabel = firstValueRt
-        ? labelFromResolveType(firstValueRt)
-        : "Section";
-      return {
-        index: idx,
-        resolveType: rt,
-        label: `Variants of ${sectionLabel}`,
-        isMultivariate: true,
-        isLazy,
-      };
-    }
-
-    // ── Lazy-wrapped saved block (e.g. Lazy → Header) ──────────────
-    const effectiveRt = isLazy ? (s.section?.__resolveType ?? rt) : rt;
-    if (
-      isLazy &&
-      effectiveRt !== "" &&
-      !effectiveRt.includes("/") &&
-      effectiveRt in decofile
-    ) {
-      const resolvedBlock = decofile[effectiveRt] as
-        | Record<string, unknown>
-        | undefined;
-      const label =
-        (typeof resolvedBlock?.name === "string" && resolvedBlock.name) ||
-        effectiveRt
-          .replace(/[-_]/g, " ")
-          .replace(/\b\w/g, (c) => c.toUpperCase()) ||
-        `Section ${idx + 1}`;
-      return {
-        index: idx,
-        resolveType: rt,
-        label,
-        isLazy: true,
-        isSavedBlock: true,
-      };
-    }
-
-    // ── Normal section (possibly lazy-wrapped) ──────────────────────
-    return {
-      index: idx,
-      resolveType: rt,
-      label: labelFromResolveType(effectiveRt) || `Section ${idx + 1}`,
-      isLazy,
-    };
-  });
 }
 
 function SectionRowContent({ section }: { section: ParsedSection }) {
@@ -390,6 +245,7 @@ export function SectionList({
   onDuplicate,
   onMakeReusable,
   onAddSection,
+  canAddSection = true,
 }: {
   listKey: string;
   sections: ParsedSection[];
@@ -400,6 +256,7 @@ export function SectionList({
   onDuplicate: (index: number) => void;
   onMakeReusable: (index: number) => void;
   onAddSection: () => void;
+  canAddSection?: boolean;
 }) {
   const [entries, setEntries] = useState<SectionEntry[]>(() =>
     createEntries(sections),
@@ -407,15 +264,33 @@ export function SectionList({
   const [activeEntry, setActiveEntry] = useState<SectionEntry | null>(null);
   const [prevListKey, setPrevListKey] = useState(listKey);
   const [prevSectionCount, setPrevSectionCount] = useState(sections.length);
+  const [prevDisplayKey, setPrevDisplayKey] = useState(() =>
+    sectionsDisplayKey(sections),
+  );
   const suppressClickRef = useRef(false);
+
+  const displayKey = sectionsDisplayKey(sections);
 
   if (prevListKey !== listKey) {
     setPrevListKey(listKey);
     setPrevSectionCount(sections.length);
+    setPrevDisplayKey(displayKey);
     setEntries(createEntries(sections));
   } else if (prevSectionCount !== sections.length) {
     setPrevSectionCount(sections.length);
+    setPrevDisplayKey(displayKey);
     setEntries(createEntries(sections));
+  } else if (prevDisplayKey !== displayKey) {
+    setPrevDisplayKey(displayKey);
+    setEntries((current) =>
+      sections.map((section, index) => {
+        const prior = current[index];
+        return {
+          id: prior?.id ?? crypto.randomUUID(),
+          section: { ...section, index },
+        };
+      }),
+    );
   }
 
   const sensors = useSensors(
@@ -472,6 +347,7 @@ export function SectionList({
           variant="outline"
           size="sm"
           className="w-full"
+          disabled={!canAddSection}
           onClick={onAddSection}
         >
           <Plus size={14} />
@@ -528,6 +404,7 @@ export function SectionList({
         variant="outline"
         size="sm"
         className="mt-2 w-full"
+        disabled={!canAddSection}
         onClick={onAddSection}
       >
         <Plus size={14} />

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { cn } from "@deco/ui/lib/utils.js";
+import { Button } from "@deco/ui/components/button.tsx";
 import {
   Copy01,
   DotsGrid,
@@ -7,10 +8,10 @@ import {
   Eye,
   EyeOff,
   LayoutAlt01,
+  Plus,
   Trash01,
   Zap,
 } from "@untitledui/icons";
-import { Button } from "@deco/ui/components/button.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -85,16 +86,9 @@ interface RawSection {
   [key: string]: unknown;
 }
 
-// ─── parsing helpers ───────────────────────────────────────────────────────────
+import { isLazyResolveType } from "./section-lazy";
 
-const LAZY_SUFFIXES = [
-  "website/sections/Rendering/Lazy.tsx",
-  "website/sections/Rendering/SingleDeferred.tsx",
-];
-
-export function isLazyResolveType(rt: string): boolean {
-  return LAZY_SUFFIXES.some((suffix) => rt.endsWith(suffix));
-}
+export { isLazyResolveType } from "./section-lazy";
 
 function labelFromResolveType(rt: string): string {
   const parts = rt.split("/");
@@ -395,6 +389,7 @@ export function SectionList({
   onDelete,
   onDuplicate,
   onMakeReusable,
+  onAddSection,
 }: {
   listKey: string;
   sections: ParsedSection[];
@@ -404,6 +399,7 @@ export function SectionList({
   onDelete: (index: number) => void;
   onDuplicate: (index: number) => void;
   onMakeReusable: (index: number) => void;
+  onAddSection: () => void;
 }) {
   const [entries, setEntries] = useState<SectionEntry[]>(() =>
     createEntries(sections),
@@ -467,9 +463,21 @@ export function SectionList({
 
   if (entries.length === 0) {
     return (
-      <p className="text-xs text-muted-foreground px-2 py-3">
-        No sections in this page.
-      </p>
+      <div className="space-y-2">
+        <p className="px-2 py-3 text-xs text-muted-foreground">
+          No sections in this page.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={onAddSection}
+        >
+          <Plus size={14} />
+          Add section
+        </Button>
+      </div>
     );
   }
 
@@ -515,6 +523,16 @@ export function SectionList({
           ) : null}
         </DragOverlay>
       </DndContext>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-2 w-full"
+        onClick={onAddSection}
+      >
+        <Plus size={14} />
+        Add section
+      </Button>
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/section-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-list.tsx
@@ -358,7 +358,7 @@ export function SectionList({
   }
 
   return (
-    <div className={activeEntry ? "cursor-grabbing" : undefined}>
+    <div className={cn(activeEntry && "cursor-grabbing")}>
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}

--- a/apps/mesh/src/web/components/sections-editor/section-preview-url.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-preview-url.ts
@@ -1,0 +1,25 @@
+/** Matches admin `encodeProps` — URI-encode then base64. */
+export function encodePreviewProps(json: string): string {
+  return btoa(encodeURIComponent(json));
+}
+
+export function buildSectionPreviewUrl(
+  previewBaseUrl: string,
+  livePageResolveType: string,
+  block: string,
+  theme?: Record<string, unknown>,
+): string {
+  const origin = new URL(previewBaseUrl).origin;
+  const url = new URL(
+    `/live/previews/${encodeURIComponent(livePageResolveType)}`,
+    origin,
+  );
+  url.searchParams.set("__d", "");
+  const sections: unknown[] = [{ __resolveType: "preview", block }];
+  if (theme) sections.push(theme);
+  url.searchParams.set(
+    "props",
+    encodePreviewProps(JSON.stringify({ sections })),
+  );
+  return url.toString();
+}

--- a/apps/mesh/src/web/components/sections-editor/section-types.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-types.ts
@@ -1,0 +1,43 @@
+export interface RawSection {
+  __resolveType: string;
+  section?: { __resolveType?: string; [key: string]: unknown };
+  variants?: Array<{
+    value?: Record<string, unknown>;
+    rule?: Record<string, unknown>;
+  }>;
+  [key: string]: unknown;
+}
+
+export const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
+
+export const ALWAYS_MATCHER_RESOLVE_TYPE = "website/matchers/always.ts";
+
+/** Human label from a deco resolve type path or block id. */
+export function labelFromResolveType(rt: string): string {
+  const segments = rt.split("/");
+  const filename = segments[segments.length - 1] ?? rt;
+  return (
+    filename
+      .replace(/\.(tsx?|jsx?)$/, "")
+      .replace(/[-_]/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase()) || rt
+  );
+}
+
+export function sectionsDisplayKey(
+  sections: Array<{
+    resolveType: string;
+    label: string;
+    isHidden?: boolean;
+    isSavedBlock?: boolean;
+    isMultivariate?: boolean;
+    isLazy?: boolean;
+  }>,
+): string {
+  return sections
+    .map(
+      (section) =>
+        `${section.resolveType}|${section.label}|${section.isHidden ?? false}|${section.isSavedBlock ?? false}|${section.isMultivariate ?? false}|${section.isLazy ?? false}`,
+    )
+    .join("\n");
+}

--- a/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
@@ -29,13 +29,6 @@ export interface SectionVariantEntry {
   label: string;
 }
 
-function variantRowClassName(selected: boolean) {
-  return cn(
-    "group flex select-none items-center gap-2 rounded-md px-2 py-2.5 transition-colors cursor-pointer",
-    selected ? VARIANT_SELECTED_ROW_CLASS : VARIANT_ROW_CLASS,
-  );
-}
-
 function VariantRow({
   variant,
   selected,
@@ -62,7 +55,10 @@ function VariantRow({
           onSelect();
         }
       }}
-      className={variantRowClassName(selected)}
+      className={cn(
+        "group flex select-none items-center gap-2 rounded-md px-2 py-2.5 transition-colors cursor-pointer",
+        selected ? VARIANT_SELECTED_ROW_CLASS : VARIANT_ROW_CLASS,
+      )}
     >
       <LayoutAlt01
         className="h-4 w-4 shrink-0"

--- a/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
@@ -1,0 +1,170 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
+  Copy01,
+  DotsHorizontal,
+  LayoutAlt01,
+  Trash01,
+} from "@untitledui/icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+
+const VARIANT_ICON_COLOR = "oklch(0.65 0.15 160)";
+const VARIANT_ROW_CLASS =
+  "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]";
+const VARIANT_SELECTED_ROW_CLASS =
+  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.2)]";
+
+export interface SectionVariantEntry {
+  index: number;
+  label: string;
+}
+
+function variantRowClassName(selected: boolean) {
+  return cn(
+    "group flex select-none items-center gap-2 rounded-md px-2 py-2.5 transition-colors cursor-pointer",
+    selected ? VARIANT_SELECTED_ROW_CLASS : VARIANT_ROW_CLASS,
+  );
+}
+
+function VariantRow({
+  variant,
+  selected,
+  canDelete,
+  onSelect,
+  onDuplicate,
+  onDelete,
+}: {
+  variant: SectionVariantEntry;
+  selected: boolean;
+  canDelete: boolean;
+  onSelect: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className={variantRowClassName(selected)}
+    >
+      <LayoutAlt01
+        className="h-4 w-4 shrink-0"
+        style={{ color: VARIANT_ICON_COLOR }}
+      />
+      <span className="min-w-0 flex-1 truncate text-sm font-medium">
+        {variant.label}
+      </span>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Open actions for ${variant.label}`}
+            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <DotsHorizontal size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              onDuplicate();
+            }}
+          >
+            <Copy01 size={14} />
+            Duplicate
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            disabled={!canDelete}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+export function SectionVariantList({
+  variants,
+  selectedIndex,
+  onSelect,
+  onDuplicate,
+  onDelete,
+  onRemoveAll,
+}: {
+  variants: SectionVariantEntry[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  onDuplicate: (index: number) => void;
+  onDelete: (index: number) => void;
+  onRemoveAll: () => void;
+}) {
+  const canDelete = variants.length > 1;
+
+  return (
+    <div className="space-y-1 border-b p-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">
+          Variants
+        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Remove all variants"
+              className="size-6 text-muted-foreground hover:text-destructive"
+              onClick={onRemoveAll}
+            >
+              <Trash01 size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Remove all variants</TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="space-y-0.5">
+        {variants.map((variant) => (
+          <VariantRow
+            key={`${variant.label}-${variant.index}`}
+            variant={variant}
+            selected={variant.index === selectedIndex}
+            canDelete={canDelete}
+            onSelect={() => onSelect(variant.index)}
+            onDuplicate={() => onDuplicate(variant.index)}
+            onDelete={() => onDelete(variant.index)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/section-variant-list.tsx
@@ -50,6 +50,7 @@ function VariantRow({
       tabIndex={0}
       onClick={onSelect}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onSelect();

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -171,7 +171,7 @@ describe("section-variants", () => {
 
   it("isDefaultVariantRule treats always matchers as default", () => {
     expect(isDefaultVariantRule(undefined)).toBe(false);
-    expect(isDefaultVariantRule({})).toBe(false);
+    expect(isDefaultVariantRule({})).toBe(true);
     expect(
       isDefaultVariantRule({ __resolveType: "website/matchers/always.ts" }),
     ).toBe(true);

--- a/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "bun:test";
+import {
+  deleteMultivariateSectionVariant,
+  duplicateMultivariateSectionVariant,
+  flattenMultivariateSection,
+  getMultivariateSectionObject,
+  isDefaultVariantRule,
+  parseSectionFlagVariants,
+  pickVariantToKeepIndex,
+  unwrapVariantSectionValue,
+  updateMultivariateSectionVariantValue,
+  writeVariantSectionValue,
+} from "./section-variants";
+
+describe("section-variants", () => {
+  it("getMultivariateSectionObject unwraps lazy multivariate sections", () => {
+    const raw = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: {
+        __resolveType: "website/flags/multivariate/section.ts",
+        variants: [],
+      },
+    };
+
+    expect(
+      getMultivariateSectionObject(raw, {
+        isLazy: true,
+        isMultivariate: true,
+      })?.__resolveType,
+    ).toBe("website/flags/multivariate/section.ts");
+  });
+
+  it("parseSectionFlagVariants labels variants from matcher rules", () => {
+    const mvObj = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: { __resolveType: "site/sections/Hero.tsx" },
+        },
+        {
+          rule: {
+            __resolveType: "website/matchers/device.ts",
+            mobile: true,
+          },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "Mobile" },
+        },
+      ],
+    };
+
+    const variants = parseSectionFlagVariants(mvObj, (rule) =>
+      rule?.__resolveType === "website/matchers/device.ts"
+        ? "Mobile"
+        : "Default",
+    );
+
+    expect(variants).toHaveLength(2);
+    expect(variants[0]?.label).toBe("Default");
+    expect(variants[1]?.label).toBe("Mobile");
+  });
+
+  it("unwrapVariantSectionValue reads inline and lazy variant payloads", () => {
+    const decofile = {
+      Header: {
+        __resolveType: "site/sections/Header.tsx",
+        title: "Global header",
+      },
+    };
+
+    expect(
+      unwrapVariantSectionValue(
+        { __resolveType: "site/sections/Hero.tsx", title: "Hero" },
+        decofile,
+      )?.resolveType,
+    ).toBe("site/sections/Hero.tsx");
+
+    expect(
+      unwrapVariantSectionValue(
+        {
+          __resolveType: "website/sections/Rendering/Lazy.tsx",
+          section: { __resolveType: "Header" },
+        },
+        decofile,
+      )?.data.title,
+    ).toBe("Global header");
+  });
+
+  it("writeVariantSectionValue preserves lazy wrappers", () => {
+    const original = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: { __resolveType: "site/sections/Hero.tsx", title: "A" },
+    };
+
+    expect(
+      writeVariantSectionValue(original, {
+        __resolveType: "site/sections/Hero.tsx",
+        title: "B",
+      }),
+    ).toEqual({
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: { __resolveType: "site/sections/Hero.tsx", title: "B" },
+    });
+  });
+
+  it("updateMultivariateSectionVariantValue updates one variant value", () => {
+    const mvObj = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          value: { __resolveType: "site/sections/Hero.tsx", title: "A" },
+        },
+        {
+          value: { __resolveType: "site/sections/Hero.tsx", title: "B" },
+        },
+      ],
+    };
+
+    const updated = updateMultivariateSectionVariantValue(mvObj, 1, {
+      __resolveType: "site/sections/Hero.tsx",
+      title: "Updated",
+    }) as {
+      variants: Array<{ value: { title: string } }>;
+    };
+
+    expect(updated.variants[0]?.value.title).toBe("A");
+    expect(updated.variants[1]?.value.title).toBe("Updated");
+  });
+
+  it("duplicateMultivariateSectionVariant inserts a clone after the source", () => {
+    const mvObj = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "A" },
+        },
+        {
+          rule: {
+            __resolveType: "website/matchers/device.ts",
+            mobile: true,
+          },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "B" },
+        },
+      ],
+    };
+
+    const updated = duplicateMultivariateSectionVariant(mvObj, 0) as {
+      variants: Array<{ value: { title: string } }>;
+    };
+
+    expect(updated.variants).toHaveLength(3);
+    expect(updated.variants[0]?.value.title).toBe("A");
+    expect(updated.variants[1]?.value.title).toBe("A");
+    expect(updated.variants[2]?.value.title).toBe("B");
+  });
+
+  it("deleteMultivariateSectionVariant removes a variant but keeps at least one", () => {
+    const mvObj = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [{ value: { title: "A" } }, { value: { title: "B" } }],
+    };
+
+    const updated = deleteMultivariateSectionVariant(mvObj, 1) as {
+      variants: Array<{ value: { title: string } }>;
+    };
+
+    expect(updated.variants).toHaveLength(1);
+    expect(updated.variants[0]?.value.title).toBe("A");
+    expect(deleteMultivariateSectionVariant(updated, 0)).toBeNull();
+  });
+
+  it("isDefaultVariantRule treats always matchers as default", () => {
+    expect(isDefaultVariantRule(undefined)).toBe(false);
+    expect(isDefaultVariantRule({})).toBe(false);
+    expect(
+      isDefaultVariantRule({ __resolveType: "website/matchers/always.ts" }),
+    ).toBe(true);
+    expect(
+      isDefaultVariantRule({
+        __resolveType: "website/matchers/device.ts",
+        mobile: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("pickVariantToKeepIndex prefers default and falls back to last", () => {
+    const mvObj = {
+      variants: [
+        {
+          rule: {
+            __resolveType: "website/matchers/device.ts",
+            mobile: true,
+          },
+          value: { title: "Mobile" },
+        },
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: { title: "Default" },
+        },
+      ],
+    };
+
+    expect(pickVariantToKeepIndex(mvObj)).toBe(1);
+
+    const withoutDefault = {
+      variants: [{ value: { title: "A" } }, { value: { title: "B" } }],
+    };
+    expect(pickVariantToKeepIndex(withoutDefault)).toBe(1);
+  });
+
+  it("flattenMultivariateSection keeps default variant and preserves lazy wrappers", () => {
+    const mvObj = {
+      __resolveType: "website/flags/multivariate/section.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/device.ts", mobile: true },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "Mobile" },
+        },
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: { __resolveType: "site/sections/Hero.tsx", title: "Default" },
+        },
+      ],
+    };
+
+    expect(
+      flattenMultivariateSection(mvObj as never, { isLazy: false }, mvObj),
+    ).toEqual({
+      __resolveType: "site/sections/Hero.tsx",
+      title: "Default",
+    });
+
+    const lazyRaw = {
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: mvObj,
+    };
+
+    expect(
+      flattenMultivariateSection(lazyRaw as never, { isLazy: true }, mvObj),
+    ).toEqual({
+      __resolveType: "website/sections/Rendering/Lazy.tsx",
+      section: {
+        __resolveType: "site/sections/Hero.tsx",
+        title: "Default",
+      },
+    });
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -47,11 +47,6 @@ export function flattenMultivariateSection(
   if (!keptValue) return null;
 
   const nextValue = structuredClone(keptValue);
-  const keptRt = (nextValue.__resolveType as string) ?? "";
-
-  if (isLazyResolveType(keptRt)) {
-    return nextValue as RawSection;
-  }
 
   if (parsed.isLazy) {
     return {

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -1,14 +1,7 @@
 import { isLazyResolveType } from "./section-lazy";
+import type { RawSection } from "./section-types";
 
-interface RawSection {
-  __resolveType: string;
-  section?: { __resolveType?: string; [key: string]: unknown };
-  variants?: Array<{
-    value?: Record<string, unknown>;
-    rule?: Record<string, unknown>;
-  }>;
-  [key: string]: unknown;
-}
+export type { RawSection };
 
 export interface SectionFlagVariant {
   label: string;
@@ -24,7 +17,7 @@ const DEFAULT_MATCHER_TYPES = [
 export function isDefaultVariantRule(rule?: Record<string, unknown>): boolean {
   if (!rule) return false;
   const rt = (rule.__resolveType as string) ?? "";
-  if (rt === "") return false;
+  if (rt === "") return Object.keys(rule).length === 0;
   return DEFAULT_MATCHER_TYPES.includes(rt) || rt.includes("always");
 }
 

--- a/apps/mesh/src/web/components/sections-editor/section-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-variants.ts
@@ -1,0 +1,232 @@
+import { isLazyResolveType } from "./section-lazy";
+
+interface RawSection {
+  __resolveType: string;
+  section?: { __resolveType?: string; [key: string]: unknown };
+  variants?: Array<{
+    value?: Record<string, unknown>;
+    rule?: Record<string, unknown>;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface SectionFlagVariant {
+  label: string;
+  value: Record<string, unknown>;
+  rule?: Record<string, unknown>;
+}
+
+const DEFAULT_MATCHER_TYPES = [
+  "website/matchers/always.ts",
+  "$live/matchers/MatchAlways.ts",
+];
+
+export function isDefaultVariantRule(rule?: Record<string, unknown>): boolean {
+  if (!rule) return false;
+  const rt = (rule.__resolveType as string) ?? "";
+  if (rt === "") return false;
+  return DEFAULT_MATCHER_TYPES.includes(rt) || rt.includes("always");
+}
+
+export function pickVariantToKeepIndex(mvObj: Record<string, unknown>): number {
+  const variants = (mvObj.variants as Array<Record<string, unknown>>) ?? [];
+  if (variants.length === 0) return -1;
+
+  const defaultIndex = variants.findIndex((variant) =>
+    isDefaultVariantRule(variant.rule as Record<string, unknown> | undefined),
+  );
+  if (defaultIndex !== -1) return defaultIndex;
+  return variants.length - 1;
+}
+
+export function flattenMultivariateSection(
+  raw: RawSection,
+  parsed: { isLazy?: boolean },
+  mvObj: Record<string, unknown>,
+): RawSection | null {
+  const variants = (mvObj.variants as Array<Record<string, unknown>>) ?? [];
+  if (variants.length === 0) return null;
+
+  const keepIndex = pickVariantToKeepIndex(mvObj);
+  const keptValue = variants[keepIndex]?.value as
+    | Record<string, unknown>
+    | undefined;
+  if (!keptValue) return null;
+
+  const nextValue = structuredClone(keptValue);
+  const keptRt = (nextValue.__resolveType as string) ?? "";
+
+  if (isLazyResolveType(keptRt)) {
+    return nextValue as RawSection;
+  }
+
+  if (parsed.isLazy) {
+    return {
+      ...raw,
+      section: nextValue,
+    } as RawSection;
+  }
+
+  return nextValue as RawSection;
+}
+
+export function getMultivariateSectionObject(
+  raw: RawSection,
+  parsed: { isLazy?: boolean; isMultivariate?: boolean },
+): Record<string, unknown> | null {
+  if (!parsed.isMultivariate) return null;
+  if (parsed.isLazy) {
+    const inner = raw.section as Record<string, unknown> | undefined;
+    return inner ?? null;
+  }
+  return raw as Record<string, unknown>;
+}
+
+export function parseSectionFlagVariants(
+  mvObj: Record<string, unknown>,
+  formatMatcher: (rule?: Record<string, unknown>) => string,
+): SectionFlagVariant[] {
+  if (!Array.isArray(mvObj.variants)) return [];
+
+  return (mvObj.variants as Array<Record<string, unknown>>).map(
+    (variant, index) => ({
+      label:
+        formatMatcher(variant.rule as Record<string, unknown> | undefined) ||
+        `Variant ${index + 1}`,
+      value: (variant.value ?? {}) as Record<string, unknown>,
+      rule: variant.rule as Record<string, unknown> | undefined,
+    }),
+  );
+}
+
+export function unwrapVariantSectionValue(
+  value: Record<string, unknown>,
+  decofile: Record<string, unknown>,
+): { data: Record<string, unknown>; resolveType: string } | null {
+  const rt = (value.__resolveType as string) ?? "";
+  if (!rt) return null;
+
+  if (isLazyResolveType(rt)) {
+    const inner = (value.section as Record<string, unknown>) ?? value;
+    const innerRt = (inner.__resolveType as string) ?? rt;
+
+    if (!innerRt.includes("/") && innerRt in decofile) {
+      const blockData = (decofile[innerRt] as Record<string, unknown>) ?? {};
+      return {
+        data: { ...blockData },
+        resolveType: (blockData.__resolveType as string) ?? innerRt,
+      };
+    }
+
+    return {
+      data: { ...inner },
+      resolveType: innerRt,
+    };
+  }
+
+  if (!rt.includes("/") && rt in decofile) {
+    const blockData = (decofile[rt] as Record<string, unknown>) ?? {};
+    return {
+      data: { ...blockData },
+      resolveType: (blockData.__resolveType as string) ?? rt,
+    };
+  }
+
+  return {
+    data: { ...value },
+    resolveType: rt,
+  };
+}
+
+export function writeVariantSectionValue(
+  originalValue: Record<string, unknown>,
+  nextValue: Record<string, unknown>,
+): Record<string, unknown> {
+  const rt = (originalValue.__resolveType as string) ?? "";
+  if (isLazyResolveType(rt)) {
+    return {
+      ...originalValue,
+      section: nextValue,
+    };
+  }
+  return nextValue;
+}
+
+export function rebuildSectionWithMultivariate(
+  raw: RawSection,
+  parsed: { isLazy?: boolean },
+  mvObj: Record<string, unknown>,
+): RawSection {
+  if (parsed.isLazy) {
+    return {
+      ...raw,
+      section: mvObj,
+    } as RawSection;
+  }
+  return mvObj as RawSection;
+}
+
+export function updateMultivariateSectionVariantValue(
+  mvObj: Record<string, unknown>,
+  variantIndex: number,
+  nextValue: Record<string, unknown>,
+): Record<string, unknown> {
+  const variants = [
+    ...((mvObj.variants as Array<Record<string, unknown>>) ?? []),
+  ];
+  const currentVariant = variants[variantIndex];
+  if (!currentVariant) return mvObj;
+
+  const originalValue = (currentVariant.value ?? {}) as Record<string, unknown>;
+  variants[variantIndex] = {
+    ...currentVariant,
+    value: writeVariantSectionValue(originalValue, nextValue),
+  };
+
+  return { ...mvObj, variants };
+}
+
+export function updateMultivariateSectionVariantRule(
+  mvObj: Record<string, unknown>,
+  variantIndex: number,
+  nextRule: Record<string, unknown>,
+): Record<string, unknown> {
+  const variants = [
+    ...((mvObj.variants as Array<Record<string, unknown>>) ?? []),
+  ];
+  if (!variants[variantIndex]) return mvObj;
+
+  variants[variantIndex] = {
+    ...variants[variantIndex],
+    rule: nextRule,
+  };
+
+  return { ...mvObj, variants };
+}
+
+export function duplicateMultivariateSectionVariant(
+  mvObj: Record<string, unknown>,
+  variantIndex: number,
+): Record<string, unknown> {
+  const variants = [
+    ...((mvObj.variants as Array<Record<string, unknown>>) ?? []),
+  ];
+  const source = variants[variantIndex];
+  if (!source) return mvObj;
+
+  variants.splice(variantIndex + 1, 0, structuredClone(source));
+  return { ...mvObj, variants };
+}
+
+export function deleteMultivariateSectionVariant(
+  mvObj: Record<string, unknown>,
+  variantIndex: number,
+): Record<string, unknown> | null {
+  const variants = [
+    ...((mvObj.variants as Array<Record<string, unknown>>) ?? []),
+  ];
+  if (variants.length <= 1) return null;
+
+  variants.splice(variantIndex, 1);
+  return { ...mvObj, variants };
+}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -624,6 +624,7 @@ export function SectionsEditor({
     sectionIndex: number,
   ) => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    const targetSectionVariantIndex = latestRef.current.sectionVariantIndex;
 
     debounceRef.current = setTimeout(() => {
       const {
@@ -633,7 +634,6 @@ export function SectionsEditor({
         activePageKey: latestPageKey,
         pageVariants: latestVariants,
         variantIndex: latestVariantIndex,
-        sectionVariantIndex: latestSectionVariantIndex,
       } = latestRef.current;
       const rawSection = latestRawSections[sectionIndex];
       if (!rawSection) return;
@@ -669,7 +669,7 @@ export function SectionsEditor({
 
         const updatedMvObj = updateMultivariateSectionVariantValue(
           mvObj,
-          latestSectionVariantIndex,
+          targetSectionVariantIndex,
           nextValue,
         );
         updatedSections[sectionIndex] = rebuildSectionWithMultivariate(
@@ -1149,6 +1149,12 @@ export function SectionsEditor({
     if (sectionRuleDebounceRef.current) {
       clearTimeout(sectionRuleDebounceRef.current);
     }
+    const {
+      selectedSectionIndex: targetSectionIndex,
+      sectionVariantIndex: targetSectionVariantIndex,
+    } = latestRef.current;
+    if (targetSectionIndex === null) return;
+
     sectionRuleDebounceRef.current = setTimeout(() => {
       const {
         rawSections: latestRawSections,
@@ -1157,13 +1163,11 @@ export function SectionsEditor({
         activePageKey: latestPageKey,
         pageVariants: latestVariants,
         variantIndex: latestVariantIndex,
-        sectionVariantIndex: latestSectionVariantIndex,
-        selectedSectionIndex: latestSelectedSectionIndex,
       } = latestRef.current;
-      if (!latestPageKey || latestSelectedSectionIndex === null) return;
+      if (!latestPageKey) return;
 
-      const rawSection = latestRawSections[latestSelectedSectionIndex];
-      const parsed = latestParsedSections[latestSelectedSectionIndex];
+      const rawSection = latestRawSections[targetSectionIndex];
+      const parsed = latestParsedSections[targetSectionIndex];
       if (!rawSection || !parsed?.isMultivariate) return;
 
       const mvObj = getMultivariateSectionObject(rawSection, parsed);
@@ -1171,12 +1175,15 @@ export function SectionsEditor({
 
       const updatedMvObj = updateMultivariateSectionVariantRule(
         mvObj,
-        latestSectionVariantIndex,
+        targetSectionVariantIndex,
         newRule,
       );
       const updatedSections = [...latestRawSections];
-      updatedSections[latestSelectedSectionIndex] =
-        rebuildSectionWithMultivariate(rawSection, parsed, updatedMvObj);
+      updatedSections[targetSectionIndex] = rebuildSectionWithMultivariate(
+        rawSection,
+        parsed,
+        updatedMvObj,
+      );
 
       const fullPageData = buildPageDataWithSections(
         latestDecofile,

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -16,13 +16,9 @@ import { resolveSchema } from "./resolve-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
-import {
-  extractSectionCatalog,
-  findLivePageResolveType,
-  findSiteThemeBlock,
-  type SectionCatalogEntry,
-} from "./section-catalog";
+import type { SectionCatalogEntry } from "./section-catalog";
 import { SectionVariantList } from "./section-variant-list";
+import { ALWAYS_MATCHER_RESOLVE_TYPE, type RawSection } from "./section-types";
 import {
   buildPageDataWithSections,
   cloneSection,
@@ -40,16 +36,6 @@ import {
   updateMultivariateSectionVariantRule,
   updateMultivariateSectionVariantValue,
 } from "./section-variants";
-
-interface RawSection {
-  __resolveType: string;
-  section?: { __resolveType?: string; [key: string]: unknown };
-  variants?: Array<{
-    value?: Record<string, unknown>;
-    rule?: Record<string, unknown>;
-  }>;
-  [key: string]: unknown;
-}
 
 const AUTOSAVE_DELAY = 700;
 
@@ -853,6 +839,9 @@ export function SectionsEditor({
     if (!section) return;
     const updatedSections = [...rawSections];
     updatedSections.splice(index + 1, 0, cloneSection(section));
+    if (selectedSectionIndex !== null && selectedSectionIndex > index) {
+      setSelectedSectionIndex(selectedSectionIndex + 1);
+    }
     savePageSections(updatedSections);
   };
 
@@ -1096,10 +1085,7 @@ export function SectionsEditor({
   }
 
   const availableMatchers = meta ? extractMatchers(meta) : [];
-  const sectionCatalog =
-    meta && decofile ? extractSectionCatalog(meta, decofile) : [];
-  const livePageResolveType = meta ? findLivePageResolveType(meta) : "";
-  const siteTheme = decofile ? findSiteThemeBlock(decofile) : undefined;
+  const canAddSection = !!(previewUrl && meta && decofile);
 
   const ruleSchema =
     ruleResolveType && meta ? resolveSchema(ruleResolveType, meta) : null;
@@ -1145,7 +1131,7 @@ export function SectionsEditor({
     setRuleResolveType(newRt);
     const newRule: Record<string, unknown> = newRt
       ? { __resolveType: newRt }
-      : {};
+      : { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE };
     setRuleFormValue({});
     scheduleRuleSave(newRule);
   };
@@ -1213,7 +1199,11 @@ export function SectionsEditor({
   const handleSectionMatcherTypeChange = (newRt: string) => {
     setSectionRuleResolveType(newRt);
     setSectionRuleFormValue({});
-    scheduleSectionRuleSave(newRt ? { __resolveType: newRt } : {});
+    scheduleSectionRuleSave(
+      newRt
+        ? { __resolveType: newRt }
+        : { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE },
+    );
   };
 
   const handleSectionRuleFormChange = (val: unknown) => {
@@ -1479,6 +1469,7 @@ export function SectionsEditor({
               onDuplicate={handleDuplicateSection}
               onMakeReusable={setMakeReusableIndex}
               onAddSection={() => setAddSectionOpen(true)}
+              canAddSection={canAddSection}
             />
           </div>
         </ScrollArea>
@@ -1498,14 +1489,13 @@ export function SectionsEditor({
         onSubmit={handleMakeReusableSubmit}
       />
 
-      {previewUrl && livePageResolveType && (
+      {previewUrl && (
         <AddSectionModal
           open={addSectionOpen}
           onOpenChange={setAddSectionOpen}
-          sections={sectionCatalog}
+          meta={meta}
+          decofile={decofile}
           previewBaseUrl={previewUrl}
-          livePageResolveType={livePageResolveType}
-          siteTheme={siteTheme}
           onSelect={handleAddSection}
         />
       )}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -7,19 +7,39 @@ import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
 import { useSaveBlock } from "./use-save-block";
 import { extractPages } from "./page-list";
-import { SectionList, parseSections, isLazyResolveType } from "./section-list";
+import { SectionList, parseSections } from "./section-list";
+import { isLazyResolveType } from "./section-lazy";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
 import { MakeReusableModal } from "./make-reusable-modal";
+import { AddSectionModal } from "./add-section-modal";
+import {
+  extractSectionCatalog,
+  findLivePageResolveType,
+  findSiteThemeBlock,
+  type SectionCatalogEntry,
+} from "./section-catalog";
+import { SectionVariantList } from "./section-variant-list";
 import {
   buildPageDataWithSections,
   cloneSection,
   suggestBlockId,
   validateBlockId,
 } from "./page-sections";
+import {
+  deleteMultivariateSectionVariant,
+  duplicateMultivariateSectionVariant,
+  flattenMultivariateSection,
+  getMultivariateSectionObject,
+  parseSectionFlagVariants,
+  rebuildSectionWithMultivariate,
+  unwrapVariantSectionValue,
+  updateMultivariateSectionVariantRule,
+  updateMultivariateSectionVariantValue,
+} from "./section-variants";
 
 interface RawSection {
   __resolveType: string;
@@ -352,6 +372,7 @@ export function SectionsEditor({
   virtualMcpId,
   branch,
   previewReady = true,
+  previewUrl,
   currentPath,
   externalSelectedIndex,
   onSaved,
@@ -361,6 +382,8 @@ export function SectionsEditor({
   branch: string;
   /** When false, waits for the sandbox dev server before preview-fetch. */
   previewReady?: boolean;
+  /** Sandbox preview base URL used for section gallery previews. */
+  previewUrl?: string;
   currentPath: string;
   /** Section index selected via click-through from the preview iframe. */
   externalSelectedIndex?: number | null;
@@ -398,6 +421,15 @@ export function SectionsEditor({
   const [makeReusableIndex, setMakeReusableIndex] = useState<number | null>(
     null,
   );
+  const [addSectionOpen, setAddSectionOpen] = useState(false);
+  const [activeSectionVariantIndex, setActiveSectionVariantIndex] = useState(0);
+  const [sectionRuleFormValue, setSectionRuleFormValue] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const [sectionRuleResolveType, setSectionRuleResolveType] = useState<
+    string | null
+  >(null);
 
   // Reset form state when the active page changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -409,6 +441,9 @@ export function SectionsEditor({
     setActiveVariantIndex(0);
     setRuleFormValue(null);
     setRuleResolveType(null);
+    setActiveSectionVariantIndex(0);
+    setSectionRuleFormValue(null);
+    setSectionRuleResolveType(null);
     setFieldBreadcrumbs([]);
     setFormResetKey((key) => key + 1);
   }
@@ -417,6 +452,9 @@ export function SectionsEditor({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pageDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sectionRuleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   // Accumulates pending page header field changes to avoid losing edits
   const pendingPageFieldsRef = useRef<Record<string, string>>({});
 
@@ -429,6 +467,8 @@ export function SectionsEditor({
     activePageKey: string | null;
     pageVariants: PageVariant[];
     variantIndex: number;
+    sectionVariantIndex: number;
+    selectedSectionIndex: number | null;
   }>({
     rawSections: [],
     parsedSections: [],
@@ -436,6 +476,8 @@ export function SectionsEditor({
     activePageKey: null,
     pageVariants: [],
     variantIndex: 0,
+    sectionVariantIndex: 0,
+    selectedSectionIndex: null,
   });
 
   if (!previewReady || decofileLoading || metaLoading) {
@@ -482,6 +524,46 @@ export function SectionsEditor({
     activePageKey,
     pageVariants,
     variantIndex: safeVariantIndex,
+    sectionVariantIndex: activeSectionVariantIndex,
+    selectedSectionIndex,
+  };
+
+  const applySectionVariant = (
+    rawSection: RawSection,
+    parsed: ParsedSection,
+    variantIndex: number,
+  ) => {
+    const mvObj = getMultivariateSectionObject(rawSection, parsed);
+    if (!mvObj) {
+      setFormValue(null);
+      setActiveResolveType(null);
+      setSectionRuleResolveType(null);
+      setSectionRuleFormValue(null);
+      return;
+    }
+
+    const variants = parseSectionFlagVariants(mvObj, formatMatcher);
+    const variant = variants[variantIndex];
+    if (!variant) {
+      setFormValue(null);
+      setActiveResolveType(null);
+      setSectionRuleResolveType(null);
+      setSectionRuleFormValue(null);
+      return;
+    }
+
+    const unwrapped = unwrapVariantSectionValue(variant.value, decofile);
+    setFormValue(unwrapped?.data ?? null);
+    setActiveResolveType(unwrapped?.resolveType ?? null);
+
+    const ruleRt = (variant.rule?.__resolveType as string) ?? "";
+    setSectionRuleResolveType(ruleRt);
+    if (variant.rule) {
+      const { __resolveType: _, ...ruleData } = variant.rule;
+      setSectionRuleFormValue(ruleData);
+    } else {
+      setSectionRuleFormValue(null);
+    }
   };
 
   // Auto-select section when parent signals a click-through from the preview.
@@ -494,14 +576,23 @@ export function SectionsEditor({
       const rawSection = rawSections[externalSelectedIndex];
       const parsed = parsedSections[externalSelectedIndex];
       if (rawSection && parsed) {
-        const unwrapped = unwrapSection(rawSection, parsed, decofile);
         setSelectedSectionIndex(externalSelectedIndex);
-        if (!unwrapped) {
-          setFormValue(null);
-          setActiveResolveType(null);
+        setActiveSectionVariantIndex(0);
+        setFieldBreadcrumbs([]);
+        setFormResetKey((key) => key + 1);
+        if (parsed.isMultivariate) {
+          applySectionVariant(rawSection, parsed, 0);
         } else {
-          setFormValue(unwrapped.data);
-          setActiveResolveType(unwrapped.resolveType);
+          const unwrapped = unwrapSection(rawSection, parsed, decofile);
+          if (!unwrapped) {
+            setFormValue(null);
+            setActiveResolveType(null);
+          } else {
+            setFormValue(unwrapped.data);
+            setActiveResolveType(unwrapped.resolveType);
+          }
+          setSectionRuleResolveType(null);
+          setSectionRuleFormValue(null);
         }
       }
     }
@@ -535,6 +626,9 @@ export function SectionsEditor({
     setSelectedSectionIndex(null);
     setFormValue(null);
     setActiveResolveType(null);
+    setActiveSectionVariantIndex(0);
+    setSectionRuleFormValue(null);
+    setSectionRuleResolveType(null);
     setFieldBreadcrumbs([]);
     setFormResetKey((key) => key + 1);
   };
@@ -553,6 +647,7 @@ export function SectionsEditor({
         activePageKey: latestPageKey,
         pageVariants: latestVariants,
         variantIndex: latestVariantIndex,
+        sectionVariantIndex: latestSectionVariantIndex,
       } = latestRef.current;
       const rawSection = latestRawSections[sectionIndex];
       if (!rawSection) return;
@@ -582,7 +677,21 @@ export function SectionsEditor({
       };
       const updatedSections = [...latestRawSections];
 
-      if (parsed.isHidden) {
+      if (parsed.isMultivariate) {
+        const mvObj = getMultivariateSectionObject(rawSection, parsed);
+        if (!mvObj || !latestPageKey) return;
+
+        const updatedMvObj = updateMultivariateSectionVariantValue(
+          mvObj,
+          latestSectionVariantIndex,
+          nextValue,
+        );
+        updatedSections[sectionIndex] = rebuildSectionWithMultivariate(
+          rawSection,
+          parsed,
+          updatedMvObj,
+        );
+      } else if (parsed.isHidden) {
         // Re-wrap into multivariate+never structure
         const isLazy = isLazyResolveType(rawSection.__resolveType);
         const mvObj = isLazy
@@ -646,22 +755,31 @@ export function SectionsEditor({
 
   const handleSelectSection = (index: number) => {
     setSelectedSectionIndex(index);
+    setActiveSectionVariantIndex(0);
     setFieldBreadcrumbs([]);
     setFormResetKey((key) => key + 1);
     const rawSection = rawSections[index];
     const parsed = parsedSections[index];
     if (!rawSection || !parsed) return;
 
+    if (parsed.isMultivariate) {
+      applySectionVariant(rawSection, parsed, 0);
+      return;
+    }
+
     const unwrapped = unwrapSection(rawSection, parsed, decofile);
     if (!unwrapped) {
-      // Multivariate — no form editing for now
       setFormValue(null);
       setActiveResolveType(null);
+      setSectionRuleResolveType(null);
+      setSectionRuleFormValue(null);
       return;
     }
 
     setFormValue(unwrapped.data);
     setActiveResolveType(unwrapped.resolveType);
+    setSectionRuleResolveType(null);
+    setSectionRuleFormValue(null);
   };
 
   const handleFormChange = (val: unknown) => {
@@ -738,6 +856,175 @@ export function SectionsEditor({
     savePageSections(updatedSections);
   };
 
+  const handleAddSection = (entry: SectionCatalogEntry) => {
+    if (!activePageKey) return;
+
+    const updatedSections = [
+      ...rawSections,
+      { __resolveType: entry.resolveType } as RawSection,
+    ];
+    const newIndex = updatedSections.length - 1;
+
+    savePageSections(updatedSections, {
+      onSuccess: () => {
+        setAddSectionOpen(false);
+        setSelectedSectionIndex(newIndex);
+        setActiveSectionVariantIndex(0);
+        setFieldBreadcrumbs([]);
+        setFormResetKey((key) => key + 1);
+
+        const rawSection = updatedSections[newIndex];
+        const parsed = parseSections(updatedSections, decofile)[newIndex];
+        if (!rawSection || !parsed) return;
+
+        if (parsed.isMultivariate) {
+          applySectionVariant(rawSection, parsed, 0);
+          return;
+        }
+
+        const unwrapped = unwrapSection(rawSection, parsed, decofile);
+        if (!unwrapped) {
+          setFormValue(null);
+          setActiveResolveType(null);
+          setSectionRuleResolveType(null);
+          setSectionRuleFormValue(null);
+          return;
+        }
+
+        setFormValue(unwrapped.data);
+        setActiveResolveType(unwrapped.resolveType);
+        setSectionRuleResolveType(null);
+        setSectionRuleFormValue(null);
+      },
+    });
+  };
+
+  const handleSelectSectionVariant = (variantIndex: number) => {
+    if (selectedSectionIndex === null) return;
+    const rawSection = rawSections[selectedSectionIndex];
+    const parsed = parsedSections[selectedSectionIndex];
+    if (!rawSection || !parsed?.isMultivariate) return;
+
+    setActiveSectionVariantIndex(variantIndex);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+    applySectionVariant(rawSection, parsed, variantIndex);
+  };
+
+  const handleDeleteSectionVariant = (variantIndex: number) => {
+    if (selectedSectionIndex === null || !activePageKey) return;
+    const rawSection = rawSections[selectedSectionIndex];
+    const parsed = parsedSections[selectedSectionIndex];
+    if (!rawSection || !parsed?.isMultivariate) return;
+
+    const mvObj = getMultivariateSectionObject(rawSection, parsed);
+    if (!mvObj) return;
+
+    const updatedMvObj = deleteMultivariateSectionVariant(mvObj, variantIndex);
+    if (!updatedMvObj) {
+      toast.error("Cannot delete the only variant.");
+      return;
+    }
+
+    const updatedSections = [...rawSections];
+    updatedSections[selectedSectionIndex] = rebuildSectionWithMultivariate(
+      rawSection,
+      parsed,
+      updatedMvObj,
+    );
+
+    const variants = updatedMvObj.variants as unknown[];
+    let nextIndex = activeSectionVariantIndex;
+    if (variantIndex === activeSectionVariantIndex) {
+      nextIndex = Math.min(variantIndex, variants.length - 1);
+    } else if (variantIndex < activeSectionVariantIndex) {
+      nextIndex = activeSectionVariantIndex - 1;
+    }
+
+    setActiveSectionVariantIndex(nextIndex);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+    applySectionVariant(
+      updatedSections[selectedSectionIndex],
+      parsed,
+      nextIndex,
+    );
+    savePageSections(updatedSections);
+  };
+
+  const handleDuplicateSectionVariant = (variantIndex: number) => {
+    if (selectedSectionIndex === null || !activePageKey) return;
+    const rawSection = rawSections[selectedSectionIndex];
+    const parsed = parsedSections[selectedSectionIndex];
+    if (!rawSection || !parsed?.isMultivariate) return;
+
+    const mvObj = getMultivariateSectionObject(rawSection, parsed);
+    if (!mvObj) return;
+
+    const updatedMvObj = duplicateMultivariateSectionVariant(
+      mvObj,
+      variantIndex,
+    );
+    const updatedSections = [...rawSections];
+    updatedSections[selectedSectionIndex] = rebuildSectionWithMultivariate(
+      rawSection,
+      parsed,
+      updatedMvObj,
+    );
+
+    const nextIndex = variantIndex + 1;
+    setActiveSectionVariantIndex(nextIndex);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+    applySectionVariant(
+      updatedSections[selectedSectionIndex],
+      parsed,
+      nextIndex,
+    );
+    savePageSections(updatedSections);
+  };
+
+  const handleRemoveAllSectionVariants = () => {
+    if (selectedSectionIndex === null || !activePageKey) return;
+    const rawSection = rawSections[selectedSectionIndex];
+    const parsed = parsedSections[selectedSectionIndex];
+    if (!rawSection || !parsed?.isMultivariate) return;
+
+    const mvObj = getMultivariateSectionObject(rawSection, parsed);
+    if (!mvObj) return;
+
+    const flattened = flattenMultivariateSection(rawSection, parsed, mvObj);
+    if (!flattened) {
+      toast.error("Could not remove variants.");
+      return;
+    }
+
+    const updatedSections = [...rawSections];
+    updatedSections[selectedSectionIndex] = flattened;
+
+    const nextParsed = parseSections(updatedSections, decofile)[
+      selectedSectionIndex
+    ];
+    if (!nextParsed) return;
+
+    setActiveSectionVariantIndex(0);
+    setSectionRuleResolveType(null);
+    setSectionRuleFormValue(null);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+
+    const unwrapped = unwrapSection(flattened, nextParsed, decofile);
+    if (!unwrapped) {
+      setFormValue(null);
+      setActiveResolveType(null);
+    } else {
+      setFormValue(unwrapped.data);
+      setActiveResolveType(unwrapped.resolveType);
+    }
+
+    savePageSections(updatedSections);
+  };
+
   const handleMakeReusableSubmit = async (blockId: string) => {
     if (makeReusableIndex === null || !activePageKey) return;
 
@@ -809,6 +1096,10 @@ export function SectionsEditor({
   }
 
   const availableMatchers = meta ? extractMatchers(meta) : [];
+  const sectionCatalog =
+    meta && decofile ? extractSectionCatalog(meta, decofile) : [];
+  const livePageResolveType = meta ? findLivePageResolveType(meta) : "";
+  const siteTheme = decofile ? findSiteThemeBlock(decofile) : undefined;
 
   const ruleSchema =
     ruleResolveType && meta ? resolveSchema(ruleResolveType, meta) : null;
@@ -868,6 +1159,72 @@ export function SectionsEditor({
     scheduleRuleSave(newRule);
   };
 
+  const scheduleSectionRuleSave = (newRule: Record<string, unknown>) => {
+    if (sectionRuleDebounceRef.current) {
+      clearTimeout(sectionRuleDebounceRef.current);
+    }
+    sectionRuleDebounceRef.current = setTimeout(() => {
+      const {
+        rawSections: latestRawSections,
+        parsedSections: latestParsedSections,
+        decofile: latestDecofile,
+        activePageKey: latestPageKey,
+        pageVariants: latestVariants,
+        variantIndex: latestVariantIndex,
+        sectionVariantIndex: latestSectionVariantIndex,
+        selectedSectionIndex: latestSelectedSectionIndex,
+      } = latestRef.current;
+      if (!latestPageKey || latestSelectedSectionIndex === null) return;
+
+      const rawSection = latestRawSections[latestSelectedSectionIndex];
+      const parsed = latestParsedSections[latestSelectedSectionIndex];
+      if (!rawSection || !parsed?.isMultivariate) return;
+
+      const mvObj = getMultivariateSectionObject(rawSection, parsed);
+      if (!mvObj) return;
+
+      const updatedMvObj = updateMultivariateSectionVariantRule(
+        mvObj,
+        latestSectionVariantIndex,
+        newRule,
+      );
+      const updatedSections = [...latestRawSections];
+      updatedSections[latestSelectedSectionIndex] =
+        rebuildSectionWithMultivariate(rawSection, parsed, updatedMvObj);
+
+      const fullPageData = buildPageDataWithSections(
+        latestDecofile,
+        latestPageKey,
+        updatedSections,
+        latestVariantIndex,
+        latestVariants,
+      );
+
+      saveBlock.mutate(
+        { blockKey: latestPageKey, data: fullPageData },
+        {
+          onSuccess: () => onSaved?.(),
+          onError: (err) => toast.error(`Save failed: ${err.message}`),
+        },
+      );
+    }, AUTOSAVE_DELAY);
+  };
+
+  const handleSectionMatcherTypeChange = (newRt: string) => {
+    setSectionRuleResolveType(newRt);
+    setSectionRuleFormValue({});
+    scheduleSectionRuleSave(newRt ? { __resolveType: newRt } : {});
+  };
+
+  const handleSectionRuleFormChange = (val: unknown) => {
+    const next = val as Record<string, unknown>;
+    setSectionRuleFormValue(next);
+    const newRule: Record<string, unknown> = sectionRuleResolveType
+      ? { __resolveType: sectionRuleResolveType, ...next }
+      : { ...next };
+    scheduleSectionRuleSave(newRule);
+  };
+
   if (!activePage) {
     return (
       <div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">
@@ -880,10 +1237,40 @@ export function SectionsEditor({
     selectedSectionIndex !== null
       ? (parsedSections[selectedSectionIndex] ?? null)
       : null;
-
-  const isEditing = activeSchema && formValue && selectedParsed;
+  const selectedRawSection =
+    selectedSectionIndex !== null ? rawSections[selectedSectionIndex] : null;
+  const sectionMvObj =
+    selectedRawSection && selectedParsed?.isMultivariate
+      ? getMultivariateSectionObject(selectedRawSection, selectedParsed)
+      : null;
+  const sectionFlagVariants = sectionMvObj
+    ? parseSectionFlagVariants(sectionMvObj, formatMatcher)
+    : [];
+  const safeSectionVariantIndex = Math.min(
+    activeSectionVariantIndex,
+    Math.max(sectionFlagVariants.length - 1, 0),
+  );
+  const activeSectionFlagVariant =
+    sectionFlagVariants[safeSectionVariantIndex] ?? null;
+  const isEditingMultivariateSection = selectedParsed?.isMultivariate === true;
+  const isEditingSection =
+    selectedSectionIndex !== null && selectedParsed !== null;
+  const isEditing =
+    isEditingSection &&
+    (isEditingMultivariateSection || !!(activeSchema && formValue));
+  const sectionRuleSchema =
+    sectionRuleResolveType && meta
+      ? resolveSchema(sectionRuleResolveType, meta)
+      : null;
   const editingBreadcrumbs = isEditing
-    ? [activePage.name, selectedParsed.label, ...fieldBreadcrumbs]
+    ? [
+        activePage.name,
+        selectedParsed.label,
+        ...(isEditingMultivariateSection && activeSectionFlagVariant
+          ? [activeSectionFlagVariant.label]
+          : []),
+        ...fieldBreadcrumbs,
+      ]
     : [];
   const exitSectionEditing = () => {
     clearSectionEditing();
@@ -900,7 +1287,14 @@ export function SectionsEditor({
       return;
     }
 
-    setFieldBreadcrumbs(fieldBreadcrumbs.slice(0, index - 1));
+    if (isEditingMultivariateSection && index === 2) {
+      setFieldBreadcrumbs([]);
+      setFormResetKey((key) => key + 1);
+      return;
+    }
+
+    const fieldBase = isEditingMultivariateSection ? 2 : 1;
+    setFieldBreadcrumbs(fieldBreadcrumbs.slice(0, index - fieldBase));
   };
 
   return (
@@ -992,20 +1386,60 @@ export function SectionsEditor({
       {/* Drill-down: section list OR section form */}
       {isEditing ? (
         <ScrollArea className="flex-1 min-h-0">
-          {/* overflow-x-hidden + max-w-full forces internal content to
-              fit the panel width, no matter what nested field misbehaves.
-              ScrollArea's viewport otherwise creates a horizontal
-              scrollbar the moment anything overflows. */}
+          {isEditingMultivariateSection && sectionFlagVariants.length > 0 && (
+            <>
+              <SectionVariantList
+                variants={sectionFlagVariants.map((variant, index) => ({
+                  index,
+                  label: variant.label,
+                }))}
+                selectedIndex={safeSectionVariantIndex}
+                onSelect={handleSelectSectionVariant}
+                onDuplicate={handleDuplicateSectionVariant}
+                onDelete={handleDeleteSectionVariant}
+                onRemoveAll={handleRemoveAllSectionVariants}
+              />
+              {isEditingMultivariateSection && (
+                <div className="px-3 py-3 border-b space-y-2">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Variant rule
+                  </span>
+                  <MatcherPicker
+                    currentRt={sectionRuleResolveType ?? ""}
+                    currentLabel={formatMatcher(activeSectionFlagVariant?.rule)}
+                    matchers={availableMatchers}
+                    onSelect={handleSectionMatcherTypeChange}
+                  />
+                  {sectionRuleSchema && sectionRuleFormValue && (
+                    <div className="pt-1">
+                      <SchemaForm
+                        schema={sectionRuleSchema}
+                        value={sectionRuleFormValue}
+                        onChange={handleSectionRuleFormChange}
+                        basePath=""
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          )}
           <div className="min-w-0 max-w-full overflow-x-hidden p-4">
-            <SchemaForm
-              key={formResetKey}
-              schema={activeSchema}
-              value={formValue}
-              onChange={handleFormChange}
-              basePath=""
-              breadcrumbPath={[]}
-              onBreadcrumbChange={setFieldBreadcrumbs}
-            />
+            {activeSchema && formValue ? (
+              <SchemaForm
+                key={formResetKey}
+                schema={activeSchema}
+                value={formValue}
+                onChange={handleFormChange}
+                basePath=""
+                breadcrumbPath={[]}
+                onBreadcrumbChange={setFieldBreadcrumbs}
+              />
+            ) : (
+              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                No editable fields for this variant.
+              </div>
+            )}
           </div>
         </ScrollArea>
       ) : (
@@ -1044,6 +1478,7 @@ export function SectionsEditor({
               onDelete={handleDeleteSection}
               onDuplicate={handleDuplicateSection}
               onMakeReusable={setMakeReusableIndex}
+              onAddSection={() => setAddSectionOpen(true)}
             />
           </div>
         </ScrollArea>
@@ -1062,6 +1497,18 @@ export function SectionsEditor({
         isPending={saveBlock.isPending}
         onSubmit={handleMakeReusableSubmit}
       />
+
+      {previewUrl && livePageResolveType && (
+        <AddSectionModal
+          open={addSectionOpen}
+          onOpenChange={setAddSectionOpen}
+          sections={sectionCatalog}
+          previewBaseUrl={previewUrl}
+          livePageResolveType={livePageResolveType}
+          siteTheme={siteTheme}
+          onSelect={handleAddSection}
+        />
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -13,6 +13,13 @@ import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
+import { MakeReusableModal } from "./make-reusable-modal";
+import {
+  buildPageDataWithSections,
+  cloneSection,
+  suggestBlockId,
+  validateBlockId,
+} from "./page-sections";
 
 interface RawSection {
   __resolveType: string;
@@ -388,6 +395,9 @@ export function SectionsEditor({
   const [ruleResolveType, setRuleResolveType] = useState<string | null>(null);
   const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
   const [formResetKey, setFormResetKey] = useState(0);
+  const [makeReusableIndex, setMakeReusableIndex] = useState<number | null>(
+    null,
+  );
 
   // Reset form state when the active page changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -499,6 +509,35 @@ export function SectionsEditor({
 
   const activeSchema =
     activeResolveType && meta ? resolveSchema(activeResolveType, meta) : null;
+
+  const savePageSections = (
+    updatedSections: RawSection[],
+    options?: { onSuccess?: () => void },
+  ) => {
+    if (!activePageKey) return;
+    const fullPageData = buildPageDataWithSections(
+      decofile,
+      activePageKey,
+      updatedSections,
+      safeVariantIndex,
+      pageVariants,
+    );
+    saveBlock.mutate(
+      { blockKey: activePageKey, data: fullPageData },
+      {
+        onSuccess: () => options?.onSuccess?.() ?? onSaved?.(),
+        onError: (err) => toast.error(`Save failed: ${err.message}`),
+      },
+    );
+  };
+
+  const clearSectionEditing = () => {
+    setSelectedSectionIndex(null);
+    setFormValue(null);
+    setActiveResolveType(null);
+    setFieldBreadcrumbs([]);
+    setFormResetKey((key) => key + 1);
+  };
 
   const scheduleAutoSave = (
     nextValue: Record<string, unknown>,
@@ -659,32 +698,99 @@ export function SectionsEditor({
   const handleReorder = (fromIndex: number, toIndex: number) => {
     if (!activePageKey) return;
     const reordered = arrayMove([...rawSections], fromIndex, toIndex);
-    const fullPageData = {
-      ...(decofile[activePageKey] as Record<string, unknown>),
-    };
-    if (hasMultipleVariants) {
-      const currentSections = fullPageData.sections as Record<string, unknown>;
-      const variants = [
-        ...((currentSections?.variants as Array<Record<string, unknown>>) ??
-          []),
-      ];
-      if (variants[safeVariantIndex]) {
-        variants[safeVariantIndex] = {
-          ...variants[safeVariantIndex],
-          value: reordered,
-        };
+
+    if (selectedSectionIndex !== null) {
+      if (selectedSectionIndex === fromIndex) {
+        setSelectedSectionIndex(toIndex);
+      } else if (
+        fromIndex < selectedSectionIndex &&
+        toIndex >= selectedSectionIndex
+      ) {
+        setSelectedSectionIndex(selectedSectionIndex - 1);
+      } else if (
+        fromIndex > selectedSectionIndex &&
+        toIndex <= selectedSectionIndex
+      ) {
+        setSelectedSectionIndex(selectedSectionIndex + 1);
       }
-      fullPageData.sections = { ...currentSections, variants };
-    } else {
-      fullPageData.sections = reordered;
     }
-    saveBlock.mutate(
-      { blockKey: activePageKey, data: fullPageData },
-      {
-        onSuccess: () => onSaved?.(),
-        onError: (err) => toast.error(`Reorder failed: ${err.message}`),
-      },
-    );
+
+    savePageSections(reordered);
+  };
+
+  const handleDeleteSection = (index: number) => {
+    if (!activePageKey) return;
+    const updatedSections = rawSections.filter((_, i) => i !== index);
+    if (selectedSectionIndex === index) {
+      clearSectionEditing();
+    } else if (selectedSectionIndex !== null && selectedSectionIndex > index) {
+      setSelectedSectionIndex(selectedSectionIndex - 1);
+    }
+    savePageSections(updatedSections);
+  };
+
+  const handleDuplicateSection = (index: number) => {
+    if (!activePageKey) return;
+    const section = rawSections[index];
+    if (!section) return;
+    const updatedSections = [...rawSections];
+    updatedSections.splice(index + 1, 0, cloneSection(section));
+    savePageSections(updatedSections);
+  };
+
+  const handleMakeReusableSubmit = async (blockId: string) => {
+    if (makeReusableIndex === null || !activePageKey) return;
+
+    const validationError = validateBlockId(blockId, decofile);
+    if (validationError) {
+      toast.error(validationError);
+      return;
+    }
+
+    const rawSection = rawSections[makeReusableIndex];
+    const parsed = parsedSections[makeReusableIndex];
+    if (!rawSection || !parsed) return;
+
+    const unwrapped = unwrapSection(rawSection, parsed, decofile);
+    if (!unwrapped) {
+      toast.error("This section cannot be saved as global.");
+      return;
+    }
+
+    const blockData = {
+      ...unwrapped.data,
+      name: blockId,
+    };
+
+    try {
+      await saveBlock.mutateAsync({ blockKey: blockId, data: blockData });
+
+      const updatedSections = [...rawSections];
+      updatedSections[makeReusableIndex] = { __resolveType: blockId };
+
+      await saveBlock.mutateAsync({
+        blockKey: activePageKey,
+        data: buildPageDataWithSections(
+          decofile,
+          activePageKey,
+          updatedSections,
+          safeVariantIndex,
+          pageVariants,
+        ),
+      });
+
+      if (selectedSectionIndex === makeReusableIndex) {
+        clearSectionEditing();
+      }
+
+      setMakeReusableIndex(null);
+      toast.success(`Saved global block "${blockId}"`);
+      onSaved?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to save global block",
+      );
+    }
   };
 
   // Sync rule form state when variant changes
@@ -780,11 +886,7 @@ export function SectionsEditor({
     ? [activePage.name, selectedParsed.label, ...fieldBreadcrumbs]
     : [];
   const exitSectionEditing = () => {
-    setSelectedSectionIndex(null);
-    setFormValue(null);
-    setActiveResolveType(null);
-    setFieldBreadcrumbs([]);
-    setFormResetKey((key) => key + 1);
+    clearSectionEditing();
   };
   const handleBreadcrumbClick = (index: number) => {
     if (index === 0) {
@@ -934,14 +1036,32 @@ export function SectionsEditor({
           )}
           <div className="p-2">
             <SectionList
+              listKey={`${activePageKey ?? ""}-${safeVariantIndex}`}
               sections={parsedSections}
               selectedIndex={selectedSectionIndex}
               onSelect={handleSelectSection}
               onReorder={handleReorder}
+              onDelete={handleDeleteSection}
+              onDuplicate={handleDuplicateSection}
+              onMakeReusable={setMakeReusableIndex}
             />
           </div>
         </ScrollArea>
       )}
+
+      <MakeReusableModal
+        open={makeReusableIndex !== null}
+        onOpenChange={(open) => {
+          if (!open) setMakeReusableIndex(null);
+        }}
+        defaultBlockId={
+          makeReusableIndex !== null
+            ? suggestBlockId(parsedSections[makeReusableIndex]?.label ?? "")
+            : ""
+        }
+        isPending={saveBlock.isPending}
+        onSubmit={handleMakeReusableSubmit}
+      />
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -40,11 +40,35 @@ export function useSaveBlock({
       }
       return res.json();
     },
-    onSuccess: () => {
+    onMutate: async ({ blockKey, data }) => {
       const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
-      queryClient.invalidateQueries({
-        queryKey: KEYS.decofile(cacheKey),
-      });
+      const queryKey = KEYS.decofile(cacheKey);
+      await queryClient.cancelQueries({ queryKey });
+      const previous =
+        queryClient.getQueryData<Record<string, unknown>>(queryKey);
+      queryClient.setQueryData(
+        queryKey,
+        (current: Record<string, unknown> | undefined) => {
+          if (!current) return current;
+          return { ...current, [blockKey]: data };
+        },
+      );
+      return { previous, queryKey };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.queryKey) {
+        queryClient.setQueryData(context.queryKey, context.previous);
+      }
+    },
+    onSuccess: (_result, { blockKey, data }) => {
+      const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
+      queryClient.setQueryData(
+        KEYS.decofile(cacheKey),
+        (current: Record<string, unknown> | undefined) => {
+          if (!current) return current;
+          return { ...current, [blockKey]: data };
+        },
+      );
     },
   });
 }

--- a/packages/sandbox/daemon/constants.ts
+++ b/packages/sandbox/daemon/constants.ts
@@ -1,4 +1,6 @@
-import { IFRAME_BOOTSTRAP_SCRIPT } from "../shared";
+import { IFRAME_BOOTSTRAP_SCRIPT, WELL_KNOWN_STARTERS } from "../shared";
+
+export { WELL_KNOWN_STARTERS };
 
 // Per-daemon SSE subscriber cap. Each browser tab opens one
 // /api/.../vm-events SSE upstream to the daemon's /_sandbox/events,
@@ -72,8 +74,6 @@ export const PACKAGE_MANAGER_DAEMON_CONFIG: Record<
     manifests: ["deno.json", "deno.jsonc", "package.json"],
   },
 };
-
-export const WELL_KNOWN_STARTERS = ["dev", "start"] as const;
 
 export function buildDevEnv(
   config: { application?: { port?: number } },

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -184,4 +184,15 @@ describe("fs handlers", () => {
     const body = (await res.json()) as { files: string[] };
     expect(body.files).toContain(".deco/blocks/foo.json");
   });
+
+  it("glob: excludes sensitive dotfiles outside .deco", async () => {
+    writeFileSync(join(appRoot, ".env"), "SECRET=1");
+    mkdirSync(join(appRoot, ".deco/blocks"), { recursive: true });
+    writeFileSync(join(appRoot, ".deco/blocks/foo.json"), "{}");
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
+    const body = (await res.json()) as { files: string[] };
+    expect(body.files).not.toContain(".env");
+    expect(body.files).toContain(".deco/blocks/foo.json");
+  });
 });

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -168,5 +174,14 @@ describe("fs handlers", () => {
     const res = await h(post("/_sandbox/glob", { pattern: "*.txt" }));
     const body = (await res.json()) as { files: string[] };
     expect(body.files).toContain("x.txt");
+  });
+
+  it("glob: includes dot-directories such as .deco", async () => {
+    mkdirSync(join(appRoot, ".deco/blocks"), { recursive: true });
+    writeFileSync(join(appRoot, ".deco/blocks/foo.json"), "{}");
+    const h = makeGlobHandler({ appRoot, repoDir: appRoot });
+    const res = await h(post("/_sandbox/glob", { pattern: "**/*" }));
+    const body = (await res.json()) as { files: string[] };
+    expect(body.files).toContain(".deco/blocks/foo.json");
   });
 });

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -584,6 +584,7 @@ export function makeGlobHandler(deps: FsDeps) {
         cwd: searchPath,
         onlyFiles: true,
         followSymlinks: false,
+        dot: true,
       })) {
         if (rel.split("/").some((seg) => GLOB_EXCLUDE_DIRS.has(seg))) continue;
         const abs = path.join(searchPath, rel);

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -556,8 +556,20 @@ const GLOB_EXCLUDE_DIRS = new Set([
   "build",
   ".turbo",
   ".cache",
+  ".ssh",
+  ".aws",
+  ".gnupg",
 ]);
 const GLOB_RESULT_LIMIT = 1000;
+
+function isGlobPathAllowed(rel: string): boolean {
+  for (const seg of rel.split("/")) {
+    if (GLOB_EXCLUDE_DIRS.has(seg)) return false;
+    // Surface `.deco/**` without exposing other dotfiles (`.env`, `.npmrc`, …).
+    if (seg.startsWith(".") && seg !== ".deco") return false;
+  }
+  return true;
+}
 
 export function makeGlobHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
@@ -586,7 +598,7 @@ export function makeGlobHandler(deps: FsDeps) {
         followSymlinks: false,
         dot: true,
       })) {
-        if (rel.split("/").some((seg) => GLOB_EXCLUDE_DIRS.has(seg))) continue;
+        if (!isGlobPathAllowed(rel)) continue;
         const abs = path.join(searchPath, rel);
         files.push(
           abs.startsWith(`${deps.repoDir}/`)

--- a/packages/sandbox/shared.ts
+++ b/packages/sandbox/shared.ts
@@ -15,6 +15,9 @@ export const PLUGIN_DESCRIPTION =
 export const DAEMON_PORT = 9000;
 export const DEFAULT_IMAGE = "studio-sandbox:local";
 
+/** Auto-start script priority — first match in the manifest wins. */
+export const WELL_KNOWN_STARTERS = ["dev", "start"] as const;
+
 /** Shell-quote a value for safe inclusion in a `bash -lc` script. */
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;


### PR DESCRIPTION
## Summary
- Adds a three-dot menu on each CMS section row with **Delete**, **Duplicate**, and **Save as global** (inline sections only)
- **Save as global** opens a modal, writes `.deco/blocks/{name}.json`, and replaces the inline section with a block reference
- Improves section list UX: full-row click to edit, pointer cursor on hover, grabbing cursor while dragging
- Fixes drag-and-drop flicker with local list ordering, `DragOverlay`, disabled layout animations, and optimistic decofile cache updates

## Test plan
- [ ] Open sandbox preview CMS panel on a page with multiple sections
- [ ] Click a section row to open the schema form
- [ ] Drag reorder sections — list should update instantly with no blink
- [ ] Duplicate a section — new row appears immediately after the original
- [ ] Delete a section — row removed and page saved
- [ ] Save as global on an inline section — modal validates name, creates block file, section becomes purple global reference
- [ ] Confirm duplicate/delete/reorder reflect in preview after save
- [x] `bun test apps/mesh/src/web/components/sections-editor/page-sections.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds section row actions and smooth drag reorder with optimistic updates, plus a searchable add‑section gallery with sandboxed, pooled previews and multivariate variant editing. Saving as global writes `.deco/blocks/{name}.json` and swaps the inline section for a block reference; the catalog merges manifest sections with saved globals.

- **New Features**
  - Three-dot menu per section: Delete, Duplicate, Save as global (inline only).
  - Add-section modal with search and lazy iframe previews (pooled/sandboxed).
  - Multivariate variant editor with matcher icons.

- **Bug Fixes**
  - Hardened sandbox glob to expose only `.deco/**`; gallery iframes now sandboxed with a concurrency cap and retry.
  - Smoother DnD with DragOverlay and disabled layout animations; fixed list sync and duplicate selection.
  - Fix debounced updates to capture section/variant indices; improved keyboard handling on variant rows.
  - Correct saved‑block labels by reading schema titles; hardened catalog metadata and preview URL helpers; exported `WELL_KNOWN_STARTERS` from `@decocms/sandbox/shared` for UI/daemon parity.
  - Fix `matcher-icons` tests by importing `cn` from `@deco/ui/lib/utils.ts`.

<sup>Written for commit b1767ef6f433d0d169336d2ad1b28be4ac8342be. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3489?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

