### PR TITLE
test(object-storage): MinIO integration test for S3Service read paths

### DIFF
--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -91,6 +91,10 @@ jobs:
           --health-retries 10
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      # MinIO, started below — backs the s3-service integration test.
+      S3_ENDPOINT: http://localhost:9000
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -105,6 +109,18 @@ jobs:
 
       - name: Run migrations
         run: bun run --cwd=apps/mesh migrate
+
+      # MinIO runs the server by default only with an explicit command, which
+      # GitHub `services:` can't override — so start it as a step, mirroring how
+      # e2e.yml brings up NATS.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          for i in $(seq 1 15); do nc -z localhost 9000 && break || sleep 1; done
+          nc -z localhost 9000
 
       # Convention: every `*.integration.test.ts` file is picked up here.
       # Adding a new integration test = create a `something.integration.test.ts`

--- a/apps/mesh/src/object-storage/s3-service.integration.test.ts
+++ b/apps/mesh/src/object-storage/s3-service.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration: S3Service against a real S3-compatible store (MinIO in CI).
+ *
+ * Guards the read-path contract that broke image generation (#3595):
+ * getBytesOrPresign caps inline content at the caller's threshold, while
+ * getBytes returns the full object regardless of size. DevObjectStorage (the
+ * local backend) never capped, so only a real S3 backend exercises this.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { CreateBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import { S3Service } from "./s3-service";
+
+const ENDPOINT = process.env.S3_ENDPOINT ?? "http://localhost:9000";
+const ACCESS_KEY = process.env.S3_ACCESS_KEY_ID ?? "minioadmin";
+const SECRET_KEY = process.env.S3_SECRET_ACCESS_KEY ?? "minioadmin";
+const BUCKET = "s3-service-integration";
+const ORG = "org_test";
+const MIB = 1024 * 1024;
+
+const config = {
+  endpoint: ENDPOINT,
+  bucket: BUCKET,
+  region: "us-east-1",
+  accessKeyId: ACCESS_KEY,
+  secretAccessKey: SECRET_KEY,
+  forcePathStyle: true,
+};
+
+const s3 = new S3Service(config);
+
+function patternedBytes(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  for (let i = 0; i < size; i++) bytes[i] = i % 256;
+  return bytes;
+}
+
+beforeAll(async () => {
+  const client = new S3Client({
+    endpoint: ENDPOINT,
+    region: config.region,
+    credentials: { accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY },
+    forcePathStyle: true,
+  });
+  try {
+    await client.send(new CreateBucketCommand({ Bucket: BUCKET }));
+  } catch {
+    // Bucket may already exist from a previous run.
+  }
+});
+
+describe("S3Service read paths", () => {
+  test("getBytesOrPresign inlines content under the threshold", async () => {
+    const key = "small.txt";
+    await s3.put(ORG, key, "hello world");
+
+    const result = await s3.getBytesOrPresign(ORG, key, {
+      presignWhenLargerThan: MIB,
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("unreachable");
+    expect(result.encoding).toBe("utf-8");
+    expect(result.content).toBe("hello world");
+  });
+
+  test("getBytesOrPresign returns a presigned URL above the threshold", async () => {
+    const key = "large.png";
+    const bytes = patternedBytes(2 * MIB);
+    await s3.put(ORG, key, bytes);
+
+    const result = await s3.getBytesOrPresign(ORG, key, {
+      presignWhenLargerThan: MIB,
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("unreachable");
+    expect(result.error).toBe("FILE_TOO_LARGE");
+    expect(result.size).toBe(2 * MIB);
+    expect(result.presignedUrl).toContain("http");
+  });
+
+  test("getBytes returns the full object regardless of size", async () => {
+    const key = "large.png";
+    const bytes = patternedBytes(2 * MIB);
+    await s3.put(ORG, key, bytes);
+
+    const raw = await s3.getBytes(ORG, key);
+
+    expect(raw.byteLength).toBe(2 * MIB);
+    expect(raw[0]).toBe(0);
+    expect(raw[257]).toBe(1);
+    expect(raw[2 * MIB - 1]).toBe((2 * MIB - 1) % 256);
+  });
+
+  test("a threshold above the object size inlines it instead of presigning", async () => {
+    const key = "large.png";
+    await s3.put(ORG, key, patternedBytes(2 * MIB));
+
+    const result = await s3.getBytesOrPresign(ORG, key, {
+      presignWhenLargerThan: 4 * MIB,
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("unreachable");
+    expect(result.encoding).toBe("base64");
+    expect(Buffer.from(result.content, "base64").byteLength).toBe(2 * MIB);
+  });
+});


### PR DESCRIPTION
Fast-follow to #3595. Adds the regression guard that neither test tier could provide before.

## Why

#3595 fixed image generation failing for reference images >1 MiB: the read went through the inline-capped path (`get()` → now `getBytesOrPresign`) instead of an uncapped raw read (`getBytes`). Nothing guarded it — local e2e uses `DevObjectStorage` (filesystem, never caps) and CI had no S3 backend.

## What

- **`s3-service.integration.test.ts`** — runs against a real S3 store and asserts the read-path contract:
  - `getBytesOrPresign` inlines content under the threshold,
  - returns a `FILE_TOO_LARGE` marker + presigned URL above it,
  - `getBytes` returns the **full** object regardless of size (the assertion that would have caught the bug),
  - a threshold above the object size inlines it instead of presigning.
  - Auto-routed to the storage-integration workflow by the `*.integration.test.ts` convention.
- **`storage-integration.yml`** — brings up MinIO via `docker run` (GitHub `services:` can't override MinIO's required `server` command), mirroring how `e2e.yml` starts NATS. Pinned to a release tag.

## Testing

Ran locally against MinIO (`minio/minio:RELEASE.2025-09-07...`): **4 pass, 0 fail**. `bun run check` + `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a MinIO-backed integration test for `S3Service` read paths to prevent regressions in large-object handling (as fixed in #3595). The test verifies `getBytesOrPresign` inlines under a threshold and presigns with `FILE_TOO_LARGE` above it, and that `getBytes` always returns the full object; CI starts `minio/minio` via `docker run` in `storage-integration.yml`.

<sup>Written for commit 1f643c380367181ccb029ff3955387184090aedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

