### PR TITLE
feat(sections-editor): multivariate page variant shape and drag-to-reorder tabs

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-variant-tabs.tsx
@@ -1,0 +1,394 @@
+import { useRef, useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { DotsHorizontal, Edit01, Plus, Trash01 } from "@untitledui/icons";
+import { getIconComponent } from "../agent-icon";
+import { resolveEffectiveMatcherRule } from "./matcher-rules";
+import { resolveMatcherIconName } from "./matcher-icons";
+import type { PageVariant } from "./page-variants";
+import type { LiveMeta } from "./resolve-schema";
+
+const VARIANT_GREEN_TEXT = "oklch(0.65 0.15 160)";
+const VARIANT_TAB_ACTIVE_CLASS =
+  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
+
+export function VariantTabIcon({
+  rule,
+  matchers,
+}: {
+  rule: Record<string, unknown> | undefined;
+  matchers: Array<{ resolveType: string; iconName: string }>;
+}) {
+  const rt = (rule?.__resolveType as string) ?? "";
+  const fromSchema = matchers.find((m) => m.resolveType === rt)?.iconName;
+  const iconName = fromSchema ?? resolveMatcherIconName(rt);
+  const Icon = getIconComponent(iconName);
+  if (!Icon) return null;
+  return <Icon size={14} className="shrink-0" />;
+}
+
+interface VariantTabEntry {
+  id: string;
+  index: number;
+  variant: PageVariant;
+}
+
+function pageVariantsDisplayKey(variants: PageVariant[]): string {
+  return variants
+    .map(
+      (variant) =>
+        `${variant.label}|${(variant.rule?.__resolveType as string) ?? ""}`,
+    )
+    .join("\n");
+}
+
+function createEntries(variants: PageVariant[]): VariantTabEntry[] {
+  return variants.map((variant, index) => ({
+    id: crypto.randomUUID(),
+    index,
+    variant,
+  }));
+}
+
+function remapEntryIndices(entries: VariantTabEntry[]): VariantTabEntry[] {
+  return entries.map((entry, index) => ({
+    ...entry,
+    index,
+  }));
+}
+
+function SortablePageVariantTab({
+  entry,
+  sortableId,
+  isActive,
+  canDelete,
+  decofile,
+  meta,
+  matchers,
+  onSelect,
+  onRename,
+  onDelete,
+}: {
+  entry: VariantTabEntry;
+  sortableId: string;
+  isActive: boolean;
+  canDelete: boolean;
+  decofile: Record<string, unknown>;
+  meta?: LiveMeta | null;
+  matchers: Array<{ resolveType: string; iconName: string }>;
+  onSelect: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useSortable({
+      id: sortableId,
+      animateLayoutChanges: () => false,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(
+      transform ? { ...transform, y: 0 } : null,
+    ),
+    opacity: isDragging ? 0 : undefined,
+  };
+
+  const effectiveRule = resolveEffectiveMatcherRule(
+    entry.variant.rule,
+    decofile,
+    meta ?? undefined,
+  );
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group shrink-0 inline-flex items-center rounded-md transition-colors touch-none",
+        isActive
+          ? VARIANT_TAB_ACTIVE_CLASS
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        isDragging ? "cursor-grabbing" : "cursor-grab",
+      )}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        onClick={onSelect}
+        className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-[inherit]"
+      >
+        <VariantTabIcon rule={effectiveRule} matchers={matchers} />
+        <span className="truncate">{entry.variant.label}</span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Actions for ${entry.variant.label}`}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className={cn(
+              "inline-flex h-8 w-6 items-center justify-center pr-1 cursor-pointer transition-opacity",
+              "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
+              isActive && "opacity-100",
+            )}
+          >
+            <DotsHorizontal size={12} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-36">
+          <DropdownMenuItem onClick={onRename}>
+            <Edit01 size={14} />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            disabled={!canDelete}
+            onClick={onDelete}
+          >
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function PageVariantTabPreview({
+  variant,
+  decofile,
+  meta,
+  matchers,
+}: {
+  variant: PageVariant;
+  decofile: Record<string, unknown>;
+  meta?: LiveMeta | null;
+  matchers: Array<{ resolveType: string; iconName: string }>;
+}) {
+  const effectiveRule = resolveEffectiveMatcherRule(
+    variant.rule,
+    decofile,
+    meta ?? undefined,
+  );
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 h-8 pl-3 pr-3 text-sm font-medium rounded-md shadow-lg ring-1 ring-border/60 cursor-grabbing",
+        VARIANT_TAB_ACTIVE_CLASS,
+      )}
+    >
+      <VariantTabIcon rule={effectiveRule} matchers={matchers} />
+      <span className="truncate">{variant.label}</span>
+    </div>
+  );
+}
+
+export function PageVariantTabs({
+  listKey,
+  variants,
+  activeIndex,
+  decofile,
+  meta,
+  matchers,
+  onSelect,
+  onReorder,
+  onRename,
+  onDelete,
+  onAdd,
+}: {
+  listKey: string;
+  variants: PageVariant[];
+  activeIndex: number;
+  decofile: Record<string, unknown>;
+  meta?: LiveMeta | null;
+  matchers: Array<{ resolveType: string; iconName: string }>;
+  onSelect: (index: number) => void;
+  onReorder: (fromIndex: number, toIndex: number) => void;
+  onRename: (index: number) => void;
+  onDelete: (index: number) => void;
+  onAdd: () => void;
+}) {
+  const [entries, setEntries] = useState<VariantTabEntry[]>(() =>
+    createEntries(variants),
+  );
+  const [activeEntry, setActiveEntry] = useState<VariantTabEntry | null>(null);
+  const [prevListKey, setPrevListKey] = useState(listKey);
+  const [prevVariantCount, setPrevVariantCount] = useState(variants.length);
+  const [prevDisplayKey, setPrevDisplayKey] = useState(() =>
+    pageVariantsDisplayKey(variants),
+  );
+  const suppressClickRef = useRef(false);
+
+  const displayKey = pageVariantsDisplayKey(variants);
+
+  if (prevListKey !== listKey) {
+    setPrevListKey(listKey);
+    setPrevVariantCount(variants.length);
+    setPrevDisplayKey(displayKey);
+    setEntries(createEntries(variants));
+  } else if (prevVariantCount !== variants.length) {
+    setPrevVariantCount(variants.length);
+    setPrevDisplayKey(displayKey);
+    setEntries(createEntries(variants));
+  } else if (prevDisplayKey !== displayKey) {
+    setPrevDisplayKey(displayKey);
+    setEntries((current) =>
+      variants.map((variant, index) => {
+        const prior = current[index];
+        return {
+          id: prior?.id ?? crypto.randomUUID(),
+          index,
+          variant,
+        };
+      }),
+    );
+  }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const entryIds = entries.map((entry) => entry.id);
+  const canDelete = variants.length > 1;
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const id = String(event.active.id);
+    setActiveEntry(entries.find((entry) => entry.id === id) ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveEntry(null);
+
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = entryIds.indexOf(String(active.id));
+    const newIndex = entryIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    setEntries((current) =>
+      remapEntryIndices(arrayMove([...current], oldIndex, newIndex)),
+    );
+    suppressClickRef.current = true;
+    requestAnimationFrame(() => {
+      suppressClickRef.current = false;
+    });
+    onReorder(oldIndex, newIndex);
+  };
+
+  const handleDragCancel = () => {
+    setActiveEntry(null);
+  };
+
+  const handleSelect = (index: number) => {
+    if (suppressClickRef.current) return;
+    onSelect(index);
+  };
+
+  return (
+    <div className="flex items-center border-b shrink-0">
+      <div
+        className={cn(
+          "flex flex-1 min-w-0 items-center gap-1.5 pl-3 pr-2 py-2 overflow-x-auto",
+          activeEntry && "cursor-grabbing",
+        )}
+      >
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          <SortableContext
+            items={entryIds}
+            strategy={horizontalListSortingStrategy}
+          >
+            {entries.map((entry) => (
+              <SortablePageVariantTab
+                key={entry.id}
+                sortableId={entry.id}
+                entry={entry}
+                isActive={entry.index === activeIndex}
+                canDelete={canDelete}
+                decofile={decofile}
+                meta={meta}
+                matchers={matchers}
+                onSelect={() => handleSelect(entry.index)}
+                onRename={() => onRename(entry.index)}
+                onDelete={() => onDelete(entry.index)}
+              />
+            ))}
+          </SortableContext>
+
+          <DragOverlay dropAnimation={null}>
+            {activeEntry ? (
+              <PageVariantTabPreview
+                variant={activeEntry.variant}
+                decofile={decofile}
+                meta={meta}
+                matchers={matchers}
+              />
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      </div>
+      <div className="shrink-0 pr-3 pl-1 py-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Add variant"
+              className="size-8 shrink-0 cursor-pointer"
+              style={{ color: VARIANT_GREEN_TEXT }}
+              onClick={onAdd}
+            >
+              <Plus size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Add variant</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/page-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.test.ts
@@ -38,7 +38,17 @@ describe("page-variants", () => {
     const seed = [{ __resolveType: "site/sections/Hero.tsx" }];
     const result = appendPageVariantSections([{ __resolveType: "A" }], seed);
     expect(result).toEqual({
-      variants: [{ value: [{ __resolveType: "A" }] }, { value: seed }],
+      __resolveType: "website/flags/multivariate.ts",
+      variants: [
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: [{ __resolveType: "A" }],
+        },
+        {
+          rule: { __resolveType: "website/matchers/always.ts" },
+          value: seed,
+        },
+      ],
     });
   });
 
@@ -58,9 +68,14 @@ describe("page-variants", () => {
     expect(variantHasRule(variants[0])).toBe(true);
   });
 
-  it("collapses to a flat array when the last variant has no rule", () => {
+  it("collapses to a flat array when the last variant has the default rule", () => {
     const obj = { __resolveType: "website/flags/multivariate.ts" };
-    const variants = [{ value: [{ __resolveType: "A" }] }];
+    const variants = [
+      {
+        rule: { __resolveType: "website/matchers/always.ts" },
+        value: [{ __resolveType: "A" }],
+      },
+    ];
 
     expect(buildPageSectionsFromVariants(obj, variants)).toEqual([
       { __resolveType: "A" },

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -3,7 +3,12 @@ import {
   isSavedMatcherBlockReference,
   resolveVariantRuleLabel,
 } from "./matcher-rules";
+import { isDefaultVariantRule } from "./section-variants";
 import type { RawSection } from "./section-types";
+import {
+  ALWAYS_MATCHER_RESOLVE_TYPE,
+  PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+} from "./section-types";
 
 const PAGE_RESOLVE_TYPES = new Set([
   "website/pages/Page.tsx",
@@ -102,6 +107,28 @@ export function parsePageVariants(
   return [];
 }
 
+function defaultPageVariantRule(): Record<string, unknown> {
+  return { __resolveType: ALWAYS_MATCHER_RESOLVE_TYPE };
+}
+
+function createPageVariantEntry(value: RawSection[]): Record<string, unknown> {
+  return {
+    rule: defaultPageVariantRule(),
+    value,
+  };
+}
+
+function createMultivariatePageSections(
+  variants: Array<Record<string, unknown>>,
+  existing?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    __resolveType: PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+    ...existing,
+    variants,
+  };
+}
+
 /**
  * Append a new page variant seeded from `seedSections`. Returns null when the
  * current sections shape cannot be extended.
@@ -112,21 +139,28 @@ export function appendPageVariantSections(
 ): Record<string, unknown> | null {
   const seed = structuredClone(seedSections);
   if (Array.isArray(current)) {
-    return {
-      variants: [{ value: current }, { value: seed }],
-    };
+    return createMultivariatePageSections([
+      createPageVariantEntry(current),
+      createPageVariantEntry(seed),
+    ]);
   }
   if (current && typeof current === "object") {
     const obj = current as Record<string, unknown>;
     if (Array.isArray(obj.variants)) {
-      return {
-        ...obj,
-        variants: [...(obj.variants as unknown[]), { value: seed }],
-      };
+      return createMultivariatePageSections(
+        [
+          ...(obj.variants as Array<Record<string, unknown>>),
+          createPageVariantEntry(seed),
+        ],
+        obj,
+      );
     }
     return null;
   }
-  return { variants: [{ value: [] }, { value: seed }] };
+  return createMultivariatePageSections([
+    createPageVariantEntry([]),
+    createPageVariantEntry(seed),
+  ]);
 }
 
 export function getLastVariantIndex(
@@ -153,18 +187,19 @@ export function buildPageSectionsFromVariants(
   variants: Array<Record<string, unknown>>,
 ): unknown {
   if (variants.length === 0) {
-    return { ...obj, variants: [] };
+    return createMultivariatePageSections([], obj);
   }
   if (variants.length === 1) {
     const only = variants[0];
-    if (variantHasRule(only)) {
-      return { ...obj, variants };
+    const rule = only?.rule as Record<string, unknown> | undefined;
+    if (!isDefaultVariantRule(rule)) {
+      return createMultivariatePageSections(variants, obj);
     }
     if (Array.isArray(only?.value)) {
       return only.value as unknown[];
     }
   }
-  return { ...obj, variants };
+  return createMultivariatePageSections(variants, obj);
 }
 
 function forEachPageVariantRule(

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -123,8 +123,8 @@ function createMultivariatePageSections(
   existing?: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
-    __resolveType: PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
     ...existing,
+    __resolveType: PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
     variants,
   };
 }

--- a/apps/mesh/src/web/components/sections-editor/section-types.ts
+++ b/apps/mesh/src/web/components/sections-editor/section-types.ts
@@ -12,6 +12,9 @@ export const GLOBAL_SECTION_ICON_COLOR = "oklch(0.7278 0.151 289)";
 
 export const ALWAYS_MATCHER_RESOLVE_TYPE = "website/matchers/always.ts";
 
+export const PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE =
+  "website/flags/multivariate.ts";
+
 /** Human label from a deco resolve type path or block id. */
 export function labelFromResolveType(rt: string): string {
   const segments = rt.split("/");

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1538,24 +1538,15 @@ export function SectionsEditor({
   const handleReorderPageVariants = (fromIndex: number, toIndex: number) => {
     if (fromIndex === toIndex) return;
 
-    mutatePageVariants(
-      (variants) => arrayMove(variants, fromIndex, toIndex),
-      () => {
-        if (safeVariantIndex === fromIndex) {
-          setActiveVariantIndex(toIndex);
-        } else if (
-          fromIndex < safeVariantIndex &&
-          toIndex >= safeVariantIndex
-        ) {
-          setActiveVariantIndex(safeVariantIndex - 1);
-        } else if (
-          fromIndex > safeVariantIndex &&
-          toIndex <= safeVariantIndex
-        ) {
-          setActiveVariantIndex(safeVariantIndex + 1);
-        }
-      },
-    );
+    if (safeVariantIndex === fromIndex) {
+      setActiveVariantIndex(toIndex);
+    } else if (fromIndex < safeVariantIndex && toIndex >= safeVariantIndex) {
+      setActiveVariantIndex(safeVariantIndex - 1);
+    } else if (fromIndex > safeVariantIndex && toIndex <= safeVariantIndex) {
+      setActiveVariantIndex(safeVariantIndex + 1);
+    }
+
+    mutatePageVariants((variants) => arrayMove(variants, fromIndex, toIndex));
   };
 
   const handleDeletePageVariant = (variantIndex: number) => {

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -3,21 +3,10 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronUp,
-  DotsHorizontal,
-  Edit01,
   Flag01,
   Loading01,
-  Plus,
-  Trash01,
 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import {
   Tooltip,
@@ -40,8 +29,7 @@ import type { ParsedSection } from "./section-list";
 import { SchemaForm } from "./schema-form";
 import { resolveSchema } from "./resolve-schema";
 import { MatcherPicker, extractMatchers } from "./matcher-picker";
-import { resolveMatcherIconName } from "./matcher-icons";
-import { getIconComponent } from "../agent-icon";
+import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
 import type { SectionCatalogEntry } from "./section-catalog";
@@ -86,27 +74,8 @@ import {
 
 const AUTOSAVE_DELAY = 700;
 
-const VARIANT_GREEN_TEXT = "oklch(0.65 0.15 160)";
 const VARIANT_TAB_ACTIVE_CLASS =
   "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
-
-function VariantTabIcon({
-  rule,
-  matchers,
-}: {
-  rule: Record<string, unknown> | undefined;
-  matchers: Array<{ resolveType: string; iconName: string }>;
-}) {
-  const rt = (rule?.__resolveType as string) ?? "";
-  // Prefer the schema-defined icon (resolved by extractMatchers) so custom
-  // matchers like "Birthday" pick up the Calendar icon set in their schema
-  // metadata, instead of falling back to FilterLines via regex matching.
-  const fromSchema = matchers.find((m) => m.resolveType === rt)?.iconName;
-  const iconName = fromSchema ?? resolveMatcherIconName(rt);
-  const Icon = getIconComponent(iconName);
-  if (!Icon) return null;
-  return <Icon size={14} className="shrink-0" />;
-}
 
 const capitalize = (s: string) =>
   s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
@@ -1549,6 +1518,46 @@ export function SectionsEditor({
     );
   };
 
+  const selectPageVariant = (index: number) => {
+    setRenameVariantIndex(null);
+    setActiveVariantIndex(index);
+    setSelectedSectionIndex(null);
+    setFormValue(null);
+    setActiveResolveType(null);
+    setFieldBreadcrumbs([]);
+    const variantRule = pageVariants[index]?.rule;
+    const { resolveType, formValue } = readMatcherRuleFormState(
+      variantRule,
+      decofile ?? {},
+      meta ?? undefined,
+    );
+    setRuleResolveType(resolveType);
+    setRuleFormValue(formValue);
+  };
+
+  const handleReorderPageVariants = (fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return;
+
+    mutatePageVariants(
+      (variants) => arrayMove(variants, fromIndex, toIndex),
+      () => {
+        if (safeVariantIndex === fromIndex) {
+          setActiveVariantIndex(toIndex);
+        } else if (
+          fromIndex < safeVariantIndex &&
+          toIndex >= safeVariantIndex
+        ) {
+          setActiveVariantIndex(safeVariantIndex - 1);
+        } else if (
+          fromIndex > safeVariantIndex &&
+          toIndex <= safeVariantIndex
+        ) {
+          setActiveVariantIndex(safeVariantIndex + 1);
+        }
+      },
+    );
+  };
+
   const handleDeletePageVariant = (variantIndex: number) => {
     const deletedRule = pageVariants[variantIndex]?.rule;
     const orphanMatcherBlockKey = getSavedMatcherBlockKey(
@@ -1843,110 +1852,20 @@ export function SectionsEditor({
       </div>
 
       {/* Variant selector (when page sections are multivariate) */}
-      {hasMultipleVariants && !isEditing && (
-        <div className="flex items-center border-b shrink-0">
-          <div className="flex flex-1 min-w-0 items-center gap-1.5 pl-3 pr-2 py-2 overflow-x-auto">
-            {pageVariants.map((variant, i) => {
-              const isActive = i === safeVariantIndex;
-              const canDelete = pageVariants.length > 1;
-              return (
-                <div
-                  key={i}
-                  className={cn(
-                    "group shrink-0 inline-flex items-center rounded-md transition-colors",
-                    isActive
-                      ? VARIANT_TAB_ACTIVE_CLASS
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                  )}
-                >
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setRenameVariantIndex(null);
-                      setActiveVariantIndex(i);
-                      setSelectedSectionIndex(null);
-                      setFormValue(null);
-                      setActiveResolveType(null);
-                      setFieldBreadcrumbs([]);
-                      const variantRule = pageVariants[i]?.rule;
-                      const { resolveType, formValue } =
-                        readMatcherRuleFormState(
-                          variantRule,
-                          decofile ?? {},
-                          meta ?? undefined,
-                        );
-                      setRuleResolveType(resolveType);
-                      setRuleFormValue(formValue);
-                    }}
-                    className="inline-flex items-center gap-1.5 h-8 pl-3 pr-1.5 text-sm font-medium cursor-pointer"
-                  >
-                    <VariantTabIcon
-                      rule={resolveEffectiveMatcherRule(
-                        variant.rule,
-                        decofile ?? {},
-                        meta ?? undefined,
-                      )}
-                      matchers={availableMatchers}
-                    />
-                    <span className="truncate">{variant.label}</span>
-                  </button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label={`Actions for ${variant.label}`}
-                        onClick={(e) => e.stopPropagation()}
-                        className={cn(
-                          "inline-flex h-8 w-6 items-center justify-center pr-1 cursor-pointer transition-opacity",
-                          "opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100",
-                          isActive && "opacity-100",
-                        )}
-                      >
-                        <DotsHorizontal size={12} />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="w-36">
-                      <DropdownMenuItem
-                        onClick={() => setRenameVariantIndex(i)}
-                      >
-                        <Edit01 size={14} />
-                        Rename
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        variant="destructive"
-                        disabled={!canDelete}
-                        onClick={() => handleDeletePageVariant(i)}
-                      >
-                        <Trash01 size={14} />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              );
-            })}
-          </div>
-          {/* Pinned "+" — stays visible regardless of horizontal scroll. */}
-          <div className="shrink-0 pr-3 pl-1 py-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Add variant"
-                  className="size-8 shrink-0 cursor-pointer"
-                  style={{ color: VARIANT_GREEN_TEXT }}
-                  onClick={handleAddPageVariant}
-                >
-                  <Plus size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Add variant</TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
+      {hasMultipleVariants && !isEditing && activePageKey && (
+        <PageVariantTabs
+          listKey={activePageKey}
+          variants={pageVariants}
+          activeIndex={safeVariantIndex}
+          decofile={decofile ?? {}}
+          meta={meta}
+          matchers={availableMatchers}
+          onSelect={selectPageVariant}
+          onReorder={handleReorderPageVariants}
+          onRename={setRenameVariantIndex}
+          onDelete={handleDeletePageVariant}
+          onAdd={handleAddPageVariant}
+        />
       )}
 
       {/* Drill-down: section list OR section form */}


### PR DESCRIPTION
## Summary
- Ensure new page variants are persisted with the correct multivariate decofile shape: `website/flags/multivariate.ts` wrapper, and each variant entry includes both `rule` and `value` (default rule uses `website/matchers/always.ts`).
- Add drag-and-drop reordering for page variant tabs in the sections editor, persisting order to the sandbox decofile on drop.
- Extract variant tab UI into `page-variant-tabs.tsx` for cleaner sections editor code.

## Test plan
- [x] `bun test apps/mesh/src/web/components/sections-editor/page-variants.test.ts`
- [ ] Open a page in the sections editor, click **Add variant**, and confirm the saved block uses `website/flags/multivariate.ts` with `rule` + `value` on each variant
- [ ] Drag variant tabs left/right and confirm order persists after reload
- [ ] Delete down to one default variant and confirm the page collapses back to a flat sections array


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns page variants to the multivariate flag shape and adds drag-to-reorder tabs in the sections editor. Fixes resolveType overrides and keeps the active tab correct during reordering.

- New Features
  - Drag-and-drop reorder for page variant tabs; order persists to the sandbox decofile.
  - New variants saved under `website/flags/multivariate.ts` with `rule` + `value`; default rule is `website/matchers/always.ts`.
  - Collapses back to a flat sections array when only one default-rule variant remains.

- Bug Fixes
  - Always set `__resolveType` to `website/flags/multivariate.ts` so legacy fields can’t override the multivariate wrapper.
  - Update the active variant index synchronously on reorder to keep selection in sync.

<sup>Written for commit 3f3f2ee5adebad1619e4dc5e1712a0de8a745b2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

