### PR TITLE
feat(models): default to Claude Opus 4.8

### DIFF
--- a/apps/mesh/src/ai-providers/agent-tiers.ts
+++ b/apps/mesh/src/ai-providers/agent-tiers.ts
@@ -20,7 +20,7 @@ export type AgentTierMap = Record<ChatTier, AgentTierEntry>;
 const CLAUDE_CODE_TIERS: AgentTierMap = {
   fast: { modelId: "claude-code:haiku", label: "Haiku 4.5" },
   smart: { modelId: "claude-code:sonnet", label: "Sonnet 4.6" },
-  thinking: { modelId: "claude-code:opus", label: "Opus 4.7" },
+  thinking: { modelId: "claude-code:opus", label: "Opus 4.8" },
 };
 
 const CODEX_TIERS: AgentTierMap = {

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -42,7 +42,7 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
   },
   thinking: {
     modelId: "claude-code:opus",
-    label: "Opus 4.7",
+    label: "Opus 4.8",
     description: "Deeper reasoning",
     iconNode: <ClaudeCodeIcon size={16} />,
   },

--- a/apps/mesh/src/web/components/chat/select-model/decopilot.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/decopilot.tsx
@@ -59,7 +59,7 @@ const TIER_PATTERNS: Array<{ tier: TierId; prefixes: string[] }> = [
   {
     tier: "smarter",
     prefixes: [
-      "anthropic/claude-opus-4.7",
+      "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-4.6",
       "anthropic/claude-4.6-sonnet",
       "openai/gpt-5.3-codex",
@@ -163,7 +163,7 @@ const SHORTLIST_KEY_PREFIX = "mesh:model-shortlist:";
 
 const DEFAULT_SHORTLIST = new Set([
   // Smarter
-  "anthropic/claude-opus-4.7",
+  "anthropic/claude-opus-4.8",
   "anthropic/claude-sonnet-4.6",
   "anthropic/claude-4.6-sonnet",
   "anthropic/claude-sonnet-4.6:extended",

--- a/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
+++ b/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
@@ -39,9 +39,9 @@ describe("resolveTierSubtitle", () => {
         "Sonnet 4.6",
       );
     });
-    it("thinking → Opus 4.7", () => {
+    it("thinking → Opus 4.8", () => {
       expect(resolveTierSubtitle("local-claude-code", "thinking")).toBe(
-        "Opus 4.7",
+        "Opus 4.8",
       );
     });
   });

--- a/apps/mesh/src/web/lib/release-feed.ts
+++ b/apps/mesh/src/web/lib/release-feed.ts
@@ -30,6 +30,30 @@ export interface Release {
  */
 export const RELEASES: Release[] = [
   {
+    id: "claude-opus-4-8",
+    date: "2026-05-28",
+    eyebrow: "Now Available",
+    title: "Claude Opus 4.8 is the new default",
+    bullets: [
+      {
+        icon: Stars02,
+        title: "Smarter thinking, same price",
+        body: "Opus 4.8 now leads the Thinking and Smarter tiers, outperforming Opus 4.7 on coding, reasoning, and agent tasks at the same cost.",
+      },
+      {
+        icon: CheckCircle,
+        title: "More honest answers",
+        body: "It's about 4× less likely to let a code flaw slip through unflagged, and surfaces uncertainty instead of making unsupported claims.",
+      },
+      {
+        icon: Zap,
+        title: "Nothing to change",
+        body: "Chats and agents pick up Opus 4.8 automatically wherever the Thinking or Smarter tier is selected.",
+      },
+    ],
+    learnMoreHref: "https://www.anthropic.com/news/claude-opus-4-8",
+  },
+  {
     id: "enhanced-sidebar",
     date: "2026-05-28",
     eyebrow: "Now Available",

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -15,7 +15,7 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
     anthropic: ["claude-sonnet-4-6", "claude-sonnet", "claude"],
     openrouter: [
-      "anthropic/claude-opus-4.7",
+      "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-4-6",
       "anthropic/claude-sonnet",
       "anthropic/claude",
@@ -70,7 +70,7 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
   openrouter: [
     "anthropic/claude-sonnet-4.6",
     "anthropic/claude-sonnet",
-    "anthropic/claude-opus-4.7",
+    "anthropic/claude-opus-4.8",
     "google/gemini-3-pro",
   ],
   deco: [
@@ -89,9 +89,9 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
  */
 export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
   {
-    anthropic: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-sonnet"],
+    anthropic: ["claude-opus-4-8", "claude-sonnet-4-6", "claude-sonnet"],
     openrouter: [
-      "anthropic/claude-opus-4.7",
+      "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-4.6:extended",
       "anthropic/claude-sonnet-4.6",
       "google/gemini-3-pro",


### PR DESCRIPTION
## What is this contribution about?
Claude Opus 4.8 was released, so this promotes it to the default "Thinking"/"Smarter" tier model. It updates the mesh SDK preference lists (`DEFAULT`, `SMART`, `THINKING` for anthropic + openrouter), the Decopilot model selector's tier classification and default shortlist, and the desktop CLI (Claude Code) thinking-tier labels from `Opus 4.7` → `Opus 4.8`. The previous Sonnet 4.6 / Opus entries remain as fallbacks, and a release-feed entry announces the change to users.

## Screenshots/Demonstration
N/A — copy/label and model-preference changes only; no layout changes.

## How to Test
1. Open the chat model selector and confirm the Claude Code "Thinking" tier shows "Opus 4.8".
2. With an OpenRouter/Anthropic key connected, verify the default selected model resolves to Opus 4.8 where available (falling back to Sonnet 4.6 otherwise).
3. Run `bun test apps/mesh/src/web/components/chat/use-agent-mode.test.ts` — expects "Opus 4.8".

## Migration Notes
Not applicable — no DB migrations or config changes. Chats/agents pick up Opus 4.8 automatically wherever the Thinking/Smarter tier was selected.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Claude Opus 4.8 as the default model for the Thinking/Smarter tiers across the SDK, Decopilot, and CLI. Sonnet 4.6 remains as fallback; users get Opus 4.8 automatically where available.

- New Features
  - Prioritize `claude-opus-4.8` in SDK model preferences (`DEFAULT`, `SMART`, `THINKING`) for `anthropic` and `openrouter`.
  - Update Decopilot tier patterns and default shortlist to 4.8, and refresh selector labels.
  - Update Claude Code “Thinking” tier label to “Opus 4.8”.
  - Add a release-feed entry announcing the change and update tests to expect “Opus 4.8”.

<sup>Written for commit d2a647794adbdb97e79a785fa214852bc999fa85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3538?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

