### PR TITLE
feat(content): improve page variants UX and unify search input

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -318,7 +318,12 @@ function ContentBrowserReady({
   const handleAddPageVariant = async (page: PageEntry) => {
     const fullPageData = decofile[page.key] as Record<string, unknown>;
     if (!fullPageData) return;
-    const seedSections = getPageVariantSectionsAt(decofile, page.key, 0);
+    const variantCount = getPageVariantCount(decofile, page.key);
+    const seedSections = getPageVariantSectionsAt(
+      decofile,
+      page.key,
+      Math.max(0, variantCount - 1),
+    );
     const updatedSections = appendPageVariantSections(
       fullPageData.sections,
       seedSections,

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -4,6 +4,7 @@ import {
   Copy01,
   DotsHorizontal,
   Edit01,
+  Flag01,
   Globe02,
   LayoutAlt01,
   Loading01,
@@ -95,10 +96,24 @@ const AddSectionModal = lazy(() =>
   })),
 );
 
+const VARIANT_GREEN = "oklch(0.65 0.15 160)";
+
+function getPageVariantCount(
+  decofile: Record<string, unknown>,
+  pageKey: string,
+): number {
+  const pageData = decofile[pageKey] as Record<string, unknown> | undefined;
+  const sections = pageData?.sections;
+  if (!sections || Array.isArray(sections)) return 1;
+  const obj = sections as Record<string, unknown>;
+  if (Array.isArray(obj.variants)) return (obj.variants as unknown[]).length;
+  return 1;
+}
+
 type CollectionId = "pages" | "sections";
 
 type Selection =
-  | { collection: "pages"; path: string }
+  | { collection: "pages"; key: string; path: string }
   | { collection: "sections"; key: string }
   | null;
 
@@ -306,6 +321,48 @@ function ContentBrowserReady({
   const takenPageNames = new Set(pages.map((p) => p.name));
   const takenSectionNames = new Set(globalSections.map((s) => s.name));
 
+  // ------------------ Variant ------------------
+  const handleAddPageVariant = async (page: PageEntry) => {
+    const fullPageData = decofile[page.key] as Record<string, unknown>;
+    if (!fullPageData) return;
+    const current = fullPageData.sections;
+    let updatedSections: Record<string, unknown>;
+    if (Array.isArray(current)) {
+      // Fork: new variant starts as a clone of the existing sections so the
+      // user has a working baseline to tweak (matches A/B-test mental model).
+      const cloned = structuredClone(current);
+      updatedSections = {
+        variants: [{ value: current }, { value: cloned }],
+      };
+    } else if (current && typeof current === "object") {
+      const obj = current as Record<string, unknown>;
+      if (Array.isArray(obj.variants)) {
+        const variants = obj.variants as Array<Record<string, unknown>>;
+        // Clone the active/last variant's sections as the seed.
+        const seed = variants[variants.length - 1]?.value;
+        const cloned = Array.isArray(seed) ? structuredClone(seed) : [];
+        updatedSections = {
+          ...obj,
+          variants: [...variants, { value: cloned }],
+        };
+      } else {
+        return;
+      }
+    } else {
+      updatedSections = { variants: [{ value: [] }, { value: [] }] };
+    }
+    try {
+      await saveBlock.mutateAsync({
+        blockKey: page.key,
+        data: { ...fullPageData, sections: updatedSections },
+      });
+      toast.success(`Variant added to "${page.name}"`);
+      setSelection({ collection: "pages", key: page.key, path: page.path });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not add variant");
+    }
+  };
+
   // ------------------ Page CRUD ------------------
   const openCreatePage = () => {
     setPageDialogError(undefined);
@@ -346,7 +403,7 @@ function ContentBrowserReady({
         const key = generateUniquePageBlockKey(decofile, values.name);
         await saveBlock.mutateAsync({ blockKey: key, data });
         toast.success(`Created "${values.name}"`);
-        setSelection({ collection: "pages", path: values.path });
+        setSelection({ collection: "pages", key, path: values.path });
       } else if (mode === "duplicate" && sourceKey) {
         const source = decofile[sourceKey] as
           | Record<string, unknown>
@@ -360,7 +417,7 @@ function ContentBrowserReady({
         });
         await saveBlock.mutateAsync({ blockKey: key, data });
         toast.success(`Duplicated as "${values.name}"`);
-        setSelection({ collection: "pages", path: values.path });
+        setSelection({ collection: "pages", key, path: values.path });
       } else if (mode === "rename" && sourceKey) {
         const source = decofile[sourceKey] as
           | Record<string, unknown>
@@ -373,12 +430,12 @@ function ContentBrowserReady({
         };
         await saveBlock.mutateAsync({ blockKey: sourceKey, data });
         toast.success("Page updated");
-        if (
-          selection?.collection === "pages" &&
-          normalizePagePath(selection.path) ===
-            normalizePagePath(pageDialog.initialPath)
-        ) {
-          setSelection({ collection: "pages", path: values.path });
+        if (selection?.collection === "pages" && selection.key === sourceKey) {
+          setSelection({
+            collection: "pages",
+            key: sourceKey,
+            path: values.path,
+          });
         }
       }
       setPageDialog(null);
@@ -478,12 +535,7 @@ function ContentBrowserReady({
       await deleteBlock.mutateAsync({ blockKey: key });
       toast.success(`Deleted "${label}"`);
       if (kind === "page") {
-        const deletedPath = pages.find((p) => p.key === key)?.path;
-        if (
-          deletedPath &&
-          selection?.collection === "pages" &&
-          normalizePagePath(selection.path) === normalizePagePath(deletedPath)
-        ) {
+        if (selection?.collection === "pages" && selection.key === key) {
           setSelection(null);
         }
       } else if (
@@ -513,6 +565,7 @@ function ContentBrowserReady({
         activeCollection={activeCollection}
         pages={pages}
         sections={globalSections}
+        decofile={decofile}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         selection={selection}
@@ -529,6 +582,7 @@ function ContentBrowserReady({
         }}
         onDuplicatePage={openDuplicatePage}
         onRenamePage={openRenamePage}
+        onAddPageVariant={handleAddPageVariant}
         onDeletePage={(page) =>
           setDeleteTarget({ kind: "page", key: page.key, label: page.name })
         }
@@ -553,7 +607,7 @@ function ContentBrowserReady({
             <SectionsEditor
               key={
                 selection.collection === "pages"
-                  ? `page:${selection.path}`
+                  ? `page:${selection.key}`
                   : `section:${selection.key}`
               }
               orgSlug={orgSlug}
@@ -563,6 +617,9 @@ function ContentBrowserReady({
               previewUrl={previewUrl ?? undefined}
               currentPath={
                 selection.collection === "pages" ? selection.path : "/"
+              }
+              activePageBlockKey={
+                selection.collection === "pages" ? selection.key : null
               }
               activeGlobalBlockKey={
                 selection.collection === "sections" ? selection.key : null
@@ -764,6 +821,7 @@ function ItemList({
   activeCollection,
   pages,
   sections,
+  decofile,
   previewUrl,
   searchQuery,
   onSearchChange,
@@ -772,6 +830,7 @@ function ItemList({
   onCreate,
   onDuplicatePage,
   onRenamePage,
+  onAddPageVariant,
   onDeletePage,
   onDuplicateSection,
   onRenameSection,
@@ -780,6 +839,7 @@ function ItemList({
   activeCollection: CollectionId;
   pages: PageEntry[];
   sections: GlobalSectionEntry[];
+  decofile: Record<string, unknown>;
   previewUrl: string | null;
   searchQuery: string;
   onSearchChange: (q: string) => void;
@@ -788,6 +848,7 @@ function ItemList({
   onCreate: () => void;
   onDuplicatePage: (page: PageEntry) => void;
   onRenamePage: (page: PageEntry) => void;
+  onAddPageVariant: (page: PageEntry) => void;
   onDeletePage: (page: PageEntry) => void;
   onDuplicateSection: (section: GlobalSectionEntry) => void;
   onRenameSection: (section: GlobalSectionEntry) => void;
@@ -866,7 +927,8 @@ function ItemList({
               filteredPages.map((page) => {
                 const isActive =
                   selection?.collection === "pages" &&
-                  selection.path === page.path;
+                  selection.key === page.key;
+                const variantCount = getPageVariantCount(decofile, page.key);
                 return (
                   <ItemRow
                     key={page.key}
@@ -874,13 +936,19 @@ function ItemList({
                     title={page.name}
                     subtitle={page.path}
                     active={isActive}
+                    variantCount={variantCount}
                     onClick={() =>
-                      onSelect({ collection: "pages", path: page.path })
+                      onSelect({
+                        collection: "pages",
+                        key: page.key,
+                        path: page.path,
+                      })
                     }
                     menu={
                       <ItemActions
                         onDuplicate={() => onDuplicatePage(page)}
                         onRename={() => onRenamePage(page)}
+                        onAddVariant={() => onAddPageVariant(page)}
                         onDelete={() => onDeletePage(page)}
                       />
                     }
@@ -935,13 +1003,19 @@ function ItemRow({
   title,
   subtitle,
   active,
+  variantCount,
   onClick,
   menu,
 }: {
-  icon: React.ComponentType<{ size?: number; className?: string }>;
+  icon: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
   title: string;
   subtitle: string;
   active: boolean;
+  variantCount?: number;
   onClick: () => void;
   menu?: React.ReactNode;
 }) {
@@ -957,13 +1031,28 @@ function ItemRow({
         onClick={onClick}
         className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2.5 py-2 text-left cursor-pointer"
       >
-        <Icon
-          size={16}
-          className={cn(
-            "shrink-0",
-            active ? "text-accent-foreground" : "text-muted-foreground",
-          )}
-        />
+        {variantCount && variantCount > 1 ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Icon
+                size={16}
+                className="shrink-0"
+                style={{ color: VARIANT_GREEN }}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {variantCount} variants
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <Icon
+            size={16}
+            className={cn(
+              "shrink-0",
+              active ? "text-accent-foreground" : "text-muted-foreground",
+            )}
+          />
+        )}
         <span className="min-w-0 flex-1">
           <span className="block truncate text-sm font-medium">{title}</span>
           <span
@@ -993,10 +1082,12 @@ function ItemRow({
 function ItemActions({
   onDuplicate,
   onRename,
+  onAddVariant,
   onDelete,
 }: {
   onDuplicate: () => void;
   onRename: () => void;
+  onAddVariant?: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -1011,7 +1102,7 @@ function ItemActions({
           <DotsHorizontal size={14} />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-40">
+      <DropdownMenuContent align="end" className="w-44">
         <DropdownMenuItem onClick={onRename}>
           <Edit01 size={14} />
           Rename
@@ -1020,6 +1111,19 @@ function ItemActions({
           <Copy01 size={14} />
           Duplicate
         </DropdownMenuItem>
+        {onAddVariant && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={onAddVariant}
+              className="cursor-pointer"
+              style={{ color: VARIANT_GREEN }}
+            >
+              <Flag01 size={14} style={{ color: VARIANT_GREEN }} />
+              Add variant
+            </DropdownMenuItem>
+          </>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={onDelete}

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -58,6 +58,11 @@ import {
   type PageEntry,
 } from "@/web/components/sections-editor/page-list";
 import { normalizePagePath } from "@/web/components/sections-editor/page-path-utils";
+import {
+  appendPageVariantSections,
+  getPageVariantCount,
+  getPageVariantSectionsAt,
+} from "@/web/components/sections-editor/page-variants";
 import type { SectionCatalogEntry } from "@/web/components/sections-editor/section-catalog";
 import { useNavigate } from "@tanstack/react-router";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
@@ -97,18 +102,6 @@ const AddSectionModal = lazy(() =>
 );
 
 const VARIANT_GREEN = "oklch(0.65 0.15 160)";
-
-function getPageVariantCount(
-  decofile: Record<string, unknown>,
-  pageKey: string,
-): number {
-  const pageData = decofile[pageKey] as Record<string, unknown> | undefined;
-  const sections = pageData?.sections;
-  if (!sections || Array.isArray(sections)) return 1;
-  const obj = sections as Record<string, unknown>;
-  if (Array.isArray(obj.variants)) return (obj.variants as unknown[]).length;
-  return 1;
-}
 
 type CollectionId = "pages" | "sections";
 
@@ -325,32 +318,12 @@ function ContentBrowserReady({
   const handleAddPageVariant = async (page: PageEntry) => {
     const fullPageData = decofile[page.key] as Record<string, unknown>;
     if (!fullPageData) return;
-    const current = fullPageData.sections;
-    let updatedSections: Record<string, unknown>;
-    if (Array.isArray(current)) {
-      // Fork: new variant starts as a clone of the existing sections so the
-      // user has a working baseline to tweak (matches A/B-test mental model).
-      const cloned = structuredClone(current);
-      updatedSections = {
-        variants: [{ value: current }, { value: cloned }],
-      };
-    } else if (current && typeof current === "object") {
-      const obj = current as Record<string, unknown>;
-      if (Array.isArray(obj.variants)) {
-        const variants = obj.variants as Array<Record<string, unknown>>;
-        // Clone the active/last variant's sections as the seed.
-        const seed = variants[variants.length - 1]?.value;
-        const cloned = Array.isArray(seed) ? structuredClone(seed) : [];
-        updatedSections = {
-          ...obj,
-          variants: [...variants, { value: cloned }],
-        };
-      } else {
-        return;
-      }
-    } else {
-      updatedSections = { variants: [{ value: [] }, { value: [] }] };
-    }
+    const seedSections = getPageVariantSectionsAt(decofile, page.key, 0);
+    const updatedSections = appendPageVariantSections(
+      fullPageData.sections,
+      seedSections,
+    );
+    if (!updatedSections) return;
     try {
       await saveBlock.mutateAsync({
         blockKey: page.key,

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -18,6 +18,7 @@ import {
   LayoutAlt01,
   LinkExternal01,
   Plus,
+  SearchLg,
   TextInput,
   Loading01,
   Monitor04,
@@ -832,13 +833,18 @@ export function PreviewContent() {
 
                   {pagesOpen && (
                     <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
-                      <div className="px-2 pt-2 pb-1">
+                      <div className="px-2 h-10 flex items-center gap-2 border-b">
+                        <SearchLg
+                          size={14}
+                          className="shrink-0 text-muted-foreground"
+                          aria-hidden
+                        />
                         <input
                           type="text"
                           value={pagesSearch}
                           onChange={(e) => setPagesSearch(e.target.value)}
                           placeholder="Search pages and components..."
-                          className="w-full rounded-md border border-input bg-transparent px-2.5 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
+                          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                           autoFocus
                         />
                       </div>

--- a/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-type-utils.ts
@@ -31,6 +31,14 @@ export function isManifestSectionResolveType(
   return blockType !== null && blockType.includes("sections");
 }
 
+export function isManifestMatcherResolveType(
+  meta: LiveMeta,
+  resolveType: string,
+): boolean {
+  const blockType = getManifestBlockType(meta, resolveType);
+  return blockType !== null && blockType.includes("matchers");
+}
+
 /** Block id reference (no module path) — e.g. `Header`, not `site/sections/Header.tsx`. */
 export function isSavedBlockResolveType(resolveType: string): boolean {
   return !resolveType.includes("/");

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -1,9 +1,23 @@
+import { useState } from "react";
+import { Calendar as CalendarIcon } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Calendar } from "@deco/ui/components/calendar.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
-import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
 import type { FieldProps } from "./field-props";
 
 const pad = (n: number) => String(n).padStart(2, "0");
+
+const DATE_MIN = "1900-01-01";
+const DATE_MAX = "2099-12-31";
+const DATETIME_MIN = "1900-01-01T00:00";
+const DATETIME_MAX = "2099-12-31T23:59";
 
 /**
  * Native <input type="date"> / <input type="datetime-local"> give us the
@@ -19,7 +33,6 @@ function isoToDateInput(iso: string): string {
 
 function dateInputToIso(dateValue: string): string {
   if (!dateValue) return "";
-  // Interpret as local midnight so the date the user picked is what gets stored.
   const d = new Date(`${dateValue}T00:00:00`);
   return Number.isNaN(d.getTime()) ? "" : d.toISOString();
 }
@@ -35,6 +48,91 @@ function dateTimeInputToIso(localValue: string): string {
   if (!localValue) return "";
   const d = new Date(localValue);
   return Number.isNaN(d.getTime()) ? "" : d.toISOString();
+}
+
+/**
+ * Wraps a native segmented date/datetime input with a shadcn Calendar
+ * popover trigger. The native input gives us auto-advancing MM/DD/YYYY
+ * segments; the popover gives users a point-and-click fallback and
+ * replaces the (locale-dependent, ugly) browser-native picker indicator.
+ */
+function DatePickerInput({
+  id,
+  withTime,
+  value,
+  onChange,
+}: {
+  id: string;
+  withTime: boolean;
+  value: string;
+  onChange: (iso: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const inputValue = withTime
+    ? isoToDateTimeInput(value)
+    : isoToDateInput(value);
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(
+      withTime
+        ? dateTimeInputToIso(e.target.value)
+        : dateInputToIso(e.target.value),
+    );
+  };
+
+  const parsed = value ? new Date(value) : null;
+  const selected = parsed && !Number.isNaN(parsed.getTime()) ? parsed : null;
+
+  const handleCalendarSelect = (next: Date | undefined) => {
+    if (!next) return;
+    // Preserve the existing time when picking a date for a datetime field.
+    if (withTime) {
+      if (selected) {
+        next.setHours(selected.getHours(), selected.getMinutes(), 0, 0);
+      } else {
+        next.setHours(0, 0, 0, 0);
+      }
+    } else {
+      next.setHours(0, 0, 0, 0);
+    }
+    onChange(next.toISOString());
+    setOpen(false);
+  };
+
+  return (
+    <div className="flex gap-1">
+      <Input
+        id={id}
+        type={withTime ? "datetime-local" : "date"}
+        min={withTime ? DATETIME_MIN : DATE_MIN}
+        max={withTime ? DATETIME_MAX : DATE_MAX}
+        value={inputValue}
+        onChange={handleInputChange}
+        className="h-10 flex-1 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:opacity-0"
+      />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-10 w-10 shrink-0"
+            aria-label="Open calendar"
+          >
+            <CalendarIcon className="h-4 w-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="end">
+          <Calendar
+            mode="single"
+            selected={selected ?? undefined}
+            onSelect={handleCalendarSelect}
+            initialFocus
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
 }
 
 function FieldLabel({
@@ -91,7 +189,7 @@ export function StringField({
     );
   }
 
-  if (format === "date") {
+  if (format === "date" || format === "date-time") {
     return (
       <div className="space-y-2">
         <FieldLabel
@@ -99,31 +197,11 @@ export function StringField({
           label={label}
           description={schema.description}
         />
-        <Input
+        <DatePickerInput
           id={path}
-          type="date"
-          value={isoToDateInput(strValue)}
-          onChange={(e) => onChange(dateInputToIso(e.target.value))}
-          className="h-10"
-        />
-      </div>
-    );
-  }
-
-  if (format === "date-time") {
-    return (
-      <div className="space-y-2">
-        <FieldLabel
-          htmlFor={path}
-          label={label}
-          description={schema.description}
-        />
-        <Input
-          id={path}
-          type="datetime-local"
-          value={isoToDateTimeInput(strValue)}
-          onChange={(e) => onChange(dateTimeInputToIso(e.target.value))}
-          className="h-10"
+          withTime={format === "date-time"}
+          value={strValue}
+          onChange={onChange}
         />
       </div>
     );

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -3,6 +3,40 @@ import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import type { FieldProps } from "./field-props";
 
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Native <input type="date"> / <input type="datetime-local"> give us the
+ * segmented MM/DD/YYYY auto-advance UX users expect from a date picker.
+ * Deco persists ISO 8601 strings, so we convert at the edges.
+ */
+function isoToDateInput(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function dateInputToIso(dateValue: string): string {
+  if (!dateValue) return "";
+  // Interpret as local midnight so the date the user picked is what gets stored.
+  const d = new Date(`${dateValue}T00:00:00`);
+  return Number.isNaN(d.getTime()) ? "" : d.toISOString();
+}
+
+function isoToDateTimeInput(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function dateTimeInputToIso(localValue: string): string {
+  if (!localValue) return "";
+  const d = new Date(localValue);
+  return Number.isNaN(d.getTime()) ? "" : d.toISOString();
+}
+
 function FieldLabel({
   htmlFor,
   label,
@@ -52,6 +86,44 @@ export function StringField({
           value={strValue}
           onChange={(e) => onChange(e.target.value)}
           rows={4}
+        />
+      </div>
+    );
+  }
+
+  if (format === "date") {
+    return (
+      <div className="space-y-2">
+        <FieldLabel
+          htmlFor={path}
+          label={label}
+          description={schema.description}
+        />
+        <Input
+          id={path}
+          type="date"
+          value={isoToDateInput(strValue)}
+          onChange={(e) => onChange(dateInputToIso(e.target.value))}
+          className="h-10"
+        />
+      </div>
+    );
+  }
+
+  if (format === "date-time") {
+    return (
+      <div className="space-y-2">
+        <FieldLabel
+          htmlFor={path}
+          label={label}
+          description={schema.description}
+        />
+        <Input
+          id={path}
+          type="datetime-local"
+          value={isoToDateTimeInput(strValue)}
+          onChange={(e) => onChange(dateTimeInputToIso(e.target.value))}
+          className="h-10"
         />
       </div>
     );

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -26,15 +26,17 @@ const DATETIME_MAX = "2099-12-31T23:59";
  */
 function isoToDateInput(iso: string): string {
   if (!iso) return "";
+  const datePart = iso.slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return datePart;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
 }
 
 function dateInputToIso(dateValue: string): string {
   if (!dateValue) return "";
-  const d = new Date(`${dateValue}T00:00:00`);
-  return Number.isNaN(d.getTime()) ? "" : d.toISOString();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateValue)) return "";
+  return `${dateValue}T00:00:00.000Z`;
 }
 
 function isoToDateTimeInput(iso: string): string {

--- a/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
+++ b/apps/mesh/src/web/components/sections-editor/matcher-picker.tsx
@@ -12,6 +12,7 @@ import {
 import { resolveBlockSchemaMetadata, type LiveMeta } from "./resolve-schema";
 import { MatcherIcon, resolveMatcherIconName } from "./matcher-icons";
 import { labelFromResolveType } from "./section-types";
+import { getIconComponent } from "../agent-icon";
 
 export interface MatcherEntry {
   resolveType: string;
@@ -80,6 +81,7 @@ export function MatcherPicker({
 }) {
   const [open, setOpen] = useState(false);
   const currentIconName = resolveCurrentMatcherIcon(currentRt, matchers);
+  const CurrentIcon = getIconComponent(currentIconName);
 
   const handleSelect = (rt: string) => {
     onSelect(rt);
@@ -91,9 +93,11 @@ export function MatcherPicker({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex h-9 w-full items-center gap-2 rounded-md border border-input bg-transparent px-3 text-left text-sm shadow-xs transition-colors hover:bg-accent/40"
+        className="flex h-10 w-full items-center gap-2 rounded-md border border-input bg-transparent px-3 text-left text-sm shadow-xs transition-colors hover:bg-accent/40 cursor-pointer"
       >
-        <MatcherIcon iconName={currentIconName} size="sm" />
+        {CurrentIcon && (
+          <CurrentIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
         <span className="flex-1 truncate">{currentLabel}</span>
         <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       </button>

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildMatcherBlockData,
+  buildMatcherBlockReference,
+  inlineMatcherRule,
+  isSavedMatcherBlockReference,
+  resolveVariantRuleLabel,
+  unwrapMatcherRule,
+} from "./matcher-rules";
+
+describe("matcher-rules", () => {
+  const decofile = {
+    MobilePromo: {
+      __resolveType: "website/matchers/device.ts",
+      mobile: true,
+      name: "Mobile Promo",
+    },
+  };
+
+  it("detects saved matcher block references", () => {
+    expect(
+      isSavedMatcherBlockReference({ __resolveType: "MobilePromo" }, decofile),
+    ).toBe(true);
+    expect(
+      isSavedMatcherBlockReference(
+        { __resolveType: "website/matchers/device.ts", mobile: true },
+        decofile,
+      ),
+    ).toBe(false);
+  });
+
+  it("unwraps inline and saved matcher rules", () => {
+    expect(
+      unwrapMatcherRule(
+        { __resolveType: "website/matchers/device.ts", mobile: true },
+        decofile,
+      ),
+    ).toEqual({
+      resolveType: "website/matchers/device.ts",
+      data: { mobile: true },
+    });
+
+    expect(
+      unwrapMatcherRule({ __resolveType: "MobilePromo" }, decofile),
+    ).toEqual({
+      resolveType: "website/matchers/device.ts",
+      data: { mobile: true },
+      blockKey: "MobilePromo",
+    });
+  });
+
+  it("inlines saved matcher rules for persistence on the page", () => {
+    expect(
+      inlineMatcherRule({ __resolveType: "MobilePromo" }, decofile),
+    ).toEqual({
+      __resolveType: "website/matchers/device.ts",
+      mobile: true,
+    });
+  });
+
+  it("labels saved matcher blocks from block name", () => {
+    expect(
+      resolveVariantRuleLabel(
+        { __resolveType: "MobilePromo" },
+        decofile,
+        () => "Fallback",
+      ),
+    ).toBe("Mobile Promo");
+  });
+
+  it("builds matcher block payloads and references", () => {
+    expect(
+      buildMatcherBlockData(
+        "website/matchers/device.ts",
+        { mobile: true },
+        "Mobile Promo",
+      ),
+    ).toEqual({
+      __resolveType: "website/matchers/device.ts",
+      mobile: true,
+      name: "Mobile Promo",
+    });
+    expect(buildMatcherBlockReference("MobilePromo")).toEqual({
+      __resolveType: "MobilePromo",
+    });
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "bun:test";
 import {
   buildMatcherBlockData,
   buildMatcherBlockReference,
+  getSavedMatcherBlockKey,
   inlineMatcherRule,
   isSavedMatcherBlockReference,
+  readMatcherRuleFormState,
+  resolveEffectiveMatcherRule,
   resolveVariantRuleLabel,
   unwrapMatcherRule,
 } from "./matcher-rules";
@@ -15,6 +18,15 @@ describe("matcher-rules", () => {
       mobile: true,
       name: "Mobile Promo",
     },
+    Header: {
+      __resolveType: "site/sections/Header.tsx",
+      title: "Header",
+    },
+    "pages-home-abc123": {
+      __resolveType: "website/pages/Page.tsx",
+      path: "/",
+      name: "Home",
+    },
   };
 
   it("detects saved matcher block references", () => {
@@ -24,6 +36,18 @@ describe("matcher-rules", () => {
     expect(
       isSavedMatcherBlockReference(
         { __resolveType: "website/matchers/device.ts", mobile: true },
+        decofile,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects section and page keys masquerading as matcher refs", () => {
+    expect(
+      isSavedMatcherBlockReference({ __resolveType: "Header" }, decofile),
+    ).toBe(false);
+    expect(
+      isSavedMatcherBlockReference(
+        { __resolveType: "pages-home-abc123" },
         decofile,
       ),
     ).toBe(false);
@@ -83,5 +107,42 @@ describe("matcher-rules", () => {
     expect(buildMatcherBlockReference("MobilePromo")).toEqual({
       __resolveType: "MobilePromo",
     });
+  });
+
+  it("reads matcher form state for inline and saved refs", () => {
+    expect(
+      readMatcherRuleFormState(
+        { __resolveType: "website/matchers/device.ts", mobile: true },
+        decofile,
+      ),
+    ).toEqual({
+      resolveType: "website/matchers/device.ts",
+      formValue: { mobile: true },
+    });
+
+    expect(
+      readMatcherRuleFormState({ __resolveType: "MobilePromo" }, decofile),
+    ).toEqual({
+      resolveType: "website/matchers/device.ts",
+      formValue: { mobile: true },
+    });
+  });
+
+  it("resolves effective matcher rules", () => {
+    expect(
+      resolveEffectiveMatcherRule({ __resolveType: "MobilePromo" }, decofile),
+    ).toEqual({
+      __resolveType: "website/matchers/device.ts",
+      mobile: true,
+    });
+  });
+
+  it("returns saved matcher block keys", () => {
+    expect(
+      getSavedMatcherBlockKey({ __resolveType: "MobilePromo" }, decofile),
+    ).toBe("MobilePromo");
+    expect(
+      getSavedMatcherBlockKey({ __resolveType: "Header" }, decofile),
+    ).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
@@ -1,5 +1,14 @@
-import { isSavedBlockResolveType } from "./block-type-utils";
+import {
+  isManifestMatcherResolveType,
+  isSavedBlockResolveType,
+} from "./block-type-utils";
 import { globalSectionLabel } from "./page-list";
+import type { LiveMeta } from "./resolve-schema";
+
+const PAGE_RESOLVE_TYPES = new Set([
+  "website/pages/Page.tsx",
+  "$live/pages/LivePage.tsx",
+]);
 
 export interface UnwrappedMatcherRule {
   resolveType: string;
@@ -7,24 +16,68 @@ export interface UnwrappedMatcherRule {
   blockKey?: string;
 }
 
+function isMatcherModuleResolveType(resolveType: string): boolean {
+  return resolveType.includes("matchers") || resolveType.includes("Match");
+}
+
+function isMatcherBlockData(
+  blockData: Record<string, unknown>,
+  meta?: LiveMeta | null,
+): boolean {
+  if (typeof blockData.path === "string") return false;
+  if (
+    typeof blockData.__resolveType === "string" &&
+    PAGE_RESOLVE_TYPES.has(blockData.__resolveType)
+  ) {
+    return false;
+  }
+
+  const moduleRt = (blockData.__resolveType as string) ?? "";
+  if (!moduleRt) return false;
+
+  if (meta) {
+    return isManifestMatcherResolveType(meta, moduleRt);
+  }
+
+  return isMatcherModuleResolveType(moduleRt);
+}
+
 export function isSavedMatcherBlockReference(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
 ): boolean {
   if (!rule) return false;
   const rt = (rule.__resolveType as string) ?? "";
-  return isSavedBlockResolveType(rt) && rt in decofile;
+  if (!isSavedBlockResolveType(rt) || !(rt in decofile)) return false;
+
+  const blockData = decofile[rt] as Record<string, unknown>;
+  if (!blockData || typeof blockData !== "object" || Array.isArray(blockData)) {
+    return false;
+  }
+
+  return isMatcherBlockData(blockData, meta);
+}
+
+export function getSavedMatcherBlockKey(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
+): string | null {
+  if (!isSavedMatcherBlockReference(rule, decofile, meta)) return null;
+  return (rule?.__resolveType as string) ?? null;
 }
 
 export function unwrapMatcherRule(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
 ): UnwrappedMatcherRule | null {
   if (!rule) return null;
   const rt = (rule.__resolveType as string) ?? "";
   if (!rt) return null;
 
-  if (isSavedMatcherBlockReference(rule, decofile)) {
+  if (isSavedMatcherBlockReference(rule, decofile, meta)) {
     const blockData = (decofile[rt] as Record<string, unknown>) ?? {};
     const matcherRt = (blockData.__resolveType as string) ?? rt;
     const { __resolveType: _, name: _name, ...data } = blockData;
@@ -38,8 +91,9 @@ export function unwrapMatcherRule(
 export function inlineMatcherRule(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
 ): Record<string, unknown> {
-  const unwrapped = unwrapMatcherRule(rule, decofile);
+  const unwrapped = unwrapMatcherRule(rule, decofile, meta);
   if (!unwrapped) return { __resolveType: "" };
   return { __resolveType: unwrapped.resolveType, ...unwrapped.data };
 }
@@ -47,10 +101,11 @@ export function inlineMatcherRule(
 export function resolveEffectiveMatcherRule(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
 ): Record<string, unknown> | undefined {
   if (!rule) return undefined;
-  if (isSavedMatcherBlockReference(rule, decofile)) {
-    return inlineMatcherRule(rule, decofile);
+  if (isSavedMatcherBlockReference(rule, decofile, meta)) {
+    return inlineMatcherRule(rule, decofile, meta);
   }
   return rule;
 }
@@ -59,9 +114,10 @@ export function resolveVariantRuleLabel(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,
   formatMatcher: (rule?: Record<string, unknown>) => string,
+  meta?: LiveMeta | null,
 ): string {
   if (!rule) return "Default";
-  if (isSavedMatcherBlockReference(rule, decofile)) {
+  if (isSavedMatcherBlockReference(rule, decofile, meta)) {
     const blockKey = (rule.__resolveType as string) ?? "";
     const block = decofile[blockKey] as Record<string, unknown>;
     return globalSectionLabel(blockKey, block);
@@ -90,8 +146,9 @@ export function buildMatcherBlockReference(
 export function readMatcherRuleFormState(
   rule: Record<string, unknown> | undefined,
   decofile: Record<string, unknown>,
+  meta?: LiveMeta | null,
 ): { resolveType: string; formValue: Record<string, unknown> } {
-  const unwrapped = unwrapMatcherRule(rule, decofile);
+  const unwrapped = unwrapMatcherRule(rule, decofile, meta);
   if (!unwrapped) {
     return { resolveType: "", formValue: {} };
   }

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
@@ -1,0 +1,99 @@
+import { isSavedBlockResolveType } from "./block-type-utils";
+import { globalSectionLabel } from "./page-list";
+
+export interface UnwrappedMatcherRule {
+  resolveType: string;
+  data: Record<string, unknown>;
+  blockKey?: string;
+}
+
+export function isSavedMatcherBlockReference(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+): boolean {
+  if (!rule) return false;
+  const rt = (rule.__resolveType as string) ?? "";
+  return isSavedBlockResolveType(rt) && rt in decofile;
+}
+
+export function unwrapMatcherRule(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+): UnwrappedMatcherRule | null {
+  if (!rule) return null;
+  const rt = (rule.__resolveType as string) ?? "";
+  if (!rt) return null;
+
+  if (isSavedMatcherBlockReference(rule, decofile)) {
+    const blockData = (decofile[rt] as Record<string, unknown>) ?? {};
+    const matcherRt = (blockData.__resolveType as string) ?? rt;
+    const { __resolveType: _, name: _name, ...data } = blockData;
+    return { resolveType: matcherRt, data, blockKey: rt };
+  }
+
+  const { __resolveType: _, ...data } = rule;
+  return { resolveType: rt, data };
+}
+
+export function inlineMatcherRule(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+): Record<string, unknown> {
+  const unwrapped = unwrapMatcherRule(rule, decofile);
+  if (!unwrapped) return { __resolveType: "" };
+  return { __resolveType: unwrapped.resolveType, ...unwrapped.data };
+}
+
+export function resolveEffectiveMatcherRule(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!rule) return undefined;
+  if (isSavedMatcherBlockReference(rule, decofile)) {
+    return inlineMatcherRule(rule, decofile);
+  }
+  return rule;
+}
+
+export function resolveVariantRuleLabel(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+  formatMatcher: (rule?: Record<string, unknown>) => string,
+): string {
+  if (!rule) return "Default";
+  if (isSavedMatcherBlockReference(rule, decofile)) {
+    const blockKey = (rule.__resolveType as string) ?? "";
+    const block = decofile[blockKey] as Record<string, unknown>;
+    return globalSectionLabel(blockKey, block);
+  }
+  return formatMatcher(rule);
+}
+
+export function buildMatcherBlockData(
+  resolveType: string,
+  data: Record<string, unknown>,
+  displayName: string,
+): Record<string, unknown> {
+  return {
+    __resolveType: resolveType,
+    ...data,
+    name: displayName,
+  };
+}
+
+export function buildMatcherBlockReference(
+  blockKey: string,
+): Record<string, unknown> {
+  return { __resolveType: blockKey };
+}
+
+export function readMatcherRuleFormState(
+  rule: Record<string, unknown> | undefined,
+  decofile: Record<string, unknown>,
+): { resolveType: string; formValue: Record<string, unknown> } {
+  const unwrapped = unwrapMatcherRule(rule, decofile);
+  if (!unwrapped) {
+    return { resolveType: "", formValue: {} };
+  }
+  return { resolveType: unwrapped.resolveType, formValue: unwrapped.data };
+}

--- a/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
+++ b/apps/mesh/src/web/components/sections-editor/matcher-rules.ts
@@ -24,16 +24,9 @@ function isMatcherBlockData(
   blockData: Record<string, unknown>,
   meta?: LiveMeta | null,
 ): boolean {
-  if (typeof blockData.path === "string") return false;
-  if (
-    typeof blockData.__resolveType === "string" &&
-    PAGE_RESOLVE_TYPES.has(blockData.__resolveType)
-  ) {
-    return false;
-  }
-
-  const moduleRt = (blockData.__resolveType as string) ?? "";
-  if (!moduleRt) return false;
+  const moduleRt = blockData.__resolveType;
+  if (typeof moduleRt !== "string" || !moduleRt) return false;
+  if (PAGE_RESOLVE_TYPES.has(moduleRt)) return false;
 
   if (meta) {
     return isManifestMatcherResolveType(meta, moduleRt);
@@ -48,8 +41,9 @@ export function isSavedMatcherBlockReference(
   meta?: LiveMeta | null,
 ): boolean {
   if (!rule) return false;
-  const rt = (rule.__resolveType as string) ?? "";
-  if (!isSavedBlockResolveType(rt) || !(rt in decofile)) return false;
+  const rt = rule.__resolveType;
+  if (typeof rt !== "string" || !isSavedBlockResolveType(rt)) return false;
+  if (!Object.hasOwn(decofile, rt)) return false;
 
   const blockData = decofile[rt] as Record<string, unknown>;
   if (!blockData || typeof blockData !== "object" || Array.isArray(blockData)) {

--- a/apps/mesh/src/web/components/sections-editor/page-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.ts
@@ -1,10 +1,7 @@
 import type { RawSection } from "./section-types";
+import type { PageVariant } from "./page-variants";
 
-interface PageVariant {
-  label: string;
-  sections: RawSection[];
-  rule?: Record<string, unknown>;
-}
+export type { PageVariant };
 
 export function buildPageDataWithSections(
   decofile: Record<string, unknown>,

--- a/apps/mesh/src/web/components/sections-editor/page-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import {
+  appendPageVariantSections,
+  buildPageSectionsFromVariants,
+  countSavedMatcherBlockReferences,
+  getPageVariantCount,
+  variantHasRule,
+} from "./page-variants";
+
+describe("page-variants", () => {
+  it("counts variants on flat and multivariate pages", () => {
+    const decofile = {
+      home: {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/",
+        sections: [{ __resolveType: "site/sections/Hero.tsx" }],
+      },
+      promo: {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/promo",
+        sections: {
+          variants: [
+            { value: [] },
+            {
+              rule: { __resolveType: "website/matchers/device.ts" },
+              value: [],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(getPageVariantCount(decofile, "home")).toBe(1);
+    expect(getPageVariantCount(decofile, "promo")).toBe(2);
+  });
+
+  it("appends a variant seeded from provided sections", () => {
+    const seed = [{ __resolveType: "site/sections/Hero.tsx" }];
+    const result = appendPageVariantSections([{ __resolveType: "A" }], seed);
+    expect(result).toEqual({
+      variants: [{ value: [{ __resolveType: "A" }] }, { value: seed }],
+    });
+  });
+
+  it("keeps multivariate shape when the last variant has a rule", () => {
+    const obj = { __resolveType: "website/flags/multivariate.ts" };
+    const variants = [
+      {
+        rule: { __resolveType: "website/matchers/device.ts", mobile: true },
+        value: [{ __resolveType: "A" }],
+      },
+    ];
+
+    expect(buildPageSectionsFromVariants(obj, variants)).toEqual({
+      ...obj,
+      variants,
+    });
+    expect(variantHasRule(variants[0])).toBe(true);
+  });
+
+  it("collapses to a flat array when the last variant has no rule", () => {
+    const obj = { __resolveType: "website/flags/multivariate.ts" };
+    const variants = [{ value: [{ __resolveType: "A" }] }];
+
+    expect(buildPageSectionsFromVariants(obj, variants)).toEqual([
+      { __resolveType: "A" },
+    ]);
+  });
+
+  it("counts saved matcher block references across pages", () => {
+    const decofile = {
+      MobilePromo: {
+        __resolveType: "website/matchers/device.ts",
+        mobile: true,
+        name: "Mobile Promo",
+      },
+      home: {
+        __resolveType: "website/pages/Page.tsx",
+        path: "/",
+        sections: {
+          variants: [
+            { rule: { __resolveType: "MobilePromo" }, value: [] },
+            {
+              rule: { __resolveType: "website/matchers/always.ts" },
+              value: [],
+            },
+          ],
+        },
+      },
+    };
+
+    expect(countSavedMatcherBlockReferences(decofile, "MobilePromo")).toBe(1);
+    expect(
+      countSavedMatcherBlockReferences(decofile, "website/matchers/always.ts"),
+    ).toBe(0);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -167,7 +167,7 @@ export function buildPageSectionsFromVariants(
   return { ...obj, variants };
 }
 
-export function forEachPageVariantRule(
+function forEachPageVariantRule(
   decofile: Record<string, unknown>,
   visit: (
     rule: Record<string, unknown> | undefined,

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -1,0 +1,209 @@
+import type { LiveMeta } from "./resolve-schema";
+import {
+  isSavedMatcherBlockReference,
+  resolveVariantRuleLabel,
+} from "./matcher-rules";
+import type { RawSection } from "./section-types";
+
+const PAGE_RESOLVE_TYPES = new Set([
+  "website/pages/Page.tsx",
+  "$live/pages/LivePage.tsx",
+]);
+
+export interface PageVariant {
+  label: string;
+  sections: RawSection[];
+  rule?: Record<string, unknown>;
+}
+
+function isPageBlock(val: unknown): val is Record<string, unknown> {
+  if (!val || typeof val !== "object" || Array.isArray(val)) return false;
+  const obj = val as Record<string, unknown>;
+  return (
+    typeof obj.__resolveType === "string" &&
+    PAGE_RESOLVE_TYPES.has(obj.__resolveType) &&
+    typeof obj.path === "string"
+  );
+}
+
+export function getPageVariantCount(
+  decofile: Record<string, unknown>,
+  pageKey: string,
+): number {
+  const pageData = decofile[pageKey] as Record<string, unknown> | undefined;
+  const sections = pageData?.sections;
+  if (!sections || Array.isArray(sections)) return 1;
+  const obj = sections as Record<string, unknown>;
+  if (Array.isArray(obj.variants)) return (obj.variants as unknown[]).length;
+  return 1;
+}
+
+export function getPageVariantSectionsAt(
+  decofile: Record<string, unknown>,
+  pageKey: string,
+  variantIndex: number,
+): RawSection[] {
+  const pageData = decofile[pageKey] as Record<string, unknown> | undefined;
+  const sections = pageData?.sections;
+  if (Array.isArray(sections)) {
+    return variantIndex === 0 ? sections : [];
+  }
+  if (sections && typeof sections === "object") {
+    const variants = (sections as Record<string, unknown>).variants;
+    if (Array.isArray(variants)) {
+      const entry = variants[variantIndex] as
+        | Record<string, unknown>
+        | undefined;
+      return Array.isArray(entry?.value) ? (entry.value as RawSection[]) : [];
+    }
+  }
+  return [];
+}
+
+export function parsePageVariants(
+  sections: unknown,
+  decofile: Record<string, unknown>,
+  formatMatcher: (rule?: Record<string, unknown>) => string,
+): PageVariant[] {
+  if (Array.isArray(sections)) {
+    return [{ label: "Default", sections }];
+  }
+  if (sections && typeof sections === "object") {
+    const obj = sections as Record<string, unknown>;
+    if (Array.isArray(obj.variants)) {
+      const raw = obj.variants as Array<{
+        rule?: Record<string, unknown>;
+        value?: unknown;
+      }>;
+      const labels = raw.map((v) =>
+        resolveVariantRuleLabel(v.rule, decofile, formatMatcher),
+      );
+      const labelCounts = labels.reduce<Record<string, number>>((acc, l) => {
+        acc[l] = (acc[l] ?? 0) + 1;
+        return acc;
+      }, {});
+      const seen: Record<string, number> = {};
+      return raw.map((v, i) => {
+        const baseLabel = labels[i] ?? `Variant ${i + 1}`;
+        const total = labelCounts[baseLabel] ?? 1;
+        let label = baseLabel;
+        if (total > 1) {
+          seen[baseLabel] = (seen[baseLabel] ?? 0) + 1;
+          label = `${baseLabel} ${seen[baseLabel]}`;
+        }
+        return {
+          label: label || `Variant ${i + 1}`,
+          sections: Array.isArray(v.value) ? (v.value as RawSection[]) : [],
+          rule: v.rule,
+        };
+      });
+    }
+  }
+  return [];
+}
+
+/**
+ * Append a new page variant seeded from `seedSections`. Returns null when the
+ * current sections shape cannot be extended.
+ */
+export function appendPageVariantSections(
+  current: unknown,
+  seedSections: RawSection[],
+): Record<string, unknown> | null {
+  const seed = structuredClone(seedSections);
+  if (Array.isArray(current)) {
+    return {
+      variants: [{ value: current }, { value: seed }],
+    };
+  }
+  if (current && typeof current === "object") {
+    const obj = current as Record<string, unknown>;
+    if (Array.isArray(obj.variants)) {
+      return {
+        ...obj,
+        variants: [...(obj.variants as unknown[]), { value: seed }],
+      };
+    }
+    return null;
+  }
+  return { variants: [{ value: [] }, { value: seed }] };
+}
+
+export function getLastVariantIndex(
+  updatedSections: Record<string, unknown>,
+): number {
+  const variants = updatedSections.variants;
+  return Array.isArray(variants) ? variants.length - 1 : 1;
+}
+
+/** Returns true when the variant entry carries a targeting rule. */
+export function variantHasRule(
+  variant: Record<string, unknown> | undefined,
+): boolean {
+  if (!variant?.rule || typeof variant.rule !== "object") return false;
+  return Object.keys(variant.rule as Record<string, unknown>).length > 0;
+}
+
+/**
+ * Persist page sections after a variant mutation. Keeps multivariate shape when
+ * the sole remaining variant still has a rule so targeting is not dropped.
+ */
+export function buildPageSectionsFromVariants(
+  obj: Record<string, unknown>,
+  variants: Array<Record<string, unknown>>,
+): unknown {
+  if (variants.length === 0) {
+    return { ...obj, variants: [] };
+  }
+  if (variants.length === 1) {
+    const only = variants[0];
+    if (variantHasRule(only)) {
+      return { ...obj, variants };
+    }
+    if (Array.isArray(only?.value)) {
+      return only.value as unknown[];
+    }
+  }
+  return { ...obj, variants };
+}
+
+export function forEachPageVariantRule(
+  decofile: Record<string, unknown>,
+  visit: (
+    rule: Record<string, unknown> | undefined,
+    pageKey: string,
+    variantIndex: number,
+  ) => void,
+): void {
+  for (const [pageKey, val] of Object.entries(decofile)) {
+    if (!isPageBlock(val)) continue;
+    const sections = val.sections;
+    if (Array.isArray(sections)) {
+      visit(undefined, pageKey, 0);
+      continue;
+    }
+    if (!sections || typeof sections !== "object") continue;
+    const variants = (sections as Record<string, unknown>).variants;
+    if (!Array.isArray(variants)) continue;
+    for (let i = 0; i < variants.length; i++) {
+      const variant = variants[i] as Record<string, unknown> | undefined;
+      visit(variant?.rule as Record<string, unknown> | undefined, pageKey, i);
+    }
+  }
+}
+
+export function countSavedMatcherBlockReferences(
+  decofile: Record<string, unknown>,
+  blockKey: string,
+  meta?: LiveMeta | null,
+): number {
+  let count = 0;
+  forEachPageVariantRule(decofile, (rule) => {
+    if (!rule) return;
+    const rt = (rule.__resolveType as string) ?? "";
+    if (rt === blockKey && isSavedMatcherBlockReference(rule, decofile, meta)) {
+      count++;
+    }
+  });
+  return count;
+}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,6 +1,12 @@
 import { useState, useRef } from "react";
-import { ChevronRight, Loading01 } from "@untitledui/icons";
+import { ChevronRight, Flag01, Loading01, Plus } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import { toast } from "sonner";
 import { useDecofile } from "./use-decofile";
@@ -15,6 +21,8 @@ import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
+import { resolveMatcherIconName } from "./matcher-icons";
+import { getIconComponent } from "../agent-icon";
 import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
 import type { SectionCatalogEntry } from "./section-catalog";
@@ -39,6 +47,28 @@ import {
 } from "./section-variants";
 
 const AUTOSAVE_DELAY = 700;
+
+const VARIANT_GREEN_TEXT = "oklch(0.65 0.15 160)";
+const VARIANT_TAB_ACTIVE_CLASS =
+  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
+
+function VariantTabIcon({
+  rule,
+  matchers,
+}: {
+  rule: Record<string, unknown> | undefined;
+  matchers: Array<{ resolveType: string; iconName: string }>;
+}) {
+  const rt = (rule?.__resolveType as string) ?? "";
+  // Prefer the schema-defined icon (resolved by extractMatchers) so custom
+  // matchers like "Birthday" pick up the Calendar icon set in their schema
+  // metadata, instead of falling back to FilterLines via regex matching.
+  const fromSchema = matchers.find((m) => m.resolveType === rt)?.iconName;
+  const iconName = fromSchema ?? resolveMatcherIconName(rt);
+  const Icon = getIconComponent(iconName);
+  if (!Icon) return null;
+  return <Icon size={14} className="shrink-0" />;
+}
 
 interface PageVariant {
   label: string;
@@ -223,11 +253,29 @@ function parsePageVariants(sections: unknown): PageVariant[] {
         rule?: Record<string, unknown>;
         value?: unknown;
       }>;
-      return raw.map((v, i) => ({
-        label: formatMatcher(v.rule) || `Variant ${i + 1}`,
-        sections: Array.isArray(v.value) ? (v.value as RawSection[]) : [],
-        rule: v.rule,
-      }));
+      // When several variants share the same matcher label (e.g. all "Default"
+      // because none have a rule set yet), append an index so the user can
+      // tell them apart in the tab bar.
+      const labels = raw.map((v) => formatMatcher(v.rule));
+      const labelCounts = labels.reduce<Record<string, number>>((acc, l) => {
+        acc[l] = (acc[l] ?? 0) + 1;
+        return acc;
+      }, {});
+      const seen: Record<string, number> = {};
+      return raw.map((v, i) => {
+        const baseLabel = labels[i] ?? `Variant ${i + 1}`;
+        const total = labelCounts[baseLabel] ?? 1;
+        let label = baseLabel;
+        if (total > 1) {
+          seen[baseLabel] = (seen[baseLabel] ?? 0) + 1;
+          label = `${baseLabel} ${seen[baseLabel]}`;
+        }
+        return {
+          label: label || `Variant ${i + 1}`,
+          sections: Array.isArray(v.value) ? (v.value as RawSection[]) : [],
+          rule: v.rule,
+        };
+      });
     }
   }
   return [];
@@ -361,6 +409,7 @@ export function SectionsEditor({
   previewReady = true,
   previewUrl,
   currentPath,
+  activePageBlockKey = null,
   activeGlobalBlockKey = null,
   externalSelectedIndex,
   onSaved,
@@ -373,6 +422,10 @@ export function SectionsEditor({
   /** Sandbox preview base URL used for section gallery previews. */
   previewUrl?: string;
   currentPath: string;
+  /** When set, identifies the page by its unique decofile block key. Takes
+   * precedence over `currentPath` for selection — required when multiple
+   * pages share the same `path`. */
+  activePageBlockKey?: string | null;
   /** When set, edits a saved global block instead of a page. */
   activeGlobalBlockKey?: string | null;
   /** Section index selected via click-through from the preview iframe. */
@@ -497,7 +550,9 @@ export function SectionsEditor({
   const isGlobalBlockMode = !!activeGlobalBlockKey;
   const activePage = isGlobalBlockMode
     ? null
-    : pages.find((p) => norm(p.path) === norm(currentPath));
+    : activePageBlockKey
+      ? (pages.find((p) => p.key === activePageBlockKey) ?? null)
+      : (pages.find((p) => norm(p.path) === norm(currentPath)) ?? null);
   const activePageKey = isGlobalBlockMode
     ? activeGlobalBlockKey
     : (activePage?.key ?? null);
@@ -1339,6 +1394,57 @@ export function SectionsEditor({
             ...fieldBreadcrumbs,
           ]
       : [];
+  const handleAddPageVariant = () => {
+    if (!activePageKey) return;
+    const fullPageData = decofile[activePageKey] as Record<string, unknown>;
+    const current = fullPageData.sections;
+    // Seed the new variant with a clone of the currently active variant's
+    // sections — gives the user a working baseline to modify (matches the
+    // A/B-test mental model: fork-then-tweak).
+    const seedSections = structuredClone(rawSections);
+    let updatedSections: Record<string, unknown>;
+    if (Array.isArray(current)) {
+      updatedSections = {
+        variants: [{ value: current }, { value: seedSections }],
+      };
+    } else if (current && typeof current === "object") {
+      const obj = current as Record<string, unknown>;
+      if (Array.isArray(obj.variants)) {
+        updatedSections = {
+          ...obj,
+          variants: [...(obj.variants as unknown[]), { value: seedSections }],
+        };
+      } else {
+        return;
+      }
+    } else {
+      updatedSections = {
+        variants: [{ value: [] }, { value: seedSections }],
+      };
+    }
+    const newVariantIndex = Array.isArray(updatedSections.variants as unknown[])
+      ? (updatedSections.variants as unknown[]).length - 1
+      : 1;
+    saveBlock.mutate(
+      {
+        blockKey: activePageKey,
+        data: { ...fullPageData, sections: updatedSections },
+      },
+      {
+        onSuccess: () => {
+          setActiveVariantIndex(newVariantIndex);
+          setSelectedSectionIndex(null);
+          setFormValue(null);
+          setActiveResolveType(null);
+          setFieldBreadcrumbs([]);
+          setRuleFormValue(null);
+          setRuleResolveType(null);
+        },
+        onError: (err) => toast.error(`Save failed: ${err.message}`),
+      },
+    );
+  };
+
   const exitSectionEditing = () => {
     clearSectionEditing();
   };
@@ -1419,49 +1525,92 @@ export function SectionsEditor({
             </div>
           </div>
         ) : (
-          <PageHeaderInputs
-            pageKey={activePageKey!}
-            initialName={activePage!.name}
-            initialPath={activePage!.path}
-            onFieldChange={savePageField}
-          />
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0">
+              <PageHeaderInputs
+                pageKey={activePageKey!}
+                initialName={activePage!.name}
+                initialPath={activePage!.path}
+                onFieldChange={savePageField}
+              />
+            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Add variant"
+                  className="size-7 shrink-0"
+                  style={{ color: "oklch(0.65 0.15 160)" }}
+                  onClick={handleAddPageVariant}
+                >
+                  <Flag01 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Add variant</TooltipContent>
+            </Tooltip>
+          </div>
         )}
       </div>
 
       {/* Variant selector (when page sections are multivariate) */}
       {hasMultipleVariants && !isEditing && (
-        <div className="flex gap-1 px-3 py-1.5 border-b shrink-0 overflow-x-auto">
-          {pageVariants.map((variant, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => {
-                setActiveVariantIndex(i);
-                setSelectedSectionIndex(null);
-                setFormValue(null);
-                setActiveResolveType(null);
-                setFieldBreadcrumbs([]);
-                const variantRule = pageVariants[i]?.rule;
-                const variantRuleRt =
-                  (variantRule?.__resolveType as string) ?? "";
-                setRuleResolveType(variantRuleRt);
-                if (variantRule) {
-                  const { __resolveType: _, ...ruleData } = variantRule;
-                  setRuleFormValue(ruleData);
-                } else {
-                  setRuleFormValue(null);
-                }
-              }}
-              className={cn(
-                "shrink-0 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                i === safeVariantIndex
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              )}
-            >
-              {variant.label}
-            </button>
-          ))}
+        <div className="flex items-center gap-1.5 px-3 py-2 border-b shrink-0 overflow-x-auto">
+          {pageVariants.map((variant, i) => {
+            const isActive = i === safeVariantIndex;
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={() => {
+                  setActiveVariantIndex(i);
+                  setSelectedSectionIndex(null);
+                  setFormValue(null);
+                  setActiveResolveType(null);
+                  setFieldBreadcrumbs([]);
+                  const variantRule = pageVariants[i]?.rule;
+                  const variantRuleRt =
+                    (variantRule?.__resolveType as string) ?? "";
+                  setRuleResolveType(variantRuleRt);
+                  if (variantRule) {
+                    const { __resolveType: _, ...ruleData } = variantRule;
+                    setRuleFormValue(ruleData);
+                  } else {
+                    setRuleFormValue(null);
+                  }
+                }}
+                className={cn(
+                  "shrink-0 inline-flex items-center gap-1.5 rounded-md px-3 h-8 text-sm font-medium transition-colors cursor-pointer",
+                  isActive
+                    ? VARIANT_TAB_ACTIVE_CLASS
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                )}
+              >
+                <VariantTabIcon
+                  rule={variant.rule}
+                  matchers={availableMatchers}
+                />
+                <span className="truncate">{variant.label}</span>
+              </button>
+            );
+          })}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Add variant"
+                className="size-8 shrink-0 ml-auto cursor-pointer"
+                style={{ color: VARIANT_GREEN_TEXT }}
+                onClick={handleAddPageVariant}
+              >
+                <Plus size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Add variant</TooltipContent>
+          </Tooltip>
         </div>
       )}
 

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -31,7 +31,7 @@ import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
 import { useDeleteBlock } from "./use-delete-block";
 import { useSaveBlock } from "./use-save-block";
-import { extractPages } from "./page-list";
+import { extractPages, globalSectionLabel } from "./page-list";
 import { normalizePagePath } from "./page-path-utils";
 import { SectionList, parseSections } from "./section-list";
 import { isLazyResolveType } from "./section-lazy";
@@ -530,7 +530,7 @@ export function SectionsEditor({
   }>({
     rawSections: [],
     parsedSections: [],
-    decofile: {},
+    decofile: {} as Record<string, unknown>,
     activePageKey: null,
     pageVariants: [],
     variantIndex: 0,
@@ -628,7 +628,7 @@ export function SectionsEditor({
   latestRef.current = {
     rawSections,
     parsedSections,
-    decofile,
+    decofile: decofile ?? ({} as Record<string, unknown>),
     activePageKey,
     pageVariants,
     variantIndex: safeVariantIndex,
@@ -1584,8 +1584,8 @@ export function SectionsEditor({
   ) => {
     cancelPendingRuleSaves();
 
-    const { activePageKey: pageKey, decofile: latestDecofile } =
-      latestRef.current;
+    const pageKey = latestRef.current.activePageKey;
+    const latestDecofile: Record<string, unknown> = latestRef.current.decofile;
     if (!pageKey) return;
 
     const fullPageData = latestDecofile[pageKey] as Record<string, unknown>;
@@ -1597,26 +1597,26 @@ export function SectionsEditor({
 
     const variants = [...(obj.variants as Array<Record<string, unknown>>)];
     const target = variants[variantIndex];
-    if (!target?.rule) {
+    if (!target?.rule || typeof target.rule !== "object") {
       toast.error("This variant has no matcher rule to rename.");
       return;
     }
+    const targetRule = target.rule as Record<string, unknown>;
 
     const trimmed = nextName.trim();
     setRenameVariantPending(true);
 
     try {
       if (!trimmed) {
-        if (!isSavedMatcherBlockReference(target.rule, latestDecofile, meta)) {
+        if (!isSavedMatcherBlockReference(targetRule, latestDecofile, meta)) {
           setRenameVariantIndex(null);
           return;
         }
 
-        const blockKey = (target.rule as Record<string, unknown>)
-          .__resolveType as string;
+        const blockKey = (targetRule.__resolveType as string) ?? "";
         variants[variantIndex] = {
           ...target,
-          rule: inlineMatcherRule(target.rule, latestDecofile, meta),
+          rule: inlineMatcherRule(targetRule, latestDecofile, meta),
         };
 
         const projectedDecofile = {
@@ -1634,7 +1634,7 @@ export function SectionsEditor({
         return;
       }
 
-      const unwrapped = unwrapMatcherRule(target.rule, latestDecofile, meta);
+      const unwrapped = unwrapMatcherRule(targetRule, latestDecofile, meta);
       if (!unwrapped) {
         toast.error("Could not read this variant's matcher rule.");
         return;

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef } from "react";
 import {
+  ChevronDown,
   ChevronRight,
+  ChevronUp,
   DotsHorizontal,
   Edit01,
   Flag01,
@@ -499,6 +501,7 @@ export function SectionsEditor({
   const [renameVariantIndex, setRenameVariantIndex] = useState<number | null>(
     null,
   );
+  const [isVariantRuleOpen, setIsVariantRuleOpen] = useState(true);
   const [addSectionOpen, setAddSectionOpen] = useState(false);
   const [activeSectionVariantIndex, setActiveSectionVariantIndex] = useState(0);
   const [sectionRuleFormValue, setSectionRuleFormValue] = useState<Record<
@@ -1597,7 +1600,26 @@ export function SectionsEditor({
       {/* Page header */}
       <div className="px-3 py-2.5 border-b shrink-0">
         {isEditing && (!isGlobalBlockMode || fieldBreadcrumbs.length > 0) ? (
-          <div className="flex min-w-0 items-center overflow-hidden">
+          <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+            {!isGlobalBlockMode && hasMultipleVariants && activeVariant && (
+              <button
+                type="button"
+                onClick={exitSectionEditing}
+                title={`Editing in variant: ${activeVariant.label}`}
+                className={cn(
+                  "shrink-0 inline-flex items-center gap-1 rounded-md h-6 px-1.5 text-xs font-medium cursor-pointer transition-opacity hover:opacity-80",
+                  VARIANT_TAB_ACTIVE_CLASS,
+                )}
+              >
+                <VariantTabIcon
+                  rule={activeVariant.rule}
+                  matchers={availableMatchers}
+                />
+                <span className="max-w-[160px] truncate">
+                  {activeVariant.label}
+                </span>
+              </button>
+            )}
             <nav
               aria-label="Editing breadcrumb"
               className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
@@ -1672,97 +1694,104 @@ export function SectionsEditor({
 
       {/* Variant selector (when page sections are multivariate) */}
       {hasMultipleVariants && !isEditing && (
-        <div className="flex items-center gap-1.5 px-3 py-2 border-b shrink-0 overflow-x-auto">
-          {pageVariants.map((variant, i) => {
-            const isActive = i === safeVariantIndex;
-            const canDelete = pageVariants.length > 1;
-            return (
-              <div
-                key={i}
-                className={cn(
-                  "group shrink-0 inline-flex items-center rounded-md transition-colors",
-                  isActive
-                    ? VARIANT_TAB_ACTIVE_CLASS
-                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                )}
-              >
-                <button
-                  type="button"
-                  onClick={() => {
-                    setActiveVariantIndex(i);
-                    setSelectedSectionIndex(null);
-                    setFormValue(null);
-                    setActiveResolveType(null);
-                    setFieldBreadcrumbs([]);
-                    const variantRule = pageVariants[i]?.rule;
-                    const variantRuleRt =
-                      (variantRule?.__resolveType as string) ?? "";
-                    setRuleResolveType(variantRuleRt);
-                    if (variantRule) {
-                      const { __resolveType: _, ...ruleData } = variantRule;
-                      setRuleFormValue(ruleData);
-                    } else {
-                      setRuleFormValue(null);
-                    }
-                  }}
-                  className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-pointer"
+        <div className="flex items-center border-b shrink-0">
+          <div className="flex flex-1 min-w-0 items-center gap-1.5 pl-3 pr-2 py-2 overflow-x-auto">
+            {pageVariants.map((variant, i) => {
+              const isActive = i === safeVariantIndex;
+              const canDelete = pageVariants.length > 1;
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    "group shrink-0 inline-flex items-center rounded-md transition-colors",
+                    isActive
+                      ? VARIANT_TAB_ACTIVE_CLASS
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
                 >
-                  <VariantTabIcon
-                    rule={variant.rule}
-                    matchers={availableMatchers}
-                  />
-                  <span className="truncate">{variant.label}</span>
-                </button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label={`Actions for ${variant.label}`}
-                      onClick={(e) => e.stopPropagation()}
-                      className={cn(
-                        "inline-flex h-8 w-6 items-center justify-center pr-1 cursor-pointer transition-opacity",
-                        "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
-                        isActive && "opacity-100",
-                      )}
-                    >
-                      <DotsHorizontal size={12} />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="w-36">
-                    <DropdownMenuItem onClick={() => setRenameVariantIndex(i)}>
-                      <Edit01 size={14} />
-                      Rename
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      variant="destructive"
-                      disabled={!canDelete}
-                      onClick={() => handleDeletePageVariant(i)}
-                    >
-                      <Trash01 size={14} />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="Add variant"
-                className="size-8 shrink-0 ml-auto cursor-pointer"
-                style={{ color: VARIANT_GREEN_TEXT }}
-                onClick={handleAddPageVariant}
-              >
-                <Plus size={14} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Add variant</TooltipContent>
-          </Tooltip>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setActiveVariantIndex(i);
+                      setSelectedSectionIndex(null);
+                      setFormValue(null);
+                      setActiveResolveType(null);
+                      setFieldBreadcrumbs([]);
+                      const variantRule = pageVariants[i]?.rule;
+                      const variantRuleRt =
+                        (variantRule?.__resolveType as string) ?? "";
+                      setRuleResolveType(variantRuleRt);
+                      if (variantRule) {
+                        const { __resolveType: _, ...ruleData } = variantRule;
+                        setRuleFormValue(ruleData);
+                      } else {
+                        setRuleFormValue(null);
+                      }
+                    }}
+                    className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-pointer"
+                  >
+                    <VariantTabIcon
+                      rule={variant.rule}
+                      matchers={availableMatchers}
+                    />
+                    <span className="truncate">{variant.label}</span>
+                  </button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={`Actions for ${variant.label}`}
+                        onClick={(e) => e.stopPropagation()}
+                        className={cn(
+                          "inline-flex h-8 w-6 items-center justify-center pr-1 cursor-pointer transition-opacity",
+                          "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
+                          isActive && "opacity-100",
+                        )}
+                      >
+                        <DotsHorizontal size={12} />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="w-36">
+                      <DropdownMenuItem
+                        onClick={() => setRenameVariantIndex(i)}
+                      >
+                        <Edit01 size={14} />
+                        Rename
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        variant="destructive"
+                        disabled={!canDelete}
+                        onClick={() => handleDeletePageVariant(i)}
+                      >
+                        <Trash01 size={14} />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              );
+            })}
+          </div>
+          {/* Pinned "+" — stays visible regardless of horizontal scroll. */}
+          <div className="shrink-0 pr-3 pl-1 py-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Add variant"
+                  className="size-8 shrink-0 cursor-pointer"
+                  style={{ color: VARIANT_GREEN_TEXT }}
+                  onClick={handleAddPageVariant}
+                >
+                  <Plus size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Add variant</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       )}
 
@@ -1847,27 +1876,48 @@ export function SectionsEditor({
         </ScrollArea>
       ) : (
         <ScrollArea className="flex-1 min-h-0">
-          {/* Variant rule editor */}
+          {/* Variant rule editor (collapsible so users can reclaim space) */}
           {hasMultipleVariants && ruleResolveType !== null && (
-            <div className="px-3 pt-3 pb-5 border-b space-y-3">
-              <span className="text-xs font-medium text-muted-foreground">
-                Variant rule
-              </span>
-              <MatcherPicker
-                currentRt={ruleResolveType}
-                currentLabel={formatMatcher(activeVariant?.rule)}
-                matchers={availableMatchers}
-                onSelect={handleMatcherTypeChange}
-              />
-              {ruleSchema && ruleFormValue && (
-                <div className="space-y-3">
-                  <SchemaForm
-                    schema={ruleSchema}
-                    value={ruleFormValue}
-                    onChange={handleRuleFormChange}
-                    basePath=""
+            <div
+              className={cn(
+                "px-3 border-b",
+                isVariantRuleOpen ? "pt-3 pb-5 space-y-3" : "py-2",
+              )}
+            >
+              <button
+                type="button"
+                onClick={() => setIsVariantRuleOpen((v) => !v)}
+                className="flex w-full items-center justify-between gap-2 text-left cursor-pointer rounded-sm py-0.5 hover:bg-muted/40"
+                aria-expanded={isVariantRuleOpen}
+              >
+                <span className="text-xs font-medium text-muted-foreground">
+                  Variant rule
+                </span>
+                {isVariantRuleOpen ? (
+                  <ChevronUp className="size-3.5 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+                )}
+              </button>
+              {isVariantRuleOpen && (
+                <>
+                  <MatcherPicker
+                    currentRt={ruleResolveType}
+                    currentLabel={formatMatcher(activeVariant?.rule)}
+                    matchers={availableMatchers}
+                    onSelect={handleMatcherTypeChange}
                   />
-                </div>
+                  {ruleSchema && ruleFormValue && (
+                    <div className="space-y-3">
+                      <SchemaForm
+                        schema={ruleSchema}
+                        value={ruleFormValue}
+                        onChange={handleRuleFormChange}
+                        basePath=""
+                      />
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,6 +1,21 @@
 import { useState, useRef } from "react";
-import { ChevronRight, Flag01, Loading01, Plus } from "@untitledui/icons";
+import {
+  ChevronRight,
+  DotsHorizontal,
+  Edit01,
+  Flag01,
+  Loading01,
+  Plus,
+  Trash01,
+} from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import {
   Tooltip,
@@ -8,6 +23,7 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
+import { VariantRenameDialog } from "./variant-rename-dialog";
 import { toast } from "sonner";
 import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
@@ -71,7 +87,10 @@ function VariantTabIcon({
 }
 
 interface PageVariant {
+  /** Display label (custom name if set, otherwise derived from the rule). */
   label: string;
+  /** User-provided custom name override. */
+  name?: string;
   sections: RawSection[];
   rule?: Record<string, unknown>;
 }
@@ -88,6 +107,36 @@ function labelFromResolveType(rt: string): string {
       .replace(/[-_]/g, " ")
       .replace(/\b\w/g, (c) => c.toUpperCase()) || rt
   );
+}
+
+/**
+ * Render a `start`/`end` ISO-date pair as a compact range — used by deco's
+ * built-in date matcher AND by any custom matcher whose rule happens to
+ * carry the same field names (e.g. project-defined `Date` / `Birthday`
+ * matchers that don't share resolveType with the website package). Returns
+ * null when the rule has no readable date fields so callers can fall back.
+ */
+function formatDateRange(rule: Record<string, unknown>): string | null {
+  const { start, end } = rule as { start?: unknown; end?: unknown };
+  const startStr = typeof start === "string" ? start : "";
+  const endStr = typeof end === "string" ? end : "";
+  if (!startStr && !endStr) return null;
+  const fmt = new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+  const tryFormat = (iso: string): string | null => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return fmt.format(d);
+  };
+  const startFmt = tryFormat(startStr);
+  const endFmt = tryFormat(endStr);
+  if (startFmt && endFmt) return `${startFmt} → ${endFmt}`;
+  if (startFmt) return `From ${startFmt}`;
+  if (endFmt) return `Until ${endFmt}`;
+  return null;
 }
 
 function formatMatcher(rule: Record<string, unknown> | undefined): string {
@@ -127,36 +176,8 @@ function formatMatcher(rule: Record<string, unknown> | undefined): string {
     }
 
     case "website/matchers/date.ts":
-    case "$live/matchers/MatchDate.ts": {
-      const { start, end } = rule as { start?: string; end?: string };
-      if (!start && !end) return labelFromResolveType(rt);
-      const fmt = new Intl.DateTimeFormat("en", {
-        dateStyle: "medium",
-        timeStyle: "short",
-      });
-      if (start && end) {
-        try {
-          return `${fmt.format(new Date(start))} \u2192 ${fmt.format(new Date(end))}`;
-        } catch {
-          return labelFromResolveType(rt);
-        }
-      }
-      if (start) {
-        try {
-          return `From ${fmt.format(new Date(start))}`;
-        } catch {
-          return labelFromResolveType(rt);
-        }
-      }
-      if (end) {
-        try {
-          return `Until ${fmt.format(new Date(end))}`;
-        } catch {
-          return labelFromResolveType(rt);
-        }
-      }
-      return labelFromResolveType(rt);
-    }
+    case "$live/matchers/MatchDate.ts":
+      return formatDateRange(rule) ?? labelFromResolveType(rt);
 
     case "website/matchers/random.ts":
     case "$live/matchers/MatchRandom.ts": {
@@ -232,8 +253,14 @@ function formatMatcher(rule: Record<string, unknown> | undefined): string {
       return labelFromResolveType(rt);
     }
 
-    default:
+    default: {
+      // Project-defined matchers (e.g. "Date", "Birthday") don't share
+      // resolveType with the website package, so generic field inspection
+      // is the only way to surface their actual configuration on the tab.
+      const range = formatDateRange(rule);
+      if (range) return range;
       return labelFromResolveType(rt) || "Default";
+    }
   }
 }
 
@@ -252,11 +279,14 @@ function parsePageVariants(sections: unknown): PageVariant[] {
       const raw = obj.variants as Array<{
         rule?: Record<string, unknown>;
         value?: unknown;
+        name?: unknown;
       }>;
-      // When several variants share the same matcher label (e.g. all "Default"
-      // because none have a rule set yet), append an index so the user can
-      // tell them apart in the tab bar.
-      const labels = raw.map((v) => formatMatcher(v.rule));
+      // Custom name (if set) wins over the rule-derived label. Disambiguate
+      // remaining duplicates with an index ("Default 1", "Default 2").
+      const labels = raw.map((v) => {
+        const customName = typeof v.name === "string" ? v.name.trim() : "";
+        return customName || formatMatcher(v.rule);
+      });
       const labelCounts = labels.reduce<Record<string, number>>((acc, l) => {
         acc[l] = (acc[l] ?? 0) + 1;
         return acc;
@@ -270,8 +300,10 @@ function parsePageVariants(sections: unknown): PageVariant[] {
           seen[baseLabel] = (seen[baseLabel] ?? 0) + 1;
           label = `${baseLabel} ${seen[baseLabel]}`;
         }
+        const customName = typeof v.name === "string" ? v.name.trim() : "";
         return {
           label: label || `Variant ${i + 1}`,
+          name: customName || undefined,
           sections: Array.isArray(v.value) ? (v.value as RawSection[]) : [],
           rule: v.rule,
         };
@@ -462,6 +494,9 @@ export function SectionsEditor({
   const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
   const [formResetKey, setFormResetKey] = useState(0);
   const [makeReusableIndex, setMakeReusableIndex] = useState<number | null>(
+    null,
+  );
+  const [renameVariantIndex, setRenameVariantIndex] = useState<number | null>(
     null,
   );
   const [addSectionOpen, setAddSectionOpen] = useState(false);
@@ -1445,6 +1480,87 @@ export function SectionsEditor({
     );
   };
 
+  /**
+   * Read the page's variants array, apply a transform, then either persist
+   * the modified `{ variants: [...] }` shape or collapse back to a flat
+   * sections array when only one variant remains. Shared by delete + rename.
+   */
+  const mutatePageVariants = (
+    transform: (
+      variants: Array<Record<string, unknown>>,
+    ) => Array<Record<string, unknown>> | null,
+    onSaved?: () => void,
+  ) => {
+    if (!activePageKey) return;
+    const fullPageData = decofile[activePageKey] as Record<string, unknown>;
+    const current = fullPageData.sections;
+    if (!current || typeof current !== "object" || Array.isArray(current))
+      return;
+    const obj = current as Record<string, unknown>;
+    if (!Array.isArray(obj.variants)) return;
+    const next = transform([
+      ...(obj.variants as Array<Record<string, unknown>>),
+    ]);
+    if (!next) return;
+    const updatedSections: unknown =
+      next.length === 1 && Array.isArray(next[0]?.value)
+        ? (next[0].value as unknown[])
+        : { ...obj, variants: next };
+    saveBlock.mutate(
+      {
+        blockKey: activePageKey,
+        data: { ...fullPageData, sections: updatedSections },
+      },
+      {
+        onSuccess: () => onSaved?.(),
+        onError: (err) => toast.error(`Save failed: ${err.message}`),
+      },
+    );
+  };
+
+  const handleDeletePageVariant = (variantIndex: number) => {
+    mutatePageVariants(
+      (variants) => {
+        if (variants.length <= 1) return null;
+        variants.splice(variantIndex, 1);
+        return variants;
+      },
+      () => {
+        // After delete, keep the user on a valid neighboring variant.
+        const collapsing = pageVariants.length - 1 === 1;
+        if (collapsing) {
+          setActiveVariantIndex(0);
+        } else if (variantIndex < safeVariantIndex) {
+          setActiveVariantIndex(safeVariantIndex - 1);
+        } else if (variantIndex === safeVariantIndex) {
+          setActiveVariantIndex(Math.max(0, variantIndex - 1));
+        }
+        setSelectedSectionIndex(null);
+        setFormValue(null);
+        setActiveResolveType(null);
+        setFieldBreadcrumbs([]);
+        setRuleFormValue(null);
+        setRuleResolveType(null);
+      },
+    );
+  };
+
+  const handleRenamePageVariant = (variantIndex: number, nextName: string) => {
+    mutatePageVariants((variants) => {
+      const target = variants[variantIndex];
+      if (!target) return null;
+      const trimmed = nextName.trim();
+      if (trimmed) {
+        variants[variantIndex] = { ...target, name: trimmed };
+      } else {
+        // Clearing the name reverts to the auto-derived label.
+        const { name: _drop, ...rest } = target as Record<string, unknown>;
+        variants[variantIndex] = rest;
+      }
+      return variants;
+    });
+  };
+
   const exitSectionEditing = () => {
     clearSectionEditing();
   };
@@ -1559,40 +1675,76 @@ export function SectionsEditor({
         <div className="flex items-center gap-1.5 px-3 py-2 border-b shrink-0 overflow-x-auto">
           {pageVariants.map((variant, i) => {
             const isActive = i === safeVariantIndex;
+            const canDelete = pageVariants.length > 1;
             return (
-              <button
+              <div
                 key={i}
-                type="button"
-                onClick={() => {
-                  setActiveVariantIndex(i);
-                  setSelectedSectionIndex(null);
-                  setFormValue(null);
-                  setActiveResolveType(null);
-                  setFieldBreadcrumbs([]);
-                  const variantRule = pageVariants[i]?.rule;
-                  const variantRuleRt =
-                    (variantRule?.__resolveType as string) ?? "";
-                  setRuleResolveType(variantRuleRt);
-                  if (variantRule) {
-                    const { __resolveType: _, ...ruleData } = variantRule;
-                    setRuleFormValue(ruleData);
-                  } else {
-                    setRuleFormValue(null);
-                  }
-                }}
                 className={cn(
-                  "shrink-0 inline-flex items-center gap-1.5 rounded-md px-3 h-8 text-sm font-medium transition-colors cursor-pointer",
+                  "group shrink-0 inline-flex items-center rounded-md transition-colors",
                   isActive
                     ? VARIANT_TAB_ACTIVE_CLASS
                     : "text-muted-foreground hover:bg-muted hover:text-foreground",
                 )}
               >
-                <VariantTabIcon
-                  rule={variant.rule}
-                  matchers={availableMatchers}
-                />
-                <span className="truncate">{variant.label}</span>
-              </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setActiveVariantIndex(i);
+                    setSelectedSectionIndex(null);
+                    setFormValue(null);
+                    setActiveResolveType(null);
+                    setFieldBreadcrumbs([]);
+                    const variantRule = pageVariants[i]?.rule;
+                    const variantRuleRt =
+                      (variantRule?.__resolveType as string) ?? "";
+                    setRuleResolveType(variantRuleRt);
+                    if (variantRule) {
+                      const { __resolveType: _, ...ruleData } = variantRule;
+                      setRuleFormValue(ruleData);
+                    } else {
+                      setRuleFormValue(null);
+                    }
+                  }}
+                  className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-pointer"
+                >
+                  <VariantTabIcon
+                    rule={variant.rule}
+                    matchers={availableMatchers}
+                  />
+                  <span className="truncate">{variant.label}</span>
+                </button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={`Actions for ${variant.label}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className={cn(
+                        "inline-flex h-8 w-6 items-center justify-center pr-1 cursor-pointer transition-opacity",
+                        "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
+                        isActive && "opacity-100",
+                      )}
+                    >
+                      <DotsHorizontal size={12} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="w-36">
+                    <DropdownMenuItem onClick={() => setRenameVariantIndex(i)}>
+                      <Edit01 size={14} />
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      variant="destructive"
+                      disabled={!canDelete}
+                      onClick={() => handleDeletePageVariant(i)}
+                    >
+                      <Trash01 size={14} />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             );
           })}
           <Tooltip>
@@ -1697,7 +1849,7 @@ export function SectionsEditor({
         <ScrollArea className="flex-1 min-h-0">
           {/* Variant rule editor */}
           {hasMultipleVariants && ruleResolveType !== null && (
-            <div className="px-3 py-3 border-b space-y-2">
+            <div className="px-3 pt-3 pb-5 border-b space-y-3">
               <span className="text-xs font-medium text-muted-foreground">
                 Variant rule
               </span>
@@ -1708,7 +1860,7 @@ export function SectionsEditor({
                 onSelect={handleMatcherTypeChange}
               />
               {ruleSchema && ruleFormValue && (
-                <div className="pt-1">
+                <div className="space-y-3">
                   <SchemaForm
                     schema={ruleSchema}
                     value={ruleFormValue}
@@ -1719,7 +1871,7 @@ export function SectionsEditor({
               )}
             </div>
           )}
-          <div className="p-2">
+          <div className="p-2 pt-3">
             <SectionList
               listKey={`${activePageKey ?? ""}-${safeVariantIndex}`}
               sections={parsedSections}
@@ -1758,6 +1910,21 @@ export function SectionsEditor({
           decofile={decofile}
           previewBaseUrl={previewUrl}
           onSelect={handleAddSection}
+        />
+      )}
+
+      {renameVariantIndex !== null && (
+        <VariantRenameDialog
+          open
+          initialName={pageVariants[renameVariantIndex]?.name ?? ""}
+          autoLabel={formatMatcher(pageVariants[renameVariantIndex]?.rule)}
+          onSubmit={(name) => {
+            handleRenamePageVariant(renameVariantIndex, name);
+            setRenameVariantIndex(null);
+          }}
+          onOpenChange={(open) => {
+            if (!open) setRenameVariantIndex(null);
+          }}
         />
       )}
     </div>

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -31,7 +31,7 @@ import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
 import { useDeleteBlock } from "./use-delete-block";
 import { useSaveBlock } from "./use-save-block";
-import { extractPages, globalSectionLabel } from "./page-list";
+import { extractPages } from "./page-list";
 import { normalizePagePath } from "./page-path-utils";
 import { SectionList, parseSections } from "./section-list";
 import { isLazyResolveType } from "./section-lazy";
@@ -50,6 +50,7 @@ import { ALWAYS_MATCHER_RESOLVE_TYPE, type RawSection } from "./section-types";
 import {
   buildMatcherBlockData,
   buildMatcherBlockReference,
+  getSavedMatcherBlockKey,
   inlineMatcherRule,
   isSavedMatcherBlockReference,
   readMatcherRuleFormState,
@@ -57,6 +58,14 @@ import {
   resolveVariantRuleLabel,
   unwrapMatcherRule,
 } from "./matcher-rules";
+import {
+  appendPageVariantSections,
+  buildPageSectionsFromVariants,
+  countSavedMatcherBlockReferences,
+  getLastVariantIndex,
+  parsePageVariants,
+  type PageVariant,
+} from "./page-variants";
 import {
   buildPageDataWithSections,
   cloneSection,
@@ -97,13 +106,6 @@ function VariantTabIcon({
   const Icon = getIconComponent(iconName);
   if (!Icon) return null;
   return <Icon size={14} className="shrink-0" />;
-}
-
-interface PageVariant {
-  /** Display label (global block name if saved, otherwise derived from the rule). */
-  label: string;
-  sections: RawSection[];
-  rule?: Record<string, unknown>;
 }
 
 const capitalize = (s: string) =>
@@ -275,50 +277,11 @@ function formatMatcher(rule: Record<string, unknown> | undefined): string {
   }
 }
 
-/**
- * Parse page-level `sections` into an array of variants.
- * - Plain array → single variant labelled "Default"
- * - Multivariate flag object → one variant per entry in `variants`
- */
-function parsePageVariants(
+function parsePageVariantsForEditor(
   sections: unknown,
   decofile: Record<string, unknown>,
 ): PageVariant[] {
-  if (Array.isArray(sections)) {
-    return [{ label: "Default", sections }];
-  }
-  if (sections && typeof sections === "object") {
-    const obj = sections as Record<string, unknown>;
-    if (Array.isArray(obj.variants)) {
-      const raw = obj.variants as Array<{
-        rule?: Record<string, unknown>;
-        value?: unknown;
-      }>;
-      const labels = raw.map((v) =>
-        resolveVariantRuleLabel(v.rule, decofile, formatMatcher),
-      );
-      const labelCounts = labels.reduce<Record<string, number>>((acc, l) => {
-        acc[l] = (acc[l] ?? 0) + 1;
-        return acc;
-      }, {});
-      const seen: Record<string, number> = {};
-      return raw.map((v, i) => {
-        const baseLabel = labels[i] ?? `Variant ${i + 1}`;
-        const total = labelCounts[baseLabel] ?? 1;
-        let label = baseLabel;
-        if (total > 1) {
-          seen[baseLabel] = (seen[baseLabel] ?? 0) + 1;
-          label = `${baseLabel} ${seen[baseLabel]}`;
-        }
-        return {
-          label: label || `Variant ${i + 1}`,
-          sections: Array.isArray(v.value) ? (v.value as RawSection[]) : [],
-          rule: v.rule,
-        };
-      });
-    }
-  }
-  return [];
+  return parsePageVariants(sections, decofile, formatMatcher);
 }
 
 /**
@@ -624,7 +587,7 @@ export function SectionsEditor({
           sections: [{ __resolveType: activeGlobalBlockKey! } as RawSection],
         },
       ]
-    : parsePageVariants(pageData?.sections, decofile ?? {});
+    : parsePageVariantsForEditor(pageData?.sections, decofile ?? {});
   const hasMultipleVariants = pageVariants.length > 1;
   const safeVariantIndex = Math.min(
     activeVariantIndex,
@@ -701,14 +664,13 @@ export function SectionsEditor({
     setFormValue(unwrapped?.data ?? null);
     setActiveResolveType(unwrapped?.resolveType ?? null);
 
-    const ruleRt = (variant.rule?.__resolveType as string) ?? "";
-    setSectionRuleResolveType(ruleRt);
-    if (variant.rule) {
-      const { __resolveType: _, ...ruleData } = variant.rule;
-      setSectionRuleFormValue(ruleData);
-    } else {
-      setSectionRuleFormValue(null);
-    }
+    const { resolveType, formValue } = readMatcherRuleFormState(
+      variant.rule,
+      decofile,
+      meta ?? undefined,
+    );
+    setSectionRuleResolveType(resolveType);
+    setSectionRuleFormValue(formValue);
   };
 
   // Auto-select section when parent signals a click-through from the preview.
@@ -1240,6 +1202,7 @@ export function SectionsEditor({
     const { resolveType, formValue } = readMatcherRuleFormState(
       activeRule,
       decofile ?? {},
+      meta ?? undefined,
     );
     setRuleResolveType(resolveType);
     setRuleFormValue(formValue);
@@ -1251,6 +1214,35 @@ export function SectionsEditor({
 
   const ruleSchema =
     ruleResolveType && meta ? resolveSchema(ruleResolveType, meta) : null;
+
+  const cancelPendingRuleSaves = () => {
+    if (ruleDebounceRef.current) {
+      clearTimeout(ruleDebounceRef.current);
+      ruleDebounceRef.current = null;
+    }
+    if (sectionRuleDebounceRef.current) {
+      clearTimeout(sectionRuleDebounceRef.current);
+      sectionRuleDebounceRef.current = null;
+    }
+  };
+
+  const cleanupOrphanMatcherBlock = async (
+    blockKey: string,
+    projectedDecofile: Record<string, unknown>,
+  ) => {
+    if (
+      countSavedMatcherBlockReferences(projectedDecofile, blockKey, meta) > 0
+    ) {
+      return;
+    }
+    try {
+      await deleteBlock.mutateAsync({ blockKey });
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Could not delete matcher block",
+      );
+    }
+  };
 
   const scheduleRuleSave = (newRule: Record<string, unknown>) => {
     if (ruleDebounceRef.current) clearTimeout(ruleDebounceRef.current);
@@ -1276,7 +1268,7 @@ export function SectionsEditor({
         | Record<string, unknown>
         | undefined;
 
-      if (isSavedMatcherBlockReference(currentRule, latestDecofile)) {
+      if (isSavedMatcherBlockReference(currentRule, latestDecofile, meta)) {
         const blockKey = (currentRule?.__resolveType as string) ?? "";
         const existingBlock = latestDecofile[blockKey] as
           | Record<string, unknown>
@@ -1477,34 +1469,13 @@ export function SectionsEditor({
   const handleAddPageVariant = () => {
     if (!activePageKey) return;
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
-    const current = fullPageData.sections;
-    // Seed the new variant with a clone of the currently active variant's
-    // sections — gives the user a working baseline to modify (matches the
-    // A/B-test mental model: fork-then-tweak).
-    const seedSections = structuredClone(rawSections);
-    let updatedSections: Record<string, unknown>;
-    if (Array.isArray(current)) {
-      updatedSections = {
-        variants: [{ value: current }, { value: seedSections }],
-      };
-    } else if (current && typeof current === "object") {
-      const obj = current as Record<string, unknown>;
-      if (Array.isArray(obj.variants)) {
-        updatedSections = {
-          ...obj,
-          variants: [...(obj.variants as unknown[]), { value: seedSections }],
-        };
-      } else {
-        return;
-      }
-    } else {
-      updatedSections = {
-        variants: [{ value: [] }, { value: seedSections }],
-      };
-    }
-    const newVariantIndex = Array.isArray(updatedSections.variants as unknown[])
-      ? (updatedSections.variants as unknown[]).length - 1
-      : 1;
+    const updatedSections = appendPageVariantSections(
+      fullPageData.sections,
+      rawSections,
+    );
+    if (!updatedSections) return;
+
+    const newVariantIndex = getLastVariantIndex(updatedSections);
     saveBlock.mutate(
       {
         blockKey: activePageKey,
@@ -1526,15 +1497,15 @@ export function SectionsEditor({
   };
 
   /**
-   * Read the page's variants array, apply a transform, then either persist
-   * the modified `{ variants: [...] }` shape or collapse back to a flat
-   * sections array when only one variant remains. Shared by delete + rename.
+   * Read the page's variants array, apply a transform, then persist the
+   * modified shape. Shared by delete variant flows.
    */
   const mutatePageVariants = (
     transform: (
       variants: Array<Record<string, unknown>>,
     ) => Array<Record<string, unknown>> | null,
     onSaved?: () => void,
+    orphanMatcherBlockKey?: string | null,
   ) => {
     if (!activePageKey) return;
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
@@ -1547,23 +1518,39 @@ export function SectionsEditor({
       ...(obj.variants as Array<Record<string, unknown>>),
     ]);
     if (!next) return;
-    const updatedSections: unknown =
-      next.length === 1 && Array.isArray(next[0]?.value)
-        ? (next[0].value as unknown[])
-        : { ...obj, variants: next };
+    const updatedSections = buildPageSectionsFromVariants(obj, next);
+    const projectedDecofile = {
+      ...decofile,
+      [activePageKey]: { ...fullPageData, sections: updatedSections },
+    };
     saveBlock.mutate(
       {
         blockKey: activePageKey,
-        data: { ...fullPageData, sections: updatedSections },
+        data: projectedDecofile[activePageKey] as Record<string, unknown>,
       },
       {
-        onSuccess: () => onSaved?.(),
+        onSuccess: () => {
+          onSaved?.();
+          if (orphanMatcherBlockKey) {
+            void cleanupOrphanMatcherBlock(
+              orphanMatcherBlockKey,
+              projectedDecofile,
+            );
+          }
+        },
         onError: (err) => toast.error(`Save failed: ${err.message}`),
       },
     );
   };
 
   const handleDeletePageVariant = (variantIndex: number) => {
+    const deletedRule = pageVariants[variantIndex]?.rule;
+    const orphanMatcherBlockKey = getSavedMatcherBlockKey(
+      deletedRule,
+      decofile ?? {},
+      meta ?? undefined,
+    );
+
     mutatePageVariants(
       (variants) => {
         if (variants.length <= 1) return null;
@@ -1587,6 +1574,7 @@ export function SectionsEditor({
         setRuleFormValue(null);
         setRuleResolveType(null);
       },
+      orphanMatcherBlockKey,
     );
   };
 
@@ -1594,9 +1582,13 @@ export function SectionsEditor({
     variantIndex: number,
     nextName: string,
   ) => {
-    if (!activePageKey) return;
+    cancelPendingRuleSaves();
 
-    const fullPageData = decofile[activePageKey] as Record<string, unknown>;
+    const { activePageKey: pageKey, decofile: latestDecofile } =
+      latestRef.current;
+    if (!pageKey) return;
+
+    const fullPageData = latestDecofile[pageKey] as Record<string, unknown>;
     const current = fullPageData.sections;
     if (!current || typeof current !== "object" || Array.isArray(current))
       return;
@@ -1605,14 +1597,17 @@ export function SectionsEditor({
 
     const variants = [...(obj.variants as Array<Record<string, unknown>>)];
     const target = variants[variantIndex];
-    if (!target?.rule) return;
+    if (!target?.rule) {
+      toast.error("This variant has no matcher rule to rename.");
+      return;
+    }
 
     const trimmed = nextName.trim();
     setRenameVariantPending(true);
 
     try {
       if (!trimmed) {
-        if (!isSavedMatcherBlockReference(target.rule, decofile)) {
+        if (!isSavedMatcherBlockReference(target.rule, latestDecofile, meta)) {
           setRenameVariantIndex(null);
           return;
         }
@@ -1621,21 +1616,29 @@ export function SectionsEditor({
           .__resolveType as string;
         variants[variantIndex] = {
           ...target,
-          rule: inlineMatcherRule(target.rule, decofile),
+          rule: inlineMatcherRule(target.rule, latestDecofile, meta),
+        };
+
+        const projectedDecofile = {
+          ...latestDecofile,
+          [pageKey]: { ...fullPageData, sections: { ...obj, variants } },
         };
 
         await saveBlock.mutateAsync({
-          blockKey: activePageKey,
-          data: { ...fullPageData, sections: { ...obj, variants } },
+          blockKey: pageKey,
+          data: projectedDecofile[pageKey] as Record<string, unknown>,
         });
-        await deleteBlock.mutateAsync({ blockKey });
+        await cleanupOrphanMatcherBlock(blockKey, projectedDecofile);
         setRenameVariantIndex(null);
         onSaved?.();
         return;
       }
 
-      const unwrapped = unwrapMatcherRule(target.rule, decofile);
-      if (!unwrapped) return;
+      const unwrapped = unwrapMatcherRule(target.rule, latestDecofile, meta);
+      if (!unwrapped) {
+        toast.error("Could not read this variant's matcher rule.");
+        return;
+      }
 
       if (unwrapped.blockKey) {
         await saveBlock.mutateAsync({
@@ -1652,30 +1655,42 @@ export function SectionsEditor({
       }
 
       const blockId = suggestBlockId(trimmed);
-      const validationError = validateBlockId(blockId, decofile);
+      const validationError = validateBlockId(blockId, latestDecofile);
       if (validationError) {
         toast.error(validationError);
         return;
       }
 
-      await saveBlock.mutateAsync({
-        blockKey: blockId,
-        data: buildMatcherBlockData(
-          unwrapped.resolveType,
-          unwrapped.data,
-          trimmed,
-        ),
-      });
+      const blockData = buildMatcherBlockData(
+        unwrapped.resolveType,
+        unwrapped.data,
+        trimmed,
+      );
 
-      variants[variantIndex] = {
-        ...target,
-        rule: buildMatcherBlockReference(blockId),
-      };
-
-      await saveBlock.mutateAsync({
-        blockKey: activePageKey,
-        data: { ...fullPageData, sections: { ...obj, variants } },
-      });
+      let createdBlockId: string | null = null;
+      try {
+        await saveBlock.mutateAsync({ blockKey: blockId, data: blockData });
+        createdBlockId = blockId;
+        variants[variantIndex] = {
+          ...target,
+          rule: buildMatcherBlockReference(blockId),
+        };
+        await saveBlock.mutateAsync({
+          blockKey: pageKey,
+          data: {
+            ...fullPageData,
+            sections: { ...obj, variants },
+          },
+        });
+        createdBlockId = null;
+      } catch (err) {
+        if (createdBlockId) {
+          await deleteBlock
+            .mutateAsync({ blockKey: createdBlockId })
+            .catch(() => {});
+        }
+        throw err;
+      }
 
       setRenameVariantIndex(null);
       toast.success(`Saved matcher as global block "${trimmed}"`);
@@ -1740,6 +1755,7 @@ export function SectionsEditor({
                   rule={resolveEffectiveMatcherRule(
                     activeVariant.rule,
                     decofile ?? {},
+                    meta ?? undefined,
                   )}
                   matchers={availableMatchers}
                 />
@@ -1840,6 +1856,7 @@ export function SectionsEditor({
                   <button
                     type="button"
                     onClick={() => {
+                      setRenameVariantIndex(null);
                       setActiveVariantIndex(i);
                       setSelectedSectionIndex(null);
                       setFormValue(null);
@@ -1847,7 +1864,11 @@ export function SectionsEditor({
                       setFieldBreadcrumbs([]);
                       const variantRule = pageVariants[i]?.rule;
                       const { resolveType, formValue } =
-                        readMatcherRuleFormState(variantRule, decofile ?? {});
+                        readMatcherRuleFormState(
+                          variantRule,
+                          decofile ?? {},
+                          meta ?? undefined,
+                        );
                       setRuleResolveType(resolveType);
                       setRuleFormValue(formValue);
                     }}
@@ -1857,6 +1878,7 @@ export function SectionsEditor({
                       rule={resolveEffectiveMatcherRule(
                         variant.rule,
                         decofile ?? {},
+                        meta ?? undefined,
                       )}
                       matchers={availableMatchers}
                     />
@@ -2026,13 +2048,19 @@ export function SectionsEditor({
                 )}
               </button>
               {isVariantRuleOpen && (
-                <>
+                <div
+                  className={cn(
+                    "space-y-3",
+                    renameVariantPending && "pointer-events-none opacity-50",
+                  )}
+                >
                   <MatcherPicker
                     currentRt={ruleResolveType}
                     currentLabel={resolveVariantRuleLabel(
                       activeVariant?.rule,
                       decofile ?? {},
                       formatMatcher,
+                      meta ?? undefined,
                     )}
                     matchers={availableMatchers}
                     onSelect={handleMatcherTypeChange}
@@ -2047,7 +2075,7 @@ export function SectionsEditor({
                       />
                     </div>
                   )}
-                </>
+                </div>
               )}
             </div>
           )}
@@ -2100,11 +2128,13 @@ export function SectionsEditor({
             isSavedMatcherBlockReference(
               pageVariants[renameVariantIndex]?.rule,
               decofile ?? {},
+              meta ?? undefined,
             )
               ? resolveVariantRuleLabel(
                   pageVariants[renameVariantIndex]?.rule,
                   decofile ?? {},
                   formatMatcher,
+                  meta ?? undefined,
                 )
               : ""
           }
@@ -2112,6 +2142,7 @@ export function SectionsEditor({
             resolveEffectiveMatcherRule(
               pageVariants[renameVariantIndex]?.rule,
               decofile ?? {},
+              meta ?? undefined,
             ),
           )}
           isPending={renameVariantPending}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -486,10 +486,16 @@ export function SectionsEditor({
 
   // Reset form state when the active page or global block changes
   const [prevPath, setPrevPath] = useState(currentPath);
+  const [prevPageBlockKey, setPrevPageBlockKey] = useState(activePageBlockKey);
   const [prevGlobalBlockKey, setPrevGlobalBlockKey] =
     useState(activeGlobalBlockKey);
-  if (prevPath !== currentPath || prevGlobalBlockKey !== activeGlobalBlockKey) {
+  if (
+    prevPath !== currentPath ||
+    prevPageBlockKey !== activePageBlockKey ||
+    prevGlobalBlockKey !== activeGlobalBlockKey
+  ) {
     setPrevPath(currentPath);
+    setPrevPageBlockKey(activePageBlockKey);
     setPrevGlobalBlockKey(activeGlobalBlockKey);
     setSelectedSectionIndex(null);
     setFormValue(null);

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -29,6 +29,7 @@ import { VariantRenameDialog } from "./variant-rename-dialog";
 import { toast } from "sonner";
 import { useDecofile } from "./use-decofile";
 import { useLiveMeta } from "./use-live-meta";
+import { useDeleteBlock } from "./use-delete-block";
 import { useSaveBlock } from "./use-save-block";
 import { extractPages, globalSectionLabel } from "./page-list";
 import { normalizePagePath } from "./page-path-utils";
@@ -46,6 +47,16 @@ import { AddSectionModal } from "./add-section-modal";
 import type { SectionCatalogEntry } from "./section-catalog";
 import { SectionVariantList } from "./section-variant-list";
 import { ALWAYS_MATCHER_RESOLVE_TYPE, type RawSection } from "./section-types";
+import {
+  buildMatcherBlockData,
+  buildMatcherBlockReference,
+  inlineMatcherRule,
+  isSavedMatcherBlockReference,
+  readMatcherRuleFormState,
+  resolveEffectiveMatcherRule,
+  resolveVariantRuleLabel,
+  unwrapMatcherRule,
+} from "./matcher-rules";
 import {
   buildPageDataWithSections,
   cloneSection,
@@ -89,10 +100,8 @@ function VariantTabIcon({
 }
 
 interface PageVariant {
-  /** Display label (custom name if set, otherwise derived from the rule). */
+  /** Display label (global block name if saved, otherwise derived from the rule). */
   label: string;
-  /** User-provided custom name override. */
-  name?: string;
   sections: RawSection[];
   rule?: Record<string, unknown>;
 }
@@ -271,7 +280,10 @@ function formatMatcher(rule: Record<string, unknown> | undefined): string {
  * - Plain array → single variant labelled "Default"
  * - Multivariate flag object → one variant per entry in `variants`
  */
-function parsePageVariants(sections: unknown): PageVariant[] {
+function parsePageVariants(
+  sections: unknown,
+  decofile: Record<string, unknown>,
+): PageVariant[] {
   if (Array.isArray(sections)) {
     return [{ label: "Default", sections }];
   }
@@ -281,14 +293,10 @@ function parsePageVariants(sections: unknown): PageVariant[] {
       const raw = obj.variants as Array<{
         rule?: Record<string, unknown>;
         value?: unknown;
-        name?: unknown;
       }>;
-      // Custom name (if set) wins over the rule-derived label. Disambiguate
-      // remaining duplicates with an index ("Default 1", "Default 2").
-      const labels = raw.map((v) => {
-        const customName = typeof v.name === "string" ? v.name.trim() : "";
-        return customName || formatMatcher(v.rule);
-      });
+      const labels = raw.map((v) =>
+        resolveVariantRuleLabel(v.rule, decofile, formatMatcher),
+      );
       const labelCounts = labels.reduce<Record<string, number>>((acc, l) => {
         acc[l] = (acc[l] ?? 0) + 1;
         return acc;
@@ -302,10 +310,8 @@ function parsePageVariants(sections: unknown): PageVariant[] {
           seen[baseLabel] = (seen[baseLabel] ?? 0) + 1;
           label = `${baseLabel} ${seen[baseLabel]}`;
         }
-        const customName = typeof v.name === "string" ? v.name.trim() : "";
         return {
           label: label || `Variant ${i + 1}`,
-          name: customName || undefined,
           sections: Array.isArray(v.value) ? (v.value as RawSection[]) : [],
           rule: v.rule,
         };
@@ -536,6 +542,8 @@ export function SectionsEditor({
   }
 
   const saveBlock = useSaveBlock({ orgSlug, virtualMcpId, branch });
+  const deleteBlock = useDeleteBlock({ orgSlug, virtualMcpId, branch });
+  const [renameVariantPending, setRenameVariantPending] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pageDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ruleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -616,7 +624,7 @@ export function SectionsEditor({
           sections: [{ __resolveType: activeGlobalBlockKey! } as RawSection],
         },
       ]
-    : parsePageVariants(pageData?.sections);
+    : parsePageVariants(pageData?.sections, decofile ?? {});
   const hasMultipleVariants = pageVariants.length > 1;
   const safeVariantIndex = Math.min(
     activeVariantIndex,
@@ -1222,7 +1230,6 @@ export function SectionsEditor({
 
   // Sync rule form state when variant changes
   const activeRule = activeVariant?.rule;
-  const activeRuleRt = (activeRule?.__resolveType as string) ?? "";
   // Initialize rule form state when switching variants
   if (
     hasMultipleVariants &&
@@ -1230,9 +1237,12 @@ export function SectionsEditor({
     ruleResolveType === null &&
     activeRule
   ) {
-    setRuleResolveType(activeRuleRt);
-    const { __resolveType: _, ...ruleData } = activeRule;
-    setRuleFormValue(ruleData);
+    const { resolveType, formValue } = readMatcherRuleFormState(
+      activeRule,
+      decofile ?? {},
+    );
+    setRuleResolveType(resolveType);
+    setRuleFormValue(formValue);
   }
 
   const availableMatchers = meta ? extractMatchers(meta) : [];
@@ -1261,9 +1271,41 @@ export function SectionsEditor({
       const variants = [
         ...((mv.variants as Array<Record<string, unknown>>) ?? []),
       ];
-      if (variants[latestVariantIndex]) {
+      const currentVariant = variants[latestVariantIndex];
+      const currentRule = currentVariant?.rule as
+        | Record<string, unknown>
+        | undefined;
+
+      if (isSavedMatcherBlockReference(currentRule, latestDecofile)) {
+        const blockKey = (currentRule?.__resolveType as string) ?? "";
+        const existingBlock = latestDecofile[blockKey] as
+          | Record<string, unknown>
+          | undefined;
+        const displayName =
+          typeof existingBlock?.name === "string"
+            ? existingBlock.name
+            : blockKey;
+        const { __resolveType: matcherRt, ...matcherData } = newRule;
+        saveBlock.mutate(
+          {
+            blockKey,
+            data: buildMatcherBlockData(
+              (matcherRt as string) ?? "",
+              matcherData,
+              displayName,
+            ),
+          },
+          {
+            onSuccess: () => onSaved?.(),
+            onError: (err) => toast.error(`Save failed: ${err.message}`),
+          },
+        );
+        return;
+      }
+
+      if (currentVariant) {
         variants[latestVariantIndex] = {
-          ...variants[latestVariantIndex],
+          ...currentVariant,
           rule: newRule,
         };
       }
@@ -1548,20 +1590,103 @@ export function SectionsEditor({
     );
   };
 
-  const handleRenamePageVariant = (variantIndex: number, nextName: string) => {
-    mutatePageVariants((variants) => {
-      const target = variants[variantIndex];
-      if (!target) return null;
-      const trimmed = nextName.trim();
-      if (trimmed) {
-        variants[variantIndex] = { ...target, name: trimmed };
-      } else {
-        // Clearing the name reverts to the auto-derived label.
-        const { name: _drop, ...rest } = target as Record<string, unknown>;
-        variants[variantIndex] = rest;
+  const handleRenamePageVariant = async (
+    variantIndex: number,
+    nextName: string,
+  ) => {
+    if (!activePageKey) return;
+
+    const fullPageData = decofile[activePageKey] as Record<string, unknown>;
+    const current = fullPageData.sections;
+    if (!current || typeof current !== "object" || Array.isArray(current))
+      return;
+    const obj = current as Record<string, unknown>;
+    if (!Array.isArray(obj.variants)) return;
+
+    const variants = [...(obj.variants as Array<Record<string, unknown>>)];
+    const target = variants[variantIndex];
+    if (!target?.rule) return;
+
+    const trimmed = nextName.trim();
+    setRenameVariantPending(true);
+
+    try {
+      if (!trimmed) {
+        if (!isSavedMatcherBlockReference(target.rule, decofile)) {
+          setRenameVariantIndex(null);
+          return;
+        }
+
+        const blockKey = (target.rule as Record<string, unknown>)
+          .__resolveType as string;
+        variants[variantIndex] = {
+          ...target,
+          rule: inlineMatcherRule(target.rule, decofile),
+        };
+
+        await saveBlock.mutateAsync({
+          blockKey: activePageKey,
+          data: { ...fullPageData, sections: { ...obj, variants } },
+        });
+        await deleteBlock.mutateAsync({ blockKey });
+        setRenameVariantIndex(null);
+        onSaved?.();
+        return;
       }
-      return variants;
-    });
+
+      const unwrapped = unwrapMatcherRule(target.rule, decofile);
+      if (!unwrapped) return;
+
+      if (unwrapped.blockKey) {
+        await saveBlock.mutateAsync({
+          blockKey: unwrapped.blockKey,
+          data: buildMatcherBlockData(
+            unwrapped.resolveType,
+            unwrapped.data,
+            trimmed,
+          ),
+        });
+        setRenameVariantIndex(null);
+        onSaved?.();
+        return;
+      }
+
+      const blockId = suggestBlockId(trimmed);
+      const validationError = validateBlockId(blockId, decofile);
+      if (validationError) {
+        toast.error(validationError);
+        return;
+      }
+
+      await saveBlock.mutateAsync({
+        blockKey: blockId,
+        data: buildMatcherBlockData(
+          unwrapped.resolveType,
+          unwrapped.data,
+          trimmed,
+        ),
+      });
+
+      variants[variantIndex] = {
+        ...target,
+        rule: buildMatcherBlockReference(blockId),
+      };
+
+      await saveBlock.mutateAsync({
+        blockKey: activePageKey,
+        data: { ...fullPageData, sections: { ...obj, variants } },
+      });
+
+      setRenameVariantIndex(null);
+      toast.success(`Saved matcher as global block "${trimmed}"`);
+      onSaved?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to rename variant",
+      );
+    } finally {
+      setRenameVariantPending(false);
+    }
   };
 
   const exitSectionEditing = () => {
@@ -1612,7 +1737,10 @@ export function SectionsEditor({
                 )}
               >
                 <VariantTabIcon
-                  rule={activeVariant.rule}
+                  rule={resolveEffectiveMatcherRule(
+                    activeVariant.rule,
+                    decofile ?? {},
+                  )}
                   matchers={availableMatchers}
                 />
                 <span className="max-w-[160px] truncate">
@@ -1718,20 +1846,18 @@ export function SectionsEditor({
                       setActiveResolveType(null);
                       setFieldBreadcrumbs([]);
                       const variantRule = pageVariants[i]?.rule;
-                      const variantRuleRt =
-                        (variantRule?.__resolveType as string) ?? "";
-                      setRuleResolveType(variantRuleRt);
-                      if (variantRule) {
-                        const { __resolveType: _, ...ruleData } = variantRule;
-                        setRuleFormValue(ruleData);
-                      } else {
-                        setRuleFormValue(null);
-                      }
+                      const { resolveType, formValue } =
+                        readMatcherRuleFormState(variantRule, decofile ?? {});
+                      setRuleResolveType(resolveType);
+                      setRuleFormValue(formValue);
                     }}
                     className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-pointer"
                   >
                     <VariantTabIcon
-                      rule={variant.rule}
+                      rule={resolveEffectiveMatcherRule(
+                        variant.rule,
+                        decofile ?? {},
+                      )}
                       matchers={availableMatchers}
                     />
                     <span className="truncate">{variant.label}</span>
@@ -1903,7 +2029,11 @@ export function SectionsEditor({
                 <>
                   <MatcherPicker
                     currentRt={ruleResolveType}
-                    currentLabel={formatMatcher(activeVariant?.rule)}
+                    currentLabel={resolveVariantRuleLabel(
+                      activeVariant?.rule,
+                      decofile ?? {},
+                      formatMatcher,
+                    )}
                     matchers={availableMatchers}
                     onSelect={handleMatcherTypeChange}
                   />
@@ -1966,14 +2096,30 @@ export function SectionsEditor({
       {renameVariantIndex !== null && (
         <VariantRenameDialog
           open
-          initialName={pageVariants[renameVariantIndex]?.name ?? ""}
-          autoLabel={formatMatcher(pageVariants[renameVariantIndex]?.rule)}
-          onSubmit={(name) => {
-            handleRenamePageVariant(renameVariantIndex, name);
-            setRenameVariantIndex(null);
+          initialName={
+            isSavedMatcherBlockReference(
+              pageVariants[renameVariantIndex]?.rule,
+              decofile ?? {},
+            )
+              ? resolveVariantRuleLabel(
+                  pageVariants[renameVariantIndex]?.rule,
+                  decofile ?? {},
+                  formatMatcher,
+                )
+              : ""
+          }
+          autoLabel={formatMatcher(
+            resolveEffectiveMatcherRule(
+              pageVariants[renameVariantIndex]?.rule,
+              decofile ?? {},
+            ),
+          )}
+          isPending={renameVariantPending}
+          onSubmit={async (name) => {
+            await handleRenamePageVariant(renameVariantIndex, name);
           }}
           onOpenChange={(open) => {
-            if (!open) setRenameVariantIndex(null);
+            if (!open && !renameVariantPending) setRenameVariantIndex(null);
           }}
         />
       )}

--- a/apps/mesh/src/web/components/sections-editor/variant-rename-dialog.tsx
+++ b/apps/mesh/src/web/components/sections-editor/variant-rename-dialog.tsx
@@ -9,23 +9,25 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
+import { Loading01 } from "@untitledui/icons";
 
 /**
- * Renames a page variant by setting a custom `name` on its entry. When the
- * user clears the input, the variant falls back to the rule-derived label
- * (e.g. "Mobile", "Feb 23 → Mar 1") on the next render.
+ * Renames a page variant by saving its matcher as a global block and pointing
+ * the variant rule at that block. Clearing the input inlines the matcher again.
  */
 export function VariantRenameDialog({
   open,
   initialName,
   autoLabel,
+  isPending = false,
   onSubmit,
   onOpenChange,
 }: {
   open: boolean;
   initialName: string;
   autoLabel: string;
-  onSubmit: (name: string) => void;
+  isPending?: boolean;
+  onSubmit: (name: string) => void | Promise<void>;
   onOpenChange: (open: boolean) => void;
 }) {
   const [name, setName] = useState(initialName);
@@ -36,19 +38,27 @@ export function VariantRenameDialog({
     if (open) setName(initialName);
   }
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && !isPending) {
+      onOpenChange(false);
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    onSubmit(name.trim());
+    if (isPending) return;
+    await onSubmit(name.trim());
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Rename variant</DialogTitle>
             <DialogDescription>
-              Override the auto-generated label. Leave empty to fall back to{" "}
+              Save this matcher as a global block with a custom label. Leave
+              empty to inline the matcher again and fall back to{" "}
               <span className="font-medium">{autoLabel || "the rule"}</span>.
             </DialogDescription>
           </DialogHeader>
@@ -66,6 +76,7 @@ export function VariantRenameDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder={autoLabel}
               autoFocus
+              disabled={isPending}
             />
           </div>
 
@@ -74,10 +85,20 @@ export function VariantRenameDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
+              disabled={isPending}
             >
               Cancel
             </Button>
-            <Button type="submit">Save</Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? (
+                <>
+                  <Loading01 size={14} className="animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                "Save"
+              )}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/apps/mesh/src/web/components/sections-editor/variant-rename-dialog.tsx
+++ b/apps/mesh/src/web/components/sections-editor/variant-rename-dialog.tsx
@@ -1,0 +1,86 @@
+import { type FormEvent, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+
+/**
+ * Renames a page variant by setting a custom `name` on its entry. When the
+ * user clears the input, the variant falls back to the rule-derived label
+ * (e.g. "Mobile", "Feb 23 → Mar 1") on the next render.
+ */
+export function VariantRenameDialog({
+  open,
+  initialName,
+  autoLabel,
+  onSubmit,
+  onOpenChange,
+}: {
+  open: boolean;
+  initialName: string;
+  autoLabel: string;
+  onSubmit: (name: string) => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState(initialName);
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setName(initialName);
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit(name.trim());
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Rename variant</DialogTitle>
+            <DialogDescription>
+              Override the auto-generated label. Leave empty to fall back to{" "}
+              <span className="font-medium">{autoLabel || "the rule"}</span>.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-1.5 py-4">
+            <label
+              htmlFor="variant-rename-name"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Name
+            </label>
+            <Input
+              id="variant-rename-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={autoLabel}
+              autoFocus
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## What is this contribution about?

Several UX fixes for the Content tab on deco sites, focused on making page **variants** a first-class flow (creating them, identifying them, and editing their rules) and tightening a few rough edges around it.

**Variants**
- Content browser: pages with multiple variants render with a green icon + "X variants" tooltip, and the row's `…` menu gains an "Add variant" action.
- Sections editor: page header has a green flag button to add a variant, and the variant tab bar has a `+` button to add more. Tabs are now larger, show the matcher's icon (Calendar for Date, Phone for Device, Shuffle for Random, etc.), and use a green active state. Icon resolution mirrors the matcher picker so custom matchers (e.g. "Birthday") pick up their schema-defined icon instead of falling back to FilterLines.
- New variants seed from the active variant's sections (fork-then-tweak A/B flow) instead of starting empty.
- `parsePageVariants` disambiguates labels when multiple variants share the same matcher (e.g. two "Default" → "Default 1" / "Default 2").

**Selection model**
- Pages were identified by `path` in the Content selection, but the decofile can legitimately have multiple page blocks with the same path. That caused two visible bugs: every same-path row lit up as selected, and the sections editor would load the wrong page (no variants shown). Selection now carries the unique block `key`; `SectionsEditor` accepts an optional `activePageBlockKey` prop and prefers it over the path lookup.

**Matcher form**
- Date / date-time matcher fields now render native segmented inputs (`<input type="date" / "datetime-local">`) with auto-advancing MM/DD/YYYY behavior and a browser-native calendar dropdown, backed by ISO 8601 strings — replacing the plain text inputs.

**Preview**
- Preview's "Search pages and components…" input restyled to match the Content tab's search (icon prefix, borderless, bottom border) for visual consistency.

## Screenshots/Demonstration

Variant tabs (active = green, with matcher icon), new "Add variant" entry in the row menu, native date input on the date matcher, and the unified search style in Preview.

## How to Test

1. Open a deco site project in Studio → Content tab.
2. On any page row, open the `…` menu → click **Add variant**. Confirm the row's icon turns green, the tooltip reads "2 variants", and the right pane jumps to the new variant with a clone of the original sections.
3. Open the page → click the flag/`+` to add another variant. Pick **Date** in the variant rule picker → confirm `Start` and `End` render as segmented date inputs and round-trip ISO strings on save.
4. Click each variant tab — active tab is green, with the matcher's icon next to its label.
5. Switch to Preview tab → open the pages dropdown → search input should look identical to the Content tab's search.

## Migration Notes

None. The variant data shape (`{ variants: [{ rule, value }] }`) is the same one deco's `MultivariateFlag<Section[]>` already understands at runtime.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed) — N/A
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes page variants a first-class flow in the Content tab with clearer tabs, add-variant actions, and reliable rules. Also aligns Preview’s page search with Content’s search.

- **New Features**
  - Content browser: green icon + “X variants” tooltip on pages with variants; row menu gets “Add variant” that seeds from the last variant; new variants in the editor clone the active one.
  - Variant tabs: larger, icon-led, green active state; Rename saves the matcher as a reusable global block (clearing the name inlines it); Delete keeps multivariate if the last variant has a rule and collapses only when it doesn’t.
  - Editing UX: pinned “+” add-variant button; small green variant badge in the breadcrumb while editing; “Variant rule” panel is collapsible; labels use saved block names and real rule info (works for custom matchers); date/date-time fields use native segmented inputs with a calendar popover and ISO 8601 values; matcher picker trigger matches Input styling.
  - Preview: pages dropdown uses the same search input style as the Content tab.

- **Bug Fixes**
  - Content selection keyed by page block `key` (not `path`); `SectionsEditor` accepts `activePageBlockKey` to load the exact page and resets form state on block-key change.
  - Hardened matcher refs and variant persistence: validate saved refs with `Object.hasOwn`, preserve rules when collapsing to one variant, clean up unused matcher blocks on delete, and rollback safely on failures.
  - Date handling: date fields round-trip as UTC date-only (00:00Z) to avoid time zone shifts.

<sup>Written for commit 902cbc0185b75fe22009757b430def72f3774741. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

