### PR TITLE
fix(web-search): parse Gemini Interactions steps schema (outputs→steps)

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/gemini-interactions.test.ts
+++ b/apps/mesh/src/ai-providers/adapters/gemini-interactions.test.ts
@@ -132,6 +132,82 @@ describe("pollInteraction", () => {
     expect(progress.at(-1)).toContain("Researching");
   });
 
+  test("parses the new steps schema (model_output content + total_* usage)", async () => {
+    const progress: string[] = [];
+    queueFetch([
+      () =>
+        jsonResponse({
+          status: "completed",
+          steps: [
+            {
+              type: "thought",
+              content: [{ type: "text", text: "Researching…" }],
+            },
+            { type: "google_search_call" },
+            {
+              type: "model_output",
+              content: [
+                {
+                  type: "text",
+                  text: "The answer is 42.",
+                  annotations: [
+                    {
+                      type: "url_citation",
+                      url: "https://example.com",
+                      title: "Example",
+                      start_index: 0,
+                      end_index: 5,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          usage: {
+            total_input_tokens: 100,
+            total_output_tokens: 50,
+            total_tokens: 199,
+          },
+        }),
+    ]);
+
+    const result = await pollInteraction({
+      apiKey: "k",
+      interactionId: "i_steps",
+      pollIntervalMs: 0,
+      onProgress: (t) => progress.push(t),
+    });
+
+    expect(result.text).toBe("The answer is 42.");
+    expect(result.citations).toEqual([
+      { url: "https://example.com", title: "Example" },
+    ]);
+    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+    expect(progress.at(-1)).toContain("The answer is 42.");
+    expect(progress.at(-1)).toContain("Researching");
+  });
+
+  test("usage falls back to total_tokens when only the aggregate is present", async () => {
+    // Reproduces the field client's failing thread: new schema usage carried
+    // only total_tokens (199555), no total_output_tokens → fall back.
+    queueFetch([
+      () =>
+        jsonResponse({
+          status: "completed",
+          steps: [
+            { type: "model_output", content: [{ type: "text", text: "x" }] },
+          ],
+          usage: { total_tokens: 199555 },
+        }),
+    ]);
+    const result = await pollInteraction({
+      apiKey: "k",
+      interactionId: "i_agg",
+      pollIntervalMs: 0,
+    });
+    expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 199555 });
+  });
+
   test("throws AsyncResearchTerminalError on failed status", async () => {
     queueFetch([
       () => jsonResponse({ status: "failed", error: "model overloaded" }),

--- a/apps/mesh/src/ai-providers/adapters/gemini-interactions.test.ts
+++ b/apps/mesh/src/ai-providers/adapters/gemini-interactions.test.ts
@@ -139,9 +139,16 @@ describe("pollInteraction", () => {
         jsonResponse({
           status: "completed",
           steps: [
+            // user_input carries the prompt in content[] — must NOT leak into
+            // the answer.
+            {
+              type: "user_input",
+              content: [{ type: "text", text: "what is the meaning of life?" }],
+            },
+            // thought exposes thinking in `summary` (a TextContent), not content.
             {
               type: "thought",
-              content: [{ type: "text", text: "Researching…" }],
+              summary: { type: "text", text: "Researching…" },
             },
             { type: "google_search_call" },
             {
@@ -179,12 +186,39 @@ describe("pollInteraction", () => {
     });
 
     expect(result.text).toBe("The answer is 42.");
+    expect(result.text).not.toContain("meaning of life");
     expect(result.citations).toEqual([
       { url: "https://example.com", title: "Example" },
     ]);
     expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 50 });
     expect(progress.at(-1)).toContain("The answer is 42.");
     expect(progress.at(-1)).toContain("Researching");
+  });
+
+  test("a bare-string thought summary still feeds the transcript", async () => {
+    const progress: string[] = [];
+    queueFetch([
+      () =>
+        jsonResponse({
+          status: "completed",
+          steps: [
+            { type: "thought", summary: "Looking into it…" },
+            {
+              type: "model_output",
+              content: [{ type: "text", text: "Done." }],
+            },
+          ],
+          usage: { total_tokens: 10 },
+        }),
+    ]);
+    await pollInteraction({
+      apiKey: "k",
+      interactionId: "i_thought_str",
+      pollIntervalMs: 0,
+      onProgress: (t) => progress.push(t),
+    });
+    expect(progress.at(-1)).toContain("Looking into it");
+    expect(progress.at(-1)).toContain("Done.");
   });
 
   test("usage falls back to total_tokens when only the aggregate is present", async () => {

--- a/apps/mesh/src/ai-providers/adapters/gemini-interactions.ts
+++ b/apps/mesh/src/ai-providers/adapters/gemini-interactions.ts
@@ -261,13 +261,32 @@ function finalize(
 }
 
 /**
+ * Pull the thinking-summary text out of a thought step. New schema: `thought`
+ * step with a `summary` TextContent (`{type:"text", text}`). Legacy: flat
+ * `thought_summary` block carrying `text` directly. Tolerates `summary` being a
+ * bare string too. Feeds the progress transcript only — never the answer.
+ */
+function thoughtText(step: Record<string, unknown>): string {
+  const direct = stringField(step, "text");
+  if (direct) return direct;
+  const summary = step.summary;
+  if (typeof summary === "string") return summary;
+  if (summary && typeof summary === "object") {
+    return stringField(summary as Record<string, unknown>, "text") ?? "";
+  }
+  return "";
+}
+
+/**
  * Flatten an interaction payload into answer/thinking blocks, tolerating both
  * schemas:
  *
- *   New (default 2026-05-26): `steps[]`, where a `model_output` step nests the
- *     answer in `content[]` items (`{type:"text", text, annotations}`) and a
- *     `thought` step carries the thinking summary. Other step types
- *     (google_search_call, function_call, …) carry no answer text.
+ *   New (default 2026-05-26): `steps[]`. A `model_output` step nests the answer
+ *     in `content[]` TextContent items (`{type:"text", text, annotations}`); a
+ *     `thought` step carries thinking in `summary`. Crucially, `user_input`
+ *     ALSO has a `content[]` (the prompt) and search/tool steps carry no answer
+ *     text — only `model_output` content becomes the report, or the prompt
+ *     leaks into it.
  *
  *   Legacy (removed 2026-06-08): flat `outputs[]` blocks with `text` and
  *     `annotations` directly on the block, typed `text` / `thought_summary`.
@@ -282,17 +301,27 @@ function parseSteps(payload: Record<string, unknown>): OutputBlock[] {
   for (const r of raw) {
     if (!r || typeof r !== "object") continue;
     const step = r as Record<string, unknown>;
-    const stepType = stringField(step, "type") ?? "text";
-    const isThought = stepType === "thought" || stepType === "thought_summary";
+    const type = stringField(step, "type") ?? "text";
+
+    // Thinking — transcript only, never the answer.
+    if (type === "thought" || type === "thought_summary") {
+      const text = thoughtText(step);
+      if (text) out.push({ type: "thought_summary", text, annotations: [] });
+      continue;
+    }
+
+    // Answer text. New schema nests it in `model_output.content[]`. Skip any
+    // other content-bearing step (notably `user_input`, whose content is the
+    // prompt) so it never bleeds into the report.
     const content = arrayField(step, "content");
     if (content) {
-      // New nested shape: pull text items out of `content[]`.
+      if (type !== "model_output") continue;
       for (const c of content) {
         if (!c || typeof c !== "object") continue;
         const item = c as Record<string, unknown>;
         if ((stringField(item, "type") ?? "text") !== "text") continue;
         out.push({
-          type: isThought ? "thought_summary" : "text",
+          type: "text",
           text: stringField(item, "text") ?? "",
           annotations:
             (arrayField(item, "annotations") as OutputBlock["annotations"]) ??
@@ -301,13 +330,17 @@ function parseSteps(payload: Record<string, unknown>): OutputBlock[] {
       }
       continue;
     }
-    // Legacy flat shape: text + annotations live on the block itself.
-    out.push({
-      type: isThought ? "thought_summary" : stepType,
-      text: stringField(step, "text") ?? "",
-      annotations:
-        (arrayField(step, "annotations") as OutputBlock["annotations"]) ?? [],
-    });
+
+    // Legacy flat answer block (`outputs` schema). Unknown step types with no
+    // content (google_search_call, function_call, …) carry no answer text.
+    if (type === "text") {
+      out.push({
+        type: "text",
+        text: stringField(step, "text") ?? "",
+        annotations:
+          (arrayField(step, "annotations") as OutputBlock["annotations"]) ?? [],
+      });
+    }
   }
   return out;
 }

--- a/apps/mesh/src/ai-providers/adapters/gemini-interactions.ts
+++ b/apps/mesh/src/ai-providers/adapters/gemini-interactions.ts
@@ -136,12 +136,35 @@ export async function pollInteraction(
 
     const payload = (await res.json()) as Record<string, unknown>;
     const status = stringField(payload, "status") ?? "in_progress";
-    const outputs = parseOutputs(arrayField(payload, "outputs") ?? []);
+    const outputs = parseSteps(payload);
     if (opts.onProgress) opts.onProgress(buildTranscript(outputs));
 
     switch (status) {
       case "completed": {
         const result = finalize(outputs, parseUsage(payload));
+        // Diagnostic: a completed interaction with empty text means we mapped no
+        // answer text out of the payload. The Interactions API replaced `outputs`
+        // with `steps` (default 2026-05-26, legacy removed 2026-06-08); if Google
+        // shifts the shape again this fires. Log the raw top-level step/output
+        // `type`s so we can see what the model actually returned.
+        if (result.text.trim() === "") {
+          const rawSteps =
+            arrayField(payload, "steps") ??
+            arrayField(payload, "outputs") ??
+            [];
+          const types = [
+            ...new Set(
+              rawSteps.map((s) =>
+                s && typeof s === "object"
+                  ? ((s as Record<string, unknown>).type ?? "?")
+                  : typeof s,
+              ),
+            ),
+          ];
+          console.warn(
+            `[gemini-interactions] completed with empty text — step types=${JSON.stringify(types)} steps=${rawSteps.length} outputTokens=${result.usage.outputTokens}`,
+          );
+        }
         // Gemini surfaces citation URLs as `vertexaisearch.cloud.google.com/...`
         // redirects rather than the underlying source. Resolve them so the
         // UI shows the real domain instead of an opaque Google URL.
@@ -237,16 +260,53 @@ function finalize(
   return { text: textParts.join("\n\n"), citations, usage };
 }
 
-function parseOutputs(raw: unknown[]): OutputBlock[] {
+/**
+ * Flatten an interaction payload into answer/thinking blocks, tolerating both
+ * schemas:
+ *
+ *   New (default 2026-05-26): `steps[]`, where a `model_output` step nests the
+ *     answer in `content[]` items (`{type:"text", text, annotations}`) and a
+ *     `thought` step carries the thinking summary. Other step types
+ *     (google_search_call, function_call, …) carry no answer text.
+ *
+ *   Legacy (removed 2026-06-08): flat `outputs[]` blocks with `text` and
+ *     `annotations` directly on the block, typed `text` / `thought_summary`.
+ *
+ * Both collapse to the same {type:"text"|"thought_summary", text, annotations}
+ * shape so finalize()/buildTranscript() stay schema-agnostic.
+ */
+function parseSteps(payload: Record<string, unknown>): OutputBlock[] {
+  const raw =
+    arrayField(payload, "steps") ?? arrayField(payload, "outputs") ?? [];
   const out: OutputBlock[] = [];
   for (const r of raw) {
     if (!r || typeof r !== "object") continue;
-    const o = r as Record<string, unknown>;
-    const annotations = arrayField(o, "annotations");
+    const step = r as Record<string, unknown>;
+    const stepType = stringField(step, "type") ?? "text";
+    const isThought = stepType === "thought" || stepType === "thought_summary";
+    const content = arrayField(step, "content");
+    if (content) {
+      // New nested shape: pull text items out of `content[]`.
+      for (const c of content) {
+        if (!c || typeof c !== "object") continue;
+        const item = c as Record<string, unknown>;
+        if ((stringField(item, "type") ?? "text") !== "text") continue;
+        out.push({
+          type: isThought ? "thought_summary" : "text",
+          text: stringField(item, "text") ?? "",
+          annotations:
+            (arrayField(item, "annotations") as OutputBlock["annotations"]) ??
+            [],
+        });
+      }
+      continue;
+    }
+    // Legacy flat shape: text + annotations live on the block itself.
     out.push({
-      type: stringField(o, "type") ?? "text",
-      text: stringField(o, "text") ?? "",
-      annotations: (annotations as OutputBlock["annotations"]) ?? [],
+      type: isThought ? "thought_summary" : stepType,
+      text: stringField(step, "text") ?? "",
+      annotations:
+        (arrayField(step, "annotations") as OutputBlock["annotations"]) ?? [],
     });
   }
   return out;
@@ -258,8 +318,15 @@ function parseUsage(payload: Record<string, unknown>): {
 } {
   const usage = payload.usage as Record<string, unknown> | undefined;
   if (!usage) return { inputTokens: 0, outputTokens: 0 };
-  const inputTokens = numberField(usage, "input_tokens") ?? 0;
+  // New schema (2026-05-26): total_input_tokens / total_output_tokens.
+  // Legacy: input_tokens / output_tokens. Fall back to total_tokens - input
+  // when only the aggregate is present.
+  const inputTokens =
+    numberField(usage, "total_input_tokens") ??
+    numberField(usage, "input_tokens") ??
+    0;
   const outputTokens =
+    numberField(usage, "total_output_tokens") ??
     numberField(usage, "output_tokens") ??
     Math.max(0, (numberField(usage, "total_tokens") ?? 0) - inputTokens);
   return { inputTokens, outputTokens };

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/constants.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/constants.ts
@@ -1,4 +1,4 @@
 export const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
 
 /** Results above this threshold are offloaded to blob storage. */
-export const LARGE_RESULT_TOKEN_THRESHOLD = 8_000;
+export const LARGE_RESULT_TOKEN_THRESHOLD = 32_000;

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/web-search.ts
@@ -23,8 +23,8 @@
  * tokens, result preview. Debugging is one SQL query against thread_id.
  *
  * Small results stay inline in the tool result (kept in thread history).
- * Large results (> 8k output tokens) move to blob storage and the tool
- * result carries only a preview + mesh-storage:// URI.
+ * Large results (> LARGE_RESULT_TOKEN_THRESHOLD output tokens) move to blob
+ * storage and the tool result carries only a preview + mesh-storage:// URI.
  */
 
 import { tool, zodSchema, streamText, type UIMessageStreamWriter } from "ai";
@@ -293,6 +293,24 @@ async function runAsyncResearch({
 
     // Final flush — drops the *thinking* prefix streamed during the run.
     writeProgress(result.text);
+
+    // Guard: a "completed" job with empty text is a failure, not a success.
+    // Gemini deep-research can finish with only thought_summary blocks (no
+    // `type:"text"`), which finalize() collapses to "". Persisting that would
+    // write a 0-byte blob and hand the agent a bogus success:true. Throwing
+    // here routes through the catch below (markFailed + rethrow), so a retry
+    // gets a fresh interaction instead of reusing the empty one. See the
+    // empty-text diagnostic in gemini-interactions.ts for the raw block types.
+    if (result.text.trim() === "") {
+      log("error", "empty-result", {
+        ...logFields,
+        job: job.id,
+        tokens: result.usage.outputTokens,
+      });
+      throw new AsyncResearchTerminalError(
+        "research completed with empty result",
+      );
+    }
 
     // 4. Persist result + return tool-shaped response.
     const usageMeta = {


### PR DESCRIPTION
## What is this contribution about?
The Gemini Interactions API (deep-research models) replaced its flat `outputs` array with a nested `steps` array — new schema became the default on 2026-05-26 and the legacy `outputs` field is removed on 2026-06-08. Our adapter still read `outputs`, so completed deep-research jobs parsed to empty text: the `web_search` tool wrote a 0-byte blob to object storage and returned `success: true`, surfacing as blank "no results" replies to users (confirmed against a self-hosted client thread where usage showed `outputTokens: 199555` with empty content). This PR makes `parseSteps` read the `steps` schema (flattening `model_output.content[]` and `thought` steps, with a fallback to legacy `outputs` during the migration window), fixes `parseUsage` to read `total_input_tokens`/`total_output_tokens`, guards against persisting empty results, and raises `LARGE_RESULT_TOKEN_THRESHOLD` (8k→32k) so we stop over-offloading research to blob storage.

## Screenshots/Demonstration
N/A — server-side parsing change.

## How to Test
1. `bun test apps/mesh/src/ai-providers/adapters/gemini-interactions.test.ts` — covers the new `steps` schema and the `total_tokens`-only usage fallback.
2. Run a deep-research `web_search` against a Gemini deep-research model and confirm the report comes back with text + citations (not an empty blob).
3. Confirm no `[gemini-interactions] completed with empty text` warning is logged.

## Migration Notes
None. Backward-compatible: legacy `outputs` payloads still parse during the 2026-05-26 → 2026-06-08 window.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank deep‑research results by parsing the new `steps` schema, keeping the thinking transcript, computing usage correctly, and blocking empty “success” writes. Also raises the large‑result threshold to reduce unnecessary blob offloading.

- **Bug Fixes**
  - Parse `steps[]` with a fallback to legacy `outputs[]`; only `model_output.content[]` becomes the answer (avoid `user_input` prompt leaks); read `thought.summary` (incl. bare string) for progress.
  - Read `total_input_tokens` / `total_output_tokens` with a fallback to `total_tokens` when needed.
  - Treat completed jobs with empty text as failures in `web_search` (log, no 0‑byte blob, retryable).
  - Increase `LARGE_RESULT_TOKEN_THRESHOLD` from 8k to 32k to avoid over‑offloading long reports.

<sup>Written for commit 7ee86b62757e9f004c8183392a6392cba47ada05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

