### PR TITLE
Update GitHub Actions workflows to ignore changes in apps/mesh/packag…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
+    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    paths-ignore:
+      - "apps/mesh/package.json"
   pull_request:
 
 jobs:

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
+    # here so the version bump doesn't re-spawn this heavy suite.
+    paths-ignore:
+      - "apps/mesh/package.json"
   pull_request:
     # Multi-pod tests are slow (~7-10 min cold image build + serialized
     # boot + scenarios). Only run on PRs that change code the framework

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -1,14 +1,15 @@
 name: Release Mesh
 
 on:
+  # Releases are driven by the version bump. release-tagging commits
+  # "[release]: bump to X" touching ONLY apps/mesh/package.json, and that push
+  # (App token → re-triggers workflows) is what fires this. Triggering on
+  # package.json alone means we run exactly ONCE per release — the feature
+  # commit that preceded the bump no longer also spawns a (redundant) run.
   push:
     branches: [main]
     paths:
-      - "apps/mesh/**"
-      - "packages/runtime/**"
-      - "packages/mesh-plugin-*/**"
-      - "packages/mesh-sdk/**"
-      - "packages/sandbox/**"
+      - "apps/mesh/package.json"
   workflow_dispatch:
     inputs:
       deploy_to_production:

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
+    # here so the version bump doesn't re-spawn this heavy suite.
+    paths-ignore:
+      - "apps/mesh/package.json"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -10,6 +10,10 @@ on:
   push:
     branches:
       - main
+    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
+    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    paths-ignore:
+      - "apps/mesh/package.json"
   pull_request:
     branches:
       - main

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -14,6 +14,10 @@ on:
   push:
     branches:
       - main
+    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
+    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    paths-ignore:
+      - "apps/mesh/package.json"
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
+    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    paths-ignore:
+      - "apps/mesh/package.json"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
…e.json during pushes, preventing unnecessary re-runs of workflows triggered by version bumps.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops CI from rerunning on version bump commits by ignoring pushes that only change `apps/mesh/package.json`. Also makes `release-mesh` run exactly once per release by triggering only on that file.

- **Refactors**
  - Added `paths-ignore: apps/mesh/package.json` to e2e, multi-pod, resilience, sandbox-daemon, storage-integration, and test workflows.
  - Updated `release-mesh.yaml` to trigger only on `apps/mesh/package.json`.

<sup>Written for commit f57534f8c37d3118330489fd4a9e9a5efea7eaae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3554?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

