### PR TITLE
feat(home-next-actions): enhance API to include tile UIs for home agents

### DIFF
--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -26,7 +26,7 @@ import {
 } from "@/tools/virtual/studio-pack";
 
 /** Per default-home agent, cap prompts so a chatty agent can't flood the row. */
-const MAX_PROMPTS_PER_AGENT = 3;
+const MAX_PROMPTS_PER_AGENT = 10;
 /** Bound a slow/unreachable agent so it can't hang the home request. */
 const LIST_PROMPTS_TIMEOUT_MS = 5000;
 
@@ -52,6 +52,22 @@ interface PromptEntry {
   _meta?: Prompt["_meta"];
 }
 
+/**
+ * Tile UI for a home agent. Rendered as an MCP UI iframe inside the agent's
+ * tile on `/$org`. The frontend opens an MCP client to `connectionId` (the
+ * connection that owns the resource, not the virtual MCP gateway) so the
+ * iframe can call tools by their bare names.
+ */
+interface TileEntry {
+  agentId: string;
+  agentName: string;
+  agentIcon: string | null;
+  connectionId: string;
+  resourceUri: string;
+  minHeight?: number;
+  maxHeight?: number;
+}
+
 function indexPromptsByName() {
   const all = getPrompts();
   const byName = new Map<string, (typeof all)[number]>();
@@ -60,73 +76,101 @@ function indexPromptsByName() {
 }
 
 /**
- * Prompts from the org's configured default home agents (custom virtual MCPs).
- * Unlike Studio Pack prompts — which are static guide prompts on the org "self"
- * MCP — these are listed live from each agent's gateway, so their `name`/`_meta`
- * already carry the namespacing the mention chip needs. Studio Pack agent ids
- * are skipped (surfaced via the static path). Agents with no prompts (or an
- * unreachable gateway) still get one fallback card so every configured default
- * home agent shows up on the home row.
+ * Prompts + tile UIs from the org's configured default home agents (custom
+ * virtual MCPs). Prompts are listed live from each agent's gateway; tile UIs
+ * come from `metadata.ui.homeTile` on the virtual MCP and are surfaced as a
+ * separate `tiles` array so the frontend can render iframes independently of
+ * the prompt row. Studio Pack agent ids are skipped (prompts surfaced via the
+ * static path; Studio Pack agents don't declare tile UIs today). Agents with
+ * no prompts (or an unreachable gateway) still get one fallback card so every
+ * configured default home agent shows up on the home row.
  */
-async function defaultHomeAgentPrompts(
+async function defaultHomeAgentNextActions(
   orgId: string,
   ctx: MeshContext,
   skipAgentIds: Set<string>,
-): Promise<PromptEntry[]> {
+): Promise<{ prompts: PromptEntry[]; tiles: TileEntry[] }> {
   const settings = await ctx.storage.organizationSettings.get(orgId);
   const ids = settings?.default_home_agents?.ids ?? [];
   const uniqueIds = [...new Set(ids)].filter((id) => !skipAgentIds.has(id));
 
   const perId = await Promise.all(
-    uniqueIds.map(async (id): Promise<PromptEntry[]> => {
-      const virtualMcp = await ctx.storage.virtualMcps.findById(id);
-      if (!virtualMcp) return [];
-      const fallback = (): PromptEntry => ({
-        agentId: id,
-        agentName: virtualMcp.title,
-        agentIcon: virtualMcp.icon,
-        promptName: "",
-        title: virtualMcp.description || "Start a new chat",
-        description: "",
-        hasArguments: false,
-      });
-      try {
-        const client = await createVirtualClientFrom(
-          virtualMcp,
-          ctx,
-          "passthrough",
-          false,
-          { listTimeoutMs: LIST_PROMPTS_TIMEOUT_MS },
-        );
-        try {
-          const { prompts } = await client.listPrompts();
-          const entries = prompts
-            .slice(0, MAX_PROMPTS_PER_AGENT)
-            .map((prompt) => ({
-              agentId: id,
-              agentName: virtualMcp.title,
-              agentIcon: virtualMcp.icon,
-              promptName: prompt.name,
-              title: prompt.title ?? prompt.name,
-              description: prompt.description ?? "",
-              hasArguments: (prompt.arguments?.length ?? 0) > 0,
-              arguments: prompt.arguments,
-              _meta: prompt._meta,
-            }));
-          return entries.length > 0 ? entries : [fallback()];
-        } finally {
-          await client.close();
-        }
-      } catch (error) {
-        console.error("[home-next-actions] failed to list agent prompts", {
+    uniqueIds.map(
+      async (
+        id,
+      ): Promise<{ prompts: PromptEntry[]; tile: TileEntry | null }> => {
+        const virtualMcp = await ctx.storage.virtualMcps.findById(id);
+        if (!virtualMcp) return { prompts: [], tile: null };
+
+        const homeTile = virtualMcp.metadata?.ui?.homeTile;
+        const tile: TileEntry | null =
+          homeTile?.resourceUri && homeTile.connectionId
+            ? {
+                agentId: id,
+                agentName: virtualMcp.title,
+                agentIcon: virtualMcp.icon,
+                connectionId: homeTile.connectionId,
+                resourceUri: homeTile.resourceUri,
+                minHeight: homeTile.minHeight,
+                maxHeight: homeTile.maxHeight,
+              }
+            : null;
+
+        const fallback = (): PromptEntry => ({
           agentId: id,
-          error,
+          agentName: virtualMcp.title,
+          agentIcon: virtualMcp.icon,
+          promptName: "",
+          title: virtualMcp.description || "Start a new chat",
+          description: "",
+          hasArguments: false,
         });
-        return [fallback()];
-      }
-    }),
+
+        try {
+          const client = await createVirtualClientFrom(
+            virtualMcp,
+            ctx,
+            "passthrough",
+            false,
+            { listTimeoutMs: LIST_PROMPTS_TIMEOUT_MS },
+          );
+          try {
+            const { prompts } = await client.listPrompts();
+            const entries = prompts
+              .slice(0, MAX_PROMPTS_PER_AGENT)
+              .map((prompt) => ({
+                agentId: id,
+                agentName: virtualMcp.title,
+                agentIcon: virtualMcp.icon,
+                promptName: prompt.name,
+                title: prompt.title ?? prompt.name,
+                description: prompt.description ?? "",
+                hasArguments: (prompt.arguments?.length ?? 0) > 0,
+                arguments: prompt.arguments,
+                _meta: prompt._meta,
+              }));
+            return {
+              prompts: entries.length > 0 ? entries : [fallback()],
+              tile,
+            };
+          } finally {
+            await client.close();
+          }
+        } catch (error) {
+          console.error("[home-next-actions] failed to list agent prompts", {
+            agentId: id,
+            error,
+          });
+          return { prompts: [fallback()], tile };
+        }
+      },
+    ),
   );
-  return perId.flat();
+
+  return {
+    prompts: perId.flatMap((r) => r.prompts),
+    tiles: perId.map((r) => r.tile).filter((t): t is TileEntry => t !== null),
+  };
 }
 
 export function createHomeNextActionsRoutes() {
@@ -184,15 +228,12 @@ export function createHomeNextActionsRoutes() {
     const studioPackAgentIds = new Set(
       STUDIO_PACK_AGENTS.map((agent) => agent.getId(orgId)),
     );
-    const defaultPrompts = await defaultHomeAgentPrompts(
-      orgId,
-      mesh,
-      studioPackAgentIds,
-    );
+    const { prompts: defaultPrompts, tiles } =
+      await defaultHomeAgentNextActions(orgId, mesh, studioPackAgentIds);
     prompts.push(...defaultPrompts);
 
     c.header("Cache-Control", "private, max-age=10");
-    return c.json({ prompts });
+    return c.json({ prompts, tiles });
   });
 
   return app;

--- a/apps/mesh/src/web/components/home/next-actions-row.tsx
+++ b/apps/mesh/src/web/components/home/next-actions-row.tsx
@@ -8,10 +8,13 @@
  */
 
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
-import { useProjectContext } from "@decocms/mesh-sdk";
+import { useMCPClient, useProjectContext } from "@decocms/mesh-sdk";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import {
   type HomePromptEntry,
+  type HomeTileEntry,
   useHomeNextActions,
 } from "@/web/hooks/use-home-next-actions";
 import { useStartThreadFromPrompt } from "@/web/hooks/use-start-thread-from-prompt";
@@ -19,21 +22,36 @@ import { useStartThreadFromPrompt } from "@/web/hooks/use-start-thread-from-prom
 function PromptCard({
   entry,
   onClick,
+  hideAgent = false,
+  disabled = false,
 }: {
   entry: HomePromptEntry;
   onClick: () => void;
+  /**
+   * Inside a tile/group the agent header is already shown above the cards,
+   * so don't repeat the avatar + agent name on every card.
+   */
+  hideAgent?: boolean;
+  /** Set while a thread creation is in flight to block duplicate clicks. */
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="group/row flex w-72 grow basis-72 items-center gap-3 rounded-xl border border-border bg-background px-3 py-2.5 text-left outline-none transition-colors hover:border-border hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-ring"
+      disabled={disabled}
+      aria-busy={disabled}
+      className="group/row flex w-72 shrink-0 items-center gap-3 rounded-xl border border-border bg-background px-3 py-2.5 text-left outline-none transition-colors hover:border-border hover:bg-accent/40 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
     >
-      <AgentAvatar icon={entry.agentIcon} name={entry.agentName} size="sm+" />
+      {!hideAgent && (
+        <AgentAvatar icon={entry.agentIcon} name={entry.agentName} size="sm+" />
+      )}
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <div className="w-full truncate text-xs text-muted-foreground">
-          {entry.agentName}
-        </div>
+        {!hideAgent && (
+          <div className="w-full truncate text-xs text-muted-foreground">
+            {entry.agentName}
+          </div>
+        )}
         <div className="line-clamp-2 w-full text-sm font-medium text-foreground">
           {entry.title}
         </div>
@@ -49,7 +67,9 @@ function AgentPromptCardGroup({
   agentId: string;
   entries: HomePromptEntry[];
 }) {
-  const { start, startBlank, dialog } = useStartThreadFromPrompt({ agentId });
+  const { start, startBlank, dialog, starting } = useStartThreadFromPrompt({
+    agentId,
+  });
 
   const handleClick = (entry: HomePromptEntry) => {
     if (!entry.promptName) {
@@ -73,6 +93,7 @@ function AgentPromptCardGroup({
           key={entry.promptName || `${entry.agentId}:blank`}
           entry={entry}
           onClick={() => handleClick(entry)}
+          disabled={starting}
         />
       ))}
       {dialog}
@@ -98,30 +119,159 @@ function PromptCardRow({ entries }: { entries: HomePromptEntry[] }) {
   );
 }
 
-export function NextActionsRow() {
+function AgentUITile({
+  tile,
+  prompts,
+}: {
+  tile: HomeTileEntry;
+  prompts: HomePromptEntry[];
+}) {
   const { org } = useProjectContext();
-  const { isLoading, prompts } = useHomeNextActions(org.slug);
+  // The iframe's tool calls go to the *underlying* connection, not the
+  // virtual MCP gateway — the gateway namespaces all tool names and would
+  // reject bare-name calls coming from the embedded UI.
+  const client = useMCPClient({
+    connectionId: tile.connectionId,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const { start, startBlank, dialog, starting } = useStartThreadFromPrompt({
+    agentId: tile.agentId,
+  });
 
-  const isEmpty = !isLoading && prompts.length === 0;
-  if (isEmpty) return null;
+  const handlePromptClick = (entry: HomePromptEntry) => {
+    if (!entry.promptName) {
+      void startBlank();
+      return;
+    }
+    void start({
+      name: entry.promptName,
+      title: entry.title,
+      description: entry.description,
+      arguments: entry.arguments,
+      _meta: entry._meta,
+    } satisfies Prompt);
+  };
+
+  // The blank fallback card is already covered by clicking the tile header,
+  // so omit it from the in-tile chips to avoid duplicating "Open chat".
+  const promptChips = prompts.filter((p) => !!p.promptName);
 
   return (
-    <div className="w-full max-w-5xl mt-4">
-      <div className="flex flex-wrap gap-3">
-        {isLoading ? (
-          Array.from({ length: 3 }, (_, i) => (
-            <div
-              key={`skeleton-${i}`}
-              className="flex w-72 grow basis-72 flex-col gap-1.5 rounded-xl border border-border bg-background px-3 py-2.5"
-            >
-              <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
-              <div className="h-2.5 w-full animate-pulse rounded bg-muted/70" />
-            </div>
-          ))
-        ) : (
-          <PromptCardRow entries={prompts} />
+    <div className="flex w-full grow basis-80 flex-col gap-3 rounded-xl border border-border bg-background p-3">
+      <button
+        type="button"
+        onClick={() => void startBlank()}
+        disabled={starting}
+        aria-busy={starting}
+        className="flex items-center gap-3 rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-progress disabled:opacity-60"
+      >
+        <AgentAvatar icon={tile.agentIcon} name={tile.agentName} size="sm+" />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="truncate text-sm font-medium text-foreground">
+            {tile.agentName}
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            Open chat
+          </div>
+        </div>
+      </button>
+      <div className="flex min-h-[420px] flex-col gap-3 lg:flex-row lg:items-stretch">
+        <div className="flex-1 overflow-hidden rounded-lg border border-border">
+          <MCPAppRenderer
+            resourceURI={tile.resourceUri}
+            orgId={org.id}
+            client={client}
+            displayMode="fullscreen"
+            minHeight={tile.minHeight ?? 420}
+            maxHeight={tile.maxHeight ?? 800}
+            className="h-full"
+          />
+        </div>
+        {promptChips.length > 0 && (
+          <div className="flex flex-wrap gap-3 lg:w-72 lg:shrink-0 lg:flex-col lg:flex-nowrap">
+            {promptChips.map((entry) => (
+              <PromptCard
+                key={entry.promptName}
+                entry={entry}
+                onClick={() => handlePromptClick(entry)}
+                hideAgent
+                disabled={starting}
+              />
+            ))}
+          </div>
         )}
       </div>
+      {dialog}
+    </div>
+  );
+}
+
+export function NextActionsRow() {
+  const { org } = useProjectContext();
+  const { isLoading, prompts, tiles } = useHomeNextActions(org.slug);
+
+  const isEmpty = !isLoading && prompts.length === 0 && tiles.length === 0;
+  if (isEmpty) return null;
+
+  // Group prompts by agent. Agents that have a tile UI get their prompts
+  // rendered inside the tile (as chips); everyone else falls through to the
+  // standalone prompt-card row below.
+  const tileAgentIds = new Set(tiles.map((t) => t.agentId));
+  const promptsByAgent = new Map<string, HomePromptEntry[]>();
+  for (const p of prompts) {
+    const existing = promptsByAgent.get(p.agentId);
+    if (existing) existing.push(p);
+    else promptsByAgent.set(p.agentId, [p]);
+  }
+  const loosePrompts = prompts.filter((p) => !tileAgentIds.has(p.agentId));
+
+  // When the home has at least one UI tile, switch to a 2-column layout on
+  // wide screens: tile(s) on the left, loose prompts stacked on the right.
+  // Without a tile, prompts fall back to the original wrapping row.
+  const hasTile = tiles.length > 0;
+  const showRightColumn = isLoading || loosePrompts.length > 0;
+
+  return (
+    <div
+      className={cn(
+        "mt-4 flex w-full max-w-7xl gap-3",
+        hasTile ? "flex-col lg:flex-row lg:items-start" : "flex-col",
+      )}
+    >
+      {hasTile && (
+        <div className="flex min-w-0 flex-col gap-3 lg:flex-1">
+          {tiles.map((tile) => (
+            <AgentUITile
+              key={tile.agentId}
+              tile={tile}
+              prompts={promptsByAgent.get(tile.agentId) ?? []}
+            />
+          ))}
+        </div>
+      )}
+      {showRightColumn && (
+        <div
+          className={cn(
+            "flex gap-3",
+            hasTile ? "flex-col lg:w-72 lg:shrink-0" : "flex-wrap",
+          )}
+        >
+          {isLoading ? (
+            Array.from({ length: 3 }, (_, i) => (
+              <div
+                key={`skeleton-${i}`}
+                className="flex w-72 shrink-0 flex-col gap-1.5 rounded-xl border border-border bg-background px-3 py-2.5"
+              >
+                <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+                <div className="h-2.5 w-full animate-pulse rounded bg-muted/70" />
+              </div>
+            ))
+          ) : (
+            <PromptCardRow entries={loosePrompts} />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/hooks/use-home-next-actions.ts
+++ b/apps/mesh/src/web/hooks/use-home-next-actions.ts
@@ -14,8 +14,19 @@ export interface HomePromptEntry {
   _meta?: Prompt["_meta"];
 }
 
+export interface HomeTileEntry {
+  agentId: string;
+  agentName: string;
+  agentIcon: string | null;
+  connectionId: string;
+  resourceUri: string;
+  minHeight?: number;
+  maxHeight?: number;
+}
+
 interface HomeNextActionsResponse {
   prompts: HomePromptEntry[];
+  tiles?: HomeTileEntry[];
 }
 
 export function useHomeNextActions(orgSlug: string) {
@@ -33,5 +44,6 @@ export function useHomeNextActions(orgSlug: string) {
   return {
     isLoading: query.isLoading,
     prompts: query.data?.prompts ?? [],
+    tiles: query.data?.tiles ?? [],
   };
 }

--- a/apps/mesh/src/web/hooks/use-start-thread-from-prompt.tsx
+++ b/apps/mesh/src/web/hooks/use-start-thread-from-prompt.tsx
@@ -19,7 +19,7 @@ import {
 } from "@decocms/mcp-utils/aggregate";
 import { getPrompt, useMCPClient, useProjectContext } from "@decocms/mesh-sdk";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 import {
   PromptArgsDialog,
@@ -42,6 +42,12 @@ export interface UseStartThreadFromPromptResult {
   dialog: ReactNode;
   /** Exposed for tests / loading states. */
   dialogPrompt: Prompt | null;
+  /**
+   * True while a thread creation is in flight. Consumers should disable
+   * their trigger button so repeated clicks during the autosend round-trip
+   * can't spawn duplicate threads.
+   */
+  starting: boolean;
 }
 
 export function useStartThreadFromPrompt({
@@ -58,12 +64,21 @@ export function useStartThreadFromPrompt({
   const { create } = useThreadActions();
   const { setTaskId } = usePanelActions();
   const [dialogPrompt, setDialogPrompt] = useState<Prompt | null>(null);
+  const [starting, setStarting] = useState(false);
+  // `inFlightRef` is the race-safe guard — `starting` (state) is one render
+  // behind on rapid double-clicks, so a ref is what actually prevents the
+  // second invocation from getting past the gate before React commits.
+  const inFlightRef = useRef(false);
 
   const loadAndStart = async (prompt: Prompt, args?: PromptArgumentValues) => {
     if (!client) {
       toast.error("MCP client not available");
       return;
     }
+    if (inFlightRef.current) return;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- in-flight guard for duplicate-click prevention
+    inFlightRef.current = true;
+    setStarting(true);
     try {
       const result = await getPrompt(client, prompt.name, args);
       // Mirror the editor's `/`-mention insertion shape (mention atom +
@@ -102,10 +117,15 @@ export function useStartThreadFromPrompt({
     } catch (error) {
       console.error("[start-thread-from-prompt] failed", error);
       toast.error("Failed to start thread. Please try again.");
+    } finally {
+      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- release in-flight guard
+      inFlightRef.current = false;
+      setStarting(false);
     }
   };
 
   const start = async (prompt: Prompt) => {
+    if (inFlightRef.current) return;
     if (prompt.arguments && prompt.arguments.length > 0) {
       setDialogPrompt(prompt);
       return;
@@ -121,6 +141,10 @@ export function useStartThreadFromPrompt({
   };
 
   const startBlank = async () => {
+    if (inFlightRef.current) return;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- in-flight guard for duplicate-click prevention
+    inFlightRef.current = true;
+    setStarting(true);
     try {
       const newId = crypto.randomUUID();
       await create({ id: newId, virtual_mcp_id: agentId });
@@ -128,6 +152,10 @@ export function useStartThreadFromPrompt({
     } catch (error) {
       console.error("[start-thread-from-prompt] startBlank failed", error);
       toast.error("Failed to start thread. Please try again.");
+    } finally {
+      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- release in-flight guard
+      inFlightRef.current = false;
+      setStarting(false);
     }
   };
 
@@ -139,5 +167,5 @@ export function useStartThreadFromPrompt({
     />
   );
 
-  return { start, startBlank, dialog, dialogPrompt };
+  return { start, startBlank, dialog, dialogPrompt, starting };
 }

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -599,6 +599,7 @@ function ConnectionItemSkeleton() {
 interface UITool {
   name: string;
   description?: string;
+  resourceUri: string;
 }
 
 interface PinnedView {
@@ -660,9 +661,13 @@ function LayoutTabContent({
                 }> | null;
               } | null;
             }>(result);
-            const uiTools: UITool[] = (item?.tools ?? [])
-              .filter((t) => !!getUIResourceUri(t._meta))
-              .map((t) => ({ name: t.name, description: t.description }));
+            const uiTools: UITool[] = (item?.tools ?? []).flatMap((t) => {
+              const resourceUri = getUIResourceUri(t._meta);
+              if (!resourceUri) return [];
+              return [
+                { name: t.name, description: t.description, resourceUri },
+              ];
+            });
             return {
               fetchOk: true,
               id: connId,
@@ -699,6 +704,7 @@ function LayoutTabContent({
   const layoutMeta = form.watch("metadata.ui.layout") ?? null;
   const currentDefaultMain = layoutMeta?.defaultMainView ?? null;
   const chatDefaultOpen = layoutMeta?.chatDefaultOpen ?? false;
+  const homeTile = form.watch("metadata.ui.homeTile") ?? null;
 
   // Convert the stored {type, id, toolName} object into the string composite
   // key used by the <Select> UI. Legacy tab types fold into "settings".
@@ -856,6 +862,33 @@ function LayoutTabContent({
     flushAndSave();
   };
 
+  // Flatten UI tools across connections so the home-tile picker can offer a
+  // single Select. We key by resourceUri (unique per ui:// URI) but also
+  // capture the owning connection — the home page opens a direct client to
+  // that connection so iframe tool calls hit bare tool names.
+  const homeTileOptions = connectionsData.flatMap((conn) =>
+    conn.uiTools.map((tool) => ({
+      resourceUri: tool.resourceUri,
+      connectionId: conn.id,
+      label: `${conn.title} — ${toTitleCase(tool.name)}`,
+    })),
+  );
+
+  const handleHomeTileChange = (value: string) => {
+    if (value === "none") {
+      form.setValue("metadata.ui.homeTile", null, { shouldDirty: true });
+    } else {
+      const opt = homeTileOptions.find((o) => o.resourceUri === value);
+      if (!opt) return;
+      form.setValue(
+        "metadata.ui.homeTile",
+        { resourceUri: opt.resourceUri, connectionId: opt.connectionId },
+        { shouldDirty: true },
+      );
+    }
+    flushAndSave();
+  };
+
   const noConnections = connectionIds.length === 0;
   const noInteractiveTools =
     connectionsWithTools && connectionsData.length === 0;
@@ -949,6 +982,40 @@ function LayoutTabContent({
                 </TooltipContent>
               )}
             </Tooltip>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5 min-w-0">
+              <Label className="font-normal text-foreground">Home tile</Label>
+              <p className="text-xs text-muted-foreground">
+                Render an interactive tool UI inside this agent's tile on the
+                org home page. Only takes effect when the agent is in the org's
+                default home agents.
+              </p>
+            </div>
+            <Select
+              value={homeTile?.resourceUri ?? "none"}
+              onValueChange={handleHomeTileChange}
+              disabled={homeTileOptions.length === 0}
+            >
+              <SelectTrigger className="w-56 h-8 text-sm shrink-0">
+                <SelectValue
+                  placeholder={
+                    homeTileOptions.length === 0
+                      ? "No interactive tools"
+                      : "None"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                {homeTileOptions.map((opt) => (
+                  <SelectItem key={opt.resourceUri} value={opt.resourceUri}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </CardContent>
 

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -102,6 +102,41 @@ export const VirtualMcpUILayoutSchema = z.object({
 export type VirtualMcpUILayout = z.infer<typeof VirtualMcpUILayoutSchema>;
 
 /**
+ * Tile UI declared by a home agent. When present, the `/$org` home page
+ * renders the resource as an iframe inside the agent's tile (same MCP UI
+ * iframe pattern used for tool results in chat).
+ *
+ * The resource lives on a specific underlying connection — not the virtual
+ * MCP gateway — so we store the source `connectionId` here. The host opens
+ * an MCP client to that connection directly so tool calls from inside the
+ * iframe hit bare tool names (the gateway would otherwise reject calls that
+ * don't carry its namespace prefix).
+ */
+const VirtualMcpHomeTileSchema = z.object({
+  /**
+   * Optional for backward compatibility with tiles saved before this field
+   * existed. The home API drops tiles that don't carry a connectionId (they
+   * can't render correctly without it), but parsing must still succeed so
+   * existing virtual MCPs don't fail output validation on COLLECTION_*_LIST.
+   */
+  connectionId: z
+    .string()
+    .optional()
+    .describe(
+      "Connection that owns the resource — the host opens a direct MCP client to this connection so the iframe can call tools by their bare names.",
+    ),
+  resourceUri: z
+    .string()
+    .describe(
+      "ui:// resource URI exposed by `connectionId`. Read on the home page and rendered via MCPAppRenderer.",
+    ),
+  minHeight: z.number().int().positive().optional(),
+  maxHeight: z.number().int().positive().optional(),
+});
+
+export type VirtualMcpHomeTile = z.infer<typeof VirtualMcpHomeTileSchema>;
+
+/**
  * Virtual MCP UI customization schema
  */
 const VirtualMcpUISchema = z.object({
@@ -111,6 +146,7 @@ const VirtualMcpUISchema = z.object({
   themeColor: z.string().nullable().optional(),
   pinnedViews: z.array(VirtualMcpPinnedViewSchema).nullable().optional(),
   layout: VirtualMcpUILayoutSchema.nullable().optional(),
+  homeTile: VirtualMcpHomeTileSchema.nullable().optional(),
 });
 
 export type VirtualMcpUI = z.infer<typeof VirtualMcpUISchema>;


### PR DESCRIPTION
This update modifies the home-next-actions API to return both prompts and tile UIs for the organization's configured default home agents. The new TileEntry interface is introduced to structure the tile data, allowing the frontend to render agent UIs as iframes. Additionally, the handling of prompts is refined to ensure a seamless integration of prompts and tiles in the home interface, improving user experience and interaction with agent functionalities.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enhances the home-next-actions flow: the API now returns both prompts and tile UIs for default home agents, and the home page renders agent tiles as MCP iframes with prompt chips. Also adds a “Home tile” setting to virtual MCPs and prevents duplicate thread creation on rapid clicks.

- New Features
  - API: returns `tiles` alongside `prompts` for default home agents using `metadata.ui.homeTile`; prompts cap raised to 10 per agent.
  - Home UI: renders agent tiles via `MCPAppRenderer`, opening a client to the tile’s `connectionId` so iframe tool calls use bare names; shows the agent header as a blank-chat shortcut; prompt chips render inside the tile.
  - Layout: when tiles exist, switches to a 2-column layout (tiles left, loose prompt cards right).
  - Settings: adds a “Home tile” selector in the virtual MCP editor; persists `metadata.ui.homeTile` with `resourceUri`, `connectionId`, and optional `minHeight`/`maxHeight`; schema updated to include `homeTile`.
  - Hooks: `useHomeNextActions` now exposes `tiles` for rendering.

- Bug Fixes
  - Blocks duplicate thread creation with an in-flight guard and `starting` state in `useStartThreadFromPrompt`; disables buttons during start to prevent double-clicks.

<sup>Written for commit b1593fa93340274beec31b6cab497077420b0630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3522?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

