### PR TITLE
Update GitHub Actions workflows to ignore changes in the .github dire…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
-    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
-    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-mesh).
     paths-ignore:
       - "apps/mesh/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
   pull_request:
 
 jobs:

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
-    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
-    # here so the version bump doesn't re-spawn this heavy suite.
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need this heavy suite re-run.
     paths-ignore:
       - "apps/mesh/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
   pull_request:
     # Multi-pod tests are slow (~7-10 min cold image build + serialized
     # boot + scenarios). Only run on PRs that change code the framework

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
-    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
-    # here so the version bump doesn't re-spawn this heavy suite.
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need this heavy suite re-run.
     paths-ignore:
       - "apps/mesh/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -10,10 +10,14 @@ on:
   push:
     branches:
       - main
-    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
-    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-mesh).
     paths-ignore:
       - "apps/mesh/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
   pull_request:
     branches:
       - main

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -14,10 +14,14 @@ on:
   push:
     branches:
       - main
-    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
-    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-mesh).
     paths-ignore:
       - "apps/mesh/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - main
-    # The "[release]: bump" commit touches only apps/mesh/package.json; skip it
-    # here so the version bump doesn't re-spawn this suite (release-mesh owns it).
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-mesh).
     paths-ignore:
       - "apps/mesh/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
…ctory, apps/docs, and markdown files during pushes, preventing unnecessary re-runs of workflows triggered by documentation or configuration updates.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update GitHub Actions to skip runs on main when only CI config, docs, or markdown files change. This reduces unnecessary workflow runs and saves CI time.

- **Refactors**
  - Added `paths-ignore` for `.github/**`, `apps/docs/**`, and `**/*.md` to `.github/workflows/{e2e,multi-pod,resilience,sandbox-daemon,storage-integration,test}.yml` (existing `apps/mesh/package.json` ignore kept).
  - PR triggers stay the same, so docs/config changes are still validated in PRs.

<sup>Written for commit 171f0e30b45d194d228c267b7b94cf82523e4ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3556?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

