### PR TITLE
ci(storage): migrate remaining 4 storage tests off PGlite

### DIFF
--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -57,7 +57,11 @@ jobs:
       # doesn't poison the next — same protection as the unit job.
       - name: Run storage integration tests
         run: |
-          files="apps/mesh/src/storage/virtual.test.ts"
+          files="apps/mesh/src/storage/virtual.test.ts \
+                 apps/mesh/src/storage/downstream-token.test.ts \
+                 apps/mesh/src/storage/sandbox-runner-state.test.ts \
+                 apps/mesh/src/storage/threads.test.ts \
+                 apps/mesh/src/storage/connection.test.ts"
           for f in $files; do
             echo "::group::$f"
             bun test "$f"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,15 @@ jobs:
           # own workflows so this job stays infrastructure-free per
           # TESTING.md.
           #   - daemon.e2e.test.ts → .github/workflows/sandbox-daemon.yml
-          #   - storage/virtual.test.ts → .github/workflows/storage-integration.yml
+          #   - storage/*.test.ts → .github/workflows/storage-integration.yml
           files=$(find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -path '*/daemon/daemon.e2e.test.ts' \
-            ! -path '*/storage/virtual.test.ts')
+            ! -path '*/storage/virtual.test.ts' \
+            ! -path '*/storage/downstream-token.test.ts' \
+            ! -path '*/storage/sandbox-runner-state.test.ts' \
+            ! -path '*/storage/threads.test.ts' \
+            ! -path '*/storage/connection.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"
           echo "$files"

--- a/apps/mesh/src/database/test-db-pg.ts
+++ b/apps/mesh/src/database/test-db-pg.ts
@@ -52,6 +52,35 @@ export async function closeTestPgDatabase(
 }
 
 /**
+ * Seed the common users + organizations that several storage tests
+ * implicitly depend on (matches the PGlite-era `seedCommonTestFixtures`
+ * shape, with the difference that `emailVerified` is the BOOLEAN that real
+ * Postgres expects — PGlite happened to tolerate `0`).
+ *
+ * Call this from a test's `beforeAll` after `resetTestPgDatabase`. If a
+ * test only needs its own bespoke seed, skip this helper entirely.
+ */
+export async function seedCommonTestPgFixtures(
+  database: MeshDatabase,
+): Promise<void> {
+  const now = new Date().toISOString();
+  for (const userId of ["user_1", "user_123", "user_test", "test_user"]) {
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${userId}, ${userId + "@test.com"}, false, ${"Test " + userId}, ${now}, ${now})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+  }
+  for (const orgId of ["org_1", "org_123", "org_456", "org_test"]) {
+    await sql`
+      INSERT INTO "organization" (id, name, slug, "createdAt")
+      VALUES (${orgId}, ${orgId}, ${orgId}, ${now})
+      ON CONFLICT (id) DO NOTHING
+    `.execute(database.db);
+  }
+}
+
+/**
  * Truncate every user table in the `public` schema so the next test starts
  * from a clean slate. Preserves migrations (and the migrations bookkeeping
  * table) so we don't need to re-run them between tests.

--- a/apps/mesh/src/storage/connection.test.ts
+++ b/apps/mesh/src/storage/connection.test.ts
@@ -1,28 +1,29 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { ConnectionStorage } from "./connection";
 import { CredentialVault } from "../encryption/credential-vault";
-import { createTestSchema, seedCommonTestFixtures } from "./test-helpers";
 
 describe("ConnectionStorage", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let storage: ConnectionStorage;
   let vault: CredentialVault;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
     vault = new CredentialVault(CredentialVault.generateKey());
     storage = new ConnectionStorage(database.db, vault);
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   describe("create", () => {

--- a/apps/mesh/src/storage/downstream-token.test.ts
+++ b/apps/mesh/src/storage/downstream-token.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
 import { sql } from "kysely";
-import { createTestSchema, seedCommonTestFixtures } from "./test-helpers";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { CredentialVault } from "../encryption/credential-vault";
 import {
   DownstreamTokenStorage,
@@ -13,13 +14,13 @@ import {
 } from "./downstream-token";
 
 describe("DownstreamTokenStorage", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let storage: DownstreamTokenStorage;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
 
     // Create test connections required by FK constraints
     const now = new Date().toISOString();
@@ -36,7 +37,7 @@ describe("DownstreamTokenStorage", () => {
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   it("should fail-safe invalid expiration date as expired", async () => {

--- a/apps/mesh/src/storage/sandbox-runner-state.test.ts
+++ b/apps/mesh/src/storage/sandbox-runner-state.test.ts
@@ -1,25 +1,25 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import type { SandboxId } from "@decocms/sandbox/provider";
 import {
-  closeTestDatabase,
-  createTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { KyselySandboxProviderStateStore } from "./sandbox-runner-state";
-import { createTestSchema } from "./test-helpers";
 
 describe("KyselySandboxProviderStateStore", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let store: KyselySandboxProviderStateStore;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
     store = new KyselySandboxProviderStateStore(database.db);
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   // Each test uses a unique id to avoid cross-test pollution.
@@ -67,7 +67,7 @@ describe("KyselySandboxProviderStateStore", () => {
     expect(row!.state).toEqual({ version: 2 });
 
     // Verify only one row exists for this (user, project, kind).
-    const { rows } = await database.pglite.query<{ count: string }>(
+    const { rows } = await database.pool.query<{ count: string }>(
       `SELECT COUNT(*)::text AS count FROM sandbox_runner_state
          WHERE user_id = $1 AND project_ref = $2 AND sandbox_provider_kind = $3`,
       [id.userId, id.projectRef, "local-docker"],

--- a/apps/mesh/src/storage/threads.test.ts
+++ b/apps/mesh/src/storage/threads.test.ts
@@ -1,20 +1,21 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { sql } from "kysely";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
-import { createTestSchema } from "./test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { SqlThreadStorage } from "./threads";
 import type { ThreadMessage } from "./types";
 
 describe("SqlThreadStorage", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let storage: SqlThreadStorage;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
     // Insert org and user for thread FK constraints
     await database.db
       .insertInto("organization")
@@ -25,22 +26,20 @@ describe("SqlThreadStorage", () => {
         createdAt: new Date().toISOString(),
       })
       .execute();
-    await database.db
-      .insertInto("user")
-      .values({
-        id: "user_1",
-        email: "test@test.com",
-        emailVerified: 0,
-        name: "Test",
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      })
-      .execute();
+    // Use raw SQL: the Database schema type still has emailVerified as
+    // `number` (matching the old PGlite hand-rolled schema). Real Postgres
+    // has it as BOOLEAN per Better Auth's migration. Bypassing the typed
+    // builder until storage/types.ts gets regenerated against real PG.
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES ('user_1', 'test@test.com', false, 'Test', ${now}, ${now})
+    `.execute(database.db);
     storage = new SqlThreadStorage(database.db);
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   describe("saveMessages (upsert)", () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #3526 (which proved the harness with \`virtual.test.ts\` plus surfaced the \`emailVerified\` BOOLEAN-vs-INTEGER divergence). Moves the four remaining storage tests:

- \`storage/downstream-token.test.ts\`
- \`storage/sandbox-runner-state.test.ts\`
- \`storage/threads.test.ts\`
- \`storage/connection.test.ts\`

Each now:

- Uses \`connectTestPgDatabase\` / \`closeTestPgDatabase\` / \`resetTestPgDatabase\` from the new helper
- Uses a new \`seedCommonTestPgFixtures\` export (mirrors the PGlite-era \`seedCommonTestFixtures\` shape with \`emailVerified: false\` instead of \`0\`)
- Falls back to raw SQL via the \`sql\` template when the Database TypeScript schema still says \`emailVerified: number\` and Kysely's typed builder would reject \`false\`

Workflow file lists updated:

- \`storage-integration.yml\` runs all 5 storage tests
- \`test.yml\` unit shard excludes them so they don't double-run

## Known remaining issue (separate PR)

\`apps/mesh/src/storage/types.ts\` still has \`emailVerified: number\` for the \`user\` table (legacy PGlite shape). Fixing properly likely means regenerating types against the real schema. The raw-SQL workaround in this PR is intentional and tagged with a comment in each file.

## Notes

**This PR does not auto-merge — paused for review.** CI will validate each against real Postgres; expect a couple of hidden divergences to surface (same shape as the \`emailVerified\` one from the previous PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the remaining four storage tests to the Postgres-backed test harness for consistent, real-DB coverage. CI now runs all storage tests in `storage-integration.yml` and excludes them from the unit shard; includes a temporary SQL fallback for the `emailVerified` type gap.

- **Refactors**
  - Replace PGlite helpers with `connectTestPgDatabase` / `resetTestPgDatabase` / `closeTestPgDatabase`.
  - Add `seedCommonTestPgFixtures` and use it where needed (BOOLEAN-correct `emailVerified`).
  - Insert `user` rows via raw `sql` where the schema still expects `number` for `emailVerified` (until `apps/mesh/src/storage/types.ts` is regenerated).
  - CI: `storage-integration.yml` runs `virtual`, `downstream-token`, `sandbox-runner-state`, `threads`, `connection`; `test.yml` excludes them to avoid double runs.

<sup>Written for commit 188fcb316457f4a1c6ef2f2be259ca7e6ca835e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3528?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

