### PR TITLE
refactor(oauth-proxy): extract pure metadata transforms + mock-free unit tests

### DIFF
--- a/apps/mesh/src/api/routes/oauth-proxy-metadata.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy-metadata.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Pure unit tests for the OAuth proxy transforms. No mocks: every function
+ * here is data-in / data-out, so we just assert outputs. The fetch
+ * orchestration and connection lookup that wire these together live in
+ * oauth-proxy.ts and are covered by e2e against a real origin server.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  authorizationServerMetadataUrls,
+  buildPathPrefix,
+  isAuthError,
+  isAuthServerMetadata,
+  looksLikeOAuthWwwAuthenticate,
+  protectedResourceMetadataUrls,
+  resourceMetadataChallenge,
+  rewriteAuthServerMetadata,
+  rewriteProtectedResourceMetadata,
+  scopesFromOrigin,
+  syntheticProtectedResourceMetadata,
+} from "./oauth-proxy-metadata";
+
+describe("buildPathPrefix", () => {
+  test("org slug → /api/<slug>", () => {
+    expect(buildPathPrefix("acme")).toBe("/api/acme");
+  });
+  test("no slug → empty (legacy root shape)", () => {
+    expect(buildPathPrefix(undefined)).toBe("");
+  });
+});
+
+describe("protectedResourceMetadataUrls (RFC 9728 probe order)", () => {
+  test("emits resource-relative, well-known-prefix, then root", () => {
+    expect(
+      protectedResourceMetadataUrls("https://origin.example.com/mcp"),
+    ).toEqual([
+      "https://origin.example.com/mcp/.well-known/oauth-protected-resource",
+      "https://origin.example.com/.well-known/oauth-protected-resource/mcp",
+      "https://origin.example.com/.well-known/oauth-protected-resource",
+    ]);
+  });
+
+  test("strips a trailing slash on the resource path", () => {
+    const [format1] = protectedResourceMetadataUrls(
+      "https://origin.example.com/mcp/",
+    );
+    expect(format1).toBe(
+      "https://origin.example.com/mcp/.well-known/oauth-protected-resource",
+    );
+  });
+
+  test("handles a multi-segment resource path (Smithery-style)", () => {
+    expect(
+      protectedResourceMetadataUrls(
+        "https://server.smithery.ai/@exa-labs/exa-code-mcp/mcp",
+      ),
+    ).toEqual([
+      "https://server.smithery.ai/@exa-labs/exa-code-mcp/mcp/.well-known/oauth-protected-resource",
+      "https://server.smithery.ai/.well-known/oauth-protected-resource/@exa-labs/exa-code-mcp/mcp",
+      "https://server.smithery.ai/.well-known/oauth-protected-resource",
+    ]);
+  });
+
+  test("root-path connection collapses format 1 and 2 onto the root URL", () => {
+    expect(
+      protectedResourceMetadataUrls("https://origin.example.com/"),
+    ).toEqual([
+      "https://origin.example.com/.well-known/oauth-protected-resource",
+      "https://origin.example.com/.well-known/oauth-protected-resource",
+      "https://origin.example.com/.well-known/oauth-protected-resource",
+    ]);
+  });
+});
+
+describe("authorizationServerMetadataUrls (RFC 8414 / OIDC probe order)", () => {
+  test("root issuer → OAuth 2.0 then OIDC, no path suffix", () => {
+    expect(
+      authorizationServerMetadataUrls("https://auth.example.com/"),
+    ).toEqual([
+      "https://auth.example.com/.well-known/oauth-authorization-server",
+      "https://auth.example.com/.well-known/openid-configuration",
+    ]);
+    for (const url of authorizationServerMetadataUrls(
+      "https://auth.example.com/",
+    )) {
+      expect(url).not.toEndWith("/");
+    }
+  });
+
+  test("issuer with a path → insertion (OAuth + OIDC) then append (OIDC)", () => {
+    expect(
+      authorizationServerMetadataUrls("https://auth.example.com/tenant1"),
+    ).toEqual([
+      "https://auth.example.com/.well-known/oauth-authorization-server/tenant1",
+      "https://auth.example.com/.well-known/openid-configuration/tenant1",
+      "https://auth.example.com/tenant1/.well-known/openid-configuration",
+    ]);
+  });
+
+  test("deep issuer path is preserved verbatim", () => {
+    const [oauth] = authorizationServerMetadataUrls(
+      "https://auth.example.com/v1/oauth/server",
+    );
+    expect(oauth).toBe(
+      "https://auth.example.com/.well-known/oauth-authorization-server/v1/oauth/server",
+    );
+  });
+});
+
+describe("isAuthServerMetadata", () => {
+  test("true for AS metadata (issuer + endpoints, no resource)", () => {
+    expect(
+      isAuthServerMetadata({
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+      }),
+    ).toBe(true);
+  });
+
+  test("false when a resource field is present (real PR metadata)", () => {
+    expect(
+      isAuthServerMetadata({
+        issuer: "https://auth.example.com",
+        resource: "https://origin.example.com/mcp",
+        authorization_endpoint: "https://auth.example.com/authorize",
+      }),
+    ).toBe(false);
+  });
+
+  test("false when there are no endpoint fields", () => {
+    expect(isAuthServerMetadata({ issuer: "https://auth.example.com" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("looksLikeOAuthWwwAuthenticate", () => {
+  test("true for RFC 9728 resource_metadata", () => {
+    expect(
+      looksLikeOAuthWwwAuthenticate(
+        'Bearer resource_metadata="https://x/.well-known/oauth-protected-resource"',
+      ),
+    ).toBe(true);
+  });
+  test("true for standard OAuth hints (invalid_token / oauth)", () => {
+    expect(looksLikeOAuthWwwAuthenticate('Bearer error="invalid_token"')).toBe(
+      true,
+    );
+    expect(looksLikeOAuthWwwAuthenticate("OAuth realm=mcp")).toBe(true);
+  });
+  test("false for a bare Bearer/API-key challenge", () => {
+    expect(looksLikeOAuthWwwAuthenticate('Bearer realm="api"')).toBe(false);
+  });
+});
+
+describe("isAuthError", () => {
+  test("true on status/code 401", () => {
+    expect(isAuthError({ status: 401 })).toBe(true);
+    expect(isAuthError({ code: 401 })).toBe(true);
+  });
+  test("true on auth-flavored messages", () => {
+    expect(isAuthError({ message: "HTTP 401 Unauthorized" })).toBe(true);
+    expect(isAuthError({ message: "invalid_token" })).toBe(true);
+    expect(isAuthError({ message: "API key required" })).toBe(true);
+    expect(isAuthError({ message: "api-key required" })).toBe(true);
+  });
+  test("false for unrelated errors", () => {
+    expect(isAuthError({ status: 500, message: "boom" })).toBe(false);
+    expect(isAuthError({})).toBe(false);
+  });
+});
+
+const PROXY = {
+  proxyResourceUrl: "http://localhost:3000/mcp/conn_123",
+  proxyAuthServer: "http://localhost:3000/oauth-proxy/conn_123",
+};
+
+describe("rewriteProtectedResourceMetadata", () => {
+  test("rewrites resource + authorization_servers, preserves other fields", () => {
+    expect(
+      rewriteProtectedResourceMetadata(
+        {
+          resource: "https://origin.example.com/mcp",
+          authorization_servers: ["https://origin.example.com"],
+          scopes_supported: ["read", "write"],
+        },
+        PROXY,
+      ),
+    ).toEqual({
+      resource: "http://localhost:3000/mcp/conn_123",
+      authorization_servers: ["http://localhost:3000/oauth-proxy/conn_123"],
+      scopes_supported: ["read", "write"],
+    });
+  });
+});
+
+describe("syntheticProtectedResourceMetadata", () => {
+  test("defaults scopes to ['*']", () => {
+    expect(syntheticProtectedResourceMetadata(PROXY)).toEqual({
+      resource: "http://localhost:3000/mcp/conn_123",
+      authorization_servers: ["http://localhost:3000/oauth-proxy/conn_123"],
+      bearer_methods_supported: ["header"],
+      scopes_supported: ["*"],
+    });
+  });
+
+  test("honors provided scopes and never spreads origin fields", () => {
+    const out = syntheticProtectedResourceMetadata({
+      ...PROXY,
+      scopesSupported: ["a", "b"],
+    });
+    expect(out.scopes_supported).toEqual(["a", "b"]);
+    expect(out).not.toHaveProperty("issuer");
+  });
+});
+
+describe("scopesFromOrigin", () => {
+  test("uses a non-empty origin scopes array", () => {
+    expect(scopesFromOrigin({ scopes_supported: ["x"] })).toEqual(["x"]);
+  });
+  test("falls back to ['*'] for empty/missing/non-array", () => {
+    expect(scopesFromOrigin({ scopes_supported: [] })).toEqual(["*"]);
+    expect(scopesFromOrigin({})).toEqual(["*"]);
+    expect(scopesFromOrigin({ scopes_supported: "nope" })).toEqual(["*"]);
+  });
+});
+
+describe("rewriteAuthServerMetadata", () => {
+  const base = "http://localhost:3000/api/acme/oauth-proxy/conn_123";
+
+  test("rewrites present endpoints to our proxy, preserves other fields", () => {
+    expect(
+      rewriteAuthServerMetadata(
+        {
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+        },
+        base,
+      ),
+    ).toEqual({
+      issuer: "https://auth.example.com",
+      authorization_endpoint: `${base}/authorize`,
+      token_endpoint: `${base}/token`,
+      registration_endpoint: `${base}/register`,
+    });
+  });
+
+  test("leaves absent endpoints undefined (does not invent them)", () => {
+    const out = rewriteAuthServerMetadata(
+      {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+      },
+      base,
+    );
+    expect(out.registration_endpoint).toBeUndefined();
+    expect(out.authorization_endpoint).toBe(`${base}/authorize`);
+  });
+});
+
+describe("resourceMetadataChallenge", () => {
+  test("legacy shape (no prefix)", () => {
+    expect(
+      resourceMetadataChallenge({
+        origin: "http://localhost:3000",
+        prefix: "",
+        connectionId: "conn_123",
+      }),
+    ).toBe(
+      'Bearer realm="mcp",resource_metadata="http://localhost:3000/mcp/conn_123/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  test("org-scoped shape (with /api/<slug> prefix)", () => {
+    expect(
+      resourceMetadataChallenge({
+        origin: "http://localhost:3000",
+        prefix: "/api/acme",
+        connectionId: "conn_123",
+      }),
+    ).toBe(
+      'Bearer realm="mcp",resource_metadata="http://localhost:3000/api/acme/mcp/conn_123/.well-known/oauth-protected-resource"',
+    );
+  });
+});

--- a/apps/mesh/src/api/routes/oauth-proxy-metadata.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy-metadata.ts
@@ -1,0 +1,238 @@
+/**
+ * Pure transforms for the OAuth proxy.
+ *
+ * Everything here is data-in / data-out: no fetch, no storage, no Hono. The
+ * OAuth proxy's genuinely tricky parts — RFC 9728 / RFC 8414 / OIDC well-known
+ * URL-format probing order, rewriting an origin's metadata to point back at our
+ * proxy, synthesizing metadata for servers that don't implement RFC 9728, and
+ * classifying auth challenges — all live here so they can be unit-tested
+ * without mocking `fetch` or the connection store.
+ *
+ * The handlers in `oauth-proxy.ts` wire these to real origin fetches and the
+ * connection lookup; that fetch orchestration is covered by e2e against a real
+ * origin server, not by faking `fetch`.
+ */
+
+/**
+ * HTTP statuses that mean "no metadata at this path, but the server might
+ * support OAuth elsewhere" — they drive the well-known URL-format fallback.
+ * - 404: path not found (most common)
+ * - 401: some servers return this for metadata endpoints
+ * - 406: Grain returns this when MCP endpoints don't support .well-known paths
+ */
+export const NO_METADATA_STATUSES = [404, 401, 406];
+
+/**
+ * URL prefix for OAuth-related URLs based on org slug.
+ * - With slug: `/api/${slug}` (org-scoped path shape)
+ * - Without slug: `` (legacy shape — `/mcp/...` / `/oauth-proxy/...` at root)
+ */
+export function buildPathPrefix(orgSlug: string | undefined): string {
+  return orgSlug ? `/api/${orgSlug}` : "";
+}
+
+/**
+ * The RFC 9728 protected-resource-metadata well-known URLs to probe, in order:
+ *   1. `{resource}/.well-known/oauth-protected-resource` (resource-relative)
+ *   2. `/.well-known/oauth-protected-resource{resource-path}` (well-known
+ *      prefix — Smithery-style)
+ *   3. `/.well-known/oauth-protected-resource` (root)
+ * Per RFC 9728 the resource path's trailing slash is stripped first.
+ */
+export function protectedResourceMetadataUrls(connectionUrl: string): string[] {
+  const connUrl = new URL(connectionUrl);
+  let resourcePath = connUrl.pathname;
+  if (resourcePath.endsWith("/")) {
+    resourcePath = resourcePath.slice(0, -1);
+  }
+
+  const withPathname = (pathname: string): string => {
+    const u = new URL(connectionUrl);
+    u.pathname = pathname;
+    return u.toString();
+  };
+
+  return [
+    withPathname(`${resourcePath}/.well-known/oauth-protected-resource`),
+    withPathname(`/.well-known/oauth-protected-resource${resourcePath}`),
+    withPathname(`/.well-known/oauth-protected-resource`),
+  ];
+}
+
+/**
+ * The authorization-server-metadata well-known URLs to probe, in order.
+ *
+ * With a path component (e.g. `https://auth.example.com/tenant1`):
+ *   1. OAuth 2.0 with path insertion:
+ *      `/.well-known/oauth-authorization-server/tenant1`
+ *   2. OIDC with path insertion: `/.well-known/openid-configuration/tenant1`
+ *   3. OIDC with path append: `/tenant1/.well-known/openid-configuration`
+ * Without a path component:
+ *   1. `/.well-known/oauth-authorization-server`
+ *   2. `/.well-known/openid-configuration`
+ */
+export function authorizationServerMetadataUrls(
+  authServerUrl: string,
+): string[] {
+  const url = new URL(authServerUrl);
+  let authServerPath = url.pathname;
+  if (authServerPath.endsWith("/")) {
+    authServerPath = authServerPath.slice(0, -1);
+  }
+  const hasPath = authServerPath !== "" && authServerPath !== "/";
+
+  const withPathname = (pathname: string): string => {
+    const u = new URL(authServerUrl);
+    u.pathname = pathname;
+    return u.toString();
+  };
+
+  if (hasPath) {
+    return [
+      withPathname(`/.well-known/oauth-authorization-server${authServerPath}`),
+      withPathname(`/.well-known/openid-configuration${authServerPath}`),
+      withPathname(`${authServerPath}/.well-known/openid-configuration`),
+    ];
+  }
+  return [
+    withPathname("/.well-known/oauth-authorization-server"),
+    withPathname("/.well-known/openid-configuration"),
+  ];
+}
+
+/**
+ * True when `data` is RFC 8414 Authorization Server Metadata rather than RFC
+ * 9728 Protected Resource Metadata. Some servers (ClickHouse) incorrectly
+ * return AS metadata at the protected-resource endpoint: it carries `issuer`
+ * and endpoint URLs but no `resource`.
+ */
+export function isAuthServerMetadata(data: Record<string, unknown>): boolean {
+  return (
+    "issuer" in data &&
+    !("resource" in data) &&
+    ("authorization_endpoint" in data || "token_endpoint" in data)
+  );
+}
+
+/**
+ * Whether a `WWW-Authenticate` value is a *meaningful* OAuth challenge. MCP
+ * OAuth uses RFC 9728 `resource_metadata=` (strong signal); we also accept
+ * standard OAuth error hints for servers that don't implement RFC 9728.
+ */
+export function looksLikeOAuthWwwAuthenticate(wwwAuth: string): boolean {
+  const lower = wwwAuth.toLowerCase();
+  return (
+    lower.includes("resource_metadata=") ||
+    lower.includes("invalid_token") ||
+    lower.includes("oauth")
+  );
+}
+
+/** Classify a downstream connection error as a 401-style auth error. */
+export function isAuthError(error: {
+  message?: string;
+  status?: number;
+  code?: number;
+}): boolean {
+  const message = error.message?.toLowerCase() ?? "";
+  return (
+    error.status === 401 ||
+    error.code === 401 ||
+    (error.message?.includes("401") ?? false) ||
+    message.includes("unauthorized") ||
+    message.includes("invalid_token") ||
+    message.includes("api key required") ||
+    message.includes("api-key required")
+  );
+}
+
+export interface ProxyMetadataUrls {
+  /** `…/mcp/:connectionId` on our proxy (the `resource` value). */
+  proxyResourceUrl: string;
+  /** `…/oauth-proxy/:connectionId` on our proxy (the `authorization_servers` value). */
+  proxyAuthServer: string;
+}
+
+/**
+ * Rewrite an origin's protected-resource metadata so `resource` and
+ * `authorization_servers` point at our proxy, preserving every other field.
+ */
+export function rewriteProtectedResourceMetadata(
+  originData: Record<string, unknown>,
+  { proxyResourceUrl, proxyAuthServer }: ProxyMetadataUrls,
+): Record<string, unknown> {
+  return {
+    ...originData,
+    resource: proxyResourceUrl,
+    authorization_servers: [proxyAuthServer],
+  };
+}
+
+/**
+ * Clean synthetic protected-resource metadata pointing at our proxy, for
+ * servers that support OAuth but don't expose RFC 9728 metadata (or that
+ * returned AS metadata at the PR endpoint). We deliberately don't spread the
+ * origin fields, to avoid confusing MCP SDK clients with unexpected keys.
+ */
+export function syntheticProtectedResourceMetadata({
+  proxyResourceUrl,
+  proxyAuthServer,
+  scopesSupported = ["*"],
+}: ProxyMetadataUrls & {
+  scopesSupported?: unknown[];
+}): Record<string, unknown> {
+  return {
+    resource: proxyResourceUrl,
+    authorization_servers: [proxyAuthServer],
+    bearer_methods_supported: ["header"],
+    scopes_supported: scopesSupported,
+  };
+}
+
+/** Honor non-empty origin `scopes_supported`, else fall back to `["*"]`. */
+export function scopesFromOrigin(data: Record<string, unknown>): unknown[] {
+  return "scopes_supported" in data &&
+    Array.isArray(data.scopes_supported) &&
+    data.scopes_supported.length > 0
+    ? (data.scopes_supported as unknown[])
+    : ["*"];
+}
+
+/**
+ * Rewrite an origin auth server's endpoint URLs (authorize/token/register) to
+ * route through our proxy, preserving every other field. Endpoints absent on
+ * the origin stay absent (`undefined`).
+ */
+export function rewriteAuthServerMetadata(
+  originData: Record<string, unknown>,
+  proxyBase: string,
+): Record<string, unknown> {
+  return {
+    ...originData,
+    authorization_endpoint: originData.authorization_endpoint
+      ? `${proxyBase}/authorize`
+      : undefined,
+    token_endpoint: originData.token_endpoint
+      ? `${proxyBase}/token`
+      : undefined,
+    registration_endpoint: originData.registration_endpoint
+      ? `${proxyBase}/register`
+      : undefined,
+  };
+}
+
+/**
+ * The `WWW-Authenticate` challenge we return when the origin supports OAuth:
+ * advertises our proxy's `resource_metadata` discovery URL.
+ */
+export function resourceMetadataChallenge({
+  origin,
+  prefix,
+  connectionId,
+}: {
+  origin: string;
+  prefix: string;
+  connectionId: string;
+}): string {
+  return `Bearer realm="mcp",resource_metadata="${origin}${prefix}/mcp/${connectionId}/.well-known/oauth-protected-resource"`;
+}

--- a/apps/mesh/src/api/routes/oauth-proxy.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.test.ts
@@ -1,3 +1,16 @@
+/**
+ * Handler-wiring tests for the OAuth proxy.
+ *
+ * The pure metadata transforms (URL-format probe order, rewriting, synthesis,
+ * classification) now live in oauth-proxy-metadata.ts and are tested without
+ * mocks in oauth-proxy-metadata.test.ts. What's left here exercises the
+ * fetch-orchestration + connection-lookup wiring, which still mocks the origin
+ * `fetch` and the connection store. Per TESTING.md that wiring belongs in an
+ * e2e against a real origin server (extend e2e/fixtures/test-mcp-server.ts to
+ * serve the well-known endpoints) — tracked as a follow-up; kept here meanwhile
+ * so the orchestration stays covered during the transition.
+ */
+
 import {
   describe,
   expect,
@@ -746,37 +759,11 @@ describe("OAuth Proxy Routes", () => {
   });
 });
 
-describe("OAuth URL Path Construction", () => {
-  test("root path results in no suffix", () => {
-    const authServerUrl = new URL("https://example.com/");
-    const authServerPath =
-      authServerUrl.pathname === "/" ? "" : authServerUrl.pathname;
-    const result = `/.well-known/oauth-authorization-server${authServerPath}`;
-
-    expect(result).toBe("/.well-known/oauth-authorization-server");
-    expect(result).not.toEndWith("/");
-  });
-
-  test("non-root path is appended correctly", () => {
-    const authServerUrl = new URL("https://example.com/oauth");
-    const authServerPath =
-      authServerUrl.pathname === "/" ? "" : authServerUrl.pathname;
-    const result = `/.well-known/oauth-authorization-server${authServerPath}`;
-
-    expect(result).toBe("/.well-known/oauth-authorization-server/oauth");
-  });
-
-  test("deep path is appended correctly", () => {
-    const authServerUrl = new URL("https://example.com/v1/oauth/server");
-    const authServerPath =
-      authServerUrl.pathname === "/" ? "" : authServerUrl.pathname;
-    const result = `/.well-known/oauth-authorization-server${authServerPath}`;
-
-    expect(result).toBe(
-      "/.well-known/oauth-authorization-server/v1/oauth/server",
-    );
-  });
-});
+// NOTE: the former "OAuth URL Path Construction" suite reimplemented the
+// auth-server well-known URL logic *inline in the test* and asserted against
+// that copy — it never exercised the real code. That logic is now the exported
+// `authorizationServerMetadataUrls`, tested directly (no reimplementation, no
+// mocks) in oauth-proxy-metadata.test.ts.
 
 describe("Deco-Hosted MCP Detection", () => {
   test("DECO_CMS_API_HOST is correct", () => {

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -15,6 +15,20 @@
 import { Hono } from "hono";
 import { ContextFactory } from "../../core/context-factory";
 import type { MeshContext } from "../../core/mesh-context";
+import {
+  authorizationServerMetadataUrls,
+  buildPathPrefix,
+  isAuthError,
+  isAuthServerMetadata,
+  looksLikeOAuthWwwAuthenticate,
+  NO_METADATA_STATUSES,
+  protectedResourceMetadataUrls,
+  resourceMetadataChallenge,
+  rewriteAuthServerMetadata,
+  rewriteProtectedResourceMetadata,
+  scopesFromOrigin,
+  syntheticProtectedResourceMetadata,
+} from "./oauth-proxy-metadata";
 
 // Define Hono variables type
 type Variables = {
@@ -22,19 +36,6 @@ type Variables = {
 };
 
 type HonoEnv = { Variables: Variables };
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-/**
- * HTTP status codes that indicate the server doesn't have OAuth metadata at this path,
- * but might support OAuth via an alternative path or WWW-Authenticate header.
- * - 404: Path not found (most common)
- * - 401: Unauthorized (some servers return this for metadata endpoints)
- * - 406: Not Acceptable (Grain returns this when MCP endpoints don't support .well-known paths)
- */
-const NO_METADATA_STATUSES = [404, 401, 406];
 
 // ============================================================================
 // Helper Functions
@@ -56,22 +57,6 @@ async function getConnectionUrl(
     organizationId,
   );
   return connection?.connection_url ?? null;
-}
-
-/**
- * Check if origin MCP server supports OAuth by looking for WWW-Authenticate header on 401 response.
- * This is useful for servers that support OAuth but don't implement RFC 9728 Protected Resource Metadata.
- * Returns the WWW-Authenticate header value if OAuth is supported, null otherwise.
- */
-function looksLikeOAuthWwwAuthenticate(wwwAuth: string): boolean {
-  const wwwAuthLower = wwwAuth.toLowerCase();
-  // MCP OAuth uses RFC 9728 `resource_metadata=...` (strong signal)
-  // Some servers may not implement RFC 9728 but still include standard OAuth error hints.
-  return (
-    wwwAuthLower.includes("resource_metadata=") ||
-    wwwAuthLower.includes("invalid_token") ||
-    wwwAuthLower.includes("oauth")
-  );
 }
 
 async function checkOriginSupportsOAuth(
@@ -165,45 +150,29 @@ async function checkHasOAuthMetadata(connectionUrl: string): Promise<boolean> {
 export async function fetchProtectedResourceMetadata(
   connectionUrl: string,
 ): Promise<Response> {
-  const connUrl = new URL(connectionUrl);
-  // Normalize: strip trailing slash per RFC 9728
-  let resourcePath = connUrl.pathname;
-  if (resourcePath.endsWith("/")) {
-    resourcePath = resourcePath.slice(0, -1);
+  // URL formats (resource-relative, well-known prefix, root) per RFC 9728 are
+  // built in oauth-proxy-metadata.ts; here we just probe them in order.
+  const urls = protectedResourceMetadataUrls(connectionUrl);
+
+  let response!: Response;
+  for (let i = 0; i < urls.length; i++) {
+    response = await fetch(urls[i]!, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+
+    if (response.ok) return response;
+
+    // Try the next format only on a "no metadata" status. Any other status
+    // (e.g. 500) is a real error — return it to preserve the info. The last
+    // URL's response is returned regardless.
+    if (
+      i < urls.length - 1 &&
+      !NO_METADATA_STATUSES.includes(response.status)
+    ) {
+      return response;
+    }
   }
-
-  // Try format 1 first (most common)
-  const format1Url = new URL(connectionUrl);
-  format1Url.pathname = `${resourcePath}/.well-known/oauth-protected-resource`;
-
-  let response = await fetch(format1Url.toString(), {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  });
-
-  if (response.ok) return response;
-
-  // If format 1 returns a "no metadata" status, try format 2 (Smithery-style: well-known prefix)
-  // For other errors (500, etc.), return immediately to preserve error info
-  if (!NO_METADATA_STATUSES.includes(response.status)) return response;
-
-  const format2Url = new URL(connectionUrl);
-  format2Url.pathname = `/.well-known/oauth-protected-resource${resourcePath}`;
-
-  response = await fetch(format2Url.toString(), {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  });
-
-  if (!NO_METADATA_STATUSES.includes(response.status)) return response;
-
-  const format3Url = new URL(connectionUrl);
-  format3Url.pathname = `/.well-known/oauth-protected-resource`;
-
-  response = await fetch(format3Url.toString(), {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  });
 
   return response;
 }
@@ -286,16 +255,6 @@ export interface HandleAuthErrorOptions {
 }
 
 /**
- * Build the URL prefix for OAuth-related URLs based on org slug.
- * - With slug: `/api/${slug}` (new path shape)
- * - Without slug: `` (legacy path shape — `/mcp/...` and `/oauth-proxy/...`
- *   live at the root)
- */
-function buildPathPrefix(orgSlug: string | undefined): string {
-  return orgSlug ? `/api/${orgSlug}` : "";
-}
-
-/**
  * Handles 401 auth errors from MCP origin servers.
  *
  * Checks if the origin server supports OAuth by looking for WWW-Authenticate header.
@@ -311,17 +270,7 @@ export async function handleAuthError({
   headers,
   orgSlug,
 }: HandleAuthErrorOptions): Promise<Response | null> {
-  const message = error.message?.toLowerCase() ?? "";
-  const isAuthError =
-    error.status === 401 ||
-    error.code === 401 ||
-    error.message?.includes("401") ||
-    message.includes("unauthorized") ||
-    message.includes("invalid_token") ||
-    message.includes("api key required") ||
-    message.includes("api-key required");
-
-  if (!isAuthError) {
+  if (!isAuthError(error)) {
     return null;
   }
 
@@ -332,11 +281,14 @@ export async function handleAuthError({
   );
 
   if (originSupportsOAuth) {
-    const prefix = buildPathPrefix(orgSlug);
     return new Response(null, {
       status: 401,
       headers: {
-        "WWW-Authenticate": `Bearer realm="mcp",resource_metadata="${reqUrl.origin}${prefix}/mcp/${connectionId}/.well-known/oauth-protected-resource"`,
+        "WWW-Authenticate": resourceMetadataChallenge({
+          origin: reqUrl.origin,
+          prefix: buildPathPrefix(orgSlug),
+          connectionId,
+        }),
       },
     });
   }
@@ -458,15 +410,12 @@ export const protectedResourceMetadataHandler = async (c: {
     if (!response.ok && NO_METADATA_STATUSES.includes(response.status)) {
       const wwwAuth = await checkOriginSupportsOAuth(connectionUrl);
       if (wwwAuth) {
-        // Server supports OAuth but doesn't have metadata endpoint
-        // Generate synthetic metadata pointing to our proxy
-        const syntheticData = {
-          resource: proxyResourceUrl,
-          authorization_servers: [proxyAuthServer],
-          // Standard fields per RFC 9728
-          bearer_methods_supported: ["header"],
-          scopes_supported: ["*"],
-        };
+        // Server supports OAuth but doesn't have metadata endpoint —
+        // synthesize metadata pointing to our proxy.
+        const syntheticData = syntheticProtectedResourceMetadata({
+          proxyResourceUrl,
+          proxyAuthServer,
+        });
 
         return new Response(JSON.stringify(syntheticData), {
           status: 200,
@@ -494,32 +443,16 @@ export const protectedResourceMetadataHandler = async (c: {
     // Parse the response and rewrite URLs to point to our proxy
     const data = (await response.json()) as Record<string, unknown>;
 
-    // Detect if origin returned Authorization Server Metadata (RFC 8414) instead of
-    // Protected Resource Metadata (RFC 9728). Some servers like ClickHouse incorrectly
-    // return auth server metadata at the protected resource endpoint.
-    // Auth server metadata has 'issuer' but not 'resource', while protected resource
-    // metadata should have 'resource'.
-    const isAuthServerMetadata =
-      "issuer" in data &&
-      !("resource" in data) &&
-      ("authorization_endpoint" in data || "token_endpoint" in data);
-
-    if (isAuthServerMetadata) {
-      // Server returned auth server metadata instead of protected resource metadata.
-      // Generate clean synthetic protected resource metadata that points to our proxy.
-      // We don't spread the original data to avoid polluting the response with
-      // unexpected fields that could confuse MCP SDK clients.
-      const syntheticData = {
-        resource: proxyResourceUrl,
-        authorization_servers: [proxyAuthServer],
-        bearer_methods_supported: ["header"],
-        scopes_supported:
-          "scopes_supported" in data &&
-          Array.isArray(data.scopes_supported) &&
-          data.scopes_supported.length > 0
-            ? data.scopes_supported
-            : ["*"],
-      };
+    // Some servers (ClickHouse) incorrectly return Authorization Server
+    // Metadata (RFC 8414) at the protected-resource endpoint. Detect that and
+    // emit clean synthetic protected-resource metadata instead — see
+    // isAuthServerMetadata / syntheticProtectedResourceMetadata.
+    if (isAuthServerMetadata(data)) {
+      const syntheticData = syntheticProtectedResourceMetadata({
+        proxyResourceUrl,
+        proxyAuthServer,
+        scopesSupported: scopesFromOrigin(data),
+      });
 
       return new Response(JSON.stringify(syntheticData), {
         status: 200,
@@ -528,11 +461,10 @@ export const protectedResourceMetadataHandler = async (c: {
     }
 
     // Origin returned proper protected resource metadata - rewrite URLs to our proxy
-    const rewrittenData = {
-      ...data,
-      resource: proxyResourceUrl,
-      authorization_servers: [proxyAuthServer],
-    };
+    const rewrittenData = rewriteProtectedResourceMetadata(data, {
+      proxyResourceUrl,
+      proxyAuthServer,
+    });
 
     return new Response(JSON.stringify(rewrittenData), {
       status: response.status,
@@ -653,50 +585,13 @@ async function fetchMetadataWithRetry(
 export async function fetchAuthorizationServerMetadata(
   authServerUrl: string,
 ): Promise<Response> {
-  const url = new URL(authServerUrl);
-  // Normalize: strip trailing slash
-  let authServerPath = url.pathname;
-  if (authServerPath.endsWith("/")) {
-    authServerPath = authServerPath.slice(0, -1);
-  }
+  // URL formats (OAuth 2.0 / OIDC, with/without path component) per RFC 8414
+  // are built in oauth-proxy-metadata.ts; here we just probe them in order.
+  const urlsToTry = authorizationServerMetadataUrls(authServerUrl);
 
-  // Check if URL has a path component
-  const hasPath = authServerPath !== "" && authServerPath !== "/";
-
-  // Build list of URLs to try in priority order
-  const urlsToTry: URL[] = [];
-
-  if (hasPath) {
-    // Format 1: OAuth 2.0 with path insertion
-    const format1 = new URL(authServerUrl);
-    format1.pathname = `/.well-known/oauth-authorization-server${authServerPath}`;
-    urlsToTry.push(format1);
-
-    // Format 2: OpenID Connect with path insertion
-    const format2 = new URL(authServerUrl);
-    format2.pathname = `/.well-known/openid-configuration${authServerPath}`;
-    urlsToTry.push(format2);
-
-    // Format 3: OpenID Connect with path append
-    const format3 = new URL(authServerUrl);
-    format3.pathname = `${authServerPath}/.well-known/openid-configuration`;
-    urlsToTry.push(format3);
-  } else {
-    // Format 1: OAuth 2.0 at root
-    const format1 = new URL(authServerUrl);
-    format1.pathname = "/.well-known/oauth-authorization-server";
-    urlsToTry.push(format1);
-
-    // Format 2: OpenID Connect at root
-    const format2 = new URL(authServerUrl);
-    format2.pathname = "/.well-known/openid-configuration";
-    urlsToTry.push(format2);
-  }
-
-  // Try each URL in order
   let response: Response | null = null;
   for (const tryUrl of urlsToTry) {
-    response = await fetchMetadataWithRetry(tryUrl.toString(), {
+    response = await fetchMetadataWithRetry(tryUrl, {
       method: "GET",
       headers: { Accept: "application/json" },
     });
@@ -782,16 +677,7 @@ const authServerMetadataHandler = async (c: {
       : `${requestUrl.origin}/oauth-proxy/${connectionId}`;
 
     // Rewrite OAuth endpoint URLs to go through our proxy
-    const rewrittenData = {
-      ...data,
-      authorization_endpoint: data.authorization_endpoint
-        ? `${proxyBase}/authorize`
-        : undefined,
-      token_endpoint: data.token_endpoint ? `${proxyBase}/token` : undefined,
-      registration_endpoint: data.registration_endpoint
-        ? `${proxyBase}/register`
-        : undefined,
-    };
+    const rewrittenData = rewriteAuthServerMetadata(data, proxyBase);
 
     return new Response(JSON.stringify(rewrittenData), {
       status: 200,


### PR DESCRIPTION
## Summary

Continues the test-suite cleanup (after #3579, #3581). The OAuth proxy was the case where the honest fix is a **source refactor**, not just relocating tests.

Its genuinely bug-prone logic — RFC 9728 / RFC 8414 / OIDC well-known URL probe order, rewriting an origin's metadata to point back at our proxy, synthesizing metadata for servers that don't implement RFC 9728, and classifying auth challenges — was only reachable through handlers that `fetch` from an origin server. So the tests faked `global.fetch` + the connection store to drive it. But that logic was never *coupled* to fetch; it was just trapped behind it.

## Changes

- **`oauth-proxy-metadata.ts` (new)** — the pure, data-in/data-out transforms: `protectedResourceMetadataUrls`, `authorizationServerMetadataUrls`, `rewriteProtectedResourceMetadata`, `syntheticProtectedResourceMetadata`, `rewriteAuthServerMetadata`, `isAuthServerMetadata`, `looksLikeOAuthWwwAuthenticate`, `isAuthError`, `scopesFromOrigin`, `resourceMetadataChallenge`, `buildPathPrefix`.
- **`oauth-proxy.ts`** — refactored to delegate to those. Behavior-preserving; the externally-imported `fetchProtectedResourceMetadata` / `fetchAuthorizationServerMetadata` / `handleAuthError` keep their exact signatures (verified `proxy.ts`, `app.ts`, `resolve-token-endpoint.ts` still typecheck).
- **`oauth-proxy-metadata.test.ts` (new)** — 27 tests, **zero mocks**. This is the new home for the RFC/rewriting/synthesis/classification coverage.
- **`oauth-proxy.test.ts`** — deleted the "OAuth URL Path Construction" suite (it reimplemented the URL logic *inline in the test* and asserted against the copy — it never ran the real code); trimmed to the genuine fetch-orchestration + connection-lookup wiring, with a header noting that wiring should move to an e2e against a real origin server.

## Testing

- `oauth-proxy-metadata.test.ts` — 27 pass (no mocks)
- `oauth-proxy.test.ts` — 23 pass (wiring)
- `oauth-proxy.auth-detection.test.ts` — 4 pass
- `tsc`, `knip`, `bun run fmt` all clean

## Follow-up (not in this PR)
- Migrate the remaining mocked fetch-orchestration tests to an e2e against a real origin server (extend `e2e/fixtures/test-mcp-server.ts` to serve the well-known endpoints). The pure logic they used to cover now lives in the mock-free suite, so what's left is genuinely the fetch wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted pure OAuth metadata transforms into a new module and refactored `oauth-proxy.ts` to use them. Behavior stays the same while enabling fast, mock-free unit tests and clearer RFC 9728/8414 probing.

- **Refactors**
  - Added `oauth-proxy-metadata.ts` with pure helpers for URL probing (RFC 9728/8414), metadata rewrite/synthesis, auth error and challenge checks, and path prefix building.
  - Updated `oauth-proxy.ts` to delegate to these helpers; preserved signatures of `fetchProtectedResourceMetadata`, `fetchAuthorizationServerMetadata`, and `handleAuthError`.
  - Added `oauth-proxy-metadata.test.ts` (27 tests, no mocks). Trimmed `oauth-proxy.test.ts` to wiring-only and removed the duplicated “OAuth URL Path Construction” suite.

<sup>Written for commit 024492b152ddb0756b9de47a8b3218423c880c98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

