### PR TITLE
refactor(async): centralize retry/backoff on a Deno-std port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,26 @@ Database schema key concepts:
 
 ## Coding Style & Naming Conventions
 
+### Retry & Backoff — use the shared helper, never hand-roll
+
+There is ONE canonical retry/backoff implementation: `apps/mesh/src/shared/async/`
+(ported from Deno std, isomorphic). It was consolidated from ~9 ad-hoc copies —
+do NOT write another `Math.min(base * 2 ** attempt, cap)` formula, jitter
+expression, or `for`/`while` retry loop.
+
+- **`retry(fn, opts)`** (`@/shared/async/retry`) — call a possibly-async function
+  until it succeeds. Supports `maxAttempts`, `minTimeout`/`maxTimeout`,
+  `multiplier`, `jitter` (0–1), an `isRetriable(err)` predicate (e.g. retry only
+  5xx), and an `AbortSignal`. Throws `RetryError` (with `.cause`) on exhaustion.
+- **`exponentialBackoffWithJitter(cap, base, attempt, multiplier, jitter)`**
+  (`@/shared/async/backoff`) — the pure delay calculator, for stateful loops that
+  can't be a single function (WebSocket/SSE reconnect, durable event delivery).
+  `jitter`: `0` = none, `0.5` = equal `[exp/2, exp]`, `1` = full `[0, exp]`.
+
+If you think you need a new retry mechanism, you don't — extend the options or
+ask. The circuit breaker (`mcp-clients/circuit-breaker.ts`) is a different
+pattern (fault isolation) and is intentionally separate.
+
 ### Style & Formatting
 - **Biome** enforces two-space indentation and double quotes
 - **ALWAYS** run `bun run fmt` after making code changes (pre-commit hook via lefthook)

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -606,8 +606,6 @@ async function fetchMetadataWithRetry(
   }: { attempts?: number; timeoutMs?: number } = {},
 ): Promise<Response> {
   try {
-    // minTimeout 150 + multiplier 2 + jitter 0 reproduces the prior 150ms,
-    // 300ms backoff. 5xx is retried (by throwing); 4xx/2xx is returned as-is.
     return await retry(
       async () => {
         const res = await fetchWithTimeout(url, init, timeoutMs);
@@ -618,8 +616,8 @@ async function fetchMetadataWithRetry(
     );
   } catch (err) {
     if (err instanceof RetryError) {
-      // Exhausted on a 5xx → return that last response (the caller inspects
-      // status). Exhausted on a network error / timeout → rethrow the cause.
+      // 5xx exhausted → return the last response (caller inspects status);
+      // network error / timeout exhausted → rethrow the cause.
       if (err.cause instanceof RetriableServerResponse) {
         return err.cause.response;
       }

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -15,6 +15,7 @@
 import { Hono } from "hono";
 import { ContextFactory } from "../../core/context-factory";
 import type { MeshContext } from "../../core/mesh-context";
+import { retry, RetryError } from "@/shared/async/retry";
 import {
   authorizationServerMetadataUrls,
   buildPathPrefix,
@@ -591,6 +592,11 @@ function fetchWithTimeout(
  * backoff; 4xx (incl. 404/401, which drive well-known format fallback) is
  * returned as-is so the caller's discovery logic is unchanged.
  */
+/** Wraps a 5xx response so `retry()` (which retries on throw) re-probes it. */
+class RetriableServerResponse {
+  constructor(readonly response: Response) {}
+}
+
 async function fetchMetadataWithRetry(
   url: string,
   init: RequestInit,
@@ -599,21 +605,28 @@ async function fetchMetadataWithRetry(
     timeoutMs = METADATA_FETCH_TIMEOUT_MS,
   }: { attempts?: number; timeoutMs?: number } = {},
 ): Promise<Response> {
-  let lastErr: unknown;
-  for (let i = 0; i < attempts; i++) {
-    const isLast = i === attempts - 1;
-    try {
-      const res = await fetchWithTimeout(url, init, timeoutMs);
-      if (res.status < 500 || isLast) return res;
-    } catch (err) {
-      lastErr = err;
-      if (isLast) throw err;
+  try {
+    // minTimeout 150 + multiplier 2 + jitter 0 reproduces the prior 150ms,
+    // 300ms backoff. 5xx is retried (by throwing); 4xx/2xx is returned as-is.
+    return await retry(
+      async () => {
+        const res = await fetchWithTimeout(url, init, timeoutMs);
+        if (res.status >= 500) throw new RetriableServerResponse(res);
+        return res;
+      },
+      { maxAttempts: attempts, minTimeout: 150, multiplier: 2, jitter: 0 },
+    );
+  } catch (err) {
+    if (err instanceof RetryError) {
+      // Exhausted on a 5xx → return that last response (the caller inspects
+      // status). Exhausted on a network error / timeout → rethrow the cause.
+      if (err.cause instanceof RetriableServerResponse) {
+        return err.cause.response;
+      }
+      throw err.cause;
     }
-    // Backoff before the next attempt: 150ms, then 300ms.
-    await new Promise((r) => setTimeout(r, 150 * (i + 1)));
+    throw err;
   }
-  // Unreachable (the loop returns or throws on the last attempt).
-  throw lastErr ?? new Error("fetchMetadataWithRetry: retries exhausted");
 }
 
 export async function fetchAuthorizationServerMetadata(

--- a/apps/mesh/src/event-bus/index.ts
+++ b/apps/mesh/src/event-bus/index.ts
@@ -61,9 +61,6 @@ async function startWithRetry(
   maxRetries = 5,
 ): Promise<void> {
   try {
-    // Exponential backoff 1s→2s→4s→8s, capped at 10s, no jitter (same schedule
-    // as before). On exhaustion, log and swallow — a deferred start failing
-    // must not take the process down.
     await retry(fn, {
       maxAttempts: maxRetries,
       minTimeout: 1000,
@@ -71,6 +68,7 @@ async function startWithRetry(
       jitter: 0,
     });
   } catch (err) {
+    // Log and swallow — a deferred start failing must not crash the process.
     console.error(
       `${label} Deferred start failed:`,
       err instanceof RetryError ? err.cause : err,

--- a/apps/mesh/src/event-bus/index.ts
+++ b/apps/mesh/src/event-bus/index.ts
@@ -17,6 +17,7 @@
  * ```
  */
 
+import { retry, RetryError } from "@/shared/async/retry";
 import type { NatsConnectionProvider } from "../nats/connection";
 import type { MeshDatabase } from "../database";
 import { createEventBusStorage } from "../storage/event-bus";
@@ -59,21 +60,21 @@ async function startWithRetry(
   fn: () => Promise<void>,
   maxRetries = 5,
 ): Promise<void> {
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      await fn();
-      return;
-    } catch (err) {
-      if (attempt === maxRetries) {
-        console.error(`${label} Deferred start failed:`, err);
-        return;
-      }
-      const delay = Math.min(1000 * 2 ** (attempt - 1), 10_000);
-      console.warn(
-        `${label} Start attempt ${attempt}/${maxRetries} failed, retrying in ${delay}ms`,
-      );
-      await new Promise((r) => setTimeout(r, delay));
-    }
+  try {
+    // Exponential backoff 1s→2s→4s→8s, capped at 10s, no jitter (same schedule
+    // as before). On exhaustion, log and swallow — a deferred start failing
+    // must not take the process down.
+    await retry(fn, {
+      maxAttempts: maxRetries,
+      minTimeout: 1000,
+      maxTimeout: 10_000,
+      jitter: 0,
+    });
+  } catch (err) {
+    console.error(
+      `${label} Deferred start failed:`,
+      err instanceof RetryError ? err.cause : err,
+    );
   }
 }
 

--- a/apps/mesh/src/link-daemon/reconnect-backoff.ts
+++ b/apps/mesh/src/link-daemon/reconnect-backoff.ts
@@ -13,8 +13,6 @@ const CAP_MS = 30_000;
 
 export function computeBackoffMs(attempt: number): number {
   if (attempt < 1) throw new Error("attempt must be >= 1");
-  // Equal jitter ([exp/2, exp]). `attempt` is 1-based here; the primitive's is
-  // 0-based, hence `attempt - 1`.
   return exponentialBackoffWithJitter(CAP_MS, BASE_MS, attempt - 1, 2, 0.5);
 }
 

--- a/apps/mesh/src/link-daemon/reconnect-backoff.ts
+++ b/apps/mesh/src/link-daemon/reconnect-backoff.ts
@@ -5,15 +5,17 @@
  * would just oscillate, so we don't.
  */
 
+import { exponentialBackoffWithJitter } from "@/shared/async/backoff";
+
 export const WS_CLOSE_SUPERSEDED = 4001;
 const BASE_MS = 500;
 const CAP_MS = 30_000;
 
 export function computeBackoffMs(attempt: number): number {
   if (attempt < 1) throw new Error("attempt must be >= 1");
-  const exp = Math.min(BASE_MS * 2 ** (attempt - 1), CAP_MS);
-  // Full jitter: [exp/2, exp]
-  return exp / 2 + Math.random() * (exp / 2);
+  // Equal jitter ([exp/2, exp]). `attempt` is 1-based here; the primitive's is
+  // 0-based, hence `attempt - 1`.
+  return exponentialBackoffWithJitter(CAP_MS, BASE_MS, attempt - 1, 2, 0.5);
 }
 
 export function shouldReconnectOnClose(code: number): boolean {

--- a/apps/mesh/src/nats/connection.ts
+++ b/apps/mesh/src/nats/connection.ts
@@ -114,7 +114,6 @@ export function createNatsConnectionProvider(
         return;
       } catch {
         attempt++;
-        // Equal jitter ([exp/2, exp]) — see exponentialBackoffWithJitter.
         const jitteredDelay = exponentialBackoffWithJitter(
           MAX_DELAY_MS,
           BASE_DELAY_MS,

--- a/apps/mesh/src/nats/connection.ts
+++ b/apps/mesh/src/nats/connection.ts
@@ -17,6 +17,7 @@ import {
   type JetStreamClient,
   type NatsConnection,
 } from "nats";
+import { exponentialBackoffWithJitter } from "@/shared/async/backoff";
 
 const BASE_DELAY_MS = 100;
 const MAX_DELAY_MS = 3_000;
@@ -113,11 +114,14 @@ export function createNatsConnectionProvider(
         return;
       } catch {
         attempt++;
-        const delay = Math.min(
-          BASE_DELAY_MS * 2 ** (attempt - 1),
+        // Equal jitter ([exp/2, exp]) — see exponentialBackoffWithJitter.
+        const jitteredDelay = exponentialBackoffWithJitter(
           MAX_DELAY_MS,
+          BASE_DELAY_MS,
+          attempt - 1,
+          2,
+          0.5,
         );
-        const jitteredDelay = delay * (0.5 + Math.random() * 0.5);
         await sleep(jitteredDelay);
       }
     }

--- a/apps/mesh/src/shared/async/backoff.test.ts
+++ b/apps/mesh/src/shared/async/backoff.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { exponentialBackoffWithJitter } from "./backoff";
+
+describe("exponentialBackoffWithJitter", () => {
+  describe("jitter = 0 (deterministic)", () => {
+    test("grows base * multiplier ** attempt", () => {
+      expect(exponentialBackoffWithJitter(60000, 1000, 0, 2, 0)).toBe(1000);
+      expect(exponentialBackoffWithJitter(60000, 1000, 1, 2, 0)).toBe(2000);
+      expect(exponentialBackoffWithJitter(60000, 1000, 2, 2, 0)).toBe(4000);
+      expect(exponentialBackoffWithJitter(60000, 1000, 3, 2, 0)).toBe(8000);
+    });
+
+    test("attempt 0 is always the base delay", () => {
+      expect(exponentialBackoffWithJitter(60000, 500, 0, 2, 0)).toBe(500);
+    });
+
+    test("is capped at `cap`", () => {
+      // would be 4000 at attempt 2, capped to 1500
+      expect(exponentialBackoffWithJitter(1500, 1000, 2, 2, 0)).toBe(1500);
+    });
+
+    test("honors a non-2 multiplier", () => {
+      expect(exponentialBackoffWithJitter(60000, 100, 3, 3, 0)).toBe(2700); // 100 * 3^3
+    });
+  });
+
+  describe("jitter ranges (probabilistic, 1000 samples)", () => {
+    const samples = (fn: () => number, n = 1000) =>
+      Array.from({ length: n }, fn);
+
+    test("jitter = 1 → uniformly within [0, exp]", () => {
+      const exp = 1000; // base at attempt 0
+      const xs = samples(() =>
+        exponentialBackoffWithJitter(60000, 1000, 0, 2, 1),
+      );
+      for (const x of xs) {
+        expect(x).toBeGreaterThanOrEqual(0);
+        expect(x).toBeLessThanOrEqual(exp);
+      }
+      // Sanity: not all clustered at the cap.
+      expect(Math.min(...xs)).toBeLessThan(exp / 2);
+    });
+
+    test("jitter = 0.5 → 'equal jitter' within [exp/2, exp]", () => {
+      const exp = 1000;
+      const xs = samples(() =>
+        exponentialBackoffWithJitter(60000, 1000, 0, 2, 0.5),
+      );
+      for (const x of xs) {
+        expect(x).toBeGreaterThanOrEqual(exp / 2);
+        expect(x).toBeLessThanOrEqual(exp);
+      }
+    });
+  });
+});

--- a/apps/mesh/src/shared/async/backoff.ts
+++ b/apps/mesh/src/shared/async/backoff.ts
@@ -1,0 +1,34 @@
+// Ported from Deno std @std/async (_util.ts). MIT license, Copyright the Deno
+// authors. https://github.com/denoland/std/blob/main/async/_util.ts
+//
+// The canonical exponential-backoff-with-jitter calculator for this repo. Use
+// this (and `retry()` in ./retry) for ALL retry/backoff timing — do NOT
+// hand-roll another `Math.min(base * 2 ** attempt, cap)` + jitter formula. This
+// was consolidated from ~9 ad-hoc copies.
+
+/**
+ * Exponential backoff delay with optional jitter.
+ *
+ * Base delay grows as `base * multiplier ** attempt` (attempt is 0-based),
+ * capped at `cap`. Jitter then scales the result down by a random factor:
+ *   - `jitter = 0`  → no jitter, the full capped backoff.
+ *   - `jitter = 1`  → "full jitter", uniformly random in `[0, exp]`.
+ *   - `jitter = 0.5`→ "equal jitter", uniformly random in `[exp/2, exp]`.
+ *
+ * @param cap maximum delay in ms (the backoff is capped here before jitter).
+ * @param base initial/minimum delay in ms (the delay at attempt 0).
+ * @param attempt 0-based attempt index.
+ * @param multiplier growth factor per attempt (commonly 2).
+ * @param jitter randomization amount in `[0, 1]`.
+ * @returns the delay in milliseconds to wait before the next attempt.
+ */
+export function exponentialBackoffWithJitter(
+  cap: number,
+  base: number,
+  attempt: number,
+  multiplier: number,
+  jitter: number,
+): number {
+  const exp = Math.min(cap, base * multiplier ** attempt);
+  return (1 - jitter * Math.random()) * exp;
+}

--- a/apps/mesh/src/shared/async/delay.ts
+++ b/apps/mesh/src/shared/async/delay.ts
@@ -1,0 +1,69 @@
+// Ported from Deno std @std/async (delay.ts). MIT license, Copyright the Deno
+// authors. https://github.com/denoland/std/blob/main/async/delay.ts
+//
+// Adapted for node/bun/browser: the upstream `persistent` option (Deno-only
+// `Deno.unrefTimer`) is dropped. The arbitrary-length-timeout handling is kept
+// so delays beyond the 32-bit setTimeout ceiling still resolve.
+
+/** Options for {@linkcode delay}. */
+export interface DelayOptions {
+  /** Signal used to abort the delay. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Resolve a {@linkcode Promise} after a given amount of milliseconds.
+ *
+ * If the optional signal is aborted before the delay duration, the returned
+ * promise rejects with the signal's reason. If no reason is provided to
+ * `abort()`, the runtime's default `AbortError` `DOMException` is used.
+ *
+ * @param ms Duration in milliseconds for how long the delay should last.
+ * @param options Additional options.
+ */
+export function delay(ms: number, options: DelayOptions = {}): Promise<void> {
+  const { signal } = options;
+  if (signal?.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      clearTimeout(+i);
+      reject(signal?.reason);
+    };
+    const done = () => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    };
+    const i = setArbitraryLengthTimeout(done, ms);
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+const I32_MAX = 2 ** 31 - 1;
+
+function setArbitraryLengthTimeout(
+  callback: () => void,
+  delay: number,
+): { valueOf(): number } {
+  // ensure non-negative integer (but > I32_MAX is OK, even if Infinity)
+  delay = Math.trunc(Math.max(delay, 0) || 0);
+
+  if (delay <= I32_MAX) {
+    const id = Number(setTimeout(callback, delay));
+    return { valueOf: () => id };
+  }
+
+  const start = Date.now();
+  let timeoutId: number;
+
+  const queueTimeout = () => {
+    const currentDelay = delay - (Date.now() - start);
+    timeoutId =
+      currentDelay > I32_MAX
+        ? Number(setTimeout(queueTimeout, I32_MAX))
+        : Number(setTimeout(callback, currentDelay));
+  };
+
+  queueTimeout();
+
+  return { valueOf: () => timeoutId };
+}

--- a/apps/mesh/src/shared/async/retry.test.ts
+++ b/apps/mesh/src/shared/async/retry.test.ts
@@ -1,0 +1,258 @@
+// Behavioral port of Deno std async/retry_test.ts to bun:test. Deno's exact-ms
+// timing tests rely on FakeTime (tick-advancing fake timers), which bun:test
+// lacks; the timing math is instead covered deterministically in backoff.test.ts
+// (exponentialBackoffWithJitter with jitter:0). Here we use real but tiny
+// timeouts and assert behavior (success, attempt counts, isRetriable, signal,
+// validation).
+
+import { describe, expect, test } from "bun:test";
+import { retry, RetryError } from "./retry";
+
+// Fast settings so real-timer tests don't sleep meaningfully.
+const FAST = { minTimeout: 1, maxTimeout: 1, jitter: 0 } as const;
+
+function generateErroringFunction(errorsBeforeSucceeds: number) {
+  let errorCount = 0;
+  return () => {
+    if (errorCount >= errorsBeforeSucceeds) return errorCount;
+    errorCount++;
+    throw `Only errored ${errorCount} times`;
+  };
+}
+
+describe("retry() — success paths", () => {
+  test("succeeds after a few errors", async () => {
+    const result = await retry(generateErroringFunction(3), FAST);
+    expect(result).toBe(3);
+  });
+
+  test("works with async functions", async () => {
+    let attempts = 0;
+    const result = await retry(async () => {
+      await Promise.resolve();
+      attempts++;
+      if (attempts < 3) throw new Error("Not yet");
+      return "async success";
+    }, FAST);
+    expect(result).toBe("async success");
+    expect(attempts).toBe(3);
+  });
+
+  test("returns immediately on first success (fn called once)", async () => {
+    let calls = 0;
+    const result = await retry(() => {
+      calls++;
+      return "immediate";
+    });
+    expect(result).toBe("immediate");
+    expect(calls).toBe(1);
+  });
+});
+
+describe("retry() — exhaustion", () => {
+  test("fails after five attempts by default, wrapping the last error", async () => {
+    let calls = 0;
+    const specific = new Error("Specific failure");
+    const err = await retry(() => {
+      calls++;
+      throw specific;
+    }, FAST).catch((e) => e);
+
+    expect(err).toBeInstanceOf(RetryError);
+    expect((err as RetryError).cause).toBe(specific);
+    expect((err as Error).message).toBe(
+      "Retrying exceeded the maxAttempts (5).",
+    );
+    expect(calls).toBe(5);
+  });
+
+  test("respects a custom maxAttempts", async () => {
+    let attempts = 0;
+    const err = await retry(
+      () => {
+        attempts++;
+        throw new Error();
+      },
+      { ...FAST, maxAttempts: 3 },
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(RetryError);
+    expect((err as Error).message).toBe(
+      "Retrying exceeded the maxAttempts (3).",
+    );
+    expect(attempts).toBe(3);
+  });
+});
+
+describe("retry() — isRetriable", () => {
+  class HttpError extends Error {
+    status: number;
+    constructor(status: number) {
+      super(`HTTP ${status}`);
+      this.status = status;
+    }
+  }
+  const opts = {
+    ...FAST,
+    isRetriable: (err: unknown) =>
+      err instanceof HttpError && (err.status === 429 || err.status >= 500),
+  };
+
+  test("non-retriable error is thrown immediately (no retries)", async () => {
+    let n = 0;
+    const err = await retry(() => {
+      n++;
+      throw new HttpError(400);
+    }, opts).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(n).toBe(1);
+  });
+
+  test("retriable error is retried to exhaustion", async () => {
+    let n = 0;
+    const err = await retry(() => {
+      n++;
+      throw new HttpError(500);
+    }, opts).catch((e) => e);
+    expect(err).toBeInstanceOf(RetryError);
+    expect(n).toBe(5);
+  });
+
+  test("stops as soon as a non-retriable error appears", async () => {
+    let n = 0;
+    const err = await retry(() => {
+      throw new HttpError(++n === 3 ? 400 : 500);
+    }, opts).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(n).toBe(3);
+  });
+});
+
+describe("retry() — AbortSignal", () => {
+  test("aborts during the delay between attempts", async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+    const promise = retry(
+      () => {
+        attempts++;
+        throw new Error("fail");
+      },
+      {
+        signal: controller.signal,
+        jitter: 0,
+        minTimeout: 200,
+        maxTimeout: 200,
+      },
+    );
+
+    // First attempt runs, then enters a 200ms delay; abort well within it.
+    setTimeout(() => controller.abort("cancelled"), 40);
+    const err = await promise.catch((e) => e);
+    expect(err).toBe("cancelled");
+    expect(attempts).toBe(1);
+  });
+
+  test("throws immediately if the signal is already aborted (fn never runs)", async () => {
+    const controller = new AbortController();
+    controller.abort("pre-aborted");
+    let called = false;
+    const err = await retry(
+      () => {
+        called = true;
+        return "ok";
+      },
+      { signal: controller.signal },
+    ).catch((e) => e);
+    expect(err).toBe("pre-aborted");
+    expect(called).toBe(false);
+  });
+
+  test("rejects with an AbortError when aborted without a reason", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const err = await retry(
+      () => {
+        throw new Error();
+      },
+      { signal: controller.signal },
+    ).catch((e) => e);
+    expect((err as Error).name).toBe("AbortError");
+  });
+});
+
+describe("retry() — option validation (RangeError)", () => {
+  const cases: Array<[string, Parameters<typeof retry>[1], string]> = [
+    [
+      "minTimeout > maxTimeout",
+      { minTimeout: 1000, maxTimeout: 100 },
+      "Cannot retry as 'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=1000', 'maxTimeout=100'",
+    ],
+    [
+      "maxTimeout <= 0",
+      { maxTimeout: -1 },
+      "Cannot retry as 'maxTimeout' must be a positive number: current value is -1",
+    ],
+    [
+      "maxTimeout NaN",
+      { maxTimeout: NaN },
+      "Cannot retry as 'maxTimeout' must be a positive number: current value is NaN",
+    ],
+    [
+      "jitter > 1",
+      { jitter: 2 },
+      "Cannot retry as 'jitter' must be between 0 and 1: current value is 2",
+    ],
+    [
+      "jitter < 0",
+      { jitter: -0.5 },
+      "Cannot retry as 'jitter' must be between 0 and 1: current value is -0.5",
+    ],
+    [
+      "jitter NaN",
+      { jitter: NaN },
+      "Cannot retry as 'jitter' must be between 0 and 1: current value is NaN",
+    ],
+    [
+      "maxAttempts 0",
+      { maxAttempts: 0 },
+      "Cannot retry as 'maxAttempts' must be a positive integer: current value is 0",
+    ],
+    [
+      "maxAttempts non-integer",
+      { maxAttempts: 2.5 },
+      "Cannot retry as 'maxAttempts' must be a positive integer: current value is 2.5",
+    ],
+    [
+      "multiplier < 1",
+      { multiplier: 0.5 },
+      "Cannot retry as 'multiplier' must be a finite number >= 1: current value is 0.5",
+    ],
+    [
+      "multiplier NaN",
+      { multiplier: NaN },
+      "Cannot retry as 'multiplier' must be a finite number >= 1: current value is NaN",
+    ],
+    [
+      "multiplier Infinity",
+      { multiplier: Number.POSITIVE_INFINITY },
+      "Cannot retry as 'multiplier' must be a finite number >= 1: current value is Infinity",
+    ],
+    [
+      "minTimeout < 0",
+      { minTimeout: -100 },
+      "Cannot retry as 'minTimeout' must be >= 0: current value is -100",
+    ],
+    [
+      "minTimeout NaN",
+      { minTimeout: NaN },
+      "Cannot retry as 'minTimeout' must be >= 0: current value is NaN",
+    ],
+  ];
+
+  for (const [name, options, message] of cases) {
+    test(name, async () => {
+      const err = await retry(() => {}, options).catch((e) => e);
+      expect(err).toBeInstanceOf(RangeError);
+      expect((err as Error).message).toBe(message);
+    });
+  }
+});

--- a/apps/mesh/src/shared/async/retry.ts
+++ b/apps/mesh/src/shared/async/retry.ts
@@ -1,0 +1,161 @@
+// Ported from Deno std @std/async (retry.ts). MIT license, Copyright the Deno
+// authors. https://github.com/denoland/std/blob/main/async/retry.ts
+//
+// The canonical retry wrapper for this repo. Use `retry()` to call a possibly
+// async function until it succeeds, and `exponentialBackoffWithJitter()` (from
+// ./backoff) for stateful loops that can't be expressed as a single function
+// (e.g. WebSocket reconnect, durable delivery). Do NOT hand-roll new retry
+// loops — this was consolidated from ~9 ad-hoc copies.
+
+import { exponentialBackoffWithJitter } from "./backoff";
+import { delay } from "./delay";
+
+/**
+ * Error thrown in {@linkcode retry} once the maximum number of failed attempts
+ * has been reached. The original failure is available on `.cause`.
+ */
+export class RetryError extends Error {
+  constructor(cause: unknown, attempts: number) {
+    super(`Retrying exceeded the maxAttempts (${attempts}).`);
+    this.name = "RetryError";
+    this.cause = cause;
+  }
+}
+
+/** Options for {@linkcode retry}. */
+export interface RetryOptions {
+  /**
+   * How much to backoff after each retry.
+   *
+   * @default {2}
+   */
+  multiplier?: number;
+  /**
+   * The maximum milliseconds between attempts.
+   *
+   * @default {60000}
+   */
+  maxTimeout?: number;
+  /**
+   * The maximum amount of attempts until failure.
+   *
+   * @default {5}
+   */
+  maxAttempts?: number;
+  /**
+   * The initial and minimum amount of milliseconds between attempts.
+   *
+   * @default {1000}
+   */
+  minTimeout?: number;
+  /**
+   * Amount of jitter to introduce to the time between attempts. This is `1`
+   * for full jitter by default.
+   *
+   * @default {1}
+   */
+  jitter?: number;
+  /**
+   * Callback to determine if an error or other thrown value is retriable.
+   *
+   * @default {() => true}
+   */
+  isRetriable?: (err: unknown) => boolean;
+  /**
+   * An AbortSignal to cancel the retry operation. Checked before each attempt
+   * and during the delay between attempts; rejects with the signal's reason.
+   *
+   * @default {undefined}
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Calls the given (possibly asynchronous) function up to `maxAttempts` times.
+ * Retries as long as the given function throws (and `isRetriable` returns true
+ * for the thrown value). If the attempts are exhausted, throws a
+ * {@linkcode RetryError} with `cause` set to the inner exception.
+ *
+ * The backoff is exponential with jitter — see
+ * {@linkcode exponentialBackoffWithJitter}.
+ *
+ * @typeParam T The return type of the function to retry.
+ * @param fn The function to retry.
+ * @param options Additional options.
+ * @returns The value returned by `fn` on its first successful attempt.
+ * @throws {RetryError} If the function fails after `maxAttempts` attempts.
+ * @throws The thrown value, if `isRetriable` returns `false` for it.
+ * @throws The signal's reason, if `signal` is aborted.
+ */
+export async function retry<T>(
+  fn: (() => Promise<T>) | (() => T),
+  options?: RetryOptions,
+): Promise<T> {
+  const {
+    multiplier = 2,
+    maxTimeout = 60000,
+    maxAttempts = 5,
+    minTimeout = 1000,
+    jitter = 1,
+    isRetriable = () => true,
+    signal,
+  } = options ?? {};
+
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError(
+      `Cannot retry as 'maxAttempts' must be a positive integer: current value is ${maxAttempts}`,
+    );
+  }
+  if (!Number.isFinite(multiplier) || multiplier < 1) {
+    throw new RangeError(
+      `Cannot retry as 'multiplier' must be a finite number >= 1: current value is ${multiplier}`,
+    );
+  }
+  if (Number.isNaN(maxTimeout) || maxTimeout <= 0) {
+    throw new RangeError(
+      `Cannot retry as 'maxTimeout' must be a positive number: current value is ${maxTimeout}`,
+    );
+  }
+  if (Number.isNaN(minTimeout) || minTimeout < 0) {
+    throw new RangeError(
+      `Cannot retry as 'minTimeout' must be >= 0: current value is ${minTimeout}`,
+    );
+  }
+  if (minTimeout > maxTimeout) {
+    throw new RangeError(
+      `Cannot retry as 'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=${minTimeout}', 'maxTimeout=${maxTimeout}'`,
+    );
+  }
+  if (Number.isNaN(jitter) || jitter < 0 || jitter > 1) {
+    throw new RangeError(
+      `Cannot retry as 'jitter' must be between 0 and 1: current value is ${jitter}`,
+    );
+  }
+
+  let attempt = 0;
+  while (true) {
+    signal?.throwIfAborted();
+
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isRetriable(error)) {
+        throw error;
+      }
+
+      if (attempt + 1 >= maxAttempts) {
+        throw new RetryError(error, maxAttempts);
+      }
+
+      const timeout = exponentialBackoffWithJitter(
+        maxTimeout,
+        minTimeout,
+        attempt,
+        multiplier,
+        jitter,
+      );
+      await delay(timeout, signal ? { signal } : undefined);
+    }
+    attempt++;
+  }
+}

--- a/apps/mesh/src/storage/event-bus.ts
+++ b/apps/mesh/src/storage/event-bus.ts
@@ -14,6 +14,7 @@
  */
 
 import { sql, type Kysely, type Selectable } from "kysely";
+import { exponentialBackoffWithJitter } from "@/shared/async/backoff";
 import type {
   Database,
   Event,
@@ -719,11 +720,14 @@ class KyselyEventBusStorage implements EventBusStorage {
           .where("id", "=", id)
           .execute();
       } else {
-        // Calculate exponential backoff: delay = retryDelayMs * 2^(attempts-1)
-        // Cap at maxDelayMs (default 1 hour)
-        const backoffDelay = Math.min(
-          retryDelayMs * Math.pow(2, newAttempts - 1),
+        // Exponential backoff, no jitter (durable delivery — preserves the
+        // prior `retryDelayMs * 2^(attempts-1)` schedule, capped at maxDelayMs).
+        const backoffDelay = exponentialBackoffWithJitter(
           maxDelayMs,
+          retryDelayMs,
+          newAttempts - 1,
+          2,
+          0,
         );
         const nextRetryAt = new Date(Date.now() + backoffDelay).toISOString();
 

--- a/apps/mesh/src/storage/event-bus.ts
+++ b/apps/mesh/src/storage/event-bus.ts
@@ -720,8 +720,6 @@ class KyselyEventBusStorage implements EventBusStorage {
           .where("id", "=", id)
           .execute();
       } else {
-        // Exponential backoff, no jitter (durable delivery — preserves the
-        // prior `retryDelayMs * 2^(attempts-1)` schedule, capped at maxDelayMs).
         const backoffDelay = exponentialBackoffWithJitter(
           maxDelayMs,
           retryDelayMs,

--- a/apps/mesh/src/web/hooks/create-sse-subscription.ts
+++ b/apps/mesh/src/web/hooks/create-sse-subscription.ts
@@ -15,6 +15,8 @@
  * connection opens (initial connect does NOT fire `onReconnect`).
  */
 
+import { exponentialBackoffWithJitter } from "@/shared/async/backoff";
+
 /** Max reconnect delay in ms */
 const MAX_RECONNECT_DELAY_MS = 30_000;
 /** Base reconnect delay in ms */
@@ -108,9 +110,13 @@ export function createSSESubscription(
 
     if (conn.reconnectTimer) return;
 
-    const delay = Math.min(
-      BASE_RECONNECT_DELAY_MS * 2 ** conn.reconnectAttempt,
+    // No jitter — preserves the prior fixed 1s→2s→4s…30s schedule.
+    const delay = exponentialBackoffWithJitter(
       MAX_RECONNECT_DELAY_MS,
+      BASE_RECONNECT_DELAY_MS,
+      conn.reconnectAttempt,
+      2,
+      0,
     );
     conn.reconnectAttempt++;
 

--- a/apps/mesh/src/web/hooks/create-sse-subscription.ts
+++ b/apps/mesh/src/web/hooks/create-sse-subscription.ts
@@ -110,7 +110,6 @@ export function createSSESubscription(
 
     if (conn.reconnectTimer) return;
 
-    // No jitter — preserves the prior fixed 1s→2s→4s…30s schedule.
     const delay = exponentialBackoffWithJitter(
       MAX_RECONNECT_DELAY_MS,
       BASE_RECONNECT_DELAY_MS,


### PR DESCRIPTION
## Summary

We had **~9 ad-hoc exponential-backoff implementations** scattered across the codebase — all sharing the same `min(base * 2 ** attempt, cap)` core, but each reinventing jitter (none / multiplicative / full / additive). Two were even algebraically identical, just written differently. No shared code, no third-party dep.

This adds **one canonical, isomorphic implementation** (ported from Deno std `@std/async`, MIT) and migrates the in-scope call sites onto it.

## The module — `apps/mesh/src/shared/async/`

- **`backoff.ts`** — `exponentialBackoffWithJitter(cap, base, attempt, multiplier, jitter)`: the pure delay primitive (`jitter`: `0` none, `0.5` equal `[exp/2, exp]`, `1` full `[0, exp]`).
- **`delay.ts`** — `delay()` with `AbortSignal` (the Deno-only `persistent`/`unrefTimer` branch dropped; arbitrary-length-timeout handling kept).
- **`retry.ts`** — `retry(fn, opts)`: `maxAttempts`, `min`/`maxTimeout`, `multiplier`, `jitter`, an **`isRetriable(err)`** predicate, and an **`AbortSignal`**; throws `RetryError` (with `.cause`) on exhaustion.
- **Tests** — behavioral port of Deno's `retry_test.ts` to `bun:test` (30 tests). Deno's exact-ms `FakeTime` cases are re-expressed as deterministic `jitter:0` backoff-math tests, since `bun:test` lacks tick-advancing fake timers.

## Migrations (behavior-preserving — jitter mode matches each site's prior schedule)

| Site | Now uses | Notes |
|---|---|---|
| `oauth-proxy` `fetchMetadataWithRetry` | `retry()` + `isRetriable` (5xx) | `minTimeout:150, jitter:0` reproduces the prior 150/300ms; wrapped to keep returning a `Response` after retries |
| `event-bus` `startWithRetry` | `retry()` | drops a per-attempt `warn` log (debug noise) |
| `nats` `connectWithRetry` | `exponentialBackoffWithJitter` | equal jitter; keeps its forever-loop (`retry()` can't loop infinitely) |
| `link-daemon` `reconnect-backoff` | primitive | equal jitter `[exp/2, exp]` |
| `web` SSE `scheduleReconnect` | primitive | `jitter:0` |
| `event-bus` durable delivery delay | primitive | `jitter:0`, formula-identical |

**Out of scope:** circuit breaker (different pattern — fault isolation), CLI `port-wait` (fixed poll), sandbox loopback (single fallback), workflows orchestrator (different package, not yet wired).

## Anti-fragmentation

`AGENTS.md` gains a **"use the shared helper, never hand-roll"** directive (with the `@/shared/async` API) so this doesn't re-fragment — and a clear "the circuit breaker is intentionally separate" note.

## Testing

- New module: 30 tests pass (no mocks)
- Affected sites pass unchanged: `reconnect-backoff` (7), `nats/connection` (11), `event-bus/worker` (19), `oauth-proxy` (23) + `oauth-proxy-metadata` (27) + `auth-detection` (4)
- `tsc` 0 errors, `knip` clean, `lint` 0 errors, `bun run fmt` applied

## Follow-up (optional)
An oxlint rule in `plugins/` to flag the tell-tale `Math.random()`-into-`setTimeout` / new `*Retry`/`backoff` pattern outside the canonical module — CI-enforced belt to the AGENTS.md suspenders. Happy to add as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized retry and exponential backoff into a single shared module ported from Deno std for consistent behavior and easier maintenance. Migrated six call sites to the new helpers with schedules preserved, and trimmed noisy call-site comments.

- **Refactors**
  - Added `@/shared/async`: `retry()` with `RetryError` and `AbortSignal` support, `exponentialBackoffWithJitter()`, and `delay()`.
  - Added `backoff.test.ts` and `retry.test.ts`. Updated `AGENTS.md` to require using the shared helpers.
  - Trimmed per-call-site backoff comments; kept the two non-obvious notes (return last 5xx in `oauth-proxy`, log-and-swallow in `event-bus`).

- **Migrations**
  - `oauth-proxy` metadata fetch now uses `retry()`; retries 5xx; 150ms→300ms (no jitter).
  - Deferred starts in `event-bus` now use `retry()`; 1s→2s→4s→8s capped at 10s (no jitter).
  - Connection/reconnect loops use `exponentialBackoffWithJitter()`: `nats` and `link-daemon` use equal jitter; `web` SSE uses no jitter.
  - Durable delivery in `storage/event-bus` now uses `exponentialBackoffWithJitter()` (no jitter), keeping the same `retryDelayMs * 2^(attempts-1)` schedule.

<sup>Written for commit 5ad32ba255469aabdc1dcc436f80c059d7586c80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

