### PR TITLE
feat(preview): page picker with create page and global blocks

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -14,7 +14,10 @@ import {
   Code02,
   CursorClick01,
   DotsHorizontal,
+  Globe02,
+  LayoutAlt01,
   LinkExternal01,
+  Plus,
   TextInput,
   Loading01,
   Monitor04,
@@ -38,9 +41,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
-import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
-import { extractPages } from "@/web/components/sections-editor/page-list";
+import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
+import {
+  extractGlobalSections,
+  extractPages,
+  type GlobalSectionEntry,
+} from "@/web/components/sections-editor/page-list";
+import { findLivePageResolveType } from "@/web/components/sections-editor/section-catalog";
+import { buildGlobalSectionPreviewUrl } from "@/web/components/sections-editor/section-preview-url";
+import { useCreatePage } from "@/web/components/sections-editor/use-create-page";
+import { CreatePageModal } from "@/web/components/sections-editor/create-page-modal";
+import { toast } from "sonner";
 import {
   VISUAL_EDITOR_SCRIPT,
   VisualEditorPayloadSchema,
@@ -136,6 +148,12 @@ export function PreviewContent() {
   const [pagesOpen, setPagesOpen] = useState(false);
   const [pagesSearch, setPagesSearch] = useState("");
   const pagesContainerRef = useRef<HTMLDivElement>(null);
+  const [createPageDialogOpen, setCreatePageDialogOpen] = useState(false);
+  const [createPageError, setCreatePageError] = useState<string | undefined>();
+  const [activeGlobalSection, setActiveGlobalSection] =
+    useState<GlobalSectionEntry | null>(null);
+  /** Overrides iframe src for global-section live previews (stable URL, not recomputed). */
+  const [directPreviewUrl, setDirectPreviewUrl] = useState<string | null>(null);
 
   // Current iframe path (for sections editor)
   const [currentPath, setCurrentPath] = useState("/");
@@ -170,19 +188,50 @@ export function PreviewContent() {
       ? { orgSlug: org.slug, virtualMcpId, branch }
       : null;
   const { data: decofile } = useDecofile(decofileParams);
+  const { data: meta } = useLiveMeta(decofileParams);
+  const createPage = useCreatePage(
+    virtualMcpId && branch
+      ? { orgSlug: org.slug, virtualMcpId, branch }
+      : { orgSlug: org.slug, virtualMcpId: "", branch: "" },
+  );
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
     : [];
-  const currentPageName = pages.find((p) => p.path === currentPath)?.name;
+  const globalSections =
+    decofile && meta ? extractGlobalSections(decofile, meta) : [];
+  const normPath = (path: string) => path.replace(/\/+$/, "") || "/";
+  const filteredPages = pages.filter((page) => {
+    if (!pagesSearch) return true;
+    const q = pagesSearch.toLowerCase();
+    return (
+      page.name.toLowerCase().includes(q) || page.path.toLowerCase().includes(q)
+    );
+  });
+  const filteredGlobalSections = globalSections.filter((section) => {
+    if (!pagesSearch) return true;
+    const q = pagesSearch.toLowerCase();
+    return (
+      section.name.toLowerCase().includes(q) ||
+      section.key.toLowerCase().includes(q) ||
+      section.resolveType.toLowerCase().includes(q)
+    );
+  });
+  const currentPageName = activeGlobalSection
+    ? activeGlobalSection.name
+    : pages.find((p) => normPath(p.path) === normPath(currentPath))?.name;
+
+  const iframeSrcRef = useRef<string | null>(null);
+  /** Path we navigated to programmatically; ignore stale iframe onLoad events. */
+  const intendedPathRef = useRef<string | null>(null);
 
   // "reload" fires on config edits framework HMR won't catch (.ts/.tsx use HMR).
   useSandboxReloadHandler(() => {
     const iframe = previewIframeRef.current;
-    if (!iframe) return;
-    // biome-ignore lint/correctness/noSelfAssign: reloads the iframe
-    // oxlint-disable-next-line no-self-assign
-    iframe.src = iframe.src;
+    const src = iframeSrcRef.current;
+    if (!iframe || !src) return;
+    iframe.src = src;
   });
+
   // `running` lifecycle phase carries the live port + htmlSupport flag;
   // `crashed` means the dev server stopped responding after coming up.
   // Everything else maps to "booting" for the preview overlay.
@@ -282,6 +331,30 @@ export function PreviewContent() {
     notFound: vmEvents.notFound,
     userStopped,
   });
+
+  const iframeSrc =
+    previewState.kind === "iframe"
+      ? (directPreviewUrl ?? new URL(currentPath, previewState.previewUrl).href)
+      : null;
+
+  // Reset navigation when the VM preview base URL changes (branch switch, etc.)
+  const prevIframeBaseRef = useRef<string | null>(null);
+  if (
+    previewState.kind === "iframe" &&
+    prevIframeBaseRef.current !== previewState.previewUrl
+  ) {
+    const hadPreviousBase = prevIframeBaseRef.current !== null;
+    prevIframeBaseRef.current = previewState.previewUrl;
+    if (hadPreviousBase) {
+      intendedPathRef.current = null;
+      setCurrentPath("/");
+      setDirectPreviewUrl(null);
+      setActiveGlobalSection(null);
+    }
+  }
+
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- ref read in reload handler
+  iframeSrcRef.current = iframeSrc;
 
   // Daemon is reachable independent of the dev script: ready claim, handle
   // still present, not user-stopped/suspended. Gates surfaces (FileExplorer,
@@ -565,17 +638,17 @@ export function PreviewContent() {
   };
 
   const handleRefresh = () => {
-    if (!previewIframeRef.current) return;
+    if (!previewIframeRef.current || !iframeSrc) return;
     const iframe = previewIframeRef.current;
     // biome-ignore lint/correctness/noSelfAssign: reloads the iframe
     // oxlint-disable-next-line no-self-assign
-    iframe.src = iframe.src;
+    iframe.src = iframeSrc;
   };
 
   const handleHardReload = () => {
-    if (!previewIframeRef.current || !previewUrl) return;
-    const sep = previewUrl.includes("?") ? "&" : "?";
-    previewIframeRef.current.src = `${previewUrl}${sep}_r=${Date.now()}`;
+    if (!previewIframeRef.current || !iframeSrc) return;
+    const sep = iframeSrc.includes("?") ? "&" : "?";
+    previewIframeRef.current.src = `${iframeSrc}${sep}_r=${Date.now()}`;
   };
 
   const handleCopyUrl = () => {
@@ -586,6 +659,7 @@ export function PreviewContent() {
 
   const previewLabel = (() => {
     if (!previewUrl) return "No server running";
+    if (activeGlobalSection) return activeGlobalSection.name;
     try {
       const url = new URL(previewUrl);
       const path = currentPath === "/" ? "" : currentPath;
@@ -594,6 +668,58 @@ export function PreviewContent() {
       return previewUrl;
     }
   })();
+
+  const navigatePreviewToPage = (path: string) => {
+    intendedPathRef.current = path;
+    setActiveGlobalSection(null);
+    setDirectPreviewUrl(null);
+    setCurrentPath(path);
+    setCmsSelectedSectionIndex(null);
+  };
+
+  const navigatePreviewToGlobalSection = (section: GlobalSectionEntry) => {
+    if (!previewUrl || !meta) return;
+    const livePageRt = findLivePageResolveType(meta);
+    const url = buildGlobalSectionPreviewUrl(
+      previewUrl,
+      livePageRt,
+      section.key,
+    );
+    setActiveGlobalSection(section);
+    setDirectPreviewUrl(url);
+    setCmsSelectedSectionIndex(null);
+  };
+
+  const handleCreatePage = async ({
+    name,
+    path,
+  }: {
+    name: string;
+    path: string;
+  }) => {
+    if (!virtualMcpId || !branch) return;
+    const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+    if (pages.some((p) => normPath(p.path) === normPath(trimmedPath))) {
+      setCreatePageError(`A page with path "${trimmedPath}" already exists.`);
+      return;
+    }
+    setCreatePageError(undefined);
+    try {
+      const result = await createPage.mutateAsync({
+        name,
+        path: trimmedPath,
+      });
+      setCreatePageDialogOpen(false);
+      toast.success(`Page "${name}" created`);
+      await new Promise((resolve) => setTimeout(resolve, DEV_SERVER_SETTLE_MS));
+      navigatePreviewToPage(result.path);
+      handleViewModeChange("cms");
+    } catch (error) {
+      setCreatePageError(
+        error instanceof Error ? error.message : "Failed to create page",
+      );
+    }
+  };
 
   // visual + cms require a live iframe (they inject overlays into the dev
   // server); when the iframe isn't up we still offer preview + code so the
@@ -609,7 +735,8 @@ export function PreviewContent() {
           },
         ]
       : []),
-    ...(previewState.kind === "iframe" && pages.length > 0
+    ...(previewState.kind === "iframe" &&
+    (pages.length > 0 || globalSections.length > 0)
       ? [
           {
             value: "cms" as PreviewViewMode,
@@ -669,23 +796,21 @@ export function PreviewContent() {
                     <span className="min-w-0 flex-1 truncate text-left text-[12px] text-foreground/88">
                       {previewLabel}
                     </span>
-                    {currentPageName && (
+                    {currentPageName && !activeGlobalSection && (
                       <span className="shrink-0 text-[12px] text-muted-foreground">
                         {currentPageName}
                       </span>
                     )}
-                    {pages.length > 0 && (
-                      <ChevronDown
-                        size={12}
-                        className={cn(
-                          "shrink-0 text-muted-foreground transition-transform",
-                          pagesOpen && "rotate-180",
-                        )}
-                      />
-                    )}
+                    <ChevronDown
+                      size={12}
+                      className={cn(
+                        "shrink-0 text-muted-foreground transition-transform",
+                        pagesOpen && "rotate-180",
+                      )}
+                    />
                   </button>
 
-                  {pagesOpen && pages.length > 0 && (
+                  {pagesOpen && (
                     <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
                       <div className="px-2 pt-2 pb-1">
                         <input
@@ -697,58 +822,105 @@ export function PreviewContent() {
                           autoFocus
                         />
                       </div>
-                      <ScrollArea className="max-h-[60vh]">
-                        <div className="p-1.5">
-                          {pages
-                            .filter((page) => {
-                              if (!pagesSearch) return true;
-                              const q = pagesSearch.toLowerCase();
-                              return (
-                                page.name.toLowerCase().includes(q) ||
-                                page.path.toLowerCase().includes(q)
-                              );
-                            })
-                            .map((page) => (
-                              <button
-                                key={page.key}
-                                type="button"
-                                className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                                onClick={() => {
-                                  setPagesOpen(false);
-                                  setPagesSearch("");
-                                  setCurrentPath(page.path);
-                                  // Navigate the iframe
-                                  const iframe = previewIframeRef.current;
-                                  if (iframe && previewUrl) {
-                                    iframe.src = new URL(
-                                      page.path,
-                                      previewUrl,
-                                    ).href;
-                                  }
-                                }}
-                              >
-                                <span className="min-w-0 flex-1 truncate font-medium">
-                                  {page.name}
-                                </span>
-                                <span className="shrink-0 text-xs text-muted-foreground">
-                                  {page.path}
-                                </span>
-                              </button>
-                            ))}
-                          {pagesSearch &&
-                            pages.every((page) => {
-                              const q = pagesSearch.toLowerCase();
-                              return (
-                                !page.name.toLowerCase().includes(q) &&
-                                !page.path.toLowerCase().includes(q)
-                              );
-                            }) && (
-                              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                                No pages match "{pagesSearch}"
-                              </div>
-                            )}
+                      <div className="p-1.5 border-b">
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            setPagesOpen(false);
+                            setPagesSearch("");
+                            setCreatePageError(undefined);
+                            setCreatePageDialogOpen(true);
+                          }}
+                        >
+                          <Plus
+                            size={16}
+                            className="shrink-0 text-muted-foreground"
+                          />
+                          <span className="flex-1 font-medium">
+                            Create new page
+                          </span>
+                        </button>
+                      </div>
+                      {filteredPages.length === 0 &&
+                      filteredGlobalSections.length === 0 ? (
+                        <div className="px-4 py-5 text-center text-xs text-muted-foreground">
+                          {pages.length === 0 && globalSections.length === 0
+                            ? "No pages found in this site."
+                            : "No results match your search."}
                         </div>
-                      </ScrollArea>
+                      ) : (
+                        <div className="max-h-80 overflow-y-auto overscroll-contain">
+                          {filteredPages.length > 0 && (
+                            <div className="p-1.5">
+                              {filteredPages.map((page) => (
+                                <button
+                                  key={page.key}
+                                  type="button"
+                                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                  onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    setPagesOpen(false);
+                                    setPagesSearch("");
+                                    navigatePreviewToPage(page.path);
+                                  }}
+                                >
+                                  <LayoutAlt01
+                                    size={16}
+                                    className="shrink-0 text-muted-foreground"
+                                  />
+                                  <span className="min-w-0 flex-1 truncate font-medium">
+                                    {page.name}
+                                  </span>
+                                  <span className="shrink-0 text-xs text-muted-foreground">
+                                    {page.path}
+                                  </span>
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                          {filteredGlobalSections.length > 0 && (
+                            <div
+                              className={cn(
+                                "p-1.5",
+                                filteredPages.length > 0 && "border-t",
+                              )}
+                            >
+                              <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+                                Global components
+                              </div>
+                              {filteredGlobalSections.map((section) => (
+                                <button
+                                  key={section.key}
+                                  type="button"
+                                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                  onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    setPagesOpen(false);
+                                    setPagesSearch("");
+                                    navigatePreviewToGlobalSection(section);
+                                  }}
+                                >
+                                  <Globe02
+                                    size={16}
+                                    className="shrink-0 text-muted-foreground"
+                                  />
+                                  <span className="min-w-0 flex-1 truncate font-medium">
+                                    {section.name}
+                                  </span>
+                                  <span className="shrink-0 text-xs text-muted-foreground">
+                                    {section.resolveType
+                                      .split("/")
+                                      .pop()
+                                      ?.replace(/\.tsx?$/, "")}
+                                  </span>
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>
@@ -832,7 +1004,10 @@ export function PreviewContent() {
                   previewReady={devServerReady}
                   previewUrl={previewUrl}
                   currentPath={currentPath}
-                  externalSelectedIndex={cmsSelectedSectionIndex}
+                  activeGlobalBlockKey={activeGlobalSection?.key ?? null}
+                  externalSelectedIndex={
+                    activeGlobalSection ? null : cmsSelectedSectionIndex
+                  }
                   onSaved={() => {
                     setTimeout(() => {
                       const iframe = previewIframeRef.current;
@@ -1018,13 +1193,13 @@ export function PreviewContent() {
             </div>
           )}
 
-          {previewState.kind === "iframe" && (
+          {previewState.kind === "iframe" && iframeSrc && (
             <iframe
-              // Key on previewUrl: `src` mutations don't reliably refetch in all
-              // browsers and leak in-frame state across branches.
+              // Key on previewUrl: remount when the VM base URL changes (branch
+              // switch). Path navigation is driven by `iframeSrc` state.
               key={previewState.previewUrl}
               ref={previewIframeRef}
-              src={previewState.previewUrl}
+              src={iframeSrc}
               className={cn(
                 "w-full h-full border-0",
                 viewMode === "code" && "invisible",
@@ -1040,14 +1215,26 @@ export function PreviewContent() {
                   // Intentionally excluding the full previewUrl — it can contain
                   // ephemeral tokens / user data in the query string.
                 });
-                // Sync currentPath with the iframe's actual location so the
-                // sections editor always reflects the displayed page.
-                try {
-                  const iframePath =
-                    previewIframeRef.current?.contentWindow?.location?.pathname;
-                  if (iframePath) setCurrentPath(iframePath);
-                } catch {
-                  // Cross-origin — can't read, keep current value
+                // Sync currentPath when the user navigates inside the iframe.
+                // Skip while a programmatic navigation is pending — stale
+                // onLoad events from the previous URL would reset us to "/".
+                if (!activeGlobalSection) {
+                  try {
+                    const iframePath =
+                      previewIframeRef.current?.contentWindow?.location
+                        ?.pathname;
+                    if (!iframePath) return;
+                    const intended = intendedPathRef.current;
+                    if (intended !== null) {
+                      if (normPath(iframePath) === normPath(intended)) {
+                        intendedPathRef.current = null;
+                      }
+                      return;
+                    }
+                    setCurrentPath(iframePath);
+                  } catch {
+                    // Cross-origin — can't read, keep current value
+                  }
                 }
                 if (viewMode === "visual") injectVisualEditor();
                 if (viewMode === "cms") injectCmsEditor();
@@ -1074,6 +1261,13 @@ export function PreviewContent() {
         onRestart={handleRestart}
         onResume={retryAutoStart}
         onRetry={retryAutoStart}
+      />
+      <CreatePageModal
+        open={createPageDialogOpen}
+        onOpenChange={setCreatePageDialogOpen}
+        isPending={createPage.isPending}
+        error={createPageError}
+        onSubmit={handleCreatePage}
       />
     </div>
   );

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -340,14 +340,15 @@ export function PreviewContent() {
       : null;
 
   // Reset navigation when the VM preview base URL changes (branch switch, etc.)
-  const prevIframeBaseRef = useRef<string | null>(null);
+  const [prevIframeBase, setPrevIframeBase] = useState<string | null>(null);
   if (
     previewState.kind === "iframe" &&
-    prevIframeBaseRef.current !== previewState.previewUrl
+    prevIframeBase !== previewState.previewUrl
   ) {
-    const hadPreviousBase = prevIframeBaseRef.current !== null;
-    prevIframeBaseRef.current = previewState.previewUrl;
+    const hadPreviousBase = prevIframeBase !== null;
+    setPrevIframeBase(previewState.previewUrl);
     if (hadPreviousBase) {
+      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- clear stale navigation intent on branch switch
       intendedPathRef.current = null;
       setCurrentPath("/");
       setDirectPreviewUrl(null);

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -48,6 +48,10 @@ import {
   extractPages,
   type GlobalSectionEntry,
 } from "@/web/components/sections-editor/page-list";
+import {
+  normalizePagePath,
+  validatePagePath,
+} from "@/web/components/sections-editor/page-path-utils";
 import { findLivePageResolveType } from "@/web/components/sections-editor/section-catalog";
 import { buildGlobalSectionPreviewUrl } from "@/web/components/sections-editor/section-preview-url";
 import { useCreatePage } from "@/web/components/sections-editor/use-create-page";
@@ -189,17 +193,15 @@ export function PreviewContent() {
       : null;
   const { data: decofile } = useDecofile(decofileParams);
   const { data: meta } = useLiveMeta(decofileParams);
-  const createPage = useCreatePage(
-    virtualMcpId && branch
-      ? { orgSlug: org.slug, virtualMcpId, branch }
-      : { orgSlug: org.slug, virtualMcpId: "", branch: "" },
-  );
+  const createPageParams =
+    virtualMcpId && branch ? { orgSlug: org.slug, virtualMcpId, branch } : null;
+  const createPage = useCreatePage(createPageParams);
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
     : [];
   const globalSections =
     decofile && meta ? extractGlobalSections(decofile, meta) : [];
-  const normPath = (path: string) => path.replace(/\/+$/, "") || "/";
+  const normPath = normalizePagePath;
   const filteredPages = pages.filter((page) => {
     if (!pagesSearch) return true;
     const q = pagesSearch.toLowerCase();
@@ -653,7 +655,9 @@ export function PreviewContent() {
 
   const handleCopyUrl = () => {
     const url =
-      previewIframeRef.current?.contentWindow?.location?.href ?? previewUrl;
+      previewIframeRef.current?.contentWindow?.location?.href ??
+      iframeSrc ??
+      previewUrl;
     if (url) navigator.clipboard.writeText(url);
   };
 
@@ -678,7 +682,11 @@ export function PreviewContent() {
   };
 
   const navigatePreviewToGlobalSection = (section: GlobalSectionEntry) => {
-    if (!previewUrl || !meta) return;
+    if (!previewUrl || !meta) {
+      toast.error("Preview metadata not ready yet");
+      return;
+    }
+    intendedPathRef.current = null;
     const livePageRt = findLivePageResolveType(meta);
     const url = buildGlobalSectionPreviewUrl(
       previewUrl,
@@ -698,7 +706,14 @@ export function PreviewContent() {
     path: string;
   }) => {
     if (!virtualMcpId || !branch) return;
-    const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+    const pathError = validatePagePath(path);
+    if (pathError) {
+      setCreatePageError(pathError);
+      return;
+    }
+    const trimmedPath = path.trim().startsWith("/")
+      ? path.trim()
+      : `/${path.trim()}`;
     if (pages.some((p) => normPath(p.path) === normPath(trimmedPath))) {
       setCreatePageError(`A page with path "${trimmedPath}" already exists.`);
       return;
@@ -817,7 +832,7 @@ export function PreviewContent() {
                           type="text"
                           value={pagesSearch}
                           onChange={(e) => setPagesSearch(e.target.value)}
-                          placeholder="Search pages..."
+                          placeholder="Search pages and components..."
                           className="w-full rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
                           autoFocus
                         />
@@ -939,17 +954,8 @@ export function PreviewContent() {
                       variant="ghost"
                       size="icon"
                       onClick={() => {
-                        let url = previewState.previewUrl;
-                        if (url && currentPath && currentPath !== "/") {
-                          try {
-                            const parsed = new URL(url);
-                            parsed.pathname = currentPath;
-                            url = parsed.href;
-                          } catch {
-                            // keep original url
-                          }
-                        }
-                        window.open(url, "_blank", "noopener");
+                        const url = iframeSrc ?? previewState.previewUrl;
+                        if (url) window.open(url, "_blank", "noopener");
                       }}
                     >
                       <LinkExternal01 size={14} />
@@ -1022,10 +1028,8 @@ export function PreviewContent() {
                       try {
                         iframe.contentWindow?.location.reload();
                       } catch {
-                        // Cross-origin fallback
-                        // biome-ignore lint/correctness/noSelfAssign: reloads the iframe
-                        // oxlint-disable-next-line no-self-assign
-                        iframe.src = iframe.src;
+                        const src = iframeSrcRef.current;
+                        if (src) iframe.src = src;
                       }
                       const restore = () => {
                         iframe.tabIndex = prevTabIndex;
@@ -1226,8 +1230,9 @@ export function PreviewContent() {
                     if (!iframePath) return;
                     const intended = intendedPathRef.current;
                     if (intended !== null) {
+                      intendedPathRef.current = null;
                       if (normPath(iframePath) === normPath(intended)) {
-                        intendedPathRef.current = null;
+                        setCurrentPath(iframePath);
                       }
                       return;
                     }

--- a/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
@@ -1,0 +1,120 @@
+import { useState, type FormEvent } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Loading01 } from "@untitledui/icons";
+
+export function CreatePageModal({
+  open,
+  onOpenChange,
+  isPending = false,
+  error,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isPending?: boolean;
+  error?: string;
+  onSubmit: (values: { name: string; path: string }) => void | Promise<void>;
+}) {
+  const [name, setName] = useState("My New Page");
+  const [path, setPath] = useState("/example-path");
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setName("My New Page");
+      setPath("/example-path");
+    }
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && !isPending) onOpenChange(false);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    const trimmedPath = path.trim();
+    if (!trimmedName || !trimmedPath || isPending) return;
+    await onSubmit({ name: trimmedName, path: trimmedPath });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create new page</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="new-page-name"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Name
+              </label>
+              <Input
+                id="new-page-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My New Page"
+                autoFocus
+                disabled={isPending}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label
+                htmlFor="new-page-path"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Path
+              </label>
+              <Input
+                id="new-page-path"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                placeholder="/example-path"
+                disabled={isPending}
+              />
+            </div>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!name.trim() || !path.trim() || isPending}
+            >
+              {isPending ? (
+                <>
+                  <Loading01 size={14} className="animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                "Create"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
+++ b/apps/mesh/src/web/components/sections-editor/create-page-modal.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Loading01 } from "@untitledui/icons";
+import { validatePagePath } from "./page-path-utils";
 
 export function CreatePageModal({
   open,
@@ -25,6 +26,7 @@ export function CreatePageModal({
 }) {
   const [name, setName] = useState("My New Page");
   const [path, setPath] = useState("/example-path");
+  const [localError, setLocalError] = useState<string | null>(null);
   const [prevOpen, setPrevOpen] = useState(open);
 
   if (open !== prevOpen) {
@@ -32,11 +34,15 @@ export function CreatePageModal({
     if (open) {
       setName("My New Page");
       setPath("/example-path");
+      setLocalError(null);
     }
   }
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen && !isPending) onOpenChange(false);
+    if (!nextOpen && !isPending) {
+      setLocalError(null);
+      onOpenChange(false);
+    }
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -44,8 +50,16 @@ export function CreatePageModal({
     const trimmedName = name.trim();
     const trimmedPath = path.trim();
     if (!trimmedName || !trimmedPath || isPending) return;
+    const pathError = validatePagePath(trimmedPath);
+    if (pathError) {
+      setLocalError(pathError);
+      return;
+    }
+    setLocalError(null);
     await onSubmit({ name: trimmedName, path: trimmedPath });
   };
+
+  const displayError = localError ?? error;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -87,7 +101,9 @@ export function CreatePageModal({
                 disabled={isPending}
               />
             </div>
-            {error && <p className="text-xs text-destructive">{error}</p>}
+            {displayError && (
+              <p className="text-xs text-destructive">{displayError}</p>
+            )}
           </div>
 
           <DialogFooter>

--- a/apps/mesh/src/web/components/sections-editor/page-block-template.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-block-template.test.ts
@@ -16,7 +16,9 @@ describe("page-block-template", () => {
     });
   });
 
-  it("generatePageBlockKey encodes the page name", () => {
-    expect(generatePageBlockKey("My Page")).toMatch(/^pages-My%20Page-\d+$/);
+  it("generatePageBlockKey encodes the page name with a unique suffix", () => {
+    expect(generatePageBlockKey("My Page")).toMatch(
+      /^pages-My%20Page-[0-9a-f-]{36}$/,
+    );
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/page-block-template.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-block-template.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createEmptyPageBlock,
+  DEFAULT_PAGE_BLOCK,
+  generatePageBlockKey,
+} from "./page-block-template";
+
+describe("page-block-template", () => {
+  it("createEmptyPageBlock uses default resolve types", () => {
+    expect(createEmptyPageBlock("About", "/about")).toEqual({
+      name: "About",
+      path: "/about",
+      sections: [],
+      seo: { __resolveType: DEFAULT_PAGE_BLOCK.seoResolveType },
+      __resolveType: DEFAULT_PAGE_BLOCK.resolveType,
+    });
+  });
+
+  it("generatePageBlockKey encodes the page name", () => {
+    expect(generatePageBlockKey("My Page")).toMatch(/^pages-My%20Page-\d+$/);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/page-block-template.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-block-template.ts
@@ -1,0 +1,19 @@
+/** Default block types for new pages created from the preview page picker. */
+export const DEFAULT_PAGE_BLOCK = {
+  resolveType: "website/pages/Page.tsx",
+  seoResolveType: "website/sections/Seo/SeoV2.tsx",
+} as const;
+
+export function generatePageBlockKey(name: string): string {
+  return `pages-${encodeURIComponent(name)}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+export function createEmptyPageBlock(name: string, path: string) {
+  return {
+    name,
+    path,
+    sections: [] as unknown[],
+    seo: { __resolveType: DEFAULT_PAGE_BLOCK.seoResolveType },
+    __resolveType: DEFAULT_PAGE_BLOCK.resolveType,
+  };
+}

--- a/apps/mesh/src/web/components/sections-editor/page-block-template.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-block-template.ts
@@ -5,7 +5,7 @@ export const DEFAULT_PAGE_BLOCK = {
 } as const;
 
 export function generatePageBlockKey(name: string): string {
-  return `pages-${encodeURIComponent(name)}-${Math.floor(Math.random() * 1e6)}`;
+  return `pages-${encodeURIComponent(name)}-${crypto.randomUUID()}`;
 }
 
 export function createEmptyPageBlock(name: string, path: string) {

--- a/apps/mesh/src/web/components/sections-editor/page-list.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-list.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { extractGlobalSections, extractPages } from "./page-list";
+import type { LiveMeta } from "./resolve-schema";
+
+describe("page-list", () => {
+  it("extractPages finds page blocks with paths", () => {
+    const decofile = {
+      "pages-home-abc123456789": {
+        __resolveType: "website/pages/Page.tsx",
+        name: "Home",
+        path: "/",
+      },
+      Header: {
+        __resolveType: "site/sections/Header.tsx",
+      },
+    };
+
+    expect(extractPages(decofile)).toEqual([
+      { key: "pages-home-abc123456789", name: "Home", path: "/" },
+    ]);
+  });
+
+  it("extractGlobalSections uses catalog filters for saved blocks", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          sections: {
+            "site/sections/Header.tsx": { $ref: "#/definitions/Header" },
+            "site/sections/Theme/Theme.tsx": { $ref: "#/definitions/Theme" },
+          },
+        },
+      },
+      schema: {},
+    };
+    const decofile = {
+      Header: {
+        __resolveType: "site/sections/Header.tsx",
+        name: "Site Header",
+      },
+      "Preview Hero": {
+        __resolveType: "site/sections/Hero.tsx",
+      },
+      "pages-about-abc123456789": {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/about",
+      },
+    };
+
+    const sections = extractGlobalSections(decofile, meta);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toEqual({
+      key: "Header",
+      name: "Site Header",
+      resolveType: "site/sections/Header.tsx",
+    });
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/page-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-list.tsx
@@ -1,7 +1,16 @@
-interface PageEntry {
+import type { LiveMeta } from "./resolve-schema";
+import { isManifestSectionResolveType } from "./block-type-utils";
+
+export interface PageEntry {
   key: string;
   name: string;
   path: string;
+}
+
+export interface GlobalSectionEntry {
+  key: string;
+  name: string;
+  resolveType: string;
 }
 
 function parsePageName(key: string): string {
@@ -49,4 +58,38 @@ export function extractPages(decofile: Record<string, unknown>): PageEntry[] {
     }
   }
   return pages;
+}
+
+function globalSectionLabel(
+  blockId: string,
+  block: Record<string, unknown>,
+): string {
+  if (typeof block.name === "string" && block.name) return block.name;
+  return blockId.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Saved section blocks from the decofile (no `path`, manifest section type). */
+export function extractGlobalSections(
+  decofile: Record<string, unknown>,
+  meta: LiveMeta,
+): GlobalSectionEntry[] {
+  const sections: GlobalSectionEntry[] = [];
+
+  for (const [blockId, val] of Object.entries(decofile)) {
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+
+    const block = val as Record<string, unknown>;
+    const rt = block.__resolveType;
+    if (typeof rt !== "string") continue;
+    if (typeof block.path === "string") continue;
+    if (!isManifestSectionResolveType(meta, rt)) continue;
+
+    sections.push({
+      key: blockId,
+      name: globalSectionLabel(blockId, block),
+      resolveType: rt,
+    });
+  }
+
+  return sections.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/apps/mesh/src/web/components/sections-editor/page-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-list.tsx
@@ -64,7 +64,10 @@ export function globalSectionLabel(
   blockId: string,
   block: Record<string, unknown>,
 ): string {
-  if (typeof block.name === "string" && block.name) return block.name;
+  if (typeof block.name === "string") {
+    const trimmed = block.name.trim();
+    if (trimmed) return trimmed;
+  }
   return blockId.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 

--- a/apps/mesh/src/web/components/sections-editor/page-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-list.tsx
@@ -1,5 +1,5 @@
 import type { LiveMeta } from "./resolve-schema";
-import { isManifestSectionResolveType } from "./block-type-utils";
+import { listSavedSectionBlocks } from "./section-catalog";
 
 export interface PageEntry {
   key: string;
@@ -60,7 +60,7 @@ export function extractPages(decofile: Record<string, unknown>): PageEntry[] {
   return pages;
 }
 
-function globalSectionLabel(
+export function globalSectionLabel(
   blockId: string,
   block: Record<string, unknown>,
 ): string {
@@ -68,28 +68,21 @@ function globalSectionLabel(
   return blockId.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Saved section blocks from the decofile (no `path`, manifest section type). */
+/** Saved section blocks from the decofile (same filters as the section catalog). */
 export function extractGlobalSections(
   decofile: Record<string, unknown>,
   meta: LiveMeta,
 ): GlobalSectionEntry[] {
-  const sections: GlobalSectionEntry[] = [];
-
-  for (const [blockId, val] of Object.entries(decofile)) {
-    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
-
-    const block = val as Record<string, unknown>;
-    const rt = block.__resolveType;
-    if (typeof rt !== "string") continue;
-    if (typeof block.path === "string") continue;
-    if (!isManifestSectionResolveType(meta, rt)) continue;
-
-    sections.push({
-      key: blockId,
-      name: globalSectionLabel(blockId, block),
-      resolveType: rt,
-    });
-  }
-
-  return sections.sort((a, b) => a.name.localeCompare(b.name));
+  return listSavedSectionBlocks(meta, decofile)
+    .map((entry) => {
+      const block = decofile[entry.resolveType] as Record<string, unknown>;
+      const resolveType =
+        typeof block.__resolveType === "string" ? block.__resolveType : "";
+      return {
+        key: entry.resolveType,
+        name: entry.description ?? globalSectionLabel(entry.resolveType, block),
+        resolveType,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isValidPagePath,
+  normalizePagePath,
+  validatePagePath,
+} from "./page-path-utils";
+
+describe("page-path-utils", () => {
+  it("normalizePagePath collapses trailing slashes", () => {
+    expect(normalizePagePath("/about/")).toBe("/about");
+    expect(normalizePagePath("/")).toBe("/");
+  });
+
+  it("isValidPagePath rejects unsafe paths", () => {
+    expect(isValidPagePath("/about")).toBe(true);
+    expect(isValidPagePath("//evil.com")).toBe(false);
+    expect(isValidPagePath("/../secret")).toBe(false);
+    expect(isValidPagePath("about")).toBe(false);
+  });
+
+  it("validatePagePath returns error messages", () => {
+    expect(validatePagePath("/about")).toBeNull();
+    expect(validatePagePath("//evil.com")).toMatch(/must start with/);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
@@ -1,0 +1,23 @@
+/** Normalize trailing slashes; root stays "/". */
+export function normalizePagePath(path: string): string {
+  return path.replace(/\/+$/, "") || "/";
+}
+
+/** Reject protocol-relative paths, parent segments, and non-path values. */
+export function isValidPagePath(path: string): boolean {
+  const trimmed = path.trim();
+  if (!trimmed.startsWith("/")) return false;
+  if (trimmed.startsWith("//")) return false;
+  if (trimmed.includes("..")) return false;
+  if (trimmed.includes("\\")) return false;
+  return true;
+}
+
+export function validatePagePath(path: string): string | null {
+  const trimmed = path.trim();
+  if (!trimmed) return "Path is required.";
+  if (!isValidPagePath(trimmed)) {
+    return "Path must start with / and must not contain .. or //.";
+  }
+  return null;
+}

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.test.ts
@@ -5,6 +5,7 @@ import {
   findSiteThemeBlock,
 } from "./section-catalog";
 import {
+  buildGlobalSectionPreviewUrl,
   buildSectionPreviewUrl,
   encodePreviewProps,
 } from "./section-preview-url";
@@ -47,6 +48,25 @@ describe("section-preview-url", () => {
       block: "Header",
     });
     expect(decoded.sections[1]).toEqual(theme);
+  });
+
+  it("buildGlobalSectionPreviewUrl wraps a saved block in page preview props", () => {
+    const url = buildGlobalSectionPreviewUrl(
+      "https://abc.preview.example.com/",
+      "website/pages/Page.tsx",
+      "Header",
+    );
+    expect(url).toContain("/live/previews/website%2Fpages%2FPage.tsx");
+    expect(new URL(url).searchParams.get("path")).toBe("/");
+    const propsParam = new URL(url).searchParams.get("props");
+    expect(propsParam).toBeTruthy();
+    const decoded = JSON.parse(decodeURIComponent(atob(propsParam!))) as {
+      path: string;
+      sections: Array<{ __resolveType: string }>;
+    };
+    expect(decoded.path).toBe("/");
+    expect(decoded.sections).toEqual([{ __resolveType: "Header" }]);
+    expect(new URL(url).searchParams.has("__cb")).toBe(true);
   });
 });
 

--- a/apps/mesh/src/web/components/sections-editor/section-catalog.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-catalog.ts
@@ -95,7 +95,7 @@ function listManifestSections(meta: LiveMeta): SectionCatalogEntry[] {
   return entries;
 }
 
-function listSavedSectionBlocks(
+export function listSavedSectionBlocks(
   meta: LiveMeta,
   decofile: Record<string, unknown>,
 ): SectionCatalogEntry[] {

--- a/apps/mesh/src/web/components/sections-editor/section-preview-url.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-preview-url.ts
@@ -3,6 +3,32 @@ export function encodePreviewProps(json: string): string {
   return btoa(encodeURIComponent(json));
 }
 
+/** Preview URL for a saved global block (single section on a blank page). */
+export function buildGlobalSectionPreviewUrl(
+  previewBaseUrl: string,
+  livePageResolveType: string,
+  blockKey: string,
+): string {
+  const origin = new URL(previewBaseUrl).origin;
+  const url = new URL(
+    `/live/previews/${encodeURIComponent(livePageResolveType)}`,
+    origin,
+  );
+  url.searchParams.set("path", "/");
+  url.searchParams.set("pathTemplate", "/");
+  url.searchParams.set(
+    "props",
+    encodePreviewProps(
+      JSON.stringify({
+        path: "/",
+        sections: [{ __resolveType: blockKey }],
+      }),
+    ),
+  );
+  url.searchParams.set("__cb", crypto.randomUUID());
+  return url.toString();
+}
+
 export function buildSectionPreviewUrl(
   previewBaseUrl: string,
   livePageResolveType: string,

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -6,7 +6,8 @@ import { toast } from "sonner";
 import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
 import { useSaveBlock } from "./use-save-block";
-import { extractPages } from "./page-list";
+import { extractPages, globalSectionLabel } from "./page-list";
+import { normalizePagePath } from "./page-path-utils";
 import { SectionList, parseSections } from "./section-list";
 import { isLazyResolveType } from "./section-lazy";
 import { arrayMove } from "@dnd-kit/sortable";
@@ -419,6 +420,9 @@ export function SectionsEditor({
   const [sectionRuleResolveType, setSectionRuleResolveType] = useState<
     string | null
   >(null);
+  const [prevAutoGlobalKey, setPrevAutoGlobalKey] = useState<string | null>(
+    null,
+  );
 
   // Reset form state when the active page or global block changes
   const [prevPath, setPrevPath] = useState(currentPath);
@@ -489,7 +493,7 @@ export function SectionsEditor({
   }
 
   const pages = extractPages(decofile);
-  const norm = (s: string) => s.replace(/\/+$/, "") || "/";
+  const norm = normalizePagePath;
   const isGlobalBlockMode = !!activeGlobalBlockKey;
   const activePage = isGlobalBlockMode
     ? null
@@ -502,13 +506,11 @@ export function SectionsEditor({
       ? (decofile[activeGlobalBlockKey] as Record<string, unknown> | undefined)
       : undefined;
   const globalBlockName =
-    isGlobalBlockMode && activeGlobalBlockKey
-      ? typeof globalBlockData?.name === "string" && globalBlockData.name
-        ? globalBlockData.name
-        : activeGlobalBlockKey
-            .replace(/[-_]/g, " ")
-            .replace(/\b\w/g, (c) => c.toUpperCase())
-      : "";
+    isGlobalBlockMode && activeGlobalBlockKey && globalBlockData
+      ? globalSectionLabel(activeGlobalBlockKey, globalBlockData)
+      : isGlobalBlockMode && activeGlobalBlockKey
+        ? activeGlobalBlockKey
+        : "";
 
   const pageData =
     !isGlobalBlockMode && activePageKey && decofile[activePageKey]
@@ -532,9 +534,6 @@ export function SectionsEditor({
   const parsedSections = parseSections(rawSections, decofile);
 
   // Global blocks open directly into the section form (single saved block).
-  const [prevAutoGlobalKey, setPrevAutoGlobalKey] = useState<string | null>(
-    null,
-  );
   if (
     isGlobalBlockMode &&
     activeGlobalBlockKey &&

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -360,6 +360,7 @@ export function SectionsEditor({
   previewReady = true,
   previewUrl,
   currentPath,
+  activeGlobalBlockKey = null,
   externalSelectedIndex,
   onSaved,
 }: {
@@ -371,6 +372,8 @@ export function SectionsEditor({
   /** Sandbox preview base URL used for section gallery previews. */
   previewUrl?: string;
   currentPath: string;
+  /** When set, edits a saved global block instead of a page. */
+  activeGlobalBlockKey?: string | null;
   /** Section index selected via click-through from the preview iframe. */
   externalSelectedIndex?: number | null;
   /** Called after a successful auto-save so the parent can reload the preview. */
@@ -417,10 +420,13 @@ export function SectionsEditor({
     string | null
   >(null);
 
-  // Reset form state when the active page changes
+  // Reset form state when the active page or global block changes
   const [prevPath, setPrevPath] = useState(currentPath);
-  if (prevPath !== currentPath) {
+  const [prevGlobalBlockKey, setPrevGlobalBlockKey] =
+    useState(activeGlobalBlockKey);
+  if (prevPath !== currentPath || prevGlobalBlockKey !== activeGlobalBlockKey) {
     setPrevPath(currentPath);
+    setPrevGlobalBlockKey(activeGlobalBlockKey);
     setSelectedSectionIndex(null);
     setFormValue(null);
     setActiveResolveType(null);
@@ -484,14 +490,38 @@ export function SectionsEditor({
 
   const pages = extractPages(decofile);
   const norm = (s: string) => s.replace(/\/+$/, "") || "/";
-  const activePage = pages.find((p) => norm(p.path) === norm(currentPath));
-  const activePageKey = activePage?.key ?? null;
+  const isGlobalBlockMode = !!activeGlobalBlockKey;
+  const activePage = isGlobalBlockMode
+    ? null
+    : pages.find((p) => norm(p.path) === norm(currentPath));
+  const activePageKey = isGlobalBlockMode
+    ? activeGlobalBlockKey
+    : (activePage?.key ?? null);
+  const globalBlockData =
+    isGlobalBlockMode && activeGlobalBlockKey
+      ? (decofile[activeGlobalBlockKey] as Record<string, unknown> | undefined)
+      : undefined;
+  const globalBlockName =
+    isGlobalBlockMode && activeGlobalBlockKey
+      ? typeof globalBlockData?.name === "string" && globalBlockData.name
+        ? globalBlockData.name
+        : activeGlobalBlockKey
+            .replace(/[-_]/g, " ")
+            .replace(/\b\w/g, (c) => c.toUpperCase())
+      : "";
 
   const pageData =
-    activePageKey && decofile[activePageKey]
+    !isGlobalBlockMode && activePageKey && decofile[activePageKey]
       ? (decofile[activePageKey] as Record<string, unknown>)
       : null;
-  const pageVariants = parsePageVariants(pageData?.sections);
+  const pageVariants = isGlobalBlockMode
+    ? [
+        {
+          label: "Default",
+          sections: [{ __resolveType: activeGlobalBlockKey! } as RawSection],
+        },
+      ]
+    : parsePageVariants(pageData?.sections);
   const hasMultipleVariants = pageVariants.length > 1;
   const safeVariantIndex = Math.min(
     activeVariantIndex,
@@ -500,6 +530,35 @@ export function SectionsEditor({
   const activeVariant = pageVariants[safeVariantIndex];
   const rawSections: RawSection[] = activeVariant?.sections ?? [];
   const parsedSections = parseSections(rawSections, decofile);
+
+  // Global blocks open directly into the section form (single saved block).
+  const [prevAutoGlobalKey, setPrevAutoGlobalKey] = useState<string | null>(
+    null,
+  );
+  if (
+    isGlobalBlockMode &&
+    activeGlobalBlockKey &&
+    prevAutoGlobalKey !== activeGlobalBlockKey
+  ) {
+    setPrevAutoGlobalKey(activeGlobalBlockKey);
+    const rawSection = rawSections[0];
+    const parsed = parsedSections[0];
+    if (rawSection && parsed) {
+      setSelectedSectionIndex(0);
+      setActiveSectionVariantIndex(0);
+      setFieldBreadcrumbs([]);
+      const unwrapped = unwrapSection(rawSection, parsed, decofile);
+      if (unwrapped) {
+        setFormValue(unwrapped.data);
+        setActiveResolveType(unwrapped.resolveType);
+        setSectionRuleResolveType(null);
+        setSectionRuleFormValue(null);
+      }
+    }
+  }
+  if (!isGlobalBlockMode && prevAutoGlobalKey !== null) {
+    setPrevAutoGlobalKey(null);
+  }
 
   // Sync ref so debounced callbacks always see the latest values.
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- ref is only read in setTimeout callbacks, not during render
@@ -1085,7 +1144,8 @@ export function SectionsEditor({
   }
 
   const availableMatchers = meta ? extractMatchers(meta) : [];
-  const canAddSection = !!(previewUrl && meta && decofile);
+  const canAddSection =
+    !isGlobalBlockMode && !!(previewUrl && meta && decofile);
 
   const ruleSchema =
     ruleResolveType && meta ? resolveSchema(ruleResolveType, meta) : null;
@@ -1222,10 +1282,18 @@ export function SectionsEditor({
     scheduleSectionRuleSave(newRule);
   };
 
-  if (!activePage) {
+  if (!isGlobalBlockMode && !activePage) {
     return (
       <div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">
         No page found for {currentPath}
+      </div>
+    );
+  }
+
+  if (isGlobalBlockMode && !globalBlockData) {
+    return (
+      <div className="h-full w-full flex items-center justify-center text-sm text-muted-foreground">
+        Global block not found
       </div>
     );
   }
@@ -1259,20 +1327,29 @@ export function SectionsEditor({
     sectionRuleResolveType && meta
       ? resolveSchema(sectionRuleResolveType, meta)
       : null;
-  const editingBreadcrumbs = isEditing
-    ? [
-        activePage.name,
-        selectedParsed.label,
-        ...(isEditingMultivariateSection && activeSectionFlagVariant
-          ? [activeSectionFlagVariant.label]
-          : []),
-        ...fieldBreadcrumbs,
-      ]
-    : [];
+  const editingBreadcrumbs =
+    isEditing && (!isGlobalBlockMode || fieldBreadcrumbs.length > 0)
+      ? isGlobalBlockMode
+        ? [globalBlockName, ...fieldBreadcrumbs]
+        : [
+            activePage!.name,
+            selectedParsed!.label,
+            ...(isEditingMultivariateSection && activeSectionFlagVariant
+              ? [activeSectionFlagVariant.label]
+              : []),
+            ...fieldBreadcrumbs,
+          ]
+      : [];
   const exitSectionEditing = () => {
     clearSectionEditing();
   };
   const handleBreadcrumbClick = (index: number) => {
+    if (isGlobalBlockMode) {
+      setFieldBreadcrumbs(fieldBreadcrumbs.slice(0, index));
+      setFormResetKey((key) => key + 1);
+      return;
+    }
+
     if (index === 0) {
       exitSectionEditing();
       return;
@@ -1298,7 +1375,7 @@ export function SectionsEditor({
     <div className="flex h-full min-w-0 w-full flex-col">
       {/* Page header */}
       <div className="px-3 py-2.5 border-b shrink-0">
-        {isEditing ? (
+        {isEditing && (!isGlobalBlockMode || fieldBreadcrumbs.length > 0) ? (
           <div className="flex min-w-0 items-center overflow-hidden">
             <nav
               aria-label="Editing breadcrumb"
@@ -1333,11 +1410,20 @@ export function SectionsEditor({
               })}
             </nav>
           </div>
+        ) : isGlobalBlockMode ? (
+          <div className="space-y-0.5">
+            <div className="text-sm font-medium truncate">
+              {globalBlockName}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Global component
+            </div>
+          </div>
         ) : (
           <PageHeaderInputs
             pageKey={activePageKey!}
-            initialName={activePage.name}
-            initialPath={activePage.path}
+            initialName={activePage!.name}
+            initialPath={activePage!.path}
             onFieldChange={savePageField}
           />
         )}
@@ -1435,6 +1521,26 @@ export function SectionsEditor({
             ) : (
               <div className="px-3 py-6 text-center text-xs text-muted-foreground">
                 No editable fields for this variant.
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      ) : isGlobalBlockMode ? (
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="min-w-0 max-w-full overflow-x-hidden p-4">
+            {activeSchema && formValue ? (
+              <SchemaForm
+                key={formResetKey}
+                schema={activeSchema}
+                value={formValue}
+                onChange={handleFormChange}
+                basePath=""
+                breadcrumbPath={[]}
+                onBreadcrumbChange={setFieldBreadcrumbs}
+              />
+            ) : (
+              <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+                No editable fields for this global block.
               </div>
             )}
           </div>

--- a/apps/mesh/src/web/components/sections-editor/use-create-page.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-create-page.ts
@@ -1,5 +1,9 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { KEYS } from "@/web/lib/query-keys";
+import { useMutation } from "@tanstack/react-query";
+import {
+  createEmptyPageBlock,
+  generatePageBlockKey,
+} from "./page-block-template";
+import { useSaveBlock } from "./use-save-block";
 
 interface UseCreatePageParams {
   orgSlug: string;
@@ -13,13 +17,10 @@ export interface CreatePageResult {
   path: string;
 }
 
-export function useCreatePage({
-  orgSlug,
-  virtualMcpId,
-  branch,
-}: UseCreatePageParams) {
-  const queryClient = useQueryClient();
-  const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
+export function useCreatePage(params: UseCreatePageParams | null) {
+  const saveBlock = useSaveBlock(
+    params ?? { orgSlug: "", virtualMcpId: "", branch: "" },
+  );
 
   return useMutation({
     mutationFn: async ({
@@ -29,51 +30,13 @@ export function useCreatePage({
       name: string;
       path: string;
     }): Promise<CreatePageResult> => {
-      const blockKey = `pages-${encodeURIComponent(name)}-${Math.floor(Math.random() * 1e6)}`;
-      const newBlock = {
-        name,
-        path,
-        sections: [],
-        seo: { __resolveType: "website/sections/Seo/SeoV2.tsx" },
-        __resolveType: "website/pages/Page.tsx",
-      };
-      const res = await fetch(
-        `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/write`,
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            path: `.deco/blocks/${blockKey}.json`,
-            content: JSON.stringify(newBlock, null, 2),
-          }),
-        },
-      );
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `Write failed (${res.status})`,
-        );
+      if (!params?.virtualMcpId || !params.branch) {
+        throw new Error("Sandbox not ready");
       }
+      const blockKey = generatePageBlockKey(name);
+      const data = createEmptyPageBlock(name, path);
+      await saveBlock.mutateAsync({ blockKey, data });
       return { key: blockKey, name, path };
-    },
-    onSuccess: (result) => {
-      const queryKey = KEYS.decofile(cacheKey);
-      queryClient.setQueryData(
-        queryKey,
-        (current: Record<string, unknown> | undefined) => {
-          if (!current) return current;
-          return {
-            ...current,
-            [result.key]: {
-              name: result.name,
-              path: result.path,
-              sections: [],
-              seo: { __resolveType: "website/sections/Seo/SeoV2.tsx" },
-              __resolveType: "website/pages/Page.tsx",
-            },
-          };
-        },
-      );
     },
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-create-page.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-create-page.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+interface UseCreatePageParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+export interface CreatePageResult {
+  key: string;
+  name: string;
+  path: string;
+}
+
+export function useCreatePage({
+  orgSlug,
+  virtualMcpId,
+  branch,
+}: UseCreatePageParams) {
+  const queryClient = useQueryClient();
+  const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
+
+  return useMutation({
+    mutationFn: async ({
+      name,
+      path,
+    }: {
+      name: string;
+      path: string;
+    }): Promise<CreatePageResult> => {
+      const blockKey = `pages-${encodeURIComponent(name)}-${Math.floor(Math.random() * 1e6)}`;
+      const newBlock = {
+        name,
+        path,
+        sections: [],
+        seo: { __resolveType: "website/sections/Seo/SeoV2.tsx" },
+        __resolveType: "website/pages/Page.tsx",
+      };
+      const res = await fetch(
+        `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/write`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            path: `.deco/blocks/${blockKey}.json`,
+            content: JSON.stringify(newBlock, null, 2),
+          }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error ?? `Write failed (${res.status})`,
+        );
+      }
+      return { key: blockKey, name, path };
+    },
+    onSuccess: (result) => {
+      const queryKey = KEYS.decofile(cacheKey);
+      queryClient.setQueryData(
+        queryKey,
+        (current: Record<string, unknown> | undefined) => {
+          if (!current) return current;
+          return {
+            ...current,
+            [result.key]: {
+              name: result.name,
+              path: result.path,
+              sections: [],
+              seo: { __resolveType: "website/sections/Seo/SeoV2.tsx" },
+              __resolveType: "website/pages/Page.tsx",
+            },
+          };
+        },
+      );
+    },
+  });
+}

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -48,10 +48,10 @@ export function useSaveBlock({
         queryClient.getQueryData<Record<string, unknown>>(queryKey);
       queryClient.setQueryData(
         queryKey,
-        (current: Record<string, unknown> | undefined) => {
-          if (!current) return current;
-          return { ...current, [blockKey]: data };
-        },
+        (current: Record<string, unknown> | undefined) => ({
+          ...(current ?? {}),
+          [blockKey]: data,
+        }),
       );
       return { previous, queryKey };
     },
@@ -64,10 +64,10 @@ export function useSaveBlock({
       const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
       queryClient.setQueryData(
         KEYS.decofile(cacheKey),
-        (current: Record<string, unknown> | undefined) => {
-          if (!current) return current;
-          return { ...current, [blockKey]: data };
-        },
+        (current: Record<string, unknown> | undefined) => ({
+          ...(current ?? {}),
+          [blockKey]: data,
+        }),
       );
     },
   });


### PR DESCRIPTION
## Summary
- Add a searchable pages dropdown in the sandbox preview toolbar with **Create new page**, page list, and **Global components** section (mirroring admin-mcp).
- Wire create-page flow via sandbox write API; navigate preview to the new page and open CMS mode after a short dev-server settle delay.
- Fix preview iframe navigation by deriving `src` from `currentPath` and guarding against stale `onLoad` events resetting the path to `/`.
- Support editing global blocks in the sections editor with simplified breadcrumbs and direct schema form.

## Test plan
- [ ] Open sandbox preview with a deco site that has pages and global blocks
- [ ] Verify dropdown: search, scroll, page navigation, global component preview/edit
- [ ] Create a new page — preview should land on the new path (not `/`)
- [ ] Drill into nested fields on a global block — breadcrumb should not show duplicate labels or empty form on root click
- [ ] Switch branches — preview should reset to `/`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a searchable Pages picker in the sandbox preview with Create new page and Global components, plus stable global previews and direct editing of global blocks. Hardens preview navigation, URL handling, and page path validation; branch switches now reset cleanly.

- New Features
  - Pages picker: search pages and Global components; shows active page/global name; Global list mirrors catalog filters; global previews use stable URLs.
  - Create page: modal with strict path validation/normalization; new pages use default page/SEO resolve types; keys via `crypto.randomUUID`; writes via sandbox API, navigates to the new path, opens CMS; blocks duplicate (normalized) paths.

- Bug Fixes
  - Iframe/navigation: derive `src` from `currentPath` or a stable global-preview URL; ignore stale onLoad; refresh/hard reload/copy/open use the current URL; branch switch resets to “/”, clears global selection, and drops transient URLs.
  - Sections editor: open global blocks directly in the form with clean breadcrumbs and no add-section; trim whitespace-only global labels; fix Rules of Hooks; reliable cross-origin reload fallback.

<sup>Written for commit e04684ae029577974ee4fd1490bf687f24505553. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3499?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

