### PR TITLE
fix(decopilot): image generation with reference images >1 MiB

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
@@ -67,6 +67,28 @@ export type GenerateImageInput = z.infer<typeof GenerateImageInputSchema>;
 const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 
 /**
+ * Upper bound on a single reference image fetched for image-to-image.
+ *
+ * Generous enough to cover real phone photos (a 48 MP shot is ~10–20 MB)
+ * while bounding the in-memory buffer (uploads themselves allow up to
+ * 100 MiB) and roughly tracking the most permissive common provider input
+ * limit — Gemini's ~20 MB inline request budget. Stricter providers (OpenAI
+ * image edits cap at ~4 MB, Anthropic vision at 5 MB) reject oversize inputs
+ * with their own error; this is a sanity guardrail, not a per-provider mirror.
+ */
+const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024; // 20 MiB
+
+function assertReferenceImageSize(bytes: number): void {
+  if (bytes > MAX_REFERENCE_IMAGE_BYTES) {
+    const mb = (bytes / (1024 * 1024)).toFixed(1);
+    const maxMb = MAX_REFERENCE_IMAGE_BYTES / (1024 * 1024);
+    throw new Error(
+      `Reference image too large: ${mb} MB (max ${maxMb} MB). Use a smaller image.`,
+    );
+  }
+}
+
+/**
  * Resolve an image URL to raw bytes.
  * Handles mesh-storage: URIs, our own /api/:org/files/ URLs,
  * data: URIs, and external HTTP(S) URLs.
@@ -92,7 +114,9 @@ async function fetchImageBytes(
   if (url.startsWith("data:")) {
     const match = url.match(/^data:[^;]+;base64,(.+)$/s);
     if (!match) throw new Error("Invalid data: URI");
-    return Buffer.from(match[1]!, "base64");
+    const bytes = Buffer.from(match[1]!, "base64");
+    assertReferenceImageSize(bytes.byteLength);
+    return bytes;
   }
 
   // External HTTP(S) URL — validate before fetching to prevent SSRF
@@ -101,7 +125,9 @@ async function fetchImageBytes(
   if (!res.ok) {
     throw new Error(`Failed to fetch image from ${url}: ${res.status}`);
   }
-  return new Uint8Array(await res.arrayBuffer());
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  assertReferenceImageSize(bytes.byteLength);
+  return bytes;
 }
 
 const PRIVATE_HOST_PATTERNS = [
@@ -151,6 +177,12 @@ async function readFromObjectStorage(
   if (!ctx.objectStorage) {
     throw new Error("Object storage not available");
   }
+  // Check size via HEAD before reading so we don't buffer a pathologically
+  // large object into memory (uploads allow up to 100 MiB). The reference-size
+  // policy lives here in the consumer; getBytes itself stays a dumb uncapped
+  // primitive (mirrors the getBytesOrPresign vs getBytes split).
+  const { size } = await ctx.objectStorage.head(key);
+  assertReferenceImageSize(size);
   // Read raw bytes via getBytes, NOT getBytesOrPresign: the latter is for content
   // that gets inlined into a size-limited channel (model context / NATS) and
   // refuses to inline past the caller's threshold. Reference bytes are

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
@@ -151,14 +151,14 @@ async function readFromObjectStorage(
   if (!ctx.objectStorage) {
     throw new Error("Object storage not available");
   }
-  const result = await ctx.objectStorage.get(key);
-  if ("content" in result && typeof result.content === "string") {
-    if (result.encoding === "base64") {
-      return Buffer.from(result.content, "base64");
-    }
-    return new TextEncoder().encode(result.content);
-  }
-  throw new Error(`Failed to read from object storage: ${key}`);
+  // Read raw bytes via getBytes, NOT getBytesOrPresign: the latter is for content
+  // that gets inlined into a size-limited channel (model context / NATS) and
+  // refuses to inline past the caller's threshold. Reference bytes are
+  // consumed server-side and handed straight to the image provider's API —
+  // never relayed through NATS — so no size cap applies. Routing this through
+  // the capped path used to make generation throw for any reference image
+  // above ~1 MiB (e.g. a phone photo).
+  return ctx.objectStorage.getBytes(key);
 }
 
 export function createGenerateImageTool(

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/generate-image.ts
@@ -66,17 +66,9 @@ export type GenerateImageInput = z.infer<typeof GenerateImageInputSchema>;
 /** Pattern to extract the storage key from our own files endpoint URL. */
 const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 
-/**
- * Upper bound on a single reference image fetched for image-to-image.
- *
- * Generous enough to cover real phone photos (a 48 MP shot is ~10–20 MB)
- * while bounding the in-memory buffer (uploads themselves allow up to
- * 100 MiB) and roughly tracking the most permissive common provider input
- * limit — Gemini's ~20 MB inline request budget. Stricter providers (OpenAI
- * image edits cap at ~4 MB, Anthropic vision at 5 MB) reject oversize inputs
- * with their own error; this is a sanity guardrail, not a per-provider mirror.
- */
-const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024; // 20 MiB
+// Sanity cap on a reference image read into memory; providers enforce their
+// own (stricter) input limits.
+const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024;
 
 function assertReferenceImageSize(bytes: number): void {
   if (bytes > MAX_REFERENCE_IMAGE_BYTES) {
@@ -177,19 +169,9 @@ async function readFromObjectStorage(
   if (!ctx.objectStorage) {
     throw new Error("Object storage not available");
   }
-  // Check size via HEAD before reading so we don't buffer a pathologically
-  // large object into memory (uploads allow up to 100 MiB). The reference-size
-  // policy lives here in the consumer; getBytes itself stays a dumb uncapped
-  // primitive (mirrors the getBytesOrPresign vs getBytes split).
+  // HEAD first to reject oversize before buffering the whole object.
   const { size } = await ctx.objectStorage.head(key);
   assertReferenceImageSize(size);
-  // Read raw bytes via getBytes, NOT getBytesOrPresign: the latter is for content
-  // that gets inlined into a size-limited channel (model context / NATS) and
-  // refuses to inline past the caller's threshold. Reference bytes are
-  // consumed server-side and handed straight to the image provider's API —
-  // never relayed through NATS — so no size cap applies. Routing this through
-  // the capped path used to make generation throw for any reference image
-  // above ~1 MiB (e.g. a phone photo).
   return ctx.objectStorage.getBytes(key);
 }
 

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/resources.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/resources.ts
@@ -9,6 +9,13 @@ import {
 } from "./read-tool-output";
 import { parseMeshStorageKey } from "../../../api/routes/decopilot/mesh-storage-uri";
 
+// read_resource inlines the resource body straight into the model context,
+// which is relayed to the UI over NATS JetStream (~1 MiB max_payload). Past
+// this size we hand back a presigned URL instead of inlining. The budget
+// lives HERE — with the consumer that does the inlining — not in the storage
+// layer, which has no business knowing about NATS or the model context.
+const INLINE_RESOURCE_BYTE_LIMIT = 1_048_576; // 1 MiB
+
 export interface ResourceToolParams {
   readonly passthroughClient: VirtualClient;
   readonly toolOutputMap: Map<string, string>;
@@ -38,7 +45,9 @@ export function createReadResourceTool(params: ResourceToolParams) {
           return { result: "Object storage is not configured." };
         }
         try {
-          const data = await ctx.objectStorage.get(key);
+          const data = await ctx.objectStorage.getBytesOrPresign(key, {
+            presignWhenLargerThan: INLINE_RESOURCE_BYTE_LIMIT,
+          });
           if ("error" in data) {
             return {
               result: `Resource too large to inline (${data.size} bytes). Presigned URL: ${data.presignedUrl}`,

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/resources.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/resources.ts
@@ -9,11 +9,8 @@ import {
 } from "./read-tool-output";
 import { parseMeshStorageKey } from "../../../api/routes/decopilot/mesh-storage-uri";
 
-// read_resource inlines the resource body straight into the model context,
-// which is relayed to the UI over NATS JetStream (~1 MiB max_payload). Past
-// this size we hand back a presigned URL instead of inlining. The budget
-// lives HERE — with the consumer that does the inlining — not in the storage
-// layer, which has no business knowing about NATS or the model context.
+// Above this we return a presigned URL instead of inlining the body, which is
+// relayed to the UI over NATS (~1 MiB max_payload).
 const INLINE_RESOURCE_BYTE_LIMIT = 1_048_576; // 1 MiB
 
 export interface ResourceToolParams {

--- a/apps/mesh/src/object-storage/bound-object-storage.ts
+++ b/apps/mesh/src/object-storage/bound-object-storage.ts
@@ -12,7 +12,23 @@ import type {
  * Bakes in the org ID so callers don't need to pass it on every call.
  */
 export interface BoundObjectStorage {
-  get(key: string): Promise<GetObjectResult | GetObjectTooLargeResult>;
+  /**
+   * Read an object for inlining, capped at a caller-supplied size threshold.
+   * Objects larger than `presignWhenLargerThan` come back as a
+   * `FILE_TOO_LARGE` marker with a presigned URL instead of inline content.
+   * The threshold is the caller's policy (NATS payload / model-context
+   * budget) — pass it explicitly.
+   */
+  getBytesOrPresign(
+    key: string,
+    opts: { presignWhenLargerThan: number; presignExpiresIn?: number },
+  ): Promise<GetObjectResult | GetObjectTooLargeResult>;
+  /**
+   * Read an object's raw bytes regardless of size. Unlike `getBytesOrPresign`,
+   * this is not capped — use it for server-side consumers that need the full
+   * content and don't relay it through NATS.
+   */
+  getBytes(key: string): Promise<Uint8Array>;
   put(
     key: string,
     body: string | Uint8Array,
@@ -44,7 +60,8 @@ export function createBoundObjectStorage(
   orgId: string,
 ): BoundObjectStorage {
   return {
-    get: (key) => s3.get(orgId, key),
+    getBytesOrPresign: (key, opts) => s3.getBytesOrPresign(orgId, key, opts),
+    getBytes: (key) => s3.getBytes(orgId, key),
     put: (key, body, options) => s3.put(orgId, key, body, options),
     list: (options) => s3.list(orgId, options),
     delete: (key) => s3.delete(orgId, key),

--- a/apps/mesh/src/object-storage/bound-object-storage.ts
+++ b/apps/mesh/src/object-storage/bound-object-storage.ts
@@ -13,21 +13,14 @@ import type {
  */
 export interface BoundObjectStorage {
   /**
-   * Read an object for inlining, capped at a caller-supplied size threshold.
-   * Objects larger than `presignWhenLargerThan` come back as a
-   * `FILE_TOO_LARGE` marker with a presigned URL instead of inline content.
-   * The threshold is the caller's policy (NATS payload / model-context
-   * budget) — pass it explicitly.
+   * Read an object, or return a `FILE_TOO_LARGE` marker with a presigned URL
+   * when it exceeds `presignWhenLargerThan` (the caller's inline budget).
    */
   getBytesOrPresign(
     key: string,
     opts: { presignWhenLargerThan: number; presignExpiresIn?: number },
   ): Promise<GetObjectResult | GetObjectTooLargeResult>;
-  /**
-   * Read an object's raw bytes regardless of size. Unlike `getBytesOrPresign`,
-   * this is not capped — use it for server-side consumers that need the full
-   * content and don't relay it through NATS.
-   */
+  /** Read an object's raw bytes, uncapped. */
   getBytes(key: string): Promise<Uint8Array>;
   put(
     key: string,

--- a/apps/mesh/src/object-storage/dev-object-storage.ts
+++ b/apps/mesh/src/object-storage/dev-object-storage.ts
@@ -48,10 +48,24 @@ export class DevObjectStorage implements BoundObjectStorage {
     private readonly baseUrl?: string,
   ) {}
 
-  async get(key: string): Promise<GetObjectResult | GetObjectTooLargeResult> {
+  async getBytesOrPresign(
+    key: string,
+    opts: { presignWhenLargerThan: number; presignExpiresIn?: number },
+  ): Promise<GetObjectResult | GetObjectTooLargeResult> {
     const path = filePath(this.orgId, key);
     const info = await stat(path);
     const contentType = detectContentType(key);
+
+    if (info.size > opts.presignWhenLargerThan) {
+      return {
+        error: "FILE_TOO_LARGE",
+        size: info.size,
+        maxInlineSize: opts.presignWhenLargerThan,
+        presignedUrl: await this.presignedGetUrl(key),
+        contentType,
+      };
+    }
+
     const bytes = await readFile(path);
     const isText = isTextContentType(contentType);
 
@@ -64,6 +78,11 @@ export class DevObjectStorage implements BoundObjectStorage {
       size: info.size,
       lastModified: info.mtime,
     };
+  }
+
+  async getBytes(key: string): Promise<Uint8Array> {
+    const bytes = await readFile(filePath(this.orgId, key));
+    return new Uint8Array(bytes);
   }
 
   async put(

--- a/apps/mesh/src/object-storage/s3-service.ts
+++ b/apps/mesh/src/object-storage/s3-service.ts
@@ -86,14 +86,9 @@ export class S3Service {
   }
 
   /**
-   * Read an object for inlining into a size-limited channel.
-   *
-   * HEADs first; if the object is larger than `presignWhenLargerThan` bytes
-   * it returns a `FILE_TOO_LARGE` marker carrying a presigned URL instead of
-   * the content, so the caller can hand back a link rather than inline a
-   * blob. The threshold is the CALLER's policy (e.g. the NATS payload / model
-   * context budget) — the storage layer holds no opinion about it. For raw
-   * server-side reads that never get inlined, use `getBytes`.
+   * Read an object, or — when larger than `presignWhenLargerThan` — return a
+   * `FILE_TOO_LARGE` marker with a presigned URL instead of its content. The
+   * threshold is the caller's policy. For raw uncapped reads, use `getBytes`.
    */
   async getBytesOrPresign(
     orgId: string,
@@ -145,15 +140,7 @@ export class S3Service {
     };
   }
 
-  /**
-   * Read an object's raw bytes regardless of size.
-   *
-   * Unlike `getBytesOrPresign` — which caps inlined content at a caller-supplied
-   * threshold so the payload fits a size-limited channel — this streams the
-   * object body straight to bytes. Use it for server-side consumers that need
-   * the raw content and never round-trip it through NATS (e.g. loading a
-   * reference image to hand to an image model).
-   */
+  /** Read an object's raw bytes, uncapped. */
   async getBytes(orgId: string, key: string): Promise<Uint8Array> {
     const s3Key = buildS3Key(orgId, key);
     const response = await this.client.send(

--- a/apps/mesh/src/object-storage/s3-service.ts
+++ b/apps/mesh/src/object-storage/s3-service.ts
@@ -15,9 +15,6 @@ import {
   stripOrgPrefix,
 } from "./key-utils";
 
-/** 1 MB inline read limit */
-const MAX_INLINE_SIZE = 1_048_576;
-
 export interface S3ServiceConfig {
   endpoint: string;
   bucket: string;
@@ -88,9 +85,20 @@ export class S3Service {
     });
   }
 
-  async get(
+  /**
+   * Read an object for inlining into a size-limited channel.
+   *
+   * HEADs first; if the object is larger than `presignWhenLargerThan` bytes
+   * it returns a `FILE_TOO_LARGE` marker carrying a presigned URL instead of
+   * the content, so the caller can hand back a link rather than inline a
+   * blob. The threshold is the CALLER's policy (e.g. the NATS payload / model
+   * context budget) — the storage layer holds no opinion about it. For raw
+   * server-side reads that never get inlined, use `getBytes`.
+   */
+  async getBytesOrPresign(
     orgId: string,
     key: string,
+    opts: { presignWhenLargerThan: number; presignExpiresIn?: number },
   ): Promise<GetObjectResult | GetObjectTooLargeResult> {
     const s3Key = buildS3Key(orgId, key);
 
@@ -102,17 +110,17 @@ export class S3Service {
     const size = headResult.ContentLength ?? 0;
     const contentType = headResult.ContentType ?? detectContentType(key);
 
-    if (size > MAX_INLINE_SIZE) {
+    if (size > opts.presignWhenLargerThan) {
       const presignedUrl = await getSignedUrl(
         this.client,
         new GetObjectCommand({ Bucket: this.bucket, Key: s3Key }),
-        { expiresIn: 3600 },
+        { expiresIn: opts.presignExpiresIn ?? 3600 },
       );
 
       return {
         error: "FILE_TOO_LARGE",
         size,
-        maxInlineSize: MAX_INLINE_SIZE,
+        maxInlineSize: opts.presignWhenLargerThan,
         presignedUrl,
         contentType,
       };
@@ -135,6 +143,23 @@ export class S3Service {
       lastModified: headResult.LastModified,
       etag: headResult.ETag,
     };
+  }
+
+  /**
+   * Read an object's raw bytes regardless of size.
+   *
+   * Unlike `getBytesOrPresign` — which caps inlined content at a caller-supplied
+   * threshold so the payload fits a size-limited channel — this streams the
+   * object body straight to bytes. Use it for server-side consumers that need
+   * the raw content and never round-trip it through NATS (e.g. loading a
+   * reference image to hand to an image model).
+   */
+  async getBytes(orgId: string, key: string): Promise<Uint8Array> {
+    const s3Key = buildS3Key(orgId, key);
+    const response = await this.client.send(
+      new GetObjectCommand({ Bucket: this.bucket, Key: s3Key }),
+    );
+    return response.Body!.transformToByteArray();
   }
 
   async put(


### PR DESCRIPTION
## Problem

`generate_image` failed instantly (~0.1s, before any model call) whenever the user attached a **reference image larger than 1 MiB** — e.g. a phone photo. Reported by @vibegui (chihuahua "Beto" thread).

**Root cause:** the reference read went through `S3Service.get()`, which HEADs first and refuses to inline anything over a hardcoded 1 MiB cap, returning a `FILE_TOO_LARGE` marker with no `content`. `readFromObjectStorage` only handled the content case, so it threw `Failed to read from object storage: <key>`.

That cap exists to keep **inlined** content under the NATS JetStream `max_payload`. But reference bytes are consumed **server-side** and handed straight to the image provider's API — they never round-trip through NATS — so the cap should never have applied here.

**Confirmed in prod** (vibegui's org): the failing thread's tool part had
`errorText = "Failed to read from object storage: chat-uploads/<uuid>.png"` with a `mesh-storage://chat-uploads/...` reference — a >1 MiB upload hitting the `FILE_TOO_LARGE` branch. The "openrouter vs deco gateway" difference noticed during triage was a red herring; the trigger was reference size.

## Fix + layering cleanup

The 1 MiB cap was a NATS/model-context policy living in the storage layer — a leaky abstraction (the storage shouldn't know NATS exists). This PR fixes the bug and moves the policy to where it belongs:

- **Add `getBytes(key)`** to `S3Service` / `BoundObjectStorage` — raw bytes, no size cap. `generate_image` reference reads use it.
- **`get()` → `getBytesOrPresign(key, { presignWhenLargerThan })`** — the threshold is now an explicit, caller-owned parameter (plus optional `presignExpiresIn`). The magic `MAX_INLINE_SIZE = 1_048_576` constant leaves storage entirely.
- **`read_resource`** (the one consumer that inlines content into the model context / NATS) now owns the threshold via `INLINE_RESOURCE_BYTE_LIMIT`, documented next to the code that does the inlining.
- **`DevObjectStorage` now honors the threshold too**, so the dev↔prod contract matches. The dev backend never capping (filesystem, always inlines) is exactly why this bug was invisible locally.

## Testing

- `bun run check` (tsc) — clean
- `bun run lint` — 0 errors (4 pre-existing warnings in unrelated files)
- `bun test` object-storage + built-in tools — pass (1 unrelated integration test needs a live DB)

⚠️ **No automated regression test yet.** Neither test tier currently catches this: local e2e uses `DevObjectStorage` (no cap) and runs without AI credentials, and CI has no S3. Follow-up options being discussed: a MinIO-backed storage integration test (asserts `getBytesOrPresign` caps but `getBytes` returns full bytes for a >1 MiB object) and/or a daily prod smoke test for image generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image generation failures with reference images >1 MiB by reading uncapped bytes and moving the inline limit to the consumer. Adds a 20 MiB guardrail for reference images with clear errors to prevent buffering huge files.

- **Bug Fixes**
  - `generate_image` reads references via `getBytes`, so large photos no longer fail with `FILE_TOO_LARGE`.
  - Removes the unintended 1 MiB cap from server-side reference reads; “Failed to read from object storage” errors are resolved.
  - Adds a 20 MiB max for reference images (data:/HTTP(S)/object storage): HEAD-checks size before reads and validates fetched/decoded bytes, returning a friendly error when oversized.

- **Refactors**
  - Added `getBytes(key)` to `S3Service` and `BoundObjectStorage` for uncapped reads.
  - Replaced `get()` with `getBytesOrPresign(key, { presignWhenLargerThan, presignExpiresIn? })` to make the inline limit caller-owned.
  - Moved the inline cap to `read_resource` as `INLINE_RESOURCE_BYTE_LIMIT`; `DevObjectStorage` now enforces the same threshold and trimmed verbose comments in image-storage paths.

<sup>Written for commit 7306c588a9601888f5155b79d8d21d4dcd0a01db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

