### PR TITLE
feat(storage): add filtering for threads from deleted agents

### DIFF
--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -5,7 +5,12 @@
  * Threads are organization-scoped, messages are thread-scoped.
  */
 
-import { type Kysely } from "kysely";
+import {
+  type Expression,
+  type ExpressionBuilder,
+  type Kysely,
+  type SqlBool,
+} from "kysely";
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
 import type { ThreadStoragePort } from "./ports";
@@ -308,6 +313,31 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .execute();
   }
 
+  /**
+   * Exclude threads whose agent was deleted.
+   *
+   * User agents are VIRTUAL connections with `vir_`-prefixed ids and are
+   * hard-deleted from `connections`, leaving their threads dangling. We drop a
+   * thread only when its `virtual_mcp_id` is such an id with no surviving row.
+   * Well-known synthetic agents (`decopilot_`, `brand-context-setup_`, …) and
+   * agent-less threads (empty id) don't use the `vir_` prefix, so they're kept.
+   */
+  private notFromDeletedAgent(
+    eb: ExpressionBuilder<Database, "threads">,
+  ): Expression<SqlBool> {
+    return eb.or([
+      // `\_` escapes the LIKE single-char wildcard to match a literal `vir_`.
+      eb("threads.virtual_mcp_id", "not like", "vir\\_%"),
+      eb.exists(
+        eb
+          .selectFrom("connections")
+          .select("connections.id")
+          .whereRef("connections.id", "=", "threads.virtual_mcp_id")
+          .where("connections.connection_type", "=", "VIRTUAL"),
+      ),
+    ]);
+  }
+
   async list(
     organizationId: string,
     createdBy?: string,
@@ -330,6 +360,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .selectAll()
       .where("organization_id", "=", organizationId)
       .where("hidden", "=", archived)
+      .where((eb) => this.notFromDeletedAgent(eb))
       .orderBy("updated_at", "desc");
 
     if (createdBy) {
@@ -370,7 +401,8 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .selectFrom("threads")
       .select((eb) => eb.fn.count("id").as("count"))
       .where("organization_id", "=", organizationId)
-      .where("hidden", "=", archived);
+      .where("hidden", "=", archived)
+      .where((eb) => this.notFromDeletedAgent(eb));
 
     if (createdBy) {
       countQuery = countQuery.where("created_by", "=", createdBy);


### PR DESCRIPTION
Introduces a new method `notFromDeletedAgent` in `SqlThreadStorage` to exclude threads associated with deleted user agents. This method ensures that threads linked to virtual connections with `vir_`-prefixed IDs are filtered out, while retaining well-known synthetic agents and agent-less threads. Updates the `list` and `count` methods to apply this filtering logic, enhancing data integrity in thread management.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out threads from deleted virtual agents so thread lists and counts no longer include dangling items. Keeps synthetic agents and agent-less threads.

- **New Features**
  - Added `notFromDeletedAgent` in `SqlThreadStorage` to exclude threads whose `virtual_mcp_id` is a `vir_`-prefixed id without a surviving `VIRTUAL` connection.
  - Applied this filter to `list` and `count` queries.

<sup>Written for commit 6346bd2c53e8a3b6041909e44f3982f7244211b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3509?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

