### PR TITLE
feat(sandbox-env): LB-terminated TLS option for preview Gateway (0.7.4)

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-version: 0.7.3
+version: 0.7.4
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "0.5.7"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -128,6 +128,10 @@ atomic and gives a pointer to the right install command.
 */}}
 {{- define "sandbox-env.validatePreviewGateway" -}}
 {{- if .Values.previewGateway.enabled }}
+{{- $tlsTermination := default "gateway" .Values.previewGateway.tlsTermination }}
+{{- if not (or (eq $tlsTermination "gateway") (eq $tlsTermination "loadBalancer")) }}
+{{- fail (printf "sandbox-env: previewGateway.tlsTermination must be \"gateway\" or \"loadBalancer\" (got %q)" $tlsTermination) -}}
+{{- end }}
 {{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
 {{- fail "sandbox-env: previewGateway.enabled=true requires the Gateway API CRDs (gateway.networking.k8s.io/v1). Install: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml — and a Gateway controller (Istio, Envoy Gateway, Cilium, ...) implementing the chosen gatewayClassName." -}}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -131,8 +131,13 @@ atomic and gives a pointer to the right install command.
 {{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
 {{- fail "sandbox-env: previewGateway.enabled=true requires the Gateway API CRDs (gateway.networking.k8s.io/v1). Install: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml — and a Gateway controller (Istio, Envoy Gateway, Cilium, ...) implementing the chosen gatewayClassName." -}}
 {{- end }}
+{{/* cert-manager is only needed when Envoy terminates TLS. With
+     tlsTermination=loadBalancer the cloud LB owns the cert, so cert-manager
+     is not a prerequisite. */}}
+{{- if ne .Values.previewGateway.tlsTermination "loadBalancer" }}
 {{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
-{{- fail "sandbox-env: previewGateway.enabled=true requires cert-manager (cert-manager.io/v1). Install: helm install cert-manager jetstack/cert-manager -n cert-manager --create-namespace --set crds.enabled=true" -}}
+{{- fail "sandbox-env: previewGateway.enabled=true with tlsTermination=gateway requires cert-manager (cert-manager.io/v1). Install: helm install cert-manager jetstack/cert-manager -n cert-manager --create-namespace --set crds.enabled=true — or set previewGateway.tlsTermination=loadBalancer to terminate TLS at the cloud LB instead." -}}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-preview-cert.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-preview-cert.yaml
@@ -1,9 +1,12 @@
-{{- if .Values.previewGateway.enabled }}
+{{- if and .Values.previewGateway.enabled (ne .Values.previewGateway.tlsTermination "loadBalancer") }}
 {{- $domain := required "previewGateway.domain is required when previewGateway.enabled=true" .Values.previewGateway.domain }}
-{{- $issuer := required "previewGateway.clusterIssuer is required when previewGateway.enabled=true" .Values.previewGateway.clusterIssuer }}
+{{- $issuer := required "previewGateway.clusterIssuer is required when previewGateway.enabled=true and tlsTermination=gateway" .Values.previewGateway.clusterIssuer }}
 {{- $gwNamespace := .Values.previewGateway.namespace }}
 {{- $tlsSecretName := include "sandbox-env.previewTlsSecretName" . }}
-# Wildcard cert for the sandbox preview Gateway. cert-manager places the
+# Wildcard cert for the sandbox preview Gateway. Only rendered when
+# tlsTermination=gateway (Envoy terminates TLS). With tlsTermination=
+# loadBalancer the cloud LB owns the cert and this is skipped.
+# cert-manager places the
 # Secret in the gateway namespace so the Gateway listener can mount it
 # without a cross-namespace reference.
 #

--- a/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
@@ -1,25 +1,37 @@
 {{- if .Values.previewGateway.enabled }}
 {{- $domain := required "previewGateway.domain is required when previewGateway.enabled=true" .Values.previewGateway.domain }}
-{{- $issuer := required "previewGateway.clusterIssuer is required when previewGateway.enabled=true" .Values.previewGateway.clusterIssuer }}
+{{- $lbTermination := eq .Values.previewGateway.tlsTermination "loadBalancer" }}
+{{- $issuer := "" }}
+{{- if not $lbTermination }}
+{{- $issuer = required "previewGateway.clusterIssuer is required when previewGateway.enabled=true and tlsTermination=gateway" .Values.previewGateway.clusterIssuer }}
+{{- end }}
 {{- $gwNamespace := .Values.previewGateway.namespace }}
 {{- $tlsSecretName := include "sandbox-env.previewTlsSecretName" . }}
 {{- $hostname := printf "*.%s" $domain }}
 {{- $previewName := include "sandbox-env.previewName" . }}
-# Wildcard preview-URL ingress. The Gateway terminates TLS for
-# `*.<domain>`; per-claim HTTPRoutes are minted by the mesh runner against
-# this Gateway and route directly to each sandbox's headless Service at
-# port 9000 (daemon owns the public surface — routing straight at the dev
-# port 3000 would bypass CSP/HMR rewrites and break iframe embedding + SSE).
+{{- $infra := .Values.previewGateway.infrastructure | default dict }}
+# Wildcard preview-URL ingress. The Gateway fronts `*.<domain>`; per-claim
+# HTTPRoutes are minted by the mesh runner against this Gateway and route
+# directly to each sandbox's headless Service at port 9000 (daemon owns the
+# public surface — routing straight at the dev port 3000 would bypass CSP/HMR
+# rewrites and break iframe embedding + SSE).
 #
-# This chart creates ONLY the Gateway + Certificate. It deliberately does
-# NOT render a wildcard HTTPRoute backed by mesh — keeping mesh in the
+# TLS termination is controlled by previewGateway.tlsTermination:
+#   gateway      → HTTPS listener; Envoy terminates with a cert-manager Secret
+#                  (a Certificate is rendered in sandbox-preview-cert.yaml).
+#   loadBalancer → HTTP listener on 443; the load balancer in front terminates
+#                  TLS (cert wired via infrastructure.annotations) and forwards
+#                  plaintext to Envoy over a trusted hop. No Certificate.
+#
+# This chart creates ONLY the Gateway (+ optional Certificate). It deliberately
+# does NOT render a wildcard HTTPRoute backed by mesh — keeping mesh in the
 # request path was the previous design, and it's been replaced by per-claim
 # routing. Mesh now creates one HTTPRoute per SandboxClaim in
 # `agent-sandbox-system` (same namespace as the operator's Service, no
 # ReferenceGrant needed) and tears it down on claim delete. RBAC for that
 # lives in templates/sandbox-rbac.yaml.
 #
-# Browser → Gateway → HTTPRoute(handle) → Service(handle):9000 → pod.
+# Browser → (LB) → Gateway → HTTPRoute(handle) → Service(handle):9000 → pod.
 # Mesh is no longer the data-path proxy.
 #
 # AUTH MODEL — read before exposing this. The Host header carries the
@@ -44,15 +56,48 @@ metadata:
   namespace: {{ $gwNamespace }}
   labels:
     {{- include "sandbox-env.sandboxPreviewLabels" . | nindent 4 }}
+  {{- if not $lbTermination }}
   annotations:
     # cert-manager picks up the cert from the listener's TLS secret ref;
     # this annotation tells it which ClusterIssuer to use when minting
     # the wildcard. Required because Gateway listeners don't have a
     # built-in `issuerRef` field.
     cert-manager.io/cluster-issuer: {{ $issuer | quote }}
+  {{- end }}
 spec:
   gatewayClassName: {{ .Values.previewGateway.gatewayClassName | quote }}
+  {{- if or $infra.annotations $infra.labels }}
+  # Applied by the Gateway controller to the resources it generates for this
+  # Gateway. For Istio this reaches the generated Deployment AND the
+  # LoadBalancer Service — the place to pin a stable external-dns hostname
+  # and/or (with tlsTermination=loadBalancer) attach the LB's TLS cert.
+  infrastructure:
+    {{- with $infra.labels }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $infra.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
   listeners:
+    {{- if $lbTermination }}
+    - name: http
+      protocol: HTTP
+      port: 443
+      hostname: {{ $hostname | quote }}
+      allowedRoutes:
+        namespaces:
+          # Per-claim HTTPRoutes live in `agent-sandbox-system` (same
+          # namespace as the operator-created Service they back) so mesh
+          # can write them with the same Role used for SandboxClaim
+          # CRUD. Without this selector the routes would silently drop.
+          from: Selector
+          selector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-sandbox-system
+    {{- else }}
     - name: https
       protocol: HTTPS
       port: 443
@@ -73,4 +118,5 @@ spec:
           selector:
             matchLabels:
               kubernetes.io/metadata.name: agent-sandbox-system
+    {{- end }}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-preview-gateway.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.previewGateway.enabled }}
 {{- $domain := required "previewGateway.domain is required when previewGateway.enabled=true" .Values.previewGateway.domain }}
-{{- $lbTermination := eq .Values.previewGateway.tlsTermination "loadBalancer" }}
+{{/* tlsTermination is validated against its enum in
+     sandbox-env.validatePreviewGateway (templates/validations.yaml). */}}
+{{- $lbTermination := eq (default "gateway" .Values.previewGateway.tlsTermination) "loadBalancer" }}
 {{- $issuer := "" }}
 {{- if not $lbTermination }}
 {{- $issuer = required "previewGateway.clusterIssuer is required when previewGateway.enabled=true and tlsTermination=gateway" .Values.previewGateway.clusterIssuer }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -253,15 +253,36 @@ previewGateway:
   # Wildcard domain for previews — e.g. "preview.decocms.com" yields
   # `*.preview.decocms.com`. Required when enabled=true.
   domain: ""
-  # cert-manager ClusterIssuer that issues the wildcard cert. Required
-  # when enabled=true. The chart does NOT template the ClusterIssuer
-  # itself — that is per-cluster infrastructure (a Cloudflare DNS-01
-  # issuer, for example, needs your API token in a Secret).
+
+  # Where TLS for the wildcard listener terminates:
+  #   gateway      — (default) Envoy terminates TLS on the listener using a
+  #                  cert-manager-issued Secret. Renders an HTTPS listener + a
+  #                  Certificate; requires `clusterIssuer` and cert-manager.
+  #   loadBalancer — the load balancer in front of the Gateway terminates TLS.
+  #                  The listener is plain HTTP on 443 and NO Certificate is
+  #                  rendered; attach the LB-side cert via
+  #                  `infrastructure.annotations`. Keep the LB→Envoy hop on a
+  #                  trusted network (it carries plaintext).
+  tlsTermination: "gateway"
+
+  # cert-manager ClusterIssuer for the wildcard cert. Required when enabled=true
+  # AND tlsTermination=gateway; ignored for loadBalancer. The chart does not
+  # template the ClusterIssuer itself (per-cluster infra; a DNS-01 issuer is
+  # needed for a wildcard SAN).
   clusterIssuer: ""
-  # PEM-format secret name created by cert-manager. Defaults to
-  # `agent-sandbox-preview-<envName>-tls`. Override only if the cert
-  # lives under a name dictated by external tooling.
+  # cert-manager Secret name. Defaults to `agent-sandbox-preview-<envName>-tls`.
+  # Used only when tlsTermination=gateway.
   tlsSecretName: ""
+
+  # Passed through verbatim into the Gateway's `spec.infrastructure`, which the
+  # controller applies to the resources it generates (for Istio: the Deployment
+  # and the LoadBalancer Service). Use it to set provider-specific annotations/
+  # labels on the LB — e.g. to pin a stable DNS name or, with
+  # tlsTermination=loadBalancer, attach the LB's TLS cert. Keys are
+  # controller-specific and not interpreted by this chart.
+  infrastructure:
+    annotations: {}
+    labels: {}
 
 # ── mesh cross-references ──────────────────────────────────────────────
 # Tells this chart where the chart-deco-studio release for THIS


### PR DESCRIPTION
## What

Adds two **generic, backward-compatible** knobs to the `sandbox-env` preview Gateway:

- `previewGateway.tlsTermination`: `gateway` (default, unchanged) | `loadBalancer`
- `previewGateway.infrastructure` (`annotations` + `labels`) → passed through to the Gateway's `spec.infrastructure` (Istio applies it to the generated Deployment + LoadBalancer Service)

### `loadBalancer` mode
HTTP listener on 443, **no Certificate rendered** — the load balancer in front terminates TLS (cert attached via `infrastructure.annotations`). Lets you use a provider-managed/public cert without cert-manager, and pin a stable external-dns name on the LB.

## Backward compatibility
With the default `tlsTermination: gateway` and empty `infrastructure`, rendered resources are **byte-identical to 0.7.3** (verified via `helm template` diff against current prod values; only comments differ). Existing installs (pinned to 0.7.3) are untouched.

Chart bumped 0.7.3 → 0.7.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an option to terminate TLS at the load balancer for the `sandbox-env` preview Gateway and a pass‑through for Gateway `spec.infrastructure`. Also validates `previewGateway.tlsTermination` values; default behavior is unchanged; chart bumped to 0.7.4.

- **New Features**
  - `previewGateway.tlsTermination`: `gateway` (default) or `loadBalancer`. In `loadBalancer`, the listener is HTTP on 443, no Certificate is rendered, and `cert-manager` is not required.
  - `previewGateway.infrastructure`: pass `annotations`/`labels` to Gateway `spec.infrastructure` so the controller (e.g., Istio) applies them to the Deployment and LoadBalancer Service (use for LB cert/DNS). Backward compatible with 0.7.3.

- **Bug Fixes**
  - Validate `previewGateway.tlsTermination` enum (`gateway`|`loadBalancer`) at template time and fail fast on invalid values.

<sup>Written for commit 6bbe955b6a8f952fc7a9558881e009fe7b1351c7. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3491?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

