### PR TITLE
feat(web): make deco logo the home affordance in shell headers

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toolbar.tsx
@@ -16,6 +16,7 @@
 
 import { createContext, Suspense, use, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { Link, useParams } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight } from "@untitledui/icons";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 import { DEFAULT_LOGO, usePublicConfig } from "@/web/hooks/use-public-config";
@@ -150,6 +151,25 @@ function ToolbarLogo() {
   );
 }
 
+/**
+ * The logo wrapped in a link back to the org home (`/$org`). Used as the
+ * "home" affordance in the shell headers.
+ */
+function ToolbarLogoLink() {
+  const { org } = useParams({ from: "/shell/$org" });
+  return (
+    <Link
+      to="/$org"
+      params={{ org }}
+      aria-label="Back to home"
+      title="Back to home"
+      className="wco-no-drag flex items-center shrink-0 cursor-pointer pl-1"
+    >
+      <ToolbarLogo />
+    </Link>
+  );
+}
+
 function ToolbarCenterSlot() {
   const { setCenterEl } = useToolbarCtx();
   return (
@@ -213,6 +233,7 @@ Toolbar.LeftColumn = ToolbarLeftColumn;
 Toolbar.RightColumn = ToolbarRightColumn;
 Toolbar.Nav = ToolbarNav;
 Toolbar.Logo = ToolbarLogo;
+Toolbar.LogoLink = ToolbarLogoLink;
 Toolbar.CenterSlot = ToolbarCenterSlot;
 Toolbar.Center = ToolbarCenter;
 Toolbar.TabsSlot = ToolbarTabsSlot;

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -64,7 +64,7 @@ export default function OrgShellLayout() {
             <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
               <Toolbar.Header>
                 <Toolbar.LeftColumn>
-                  <Toolbar.Logo />
+                  <Toolbar.LogoLink />
                   <SidebarTriggerButton />
                   <span className="hidden md:contents">
                     <Toolbar.Nav />

--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -32,7 +32,6 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import { PageContentClassNameProvider } from "@/web/components/page";
 import {
-  ArrowNarrowLeft,
   BarChart10,
   BookOpen01,
   Building02,
@@ -432,7 +431,6 @@ function SettingsInset() {
 
 export default function SettingsLayout() {
   const isMobile = useIsMobile();
-  const { org } = useParams({ from: "/shell/$org" });
 
   return (
     <Toolbar.Provider>
@@ -440,14 +438,7 @@ export default function SettingsLayout() {
         <div className="app-shell-root flex flex-col h-dvh overflow-hidden">
           <Toolbar.Header>
             <Toolbar.LeftColumn>
-              <Link
-                to="/$org"
-                params={{ org }}
-                className="wco-no-drag flex items-center gap-1.5 px-2 h-7 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-              >
-                <ArrowNarrowLeft size={14} className="shrink-0" />
-                <span>Settings</span>
-              </Link>
+              <Toolbar.LogoLink />
               {isMobile && <SidebarTriggerButton />}
               <span className="hidden md:contents">
                 <Toolbar.Nav />


### PR DESCRIPTION
## What is this contribution about?
The settings header now leads with the deco logo instead of a "← Settings" back button, and the logo is a clickable link back to the org home (`/$org`) in both the org and settings shells. The shared `Toolbar.LogoLink` component is aligned with the collapsed sidebar's icon column (logo and sidebar icons both center at x=28) and shows a plain `cursor-pointer` with no hover background.

## Screenshots/Demonstration
On `/$org` and `/$org/settings/*` the deco logo sits directly above the collapsed sidebar's home icon; clicking it navigates to the org home.

## How to Test
> 1. Open `/$org` and `/$org/settings/general`.
> 2. Confirm the deco logo appears top-left and is horizontally aligned with the collapsed sidebar icons.
> 3. Click the logo from settings — it should navigate back to the org home; the old "← Settings" button is gone.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the deco logo as the home affordance in org and settings headers. Clicking the logo returns to org home (/$org); the old "← Settings" button is removed, and the logo aligns with the collapsed sidebar icon column.

- **New Features**
  - Added `Toolbar.LogoLink`, a shared logo link component for both shells.
  - Uses the current `org` param to link to `/$org`.

<sup>Written for commit d37d0b58fb47b54bbcca095e3d157dc1713d680f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

