### PR TITLE
fix(chat): stop playing chime on message submit

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -367,8 +367,6 @@ export function ChatInput({
   // model's context is much fuller than it actually is.
   const lastTotalTokens = lastUsage?.contextTokens ?? 0;
 
-  const playClickSound = useSound(question004Sound);
-
   const canSubmit =
     !isStreaming && !isModelsLoading && !isTiptapDocEmpty(tiptapDoc);
 
@@ -391,7 +389,6 @@ export function ChatInput({
         virtual_mcp_id: selectedVirtualMcp?.id ?? null,
         submission: e ? "button_or_enter" : "programmatic",
       });
-      playClickSound();
       if (stream) {
         void stream.sendMessage(tiptapDoc);
       } else {


### PR DESCRIPTION
## Summary
- The chat input was playing `question004Sound` on every submit, and `useStatusSounds` was playing the same chime again when the thread reached `completed` / `failed` / `requires_action` — two chimes per turn for the same event.
- Drop the submit-side play call so the chime is reserved for thread lifecycle events. Visual feedback on submit (input clears, streaming spinner) is unchanged.
- `useSound` / `question004Sound` imports are kept — `playSwitchSound` (mode/tool toggles) still uses them.

## Test plan
- [ ] Send a message in the chat — verify no chime on submit
- [ ] Wait for the assistant to finish — verify chime fires on `completed`
- [ ] Trigger a failure or `requires_action` state — verify chime still fires
- [ ] Toggle the chat mode / tool popover switches — verify their click sounds still play
- [ ] Toggle `enableSounds` off in profile preferences — verify no chime fires anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the chat from playing a chime on submit to avoid duplicate sounds. The chime now only plays on thread lifecycle events; submit visuals remain unchanged.

- **Bug Fixes**
  - Removed submit-side `playClickSound()` so `useStatusSounds` handles `completed`/`failed`/`requires_action` chimes.
  - Kept `useSound` and `question004Sound` imports for `playSwitchSound` (mode/tool toggles).

<sup>Written for commit f22939851336a0d1de591811778a81d0d9e5f3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

