### PR TITLE
feat(e2e): migrate org-scoped routing assertions to Playwright

### DIFF
--- a/apps/mesh/e2e/tests/org-scoped-routing.spec.ts
+++ b/apps/mesh/e2e/tests/org-scoped-routing.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Org-scoped routing boundary tests.
+ *
+ * Migrates the routing-layer assertions from
+ * apps/mesh/src/api/integration-org-scoped.test.ts to real Playwright
+ * specs against real Better Auth + resolveOrgFromPath middleware:
+ *
+ *   - new path serves the route (200)
+ *   - legacy unscoped path still serves (200) [log assertion dropped:
+ *     can't capture dev-server stdout from Playwright]
+ *   - new path 404 for unknown slug
+ *   - new path 403 for non-member principal
+ *
+ * The remaining tests in that file (well-known prefix discovery, OAuth
+ * DCR, auth-server-metadata, oauth-proxy slug-spoofing) are deferred to
+ * follow-up PRs — they need OAuth client registration plumbing that this
+ * migration scope doesn't cover.
+ *
+ * Endpoint choice: we hit `/mcp/self` (the built-in management MCP)
+ * because it's a cheap tools/list call that goes through the same
+ * resolveOrgFromPath middleware as the connection-scoped routes the
+ * unit test used — no real downstream connection required.
+ */
+
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const MCP_HEADERS = { Accept: "application/json, text/event-stream" };
+
+const toolsListBody = {
+  jsonrpc: "2.0" as const,
+  id: 1,
+  method: "tools/list",
+};
+
+test.describe("org-scoped routing middleware", () => {
+  test("new path returns 200 for a member of the resolved org", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+
+    const res = await ctx.post(`/api/${user.orgSlug}/mcp/self`, {
+      data: toolsListBody,
+      headers: MCP_HEADERS,
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    expect(Array.isArray(body.result?.tools)).toBe(true);
+
+    await ctx.dispose();
+  });
+
+  test("legacy unscoped path still serves the same request", async ({
+    playwright,
+  }) => {
+    // Legacy mount is at `/mcp/self` (no org prefix). It survives behind a
+    // deprecation log middleware; we only assert it still responds —
+    // capturing the actual log line would require dev-server stdout, which
+    // Playwright doesn't surface.
+    const ctx = await newApiContext(playwright);
+    await signUpViaApi(ctx);
+
+    const res = await ctx.post(`/mcp/self`, {
+      data: toolsListBody,
+      headers: MCP_HEADERS,
+    });
+    expect(res.status()).toBe(200);
+
+    await ctx.dispose();
+  });
+
+  test("new path returns 404 for an unknown slug", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+    await signUpViaApi(ctx);
+
+    // The signed-in user has cookies, so auth would pass — the slug lookup
+    // in resolveOrgFromPath is what 404s.
+    const res = await ctx.post(
+      `/api/definitely-not-a-real-org-${Date.now()}/mcp/self`,
+      { data: toolsListBody, headers: MCP_HEADERS },
+    );
+    expect(res.status()).toBe(404);
+
+    await ctx.dispose();
+  });
+
+  test("new path returns 403 for a principal who isn't a member", async ({
+    playwright,
+  }) => {
+    // User A owns org A.
+    const userACtx = await newApiContext(playwright);
+    const userA = await signUpViaApi(userACtx);
+
+    // User B has their own org but no membership in org A.
+    const userBCtx = await newApiContext(playwright);
+    await signUpViaApi(userBCtx);
+
+    // B tries to hit A's org — middleware should 403.
+    const res = await userBCtx.post(`/api/${userA.orgSlug}/mcp/self`, {
+      data: toolsListBody,
+      headers: MCP_HEADERS,
+    });
+    expect(res.status()).toBe(403);
+
+    await userACtx.dispose();
+    await userBCtx.dispose();
+  });
+});

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -182,31 +182,11 @@ describe("org-scoped API coexistence", () => {
     expect(deprecationCalls.length).toBeGreaterThan(0);
   });
 
-  it("new path returns 404 for unknown slug", async () => {
-    const res = await app.fetch(
-      new Request(
-        "http://test/api/non-existent-slug/connections/conn_1/oauth-token/status",
-        { headers: { Authorization: "Bearer test-key" } },
-      ),
-    );
-
-    expect(res.status).toBe(404);
-  });
-
-  it("new path returns 403 for non-member principal", async () => {
-    // Swap the API key mock so the request is authenticated as user_outsider,
-    // who has no membership row in org_1.
-    mockApiKey("user_outsider", "org_1", "org_1");
-
-    const res = await app.fetch(
-      new Request(
-        "http://test/api/org_1/connections/conn_1/oauth-token/status",
-        { headers: { Authorization: "Bearer test-key" } },
-      ),
-    );
-
-    expect(res.status).toBe(403);
-  });
+  // Routing assertions for unknown-slug (404) and non-member-principal
+  // (403) migrated to apps/mesh/e2e/tests/org-scoped-routing.spec.ts —
+  // they're exercised through real Better Auth sessions there.
+  // Deprecation-log assertions remain above (Playwright can't capture
+  // dev-server stdout).
 
   it("well-known prefix discovery for org-scoped MCP resolves the right org", async () => {
     // The MCP SDK probes /.well-known/oauth-protected-resource{resource-path}


### PR DESCRIPTION
## Summary

Partial migration of row 3 from the plan's table. The simple routing-boundary assertions move to real Playwright; the harder ones (OAuth DCR, well-known prefix discovery, auth-server metadata, oauth-proxy slug-spoofing) defer to follow-ups since they need OAuth client-registration plumbing we don't have e2e helpers for yet.

### Migrated (4 tests)

- new path returns 200 for a member of the resolved org
- legacy unscoped path still serves (deprecation-log assertion remains in the unit test — Playwright can't capture dev-server stdout)
- new path returns 404 for an unknown slug
- new path returns 403 for a principal who isn't a member

Hits \`/api/:org/mcp/self\` (cheap \`tools/list\`) because it goes through the same \`resolveOrgFromPath\` middleware the unit tests hit via \`/api/:org/connections/:connId/oauth-token/status\`, without needing to seed a connection per test.

### Deletions

Removed the two fully-migrated unit tests (404, 403). Kept the two that also assert on the deprecation log — Playwright can't replicate that assertion without dev-server stdout capture.

The other 9 tests in \`integration-org-scoped.test.ts\` (well-known + DCR + OAuth-proxy + auth-server) remain as units, plus all of \`access-control.integration.test.ts\`. They'll migrate when we have helpers for OAuth client registration and protected-resource discovery.

## Test plan

- [x] \`bun run fmt\` / tsc / knip clean
- [x] \`playwright test --list\` discovers all 19 tests (15 prior + 4 new)
- [ ] CI \`e2e\` passes
- [ ] CI \`unit\` smaller (2 fewer tests in shard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated org-scoped routing boundary tests to `Playwright` E2E against real Better Auth and `resolveOrgFromPath`. Covers 200 for a member, 200 on the legacy unscoped path, 404 for unknown slug, and 403 for non-member; removed the two equivalent unit tests while keeping deprecation-log checks in units.

- **Refactors**
  - Added `apps/mesh/e2e/tests/org-scoped-routing.spec.ts` hitting `/api/:org/mcp/self` via a cheap tools/list call (no connection seeding).
  - Removed the 404 and 403 unit tests from `integration-org-scoped.test.ts`; kept deprecation-log assertions there.
  - Deferred well-known discovery, OAuth DCR, auth-server metadata, and oauth-proxy slug-spoofing to follow-ups pending OAuth client-registration helpers.

<sup>Written for commit 841e82ea73ffd04849f19e437b84ddae3e11a722. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

