### PR TITLE
refactor(generate-image): improve error handling and remove fallback …

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
@@ -213,34 +213,27 @@ export function createGenerateImageTool(
 
         // Upload images to object storage, return stable mesh-storage: URIs.
         // The model sees only URIs (lightweight, opaque); the frontend resolves
-        // them to fetchable URLs for rendering.
+        // them to fetchable URLs for rendering. We must NOT inline base64 data:
+        // URIs into the result: a single image is ~1 MB+ of base64, which
+        // exceeds the NATS JetStream max_payload (1 MiB) backing the Decopilot
+        // UI stream and blows past the model's context window. Fail loudly
+        // instead so the failure is visible rather than poisoning the thread.
+        if (!ctx.objectStorage) {
+          throw new Error(
+            "Object storage is unavailable; cannot persist the generated image.",
+          );
+        }
+        const objectStorage = ctx.objectStorage;
         const images = await Promise.all(
           result.images.map(async (img) => {
             const mediaType = img.mediaType ?? "image/png";
             const ext = mediaType.split("/")[1] ?? "png";
             const key = `generated-images/${crypto.randomUUID()}.${ext}`;
-
-            if (ctx.objectStorage) {
-              try {
-                const bytes = Uint8Array.from(atob(img.base64), (c) =>
-                  c.charCodeAt(0),
-                );
-                await ctx.objectStorage.put(key, bytes, {
-                  contentType: mediaType,
-                });
-                return { uri: toMeshStorageUri(key), mediaType };
-              } catch (err) {
-                console.error(
-                  "[generate-image] Failed to upload, falling back to data: URI",
-                  err,
-                );
-              }
-            }
-            // Fallback: inline data: URI (no object storage configured)
-            return {
-              uri: `data:${mediaType};base64,${img.base64}`,
-              mediaType,
-            };
+            const bytes = Uint8Array.from(atob(img.base64), (c) =>
+              c.charCodeAt(0),
+            );
+            await objectStorage.put(key, bytes, { contentType: mediaType });
+            return { uri: toMeshStorageUri(key), mediaType };
           }),
         );
 


### PR DESCRIPTION
…to inline data URIs for image uploads. Ensure object storage is available before attempting to persist generated images, enhancing reliability and preventing payload size issues.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the generate-image tool to always upload to object storage and remove the base64 data: URI fallback. This prevents oversized payloads and surfaces clear errors when storage is unavailable.

- **Refactors**
  - Require `ctx.objectStorage`; throw a clear error if missing.
  - Always upload bytes to object storage and return mesh-storage URIs.
  - Remove inline `data:` URI path to avoid payload limits and context bloat.

- **Migration**
  - Ensure object storage is configured and available in the runtime context.
  - Environments relying on inline data URIs must switch to object storage or this tool will fail.

<sup>Written for commit 2fdb389b0317b12ebf243a00483b96ae494d93b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3553?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

