### PR TITLE
fix(observability): update context handling in withRequest function

### DIFF
--- a/apps/mesh/src/observability/index.ts
+++ b/apps/mesh/src/observability/index.ts
@@ -6,9 +6,10 @@
  */
 
 import {
-  context,
   createContextKey,
   metrics,
+  propagation,
+  ROOT_CONTEXT,
   SpanStatusCode,
   trace,
   type Attributes,
@@ -501,10 +502,19 @@ console.debug = (...args: unknown[]) => {
 };
 
 /**
- * Create a context with the request set for sampling decisions
+ * Build the parent context for an inbound request span.
+ *
+ * Starts from ROOT_CONTEXT — never the ambient `context.active()`. Inheriting
+ * the active context is what let spans from unrelated requests chain into one
+ * ever-growing trace (the "infinite trace parent"). If the caller sent a valid
+ * W3C `traceparent`, we continue that trace; otherwise this is a fresh root.
  */
 export const withRequest = (req: Request): Context => {
-  return context.active().setValue(REQUEST_CONTEXT_KEY, req);
+  const extracted = propagation.extract(ROOT_CONTEXT, req.headers, {
+    get: (headers, key) => (headers as Headers).get(key) ?? undefined,
+    keys: (headers) => [...(headers as Headers).keys()],
+  });
+  return extracted.setValue(REQUEST_CONTEXT_KEY, req);
 };
 
 /**


### PR DESCRIPTION
Replaced the use of the ambient context with ROOT_CONTEXT for building the parent context of an inbound request span. This change ensures that spans from unrelated requests do not chain into a single trace, improving traceability and context management. The propagation.extract method is now used to handle incoming request headers correctly.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inbound trace context handling by starting spans from `ROOT_CONTEXT` and extracting headers, preventing unrelated requests from chaining into one trace. This isolates traces and correctly continues upstream context from W3C headers.

- **Bug Fixes**
  - Build parent context from `ROOT_CONTEXT`, not the ambient context.
  - Use `propagation.extract` to read trace headers from `Request.headers`.
  - Stops the “infinite trace parent” issue across requests.

<sup>Written for commit e627bced06dea98ad09a7a689b6cc5bc9b453d29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

