### PR TITLE
test(object-storage): MinIO-backed object-storage e2e through the app

### DIFF
--- a/.github/actions/start-minio/action.yml
+++ b/.github/actions/start-minio/action.yml
@@ -29,5 +29,12 @@ runs:
           -e MINIO_ROOT_USER=${{ inputs.root-user }} \
           -e MINIO_ROOT_PASSWORD=${{ inputs.root-password }} \
           ${{ inputs.image }} server /data
-        for i in $(seq 1 15); do nc -z localhost ${{ inputs.port }} && break || sleep 1; done
-        nc -z localhost ${{ inputs.port }}
+        # Poll MinIO's readiness endpoint, not a bare TCP probe: `nc -z` passes
+        # as soon as the port is listening, but the object layer isn't serving
+        # yet and resets S3 requests (ECONNRESET). /minio/health/ready returns
+        # 200 only once it can actually serve.
+        ready="http://localhost:${{ inputs.port }}/minio/health/ready"
+        for i in $(seq 1 30); do
+          curl -fsS "$ready" >/dev/null 2>&1 && break || sleep 1
+        done
+        curl -fsS "$ready" >/dev/null

--- a/.github/actions/start-minio/action.yml
+++ b/.github/actions/start-minio/action.yml
@@ -1,0 +1,33 @@
+name: Start MinIO
+description: >-
+  Start a MinIO (S3-compatible) server as a detached container and wait until it
+  accepts connections. MinIO only runs the server with an explicit command,
+  which GitHub `services:` can't provide — so it has to be a step, not a service.
+  Shared by e2e.yml and storage-integration.yml so the pinned image version
+  lives in exactly one place.
+
+inputs:
+  image:
+    description: MinIO container image — single source of truth for the pinned version.
+    default: minio/minio:RELEASE.2025-09-07T16-13-09Z
+  port:
+    description: Host port to publish and probe for readiness.
+    default: "9000"
+  root-user:
+    description: MINIO_ROOT_USER.
+    default: minioadmin
+  root-password:
+    description: MINIO_ROOT_PASSWORD.
+    default: minioadmin
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        docker run -d --name minio -p ${{ inputs.port }}:9000 \
+          -e MINIO_ROOT_USER=${{ inputs.root-user }} \
+          -e MINIO_ROOT_PASSWORD=${{ inputs.root-password }} \
+          ${{ inputs.image }} server /data
+        for i in $(seq 1 15); do nc -z localhost ${{ inputs.port }} && break || sleep 1; done
+        nc -z localhost ${{ inputs.port }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,6 +90,13 @@ jobs:
       # signups per run; without this they get 429s and only pass on retry,
       # which masks real regressions as "flaky".
       DISABLE_RATE_LIMIT: "true"
+      # MinIO, started below — makes the app resolve OBJECT_STORAGE to the real
+      # S3Service path (not the DevObjectStorage filesystem fallback) so the
+      # object-storage e2e exercises production code end-to-end.
+      S3_ENDPOINT: http://localhost:9000
+      S3_BUCKET: studio-e2e
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
 
     steps:
       - name: Checkout repository
@@ -109,6 +116,34 @@ jobs:
           docker run -d --name nats -p 4222:4222 nats:2.10 -js
           for i in $(seq 1 10); do nc -z localhost 4222 && break || sleep 1; done
           nc -z localhost 4222
+
+      # MinIO runs the server only with an explicit command, which GitHub
+      # `services:` can't override — start it as a step, mirroring NATS above
+      # and the storage-integration workflow. Then create the bucket the app
+      # expects (S3Service never auto-creates it); reuse the already-installed
+      # @aws-sdk/client-s3 so there's no `mc` version to keep in sync.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          for i in $(seq 1 15); do nc -z localhost 9000 && break || sleep 1; done
+          nc -z localhost 9000
+          bun -e '
+            import { S3Client, CreateBucketCommand } from "@aws-sdk/client-s3";
+            const c = new S3Client({
+              endpoint: process.env.S3_ENDPOINT,
+              region: "auto",
+              credentials: {
+                accessKeyId: process.env.S3_ACCESS_KEY_ID,
+                secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+              },
+              forcePathStyle: true,
+            });
+            await c.send(new CreateBucketCommand({ Bucket: process.env.S3_BUCKET }));
+            console.log("created bucket", process.env.S3_BUCKET);
+          '
 
       - name: Cache Playwright browsers
         id: cache-playwright

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,19 +117,14 @@ jobs:
           for i in $(seq 1 10); do nc -z localhost 4222 && break || sleep 1; done
           nc -z localhost 4222
 
-      # MinIO runs the server only with an explicit command, which GitHub
-      # `services:` can't override — start it as a step, mirroring NATS above
-      # and the storage-integration workflow. Then create the bucket the app
-      # expects (S3Service never auto-creates it); reuse the already-installed
-      # @aws-sdk/client-s3 so there's no `mc` version to keep in sync.
       - name: Start MinIO
+        uses: ./.github/actions/start-minio
+
+      # Create the bucket the app expects (S3Service never auto-creates it);
+      # reuse the already-installed @aws-sdk/client-s3 so there's no `mc`
+      # version to keep in sync.
+      - name: Create S3 bucket
         run: |
-          docker run -d --name minio -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
-          for i in $(seq 1 15); do nc -z localhost 9000 && break || sleep 1; done
-          nc -z localhost 9000
           bun -e '
             import { S3Client, CreateBucketCommand } from "@aws-sdk/client-s3";
             const c = new S3Client({

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -91,6 +91,10 @@ jobs:
           --health-retries 10
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      # MinIO, started below — backs the s3-service integration test.
+      S3_ENDPOINT: http://localhost:9000
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -105,6 +109,18 @@ jobs:
 
       - name: Run migrations
         run: bun run --cwd=apps/mesh migrate
+
+      # MinIO runs the server by default only with an explicit command, which
+      # GitHub `services:` can't override — so start it as a step, mirroring how
+      # e2e.yml brings up NATS.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          for i in $(seq 1 15); do nc -z localhost 9000 && break || sleep 1; done
+          nc -z localhost 9000
 
       # Convention: every `*.integration.test.ts` file is picked up here.
       # Adding a new integration test = create a `something.integration.test.ts`

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -110,17 +110,11 @@ jobs:
       - name: Run migrations
         run: bun run --cwd=apps/mesh migrate
 
-      # MinIO runs the server by default only with an explicit command, which
-      # GitHub `services:` can't override — so start it as a step, mirroring how
-      # e2e.yml brings up NATS.
+      # Backs the s3-service integration test. The test creates its own bucket
+      # in beforeAll, so this only needs the server up. Shared composite action
+      # so the pinned image version stays in sync with e2e.yml.
       - name: Start MinIO
-        run: |
-          docker run -d --name minio -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
-          for i in $(seq 1 15); do nc -z localhost 9000 && break || sleep 1; done
-          nc -z localhost 9000
+        uses: ./.github/actions/start-minio
 
       # Convention: every `*.integration.test.ts` file is picked up here.
       # Adding a new integration test = create a `something.integration.test.ts`

--- a/apps/mesh/e2e/tests/object-storage-roundtrip.spec.ts
+++ b/apps/mesh/e2e/tests/object-storage-roundtrip.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * End-to-end roundtrip for mesh's object storage tools against real S3.
+ *
+ * In CI (e2e.yml) the running app is configured with S3_* env vars pointing at
+ * a MinIO container, so the OBJECT_STORAGE binding resolves to the production
+ * S3Service path (not the DevObjectStorage filesystem fallback). This exercises
+ * the whole chain through the app:
+ *
+ *   PUT_PRESIGNED_URL (mcp/self)  → presigned PUT URL at MinIO
+ *     → client uploads bytes straight to MinIO
+ *   LIST_OBJECTS / GET_OBJECT_METADATA → object is visible + sized correctly
+ *   GET_PRESIGNED_URL → presigned GET URL → client downloads the same bytes
+ *   DELETE_OBJECT → object is gone
+ *
+ * Skips when S3 isn't configured (e.g. a plain local `bun run test:e2e` with no
+ * MinIO) so it stays green on the filesystem-backed dev path, where presigned
+ * GET returns a data: URL rather than a fetchable MinIO URL.
+ */
+
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const s3Configured = !!(
+  process.env.S3_ENDPOINT &&
+  process.env.S3_BUCKET &&
+  process.env.S3_ACCESS_KEY_ID &&
+  process.env.S3_SECRET_ACCESS_KEY
+);
+
+test.describe("Object storage roundtrip (S3)", () => {
+  test.skip(
+    !s3Configured,
+    "requires S3 env (S3_ENDPOINT/S3_BUCKET/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY); see e2e.yml MinIO setup",
+  );
+
+  test("uploads, lists, downloads and deletes an object through MCP tools", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+    const { orgSlug } = user;
+
+    const key = `e2e/${Date.now()}-${Math.random().toString(36).slice(2)}.bin`;
+    const contentType = "application/octet-stream";
+    const payload = Buffer.from(`object-storage roundtrip ${key}\n`.repeat(8));
+
+    // 1. Mint a presigned PUT URL and upload bytes straight to MinIO.
+    const put = await callSelfMcpTool<{ url: string; expiresIn: number }>(
+      ctx,
+      orgSlug,
+      "PUT_PRESIGNED_URL",
+      { key, contentType },
+    );
+    expect(put.url).toMatch(/^https?:\/\//);
+
+    // contentType is part of the signed headers, so the upload must replay it
+    // verbatim or MinIO rejects the signature.
+    const uploadRes = await ctx.fetch(put.url, {
+      method: "PUT",
+      data: payload,
+      headers: { "content-type": contentType },
+    });
+    expect(
+      uploadRes.ok(),
+      `upload failed: HTTP ${uploadRes.status()} — ${await uploadRes
+        .text()
+        .catch(() => "<unreadable>")}`,
+    ).toBe(true);
+
+    // 2. The object shows up in a prefix listing, scoped to this org.
+    const listed = await callSelfMcpTool<{
+      objects: Array<{ key: string; size: number }>;
+    }>(ctx, orgSlug, "LIST_OBJECTS", { prefix: "e2e/" });
+    const entry = listed.objects.find((o) => o.key === key);
+    expect(entry, `object ${key} not found in listing`).toBeDefined();
+    expect(entry!.size).toBe(payload.length);
+
+    // 3. HEAD metadata matches what we uploaded.
+    const meta = await callSelfMcpTool<{
+      contentType?: string;
+      contentLength: number;
+    }>(ctx, orgSlug, "GET_OBJECT_METADATA", { key });
+    expect(meta.contentLength).toBe(payload.length);
+    expect(meta.contentType).toBe(contentType);
+
+    // 4. Presigned GET returns the exact bytes back.
+    const get = await callSelfMcpTool<{ url: string }>(
+      ctx,
+      orgSlug,
+      "GET_PRESIGNED_URL",
+      { key },
+    );
+    const downloadRes = await ctx.get(get.url);
+    expect(downloadRes.ok()).toBe(true);
+    const downloaded = await downloadRes.body();
+    expect(downloaded.equals(payload)).toBe(true);
+
+    // 5. Delete removes it — a follow-up metadata read fails closed.
+    const del = await callSelfMcpTool<{ success: boolean; key: string }>(
+      ctx,
+      orgSlug,
+      "DELETE_OBJECT",
+      { key },
+    );
+    expect(del.success).toBe(true);
+    await expect(
+      callSelfMcpTool(ctx, orgSlug, "GET_OBJECT_METADATA", { key }),
+    ).rejects.toThrow();
+
+    await ctx.dispose();
+  });
+});

--- a/apps/mesh/src/object-storage/s3-service.integration.test.ts
+++ b/apps/mesh/src/object-storage/s3-service.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration: S3Service against a real S3-compatible store (MinIO in CI).
+ *
+ * Guards the read-path contract that broke image generation (#3595):
+ * getBytesOrPresign caps inline content at the caller's threshold, while
+ * getBytes returns the full object regardless of size. DevObjectStorage (the
+ * local backend) never capped, so only a real S3 backend exercises this.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { CreateBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import { S3Service } from "./s3-service";
+
+const ENDPOINT = process.env.S3_ENDPOINT ?? "http://localhost:9000";
+const ACCESS_KEY = process.env.S3_ACCESS_KEY_ID ?? "minioadmin";
+const SECRET_KEY = process.env.S3_SECRET_ACCESS_KEY ?? "minioadmin";
+const BUCKET = "s3-service-integration";
+const ORG = "org_test";
+const MIB = 1024 * 1024;
+
+const config = {
+  endpoint: ENDPOINT,
+  bucket: BUCKET,
+  region: "us-east-1",
+  accessKeyId: ACCESS_KEY,
+  secretAccessKey: SECRET_KEY,
+  forcePathStyle: true,
+};
+
+const s3 = new S3Service(config);
+
+function patternedBytes(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  for (let i = 0; i < size; i++) bytes[i] = i % 256;
+  return bytes;
+}
+
+beforeAll(async () => {
+  const client = new S3Client({
+    endpoint: ENDPOINT,
+    region: config.region,
+    credentials: { accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY },
+    forcePathStyle: true,
+  });
+  try {
+    await client.send(new CreateBucketCommand({ Bucket: BUCKET }));
+  } catch {
+    // Bucket may already exist from a previous run.
+  }
+});
+
+describe("S3Service read paths", () => {
+  test("getBytesOrPresign inlines content under the threshold", async () => {
+    const key = "small.txt";
+    await s3.put(ORG, key, "hello world");
+
+    const result = await s3.getBytesOrPresign(ORG, key, {
+      presignWhenLargerThan: MIB,
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("unreachable");
+    expect(result.encoding).toBe("utf-8");
+    expect(result.content).toBe("hello world");
+  });
+
+  test("getBytesOrPresign returns a presigned URL above the threshold", async () => {
+    const key = "large.png";
+    const bytes = patternedBytes(2 * MIB);
+    await s3.put(ORG, key, bytes);
+
+    const result = await s3.getBytesOrPresign(ORG, key, {
+      presignWhenLargerThan: MIB,
+    });
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) throw new Error("unreachable");
+    expect(result.error).toBe("FILE_TOO_LARGE");
+    expect(result.size).toBe(2 * MIB);
+    expect(result.presignedUrl).toContain("http");
+  });
+
+  test("getBytes returns the full object regardless of size", async () => {
+    const key = "large.png";
+    const bytes = patternedBytes(2 * MIB);
+    await s3.put(ORG, key, bytes);
+
+    const raw = await s3.getBytes(ORG, key);
+
+    expect(raw.byteLength).toBe(2 * MIB);
+    expect(raw[0]).toBe(0);
+    expect(raw[257]).toBe(1);
+    expect(raw[2 * MIB - 1]).toBe((2 * MIB - 1) % 256);
+  });
+
+  test("a threshold above the object size inlines it instead of presigning", async () => {
+    const key = "large.png";
+    await s3.put(ORG, key, patternedBytes(2 * MIB));
+
+    const result = await s3.getBytesOrPresign(ORG, key, {
+      presignWhenLargerThan: 4 * MIB,
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("unreachable");
+    expect(result.encoding).toBe("base64");
+    expect(Buffer.from(result.content, "base64").byteLength).toBe(2 * MIB);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the [SDK-level S3Service MinIO integration test](https://github.com/decocms/studio/commit/1f643c380). The e2e workflow is the one that stands up the whole app infra (real Postgres + NATS + the running dev server), so this folds MinIO into it and exercises the object-storage path **through the running app** rather than the SDK in isolation.

- **`.github/workflows/e2e.yml`** — adds `S3_ENDPOINT`/`S3_BUCKET`/`S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY` to the job env and a **Start MinIO** step (mirroring the existing NATS step and `storage-integration.yml`). With `S3_*` set, the context factory resolves `OBJECT_STORAGE` to the real `S3Service` instead of the `DevObjectStorage` filesystem fallback (no `NODE_ENV` gate). The bucket is created via the already-installed `@aws-sdk/client-s3` (`bun -e`) since `S3Service` never auto-creates it — no `mc` version to keep in sync.
- **`apps/mesh/e2e/tests/object-storage-roundtrip.spec.ts`** — drives the full roundtrip via `/api/:org/mcp/self`:
  - `PUT_PRESIGNED_URL` → upload bytes straight to MinIO
  - `LIST_OBJECTS` (size matches) → `GET_OBJECT_METADATA` (content-length + type match)
  - `GET_PRESIGNED_URL` → download + byte-compare
  - `DELETE_OBJECT` → confirm a follow-up metadata read fails closed

  The spec `test.skip`s when `S3_*` is unset, so a plain local `bun run test:e2e` (filesystem-backed dev path) stays green; only CI, where MinIO is up, runs it.

## Testing

- Verified locally end-to-end against a real MinIO + dedicated Postgres/NATS (mirroring CI): **1 passed**.
- `bun run check` and `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable MinIO in e2e and storage-integration workflows and run object storage tests through the running app. Extract MinIO startup into a shared action with a pinned image and readiness check to prevent flakiness.

- **New Features**
  - Set `S3_*` envs in `e2e.yml` and create the bucket via `@aws-sdk/client-s3` so the app uses the production `S3Service`.
  - Add `object-storage-roundtrip.spec.ts` (full MCP tool roundtrip) and keep `s3-service.integration.test.ts` for `getBytesOrPresign` vs `getBytes`.

- **Refactors**
  - Add `.github/actions/start-minio` and use it in `e2e.yml` and `storage-integration.yml` with a `/minio/health/ready` readiness probe and pinned image to avoid drift.

<sup>Written for commit 77604b0a25954452fc140fd60e7b93f3f68fb662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

