### PR TITLE
feat(chat): add NextActionChip component to suggest next actions in c…

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -24,6 +24,7 @@ import {
   BrandContextGetPart,
   BrandContextListPart,
 } from "./parts/tool-call-part/index.ts";
+import { NextActionChip } from "./next-action-chip.tsx";
 import { SmartAutoScroll } from "./smart-auto-scroll.tsx";
 import { ThreadHtmlPreviews } from "./thread-html-previews.tsx";
 import { ThreadOutputs } from "./thread-outputs.tsx";
@@ -721,6 +722,7 @@ export function MessageAssistant({
             <>
               <ThreadHtmlPreviews />
               <ThreadOutputs threadId={taskId} />
+              {isTerminallyDone && <NextActionChip />}
             </>
           )}
         </div>

--- a/apps/mesh/src/web/components/chat/message/next-action-chip.tsx
+++ b/apps/mesh/src/web/components/chat/message/next-action-chip.tsx
@@ -1,0 +1,131 @@
+import {
+  getGatewayClientId,
+  stripToolNamespace,
+} from "@decocms/mcp-utils/aggregate";
+import { ArrowRight, Stars02 } from "@untitledui/icons";
+import { getPrompt, useMCPClient, useProjectContext } from "@decocms/mesh-sdk";
+import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  PromptArgsDialog,
+  type PromptArgumentValues,
+} from "../dialog-prompt-arguments";
+import { createMentionDoc } from "../tiptap/mention/node";
+import { useChatStream, useOptionalChatTask } from "../context.tsx";
+import { useHomeNextActions } from "@/web/hooks/use-home-next-actions";
+
+export function NextActionChip() {
+  const task = useOptionalChatTask();
+  const { sendMessage, isStreaming, messages } = useChatStream();
+  const { org } = useProjectContext();
+  const virtualMcpId = task?.virtualMcpId;
+  const { prompts } = useHomeNextActions(org.slug);
+  const client = useMCPClient({
+    connectionId: virtualMcpId ?? null,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const [dialogPrompt, setDialogPrompt] = useState<Prompt | null>(null);
+
+  if (!virtualMcpId || isStreaming) return null;
+
+  // Only suggest a "next" once the user has actually done something in
+  // this thread. A user_ask resolution flips the part to `output-available`
+  // on the existing assistant message — it doesn't produce a user-role
+  // message — so a strict `role === "user"` check would miss it.
+  const hasEngagement = messages.some(
+    (m) =>
+      m.role === "user" ||
+      m.parts.some(
+        (p) =>
+          (p as { type?: string }).type === "tool-user_ask" &&
+          (p as { state?: string }).state === "output-available",
+      ),
+  );
+  if (!hasEngagement) return null;
+
+  // home-next-actions is keyed by agentId and already drops completed
+  // items server-side, so the first match is this thread's next step.
+  const next = prompts.find((p) => p.agentId === virtualMcpId);
+  if (!next) return null;
+
+  const send = async (prompt: Prompt, args?: PromptArgumentValues) => {
+    if (!client) {
+      toast.error("MCP client not available");
+      return;
+    }
+    try {
+      const result = await getPrompt(client, prompt.name, args);
+      // Match `insertMention`'s output (mention atom + trailing " ") so the
+      // sent message renders with the same chip styling as the / picker.
+      await sendMessage({
+        type: "doc" as const,
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              createMentionDoc({
+                id: prompt.name,
+                name: stripToolNamespace(
+                  prompt.name,
+                  getGatewayClientId(prompt._meta),
+                ),
+                metadata: result.messages,
+                char: "/",
+                kind: "prompt",
+                args,
+              }),
+              { type: "text" as const, text: " " },
+            ],
+          },
+        ],
+      });
+    } catch (error) {
+      console.error("[next-action-chip] failed", error);
+      toast.error("Failed to load prompt. Please try again.");
+    }
+  };
+
+  const handleClick = () => {
+    const prompt: Prompt = {
+      name: next.promptName,
+      title: next.title,
+      description: next.description,
+      arguments: next.arguments,
+      _meta: next._meta,
+    };
+    if (prompt.arguments && prompt.arguments.length > 0) {
+      setDialogPrompt(prompt);
+      return;
+    }
+    void send(prompt);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="group mt-3 flex items-center gap-2 self-start rounded-full border border-border bg-background px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:border-border hover:bg-accent/40 hover:text-foreground"
+      >
+        <Stars02 size={12} className="shrink-0 text-purple-500" />
+        <span className="font-medium text-foreground/80">Next:</span>
+        <span className="truncate">{next.title}</span>
+        <ArrowRight
+          size={12}
+          className="shrink-0 transition-transform duration-150 group-hover:translate-x-0.5"
+        />
+      </button>
+      <PromptArgsDialog
+        prompt={dialogPrompt}
+        setPrompt={(p) => setDialogPrompt(p)}
+        onSubmit={async (values) => {
+          const prompt = dialogPrompt;
+          setDialogPrompt(null);
+          if (prompt) await send(prompt, values);
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
…hat interface

- Introduced NextActionChip component to display suggested next actions based on user engagement.
- Integrated NextActionChip into MessageAssistant, rendering it conditionally when the task is terminally done.
- Enhanced user experience by providing actionable prompts directly within the chat context.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NextActionChip to suggest the next action in chat and let users trigger it with one click. Integrated into MessageAssistant and shown when a task is terminally done to keep the conversation moving.

- New Features
  - Shows a “Next:” chip when not streaming, the user has engaged, and a `virtualMcpId` exists.
  - Selects the first next action from the current agent’s `useHomeNextActions`.
  - Clicking runs the prompt via `getPrompt` from `@decocms/mesh-sdk`; opens an arguments dialog when required and sends a mention-style message.
  - Hides automatically if no suggestion is available.

<sup>Written for commit fa7519272db0f704ddc51cc90f8e10d306975462. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3495?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

