### PR TITLE
fix(web-search): decouple deep research provider from chat provider

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -53,6 +53,7 @@ import { buildOnTitleUpdated } from "./on-title-updated";
 import {
   checkModelPermission,
   fetchModelPermissions,
+  filterToolTiersByPermission,
 } from "./model-permissions";
 import type { RunRegistry } from "./run-registry";
 import { resolveThreadStatus } from "./status";
@@ -472,6 +473,10 @@ async function prepareRun(
     // 1. Check model permissions (decopilot-only; CLI harnesses run with
     //    the user's own provider credential / local CLI binary, which is
     //    already vetted at credential-creation time).
+    //    Also filters image/deepResearch tier slots: routes.ts already
+    //    strips disallowed tiers at HTTP entry, but resume + automation
+    //    paths re-enter through dispatch-run without that gate, so this
+    //    second pass keeps the policy consistent across entry points.
     if (harnessId === "decopilot") {
       const allowedModels = await fetchModelPermissions(
         ctx.db,
@@ -488,6 +493,10 @@ async function prepareRun(
       ) {
         throw new Error("Model not allowed for your role");
       }
+      input = {
+        ...input,
+        models: filterToolTiersByPermission(allowedModels, input.models),
+      };
     }
 
     const windowSize = input.windowSize ?? DEFAULT_WINDOW_SIZE;

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -496,22 +496,39 @@ async function prepareRun(
       throw new Error("dispatchRunAndWait: taskId is required");
     }
 
-    // 2. Load entities and create/load memory in parallel
-    const [virtualMcp, provider, mem] = await Promise.all([
-      ctx.storage.virtualMcps.findById(input.agent.id, input.organizationId),
-      harnessId === "decopilot"
-        ? ctx.aiProviders.activate(
-            input.models.credentialId,
-            input.organizationId,
-          )
-        : Promise.resolve(null),
-      createMemory(ctx.storage.threads, {
-        organization_id: input.organizationId,
-        thread_id: input.taskId,
-        userId: input.userId,
-        defaultWindowSize: windowSize,
-      }),
-    ]);
+    // 2. Load entities and create/load memory in parallel.
+    // Activate per-tool providers when their tier resolves to a different
+    // credential than the chat tier (image, deep research). Skip the extra
+    // activation when the credential matches — the chat provider is reused.
+    const chatCredId = input.models.credentialId;
+    const imageCredId = input.models.image?.credentialId;
+    const deepResearchCredId = input.models.deepResearch?.credentialId;
+    const needsImageProvider =
+      harnessId === "decopilot" && !!imageCredId && imageCredId !== chatCredId;
+    const needsDeepResearchProvider =
+      harnessId === "decopilot" &&
+      !!deepResearchCredId &&
+      deepResearchCredId !== chatCredId;
+
+    const [virtualMcp, provider, imageProvider, deepResearchProvider, mem] =
+      await Promise.all([
+        ctx.storage.virtualMcps.findById(input.agent.id, input.organizationId),
+        harnessId === "decopilot"
+          ? ctx.aiProviders.activate(chatCredId, input.organizationId)
+          : Promise.resolve(null),
+        needsImageProvider
+          ? ctx.aiProviders.activate(imageCredId, input.organizationId)
+          : Promise.resolve(null),
+        needsDeepResearchProvider
+          ? ctx.aiProviders.activate(deepResearchCredId, input.organizationId)
+          : Promise.resolve(null),
+        createMemory(ctx.storage.threads, {
+          organization_id: input.organizationId,
+          thread_id: input.taskId,
+          userId: input.userId,
+          defaultWindowSize: windowSize,
+        }),
+      ]);
 
     // Diagnostic (resume only): record whether the provider activated and
     // whether the optional model slots are present. Paired with the log in
@@ -523,6 +540,8 @@ async function prepareRun(
         taskId: input.taskId,
         harnessId,
         providerActivated: !!provider,
+        imageProviderActivated: !!imageProvider,
+        deepResearchProviderActivated: !!deepResearchProvider,
         thinkingModelId: input.models.thinking.id,
         hasImage: !!input.models.image,
         hasDeepResearch: !!input.models.deepResearch,
@@ -757,6 +776,8 @@ async function prepareRun(
           registrySignal,
           runRegistry,
           provider,
+          imageProvider: imageProvider ?? provider,
+          deepResearchProvider: deepResearchProvider ?? provider,
           htmlPageBuffer,
           registerPendingOp: (op) => {
             pendingOps.push(op);

--- a/apps/mesh/src/api/routes/decopilot/model-permissions.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-permissions.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "bun:test";
 import {
   checkModelPermission,
   extractModelPermissions,
+  filterToolTiersByPermission,
   parseModelsToMap,
 } from "./model-permissions";
 
@@ -122,6 +123,84 @@ describe("checkModelPermission", () => {
       expect(checkModelPermission(models, connB, modelGemini)).toBe(true);
       expect(checkModelPermission(models, connB, modelClaude)).toBe(false);
     });
+  });
+});
+
+// ============================================================================
+// filterToolTiersByPermission
+// ============================================================================
+
+describe("filterToolTiersByPermission", () => {
+  const chatKey = "550e8400-e29b-41d4-a716-446655440000";
+  const imageKey = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+  const drKey = "9c858901-8a57-4791-81d8-1041e02b3e0e";
+
+  const sampleModels = {
+    credentialId: chatKey,
+    thinking: { id: "claude-opus-4-5" },
+    image: { credentialId: imageKey, id: "gpt-image-1" },
+    deepResearch: {
+      credentialId: drKey,
+      id: "deep-research-pro-preview-12-2025",
+    },
+  };
+
+  it("returns models unchanged when allowedModels is undefined (admin/owner)", () => {
+    const result = filterToolTiersByPermission(undefined, sampleModels);
+    expect(result).toBe(sampleModels);
+  });
+
+  it("keeps image tier when its (key, model) is permitted", () => {
+    const allowed = [
+      `${chatKey}:claude-opus-4-5`,
+      `${imageKey}:gpt-image-1`,
+      `${drKey}:deep-research-pro-preview-12-2025`,
+    ];
+    const result = filterToolTiersByPermission(allowed, sampleModels);
+    expect(result.image).toEqual(sampleModels.image);
+    expect(result.deepResearch).toEqual(sampleModels.deepResearch);
+  });
+
+  it("strips image tier when its key is not permitted at all", () => {
+    const allowed = [
+      `${chatKey}:claude-opus-4-5`,
+      `${drKey}:deep-research-pro-preview-12-2025`,
+    ];
+    const result = filterToolTiersByPermission(allowed, sampleModels);
+    expect(result.image).toBeUndefined();
+    expect(result.deepResearch).toEqual(sampleModels.deepResearch);
+  });
+
+  it("strips deepResearch tier when only its modelId is not permitted", () => {
+    const allowed = [
+      `${chatKey}:*`,
+      `${imageKey}:gpt-image-1`,
+      `${drKey}:some-other-model`,
+    ];
+    const result = filterToolTiersByPermission(allowed, sampleModels);
+    expect(result.image).toEqual(sampleModels.image);
+    expect(result.deepResearch).toBeUndefined();
+  });
+
+  it("strips both tiers when neither is permitted", () => {
+    const allowed = [`${chatKey}:claude-opus-4-5`];
+    const result = filterToolTiersByPermission(allowed, sampleModels);
+    expect(result.image).toBeUndefined();
+    expect(result.deepResearch).toBeUndefined();
+    expect(result.thinking).toEqual(sampleModels.thinking);
+    expect(result.credentialId).toBe(sampleModels.credentialId);
+  });
+
+  it("does not filter the chat (thinking) slot — caller throws for that", () => {
+    const allowed = [`${imageKey}:gpt-image-1`];
+    const result = filterToolTiersByPermission(allowed, sampleModels);
+    expect(result.thinking).toEqual(sampleModels.thinking);
+  });
+
+  it("treats *:* as allow-all and keeps every tier", () => {
+    const result = filterToolTiersByPermission(["*:*"], sampleModels);
+    expect(result.image).toEqual(sampleModels.image);
+    expect(result.deepResearch).toEqual(sampleModels.deepResearch);
   });
 });
 

--- a/apps/mesh/src/api/routes/decopilot/model-permissions.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-permissions.ts
@@ -64,6 +64,50 @@ export function checkModelPermission(
 }
 
 /**
+ * Strip per-tool tier slots (image, deepResearch) when the caller's role
+ * does not have permission to use the underlying (keyId, modelId) pair.
+ *
+ * The image and web_research tier slots are configured at the org level and
+ * may reference a credential the current user's role cannot access. Silently
+ * dropping the slot disables the corresponding built-in tool for this user
+ * rather than failing the whole request — failing would block every chat
+ * turn for a restricted role just because the admin paired the web_search
+ * tier with a key that role can't touch.
+ *
+ * Chat (thinking) is intentionally NOT filtered here — chat must error out
+ * loudly via `checkModelPermission` at the caller. Only optional tool tiers
+ * are silently downgraded.
+ */
+export function filterToolTiersByPermission<
+  M extends {
+    image?: { credentialId: string; id: string } | undefined;
+    deepResearch?: { credentialId: string; id: string } | undefined;
+  },
+>(allowedModels: string[] | undefined, models: M): M {
+  if (allowedModels === undefined) return models;
+  let next = models;
+  if (
+    next.image &&
+    !checkModelPermission(allowedModels, next.image.credentialId, next.image.id)
+  ) {
+    const { image: _image, ...rest } = next;
+    next = rest as M;
+  }
+  if (
+    next.deepResearch &&
+    !checkModelPermission(
+      allowedModels,
+      next.deepResearch.credentialId,
+      next.deepResearch.id,
+    )
+  ) {
+    const { deepResearch: _deepResearch, ...rest } = next;
+    next = rest as M;
+  }
+  return next;
+}
+
+/**
  * Parse the models array into a key-scoped map.
  * Used by the allowed-models API endpoint to return structured data to the client.
  *

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -36,6 +36,7 @@ import type { RunRegistry } from "./run-registry";
 import {
   checkModelPermission,
   fetchModelPermissions,
+  filterToolTiersByPermission,
   parseModelsToMap,
 } from "./model-permissions";
 import { StreamRequestSchema } from "./schemas";
@@ -272,7 +273,7 @@ async function validate(
     throw new HTTPException(401, { message: "User ID is required" });
   }
 
-  const models = await resolvePerRequestModels(ctx, tier, harnessId);
+  const resolvedModels = await resolvePerRequestModels(ctx, tier, harnessId);
 
   const allowedModels = await fetchModelPermissions(
     ctx.db,
@@ -283,14 +284,19 @@ async function validate(
     allowedModels !== undefined &&
     !checkModelPermission(
       allowedModels,
-      models.credentialId,
-      models.thinking.id,
+      resolvedModels.credentialId,
+      resolvedModels.thinking.id,
     )
   ) {
     throw new HTTPException(403, {
       message: "Model not allowed for your role",
     });
   }
+  // Silently drop tool tiers (image, deepResearch) that resolve to a key
+  // the user's role can't access — otherwise an admin-set tier slot would
+  // grant restricted users implicit access to the underlying credential
+  // via generate_image / web_search.
+  const models = filterToolTiersByPermission(allowedModels, resolvedModels);
 
   return {
     messages: [...systemMessages, requestMessage],

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -201,8 +201,17 @@ async function resolvePerRequestModels(
   return {
     credentialId: chat.credentialId,
     thinking: toModelInfo(chat),
-    ...(image ? { image: toModelInfo(image) } : {}),
-    ...(webResearch ? { deepResearch: toModelInfo(webResearch) } : {}),
+    ...(image
+      ? { image: { ...toModelInfo(image), credentialId: image.credentialId } }
+      : {}),
+    ...(webResearch
+      ? {
+          deepResearch: {
+            ...toModelInfo(webResearch),
+            credentialId: webResearch.credentialId,
+          },
+        }
+      : {}),
   };
 }
 

--- a/apps/mesh/src/api/routes/decopilot/run-config.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-config.ts
@@ -33,6 +33,16 @@ const PersistedModelInfoSchema = z.object({
   provider: z.string().nullish(),
 });
 
+/**
+ * Image and deepResearch tiers can resolve to a different credential than the
+ * chat tier. Pre-fix runs persisted without these per-tool credentialIds — on
+ * resume, the dispatch falls back to the chat credential, matching the
+ * legacy single-provider behavior.
+ */
+const PersistedToolModelInfoSchema = PersistedModelInfoSchema.extend({
+  credentialId: z.string().optional(),
+});
+
 /** Raw DB shape may include legacy `toolApprovalLevel: "plan"`. */
 const PersistedRunConfigRawSchema = z.object({
   models: z.object({
@@ -40,8 +50,8 @@ const PersistedRunConfigRawSchema = z.object({
     thinking: PersistedModelInfoSchema,
     coding: PersistedModelInfoSchema.optional(),
     fast: PersistedModelInfoSchema.optional(),
-    image: PersistedModelInfoSchema.optional(),
-    deepResearch: PersistedModelInfoSchema.optional(),
+    image: PersistedToolModelInfoSchema.optional(),
+    deepResearch: PersistedToolModelInfoSchema.optional(),
   }),
   agent: z.object({ id: z.string() }),
   temperature: z.number(),
@@ -95,14 +105,23 @@ function toModelInfo(m: PersistedModelInfo) {
  * have been omitted at persistence time.
  */
 export function toModelsConfig(models: PersistedRunConfig["models"]) {
+  const chatCred = models.credentialId;
   return {
-    credentialId: models.credentialId,
+    credentialId: chatCred,
     thinking: toModelInfo(models.thinking),
     ...(models.coding && { coding: toModelInfo(models.coding) }),
     ...(models.fast && { fast: toModelInfo(models.fast) }),
-    ...(models.image && { image: toModelInfo(models.image) }),
+    ...(models.image && {
+      image: {
+        ...toModelInfo(models.image),
+        credentialId: models.image.credentialId ?? chatCred,
+      },
+    }),
     ...(models.deepResearch && {
-      deepResearch: toModelInfo(models.deepResearch),
+      deepResearch: {
+        ...toModelInfo(models.deepResearch),
+        credentialId: models.deepResearch.credentialId ?? chatCred,
+      },
     }),
   };
 }

--- a/apps/mesh/src/api/routes/decopilot/types.ts
+++ b/apps/mesh/src/api/routes/decopilot/types.ts
@@ -77,8 +77,8 @@ export interface ModelsConfig {
   thinking: ModelInfo;
   coding?: ModelInfo;
   fast?: ModelInfo;
-  image?: ModelInfo;
-  deepResearch?: ModelInfo;
+  image?: ModelInfo & { credentialId: string };
+  deepResearch?: ModelInfo & { credentialId: string };
 }
 
 // ============================================================================

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -31,8 +31,8 @@ type ModelShape = {
 export interface ResolvedAutomationModel {
   credentialId: string;
   thinking: ModelShape;
-  image?: ModelShape;
-  deepResearch?: ModelShape;
+  image?: ModelShape & { credentialId: string };
+  deepResearch?: ModelShape & { credentialId: string };
 }
 
 export function buildStreamRequest(

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -213,8 +213,17 @@ async function prepareFireStep(
   const resolvedModel: ResolvedAutomationModel = {
     credentialId: resolved.credentialId,
     thinking: toModel(resolved),
-    ...(image ? { image: toModel(image) } : {}),
-    ...(webResearch ? { deepResearch: toModel(webResearch) } : {}),
+    ...(image
+      ? { image: { ...toModel(image), credentialId: image.credentialId } }
+      : {}),
+    ...(webResearch
+      ? {
+          deepResearch: {
+            ...toModel(webResearch),
+            credentialId: webResearch.credentialId,
+          },
+        }
+      : {}),
   };
 
   return { automation, resolvedModel };

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -74,6 +74,16 @@ export type VmContext = {
 export interface BuiltinToolParams {
   /** Provider — null for Claude Code (subtask tool is omitted when null) */
   provider: MeshProvider | null;
+  /** Provider used to instantiate `generate_image`. Caller passes the
+   *  chat provider when the org's `image` tier shares the chat credential
+   *  (or no tier is configured) — otherwise a separately-activated
+   *  provider matching the image-tier credential. */
+  imageProvider: MeshProvider | null;
+  /** Provider used to instantiate `web_search`'s deep-research path.
+   *  Same aliasing rule as `imageProvider`. Decoupling from the chat
+   *  provider lets web_search keep using a Gemini deep-research model
+   *  even when the chat is routed via LiteLLM/OpenRouter. */
+  deepResearchProvider: MeshProvider | null;
   organization: OrganizationScope;
   models: ModelsConfig;
   toolApprovalLevel?: ToolApprovalLevel;
@@ -123,6 +133,8 @@ async function buildAllTools(
 ) {
   const {
     provider,
+    imageProvider,
+    deepResearchProvider,
     organization,
     models,
     toolApprovalLevel = "auto",
@@ -264,18 +276,24 @@ async function buildAllTools(
       ctx,
     );
   }
-  // generate_image requires a provider and an image model selection
-  if (provider && models.image) {
+  // generate_image requires a provider and an image model selection.
+  // The provider is picked from `imageProvider` so the org can pair the
+  // image tier with a different credential than the chat tier (caller
+  // aliases it to `provider` when they share a credential).
+  if (imageProvider && models.image) {
     tools.generate_image = createGenerateImageTool(writer, {
-      provider,
+      provider: imageProvider,
       imageModelInfo: models.image,
       ctx,
     });
   }
-  // web_search requires a provider and a deep-research model
-  if (provider && models.deepResearch) {
+  // web_search requires a provider and a deep-research model.
+  // The provider is picked from `deepResearchProvider` so the deep
+  // research tier can use Gemini's async research API even when the
+  // chat model is served by another provider (e.g. LiteLLM).
+  if (deepResearchProvider && models.deepResearch) {
     tools.web_search = createWebSearchTool(writer, {
-      provider,
+      provider: deepResearchProvider,
       deepResearchModelInfo: models.deepResearch,
       ctx,
       toolOutputMap,

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/instrument-built-ins.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/instrument-built-ins.test.ts
@@ -15,6 +15,8 @@ import { instrumentBuiltIns, type BuiltinToolParams } from "./index";
 
 const mockParams: BuiltinToolParams = {
   provider: null,
+  imageProvider: null,
+  deepResearchProvider: null,
   organization: { id: "org_test" } as never,
   models: { connectionId: "conn_test", thinking: { id: "m" } } as never,
   toolOutputMap: new Map(),

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/registration.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/registration.test.ts
@@ -7,8 +7,11 @@
 import { describe, expect, test } from "bun:test";
 import { getBuiltInTools, type BuiltinToolParams } from "./index";
 
+const mockProvider = { thinkingModel: {} as never } as never;
 const mockParams: BuiltinToolParams = {
-  provider: { thinkingModel: {} as never } as never,
+  provider: mockProvider,
+  imageProvider: mockProvider,
+  deepResearchProvider: mockProvider,
   organization: { id: "org_test" } as never,
   models: {
     connectionId: "conn_test",

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/user-ask.e2e.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/user-ask.e2e.test.ts
@@ -19,8 +19,11 @@ import {
   userAskTool,
 } from "./user-ask";
 
+const mockProvider = { thinkingModel: {} as never } as never;
 const mockParams: BuiltinToolParams = {
-  provider: { thinkingModel: {} as never } as never,
+  provider: mockProvider,
+  imageProvider: mockProvider,
+  deepResearchProvider: mockProvider,
   organization: { id: "org_test" } as never,
   models: {
     connectionId: "conn_test",

--- a/apps/mesh/src/harnesses/decopilot/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/index.ts
@@ -63,6 +63,15 @@ interface ClusterProcessLocal {
   registrySignal: AbortSignal;
   runRegistry: RunRegistry;
   provider: MeshProvider | null;
+  /** Provider used for `generate_image`. Aliases `provider` when the org
+   *  `image` tier shares the chat credential (or no tier is configured). */
+  imageProvider: MeshProvider | null;
+  /** Provider used for `web_search`'s deep research path. Aliases
+   *  `provider` when the org `web_research` tier shares the chat
+   *  credential (or no tier is configured). Decoupling lets web_search
+   *  keep working when the chat model is routed via LiteLLM/OpenRouter
+   *  but the deep research tier is still Gemini. */
+  deepResearchProvider: MeshProvider | null;
   registerPendingOp: (op: Promise<void>) => void;
   isStreamFinished: () => boolean;
   onUsageAggregated: (totalUsage: {
@@ -161,6 +170,8 @@ export const decopilotHarnessFactory: HarnessFactory = {
           pendingImages: pl.pendingImages,
           threadId: pl.threadId,
           provider: pl.provider,
+          imageProvider: pl.imageProvider ?? pl.provider,
+          deepResearchProvider: pl.deepResearchProvider ?? pl.provider,
           htmlPageBuffer: pl.htmlPageBuffer,
         });
 

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -97,6 +97,13 @@ export interface AssembleDecopilotToolsExtras {
    *  activates this in advance — `null` is rejected by `getBuiltInTools`
    *  for tools that require it, but we forward whatever the caller has. */
   provider: MeshProvider | null;
+  /** Provider for `generate_image`. Caller passes the chat provider when
+   *  the org's `image` tier shares the chat credential. */
+  imageProvider: MeshProvider | null;
+  /** Provider for `web_search`'s deep-research path. Caller passes the
+   *  chat provider when the org's `web_research` tier shares the chat
+   *  credential. */
+  deepResearchProvider: MeshProvider | null;
   /** Per-turn HTML-page coalescing buffer. Created in dispatch-run.ts
    *  alongside `pendingOps` so the dispatch layer can also schedule a
    *  flush at step-end. */
@@ -191,6 +198,8 @@ export async function assembleDecopilotTools(
       extras.writer,
       {
         provider: extras.provider,
+        imageProvider: extras.imageProvider,
+        deepResearchProvider: extras.deepResearchProvider,
         organization,
         models: input.models,
         toolApprovalLevel: input.toolApprovalLevel,

--- a/apps/mesh/src/harnesses/types.ts
+++ b/apps/mesh/src/harnesses/types.ts
@@ -43,8 +43,8 @@ export interface ModelsConfig {
   thinking: ModelSelection;
   coding?: ModelSelection;
   fast?: ModelSelection;
-  image?: ModelSelection;
-  deepResearch?: ModelSelection;
+  image?: ModelSelection & { credentialId: string };
+  deepResearch?: ModelSelection & { credentialId: string };
 }
 
 /** UI-shape message a harness receives. Structurally compatible with the
@@ -112,6 +112,20 @@ export interface HarnessProcessLocal {
    *  before invoking us. The decopilot harness rejects `null`; CLI
    *  harnesses don't read this field. Cluster-only type. */
   provider: unknown | null;
+
+  /** Already-activated MeshProvider for the `generate_image` tool. May
+   *  alias `provider` when the org's `image` tier uses the same credential
+   *  as the chat (or no image tier is configured). Distinct activation
+   *  when admin pairs image with a different key. Cluster-only type. */
+  imageProvider?: unknown | null;
+
+  /** Already-activated MeshProvider for the `web_search` tool's deep
+   *  research path. May alias `provider` when the org's `web_research`
+   *  tier uses the same credential as the chat (or no tier is
+   *  configured). Decoupling lets web_search keep using Gemini's async
+   *  research API even when the chat model is routed via LiteLLM/OpenRouter.
+   *  Cluster-only type. */
+  deepResearchProvider?: unknown | null;
 
   /** Push callback for title-generation work. The streamText loop
    *  registers `titleHandle.promise.then(...)` as a pending op so the


### PR DESCRIPTION
## What is this contribution about?

Self-hosted customer reported `web_search` failing when the chat model was routed through LiteLLM, even with a Gemini key configured on the org's `web_research` tier. Root cause: `dispatchRunAndWait` activated a single `MeshProvider` from the chat credential and reused it for every built-in tool, so when the chat provider was LiteLLM (or any provider without `asyncResearch`), `web_search` fell back to a tool-less `streamText` call and returned no grounding. `resolvePerRequestModels` already resolved the `web_research` and `image` tier credentials but discarded them in `toModelInfo`. This PR plumbs those credentialIds through `ModelsConfig` → `dispatchRunAndWait` (parallel-activates a second provider when the tier credential differs from chat) → `HarnessProcessLocal` → `BuiltinToolParams`, so `generate_image` and `web_search` use the right provider regardless of what the chat model is. When the tier shares the chat credential (or no tier is configured), the chat provider is reused — no extra activation, no behavior change for the baseline case.

## How to Test

1. In an org, configure two AI provider keys: set the chat tier to a LiteLLM key (or any non-Gemini provider) and the `web_research` tier to a Gemini key with `deep-research-pro-preview-12-2025`.
2. Open chat, ensure the chat model is the LiteLLM one, and send "Pesquise as notícias de hoje" (or any prompt that triggers `web_search`).
3. Expected: `web_search` enters the durable async-research path (a row appears in `async_research_jobs`) and the tool call returns a report with citations. Baseline (chat = Gemini, web_research = Gemini) keeps working unchanged.

## Migration Notes

No DB migration. Persisted runs from before this change keep working: `PersistedToolModelInfoSchema.credentialId` is optional, and `toModelsConfig` falls back to the chat credential when the per-tier credentialId is absent (matches the legacy single-provider behavior on resume).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (bun run check + affected unit tests pass)
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `web_search` failing when chat uses `LiteLLM` by decoupling deep-research and image providers from chat. Also enforces role-based access to `image` and `web_research` tiers so only allowed keys/models are used.

- **Bug Fixes**
  - Preserve per-tier `credentialId` for `image`/`deepResearch` in `ModelsConfig`, routes, automations, and persisted runs.
  - Activate separate providers only when a tier’s credential differs from chat; plumb `imageProvider`/`deepResearchProvider` into the Decopilot harness and built-in tools. `generate_image`/`web_search` use them; reuse chat when credentials match.
  - Enforce permissions with `filterToolTiersByPermission`: silently drop `image`/`deepResearch` tiers not allowed for the user’s role at HTTP entry and in dispatch (resume/automation). Chat stays a hard 403 when not permitted.

- **Migration**
  - No DB changes. Old runs without per-tier credentials fall back to the chat credential on resume.

<sup>Written for commit 077e53095c4a547e3296c61dcd86d84d4f21ebe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3529?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

