### PR TITLE
feat(org-list-cache): implement caching for organization list retriev…

### DIFF
--- a/apps/mesh/src/web/components/org-access-gate.tsx
+++ b/apps/mesh/src/web/components/org-access-gate.tsx
@@ -2,6 +2,7 @@ import { AutoDomainJoinScreen } from "@/web/components/auto-domain-join-screen";
 import { NoAccessScreen } from "@/web/components/no-access-screen";
 import { PendingInviteScreen } from "@/web/components/pending-invite-screen";
 import { useOrgAccessStatus } from "@/web/hooks/use-org-access-status";
+import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 
 /**
  * Renders the right "you can't enter here yet" screen when the shell layout's
@@ -10,6 +11,19 @@ import { useOrgAccessStatus } from "@/web/hooks/use-org-access-status";
  */
 export function OrgAccessGate({ orgSlug }: { orgSlug: string }) {
   const { data } = useOrgAccessStatus(orgSlug);
+
+  // Self-heal the home route's optimistic redirect: if we sent the user here
+  // from a cached slug that turned out to be stale (org deleted or membership
+  // lost), clear it and bounce back to "/" so the home loader can pick a valid
+  // destination — instead of dead-ending on the not-found / no-access screen.
+  if (
+    (data.status === "not-found" || data.status === "no-access") &&
+    localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === orgSlug
+  ) {
+    localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+    window.location.href = "/";
+    return null;
+  }
 
   if (data.status === "not-found") {
     return <NoAccessScreen orgSlug={orgSlug} reason="not-found" />;

--- a/apps/mesh/src/web/components/pending-invite-screen.tsx
+++ b/apps/mesh/src/web/components/pending-invite-screen.tsx
@@ -1,4 +1,7 @@
-import { authClient } from "@/web/lib/auth-client";
+import {
+  authClient,
+  invalidateOrganizationListCache,
+} from "@/web/lib/auth-client";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Mail01 } from "@untitledui/icons";
@@ -27,6 +30,9 @@ export function PendingInviteScreen({
       return result.data;
     },
     onSuccess: () => {
+      // Membership changed — drop the cached org list so the home loader sees
+      // the newly joined org.
+      invalidateOrganizationListCache();
       window.location.href = `/${orgSlug}`;
     },
     onError: (error) => {

--- a/apps/mesh/src/web/components/settings/delete-organization-section.tsx
+++ b/apps/mesh/src/web/components/settings/delete-organization-section.tsx
@@ -1,3 +1,4 @@
+import { invalidateOrganizationListCache } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
@@ -65,6 +66,10 @@ export function DeleteOrganizationSection() {
       if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === org.slug) {
         localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
       }
+
+      // Drop the TTL-cached org list so the homeRoute loader doesn't redirect
+      // back to the just-deleted org (this path navigates client-side).
+      invalidateOrganizationListCache();
 
       // Drop active-org caches that might still hold the archived org
       queryClient.removeQueries({

--- a/apps/mesh/src/web/components/sidebar/footer/invitation-item.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/invitation-item.tsx
@@ -1,4 +1,7 @@
-import { authClient } from "@/web/lib/auth-client";
+import {
+  authClient,
+  invalidateOrganizationListCache,
+} from "@/web/lib/auth-client";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Check, XClose } from "@untitledui/icons";
 import { useState } from "react";
@@ -33,6 +36,9 @@ export function InvitationItem({ invitation }: { invitation: Invitation }) {
     // A failure here should not surface as "failed to accept" — fall back to
     // the root and let the post-redirect flow pick a default org.
     toast.success("Invitation accepted!");
+    // Membership changed — drop the cached org list so the home loader sees
+    // the newly joined org.
+    invalidateOrganizationListCache();
     let slug: string | undefined;
     try {
       const orgResult = await authClient.organization.getFullOrganization({

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from "react";
 
 import "../../index.css";
 
-import { authClient } from "@/web/lib/auth-client";
+import { listOrganizationsCached } from "@/web/lib/auth-client";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 
 import { sourcePlugins } from "./plugins.ts";
@@ -119,11 +119,24 @@ const homeRoute = createRoute({
   getParentRoute: () => shellLayout,
   path: "/",
   beforeLoad: async () => {
-    // Fetch org list once — used for both slug validation and redirect
-    const { data: orgs } = await authClient.organization.list();
+    // Fast path: redirect returning users immediately from the cached slug,
+    // WITHOUT awaiting the org-list network call. This is what keeps a cold
+    // load from blocking on a round-trip (the previous blank/white screen).
+    // The org layout validates membership via getFullOrganization, and a stale
+    // slug self-heals in OrgAccessGate (clears the slug + bounces back to "/").
+    const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+    if (lastOrgSlug) {
+      throw redirect({
+        to: "/$org",
+        params: { org: lastOrgSlug },
+      });
+    }
 
-    // If the list call failed, skip redirect logic to avoid clearing a
-    // valid cached slug due to a transient API failure.
+    // No cached slug — fetch the list (cached) to pick a destination.
+    const { data: orgs } = await listOrganizationsCached();
+
+    // If the list call failed, skip redirect logic to avoid a misfire on a
+    // transient API failure.
     if (!orgs) return;
 
     // Filter out archived organizations — they are soft-deleted and invisible to the UI
@@ -133,21 +146,6 @@ const homeRoute = createRoute({
     const activeOrgs = (orgs as OrgWithMeta[]).filter(
       (o) => !o.metadata?.archived,
     );
-
-    // Fast path: validate cached slug against current membership before redirecting.
-    // If stale (org deleted/archived or user removed), clear it to prevent a redirect loop.
-    const lastOrgSlug = localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug());
-    if (lastOrgSlug) {
-      const slugIsValid = activeOrgs.some((o) => o.slug === lastOrgSlug);
-      if (slugIsValid) {
-        throw redirect({
-          to: "/$org",
-          params: { org: lastOrgSlug },
-        });
-      }
-      // Stale — remove so future visits don't loop
-      localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
-    }
 
     // Redirect to first available org (every user gets a default org on signup)
     const firstOrg = activeOrgs[0];
@@ -168,7 +166,7 @@ const onboardingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/onboarding",
   beforeLoad: async () => {
-    const { data: orgs } = await authClient.organization.list();
+    const { data: orgs } = await listOrganizationsCached();
     type OrgWithMeta = NonNullable<typeof orgs>[number] & {
       metadata?: { archived?: boolean } | null;
     };
@@ -619,6 +617,11 @@ const routeTree = rootRoute.addChildren([
 
 const router = createRouter({
   routeTree,
+  // Show the splash (not a blank screen) while a route loader/beforeLoad is
+  // awaiting — e.g. the new-user org-list fetch. 200ms delay avoids a flash on
+  // instant (synchronous) redirects like the returning-user fast path.
+  defaultPendingComponent: SplashScreen,
+  defaultPendingMs: 200,
   defaultNotFoundComponent: () => (
     <div className="flex h-full items-center justify-center">
       <div className="flex flex-col items-center gap-4 p-8">

--- a/apps/mesh/src/web/lib/auth-client.ts
+++ b/apps/mesh/src/web/lib/auth-client.ts
@@ -20,3 +20,40 @@ export const authClient = createAuthClient({
     emailOTPClient(),
   ],
 });
+
+type OrgListResult = Awaited<ReturnType<typeof authClient.organization.list>>;
+
+const ORG_LIST_TTL_MS = 30_000;
+let orgListCache: { result: OrgListResult; expiresAt: number } | null = null;
+let orgListInflight: Promise<OrgListResult> | null = null;
+
+/**
+ * `organization.list()` with a short TTL cache + in-flight dedup. Used by the
+ * home/onboarding route loaders, which would otherwise each fire a fresh
+ * network call on every navigation. Only successful responses are cached so a
+ * transient failure isn't pinned for the TTL.
+ */
+export function listOrganizationsCached(): Promise<OrgListResult> {
+  if (orgListCache && orgListCache.expiresAt > Date.now()) {
+    return Promise.resolve(orgListCache.result);
+  }
+  if (orgListInflight) return orgListInflight;
+  const inflight = authClient.organization
+    .list()
+    .then((result: OrgListResult) => {
+      if (result.data) {
+        orgListCache = { result, expiresAt: Date.now() + ORG_LIST_TTL_MS };
+      }
+      return result;
+    })
+    .finally(() => {
+      orgListInflight = null;
+    });
+  orgListInflight = inflight;
+  return inflight;
+}
+
+/** Drop the cached org list — call after creating/joining/leaving an org. */
+export function invalidateOrganizationListCache(): void {
+  orgListCache = null;
+}


### PR DESCRIPTION
…al and invalidate on changes

- Introduced `listOrganizationsCached` function to cache organization list responses with a short TTL, reducing redundant network calls during navigation.
- Updated home and onboarding routes to utilize the cached organization list.
- Added `invalidateOrganizationListCache` function to clear the cache when organization membership changes, ensuring accurate routing.
- Enhanced `OrgAccessGate` to handle stale cached slugs and redirect users appropriately.
- Improved user experience by showing a splash screen during route loading to prevent blank screens.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up org selection and navigation by caching the organization list and fast-redirecting from a cached slug. Improves UX with a splash screen during loads and fixes stale slug edge cases.

- **New Features**
  - Added `listOrganizationsCached` with a 30s TTL and in-flight dedup to reduce network calls.
  - Home and onboarding use the cached list; home route fast-redirects from `LOCALSTORAGE_KEYS.lastOrgSlug` without waiting on the network.
  - Router shows `SplashScreen` during loader waits (200ms threshold) to avoid blank screens.

- **Bug Fixes**
  - Introduced `invalidateOrganizationListCache` and call it after join/accept/delete flows to keep routing accurate.
  - `OrgAccessGate` now self-heals stale slugs by clearing `lastOrgSlug` and redirecting back to `/` to select a valid org.

<sup>Written for commit 5b96dbdac824aadc0baf9cffdb97bddd087c1661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3564?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

