### PR TITLE
refactor(permissions): grant basic-usage tools at runtime, not baked into roles

### DIFF
--- a/apps/mesh/e2e/tests/basic-usage-grant.spec.ts
+++ b/apps/mesh/e2e/tests/basic-usage-grant.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * E2E: runtime basic-usage grant + its org-membership boundary.
+ *
+ * Basic-usage tools are granted at runtime by AccessControl (`checkResource`)
+ * to every org member regardless of role, rather than being baked into each
+ * role's stored permission. These specs verify that behavior through the real
+ * stack (Better Auth + resolveOrgFromPath + the self MCP), which a unit test
+ * mocking BoundAuthClient cannot honestly do:
+ *
+ *   - A member with a restrictive CUSTOM role (not owner/admin, and whose
+ *     stored permission does NOT list the tool) can still call a basic-usage
+ *     tool, yet is denied a non-basic tool it was never granted. This is the
+ *     test that actually exercises the runtime grant.
+ *   - A NON-member cannot call a basic-usage tool against the org — the grant
+ *     must never leak past membership.
+ *
+ * Tool choices have all-optional input schemas, so a denial surfaces as an
+ * access error rather than a schema-validation error:
+ *   - AUTOMATION_LIST  → basic-usage
+ *   - MONITORING_STATS → NOT basic-usage (monitoring:view capability)
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const MCP_HEADERS = { Accept: "application/json, text/event-stream" };
+
+const toolCallBody = (name: string) => ({
+  jsonrpc: "2.0" as const,
+  id: 1,
+  method: "tools/call",
+  params: { name, arguments: {} },
+});
+
+test.describe("runtime basic-usage grant", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("a restrictive custom role still gets basic-usage tools, but not others", async ({
+    playwright,
+  }) => {
+    // Owner of org A.
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org A not found after signup");
+
+    // A custom role granting exactly one non-basic tool (ORGANIZATION_GET) and
+    // nothing else — not owner/admin, and no basic-usage tools listed.
+    const roleSlug = `restricted-${Date.now()}-${Math.floor(
+      Math.random() * 1e6,
+    )}`;
+    const createRole = await ownerCtx.post(
+      "/api/auth/organization/create-role",
+      {
+        data: {
+          organizationId: orgId,
+          role: roleSlug,
+          permission: { self: ["ORGANIZATION_GET"] },
+        },
+      },
+    );
+    expect(
+      createRole.ok(),
+      `create-role failed: ${await createRole.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // A second user, invited into org A and assigned the custom role.
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+
+    const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+      data: { organizationId: orgId, email: member.email, role: "member" },
+    });
+    expect(invite.ok()).toBe(true);
+    const inviteJson = (await invite.json()) as {
+      id?: string;
+      invitation?: { id?: string };
+    };
+    const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+    expect(invitationId).toBeTruthy();
+
+    const accept = await memberCtx.post(
+      "/api/auth/organization/accept-invitation",
+      { data: { invitationId } },
+    );
+    expect(
+      accept.ok(),
+      `accept-invitation failed: ${await accept.text().catch(() => "")}`,
+    ).toBe(true);
+
+    const memberRow = await db.query<{ id: string }>(
+      `SELECT id FROM "member" WHERE "userId" = $1 AND "organizationId" = $2`,
+      [member.userId, orgId],
+    );
+    const memberId = memberRow.rows[0]?.id;
+    if (!memberId) throw new Error("member row not found after accept");
+
+    const assign = await ownerCtx.post(
+      "/api/auth/organization/update-member-role",
+      { data: { organizationId: orgId, memberId, role: [roleSlug] } },
+    );
+    expect(
+      assign.ok(),
+      `update-member-role failed: ${await assign.text().catch(() => "")}`,
+    ).toBe(true);
+
+    // Basic-usage tool the role does NOT list → granted at runtime.
+    const automations = await callSelfMcpTool<{ automations: unknown[] }>(
+      memberCtx,
+      owner.orgSlug,
+      "AUTOMATION_LIST",
+      {},
+    );
+    expect(Array.isArray(automations.automations)).toBe(true);
+
+    // Non-basic tool the role does NOT list → denied. Access denial surfaces
+    // as a tool-error envelope (isError) or a JSON-RPC error, not HTTP 403.
+    const deniedRes = await memberCtx.post(`/api/${owner.orgSlug}/mcp/self`, {
+      data: toolCallBody("MONITORING_STATS"),
+      headers: MCP_HEADERS,
+    });
+    const denied = (await deniedRes.json()) as {
+      result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      error?: { message?: string };
+    };
+    const errText =
+      denied.result?.content?.[0]?.text ?? denied.error?.message ?? "";
+    expect(
+      denied.result?.isError === true || !!denied.error,
+      `expected MONITORING_STATS to be denied, got: ${JSON.stringify(denied)}`,
+    ).toBe(true);
+    expect(errText).toMatch(/access denied|permission/i);
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+
+  test("a non-member cannot call a basic-usage tool against the org", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+
+    // Outsider has their own org but no membership in the owner's org.
+    const outsiderCtx = await newApiContext(playwright);
+    await signUpViaApi(outsiderCtx);
+
+    const res = await outsiderCtx.post(`/api/${owner.orgSlug}/mcp/self`, {
+      data: toolCallBody("AUTOMATION_LIST"),
+      headers: MCP_HEADERS,
+    });
+    // resolveOrgFromPath rejects non-members before AccessControl runs.
+    expect(res.status()).toBe(403);
+
+    await ownerCtx.dispose();
+    await outsiderCtx.dispose();
+  });
+});

--- a/apps/mesh/e2e/tests/basic-usage-grant.spec.ts
+++ b/apps/mesh/e2e/tests/basic-usage-grant.spec.ts
@@ -59,8 +59,12 @@ test.describe("runtime basic-usage grant", () => {
     const orgId = orgRow.rows[0]?.id;
     if (!orgId) throw new Error("org A not found after signup");
 
-    // A custom role granting exactly one non-basic tool (ORGANIZATION_GET) and
-    // nothing else — not owner/admin, and no basic-usage tools listed.
+    // A custom role with NO permissions — fully restrictive (not owner/admin,
+    // grants no tools). Better Auth's create-role only lets a creator grant
+    // permissions they hold *explicitly*, and the owner's `self: ["*"]` is not
+    // expanded for that check — so an empty permission is both what this test
+    // needs (the role must not grant the tool under test) and what create-role
+    // will accept.
     const roleSlug = `restricted-${Date.now()}-${Math.floor(
       Math.random() * 1e6,
     )}`;
@@ -70,7 +74,7 @@ test.describe("runtime basic-usage grant", () => {
         data: {
           organizationId: orgId,
           role: roleSlug,
-          permission: { self: ["ORGANIZATION_GET"] },
+          permission: {},
         },
       },
     );
@@ -83,8 +87,11 @@ test.describe("runtime basic-usage grant", () => {
     const memberCtx = await newApiContext(playwright);
     const member = await signUpViaApi(memberCtx);
 
+    // Invite with the built-in "user" role (defined in our auth config); the
+    // member's effective role is overwritten with the restrictive custom role
+    // below, so this is only the transient role between invite and assignment.
     const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
-      data: { organizationId: orgId, email: member.email, role: "member" },
+      data: { organizationId: orgId, email: member.email, role: "user" },
     });
     expect(invite.ok()).toBe(true);
     const inviteJson = (await invite.json()) as {

--- a/apps/mesh/migrations/073-backfill-basic-usage-roles.ts
+++ b/apps/mesh/migrations/073-backfill-basic-usage-roles.ts
@@ -1,7 +1,15 @@
 /**
  * Backfill basic-usage tools into existing custom roles.
  *
- * The role editor now bakes BASIC_USAGE_TOOLS (defined in registry-metadata)
+ * SUPERSEDED: basic-usage tools are now granted at runtime by AccessControl
+ * (`checkResource`), not baked into stored role permissions. This migration is
+ * kept as immutable history; its effect (extra valid entries in
+ * `permission.self`) is harmless and redundant. Do NOT write new backfill
+ * migrations when the basic-usage set changes — edit the capability list in
+ * registry-metadata and the runtime grant picks it up immediately.
+ *
+ * --- Original note (no longer accurate) ---
+ * The role editor bakes BASIC_USAGE_TOOLS (defined in registry-metadata)
  * into the saved `permission.self` array of every custom role at submit time.
  * Roles created before this change are missing those tools and would lose
  * access until someone re-saves them via the UI.
@@ -11,9 +19,7 @@
  * grant everything and are left untouched.
  *
  * NOTE: The list below is a SNAPSHOT — it must not import the live
- * BASIC_USAGE_TOOLS constant. Migrations are immutable history. If
- * BASIC_USAGE_TOOLS changes in the future, write a new migration with the
- * tools added since this one.
+ * BASIC_USAGE_TOOLS constant. Migrations are immutable history.
  */
 
 import { type Kysely, sql } from "kysely";

--- a/apps/mesh/migrations/093-backfill-global-search-basic-usage.ts
+++ b/apps/mesh/migrations/093-backfill-global-search-basic-usage.ts
@@ -1,12 +1,18 @@
 /**
  * Backfill GLOBAL_SEARCH into existing custom roles.
  *
+ * SUPERSEDED: basic-usage tools are now granted at runtime by AccessControl
+ * (`checkResource`), not baked into stored role permissions. This migration is
+ * kept as immutable history; its effect is harmless and redundant. Do NOT
+ * write new backfill migrations when the basic-usage set changes — edit the
+ * capability list in registry-metadata instead.
+ *
+ * --- Original note (no longer accurate) ---
  * GLOBAL_SEARCH is the new cross-resource discovery tool added to the
- * basic-usage capability in registry-metadata. Per BASIC_USAGE_TOOLS'
- * contract, every newly-saved custom role bakes the basic-usage tool
- * snapshot into `permission.self`, but roles created before this change
- * are missing GLOBAL_SEARCH and would deny the command palette for any
- * non-admin member assigned to them.
+ * basic-usage capability in registry-metadata. Every newly-saved custom role
+ * baked the basic-usage tool snapshot into `permission.self`, but roles
+ * created before this change are missing GLOBAL_SEARCH and would deny the
+ * command palette for any non-admin member assigned to them.
  *
  * Mirrors the 073 backfill pattern. Roles whose `permission.self` is
  * `["*"]` already grant everything and are left untouched.

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -6,7 +6,6 @@ import {
 } from "./access-control";
 import type { BetterAuthInstance, BoundAuthClient } from "./mesh-context";
 import type { Permission } from "../storage/types";
-import { BASIC_USAGE_TOOLS } from "../tools/registry-metadata";
 
 const createMockAuth = (): BetterAuthInstance => {
   const mockUserHasPermission = vi.fn();
@@ -220,60 +219,11 @@ describe("AccessControl", () => {
     });
   });
 
-  describe("basic-usage runtime grant", () => {
-    const basicUsageTool = [...BASIC_USAGE_TOOLS][0];
-
-    it("grants a basic-usage tool to a custom role with no stored permission", async () => {
-      const ac = new AccessControl(
-        createMockAuth(),
-        "user_1",
-        basicUsageTool,
-        createMockBoundAuth({}), // role grants nothing
-        "custom-role",
-      );
-
-      await ac.check();
-      expect(ac.granted()).toBe(true);
-    });
-
-    it("still denies a non-basic-usage tool the role lacks", async () => {
-      const ac = new AccessControl(
-        createMockAuth(),
-        "user_1",
-        "DATABASES_RUN_SQL", // dangerous, never basic-usage
-        createMockBoundAuth({}),
-        "custom-role",
-      );
-
-      await expect(ac.check()).rejects.toThrow(ForbiddenError);
-      expect(ac.granted()).toBe(false);
-    });
-
-    it("does not grant basic-usage to an unauthenticated caller", async () => {
-      const ac = new AccessControl(
-        createMockAuth(),
-        undefined, // no user
-        basicUsageTool,
-        undefined, // no boundAuth
-        undefined,
-      );
-
-      await expect(ac.check()).rejects.toThrow(UnauthorizedError);
-    });
-
-    it("does not grant basic-usage to an authenticated non-member (no role)", async () => {
-      const ac = new AccessControl(
-        createMockAuth(),
-        "user_1",
-        basicUsageTool,
-        createMockBoundAuth({}), // authenticated, but not a member → no role
-        undefined, // role undefined = not a member of this org
-      );
-
-      await expect(ac.check()).rejects.toThrow(ForbiddenError);
-      expect(ac.granted()).toBe(false);
-    });
-  });
+  // Basic-usage runtime grant + its org-membership boundary are verified
+  // end-to-end through the real stack (Better Auth + resolveOrgFromPath + self
+  // MCP) in apps/mesh/e2e/tests/basic-usage-grant.spec.ts. A unit test here
+  // would have to mock BoundAuthClient — the kind of own-contract mock
+  // TESTING.md steers away from — so the verification lives in e2e.
 
   describe("granted", () => {
     it("should return false initially", () => {

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -260,6 +260,19 @@ describe("AccessControl", () => {
 
       await expect(ac.check()).rejects.toThrow(UnauthorizedError);
     });
+
+    it("does not grant basic-usage to an authenticated non-member (no role)", async () => {
+      const ac = new AccessControl(
+        createMockAuth(),
+        "user_1",
+        basicUsageTool,
+        createMockBoundAuth({}), // authenticated, but not a member → no role
+        undefined, // role undefined = not a member of this org
+      );
+
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
+      expect(ac.granted()).toBe(false);
+    });
   });
 
   describe("granted", () => {

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./access-control";
 import type { BetterAuthInstance, BoundAuthClient } from "./mesh-context";
 import type { Permission } from "../storage/types";
+import { BASIC_USAGE_TOOLS } from "../tools/registry-metadata";
 
 const createMockAuth = (): BetterAuthInstance => {
   const mockUserHasPermission = vi.fn();
@@ -212,6 +213,48 @@ describe("AccessControl", () => {
         undefined, // No user
         "TEST_TOOL",
         undefined, // No boundAuth
+        undefined,
+      );
+
+      await expect(ac.check()).rejects.toThrow(UnauthorizedError);
+    });
+  });
+
+  describe("basic-usage runtime grant", () => {
+    const basicUsageTool = [...BASIC_USAGE_TOOLS][0];
+
+    it("grants a basic-usage tool to a custom role with no stored permission", async () => {
+      const ac = new AccessControl(
+        createMockAuth(),
+        "user_1",
+        basicUsageTool,
+        createMockBoundAuth({}), // role grants nothing
+        "custom-role",
+      );
+
+      await ac.check();
+      expect(ac.granted()).toBe(true);
+    });
+
+    it("still denies a non-basic-usage tool the role lacks", async () => {
+      const ac = new AccessControl(
+        createMockAuth(),
+        "user_1",
+        "DATABASES_RUN_SQL", // dangerous, never basic-usage
+        createMockBoundAuth({}),
+        "custom-role",
+      );
+
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
+      expect(ac.granted()).toBe(false);
+    });
+
+    it("does not grant basic-usage to an unauthenticated caller", async () => {
+      const ac = new AccessControl(
+        createMockAuth(),
+        undefined, // no user
+        basicUsageTool,
+        undefined, // no boundAuth
         undefined,
       );
 

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./access-control";
 import type { BetterAuthInstance, BoundAuthClient } from "./mesh-context";
 import type { Permission } from "../storage/types";
+import { BASIC_USAGE_TOOLS } from "../tools/registry-metadata";
 
 const createMockAuth = (): BetterAuthInstance => {
   const mockUserHasPermission = vi.fn();
@@ -219,11 +220,58 @@ describe("AccessControl", () => {
     });
   });
 
-  // Basic-usage runtime grant + its org-membership boundary are verified
-  // end-to-end through the real stack (Better Auth + resolveOrgFromPath + self
-  // MCP) in apps/mesh/e2e/tests/basic-usage-grant.spec.ts. A unit test here
-  // would have to mock BoundAuthClient — the kind of own-contract mock
-  // TESTING.md steers away from — so the verification lives in e2e.
+  // The basic-usage runtime grant lives BELOW the HTTP auth/membership
+  // middleware: resolveOrgFromPath 403s non-members and mcpAuth 401s anonymous
+  // callers before a tool runs. So the e2e specs (front door) can prove the
+  // happy path and the routing boundary, but they can never drive checkResource
+  // without an authenticated member — they can't exercise this guard at all.
+  // This is the internal-logic / single-boundary-mock case TESTING.md allows,
+  // and it's the only place the guard below can be regression-tested.
+  describe("basic-usage grant guard", () => {
+    const tool = [...BASIC_USAGE_TOOLS][0];
+
+    it("grants a basic-usage tool to an authenticated member, regardless of role", async () => {
+      const ac = new AccessControl(
+        createMockAuth(),
+        "user_1", // authenticated principal
+        tool,
+        createMockBoundAuth({}), // role grants nothing explicitly
+        "some-custom-role", // a member (role set), not owner/admin
+      );
+
+      await ac.check();
+      expect(ac.granted()).toBe(true);
+    });
+
+    it("does NOT grant basic-usage without an authenticated principal, even though boundAuth is present", async () => {
+      // boundAuth is constructed for every request, so it must never be treated
+      // as authentication. With no userId the grant must not fire. (Before the
+      // userId guard, a role-but-no-principal state would have leaked here.)
+      const ac = new AccessControl(
+        createMockAuth(),
+        undefined, // no authenticated principal
+        tool,
+        createMockBoundAuth({}), // boundAuth present, as it always is
+        "some-custom-role", // role present, but the principal is not verified
+      );
+
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
+      expect(ac.granted()).toBe(false);
+    });
+
+    it("does NOT grant basic-usage to an authenticated non-member (no role)", async () => {
+      const ac = new AccessControl(
+        createMockAuth(),
+        "user_1",
+        tool,
+        createMockBoundAuth({}),
+        undefined, // not a member of this org → no role
+      );
+
+      await expect(ac.check()).rejects.toThrow(ForbiddenError);
+      expect(ac.granted()).toBe(false);
+    });
+  });
 
   describe("granted", () => {
     it("should return false initially", () => {

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -191,11 +191,18 @@ export class AccessControl implements Disposable {
       return false;
     }
 
-    // Basic-usage tools are granted to every authenticated org member at
-    // runtime, regardless of role. Resolving them here — instead of baking
-    // them into each role's stored permission — means the set evolves with a
-    // one-line edit to BASIC_USAGE_TOOLS, with no role-backfill migration.
-    if (BASIC_USAGE_TOOLS.has(resource)) {
+    // Basic-usage tools are granted to every org MEMBER at runtime, regardless
+    // of their role. Resolving them here — instead of baking them into each
+    // role's stored permission — means the set evolves with a one-line edit to
+    // BASIC_USAGE_TOOLS, with no role-backfill migration.
+    //
+    // Gated on `this.role`: it's derived from the caller's membership row in
+    // the target org (see context-factory / resolveOrgFromPath), so it's only
+    // set for members and undefined for non-members. Without this guard the
+    // grant would leak basic-usage to any authenticated user against any org;
+    // the old bake-in model denied non-members implicitly (no role → no stored
+    // permission), so we keep that boundary explicit here.
+    if (this.role && BASIC_USAGE_TOOLS.has(resource)) {
       return true;
     }
 

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -10,6 +10,7 @@
  */
 
 import { MCP_MESH_KEY } from "@/core/constants";
+import { BASIC_USAGE_TOOLS } from "@/tools/registry-metadata";
 import type { BetterAuthInstance, BoundAuthClient } from "./mesh-context";
 
 // ============================================================================
@@ -188,6 +189,14 @@ export class AccessControl implements Disposable {
     // No user or bound auth = deny
     if (!this.userId && !this.boundAuth) {
       return false;
+    }
+
+    // Basic-usage tools are granted to every authenticated org member at
+    // runtime, regardless of role. Resolving them here — instead of baking
+    // them into each role's stored permission — means the set evolves with a
+    // one-line edit to BASIC_USAGE_TOOLS, with no role-backfill migration.
+    if (BASIC_USAGE_TOOLS.has(resource)) {
+      return true;
     }
 
     // Admin and owner roles bypass all checks (they have full access)

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -191,18 +191,21 @@ export class AccessControl implements Disposable {
       return false;
     }
 
-    // Basic-usage tools are granted to every org MEMBER at runtime, regardless
-    // of their role. Resolving them here — instead of baking them into each
-    // role's stored permission — means the set evolves with a one-line edit to
-    // BASIC_USAGE_TOOLS, with no role-backfill migration.
+    // Basic-usage tools are granted to every authenticated org MEMBER at
+    // runtime, regardless of their role. Resolving them here — instead of
+    // baking them into each role's stored permission — means the set evolves
+    // with a one-line edit to BASIC_USAGE_TOOLS, with no role-backfill
+    // migration.
     //
-    // Gated on `this.role`: it's derived from the caller's membership row in
-    // the target org (see context-factory / resolveOrgFromPath), so it's only
-    // set for members and undefined for non-members. Without this guard the
-    // grant would leak basic-usage to any authenticated user against any org;
-    // the old bake-in model denied non-members implicitly (no role → no stored
-    // permission), so we keep that boundary explicit here.
-    if (this.role && BASIC_USAGE_TOOLS.has(resource)) {
+    // Both signals are required and checked explicitly:
+    //   - `userId`: a verified authenticated principal. `boundAuth` is NOT a
+    //     proxy for auth — it's constructed for every request, including
+    //     anonymous ones, so it must never gate this grant.
+    //   - `role`: derived from the caller's membership row in the target org
+    //     (context-factory / resolveOrgFromPath); set only for members. The old
+    //     bake-in model denied non-members implicitly (no role → no stored
+    //     permission), so we keep that boundary explicit here.
+    if (this.userId && this.role && BASIC_USAGE_TOOLS.has(resource)) {
       return true;
     }
 

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1270,17 +1270,14 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
 /**
  * Tools every authenticated org member can use by default.
  *
- * The role editor (`org-role-detail.tsx`) bakes these into every custom
- * role's saved `permission.self` array at submit time, so AccessControl
- * sees them as a normal Better Auth permission — no runtime bypass.
+ * Granted at runtime by AccessControl (`checkResource`) to every member
+ * regardless of role — NOT persisted into stored role permissions. To change
+ * the set, edit the `basic-usage` capability above; it takes effect
+ * immediately for all existing and new roles, with no backfill migration.
  *
- * ⚠️  Adding or removing a tool from the basic-usage capability above?
- *     You MUST also write a Kysely migration that backfills the change
- *     into existing custom roles in the `organizationRole` table.
- *     See `apps/mesh/migrations/073-backfill-basic-usage-roles.ts` for
- *     the pattern. Snapshot the tools you're adding inside the migration
- *     — do not import this constant from a migration (migrations are
- *     immutable history).
+ * (Migrations 073 and 093 backfilled basic-usage tools into roles under the
+ * older bake-in model. They are now redundant but harmless — the runtime
+ * grant supersedes them. No new backfill migrations are needed.)
  */
 export const BASIC_USAGE_TOOLS: ReadonlySet<string> = new Set(
   PERMISSION_CAPABILITIES.find((c) => c.id === BASIC_USAGE_CAPABILITY_ID)

--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -1,5 +1,4 @@
 import {
-  BASIC_USAGE_TOOLS,
   getCapabilitySections,
   isCapabilityEnabled,
   toggleCapabilityInTools,
@@ -1132,10 +1131,10 @@ function buildPermission(
   const permission: Record<string, string[]> = {};
   if (data.allowAllStaticPermissions) {
     permission["self"] = ["*"];
-  } else {
-    const tools = new Set(data.staticPermissions);
-    for (const tool of BASIC_USAGE_TOOLS) tools.add(tool);
-    if (tools.size > 0) permission["self"] = Array.from(tools);
+  } else if (data.staticPermissions.length > 0) {
+    // Basic-usage tools are granted at runtime by AccessControl, so they are
+    // intentionally NOT persisted here — only the role's explicit grants are.
+    permission["self"] = data.staticPermissions;
   }
   for (const [connectionId, tools] of Object.entries(data.toolSet)) {
     if (tools.length > 0) {


### PR DESCRIPTION
## Summary

Basic-usage tools (the read-only / essential tools every authenticated org member should always have) are now granted **at runtime** by `AccessControl`, instead of being **baked into each custom role's stored permission** at save time.

`AccessControl.checkResource` grants any tool in `BASIC_USAGE_TOOLS` to authenticated callers before the role-specific permission check. The role editor's `buildPermission` no longer folds the basic-usage set into `permission.self`.

## Why

The bake-in model required a Kysely backfill migration **every time** the basic-usage set changed — we already accumulated two (`073-backfill-basic-usage-roles`, `093-backfill-global-search-basic-usage`). Resolving at runtime makes the set a single source of truth: editing the `basic-usage` capability list takes effect immediately for all existing and new roles, with zero migrations.

## Changes

- `core/access-control.ts` — grant `BASIC_USAGE_TOOLS` in `checkResource` (one early return, after the auth guard, before role checks).
- `web/views/settings/org-role-detail.tsx` — `buildPermission` persists only the role's explicit grants; drops the basic-usage fold-in.
- `tools/registry-metadata.ts` — rewrote the `BASIC_USAGE_TOOLS` doc comment to describe the runtime model.
- `core/access-control.test.ts` — added coverage: basic-usage granted to a custom role with no stored perms; a non-basic tool still denied; unauthenticated callers still 401.

## Migrations

Migrations `073` and `093` are left in place as immutable history. They're now redundant but harmless — the runtime grant supersedes the baked-in tools, so existing roles simply carry a few extra valid entries in `permission.self`. **No data migration is required.**

## Testing

- `bun test apps/mesh/src/core/access-control.test.ts` — 27/27 pass.
- Type-checks clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant basic-usage tools at runtime in `AccessControl` only to authenticated org members (requires `userId` + `role`), instead of baking them into stored role permissions. Changes to the `basic-usage` set now apply instantly to all roles with no migrations.

- **Refactors**
  - `AccessControl` grants `BASIC_USAGE_TOOLS` only when both `userId` and org `role` are present; `boundAuth` alone never qualifies; unauthenticated callers and non-members are denied.
  - Role editor persists only explicit grants; no basic-usage fold-in.
  - Tests: E2E verifies runtime grant and membership boundary; unit tests cover the guard (grants to authenticated members; denies without `userId` or without `role`).

- **Migration**
  - No data migration. Migrations `073` and `093` are marked SUPERSEDED and kept as harmless history.

<sup>Written for commit c0f1fb03b75ab8643fc866f69be51f6d3b0c7e65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

