### PR TITLE
fix(test): guard afterEach against partial beforeEach in integration-org-scoped

### DIFF
--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -85,7 +85,7 @@ function mockApiKey(userId: string, orgId: string, orgSlug: string) {
 describe("org-scoped API coexistence", () => {
   let database: TestDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
-  let logSpy: ReturnType<typeof spyOn>;
+  let logSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(async () => {
     database = await createTestDatabase();
@@ -141,7 +141,13 @@ describe("org-scoped API coexistence", () => {
   });
 
   afterEach(async () => {
-    logSpy.mockRestore();
+    // `logSpy` is the LAST thing beforeEach assigns. If anything before it
+    // throws (e.g. PGlite's WASM backend has intermittent migration crashes
+    // on Bun 1.3.5 — see the CI runner script), this hook would crash with
+    // `Cannot read property 'mockRestore' of undefined` and mask the real
+    // setup failure as a misleading test failure.
+    logSpy?.mockRestore();
+    logSpy = undefined;
     vi.restoreAllMocks();
     await closeTestDatabase(database);
   });


### PR DESCRIPTION
## What is this contribution about?

Fixes a misleading CI failure in `apps/mesh/src/api/integration-org-scoped.test.ts > "new path serves the route AND does NOT log deprecation"` ([run 26548079600](https://github.com/decocms/studio/actions/runs/26548079600/job/78204196559)). The actual failure was a PGlite WASM crash inside `beforeEach` (`Migration failed: RuntimeError: access to a null reference`), which threw before `logSpy` was assigned. The cleanup hook then crashed with `TypeError: undefined is not an object (evaluating 'logSpy.mockRestore')`, and Bun attributed the failure to the test that was about to run. The same test passes 5/5 locally — this is the known Bun 1.3.5 / PGlite WASM teardown flake the CI runner script already documents.

Made `logSpy` nullable and guarded `logSpy?.mockRestore()` in `afterEach` with a comment explaining why. This doesn't paper over real assertion failures — it only prevents the cleanup hook from compounding a flaky-setup crash into a confusing reported failure.

## How to Test

1. `bun test apps/mesh/src/api/integration-org-scoped.test.ts` — all 11 tests pass.
2. Inspect the diff — `afterEach` no-ops on `logSpy` cleanly when `beforeEach` throws early.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard test cleanup against partial setup in `apps/mesh/src/api/integration-org-scoped.test.ts` to avoid masking real failures in CI. `logSpy` is now nullable and restored via `logSpy?.mockRestore()` (then cleared), preventing `afterEach` crashes when `PGlite` migrations intermittently fail on `Bun` 1.3.5 in `beforeEach`.

<sup>Written for commit 5458a9b9b10653ab911ac913dc295ede0fe0d8d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3514?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

