### PR TITLE
feat(permissions): resolve member capabilities server-side

### DIFF
--- a/apps/mesh/e2e/tests/my-capabilities.spec.ts
+++ b/apps/mesh/e2e/tests/my-capabilities.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E: GET /api/auth/custom/my-capabilities/:slug
+ *
+ * The endpoint resolves the caller's gated permission capabilities in a given
+ * org into a { role, capabilities } bitmap — the server-side source of truth
+ * for UI gating. These specs exercise the auth + org-resolution + membership
+ * wiring through the real stack; the pure resolution matrix (which permission
+ * shapes grant which capabilities) is unit-tested in
+ * src/tools/registry-metadata.test.ts.
+ */
+
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const ENDPOINT = (slug: string) =>
+  `/api/auth/custom/my-capabilities/${encodeURIComponent(slug)}`;
+
+interface CapabilitiesResponse {
+  role: string | null;
+  capabilities: Record<string, boolean>;
+}
+
+test.describe("GET /api/auth/custom/my-capabilities/:slug", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("returns 401 when unauthenticated", async ({ playwright }) => {
+    const anon = await newApiContext(playwright);
+    const res = await anon.get(ENDPOINT(`unused-${Date.now()}`));
+    expect(res.status()).toBe(401);
+    await anon.dispose();
+  });
+
+  test("grants every capability to the org owner", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ctx);
+
+    const res = await ctx.get(ENDPOINT(owner.orgSlug));
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as CapabilitiesResponse;
+
+    expect(body.role).toBe("owner");
+    const values = Object.values(body.capabilities);
+    expect(values.length).toBeGreaterThan(0);
+    expect(values.every((v) => v === true)).toBe(true);
+
+    await ctx.dispose();
+  });
+
+  test("grants no gated capability to a plain member (built-in user role)", async ({
+    playwright,
+  }) => {
+    // Owner of org A.
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const orgRow = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [owner.orgSlug],
+    );
+    const orgId = orgRow.rows[0]?.id;
+    if (!orgId) throw new Error("org A not found after signup");
+
+    // A second user, invited into org A with the built-in "user" role.
+    const memberCtx = await newApiContext(playwright);
+    const member = await signUpViaApi(memberCtx);
+
+    const invite = await ownerCtx.post("/api/auth/organization/invite-member", {
+      data: { organizationId: orgId, email: member.email, role: "user" },
+    });
+    expect(invite.ok()).toBe(true);
+    const inviteJson = (await invite.json()) as {
+      id?: string;
+      invitation?: { id?: string };
+    };
+    const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+    expect(invitationId).toBeTruthy();
+
+    const accept = await memberCtx.post(
+      "/api/auth/organization/accept-invitation",
+      { data: { invitationId } },
+    );
+    expect(
+      accept.ok(),
+      `accept-invitation failed: ${await accept.text().catch(() => "")}`,
+    ).toBe(true);
+
+    const res = await memberCtx.get(ENDPOINT(owner.orgSlug));
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as CapabilitiesResponse;
+
+    expect(body.role).toBe("user");
+    const values = Object.values(body.capabilities);
+    expect(values.length).toBeGreaterThan(0);
+    expect(values.every((v) => v === false)).toBe(true);
+
+    await ownerCtx.dispose();
+    await memberCtx.dispose();
+  });
+
+  test("returns no role for a non-member of the org", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+
+    // Outsider has their own org but no membership in the owner's org.
+    const outsiderCtx = await newApiContext(playwright);
+    await signUpViaApi(outsiderCtx);
+
+    const res = await outsiderCtx.get(ENDPOINT(owner.orgSlug));
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as CapabilitiesResponse;
+    expect(body.role).toBeNull();
+    expect(body.capabilities).toEqual({});
+
+    await ownerCtx.dispose();
+    await outsiderCtx.dispose();
+  });
+});

--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -251,7 +251,13 @@ app.get("/my-capabilities/:slug", async (c) => {
   const raw = customRole?.permission;
   if (typeof raw === "string") {
     try {
-      permission = JSON.parse(raw) as Record<string, string[]>;
+      const parsed: unknown = JSON.parse(raw);
+      // Stored permission must be a JSON object map. Anything else (array,
+      // primitive, null) is treated as no permissions rather than trusted —
+      // resolveCapabilities is also defensive, but we don't pass it garbage.
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        permission = parsed as Record<string, string[]>;
+      }
     } catch {
       permission = {};
     }

--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -25,6 +25,10 @@ import {
   getLocalAdminPassword,
   isLocalMode,
 } from "@/auth/local-mode";
+import {
+  allCapabilitiesGranted,
+  resolveCapabilities,
+} from "@/tools/registry-metadata";
 
 const app = new Hono();
 
@@ -178,6 +182,82 @@ app.post("/local-session", async (c) => {
       500,
     );
   }
+});
+
+/**
+ * My Capabilities Endpoint (authenticated)
+ *
+ * Resolves which permission capabilities the current user has in the given
+ * organization, as a capability-id → boolean map. The single source of truth
+ * for proactive UI gating, so the client never re-implements role logic.
+ *
+ * Server-resolved against the role's stored permission using the same wildcard
+ * rules AccessControl applies. Better Auth's listRoles is admin-only, so this
+ * route reads the caller's own membership + role directly to support every
+ * member. The org is taken from the path (not the session's active org, which
+ * can be stale or point at a different org than the one being viewed).
+ *
+ * Route: GET /api/auth/custom/my-capabilities/:slug
+ */
+app.get("/my-capabilities/:slug", async (c) => {
+  const slug = c.req.param("slug");
+  const session = (await auth.api.getSession({
+    headers: c.req.raw.headers,
+  })) as { user?: { id: string } } | null;
+
+  if (!session?.user) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const db = getDb().db;
+
+  const org = await db
+    .selectFrom("organization")
+    .select(["id"])
+    .where("slug", "=", slug)
+    .executeTakeFirst();
+  if (!org) {
+    return c.json({ role: null, capabilities: {} });
+  }
+
+  const member = await db
+    .selectFrom("member")
+    .select(["role"])
+    .where("userId", "=", session.user.id)
+    .where("organizationId", "=", org.id)
+    .executeTakeFirst();
+
+  const role = member?.role ?? null;
+  if (!role) {
+    return c.json({ role: null, capabilities: {} });
+  }
+
+  // owner / admin bypass every permission check — match AccessControl.
+  if (role === "owner" || role === "admin") {
+    return c.json({ role, capabilities: allCapabilitiesGranted() });
+  }
+
+  // Any other role (built-in "user" or a custom role) is resolved from its
+  // stored permission. Built-in "user" has no organizationRole row, so its
+  // permission is empty and it resolves to no gated capabilities.
+  const customRole = await db
+    .selectFrom("organizationRole")
+    .select(["permission"])
+    .where("role", "=", role)
+    .where("organizationId", "=", org.id)
+    .executeTakeFirst();
+
+  let permission: Record<string, string[]> = {};
+  const raw = customRole?.permission;
+  if (typeof raw === "string") {
+    try {
+      permission = JSON.parse(raw) as Record<string, string[]>;
+    } catch {
+      permission = {};
+    }
+  }
+
+  return c.json({ role, capabilities: resolveCapabilities(permission) });
 });
 
 /**

--- a/apps/mesh/src/tools/registry-metadata.test.ts
+++ b/apps/mesh/src/tools/registry-metadata.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import {
+  allCapabilitiesGranted,
+  getCapabilitySections,
+  resolveCapabilities,
+} from "./registry-metadata";
+
+const allCaps = getCapabilitySections().flatMap((s) => s.capabilities);
+// A capability with >= 2 tools so we can test partial / split grants.
+const sampleCap = allCaps.find((c) => c.tools.length >= 2);
+if (!sampleCap) {
+  throw new Error("expected at least one gated capability with >= 2 tools");
+}
+const sampleTools = sampleCap.tools;
+
+describe("resolveCapabilities", () => {
+  it("grants no gated capability for an empty permission", () => {
+    const result = resolveCapabilities({});
+    expect(Object.keys(result).length).toBeGreaterThan(0);
+    expect(Object.values(result).every((v) => v === false)).toBe(true);
+  });
+
+  it("never includes the hidden basic-usage capability", () => {
+    expect("basic-usage" in resolveCapabilities({ self: ["*"] })).toBe(false);
+    expect("basic-usage" in resolveCapabilities({})).toBe(false);
+  });
+
+  it("grants a capability when all its tools are present", () => {
+    const result = resolveCapabilities({ self: [...sampleTools] });
+    expect(result[sampleCap.id]).toBe(true);
+  });
+
+  it("does not grant a capability when only some of its tools are present", () => {
+    const partial = sampleTools.slice(0, -1); // drop one
+    const result = resolveCapabilities({ self: partial });
+    expect(result[sampleCap.id]).toBe(false);
+  });
+
+  it("aggregates tools across resource buckets", () => {
+    // Same tools, split between self and a connection bucket, still count.
+    const result = resolveCapabilities({
+      self: sampleTools.slice(0, 1),
+      conn_x: sampleTools.slice(1),
+    });
+    expect(result[sampleCap.id]).toBe(true);
+  });
+
+  it("grants every gated capability for a self wildcard", () => {
+    const result = resolveCapabilities({ self: ["*"] });
+    expect(Object.values(result).every((v) => v === true)).toBe(true);
+  });
+
+  it("grants every gated capability for an org-wide wildcard", () => {
+    const result = resolveCapabilities({ "*": ["*"] });
+    expect(Object.values(result).every((v) => v === true)).toBe(true);
+  });
+});
+
+describe("allCapabilitiesGranted", () => {
+  it("returns every gated capability as true, excluding basic-usage", () => {
+    const result = allCapabilitiesGranted();
+    expect(Object.values(result).every((v) => v === true)).toBe(true);
+    expect("basic-usage" in result).toBe(false);
+  });
+
+  it("covers exactly the same capability ids as resolveCapabilities", () => {
+    expect(Object.keys(allCapabilitiesGranted()).sort()).toEqual(
+      Object.keys(resolveCapabilities({})).sort(),
+    );
+  });
+});

--- a/apps/mesh/src/tools/registry-metadata.test.ts
+++ b/apps/mesh/src/tools/registry-metadata.test.ts
@@ -54,6 +54,33 @@ describe("resolveCapabilities", () => {
     const result = resolveCapabilities({ "*": ["*"] });
     expect(Object.values(result).every((v) => v === true)).toBe(true);
   });
+
+  it("does NOT treat a per-connection wildcard as a global grant", () => {
+    // Full access to one connection must not light up org-management
+    // capabilities — only `*` / `self` wildcards are global.
+    const result = resolveCapabilities({ conn_abc123: ["*"] });
+    expect(Object.values(result).every((v) => v === false)).toBe(true);
+  });
+
+  it("does not throw on malformed (non-array) permission buckets", () => {
+    const malformed = {
+      self: "ORGANIZATION_GET", // string, not array
+      "*": 42, // number
+      conn_x: null, // null
+    } as unknown as Record<string, string[]>;
+    const result = resolveCapabilities(malformed);
+    // Treated as empty → no gated capability granted, and no throw.
+    expect(Object.values(result).every((v) => v === false)).toBe(true);
+  });
+
+  it("ignores non-array buckets but still resolves valid ones", () => {
+    const mixed = {
+      self: [...sampleTools],
+      conn_x: null, // malformed bucket is skipped, not fatal
+    } as unknown as Record<string, string[]>;
+    const result = resolveCapabilities(mixed);
+    expect(result[sampleCap.id]).toBe(true);
+  });
 });
 
 describe("allCapabilitiesGranted", () => {

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1325,6 +1325,52 @@ export function toggleCapabilityInTools(
   return Array.from(toolSet);
 }
 
+/**
+ * Map of gated capability id → granted, for the privileged built-in roles
+ * (owner / admin) which bypass every permission check. The hidden basic-usage
+ * capability is never part of the map — it's always-on and not UI-gated.
+ */
+export function allCapabilitiesGranted(): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const cap of PERMISSION_CAPABILITIES) {
+    if (cap.id === BASIC_USAGE_CAPABILITY_ID) continue;
+    out[cap.id] = true;
+  }
+  return out;
+}
+
+/**
+ * Resolve which gated capabilities a stored role permission grants, as a
+ * capability id → boolean map. Pure: mirrors the wildcard rules AccessControl
+ * applies, so the UI can gate actions without re-deriving role logic.
+ *
+ * A capability is granted when every tool it lists appears in some resource
+ * bucket of the permission, or when the role holds an org-wide / self wildcard.
+ * The hidden basic-usage capability is excluded (always-on, never gated).
+ */
+export function resolveCapabilities(
+  permission: Record<string, string[]>,
+): Record<string, boolean> {
+  const orgWildcard = permission["*"]?.includes("*") === true;
+  const selfWildcard = permission.self?.includes("*") === true;
+
+  const grantedActions = new Set<string>();
+  if (!orgWildcard && !selfWildcard) {
+    for (const actions of Object.values(permission)) {
+      for (const action of actions) grantedActions.add(action);
+    }
+  }
+  const hasGlobalGrant = orgWildcard || selfWildcard || grantedActions.has("*");
+
+  const out: Record<string, boolean> = {};
+  for (const cap of PERMISSION_CAPABILITIES) {
+    if (cap.id === BASIC_USAGE_CAPABILITY_ID) continue;
+    out[cap.id] =
+      hasGlobalGrant || cap.tools.every((tool) => grantedActions.has(tool));
+  }
+  return out;
+}
+
 // ============================================================================
 // Exports
 // ============================================================================

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -1347,20 +1347,34 @@ export function allCapabilitiesGranted(): Record<string, boolean> {
  * A capability is granted when every tool it lists appears in some resource
  * bucket of the permission, or when the role holds an org-wide / self wildcard.
  * The hidden basic-usage capability is excluded (always-on, never gated).
+ *
+ * Defensive by design: `permission` is JSON stored on the role, so buckets may
+ * be malformed despite the type — non-array buckets are treated as empty and
+ * never throw.
  */
 export function resolveCapabilities(
   permission: Record<string, string[]>,
 ): Record<string, boolean> {
-  const orgWildcard = permission["*"]?.includes("*") === true;
-  const selfWildcard = permission.self?.includes("*") === true;
+  const perm = permission as Record<string, unknown>;
+  const arrayBucket = (key: string): string[] => {
+    const value = perm[key];
+    return Array.isArray(value) ? (value as string[]) : [];
+  };
+
+  // ONLY an org-wide (`*`) or full org-tool (`self`) wildcard is a GLOBAL grant
+  // across every capability. A `["*"]` inside any other bucket (e.g. a
+  // connection id) means "all tools on that resource" and must NOT light up
+  // unrelated management capabilities.
+  const hasGlobalGrant =
+    arrayBucket("*").includes("*") || arrayBucket("self").includes("*");
 
   const grantedActions = new Set<string>();
-  if (!orgWildcard && !selfWildcard) {
-    for (const actions of Object.values(permission)) {
+  if (!hasGlobalGrant) {
+    for (const actions of Object.values(perm)) {
+      if (!Array.isArray(actions)) continue;
       for (const action of actions) grantedActions.add(action);
     }
   }
-  const hasGlobalGrant = orgWildcard || selfWildcard || grantedActions.has("*");
 
   const out: Record<string, boolean> = {};
   for (const cap of PERMISSION_CAPABILITIES) {


### PR DESCRIPTION
## Summary

Adds `GET /api/auth/custom/my-capabilities/:slug` — the **server-side source of truth** for proactive UI gating. The client never re-implements role logic; it reads a resolved bitmap.

Response: `{ role: string | null, capabilities: Record<capabilityId, boolean> }` for the caller in the org identified by the path slug.

- **owner / admin** bypass every permission check → all gated capabilities `true`.
- **any other role** is resolved from its stored permission JSON using the same wildcard rules `AccessControl` applies. The built-in `user` role has no `organizationRole` row, so it resolves to no gated capabilities.
- the hidden **basic-usage** capability is never in the map (always-on since #3599, not UI-gated).

The org comes from the **path slug**, not the session's `activeOrganizationId` (which can be stale or point at a different org than the one being viewed) — matching the existing `org-access-status/:slug` pattern.

## Design

Capability resolution is a **pure function** (`resolveCapabilities` / `allCapabilitiesGranted` in `registry-metadata.ts`); the endpoint is a thin DB + auth wrapper around it. This keeps the interesting logic unit-testable and the HTTP wiring e2e-testable — the two-tier split from `TESTING.md`.

## Testing

- **Unit** (`registry-metadata.test.ts`): the resolution matrix — empty permission → all false; all-of-a-capability's-tools → that capability true; partial → false; tools split across resource buckets still count; `self`/`*` wildcards → all true; basic-usage never included.
- **E2E** (`my-capabilities.spec.ts`): owner → all true; a plain `user` member (via invite + accept) → all false; unauthenticated → 401; non-member → `{ role: null, capabilities: {} }`.

## Scope

No UI consumer yet — this is the backend half. The `useCapability` hook + the gating sweep (hide/disable/redirect across ~30 call sites) land in the follow-up PR, which consumes this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-side capabilities endpoint and hardens permission resolution to prevent over-granting. This powers proactive UI gating without clients re-implementing role logic.

- **New Features**
  - Added `GET /api/auth/custom/my-capabilities/:slug` that returns `{ role, capabilities }` for the caller in the org from the path slug.
  - Owners/admins get all gated capabilities; the built‑in `user` resolves to none; the always-on `basic-usage` is excluded.
  - Introduced pure helpers `resolveCapabilities` and `allCapabilitiesGranted` in `registry-metadata.ts`.

- **Bug Fixes**
  - Scoped wildcards correctly: a per-resource `["*"]` no longer grants all capabilities; only `self` or `*` buckets are global.
  - Hardened parsing: non-array permission buckets are treated as empty; the endpoint requires a JSON object map (arrays/primitives/null → `{}`).
  - Added tests for per-connection wildcards and malformed buckets, alongside the existing E2E coverage.

<sup>Written for commit 729684015acc4d85b193dded35f21d3779209af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

