### PR TITLE
fix(connections): exclude Local Files from app-scoped connection lists

### DIFF
--- a/apps/mesh/src/tools/connection/list.ts
+++ b/apps/mesh/src/tools/connection/list.ts
@@ -42,6 +42,7 @@ import {
 } from "./dev-assets";
 import { type ConnectionEntity, ConnectionEntitySchema } from "./schema";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
+import { connectionMatchesWhere } from "./where-match";
 
 /**
  * Registry binding: matches connections that expose COLLECTION_REGISTRY_APP_LIST
@@ -209,7 +210,11 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
       const baseUrl = getBaseUrl();
       const devAssetsId = WellKnownOrgMCPId.DEV_ASSETS(organization.id);
 
-      // Only add if not already in the list and if it matches the slug filter (if any)
+      // Only add it when it isn't already present and when it would satisfy the
+      // caller's filters. The dev-assets row is injected after the SQL query, so
+      // without re-checking the slug and `where` filters here it would bypass
+      // them — e.g. leaking into the agent instance selector's `app_name` filter
+      // and appearing as a selectable instance for every connection.
       if (!connections.some((c) => c.id === devAssetsId)) {
         const devAssetsConnection = createDevAssetsConnectionEntity(
           organization.id,
@@ -217,7 +222,11 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
         );
         const slugMatches =
           !input.slug || getConnectionSlug(devAssetsConnection) === input.slug;
-        if (slugMatches) {
+        const whereMatches = connectionMatchesWhere(
+          devAssetsConnection,
+          input.where,
+        );
+        if (slugMatches && whereMatches) {
           connections.unshift(devAssetsConnection);
         }
       }

--- a/apps/mesh/src/tools/connection/where-match.test.ts
+++ b/apps/mesh/src/tools/connection/where-match.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "bun:test";
+import type { ConnectionEntity } from "./schema";
+import { connectionMatchesWhere } from "./where-match";
+
+/**
+ * Minimal stand-in for the synthetic "Local Files" (dev-assets) connection.
+ * The matcher only reads entity fields, so a partial literal is sufficient.
+ */
+const devAssets = {
+  id: "org_1_dev-assets",
+  title: "Local Files",
+  description:
+    "Local file storage for development. Files are stored in /data/assets/.",
+  app_name: "@deco/dev-assets-mcp",
+  connection_type: "HTTP",
+  connection_url: "http://localhost:3000/mcp/dev-assets",
+  status: "active",
+  bindings: ["OBJECT_STORAGE"],
+} as unknown as ConnectionEntity;
+
+describe("connectionMatchesWhere", () => {
+  it("returns true when there is no where filter", () => {
+    expect(connectionMatchesWhere(devAssets, undefined)).toBe(true);
+  });
+
+  it("excludes the dev-assets connection from an app_name filter for a different app (the instance-selector bug)", () => {
+    // The agent instance selector queries with app_name = <the connection's app>.
+    // Local Files must NOT leak into every app's instance dropdown.
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["app_name"],
+        operator: "eq",
+        value: "@deco/cms",
+      }),
+    ).toBe(false);
+  });
+
+  it("includes the dev-assets connection when the app_name filter targets its own app", () => {
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["app_name"],
+        operator: "eq",
+        value: "@deco/dev-assets-mcp",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches a case-insensitive `contains` search against the title", () => {
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["title"],
+        operator: "contains",
+        value: "FILES",
+      }),
+    ).toBe(true);
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["title"],
+        operator: "contains",
+        value: "cms",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats an unknown/absent field as a no-op (mirrors applyWhereToSql)", () => {
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["nonexistent_field"],
+        operator: "eq",
+        value: "whatever",
+      }),
+    ).toBe(true);
+  });
+
+  it("resolves the derived `slug` field via getConnectionSlug", () => {
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["slug"],
+        operator: "eq",
+        value: "@deco/dev-assets-mcp",
+      }),
+    ).toBe(true);
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["slug"],
+        operator: "eq",
+        value: "@deco/cms",
+      }),
+    ).toBe(false);
+  });
+
+  it("supports the `in` operator", () => {
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["connection_type"],
+        operator: "in",
+        value: ["HTTP", "SSE"],
+      }),
+    ).toBe(true);
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["connection_type"],
+        operator: "in",
+        value: ["STDIO"],
+      }),
+    ).toBe(false);
+    // Non-array value mirrors SQL's `false`
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["connection_type"],
+        operator: "in",
+        value: "HTTP",
+      }),
+    ).toBe(false);
+  });
+
+  it("supports the `like` operator with SQL wildcards, case-insensitively", () => {
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["app_name"],
+        operator: "like",
+        value: "@deco/%",
+      }),
+    ).toBe(true);
+    expect(
+      connectionMatchesWhere(devAssets, {
+        field: ["app_name"],
+        operator: "like",
+        value: "@other/%",
+      }),
+    ).toBe(false);
+  });
+
+  describe("logical operators", () => {
+    it("`and` requires every condition to match", () => {
+      expect(
+        connectionMatchesWhere(devAssets, {
+          operator: "and",
+          conditions: [
+            {
+              field: ["app_name"],
+              operator: "eq",
+              value: "@deco/dev-assets-mcp",
+            },
+            { field: ["connection_type"], operator: "eq", value: "HTTP" },
+          ],
+        }),
+      ).toBe(true);
+      expect(
+        connectionMatchesWhere(devAssets, {
+          operator: "and",
+          conditions: [
+            {
+              field: ["app_name"],
+              operator: "eq",
+              value: "@deco/dev-assets-mcp",
+            },
+            { field: ["connection_type"], operator: "eq", value: "STDIO" },
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    it("`or` requires at least one condition to match", () => {
+      expect(
+        connectionMatchesWhere(devAssets, {
+          operator: "or",
+          conditions: [
+            { field: ["app_name"], operator: "eq", value: "@deco/cms" },
+            { field: ["connection_type"], operator: "eq", value: "HTTP" },
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it("`not` negates the conjunction of its conditions", () => {
+      expect(
+        connectionMatchesWhere(devAssets, {
+          operator: "not",
+          conditions: [
+            { field: ["app_name"], operator: "eq", value: "@deco/cms" },
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it("an empty condition list is a no-op (true)", () => {
+      expect(
+        connectionMatchesWhere(devAssets, { operator: "and", conditions: [] }),
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/mesh/src/tools/connection/where-match.ts
+++ b/apps/mesh/src/tools/connection/where-match.ts
@@ -1,0 +1,117 @@
+/**
+ * In-memory evaluation of a collection `WhereExpression` against a single
+ * ConnectionEntity.
+ *
+ * The synthetic "Local Files" (dev-assets) connection is injected into
+ * COLLECTION_CONNECTIONS_LIST *after* the SQL query runs, so it bypasses the
+ * caller's `where` filter. Without this guard the dev-assets row leaks into
+ * queries scoped to a different app — e.g. the agent instance selector filters
+ * by `app_name = <app>`, yet Local Files appeared as a selectable instance for
+ * every connection. This evaluates the same `where` against the injected row so
+ * it is only added when it would have matched the query.
+ *
+ * Semantics intentionally mirror `applyWhereToSql()` in
+ * ../../storage/connection.ts:
+ *  - `and`/`or`/`not`, and an empty condition list => true
+ *  - a comparison on a field the entity does not have => no-op (true)
+ *  - `like`/`contains` are case-insensitive (Postgres ILIKE)
+ */
+
+import { getConnectionSlug } from "@/shared/utils/connection-slug";
+import type { WhereExpression } from "@decocms/bindings/collections";
+import type { ConnectionEntity } from "./schema";
+
+function resolveFieldValue(
+  connection: ConnectionEntity,
+  field: string[],
+): unknown {
+  if (field.length === 0) return undefined;
+  const [head, ...rest] = field;
+
+  // `slug` is a derived column in SQL; compute it the same way here so a slug
+  // filter resolves consistently for the synthetic connection.
+  let current: unknown =
+    head === "slug"
+      ? getConnectionSlug(connection)
+      : (connection as unknown as Record<string, unknown>)[head!];
+
+  for (const key of rest) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/** Translate a SQL LIKE/ILIKE pattern (`%`, `_`) into a case-insensitive regex. */
+function likeToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const translated = escaped.replace(/%/g, ".*").replace(/_/g, ".");
+  return new RegExp(`^${translated}$`, "i");
+}
+
+function matchesComparison(
+  fieldValue: unknown,
+  operator: string,
+  value: unknown,
+): boolean {
+  // Field absent on the entity: mirror SQL's "unknown field => true" no-op so
+  // we never hide the connection based on a filter it cannot be evaluated
+  // against (e.g. excluded/sensitive columns).
+  if (fieldValue === undefined) return true;
+
+  switch (operator) {
+    case "eq":
+      return value === null ? fieldValue === null : fieldValue === value;
+    case "gt":
+      return (fieldValue as number) > (value as number);
+    case "gte":
+      return (fieldValue as number) >= (value as number);
+    case "lt":
+      return (fieldValue as number) < (value as number);
+    case "lte":
+      return (fieldValue as number) <= (value as number);
+    case "in":
+      return Array.isArray(value) && value.includes(fieldValue);
+    case "like":
+      return (
+        typeof fieldValue === "string" &&
+        likeToRegExp(String(value)).test(fieldValue)
+      );
+    case "contains":
+      return String(fieldValue)
+        .toLowerCase()
+        .includes(String(value).toLowerCase());
+    default:
+      return true;
+  }
+}
+
+/**
+ * Returns true when `connection` satisfies the `where` expression (or when
+ * there is no filter).
+ */
+export function connectionMatchesWhere(
+  connection: ConnectionEntity,
+  where: WhereExpression | undefined,
+): boolean {
+  if (!where) return true;
+
+  if ("conditions" in where) {
+    const { operator, conditions } = where;
+    if (conditions.length === 0) return true;
+    switch (operator) {
+      case "and":
+        return conditions.every((c) => connectionMatchesWhere(connection, c));
+      case "or":
+        return conditions.some((c) => connectionMatchesWhere(connection, c));
+      case "not":
+        // SQL: NOT (c1 AND c2 ...)
+        return !conditions.every((c) => connectionMatchesWhere(connection, c));
+      default:
+        return true;
+    }
+  }
+
+  const fieldValue = resolveFieldValue(connection, where.field);
+  return matchesComparison(fieldValue, where.operator, where.value);
+}


### PR DESCRIPTION
## What is this contribution about?
The synthetic dev-assets **"Local Files"** connection is injected into `COLLECTION_CONNECTIONS_LIST` *after* the SQL query runs, so it bypassed the caller's `where` filter and leaked into app-scoped queries. Because the agent connection **instance selector** filters by `app_name`, Local Files showed up as a selectable instance for *every* connection (and, being always present, made the selector render even for single-instance apps). This re-applies the query's `where` to the injected row in-memory via a new pure `connectionMatchesWhere` evaluator (mirroring `applyWhereToSql` semantics) before injecting it, so the row is only added when it actually matches.

## Screenshots/Demonstration
Before: the "Deco CMS" connection on the Agent Manager showed a "Local Files / Deco CMS / + New instance" dropdown. After: no instance dropdown renders for Deco CMS (only one real instance), so Local Files can no longer be selected.

## How to Test
1. Run locally with no S3 configured (dev mode, so Local Files is active).
2. Open an agent's Settings and look at a connection (e.g. Deco CMS) that has a single instance — the instance selector must NOT offer "Local Files".
3. Confirm at the data layer: `COLLECTION_CONNECTIONS_LIST` with `where: app_name = "@deco/management-mcp"` returns only Deco CMS, while no filter still returns Local Files alongside the others. `bun test apps/mesh/src/tools/connection/where-match.test.ts` (12 passing).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the synthetic "Local Files" dev-assets connection from leaking into app-scoped connection lists by reapplying the query’s filters to the injected row. This removes the extra instance dropdown for single‑instance apps and prevents selecting Local Files where it doesn’t belong.

- **Bug Fixes**
  - Added `connectionMatchesWhere` to evaluate a `WhereExpression` in memory (supports `eq`, `in`, `like`, `contains`, `and`/`or`/`not`, derived `slug`, unknown fields treated as no-ops).
  - Updated `COLLECTION_CONNECTIONS_LIST` to inject Local Files only when both `slug` and `where` filters pass, so it no longer bypasses `app_name` filters in the agent instance selector.
  - Added tests for matcher semantics. General connection listing and the `OBJECT_STORAGE` binding path are unchanged.

<sup>Written for commit 14351539c67c585d4e2492c64eaa9e403a5520de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

