### PR TITLE
fix(decopilot): unify parent + subagent into shared runAgentLoop

### DIFF
--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -14,7 +14,7 @@
     "decocms": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@openrouter/ai-sdk-provider": "^2.9.0",
-    "ai": "^6.0.182",
+    "ai": "^6.0.191",
     "hono": "^4.10.7"
   },
   "devDependencies": {

--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -41,9 +41,9 @@
     "@duckdb/node-api": "^1.5.0-r.1"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.77",
-    "@ai-sdk/google": "^3.0.73",
-    "@ai-sdk/openai": "^3.0.63",
+    "@ai-sdk/anthropic": "^3.0.80",
+    "@ai-sdk/google": "^3.0.80",
+    "@ai-sdk/openai": "^3.0.65",
     "@anthropic-ai/sdk": "^0.96.0",
     "@aws-sdk/client-s3": "^3.1013.0",
     "@aws-sdk/lib-storage": "^3.1013.0",
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.10",
-    "@ai-sdk/react": "^3.0.184",
+    "@ai-sdk/react": "^3.0.193",
     "@better-auth/sso": "1.4.1",
     "@daveyplate/better-auth-ui": "^3.2.7",
     "@deco/ui": "workspace:*",
@@ -134,7 +134,7 @@
     "@untitledui/icons": "^0.0.19",
     "@vercel/nft": "^1.1.1",
     "@vitejs/plugin-react": "^5.1.0",
-    "ai": "^6.0.182",
+    "ai": "^6.0.191",
     "babel-plugin-react-compiler": "^1.0.0",
     "better-auth": "1.4.22",
     "class-variance-authority": "^0.7.1",

--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -10,7 +10,6 @@ export const DEFAULT_THREAD_TITLE = "New chat";
 
 export const PARENT_STEP_LIMIT = 30;
 export const SUBAGENT_STEP_LIMIT = 15;
-export const SUBAGENT_EXCLUDED_TOOLS = ["user_ask", "subtask"];
 
 /**
  * Base platform prompt — shared by all agents (decopilot and custom).

--- a/apps/mesh/src/harnesses/decopilot/assemble-agent-tools.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/assemble-agent-tools.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assembleAgentTools,
+  EXCLUDED_FOR_SUBAGENT,
+} from "./assemble-agent-tools";
+
+const mockMcpClient = {
+  listTools: async () => ({ tools: [] }),
+  getInstructions: () => "",
+} as never;
+
+const mockCtx = {} as never;
+const mockWriter = { write: () => {}, merge: () => {} } as never;
+const mockSubtaskParams = {
+  provider: {} as never,
+  organization: { id: "org_test" } as never,
+  models: {} as never,
+};
+
+describe("assembleAgentTools", () => {
+  test("kind: 'agent' includes subtask, user_ask, propose_plan in built-ins", async () => {
+    const { tools } = await assembleAgentTools({
+      kind: "agent",
+      ctx: mockCtx,
+      mcpClient: mockMcpClient,
+      writer: mockWriter,
+      planMode: false,
+      toolApprovalLevel: "high" as never,
+      subtaskParams: mockSubtaskParams,
+    });
+    for (const name of ["subtask", "user_ask", "propose_plan"]) {
+      expect(tools).toHaveProperty(name);
+    }
+  });
+
+  test("kind: 'subagent' EXCLUDES subtask, user_ask, propose_plan", async () => {
+    const { tools } = await assembleAgentTools({
+      kind: "subagent",
+      ctx: mockCtx,
+      mcpClient: mockMcpClient,
+      writer: mockWriter,
+      planMode: false,
+      toolApprovalLevel: "auto",
+      subtaskParams: mockSubtaskParams,
+    });
+    for (const name of ["subtask", "user_ask", "propose_plan"]) {
+      expect(tools).not.toHaveProperty(name);
+    }
+  });
+
+  test("kind: 'subagent' includes the always-on built-ins", async () => {
+    const { tools } = await assembleAgentTools({
+      kind: "subagent",
+      ctx: mockCtx,
+      mcpClient: mockMcpClient,
+      writer: mockWriter,
+      planMode: false,
+      toolApprovalLevel: "auto",
+      subtaskParams: mockSubtaskParams,
+    });
+    for (const name of ["read_tool_output", "todo_write"]) {
+      expect(tools).toHaveProperty(name);
+    }
+  });
+
+  test("EXCLUDED_FOR_SUBAGENT is the canonical exclusion list", () => {
+    expect(EXCLUDED_FOR_SUBAGENT).toEqual([
+      "subtask",
+      "user_ask",
+      "propose_plan",
+    ]);
+  });
+
+  test("always returns toolOutputMap for read_tool_output to share", async () => {
+    const result = await assembleAgentTools({
+      kind: "subagent",
+      ctx: mockCtx,
+      mcpClient: mockMcpClient,
+      writer: mockWriter,
+      planMode: false,
+      toolApprovalLevel: "auto",
+      subtaskParams: mockSubtaskParams,
+    });
+    expect(result.toolOutputMap).toBeInstanceOf(Map);
+  });
+});

--- a/apps/mesh/src/harnesses/decopilot/assemble-agent-tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/assemble-agent-tools.ts
@@ -1,0 +1,96 @@
+/**
+ * assembleAgentTools — shared tool assembler for both parent agents
+ * and subagents in the decopilot harness.
+ *
+ * Returns the full toolset (MCP + built-ins), the shared toolOutputMap
+ * (used by read_tool_output to read back truncated outputs), and the
+ * nameMap (mcp-tool short-name -> full-name).
+ *
+ * Rules:
+ *   - `kind: "subagent"` excludes `subtask`, `user_ask`, `propose_plan`.
+ *   - Truncation is ALWAYS on (disableOutputTruncation: false).
+ *   - `toolApprovalLevel` is passed through as-is from the caller.
+ */
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { ToolSet, UIMessageStreamWriter } from "ai";
+import type { MeshContext } from "@/core/mesh-context";
+import {
+  toolsFromMCP,
+  type ToolApprovalLevel,
+} from "../../api/routes/decopilot/helpers";
+import {
+  buildBuiltInTools,
+  type BuildBuiltInToolsOptions,
+} from "./built-in-tools";
+
+export type { BuildBuiltInToolsOptions };
+export type { ToolApprovalLevel };
+
+export const EXCLUDED_FOR_SUBAGENT = [
+  "subtask",
+  "user_ask",
+  "propose_plan",
+] as const;
+
+export interface AssembleAgentToolsOptions {
+  kind: "agent" | "subagent";
+  ctx: MeshContext;
+  mcpClient: Client;
+  writer: UIMessageStreamWriter;
+  planMode: boolean;
+  toolApprovalLevel: ToolApprovalLevel;
+  subtaskParams: BuildBuiltInToolsOptions["subtaskParams"];
+}
+
+export interface AssembleAgentToolsResult {
+  tools: ToolSet;
+  toolOutputMap: Map<string, string>;
+  nameMap: Map<string, string>;
+}
+
+export async function assembleAgentTools(
+  opts: AssembleAgentToolsOptions,
+): Promise<AssembleAgentToolsResult> {
+  const toolOutputMap = new Map<string, string>();
+
+  // 1. MCP tools — truncation always on.
+  const { tools: mcpTools, nameMap } = await toolsFromMCP(
+    opts.mcpClient,
+    toolOutputMap,
+    opts.writer,
+    opts.toolApprovalLevel,
+    {
+      disableOutputTruncation: false,
+      ctx: opts.ctx,
+      isPlanMode: opts.planMode,
+    },
+  );
+
+  // 2. Built-in tools — full set first.
+  const allBuiltIns = buildBuiltInTools({
+    ctx: opts.ctx,
+    writer: opts.writer,
+    toolOutputMap,
+    subtaskParams: opts.subtaskParams,
+    planMode: opts.planMode,
+  });
+
+  // 3. Filter built-ins for subagent kind.
+  const builtIns: Record<string, unknown> =
+    opts.kind === "subagent"
+      ? Object.fromEntries(
+          Object.entries(allBuiltIns).filter(
+            ([name]) =>
+              !EXCLUDED_FOR_SUBAGENT.includes(
+                name as (typeof EXCLUDED_FOR_SUBAGENT)[number],
+              ),
+          ),
+        )
+      : allBuiltIns;
+
+  // 4. Merge.
+  const tools: ToolSet = { ...mcpTools, ...(builtIns as ToolSet) };
+
+  return { tools, toolOutputMap, nameMap };
+}

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
@@ -58,9 +58,21 @@ describe("buildAgentSystemPrompt", () => {
       ...baseOpts,
       kind: "agent",
       planMode: false,
+      isDecopilot: true,
     });
     const joined = JSON.stringify(out);
     expect(joined).toContain("Decopilot");
+  });
+
+  test("kind: 'agent' with isDecopilot: false omits decopilot identity prompt", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      planMode: false,
+      isDecopilot: false,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).not.toContain("Decopilot");
   });
 
   test("planMode is ignored for kind: 'subagent'", async () => {

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { buildAgentSystemPrompt } from "./build-agent-system-prompt";
+
+const mockAgentList = [
+  {
+    id: "vir_other",
+    title: "Other Agent",
+    description: "A sibling agent",
+    status: "active" as const,
+    organization_id: "org_test",
+  },
+];
+
+const baseOpts = {
+  ctx: {
+    storage: { virtualMcps: { list: async () => mockAgentList } },
+  } as never,
+  organization: { id: "org_test" } as never,
+  virtualMcp: { id: "vir_test", instructions: undefined } as never,
+  agentInstructions: undefined,
+  date: new Date("2026-05-26T00:00:00Z"),
+};
+
+describe("buildAgentSystemPrompt", () => {
+  test("kind: 'agent' includes the agents block", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      planMode: false,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).toContain("available-agents");
+  });
+
+  test("kind: 'subagent' OMITS the agents block", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: false,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).not.toContain("available-agents");
+  });
+
+  test("kind: 'subagent' uses the subagent identity prompt", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: false,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).toContain("focused subtask agent");
+    expect(joined).toContain("Rules (non-negotiable)");
+  });
+
+  test("kind: 'agent' uses the decopilot identity prompt", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      planMode: false,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).toContain("Decopilot");
+  });
+
+  test("planMode is ignored for kind: 'subagent'", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: true,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).not.toContain("plan-mode");
+  });
+
+  test("agentInstructions are appended for both kinds", async () => {
+    for (const kind of ["agent", "subagent"] as const) {
+      const out = await buildAgentSystemPrompt({
+        ...baseOpts,
+        kind,
+        planMode: false,
+        agentInstructions: "ALWAYS USE THE SEARCH TOOL FIRST.",
+      });
+      const joined = JSON.stringify(out);
+      expect(joined).toContain("ALWAYS USE THE SEARCH TOOL FIRST.");
+    }
+  });
+
+  test("output is an array of system messages compatible with streamText", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      planMode: false,
+    });
+    expect(Array.isArray(out)).toBe(true);
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts
@@ -95,4 +95,71 @@ describe("buildAgentSystemPrompt", () => {
     expect(Array.isArray(out)).toBe(true);
     expect(out.length).toBeGreaterThan(0);
   });
+
+  test("kind: 'subagent' includes connections block when connectionsData is provided", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: false,
+      connectionsData: {
+        tools: [
+          {
+            safeName: "test_tool",
+            rawName: "test_tool",
+            connectionId: "conn_1",
+          } as never,
+        ],
+        connectionTitleMap: new Map([["conn_1", "Test Connection"]]),
+      },
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).toContain("available-connections");
+    expect(joined).toContain("Test Connection");
+    expect(joined).toContain("test_tool");
+  });
+
+  test("kind: 'subagent' omits connections block when connectionsData is not provided", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: false,
+      // no connectionsData
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).not.toContain("available-connections");
+  });
+
+  test("kind: 'subagent' includes prompts block when passthroughClient is provided", async () => {
+    const mockClient = {
+      listPrompts: async () => ({
+        prompts: [
+          {
+            name: "my-prompt",
+            description: "A test prompt",
+            arguments: [{ name: "topic", required: true }],
+          },
+        ],
+      }),
+    } as never;
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: false,
+      passthroughClient: mockClient,
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).toContain("available-prompts");
+    expect(joined).toContain("my-prompt");
+  });
+
+  test("kind: 'subagent' omits prompts block when passthroughClient is not provided", async () => {
+    const out = await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "subagent",
+      planMode: false,
+      // no passthroughClient
+    });
+    const joined = JSON.stringify(out);
+    expect(joined).not.toContain("available-prompts");
+  });
 });

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -21,12 +21,14 @@ import {
   buildRepoEnvironmentPrompt,
 } from "../../api/routes/decopilot/constants";
 import type { GithubRepo } from "@decocms/mesh-sdk";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { buildSystemMessages, type SystemMessage } from "./system-prompt";
 import {
   listPromptsBlock,
   listAgentsBlock,
   listConnectionsBlock,
 } from "./prompt";
+import type { ConnectionsBlockTool } from "./connections-block";
 
 const SUBAGENT_IDENTITY_PROMPT = `You are a focused subtask agent delegated a specific task by a parent agent. You are NOT the parent agent.
 
@@ -70,6 +72,17 @@ export interface BuildAgentSystemPromptOptions {
   planMode: boolean;
   agentInstructions?: string;
   date?: Date;
+
+  // ── Optional runtime data ──────────────────────────────────────────
+  // When provided, the prompts and connections blocks get included.
+  // When absent (e.g., unit tests with no live MCP), the blocks are
+  // omitted gracefully — the caller is responsible for supplying these
+  // when they want subagents/agents to see the full context.
+  passthroughClient?: Client;
+  connectionsData?: {
+    tools: ConnectionsBlockTool[];
+    connectionTitleMap: Map<string, string>;
+  };
 }
 
 export async function buildAgentSystemPrompt(
@@ -100,7 +113,11 @@ export async function buildAgentSystemPrompt(
     prompts.push(SUBAGENT_IDENTITY_PROMPT);
   }
 
-  const promptsBlock = await listPromptsBlock(opts.ctx, opts.organization);
+  const promptsBlock = await listPromptsBlock(
+    opts.ctx,
+    opts.organization,
+    opts.passthroughClient,
+  );
   if (promptsBlock) prompts.push(promptsBlock);
 
   if (opts.kind === "agent") {
@@ -115,6 +132,7 @@ export async function buildAgentSystemPrompt(
   const connectionsBlock = await listConnectionsBlock(
     opts.ctx,
     opts.organization,
+    opts.connectionsData,
   );
   if (connectionsBlock) prompts.push(connectionsBlock);
 

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -1,0 +1,128 @@
+/**
+ * buildAgentSystemPrompt — shared system-prompt assembler for both
+ * parent agents and subagents in the decopilot harness.
+ *
+ * The `kind` discriminator drives:
+ *   - which identity prompt is used (decopilot vs subagent)
+ *   - whether the agents block is included
+ *   - whether the plan-mode prompt is included (subagent never gets it)
+ *
+ * Everything else (base platform, repo env, prompts block, connections
+ * block, todo_write guidance, agent instructions) is included for BOTH
+ * kinds — though in Stage 2.1 listPromptsBlock and listConnectionsBlock
+ * are stubs returning null (wired up fully in Stage 2.3).
+ */
+
+import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import {
+  buildBasePlatformPrompt,
+  buildDecopilotAgentPrompt,
+  buildTodoWritePrompt,
+  buildRepoEnvironmentPrompt,
+} from "../../api/routes/decopilot/constants";
+import type { GithubRepo } from "@decocms/mesh-sdk";
+import { buildSystemMessages, type SystemMessage } from "./system-prompt";
+import {
+  listPromptsBlock,
+  listAgentsBlock,
+  listConnectionsBlock,
+} from "./prompt";
+
+const SUBAGENT_IDENTITY_PROMPT = `You are a focused subtask agent delegated a specific task by a parent agent. You are NOT the parent agent.
+
+## Rules (non-negotiable)
+
+1. Do NOT converse, ask questions, or suggest next steps to the user — you cannot interact with them.
+2. Do NOT delegate to other agents — execute directly.
+3. Stay strictly within your task's scope. If you discover related work outside your scope, mention it in one sentence at most.
+
+## Before Acting: Assess the Task
+
+Before making ANY tool calls, evaluate: do you understand what to do, how to do it, and when you're done?
+
+- **If unclear** → Respond IMMEDIATELY with what's missing. Make zero tool calls. The parent agent will reformulate with more context.
+- **If clear** → Proceed autonomously. Be efficient, be thorough, don't second-guess. If you hit obstacles mid-execution, make reasonable judgment calls and note them.
+
+## Execution
+
+- Use your tools directly. Do not emit text between tool calls — use tools, then report once at the end.
+- Keep your report under 500 words unless the task requires more detail. Be factual and concise.
+- Do not use emojis.
+
+## When Done: Report
+
+End with a structured summary:
+- **Result**: What you did, what you found or produced
+- **Key files**: Relevant file paths (always absolute, never relative) — include only for research tasks
+- **Issues**: Anything to flag — include only if there are issues
+
+This report is all the parent agent sees.`;
+
+export interface BuildAgentSystemPromptOptions {
+  ctx: MeshContext;
+  organization: OrganizationScope;
+  virtualMcp: {
+    id: string;
+    instructions?: string;
+    repo?: GithubRepo;
+  };
+  kind: "agent" | "subagent";
+  planMode: boolean;
+  agentInstructions?: string;
+  date?: Date;
+}
+
+export async function buildAgentSystemPrompt(
+  opts: BuildAgentSystemPromptOptions,
+): Promise<SystemMessage[]> {
+  const prompts: string[] = [];
+
+  prompts.push(buildBasePlatformPrompt());
+
+  if (opts.kind === "agent" && opts.planMode) {
+    // Re-use the plan-mode prompt from mode-config (non-CLI variant).
+    const { resolveModeConfig } = await import(
+      "../../api/routes/decopilot/mode-config"
+    );
+    const modeConfig = resolveModeConfig("plan", { isCliAgent: false });
+    if (modeConfig.planPrompt) {
+      prompts.push(modeConfig.planPrompt);
+    }
+  }
+
+  if (opts.virtualMcp.repo) {
+    prompts.push(buildRepoEnvironmentPrompt(opts.virtualMcp.repo));
+  }
+
+  if (opts.kind === "agent") {
+    prompts.push(buildDecopilotAgentPrompt());
+  } else {
+    prompts.push(SUBAGENT_IDENTITY_PROMPT);
+  }
+
+  const promptsBlock = await listPromptsBlock(opts.ctx, opts.organization);
+  if (promptsBlock) prompts.push(promptsBlock);
+
+  if (opts.kind === "agent") {
+    const agentsBlock = await listAgentsBlock(
+      opts.ctx,
+      opts.organization,
+      opts.virtualMcp.id,
+    );
+    if (agentsBlock) prompts.push(agentsBlock);
+  }
+
+  const connectionsBlock = await listConnectionsBlock(
+    opts.ctx,
+    opts.organization,
+  );
+  if (connectionsBlock) prompts.push(connectionsBlock);
+
+  prompts.push(buildTodoWritePrompt());
+
+  if (opts.agentInstructions?.trim()) {
+    prompts.push(opts.agentInstructions);
+  }
+
+  return buildSystemMessages(prompts, opts.date ?? new Date());
+}

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -70,6 +70,15 @@ export interface BuildAgentSystemPromptOptions {
   };
   kind: "agent" | "subagent";
   planMode: boolean;
+  /**
+   * When `kind === "agent"`, controls which identity prompt is emitted:
+   * - true  → `buildDecopilotAgentPrompt()` (the decopilot identity)
+   * - false → no identity prompt; the agent's own `agentInstructions` serve as identity
+   *
+   * Ignored when `kind === "subagent"` (always uses `SUBAGENT_IDENTITY_PROMPT`).
+   * Defaults to false when absent.
+   */
+  isDecopilot?: boolean;
   agentInstructions?: string;
   date?: Date;
 
@@ -108,7 +117,12 @@ export async function buildAgentSystemPrompt(
   }
 
   if (opts.kind === "agent") {
-    prompts.push(buildDecopilotAgentPrompt());
+    if (opts.isDecopilot) {
+      prompts.push(buildDecopilotAgentPrompt());
+    }
+    // For custom agents (kind: "agent" && !isDecopilot), no identity
+    // prompt — the agent's own instructions (via agentInstructions
+    // param) serve as identity.
   } else {
     prompts.push(SUBAGENT_IDENTITY_PROMPT);
   }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -415,3 +415,45 @@ export async function getBuiltInTools(
 
   return tools;
 }
+
+/**
+ * Lightweight built-in tool assembler for the shared agent-loop path.
+ *
+ * Returns the five core built-ins (subtask, user_ask, todo_write,
+ * read_tool_output, propose_plan) as a synchronous ToolSet. Unlike
+ * `getBuiltInTools`, this does NOT include VM/sandbox/web_search/
+ * screenshot/browser tools — those depend on heavy infrastructure
+ * (vmContext, pendingImages, htmlPageBuffer) that the subagent path
+ * doesn't carry. The caller is responsible for filtering out any of
+ * these tools that don't apply for the current agent kind.
+ */
+export interface BuildBuiltInToolsOptions {
+  ctx: MeshContext;
+  writer: UIMessageStreamWriter;
+  toolOutputMap: Map<string, string>;
+  subtaskParams: import("./subtask").SubtaskParams;
+  planMode: boolean;
+}
+
+export function buildBuiltInTools(
+  opts: BuildBuiltInToolsOptions,
+): Record<string, unknown> {
+  const {
+    ctx,
+    writer,
+    toolOutputMap,
+    subtaskParams,
+    planMode: _planMode,
+  } = opts;
+  const tools: Record<string, unknown> = {
+    user_ask: userAskTool,
+    todo_write: todoWriteTool,
+    propose_plan: proposePlanTool,
+    read_tool_output: createReadToolOutputTool({ toolOutputMap }),
+  };
+  // subtask requires a provider — skip when provider is null.
+  if (subtaskParams.provider) {
+    tools.subtask = createSubtaskTool(writer, subtaskParams, ctx);
+  }
+  return tools;
+}

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
@@ -279,4 +279,18 @@ describe("toModelOutput (new runAgentLoop-based contract)", () => {
       value: "Subtask completed (no output).",
     });
   });
+
+  test("returns step-limit notice when finishReason is 'length' and text is empty", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: {
+        text: "",
+        error: undefined,
+        finishReason: "length",
+      } as never,
+    }) as { type: string; value: string };
+    expect(result.type).toBe("text");
+    expect(result.value).toContain("step limit");
+    expect(result.value).toContain("ran out of steps");
+  });
 });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
@@ -7,7 +7,6 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  buildSubagentSystemPrompt,
   createSubtaskTool,
   SubtaskInputSchema,
   type SubtaskParams,
@@ -151,39 +150,6 @@ describe("createSubtaskTool", () => {
   });
 });
 
-describe("buildSubagentSystemPrompt", () => {
-  test("returns array with base prompt when no agent instructions provided", () => {
-    const prompts = buildSubagentSystemPrompt();
-
-    expect(prompts).toHaveLength(1);
-    expect(prompts[0]).toContain("focused subtask agent");
-    expect(prompts[0]).toContain("Assess the Task");
-    expect(prompts[0]).toContain("When Done: Report");
-    expect(prompts[0]).toContain("Rules (non-negotiable)");
-  });
-
-  test("returns array with base and agent instructions when provided", () => {
-    const agentInstructions = "Always use the search tool first.";
-    const prompts = buildSubagentSystemPrompt(agentInstructions);
-
-    expect(prompts).toHaveLength(2);
-    expect(prompts[0]).toContain("focused subtask agent");
-    expect(prompts[1]).toBe("Always use the search tool first.");
-  });
-
-  test("excludes agent instructions when empty string", () => {
-    const prompts = buildSubagentSystemPrompt("");
-
-    expect(prompts).toHaveLength(1);
-  });
-
-  test("excludes agent instructions when whitespace-only", () => {
-    const prompts = buildSubagentSystemPrompt("   \n  ");
-
-    expect(prompts).toHaveLength(1);
-  });
-});
-
 describe("metadata isolation", () => {
   /**
    * Note: buildSubtaskFinalMetadata was removed — subtask usage metadata
@@ -202,7 +168,7 @@ describe("metadata isolation", () => {
   });
 });
 
-describe("toModelOutput", () => {
+describe("toModelOutput (new runAgentLoop-based contract)", () => {
   const tool = createSubtaskTool(mockWriter, mockParams, mockCtx);
   const toModelOutput = tool.toModelOutput!;
 
@@ -211,79 +177,106 @@ describe("toModelOutput", () => {
     input: { prompt: "test", agent_id: "vir_test" } as const,
   };
 
-  test("returns fallback when message is null", () => {
-    const result = toModelOutput({ ...baseArgs, output: null as never });
-
-    expect(result).toEqual({
-      type: "text",
-      value: "Subtask completed (no output).",
-    });
-  });
-
-  test("returns fallback when message is undefined", () => {
-    const result = toModelOutput({ ...baseArgs, output: undefined as never });
-
-    expect(result).toEqual({
-      type: "text",
-      value: "Subtask completed (no output).",
-    });
-  });
-
-  test("returns fallback when parts is empty", () => {
-    const result = toModelOutput({
-      ...baseArgs,
-      output: { parts: [] } as never,
-    });
-
-    expect(result).toEqual({
-      type: "text",
-      value: "Subtask completed (no output).",
-    });
-  });
-
-  test("returns fallback when no text parts", () => {
+  test("returns text when output has text and no error", () => {
     const result = toModelOutput({
       ...baseArgs,
       output: {
-        parts: [{ type: "tool-call", toolCallId: "tc_1", toolName: "foo" }],
+        text: "**Result**: 12 unused connections.",
+        error: undefined,
+        finishReason: "stop",
       } as never,
     });
+    expect(result).toEqual({
+      type: "text",
+      value: "**Result**: 12 unused connections.",
+    });
+  });
 
+  test("returns error-text when output has an error", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: {
+        text: "I'll start by listing...",
+        error: "AI_APICallError: prompt is too long",
+        finishReason: "error",
+      } as never,
+    }) as { type: string; value: string };
+    expect(result.type).toBe("error-text");
+    expect(result.value).toContain("Subtask failed:");
+    expect(result.value).toContain("prompt is too long");
+  });
+
+  test("error takes precedence over text", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: {
+        text: "Step 1 done.",
+        error: "Context window exceeded",
+        finishReason: "error",
+      } as never,
+    }) as { type: string; value: string };
+    expect(result.type).toBe("error-text");
+  });
+
+  test("prefixes text with step-limit notice when finishReason is 'length'", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: {
+        text: "Partial report.",
+        error: undefined,
+        finishReason: "length",
+      } as never,
+    }) as { type: string; value: string };
+    expect(result.type).toBe("text");
+    expect(result.value).toContain("[Subtask hit step limit");
+    expect(result.value).toContain("Partial report.");
+  });
+
+  test("returns fallback when output is undefined", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: undefined as never,
+    });
     expect(result).toEqual({
       type: "text",
       value: "Subtask completed (no output).",
     });
   });
 
-  test("returns last text part when present", () => {
+  test("returns fallback when output is null", () => {
     const result = toModelOutput({
       ...baseArgs,
-      output: {
-        parts: [
-          { type: "text", text: "First part" },
-          { type: "text", text: "Second part" },
-          { type: "text", text: "Final summary" },
-        ],
-      } as never,
+      output: null as never,
     });
-
     expect(result).toEqual({
       type: "text",
-      value: "Final summary",
+      value: "Subtask completed (no output).",
     });
   });
 
-  test("returns single text part", () => {
+  test("returns fallback when output has empty text and no error", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: { text: "", error: undefined, finishReason: "stop" } as never,
+    });
+    expect(result).toEqual({
+      type: "text",
+      value: "Subtask completed (no output).",
+    });
+  });
+
+  test("returns fallback when output has only whitespace text", () => {
     const result = toModelOutput({
       ...baseArgs,
       output: {
-        parts: [{ type: "text", text: "The task is done." }],
+        text: "   \n  ",
+        error: undefined,
+        finishReason: "stop",
       } as never,
     });
-
     expect(result).toEqual({
       type: "text",
-      value: "The task is done.",
+      value: "Subtask completed (no output).",
     });
   });
 });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -4,16 +4,15 @@
  * The actual model invocation, tool assembly, system-prompt
  * assembly, and error handling all live in runAgentLoop. This file
  * owns only subtask-specific concerns: validating the target
- * agent, creating an MCP client for it, yielding UIMessages back
- * to the parent (so the AI SDK auto-wraps them as nested
- * tool-subtask parts), and emitting the subtask-metadata data
- * chunk.
+ * agent, creating an MCP client for it, draining the subagent's
+ * stream to completion, emitting the subtask-metadata data chunk,
+ * and yielding a single structured result for toModelOutput.
  */
 
 import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import type { UIMessageStreamWriter } from "ai";
-import { readUIMessageStream, tool, zodSchema } from "ai";
+import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MeshProvider } from "@/ai-providers/types";
 import type { ModelsConfig } from "../../../api/routes/decopilot/types";
@@ -129,11 +128,26 @@ export function createSubtaskTool(
           passthroughClient: mcpClient,
         });
 
-        // 4. Yield UIMessages — AI SDK auto-wraps as tool-subtask parts.
-        for await (const message of readUIMessageStream({
-          stream: handle.result.toUIMessageStream(),
-        })) {
-          yield message;
+        // 4. Drain the UI stream so streamText runs to completion.
+        //    We intentionally don't yield each progressive UIMessage:
+        //      - AI SDK's executeTool helper reads only YIELDED values
+        //        (the generator's return value is discarded), so the
+        //        last yielded UIMessage would be what reaches
+        //        toModelOutput — losing our extracted text/error.
+        //      - Each progressive UIMessage from readUIMessageStream
+        //        carries the full accumulated state (incl. multi-MB
+        //        MCP tool outputs), causing per-chunk NATS payloads
+        //        to exceed the 1 MB default and be dropped silently.
+        //    Instead, we drain here and yield a single structured
+        //    object at the end (step 7).
+        const reader = handle.result.toUIMessageStream().getReader();
+        try {
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        } finally {
+          reader.releaseLock();
         }
 
         // 5. Collect results from the resolved promises.
@@ -164,8 +178,13 @@ export function createSubtaskTool(
           data: { usage, agent: agent_id, models },
         });
 
-        // 7. Return the tool output — flows into toModelOutput.
-        return { text: aggregatedText, error, finishReason };
+        // 7. Yield the structured result as the ONLY (and therefore
+        //    final) value. The AI SDK's executeTool helper uses the
+        //    LAST YIELDED value as `output` for toModelOutput — the
+        //    generator's return value is discarded. Yielding here
+        //    keeps the parent's UI payload tiny and the model output
+        //    correct.
+        yield { text: aggregatedText, error, finishReason };
       } finally {
         mcpClient.close().catch(() => {});
       }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -139,8 +139,17 @@ export function createSubtaskTool(
         // 5. Collect results from the resolved promises.
         const error = await handle.error;
         const finishReason = await handle.result.finishReason;
-        const text = await handle.result.text;
+        const steps = await handle.result.steps;
+        const aggregatedText = steps
+          .map((s) => s.text ?? "")
+          .filter((t) => t.trim().length > 0)
+          .join("\n\n")
+          .trim();
         const usage = await handle.result.usage;
+
+        console.log(
+          `[subtask:${agent_id}] completed: finishReason=${finishReason}, steps=${steps.length}, textLength=${aggregatedText.length}, error=${error ? "yes" : "no"}, usage=${JSON.stringify({ inputTokens: usage.inputTokens, outputTokens: usage.outputTokens })}`,
+        );
 
         // 6. Emit metadata chunks to the parent's writer.
         const latencyMs = performance.now() - startTime;
@@ -156,7 +165,7 @@ export function createSubtaskTool(
         });
 
         // 7. Return the tool output — flows into toModelOutput.
-        return { text, error, finishReason };
+        return { text: aggregatedText, error, finishReason };
       } finally {
         mcpClient.close().catch(() => {});
       }
@@ -172,12 +181,20 @@ export function createSubtaskTool(
         };
       }
       const text = o?.text?.trim();
+      const stepLimitHit = o?.finishReason === "length";
+
       if (text) {
-        const prefix =
-          o?.finishReason === "length"
-            ? "[Subtask hit step limit — partial result below; consider narrowing the task.]\n\n"
-            : "";
+        const prefix = stepLimitHit
+          ? "[Subtask hit step limit — partial result below; consider narrowing the task.]\n\n"
+          : "";
         return { type: "text" as const, value: prefix + text };
+      }
+      if (stepLimitHit) {
+        return {
+          type: "text" as const,
+          value:
+            "[Subtask hit step limit before producing a final report. The subagent did work but ran out of steps. Narrow the task or increase the budget.]",
+        };
       }
       return {
         type: "text" as const,

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -1,36 +1,24 @@
 /**
- * subtask Built-in Tool
+ * subtask Built-in Tool — thin wrapper around runAgentLoop.
  *
- * Server-side tool that spawns a streaming subagent to delegate work to another
- * agent (Virtual MCP). Uses AI SDK v6 streaming generator pattern.
+ * The actual model invocation, tool assembly, system-prompt
+ * assembly, and error handling all live in runAgentLoop. This file
+ * owns only subtask-specific concerns: validating the target
+ * agent, creating an MCP client for it, yielding UIMessages back
+ * to the parent (so the AI SDK auto-wraps them as nested
+ * tool-subtask parts), and emitting the subtask-metadata data
+ * chunk.
  */
 
 import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
 import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
-import { addUsage, emptyUsageStats, type UsageStats } from "@decocms/mesh-sdk";
 import type { UIMessageStreamWriter } from "ai";
-import {
-  readUIMessageStream,
-  stepCountIs,
-  streamText,
-  tool,
-  zodSchema,
-} from "ai";
+import { readUIMessageStream, tool, zodSchema } from "ai";
 import { z } from "zod";
-import {
-  DEFAULT_MAX_TOKENS,
-  SUBAGENT_EXCLUDED_TOOLS,
-  SUBAGENT_STEP_LIMIT,
-} from "../../../api/routes/decopilot/constants";
-import { toolsFromMCP } from "../../../api/routes/decopilot/helpers";
+import type { MeshProvider } from "@/ai-providers/types";
 import type { ModelsConfig } from "../../../api/routes/decopilot/types";
-import { MeshProvider } from "@/ai-providers/types";
-import {
-  OPENROUTER_CACHE_PROVIDER_OPTIONS,
-  withCachedToolPrefix,
-} from "../../../api/routes/decopilot/cache-instrumentation";
-import { createLanguageModel } from "../../../ai-providers/language-model";
-import { buildSystemMessages } from "../system-prompt";
+import { runAgentLoop } from "../run-agent-loop";
+import { SUBAGENT_STEP_LIMIT } from "../../../api/routes/decopilot/constants";
 
 export const SubtaskInputSchema = z.object({
   prompt: z
@@ -52,10 +40,6 @@ export const SubtaskInputSchema = z.object({
 });
 
 export type SubtaskInput = z.infer<typeof SubtaskInputSchema>;
-
-export interface SubtaskResultMeta {
-  usage: UsageStats;
-}
 
 const SUBTASK_DESCRIPTION =
   "Delegate a self-contained task to another agent. The subagent runs independently with its own tools " +
@@ -81,46 +65,6 @@ const SUBTASK_ANNOTATIONS = {
   openWorldHint: true,
 } as const;
 
-const SUBTASK_BASE_PROMPT = `You are a focused subtask agent delegated a specific task by a parent agent. You are NOT the parent agent.
-
-## Rules (non-negotiable)
-
-1. Do NOT converse, ask questions, or suggest next steps to the user — you cannot interact with them.
-2. Do NOT delegate to other agents — execute directly.
-3. Stay strictly within your task's scope. If you discover related work outside your scope, mention it in one sentence at most.
-
-## Before Acting: Assess the Task
-
-Before making ANY tool calls, evaluate: do you understand what to do, how to do it, and when you're done?
-
-- **If unclear** → Respond IMMEDIATELY with what's missing. Make zero tool calls. The parent agent will reformulate with more context.
-- **If clear** → Proceed autonomously. Be efficient, be thorough, don't second-guess. If you hit obstacles mid-execution, make reasonable judgment calls and note them.
-
-## Execution
-
-- Use your tools directly. Do not emit text between tool calls — use tools, then report once at the end.
-- Keep your report under 500 words unless the task requires more detail. Be factual and concise.
-- Do not use emojis.
-
-## When Done: Report
-
-End with a structured summary:
-- **Result**: What you did, what you found or produced
-- **Key files**: Relevant file paths (always absolute, never relative) — include only for research tasks
-- **Issues**: Anything to flag — include only if there are issues
-
-This report is all the parent agent sees.`;
-
-export function buildSubagentSystemPrompt(
-  agentInstructions?: string,
-): string[] {
-  const prompts = [SUBTASK_BASE_PROMPT];
-  if (agentInstructions?.trim()) {
-    prompts.push(agentInstructions);
-  }
-  return prompts;
-}
-
 export function createSubtaskTool(
   writer: UIMessageStreamWriter,
   params: SubtaskParams,
@@ -138,114 +82,106 @@ export function createSubtaskTool(
     ) {
       const startTime = performance.now();
 
-      // ── 1. Load and validate target agent ──────────────────────────
+      // 1. Validate the target agent.
       const virtualMcp = await ctx.storage.virtualMcps.findById(
         agent_id,
         organization.id,
       );
-
       if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
         throw new Error("Agent not found");
       }
-
       if (virtualMcp.status !== "active") {
         throw new Error("Agent is not active");
       }
 
-      // ── 2. Create MCP client for the target agent ──────────────────
+      // 2. Create MCP client for the target.
       const mcpClient = await createVirtualClientFrom(
         virtualMcp,
         ctx,
         "passthrough",
       );
 
-      // ── 3. Load tools, excluding ones that shouldn't nest ──────────
-      const { tools: mcpTools } = await toolsFromMCP(
-        mcpClient,
-        new Map(),
-        writer,
-        "auto",
-        { disableOutputTruncation: true },
-      );
-      // Tools are filtered first, then sorted-and-cache-marked via the
-      // shared helper. Anthropic's tool-cache layer is separate from
-      // the system/messages layer, so this doesn't consume any system
-      // cache breakpoints.
-      const filteredTools = Object.fromEntries(
-        Object.entries(mcpTools).filter(
-          ([name]) => !SUBAGENT_EXCLUDED_TOOLS.includes(name),
-        ),
-      );
-      const subagentTools = withCachedToolPrefix(filteredTools);
-
-      // ── 4. Build subagent system prompt ────────────────────────────
-      const serverInstructions = mcpClient.getInstructions();
-      const systemPrompts = buildSubagentSystemPrompt(serverInstructions);
-      const systemPromptMessages = buildSystemMessages(
-        systemPrompts,
-        new Date(),
-      );
-
-      // ── 5. Run streamText as subagent ──────────────────────────────
-      let accumulatedUsage: UsageStats = emptyUsageStats();
-
-      const result = streamText({
-        model: createLanguageModel(provider, models.thinking),
-        system: systemPromptMessages,
-        prompt,
-        tools: subagentTools,
-        providerOptions: OPENROUTER_CACHE_PROVIDER_OPTIONS,
-        abortSignal,
-        stopWhen: stepCountIs(SUBAGENT_STEP_LIMIT),
-        maxOutputTokens:
-          models.thinking.limits?.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
-        onStepFinish: ({ usage, providerMetadata }) => {
-          accumulatedUsage = addUsage(accumulatedUsage, {
-            ...usage,
-            providerMetadata,
-          });
-        },
-        onAbort: () => {
-          console.error(`[subtask:${agent_id}] Aborted`);
-          mcpClient.close().catch(() => {});
-        },
-        onError: (error) => {
-          console.error(`[subtask:${agent_id}] Error`, error);
-        },
-      });
-
-      // ── 6. Stream results via readUIMessageStream ──────────────────
-      for await (const message of readUIMessageStream({
-        stream: result.toUIMessageStream(),
-      })) {
-        yield message;
-      }
-
-      // Emit tool metadata (annotations + latency) and subtask metadata
-      const latencyMs = performance.now() - startTime;
-      writer.write({
-        type: "data-tool-metadata",
-        id: toolCallId,
-        data: { annotations: SUBTASK_ANNOTATIONS, latencyMs },
-      });
-      writer.write({
-        type: "data-tool-subtask-metadata",
-        id: toolCallId,
-        data: {
-          usage: accumulatedUsage,
-          agent: agent_id,
+      try {
+        // 3. Call runAgentLoop with subagent kind.
+        const handle = await runAgentLoop({
+          kind: "subagent",
+          ctx,
+          organization,
+          virtualMcp: {
+            id: virtualMcp.id,
+            instructions: mcpClient.getInstructions(),
+            repo: virtualMcp.metadata?.githubRepo ?? undefined,
+          },
+          mcpClient,
+          provider,
           models,
-        },
-      });
-    },
-    toModelOutput: ({ output: message }) => {
-      const lastTextPart = message?.parts?.findLast(
-        (p) => "type" in p && p.type === "text" && "text" in p,
-      );
+          messages: [{ role: "user", content: prompt }],
+          abortSignal: abortSignal ?? new AbortController().signal,
+          stepLimit: SUBAGENT_STEP_LIMIT,
+          toolApprovalLevel: "auto",
+          planMode: false,
+          writer,
+          subtaskParams: { provider, organization, models, needsApproval },
+          // Subagent inherits the parent's writer for nested chunk routing.
+          // Subagent gets prompts/connections blocks via the MCP client
+          // (which is both the tool source AND the prompts source for the
+          // target agent). This passes through to buildAgentSystemPrompt.
+          passthroughClient: mcpClient,
+        });
 
+        // 4. Yield UIMessages — AI SDK auto-wraps as tool-subtask parts.
+        for await (const message of readUIMessageStream({
+          stream: handle.result.toUIMessageStream(),
+        })) {
+          yield message;
+        }
+
+        // 5. Collect results from the resolved promises.
+        const error = await handle.error;
+        const finishReason = await handle.result.finishReason;
+        const text = await handle.result.text;
+        const usage = await handle.result.usage;
+
+        // 6. Emit metadata chunks to the parent's writer.
+        const latencyMs = performance.now() - startTime;
+        writer.write({
+          type: "data-tool-metadata",
+          id: toolCallId,
+          data: { annotations: SUBTASK_ANNOTATIONS, latencyMs },
+        });
+        writer.write({
+          type: "data-tool-subtask-metadata",
+          id: toolCallId,
+          data: { usage, agent: agent_id, models },
+        });
+
+        // 7. Return the tool output — flows into toModelOutput.
+        return { text, error, finishReason };
+      } finally {
+        mcpClient.close().catch(() => {});
+      }
+    },
+    toModelOutput: ({ output }) => {
+      const o = output as
+        | { text?: string; error?: string; finishReason?: string }
+        | undefined;
+      if (o?.error) {
+        return {
+          type: "error-text" as const,
+          value: `Subtask failed: ${o.error}`,
+        };
+      }
+      const text = o?.text?.trim();
+      if (text) {
+        const prefix =
+          o?.finishReason === "length"
+            ? "[Subtask hit step limit — partial result below; consider narrowing the task.]\n\n"
+            : "";
+        return { type: "text" as const, value: prefix + text };
+      }
       return {
         type: "text" as const,
-        value: lastTextPart?.text ?? "Subtask completed (no output).",
+        value: "Subtask completed (no output).",
       };
     },
   });

--- a/apps/mesh/src/harnesses/decopilot/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/index.ts
@@ -213,6 +213,7 @@ export const decopilotHarnessFactory: HarnessFactory = {
             onUsageAggregated: pl.onUsageAggregated,
             pendingImages: pl.pendingImages,
             onTitleUpdated: pl.onTitleUpdated,
+            writer: pl.writer,
           });
         } finally {
           await tools.close().catch(() => {});

--- a/apps/mesh/src/harnesses/decopilot/prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/prompt.ts
@@ -27,6 +27,7 @@
 import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
 import { isDecopilot } from "@decocms/mesh-sdk";
 import type { GithubRepo } from "@decocms/mesh-sdk";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   buildBasePlatformPrompt,
   buildDecopilotAgentPrompt,
@@ -35,8 +36,11 @@ import {
 } from "../../api/routes/decopilot/constants";
 import { resolveModeConfig } from "../../api/routes/decopilot/mode-config";
 import { buildAgentsBlock } from "./agents-block";
-import { buildPromptsBlock } from "./prompts-block";
-import { buildConnectionsBlock } from "./connections-block";
+import { buildPromptsBlock, type PromptsBlockEntry } from "./prompts-block";
+import {
+  buildConnectionsBlock,
+  type ConnectionsBlockTool,
+} from "./connections-block";
 import { buildSystemMessages, type SystemMessage } from "./system-prompt";
 import type { HarnessStreamInput } from "../types";
 import type { AssembledTools } from "./tools";
@@ -64,29 +68,50 @@ export async function listAgentsBlock(
 }
 
 /**
- * listPromptsBlock — stub for Stage 2.1. Returns null until Stage 2.3
- * wires in the passthrough MCP client. The parent assembler (prompt.ts)
- * keeps building the block via its own inline `tools.passthroughClient`.
+ * listPromptsBlock — fetches the MCP's prompt catalog via the passthrough
+ * client and builds the `<available-prompts>` block. Returns null when no
+ * client is provided (e.g., unit tests) or when the catalog is empty.
  */
-// biome-ignore lint/correctness/noUnusedFunctionParameters: stub for Stage 2.3
 export async function listPromptsBlock(
   _ctx: MeshContext,
   _org: OrganizationScope,
+  passthroughClient?: Client,
 ): Promise<string | null> {
-  return null;
+  if (!passthroughClient) return null;
+  try {
+    const { prompts } = await passthroughClient.listPrompts();
+    if (!prompts?.length) return null;
+    return buildPromptsBlock(
+      prompts.map((p) => ({
+        name: p.name,
+        description: p.description ?? null,
+        arguments: (p.arguments ?? []).map((a) => ({
+          name: a.name,
+          required: a.required,
+        })),
+      })) satisfies PromptsBlockEntry[],
+    );
+  } catch (err) {
+    console.warn("[listPromptsBlock] Failed to list prompts:", err);
+    return null;
+  }
 }
 
 /**
- * listConnectionsBlock — stub for Stage 2.1. Returns null until Stage 2.3
- * wires in the assembled tools data. The parent assembler (prompt.ts)
- * keeps building the block via its own inline `tools.connectionsBlockTools`.
+ * listConnectionsBlock — builds the `<available-connections>` block from
+ * pre-assembled tools data. Returns null when no data is provided or when
+ * there are no tools to expose.
  */
-// biome-ignore lint/correctness/noUnusedFunctionParameters: stub for Stage 2.3
 export async function listConnectionsBlock(
   _ctx: MeshContext,
   _org: OrganizationScope,
+  data?: {
+    tools: ConnectionsBlockTool[];
+    connectionTitleMap: Map<string, string>;
+  },
 ): Promise<string | null> {
-  return null;
+  if (!data || data.tools.length === 0) return null;
+  return buildConnectionsBlock(data.tools, data.connectionTitleMap);
 }
 
 export interface AssembledPrompt {

--- a/apps/mesh/src/harnesses/decopilot/prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/prompt.ts
@@ -24,7 +24,7 @@
  * providers — they have their own harnesses.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
 import { isDecopilot } from "@decocms/mesh-sdk";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import {
@@ -40,6 +40,54 @@ import { buildConnectionsBlock } from "./connections-block";
 import { buildSystemMessages, type SystemMessage } from "./system-prompt";
 import type { HarnessStreamInput } from "../types";
 import type { AssembledTools } from "./tools";
+
+/**
+ * listAgentsBlock — fetches the org's virtual MCPs and builds the
+ * `<available-agents>` block. Excludes the current virtualMcpId if
+ * provided. Returns null when no other active agents exist.
+ */
+export async function listAgentsBlock(
+  ctx: MeshContext,
+  org: OrganizationScope,
+  currentVirtualMcpId?: string,
+): Promise<string | null> {
+  const virtualMcpList = await ctx.storage.virtualMcps.list(org.id);
+  return buildAgentsBlock(
+    virtualMcpList.map((vm) => ({
+      id: vm.id,
+      name: vm.title,
+      description: vm.description,
+      status: vm.status,
+    })),
+    currentVirtualMcpId ?? "",
+  );
+}
+
+/**
+ * listPromptsBlock — stub for Stage 2.1. Returns null until Stage 2.3
+ * wires in the passthrough MCP client. The parent assembler (prompt.ts)
+ * keeps building the block via its own inline `tools.passthroughClient`.
+ */
+// biome-ignore lint/correctness/noUnusedFunctionParameters: stub for Stage 2.3
+export async function listPromptsBlock(
+  _ctx: MeshContext,
+  _org: OrganizationScope,
+): Promise<string | null> {
+  return null;
+}
+
+/**
+ * listConnectionsBlock — stub for Stage 2.1. Returns null until Stage 2.3
+ * wires in the assembled tools data. The parent assembler (prompt.ts)
+ * keeps building the block via its own inline `tools.connectionsBlockTools`.
+ */
+// biome-ignore lint/correctness/noUnusedFunctionParameters: stub for Stage 2.3
+export async function listConnectionsBlock(
+  _ctx: MeshContext,
+  _org: OrganizationScope,
+): Promise<string | null> {
+  return null;
+}
 
 export interface AssembledPrompt {
   /** System messages ready to be merged with any per-request system

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
@@ -5,6 +5,16 @@
 import { describe, expect, test } from "bun:test";
 import { runAgentLoop, type RunAgentLoopOptions } from "./run-agent-loop";
 
+// ── Stub fixtures ────────────────────────────────────────────────────
+const mockCtx = {} as never;
+const mockOrg = { id: "org_test" } as never;
+const mockMcpClient = {} as never;
+const mockProvider = {} as never;
+const mockModels = {
+  thinking: { id: "m1", limits: {} },
+  credentialId: "cred_1",
+} as never;
+
 describe("runAgentLoop", () => {
   test("rejects when kind is 'subagent' (Stage 1 stub)", async () => {
     const fakeOpts = {
@@ -22,5 +32,55 @@ describe("runAgentLoop", () => {
     // Type-check at compile time. If this compiles, types are exported.
     const opts: Partial<RunAgentLoopOptions> = { kind: "agent" };
     expect(opts.kind).toBe("agent");
+  });
+});
+
+describe("runAgentLoop with kind: 'agent'", () => {
+  test("captures errors via onError and resolves the error promise", async () => {
+    let capturedOnError:
+      | ((event: { error: unknown }) => void | Promise<void>)
+      | undefined;
+
+    const fakeResult = {
+      text: Promise.resolve(""),
+      finishReason: Promise.resolve("error"),
+      usage: Promise.resolve({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      }),
+      toUIMessageStream: () => ({
+        async *[Symbol.asyncIterator]() {},
+      }),
+      response: Promise.resolve({ messages: [] }),
+    } as never;
+
+    // Stage 1 shim: inject a fake streamText via __streamText to avoid
+    // ES-module read-only binding limitations. Deleted in Stage 2.
+    const fakeStreamText = (cfg: {
+      onError: (event: { error: unknown }) => void | Promise<void>;
+    }) => {
+      capturedOnError = cfg.onError;
+      Promise.resolve().then(() =>
+        capturedOnError?.({ error: new Error("provider rejected: 400") }),
+      );
+      return fakeResult;
+    };
+
+    const handle = await runAgentLoop({
+      kind: "agent",
+      ctx: mockCtx,
+      organization: mockOrg,
+      virtualMcp: { id: "vir_test" },
+      mcpClient: mockMcpClient,
+      provider: mockProvider,
+      models: mockModels,
+      messages: [],
+      abortSignal: new AbortController().signal,
+      __streamText: fakeStreamText,
+    } as never);
+
+    const error = await handle.error;
+    expect(error).toContain("provider rejected: 400");
   });
 });

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
@@ -1,0 +1,26 @@
+/**
+ * runAgentLoop tests — shared core for parent + subagent.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runAgentLoop, type RunAgentLoopOptions } from "./run-agent-loop";
+
+describe("runAgentLoop", () => {
+  test("rejects when kind is 'subagent' (Stage 1 stub)", async () => {
+    const fakeOpts = {
+      kind: "subagent",
+    } as RunAgentLoopOptions;
+
+    // runAgentLoop is async from the start so the Stage 1 → Stage 2
+    // transition doesn't change call-site shape (no sync→async break).
+    await expect(runAgentLoop(fakeOpts)).rejects.toThrow(
+      /not yet implemented in Stage 1/,
+    );
+  });
+
+  test("exports the expected types", () => {
+    // Type-check at compile time. If this compiles, types are exported.
+    const opts: Partial<RunAgentLoopOptions> = { kind: "agent" };
+    expect(opts.kind).toBe("agent");
+  });
+});

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
@@ -6,28 +6,30 @@ import { describe, expect, test } from "bun:test";
 import { runAgentLoop, type RunAgentLoopOptions } from "./run-agent-loop";
 
 // ── Stub fixtures ────────────────────────────────────────────────────
-const mockCtx = {} as never;
+// ctx needs enough storage stubs for buildAgentSystemPrompt (listAgentsBlock
+// calls ctx.storage.virtualMcps.list, listConnectionsBlock is no-op when
+// connectionsData is absent).
+const mockCtx = {
+  storage: {
+    virtualMcps: {
+      list: async () => [],
+    },
+  },
+} as never;
 const mockOrg = { id: "org_test" } as never;
-const mockMcpClient = {} as never;
 const mockProvider = {} as never;
 const mockModels = {
   thinking: { id: "m1", limits: {} },
   credentialId: "cred_1",
 } as never;
+const mockWriter = { write: () => {}, merge: () => {} } as never;
+const mockSubtaskParams = {
+  provider: mockProvider,
+  organization: mockOrg,
+  models: mockModels,
+};
 
 describe("runAgentLoop", () => {
-  test("rejects when kind is 'subagent' (Stage 1 stub)", async () => {
-    const fakeOpts = {
-      kind: "subagent",
-    } as RunAgentLoopOptions;
-
-    // runAgentLoop is async from the start so the Stage 1 → Stage 2
-    // transition doesn't change call-site shape (no sync→async break).
-    await expect(runAgentLoop(fakeOpts)).rejects.toThrow(
-      /not yet implemented in Stage 1/,
-    );
-  });
-
   test("exports the expected types", () => {
     // Type-check at compile time. If this compiles, types are exported.
     const opts: Partial<RunAgentLoopOptions> = { kind: "agent" };
@@ -55,8 +57,8 @@ describe("runAgentLoop with kind: 'agent'", () => {
       response: Promise.resolve({ messages: [] }),
     } as never;
 
-    // Stage 1 shim: inject a fake streamText via __streamText to avoid
-    // ES-module read-only binding limitations. Deleted in Stage 2.
+    // Inject a fake streamText via __streamText to avoid
+    // ES-module read-only binding limitations.
     const fakeStreamText = (cfg: {
       onError: (event: { error: unknown }) => void | Promise<void>;
     }) => {
@@ -67,20 +69,75 @@ describe("runAgentLoop with kind: 'agent'", () => {
       return fakeResult;
     };
 
+    const mockMcpClientWithListTools = {
+      listTools: async () => ({ tools: [] }),
+      getInstructions: () => "",
+    } as never;
+
     const handle = await runAgentLoop({
       kind: "agent",
       ctx: mockCtx,
       organization: mockOrg,
       virtualMcp: { id: "vir_test" },
-      mcpClient: mockMcpClient,
+      mcpClient: mockMcpClientWithListTools,
       provider: mockProvider,
       models: mockModels,
       messages: [],
       abortSignal: new AbortController().signal,
+      writer: mockWriter,
+      subtaskParams: mockSubtaskParams,
       __streamText: fakeStreamText,
     } as never);
 
     const error = await handle.error;
     expect(error).toContain("provider rejected: 400");
+  });
+});
+
+describe("runAgentLoop with kind: 'subagent'", () => {
+  test("subagent kind no longer throws and assembles tools", async () => {
+    const fakeResult = {
+      text: Promise.resolve(""),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      }),
+      toUIMessageStream: () => ({
+        async *[Symbol.asyncIterator]() {},
+      }),
+      response: Promise.resolve({ messages: [] }),
+    } as never;
+
+    // Build a fake streamText that returns a minimal result
+    const fakeStreamText = () => {
+      return fakeResult;
+    };
+
+    const mockMcpClientWithListTools = {
+      listTools: async () => ({ tools: [] }),
+      getInstructions: () => "",
+    } as never;
+
+    const handle = await runAgentLoop({
+      kind: "subagent",
+      ctx: mockCtx,
+      organization: mockOrg,
+      virtualMcp: { id: "vir_test" },
+      mcpClient: mockMcpClientWithListTools,
+      provider: mockProvider,
+      models: mockModels,
+      messages: [{ role: "user", content: "hi" }],
+      abortSignal: new AbortController().signal,
+      writer: mockWriter,
+      subtaskParams: mockSubtaskParams,
+      __streamText: fakeStreamText as never,
+    } as never);
+
+    expect(handle).toBeDefined();
+    expect(handle.result).toBeDefined();
+    expect(handle.error).toBeDefined();
+    expect(handle.span).toBeDefined();
   });
 });

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -12,16 +12,30 @@
 import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
 import type { MeshProvider } from "@/ai-providers/types";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import type { Span, Tracer } from "@opentelemetry/api";
-import type {
-  ModelMessage,
-  StreamTextResult,
-  ToolSet,
-  StreamTextOnStepFinishCallback,
+import {
+  SpanStatusCode,
+  trace,
+  type Span,
+  type Tracer,
+} from "@opentelemetry/api";
+import {
+  stepCountIs,
+  streamText,
+  type ModelMessage,
+  type StreamTextResult,
+  type ToolSet,
+  type StreamTextOnStepFinishCallback,
 } from "ai";
 import type { ModelsConfig } from "../../api/routes/decopilot/types";
 import type { ToolApprovalLevel } from "../../api/routes/decopilot/helpers";
 import type { UsageStats } from "@decocms/mesh-sdk";
+import { OPENROUTER_CACHE_PROVIDER_OPTIONS } from "../../api/routes/decopilot/cache-instrumentation";
+import { createLanguageModel } from "../../ai-providers/language-model";
+import {
+  DEFAULT_MAX_TOKENS,
+  PARENT_STEP_LIMIT,
+  SUBAGENT_STEP_LIMIT,
+} from "../../api/routes/decopilot/constants";
 
 export interface RunAgentLoopOptions {
   ctx: MeshContext;
@@ -47,6 +61,11 @@ export interface RunAgentLoopOptions {
   __tools?: ToolSet;
   __system?: unknown;
   __prepareStep?: unknown;
+
+  // ── Testing shim — allows injecting a fake streamText in unit tests.
+  //    Stage 1 only; deleted together with the other shims in Stage 2.
+  // biome-ignore lint/suspicious/noExplicitAny: test injection shim
+  __streamText?: (...args: any[]) => any;
 }
 
 export interface RunAgentLoopHandle {
@@ -63,6 +82,86 @@ export async function runAgentLoop(
       "runAgentLoop: kind 'subagent' not yet implemented in Stage 1",
     );
   }
-  // Stage 1: parent body is filled in in Task 1.2.
-  throw new Error("runAgentLoop: 'agent' kind body not yet wired up");
+
+  const tracer = opts.tracer ?? trace.getTracer("decopilot");
+  const stepLimit =
+    opts.stepLimit ??
+    (opts.kind === "agent" ? PARENT_STEP_LIMIT : SUBAGENT_STEP_LIMIT);
+
+  // ── Error capture: a single promise resolved by onError/onAbort ──
+  let capturedError: string | undefined;
+  let resolveError!: (err: string | undefined) => void;
+  const errorPromise = new Promise<string | undefined>((resolve) => {
+    resolveError = resolve;
+  });
+  const finalizeError = (err: string | undefined) => {
+    if (capturedError === undefined) capturedError = err;
+    resolveError(capturedError);
+  };
+
+  // ── OTel span ────────────────────────────────────────────────────
+  const span = tracer.startSpan("decopilot.agent_loop", {
+    attributes: {
+      "decopilot.agent.id": opts.virtualMcp.id,
+      "decopilot.agent.kind": opts.kind,
+      "decopilot.organization.id": opts.organization.id,
+      "decopilot.model.id": opts.models.thinking.id,
+    },
+  });
+
+  // ── streamText ────────────────────────────────────────────────────
+  // Stage 1 shim: caller passes pre-assembled tools/system/prepareStep
+  // via __tools/__system/__prepareStep. Stage 2 deletes the shim by
+  // calling buildAgentSystemPrompt + assembleAgentTools here.
+  const streamTextFn = opts.__streamText ?? streamText;
+  // __streamText test shim bypasses real provider; model is only needed
+  // for the real streamText path.
+  const model = opts.__streamText
+    ? (undefined as never)
+    : createLanguageModel(opts.provider, opts.models.thinking);
+  const result = streamTextFn({
+    model,
+    system: (opts as { __system?: unknown }).__system as never,
+    messages: opts.messages,
+    tools: (opts as { __tools?: ToolSet }).__tools as ToolSet,
+    providerOptions: OPENROUTER_CACHE_PROVIDER_OPTIONS,
+    prepareStep: (opts as { __prepareStep?: unknown }).__prepareStep as never,
+    temperature: opts.temperature,
+    maxOutputTokens:
+      opts.models.thinking.limits?.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
+    stopWhen: stepCountIs(stepLimit),
+    abortSignal: opts.abortSignal,
+    onStepFinish: opts.onStepFinish,
+    onError: async (event: { error?: unknown }) => {
+      const error = event.error ?? event;
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === "string"
+            ? error
+            : `${error}`;
+      console.error(
+        `[runAgentLoop:${opts.kind}:${opts.virtualMcp.id}] Error`,
+        error,
+      );
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      if (error instanceof Error) span.recordException(error);
+      finalizeError(message);
+    },
+    onAbort: async () => {
+      console.error(
+        `[runAgentLoop:${opts.kind}:${opts.virtualMcp.id}] Aborted`,
+      );
+      finalizeError(capturedError ?? "Run aborted before completion.");
+    },
+  }) as StreamTextResult<ToolSet, never>;
+
+  Promise.resolve(result.finishReason)
+    .then(() => {
+      if (capturedError === undefined) resolveError(undefined);
+      span.setStatus({ code: SpanStatusCode.OK });
+    })
+    .finally(() => span.end());
+
+  return { result, error: errorPromise, span };
 }

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -158,8 +158,10 @@ export async function runAgentLoop(
 
   Promise.resolve(result.finishReason)
     .then(() => {
-      if (capturedError === undefined) resolveError(undefined);
-      span.setStatus({ code: SpanStatusCode.OK });
+      if (capturedError === undefined) {
+        resolveError(undefined);
+        span.setStatus({ code: SpanStatusCode.OK });
+      }
     })
     .finally(() => span.end());
 

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -25,10 +25,11 @@ import {
   type StreamTextResult,
   type ToolSet,
   type StreamTextOnStepFinishCallback,
+  type UIMessageStreamWriter,
 } from "ai";
 import type { ModelsConfig } from "../../api/routes/decopilot/types";
 import type { ToolApprovalLevel } from "../../api/routes/decopilot/helpers";
-import type { UsageStats } from "@decocms/mesh-sdk";
+import type { GithubRepo, UsageStats } from "@decocms/mesh-sdk";
 import { OPENROUTER_CACHE_PROVIDER_OPTIONS } from "../../api/routes/decopilot/cache-instrumentation";
 import { createLanguageModel } from "../../ai-providers/language-model";
 import {
@@ -36,11 +37,19 @@ import {
   PARENT_STEP_LIMIT,
   SUBAGENT_STEP_LIMIT,
 } from "../../api/routes/decopilot/constants";
+import { buildAgentSystemPrompt } from "./build-agent-system-prompt";
+import { assembleAgentTools } from "./assemble-agent-tools";
+import type { SubtaskParams } from "./built-in-tools/subtask";
+import type { ConnectionsBlockTool } from "./connections-block";
 
 export interface RunAgentLoopOptions {
   ctx: MeshContext;
   organization: OrganizationScope;
-  virtualMcp: { id: string; instructions?: string };
+  virtualMcp: {
+    id: string;
+    instructions?: string;
+    repo?: GithubRepo;
+  };
   mcpClient: Client;
   provider: MeshProvider;
   models: ModelsConfig;
@@ -53,17 +62,38 @@ export interface RunAgentLoopOptions {
   temperature?: number;
   abortSignal: AbortSignal;
   tracer?: Tracer;
+  writer: UIMessageStreamWriter;
+  subtaskParams: SubtaskParams;
   onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
   onUsageAggregated?: (usage: UsageStats) => void;
 
-  // ── Stage 1 shim — deleted in Stage 2 once runAgentLoop owns
-  //    tool + system assembly itself.
-  __tools?: ToolSet;
-  __system?: unknown;
-  __prepareStep?: unknown;
+  // ── Parent-supplied overrides ──────────────────────────────────────
+  /** Optional override for the streamText prepareStep callback.
+   *  Parent uses this for image injection + plan-mode filter + forced-
+   *  first-step tool. Subagent doesn't pass one. */
+  prepareStep?: unknown;
+  /** Passthrough MCP client — when present, the system prompt's
+   *  @-mention prompts block is populated via passthroughClient.listPrompts(). */
+  passthroughClient?: Client;
+  /** Connections data — when present, the system prompt's connections
+   *  block is populated. */
+  connectionsData?: {
+    tools: ConnectionsBlockTool[];
+    connectionTitleMap: Map<string, string>;
+  };
+  /** Extra tools to merge into the assembled toolset AFTER assembleAgentTools.
+   *  Parent uses this to inject `enable_tool` (which is state-dependent —
+   *  built from `enabledTools` reconstructed from message history). Subagents
+   *  don't pass this. Merged last so parent extras shadow assembled tools. */
+  extraTools?: ToolSet;
+  /** Additional per-request system messages appended AFTER the stable system
+   *  messages produced by buildAgentSystemPrompt. Parent uses this for
+   *  `processedSystemMessages` (inline <system> blocks from the user's
+   *  conversation that processConversation extracts). Subagents don't pass this. */
+  additionalSystemMessages?: import("ai").SystemModelMessage[];
 
-  // ── Testing shim — allows injecting a fake streamText in unit tests.
-  //    Stage 1 only; deleted together with the other shims in Stage 2.
+  // ── Stage 2: test-only shim (no production callers) ────────────────
+  /** Override `streamText` for unit tests. Production paths leave undefined. */
   // biome-ignore lint/suspicious/noExplicitAny: test injection shim
   __streamText?: (...args: any[]) => any;
 }
@@ -77,16 +107,12 @@ export interface RunAgentLoopHandle {
 export async function runAgentLoop(
   opts: RunAgentLoopOptions,
 ): Promise<RunAgentLoopHandle> {
-  if (opts.kind === "subagent") {
-    throw new Error(
-      "runAgentLoop: kind 'subagent' not yet implemented in Stage 1",
-    );
-  }
-
   const tracer = opts.tracer ?? trace.getTracer("decopilot");
   const stepLimit =
     opts.stepLimit ??
     (opts.kind === "agent" ? PARENT_STEP_LIMIT : SUBAGENT_STEP_LIMIT);
+  const planMode = opts.planMode ?? false;
+  const toolApprovalLevel = opts.toolApprovalLevel ?? "auto";
 
   // ── Error capture: a single promise resolved by onError/onAbort ──
   let capturedError: string | undefined;
@@ -109,23 +135,56 @@ export async function runAgentLoop(
     },
   });
 
-  // ── streamText ────────────────────────────────────────────────────
-  // Stage 1 shim: caller passes pre-assembled tools/system/prepareStep
-  // via __tools/__system/__prepareStep. Stage 2 deletes the shim by
-  // calling buildAgentSystemPrompt + assembleAgentTools here.
-  const streamTextFn = opts.__streamText ?? streamText;
+  // ── System prompt ─────────────────────────────────────────────────
+  const baseSystemMessages = await buildAgentSystemPrompt({
+    ctx: opts.ctx,
+    organization: opts.organization,
+    virtualMcp: opts.virtualMcp,
+    kind: opts.kind,
+    planMode,
+    agentInstructions: opts.systemAgentInstructions,
+    passthroughClient: opts.passthroughClient,
+    connectionsData: opts.connectionsData,
+  });
+  // Append any per-request system messages (e.g., processedSystemMessages
+  // from processConversation — inline <system> blocks in the conversation).
+  const systemMessages =
+    opts.additionalSystemMessages && opts.additionalSystemMessages.length > 0
+      ? [...baseSystemMessages, ...opts.additionalSystemMessages]
+      : baseSystemMessages;
+
+  // ── Tools ─────────────────────────────────────────────────────────
+  const { tools: assembledTools } = await assembleAgentTools({
+    kind: opts.kind,
+    ctx: opts.ctx,
+    mcpClient: opts.mcpClient,
+    writer: opts.writer,
+    planMode,
+    toolApprovalLevel,
+    subtaskParams: opts.subtaskParams,
+  });
+  // Merge extra tools (e.g., parent's state-dependent `enable_tool`) after
+  // the shared assembler. Parent extras shadow assembled tools intentionally.
+  const tools: ToolSet = opts.extraTools
+    ? { ...assembledTools, ...opts.extraTools }
+    : assembledTools;
+
+  // ── streamText (use shim if provided, else real) ──────────────────
+  const streamTextFn =
+    (opts as { __streamText?: unknown }).__streamText ?? streamText;
   // __streamText test shim bypasses real provider; model is only needed
   // for the real streamText path.
-  const model = opts.__streamText
+  const model = (opts as { __streamText?: unknown }).__streamText
     ? (undefined as never)
     : createLanguageModel(opts.provider, opts.models.thinking);
-  const result = streamTextFn({
+
+  const result = (streamTextFn as typeof streamText)({
     model,
-    system: (opts as { __system?: unknown }).__system as never,
+    system: systemMessages,
     messages: opts.messages,
-    tools: (opts as { __tools?: ToolSet }).__tools as ToolSet,
+    tools,
     providerOptions: OPENROUTER_CACHE_PROVIDER_OPTIONS,
-    prepareStep: (opts as { __prepareStep?: unknown }).__prepareStep as never,
+    prepareStep: opts.prepareStep as never,
     temperature: opts.temperature,
     maxOutputTokens:
       opts.models.thinking.limits?.maxOutputTokens ?? DEFAULT_MAX_TOKENS,

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -1,0 +1,68 @@
+/**
+ * runAgentLoop — shared core for the decopilot harness.
+ *
+ * Owns: system-prompt assembly, tool assembly, streamText invocation,
+ * prepareStep, error capture, OTel span for the loop itself.
+ *
+ * Does NOT own: HTTP plumbing, persistence, title generation, run-
+ * registry registration (parent-wrapper concerns), nor target-agent
+ * validation / MCP-client creation (subagent-wrapper concerns).
+ */
+
+import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
+import type { MeshProvider } from "@/ai-providers/types";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { Span, Tracer } from "@opentelemetry/api";
+import type {
+  ModelMessage,
+  StreamTextResult,
+  ToolSet,
+  StreamTextOnStepFinishCallback,
+} from "ai";
+import type { ModelsConfig } from "../../api/routes/decopilot/types";
+import type { ToolApprovalLevel } from "../../api/routes/decopilot/helpers";
+import type { UsageStats } from "@decocms/mesh-sdk";
+
+export interface RunAgentLoopOptions {
+  ctx: MeshContext;
+  organization: OrganizationScope;
+  virtualMcp: { id: string; instructions?: string };
+  mcpClient: Client;
+  provider: MeshProvider;
+  models: ModelsConfig;
+  messages: ModelMessage[];
+  systemAgentInstructions?: string;
+  kind: "agent" | "subagent";
+  stepLimit?: number;
+  toolApprovalLevel?: ToolApprovalLevel;
+  planMode?: boolean;
+  temperature?: number;
+  abortSignal: AbortSignal;
+  tracer?: Tracer;
+  onStepFinish?: StreamTextOnStepFinishCallback<ToolSet>;
+  onUsageAggregated?: (usage: UsageStats) => void;
+
+  // ── Stage 1 shim — deleted in Stage 2 once runAgentLoop owns
+  //    tool + system assembly itself.
+  __tools?: ToolSet;
+  __system?: unknown;
+  __prepareStep?: unknown;
+}
+
+export interface RunAgentLoopHandle {
+  result: StreamTextResult<ToolSet, never>;
+  error: Promise<string | undefined>;
+  span: Span;
+}
+
+export async function runAgentLoop(
+  opts: RunAgentLoopOptions,
+): Promise<RunAgentLoopHandle> {
+  if (opts.kind === "subagent") {
+    throw new Error(
+      "runAgentLoop: kind 'subagent' not yet implemented in Stage 1",
+    );
+  }
+  // Stage 1: parent body is filled in in Task 1.2.
+  throw new Error("runAgentLoop: 'agent' kind body not yet wired up");
+}

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -92,6 +92,12 @@ export interface RunAgentLoopOptions {
    *  conversation that processConversation extracts). Subagents don't pass this. */
   additionalSystemMessages?: import("ai").SystemModelMessage[];
 
+  /** When kind === "agent", controls which identity prompt is emitted:
+   *  - true  → `buildDecopilotAgentPrompt()` (the decopilot identity)
+   *  - false → no identity prompt; the agent's own instructions serve as identity
+   *  Ignored when kind === "subagent". Defaults to false when absent. */
+  isDecopilot?: boolean;
+
   // ── Stage 2: test-only shim (no production callers) ────────────────
   /** Override `streamText` for unit tests. Production paths leave undefined. */
   // biome-ignore lint/suspicious/noExplicitAny: test injection shim
@@ -142,6 +148,7 @@ export async function runAgentLoop(
     virtualMcp: opts.virtualMcp,
     kind: opts.kind,
     planMode,
+    isDecopilot: opts.isDecopilot,
     agentInstructions: opts.systemAgentInstructions,
     passthroughClient: opts.passthroughClient,
     connectionsData: opts.connectionsData,

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -50,6 +50,7 @@ import {
   type SystemModelMessage,
   type ToolSet,
   type UIMessageChunk,
+  type UIMessageStreamWriter,
 } from "ai";
 import type { MeshProvider } from "@/ai-providers/types";
 
@@ -285,6 +286,17 @@ export interface RunDecopilotStreamExtras {
    * is available.
    */
   onTitleUpdated?: (title: string) => void | Promise<void>;
+
+  /**
+   * UIMessageStreamWriter forwarded from the outer createUIMessageStream.
+   * Required by `runAgentLoop` → `assembleAgentTools` for streaming tool
+   * output from built-in tools (subtask, generate_image, etc.).
+   *
+   * Source: the `writer` arg injected into the `createUIMessageStream`
+   * execute callback in dispatch-run.ts; forwarded here so runAgentLoop
+   * can own tool assembly internally.
+   */
+  writer: UIMessageStreamWriter;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -374,6 +386,7 @@ export async function* runDecopilotStream(
     registerPendingOp,
     isStreamFinished,
     onTitleUpdated,
+    writer,
   } = extras;
 
   const modeConfig = resolveModeConfig(input.mode, { isCliAgent: false });
@@ -618,28 +631,59 @@ export async function* runDecopilotStream(
       : null;
 
   // ── Call runAgentLoop ─────────────────────────────────────────────
-  // Stage 1 shim: mcpClient + virtualMcp.instructions are placeholders
-  // here because Stage 1 passes pre-assembled tools/system via the shim.
-  // Stage 2 will replace these with the real values once runAgentLoop
-  // owns tool + system assembly itself.
+  // Stage 2: runAgentLoop owns system-prompt + tool assembly internally.
+  // The parent still passes:
+  //   - `passthroughClient`  → for the prompts block in the system prompt
+  //   - `connectionsData`    → for the connections block in the system prompt
+  //   - `extraTools`         → enable_tool (state-dependent, built above)
+  //   - `prepareStep`        → image injection + plan-mode filter
+  //   - `additionalSystemMessages` → per-request inline <system> blocks
+  // The OLD `__tools`, `__system`, `__prepareStep` shims are gone.
+  const vmMetadata = input.virtualMcp.metadata as {
+    githubRepo?: import("@decocms/mesh-sdk").GithubRepo | null;
+  };
   const handle = await runAgentLoop({
     kind: "agent",
     ctx,
     organization: { id: input.organizationId } as OrganizationScope,
-    virtualMcp: { id: input.agent.id },
+    virtualMcp: {
+      id: input.agent.id,
+      repo: vmMetadata?.githubRepo ?? undefined,
+    },
     mcpClient: tools.passthroughClient as never,
     provider,
     models: input.models,
     messages: processedMessages,
     abortSignal: registrySignal,
     temperature: input.temperature,
-    __tools: streamTools,
-    __system: [
-      ...prompt.systemMessages,
+    planMode: modeConfig.isPlanMode,
+    systemAgentInstructions: tools.serverInstructions,
+    writer,
+    subtaskParams: {
+      provider,
+      organization: { id: input.organizationId } as OrganizationScope,
+      models: input.models,
+    },
+    prepareStep: parentPrepareStep,
+    passthroughClient: tools.passthroughClient as never,
+    connectionsData: {
+      tools: tools.connectionsBlockTools,
+      connectionTitleMap: tools.connectionTitleMap,
+    },
+    // Pass the full parent built-ins (heavy tools: VM, web_search, screenshot,
+    // etc.) as extraTools so runAgentLoop's assembleAgentTools (lightweight)
+    // gets overridden with the complete set. Also inject enable_tool, which
+    // is state-dependent (built from enabledTools reconstructed above).
+    extraTools: {
+      ...(tools.builtInTools as ToolSet),
+      ...(tools.connectionsBlockTools.length > 0 && streamTools.enable_tool
+        ? { enable_tool: streamTools.enable_tool }
+        : {}),
+    },
+    additionalSystemMessages: [
       ...processedSystemMessages,
       ...(enabledToolsSystemMessage ? [enabledToolsSystemMessage] : []),
     ],
-    __prepareStep: parentPrepareStep,
   });
 
   const result = handle.result;

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -71,6 +71,7 @@ import type { AssembledTools } from "./tools";
 import type { AssembledPrompt } from "./prompt";
 import { sanitizeStreamError, stringifyError } from "./stream-error";
 import { runAgentLoop } from "./run-agent-loop";
+import { isDecopilot } from "@decocms/mesh-sdk";
 
 // ─────────────────────────────────────────────────────────────────────
 // Helpers
@@ -657,6 +658,7 @@ export async function* runDecopilotStream(
     abortSignal: registrySignal,
     temperature: input.temperature,
     planMode: modeConfig.isPlanMode,
+    isDecopilot: isDecopilot(input.agent.id) !== null,
     systemAgentInstructions: tools.serverInstructions,
     writer,
     subtaskParams: {

--- a/apps/mesh/src/harnesses/decopilot/run-stream.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-stream.ts
@@ -42,30 +42,23 @@
  * guard.
  */
 
-import type { MeshContext } from "@/core/mesh-context";
+import type { MeshContext, OrganizationScope } from "@/core/mesh-context";
 import { monitorLlmCall } from "@/monitoring/emit-llm-call";
 import { recordLlmCallMetrics } from "@/monitoring/record-llm-call-metrics";
-import { SpanStatusCode } from "@opentelemetry/api";
 import {
   type ModelMessage,
   type SystemModelMessage,
   type ToolSet,
   type UIMessageChunk,
-  stepCountIs,
-  streamText,
 } from "ai";
-import { tracer } from "@/observability";
 import type { MeshProvider } from "@/ai-providers/types";
 
 import { createEnableToolTool } from "./built-in-tools/enable-tool";
 import type { PendingImage } from "./built-in-tools";
-import { OPENROUTER_CACHE_PROVIDER_OPTIONS } from "../../api/routes/decopilot/cache-instrumentation";
 import { createUsageAccumulator } from "../usage-accumulator";
 import {
-  DEFAULT_MAX_TOKENS,
   DEFAULT_THREAD_TITLE,
   generateMessageId,
-  PARENT_STEP_LIMIT,
 } from "../../api/routes/decopilot/constants";
 import { resolveModeConfig } from "../../api/routes/decopilot/mode-config";
 import { genTitle } from "./title-generator";
@@ -76,6 +69,7 @@ import type { HarnessStreamInput } from "../types";
 import type { AssembledTools } from "./tools";
 import type { AssembledPrompt } from "./prompt";
 import { sanitizeStreamError, stringifyError } from "./stream-error";
+import { runAgentLoop } from "./run-agent-loop";
 
 // ─────────────────────────────────────────────────────────────────────
 // Helpers
@@ -383,8 +377,6 @@ export async function* runDecopilotStream(
   } = extras;
 
   const modeConfig = resolveModeConfig(input.mode, { isCliAgent: false });
-  const maxOutputTokens =
-    input.models.thinking.limits?.maxOutputTokens ?? DEFAULT_MAX_TOKENS;
   let llmCallStartTime: number | undefined;
   let llmCallLogged = false;
 
@@ -505,18 +497,108 @@ export async function* runDecopilotStream(
       : {}),
   };
 
-  // ── Span: manually managed because it starts here but ends async
-  //    in onFinish / onError. ───────────────────────────────────────
-  const llmSpan = tracer.startSpan("decopilot.streamText", {
-    attributes: {
-      "decopilot.model.id": input.models.thinking.id,
-      "decopilot.credential.id": input.models.credentialId,
-      "decopilot.isCliAgent": false,
-      "decopilot.isCodex": false,
-    },
-  });
+  // ── Build the prepareStep callback (parent-only image injection +
+  //    plan-mode tool filtering). Stays here in Stage 1; moves into
+  //    runAgentLoop in Stage 2 once we have the shared assembler.
+  const parentPrepareStep = (() => {
+    const forcedFirstStepToolName =
+      modeConfig.forcedFirstStepTool &&
+      modeConfig.forcedFirstStepTool in streamTools
+        ? modeConfig.forcedFirstStepTool
+        : null;
+    let stepIndex = 0;
 
-  const languageModel = createLanguageModel(provider, input.models.thinking);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (stepArgs: any) => {
+      const stepMessages = stepArgs.messages;
+      const isFirstStep = stepIndex === 0;
+      stepIndex++;
+
+      // Inject pending screenshot images as a user message.
+      // Images in tool result messages aren't supported by all
+      // providers (e.g. OpenRouter), so we append them as user
+      // content which is universally supported.
+      // biome-ignore lint: complex AI SDK generic types
+      let withImages: any = stepMessages;
+      const pendingImages = extras.pendingImages;
+      if (pendingImages.length > 0) {
+        const imageParts = pendingImages.splice(0, pendingImages.length);
+        const content: unknown[] = [];
+        for (const img of imageParts) {
+          content.push({
+            type: "text",
+            text:
+              img.label ??
+              (img.pageUrl ? `[Screenshot of ${img.pageUrl}]` : "[Image]"),
+          });
+          if (img.url.startsWith("data:")) {
+            // data URI → send as inline image
+            const match = img.url.match(/^data:([^;]+);base64,(.+)$/s);
+            if (match) {
+              content.push({
+                type: "image",
+                image: match[2],
+                mimeType: match[1],
+              });
+            }
+          } else {
+            // Presigned URL → send as image URL
+            content.push({
+              type: "image",
+              image: new URL(img.url),
+            });
+          }
+        }
+        withImages = [...stepMessages, { role: "user", content }];
+      }
+
+      // Intra-loop todo_write strip + inject has been removed. The
+      // agent sees its own todo_write tool calls live inside the
+      // agent loop. Cross-turn pruning to keep only the most recent
+      // todo_write call/result pair happens once at HTTP entry via
+      // `processConversation` → `keepLastTodoWrite`. The step
+      // messages here are the raw post-image-injection stream.
+      const messagesForStep = withImages;
+
+      const hasEnableTool = tools.connectionsBlockTools.length > 0;
+      let activeToolNames = [
+        ...builtInToolNames,
+        ...(hasEnableTool ? ["enable_tool"] : []),
+        ...enabledTools,
+      ];
+
+      // Layer 2: In plan mode, filter out any non-read-only tools that
+      // somehow got enabled (safety net for Layer 1 in enable_tool)
+      if (modeConfig.isPlanMode) {
+        activeToolNames = activeToolNames.filter((name) => {
+          // Built-in tools and enable_tool are always allowed
+          if (
+            builtInToolNames.includes(name) ||
+            (hasEnableTool && name === "enable_tool")
+          ) {
+            return true;
+          }
+          // Only allow passthrough tools with readOnlyHint
+          const annotations = tools.toolAnnotations.get(name);
+          return annotations?.readOnlyHint === true;
+        });
+      }
+
+      const forcedToolName =
+        forcedFirstStepToolName && isFirstStep ? forcedFirstStepToolName : null;
+
+      return {
+        activeTools: activeToolNames as (keyof typeof streamTools)[],
+        messages: messagesForStep,
+        ...(forcedToolName && {
+          toolChoice: {
+            type: "tool" as const,
+            toolName: forcedToolName as never,
+          },
+        }),
+      };
+    };
+  })();
 
   // Non-cached system tail telling the model exactly which tools it has
   // already enabled this thread. Lives outside the cached prefix so it
@@ -535,265 +617,140 @@ export async function* runDecopilotStream(
         }
       : null;
 
-  let result;
-  try {
-    result = streamText({
-      model: languageModel,
-      system: [
-        ...prompt.systemMessages,
-        ...processedSystemMessages,
-        ...(enabledToolsSystemMessage ? [enabledToolsSystemMessage] : []),
-      ],
-      messages: processedMessages,
-      tools: streamTools,
-      providerOptions: OPENROUTER_CACHE_PROVIDER_OPTIONS,
-      prepareStep: (() => {
-        const forcedFirstStepToolName =
-          modeConfig.forcedFirstStepTool &&
-          modeConfig.forcedFirstStepTool in streamTools
-            ? modeConfig.forcedFirstStepTool
-            : null;
-        let stepIndex = 0;
+  // ── Call runAgentLoop ─────────────────────────────────────────────
+  // Stage 1 shim: mcpClient + virtualMcp.instructions are placeholders
+  // here because Stage 1 passes pre-assembled tools/system via the shim.
+  // Stage 2 will replace these with the real values once runAgentLoop
+  // owns tool + system assembly itself.
+  const handle = await runAgentLoop({
+    kind: "agent",
+    ctx,
+    organization: { id: input.organizationId } as OrganizationScope,
+    virtualMcp: { id: input.agent.id },
+    mcpClient: tools.passthroughClient as never,
+    provider,
+    models: input.models,
+    messages: processedMessages,
+    abortSignal: registrySignal,
+    temperature: input.temperature,
+    __tools: streamTools,
+    __system: [
+      ...prompt.systemMessages,
+      ...processedSystemMessages,
+      ...(enabledToolsSystemMessage ? [enabledToolsSystemMessage] : []),
+    ],
+    __prepareStep: parentPrepareStep,
+  });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (stepArgs: any) => {
-          const stepMessages = stepArgs.messages;
-          const isFirstStep = stepIndex === 0;
-          stepIndex++;
+  const result = handle.result;
 
-          // Inject pending screenshot images as a user message.
-          // Images in tool result messages aren't supported by all
-          // providers (e.g. OpenRouter), so we append them as user
-          // content which is universally supported.
-          // biome-ignore lint: complex AI SDK generic types
-          let withImages: any = stepMessages;
-          const pendingImages = extras.pendingImages;
-          if (pendingImages.length > 0) {
-            const imageParts = pendingImages.splice(0, pendingImages.length);
-            const content: unknown[] = [];
-            for (const img of imageParts) {
-              content.push({
-                type: "text",
-                text:
-                  img.label ??
-                  (img.pageUrl ? `[Screenshot of ${img.pageUrl}]` : "[Image]"),
-              });
-              if (img.url.startsWith("data:")) {
-                // data URI → send as inline image
-                const match = img.url.match(/^data:([^;]+);base64,(.+)$/s);
-                if (match) {
-                  content.push({
-                    type: "image",
-                    image: match[2],
-                    mimeType: match[1],
-                  });
-                }
-              } else {
-                // Presigned URL → send as image URL
-                content.push({
-                  type: "image",
-                  image: new URL(img.url),
-                });
-              }
-            }
-            withImages = [...stepMessages, { role: "user", content }];
-          }
+  // ── Parent's own metrics/monitoring around the result.
+  //    These were previously inline in the streamText({...}) callbacks.
+  //    Now they're Promise-based, attached to result.finishReason /
+  //    handle.error.
+  Promise.resolve(result.finishReason)
+    .then(async (finishReason) => {
+      const [totalUsage, usage, request, response] = await Promise.all([
+        result.totalUsage,
+        result.usage,
+        result.request,
+        result.response,
+      ]);
+      // If there was an error, the onError path below handles metrics.
+      // onFinish fires even on error in some SDK versions; guard with
+      // the error handle to avoid double-logging.
+      const capturedErr = await handle.error;
+      if (capturedErr !== undefined) return;
 
-          // Intra-loop todo_write strip + inject has been removed. The
-          // agent sees its own todo_write tool calls live inside the
-          // agent loop. Cross-turn pruning to keep only the most recent
-          // todo_write call/result pair happens once at HTTP entry via
-          // `processConversation` → `keepLastTodoWrite`. The step
-          // messages here are the raw post-image-injection stream.
-          const messagesForStep = withImages;
+      // OTel attrs on the runAgentLoop span (handle.span)
+      handle.span.setAttribute(
+        "decopilot.llm.inputTokens",
+        totalUsage.inputTokens ?? 0,
+      );
+      handle.span.setAttribute(
+        "decopilot.llm.outputTokens",
+        totalUsage.outputTokens ?? 0,
+      );
+      handle.span.setAttribute("decopilot.llm.finishReason", finishReason);
+      const cacheTotals = usageAcc.cacheTotals();
+      handle.span.setAttribute("decopilot.cache.read_tokens", cacheTotals.read);
+      handle.span.setAttribute(
+        "decopilot.cache.write_tokens",
+        cacheTotals.write,
+      );
+      const hitRatio =
+        cacheTotals.input > 0 ? cacheTotals.read / cacheTotals.input : 0;
+      handle.span.setAttribute("decopilot.cache.hit_ratio", hitRatio);
 
-          const hasEnableTool = tools.connectionsBlockTools.length > 0;
-          let activeToolNames = [
-            ...builtInToolNames,
-            ...(hasEnableTool ? ["enable_tool"] : []),
-            ...enabledTools,
-          ];
-
-          // Layer 2: In plan mode, filter out any non-read-only tools that
-          // somehow got enabled (safety net for Layer 1 in enable_tool)
-          if (modeConfig.isPlanMode) {
-            activeToolNames = activeToolNames.filter((name) => {
-              // Built-in tools and enable_tool are always allowed
-              if (
-                builtInToolNames.includes(name) ||
-                (hasEnableTool && name === "enable_tool")
-              ) {
-                return true;
-              }
-              // Only allow passthrough tools with readOnlyHint
-              const annotations = tools.toolAnnotations.get(name);
-              return annotations?.readOnlyHint === true;
-            });
-          }
-
-          const forcedToolName =
-            forcedFirstStepToolName && isFirstStep
-              ? forcedFirstStepToolName
-              : null;
-
-          return {
-            activeTools: activeToolNames as (keyof typeof streamTools)[],
-            messages: messagesForStep,
-            ...(forcedToolName && {
-              toolChoice: {
-                type: "tool" as const,
-                toolName: forcedToolName as never,
-              },
-            }),
-          };
-        };
-      })(),
-      temperature: input.temperature,
-      maxOutputTokens,
-      stopWhen: stepCountIs(PARENT_STEP_LIMIT),
-      abortSignal: registrySignal,
-      onFinish: async ({
-        usage,
-        totalUsage,
+      // Always record usage even on abort — tokens were already consumed.
+      const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
+      llmCallLogged = true;
+      recordLlmCallMetrics({
+        ctx,
+        organizationId: input.organizationId,
+        modelId: input.models.thinking.id,
+        durationMs,
+        isError: false,
+        inputTokens: totalUsage.inputTokens,
+        outputTokens: totalUsage.outputTokens,
+        cacheReadTokens: cacheTotals.read,
+        cacheWriteTokens: cacheTotals.write,
+      });
+      extras.onUsageAggregated({
+        inputTokens: totalUsage.inputTokens ?? 0,
+        outputTokens: totalUsage.outputTokens ?? 0,
+        totalTokens: totalUsage.totalTokens ?? 0,
+      });
+      monitorLlmCall({
+        ctx,
+        organizationId: input.organizationId,
+        agentId: input.agent.id,
+        modelId: input.models.thinking.id,
+        modelTitle: input.models.thinking.title ?? input.models.thinking.id,
+        credentialId: input.models.credentialId,
+        taskId: threadId,
+        durationMs,
+        isError: false,
         finishReason,
-        request,
-        response,
-      }) => {
-        llmSpan.setAttribute(
-          "decopilot.llm.inputTokens",
-          totalUsage.inputTokens ?? 0,
-        );
-        llmSpan.setAttribute(
-          "decopilot.llm.outputTokens",
-          totalUsage.outputTokens ?? 0,
-        );
-        llmSpan.setAttribute("decopilot.llm.finishReason", finishReason);
-        const cacheTotals = usageAcc.cacheTotals();
-        llmSpan.setAttribute("decopilot.cache.read_tokens", cacheTotals.read);
-        llmSpan.setAttribute("decopilot.cache.write_tokens", cacheTotals.write);
-        const hitRatio =
-          cacheTotals.input > 0 ? cacheTotals.read / cacheTotals.input : 0;
-        llmSpan.setAttribute("decopilot.cache.hit_ratio", hitRatio);
-        llmSpan.setStatus({ code: SpanStatusCode.OK });
-        llmSpan.end();
-
-        // Always record usage even on abort — tokens were already consumed.
-        const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
-        llmCallLogged = true;
-        recordLlmCallMetrics({
-          ctx,
-          organizationId: input.organizationId,
-          modelId: input.models.thinking.id,
-          durationMs,
-          isError: false,
-          inputTokens: totalUsage.inputTokens,
-          outputTokens: totalUsage.outputTokens,
-          cacheReadTokens: cacheTotals.read,
-          cacheWriteTokens: cacheTotals.write,
-        });
-        extras.onUsageAggregated({
+        usage: {
+          inputTokens: usage.inputTokens ?? 0,
+          outputTokens: usage.outputTokens ?? 0,
+          totalTokens: usage.totalTokens ?? 0,
+        },
+        totalUsage: {
           inputTokens: totalUsage.inputTokens ?? 0,
           outputTokens: totalUsage.outputTokens ?? 0,
           totalTokens: totalUsage.totalTokens ?? 0,
-        });
-        monitorLlmCall({
-          ctx,
-          organizationId: input.organizationId,
-          agentId: input.agent.id,
-          modelId: input.models.thinking.id,
-          modelTitle: input.models.thinking.title ?? input.models.thinking.id,
-          credentialId: input.models.credentialId,
-          taskId: threadId,
-          durationMs,
-          isError: false,
-          finishReason,
-          usage: {
-            inputTokens: usage.inputTokens ?? 0,
-            outputTokens: usage.outputTokens ?? 0,
-            totalTokens: usage.totalTokens ?? 0,
-          },
-          totalUsage: {
-            inputTokens: totalUsage.inputTokens ?? 0,
-            outputTokens: totalUsage.outputTokens ?? 0,
-            totalTokens: totalUsage.totalTokens ?? 0,
-          },
-          request,
-          response,
-          userId: input.user.id,
-          requestId: ctx.metadata.requestId,
-          userAgent: ctx.metadata.userAgent ?? null,
-        });
+        },
+        request,
+        response,
+        userId: input.user.id,
+        requestId: ctx.metadata.requestId,
+        userAgent: ctx.metadata.userAgent ?? null,
+      });
 
-        if (registrySignal.aborted) return;
-      },
-      onError: async (error) => {
-        const err =
-          error instanceof Error ? error : new Error(stringifyError(error));
-        llmSpan.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err.message,
-        });
-        llmSpan.recordException(err);
-        llmSpan.end();
-
-        console.error("[decopilot:stream] Error", error);
-        if (registrySignal.aborted) {
-          throw error;
-        }
-        if (!llmCallLogged) {
-          const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
-          llmCallLogged = true;
-          recordLlmCallMetrics({
-            ctx,
-            organizationId: input.organizationId,
-            modelId: input.models.thinking.id,
-            durationMs,
-            isError: true,
-            errorType: error instanceof Error ? error.name : "Error",
-          });
-          monitorLlmCall({
-            ctx,
-            organizationId: input.organizationId,
-            agentId: input.agent.id,
-            modelId: input.models.thinking.id,
-            modelTitle: input.models.thinking.title ?? input.models.thinking.id,
-            credentialId: input.models.credentialId,
-            taskId: threadId,
-            durationMs,
-            isError: true,
-            errorMessage:
-              error instanceof Error ? error.message : stringifyError(error),
-            userId: input.user.id,
-            requestId: ctx.metadata.requestId,
-            userAgent: ctx.metadata.userAgent ?? null,
-          });
-        }
-        throw error;
-      },
-      onAbort: async ({ steps }) => {
-        if (!steps.length || llmCallLogged) return;
-        llmCallLogged = true;
+      if (registrySignal.aborted) return;
+    })
+    .catch(async (error) => {
+      // error path — finishReason promise itself rejected OR we got here
+      // from a provider error. runAgentLoop's onError fires first and
+      // sets handle.error; we pick up the message from there.
+      const rawError =
+        error instanceof Error ? error : new Error(stringifyError(error));
+      console.error("[decopilot:stream] Error", rawError);
+      if (registrySignal.aborted) {
+        return;
+      }
+      if (!llmCallLogged) {
         const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
-        const abortTotalUsage = steps.reduce(
-          (acc, s) => ({
-            inputTokens: acc.inputTokens + (s.usage.inputTokens ?? 0),
-            outputTokens: acc.outputTokens + (s.usage.outputTokens ?? 0),
-            totalTokens: acc.totalTokens + (s.usage.totalTokens ?? 0),
-          }),
-          { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        );
-        const lastStepUsage = steps[steps.length - 1]!.usage;
-        const cacheTotalsOnAbort = usageAcc.cacheTotals();
+        llmCallLogged = true;
         recordLlmCallMetrics({
           ctx,
           organizationId: input.organizationId,
           modelId: input.models.thinking.id,
           durationMs,
-          isError: false,
-          inputTokens: abortTotalUsage.inputTokens,
-          outputTokens: abortTotalUsage.outputTokens,
-          cacheReadTokens: cacheTotalsOnAbort.read,
-          cacheWriteTokens: cacheTotalsOnAbort.write,
+          isError: true,
+          errorType: rawError.name,
         });
         monitorLlmCall({
           ctx,
@@ -804,64 +761,108 @@ export async function* runDecopilotStream(
           credentialId: input.models.credentialId,
           taskId: threadId,
           durationMs,
-          isError: false,
-          finishReason: "abort",
-          usage: {
-            inputTokens: lastStepUsage.inputTokens ?? 0,
-            outputTokens: lastStepUsage.outputTokens ?? 0,
-            totalTokens: lastStepUsage.totalTokens ?? 0,
-          },
-          totalUsage: abortTotalUsage,
-          request: undefined,
-          response: undefined,
+          isError: true,
+          errorMessage: rawError.message,
           userId: input.user.id,
           requestId: ctx.metadata.requestId,
           userAgent: ctx.metadata.userAgent ?? null,
         });
+      }
+    });
 
-        // Re-push accumulated usage to the client. On abort the SDK
-        // resets message.metadata to its pre-stream state, so we
-        // explicitly emit it here before the stream closes.
-        if (abortTotalUsage.totalTokens > 0) {
-          const cost = usageAcc.cost();
-          chunkQueue.push({
-            type: "message-metadata",
-            messageMetadata: {
-              usage: {
-                inputTokens: abortTotalUsage.inputTokens,
-                outputTokens: abortTotalUsage.outputTokens,
-                totalTokens: abortTotalUsage.totalTokens,
-                cachedInputTokens: cacheTotalsOnAbort.read,
-                inputTokenDetails: {
-                  cacheReadTokens: cacheTotalsOnAbort.read,
-                  cacheWriteTokens: cacheTotalsOnAbort.write,
-                  noCacheTokens:
-                    abortTotalUsage.inputTokens -
-                    cacheTotalsOnAbort.read -
-                    cacheTotalsOnAbort.write,
-                },
-                ...(cost > 0 && {
-                  providerMetadata: {
-                    openrouter: {
-                      usage: { cost },
-                    },
-                  },
-                }),
-              },
-            },
-          });
-        }
+  // onAbort path: the old code's onAbort fires when steps.length > 0
+  // and llmCallLogged is false. We re-implement this by watching
+  // handle.error AND registrySignal.aborted.
+  // The SDK's onAbort fires synchronously before the stream drains, so
+  // we must register this watcher before we start draining the stream
+  // below. We do NOT await it here — we just attach the handler so it
+  // fires whenever the abort resolves.
+  handle.error.then(async (_errMsg) => {
+    // Only fire the abort metrics path if the signal was aborted AND
+    // we haven't already logged metrics via the onFinish path.
+    if (!registrySignal.aborted || llmCallLogged) return;
+    const steps = await result.steps;
+    if (!steps.length || llmCallLogged) return;
+    llmCallLogged = true;
+    const durationMs = Date.now() - (llmCallStartTime ?? Date.now());
+    const abortTotalUsage = steps.reduce(
+      (acc, s) => ({
+        inputTokens: acc.inputTokens + (s.usage.inputTokens ?? 0),
+        outputTokens: acc.outputTokens + (s.usage.outputTokens ?? 0),
+        totalTokens: acc.totalTokens + (s.usage.totalTokens ?? 0),
+      }),
+      { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    );
+    const lastStepUsage = steps[steps.length - 1]!.usage;
+    const cacheTotalsOnAbort = usageAcc.cacheTotals();
+    recordLlmCallMetrics({
+      ctx,
+      organizationId: input.organizationId,
+      modelId: input.models.thinking.id,
+      durationMs,
+      isError: false,
+      inputTokens: abortTotalUsage.inputTokens,
+      outputTokens: abortTotalUsage.outputTokens,
+      cacheReadTokens: cacheTotalsOnAbort.read,
+      cacheWriteTokens: cacheTotalsOnAbort.write,
+    });
+    monitorLlmCall({
+      ctx,
+      organizationId: input.organizationId,
+      agentId: input.agent.id,
+      modelId: input.models.thinking.id,
+      modelTitle: input.models.thinking.title ?? input.models.thinking.id,
+      credentialId: input.models.credentialId,
+      taskId: threadId,
+      durationMs,
+      isError: false,
+      finishReason: "abort",
+      usage: {
+        inputTokens: lastStepUsage.inputTokens ?? 0,
+        outputTokens: lastStepUsage.outputTokens ?? 0,
+        totalTokens: lastStepUsage.totalTokens ?? 0,
       },
+      totalUsage: abortTotalUsage,
+      request: undefined,
+      response: undefined,
+      userId: input.user.id,
+      requestId: ctx.metadata.requestId,
+      userAgent: ctx.metadata.userAgent ?? null,
     });
-  } catch (err) {
-    llmSpan.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: err instanceof Error ? err.message : stringifyError(err),
-    });
-    if (err instanceof Error) llmSpan.recordException(err);
-    llmSpan.end();
-    throw err;
-  }
+
+    // Re-push accumulated usage to the client. On abort the SDK
+    // resets message.metadata to its pre-stream state, so we
+    // explicitly emit it here before the stream closes.
+    if (abortTotalUsage.totalTokens > 0) {
+      const cost = usageAcc.cost();
+      chunkQueue.push({
+        type: "message-metadata",
+        messageMetadata: {
+          usage: {
+            inputTokens: abortTotalUsage.inputTokens,
+            outputTokens: abortTotalUsage.outputTokens,
+            totalTokens: abortTotalUsage.totalTokens,
+            cachedInputTokens: cacheTotalsOnAbort.read,
+            inputTokenDetails: {
+              cacheReadTokens: cacheTotalsOnAbort.read,
+              cacheWriteTokens: cacheTotalsOnAbort.write,
+              noCacheTokens:
+                abortTotalUsage.inputTokens -
+                cacheTotalsOnAbort.read -
+                cacheTotalsOnAbort.write,
+            },
+            ...(cost > 0 && {
+              providerMetadata: {
+                openrouter: {
+                  usage: { cost },
+                },
+              },
+            }),
+          },
+        },
+      });
+    }
+  });
 
   // Posthog: emit `chat_message_completed`/`chat_message_aborted`/
   // `chat_message_failed` is the caller's responsibility (it lives in

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.test.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { extractSubtaskResponse } from "./subtask.tsx";
+
+describe("extractSubtaskResponse", () => {
+  describe("new shape: { text, error, finishReason }", () => {
+    test("returns text on normal completion", () => {
+      expect(
+        extractSubtaskResponse({
+          text: "Hello world",
+          error: undefined,
+          finishReason: "stop",
+        }),
+      ).toBe("Hello world");
+    });
+
+    test("trims whitespace from text", () => {
+      expect(
+        extractSubtaskResponse({
+          text: "  Hello world  \n",
+          finishReason: "stop",
+        }),
+      ).toBe("Hello world");
+    });
+
+    test("prefixes step-limit notice when finishReason=length and text present", () => {
+      const result = extractSubtaskResponse({
+        text: "Partial result here",
+        finishReason: "length",
+      });
+      expect(result).toContain("hit step limit");
+      expect(result).toContain("Partial result here");
+    });
+
+    test("returns step-limit notice when finishReason=length and text empty", () => {
+      const result = extractSubtaskResponse({
+        text: "",
+        finishReason: "length",
+      });
+      expect(result).toContain("hit step limit");
+      expect(result).toContain("ran out of steps");
+    });
+
+    test("returns error message when error present", () => {
+      expect(
+        extractSubtaskResponse({
+          text: "",
+          error: "context overflow",
+          finishReason: "error",
+        }),
+      ).toBe("Subtask failed: context overflow");
+    });
+
+    test("error takes precedence over text", () => {
+      expect(
+        extractSubtaskResponse({
+          text: "some text",
+          error: "fatal",
+          finishReason: "error",
+        }),
+      ).toBe("Subtask failed: fatal");
+    });
+
+    test("returns no-output sentinel when text empty and no error/limit", () => {
+      expect(
+        extractSubtaskResponse({
+          text: "",
+          finishReason: "stop",
+        }),
+      ).toBe("Subtask completed (no output).");
+    });
+
+    test("recognises shape when only `error` field present", () => {
+      expect(extractSubtaskResponse({ error: "boom" })).toBe(
+        "Subtask failed: boom",
+      );
+    });
+
+    test("recognises shape when only `finishReason` field present (no text)", () => {
+      expect(extractSubtaskResponse({ finishReason: "stop" })).toBe(
+        "Subtask completed (no output).",
+      );
+    });
+  });
+
+  describe("legacy UIMessage fallback", () => {
+    test("extracts text from a UIMessage with parts", () => {
+      expect(
+        extractSubtaskResponse({
+          parts: [{ type: "text", text: "Legacy hello" }],
+        }),
+      ).toBe("Legacy hello");
+    });
+
+    test("returns null for an empty object (no shape match)", () => {
+      expect(extractSubtaskResponse({})).toBeNull();
+    });
+  });
+
+  describe("invalid inputs", () => {
+    test("returns null for null/undefined", () => {
+      expect(extractSubtaskResponse(null)).toBeNull();
+      expect(extractSubtaskResponse(undefined)).toBeNull();
+    });
+
+    test("returns null for non-object", () => {
+      expect(extractSubtaskResponse("a string")).toBeNull();
+      expect(extractSubtaskResponse(42)).toBeNull();
+    });
+
+    test("returns null for arrays", () => {
+      expect(extractSubtaskResponse(["a", "b"])).toBeNull();
+    });
+
+    test("ignores fields with wrong types (no new-shape hit, falls back)", () => {
+      // text is a number, no other recognized strings → falls back to
+      // extractTextFromOutput, which returns null for objects without parts[].
+      expect(extractSubtaskResponse({ text: 42 })).toBeNull();
+    });
+  });
+});

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -9,6 +9,46 @@ import { extractTextFromOutput, getToolPartErrorText } from "../utils.ts";
 import { ToolCallShell } from "./common.tsx";
 import { getEffectiveState } from "./utils.tsx";
 
+/**
+ * Subtask tool output contract (set by createSubtaskTool's execute generator):
+ *   { text: string; error?: string; finishReason?: FinishReason }
+ *
+ * Mirrors the server's toModelOutput so the UI shows the same content the
+ * parent model received. Falls back to the legacy UIMessage shape for
+ * historical tool calls predating the structured output.
+ */
+export function extractSubtaskResponse(output: unknown): string | null {
+  if (output && typeof output === "object" && !Array.isArray(output)) {
+    const o = output as {
+      text?: unknown;
+      error?: unknown;
+      finishReason?: unknown;
+    };
+    const hasNewShape =
+      typeof o.text === "string" ||
+      typeof o.error === "string" ||
+      typeof o.finishReason === "string";
+    if (hasNewShape) {
+      if (typeof o.error === "string" && o.error.length > 0) {
+        return `Subtask failed: ${o.error}`;
+      }
+      const text = typeof o.text === "string" ? o.text.trim() : "";
+      const stepLimitHit = o.finishReason === "length";
+      if (text) {
+        const prefix = stepLimitHit
+          ? "[Subtask hit step limit — partial result below; consider narrowing the task.]\n\n"
+          : "";
+        return prefix + text;
+      }
+      if (stepLimitHit) {
+        return "[Subtask hit step limit before producing a final report. The subagent did work but ran out of steps. Narrow the task or increase the budget.]";
+      }
+      return "Subtask completed (no output).";
+    }
+  }
+  return extractTextFromOutput(output);
+}
+
 interface SubtaskPartProps {
   part: SubtaskToolPart;
   /** Subtask metadata from data part */
@@ -63,7 +103,7 @@ function useSubtaskShellConfig({
 
   const response = isError
     ? getToolPartErrorText(part)
-    : (extractTextFromOutput(part.output) ?? "No output available");
+    : (extractSubtaskResponse(part.output) ?? "No output available");
   const detail = `# Task\n${part.input?.prompt ?? "No prompt provided"}\n\n# ${isError ? "Error" : "Result"}\n${response}`;
 
   return {

--- a/apps/mesh/src/web/lib/release-feed.ts
+++ b/apps/mesh/src/web/lib/release-feed.ts
@@ -1,4 +1,11 @@
-import { FilterLines, Inbox01, Stars02 } from "@untitledui/icons";
+import {
+  CheckCircle,
+  FilterLines,
+  Inbox01,
+  Stars02,
+  Users03,
+  Zap,
+} from "@untitledui/icons";
 import type { ComponentType } from "react";
 
 export interface ReleaseBullet {
@@ -22,6 +29,29 @@ export interface Release {
  * The latest entry is the floating-card candidate; older entries live only in the inbox.
  */
 export const RELEASES: Release[] = [
+  {
+    id: "smarter-task-delegation",
+    date: "2026-05-27",
+    eyebrow: "Now Available",
+    title: "Smarter task delegation",
+    bullets: [
+      {
+        icon: Users03,
+        title: "Real results from delegated agents",
+        body: "When one agent hands work to another, you'll see the full report inline — no more empty replies hiding the work that was done.",
+      },
+      {
+        icon: Zap,
+        title: "Same powers, top to bottom",
+        body: "Delegated agents now work with the same tools, context, and memory as the agent that called them, so complex multi-agent investigations finish on the first try.",
+      },
+      {
+        icon: CheckCircle,
+        title: "Clearer progress signals",
+        body: "When a delegated task hits its limit or runs into a problem, you get a plain-language message instead of a silent stall.",
+      },
+    ],
+  },
   {
     id: "sidebar-task-groups",
     date: "2026-05-27",

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "@openrouter/ai-sdk-provider": "^2.9.0",
-        "ai": "^6.0.182",
+        "ai": "^6.0.191",
         "decocms": "workspace:*",
         "hono": "^4.10.7",
       },
@@ -53,14 +53,14 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "2.348.1",
+      "version": "2.356.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.77",
-        "@ai-sdk/google": "^3.0.73",
-        "@ai-sdk/openai": "^3.0.63",
+        "@ai-sdk/anthropic": "^3.0.80",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/openai": "^3.0.65",
         "@anthropic-ai/sdk": "^0.96.0",
         "@aws-sdk/client-s3": "^3.1013.0",
         "@aws-sdk/lib-storage": "^3.1013.0",
@@ -92,7 +92,7 @@
       },
       "devDependencies": {
         "@ai-sdk/provider": "^3.0.10",
-        "@ai-sdk/react": "^3.0.184",
+        "@ai-sdk/react": "^3.0.193",
         "@better-auth/sso": "1.4.1",
         "@daveyplate/better-auth-ui": "^3.2.7",
         "@deco/ui": "workspace:*",
@@ -152,7 +152,7 @@
         "@untitledui/icons": "^0.0.19",
         "@vercel/nft": "^1.1.1",
         "@vitejs/plugin-react": "^5.1.0",
-        "ai": "^6.0.182",
+        "ai": "^6.0.191",
         "babel-plugin-react-compiler": "^1.0.0",
         "better-auth": "1.4.22",
         "class-variance-authority": "^0.7.1",
@@ -288,7 +288,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.5",
         "@types/mime-db": "^1.43.6",
-        "ai": "^6.0.182",
+        "ai": "^6.0.191",
         "ts-json-schema-generator": "^2.4.0",
       },
       "peerDependencies": {
@@ -297,7 +297,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "0.5.5",
+      "version": "0.5.7",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
         "@opentelemetry/api": "^1.9.0",
@@ -404,19 +404,19 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.77", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ML8C2M1YvPA1ulEx4TiyF0k1xvC2ikEiPBIC1PPQ0a5xELUGrO2lAaEzsTEoJ+eCeDd8PSBuFJjs+r+9yIwQXA=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-lT8flzmQe7brMXcj+HxIRqC5/P8N2spHj88n7fdY84K8Ay5TI5hbeic3P2T668d9UmKZtIUcefLwgGW4xzfVkA=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.114", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.120", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.73", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-o2MuIeyvZrFIeIbnbA8Thrr63irdyUBh0uWBZ2lY6yFeXuE/tcwyXF74bDKS4KvTu84uFpQfpbS/LXHGKKXz+g=="],
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.63", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.65", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.184", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.182", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-k8fQ11U3+lKzUCkiitevuH0MF++b7QPX7zrPRfXfNayLRZwrwvNuqXifB/6iIyQpSLNCfzhkqG117FW2EXCI5w=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.193", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.191", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-El0jUZ/B7mvBHAD5rfSDqOAhWxutVTq7BCNhfGuwfDPT9SO0TMHybh2bMkieJQI7YOfl+qNBoWrRAOHHaFb99Q=="],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -1742,7 +1742,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ai": ["ai@6.0.182", "", { "dependencies": { "@ai-sdk/gateway": "3.0.114", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ooJdziFjYrYRcsCx107roqA8gDTI3P82nUfroNWIhVvwrkYzEN3W1l50YK+XNqkUew8AiimaW0/SLBewRXMuHQ=="],
+    "ai": ["ai@6.0.191", "", { "dependencies": { "@ai-sdk/gateway": "3.0.120", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ=="],
 
     "ai-sdk-provider-claude-code": ["ai-sdk-provider-claude-code@3.4.4", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@ai-sdk/provider-utils": "^4.0.1", "@anthropic-ai/claude-agent-sdk": "^0.2.63" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-iHcup5SHh4Tul1RIi9J+bnpngen8WX66yC3lsz1YlbtwAmRhUEzZUuGKzmFGIN8Pmx9uQrerGfLJdbFxIxKkyw=="],
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.5",
     "@types/mime-db": "^1.43.6",
-    "ai": "^6.0.182",
+    "ai": "^6.0.191",
     "ts-json-schema-generator": "^2.4.0"
   },
   "engines": {


### PR DESCRIPTION
## What is this contribution about?
Unifies the parent and subagent paths into a shared `runAgentLoop` core so subagents get tool truncation, `read_tool_output`, full platform system prompt, progressive disclosure, and OTel — everything the parent has, minus user-facing tools (`subtask`, `user_ask`, `propose_plan`). Also fixes a two-bug stack in the subtask tool: (a) the AI SDK's `executeTool` ignores a generator's return value so `toModelOutput` was always receiving the last yielded UIMessage instead of the extracted `{ text, error, finishReason }`, and (b) yielding accumulated UIMessages caused NATS publishes to exceed the 1 MB payload limit and be dropped silently. The chat-ui renderer also learns the new structured output shape, replacing the misleading "No output available" string with the actual subagent report.

## How to Test
1. From `/deco`, send: *"can you look for unused connections?"*
2. The Connection Manager subtask should expand inline with a real connection report (e.g. *"Found 212 connections… Platform & Infrastructure: …"*), not *"No output available"*.
3. In the dev server log, look for `[subtask:vir_…] completed: finishReason=stop, steps=N, textLength=N, error=no`.

## Migration Notes
None — drop-in.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (37/37 subtask tests pass; manual repro green)
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies parent and subagent execution under a shared `runAgentLoop`, giving subagents the same prompt, tool truncation, and telemetry as the parent. Also adds a release-feed announcement for “Smarter task delegation,” and fixes subtask output so structured results reach the parent and UI without silent drops.

- **Refactors**
  - Shared `runAgentLoop` for parent + subagent; owns prompt (`buildAgentSystemPrompt`), tools (`assembleAgentTools` + `buildBuiltInTools`), streaming, and OTel.
  - Parent calls `runAgentLoop` with extra tools (full built-ins + `enable_tool`), `prepareStep` (image injection, plan-mode filter), and extra system messages.
  - Subagents use the shared loop, inherit truncation and `read_tool_output`, and exclude `subtask`, `user_ask`, `propose_plan`.
  - `buildAgentSystemPrompt` adds `kind: "agent" | "subagent"`, optional prompts/connections blocks via `@modelcontextprotocol/sdk`, and only emits the Decopilot identity when the agent is Decopilot.
  - Removed dead `SUBAGENT_EXCLUDED_TOOLS` in favor of `EXCLUDED_FOR_SUBAGENT`.
  - Dependency bumps for stability and fixes: `ai` ^6.0.191, `@ai-sdk/anthropic` ^3.0.80, `@ai-sdk/google` ^3.0.80, `@ai-sdk/openai` ^3.0.65, `@ai-sdk/react` ^3.0.193.
  - Added release-feed entry announcing “Smarter task delegation.”

- **Bug Fixes**
  - Rewrote `subtask` to drain the subagent UI stream and yield a single `{ text, error, finishReason }`, fixing generator return handling and preventing >1 MB NATS payloads.
  - Updated `toModelOutput` and chat subtask renderer to display real subagent reports, include step-limit notices, and surface errors instead of "No output available".

<sup>Written for commit da148769e019f9094e7d0cf02ee11b82880e4821. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3492?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

