### PR TITLE
ci(release-tagging): use decocms GitHub App token to bypass main branch protection

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -144,10 +144,17 @@ jobs:
       new_version: ${{ steps.determine_version.outputs.new_version }}
       deploy_to_production: ${{ steps.determine_version.outputs.deploy_to_production }}
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.RELEASE_BOT_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Find the Merged Pull Request
         id: find_pr
@@ -317,10 +324,10 @@ jobs:
       - name: Trigger Release Workflow
         if: steps.determine_version.outputs.new_version != ''
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_BOT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           curl -X POST \
-            -H "Authorization: token ${{ secrets.RELEASE_BOT_PAT }}" \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-mesh.yaml/dispatches" \
             -d '{"ref":"main", "inputs":{"deploy_to_production":"${{ steps.determine_version.outputs.deploy_to_production }}"}}'

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -147,7 +147,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_PAT }}
 
       - name: Find the Merged Pull Request
         id: find_pr
@@ -317,10 +317,10 @@ jobs:
       - name: Trigger Release Workflow
         if: steps.determine_version.outputs.new_version != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_PAT }}
         run: |
           curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.RELEASE_BOT_PAT }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-mesh.yaml/dispatches" \
             -d '{"ref":"main", "inputs":{"deploy_to_production":"${{ steps.determine_version.outputs.deploy_to_production }}"}}'


### PR DESCRIPTION
## Summary

- The `Release Tagging` workflow has been failing on every push to `main` for the last several pushes. The version-bump commit is created fine, but `git push origin main` is rejected with `GH013: Repository rule violations` because `GITHUB_TOKEN` cannot bypass the ruleset on `main` (which requires PR + status checks).
- Use the existing `decocms` GitHub App as the workflow's identity instead. App tokens don't expire and aren't tied to a personal account, so there's no PAT rotation tax.

## Required setup (all done)

- [x] Repo variable `RELEASE_BOT_APP_ID` (set to the decocms app ID).
- [x] Repo secret `RELEASE_BOT_APP_PRIVATE_KEY` (the app's PEM).
- [x] `decocms` app added to the `main` ruleset bypass list.
- [x] App has `Contents: write` and `Actions: write` on this repo (confirmed by owner).

## Test plan

- [ ] After merge, observe the next push-to-main run of `Release Tagging` — `Commit and push version bump` step should succeed and `apps/mesh/package.json` should get a `[release]: bump to …` commit authored by `decocms[bot]`.
- [ ] `release-mesh.yaml` should then be triggered via workflow_dispatch as before.

## Notes

Pushes made by `GITHUB_TOKEN` do not trigger downstream workflows, but pushes made by a GitHub App **do** trigger workflows by default. In this PR's case the curl explicitly dispatches `release-mesh.yaml`, so the behavior is unchanged in practice — flagging for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
