### PR TITLE
ci: upgrade Bun 1.3.5 → 1.3.14, fix DuckDB teardown crash, simplify workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -58,7 +58,7 @@ jobs:
         if: steps.tag-check.outputs.exists != 'true'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         if: steps.tag-check.outputs.exists != 'true'

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -56,77 +56,19 @@ jobs:
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
       #
-      # Per-file bun process + signal tolerance: heavy-DB integration
-      # tests still hit Bun teardown crashes (SIGSEGV/SIGILL/SIGABRT)
-      # after all tests pass — not fully fixed even in 1.3.14. If exit
-      # code > 128 AND we saw a (pass) marker, accept it as a Bun
-      # teardown bug, not a real failure. The unit job doesn't need
-      # this because pure-logic tests don't trigger the crash class.
+      # One bun process per file: cleanest isolation between heavy-DB
+      # files. The previous signal-tolerance branch (exit > 128 +
+      # (pass) marker → accept) is gone because the Bun teardown crash
+      # it caught was DuckDB's N-API finalizer — neutralized in code by
+      # the `monitoringEngines` stub in the context-factory test. CI
+      # confirmed no other test trips a teardown crash. If a real one
+      # ever shows up, it should fail loudly so we diagnose it instead
+      # of silently swallowing it.
       - name: Run storage integration tests
         run: |
-          failed_files=""
-          crashed_files=""
+          set -e
           while IFS= read -r f; do
             echo "::group::$f"
-            set +e
-            out=$(bun test "$f" 2>&1)
-            code=$?
-            set -e
-            echo "$out"
+            bun test "$f"
             echo "::endgroup::"
-            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
-              failed_files="$failed_files $f"
-              continue
-            fi
-            if [ "$code" -eq 0 ]; then
-              continue
-            fi
-            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
-              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
-              continue
-            fi
-            crashed_files="$crashed_files $f"
           done < <(find apps/mesh -name '*.integration.test.ts' | sort)
-          if [ -n "$failed_files" ]; then
-            echo "❌ Test failures in:$failed_files"
-            exit 1
-          fi
-          if [ -n "$crashed_files" ]; then
-            echo "❌ Bun crashed before tests ran in:$crashed_files"
-            exit 1
-          fi
-          echo "✅ All integration test files passed"
-          failed_files=""
-          crashed_files=""
-          for f in $files; do
-            echo "::group::$f"
-            set +e
-            out=$(bun test "$f" 2>&1)
-            code=$?
-            set -e
-            echo "$out"
-            echo "::endgroup::"
-            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
-              failed_files="$failed_files $f"
-              continue
-            fi
-            if [ "$code" -eq 0 ]; then
-              continue
-            fi
-            # Signal-induced exit AND we saw a (pass) marker → known Bun
-            # 1.3.5 teardown crash, accept. Mirrors the unit-shard logic.
-            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
-              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
-              continue
-            fi
-            crashed_files="$crashed_files $f"
-          done
-          if [ -n "$failed_files" ]; then
-            echo "❌ Test failures in:$failed_files"
-            exit 1
-          fi
-          if [ -n "$crashed_files" ]; then
-            echo "❌ Bun crashed before tests ran in:$crashed_files"
-            exit 1
-          fi
-          echo "✅ All storage integration files passed"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -55,12 +55,15 @@ jobs:
       # Convention: every `*.integration.test.ts` file is picked up here.
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
-      # Per-file bun process gives the same Bun 1.3.5 signal-crash
-      # tolerance as the unit job — if bun exits >128 but tests passed
-      # (saw a (pass) marker), accept it as a teardown bug, not a fail.
+      #
+      # `--isolate` runs each file in a fresh global within the same bun
+      # process (drained microtasks, closed sockets, killed subprocs).
+      # Replaces the per-file process spawn + signal-tolerance loop we
+      # needed on Bun 1.3.5 — fixed in 1.3.13.
       - name: Run storage integration tests
         run: |
-          files=$(find apps/mesh -name '*.integration.test.ts' | sort)
+          find apps/mesh -name '*.integration.test.ts' -print0 \
+            | xargs -0 bun test --isolate
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -56,17 +56,46 @@ jobs:
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
       #
-      # One bun process per file: cleanest isolation between heavy-DB
-      # files. Bun 1.3.14's teardown fixes mean we no longer need the
-      # signal-tolerance branches we had on 1.3.5.
+      # Per-file bun process + signal tolerance: heavy-DB integration
+      # tests still hit Bun teardown crashes (SIGSEGV/SIGILL/SIGABRT)
+      # after all tests pass — not fully fixed even in 1.3.14. If exit
+      # code > 128 AND we saw a (pass) marker, accept it as a Bun
+      # teardown bug, not a real failure. The unit job doesn't need
+      # this because pure-logic tests don't trigger the crash class.
       - name: Run storage integration tests
         run: |
-          set -e
+          failed_files=""
+          crashed_files=""
           while IFS= read -r f; do
             echo "::group::$f"
-            bun test "$f"
+            set +e
+            out=$(bun test "$f" 2>&1)
+            code=$?
+            set -e
+            echo "$out"
             echo "::endgroup::"
+            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
+              failed_files="$failed_files $f"
+              continue
+            fi
+            if [ "$code" -eq 0 ]; then
+              continue
+            fi
+            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
+              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
+              continue
+            fi
+            crashed_files="$crashed_files $f"
           done < <(find apps/mesh -name '*.integration.test.ts' | sort)
+          if [ -n "$failed_files" ]; then
+            echo "❌ Test failures in:$failed_files"
+            exit 1
+          fi
+          if [ -n "$crashed_files" ]; then
+            echo "❌ Bun crashed before tests ran in:$crashed_files"
+            exit 1
+          fi
+          echo "✅ All integration test files passed"
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -56,14 +56,17 @@ jobs:
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
       #
-      # `--isolate` runs each file in a fresh global within the same bun
-      # process (drained microtasks, closed sockets, killed subprocs).
-      # Replaces the per-file process spawn + signal-tolerance loop we
-      # needed on Bun 1.3.5 — fixed in 1.3.13.
+      # One bun process per file: cleanest isolation between heavy-DB
+      # files. Bun 1.3.14's teardown fixes mean we no longer need the
+      # signal-tolerance branches we had on 1.3.5.
       - name: Run storage integration tests
         run: |
-          find apps/mesh -name '*.integration.test.ts' -print0 \
-            | xargs -0 bun test --isolate
+          set -e
+          while IFS= read -r f; do
+            echo "::group::$f"
+            bun test "$f"
+            echo "::endgroup::"
+          done < <(find apps/mesh -name '*.integration.test.ts' | sort)
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -74,75 +74,28 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
 
       - name: Run tests
         run: |
-          # Single job (was a 4-shard matrix when the suite was larger). The
-          # per-file bun invocation below is what actually protects us from
-          # Bun 1.3.5's PGlite teardown crashes — sharding was orchestration
-          # overhead for little wall-time gain at the current size.
-          #
           # Tests are split by filename convention:
           #   *.test.ts             → unit (here)
           #   *.integration.test.ts → .github/workflows/storage-integration.yml
           #   *.e2e.test.ts         → reserved for the sandbox-daemon workflow
-          #                          (only daemon.e2e.test.ts uses it today)
           # See TESTING.md for the decision tree.
-          files=$(find apps/mesh/src packages \
+          #
+          # Bun 1.3.13 fixed the N-API/WASM teardown crashes that forced us
+          # to spawn one process per file with signal-tolerance branches.
+          # `--isolate` runs each file in a fresh global within the same
+          # process (drained microtasks, closed sockets, killed subprocs).
+          find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -name '*.integration.test.ts' \
-            ! -name '*.e2e.test.ts')
-          file_count=$(echo "$files" | wc -l)
-          echo "Running $file_count test files (one bun process per file)"
-          echo "$files"
-          # Bun 1.3.5 has known signal-induced crash bugs in WASM/JSC teardown
-          # (SIGILL/exit 132, SIGSEGV/exit 139, SIGBUS) — triggered most
-          # reliably by PGlite (WASM-backed test DB) when bun moves between
-          # test files. Running each file in its own bun process pushes the
-          # crash to process exit, where it's harmless (no further tests
-          # depend on the dead process).
-          failed_files=""
-          crashed_files=""
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            echo "::group::$f"
-            set +e
-            out=$(bun test "$f" 2>&1)
-            code=$?
-            set -e
-            echo "$out"
-            echo "::endgroup::"
-            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
-              failed_files="$failed_files $f"
-              continue
-            fi
-            if [ "$code" -eq 0 ]; then
-              continue
-            fi
-            # Non-zero exit with no (fail) markers. If signal-induced AND we
-            # saw a "pass" count OR at least one (pass) marker, tests ran and
-            # bun crashed at cleanup — known Bun 1.3.5 bug, accept. The
-            # (pass) marker fallback covers cases where bun panics after a
-            # test passed but before printing the end-of-run summary line.
-            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
-              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
-              continue
-            fi
-            crashed_files="$crashed_files $f"
-          done <<< "$files"
-          if [ -n "$failed_files" ]; then
-            echo "❌ Test failures in:$failed_files"
-            exit 1
-          fi
-          if [ -n "$crashed_files" ]; then
-            echo "❌ Bun crashed before tests ran in:$crashed_files"
-            exit 1
-          fi
-          echo "✅ All $file_count test files passed"
+            ! -name '*.e2e.test.ts' \
+            -print0 | xargs -0 bun test --isolate
 
   build:
     runs-on: ubuntu-latest
@@ -153,7 +106,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -179,7 +132,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,15 +87,20 @@ jobs:
           #   *.e2e.test.ts         → reserved for the sandbox-daemon workflow
           # See TESTING.md for the decision tree.
           #
-          # Bun 1.3.13 fixed the N-API/WASM teardown crashes that forced us
-          # to spawn one process per file with signal-tolerance branches.
-          # `--isolate` runs each file in a fresh global within the same
-          # process (drained microtasks, closed sockets, killed subprocs).
-          find apps/mesh/src packages \
+          # One bun process per file: cleanest isolation, doesn't share
+          # ports/sockets/DB pools between files. Bun 1.3.14's teardown
+          # fixes mean we no longer need the signal-tolerance branches
+          # we had on 1.3.5 — a real test failure is now the only way
+          # bun exits non-zero.
+          set -e
+          while IFS= read -r f; do
+            echo "::group::$f"
+            bun test "$f"
+            echo "::endgroup::"
+          done < <(find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -name '*.integration.test.ts' \
-            ! -name '*.e2e.test.ts' \
-            -print0 | xargs -0 bun test --isolate
+            ! -name '*.e2e.test.ts')
 
   build:
     runs-on: ubuntu-latest

--- a/apps/mesh/src/core/context-factory.integration.test.ts
+++ b/apps/mesh/src/core/context-factory.integration.test.ts
@@ -10,6 +10,19 @@ import type { MeshDatabase } from "../database";
 import { createMeshContextFactory } from "./context-factory";
 import type { BetterAuthInstance } from "./mesh-context";
 import type { EventBus } from "../event-bus/interface";
+import type { QueryEngine } from "../monitoring/query-engine";
+
+// Pass stub engines so the factory's default branch (which lazy-imports
+// `@duckdb/node-api`) never runs. DuckDB's native finalizer trips a
+// Bun teardown crash (SIGSEGV/SIGILL/SIGABRT) on process exit — same
+// behavior on 1.3.5, 1.3.14, and 1.4-canary. The factory doesn't use
+// `monitoringEngines` for any of the assertions in this file, so the
+// stubs just need to satisfy the interface.
+const noopEngine: QueryEngine = { query: async () => [] };
+const stubMonitoringEngines = () => ({
+  monitoringEngine: noopEngine,
+  metricEngine: noopEngine,
+});
 
 // Mock EventBus
 const createMockEventBus = (): EventBus => ({
@@ -94,6 +107,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       expect(typeof factory).toBe("function");
@@ -121,6 +135,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -149,6 +164,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -172,6 +188,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -202,6 +219,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest();
@@ -240,6 +258,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest();
@@ -261,6 +280,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -287,6 +307,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -338,6 +359,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -380,6 +402,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const request = createMockRequest({
@@ -422,6 +445,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const requestA = createMockRequest({
@@ -460,6 +484,7 @@ describe("createMeshContextFactory", () => {
           meter: {} as unknown as Meter,
         },
         eventBus: createMockEventBus(),
+        monitoringEngines: stubMonitoringEngines(),
       });
 
       const requestB = createMockRequest({

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -115,6 +115,19 @@ export interface MeshContextConfig {
   memberRoleCache?: MemberRoleCache;
   /** Required for desktop sandbox auto-resolution; tests may omit. */
   linkClaimRegistry?: LinkClaimRegistry;
+  /**
+   * Test-only escape hatch: pre-built monitoring + metric engines. When
+   * provided, skips the `@duckdb/node-api` import path that otherwise
+   * runs in dev/test (when no `clickhouseUrl` is set). DuckDB's native
+   * binding triggers a Bun teardown crash (SIGSEGV/SIGILL/SIGABRT) on
+   * process exit, even on 1.3.14 / 1.4-canary. Production never sets
+   * this — it either has a real `clickhouseUrl` or wants the real
+   * DuckDB engine.
+   */
+  monitoringEngines?: {
+    monitoringEngine: QueryEngine;
+    metricEngine: QueryEngine;
+  };
 }
 
 // ============================================================================
@@ -969,12 +982,22 @@ export async function createMeshContextFactory(
   // Create monitoring engines (shared across requests)
   const clickhouseUrl = getSettings().clickhouseUrl;
   const isClickHouse = !!clickhouseUrl;
-  const dialect: SqlDialect = isClickHouse ? "clickhouse" : "duckdb";
+  const dialect: SqlDialect = config.monitoringEngines
+    ? "duckdb"
+    : isClickHouse
+      ? "clickhouse"
+      : "duckdb";
 
   let monitoringEngine: QueryEngine;
   let metricEngine: QueryEngine;
 
-  if (isClickHouse) {
+  if (config.monitoringEngines) {
+    // Test-only path: caller supplied stubs to avoid loading
+    // `@duckdb/node-api` (whose native finalizer trips a Bun teardown
+    // crash). See MeshContextConfig.monitoringEngines for the why.
+    monitoringEngine = config.monitoringEngines.monitoringEngine;
+    metricEngine = config.monitoringEngines.metricEngine;
+  } else if (isClickHouse) {
     monitoringEngine = new ClickHouseClientEngine(clickhouseUrl!);
     metricEngine = new ClickHouseClientEngine(clickhouseUrl!);
   } else {

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -1,5 +1,5 @@
 # Build: docker build -t studio-sandbox:local -f packages/sandbox/image/Dockerfile packages/sandbox
-FROM oven/bun:1.3.13-debian
+FROM oven/bun:1.3.14-debian
 
 ARG NODE_MAJOR=22
 ARG DENO_VERSION=v1.46.3


### PR DESCRIPTION
## Summary

Bumps Bun 1.3.5 → 1.3.14 across every pinned location, identifies the real cause of our recurring "Bun teardown crash" (DuckDB native finalizer), neutralizes it in the test, and tears down ~90 lines of exit-code-parsing workaround that's no longer needed.

## What's in

**Bun version bumps** (12 places)
- 8 workflow files: `bun-version: "1.3.5"` → `"1.3.14"`
- `packages/sandbox/image/Dockerfile`: `oven/bun:1.3.13-debian` → `oven/bun:1.3.14-debian`
- Floating tags (`oven/bun:1`, `oven/bun:1-slim`, `oven/bun:1-alpine`) in `apps/mesh/Dockerfile`, test infra Dockerfiles, and README docs auto-pick up 1.3.14 on next image build.

**Root-cause fix for the storage-integration teardown crash**

The recurring `SIGSEGV/SIGILL/SIGABRT` at end of `context-factory.integration.test.ts` (reproducible on 1.3.5, 1.3.14, and 1.4-canary — bun.report URL: https://bun.report/1.3.14/lt10d9b296gnEugggC4j+hvE+ypRA2AA) traces to `@duckdb/node-api`. The factory's default branch lazy-imports DuckDB; each `it` block makes another factory → another native handle → another finalizer chain. Bun's exit path can't unwind them cleanly even after the 1.3.13 "LIFO finalizer order" fix that explicitly mentioned DuckDB.

The test has zero monitoring assertions, so DuckDB was loaded purely as a side effect. Fix:
- Add an optional `monitoringEngines` escape hatch to `MeshContextConfig`
- When provided, factory uses it directly and skips both DuckDB and ClickHouse engine init
- Test passes a `{ query: async () => [] }` stub
- Production never sets the override; behavior unchanged

**Workflow cleanup** (~90 lines removed)
- `test.yml` and `storage-integration.yml` `Run tests` blocks went from ~50 lines (per-file process spawn + signal-tolerance branches that caught `exit > 128 && saw (pass) marker`) to 5 lines each. The Bun crashes the workaround caught were the DuckDB ones; with the stub in place, CI confirmed zero tolerance hits, so it became dead code.

```bash
# After:
while IFS= read -r f; do
  echo "::group::$f"
  bun test "$f"
  echo "::endgroup::"
done < <(find ... -name '*.integration.test.ts' | sort)
```

## What we learned

- Bun 1.3.13's release notes promised the LIFO finalizer fix "specifically for sqlite3, duckdb, kuzu, node-llama-cpp". For our DuckDB call pattern it still crashes — either our version (`^1.5.0-r.1`) introduces a wrapping pattern Bun's fix doesn't cover, or the lazy `import()` path bypasses the patched finalizer ordering.
- Canary (`v1.4.0-canary.1`) didn't fix it either — confirmed via probe PR (closed).
- The signal-tolerance hack was load-bearing for exactly one cause. Neutralizing the cause in code beats catching the symptom in shell.

## Future bug-on-the-radar

If you ever want to file upstream:
- Versions confirmed crashing: 1.3.5, 1.3.14, 1.4.0-canary.1
- Module: `@duckdb/node-api` `^1.5.0-r.1`
- Symptom: process exits with SIGSEGV/SIGILL/SIGABRT after all tests in the file pass
- Repro: create N `DuckDBEngine` instances during test runtime, exit
- Crash report URL above

## Test plan

- [x] All workflows green except pre-existing `org-access-gate` UI Playwright flake (unrelated — has been failing across every PR for the past day).
- [x] `Storage Integration` passes with the simplified script and no tolerance branches — proves DuckDB stub is the complete fix.
- [x] `Checks & Unit Tests`, `Multi-Pod`, `Sandbox Daemon E2E`, `docker-smoke`, `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
