### PR TITLE
fix(release-tagging): stop infinite release loop from bot's own push

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -138,7 +138,11 @@ jobs:
             > **Note**: If multiple reactions exist, the smallest bump wins. If no reactions, the suggested bump is used (default: patch).
 
   determine-tag:
-    if: github.event_name == 'push'
+    # Skip release-bump commits so the bot's own push (made with the GitHub App
+    # token, which — unlike GITHUB_TOKEN — re-triggers workflows) does not loop.
+    if: >-
+      github.event_name == 'push' &&
+      !startsWith(github.event.head_commit.message, '[release]:')
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.determine_version.outputs.new_version }}


### PR DESCRIPTION
## Summary

`release-tagging.yaml` has been self-triggering in an infinite loop, releasing `2.367.13 → 2.367.25+` non-stop.

**Root cause:** PR #3540 swapped the version-bump push from `GITHUB_TOKEN` to a **GitHub App token** (to bypass `main` branch protection). GitHub's recursion guard only suppresses workflow re-triggers for `GITHUB_TOKEN` — pushes authenticated with a PAT or App installation token **do** trigger workflows. So the bot's own `[release]: bump` push to `main` re-matched the `push` + `apps/mesh/**` trigger and started another bump. Forever.

## Fix

Guard the `determine-tag` job to skip commits whose head message starts with `[release]:`:

```yaml
  determine-tag:
    if: >-
      github.event_name == 'push' &&
      !startsWith(github.event.head_commit.message, '[release]:')
```

This breaks the cycle while keeping the App token (still needed to bypass branch protection for the legitimate bump push).

## Testing / affected areas

- YAML validated (`yaml.safe_load`).
- Only `release-tagging.yaml` changes; `pull_request_target` path is unaffected.
- After merge, re-enable the workflow: `gh workflow enable release-tagging.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the release workflow from triggering itself after the bot’s version bump by skipping `[release]:` commits on push. This prevents the infinite release loop while keeping the GitHub App token in place.

- **Bug Fixes**
  - Guarded `determine-tag` to ignore `push` events where the head commit message starts with `[release]:`.

- **Migration**
  - After merge, re-enable the workflow: `gh workflow enable release-tagging.yaml`.

<sup>Written for commit 7c6ea0adcb78c5d8f7d4edbab319728aa3f65398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3545?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

