### PR TITLE
feat(e2e): test MCP server fixture + first round-trip spec

### DIFF
--- a/apps/mesh/e2e/fixtures/mcp-tools.ts
+++ b/apps/mesh/e2e/fixtures/mcp-tools.ts
@@ -46,7 +46,11 @@ export async function callSelfMcpTool<T = unknown>(
       method: "tools/call",
       params: { name, arguments: args },
     },
-    headers: { Accept: "application/json" },
+    // MCP's Streamable HTTP transport requires advertising both response
+    // types per spec — the server picks JSON for self-contained calls,
+    // SSE for streams. Without both, the transport responds 406 Not
+    // Acceptable. (See mesh's self.ts enableJsonResponse check.)
+    headers: { Accept: "application/json, text/event-stream" },
   });
   if (!res.ok()) {
     const body = await res.text().catch(() => "<unreadable>");

--- a/apps/mesh/e2e/fixtures/mcp-tools.ts
+++ b/apps/mesh/e2e/fixtures/mcp-tools.ts
@@ -1,0 +1,128 @@
+/**
+ * Call management MCP tools from a Playwright test via JSON-RPC.
+ *
+ * Mesh exposes built-in tools (CONNECTION_*, PROJECT_*, etc.) over the
+ * MCP protocol at `/api/:org/mcp/self`. From a spec, we sometimes need to
+ * exercise them as setup — e.g., create a connection that points at a
+ * test MCP server (see `test-mcp-server.ts`). This module wraps the
+ * JSON-RPC dance so callers don't repeat the envelope.
+ *
+ * The server-side handler at `apps/mesh/src/api/routes/self.ts` builds a
+ * fresh MCP server per request, so each call is self-contained — no
+ * explicit `initialize` handshake is needed when `Accept: application/json`
+ * is set (the JSON-response mode in the SDK's streamable HTTP transport).
+ */
+
+import type { APIRequestContext } from "@playwright/test";
+
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: {
+    content?: Array<{ type: string; text?: string }>;
+    isError?: boolean;
+    structuredContent?: T;
+  };
+  error?: { code: number; message: string; data?: unknown };
+}
+
+let nextRpcId = 1;
+
+/**
+ * Invoke a self MCP tool by name. Returns the structuredContent if the
+ * server provided it, otherwise the parsed first text-content block.
+ * Throws on JSON-RPC error or `result.isError === true`.
+ */
+export async function callSelfMcpTool<T = unknown>(
+  request: APIRequestContext,
+  orgSlug: string,
+  name: string,
+  args: unknown,
+): Promise<T> {
+  const res = await request.post(`/api/${orgSlug}/mcp/self`, {
+    data: {
+      jsonrpc: "2.0",
+      id: nextRpcId++,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok()) {
+    const body = await res.text().catch(() => "<unreadable>");
+    throw new Error(`callSelfMcpTool ${name}: HTTP ${res.status()} — ${body}`);
+  }
+  const envelope = (await res.json()) as JsonRpcResponse<T>;
+  if (envelope.error) {
+    throw new Error(
+      `callSelfMcpTool ${name}: JSON-RPC error ${envelope.error.code} — ${envelope.error.message}`,
+    );
+  }
+  const result = envelope.result;
+  if (!result) {
+    throw new Error(`callSelfMcpTool ${name}: missing result in response`);
+  }
+  if (result.isError) {
+    const errText = result.content?.[0]?.text ?? "<no text>";
+    throw new Error(
+      `callSelfMcpTool ${name}: tool returned error — ${errText}`,
+    );
+  }
+  if (result.structuredContent !== undefined) {
+    return result.structuredContent;
+  }
+  const text = result.content?.[0]?.text;
+  if (text === undefined) {
+    throw new Error(`callSelfMcpTool ${name}: no content in response`);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return text as unknown as T;
+  }
+}
+
+export interface CreateHttpConnectionArgs {
+  title: string;
+  description?: string;
+  url: string;
+  token?: string;
+}
+
+export interface CreatedConnection {
+  id: string;
+  title: string;
+  connection_type: string;
+  connection_url: string;
+}
+
+/**
+ * Convenience wrapper around COLLECTION_CONNECTIONS_CREATE for the common
+ * "HTTP connection pointing at a test MCP server" pattern.
+ */
+export async function createHttpConnection(
+  request: APIRequestContext,
+  orgSlug: string,
+  args: CreateHttpConnectionArgs,
+): Promise<CreatedConnection> {
+  const response = await callSelfMcpTool<{ item: CreatedConnection }>(
+    request,
+    orgSlug,
+    "COLLECTION_CONNECTIONS_CREATE",
+    {
+      data: {
+        title: args.title,
+        description: args.description,
+        connection_type: "HTTP",
+        connection_url: args.url,
+        connection_token: args.token,
+      },
+    },
+  );
+  if (!response.item?.id) {
+    throw new Error(
+      `createHttpConnection: response missing item.id — ${JSON.stringify(response)}`,
+    );
+  }
+  return response.item;
+}

--- a/apps/mesh/e2e/fixtures/test-mcp-server.ts
+++ b/apps/mesh/e2e/fixtures/test-mcp-server.ts
@@ -1,0 +1,169 @@
+/**
+ * In-process MCP server for Playwright tests.
+ *
+ * Spins up a tiny HTTP MCP server on a random port using `Bun.serve` so a
+ * test can create a real mesh connection that points at something real but
+ * controlled. The fixture re-uses mesh's transport
+ * (`WebStandardStreamableHTTPServerTransport`) so the wire protocol matches
+ * production exactly — no hand-rolled JSON-RPC framing.
+ *
+ * Why not Docker (like tests/resilience/everything-server)? Per-test
+ * lifecycle + parallel workers + zero startup overhead. Each test stands
+ * up its own server, configures it, and tears it down inline.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { z } from "zod";
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+) => unknown | Promise<unknown>;
+
+export interface TestMcpTool {
+  name: string;
+  description?: string;
+  /**
+   * Zod *raw shape* (e.g. `{ message: z.string() }`) — matches McpServer's
+   * `registerTool` signature. Defaults to `{}` (no args).
+   */
+  inputSchema?: Record<string, z.ZodTypeAny>;
+  /**
+   * Whatever this returns is wrapped into a `content: [{type: "text", text}]`
+   * MCP response. If omitted, the tool returns `{ ok: true }`.
+   */
+  handler?: ToolHandler;
+}
+
+export interface TestMcpServerConfig {
+  /** Tools exposed by the server. Defaults to a single `echo` tool. */
+  tools?: TestMcpTool[];
+  /**
+   * If > 0, the server returns 500 for the next N requests, then resumes
+   * normal handling. Useful for circuit-breaker / retry tests.
+   */
+  failNext?: number;
+  /** Sleep this many ms before responding. Useful for timeout tests. */
+  latencyMs?: number;
+}
+
+export interface RecordedRequest {
+  method: string;
+  body: unknown;
+  timestamp: number;
+}
+
+export interface TestMcpServer {
+  /** Base URL ending in `/`. Pass this as the connection URL in mesh. */
+  url: string;
+  /** Every JSON-RPC request the server saw, in arrival order. */
+  requests: ReadonlyArray<RecordedRequest>;
+  /** Set/reset the failure injection count at runtime. */
+  setFailNext: (n: number) => void;
+  /** Stop the server. Always `await` this in `test.afterAll` or similar. */
+  stop: () => Promise<void>;
+}
+
+const DEFAULT_TOOLS: TestMcpTool[] = [
+  {
+    name: "echo",
+    description: "Returns the input message verbatim.",
+    inputSchema: { message: z.string() },
+    handler: (args) => ({ echoed: String(args.message ?? "") }),
+  },
+];
+
+export async function startTestMcpServer(
+  config: TestMcpServerConfig = {},
+): Promise<TestMcpServer> {
+  const tools = config.tools ?? DEFAULT_TOOLS;
+  let failNext = config.failNext ?? 0;
+  const latencyMs = config.latencyMs ?? 0;
+  const recorded: RecordedRequest[] = [];
+
+  // Build a fresh server per request — the streamable transport is designed
+  // to be one-shot in JSON mode, mirroring how mesh's own /mcp/self mounts
+  // (see apps/mesh/src/api/routes/self.ts).
+  const buildServer = (): McpServer => {
+    const server = new McpServer({ name: "test-mcp", version: "1.0.0" });
+    for (const tool of tools) {
+      server.registerTool(
+        tool.name,
+        {
+          description: tool.description,
+          inputSchema: tool.inputSchema ?? {},
+        },
+        async (args: Record<string, unknown>) => {
+          const result = tool.handler ? await tool.handler(args) : { ok: true };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  typeof result === "string" ? result : JSON.stringify(result),
+              },
+            ],
+          };
+        },
+      );
+    }
+    return server;
+  };
+
+  const httpServer = Bun.serve({
+    port: 0, // OS picks an unused port
+    fetch: async (req) => {
+      if (latencyMs > 0) {
+        await new Promise((r) => setTimeout(r, latencyMs));
+      }
+
+      // Capture the JSON-RPC method name + body for later assertions, but
+      // don't fail the request if the body isn't JSON (e.g., a GET).
+      if (req.method === "POST") {
+        try {
+          const body = await req.clone().json();
+          if (body && typeof body === "object" && "method" in body) {
+            recorded.push({
+              method: String((body as { method: unknown }).method),
+              body,
+              timestamp: Date.now(),
+            });
+          }
+        } catch {
+          // not JSON; skip logging
+        }
+      }
+
+      if (failNext > 0) {
+        failNext--;
+        return new Response("test-mcp-server: injected failure", {
+          status: 500,
+        });
+      }
+
+      const server = buildServer();
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        enableJsonResponse:
+          req.headers.get("Accept")?.includes("application/json") ?? false,
+      });
+      await server.connect(transport);
+      return transport.handleRequest(req);
+    },
+  });
+
+  const host =
+    httpServer.hostname === "::" || httpServer.hostname === "0.0.0.0"
+      ? "127.0.0.1"
+      : httpServer.hostname;
+
+  return {
+    url: `http://${host}:${httpServer.port}/`,
+    requests: recorded,
+    setFailNext: (n) => {
+      failNext = n;
+    },
+    stop: async () => {
+      httpServer.stop();
+    },
+  };
+}

--- a/apps/mesh/e2e/fixtures/test-mcp-server.ts
+++ b/apps/mesh/e2e/fixtures/test-mcp-server.ts
@@ -1,19 +1,26 @@
 /**
  * In-process MCP server for Playwright tests.
  *
- * Spins up a tiny HTTP MCP server on a random port using `Bun.serve` so a
- * test can create a real mesh connection that points at something real but
- * controlled. The fixture re-uses mesh's transport
- * (`WebStandardStreamableHTTPServerTransport`) so the wire protocol matches
- * production exactly — no hand-rolled JSON-RPC framing.
+ * Spins up a tiny HTTP MCP server on a random port using `node:http` (NOT
+ * `Bun.serve` — Playwright runs specs under Node, not Bun) so a test can
+ * create a real mesh connection that points at something real but
+ * controlled. Uses the SDK's `StreamableHTTPServerTransport` (Node
+ * wrapper around the same Web-Standard transport mesh uses internally),
+ * so the wire protocol matches production exactly.
  *
  * Why not Docker (like tests/resilience/everything-server)? Per-test
- * lifecycle + parallel workers + zero startup overhead. Each test stands
+ * lifecycle, parallel workers, zero startup overhead. Each test stands
  * up its own server, configures it, and tears it down inline.
  */
 
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { AddressInfo } from "node:net";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 
 type ToolHandler = (
@@ -73,6 +80,20 @@ const DEFAULT_TOOLS: TestMcpTool[] = [
   },
 ];
 
+/**
+ * Read the request body as a UTF-8 string. The SDK transport accepts a
+ * pre-parsed body via `handleRequest(req, res, parsedBody)`, which avoids
+ * the SDK having to re-buffer the IncomingMessage we already consumed.
+ */
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
 export async function startTestMcpServer(
   config: TestMcpServerConfig = {},
 ): Promise<TestMcpServer> {
@@ -82,7 +103,7 @@ export async function startTestMcpServer(
   const recorded: RecordedRequest[] = [];
 
   // Build a fresh server per request — the streamable transport is designed
-  // to be one-shot in JSON mode, mirroring how mesh's own /mcp/self mounts
+  // to be one-shot in stateless mode, mirroring how mesh's /mcp/self mounts
   // (see apps/mesh/src/api/routes/self.ts).
   const buildServer = (): McpServer => {
     const server = new McpServer({ name: "test-mcp", version: "1.0.0" });
@@ -110,60 +131,77 @@ export async function startTestMcpServer(
     return server;
   };
 
-  const httpServer = Bun.serve({
-    port: 0, // OS picks an unused port
-    fetch: async (req) => {
-      if (latencyMs > 0) {
-        await new Promise((r) => setTimeout(r, latencyMs));
-      }
+  const httpServer = createServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      try {
+        if (latencyMs > 0) {
+          await new Promise((r) => setTimeout(r, latencyMs));
+        }
 
-      // Capture the JSON-RPC method name + body for later assertions, but
-      // don't fail the request if the body isn't JSON (e.g., a GET).
-      if (req.method === "POST") {
-        try {
-          const body = await req.clone().json();
-          if (body && typeof body === "object" && "method" in body) {
-            recorded.push({
-              method: String((body as { method: unknown }).method),
-              body,
-              timestamp: Date.now(),
-            });
+        let parsedBody: unknown = undefined;
+        if (req.method === "POST") {
+          const raw = await readBody(req);
+          try {
+            parsedBody = JSON.parse(raw);
+            if (
+              parsedBody &&
+              typeof parsedBody === "object" &&
+              "method" in parsedBody
+            ) {
+              recorded.push({
+                method: String((parsedBody as { method: unknown }).method),
+                body: parsedBody,
+                timestamp: Date.now(),
+              });
+            }
+          } catch {
+            // not JSON; pass through as undefined so transport reads raw
           }
-        } catch {
-          // not JSON; skip logging
+        }
+
+        if (failNext > 0) {
+          failNext--;
+          res.statusCode = 500;
+          res.end("test-mcp-server: injected failure");
+          return;
+        }
+
+        const server = buildServer();
+        // Stateless mode so each request stands alone — matches mesh's
+        // per-request server pattern in self.ts.
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+          enableJsonResponse:
+            req.headers.accept?.includes("application/json") ?? false,
+        });
+        await server.connect(transport);
+        await transport.handleRequest(req, res, parsedBody);
+      } catch (err) {
+        if (!res.headersSent) {
+          res.statusCode = 500;
+          res.end(`test-mcp-server: ${(err as Error).message}`);
+        } else {
+          res.end();
         }
       }
-
-      if (failNext > 0) {
-        failNext--;
-        return new Response("test-mcp-server: injected failure", {
-          status: 500,
-        });
-      }
-
-      const server = buildServer();
-      const transport = new WebStandardStreamableHTTPServerTransport({
-        enableJsonResponse:
-          req.headers.get("Accept")?.includes("application/json") ?? false,
-      });
-      await server.connect(transport);
-      return transport.handleRequest(req);
     },
-  });
+  );
 
-  const host =
-    httpServer.hostname === "::" || httpServer.hostname === "0.0.0.0"
-      ? "127.0.0.1"
-      : httpServer.hostname;
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const port = (httpServer.address() as AddressInfo).port;
 
   return {
-    url: `http://${host}:${httpServer.port}/`,
+    url: `http://127.0.0.1:${port}/`,
     requests: recorded,
     setFailNext: (n) => {
       failNext = n;
     },
     stop: async () => {
-      httpServer.stop();
+      await new Promise<void>((resolve, reject) =>
+        httpServer.close((err) => (err ? reject(err) : resolve())),
+      );
     },
   };
 }

--- a/apps/mesh/e2e/fixtures/test-mcp-server.ts
+++ b/apps/mesh/e2e/fixtures/test-mcp-server.ts
@@ -199,6 +199,10 @@ export async function startTestMcpServer(
       failNext = n;
     },
     stop: async () => {
+      // `close()` alone waits for in-flight connections to drain, which
+      // the MCP transport keeps alive (intended for SSE streams). Force
+      // them shut so the test's afterAll doesn't time out at 30s.
+      httpServer.closeAllConnections();
       await new Promise<void>((resolve, reject) =>
         httpServer.close((err) => (err ? reject(err) : resolve())),
       );

--- a/apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts
+++ b/apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * End-to-end smoke test for mesh's MCP proxy.
+ *
+ * Stands up a tiny test MCP server (apps/mesh/e2e/fixtures/test-mcp-server.ts),
+ * creates a real connection in mesh that points at it, then exercises the
+ * proxy mount at /api/:org/mcp/:connectionId. Validates the whole chain:
+ *
+ *   Playwright APIRequestContext
+ *     → /api/:org/mcp/:connectionId (mesh proxy)
+ *       → connection lookup + auth
+ *         → outbound HTTP to the test MCP server
+ *           → tool handler returns
+ *         ← MCP response
+ *       ← mesh forwards
+ *     ← client gets JSON-RPC tools/call result
+ *
+ * Also serves as the first runtime use of:
+ *   - startTestMcpServer (test-mcp-server.ts)
+ *   - createHttpConnection + callSelfMcpTool (mcp-tools.ts)
+ * — surfacing breakage in those helpers before downstream specs depend on
+ * them.
+ */
+
+import { z } from "zod";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+import {
+  startTestMcpServer,
+  type TestMcpServer,
+} from "../fixtures/test-mcp-server";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+test.describe("MCP proxy roundtrip", () => {
+  let mcpServer: TestMcpServer;
+
+  test.beforeAll(async () => {
+    mcpServer = await startTestMcpServer({
+      tools: [
+        {
+          name: "ping",
+          description: "Returns pong + the input.",
+          inputSchema: { from: z.string() },
+          handler: (args) => ({ pong: true, from: args.from }),
+        },
+      ],
+    });
+  });
+
+  test.afterAll(async () => {
+    await mcpServer?.stop();
+  });
+
+  test("calls a tool on a downstream MCP server through the proxy", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    // Create a real connection in mesh pointing at the test MCP server.
+    // This also exercises `callSelfMcpTool` indirectly via the helper.
+    const connection = await createHttpConnection(ctx, user.orgSlug, {
+      title: `Test MCP ${Date.now()}`,
+      url: mcpServer.url,
+    });
+
+    // Verify the connection is actually queryable through the management
+    // MCP — `callSelfMcpTool` direct use, also serves as a smoke check
+    // that the helper handles list-style responses.
+    const listed = await callSelfMcpTool<{
+      items?: Array<{ id: string; title: string }>;
+    }>(ctx, user.orgSlug, "COLLECTION_CONNECTIONS_LIST", {});
+    expect(listed.items?.some((c) => c.id === connection.id)).toBe(true);
+
+    // Hit the proxy mount with a JSON-RPC tools/call. The proxy resolves
+    // the connection, opens an MCP client to the underlying URL, and
+    // forwards the call.
+    const res = await ctx.post(`/api/${user.orgSlug}/mcp/${connection.id}`, {
+      data: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "ping", arguments: { from: "playwright" } },
+      },
+      headers: { Accept: "application/json" },
+    });
+    expect(res.ok()).toBe(true);
+    const envelope = (await res.json()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+      error?: unknown;
+    };
+    expect(envelope.error).toBeUndefined();
+    expect(envelope.result?.isError).not.toBe(true);
+    const text = envelope.result?.content?.[0]?.text;
+    expect(text).toBeDefined();
+    const payload = JSON.parse(text!) as { pong: boolean; from: string };
+    expect(payload).toEqual({ pong: true, from: "playwright" });
+
+    // The test MCP server should have logged at least tools/call.
+    expect(mcpServer.requests.some((r) => r.method === "tools/call")).toBe(
+      true,
+    );
+
+    await ctx.dispose();
+  });
+});

--- a/apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts
+++ b/apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts
@@ -81,7 +81,7 @@ test.describe("MCP proxy roundtrip", () => {
         method: "tools/call",
         params: { name: "ping", arguments: { from: "playwright" } },
       },
-      headers: { Accept: "application/json" },
+      headers: { Accept: "application/json, text/event-stream" },
     });
     expect(res.ok()).toBe(true);
     const envelope = (await res.json()) as {


### PR DESCRIPTION
## Summary

Lays the infrastructure that the harder migration rows (org-scoped routes' well-known/DCR tests, lazy-client circuit breaker, future MCP proxy specs) all depend on.

### New fixtures

- **\`apps/mesh/e2e/fixtures/test-mcp-server.ts\`** — \`startTestMcpServer({tools, failNext, latencyMs})\`. In-process MCP server via \`Bun.serve\` + \`McpServer\` + \`WebStandardStreamableHTTPServerTransport\` — the same transport mesh uses, so the wire protocol matches production exactly. Random port, per-test lifecycle. Exposes \`failNext\` for circuit-breaker tests and \`latencyMs\` for timeout tests.

- **\`apps/mesh/e2e/fixtures/mcp-tools.ts\`** — \`callSelfMcpTool(request, orgSlug, name, args)\` (raw JSON-RPC POST to \`/api/:org/mcp/self\`) and \`createHttpConnection\` convenience. Sends \`Accept: application/json\` so the server-side transport returns synchronous JSON envelopes — no init handshake needed since mesh builds a fresh MCP server per request.

### First consumer

**\`apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts\`** — signs up a user, starts a test MCP server with a \`ping\` tool, creates a connection that points at it, then hits \`/api/:org/mcp/:connectionId\` with a JSON-RPC \`tools/call\`. Validates the full chain:

\`\`\`
APIRequestContext
  → /api/:org/mcp/:connectionId (mesh proxy)
    → connection lookup + auth
      → outbound HTTP to the test MCP server
        → tool handler returns { pong: true, from: \"playwright\" }
      ← MCP response
    ← mesh forwards
  ← JSON-RPC tools/call result
\`\`\`

Also asserts \`COLLECTION_CONNECTIONS_LIST\` includes the new connection (exercises \`callSelfMcpTool\` directly).

This is the foundation. Next PRs migrate row 3 (org-scoped routes) and row 7 (lazy-client circuit breaker) on top of these helpers.

## Test plan

- [x] fmt / tsc / knip / playwright --list all clean
- [ ] CI \`e2e\` passes — first real validation of the new fixtures end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-process MCP server fixture and helpers for e2e tests, plus the first MCP proxy round‑trip spec to validate the full path end-to-end. Uses Node `http` with `StreamableHTTPServerTransport` for Playwright compatibility and adds safe shutdown to prevent hanging tests.

- **New Features**
  - `apps/mesh/e2e/fixtures/test-mcp-server.ts`: `startTestMcpServer({ tools, failNext, latencyMs })` — in-process server via Node `http` + `McpServer` + `StreamableHTTPServerTransport`; random port; per-test lifecycle; failure/latency injection.
  - `apps/mesh/e2e/fixtures/mcp-tools.ts`: `callSelfMcpTool` (JSON-RPC POST to `/api/:org/mcp/self` with `Accept: application/json, text/event-stream`) and `createHttpConnection` helper.
  - `apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts`: spins up a `ping` tool server, creates an HTTP connection, calls `/api/:org/mcp/:connectionId` (sends `Accept: application/json, text/event-stream`), asserts the JSON-RPC result, and verifies `COLLECTION_CONNECTIONS_LIST` includes the new connection.

- **Bug Fixes**
  - Test MCP server `stop()` now force-closes keep-alive connections before shutting down to prevent afterAll timeouts.

<sup>Written for commit 24fe6fa3b3c0c009844108ac406612eeed31bb44. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3502?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

