### PR TITLE
fix(chat): keep mobile chat within viewport when toolbar overflows

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -431,7 +431,7 @@ function AgentInsetProvider() {
 
     return (
       <InsetContext value={insetContextValue}>
-        <div className="flex flex-col flex-1 bg-background min-h-0">
+        <div className="flex flex-col flex-1 min-w-0 bg-background min-h-0">
           <Chat.Provider
             key={chatVirtualMcpId}
             virtualMcpId={chatVirtualMcpId}


### PR DESCRIPTION
## Problem

On mobile, chat messages render broken — message text overflows the layout and is clipped on the right edge with no way to scroll (reported from production). Both the user bubble and the assistant message are affected, and the "Thought for …" reasoning summary runs off-screen.

<img src="https://raw.githubusercontent.com/decocms/studio/tlgimenes/mobile-overflow-evidence/pr-evidence/before-280px.png" width="300" alt="Before — message text clipped at the right edge on mobile" />

## Root cause

The mobile branch of `AgentInsetProvider` wraps the whole chat in:

```tsx
<div className="flex flex-col flex-1 bg-background min-h-0">
```

This element is a flex item but has **no `min-w-0`**, so its automatic minimum size (`min-width: auto`) is floored at the **intrinsic content width of the `MobileToolbar`** — the menu button + the view tabs (`MainPanelTabsBar`: *Dashboard / Settings / Automations …*) + the action buttons. The toolbar is `shrink-0`, so when its content is wider than the viewport, this minimum width propagates down the whole chat column (`ChatRoot → scroller → max-w-2xl wrapper → MessagePair → every message`), forcing all of it wider than the screen. `overflow-x-hidden` higher up then clips the result, so there is no scrollbar — text is just cut off.

The amount of overflow scales with how many toolbar tabs the agent has, which is why it shows at 390 px (normal iPhone) on agents with several tabs, and at narrower widths otherwise. The toolbar's own `overflow-x-auto` never kicks in because the column grows to fit the tabs instead of constraining them.

The desktop branch already has `min-w-0` on its equivalent wrapper — only the mobile branch was missing it.

## Fix

One line — let the mobile chat column shrink to the viewport so the toolbar tabs scroll (their `overflow-x-auto`) instead of widening the whole layout:

```diff
-        <div className="flex flex-col flex-1 bg-background min-h-0">
+        <div className="flex flex-col flex-1 min-w-0 bg-background min-h-0">
```

## Verification

Ran the app locally and inspected it in Chrome DevTools' mobile emulation against a real seeded chat (the exact message from the report). Measured `scrollWidth` of the chat scroller vs. the viewport:

| viewport | before fix | after fix |
|---|---|---|
| 280 px | column **329 px** (49 px overflow) | column **280 px** ✅ |
| 320 px | column **329 px** (9 px overflow) | column **320 px** ✅ |
| 390 px | fits (few tabs) | **390 px** ✅ |

After the fix, `document.documentElement.scrollWidth === innerWidth` at every width and no element exceeds the viewport. The text now wraps within the screen and the reasoning summary truncates with an ellipsis instead of running off-edge.

| After (280 px) | After (390 px) |
|---|---|
| <img src="https://raw.githubusercontent.com/decocms/studio/tlgimenes/mobile-overflow-evidence/pr-evidence/after-280px.png" width="260" alt="After — text wraps within the viewport at 280px" /> | <img src="https://raw.githubusercontent.com/decocms/studio/tlgimenes/mobile-overflow-evidence/pr-evidence/after-390px.png" width="260" alt="After — full message renders correctly at 390px" /> |

## Testing notes

- `bun run fmt` — clean
- `bun run lint` — 0 errors (4 pre-existing warnings in unrelated files)
- `bun run check` — passes (all workspaces exit 0)
- Manual: verified mobile chat at 280/320/390 px in Chrome DevTools; desktop layout unaffected (it already had `min-w-0`).

> Screenshots are hosted on the throwaway branch `tlgimenes/mobile-overflow-evidence` (not part of this PR's diff; safe to delete after review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix mobile chat overflow by adding `min-w-0` to the mobile agent-shell wrapper in `AgentInsetProvider`, so the chat column stays within the viewport and messages don’t get clipped. When the toolbar content is wider than the screen, `MobileToolbar` tabs now scroll horizontally instead of widening the layout; desktop remains unchanged.

<sup>Written for commit 46d71fec229715510b2a3c0e5fa7a80fc7f8b5c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

