### PR TITLE
fix(sandbox): forward workload from user-desktop provider to spawned daemon

### DIFF
--- a/apps/mesh/src/link-daemon/control-handler.ts
+++ b/apps/mesh/src/link-daemon/control-handler.ts
@@ -13,7 +13,11 @@
  *                                            sandbox daemon's local port
  */
 import type { RequestFrame } from "../links/dispatch-frames";
-import type { DesktopSandboxProvider, RepoRef } from "./user-desktop-provider";
+import type {
+  DesktopSandboxProvider,
+  RepoRef,
+  Workload,
+} from "./user-desktop-provider";
 
 export interface ControlHandlerResponse {
   status: number;
@@ -30,6 +34,7 @@ export interface ControlHandlerDeps {
 interface EnsureSandboxBody {
   handle: string;
   repo?: RepoRef;
+  workload?: Workload;
 }
 
 export type StreamEvent =

--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -81,10 +81,24 @@ export async function startLinkDaemon(
       }));
     },
     postConfig: async (port, devPort, config, daemonToken) => {
-      // Daemon's TenantConfig wire shape is `{ git, application }`.
-      const payload: Record<string, unknown> = {
-        application: { port: devPort },
-      };
+      // Daemon's TenantConfig wire shape is `{ git, application }`. We
+      // always pin `application.port` to the link-allocated devPort so
+      // co-tenant sandboxes can't collide on the host network; the
+      // caller-supplied workload only drives runtime + packageManager
+      // (without these the orchestrator falls through to lockfile
+      // autodetect, which on a repo with `yarn.lock` picks yarn — a
+      // package manager the desktop daemon can't reliably PATH-shim).
+      const application: Record<string, unknown> = { port: devPort };
+      if (config.workload) {
+        application.runtime = config.workload.runtime;
+        application.packageManager = {
+          name: config.workload.packageManager,
+          ...(config.workload.packageManagerPath
+            ? { path: config.workload.packageManagerPath }
+            : {}),
+        };
+      }
+      const payload: Record<string, unknown> = { application };
       if (config.repo) {
         payload.git = {
           repository: {

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -40,9 +40,29 @@ export interface RepoRef {
   userEmail?: string;
 }
 
+/**
+ * Caller-selected runtime + package manager. Mirrors `Workload` from
+ * `@decocms/sandbox/provider`. Threaded through to the spawned sandbox
+ * daemon's `application` config so the orchestrator runs `bun install`
+ * (or pnpm/npm/yarn/deno) instead of falling through to autodetect — the
+ * desktop daemon process can't shim arbitrary corepack package managers
+ * into PATH the way the container image can, so explicit selection is
+ * the only reliable path on user-desktop.
+ */
+export interface Workload {
+  runtime: "node" | "bun" | "deno";
+  packageManager: "npm" | "pnpm" | "yarn" | "bun" | "deno";
+  /** User-pinned dev port; ignored on desktop (the provider allocates its
+   *  own ephemeral port to avoid host-network collisions). */
+  devPort?: number;
+  /** Subdirectory inside the repo where the package manifest lives. */
+  packageManagerPath?: string;
+}
+
 export interface EnsureSandboxInput {
   handle: string;
   repo?: RepoRef;
+  workload?: Workload;
 }
 
 export interface SandboxState {
@@ -96,7 +116,7 @@ export interface DesktopSandboxProviderDeps {
   postConfig: (
     port: number,
     devPort: number,
-    config: { repo?: RepoRef },
+    config: { repo?: RepoRef; workload?: Workload },
     daemonToken: string,
   ) => Promise<void>;
   waitForHealth: (port: number) => Promise<void>;
@@ -213,7 +233,12 @@ export function createDesktopSandboxProvider(
     );
     try {
       await deps.waitForHealth(port);
-      await deps.postConfig(port, devPort, { repo: input.repo }, daemonToken);
+      await deps.postConfig(
+        port,
+        devPort,
+        { repo: input.repo, workload: input.workload },
+        daemonToken,
+      );
     } catch (err) {
       try {
         spawned.kill("SIGKILL");

--- a/packages/sandbox/server/provider/desktop/runner.ts
+++ b/packages/sandbox/server/provider/desktop/runner.ts
@@ -123,10 +123,16 @@ export class DesktopSandboxProvider implements SandboxProvider {
       }
     }
 
+    // Forward the workload so the link daemon can pin runtime +
+    // packageManager on the spawned sandbox. Without it the orchestrator
+    // falls through to lockfile autodetect, which on a repo with
+    // `yarn.lock` picks yarn — and the desktop daemon can't reliably
+    // shim a yarn binary into PATH.
     const body = JSON.stringify({
       handle,
       repo: opts.repo,
       branch: opts.repo?.branch,
+      ...(opts.workload ? { workload: opts.workload } : {}),
     });
     const responseText = await this.dispatchJson(
       "POST",


### PR DESCRIPTION
## What is this contribution about?

The user-desktop sandbox path was silently dropping `EnsureOptions.workload` between the cluster and the spawned sandbox daemon, so the package manager selected in the project's runtime card never reached the orchestrator. On a repo containing `yarn.lock`, the daemon's autodetect fell through to yarn and ran `yarn install`, which fails on user-desktop because corepack can't reliably shim a yarn binary into PATH (`yarn: command not found`).

This PR plumbs `workload` end-to-end on the desktop path:
- `packages/sandbox/server/provider/desktop/runner.ts` — include `opts.workload` in the `POST /api/sandboxes` body.
- `apps/mesh/src/link-daemon/control-handler.ts` — extend `EnsureSandboxBody` with a `Workload` field.
- `apps/mesh/src/link-daemon/user-desktop-provider.ts` — add a `Workload` type, thread it through `EnsureSandboxInput` → `buildEntry` → `postConfig`.
- `apps/mesh/src/link-daemon/index.ts` — populate `application.runtime` and `application.packageManager: { name, path? }` from the workload. The devPort stays pinned to the link-allocated ephemeral port so co-tenant sandboxes can't collide on the host network.

The docker and agent-sandbox paths already do this via `buildConfigPayload`; only user-desktop was missing it.

## How to Test

1. From a project with \`yarn.lock\` at the root, set the runtime card's package manager to **bun**.
2. Choose **user-desktop** as the sandbox provider and start a sandbox.
3. Expected: the daemon's setup log shows \`bun install\` (not \`yarn install\`), the install succeeds, and the dev server boots.

## Migration Notes

None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (\`bun run check\`, \`bun test apps/mesh/src/link-daemon\`, \`bun test packages/sandbox/server/provider\`, \`bun run lint\` all pass)
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwarded `workload` from the user-desktop provider to the spawned sandbox daemon so the selected runtime and package manager reach the orchestrator. This stops autodetect from falling back to yarn on `yarn.lock` repos, which caused `yarn: command not found` on user-desktop.

- **Bug Fixes**
  - Desktop runner now includes `workload` in `POST /api/sandboxes`.
  - Control handler and user-desktop provider accept and pass `workload` through to `postConfig`.
  - Link daemon sets `application.runtime` and `application.packageManager { name, path? }`; dev port remains link-allocated to avoid host collisions.

<sup>Written for commit 4c5bb1998ca2fd36165c9e654728f73d129d15f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3536?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

