### PR TITLE
feat(ai-providers): full edit modal for connected provider keys

### DIFF
--- a/apps/mesh/src/storage/ai-provider-keys.ts
+++ b/apps/mesh/src/storage/ai-provider-keys.ts
@@ -227,6 +227,71 @@ export class AIProviderKeyStorage {
     return this.rowToKeyInfo(row);
   }
 
+  async getPreview(
+    keyId: string,
+    organizationId: string,
+  ): Promise<{ label: string; maskedKey: string; baseUrl?: string }> {
+    const { keyInfo, apiKey } = await this.resolve(keyId, organizationId);
+    if (keyInfo.providerId === "openai-compatible") {
+      try {
+        const parsed = JSON.parse(apiKey) as {
+          baseUrl?: string;
+          apiKey?: string;
+        };
+        const rawKey = parsed.apiKey ?? "";
+        const maskedKey =
+          rawKey.length > 4
+            ? `${"•".repeat(rawKey.length - 4)}${rawKey.slice(-4)}`
+            : "•".repeat(rawKey.length || 1);
+        return { label: keyInfo.label, maskedKey, baseUrl: parsed.baseUrl };
+      } catch {
+        return { label: keyInfo.label, maskedKey: "••••••••" };
+      }
+    }
+    const maskedKey =
+      apiKey.length > 4
+        ? `${"•".repeat(apiKey.length - 4)}${apiKey.slice(-4)}`
+        : "•".repeat(apiKey.length || 1);
+    return { label: keyInfo.label, maskedKey };
+  }
+
+  async updateKey(
+    keyId: string,
+    organizationId: string,
+    updates: { label?: string; apiKey?: string },
+  ): Promise<ProviderKeyInfo> {
+    if (updates.apiKey !== undefined) {
+      const encryptedApiKey = await this.vault.encrypt(updates.apiKey);
+      const keyHash = hashApiKey(updates.apiKey);
+      const row = await this.db
+        .updateTable("ai_provider_keys")
+        .set({
+          ...(updates.label !== undefined ? { label: updates.label } : {}),
+          encrypted_api_key: encryptedApiKey,
+          key_hash: keyHash,
+        })
+        .where("id", "=", keyId)
+        .where("organization_id", "=", organizationId)
+        .returning([
+          "id",
+          "provider_id",
+          "label",
+          "preset_id",
+          "organization_id",
+          "created_by",
+          "created_at",
+        ])
+        .executeTakeFirst();
+      if (!row) throw new Error(`AI provider key ${keyId} not found`);
+      this.cache?.invalidate(organizationId, keyId);
+      return this.rowToKeyInfo(row);
+    }
+    if (updates.label !== undefined) {
+      return this.updateLabel(keyId, organizationId, updates.label);
+    }
+    return this.findById(keyId, organizationId);
+  }
+
   async delete(keyId: string, organizationId: string): Promise<void> {
     const result = await this.db
       .deleteFrom("ai_provider_keys")

--- a/apps/mesh/src/storage/ai-provider-keys.ts
+++ b/apps/mesh/src/storage/ai-provider-keys.ts
@@ -241,7 +241,7 @@ export class AIProviderKeyStorage {
         const rawKey = parsed.apiKey ?? "";
         const maskedKey =
           rawKey.length > 4
-            ? `${"•".repeat(rawKey.length - 4)}${rawKey.slice(-4)}`
+            ? `${"•".repeat(8)}${rawKey.slice(-4)}`
             : "•".repeat(rawKey.length || 1);
         return { label: keyInfo.label, maskedKey, baseUrl: parsed.baseUrl };
       } catch {
@@ -250,7 +250,7 @@ export class AIProviderKeyStorage {
     }
     const maskedKey =
       apiKey.length > 4
-        ? `${"•".repeat(apiKey.length - 4)}${apiKey.slice(-4)}`
+        ? `${"•".repeat(8)}${apiKey.slice(-4)}`
         : "•".repeat(apiKey.length || 1);
     return { label: keyInfo.label, maskedKey };
   }

--- a/apps/mesh/src/tools/ai-providers/index.ts
+++ b/apps/mesh/src/tools/ai-providers/index.ts
@@ -4,6 +4,7 @@ export { AI_PROVIDERS_ACTIVE } from "./list-active";
 export { AI_PROVIDER_KEY_CREATE } from "./key-create";
 export { AI_PROVIDER_KEY_DELETE } from "./key-delete";
 export { AI_PROVIDER_KEY_UPDATE } from "./key-update";
+export { AI_PROVIDER_KEY_PREVIEW } from "./key-preview";
 export { AI_PROVIDER_KEY_LIST } from "./key-list";
 export { AI_PROVIDER_OAUTH_URL } from "./oauth-url";
 export { AI_PROVIDER_OAUTH_EXCHANGE } from "./oauth-exchange";

--- a/apps/mesh/src/tools/ai-providers/key-preview.ts
+++ b/apps/mesh/src/tools/ai-providers/key-preview.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/mesh-context";
+
+export const AI_PROVIDER_KEY_PREVIEW = defineTool({
+  name: "AI_PROVIDER_KEY_PREVIEW",
+  description:
+    "Get the label and a masked preview of a stored AI provider API key. The API key is partially obscured (only the last 4 characters are visible). For openai-compatible keys the baseUrl is also returned.",
+  inputSchema: z.object({ keyId: z.string() }),
+  outputSchema: z.object({
+    label: z.string(),
+    maskedKey: z.string(),
+    baseUrl: z.string().optional(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const org = requireOrganization(ctx);
+    await ctx.access.check();
+    return ctx.storage.aiProviderKeys.getPreview(input.keyId, org.id);
+  },
+});

--- a/apps/mesh/src/tools/ai-providers/key-update.ts
+++ b/apps/mesh/src/tools/ai-providers/key-update.ts
@@ -5,10 +5,12 @@ import { providerKeyOutputSchema } from "./key-create";
 
 export const AI_PROVIDER_KEY_UPDATE = defineTool({
   name: "AI_PROVIDER_KEY_UPDATE",
-  description: "Update the label of a stored AI provider API key.",
+  description:
+    "Update the label and/or API key of a stored AI provider key. Pass apiKey to rotate the stored credential.",
   inputSchema: z.object({
     keyId: z.string(),
-    label: z.string().min(1).max(100),
+    label: z.string().min(1).max(100).optional(),
+    apiKey: z.string().min(1).optional(),
   }),
   outputSchema: providerKeyOutputSchema,
   handler: async (input, ctx) => {
@@ -16,10 +18,10 @@ export const AI_PROVIDER_KEY_UPDATE = defineTool({
     const org = requireOrganization(ctx);
     await ctx.access.check();
 
-    const key = await ctx.storage.aiProviderKeys.updateLabel(
+    const key = await ctx.storage.aiProviderKeys.updateKey(
       input.keyId,
       org.id,
-      input.label,
+      { label: input.label, apiKey: input.apiKey },
     );
 
     return {

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -145,6 +145,7 @@ const CORE_TOOLS = [
   AiProvidersTools.AI_PROVIDER_KEY_CREATE,
   AiProvidersTools.AI_PROVIDER_KEY_DELETE,
   AiProvidersTools.AI_PROVIDER_KEY_UPDATE,
+  AiProvidersTools.AI_PROVIDER_KEY_PREVIEW,
   AiProvidersTools.AI_PROVIDER_KEY_LIST,
   AiProvidersTools.AI_PROVIDER_OAUTH_URL,
   AiProvidersTools.AI_PROVIDER_OAUTH_EXCHANGE,

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -137,6 +137,7 @@ const ALL_TOOL_NAMES = [
   "AI_PROVIDER_KEY_LIST",
   "AI_PROVIDER_KEY_DELETE",
   "AI_PROVIDER_KEY_UPDATE",
+  "AI_PROVIDER_KEY_PREVIEW",
   "AI_PROVIDER_OAUTH_URL",
   "AI_PROVIDER_OAUTH_EXCHANGE",
   "AI_PROVIDER_PROVISION_KEY",
@@ -667,7 +668,12 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   },
   {
     name: "AI_PROVIDER_KEY_UPDATE",
-    description: "Update AI provider API key label",
+    description: "Update AI provider API key label or credential",
+    category: "AI Providers",
+  },
+  {
+    name: "AI_PROVIDER_KEY_PREVIEW",
+    description: "Get masked preview of AI provider API key",
     category: "AI Providers",
   },
   {
@@ -1143,6 +1149,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "AI_PROVIDER_KEY_LIST",
       "AI_PROVIDER_KEY_DELETE",
       "AI_PROVIDER_KEY_UPDATE",
+      "AI_PROVIDER_KEY_PREVIEW",
       "AI_PROVIDER_OAUTH_URL",
       "AI_PROVIDER_OAUTH_EXCHANGE",
       "AI_PROVIDER_PROVISION_KEY",

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
@@ -1,0 +1,285 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { Eye, EyeOff } from "@untitledui/icons";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+  type AiProviderInfo,
+  type AiProviderKey,
+} from "@decocms/mesh-sdk";
+import { KEYS } from "@/web/lib/query-keys";
+import {
+  OPENAI_COMPATIBLE_PRESETS,
+  type OpenAICompatiblePreset,
+} from "@/web/utils/openai-compatible-presets";
+
+interface EditProviderKeyDialogProps {
+  providerKey: AiProviderKey;
+  provider: AiProviderInfo;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const editFormSchema = z.object({
+  label: z.string().min(1, "Label is required").max(100),
+  apiKey: z.string().optional(),
+  baseUrl: z.string().optional(),
+});
+
+type EditFormData = z.infer<typeof editFormSchema>;
+
+interface EditFormProps {
+  providerKey: AiProviderKey;
+  provider: AiProviderInfo;
+  preset?: OpenAICompatiblePreset;
+  maskedKey: string;
+  currentLabel: string;
+  currentBaseUrl?: string;
+  onCancel: () => void;
+  onSuccess: () => void;
+}
+
+function EditForm({
+  providerKey,
+  provider,
+  preset,
+  maskedKey,
+  currentLabel,
+  currentBaseUrl,
+  onCancel,
+  onSuccess,
+}: EditFormProps) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const queryClient = useQueryClient();
+  const [showKey, setShowKey] = useState(false);
+
+  const isOpenAICompatible = provider.id === "openai-compatible";
+  const supportsApiKey = provider.supportedMethods.includes("api-key");
+  const typedApiKey = watch("apiKey") ?? "";
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<EditFormData>({
+    resolver: zodResolver(editFormSchema),
+    defaultValues: {
+      label: currentLabel,
+      apiKey: "",
+      baseUrl: currentBaseUrl ?? "",
+    },
+  });
+
+  const { mutate: save, isPending } = useMutation({
+    mutationFn: async (data: EditFormData) => {
+      let apiKeyValue: string | undefined;
+
+      if (data.apiKey) {
+        if (isOpenAICompatible) {
+          apiKeyValue = JSON.stringify({
+            baseUrl: data.baseUrl || currentBaseUrl || "",
+            apiKey: data.apiKey,
+          });
+        } else {
+          apiKeyValue = data.apiKey;
+        }
+      } else if (
+        isOpenAICompatible &&
+        data.baseUrl &&
+        data.baseUrl !== currentBaseUrl
+      ) {
+        // Base URL changed but no new API key — re-encode with existing masked key not possible.
+        // We encode the new baseUrl with empty apiKey so the connection still works.
+        apiKeyValue = JSON.stringify({
+          baseUrl: data.baseUrl,
+          apiKey: "",
+        });
+      }
+
+      await client.callTool({
+        name: "AI_PROVIDER_KEY_UPDATE",
+        arguments: {
+          keyId: providerKey.id,
+          label: data.label,
+          ...(apiKeyValue !== undefined ? { apiKey: apiKeyValue } : {}),
+        },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });
+      queryClient.invalidateQueries({ queryKey: KEYS.aiProviders(org.id) });
+      toast.success("Provider updated");
+      onSuccess();
+    },
+    onError: (err) => toast.error(`Failed to update: ${err.message}`),
+  });
+
+  return (
+    <form onSubmit={handleSubmit((data) => save(data))} className="space-y-3">
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Label
+        </label>
+        <Input
+          placeholder="e.g. Personal key"
+          {...register("label")}
+          className="h-8 text-sm"
+        />
+        {errors.label && (
+          <p className="text-xs text-destructive">{errors.label.message}</p>
+        )}
+      </div>
+
+      {isOpenAICompatible && !preset?.defaultBaseUrl && (
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            Base URL
+          </label>
+          <Input
+            type="url"
+            placeholder={
+              preset?.baseUrlPlaceholder ?? "http://localhost:4000/v1"
+            }
+            {...register("baseUrl")}
+            className="h-8 text-sm"
+          />
+        </div>
+      )}
+
+      {supportsApiKey && (
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            API key{" "}
+            <span className="text-muted-foreground/60">
+              (leave blank to keep current)
+            </span>
+          </label>
+          <div className="relative">
+            <Input
+              type={showKey && typedApiKey ? "text" : "password"}
+              placeholder={maskedKey}
+              {...register("apiKey")}
+              className="ph-no-capture h-8 text-sm pr-8"
+            />
+            {typedApiKey && (
+              <button
+                type="button"
+                onClick={() => setShowKey(!showKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {preset?.helpText && (
+        <p className="text-xs text-muted-foreground">{preset.helpText}</p>
+      )}
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          disabled={isPending}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={isPending}>
+          {isPending ? "Saving..." : "Save"}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export function EditProviderKeyDialog({
+  providerKey,
+  provider,
+  open,
+  onOpenChange,
+}: EditProviderKeyDialogProps) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  const preset: OpenAICompatiblePreset | undefined =
+    provider.id === "openai-compatible" && providerKey.presetId
+      ? OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === providerKey.presetId)
+      : undefined;
+
+  const displayName = preset?.name ?? provider.name;
+
+  const { data: preview, isLoading } = useQuery({
+    queryKey: ["ai-provider-key-preview", providerKey.id],
+    queryFn: async () => {
+      const result = (await client.callTool({
+        name: "AI_PROVIDER_KEY_PREVIEW",
+        arguments: { keyId: providerKey.id },
+      })) as {
+        structuredContent?: {
+          label: string;
+          maskedKey: string;
+          baseUrl?: string;
+        };
+      };
+      return result.structuredContent!;
+    },
+    enabled: open,
+    staleTime: 0,
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit {displayName}</DialogTitle>
+        </DialogHeader>
+
+        {isLoading || !preview ? (
+          <div className="flex justify-center py-8">
+            <Spinner />
+          </div>
+        ) : (
+          <EditForm
+            providerKey={providerKey}
+            provider={provider}
+            preset={preset}
+            maskedKey={preview.maskedKey}
+            currentLabel={preview.label}
+            currentBaseUrl={preview.baseUrl}
+            onCancel={() => onOpenChange(false)}
+            onSuccess={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
@@ -75,7 +75,6 @@ function EditForm({
 
   const isOpenAICompatible = provider.id === "openai-compatible";
   const supportsApiKey = provider.supportedMethods.includes("api-key");
-  const typedApiKey = watch("apiKey") ?? "";
 
   const {
     register,
@@ -90,6 +89,8 @@ function EditForm({
       baseUrl: currentBaseUrl ?? "",
     },
   });
+
+  const typedApiKey = watch("apiKey") ?? "";
 
   const { mutate: save, isPending } = useMutation({
     mutationFn: async (data: EditFormData) => {

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
-import { Edit01, Trash01, Check, X } from "@untitledui/icons";
+import { Edit01, Trash01 } from "@untitledui/icons";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { SettingsCardItem } from "@/web/components/settings/settings-section";
@@ -28,6 +28,7 @@ import {
   OPENAI_COMPATIBLE_PRESETS,
   type OpenAICompatiblePreset,
 } from "@/web/utils/openai-compatible-presets";
+import { EditProviderKeyDialog } from "./edit-provider-dialog";
 
 interface ProviderKeyRowProps {
   providerKey: AiProviderKey;
@@ -43,8 +44,7 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
   });
   const queryClient = useQueryClient();
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [editing, setEditing] = useState(false);
-  const [draftLabel, setDraftLabel] = useState(providerKey.label);
+  const [editOpen, setEditOpen] = useState(false);
 
   const isOpenAICompatible = provider.id === "openai-compatible";
 
@@ -67,20 +67,6 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
     return `${providerKey.label} · added ${formatDistanceToNow(new Date(providerKey.createdAt))} ago`;
   })();
 
-  const { mutate: updateLabel, isPending: isUpdating } = useMutation({
-    mutationFn: async (label: string) => {
-      await client.callTool({
-        name: "AI_PROVIDER_KEY_UPDATE",
-        arguments: { keyId: providerKey.id, label },
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });
-      setEditing(false);
-    },
-    onError: () => toast.error("Failed to update key label"),
-  });
-
   const { mutate: deleteKey, isPending: isDeleting } = useMutation({
     mutationFn: async () => {
       await client.callTool({
@@ -100,17 +86,6 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
     onError: (err) => toast.error(`Failed to delete key: ${err.message}`),
   });
 
-  const startEdit = () => {
-    setDraftLabel(providerKey.label);
-    setEditing(true);
-  };
-
-  const submitEdit = () => {
-    const trimmed = draftLabel.trim();
-    if (!trimmed) return;
-    updateLabel(trimmed);
-  };
-
   return (
     <>
       <SettingsCardItem
@@ -128,74 +103,42 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
             />
           )
         }
-        title={
-          editing ? (
-            <input
-              autoFocus
-              className="font-medium bg-transparent border-b border-border outline-none w-full"
-              value={draftLabel}
-              onChange={(e) => setDraftLabel(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") submitEdit();
-                if (e.key === "Escape") setEditing(false);
-              }}
-            />
-          ) : (
-            displayName
-          )
-        }
-        description={editing ? null : description}
+        title={displayName}
+        description={description}
         action={
           <div className="flex items-center gap-0.5">
-            {editing ? (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                  disabled={isUpdating || !draftLabel.trim()}
-                  onClick={submitEdit}
-                >
-                  <Check size={14} />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                  onClick={() => setEditing(false)}
-                >
-                  <X size={14} />
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground hover:text-foreground"
-                  onClick={startEdit}
-                >
-                  <Edit01 size={14} />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                  disabled={isDeleting}
-                  onClick={() => setConfirmDelete(true)}
-                >
-                  <Trash01 size={14} />
-                </Button>
-              </>
-            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              onClick={() => setEditOpen(true)}
+            >
+              <Edit01 size={14} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-destructive"
+              disabled={isDeleting}
+              onClick={() => setConfirmDelete(true)}
+            >
+              <Trash01 size={14} />
+            </Button>
           </div>
         }
+      />
+
+      <EditProviderKeyDialog
+        providerKey={providerKey}
+        provider={provider}
+        open={editOpen}
+        onOpenChange={setEditOpen}
       />
 
       <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete API Key</AlertDialogTitle>
+            <AlertDialogTitle>Delete API key</AlertDialogTitle>
             <AlertDialogDescription>
               This action cannot be undone. This will permanently delete{" "}
               <span className="font-medium text-foreground">


### PR DESCRIPTION
## What is this contribution about?

Replaces the inline name-only editor on connected provider rows with a proper edit modal. The dialog shows the current label, API key (masked with only the last 4 characters visible), and base URL for openai-compatible connections — all editable in place. A new `AI_PROVIDER_KEY_PREVIEW` tool returns the masked credential, and `AI_PROVIDER_KEY_UPDATE` is extended to accept an optional `apiKey` for credential rotation.

## Screenshots/Demonstration

> Edit modal opens on pencil click, pre-fills label and shows masked API key as placeholder. Eye icon only appears once the user starts typing a new key.

## How to Test

1. Go to Settings → AI Providers
2. Click the pencil icon on any connected provider
3. Verify the modal shows the current label and masked API key (e.g. `••••••••3f7a`)
4. Update the label only → save → confirm label changes in the list
5. Enter a new API key → save → confirm the key is rotated (reconnect to verify)
6. For an openai-compatible provider, confirm the Base URL field is also shown and editable

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the inline name editor for provider keys with a full edit modal. Users can update the label, rotate the key with a fixed-width masked preview (last 4 shown), and edit the base URL for `openai-compatible` connections.

- New Features
  - Added an edit dialog with fields for label, API key, and base URL (when `openai-compatible`).
  - Introduced `AI_PROVIDER_KEY_PREVIEW` to fetch label, maskedKey, and baseUrl for the modal.
  - Extended `AI_PROVIDER_KEY_UPDATE` to accept optional `label` and `apiKey` for credential rotation; storage updates handle encryption, hashing, and cache invalidation.

- Bug Fixes
  - Fixed a runtime error in the edit dialog by moving the watch call after `useForm` initialization.
  - Switched to a fixed-width key mask so the last 4 characters are always visible.

<sup>Written for commit b96f651df4804165f16b84e5901ff5df571d8a82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

