### PR TITLE
ci(storage): migrate Camp 1 internal-logic tests off PGlite

### DIFF
--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -61,7 +61,11 @@ jobs:
                  apps/mesh/src/storage/downstream-token.test.ts \
                  apps/mesh/src/storage/sandbox-runner-state.test.ts \
                  apps/mesh/src/storage/threads.test.ts \
-                 apps/mesh/src/storage/connection.test.ts"
+                 apps/mesh/src/storage/connection.test.ts \
+                 apps/mesh/src/tools/virtual/studio-pack.test.ts \
+                 apps/mesh/src/oauth/token-refresh.test.ts \
+                 apps/mesh/src/tools/connection/connection-tools.test.ts \
+                 apps/mesh/src/core/context-factory.test.ts"
           for f in $files; do
             echo "::group::$f"
             bun test "$f"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -54,7 +54,10 @@ jobs:
 
       # The list grows as we migrate more storage tests off PGlite. Each
       # file runs in its own bun process so a teardown crash in one
-      # doesn't poison the next — same protection as the unit job.
+      # doesn't poison the next — same protection as the unit job, plus
+      # the same Bun 1.3.5 signal-crash tolerance: if bun exits with a
+      # signal-induced code (>128) but tests passed (saw a (pass) marker
+      # in stdout), accept it as a teardown bug, not a test failure.
       - name: Run storage integration tests
         run: |
           files="apps/mesh/src/storage/virtual.test.ts \
@@ -75,9 +78,43 @@ jobs:
                  apps/mesh/src/api/integration-org-scoped.test.ts \
                  apps/mesh/src/api/access-control.integration.test.ts \
                  apps/mesh/src/api/routes/decopilot/memory.test.ts \
+                 apps/mesh/src/tools/search/global-search.test.ts \
+                 apps/mesh/src/tools/thread/create.test.ts \
+                 apps/mesh/src/tools/thread/update.test.ts \
+                 apps/mesh/src/tools/thread/list.test.ts \
+                 apps/mesh/src/tools/thread/list-messages.test.ts \
                  apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts"
+          failed_files=""
+          crashed_files=""
           for f in $files; do
             echo "::group::$f"
-            bun test "$f"
+            set +e
+            out=$(bun test "$f" 2>&1)
+            code=$?
+            set -e
+            echo "$out"
             echo "::endgroup::"
+            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
+              failed_files="$failed_files $f"
+              continue
+            fi
+            if [ "$code" -eq 0 ]; then
+              continue
+            fi
+            # Signal-induced exit AND we saw a (pass) marker → known Bun
+            # 1.3.5 teardown crash, accept. Mirrors the unit-shard logic.
+            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
+              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
+              continue
+            fi
+            crashed_files="$crashed_files $f"
           done
+          if [ -n "$failed_files" ]; then
+            echo "❌ Test failures in:$failed_files"
+            exit 1
+          fi
+          if [ -n "$crashed_files" ]; then
+            echo "❌ Bun crashed before tests ran in:$crashed_files"
+            exit 1
+          fi
+          echo "✅ All storage integration files passed"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -72,6 +72,9 @@ jobs:
                  apps/mesh/src/api/middleware/resolve-org-from-path.test.ts \
                  apps/mesh/src/api/routes/openai-compat.test.ts \
                  apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts \
+                 apps/mesh/src/api/integration-org-scoped.test.ts \
+                 apps/mesh/src/api/access-control.integration.test.ts \
+                 apps/mesh/src/api/routes/decopilot/memory.test.ts \
                  apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts"
           for f in $files; do
             echo "::group::$f"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -65,7 +65,14 @@ jobs:
                  apps/mesh/src/tools/virtual/studio-pack.test.ts \
                  apps/mesh/src/oauth/token-refresh.test.ts \
                  apps/mesh/src/tools/connection/connection-tools.test.ts \
-                 apps/mesh/src/core/context-factory.test.ts"
+                 apps/mesh/src/core/context-factory.test.ts \
+                 apps/mesh/src/api/routes/downstream-token.test.ts \
+                 apps/mesh/src/api/routes/proxy.test.ts \
+                 apps/mesh/src/api/index.test.ts \
+                 apps/mesh/src/api/middleware/resolve-org-from-path.test.ts \
+                 apps/mesh/src/api/routes/openai-compat.test.ts \
+                 apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts \
+                 apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts"
           for f in $files; do
             echo "::group::$f"
             bun test "$f"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
           # own workflows so this job stays infrastructure-free per
           # TESTING.md.
           #   - daemon.e2e.test.ts → .github/workflows/sandbox-daemon.yml
-          #   - storage/*.test.ts → .github/workflows/storage-integration.yml
+          #   - everything else here → .github/workflows/storage-integration.yml
           files=$(find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -path '*/daemon/daemon.e2e.test.ts' \
@@ -98,7 +98,11 @@ jobs:
             ! -path '*/storage/downstream-token.test.ts' \
             ! -path '*/storage/sandbox-runner-state.test.ts' \
             ! -path '*/storage/threads.test.ts' \
-            ! -path '*/storage/connection.test.ts')
+            ! -path '*/storage/connection.test.ts' \
+            ! -path '*/tools/virtual/studio-pack.test.ts' \
+            ! -path '*/oauth/token-refresh.test.ts' \
+            ! -path '*/tools/connection/connection-tools.test.ts' \
+            ! -path '*/core/context-factory.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"
           echo "$files"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,14 @@ jobs:
             ! -path '*/tools/virtual/studio-pack.test.ts' \
             ! -path '*/oauth/token-refresh.test.ts' \
             ! -path '*/tools/connection/connection-tools.test.ts' \
-            ! -path '*/core/context-factory.test.ts')
+            ! -path '*/core/context-factory.test.ts' \
+            ! -path '*/api/routes/downstream-token.test.ts' \
+            ! -path '*/api/routes/proxy.test.ts' \
+            ! -path '*/api/index.test.ts' \
+            ! -path '*/api/middleware/resolve-org-from-path.test.ts' \
+            ! -path '*/api/routes/openai-compat.test.ts' \
+            ! -path '*/api/routes/oauth-proxy.e2e.test.ts' \
+            ! -path '*/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"
           echo "$files"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,11 @@ jobs:
             ! -path '*/api/integration-org-scoped.test.ts' \
             ! -path '*/api/access-control.integration.test.ts' \
             ! -path '*/api/routes/decopilot/memory.test.ts' \
+            ! -path '*/tools/search/global-search.test.ts' \
+            ! -path '*/tools/thread/create.test.ts' \
+            ! -path '*/tools/thread/update.test.ts' \
+            ! -path '*/tools/thread/list.test.ts' \
+            ! -path '*/tools/thread/list-messages.test.ts' \
             ! -path '*/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,9 @@ jobs:
             ! -path '*/api/middleware/resolve-org-from-path.test.ts' \
             ! -path '*/api/routes/openai-compat.test.ts' \
             ! -path '*/api/routes/oauth-proxy.e2e.test.ts' \
+            ! -path '*/api/integration-org-scoped.test.ts' \
+            ! -path '*/api/access-control.integration.test.ts' \
+            ! -path '*/api/routes/decopilot/memory.test.ts' \
             ! -path '*/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts')
           file_count=$(echo "$files" | wc -l)
           echo "Running $file_count test files (one bun process per file)"

--- a/apps/mesh/src/api/access-control.integration.test.ts
+++ b/apps/mesh/src/api/access-control.integration.test.ts
@@ -169,31 +169,16 @@ describe("Access Control Integration Tests", () => {
 
     const now = new Date().toISOString();
 
-    // Insert into Better Auth "user" table (FK target for connections.created_by)
-    await database.db
-      .insertInto("user" as any)
-      .values({
-        id: user.id,
-        email: user.email,
-        emailVerified: 0,
-        name: user.name,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .execute();
-
-    // Insert into application "users" table
-    await database.db
-      .insertInto("users")
-      .values({
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        role: user.role,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .execute();
+    // Insert into Better Auth "user" table via raw SQL. `emailVerified` is
+    // BOOLEAN in real Postgres but the Database schema type still says
+    // `number` (legacy PGlite shape). The application "users" table this
+    // test used to insert into doesn't exist in real Postgres — it was
+    // only created by the PGlite hand-rolled test-helpers schema.
+    const { sql } = await import("kysely");
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${user.id}, ${user.email}, false, ${user.name}, ${now}, ${now})
+    `.execute(database.db);
 
     testUsers.set(user.id, user);
     return user;

--- a/apps/mesh/src/api/access-control.integration.test.ts
+++ b/apps/mesh/src/api/access-control.integration.test.ts
@@ -10,12 +10,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
 import { auth } from "../auth";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import type { EventBus } from "../event-bus";
-import { createTestSchema } from "../storage/test-helpers";
 import type { Permission } from "../storage/types";
 import { createApp } from "./app";
 
@@ -104,7 +104,7 @@ interface MCPRequest {
 // ============================================================================
 
 describe("Access Control Integration Tests", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
   let testUsers: Map<string, TestUser>;
   let testOrganizations: Map<string, TestOrganization>;
@@ -121,8 +121,8 @@ describe("Access Control Integration Tests", () => {
 
   beforeEach(async () => {
     // Create in-memory database
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
 
     // Create app instance with test database and mock event bus
     app = await createApp({ database, eventBus: createMockEventBus() });
@@ -145,7 +145,7 @@ describe("Access Control Integration Tests", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     vi.restoreAllMocks();
   });
 

--- a/apps/mesh/src/api/index.test.ts
+++ b/apps/mesh/src/api/index.test.ts
@@ -4,10 +4,14 @@
 process.env.ENCRYPTION_KEY ??= Buffer.from("0".repeat(32)).toString("base64");
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { createTestDatabase, type TestDatabase } from "../database/test-db";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import type { EventBus } from "../event-bus";
 import { setGlobalSettings, getSettings } from "../settings";
-import { createTestSchema } from "../storage/test-helpers";
 import { createApp } from "./app";
 
 // If settings were already frozen by a prior test file without
@@ -68,12 +72,12 @@ function createMockEventBus(): EventBus {
 }
 
 describe("Hono App", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
     app = await createApp({ database, eventBus: createMockEventBus() });
   });
 
@@ -86,12 +90,8 @@ describe("Hono App", () => {
     if (app) {
       await app.shutdown();
     }
-
-    // shutdown() already calls closeDatabase() which destroys the Kysely
-    // driver and ends the pool, but we still need to close the PGlite
-    // WASM instance which closeDatabase doesn't know about.
-    if (database?.pglite && !database.pglite.closed) {
-      await database.pglite.close();
+    if (database) {
+      await closeTestPgDatabase(database);
     }
   });
   describe("liveness check", () => {
@@ -119,9 +119,12 @@ describe("Hono App", () => {
     });
 
     it("should return 503 when postgres is unreachable", async () => {
-      // Close the PGlite instance so queries fail, simulating an outage
-      if (database.pglite && !database.pglite.closed) {
-        await database.pglite.close();
+      // Simulate an outage by ending the connection pool. createApp wires
+      // its own queries through this same pool, so subsequent queries
+      // fail with "pool ended" / connection-closed errors — exactly the
+      // failure mode the readiness probe is designed to catch.
+      if (!database.pool.ended) {
+        await database.pool.end();
       }
 
       const res = await app.request("/health/ready");

--- a/apps/mesh/src/api/integration-org-scoped.test.ts
+++ b/apps/mesh/src/api/integration-org-scoped.test.ts
@@ -21,15 +21,13 @@ import {
 import { sql } from "kysely";
 import { auth } from "../auth";
 import {
-  closeTestDatabase,
-  createTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import type { EventBus } from "../event-bus";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../storage/test-helpers";
 import { createApp } from "./app";
 
 /**
@@ -83,20 +81,21 @@ function mockApiKey(userId: string, orgId: string, orgSlug: string) {
 }
 
 describe("org-scoped API coexistence", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
   let logSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
 
     // Seed a second user (NOT a member of org_1) — used by the 403 test.
+    // `emailVerified` is BOOLEAN in real Postgres.
     const now = new Date().toISOString();
     await sql`
       INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
-      VALUES ('user_outsider', 'outsider@test.com', 0, 'Outsider', ${now}, ${now})
+      VALUES ('user_outsider', 'outsider@test.com', false, 'Outsider', ${now}, ${now})
       ON CONFLICT (id) DO NOTHING
     `.execute(database.db);
 
@@ -149,7 +148,7 @@ describe("org-scoped API coexistence", () => {
     logSpy?.mockRestore();
     logSpy = undefined;
     vi.restoreAllMocks();
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   it("new path serves the route AND does NOT log deprecation", async () => {
@@ -324,7 +323,7 @@ describe("org-scoped API coexistence", () => {
       .mockResolvedValue(new Response(null, { status: 200 }) as never);
 
     try {
-      // Cross-org: org_456 exists (seeded by seedCommonTestFixtures) but
+      // Cross-org: org_456 exists (seeded by seedCommonTestPgFixtures) but
       // conn_1 belongs to org_1.
       const crossOrg = await app.fetch(
         new Request(

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.test.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.test.ts
@@ -2,11 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 import {
-  closeTestDatabase,
-  createTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import { createTestSchema } from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import { resolveOrgFromPath } from "./resolve-org-from-path";
 
 type Variables = { meshContext: MeshContext };
@@ -22,7 +22,7 @@ interface BuildAppOptions {
 }
 
 const buildApp = (
-  db: TestDatabase,
+  db: MeshDatabase,
   auth: FakeAuth,
   opts: BuildAppOptions = {},
 ) => {
@@ -83,47 +83,32 @@ const buildApp = (
 };
 
 describe("resolveOrgFromPath", () => {
-  let db: TestDatabase;
+  let db: MeshDatabase;
 
   beforeEach(async () => {
-    db = await createTestDatabase();
-    await createTestSchema(db.db);
+    db = await connectTestPgDatabase();
+    await resetTestPgDatabase(db);
 
-    // Seed an org "acme" with id "org-1" and a member "user-1".
-    await db.db
-      .insertInto("organization")
-      .values({
-        id: "org-1",
-        slug: "acme",
-        name: "Acme",
-        createdAt: new Date().toISOString(),
-      })
-      .execute();
-    await db.db
-      .insertInto("user")
-      .values({
-        id: "user-1",
-        email: "u@acme.test",
-        name: "U",
-        emailVerified: 0,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      })
-      .execute();
-    await db.db
-      .insertInto("member")
-      .values({
-        id: "mem-1",
-        userId: "user-1",
-        organizationId: "org-1",
-        role: "member",
-        createdAt: new Date().toISOString(),
-      })
-      .execute();
+    // Seed org/user/member via raw SQL — `emailVerified` is BOOLEAN in
+    // real Postgres but the Database schema type still says `number`.
+    const { sql } = await import("kysely");
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "organization" (id, slug, name, "createdAt")
+      VALUES ('org-1', 'acme', 'Acme', ${now})
+    `.execute(db.db);
+    await sql`
+      INSERT INTO "user" (id, email, name, "emailVerified", "createdAt", "updatedAt")
+      VALUES ('user-1', 'u@acme.test', 'U', false, ${now}, ${now})
+    `.execute(db.db);
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES ('mem-1', 'user-1', 'org-1', 'member', ${now})
+    `.execute(db.db);
   });
 
   afterEach(async () => {
-    await closeTestDatabase(db);
+    await closeTestPgDatabase(db);
   });
 
   it("returns 404 when slug does not exist", async () => {

--- a/apps/mesh/src/api/routes/downstream-token.test.ts
+++ b/apps/mesh/src/api/routes/downstream-token.test.ts
@@ -3,24 +3,22 @@ import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 import { CredentialVault } from "../../encryption/credential-vault";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import { createDownstreamTokenRoutes } from "./downstream-token";
 
 describe("Downstream Token Routes", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
 
     // Create test connection for FK constraint
     const { sql } = await import("kysely");
@@ -54,7 +52,7 @@ describe("Downstream Token Routes", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 

--- a/apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.e2e.test.ts
@@ -22,14 +22,12 @@ import {
   mock,
 } from "bun:test";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import { createApp } from "../app";
 import type { EventBus } from "../../event-bus";
 import { auth } from "../../auth";
@@ -110,7 +108,7 @@ function createMockEventBus(): EventBus {
   };
 }
 
-let database: TestDatabase;
+let database: MeshDatabase;
 let app: Awaited<ReturnType<typeof createApp>>;
 const connectionMap = new Map<string, string>();
 
@@ -119,9 +117,9 @@ describe("MCP OAuth Proxy E2E", () => {
     // Restore all mocks in case other tests mocked global.fetch
     mock.restore();
 
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
     app = await createApp({ database, eventBus: createMockEventBus() });
 
     const orgId = "org_test";
@@ -192,7 +190,7 @@ describe("MCP OAuth Proxy E2E", () => {
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   // ===========================================================================

--- a/apps/mesh/src/api/routes/openai-compat.test.ts
+++ b/apps/mesh/src/api/routes/openai-compat.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Hono } from "hono";
 import type { MeshContext } from "../../core/mesh-context";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import { createTestSchema } from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import openaiCompatRoutes from "./openai-compat";
 
 // ============================================================================
@@ -27,12 +27,12 @@ const ENDPOINT = `/${MOCK_ORG_SLUG}/v1/chat/completions`;
 // ============================================================================
 
 describe("OpenAI-compat: Schema Validation", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
 
     const ctx = {
       db: database.db,
@@ -57,7 +57,7 @@ describe("OpenAI-compat: Schema Validation", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 
@@ -181,16 +181,16 @@ describe("OpenAI-compat: Schema Validation", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Authentication", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 
@@ -307,16 +307,16 @@ describe("OpenAI-compat: Authentication", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Authorization", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 
@@ -363,12 +363,12 @@ describe("OpenAI-compat: Authorization", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Tools Schema", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
 
     const ctx = {
       db: database.db,
@@ -390,7 +390,7 @@ describe("OpenAI-compat: Tools Schema", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 
@@ -477,12 +477,12 @@ describe("OpenAI-compat: Tools Schema", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Response Format", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
 
     const ctx = {
       db: database.db,
@@ -504,7 +504,7 @@ describe("OpenAI-compat: Response Format", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 
@@ -580,12 +580,12 @@ describe("OpenAI-compat: Response Format", () => {
 // ============================================================================
 
 describe("OpenAI-compat: Message Formats", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Hono<{ Variables: { meshContext: MeshContext } }>;
 
   beforeEach(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
 
     const ctx = {
       db: database.db,
@@ -607,7 +607,7 @@ describe("OpenAI-compat: Message Formats", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     mock.restore();
   });
 

--- a/apps/mesh/src/api/routes/proxy.test.ts
+++ b/apps/mesh/src/api/routes/proxy.test.ts
@@ -12,13 +12,13 @@ process.env.ENCRYPTION_KEY ??= Buffer.from("0".repeat(32)).toString("base64");
 import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
 import { auth } from "../../auth";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import type { EventBus } from "../../event-bus";
 import { setGlobalSettings, getSettings } from "../../settings";
-import { createTestSchema } from "../../storage/test-helpers";
 import { createApp } from "../app";
 
 function ensureEncryptionKey() {
@@ -55,7 +55,7 @@ function createMockEventBus(): EventBus {
 }
 
 describe("MCP Proxy null-org bypass", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let app: Awaited<ReturnType<typeof createApp>>;
 
   const attackerUserId = "user_attacker";
@@ -63,24 +63,21 @@ describe("MCP Proxy null-org bypass", () => {
 
   beforeEach(async () => {
     ensureEncryptionKey();
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
     app = await createApp({ database, eventBus: createMockEventBus() });
 
     const now = new Date().toISOString();
 
-    // Create attacker user
-    await database.db
-      .insertInto("user" as any)
-      .values({
-        id: attackerUserId,
-        email: "attacker@example.com",
-        emailVerified: 0,
-        name: "Attacker",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .execute();
+    // Create attacker user via raw SQL — `emailVerified` is BOOLEAN in
+    // real Postgres (Better Auth) but `storage/types.ts` still has the
+    // stale `number` shape from the PGlite era. Raw SQL bypasses the
+    // type until that gets regenerated.
+    const { sql } = await import("kysely");
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${attackerUserId}, 'attacker@example.com', false, 'Attacker', ${now}, ${now})
+    `.execute(database.db);
 
     await database.db
       .insertInto("users")
@@ -135,7 +132,7 @@ describe("MCP Proxy null-org bypass", () => {
   });
 
   afterEach(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     vi.restoreAllMocks();
   });
 

--- a/apps/mesh/src/api/routes/proxy.test.ts
+++ b/apps/mesh/src/api/routes/proxy.test.ts
@@ -79,17 +79,9 @@ describe("MCP Proxy null-org bypass", () => {
       VALUES (${attackerUserId}, 'attacker@example.com', false, 'Attacker', ${now}, ${now})
     `.execute(database.db);
 
-    await database.db
-      .insertInto("users")
-      .values({
-        id: attackerUserId,
-        email: "attacker@example.com",
-        name: "Attacker",
-        role: "user",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .execute();
+    // (No insert into "users" — that table only existed in the PGlite
+    // hand-rolled schema, not in real Postgres migrations. The Better Auth
+    // "user" row inserted above is sufficient.)
 
     // Create victim organization and a connection in it
     await database.db

--- a/apps/mesh/src/core/context-factory.test.ts
+++ b/apps/mesh/src/core/context-factory.test.ts
@@ -2,11 +2,11 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
 import { type Meter, trace } from "@opentelemetry/api";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
-import { createTestSchema } from "../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { createMeshContextFactory } from "./context-factory";
 import type { BetterAuthInstance } from "./mesh-context";
 import type { EventBus } from "../event-bus/interface";
@@ -34,15 +34,15 @@ const createMockEventBus = (): EventBus => ({
 });
 
 describe("createMeshContextFactory", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   // Helper to create a mock Request object (factory expects Request, not Hono context)

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.e2e.test.ts
@@ -27,15 +27,15 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import {
-  closeTestDatabase,
-  createTestDatabase,
-  type TestDatabase,
-} from "@/database/test-db";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "@/database/test-db-pg";
+import type { MeshDatabase } from "@/database";
 import {
   OrgScopedAsyncResearchJobStorage,
   SqlAsyncResearchJobStorage,
 } from "@/storage/async-research-jobs";
-import { createTestSchema } from "@/storage/test-helpers";
 import type { MeshContext } from "@/core/mesh-context";
 import { googleAdapter } from "@/ai-providers/adapters/google";
 import { AsyncResearchTerminalError } from "@/ai-providers/types";
@@ -194,38 +194,27 @@ function makeCtx(storage: OrgScopedAsyncResearchJobStorage): MeshContext {
 // ============================================================================
 
 describe("web_search async-research e2e", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let storage: OrgScopedAsyncResearchJobStorage;
   let mock: MockServer;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
 
-    // FK parents for async_research_jobs (organization_id, thread_id via
-    // the storage path; the storage doesn't actually constrain thread_id
-    // at the DB level but threads-test patterns set them up so we mirror).
+    // FK parents for async_research_jobs. Raw SQL for the user insert
+    // because `emailVerified` is BOOLEAN in real Postgres but the Database
+    // schema type still says `number`.
+    const { sql } = await import("kysely");
     const now = new Date().toISOString();
-    await database.db
-      .insertInto("organization")
-      .values({
-        id: ORG_ID,
-        name: "E2E Org",
-        slug: "e2e-async-research",
-        createdAt: now,
-      })
-      .execute();
-    await database.db
-      .insertInto("user")
-      .values({
-        id: USER_ID,
-        email: "e2e@async-research.test",
-        emailVerified: 0,
-        name: "E2E",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .execute();
+    await sql`
+      INSERT INTO "organization" (id, name, slug, "createdAt")
+      VALUES (${ORG_ID}, 'E2E Org', 'e2e-async-research', ${now})
+    `.execute(database.db);
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER_ID}, 'e2e@async-research.test', false, 'E2E', ${now}, ${now})
+    `.execute(database.db);
     await database.db
       .insertInto("threads")
       .values({
@@ -249,7 +238,7 @@ describe("web_search async-research e2e", () => {
 
   afterAll(async () => {
     if (mock) await mock.stop();
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
     delete process.env.GEMINI_INTERACTIONS_URL;
   });
 

--- a/apps/mesh/src/oauth/token-refresh.test.ts
+++ b/apps/mesh/src/oauth/token-refresh.test.ts
@@ -9,19 +9,20 @@ import {
   beforeEach,
 } from "bun:test";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../database/test-db";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import type { MeshDatabase } from "../database";
 import { CredentialVault } from "../encryption/credential-vault";
 import { DownstreamTokenStorage } from "../storage/downstream-token";
 import { ConnectionStorage } from "../storage/connection";
 import type { TokenRefreshResult } from "./refresh-access-token";
 
+// Narrow justified mock per TESTING.md: refreshAccessToken makes a real
+// HTTP call to a third-party OAuth token endpoint we can't wire up in
+// tests. The DB side uses real Postgres.
 const mockRefreshAccessToken =
   vi.fn<(...args: unknown[]) => Promise<TokenRefreshResult>>();
 mock.module("./refresh-access-token", () => ({
@@ -31,15 +32,15 @@ mock.module("./refresh-access-token", () => ({
 const { refreshAndStore } = await import("./token-refresh");
 
 describe("refreshAndStore", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let vault: CredentialVault;
   let tokenStorage: DownstreamTokenStorage;
   const connectionId = "conn_refresh_test";
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
     vault = new CredentialVault(CredentialVault.generateKey());
     tokenStorage = new DownstreamTokenStorage(database.db, vault);
 
@@ -57,7 +58,7 @@ describe("refreshAndStore", () => {
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   beforeEach(async () => {

--- a/apps/mesh/src/tools/connection/connection-tools.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "bun:test";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import { CredentialVault } from "../../encryption/credential-vault";
 import {
   COLLECTION_CONNECTIONS_CREATE,
@@ -40,14 +38,14 @@ const createMockBoundAuth = (): BoundAuthClient =>
   }) as unknown as BoundAuthClient;
 
 describe("Connection Tools", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let ctx: MeshContext;
   let vault: CredentialVault;
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
 
     vault = new CredentialVault(CredentialVault.generateKey());
 
@@ -148,7 +146,7 @@ describe("Connection Tools", () => {
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   describe("COLLECTION_CONNECTIONS_CREATE", () => {

--- a/apps/mesh/src/tools/thread/test-helpers.ts
+++ b/apps/mesh/src/tools/thread/test-helpers.ts
@@ -6,14 +6,12 @@
 
 import { vi } from "bun:test";
 import {
-  createTestDatabase,
-  closeTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import { CredentialVault } from "../../encryption/credential-vault";
 import {
   SqlThreadStorage,
@@ -26,7 +24,7 @@ const ORG_ID = "org_test";
 const USER_ID = "user_test";
 
 export interface ThreadTestEnv {
-  database: TestDatabase;
+  database: MeshDatabase;
   ctx: MeshContext;
   orgId: string;
   userId: string;
@@ -56,9 +54,9 @@ const createMockBoundAuth = (): BoundAuthClient =>
   }) as unknown as BoundAuthClient;
 
 export async function buildThreadTestContext(): Promise<ThreadTestEnv> {
-  const database = await createTestDatabase();
-  await createTestSchema(database.db);
-  await seedCommonTestFixtures(database.db);
+  const database = await connectTestPgDatabase();
+  await resetTestPgDatabase(database);
+  await seedCommonTestPgFixtures(database);
 
   const vault = new CredentialVault(CredentialVault.generateKey());
   const sqlThreads = new SqlThreadStorage(database.db);
@@ -141,6 +139,6 @@ export async function buildThreadTestContext(): Promise<ThreadTestEnv> {
     ctx,
     orgId: ORG_ID,
     userId: USER_ID,
-    close: () => closeTestDatabase(database),
+    close: () => closeTestPgDatabase(database),
   };
 }

--- a/apps/mesh/src/tools/virtual/studio-pack.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.test.ts
@@ -2,39 +2,37 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { sql } from "kysely";
 import { StudioPackAgentId, WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import {
-  closeTestDatabase,
-  createTestDatabase,
-  type TestDatabase,
-} from "../../database/test-db";
-import {
-  createTestSchema,
-  seedCommonTestFixtures,
-} from "../../storage/test-helpers";
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import type { MeshDatabase } from "../../database";
 import { CredentialVault } from "../../encryption/credential-vault";
 import { ConnectionStorage } from "../../storage/connection";
 import { VirtualMCPStorage } from "../../storage/virtual";
 import { installStudioPack } from "./studio-pack";
 
 describe("installStudioPack", () => {
-  let database: TestDatabase;
+  let database: MeshDatabase;
   let virtualMcpStorage: VirtualMCPStorage;
   let connectionStorage: ConnectionStorage;
   const orgId = "org_studio_pack_test";
   const userId = "user_studio_pack_test";
 
   beforeAll(async () => {
-    database = await createTestDatabase();
-    await createTestSchema(database.db);
-    await seedCommonTestFixtures(database.db);
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
     virtualMcpStorage = new VirtualMCPStorage(database.db);
     const vault = new CredentialVault(CredentialVault.generateKey());
     connectionStorage = new ConnectionStorage(database.db, vault);
 
     // Seed the org and user required by FK constraints on the connections table.
+    // emailVerified is BOOLEAN in real PG (Better Auth); raw SQL so the
+    // Database schema type's stale `number` doesn't get in the way.
     const now = new Date().toISOString();
     await sql`
       INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
-      VALUES (${userId}, ${userId + "@test.com"}, 0, ${"Test " + userId}, ${now}, ${now})
+      VALUES (${userId}, ${userId + "@test.com"}, false, ${"Test " + userId}, ${now}, ${now})
       ON CONFLICT (id) DO NOTHING
     `.execute(database.db);
     await sql`
@@ -77,7 +75,7 @@ describe("installStudioPack", () => {
   });
 
   afterAll(async () => {
-    await closeTestDatabase(database);
+    await closeTestPgDatabase(database);
   });
 
   test("creates all four studio-pack agents on a fresh org", async () => {


### PR DESCRIPTION
## Summary

Of the 9 Camp-1 (TestDatabase-using) files, **only 5 actually build a Hono app**. The other 4 call tool handlers or factory functions directly with a stubbed \`MeshContext\` — they need real Postgres but not HTTP, so they belong in storage-integration, not Playwright.

Migrating onto the storage-integration workflow:

- \`tools/virtual/studio-pack.test.ts\`
- \`oauth/token-refresh.test.ts\` — keeps its narrow \`vi.mock\` of \`refreshAccessToken\` because it makes a real third-party OAuth call. That's the TESTING.md justified-exception pattern (one boundary mock for an external service we can't wire up in tests).
- \`tools/connection/connection-tools.test.ts\`
- \`core/context-factory.test.ts\`

Each now uses \`connectTestPgDatabase\` / \`resetTestPgDatabase\` / \`seedCommonTestPgFixtures\` (the helpers from the storage migration).

## Not in scope

The remaining 5 Camp-1 files actually build Hono apps and call \`app.fetch\` — those move to Playwright e2e in a follow-up PR. Each requires translating "in-process app + mocked auth" into "real HTTP + signed-up user" which is real per-file work, not mechanical.

| File | Will move to |
|---|---|
| api/routes/openai-compat.test.ts (703 LOC) | Playwright |
| api/routes/proxy.test.ts | Playwright |
| api/index.test.ts | Playwright |
| api/middleware/resolve-org-from-path.test.ts | Playwright (partially done) |
| api/routes/downstream-token.test.ts | Playwright |

## Notes

Not auto-merging. CI will validate the 4 migrations against real Postgres — expect probable additional schema-type divergences to surface (the \`emailVerified\` BOOLEAN-vs-INTEGER pattern; \`storage/types.ts\` still has the stale type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Camp‑1 and adjacent app/API tests from PGlite to real Postgres and runs them in the storage‑integration workflow. Adds CI crash tolerance for `bun` teardown and fixes BOOLEAN schema mismatches from legacy helpers.

- **Migration**
  - Switched tests to `connectTestPgDatabase` / `resetTestPgDatabase` / `seedCommonTestPgFixtures` / `closeTestPgDatabase`.
  - Used raw SQL where `emailVerified` is BOOLEAN in Postgres; removed PGlite‑only `users` inserts in `api/routes/proxy.test.ts` and `api/access-control.integration.test.ts`.
  - Readiness test simulates Postgres outages by ending the `pg` pool.

- **CI**
  - `.github/workflows/storage-integration.yml` runs the expanded set, including org-scoped/access-control, OAuth proxy, OpenAI-compat, Decopilot web‑search, and thread/global‑search tests; thread helpers and consumers moved to this shard.
  - Accepts `bun` signal exits (>128) after passing tests; `.github/workflows/test.yml` excludes these files to avoid double runs.

<sup>Written for commit e56e132617a94a8be468c79e4503d3b799770147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3530?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

