### PR TITLE
feat(query-persist): implement localStorage persistence for React Que…

### DIFF
--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -39,6 +39,7 @@ import { GitHubIcon } from "@daveyplate/better-auth-ui";
 import { SidebarMenuButton } from "@deco/ui/components/sidebar.tsx";
 import { authClient } from "@/web/lib/auth-client";
 import { track } from "@/web/lib/posthog-client";
+import { clearPersistedQueryCache } from "@/web/lib/query-persist";
 import { CreateOrganizationDialog } from "@/web/components/create-organization-dialog";
 import { usePreferences, type ThemeMode } from "@/web/hooks/use-preferences.ts";
 import { toast } from "@deco/ui/components/sonner.js";
@@ -567,6 +568,7 @@ export function AccountPopover() {
     icon: <LogOut01 size={16} />,
     onClick: () => {
       track("signed_out", { source: "account_popover" });
+      clearPersistedQueryCache();
       authClient.signOut();
     },
   };

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -56,6 +56,7 @@ import { pluginSettingsSidebarItems } from "@/web/index";
 import { useStatusSounds } from "../hooks/use-status-sounds";
 import { authClient } from "@/web/lib/auth-client";
 import { track } from "@/web/lib/posthog-client";
+import { clearPersistedQueryCache } from "@/web/lib/query-persist";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import {
   MobileSidebarSheet,
@@ -271,6 +272,7 @@ export function SettingsSidebar() {
                 <SidebarMenuButton
                   onClick={() => {
                     track("signed_out", { source: "settings_sidebar" });
+                    clearPersistedQueryCache();
                     authClient.signOut();
                   }}
                   className="flex items-center gap-2.5 text-sm"
@@ -348,7 +350,10 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
           <div className="h-px bg-border/50 my-2" />
           <button
             type="button"
-            onClick={() => authClient.signOut()}
+            onClick={() => {
+              clearPersistedQueryCache();
+              authClient.signOut();
+            }}
             className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg transition-colors text-sm text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
           >
             <span className="shrink-0">

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -218,9 +218,20 @@ function ShellLayoutContent() {
       // session breaks multi-tab usage because the session row is shared
       // across tabs. We rely on the URL slug (mounted under /api/:org/...)
       // for org resolution instead.
-      const { data } = await authClient.organization.getFullOrganization({
-        query: { organizationSlug: org },
-      });
+      // Marked for the perf_app_bootstrap timing event (see posthog-client).
+      performance.mark("mesh:active-org-fetch:start");
+      const { data } = await authClient.organization
+        .getFullOrganization({
+          query: { organizationSlug: org },
+        })
+        .finally(() => {
+          performance.mark("mesh:active-org-fetch:end");
+          performance.measure(
+            "mesh:active-org-fetch",
+            "mesh:active-org-fetch:start",
+            "mesh:active-org-fetch:end",
+          );
+        });
 
       // Don't persist archived orgs — homeRoute would just redirect off them again
       const isArchived =

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -11,8 +11,11 @@
 
 import posthog from "posthog-js";
 
+import { wasCacheRestored } from "@/web/lib/query-persist";
+
 let initialized = false;
 let lastOrgGroupKey: string | null = null;
+let bootstrapTimingSent = false;
 
 export function initPostHog(key: string, host: string) {
   if (initialized || typeof window === "undefined") return;
@@ -21,6 +24,10 @@ export function initPostHog(key: string, host: string) {
     capture_pageview: "history_change",
     capture_pageleave: true,
     autocapture: true,
+    // Real-user Core Web Vitals (LCP, FCP, CLS, INP) as $web_vitals events.
+    // On a cold refresh LCP ≈ when the app shell paints, so this is the
+    // headline "how slow is the load" signal, sliceable by org/route/device.
+    capture_performance: { web_vitals: true, network_timing: true },
     // Capture unhandled JS exceptions (DOMError, TypeError, unhandled promise
     // rejections) as $exception events — gives us client-side error tracking
     // without hand-wiring every try/catch.
@@ -59,6 +66,49 @@ export function resetUser() {
 export function track(event: string, properties?: Record<string, unknown>) {
   if (!initialized) return;
   posthog.capture(event, properties);
+}
+
+/**
+ * Emit a one-shot `perf_app_bootstrap` event breaking down how long the
+ * initial load took, per phase. Call once the app shell has rendered (PostHog
+ * is initialized by then). Phase durations come from the browser Performance
+ * API, which records them regardless of when PostHog inits — the config fetch
+ * happens *before* init, so a buffered/manual capture would miss it.
+ *
+ * `config_fetch_ms` / `active_org_fetch_ms` are absent when those queries were
+ * served from the persisted cache (no network) — which is itself the signal
+ * that persistence is doing its job (`cache_restored: true`).
+ */
+export function flushBootstrapTiming() {
+  if (!initialized || bootstrapTimingSent) return;
+  if (typeof performance === "undefined") return;
+  bootstrapTimingSent = true;
+
+  const nav = performance.getEntriesByType("navigation")[0] as
+    | PerformanceNavigationTiming
+    | undefined;
+
+  const measure = (name: string): number | undefined => {
+    const entry = performance.getEntriesByName(name, "measure")[0];
+    return entry ? Math.round(entry.duration) : undefined;
+  };
+
+  track("perf_app_bootstrap", {
+    nav_type: nav?.type,
+    // Network/document phases (relative to navigation start).
+    ttfb_ms: nav ? Math.round(nav.responseStart) : undefined,
+    dom_interactive_ms: nav ? Math.round(nav.domInteractive) : undefined,
+    dom_content_loaded_ms: nav
+      ? Math.round(nav.domContentLoadedEventEnd)
+      : undefined,
+    // SPA bootstrap phases that gate first paint (the suspense chain).
+    config_fetch_ms: measure("mesh:config-fetch"),
+    active_org_fetch_ms: measure("mesh:active-org-fetch"),
+    // Whole thing: navigation start → shell rendered.
+    time_to_shell_ms: Math.round(performance.now()),
+    // Did localStorage hydration spare us the cold fetches this load?
+    cache_restored: wasCacheRestored(),
+  });
 }
 
 /**
@@ -104,4 +154,5 @@ export function captureException(
 export function __resetForTest() {
   initialized = false;
   lastOrgGroupKey = null;
+  bootstrapTimingSent = false;
 }

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -1,0 +1,116 @@
+/**
+ * Lightweight localStorage persistence for the bootstrap React Query cache.
+ *
+ * On a hard refresh the in-memory cache is gone, so the `useSuspenseQuery`
+ * calls that gate first paint (public config, active org) refetch cold and the
+ * SplashScreen shows. Hydrating those few queries from localStorage *before*
+ * React mounts lets the suspense queries resolve synchronously — no spinner,
+ * with a background revalidation per their staleTime.
+ *
+ * Only the bootstrap queries are persisted; everything else stays in-memory.
+ * Implemented on `dehydrate`/`hydrate` from @tanstack/react-query so it needs
+ * no extra dependency.
+ */
+
+import { type QueryClient, dehydrate, hydrate } from "@tanstack/react-query";
+
+const STORAGE_KEY = "mesh:rq-cache";
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
+const WRITE_DEBOUNCE_MS = 1000;
+
+// Query-key heads that gate first paint on refresh. Keep this list tight —
+// persisting org-scoped data widens what lands in localStorage.
+const PERSISTED_KEY_HEADS = new Set([
+  "publicConfig",
+  "activeOrganization",
+  "organizations",
+]);
+
+let cacheRestored = false;
+
+function isPersistable(queryKey: readonly unknown[]): boolean {
+  const head = queryKey[0];
+  return typeof head === "string" && PERSISTED_KEY_HEADS.has(head);
+}
+
+/**
+ * Synchronously load the persisted bootstrap queries into `queryClient`.
+ * Call once at module init, before React renders, so suspense queries find
+ * their data in cache. Drops the cache on version bump or expiry.
+ */
+export function hydrateQueryClient(queryClient: QueryClient): void {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+
+    const parsed = JSON.parse(raw) as {
+      buster?: string;
+      timestamp?: number;
+      state?: Parameters<typeof hydrate>[1];
+    };
+
+    const stale =
+      !parsed.timestamp || Date.now() - parsed.timestamp > MAX_AGE_MS;
+    if (parsed.buster !== __MESH_VERSION__ || stale || !parsed.state) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+
+    hydrate(queryClient, parsed.state);
+    cacheRestored = true;
+  } catch {
+    // Corrupt entry — drop it, never let it block boot.
+    clearPersistedQueryCache();
+  }
+}
+
+/**
+ * Subscribe to cache changes and debounce-write the persistable queries to
+ * localStorage. Returns the unsubscribe fn.
+ */
+export function persistQueryClient(queryClient: QueryClient): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const write = () => {
+    timer = null;
+    try {
+      const state = dehydrate(queryClient, {
+        shouldDehydrateQuery: (query) =>
+          query.state.status === "success" && isPersistable(query.queryKey),
+      });
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          buster: __MESH_VERSION__,
+          timestamp: Date.now(),
+          state,
+        }),
+      );
+    } catch {
+      // Quota / serialization failure is non-fatal.
+    }
+  };
+
+  return queryClient.getQueryCache().subscribe(() => {
+    if (timer != null) return;
+    timer = setTimeout(write, WRITE_DEBOUNCE_MS);
+  });
+}
+
+/** Wipe the persisted cache. Call on sign-out so the next user starts clean. */
+export function clearPersistedQueryCache(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Whether this page load hydrated any query from localStorage. */
+export function wasCacheRestored(): boolean {
+  return cacheRestored;
+}

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -18,13 +18,14 @@ const STORAGE_KEY = "mesh:rq-cache";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const WRITE_DEBOUNCE_MS = 1000;
 
-// Query-key heads that gate first paint on refresh. Keep this list tight —
-// persisting org-scoped data widens what lands in localStorage.
-const PERSISTED_KEY_HEADS = new Set([
-  "publicConfig",
-  "activeOrganization",
-  "organizations",
-]);
+// Only the public config is persisted. It's the outermost suspense gate
+// (theme/styling) and is identical for every user, so caching it is pure win.
+//
+// Auth-sensitive queries are deliberately NOT persisted: `activeOrganization`
+// is an authorization gate (a stale "you're a member" value would render the
+// org shell instead of the invite / no-access screen — see shell-layout.tsx),
+// and session state must always revalidate against the server.
+const PERSISTED_KEY_HEADS = new Set(["publicConfig"]);
 
 let cacheRestored = false;
 

--- a/apps/mesh/src/web/providers/posthog-group-sync.tsx
+++ b/apps/mesh/src/web/providers/posthog-group-sync.tsx
@@ -9,7 +9,10 @@
  * `setOrganizationGroup` itself, so re-renders are cheap.
  */
 
-import { setOrganizationGroup } from "@/web/lib/posthog-client";
+import {
+  flushBootstrapTiming,
+  setOrganizationGroup,
+} from "@/web/lib/posthog-client";
 
 export function PostHogGroupSync({
   activeOrg,
@@ -25,6 +28,7 @@ export function PostHogGroupSync({
       name: activeOrg.name ?? undefined,
       slug: activeOrg.slug ?? undefined,
     });
+    flushBootstrapTiming();
   }
   return null;
 }

--- a/apps/mesh/src/web/providers/providers.tsx
+++ b/apps/mesh/src/web/providers/providers.tsx
@@ -6,6 +6,10 @@ import { BetterAuthUIProvider } from "@/web/providers/better-auth-ui-provider";
 import { PostHogIdentitySync } from "@/web/providers/posthog-provider";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { ThemeProvider } from "@/web/providers/theme-provider";
+import {
+  hydrateQueryClient,
+  persistQueryClient,
+} from "@/web/lib/query-persist";
 import { Toaster } from "sonner";
 
 const queryClient = new QueryClient({
@@ -24,6 +28,9 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+hydrateQueryClient(queryClient);
+persistQueryClient(queryClient);
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/mesh/src/web/providers/theme-provider.tsx
+++ b/apps/mesh/src/web/providers/theme-provider.tsx
@@ -13,15 +13,25 @@ import { setOAuthRedirectOrigin } from "@decocms/mesh-sdk";
 import { usePreferences } from "@/web/hooks/use-preferences";
 
 async function fetchPublicConfig(): Promise<PublicConfig> {
-  const response = await fetch("/api/config");
-  if (!response.ok) {
-    throw new Error("Failed to load public configuration");
+  performance.mark("mesh:config-fetch:start");
+  try {
+    const response = await fetch("/api/config");
+    if (!response.ok) {
+      throw new Error("Failed to load public configuration");
+    }
+    const data = await response.json();
+    if (!data.success) {
+      throw new Error(data.error || "Failed to load public configuration");
+    }
+    return data.config;
+  } finally {
+    performance.mark("mesh:config-fetch:end");
+    performance.measure(
+      "mesh:config-fetch",
+      "mesh:config-fetch:start",
+      "mesh:config-fetch:end",
+    );
   }
-  const data = await response.json();
-  if (!data.success) {
-    throw new Error(data.error || "Failed to load public configuration");
-  }
-  return data.config;
 }
 
 /**


### PR DESCRIPTION
…ry cache

- Added `query-persist` module to manage localStorage persistence for bootstrap queries, enhancing performance on hard refreshes by hydrating the cache before React mounts.
- Introduced `clearPersistedQueryCache` function to clear the cache on user sign-out, ensuring a clean state for new users.
- Updated `AccountPopover` and `SettingsSidebar` components to clear the persisted cache upon sign-out.
- Enhanced performance tracking by integrating timing events for critical fetch operations in the `posthog-client` module.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted public config to `localStorage` and added PostHog timing to speed up hard refreshes and measure real-user startup performance. Hydrates before React mounts to reduce splash and tracks key app bootstrap phases.

- **New Features**
  - Added `query-persist` using `dehydrate`/`hydrate` from `@tanstack/react-query` to cache only `publicConfig` (24h TTL, debounced writes).
  - Integrated via `hydrateQueryClient`/`persistQueryClient` in `Providers`; added `clearPersistedQueryCache` and call it on all sign-out flows.

- **Performance**
  - Instrumented config and active org fetches and send a one-shot `perf_app_bootstrap` event with TTFB, DOM milestones, phase durations, and `cache_restored`.
  - Enabled PostHog `capture_performance` (web vitals and network timing) and flush metrics after shell render with `flushBootstrapTiming`.

<sup>Written for commit 975eb7b5f84c961d2a0815ec1df98700e66a4e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3566?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

