### PR TITLE
Revert "feat(storage): add filtering for threads from deleted agents"

### DIFF
--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -5,12 +5,7 @@
  * Threads are organization-scoped, messages are thread-scoped.
  */
 
-import {
-  type Expression,
-  type ExpressionBuilder,
-  type Kysely,
-  type SqlBool,
-} from "kysely";
+import { type Kysely } from "kysely";
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { DEFAULT_THREAD_TITLE } from "@/api/routes/decopilot/constants";
 import type { ThreadStoragePort } from "./ports";
@@ -313,31 +308,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .execute();
   }
 
-  /**
-   * Exclude threads whose agent was deleted.
-   *
-   * User agents are VIRTUAL connections with `vir_`-prefixed ids and are
-   * hard-deleted from `connections`, leaving their threads dangling. We drop a
-   * thread only when its `virtual_mcp_id` is such an id with no surviving row.
-   * Well-known synthetic agents (`decopilot_`, `brand-context-setup_`, …) and
-   * agent-less threads (empty id) don't use the `vir_` prefix, so they're kept.
-   */
-  private notFromDeletedAgent(
-    eb: ExpressionBuilder<Database, "threads">,
-  ): Expression<SqlBool> {
-    return eb.or([
-      // `\_` escapes the LIKE single-char wildcard to match a literal `vir_`.
-      eb("threads.virtual_mcp_id", "not like", "vir\\_%"),
-      eb.exists(
-        eb
-          .selectFrom("connections")
-          .select("connections.id")
-          .whereRef("connections.id", "=", "threads.virtual_mcp_id")
-          .where("connections.connection_type", "=", "VIRTUAL"),
-      ),
-    ]);
-  }
-
   async list(
     organizationId: string,
     createdBy?: string,
@@ -360,7 +330,6 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .selectAll()
       .where("organization_id", "=", organizationId)
       .where("hidden", "=", archived)
-      .where((eb) => this.notFromDeletedAgent(eb))
       .orderBy("updated_at", "desc");
 
     if (createdBy) {
@@ -401,8 +370,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .selectFrom("threads")
       .select((eb) => eb.fn.count("id").as("count"))
       .where("organization_id", "=", organizationId)
-      .where("hidden", "=", archived)
-      .where((eb) => this.notFromDeletedAgent(eb));
+      .where("hidden", "=", archived);
 
     if (createdBy) {
       countQuery = countQuery.where("created_by", "=", createdBy);


### PR DESCRIPTION
Reverts decocms/studio#3509

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that hid threads tied to deleted virtual agents, restoring the previous behavior where all threads are listed and counted. Removes the `notFromDeletedAgent` predicate and related Kysely types, and drops that filter from `SqlThreadStorage.list` and `SqlThreadStorage.count`.

<sup>Written for commit 9da3c6a4a4def0943f6616b100d444421deb02e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3510?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

