### PR TITLE
fix(sidebar): hide inbox label in collapsed sidebar when unread

### DIFF
--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -133,10 +133,10 @@ function InboxFullButton() {
       <PopoverTrigger asChild>
         <SidebarMenuButton tooltip="Inbox" className="relative">
           <Inbox01 />
-          <span>Inbox</span>
           {hasUnread && (
             <span className="absolute top-1 right-1 size-2 rounded-full bg-red-500 pointer-events-none" />
           )}
+          <span>Inbox</span>
         </SidebarMenuButton>
       </PopoverTrigger>
     </InboxPopover>


### PR DESCRIPTION
## What is this contribution about?
Fixes a bug in the collapsed sidebar's inbox button: when there were unread inbox items, the "Inbox" text label remained visible next to the icon, breaking the collapsed layout. `SidebarMenuButton` hides labels via `[&>span:last-child]:hidden`, but the unread red-dot `<span>` was rendered after the label, so the dot — not the text — became `:last-child`. Reordering so the dot is rendered before the label restores the expected behavior.

## How to Test
1. Have an unread inbox item (e.g., pending invitation or unseen release).
2. Collapse the sidebar.
3. Expected: only the inbox icon (with the red unread dot) is shown — no "Inbox" text label.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a layout bug where the Inbox text stayed visible in the collapsed sidebar when there were unread items. Moves the unread dot before the label so `SidebarMenuButton`’s `[&>span:last-child]:hidden` rule hides the text, leaving only the icon (with the dot) when collapsed.

<sup>Written for commit a10dc5d6bb4429e7648396fa96f0979c68c10766. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3493?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

