### PR TITLE
fix(sidebar): remove list bullets from collapsed agent rail

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -12,7 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@deco/ui/components/select.tsx";
-import { useSidebar } from "@deco/ui/components/sidebar.tsx";
+import { SidebarMenu, useSidebar } from "@deco/ui/components/sidebar.tsx";
 import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,
@@ -157,7 +157,7 @@ export function TaskGroupsList() {
 
   if (isCollapsed) {
     return (
-      <div className="flex flex-col min-h-0 gap-1.5 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <SidebarMenu className="min-h-0 gap-1.5 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {groups.map((group) => {
           const filtered = typeFiltered(memberFiltered(group.threads));
           const dimmed = filtersActive && filtered.length === 0;
@@ -174,7 +174,7 @@ export function TaskGroupsList() {
             />
           );
         })}
-      </div>
+      </SidebarMenu>
     );
   }
 

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -394,7 +394,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu"
       data-sidebar="menu"
       className={cn(
-        "flex w-full min-w-0 flex-col gap-1 group-data-[state=collapsed]/sidebar:items-center",
+        "flex w-full min-w-0 list-none flex-col gap-1 group-data-[state=collapsed]/sidebar:items-center",
         className,
       )}
       {...props}
@@ -407,7 +407,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
     <li
       data-slot="sidebar-menu-item"
       data-sidebar="menu-item"
-      className={cn("group/menu-item relative w-full", className)}
+      className={cn("group/menu-item relative w-full list-none", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- Wrap collapsed task group avatars in `SidebarMenu` so `SidebarMenuItem` elements render inside a proper `<ul>` instead of a plain `<div>`.
- Add `list-none` to `SidebarMenu` and `SidebarMenuItem` as a defensive guard against stray list markers elsewhere in the sidebar.

## Test plan
- [ ] Collapse the sidebar and confirm agent avatars no longer show bullet dots above them
- [ ] Hover collapsed avatars and verify the task popover still opens
- [ ] Expand the sidebar and confirm task groups still render and behave normally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stray list bullets in the collapsed sidebar agent rail. Avatars now render inside a proper list and default markers are suppressed.

- **Bug Fixes**
  - Wrap collapsed task group avatars in `SidebarMenu` so `SidebarMenuItem` render inside a ul.
  - Add `list-none` to `SidebarMenu` and `SidebarMenuItem` to prevent bullets across the sidebar.

<sup>Written for commit baaa669d7accc1b6c7dec2985f07320a382d32cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

