### PR TITLE
feat(studio-pack): add alwaysSuggest property to checklist items for …

### DIFF
--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -110,7 +110,10 @@ export class PassthroughClient extends GatewayClient {
     const completed = new Set(
       items
         .filter(
-          (item) => item.completed && item.action.kind === "open-agent-thread",
+          (item) =>
+            item.completed &&
+            !item.alwaysSuggest &&
+            item.action.kind === "open-agent-thread",
         )
         .map((item) => (item.action as { promptName: string }).promptName),
     );

--- a/apps/mesh/src/tools/virtual/studio-pack/brand-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/brand-manager.ts
@@ -169,6 +169,9 @@ export const brandManagerAgent = {
         promptName: "brand-manager-create-landing-page",
       },
       isCompleted: async ({ ctx }) => hasAnyObject(ctx, "pages/"),
+      // Repeatable action — keep offering it as an icebreaker even after the
+      // first page exists.
+      alwaysSuggest: true,
     },
   ] as const satisfies readonly StudioPackChecklistItem[],
   getId: StudioPackAgentId.BRAND_MANAGER,

--- a/apps/mesh/src/tools/virtual/studio-pack/index.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/index.ts
@@ -10,6 +10,7 @@ import type {
   ResolvedChecklistItem,
   ResolvedRuntime,
   RuntimeResolveContext,
+  StudioPackChecklistItem,
   StudioPackConnectionKey,
 } from "./types";
 
@@ -64,11 +65,12 @@ export async function resolveStudioPackChecklist(
 ): Promise<ResolvedChecklistItem[]> {
   if (!("checklist" in agent)) return [];
   return Promise.all(
-    agent.checklist.map(async (item) => ({
+    agent.checklist.map(async (item: StudioPackChecklistItem) => ({
       label: item.label,
       activeForm: item.activeForm,
       action: item.action,
       completed: await item.isCompleted(c),
+      alwaysSuggest: item.alwaysSuggest,
     })),
   );
 }

--- a/apps/mesh/src/tools/virtual/studio-pack/types.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/types.ts
@@ -47,6 +47,12 @@ export type StudioPackChecklistItem = {
   activeForm: string;
   action: ChecklistItemAction;
   isCompleted: (c: ChecklistContext) => Promise<boolean>;
+  /**
+   * Keep offering this prompt as a chat icebreaker even after `isCompleted`.
+   * For repeatable actions (e.g. creating another landing page) that aren't
+   * one-time setup steps. Defaults to false (hide once complete).
+   */
+  alwaysSuggest?: boolean;
 };
 
 export type ResolvedChecklistItem = {
@@ -54,6 +60,7 @@ export type ResolvedChecklistItem = {
   activeForm: string;
   action: ChecklistItemAction;
   completed: boolean;
+  alwaysSuggest?: boolean;
 };
 
 export type StudioPackConnectionKey =


### PR DESCRIPTION
…repeatable actions

This update introduces the `alwaysSuggest` property to the `StudioPackChecklistItem` type, allowing certain actions to be suggested repeatedly even after completion. The `PassthroughClient` class has been modified to filter completed items based on this new property, ensuring that relevant prompts are consistently offered. Additionally, the `brand-manager` now utilizes this feature to keep suggesting the creation of landing pages.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `alwaysSuggest` flag to Studio Pack checklist items so repeatable actions keep showing as suggestions after completion. Updates filtering logic and enables it for the brand manager’s “create landing page” prompt.

- New Features
  - Added `alwaysSuggest?: boolean` to `StudioPackChecklistItem` and propagated to `ResolvedChecklistItem`.
  - Updated `PassthroughClient` to keep suggesting completed items when `alwaysSuggest` is true.
  - Enabled for the brand manager’s `brand-manager-create-landing-page` action.

<sup>Written for commit 9a6373fc35d44cec90c221c54312ee1041a68273. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3511?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

