### PR TITLE
fix(observability): explicitly wire OTLP trace exporter in NodeSDK co…

### DIFF
--- a/apps/mesh/src/observability/index.ts
+++ b/apps/mesh/src/observability/index.ts
@@ -332,14 +332,24 @@ export function initObservability(): void {
 
   const sdk = new NodeSDK({
     serviceName: _settings.otelServiceName,
-    traceExporter,
     metricReaders: [
       prometheusExporter,
       ...(monitoringMetricReader ? [monitoringMetricReader] : []),
     ],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sampler: headSampler,
+    // NodeSDK ignores the top-level `traceExporter` option whenever
+    // `spanProcessors` is provided, so the OTLP exporter must be wired in here
+    // explicitly — otherwise spans only reach the local NDJSON file.
     spanProcessors: [
+      ...(traceExporter
+        ? [
+            new BatchSpanProcessor(traceExporter, {
+              scheduledDelayMillis: 60_000,
+              maxExportBatchSize: 1000,
+            }),
+          ]
+        : []),
       ...(monitoringTraceExporter
         ? [
             new BatchSpanProcessor(monitoringTraceExporter, {


### PR DESCRIPTION
…nfiguration

Updated the NodeSDK initialization to include the OTLP trace exporter directly, as the top-level `traceExporter` option is ignored when `spanProcessors` are provided. This change ensures that spans are correctly exported instead of only reaching the local NDJSON file.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly wired the OTLP trace exporter into the `NodeSDK` span processors so spans are actually exported. Fixes the bug where the top-level `traceExporter` is ignored when `spanProcessors` are set, which caused spans to only be written to the local NDJSON file.

<sup>Written for commit c837167920391d00aefeb7c2f1f6665512ce69d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

