### PR TITLE
feat(sidebar): move credit balance chip into the footer

### DIFF
--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -28,6 +28,10 @@ import { InvitationItem } from "@/web/components/sidebar/footer/invitation-item"
 import { InboxReleaseItem } from "@/web/components/release-channel/inbox-release-item";
 import { ReleaseCard } from "@/web/components/release-channel/release-card";
 import { useInboxFeed } from "@/web/hooks/use-inbox-feed";
+import {
+  SidebarTopActions,
+  SidebarTopActionsInline,
+} from "@/web/components/sidebar/top-actions";
 
 function InboxPopover({ children }: { children: ReactNode }) {
   const { items, markReleaseSeen } = useInboxFeed();
@@ -271,6 +275,7 @@ export function SidebarInboxFooter() {
   if (isCollapsed) {
     return (
       <SidebarFooter className="px-2 pb-3 gap-1">
+        <SidebarTopActions />
         <SidebarMenu>
           <SidebarMenuItem>
             <ConnectionsFullButton />
@@ -302,6 +307,7 @@ export function SidebarInboxFooter() {
         <SettingsIconButton />
         <InboxIconButton />
         <ConnectionsIconButton />
+        <SidebarTopActionsInline />
       </div>
     </SidebarFooter>
   );

--- a/apps/mesh/src/web/components/sidebar/index.tsx
+++ b/apps/mesh/src/web/components/sidebar/index.tsx
@@ -6,7 +6,6 @@ import { NavigationSidebar } from "./navigation";
 import { MobileNavigationSidebar } from "./navigation-mobile";
 import { SidebarInboxFooter } from "./footer/inbox";
 import { SidebarInboxFooterMobile } from "./footer/inbox-mobile";
-import { SidebarTopActions } from "./top-actions";
 import { TaskGroupsList } from "./task-groups/task-groups-list";
 
 export type {
@@ -33,7 +32,6 @@ export function StudioSidebar() {
             }
           >
             <Separator className="mb-2" />
-            <SidebarTopActions />
             <TaskGroupsList />
           </Suspense>
         </ErrorBoundary>
@@ -54,7 +52,6 @@ export function StudioSidebarMobile({ onClose }: { onClose: () => void }) {
         <ErrorBoundary>
           <Suspense fallback={null}>
             <Separator className="mb-2" />
-            <SidebarTopActions />
             <TaskGroupsList />
           </Suspense>
         </ErrorBoundary>

--- a/apps/mesh/src/web/components/sidebar/top-actions.tsx
+++ b/apps/mesh/src/web/components/sidebar/top-actions.tsx
@@ -16,6 +16,11 @@ import {
 } from "@decocms/mesh-sdk";
 import { useAiProviderKeys } from "@/web/hooks/collections/use-ai-providers";
 import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 
 class SilentErrorBoundary extends Component<
   { children: ReactNode },
@@ -103,6 +108,80 @@ export function SidebarTopActions() {
     <SilentErrorBoundary>
       <Suspense fallback={null}>
         <CreditChipConditional />
+      </Suspense>
+    </SilentErrorBoundary>
+  );
+}
+
+function CreditChipInline() {
+  const navigate = useNavigate();
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const { data, isPending, isError } = useMCPToolCallQuery<
+    { balanceCents: number } | undefined
+  >({
+    client,
+    toolName: "AI_PROVIDER_CREDITS",
+    toolArguments: { providerId: "deco" },
+    staleTime: 60_000,
+    select: (result) =>
+      (result as { structuredContent?: { balanceCents: number } })
+        .structuredContent,
+  });
+  const balanceDollars =
+    data?.balanceCents != null ? data.balanceCents / 100 : null;
+  const tooltipLabel =
+    isPending || isError || balanceDollars == null
+      ? "Credits"
+      : `Credits: $${balanceDollars.toFixed(2)}`;
+  return (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={tooltipLabel}
+          onClick={() =>
+            navigate({
+              to: "/$org/settings/ai-providers",
+              params: { org: org.slug },
+            })
+          }
+          className={cn(
+            "relative flex h-10 md:h-7 shrink-0 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+            "hover:bg-sidebar-accent hover:text-sidebar-foreground",
+            balanceDollars != null
+              ? creditColor(balanceDollars)
+              : "text-sidebar-foreground/60",
+          )}
+        >
+          <Coins04 className="size-4" />
+          {balanceDollars != null && (
+            <span>{`$${balanceDollars.toFixed(2)}`}</span>
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CreditChipInlineConditional() {
+  const keys = useAiProviderKeys();
+  const hasDecoKey = keys.some((k) => k.providerId === "deco");
+  if (!hasDecoKey) return null;
+  return <CreditChipInline />;
+}
+
+export function SidebarTopActionsInline() {
+  return (
+    <SilentErrorBoundary>
+      <Suspense fallback={null}>
+        <CreditChipInlineConditional />
       </Suspense>
     </SilentErrorBoundary>
   );


### PR DESCRIPTION
## What is this contribution about?
Moves the deco credits chip out of the top of the sidebar (where it sat above the task groups list) and into the sidebar footer alongside Settings / Inbox / Connections. In the expanded sidebar it now sits inline as a compact pill on the rightmost slot of the footer row; in the collapsed sidebar it stacks above the icon column. Adds a small `SidebarTopActionsInline` variant in `top-actions.tsx` that renders the icon + dollar amount as a toolbar-sized button so it fits the footer row.

## How to Test
1. `bun run dev`, open the app while signed into an org that has a Deco AI provider key configured.
2. Confirm the credits chip is gone from above the task groups list.
3. Expanded sidebar: chip appears on the same row as Settings/Inbox/Connections (rightmost), shows `\$X.XX`, opens \`/$org/settings/ai-providers\` on click.
4. Collapse the sidebar: chip appears at the top of the footer column with a tooltip showing the balance.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Deco credits chip from the top of the sidebar to the footer. It now sits inline at the right in the expanded footer and stacks above the icon column in the collapsed view.

- New Features
  - Added `SidebarTopActionsInline`: a compact button that shows the credits amount with a tooltip and opens `/$org/settings/ai-providers` on click.
  - Renders only when a Deco provider key exists and fetches the balance via `AI_PROVIDER_CREDITS` (60s stale time).

<sup>Written for commit a0502efdfc42a30b4422d9461b323c1c9450c4e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3512?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

