### PR TITLE
fix(api): resolve object storage context in automation context factor…

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/automation-context.ts
+++ b/apps/mesh/src/api/routes/decopilot/automation-context.ts
@@ -22,6 +22,9 @@ import {
   SqlAsyncResearchJobStorage,
 } from "@/storage/async-research-jobs";
 import type { MeshContextFactory } from "@/automations/fire";
+import { getObjectStorageS3Service } from "@/object-storage/factory";
+import { createBoundObjectStorage } from "@/object-storage/bound-object-storage";
+import { DevObjectStorage } from "@/object-storage/dev-object-storage";
 
 export interface BuildAutomationContextDeps {
   db: Kysely<Database>;
@@ -109,6 +112,15 @@ export function createAutomationContextFactory(
       deps.asyncResearchJobStorage,
       membership.orgId,
     );
+
+    // The base context was built without `req`, so it had no organization and
+    // objectStorage was set to null (context-factory.ts). Now that the org is
+    // resolved, rebuild it the same way the request path does — otherwise tools
+    // like generate_image silently fall back to inlining base64 data: URIs.
+    const s3Service = getObjectStorageS3Service();
+    ctx.objectStorage = s3Service
+      ? createBoundObjectStorage(s3Service, membership.orgId)
+      : new DevObjectStorage(membership.orgId, ctx.baseUrl);
 
     return ctx;
   };


### PR DESCRIPTION
…y to prevent silent failures in image generation

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes object storage resolution in the automation context factory by binding storage to the resolved organization. Prevents silent image generation fallbacks and ensures `generate_image` writes to the correct org storage.

- **Bug Fixes**
  - Rebuilds `ctx.objectStorage` after `membership.orgId` is known, using `createBoundObjectStorage` with `getObjectStorageS3Service()` or `DevObjectStorage`.
  - Matches the request-built context so image tools don’t inline base64 data URIs and use org-scoped storage instead.

<sup>Written for commit 8762c27a37674c70c428dac1ab2d9409cd29978e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3552?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

