### PR TITLE
refactor(storage): enhance delete method to use transactions for conn…

### DIFF
--- a/apps/mesh/src/storage/virtual.ts
+++ b/apps/mesh/src/storage/virtual.ts
@@ -439,18 +439,27 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
   }
 
   async delete(id: string): Promise<void> {
-    // First delete aggregations (no cascade since it's a different relationship)
-    await this.db
-      .deleteFrom("connection_aggregations")
-      .where("parent_connection_id", "=", id)
-      .execute();
+    await this.db.transaction().execute(async (trx) => {
+      // Delete threads initiated with this agent. virtual_mcp_id has no DB FK,
+      // so there's no automatic cascade; thread_messages cascade via threads.id.
+      await trx
+        .deleteFrom("threads")
+        .where("virtual_mcp_id", "=", id)
+        .execute();
 
-    // Then delete the connection
-    await this.db
-      .deleteFrom("connections")
-      .where("id", "=", id)
-      .where("connection_type", "=", "VIRTUAL")
-      .execute();
+      // Delete aggregations (no cascade since it's a different relationship)
+      await trx
+        .deleteFrom("connection_aggregations")
+        .where("parent_connection_id", "=", id)
+        .execute();
+
+      // Then delete the connection
+      await trx
+        .deleteFrom("connections")
+        .where("id", "=", id)
+        .where("connection_type", "=", "VIRTUAL")
+        .execute();
+    });
   }
 
   async removeConnectionReferences(connectionId: string): Promise<void> {


### PR DESCRIPTION
…ection removal

Updated the delete method in VirtualMCPStorage to utilize a database transaction for deleting related threads, connection aggregations, and the connection itself. This change ensures that all deletions are handled atomically, improving data integrity and consistency during the delete operation.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `VirtualMCPStorage.delete` to a single database transaction that deletes related threads, connection aggregations, and the virtual connection atomically to prevent partial deletes and orphaned data.

- **Refactors**
  - Wraps all deletes in one transaction.
  - Deletes `threads` by `virtual_mcp_id` (relies on cascade to remove `thread_messages`).
  - Removes related `connection_aggregations`, then the `connections` row (`connection_type = VIRTUAL`).

<sup>Written for commit 8be61247b2b460f101eb29ce26e40588091632b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3507?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

