### PR TITLE
refactor(home-next-actions): enhance API to return default home agent…

### DIFF
--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -40,14 +40,16 @@ interface PromptEntry {
   /**
    * Gateway-namespaced prompt name — matches what `prompts/list` returns for
    * this agent's MCP client so the resulting mention chip's id lines up with
-   * the slash-command flow (enables click-to-edit on the chip).
+   * the slash-command flow (enables click-to-edit on the chip). Empty string
+   * marks an agent-only fallback card (no prompt to autosend — click just
+   * opens a fresh thread with the agent).
    */
   promptName: string;
   title: string;
   description: string;
   hasArguments: boolean;
-  arguments: Prompt["arguments"];
-  _meta: Prompt["_meta"];
+  arguments?: Prompt["arguments"];
+  _meta?: Prompt["_meta"];
 }
 
 function indexPromptsByName() {
@@ -62,8 +64,9 @@ function indexPromptsByName() {
  * Unlike Studio Pack prompts — which are static guide prompts on the org "self"
  * MCP — these are listed live from each agent's gateway, so their `name`/`_meta`
  * already carry the namespacing the mention chip needs. Studio Pack agent ids
- * are skipped (surfaced via the static path); a slow or broken agent is logged
- * and dropped rather than failing the whole row.
+ * are skipped (surfaced via the static path). Agents with no prompts (or an
+ * unreachable gateway) still get one fallback card so every configured default
+ * home agent shows up on the home row.
  */
 async function defaultHomeAgentPrompts(
   orgId: string,
@@ -78,6 +81,15 @@ async function defaultHomeAgentPrompts(
     uniqueIds.map(async (id): Promise<PromptEntry[]> => {
       const virtualMcp = await ctx.storage.virtualMcps.findById(id);
       if (!virtualMcp) return [];
+      const fallback = (): PromptEntry => ({
+        agentId: id,
+        agentName: virtualMcp.title,
+        agentIcon: virtualMcp.icon,
+        promptName: "",
+        title: virtualMcp.description || "Start a new chat",
+        description: "",
+        hasArguments: false,
+      });
       try {
         const client = await createVirtualClientFrom(
           virtualMcp,
@@ -88,17 +100,20 @@ async function defaultHomeAgentPrompts(
         );
         try {
           const { prompts } = await client.listPrompts();
-          return prompts.slice(0, MAX_PROMPTS_PER_AGENT).map((prompt) => ({
-            agentId: id,
-            agentName: virtualMcp.title,
-            agentIcon: virtualMcp.icon,
-            promptName: prompt.name,
-            title: prompt.title ?? prompt.name,
-            description: prompt.description ?? "",
-            hasArguments: (prompt.arguments?.length ?? 0) > 0,
-            arguments: prompt.arguments,
-            _meta: prompt._meta,
-          }));
+          const entries = prompts
+            .slice(0, MAX_PROMPTS_PER_AGENT)
+            .map((prompt) => ({
+              agentId: id,
+              agentName: virtualMcp.title,
+              agentIcon: virtualMcp.icon,
+              promptName: prompt.name,
+              title: prompt.title ?? prompt.name,
+              description: prompt.description ?? "",
+              hasArguments: (prompt.arguments?.length ?? 0) > 0,
+              arguments: prompt.arguments,
+              _meta: prompt._meta,
+            }));
+          return entries.length > 0 ? entries : [fallback()];
         } finally {
           await client.close();
         }
@@ -107,7 +122,7 @@ async function defaultHomeAgentPrompts(
           agentId: id,
           error,
         });
-        return [];
+        return [fallback()];
       }
     }),
   );

--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -3,12 +3,14 @@
  *
  * `GET /api/:org/home-next-actions`
  *
- * Returns the still-incomplete onboarding `prompts` for the `/$org` home
- * page. Each opens a new thread with the named agent and autosends the
- * resolved MCP prompt as the first user message.
+ * Returns the still-pending next actions for the `/$org` home page:
+ * - `prompts`: onboarding/icebreaker prompts from the Studio Pack agents and
+ *   the org's configured default home agents. Each opens a new thread with the
+ *   named agent and autosends the resolved MCP prompt as the first message.
+ * - `threads`: the caller's threads in `requires_action` status (an agent
+ *   asked a question or a tool needs approval). Each reopens that thread.
  *
- * Server-side `isCompleted` filters out finished items so the home stays
- * pared down as the user makes progress.
+ * Server-side filtering keeps the row pared down as the user makes progress.
  */
 
 import { Hono } from "hono";
@@ -16,16 +18,21 @@ import { slugify } from "@decocms/mcp-utils/aggregate";
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import type { MeshContext } from "@/core/mesh-context";
+import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
 import { getPrompts } from "@/tools/guides";
 import {
   STUDIO_PACK_AGENTS,
   resolveStudioPackChecklist,
 } from "@/tools/virtual/studio-pack";
 
+/** Per default-home agent, cap prompts so a chatty agent can't flood the row. */
+const MAX_PROMPTS_PER_AGENT = 3;
+/** Bound a slow/unreachable agent so it can't hang the home request. */
+const LIST_PROMPTS_TIMEOUT_MS = 5000;
+
 type Variables = {
   meshContext: MeshContext;
 };
-
 interface PromptEntry {
   agentId: string;
   agentName: string;
@@ -48,6 +55,63 @@ function indexPromptsByName() {
   const byName = new Map<string, (typeof all)[number]>();
   for (const p of all) byName.set(p.name, p);
   return byName;
+}
+
+/**
+ * Prompts from the org's configured default home agents (custom virtual MCPs).
+ * Unlike Studio Pack prompts — which are static guide prompts on the org "self"
+ * MCP — these are listed live from each agent's gateway, so their `name`/`_meta`
+ * already carry the namespacing the mention chip needs. Studio Pack agent ids
+ * are skipped (surfaced via the static path); a slow or broken agent is logged
+ * and dropped rather than failing the whole row.
+ */
+async function defaultHomeAgentPrompts(
+  orgId: string,
+  ctx: MeshContext,
+  skipAgentIds: Set<string>,
+): Promise<PromptEntry[]> {
+  const settings = await ctx.storage.organizationSettings.get(orgId);
+  const ids = settings?.default_home_agents?.ids ?? [];
+  const uniqueIds = [...new Set(ids)].filter((id) => !skipAgentIds.has(id));
+
+  const perId = await Promise.all(
+    uniqueIds.map(async (id): Promise<PromptEntry[]> => {
+      const virtualMcp = await ctx.storage.virtualMcps.findById(id);
+      if (!virtualMcp) return [];
+      try {
+        const client = await createVirtualClientFrom(
+          virtualMcp,
+          ctx,
+          "passthrough",
+          false,
+          { listTimeoutMs: LIST_PROMPTS_TIMEOUT_MS },
+        );
+        try {
+          const { prompts } = await client.listPrompts();
+          return prompts.slice(0, MAX_PROMPTS_PER_AGENT).map((prompt) => ({
+            agentId: id,
+            agentName: virtualMcp.title,
+            agentIcon: virtualMcp.icon,
+            promptName: prompt.name,
+            title: prompt.title ?? prompt.name,
+            description: prompt.description ?? "",
+            hasArguments: (prompt.arguments?.length ?? 0) > 0,
+            arguments: prompt.arguments,
+            _meta: prompt._meta,
+          }));
+        } finally {
+          await client.close();
+        }
+      } catch (error) {
+        console.error("[home-next-actions] failed to list agent prompts", {
+          agentId: id,
+          error,
+        });
+        return [];
+      }
+    }),
+  );
+  return perId.flat();
 }
 
 export function createHomeNextActionsRoutes() {
@@ -101,6 +165,16 @@ export function createHomeNextActionsRoutes() {
         });
       }
     }
+
+    const studioPackAgentIds = new Set(
+      STUDIO_PACK_AGENTS.map((agent) => agent.getId(orgId)),
+    );
+    const defaultPrompts = await defaultHomeAgentPrompts(
+      orgId,
+      mesh,
+      studioPackAgentIds,
+    );
+    prompts.push(...defaultPrompts);
 
     c.header("Cache-Control", "private, max-age=10");
     return c.json({ prompts });

--- a/apps/mesh/src/web/components/chat/message/next-action-chip.tsx
+++ b/apps/mesh/src/web/components/chat/message/next-action-chip.tsx
@@ -47,7 +47,9 @@ export function NextActionChip() {
 
   // home-next-actions is keyed by agentId and already drops completed
   // items server-side, so the first match is this thread's next step.
-  const next = prompts.find((p) => p.agentId === virtualMcpId);
+  // Skip fallback agent-only entries (no promptName) — the chip needs a
+  // real prompt to send.
+  const next = prompts.find((p) => p.agentId === virtualMcpId && p.promptName);
   if (!next) return null;
 
   const send = async (prompt: Prompt, args?: PromptArgumentValues) => {

--- a/apps/mesh/src/web/components/home/next-actions-row.tsx
+++ b/apps/mesh/src/web/components/home/next-actions-row.tsx
@@ -49,9 +49,13 @@ function AgentPromptCardGroup({
   agentId: string;
   entries: HomePromptEntry[];
 }) {
-  const { start, dialog } = useStartThreadFromPrompt({ agentId });
+  const { start, startBlank, dialog } = useStartThreadFromPrompt({ agentId });
 
   const handleClick = (entry: HomePromptEntry) => {
+    if (!entry.promptName) {
+      void startBlank();
+      return;
+    }
     const prompt: Prompt = {
       name: entry.promptName,
       title: entry.title,
@@ -66,7 +70,7 @@ function AgentPromptCardGroup({
     <>
       {entries.map((entry) => (
         <PromptCard
-          key={entry.promptName}
+          key={entry.promptName || `${entry.agentId}:blank`}
           entry={entry}
           onClick={() => handleClick(entry)}
         />

--- a/apps/mesh/src/web/components/home/next-actions-row.tsx
+++ b/apps/mesh/src/web/components/home/next-actions-row.tsx
@@ -4,8 +4,7 @@
  * Renders below `Chat.Input` on the /$org home page as a row of prompt
  * cards — each opens a new thread with an agent and autosends a prompt.
  *
- * Server filters out completed items so the row stays pared down as the
- * user makes progress.
+ * Server filters items so the row stays pared down as the user progresses.
  */
 
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";

--- a/apps/mesh/src/web/hooks/use-start-thread-from-prompt.tsx
+++ b/apps/mesh/src/web/hooks/use-start-thread-from-prompt.tsx
@@ -33,6 +33,11 @@ import { writeStoredAutosend } from "@/web/lib/autosend";
 export interface UseStartThreadFromPromptResult {
   /** Trigger from a card click. Opens args dialog if needed. */
   start: (prompt: Prompt) => Promise<void>;
+  /**
+   * Start a fresh thread with `agentId` without seeding a prompt — used by the
+   * fallback cards for default home agents that expose no prompts.
+   */
+  startBlank: () => Promise<void>;
   /** Render this in your component to mount the args dialog. */
   dialog: ReactNode;
   /** Exposed for tests / loading states. */
@@ -115,6 +120,17 @@ export function useStartThreadFromPrompt({
     await loadAndStart(prompt, values);
   };
 
+  const startBlank = async () => {
+    try {
+      const newId = crypto.randomUUID();
+      await create({ id: newId, virtual_mcp_id: agentId });
+      setTaskId(newId, agentId);
+    } catch (error) {
+      console.error("[start-thread-from-prompt] startBlank failed", error);
+      toast.error("Failed to start thread. Please try again.");
+    }
+  };
+
   const dialog = (
     <PromptArgsDialog
       prompt={dialogPrompt}
@@ -123,5 +139,5 @@ export function useStartThreadFromPrompt({
     />
   );
 
-  return { start, dialog, dialogPrompt };
+  return { start, startBlank, dialog, dialogPrompt };
 }

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -69,7 +69,7 @@ export const KEYS = {
   // Models list (scoped by organization)
   modelsList: (orgId: string) => ["models-list", orgId] as const,
 
-  // Home next-actions — prompts + dialog actions surfaced under Chat.Input.
+  // Home next-actions — agent prompts under Chat.Input.
   homeNextActions: (orgSlug: string) => ["home-next-actions", orgSlug] as const,
 
   // Allowed models for current user (scoped by organization)


### PR DESCRIPTION
… prompts and improve documentation

This update modifies the home-next-actions API to include prompts from the organization's configured default home agents, alongside onboarding prompts. It also improves the documentation to clarify the purpose of the returned prompts and the filtering mechanism. Additionally, minor adjustments were made to related components to reflect these changes.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the home-next-actions API to include prompts from the org’s default home agents alongside Studio Pack onboarding prompts. Adds resilient fallbacks and small UI tweaks so the row stays helpful and concise.

- **New Features**
  - Lists prompts from default home agents via virtual MCP, capped at 3 per agent with a 5s timeout; skips Studio Pack agent IDs. On errors or when an agent has no prompts, shows one agent-only fallback card.
  - Fallback cards open a fresh thread (no autosent prompt); `NextActionChip` skips them. `useStartThreadFromPrompt` now supports `startBlank`.
  - Merges with onboarding prompts; response remains `prompts` only with `Cache-Control: private, max-age=10`. `PromptEntry` allows optional `arguments`/`_meta` and empty `promptName` for fallbacks; minor doc/copy tweaks.

<sup>Written for commit c312cb8fcc7a0a7e44a76254c27dee73a08e7a1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3520?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

