### PR TITLE
feat(e2e): parallelize Playwright (workers=4 in CI)

### DIFF
--- a/apps/mesh/playwright.config.ts
+++ b/apps/mesh/playwright.config.ts
@@ -2,10 +2,14 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  // CI: cap at 4 to keep host CPU + Postgres connection pool predictable.
+  // Local: let Playwright pick (defaults to half the CPU count). Each test
+  // creates its own user + org with randomized slugs, so cross-worker DB
+  // contention should be limited to the auth.user row insert.
+  workers: process.env.CI ? 4 : undefined,
   reporter: [["html", { open: "never" }]],
   use: {
     baseURL: `http://localhost:${process.env.PORT || "3000"}`,


### PR DESCRIPTION
## Summary

Lifts the Playwright suite from `workers: 1` / `fullyParallel: false` to a real parallel configuration. This is the prerequisite for migrating mocked unit tests into the e2e tier without bloating CI wall time.

- `fullyParallel: true`
- `workers: process.env.CI ? 4 : undefined` (CI caps at 4 to keep host CPU + embedded-postgres connections predictable; local lets Playwright pick)

Safety: each spec already creates its own user + org with timestamp+random slugs/emails, so cross-worker DB contention is limited to the `auth.user` insert. No spec depends on global setup state.

If CI shows contention (Postgres pool exhaustion, transient 5xx), the answer is per-worker schemas using `testInfo.workerIndex`, not lowering workers back to 1.

## Test plan

- [x] `bun run fmt` / `tsc --noEmit` clean
- [x] `playwright test --list` discovers all 5 existing tests
- [ ] CI `e2e` job stays green with `workers: 4`
- [ ] CI `e2e` wall time observable for budgeting future suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parallel Playwright runs to speed up e2e tests and make room to move more coverage into this tier. Set `fullyParallel: true` and cap CI to 4 workers (`workers: process.env.CI ? 4 : undefined`; local uses default); tests are isolated (per-spec user/org) to avoid DB collisions.

<sup>Written for commit 2e8dd3dd66261cd70b1ace50b9197c2411a0c641. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3497?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

