### PR TITLE
feat(sandbox-operator): expose controller podAnnotations/podLabels

### DIFF
--- a/deploy/helm/sandbox-operator/Chart.yaml
+++ b/deploy/helm/sandbox-operator/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   live in this chart — see deploy/helm/sandbox-env for those.
 type: application
 # Chart version is independent of upstream agent-sandbox. Bump on any change.
-version: 0.1.2
+version: 0.1.3
 # Tracks the upstream agent-sandbox release pinned by vendor.sh.
 appVersion: "0.4.5"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml
+++ b/deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml
@@ -87,6 +87,13 @@ spec:
     metadata:
       labels:
         app: agent-sandbox-controller
+        {{- with .Values.controller.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: agent-sandbox-controller
       containers:

--- a/deploy/helm/sandbox-operator/values.yaml
+++ b/deploy/helm/sandbox-operator/values.yaml
@@ -1,12 +1,27 @@
 # Default values for the sandbox-operator chart.
 #
-# This chart deliberately exposes NO tunables. It is a thin packaging of
-# the vendored upstream kubernetes-sigs/agent-sandbox operator + CRDs.
-# All Studio-specific configuration (sandbox image, resource ceilings,
-# NetworkPolicy egress, preview Gateway, warm pool, ...) lives in the
-# companion sandbox-env chart, which is installed once per environment
-# alongside this one.
+# This chart is a thin packaging of the vendored upstream
+# kubernetes-sigs/agent-sandbox operator + CRDs. All Studio-specific
+# configuration (sandbox image, resource ceilings, egress posture,
+# preview Gateway, warm pool, ...) lives in the companion sandbox-env
+# chart, which is installed once per environment alongside this one.
 #
 # If you need to override the controller image, replicas, or args, edit
 # templates/agent-sandbox-manifest.yaml — but prefer re-running
 # vendor.sh against a newer upstream release first.
+
+controller:
+  # Annotations applied to the controller Pod template. The controller
+  # already exposes Prometheus metrics on port 8080 (/metrics) but the
+  # upstream manifest doesn't ship any scrape hint. If your cluster uses
+  # annotation-based discovery (vmagent/prometheus job=kubernetes-pods
+  # with `prometheus.io/scrape` relabeling), set:
+  #   podAnnotations:
+  #     prometheus.io/scrape: "true"
+  #     prometheus.io/port: "8080"
+  #     prometheus.io/path: "/metrics"
+  # Empty default — installs that don't scrape pods aren't affected.
+  podAnnotations: {}
+  # Extra labels for the controller Pod template (merged with the
+  # built-in `app: agent-sandbox-controller`).
+  podLabels: {}


### PR DESCRIPTION
Plumb generic `controller.podAnnotations` and `controller.podLabels` into the controller Pod template (the vendored upstream manifest only ships labels). Empty defaults — backward-compatible.

Lets clusters using annotation-based scrape discovery surface the controller's `:8080/metrics` without forking the manifest:

```yaml
controller:
  podAnnotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "8080"
    prometheus.io/path: "/metrics"
```

Chart **0.1.2 → 0.1.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes `controller.podAnnotations` and `controller.podLabels` in the sandbox-operator Helm chart to apply custom annotations/labels to the controller Pod template. Enables annotation-based scraping of `:8080/metrics` without forking; defaults are empty and backward-compatible; bumps chart to 0.1.3.

<sup>Written for commit ee02e1823c4d1228db0d10746c50b90c34dcc371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3519?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

