### PR TITLE
fix(registry): make LIST output schema tolerant of open/real data

### DIFF
--- a/apps/mesh/src/storage/registry/types.ts
+++ b/apps/mesh/src/storage/registry/types.ts
@@ -114,6 +114,7 @@ export interface PrivateRegistryDatabase {
 export interface RegistryToolMeta {
   name: string;
   description?: string | null;
+  [key: string]: unknown;
 }
 
 export interface MeshRegistryMeta {
@@ -143,6 +144,7 @@ export interface RegistryRemote {
   name?: string;
   title?: string;
   description?: string;
+  [key: string]: unknown;
 }
 
 export interface RegistryPackage {
@@ -158,13 +160,14 @@ export interface RegistryServerDefinition {
   description?: string;
   version?: string;
   websiteUrl?: string;
-  icons?: Array<{ src: string }>;
+  icons?: Array<{ src: string; [key: string]: unknown }>;
   remotes?: RegistryRemote[];
   packages?: RegistryPackage[];
   repository?: {
     url?: string;
     source?: string;
     subfolder?: string;
+    [key: string]: unknown;
   };
   [key: string]: unknown;
 }
@@ -181,6 +184,7 @@ export interface PrivateRegistryItemEntity {
   created_at: string;
   updated_at: string;
   created_by?: string;
+  [key: string]: unknown;
 }
 
 export interface PrivateRegistryCreateInput {

--- a/apps/mesh/src/tools/registry/schema.test.ts
+++ b/apps/mesh/src/tools/registry/schema.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { RegistryGetOutputSchema, RegistryListOutputSchema } from "./schema";
+
+/**
+ * Regression: the registry `LIST` and `GET` tools failed at runtime with
+ * `-32602: Structured content does not match the tool's output schema`
+ * (`data/items/N must NOT have additional properties` / `data/item must NOT
+ * have additional properties`) on every call, while `SEARCH` worked.
+ *
+ * Cause: the item output schema was a closed object, advertised as JSON Schema
+ * with `additionalProperties: false`. The deco store validates output with Zod
+ * (which strips unknown keys, so the response is returned), but MCP clients —
+ * e.g. the mesh proxy via `client.callTool` — re-validate `structuredContent`
+ * with Ajv, which rejects items carrying fields not modeled in the schema
+ * (`is_unlisted`, unmodeled `server.json` keys, etc.). `SEARCH` was unaffected
+ * because it returns a slim, exactly-projected object.
+ *
+ * These tests reproduce the proxy's client-side validation with a real
+ * in-memory MCP server <-> client round-trip (the proxy lists tools, which
+ * caches each tool's advertised output schema, then calls the tool).
+ */
+describe("registry output schema – proxy round-trip validation", () => {
+  const baseItem = {
+    id: "deco/example",
+    name: "example",
+    title: "Example",
+    description: "An example",
+    server: { name: "example" },
+    is_public: true,
+    is_unlisted: false,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+  };
+
+  async function roundTrip(
+    toolId: "LIST" | "GET",
+    outputSchema:
+      | typeof RegistryListOutputSchema
+      | typeof RegistryGetOutputSchema,
+    result: unknown,
+  ) {
+    const server = new McpServer({ name: "test-registry", version: "0.0.0" });
+    server.registerTool(
+      toolId,
+      { description: toolId, outputSchema },
+      async () => ({
+        structuredContent: result as Record<string, unknown>,
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      }),
+    );
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    try {
+      // The mesh proxy lists tools (caching each tool's advertised output
+      // schema), then calls the tool. The SDK client only validates output for
+      // tools whose schema was cached via listTools().
+      await client.listTools();
+      return await client.callTool({ name: toolId, arguments: {} });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  it("LIST: accepts items carrying the top-level is_unlisted field", async () => {
+    const result = await roundTrip("LIST", RegistryListOutputSchema, {
+      items: [baseItem],
+      totalCount: 1,
+      hasMore: false,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(
+      (result.structuredContent as { totalCount: number }).totalCount,
+    ).toBe(1);
+  });
+
+  it("LIST: accepts unmodeled keys in server.json and _meta (open data)", async () => {
+    const item = {
+      ...baseItem,
+      server: {
+        name: "example",
+        $schema: "https://modelcontextprotocol.io/schemas/server.json",
+        status: "active",
+        packages: [
+          {
+            identifier: "@foo/bar",
+            version: "1.0.0",
+            registry_type: "npm",
+            transport: { type: "stdio" },
+            environment_variables: [{ name: "TOKEN" }],
+          },
+        ],
+        icons: [{ src: "https://x/icon.png", sizes: "48x48", theme: "dark" }],
+        repository: { url: "https://github.com/foo/bar", id: "123" },
+      },
+      _meta: {
+        "mcp.mesh": { readme_url: "https://example.com/readme", extra: true },
+        "some.other.ns": { whatever: 1 },
+      },
+      some_future_field: "tolerated",
+    };
+    const result = await roundTrip("LIST", RegistryListOutputSchema, {
+      items: [item],
+      totalCount: 1,
+      hasMore: false,
+      nextCursor: "24",
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("LIST: accepts a readme_url with spaces / non-ASCII (valid URL, not strict URI)", async () => {
+    const item = {
+      ...baseItem,
+      _meta: {
+        "mcp.mesh": {
+          readme_url: "https://exämple.com/path with spaces/README.md",
+        },
+      },
+    };
+    const result = await roundTrip("LIST", RegistryListOutputSchema, {
+      items: [item],
+      totalCount: 1,
+      hasMore: false,
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("GET: accepts a full item (data/item must not be rejected)", async () => {
+    const result = await roundTrip("GET", RegistryGetOutputSchema, {
+      item: {
+        ...baseItem,
+        _meta: { "mcp.mesh": { readme_url: "https://example.com/a b" } },
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as { item: { id: string } }).item.id).toBe(
+      "deco/example",
+    );
+  });
+});

--- a/apps/mesh/src/tools/registry/schema.ts
+++ b/apps/mesh/src/tools/registry/schema.ts
@@ -1,51 +1,71 @@
 import { CollectionListInputSchema } from "@decocms/bindings/collections";
 import { z } from "zod";
 
-const RegistryServerSchema = z.object({
-  name: z.string(),
-  title: z.string().optional(),
-  description: z.string().optional(),
-  version: z.string().optional(),
-  websiteUrl: z.string().optional(),
-  icons: z
-    .array(
-      z.object({
-        src: z.string(),
-      }),
-    )
-    .optional(),
-  remotes: z
-    .array(
-      z.object({
-        type: z.string().optional(),
+// IMPORTANT: every object below is "open" (`.catchall(z.unknown())`), so its
+// JSON Schema advertises `additionalProperties: {}` rather than the default
+// `additionalProperties: false`.
+//
+// Why this matters: the registry response is built by spreading the stored
+// `server_json`/`meta_json` verbatim, and those mirror a full MCP `server.json`
+// (carrying many fields this schema does not model — `$schema`, `status`,
+// package transport details, etc.). The deco store validates output with Zod
+// (which strips unknown keys and passes), but MCP clients — e.g. the mesh proxy
+// via `client.callTool` — re-validate the structuredContent with Ajv, which
+// enforces `additionalProperties: false` and rejects the extra fields with
+// `-32602: Structured content does not match the tool's output schema`.
+// A closed schema therefore breaks LIST/GET; SEARCH is unaffected because it
+// returns a slim, exactly-projected object. Keeping these objects open is the
+// fix (and matches the open `[key: string]: unknown` storage entity types).
+const RegistryServerSchema = z
+  .object({
+    name: z.string(),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    version: z.string().optional(),
+    websiteUrl: z.string().optional(),
+    icons: z
+      .array(z.object({ src: z.string() }).catchall(z.unknown()))
+      .optional(),
+    remotes: z
+      .array(
+        z
+          .object({
+            type: z.string().optional(),
+            url: z.string().optional(),
+            name: z.string().optional(),
+            title: z.string().optional(),
+            description: z.string().optional(),
+          })
+          .catchall(z.unknown()),
+      )
+      .optional(),
+    packages: z
+      .array(
+        z
+          .object({
+            identifier: z.string(),
+            version: z.string().optional(),
+          })
+          .catchall(z.unknown()),
+      )
+      .optional(),
+    repository: z
+      .object({
         url: z.string().optional(),
-        name: z.string().optional(),
-        title: z.string().optional(),
-        description: z.string().optional(),
-      }),
-    )
-    .optional(),
-  packages: z
-    .array(
-      z.object({
-        identifier: z.string(),
-        version: z.string().optional(),
-      }),
-    )
-    .optional(),
-  repository: z
-    .object({
-      url: z.string().optional(),
-      source: z.string().optional(),
-      subfolder: z.string().optional(),
-    })
-    .optional(),
-});
+        source: z.string().optional(),
+        subfolder: z.string().optional(),
+      })
+      .catchall(z.unknown())
+      .optional(),
+  })
+  .catchall(z.unknown());
 
-const RegistryToolSchema = z.object({
-  name: z.string(),
-  description: z.string().nullable().optional(),
-});
+const RegistryToolSchema = z
+  .object({
+    name: z.string(),
+    description: z.string().nullable().optional(),
+  })
+  .catchall(z.unknown());
 
 const RegistryItemMetaSchema = z
   .object({
@@ -59,27 +79,38 @@ const RegistryItemMetaSchema = z
         short_description: z.string().max(160).nullable().optional(),
         owner: z.string().nullable().optional(),
         readme: z.string().max(50000).nullable().optional(),
-        readme_url: z.string().url().nullable().optional(),
+        // Plain string (not `.url()`): `.url()` advertises JSON Schema
+        // `format: "uri"`, which Ajv (in MCP clients) enforces more strictly
+        // than Zod's `new URL()` — rejecting otherwise-valid URLs with spaces
+        // or non-ASCII chars. Matches every other URL field in this schema.
+        readme_url: z.string().nullable().optional(),
         has_remote: z.boolean().optional(),
         has_oauth: z.boolean().optional(),
         tools: z.array(RegistryToolSchema).optional(),
       })
+      .catchall(z.unknown())
       .optional(),
   })
   .catchall(z.unknown());
 
-export const RegistryItemSchema = z.object({
-  id: z.string(),
-  name: z.string().optional(),
-  title: z.string(),
-  description: z.string().nullable().optional(),
-  _meta: RegistryItemMetaSchema.optional(),
-  server: RegistryServerSchema,
-  is_public: z.boolean().optional(),
-  created_at: z.string(),
-  updated_at: z.string(),
-  created_by: z.string().optional(),
-});
+export const RegistryItemSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    title: z.string(),
+    description: z.string().nullable().optional(),
+    _meta: RegistryItemMetaSchema.optional(),
+    server: RegistryServerSchema,
+    is_public: z.boolean().optional(),
+    // Always emitted by the storage layer's `deserialize`.
+    is_unlisted: z.boolean().optional(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    created_by: z.string().optional(),
+  })
+  // Open the item object itself (no `additionalProperties: false`) so any
+  // field the backend returns that is not modeled above does not trigger -32602.
+  .catchall(z.unknown());
 
 const RegistryCreateSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## What is this contribution about?
The Deco Store registry `LIST` and `GET` tools failed on every call with `-32602: Structured content does not match the tool's output schema` (`data/items/N` / `data/item must NOT have additional properties`). The item output schema was a closed object, so the SDK advertises it as JSON Schema with `additionalProperties: false`; the store validates output with Zod (which strips unknown keys and passes), but the mesh proxy re-validates the response client-side with Ajv, which rejects items carrying unmodeled fields (`is_unlisted`, verbatim `server.json` keys, a `readme_url` that `z.string().url()` advertises as `format: "uri"`, etc.). `SEARCH` was unaffected because it returns a slim, exactly-projected object. This opens the item object and its nested `server`/`_meta` shapes via `.catchall(z.unknown())` (no more `additionalProperties: false`), declares the always-returned `is_unlisted`, relaxes `readme_url` to a plain string, aligns the storage entity types, and adds faithful in-memory MCP round-trip regression tests for LIST and GET.

## Screenshots/Demonstration
N/A — no UI changes.

## How to Test
1. Call the Deco Store registry `LIST` (no args, then offsets 24/48/72) and `GET` by id — all return valid results with no `-32602` (89 items total across pages).
2. Confirm `SEARCH` still returns 2 results for "slack" and 1 for "github".
3. Run `bun test apps/mesh/src/tools/registry/`.

> Note: the deco-registry connection validates against the schema advertised by the remote store, so this fix takes effect for that connection only once the store is redeployed with these changes.

## Migration Notes
None — schema-only change, no database migration required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes