### PR TITLE
feat(virtual-mcp): enhance listPrompts to filter completed onboarding…

### DIFF
--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -5,8 +5,22 @@
  * enrichment on tools and VirtualMCP instructions.
  */
 
-import { GatewayClient, type ClientEntry } from "@decocms/mcp-utils/aggregate";
+import {
+  GatewayClient,
+  type ClientEntry,
+  getGatewayClientId,
+  stripToolNamespace,
+} from "@decocms/mcp-utils/aggregate";
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  ListPromptsRequest,
+  ListPromptsResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { MeshContext } from "../../core/mesh-context";
+import {
+  findStudioPackAgentByMcpId,
+  resolveStudioPackChecklist,
+} from "../../tools/virtual/studio-pack";
 import { createLazyClient } from "../lazy-client";
 import type { VirtualClientOptions } from "./types";
 
@@ -68,6 +82,49 @@ export class PassthroughClient extends GatewayClient {
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
+  }
+
+  /**
+   * Studio Pack agents back their welcome-screen icebreakers with onboarding
+   * prompts (e.g. Brand Manager's "Set up your brand"). Each prompt mirrors a
+   * checklist item whose `isCompleted` reflects org state. Once an item is
+   * done, its prompt should stop being suggested — same logic the home
+   * next-actions route already applies. Filter completed items out here so the
+   * icebreakers, tools popover, and harness prompt block all stay in sync.
+   * Non-studio-pack agents are untouched.
+   */
+  override async listPrompts(
+    params?: ListPromptsRequest["params"],
+    options?: RequestOptions,
+  ): Promise<ListPromptsResult> {
+    const result = await super.listPrompts(params, options);
+
+    const agent = findStudioPackAgentByMcpId(this.options.virtualMcp.id ?? "");
+    const orgId = this.ctx.organization?.id;
+    if (!agent || !orgId) return result;
+
+    const items = await resolveStudioPackChecklist(agent, {
+      orgId,
+      ctx: this.ctx,
+    });
+    const completed = new Set(
+      items
+        .filter(
+          (item) => item.completed && item.action.kind === "open-agent-thread",
+        )
+        .map((item) => (item.action as { promptName: string }).promptName),
+    );
+    if (completed.size === 0) return result;
+
+    return {
+      ...result,
+      prompts: result.prompts.filter(
+        (prompt) =>
+          !completed.has(
+            stripToolNamespace(prompt.name, getGatewayClientId(prompt._meta)),
+          ),
+      ),
+    };
   }
 
   override getInstructions(): string | undefined {


### PR DESCRIPTION
… prompts for studio pack agents

This update introduces a new implementation of the listPrompts method in the PassthroughClient class. It filters out completed onboarding prompts for studio pack agents, ensuring that only relevant prompts are suggested based on the organization's state. The method utilizes helper functions to resolve the studio pack checklist and identify completed items, maintaining synchronization across various UI components. Non-studio-pack agents remain unaffected by this change.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out completed onboarding prompts for Studio Pack agents so users only see relevant prompts based on org state. Keeps icebreakers, tools, and prompt blocks in sync; other agents are unchanged.

- New Features
  - Override listPrompts in PassthroughClient to drop prompts tied to completed checklist items.
  - Compute completion with resolveStudioPackChecklist and match prompts by stripping tool namespace via getGatewayClientId/stripToolNamespace from `@decocms/mcp-utils/aggregate`.
  - Falls back to the original list when no org context or no completed items are found.

<sup>Written for commit 8eadebcea65d26c5939a44cc099f33b18ff4eb3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3508?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

