### PR TITLE
Enhance release workflows by adding 'ref' input for pinning commits i…

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         default: "false"
         type: string
+      ref:
+        description: "Commit SHA to release (pins checkout to the exact version bump; empty = triggering ref)"
+        required: false
+        default: ""
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -39,6 +44,8 @@ jobs:
       image-exists: ${{ steps.image.outputs.image-exists }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Read version + check npm
         id: version
         working-directory: apps/mesh
@@ -84,6 +91,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
@@ -132,6 +141,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -241,10 +252,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
+          target_commitish: ${{ inputs.ref || github.sha }}
           name: "@decocms/mesh v${{ needs.prepare.outputs.version }}"
           body: |
             ## MCP Mesh v${{ needs.prepare.outputs.version }}

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -317,6 +317,7 @@ jobs:
           echo "Updated apps/mesh/package.json to version $NEW_VERSION"
 
       - name: Commit and push version bump
+        id: commit
         if: steps.determine_version.outputs.new_version != ''
         run: |
           git config user.name "github-actions[bot]"
@@ -324,6 +325,9 @@ jobs:
           git add apps/mesh/package.json
           git commit -m "[release]: bump to ${{ steps.determine_version.outputs.new_version }} [skip ci]"
           git push origin main
+          # Pin the release to this exact bump commit so a later push to main
+          # can't make release-mesh read a newer (untagged) version off HEAD.
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Trigger Release Workflow
         if: steps.determine_version.outputs.new_version != ''
@@ -334,4 +338,4 @@ jobs:
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-mesh.yaml/dispatches" \
-            -d '{"ref":"main", "inputs":{"deploy_to_production":"${{ steps.determine_version.outputs.deploy_to_production }}"}}'
+            -d '{"ref":"main", "inputs":{"deploy_to_production":"${{ steps.determine_version.outputs.deploy_to_production }}", "ref":"${{ steps.commit.outputs.sha }}"}}'


### PR DESCRIPTION
…n release-mesh and updating release-tagging to utilize this new input for precise version control.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `ref` input to `release-mesh` and updates `release-tagging` to pass the bump commit SHA, pinning releases to the exact version bump. This makes `@decocms/mesh` releases deterministic and prevents building from newer commits.

- New Features
  - `release-mesh.yaml`: add optional `ref` input; all `actions/checkout@v4` steps use it; GitHub release `target_commitish` falls back to `github.sha` when `ref` is empty.
  - `release-tagging.yaml`: capture the bump commit SHA and dispatch `release-mesh` with `ref` plus existing `deploy_to_production` input.

<sup>Written for commit 29534c4b05f1691c1fa739228c4a4792e3205fe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3549?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

