### PR TITLE
fix(oauth): bound protected-resource discovery fetches with timeout + retry

### DIFF
--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -79,7 +79,7 @@ async function checkOriginSupportsOAuth(
   headers: Record<string, string> = {},
 ): Promise<string | null> {
   try {
-    const response = await fetch(connectionUrl, {
+    const response = await fetchWithTimeout(connectionUrl, {
       method: "POST",
       headers: {
         ...headers,
@@ -135,7 +135,7 @@ async function checkHasOAuthMetadata(connectionUrl: string): Promise<boolean> {
       "/.well-known/oauth-authorization-server",
       connUrl.origin,
     );
-    const authServerRes = await fetch(authServerUrl.toString(), {
+    const authServerRes = await fetchWithTimeout(authServerUrl.toString(), {
       method: "GET",
       headers: { Accept: "application/json" },
     });
@@ -172,11 +172,13 @@ export async function fetchProtectedResourceMetadata(
     resourcePath = resourcePath.slice(0, -1);
   }
 
-  // Try format 1 first (most common)
+  // Try format 1 first (most common). Each format fetch is timeout-bounded and
+  // retried for transient failures so a slow/hung upstream can't stall discovery
+  // (see fetchMetadataWithRetry).
   const format1Url = new URL(connectionUrl);
   format1Url.pathname = `${resourcePath}/.well-known/oauth-protected-resource`;
 
-  let response = await fetch(format1Url.toString(), {
+  let response = await fetchMetadataWithRetry(format1Url.toString(), {
     method: "GET",
     headers: { Accept: "application/json" },
   });
@@ -190,7 +192,7 @@ export async function fetchProtectedResourceMetadata(
   const format2Url = new URL(connectionUrl);
   format2Url.pathname = `/.well-known/oauth-protected-resource${resourcePath}`;
 
-  response = await fetch(format2Url.toString(), {
+  response = await fetchMetadataWithRetry(format2Url.toString(), {
     method: "GET",
     headers: { Accept: "application/json" },
   });
@@ -200,7 +202,7 @@ export async function fetchProtectedResourceMetadata(
   const format3Url = new URL(connectionUrl);
   format3Url.pathname = `/.well-known/oauth-protected-resource`;
 
-  response = await fetch(format3Url.toString(), {
+  response = await fetchMetadataWithRetry(format3Url.toString(), {
     method: "GET",
     headers: { Accept: "application/json" },
   });
@@ -621,23 +623,55 @@ export const createOrgScopedWellKnownProtectedResourceRoutes = () => {
  * Returns the response (even if error) so caller can handle/pass-through error status
  */
 /**
- * GET with bounded retry for transient failures. The auth-server metadata
- * endpoints are third-party; a momentary 5xx or network blip otherwise surfaces
- * to the client as a hard 502 (and made the OAuth-proxy E2E suite flaky against
- * live providers like Supabase). Retries network errors and 5xx responses with
- * short backoff; 4xx (incl. 404/401, which drive well-known format fallback) is
+ * Per-attempt timeout for third-party OAuth discovery fetches. A slow upstream
+ * (observed: a ~15s hang on a cold CDN edge for OpenRouter's protected-resource
+ * endpoint) must not stall discovery for the full socket lifetime. 4s is ample
+ * headroom for a healthy metadata endpoint (real ones answer well under 1s)
+ * while aborting a true hang fast enough that 3 attempts stay comfortably under
+ * the OAuth-proxy E2E suite's 15s budget.
+ */
+const METADATA_FETCH_TIMEOUT_MS = 4000;
+
+/**
+ * GET/POST a third-party endpoint with a bounded per-attempt timeout. Discovery
+ * endpoints occasionally hang; without a deadline a single slow upstream stalls
+ * OAuth discovery indefinitely (and tipped the protected-resource E2E test past
+ * its 15s timeout). Returns the fetch Response; aborts (and throws) after
+ * `timeoutMs`. Callers that swallow errors to a fallback (null/false) pass no
+ * retry; callers that want transient-failure resilience use
+ * `fetchMetadataWithRetry`.
+ */
+function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = METADATA_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+}
+
+/**
+ * GET with a bounded per-attempt timeout and bounded retry for transient
+ * failures. The metadata endpoints are third-party; a momentary 5xx, network
+ * blip, or slow/hung response otherwise surfaces to the client as a hard 502 or
+ * a stalled request (and made the OAuth-proxy E2E suite flaky against live
+ * providers like Supabase and OpenRouter). Aborts each attempt after
+ * `timeoutMs`, retries network errors / timeouts / 5xx responses with short
+ * backoff; 4xx (incl. 404/401, which drive well-known format fallback) is
  * returned as-is so the caller's discovery logic is unchanged.
  */
 async function fetchMetadataWithRetry(
   url: string,
   init: RequestInit,
-  attempts = 3,
+  {
+    attempts = 3,
+    timeoutMs = METADATA_FETCH_TIMEOUT_MS,
+  }: { attempts?: number; timeoutMs?: number } = {},
 ): Promise<Response> {
   let lastErr: unknown;
   for (let i = 0; i < attempts; i++) {
     const isLast = i === attempts - 1;
     try {
-      const res = await fetch(url, init);
+      const res = await fetchWithTimeout(url, init, timeoutMs);
       if (res.status < 500 || isLast) return res;
     } catch (err) {
       lastErr = err;


### PR DESCRIPTION
## Failing CI

`storage-integration` failed on the OAuth-proxy E2E test:

```
(fail) MCP OAuth Proxy E2E > Protected Resource Metadata > OpenRouter - discovery and URL rewriting [15000.52ms]
  ^ this test timed out after 15000ms.
```

The upstream request `GET /.well-known/oauth-protected-resource/mcp/conn_openrouter` took **15.1s** while every other provider (Stripe 190ms, Deco GitHub 611ms, …) and even OpenRouter's *other* sub-tests (auth-server 534ms, authorize 269ms) were fast.

## Root cause

The **protected-resource discovery path** (`fetchProtectedResourceMetadata`) used bare `fetch()` with **no timeout and no retry**, so a single slow/hung upstream (here, a cold CDN edge for `sites-openrouter.decocache.com`) stalls OAuth discovery for the full socket lifetime — tipping the test past its 15s budget.

The **auth-server path** was already hardened with `fetchMetadataWithRetry` in the most recent commit to this file (#3567), added — per its own comment — because *"a momentary 5xx or network blip… made the OAuth-proxy E2E suite flaky against live providers like Supabase."* The same resilience was simply never applied to the protected-resource path.

## Fix

Close the gap with the same, maintainer-consistent mechanism:

- `fetchMetadataWithRetry` now adds a **per-attempt `AbortSignal.timeout` (4s)** on top of its existing 5xx/network-error retry, and the three protected-resource format fetches in `fetchProtectedResourceMetadata` now route through it.
- The two swallow-to-fallback probes — `checkOriginSupportsOAuth` (POST) and `checkHasOAuthMetadata` (GET) — get a bare timeout via a new `fetchWithTimeout` helper so the fallback path can't hang either.

This is a **production-resilience improvement** (a slow third-party MCP server no longer stalls OAuth discovery) that also de-flakes the E2E suite. A hung attempt is aborted at 4s and retried against a now-warm edge; worst case stays well under the 15s test budget.

**No semantic change** to URL rewriting, well-known format fallback (404/401/406 → next format), synthetic-metadata generation, or the existing 4xx/502 error contract.

## Testing

- `oauth-proxy.test.ts` (hermetic, mocked fetch): **26 pass / 0 fail** — incl. "returns 502 when origin fetch fails", "falls back to format 2 when format 1 returns 404" (exact call-count/URL assertions), and all synthetic-metadata paths.
- `oauth-proxy.integration.test.ts` (11 live servers, real Postgres): **44 pass / 0 fail**; OpenRouter protected-resource now **65ms** (was 15.1s).
- `bun run fmt` ✅ · `bun run lint` ✅ (0 errors) · `bun run check` ✅
- Design adversarially reviewed (multi-agent): no unit-test regressions; every fetch on the handler's critical path is bounded after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound OAuth protected-resource discovery with a per-attempt 4s timeout and retry to prevent hangs and de-flake CI. Aligns the protected-resource path with the existing auth-server resilience and keeps discovery under the 15s test budget.

- **Bug Fixes**
  - Use `fetchMetadataWithRetry` (now with `AbortSignal.timeout(4000)`) for all three protected-resource format fetches; retries on timeouts, network errors, and 5xx.
  - Add `fetchWithTimeout` to `checkOriginSupportsOAuth` and `checkHasOAuthMetadata` so fallback checks never hang.
  - No changes to URL rewriting, fallback order, synthetic metadata, or the 4xx/502 error contract.

<sup>Written for commit 9e8721276b5058512993ed604b95e41c1e52cca9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

