### PR TITLE
Enhance GitHub Actions workflows by adding a 'changes' job to detect …

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,53 @@ on:
   pull_request:
 
 jobs:
+  # See test.yml for why this gate exists: skip the (required) check on
+  # workflow/docs/markdown-only PRs without leaving the required check
+  # stuck pending. Pushes to main always run.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-mesh picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if [ $? -ne 0 ]; then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/*|apps/docs/*|*.md) ;;
+              *) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
   e2e:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -28,6 +28,9 @@ on:
 
 jobs:
   multi-pod:
+    # Skip the [release]: version-bump commit — it only changes the version
+    # string and would otherwise re-run this heavy suite on every release.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[release]:')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -31,9 +31,11 @@ jobs:
   prepare:
     name: Prepare release metadata
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.event.head_commit.message, '[release]:')
+    # Releases are cut by the [release]: version-bump commit that release-tagging
+    # pushes to main (the bot push uses the App token, which re-triggers
+    # workflows). We run on EVERY push here — a non-bump push just reads an
+    # already-published version and short-circuits at the version-changed check.
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -303,7 +303,13 @@ jobs:
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
       - name: Trigger deployment update
-        if: inputs.deploy_to_production == 'true'
+        # Bump the deploy repo on every real release. The release job only runs
+        # for genuine new versions, so a push here is always a release worth
+        # deploying. (Previously gated solely on the workflow_dispatch input,
+        # which silently stopped firing once that dispatch began 403'ing —
+        # freezing prod's desired image tag.) ArgoCD's manual-sync prod gate
+        # still applies: this only updates the desired tag in git.
+        if: inputs.deploy_to_production == 'true' || github.event_name == 'push'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.DEPLOY_REPO_TOKEN }}
@@ -311,7 +317,7 @@ jobs:
           event-type: image-update
           client-payload: '{"image_tag": "${{ needs.prepare.outputs.version }}"}'
       - name: Deployment summary
-        if: inputs.deploy_to_production == 'true'
+        if: inputs.deploy_to_production == 'true' || github.event_name == 'push'
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Deployment" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -323,19 +323,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/mesh/package.json
-          git commit -m "[release]: bump to ${{ steps.determine_version.outputs.new_version }} [skip ci]"
+          git commit -m "[release]: bump to ${{ steps.determine_version.outputs.new_version }}"
           git push origin main
-          # Pin the release to this exact bump commit so a later push to main
-          # can't make release-mesh read a newer (untagged) version off HEAD.
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Trigger Release Workflow
-        if: steps.determine_version.outputs.new_version != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          curl -X POST \
-            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
-            -H "Accept: application/vnd.github.everest-preview+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-mesh.yaml/dispatches" \
-            -d '{"ref":"main", "inputs":{"deploy_to_production":"${{ steps.determine_version.outputs.deploy_to_production }}", "ref":"${{ steps.commit.outputs.sha }}"}}'
+          # No [skip ci], no API dispatch: this push (made with the App token,
+          # which re-triggers workflows) is itself what kicks off release-mesh.
+          # release-mesh runs on this exact commit, so it always reads the
+          # version it's releasing — no HEAD race, and no cross-workflow
+          # dispatch token/permission to silently 403. The heavy
+          # test/multi-pod/resilience suites skip [release]: commits via guards.

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   resilience:
+    # Skip the [release]: version-bump commit — it only changes the version
+    # string and would otherwise re-run this heavy suite on every release.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[release]:')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -15,7 +15,53 @@ on:
       - main
 
 jobs:
+  # See test.yml for why this gate exists: skip the (required) check on
+  # workflow/docs/markdown-only PRs without leaving the required check
+  # stuck pending. Pushes to main always run.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-mesh picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if [ $? -ne 0 ]; then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/*|apps/docs/*|*.md) ;;
+              *) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
   daemon-e2e:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -19,7 +19,53 @@ on:
       - main
 
 jobs:
+  # See test.yml for why this gate exists: skip the (required) check on
+  # workflow/docs/markdown-only PRs without leaving the required check
+  # stuck pending. Pushes to main always run.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-mesh picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if [ $? -ne 0 ]; then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/*|apps/docs/*|*.md) ;;
+              *) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
   storage-integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,56 @@ on:
       - main
 
 jobs:
+  # Gate: skip the (required) check jobs when a PR only touches workflow YAML,
+  # docs, or markdown. Required checks can't be skipped via workflow-level
+  # `paths` filters — a never-scheduled required check blocks the merge forever.
+  # A job skipped via `if`, by contrast, reports as passed. So we keep the
+  # trigger broad and skip at the job level. Pushes to main always run.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-mesh picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if [ $? -ne 0 ]; then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          # Run unless every changed file is workflow/docs/markdown.
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/*|apps/docs/*|*.md) ;;
+              *) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
   format:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -27,6 +76,8 @@ jobs:
         run: bun run fmt:check
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -44,6 +95,8 @@ jobs:
         run: bun run lint
 
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -66,6 +119,8 @@ jobs:
         run: bun run check:ci
 
   test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -103,6 +158,8 @@ jobs:
             ! -name '*.e2e.test.ts')
 
   build:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -129,6 +186,8 @@ jobs:
         run: bun run knip
 
   docker-smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
…relevant changes in pull requests, allowing subsequent jobs to conditionally run based on the presence of non-docs or non-markdown file modifications. This prevents unnecessary runs for documentation-only changes across multiple workflows.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI changes gate to skip jobs on docs/workflow/markdown-only PRs and prevent required checks from blocking merges. Streamline releases to trigger from the `[release]:` bump commit and reliably update deployment targets without re-running heavy suites.

- **New Features**
  - Added a `changes` job to `test`, `e2e`, `storage-integration`, and `sandbox-daemon` workflows; downstream jobs run only when non-docs files change.
  - Uses `gh api` to list PR files; treats `.github/*`, `apps/docs/*`, and `*.md` as non-relevant.

- **Refactors**
  - Heavy suites (`multi-pod`, `resilience`) skip on push commits starting with `[release]:`.
  - Release flow: the bump push (no `[skip ci]`, no manual dispatch) re-triggers `release-mesh`, which runs on push and short-circuits if the version didn’t change.
  - Deployment updates: `release-mesh` now dispatches image tag updates on push (and when input is set), fixing silent failures and keeping prod’s desired tag current.

<sup>Written for commit 9cf3ac24120122a82d2a8b0035e8a6d7f956d8c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3551?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

