### PR TITLE
feat(sidebar): render credit chip icon-only with amount in tooltip

### DIFF
--- a/apps/mesh/src/web/components/sidebar/top-actions.tsx
+++ b/apps/mesh/src/web/components/sidebar/top-actions.tsx
@@ -21,6 +21,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 
 class SilentErrorBoundary extends Component<
   { children: ReactNode },
@@ -141,8 +142,7 @@ function CreditChipInline() {
   return (
     <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
-        <button
-          type="button"
+        <ToolbarIconButton
           aria-label={tooltipLabel}
           onClick={() =>
             navigate({
@@ -150,20 +150,10 @@ function CreditChipInline() {
               params: { org: org.slug },
             })
           }
-          className={cn(
-            "relative flex h-10 md:h-7 shrink-0 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-            "hover:bg-sidebar-accent hover:text-sidebar-foreground",
-            balanceDollars != null
-              ? creditColor(balanceDollars)
-              : "text-sidebar-foreground/60",
-          )}
+          className={cn(balanceDollars != null && creditColor(balanceDollars))}
         >
           <Coins04 className="size-4" />
-          {balanceDollars != null && (
-            <span>{`$${balanceDollars.toFixed(2)}`}</span>
-          )}
-        </button>
+        </ToolbarIconButton>
       </TooltipTrigger>
       <TooltipContent side="top">{tooltipLabel}</TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Summary
- Replaces the inline credit chip's bespoke button in the expanded sidebar footer with `ToolbarIconButton`, matching Settings/Inbox/Connections.
- The dollar amount is no longer rendered next to the icon — it now appears only inside the tooltip (`Credits: \$X.XX`).
- Low-balance color cues (amber/red on the icon) are preserved via `creditColor`.

## Test plan
- [ ] Expanded sidebar shows only the coin icon in the footer, no inline `\$` amount.
- [ ] Hovering the icon reveals a tooltip with the formatted balance (or "Credits" while loading).
- [ ] Low/critical balances still tint the icon amber/red.
- [ ] Collapsed sidebar credit chip is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the expanded sidebar credit chip with an icon-only `ToolbarIconButton`, matching other footer actions. The dollar amount now appears only in the tooltip, while low-balance color cues are preserved; the collapsed sidebar is unchanged.

<sup>Written for commit aa7a64b86a64e771dc0fe61e06e0a65d3b4770bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3513?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

