### PR TITLE
feat(sandbox): enhance sandbox git status polling with exponential ba…

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-git-status.ts
@@ -1,8 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   fetchGitStatus,
+  isSandboxUnreachable,
   sandboxGitStatusQueryKey,
 } from "../../thread/github/sandbox-git-api.ts";
+
+const BASE_INTERVAL_MS = 3000;
+const MAX_INTERVAL_MS = 60_000;
 
 export function useSandboxGitStatus(args: {
   orgSlug: string;
@@ -15,7 +19,15 @@ export function useSandboxGitStatus(args: {
     queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch ?? ""),
     queryFn: () => fetchGitStatus(orgSlug, virtualMcpId, branch!),
     enabled: enabled && !!branch,
-    refetchInterval: 3000,
+    // Keep polling, but back off when the sandbox is unreachable (no runner /
+    // gone) so a dead VM doesn't flood 503s every 3s. Exponential per
+    // consecutive failure, capped at 60s; snaps back to 3s once it recovers.
+    refetchInterval: (query) => {
+      if (!isSandboxUnreachable(query.state.error)) return BASE_INTERVAL_MS;
+      const failures = query.state.fetchFailureCount;
+      return Math.min(BASE_INTERVAL_MS * 2 ** failures, MAX_INTERVAL_MS);
+    },
+    retry: (_count, error) => !isSandboxUnreachable(error),
     staleTime: 1000,
   });
 }

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -49,7 +49,7 @@ function buildSandboxGitUrl(
 
 /** Error carrying the HTTP status so callers can back off on unreachable
  *  sandboxes (503 no runner, 410 handle gone) instead of polling forever. */
-export class SandboxGitError extends Error {
+class SandboxGitError extends Error {
   constructor(
     message: string,
     readonly status: number,

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -47,13 +47,35 @@ function buildSandboxGitUrl(
   return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/git/${endpoint}`;
 }
 
+/** Error carrying the HTTP status so callers can back off on unreachable
+ *  sandboxes (503 no runner, 410 handle gone) instead of polling forever. */
+export class SandboxGitError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "SandboxGitError";
+  }
+}
+
+/** The sandbox is gone / has no runner — polling it again won't help until
+ *  it's re-provisioned, so stop the interval rather than flood 503s. */
+export function isSandboxUnreachable(error: unknown): boolean {
+  return (
+    error instanceof SandboxGitError &&
+    (error.status === 503 || error.status === 410)
+  );
+}
+
 async function parseJson<T>(res: Response): Promise<T> {
   const body = (await res.json()) as T & { error?: string };
   if (!res.ok) {
-    throw new Error(
+    throw new SandboxGitError(
       typeof body.error === "string"
         ? body.error
         : `Request failed (${res.status})`,
+      res.status,
     );
   }
   return body;


### PR DESCRIPTION
…ckoff

- Introduced a mechanism to adjust the polling interval for sandbox git status based on the reachability of the sandbox.
- Implemented exponential backoff for polling when the sandbox is unreachable (HTTP 503 or 410), capping the interval at 60 seconds.
- Added a new `SandboxGitError` class to carry HTTP status information for better error handling.
- Updated the `fetchGitStatus` error handling to utilize the new error class for improved clarity and control over polling behavior.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves sandbox git status polling with exponential backoff when the sandbox is unreachable, reducing 503/410 spam and load. Polls every 3s, backs off up to 60s, and returns to 3s when it recovers.

- **New Features**
  - `useSandboxGitStatus`: dynamic `refetchInterval` with exponential backoff for 503/410 (max 60s); snaps back to 3s on success; disables `retry` when unreachable.
  - `fetchGitStatus` now throws `SandboxGitError` (carries HTTP status); `SandboxGitError` is module-scoped (not exported); added `isSandboxUnreachable`.

<sup>Written for commit cd7498c42c99d206177418bb74e59b791a506c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3541?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

