### PR TITLE
ci: dispatch deco-apps-cd bump via decobot (no new/personal token)

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -323,19 +323,22 @@ jobs:
         needs.merge-docker.result == 'success'
       )
     runs-on: ubuntu-latest
-    # The bump is a convenience and must never red the release. If the dispatch
-    # token isn't configured, the step no-ops and the job passes.
+    # Reuses DEPLOY_REPO_TOKEN — the decobot machine-user PAT already used to
+    # dispatch to argo-deploy-mesh (non-personal; decobot is admin on
+    # decocms/deco-apps-cd). Same bot, same mechanism as the legacy repo, no
+    # new/ personal token. The bump is a convenience and must never red the
+    # release: if the token isn't present the step no-ops and the job passes.
     env:
-      DISPATCH_TOKEN: ${{ secrets.DECO_APPS_CD_DISPATCH_TOKEN }}
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
     steps:
       - name: Skip notice (dispatch token not configured)
         if: env.DISPATCH_TOKEN == ''
-        run: echo "::notice::DECO_APPS_CD_DISPATCH_TOKEN not set — skipping the deco-apps-cd bump. Add the org-level PAT to enable it."
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd bump."
       - name: Dispatch studio-image-bump to deco-apps-cd
         if: env.DISPATCH_TOKEN != ''
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.DECO_APPS_CD_DISPATCH_TOKEN }}
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
           repository: decocms/deco-apps-cd
           event-type: studio-image-bump
           client-payload: '{"version": "${{ needs.prepare.outputs.version }}"}'


### PR DESCRIPTION
Point the `studio-image-bump` dispatch at `secrets.DEPLOY_REPO_TOKEN` (the **decobot** machine-user PAT already in this repo for the argo-deploy-mesh dispatch) instead of a new `DECO_APPS_CD_DISPATCH_TOKEN`.

- **Non-personal**: decobot is a bot account (admin on decocms/deco-apps-cd, admin member of decocms) — nothing tied to an individual.
- **No new token**: DEPLOY_REPO_TOKEN already exists here; it's a classic `repo`-scoped PAT (it dispatches across both deco-cx and decocms orgs), so it covers deco-apps-cd.
- Same bot + dispatch mechanism as the legacy argo-deploy-mesh flow.

Graceful no-op preserved if the token is ever absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `studio-image-bump` dispatch in `release-mesh.yaml` to use `DEPLOY_REPO_TOKEN` (decobot PAT) instead of `DECO_APPS_CD_DISPATCH_TOKEN`. Keeps the step a safe no-op if the token is missing.

- **Refactors**
  - Reuse `secrets.DEPLOY_REPO_TOKEN` to dispatch to `decocms/deco-apps-cd` via decobot.
  - Update notice and token references; matches the legacy argo-deploy-mesh setup.
  - No change to release outcome; job always passes when the token is absent.

<sup>Written for commit f3f74f8d8bc2ea2dbe514425dee076fc23c735fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3516?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

