### PR TITLE
feat(proxy): enhance connection handling with method-based probing an…

### DIFF
--- a/apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts
+++ b/apps/mesh/e2e/tests/mcp-proxy-roundtrip.spec.ts
@@ -102,4 +102,82 @@ test.describe("MCP proxy roundtrip", () => {
 
     await ctx.dispose();
   });
+
+  test("repeated tools/list does not re-handshake downstream on every poll", async ({
+    playwright,
+  }) => {
+    // Dedicated downstream server so request counts are isolated from the
+    // other test in this describe.
+    const downstream = await startTestMcpServer({
+      tools: [
+        {
+          name: "ping",
+          description: "Returns pong.",
+          handler: () => ({ pong: true }),
+        },
+      ],
+    });
+
+    try {
+      const ctx = await newApiContext(playwright);
+      const user = await signUpViaApi(ctx);
+      const connection = await createHttpConnection(ctx, user.orgSlug, {
+        title: `Poll MCP ${Date.now()}`,
+        url: downstream.url,
+      });
+
+      const url = `/api/${user.orgSlug}/mcp/${connection.id}`;
+      const headers = { Accept: "application/json, text/event-stream" };
+
+      // Standard MCP lifecycle: initialize once (the proxy probes downstream
+      // here to surface auth — that's the legitimate handshake).
+      const init = await ctx.post(url, {
+        headers,
+        data: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "e2e-poll", version: "1.0.0" },
+          },
+        },
+      });
+      expect(init.ok()).toBe(true);
+
+      // Poll tools/list many times in quick succession — the kind of traffic a
+      // UI generates. With the eager-probe gating + SWR revalidation throttle,
+      // these must NOT each trigger a fresh downstream MCP handshake.
+      const POLLS = 8;
+      let lastTools: Array<{ name: string }> = [];
+      for (let i = 0; i < POLLS; i++) {
+        const res = await ctx.post(url, {
+          headers,
+          data: { jsonrpc: "2.0", id: 10 + i, method: "tools/list" },
+        });
+        expect(res.ok()).toBe(true);
+        const body = (await res.json()) as {
+          result?: { tools?: Array<{ name: string }> };
+        };
+        if (body.result?.tools) lastTools = body.result.tools;
+      }
+
+      // Functional correctness: the proxied tool list is still served.
+      expect(lastTools.some((t) => t.name === "ping")).toBe(true);
+
+      // The core assertion: downstream handshakes are bounded by a small
+      // constant (initialize probe + at most a cold list warm-up), NOT one per
+      // request. Before the fix this would be ~POLLS + 1.
+      const initializeCount = downstream.requests.filter(
+        (r) => r.method === "initialize",
+      ).length;
+      expect(initializeCount).toBeLessThanOrEqual(3);
+      expect(initializeCount).toBeLessThan(POLLS);
+
+      await ctx.dispose();
+    } finally {
+      await downstream.stop();
+    }
+  });
 });

--- a/apps/mesh/src/api/routes/proxy-handshake.test.ts
+++ b/apps/mesh/src/api/routes/proxy-handshake.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { peekRpcMethod, probeDecision } from "./proxy-handshake";
+
+describe("probeDecision", () => {
+  it("always probes initialize (response is local, probe is the only 401 surface)", () => {
+    expect(probeDecision("initialize")).toEqual({ decision: "probe" });
+  });
+
+  it("always probes tools/call and content reads", () => {
+    expect(probeDecision("tools/call")).toEqual({ decision: "probe" });
+    expect(probeDecision("resources/read")).toEqual({ decision: "probe" });
+    expect(probeDecision("prompts/get")).toEqual({ decision: "probe" });
+  });
+
+  it("always probes unknown methods (safe default) and resources/templates/list", () => {
+    expect(probeDecision("completion/complete")).toEqual({ decision: "probe" });
+    expect(probeDecision("some/future/method")).toEqual({ decision: "probe" });
+    // templates list is not cache-served by the lazy client → probe
+    expect(probeDecision("resources/templates/list")).toEqual({
+      decision: "probe",
+    });
+  });
+
+  it("defers list methods to the cold/warm cache check", () => {
+    expect(probeDecision("tools/list")).toEqual({
+      decision: "skip-if-list-cached",
+      listType: "tools",
+    });
+    expect(probeDecision("resources/list")).toEqual({
+      decision: "skip-if-list-cached",
+      listType: "resources",
+    });
+    expect(probeDecision("prompts/list")).toEqual({
+      decision: "skip-if-list-cached",
+      listType: "prompts",
+    });
+  });
+
+  it("skips ping and all notifications", () => {
+    expect(probeDecision("ping")).toEqual({ decision: "skip" });
+    expect(probeDecision("notifications/initialized")).toEqual({
+      decision: "skip",
+    });
+    expect(probeDecision("notifications/cancelled")).toEqual({
+      decision: "skip",
+    });
+  });
+
+  it("skips when method is undefined (GET/DELETE/unparseable)", () => {
+    expect(probeDecision(undefined)).toEqual({ decision: "skip" });
+  });
+});
+
+function postJson(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("https://mesh.test/mcp/conn_1", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("peekRpcMethod", () => {
+  it("reads the method from a single JSON-RPC request", async () => {
+    expect(
+      await peekRpcMethod(
+        postJson({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+      ),
+    ).toBe("initialize");
+    expect(
+      await peekRpcMethod(
+        postJson({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+      ),
+    ).toBe("tools/list");
+  });
+
+  it("reads the first member's method from a batch", async () => {
+    expect(
+      await peekRpcMethod(
+        postJson([
+          { jsonrpc: "2.0", method: "notifications/initialized" },
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        ]),
+      ),
+    ).toBe("notifications/initialized");
+  });
+
+  it("does NOT consume the original request body (clone is read)", async () => {
+    const req = postJson({ jsonrpc: "2.0", id: 1, method: "initialize" });
+    await peekRpcMethod(req);
+    // handleRequest reads the original body afterwards — it must still be intact.
+    expect(req.bodyUsed).toBe(false);
+    const reread = (await req.json()) as { method: string };
+    expect(reread.method).toBe("initialize");
+  });
+
+  it("returns undefined for non-POST requests", async () => {
+    const get = new Request("https://mesh.test/mcp/conn_1", { method: "GET" });
+    expect(await peekRpcMethod(get)).toBeUndefined();
+    const del = new Request("https://mesh.test/mcp/conn_1", {
+      method: "DELETE",
+    });
+    expect(await peekRpcMethod(del)).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable bodies", async () => {
+    const req = new Request("https://mesh.test/mcp/conn_1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json{",
+    });
+    expect(await peekRpcMethod(req)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no method field", async () => {
+    expect(
+      await peekRpcMethod(postJson({ jsonrpc: "2.0", id: 1, result: {} })),
+    ).toBeUndefined();
+  });
+
+  it("skips parsing oversized bodies (never an initialize/list)", async () => {
+    const big = "x".repeat(70_000);
+    const req = postJson(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { big } },
+      { "content-length": "70000" },
+    );
+    expect(await peekRpcMethod(req)).toBeUndefined();
+    // Original body remains readable for handleRequest.
+    expect(req.bodyUsed).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/routes/proxy-handshake.ts
+++ b/apps/mesh/src/api/routes/proxy-handshake.ts
@@ -1,0 +1,88 @@
+/**
+ * Eager-handshake gating for the MCP proxy.
+ *
+ * The proxy eagerly opens the downstream MCP connection before handling a
+ * request so that upstream auth errors (e.g. OAuth 401) surface for methods the
+ * proxy would otherwise answer locally — chiefly `initialize`, which the proxy
+ * responds to with its own capabilities and never touches downstream.
+ *
+ * That probe is a full MCP handshake (initialize + initialized). Running it for
+ * every request defeats the NATS list cache: a `tools/list` poll served from
+ * cache would still pay a downstream handshake. But the probe is also the only
+ * place a 401 surfaces as an HTTP `WWW-Authenticate` response (errors thrown
+ * inside `transport.handleRequest` become JSON-RPC error bodies, not the 401 the
+ * frontend popup needs). So we can't blindly skip it for list methods either.
+ *
+ * The resolution: skip the probe for a list method only when its list is
+ * already cached (the warm stale-while-revalidate path). On a cold cache we
+ * still probe — that both surfaces first-load auth errors and warms the
+ * per-request pool for the lazy list call. See proxy.ts for the cache check.
+ */
+
+import type { McpListType } from "@/mcp-clients/mcp-list-cache";
+
+/** Whether/when to eagerly open the downstream connection for a request. */
+export type ProbeDecision =
+  | "probe" // always probe (initialize, tools/call, reads, unknown)
+  | "skip" // never probe (notifications, ping, GET/DELETE, unparseable)
+  | "skip-if-list-cached"; // probe only on a cold list cache
+
+/** List methods the lazy client serves from the NATS list cache, mapped to the
+ * cache type the proxy must check before deciding to skip the probe. */
+const LIST_METHOD_CACHE_TYPE: Record<string, McpListType> = {
+  "tools/list": "tools",
+  "resources/list": "resources",
+  "prompts/list": "prompts",
+};
+
+/** Methods the proxy answers locally with no downstream interaction at all. */
+const LOCAL_ONLY_METHODS = new Set(["ping"]);
+
+/**
+ * Decide whether to eagerly open the downstream connection for a JSON-RPC
+ * method. Pure — the cold/warm list-cache lookup happens in proxy.ts.
+ */
+export function probeDecision(method: string | undefined): {
+  decision: ProbeDecision;
+  listType?: McpListType;
+} {
+  if (!method) return { decision: "skip" };
+  if (method.startsWith("notifications/")) return { decision: "skip" };
+  if (LOCAL_ONLY_METHODS.has(method)) return { decision: "skip" };
+
+  const listType = LIST_METHOD_CACHE_TYPE[method];
+  if (listType) return { decision: "skip-if-list-cached", listType };
+
+  return { decision: "probe" };
+}
+
+// Initialize and list payloads are tiny; anything larger is definitely a
+// tool call or content write whose method we don't need to inspect. Skipping
+// the parse avoids buffering large bodies twice (clone + handleRequest).
+const MAX_PEEK_BYTES = 64_000;
+
+/**
+ * Read the JSON-RPC method from a request body without consuming the original
+ * stream — clones first so `transport.handleRequest` can still read it.
+ *
+ * Returns `undefined` for non-POST requests (GET SSE / DELETE), oversized
+ * bodies, or unparseable JSON. Batch requests report the first member's method
+ * (a batch containing `initialize` is invalid per spec, so this is safe).
+ */
+export async function peekRpcMethod(req: Request): Promise<string | undefined> {
+  if (req.method !== "POST") return undefined;
+
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_PEEK_BYTES) {
+    return undefined;
+  }
+
+  try {
+    const body = await req.clone().json();
+    const first = Array.isArray(body) ? body[0] : body;
+    const method = (first as { method?: unknown } | null)?.method;
+    return typeof method === "string" ? method : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -20,6 +20,8 @@ import type { MeshContext } from "../../core/mesh-context";
 import { managementMCP } from "../../tools";
 import { guardResponseStream } from "../utils/stream-guard";
 import { handleAuthError } from "./oauth-proxy";
+import { getMcpListCache } from "@/mcp-clients/mcp-list-cache";
+import { peekRpcMethod, probeDecision } from "./proxy-handshake";
 import { handleVirtualMcpRequest } from "./virtual-mcp";
 export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
 
@@ -145,7 +147,22 @@ export const createProxyRoutes = () => {
         // hiding the 401 the frontend needs to trigger the OAuth popup.
         // On success this also warms the per-request client pool, so the
         // lazy client reuses the same connection instead of double-connecting.
-        if (connection.connection_url) {
+        //
+        // Gated by method: notifications/ping/GET skip the probe entirely, and
+        // a list method skips it only when its list is already cached (warm SWR
+        // path) — so a cached list poll no longer pays a full downstream
+        // handshake. A cold list cache still probes, which surfaces first-load
+        // auth errors and warms the per-request pool. See ./proxy-handshake.
+        const rpcMethod = await peekRpcMethod(c.req.raw);
+        const { decision, listType } = probeDecision(rpcMethod);
+        let probe = decision === "probe";
+        if (decision === "skip-if-list-cached" && listType) {
+          const listCache = getMcpListCache();
+          probe = listCache
+            ? (await listCache.get(listType, connectionId)) === null
+            : true;
+        }
+        if (connection.connection_url && probe) {
           await ctx.tracer.startActiveSpan(
             "mesh.connection.handshake",
             {
@@ -267,6 +284,26 @@ export const createProxyRoutes = () => {
         },
       );
     } catch (error) {
+      // Surface upstream OAuth 401s as a WWW-Authenticate response so the
+      // frontend can trigger the OAuth popup — consistent with the main proxy
+      // route. Without this, an expired/missing credential would 500 here.
+      const connection = await ctx.storage.connections.findById(
+        connectionId,
+        ctx.organization?.id,
+      );
+      if (connection?.connection_url) {
+        const authResponse = await handleAuthError({
+          error: error as Error & { status?: number },
+          reqUrl: new URL(c.req.raw.url),
+          connectionId,
+          connectionUrl: connection.connection_url,
+          headers: {},
+          orgSlug: ctx.organization?.slug,
+        });
+        if (authResponse) {
+          return authResponse;
+        }
+      }
       return handleError(error as Error, c);
     }
   });

--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -28,7 +28,11 @@ import {
   recordSuccess,
 } from "./circuit-breaker";
 import { clientFromConnection } from "./client";
-import { fetchWithCache, type McpListCache } from "./mcp-list-cache";
+import {
+  fetchWithCache,
+  type McpListCache,
+  REVALIDATE_MIN_INTERVAL_MS,
+} from "./mcp-list-cache";
 import { getMcpReadCache } from "./mcp-read-cache";
 
 /**
@@ -113,6 +117,7 @@ export function createLazyClient(
         },
         cache,
         (p) => ctx.pendingRevalidations.push(p),
+        REVALIDATE_MIN_INTERVAL_MS,
       );
 
       return buildCachedResult(result ?? []);

--- a/apps/mesh/src/mcp-clients/mcp-list-cache.test.ts
+++ b/apps/mesh/src/mcp-clients/mcp-list-cache.test.ts
@@ -16,6 +16,7 @@ import type {
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
   fetchWithCache,
+  isRevalidationStale,
   type McpListCache,
   type McpListType,
 } from "./mcp-list-cache";
@@ -257,6 +258,91 @@ describe("fetchWithCache", () => {
     expect(revalidations).toHaveLength(0);
   });
 
+  it("throttles background revalidation within the min interval", async () => {
+    // Unique connection id so the module-level throttle map isn't shared with
+    // other tests in this file.
+    const conn = "conn_throttle_within";
+    const cache = new TestMcpListCache();
+    await cache.set("tools", conn, [makeTool("stale")]);
+
+    let callCount = 0;
+    const fetchLive = async () => {
+      callCount++;
+      return [makeTool("fresh")];
+    };
+
+    // First hit: nothing revalidated yet → revalidates and starts the clock.
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+
+    // Second hit immediately after: within the 10s window → throttled, no fetch.
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+  });
+
+  it("revalidates again once the min interval has elapsed", async () => {
+    const conn = "conn_throttle_elapsed";
+    const cache = new TestMcpListCache();
+    await cache.set("tools", conn, [makeTool("stale")]);
+
+    let callCount = 0;
+    const fetchLive = async () => {
+      callCount++;
+      return [makeTool("fresh")];
+    };
+
+    // Tiny interval so the window lapses between calls.
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 20);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+
+    await new Promise((r) => setTimeout(r, 30)); // exceed the 20ms window
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 20);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(2);
+  });
+
+  it("a cache miss starts the throttle clock (immediate hit is throttled)", async () => {
+    const conn = "conn_throttle_miss";
+    const cache = new TestMcpListCache();
+
+    let callCount = 0;
+    const fetchLive = async () => {
+      callCount++;
+      return [makeTool("t")];
+    };
+
+    // Miss → live fetch (counts) and seeds the throttle timestamp.
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+
+    // Immediate hit → throttled, no background revalidation.
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 10_000);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(1);
+  });
+
+  it("interval <= 0 disables throttling (revalidates every hit)", async () => {
+    const conn = "conn_throttle_off";
+    const cache = new TestMcpListCache();
+    await cache.set("tools", conn, [makeTool("stale")]);
+
+    let callCount = 0;
+    const fetchLive = async () => {
+      callCount++;
+      return [makeTool("fresh")];
+    };
+
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 0);
+    await new Promise((r) => setTimeout(r, 5));
+    await fetchWithCache("tools", conn, fetchLive, cache, undefined, 0);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(callCount).toBe(2);
+  });
+
   it("silently handles connection closed errors during revalidation", async () => {
     const cache = new TestMcpListCache();
     const stale = [makeTool("stale")];
@@ -279,6 +365,28 @@ describe("fetchWithCache", () => {
     await Promise.allSettled(revalidations);
     // Cache should still have stale data (revalidation failed silently)
     expect(await cache.get("tools", "conn1")).toEqual(stale);
+  });
+});
+
+// ============================================================================
+// isRevalidationStale (pure throttle predicate)
+// ============================================================================
+
+describe("isRevalidationStale", () => {
+  it("is always stale when interval <= 0 (throttle disabled)", () => {
+    expect(isRevalidationStale(undefined, 1000, 0)).toBe(true);
+    expect(isRevalidationStale(1000, 1000, 0)).toBe(true);
+    expect(isRevalidationStale(1000, 1000, -5)).toBe(true);
+  });
+
+  it("is stale when never revalidated", () => {
+    expect(isRevalidationStale(undefined, 1000, 30_000)).toBe(true);
+  });
+
+  it("is fresh within the interval and stale once it elapses", () => {
+    expect(isRevalidationStale(1000, 1000 + 29_999, 30_000)).toBe(false);
+    expect(isRevalidationStale(1000, 1000 + 30_000, 30_000)).toBe(true);
+    expect(isRevalidationStale(1000, 1000 + 60_000, 30_000)).toBe(true);
   });
 });
 

--- a/apps/mesh/src/mcp-clients/mcp-list-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-list-cache.ts
@@ -95,6 +95,31 @@ export class JetStreamKVMcpListCache implements McpListCache {
 // Module-level revalidation tracking (prevents thundering herd)
 const revalidating = new Set<string>();
 
+// Per-(type,connection) timestamp of the last revalidation we scheduled, used to
+// throttle background revalidation. Without it, every cache hit reconnects
+// downstream — so a UI polling tools/list every few seconds hammers the upstream
+// server with one MCP handshake + list per poll, forever. The connection
+// create/update path eagerly repopulates this cache (see tools/connection/*),
+// so config-driven changes stay instant; only autonomous downstream tool
+// changes lag, by at most the throttle interval.
+const lastRevalidatedAt = new Map<string, number>();
+
+/** Default minimum gap between background revalidations of the same list. */
+export const REVALIDATE_MIN_INTERVAL_MS = 30_000;
+
+/**
+ * Pure throttle predicate: is a list due for background revalidation?
+ * `minIntervalMs <= 0` disables throttling (always stale → always revalidate).
+ */
+export function isRevalidationStale(
+  lastMs: number | undefined,
+  nowMs: number,
+  minIntervalMs: number,
+): boolean {
+  if (minIntervalMs <= 0) return true;
+  return nowMs - (lastMs ?? 0) >= minIntervalMs;
+}
+
 function isMethodNotFound(err: unknown): boolean {
   return err instanceof McpError && err.code === ErrorCode.MethodNotFound;
 }
@@ -117,6 +142,7 @@ export async function fetchWithCache(
   fetchLive: () => Promise<unknown[]>,
   cache: McpListCache | null,
   onRevalidation?: (promise: Promise<void>) => void,
+  minRevalidateIntervalMs = 0,
 ): Promise<unknown[] | null> {
   if (!cache) {
     try {
@@ -132,6 +158,8 @@ export async function fetchWithCache(
     }
   }
 
+  const revalKey = `${type}:${connectionId}`;
+
   // Check cache first
   const cached = await cache.get(type, connectionId);
 
@@ -140,6 +168,9 @@ export async function fetchWithCache(
     try {
       const data = await fetchLive();
       cache.set(type, connectionId, data).catch(() => {});
+      // A live fetch just refreshed the data — start the throttle clock so an
+      // immediate subsequent hit doesn't redundantly revalidate.
+      lastRevalidatedAt.set(revalKey, Date.now());
       cacheCounter.add(1, { type, outcome: "miss", stage: "miss" });
       return data;
     } catch (err) {
@@ -157,10 +188,16 @@ export async function fetchWithCache(
   }
 
   cacheCounter.add(1, { type, outcome: "hit", stage: "hit" });
-  // Cache hit: return immediately, revalidate in background
-  const revalKey = `${type}:${connectionId}`;
-  if (!revalidating.has(revalKey)) {
+  // Cache hit: return immediately, revalidate in background — but only if the
+  // list is stale enough (throttle) and no revalidation is already in flight.
+  const isStale = isRevalidationStale(
+    lastRevalidatedAt.get(revalKey),
+    Date.now(),
+    minRevalidateIntervalMs,
+  );
+  if (isStale && !revalidating.has(revalKey)) {
     revalidating.add(revalKey);
+    lastRevalidatedAt.set(revalKey, Date.now());
     const revalPromise = fetchLive()
       .then((data) => cache.set(type, connectionId, data))
       .catch((err) => {

--- a/apps/mesh/src/mcp-clients/mcp-list-cache.ts
+++ b/apps/mesh/src/mcp-clients/mcp-list-cache.ts
@@ -116,8 +116,9 @@ export function isRevalidationStale(
   nowMs: number,
   minIntervalMs: number,
 ): boolean {
-  if (minIntervalMs <= 0) return true;
-  return nowMs - (lastMs ?? 0) >= minIntervalMs;
+  if (minIntervalMs <= 0) return true; // throttle disabled
+  if (lastMs === undefined) return true; // never revalidated → always stale
+  return nowMs - lastMs >= minIntervalMs;
 }
 
 function isMethodNotFound(err: unknown): boolean {

--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -11,6 +11,7 @@ import {
   type McpListCache,
   getMcpListCache,
   fetchWithCache,
+  REVALIDATE_MIN_INTERVAL_MS,
 } from "@/mcp-clients/mcp-list-cache";
 import type { ConnectionEntity } from "@/tools/connection/schema";
 import { AccessControl } from "@/core/access-control";
@@ -100,6 +101,7 @@ export class AuthTransport extends WrapperTransport {
       },
       cache,
       (p) => this.options.ctx.pendingRevalidations.push(p),
+      REVALIDATE_MIN_INTERVAL_MS,
     );
 
     if (!tools) {

--- a/apps/mesh/src/tools/connection/get.ts
+++ b/apps/mesh/src/tools/connection/get.ts
@@ -16,6 +16,7 @@ import { getBaseUrl } from "../../core/server-constants";
 import {
   getMcpListCache,
   fetchWithCache,
+  REVALIDATE_MIN_INTERVAL_MS,
 } from "../../mcp-clients/mcp-list-cache";
 import { clientFromConnection } from "../../mcp-clients";
 import {
@@ -95,6 +96,7 @@ export const COLLECTION_CONNECTIONS_GET = defineTool({
         fetchLive,
         getMcpListCache(),
         (p) => ctx.pendingRevalidations.push(p),
+        REVALIDATE_MIN_INTERVAL_MS,
       );
       if (tools !== null) {
         connection.tools = tools as Tool[];


### PR DESCRIPTION
…d OAuth error handling

- Introduced method-based decision logic for connection probing, allowing for optimized handling of cached lists.
- Implemented improved OAuth error handling to surface upstream 401 responses, enabling frontend OAuth popups for expired or missing credentials.
- Updated proxy handshake logic to ensure efficient connection management and error reporting.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize MCP proxy connection handling by probing downstream only when needed, throttling background list revalidation, and surfacing OAuth 401s correctly. This cuts handshakes for cached list polls and reduces upstream load during frequent polling while still enabling frontend OAuth popups.

- New Features
  - Method-based handshake probing with cache-aware skipping for `tools/list`, `resources/list`, and `prompts/list`; always probe `initialize`, `tools/call`, and reads; skip notifications and `ping`.
  - `peekRpcMethod` safely reads the JSON-RPC method from POST bodies without consuming the stream and skips oversized bodies.
  - Throttled background revalidation of cached lists with a minimum interval (30s default) via `isRevalidationStale`; applied in the lazy client, auth transport, and connection tools. Added e2e coverage to ensure repeated `tools/list` polls don’t re-handshake.

- Bug Fixes
  - Surface upstream OAuth 401s as `WWW-Authenticate` responses in proxy and handshake paths, enabling the frontend OAuth popup instead of returning JSON-RPC errors or 500s.

<sup>Written for commit 15e596998746b4b0104d3dbca470fad8b13bdd60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

