### PR TITLE
refactor(release-mesh): remove deployment update step from workflow

### DIFF
--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -303,26 +303,6 @@ jobs:
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-      - name: Trigger deployment update
-        # Bump the deploy repo on every real release. The release job only runs
-        # for genuine new versions, so a push here is always a release worth
-        # deploying. (Previously gated solely on the workflow_dispatch input,
-        # which silently stopped firing once that dispatch began 403'ing —
-        # freezing prod's desired image tag.) ArgoCD's manual-sync prod gate
-        # still applies: this only updates the desired tag in git.
-        if: inputs.deploy_to_production == 'true' || github.event_name == 'push'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
-          repository: deco-cx/argo-deploy-mesh
-          event-type: image-update
-          client-payload: '{"image_tag": "${{ needs.prepare.outputs.version }}"}'
-      - name: Deployment summary
-        if: inputs.deploy_to_production == 'true' || github.event_name == 'push'
-        run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "Triggered ArgoCD deployment with image tag \`${{ needs.prepare.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
   # GitOps: tell deco-apps-cd to bump the mesh image. We do NOT write into that


### PR DESCRIPTION
Eliminated the deployment update trigger from the release workflow to streamline the process. This change addresses issues with the previous gating mechanism and ensures that the workflow remains functional without unnecessary complexity.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deployment update trigger from the release-mesh workflow to simplify releases and avoid repository-dispatch 403 failures. The workflow now focuses on build/publish; deployment is handled outside this workflow.

- **Refactors**
  - Deleted the `Trigger deployment update` and `Deployment summary` steps in `.github/workflows/release-mesh.yaml`.
  - Removed `peter-evans/repository-dispatch@v3` and the `DEPLOY_REPO_TOKEN`.
  - Stopped updating `deco-cx/argo-deploy-mesh` with image tags.

<sup>Written for commit 75ea11296c6db65715e187b871f2ed4f2bc8ae16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

