### PR TITLE
ci: bump deco-apps-cd via repository_dispatch (not cross-repo commit)

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -302,22 +302,20 @@ jobs:
           echo "Triggered ArgoCD deployment with image tag \`${{ needs.prepare.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
-  # GitOps: commit the new mesh version into deco-apps-cd so ArgoCD picks it up.
-  # Both staging (deco-studio-stg) and prod (deco-studio) image tags are bumped.
-  # IMPORTANT: this only updates the desired version in git — it does NOT deploy
-  # prod. deco-studio-stg is auto-sync (rolls out immediately); deco-studio is
-  # manual-sync, so prod just shows OutOfSync until someone Syncs it deliberately
-  # (the promotion gate is preserved).
-  # Requires the GH_APP_ID / GH_APP_PRIVATE_KEY app (write to deco-apps-cd) —
-  # the same GitHub App the admin CI uses.
+  # GitOps: tell deco-apps-cd to bump the mesh image. We do NOT write into that
+  # repo from here — we fire a `studio-image-bump` repository_dispatch, and its
+  # own workflow (.github/workflows/bump-studio-image.yml) self-commits with its
+  # native GITHUB_TOKEN. Decoupled, race-safe (it rebases), and no cross-repo
+  # write credential lives here — only a token to trigger the dispatch.
+  # The receiver bumps deco-studio-stg (auto-sync → rolls out) + deco-studio
+  # (manual-sync → desired only; the prod promotion gate is preserved).
   # ---------------------------------------------------------------------------
   bump-deco-apps-cd:
-    name: Bump image in deco-apps-cd
+    name: Trigger deco-apps-cd bump
     needs: [prepare, merge-docker]
-    # Only bump when a VALID image for this version exists: either it was
-    # already published (image-exists == 'true', so merge-docker is skipped),
-    # or it was just built and merged successfully. A skipped merge-docker due
-    # to a failed build must NOT bump (no image was published).
+    # Only bump when a VALID image for this version exists: either already
+    # published (image-exists == 'true', so merge-docker is skipped) or just
+    # built and merged. A skipped merge-docker from a failed build must NOT bump.
     if: |
       always() &&
       (
@@ -325,43 +323,22 @@ jobs:
         needs.merge-docker.result == 'success'
       )
     runs-on: ubuntu-latest
-    # Surface the App id as an env so steps can detect whether the GitHub App
-    # is configured. When the secrets aren't present (e.g. a fork, or before
-    # the App is installed on this repo) every step below no-ops and the job
-    # passes — the bump is a convenience and must never red the release.
+    # The bump is a convenience and must never red the release. If the dispatch
+    # token isn't configured, the step no-ops and the job passes.
     env:
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
+      DISPATCH_TOKEN: ${{ secrets.DECO_APPS_CD_DISPATCH_TOKEN }}
     steps:
-      - name: Skip notice (App not configured)
-        if: env.GH_APP_ID == ''
-        run: echo "::notice::GH_APP_ID/GH_APP_PRIVATE_KEY not set — skipping the deco-apps-cd bump. Configure the GitHub App secrets to enable it."
-      - name: Generate token for deco-apps-cd
-        id: cd-token
-        if: env.GH_APP_ID != ''
-        uses: actions/create-github-app-token@v1
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DECO_APPS_CD_DISPATCH_TOKEN not set — skipping the deco-apps-cd bump. Add the org-level PAT to enable it."
+      - name: Dispatch studio-image-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: decocms
-          repositories: deco-apps-cd
-      - name: Bump mesh image (stg + prod)
-        if: env.GH_APP_ID != ''
-        env:
-          GH_TOKEN: ${{ steps.cd-token.outputs.token }}
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          set -euo pipefail
-          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/decocms/deco-apps-cd.git" cd-repo
-          cd cd-repo
-          yq -i ".studio.image.tag = \"${VERSION}\"" apps/deco-studio-stg/values.yaml
-          yq -i ".studio.image.tag = \"${VERSION}\"" apps/deco-studio/values.yaml
-          if git diff --quiet; then
-            echo "already at ${VERSION}, nothing to commit"
-            exit 0
-          fi
-          git config user.name "deco-studio-ci[bot]"
-          git config user.email "deco-studio-ci[bot]@users.noreply.github.com"
-          git commit -am "chore(studio): bump mesh image to ${VERSION} (stg + prod)"
-          git push
-          echo "### deco-apps-cd bump" >> $GITHUB_STEP_SUMMARY
-          echo "Committed \`studio.image.tag=${VERSION}\` (stg rolls out; prod awaits manual Sync)" >> $GITHUB_STEP_SUMMARY
+          token: ${{ secrets.DECO_APPS_CD_DISPATCH_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: studio-image-bump
+          client-payload: '{"version": "${{ needs.prepare.outputs.version }}"}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`studio-image-bump\` (version ${{ needs.prepare.outputs.version }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Replaces the App-based `bump-deco-apps-cd` job (which cloned + committed into deco-apps-cd, and needed `GH_APP_*`) with a lightweight `repository_dispatch` (`studio-image-bump`).

deco-apps-cd's own workflow (decocms/deco-apps-cd#37) self-commits the tag with its native `GITHUB_TOKEN` — decoupled, race-safe (rebase), and **no cross-repo write credential in this repo**: only `DECO_APPS_CD_DISPATCH_TOKEN` (org-level fine-grained PAT, Contents:write on deco-apps-cd) to fire the event. Graceful no-op preserved when the token isn't set.

Depends on decocms/deco-apps-cd#37 (the receiver) + the org PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the release workflow to trigger `decocms/deco-apps-cd` via `repository_dispatch` (`studio-image-bump`) instead of cloning and committing from this repo. This removes cross-repo write creds, improves safety, and keeps the prod promotion gate.

- **Refactors**
  - Replace GitHub App clone+commit with `repository_dispatch` using `DECO_APPS_CD_DISPATCH_TOKEN`; receiver self-commits with its `GITHUB_TOKEN` and rebases.
  - Bumps staging and prod desired tag; staging auto-syncs, prod stays manual.
  - Only runs when a valid image exists; no-ops if the dispatch token is missing.
  
- **Migration**
  - Set org-level secret `DECO_APPS_CD_DISPATCH_TOKEN` (Contents:write on `decocms/deco-apps-cd`).

<sup>Written for commit 02cb5a4ff9ae6745fa8e9a515209792ef5dda3a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3515?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

