### PR TITLE
fix(auth): update test user generation to prevent name collisions and…

### DIFF
--- a/apps/mesh/e2e/fixtures/auth-api.ts
+++ b/apps/mesh/e2e/fixtures/auth-api.ts
@@ -23,8 +23,11 @@ export interface SignUpResult {
 
 function generateTestUser(overrides?: { email?: string; name?: string }) {
   const suffix = Date.now() + Math.floor(Math.random() * 100000);
+  // The unique suffix must lead the name: the signup hook derives the default
+  // org slug from the first name only, so a shared "Test" first name would
+  // collapse every test org into a tiny shared slug namespace and collide.
   return {
-    name: overrides?.name ?? `Test User ${suffix}`,
+    name: overrides?.name ?? `T${suffix} User`,
     email: overrides?.email ?? `test-${suffix}@playwright.local`,
     password: "Playwright123!",
   };

--- a/apps/mesh/e2e/fixtures/auth.ts
+++ b/apps/mesh/e2e/fixtures/auth.ts
@@ -6,8 +6,11 @@ import { type Page } from "@playwright/test";
  */
 function generateTestUser(overrides?: { email?: string }) {
   const suffix = Date.now() + Math.floor(Math.random() * 1000);
+  // The unique suffix must lead the name: the signup hook derives the default
+  // org slug from the first name only, so a shared "Test" first name would
+  // collapse every test org into a tiny shared slug namespace and collide.
   return {
-    name: `Test User ${suffix}`,
+    name: `T${suffix} User`,
     email: overrides?.email ?? `test-${suffix}@playwright.local`,
     password: "Playwright123!",
   };

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -487,10 +487,15 @@ export const auth = betterAuth({
             ? user.name.split(" ")[0]
             : user.email.split("@")[0];
 
-          const maxAttempts = 3;
+          const maxAttempts = 5;
           for (let attempt = 0; attempt < maxAttempts; attempt++) {
             const orgName = `${firstName} ${getRandomSuffix()}`;
-            const orgSlug = slugify(orgName);
+            // After the first collision, append entropy so retries don't keep
+            // redrawing from the same small suffix pool and exhaust attempts.
+            const orgSlug =
+              attempt === 0
+                ? slugify(orgName)
+                : slugify(`${orgName} ${Math.floor(Math.random() * 1e6)}`);
 
             try {
               const created = await auth.api.createOrganization({


### PR DESCRIPTION
… increase max attempts for organization creation

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent org slug collisions during signup by making test user names unique and hardening organization creation retries. This reduces flaky signups and stabilizes e2e tests.

- **Bug Fixes**
  - Prefix test user first names with a unique token (`T{suffix} User`) so the default org slug is unique.
  - Increase organization creation attempts from 3 to 5.
  - On retries, add extra entropy to the slug to avoid repeated collisions.

<sup>Written for commit 97ef8b53f3e14dfcdb27e0dd126668931f40bf60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3550?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

