### PR TITLE
fix(links): WS gateway validates OAuth bearer (not just API keys)

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1789,9 +1789,29 @@ export async function createApp(options: CreateAppOptions = {}) {
     nats: gatewayNatsAdapter,
     podId: POD_ID,
     validateBearer: async (token) => {
-      const headers = new Headers({ authorization: `Bearer ${token}` });
-      const session = await auth.api.getSession({ headers });
-      return (session as { user?: { id?: string } } | null)?.user?.id ?? null;
+      // Production tokens are OAuth access tokens minted by the MCP OIDC
+      // provider (`decocms auth login`). `X-MCP-Session-Auth: true` tells the
+      // apiKey plugin to skip — otherwise its `customAPIKeyGetter` grabs the
+      // Bearer header and throws `INVALID_API_KEY` on non-key tokens. Build a
+      // fresh Headers so the marker is server-set, never client-trusted.
+      const headers = new Headers({
+        authorization: `Bearer ${token}`,
+        "X-MCP-Session-Auth": "true",
+      });
+      const mcp = (await auth.api
+        .getMcpSession({ headers })
+        .catch(() => null)) as { userId?: string } | null;
+      if (mcp?.userId) return mcp.userId;
+      // Dev fallback: `bootstrapDevLinkSession` stores a Better Auth API key
+      // as the bearer, since the local cluster has no OIDC flow.
+      const verified = (await auth.api
+        .verifyApiKey({ body: { key: token } })
+        .catch(() => null)) as {
+        valid?: boolean;
+        key?: { userId?: string };
+      } | null;
+      if (verified?.valid && verified.key?.userId) return verified.key.userId;
+      return null;
     },
   });
 


### PR DESCRIPTION
## Summary

The desktop link indicator stays grey for every production user. The
daemon's WS upgrade to `/api/links/connect` is rejected with 500 on
every connect attempt, the NATS `studio_links` KV bucket stays empty,
and `LINK_CURRENT_GET` always returns `{ online: false }`.

Production logs:

```
[5xx Response] GET /api/links/connect - 500: {"error":"Internal Server Error","message":"Invalid API key."}
Server error : APIError: Invalid API key.  code: "INVALID_API_KEY"
```

### Root cause

`bunx decocms link` reads `~/deco/session.json`, whose `accessToken` is
an OAuth access token minted by the MCP OIDC provider. The gateway's
`validateBearer` (`apps/mesh/src/api/app.ts:1791`) called
`auth.api.getSession`, which:

1. Doesn't validate OIDC access tokens — that's `getMcpSession`'s job.
2. Routes the Bearer header through the `apiKey` plugin's
   `customAPIKeyGetter` (`apps/mesh/src/auth/index.ts:258`), which
   pulls *any* `Authorization: Bearer …` value and tries to verify it
   as an API key. On non-key tokens it throws `INVALID_API_KEY` instead
   of returning null, so the WS upgrade dies with a 500.

The `apiKey` plugin already exposes an escape hatch: setting
`X-MCP-Session-Auth: true` makes `customAPIKeyGetter` return null and
fall through to OAuth validation. Every other MCP route in production
uses this pattern (`apps/mesh/src/core/context-factory.ts:507-516`),
the gateway just wasn't.

### Why dev wasn't affected

`bootstrapDevLinkSession` mints a Better Auth **API key** and stores
it as the bearer in the dev session file. The apiKey plugin happily
verifies it, so dev kept working through the wrong code path.

### Fix

- Build a fresh `Headers` with `Authorization: Bearer …` and the
  server-set `X-MCP-Session-Auth: true` marker. Fresh Headers (vs.
  copying `req.headers`) keeps the marker non-spoofable from the WS
  client side.
- Call `getMcpSession` to validate the OIDC access token.
- Fall back to `verifyApiKey` so the dev API-key path keeps working.

### Security implications

None new. `getMcpSession` is the same validator every authenticated
MCP route already uses. `X-MCP-Session-Auth: true` is set server-side
on a fresh Headers, so it can't be used as a bypass — it only tells the
apiKey plugin "don't try this one"; the request still has to pass OAuth
validation to succeed. No widened scope, no skipped check vs. today
(today nothing succeeds). The interesting risk — a stolen OAuth token
giving reverse access to the user's desktop daemon — is a property of
the link tunnel design, not of this patch.

## Test plan

- [ ] Pull this branch, deploy to a staging cluster
- [ ] `bunx decocms@latest link` against staging — daemon should print
      `Linked to <url>` and stay connected
- [ ] Header desktop icon shows the green pulse dot, tooltip lists
      capabilities
- [ ] `nats kv ls studio_links` shows a claim for the user
- [ ] Local `bun run dev` + auto-spawned link daemon still works
      (dev API-key fallback)
- [ ] No more `INVALID_API_KEY` 500s on `/api/links/connect` in mesh
      logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WS gateway auth so OAuth bearer tokens are accepted instead of being misread as API keys. Restores desktop link connections and removes 500s on `/api/links/connect`.

- **Bug Fixes**
  - Validate bearer via `auth.api.getMcpSession` using a fresh `Headers` with `Authorization` and `X-MCP-Session-Auth: true`.
  - Fallback to `auth.api.verifyApiKey` to keep dev sessions working.
  - Eliminates `INVALID_API_KEY` 500s and lets `LINK_CURRENT_GET` report `online: true`.

<sup>Written for commit 1d3968af8832f1e3ab9e4d7c86b9d1f89f76a53a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3533?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

