### PR TITLE
[PROBE — DO NOT MERGE] bun canary on storage-integration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -58,7 +58,7 @@ jobs:
         if: steps.tag-check.outputs.exists != 'true'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         if: steps.tag-check.outputs.exists != 'true'

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -55,12 +55,15 @@ jobs:
       # Convention: every `*.integration.test.ts` file is picked up here.
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
-      # Per-file bun process gives the same Bun 1.3.5 signal-crash
-      # tolerance as the unit job — if bun exits >128 but tests passed
-      # (saw a (pass) marker), accept it as a teardown bug, not a fail.
+      #
+      # `--isolate` runs each file in a fresh global within the same bun
+      # process (drained microtasks, closed sockets, killed subprocs).
+      # Replaces the per-file process spawn + signal-tolerance loop we
+      # needed on Bun 1.3.5 — fixed in 1.3.13.
       - name: Run storage integration tests
         run: |
-          files=$(find apps/mesh -name '*.integration.test.ts' | sort)
+          find apps/mesh -name '*.integration.test.ts' -print0 \
+            | xargs -0 bun test --isolate
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -56,17 +56,46 @@ jobs:
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
       #
-      # One bun process per file: cleanest isolation between heavy-DB
-      # files. Bun 1.3.14's teardown fixes mean we no longer need the
-      # signal-tolerance branches we had on 1.3.5.
+      # Per-file bun process + signal tolerance: heavy-DB integration
+      # tests still hit Bun teardown crashes (SIGSEGV/SIGILL/SIGABRT)
+      # after all tests pass — not fully fixed even in 1.3.14. If exit
+      # code > 128 AND we saw a (pass) marker, accept it as a Bun
+      # teardown bug, not a real failure. The unit job doesn't need
+      # this because pure-logic tests don't trigger the crash class.
       - name: Run storage integration tests
         run: |
-          set -e
+          failed_files=""
+          crashed_files=""
           while IFS= read -r f; do
             echo "::group::$f"
-            bun test "$f"
+            set +e
+            out=$(bun test "$f" 2>&1)
+            code=$?
+            set -e
+            echo "$out"
             echo "::endgroup::"
+            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
+              failed_files="$failed_files $f"
+              continue
+            fi
+            if [ "$code" -eq 0 ]; then
+              continue
+            fi
+            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
+              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
+              continue
+            fi
+            crashed_files="$crashed_files $f"
           done < <(find apps/mesh -name '*.integration.test.ts' | sort)
+          if [ -n "$failed_files" ]; then
+            echo "❌ Test failures in:$failed_files"
+            exit 1
+          fi
+          if [ -n "$crashed_files" ]; then
+            echo "❌ Bun crashed before tests ran in:$crashed_files"
+            exit 1
+          fi
+          echo "✅ All integration test files passed"
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          # CANARY PROBE: see whether the teardown SIGSEGV in
+          # context-factory.integration.test.ts (https://bun.report/1.3.14/
+          # lt10d9b296gnEugggC4j+hvE+ypRA2AA) is fixed on canary. Revert
+          # to "1.3.14" before merging.
+          bun-version: canary
 
       - name: Install dependencies
         run: bun install
@@ -52,50 +56,17 @@ jobs:
       - name: Run migrations
         run: bun run --cwd=apps/mesh migrate
 
-      # Convention: every `*.integration.test.ts` file is picked up here.
-      # Adding a new integration test = create a `something.integration.test.ts`
-      # and it auto-routes to this workflow. See TESTING.md.
-      #
-      # Per-file bun process + signal tolerance: heavy-DB integration
-      # tests still hit Bun teardown crashes (SIGSEGV/SIGILL/SIGABRT)
-      # after all tests pass — not fully fixed even in 1.3.14. If exit
-      # code > 128 AND we saw a (pass) marker, accept it as a Bun
-      # teardown bug, not a real failure. The unit job doesn't need
-      # this because pure-logic tests don't trigger the crash class.
+      # CANARY PROBE: signal-tolerance hack temporarily removed so a
+      # teardown crash surfaces honestly. Revert this whole block from
+      # main before merging.
       - name: Run storage integration tests
         run: |
-          failed_files=""
-          crashed_files=""
+          set -e
           while IFS= read -r f; do
             echo "::group::$f"
-            set +e
-            out=$(bun test "$f" 2>&1)
-            code=$?
-            set -e
-            echo "$out"
+            bun test "$f"
             echo "::endgroup::"
-            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
-              failed_files="$failed_files $f"
-              continue
-            fi
-            if [ "$code" -eq 0 ]; then
-              continue
-            fi
-            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
-              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
-              continue
-            fi
-            crashed_files="$crashed_files $f"
           done < <(find apps/mesh -name '*.integration.test.ts' | sort)
-          if [ -n "$failed_files" ]; then
-            echo "❌ Test failures in:$failed_files"
-            exit 1
-          fi
-          if [ -n "$crashed_files" ]; then
-            echo "❌ Bun crashed before tests ran in:$crashed_files"
-            exit 1
-          fi
-          echo "✅ All integration test files passed"
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -56,14 +56,17 @@ jobs:
       # Adding a new integration test = create a `something.integration.test.ts`
       # and it auto-routes to this workflow. See TESTING.md.
       #
-      # `--isolate` runs each file in a fresh global within the same bun
-      # process (drained microtasks, closed sockets, killed subprocs).
-      # Replaces the per-file process spawn + signal-tolerance loop we
-      # needed on Bun 1.3.5 — fixed in 1.3.13.
+      # One bun process per file: cleanest isolation between heavy-DB
+      # files. Bun 1.3.14's teardown fixes mean we no longer need the
+      # signal-tolerance branches we had on 1.3.5.
       - name: Run storage integration tests
         run: |
-          find apps/mesh -name '*.integration.test.ts' -print0 \
-            | xargs -0 bun test --isolate
+          set -e
+          while IFS= read -r f; do
+            echo "::group::$f"
+            bun test "$f"
+            echo "::endgroup::"
+          done < <(find apps/mesh -name '*.integration.test.ts' | sort)
           failed_files=""
           crashed_files=""
           for f in $files; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -74,75 +74,28 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
 
       - name: Run tests
         run: |
-          # Single job (was a 4-shard matrix when the suite was larger). The
-          # per-file bun invocation below is what actually protects us from
-          # Bun 1.3.5's PGlite teardown crashes — sharding was orchestration
-          # overhead for little wall-time gain at the current size.
-          #
           # Tests are split by filename convention:
           #   *.test.ts             → unit (here)
           #   *.integration.test.ts → .github/workflows/storage-integration.yml
           #   *.e2e.test.ts         → reserved for the sandbox-daemon workflow
-          #                          (only daemon.e2e.test.ts uses it today)
           # See TESTING.md for the decision tree.
-          files=$(find apps/mesh/src packages \
+          #
+          # Bun 1.3.13 fixed the N-API/WASM teardown crashes that forced us
+          # to spawn one process per file with signal-tolerance branches.
+          # `--isolate` runs each file in a fresh global within the same
+          # process (drained microtasks, closed sockets, killed subprocs).
+          find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -name '*.integration.test.ts' \
-            ! -name '*.e2e.test.ts')
-          file_count=$(echo "$files" | wc -l)
-          echo "Running $file_count test files (one bun process per file)"
-          echo "$files"
-          # Bun 1.3.5 has known signal-induced crash bugs in WASM/JSC teardown
-          # (SIGILL/exit 132, SIGSEGV/exit 139, SIGBUS) — triggered most
-          # reliably by PGlite (WASM-backed test DB) when bun moves between
-          # test files. Running each file in its own bun process pushes the
-          # crash to process exit, where it's harmless (no further tests
-          # depend on the dead process).
-          failed_files=""
-          crashed_files=""
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            echo "::group::$f"
-            set +e
-            out=$(bun test "$f" 2>&1)
-            code=$?
-            set -e
-            echo "$out"
-            echo "::endgroup::"
-            if echo "$out" | grep -qE '^\(fail\)|[1-9][0-9]* fail'; then
-              failed_files="$failed_files $f"
-              continue
-            fi
-            if [ "$code" -eq 0 ]; then
-              continue
-            fi
-            # Non-zero exit with no (fail) markers. If signal-induced AND we
-            # saw a "pass" count OR at least one (pass) marker, tests ran and
-            # bun crashed at cleanup — known Bun 1.3.5 bug, accept. The
-            # (pass) marker fallback covers cases where bun panics after a
-            # test passed but before printing the end-of-run summary line.
-            if [ "$code" -gt 128 ] && echo "$out" | grep -qE '^\(pass\)|[1-9][0-9]* pass'; then
-              echo "⚠️  $f: bun crashed at teardown (exit $code) after tests passed — accepting"
-              continue
-            fi
-            crashed_files="$crashed_files $f"
-          done <<< "$files"
-          if [ -n "$failed_files" ]; then
-            echo "❌ Test failures in:$failed_files"
-            exit 1
-          fi
-          if [ -n "$crashed_files" ]; then
-            echo "❌ Bun crashed before tests ran in:$crashed_files"
-            exit 1
-          fi
-          echo "✅ All $file_count test files passed"
+            ! -name '*.e2e.test.ts' \
+            -print0 | xargs -0 bun test --isolate
 
   build:
     runs-on: ubuntu-latest
@@ -153,7 +106,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install
@@ -179,7 +132,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,15 +87,20 @@ jobs:
           #   *.e2e.test.ts         → reserved for the sandbox-daemon workflow
           # See TESTING.md for the decision tree.
           #
-          # Bun 1.3.13 fixed the N-API/WASM teardown crashes that forced us
-          # to spawn one process per file with signal-tolerance branches.
-          # `--isolate` runs each file in a fresh global within the same
-          # process (drained microtasks, closed sockets, killed subprocs).
-          find apps/mesh/src packages \
+          # One bun process per file: cleanest isolation, doesn't share
+          # ports/sockets/DB pools between files. Bun 1.3.14's teardown
+          # fixes mean we no longer need the signal-tolerance branches
+          # we had on 1.3.5 — a real test failure is now the only way
+          # bun exits non-zero.
+          set -e
+          while IFS= read -r f; do
+            echo "::group::$f"
+            bun test "$f"
+            echo "::endgroup::"
+          done < <(find apps/mesh/src packages \
             \( -name '*.test.ts' -o -name '*.test.tsx' \) \
             ! -name '*.integration.test.ts' \
-            ! -name '*.e2e.test.ts' \
-            -print0 | xargs -0 bun test --isolate
+            ! -name '*.e2e.test.ts')
 
   build:
     runs-on: ubuntu-latest

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -1,5 +1,5 @@
 # Build: docker build -t studio-sandbox:local -f packages/sandbox/image/Dockerfile packages/sandbox
-FROM oven/bun:1.3.13-debian
+FROM oven/bun:1.3.14-debian
 
 ARG NODE_MAJOR=22
 ARG DENO_VERSION=v1.46.3


### PR DESCRIPTION
## Probe purpose

Test whether the SIGSEGV teardown crash on `context-factory.integration.test.ts` from PR #3534 is fixed on Bun's canary build.

Crash report URL from 1.3.14: https://bun.report/1.3.14/lt10d9b296gnEugggC4j+hvE+ypRA2AA

## What's changed

- `storage-integration.yml`: `bun-version: canary` (was `1.3.14`)
- `storage-integration.yml`: signal-tolerance branch removed so a teardown crash surfaces honestly instead of being accepted

## Result

The `Storage Integration` job's status here tells us:
- ✅ → canary fixed it, follow-up PR can revert the signal-tolerance hack on main
- ❌ with SIGSEGV in `context-factory` → bug still present, file upstream

**Do not merge this branch.** Close it after we read the result.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `storage-integration` tests on Bun canary with the signal-tolerance hack removed to verify whether the teardown SIGSEGV in `context-factory.integration.test.ts` is fixed. Also bump other CI jobs and the sandbox image to `1.3.14` for consistency.

- **Migration**
  - Storage Integration result: ✅ pass → canary fixed; revert the tolerance hack on main. ❌ SIGSEGV → bug persists; file upstream.
  - Do not merge; close this PR after reviewing the result.

<sup>Written for commit b1c6360739a19903f3c27f675545bb139776433b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3535?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

