### PR TITLE
feat(cache): implement TTL + LRU caching for public registry app list

### DIFF
--- a/apps/mesh/src/api/routes/registry/list-cache.ts
+++ b/apps/mesh/src/api/routes/registry/list-cache.ts
@@ -1,0 +1,48 @@
+/**
+ * In-process TTL + LRU cache for the public registry app list.
+ *
+ * The public list endpoint is unauthenticated, read-heavy, and tolerant of
+ * brief staleness, so we cache results per (org, query) for a short window.
+ */
+
+interface Entry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export class TtlLruCache<V> {
+  private readonly store = new Map<string, Entry<V>>();
+
+  constructor(
+    private readonly maxEntries: number,
+    private readonly ttlMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  get(key: string): V | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= this.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+    // Mark as most-recently-used.
+    this.store.delete(key);
+    this.store.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: V): void {
+    this.store.delete(key);
+    this.store.set(key, { value, expiresAt: this.now() + this.ttlMs });
+    while (this.store.size > this.maxEntries) {
+      const oldest = this.store.keys().next().value;
+      if (oldest === undefined) break;
+      this.store.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/apps/mesh/src/api/routes/registry/public-mcp-server.ts
+++ b/apps/mesh/src/api/routes/registry/public-mcp-server.ts
@@ -16,7 +16,7 @@ import {
 } from "@/tools/registry/schema";
 import { TtlLruCache } from "./list-cache";
 
-const LIST_CACHE_TTL_MS = 60_000;
+const LIST_CACHE_TTL_MS = 60_000 * 60; // 1 hour
 const LIST_CACHE_MAX_ENTRIES = 500;
 
 // Shared across requests: the public list is unauthenticated and read-heavy.

--- a/apps/mesh/src/api/routes/registry/public-mcp-server.ts
+++ b/apps/mesh/src/api/routes/registry/public-mcp-server.ts
@@ -4,6 +4,7 @@ import { withRuntime } from "@decocms/runtime";
 import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import { RegistryItemStorage } from "@/storage/registry/registry-item";
+import type { PrivateRegistryListResult } from "@/storage/registry/types";
 import {
   RegistryListInputSchema,
   RegistryListOutputSchema,
@@ -13,6 +14,16 @@ import {
   RegistrySearchInputSchema,
   RegistrySearchOutputSchema,
 } from "@/tools/registry/schema";
+import { TtlLruCache } from "./list-cache";
+
+const LIST_CACHE_TTL_MS = 60_000;
+const LIST_CACHE_MAX_ENTRIES = 500;
+
+// Shared across requests: the public list is unauthenticated and read-heavy.
+const publicListCache = new TtlLruCache<PrivateRegistryListResult>(
+  LIST_CACHE_MAX_ENTRIES,
+  LIST_CACHE_TTL_MS,
+);
 
 /**
  * Create public MCP tools for the registry
@@ -29,14 +40,21 @@ function createPublicMCPTools(storage: RegistryItemStorage, orgId: string) {
     inputSchema: RegistryListInputSchema,
     outputSchema: RegistryListOutputSchema,
     execute: async ({ context }) => {
-      const result = await storage.listPublic(orgId, {
+      const query = {
         limit: context.limit,
         offset: context.offset,
         cursor: context.cursor,
         tags: context.tags,
         categories: context.categories,
         where: context.where,
-      });
+      };
+      const cacheKey = `${orgId}:${JSON.stringify(query)}`;
+
+      const cached = publicListCache.get(cacheKey);
+      if (cached) return cached;
+
+      const result = await storage.listPublic(orgId, query);
+      publicListCache.set(cacheKey, result);
       return result;
     },
   });


### PR DESCRIPTION
Add a new TtlLruCache class to manage in-process caching of the public registry app list. This cache supports a time-to-live (TTL) and a maximum number of entries, optimizing performance for read-heavy, unauthenticated requests. Integrate the cache into the public MCP server to reduce redundant data fetching and improve response times.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-process TTL + LRU cache for the public registry app list to cut repeated reads and speed up unauthenticated requests. The public MCP list tool now caches results per org and query for 1 hour, up to 500 entries.

- New Features
  - Introduced `TtlLruCache` with TTL and LRU eviction.
  - Integrated into the public list tool using key `${orgId}:${JSON.stringify(query)}`; shared across requests; TTL 1 hour; max 500; evicts oldest on overflow.

<sup>Written for commit 88ccb2e3e1cd550eb671f66025fc64aeecf16b0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3561?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

