### PR TITLE
chore: add [skip ci] to release commit message

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -322,7 +322,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/mesh/package.json
-          git commit -m "[release]: bump to ${{ steps.determine_version.outputs.new_version }}"
+          git commit -m "[release]: bump to ${{ steps.determine_version.outputs.new_version }} [skip ci]"
           git push origin main
 
       - name: Trigger Release Workflow

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "major_version=$NEW_MAJOR_VERSION" >> $GITHUB_OUTPUT
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Auto-suggest version bump from PR title
+      - name: Auto-suggest version bump from PR title 
         id: suggest_bump
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add [skip ci] to the release bump commit in `.github/workflows/release-tagging.yaml` to prevent CI from running and speed up releases; also tidy a minor whitespace in a job name.

<sup>Written for commit 1120edf91a66039479ad686b6f9131e729e431c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3547?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

