### PR TITLE
fix(query-persist): update organization cache key prefix to 'studio' …

### DIFF
--- a/apps/mesh/src/web/lib/query-persist.ts
+++ b/apps/mesh/src/web/lib/query-persist.ts
@@ -111,7 +111,7 @@ export function persistQueryClient(queryClient: QueryClient): () => void {
 // `initialData` so the suspense query renders instantly and revalidates in the
 // background.
 
-const ORG_KEY_PREFIX = "mesh:org-cache:";
+const ORG_KEY_PREFIX = "studio:org-cache:";
 
 type CachedOrgMap = Record<string, { data: unknown; updatedAt: number }>;
 


### PR DESCRIPTION
…(#3575)

Changed the organization cache key prefix from 'mesh' to 'studio' to better reflect the current application context. This update ensures consistency in cache management across the application.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated organization cache key prefix from `mesh:org-cache:` to `studio:org-cache:` to match the Studio context and keep cache keys consistent. Old entries will be ignored and org data will repopulate under the new prefix.

<sup>Written for commit 8c69d3917a3d3bc8e965720baf7c69a85c447659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

