### PR TITLE
feat(chat): friendlier error banner with collapsible technical details

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@deco/ui/components/button.tsx";
-import { AlertCircle, AlertTriangle } from "@untitledui/icons";
+import { AlertCircle, AlertTriangle, Copy01 } from "@untitledui/icons";
+import { toast } from "sonner";
 import {
   readToolApprovalLevel,
   usePreferences,
@@ -28,6 +29,53 @@ const WARNING_DESCRIPTIONS: Record<string, string> = {
     "Response paused after tool execution to prevent infinite loops and save costs. Click continue to keep working.",
 };
 
+// Raw error.message strings can be anything: a clean string, an HTML page
+// from an upstream proxy (Cloudflare 5xx), a JSON blob, a network failure.
+// Classify to pick a human summary + recovery hint; preserve the original
+// payload so devs can still inspect it under "Show technical details".
+function parseErrorMessage(message: string): {
+  summary: string;
+  rawDetails: string | null;
+} {
+  const trimmed = message.trim();
+  const looksLikeHtml =
+    trimmed.startsWith("<") && /<[a-z][\s\S]*>/i.test(trimmed);
+  const isCloudflare =
+    /cloudflare|cf-[a-z-]+|error[\s_-]?code[\s_-]?5\d\d/i.test(trimmed);
+  const isNetwork = /failed to fetch|networkerror|load failed|offline/i.test(
+    trimmed,
+  );
+  const isTimeout = /timeout|timed out|aborted|deadline/i.test(trimmed);
+  const isTooLong = trimmed.length > 240;
+
+  if (isCloudflare || (looksLikeHtml && isTooLong)) {
+    return {
+      summary:
+        "Our servers are having a moment. Try sending again in a few seconds.",
+      rawDetails: message,
+    };
+  }
+  if (isNetwork) {
+    return {
+      summary: "Lost connection. Check your network and try again.",
+      rawDetails: message,
+    };
+  }
+  if (isTimeout) {
+    return {
+      summary: "That took longer than expected. Try again.",
+      rawDetails: message,
+    };
+  }
+  if (looksLikeHtml || isTooLong) {
+    return {
+      summary: "Something unexpected came back from the server. Try again.",
+      rawDetails: message,
+    };
+  }
+  return { summary: message, rawDetails: null };
+}
+
 type StatusHighlightProps =
   | {
       variant: "error";
@@ -47,17 +95,22 @@ function StatusHighlight(props: StatusHighlightProps) {
   const isError = variant === "error";
 
   const label = isError ? "Error occurred" : "Response incomplete";
-  const message = isError
+  const Icon = isError ? AlertCircle : AlertTriangle;
+
+  const rawMessage = isError
     ? props.error.message
     : (WARNING_DESCRIPTIONS[props.finishReason] ??
       `Response stopped unexpectedly: ${props.finishReason}`);
-  const Icon = isError ? AlertCircle : AlertTriangle;
+
+  const { summary, rawDetails } = isError
+    ? parseErrorMessage(rawMessage)
+    : { summary: rawMessage, rawDetails: null };
 
   return (
     <CollapsibleHighlight
       icon={<Icon size={14} />}
       label={label}
-      title={message}
+      title={summary}
       defaultExpanded={true}
       variant={variant}
       onClose={onDismiss}
@@ -83,7 +136,47 @@ function StatusHighlight(props: StatusHighlightProps) {
         )
       }
     >
-      {null}
+      {rawDetails ? (
+        <details className="group mx-4">
+          <summary className="flex cursor-pointer list-none items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
+            <svg
+              aria-hidden="true"
+              className="size-3 transition-transform group-open:rotate-90"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m4.5 3 3 3-3 3" />
+            </svg>
+            <span className="group-open:hidden">Show technical details</span>
+            <span className="hidden group-open:inline">
+              Hide technical details
+            </span>
+          </summary>
+          <div className="relative mt-2">
+            <button
+              type="button"
+              onClick={() => {
+                void navigator.clipboard
+                  .writeText(rawDetails)
+                  .then(() => toast.success("Copied to clipboard"))
+                  .catch(() => toast.error("Could not copy"));
+              }}
+              aria-label="Copy error details"
+              title="Copy"
+              className="absolute right-1.5 top-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:bg-background hover:text-foreground"
+            >
+              <Copy01 className="size-3.5" />
+            </button>
+            <pre className="max-h-40 overflow-auto rounded-md border border-border/60 bg-background px-3 py-2 pr-8 font-mono text-xs text-foreground/80 whitespace-pre-wrap break-all">
+              {rawDetails}
+            </pre>
+          </div>
+        </details>
+      ) : null}
     </CollapsibleHighlight>
   );
 }


### PR DESCRIPTION
## What is this contribution about?

The chat error banner was dumping raw error payloads — including full Cloudflare 5xx HTML pages — straight into the title slot, which looked frightening and gave the user no idea what to do. This PR classifies the raw `error.message` into a human summary with a recovery hint (network / timeout / Cloudflare 5xx / generic), hides the raw payload behind a "Show technical details" disclosure, and adds a copy button so debugging is still one click away. The code surface inside the disclosure was also switched from `bg-muted` to `bg-background` with a hairline border because the muted gray was reading muddy against the destructive red tint.

## Screenshots/Demonstration

Before: wall of HTML rendered as the error title.
After: "Our servers are having a moment. Try sending again in a few seconds." with details tucked behind a disclosure.

## How to Test

1. Open a chat thread on the dev server.
2. In DevTools, intercept the next `/messages` POST to return a fake Cloudflare HTML body:
   ```js
   const _fetch = window.fetch;
   window.fetch = function(input, init) {
     const url = typeof input === 'string' ? input : input.url;
     if (url?.includes('/messages') && init?.method === 'POST') {
       window.fetch = _fetch;
       return Promise.resolve(new Response(
         '<!DOCTYPE html><html><body><div id="error-footer"><a href="https://cloudflare.com/5xx-error-landing?utm_source=errorcode_520">Cloudflare</a></div></body></html>',
         { status: 520, headers: { 'Content-Type': 'text/html' } }
       ));
     }
     return _fetch.apply(this, arguments);
   };
   ```
3. Send any message. Expect a calm banner with "Our servers are having a moment…", a collapsed "Show technical details" toggle, and a working copy button (toast confirms). Verify in both light and dark mode.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Friendlier chat error banner that shows a short, actionable message and hides raw error payloads behind a collapsible details panel. Prevents Cloudflare 5xx HTML and long error strings from flooding the UI.

- **New Features**
  - Classifies raw `error.message` into human summaries (Cloudflare 5xx, network loss, timeout, generic) and uses the summary as the banner title; preserves the original payload as details.
  - Adds a collapsible “Show technical details” with a copy button (uses `sonner` toasts) and cleaner styling (background + hairline border).

<sup>Written for commit 51bbf99ac8bef88fcc143c80061543f92e57107f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

