### PR TITLE
fix(ci): make deco-apps-cd bump skip gracefully without the GitHub App

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -325,9 +325,19 @@ jobs:
         needs.merge-docker.result == 'success'
       )
     runs-on: ubuntu-latest
+    # Surface the App id as an env so steps can detect whether the GitHub App
+    # is configured. When the secrets aren't present (e.g. a fork, or before
+    # the App is installed on this repo) every step below no-ops and the job
+    # passes — the bump is a convenience and must never red the release.
+    env:
+      GH_APP_ID: ${{ secrets.GH_APP_ID }}
     steps:
+      - name: Skip notice (App not configured)
+        if: env.GH_APP_ID == ''
+        run: echo "::notice::GH_APP_ID/GH_APP_PRIVATE_KEY not set — skipping the deco-apps-cd bump. Configure the GitHub App secrets to enable it."
       - name: Generate token for deco-apps-cd
         id: cd-token
+        if: env.GH_APP_ID != ''
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.GH_APP_ID }}
@@ -335,6 +345,7 @@ jobs:
           owner: decocms
           repositories: deco-apps-cd
       - name: Bump mesh image (stg + prod)
+        if: env.GH_APP_ID != ''
         env:
           GH_TOKEN: ${{ steps.cd-token.outputs.token }}
           VERSION: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Problem
We added the `bump-deco-apps-cd` job to `release-mesh.yaml`, but `GH_APP_ID`/`GH_APP_PRIVATE_KEY` were never configured on this repo. With `if: always() && image-exists`, the job runs on **every push** (the current version's image always exists) and **fails** at `create-github-app-token` → every Release Mesh run goes red.

`release` never `needs` this job, so prod releases weren't truly blocked — but the constant red is alarming and the auto-bump never worked.

## Fix
Gate the token + bump steps on `env.GH_APP_ID != ''`:
- App **not** configured → steps no-op, a notice is logged, the job **passes**.
- App configured (add the two secrets) → bump runs automatically, no further changes.

## Validation
YAML parses; logic verified. The merge to main will trigger a fresh Release Mesh run that should be green (bump skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `deco-apps-cd` bump job skip gracefully when the GitHub App secrets are missing. This stops Release Mesh runs from going red on every push; when secrets are set, the bump runs as before.

- **Bug Fixes**
  - Gate token and bump steps on `env.GH_APP_ID != ''`.
  - Add a skip notice when secrets are absent; the job no-ops and passes.
  - No behavior change when `GH_APP_ID`/`GH_APP_PRIVATE_KEY` are configured.

<sup>Written for commit 1e945cc89a6b1839eec0df05eb87a6d751922160. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3494?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

