### PR TITLE
ci(sandbox): split daemon.e2e.test.ts into its own workflow

### DIFF
--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -1,0 +1,36 @@
+name: Sandbox Daemon E2E
+
+# packages/sandbox/daemon/daemon.e2e.test.ts spawns the built daemon binary
+# and exercises real HTTP/SSE endpoints — it's an integration test that
+# runs under `bun test` purely because of where it lives in the tree.
+# Split into its own workflow so the unit-test job stays infrastructure-free
+# (no daemon-bundle build, no per-test process spawning) per TESTING.md.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  daemon-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build daemon bundle
+        run: bun run --cwd=packages/sandbox build
+
+      - name: Run daemon e2e tests
+        run: bun test packages/sandbox/daemon/daemon.e2e.test.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,20 +79,18 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      # Required by packages/sandbox/daemon/daemon.e2e.test.ts, which spawns
-      # the built daemon binary. Despite the name, that test runs under
-      # `bun test` (not Playwright) because it lives in the sandbox package.
-      # Worth migrating to its own workflow eventually.
-      - name: Build daemon bundle
-        run: bun run --cwd=packages/sandbox build
-
       - name: Run tests
         run: |
           # Single job (was a 4-shard matrix when the suite was larger). The
           # per-file bun invocation below is what actually protects us from
           # Bun 1.3.5's PGlite teardown crashes — sharding was orchestration
           # overhead for little wall-time gain at the current size.
-          files=$(find apps/mesh/src packages -name '*.test.ts' -o -name '*.test.tsx')
+          #
+          # `daemon.e2e.test.ts` is excluded — it spawns the built daemon
+          # binary and is run by .github/workflows/sandbox-daemon.yml.
+          files=$(find apps/mesh/src packages \
+            \( -name '*.test.ts' -o -name '*.test.tsx' \) \
+            ! -path '*/daemon/daemon.e2e.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"
           echo "$files"


### PR DESCRIPTION
## Summary

\`packages/sandbox/daemon/daemon.e2e.test.ts\` is 820 lines of integration tests that:

- \`spawn()\` the built daemon binary as a child process
- Exercise real HTTP/SSE endpoints against it
- Use \`mkdtempSync\` for filesystem fixtures

It runs under \`bun test\` purely because of where it lives in the tree. The unit-test job had to build the daemon bundle just to feed this one file — TESTING.md says unit tests shouldn't need infrastructure, so this was a leaky abstraction.

### What changed

- New workflow \`.github/workflows/sandbox-daemon.yml\` ("Sandbox Daemon E2E") runs on the same triggers (push to main, PRs) and runs only this file.
- Unit job no longer builds the daemon bundle.
- Unit-shard \`find\` excludes \`daemon.e2e.test.ts\` so it doesn't get picked up by both.

Net: the "Checks & Unit Tests / test" job is genuinely infrastructure-free now (no Docker, no apt-installs, no bundle builds). Daemon e2e gets a clearly-named check of its own.

## Test plan

- [x] yaml syntax (workflow file loads in CI)
- [ ] \`Sandbox Daemon E2E / daemon-e2e\` runs and passes
- [ ] \`Checks & Unit Tests / test\` runs without the daemon-bundle step and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the sandbox daemon E2E test into its own CI workflow so unit tests stay infrastructure-free. Adds a dedicated `Sandbox Daemon E2E` check that builds the daemon bundle and runs `packages/sandbox/daemon/daemon.e2e.test.ts`.

- **Refactors**
  - Added `.github/workflows/sandbox-daemon.yml` to run the daemon E2E on push/PR to `main`.
  - Removed daemon bundle build from the unit job in `.github/workflows/test.yml`.
  - Excluded `*/daemon/daemon.e2e.test.ts` from unit test discovery to prevent double runs.

<sup>Written for commit dbb36ccf201dd428dcfb3e644275d21ced72523d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3525?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

