### PR TITLE
ci(storage): real Postgres for storage tests, retiring PGlite

### DIFF
--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -1,0 +1,65 @@
+name: Storage Integration
+
+# Storage-layer tests that previously used PGlite (WASM-emulated Postgres)
+# now run against a real `postgres:16` service so the SQL surface, query
+# planner, RETURNING/ON CONFLICT semantics, advisory locks, LISTEN/NOTIFY,
+# and extension behavior all match production. PGlite produced false
+# confidence — passing locally, sometimes failing in prod.
+#
+# Lives outside the unit-test workflow because real Postgres is
+# infrastructure per TESTING.md. No HTTP, no auth, no Playwright — just
+# the storage adapters being exercised against a real DB.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  storage-integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run migrations
+        run: bun run --cwd=apps/mesh migrate
+
+      # The list grows as we migrate more storage tests off PGlite. Each
+      # file runs in its own bun process so a teardown crash in one
+      # doesn't poison the next — same protection as the unit job.
+      - name: Run storage integration tests
+        run: |
+          files="apps/mesh/src/storage/virtual.test.ts"
+          for f in $files; do
+            echo "::group::$f"
+            bun test "$f"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,11 +86,15 @@ jobs:
           # Bun 1.3.5's PGlite teardown crashes — sharding was orchestration
           # overhead for little wall-time gain at the current size.
           #
-          # `daemon.e2e.test.ts` is excluded — it spawns the built daemon
-          # binary and is run by .github/workflows/sandbox-daemon.yml.
+          # Exclusions: tests that need real infrastructure live in their
+          # own workflows so this job stays infrastructure-free per
+          # TESTING.md.
+          #   - daemon.e2e.test.ts → .github/workflows/sandbox-daemon.yml
+          #   - storage/virtual.test.ts → .github/workflows/storage-integration.yml
           files=$(find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
-            ! -path '*/daemon/daemon.e2e.test.ts')
+            ! -path '*/daemon/daemon.e2e.test.ts' \
+            ! -path '*/storage/virtual.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"
           echo "$files"

--- a/apps/mesh/src/database/test-db-pg.ts
+++ b/apps/mesh/src/database/test-db-pg.ts
@@ -1,0 +1,79 @@
+/**
+ * Real-Postgres test database connector for storage-layer tests.
+ *
+ * Storage tests that previously used `createTestDatabase()` (PGlite, WASM)
+ * should use this helper instead — PGlite is Postgres-compatible at the SQL
+ * surface but the query planner, indexes, RETURNING/ON CONFLICT semantics,
+ * advisory locks, LISTEN/NOTIFY, and extension behavior all diverge from
+ * real Postgres. A test that passes against PGlite can still fail in prod.
+ *
+ * Tests using this helper must run in the `Storage Integration` workflow
+ * (.github/workflows/storage-integration.yml), which boots `postgres:16`
+ * as a service and runs all migrations before tests start. Locally:
+ *
+ *   docker run -d --name pg -p 5432:5432 \
+ *     -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+ *     postgres:16
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+ *     bun run --cwd=apps/mesh migrate
+ *   DATABASE_URL=... bun test apps/mesh/src/storage/some.test.ts
+ */
+
+import { Kysely, PostgresDialect, sql } from "kysely";
+import { Pool } from "pg";
+import type { Database as DatabaseSchema } from "../storage/types";
+import type { MeshDatabase } from "./index";
+
+const DEFAULT_DATABASE_URL =
+  "postgresql://postgres:postgres@localhost:5432/postgres";
+
+/**
+ * Connect to the real Postgres test database. Honors `DATABASE_URL` first,
+ * falls back to the standard local-dev shape.
+ */
+export async function connectTestPgDatabase(): Promise<MeshDatabase> {
+  const connectionString = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL;
+  const pool = new Pool({ connectionString });
+  const dialect = new PostgresDialect({ pool });
+  const db = new Kysely<DatabaseSchema>({ dialect });
+  return { type: "postgres", db, pool };
+}
+
+/**
+ * Close the test database, releasing the connection pool.
+ */
+export async function closeTestPgDatabase(
+  database: MeshDatabase,
+): Promise<void> {
+  await database.db.destroy();
+  if (!database.pool.ended) {
+    await database.pool.end();
+  }
+}
+
+/**
+ * Truncate every user table in the `public` schema so the next test starts
+ * from a clean slate. Preserves migrations (and the migrations bookkeeping
+ * table) so we don't need to re-run them between tests.
+ *
+ * The list is computed at runtime via `pg_tables` rather than hardcoded —
+ * adding a migration that introduces a new table doesn't require us to
+ * remember to update a cleanup list.
+ */
+export async function resetTestPgDatabase(
+  database: MeshDatabase,
+): Promise<void> {
+  const result = await sql<{
+    tablename: string;
+  }>`
+    SELECT tablename FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename NOT IN ('kysely_migration', 'kysely_migration_lock')
+  `.execute(database.db);
+  if (result.rows.length === 0) return;
+  const list = result.rows.map((r) => `"${r.tablename}"`).join(", ");
+  // CASCADE handles FK chains; one statement keeps it fast.
+  await sql
+    .raw(`TRUNCATE TABLE ${list} RESTART IDENTITY CASCADE`)
+    .execute(database.db);
+}

--- a/apps/mesh/src/storage/virtual.test.ts
+++ b/apps/mesh/src/storage/virtual.test.ts
@@ -28,9 +28,12 @@ describe("VirtualMCPStorage.findById (Decopilot)", () => {
       VALUES (${orgId}, ${orgId}, ${orgId}, ${now})
       ON CONFLICT (id) DO NOTHING
     `.execute(database.db);
+    // emailVerified is BOOLEAN in real Postgres (Better Auth's migration);
+    // PGlite test-helpers hand-rolled it as INTEGER, which is why the old
+    // version of this test inserted `0` and got away with it.
     await sql`
       INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
-      VALUES ('user_decopilot_test', 'user_decopilot_test@test.com', 0, 'Test Decopilot', ${now}, ${now})
+      VALUES ('user_decopilot_test', 'user_decopilot_test@test.com', false, 'Test Decopilot', ${now}, ${now})
       ON CONFLICT (id) DO NOTHING
     `.execute(database.db);
     await database.db

--- a/apps/mesh/src/storage/virtual.test.ts
+++ b/apps/mesh/src/storage/virtual.test.ts
@@ -1,23 +1,24 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { sql } from "kysely";
 import {
-  closeTestDatabase,
-  createTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
-import { createTestSchema, seedCommonTestFixtures } from "./test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { VirtualMCPStorage } from "./virtual";
 import { getDecopilotId } from "@decocms/mesh-sdk";
 
 describe("VirtualMCPStorage.findById (Decopilot)", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let storage: VirtualMCPStorage;
   const orgId = "org_decopilot_test";
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    // Wipe whatever the previous test file left behind. Migrations have
+    // already been run by the workflow before any test starts.
+    await resetTestPgDatabase(database);
 
     // Seed an org and an active connection for it so we can verify decopilot
     // does NOT aggregate connections (old code would return this connection).
@@ -65,7 +66,7 @@ describe("VirtualMCPStorage.findById (Decopilot)", () => {
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   test("returns the synthesized decopilot entity with NO aggregated connections", async () => {


### PR DESCRIPTION
## Summary

PGlite is Postgres-compatible at the SQL surface but the query planner, indexes, \`RETURNING\`/\`ON CONFLICT\` semantics, advisory locks, \`LISTEN/NOTIFY\`, and extensions all diverge from production. For tests whose entire purpose is "do these queries work," that's the worst failure mode — passes against PGlite, breaks in prod.

This PR establishes the model with the smallest storage test as proof.

### What's in

- **New workflow** \`.github/workflows/storage-integration.yml\` boots \`postgres:16\` as a service, runs migrations, then runs storage tests directly with \`bun test\`. No HTTP, no auth, no Playwright — same fast-feedback feel as PGlite but prod-faithful.
- **New helper** \`apps/mesh/src/database/test-db-pg.ts\`:
  - \`connectTestPgDatabase\` — \`pg.Pool\` against \`DATABASE_URL\`
  - \`closeTestPgDatabase\` — drain + destroy
  - \`resetTestPgDatabase\` — \`TRUNCATE\` every user table found at runtime via \`pg_tables\` (excluding the kysely migration bookkeeping). New tables added in future migrations get cleaned automatically — no list to maintain.
- **Migrated** \`apps/mesh/src/storage/virtual.test.ts\` (the smallest of the five storage tests) onto the new helper.
- **Unit shard** excludes the migrated file so it doesn't run twice.

### Not in scope

The other 4 storage tests (\`connection\`, \`threads\`, \`downstream-token\`, \`sandbox-runner-state\`) and the Camp 1 API integration tests stay on PGlite for now. Migrating them is mechanical once this PR proves the harness — each follow-up PR moves another file off PGlite, adds it to the storage workflow's file list (or to Playwright if it needs HTTP), and removes it from the unit shard exclusion. Once the list is empty we can delete \`createTestDatabase\` and the PGlite dep entirely.

## Test plan

- [x] fmt / tsc / knip clean locally
- [ ] \`Storage Integration / storage-integration\` job passes — first runtime proof
- [ ] \`Checks & Unit Tests / test\` still passes without virtual.test.ts in the shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs storage tests against a real Postgres to match production behavior and avoid PGlite false positives. Adds a Postgres-backed CI workflow and helper, migrates the first storage test, and fixes a schema mismatch surfaced by real Postgres.

- **New Features**
  - Added `.github/workflows/storage-integration.yml` to start `postgres:16`, run migrations, then execute storage tests with `bun test` (no HTTP/auth/Playwright).
  - Added `apps/mesh/src/database/test-db-pg.ts`:
    - `connectTestPgDatabase` using `pg` + `kysely` with `DATABASE_URL`.
    - `resetTestPgDatabase` truncates all user tables (keeps Kysely migration tables).
    - `closeTestPgDatabase` cleans up the pool.
  - Migrated `apps/mesh/src/storage/virtual.test.ts` to the new helper.
  - Updated unit test workflow to exclude `storage/virtual.test.ts` so it runs only in the storage workflow.

- **Bug Fixes**
  - In `apps/mesh/src/storage/virtual.test.ts`, set `emailVerified` to `false` (BOOLEAN) to match real migrations; PGlite had accepted `0` (INTEGER).

<sup>Written for commit 499d1e05d1665b8f1eaf9d8569a1d0877825c36f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3526?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

