### PR TITLE
feat(take-screenshot): implement TakeScreenshotPart component and enh…

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/take-screenshot.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/take-screenshot.ts
@@ -114,10 +114,12 @@ export function createTakeScreenshotTool(
         const mediaType = "image/jpeg";
         const key = `screenshots/${crypto.randomUUID()}.jpg`;
 
-        // Upload to object storage — needed for UI rendering.
-        // Also generates a presigned URL or data URI for injecting
-        // the image into the conversation via prepareStep.
-        let uri = `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
+        // Upload to object storage and return a stable mesh-storage:// URI
+        // (mirrors generate-image). `uri` is the opaque reference persisted
+        // in the tool result; `imageUrl` is a fetchable URL the model can
+        // load this turn via the prepareStep image injection. Inline base64
+        // is only used as a fallback when no object storage is configured.
+        let uri: string;
         let imageUrl: string | null = null;
 
         if (ctx.objectStorage) {
@@ -132,12 +134,18 @@ export function createTakeScreenshotTool(
               "[take-screenshot] Failed to upload, using data: URI fallback",
               err,
             );
+            uri = `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
           }
+        } else {
+          uri = `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
         }
 
-        // Fallback: use the data URI directly if no presigned URL
+        // pendingImages needs a URL the model can fetch this turn; fall back
+        // to the inline data URI when no presigned URL is available.
         if (!imageUrl) {
-          imageUrl = `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
+          imageUrl = uri.startsWith("data:")
+            ? uri
+            : `data:${mediaType};base64,${Buffer.from(imgBytes).toString("base64")}`;
         }
 
         // Queue the image for injection as a user message in prepareStep.

--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -15,6 +15,7 @@ import { MessageTextPart } from "./parts/text-part.tsx";
 import {
   GenericToolCallPart,
   GenerateImagePart,
+  TakeScreenshotPart,
   WebSearchPart,
   ProposePlanPart,
   SubtaskPart,
@@ -438,6 +439,13 @@ function MessagePart({
     case "tool-generate_image":
       return (
         <GenerateImagePart
+          part={part}
+          latency={getMeta(part.toolCallId)?.latencySeconds}
+        />
+      );
+    case "tool-take_screenshot":
+      return (
+        <TakeScreenshotPart
           part={part}
           latency={getMeta(part.toolCallId)?.latencySeconds}
         />

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/index.ts
@@ -1,5 +1,6 @@
 export { GenericToolCallPart } from "./generic.tsx";
 export { GenerateImagePart } from "./generate-image.tsx";
+export { TakeScreenshotPart } from "./take-screenshot.tsx";
 export { WebSearchPart } from "./web-search.tsx";
 export { UserAskPart } from "./user-ask.tsx";
 export { SubtaskPart, SubtaskPartFallback } from "./subtask.tsx";

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/take-screenshot.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/take-screenshot.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Monitor01 } from "@untitledui/icons";
+import type { ToolUIPart } from "ai";
+import { useOrg } from "@decocms/mesh-sdk";
+import { ToolCallShell } from "./common.tsx";
+import { getEffectiveState } from "./utils.tsx";
+import { ImageLightbox } from "../../../image-lightbox.tsx";
+import { formatDuration } from "@/web/lib/format-time.ts";
+import { parseMeshStorageKey } from "@/api/routes/decopilot/mesh-storage-uri";
+
+function resolveImageSrc(uri: string, orgSlug: string): string {
+  const key = parseMeshStorageKey(uri);
+  if (key !== null) return `/api/${orgSlug}/files/${key}`;
+  // data: URIs or any other URL — use as-is
+  return uri;
+}
+
+interface TakeScreenshotResult {
+  success?: boolean;
+  image?: { uri?: string; mediaType?: string };
+  url?: string;
+  error?: string;
+}
+
+interface TakeScreenshotInput {
+  url?: string;
+  fullPage?: boolean;
+}
+
+interface TakeScreenshotPartProps {
+  part: ToolUIPart;
+  /** Latency in seconds from data-tool-metadata part */
+  latency?: number;
+}
+
+export function TakeScreenshotPart({ part, latency }: TakeScreenshotPartProps) {
+  const org = useOrg();
+  const state = getEffectiveState(part.state);
+  const input = part.input as TakeScreenshotInput | undefined;
+  const result = part.output as TakeScreenshotResult | undefined;
+  const uri = result?.image?.uri;
+  const pageUrl = result?.url ?? input?.url;
+  const latencyLabel =
+    latency != null && latency > 0 ? (
+      <span className="text-[11px] font-mono tabular-nums text-muted-foreground/60">
+        {formatDuration(latency)}
+      </span>
+    ) : null;
+
+  if (state === "loading") {
+    return (
+      <ToolCallShell
+        icon={<Monitor01 size={14} />}
+        title="Taking screenshot"
+        summary={pageUrl}
+        state="loading"
+      />
+    );
+  }
+
+  if (state === "error" || result?.success === false || !uri) {
+    return (
+      <ToolCallShell
+        icon={<Monitor01 size={14} />}
+        title="Take screenshot"
+        summary={result?.error ?? "Failed"}
+        state="error"
+        trailing={latencyLabel}
+      />
+    );
+  }
+
+  const src = resolveImageSrc(uri, org.slug);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ToolCallShell
+        icon={<Monitor01 size={14} className="text-blue-500" />}
+        title="Screenshot"
+        summary={pageUrl}
+        state="idle"
+        trailing={latencyLabel}
+      />
+      <div className="flex flex-wrap gap-2">
+        <ImageLightbox src={src} alt={pageUrl ?? "Screenshot"}>
+          <img
+            src={src}
+            alt={pageUrl ?? "Screenshot"}
+            className="max-w-sm max-h-80 object-contain rounded-lg border border-border hover:border-foreground/20 transition-colors"
+          />
+        </ImageLightbox>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…ance screenshot handling

- Added a new TakeScreenshotPart component to display screenshot results in the chat interface.
- Updated take-screenshot.ts to improve URI handling for screenshots, ensuring a stable mesh-storage URI is returned.
- Enhanced fallback logic for image URLs to ensure proper rendering when object storage is unavailable.
- Integrated the new TakeScreenshotPart into the message rendering logic for tool calls.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TakeScreenshotPart to render screenshot results in chat and stabilizes screenshot URIs using `mesh-storage://`, with a safe `data:` fallback. Integrates the part into assistant message rendering so screenshots always display, even without object storage.

- **New Features**
  - New `TakeScreenshotPart` with lightbox preview and latency label; wired into `assistant.tsx`.
  - Tool now returns a stable `mesh-storage://` URI and a fetchable URL for the current turn; falls back to `data:` URIs on upload failure or when storage is disabled.
  - UI resolves `mesh-storage://` to `/api/{org}/files/{key}` for reliable image rendering.

<sup>Written for commit 4f665471b88cff725a7256a1c6a361546f817335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3539?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

