### PR TITLE
ci(test): drop 4-shard matrix, rename workflow to 'Unit Tests'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit Tests
 
 on:
   push:
@@ -69,11 +69,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NATS_URL: nats://localhost:4222
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3]
-        total_shards: [4]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -98,20 +93,13 @@ jobs:
           for i in $(seq 1 10); do nc -z localhost 4222 && break || sleep 1; done
           nc -z localhost 4222
 
-      - name: Run tests (shard ${{ matrix.shard }}/${{ matrix.total_shards }})
+      - name: Run tests
         run: |
-          # Hash-based shard assignment: a file's shard is a stable function of
-          # its path, not its position in the sorted list. This prevents
-          # adding/removing test files from reshuffling other tests across
-          # shards (which can move resource-sensitive tests like
-          # pty-spawn.test.ts into a heavier-loaded shard and break them).
-          files=$(find apps/mesh/src packages -name '*.test.ts' -o -name '*.test.tsx' \
-            | while read -r f; do
-                hash=$(printf '%s' "$f" | cksum | awk '{print $1}')
-                if [ $((hash % ${{ matrix.total_shards }})) -eq ${{ matrix.shard }} ]; then
-                  echo "$f"
-                fi
-              done)
+          # Single job (was a 4-shard matrix when the suite was larger). The
+          # per-file bun invocation below is what actually protects us from
+          # Bun 1.3.5's PGlite teardown crashes — sharding was orchestration
+          # overhead for little wall-time gain at the current size.
+          files=$(find apps/mesh/src packages -name '*.test.ts' -o -name '*.test.tsx')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"
           echo "$files"


### PR DESCRIPTION
## Summary

The 4-shard matrix in \`.github/workflows/test.yml\` was orchestration overhead for little wall-time benefit at the current suite size. What actually protects against Bun 1.3.5's PGlite teardown crashes is the per-file \`bun test \$f\` invocation in the run-tests step — sharding was on top of that.

- Drops the \`strategy.matrix.shard\` config; single \`test\` job runs all files.
- Renames workflow display name from "Tests" to "Unit Tests" to match the two-tier vocabulary established in TESTING.md.
- **File path stays \`test.yml\`** so external badges / branch-protection required-check rules keep resolving.

Side benefit: a flake in one file no longer hides behind 3 green shards. The failure becomes visible on a single \`test\` check instead of "test (N, 4)".

## Test plan

- [ ] CI runs as a single \`Unit Tests / test\` check (no longer 4 sharded checks)
- [ ] Wall time stays reasonable (most time is per-file bun startup, which doesn't shard well anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the unit-test CI by dropping the 4-shard matrix and running tests in a single job, and renames the workflow to "Unit Tests". This trims orchestration overhead and surfaces failures on a single check.

- **Refactors**
  - Removed matrix sharding; single job runs all files with one Bun process per file (keeps mitigation for Bun 1.3.5 PGlite/PGlite teardown crashes).
  - Renamed workflow display name to "Unit Tests".
  - Kept file path .github/workflows/test.yml so badges and required checks still resolve.
  - Wall time expected to remain similar since per-file Bun startup dominates.

<sup>Written for commit 5801417d2481168d08480d8791a93ecbd0b1f271. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/studio/pull/3505?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

