### PR TITLE
feat(query-persist): enhance user-scoped organization caching

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -8,6 +8,7 @@ import RequiredAuthLayout from "@/web/layouts/required-auth-layout";
 import { authClient } from "@/web/lib/auth-client";
 import { AUTOSEND_QUERY_VALUE } from "@/web/lib/autosend";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
+import { readCachedOrg, writeCachedOrg } from "@/web/lib/query-persist";
 import { PostHogGroupSync } from "@/web/providers/posthog-group-sync";
 import {
   getWellKnownDecopilotVirtualMCP,
@@ -194,6 +195,12 @@ function ShellLayoutContent() {
   const org = orgMatch?.params.org;
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false);
 
+  // Session is guaranteed present here (this renders inside <SignedIn>), so the
+  // user id is available synchronously to scope the org cache by principal.
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+  const cachedOrg = org && userId ? readCachedOrg(userId, org) : null;
+
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscribes to document keydown for ⌘K shortcuts dialog; DOM event listener has no React 19 alternative
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {
@@ -244,8 +251,22 @@ function ShellLayoutContent() {
         localStorage.setItem(LOCALSTORAGE_KEYS.lastOrgSlug(), org);
       }
 
+      // Seed the user-scoped cache so the next refresh renders instantly.
+      if (userId && data) {
+        writeCachedOrg(userId, org, data);
+      }
+
       return data;
     },
+    // Hydrate from the user-scoped cache so the shell paints without waiting on
+    // the network; the stale `initialDataUpdatedAt` triggers a background
+    // refetch that flips to the access gate if membership was revoked.
+    initialData: cachedOrg
+      ? (cachedOrg.data as Awaited<
+          ReturnType<typeof authClient.organization.getFullOrganization>
+        >["data"])
+      : undefined,
+    initialDataUpdatedAt: cachedOrg?.updatedAt,
     gcTime: Infinity,
     refetchOnWindowFocus: false,
   });

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -11,7 +11,7 @@
 
 import posthog from "posthog-js";
 
-import { wasCacheRestored } from "@/web/lib/query-persist";
+import { wasCacheRestored, wasOrgCacheRestored } from "@/web/lib/query-persist";
 
 let initialized = false;
 let lastOrgGroupKey: string | null = null;
@@ -107,7 +107,10 @@ export function flushBootstrapTiming() {
     // Whole thing: navigation start → shell rendered.
     time_to_shell_ms: Math.round(performance.now()),
     // Did localStorage hydration spare us the cold fetches this load?
+    // `active_org_fetch_ms` still reflects the background revalidation when the
+    // org was cached — `org_cache_restored` tells you it didn't block paint.
     cache_restored: wasCacheRestored(),
+    org_cache_restored: wasOrgCacheRestored(),
   });
 }
 

--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -28,6 +28,7 @@ const WRITE_DEBOUNCE_MS = 1000;
 const PERSISTED_KEY_HEADS = new Set(["publicConfig"]);
 
 let cacheRestored = false;
+let orgCacheRestored = false;
 
 function isPersistable(queryKey: readonly unknown[]): boolean {
   const head = queryKey[0];
@@ -101,17 +102,81 @@ export function persistQueryClient(queryClient: QueryClient): () => void {
   });
 }
 
-/** Wipe the persisted cache. Call on sign-out so the next user starts clean. */
+// --- Active-org cache (user-scoped) -----------------------------------------
+// Org membership is auth-sensitive, so unlike publicConfig it is NOT persisted
+// through the generic dehydrate path. Instead it's keyed by the authenticated
+// user id and only ever read back for that same user. A different principal —
+// e.g. after a cookie-only logout that leaves localStorage intact — gets a
+// cache miss and falls through to a fresh fetch + the access gate. Consumed via
+// `initialData` so the suspense query renders instantly and revalidates in the
+// background.
+
+const ORG_KEY_PREFIX = "mesh:org-cache:";
+
+type CachedOrgMap = Record<string, { data: unknown; updatedAt: number }>;
+
+function orgCacheKey(userId: string): string {
+  return `${ORG_KEY_PREFIX}${userId}`;
+}
+
+/** Read the cached org for (user, slug), or null on miss/expiry. */
+export function readCachedOrg(
+  userId: string,
+  slug: string,
+): { data: unknown; updatedAt: number } | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(orgCacheKey(userId));
+    if (!raw) return null;
+    const entry = (JSON.parse(raw) as CachedOrgMap)[slug];
+    if (!entry || Date.now() - entry.updatedAt > MAX_AGE_MS) return null;
+    orgCacheRestored = true;
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+/** Store the org for (user, slug). */
+export function writeCachedOrg(
+  userId: string,
+  slug: string,
+  data: unknown,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = orgCacheKey(userId);
+    const raw = window.localStorage.getItem(key);
+    const map: CachedOrgMap = raw ? JSON.parse(raw) : {};
+    map[slug] = { data, updatedAt: Date.now() };
+    window.localStorage.setItem(key, JSON.stringify(map));
+  } catch {
+    // Quota / serialization failure is non-fatal.
+  }
+}
+
+/** Wipe all persisted caches. Call on sign-out so the next user starts clean. */
 export function clearPersistedQueryCache(): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.removeItem(STORAGE_KEY);
+    for (let i = window.localStorage.length - 1; i >= 0; i--) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith(ORG_KEY_PREFIX)) {
+        window.localStorage.removeItem(key);
+      }
+    }
   } catch {
     // ignore
   }
 }
 
-/** Whether this page load hydrated any query from localStorage. */
+/** Whether this page load hydrated the public config from localStorage. */
 export function wasCacheRestored(): boolean {
   return cacheRestored;
+}
+
+/** Whether the active org was served from the user-scoped cache this load. */
+export function wasOrgCacheRestored(): boolean {
+  return orgCacheRestored;
 }


### PR DESCRIPTION
- Implemented functions to read and write organization data to localStorage, scoped by user ID, improving performance by allowing instant rendering from cache.
- Updated the ShellLayout to utilize the new caching mechanism, ensuring the organization data is hydrated on initial render and refetched in the background if necessary.
- Added tracking for whether the organization cache was restored during page load, enhancing performance metrics in the posthog-client module.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a user-scoped localStorage cache for organization data so the shell renders instantly from cache, then revalidates in the background. Also adds analytics to track when this cache is used.

- **New Features**
  - Added `readCachedOrg(userId, slug)` and `writeCachedOrg(...)` to store org data per user with expiry in localStorage.
  - `ShellLayout` hydrates org via `initialData`/`initialDataUpdatedAt` for instant paint, then refetches in the background to handle revoked access.
  - Exposed `wasOrgCacheRestored` and sent `org_cache_restored` in `posthog-client`; `clearPersistedQueryCache` now also clears user-scoped org caches.

<sup>Written for commit 12292aac6c807d45391f595b0dfffb2d153a45fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

