### PR TITLE
feat(nats-stream-buffer): implement chunked message publishing and re…

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -214,9 +214,9 @@ describe("NatsStreamBuffer", () => {
       const buffer = bufferWith(() => Promise.resolve(sub));
       const stream = await buffer.createTailStream("task-1");
 
-      const stale = fragmentChunk("X".repeat(120), 3);
-      push(stale[1]); // joined mid-sequence — index 0 never seen
-      push(stale[2]);
+      const [, stale1, stale2] = fragmentChunk("X".repeat(120), 3);
+      push(stale1!); // joined mid-sequence — index 0 never seen
+      push(stale2!);
       const good = "good-payload-after-join";
       for (const f of fragmentChunk(good, 3)) push(f);
       end();
@@ -232,9 +232,9 @@ describe("NatsStreamBuffer", () => {
       const buffer = bufferWith(() => Promise.resolve(sub));
       const stream = await buffer.createTailStream("task-1");
 
-      const lost = fragmentChunk("Y".repeat(120), 3);
-      push(lost[0]); // index 1 publish "failed" — never arrives
-      push(lost[2]);
+      const [lost0, , lost2] = fragmentChunk("Y".repeat(120), 3);
+      push(lost0!); // index 1 publish "failed" — never arrives
+      push(lost2!);
       const recovered = "recovered-after-loss";
       for (const f of fragmentChunk(recovered, 3)) push(f);
       end();

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, mock } from "bun:test";
 import { NatsStreamBuffer } from "./nats-stream-buffer";
 
-type DeferredMsg = { data: Uint8Array };
+type DeferredMsg = {
+  data: Uint8Array;
+  headers?: { get(name: string): string | undefined };
+};
 
 function createControlledSubscription() {
   const queue: Array<{ done: false; value: DeferredMsg } | { done: true }> = [];
@@ -157,6 +160,88 @@ describe("NatsStreamBuffer", () => {
     function encodeMsg(payload: unknown): DeferredMsg {
       return { data: new TextEncoder().encode(JSON.stringify(payload)) };
     }
+
+    // Mirror the producer's fragment headers (see `publishChunk`): split the
+    // encoded `{ p: value }` bytes into `parts` ordered fragment messages.
+    function fragmentChunk(value: unknown, parts: number): DeferredMsg[] {
+      const bytes = new TextEncoder().encode(JSON.stringify({ p: value }));
+      const sliceSize = Math.ceil(bytes.length / parts);
+      const msgs: DeferredMsg[] = [];
+      for (let i = 0; i < parts; i++) {
+        const data = bytes.slice(i * sliceSize, (i + 1) * sliceSize);
+        const hdr: Record<string, string> = {
+          "Dp-Frag-Idx": String(i),
+          "Dp-Frag-Total": String(parts),
+        };
+        msgs.push({ data, headers: { get: (name) => hdr[name] } });
+      }
+      return msgs;
+    }
+
+    it("reassembles a fragmented chunk byte-exact", async () => {
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+      const stream = await buffer.createTailStream("task-1");
+
+      const value = { type: "text-delta", text: "x".repeat(200) };
+      for (const f of fragmentChunk(value, 4)) push(f);
+      end();
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual([value]);
+    });
+
+    it("keeps consecutive same-total fragmented chunks separate", async () => {
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+      const stream = await buffer.createTailStream("task-1");
+
+      const a = "A".repeat(120);
+      const b = "B".repeat(120);
+      for (const f of fragmentChunk(a, 3)) push(f);
+      for (const f of fragmentChunk(b, 3)) push(f);
+      end();
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual([a, b]);
+    });
+
+    it("drops a mid-sequence fragment join without poisoning the next chunk", async () => {
+      // A `deliverPolicy: "new"` subscriber can land mid-fragment, seeing
+      // index>0 first with no index-0 anchor. Those strays must be discarded
+      // so they don't corrupt the next complete chunk.
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+      const stream = await buffer.createTailStream("task-1");
+
+      const stale = fragmentChunk("X".repeat(120), 3);
+      push(stale[1]); // joined mid-sequence — index 0 never seen
+      push(stale[2]);
+      const good = "good-payload-after-join";
+      for (const f of fragmentChunk(good, 3)) push(f);
+      end();
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual([good]);
+    });
+
+    it("drops an incomplete chunk (lost fragment) and recovers on the next", async () => {
+      // A failed middle publish leaves a gap. The stale accumulator must not
+      // bleed into a following same-total chunk.
+      const { sub, push, end } = createControlledSubscription();
+      const buffer = bufferWith(() => Promise.resolve(sub));
+      const stream = await buffer.createTailStream("task-1");
+
+      const lost = fragmentChunk("Y".repeat(120), 3);
+      push(lost[0]); // index 1 publish "failed" — never arrives
+      push(lost[2]);
+      const recovered = "recovered-after-loss";
+      for (const f of fragmentChunk(recovered, 3)) push(f);
+      end();
+
+      const chunks = await readAll(stream!);
+      expect(chunks).toEqual([recovered]);
+    });
 
     it("returns null when JetStream is unavailable", async () => {
       const buffer = new NatsStreamBuffer({

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -18,10 +18,12 @@ import {
   AckPolicy,
   DeliverPolicy,
   DiscardPolicy,
+  headers as natsHeaders,
   RetentionPolicy,
   StorageType,
   type JetStreamClient,
   type JetStreamManager,
+  type MsgHdrs,
   type NatsConnection,
 } from "nats";
 import type { StreamBuffer } from "./stream-buffer";
@@ -31,6 +33,20 @@ const SUBJECT_PREFIX = "decopilot.stream";
 const MAX_AGE_NS = 5 * 60 * 1_000_000_000; // 5 min
 const MAX_BYTES = 500 * 1024 * 1024; // 500 MB
 const MAX_MSGS_PER_SUBJECT = 20_000; // ~20K chunks per thread
+
+// NATS rejects any single message larger than the server's `max_payload`
+// (default 1 MiB) with MAX_PAYLOAD_EXCEEDED, which would silently drop the
+// chunk and break the UI stream. We keep each published message comfortably
+// under that, and transparently split anything larger across multiple
+// fragment messages (reassembled by the tail consumer). Headroom below 1 MiB
+// covers the subject, JetStream headers, and the fragment headers below.
+const MAX_PUBLISH_BYTES = 768 * 1024;
+// Above this a single chunk is pathological (not a normal UI stream part).
+// Splitting it would hold tens of MB in memory on reassembly, so we drop it
+// loudly instead.
+const MAX_CHUNKED_BYTES = 32 * 1024 * 1024;
+const FRAG_INDEX_HEADER = "Dp-Frag-Idx";
+const FRAG_TOTAL_HEADER = "Dp-Frag-Total";
 
 function assertSafeSubjectToken(id: string): void {
   if (/[.*>\s]/.test(id)) throw new Error("Invalid NATS subject token");
@@ -44,16 +60,23 @@ function streamSubject(taskId: string): string {
 function createPublishTracker(taskId: string) {
   let errors = 0;
   return {
-    publish(js: JetStreamClient, subj: string, data: Uint8Array): void {
-      js.publish(subj, data).catch((err) => {
-        errors++;
-        if (errors === 1 || errors % 100 === 0) {
-          console.warn(
-            `[Decopilot] JetStream publish failed for thread ${taskId} (${errors} total):`,
-            err,
-          );
-        }
-      });
+    publish(
+      js: JetStreamClient,
+      subj: string,
+      data: Uint8Array,
+      hdrs?: MsgHdrs,
+    ): void {
+      js.publish(subj, data, hdrs ? { headers: hdrs } : undefined).catch(
+        (err) => {
+          errors++;
+          if (errors === 1 || errors % 100 === 0) {
+            console.warn(
+              `[Decopilot] JetStream publish failed for thread ${taskId} (${errors} total):`,
+              err,
+            );
+          }
+        },
+      );
     },
     get errorCount() {
       return errors;
@@ -133,17 +156,47 @@ export class NatsStreamBuffer implements StreamBuffer {
     // also wire `registrySignal` straight to the sentinel.
     registrySignal.addEventListener("abort", publishDone, { once: true });
 
+    // Publish one stream chunk. Small chunks go straight through; anything
+    // over the NATS payload limit is split into ordered fragment messages
+    // (same subject, same connection → server preserves order) and stitched
+    // back together by `createTailStream`. Fragments carry raw byte slices
+    // of the encoded `{ p: value }` JSON, so reassembly is byte-exact.
+    const publishChunk = (value: unknown): void => {
+      const bytes = encoder.encode(JSON.stringify({ p: value }));
+      if (bytes.length <= MAX_PUBLISH_BYTES) {
+        tracker.publish(js, subj, bytes);
+        return;
+      }
+      if (bytes.length > MAX_CHUNKED_BYTES) {
+        console.warn(
+          `[Decopilot] dropping oversized stream chunk for thread ${taskId}: ${(
+            bytes.length / (1024 * 1024)
+          ).toFixed(
+            1,
+          )} MiB exceeds ${MAX_CHUNKED_BYTES / (1024 * 1024)} MiB cap`,
+        );
+        return;
+      }
+      const total = Math.ceil(bytes.length / MAX_PUBLISH_BYTES);
+      for (let i = 0; i < total; i++) {
+        const slice = bytes.slice(
+          i * MAX_PUBLISH_BYTES,
+          (i + 1) * MAX_PUBLISH_BYTES,
+        );
+        const hdrs = natsHeaders();
+        hdrs.set(FRAG_INDEX_HEADER, String(i));
+        hdrs.set(FRAG_TOTAL_HEADER, String(total));
+        tracker.publish(js, subj, slice, hdrs);
+      }
+    };
+
     void (async () => {
       const reader = stream.getReader();
       try {
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          tracker.publish(
-            js,
-            subj,
-            encoder.encode(JSON.stringify({ p: value })),
-          );
+          publishChunk(value);
         }
       } catch (err) {
         console.warn(
@@ -193,6 +246,36 @@ export class NatsStreamBuffer implements StreamBuffer {
 
     const decoder = new TextDecoder();
 
+    // Reassembly buffer for chunks the producer split across fragment
+    // messages (see `publishChunk`). Fragments for one chunk arrive in order
+    // and contiguously, so a single in-flight accumulator is sufficient.
+    let frag: { total: number; received: number; parts: Uint8Array[] } | null =
+      null;
+    const reassembleFragment = (msg: {
+      headers?: MsgHdrs;
+      data: Uint8Array;
+    }): Uint8Array | null => {
+      const totalStr = msg.headers?.get(FRAG_TOTAL_HEADER);
+      if (!totalStr) return null; // not a fragment — caller handles as JSON
+      const total = Number(totalStr);
+      const index = Number(msg.headers?.get(FRAG_INDEX_HEADER) ?? "0");
+      if (!frag || frag.total !== total) {
+        frag = { total, received: 0, parts: new Array(total) };
+      }
+      if (!frag.parts[index]) frag.received++;
+      frag.parts[index] = msg.data;
+      if (frag.received < frag.total) return null; // need more fragments
+      const size = frag.parts.reduce((sum, p) => sum + (p?.length ?? 0), 0);
+      const merged = new Uint8Array(size);
+      let offset = 0;
+      for (const part of frag.parts) {
+        merged.set(part, offset);
+        offset += part.length;
+      }
+      frag = null;
+      return merged;
+    };
+
     // Use explicit iterator so pull() maintains position across invocations
     const iter = (async function* () {
       for await (const msg of sub) {
@@ -220,8 +303,13 @@ export class NatsStreamBuffer implements StreamBuffer {
             return;
           }
           const msg = result.value;
+          // Stitch fragmented chunks back together before decoding. A
+          // fragment that doesn't complete the set yields null → read more.
+          const reassembled = reassembleFragment(msg);
+          if (msg.headers?.get(FRAG_TOTAL_HEADER) && !reassembled) continue;
+          const payload = reassembled ?? msg.data;
           try {
-            const data = JSON.parse(decoder.decode(msg.data));
+            const data = JSON.parse(decoder.decode(payload));
             if (data.done) {
               if (closeOnDone) {
                 cleanup();

--- a/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -247,8 +247,10 @@ export class NatsStreamBuffer implements StreamBuffer {
     const decoder = new TextDecoder();
 
     // Reassembly buffer for chunks the producer split across fragment
-    // messages (see `publishChunk`). Fragments for one chunk arrive in order
-    // and contiguously, so a single in-flight accumulator is sufficient.
+    // messages (see `publishChunk`). A fresh accumulator is anchored on the
+    // index-0 fragment; any fragment arriving without a live, matching
+    // accumulator (a lost fragment, or a `deliverPolicy: "new"` subscriber
+    // that joined mid-sequence) is dropped so it can't poison the next chunk.
     let frag: { total: number; received: number; parts: Uint8Array[] } | null =
       null;
     const reassembleFragment = (msg: {
@@ -259,8 +261,10 @@ export class NatsStreamBuffer implements StreamBuffer {
       if (!totalStr) return null; // not a fragment — caller handles as JSON
       const total = Number(totalStr);
       const index = Number(msg.headers?.get(FRAG_INDEX_HEADER) ?? "0");
-      if (!frag || frag.total !== total) {
+      if (index === 0) {
         frag = { total, received: 0, parts: new Array(total) };
+      } else if (!frag || frag.total !== total) {
+        return null; // stray fragment — no matching in-flight chunk
       }
       if (!frag.parts[index]) frag.received++;
       frag.parts[index] = msg.data;


### PR DESCRIPTION
…assembly for NATS streams. Introduce limits for message sizes and headers for fragment tracking, enhancing reliability in handling large payloads.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds chunked publishing and robust reassembly to the `nats` stream buffer to handle payloads over the server limit. Handles mid-sequence joins and lost fragments so large streams stay reliable.

- **New Features**
  - Split oversized chunks into ≤768 KiB fragments with headers `Dp-Frag-Idx` and `Dp-Frag-Total`; drop chunks >32 MiB with a clear warning.
  - Reassemble on the consumer before JSON decode; ignore stray or incomplete fragment sets, keep consecutive same-total sets separate, and recover on the next index-0, preserving order and byte-exact payloads.

<sup>Written for commit 84228509f08bfc8a24f34bab851efa65bb030d25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3555?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

