### PR TITLE
feat(org-popover): inline search for organization list

### DIFF
--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -157,19 +157,20 @@ function OrganizationsPanel({
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
 
-  const filtered = query
+  const q = query.toLowerCase();
+  const filtered = q
     ? sortedOrgs.filter(
         (o) =>
-          o.name.toLowerCase().includes(query.toLowerCase()) ||
-          o.slug.toLowerCase().includes(query.toLowerCase()),
+          o.name.toLowerCase().includes(q) || o.slug.toLowerCase().includes(q),
       )
     : sortedOrgs;
 
+  const iconBtnClass =
+    "flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors";
+
   function toggleSearch() {
-    setSearchOpen((prev) => {
-      if (prev) setQuery("");
-      return !prev;
-    });
+    if (searchOpen) setQuery("");
+    setSearchOpen((prev) => !prev);
   }
 
   return (
@@ -181,6 +182,7 @@ function OrganizationsPanel({
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Escape" && toggleSearch()}
             placeholder="Search organizations..."
             className="flex-1 min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
           />
@@ -190,23 +192,20 @@ function OrganizationsPanel({
           </span>
         )}
         <div className="flex items-center gap-1 shrink-0">
-          <button
-            type="button"
-            onClick={toggleSearch}
-            className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
-          >
+          <button type="button" onClick={toggleSearch} className={iconBtnClass}>
             {searchOpen ? <XClose size={16} /> : <SearchMd size={16} />}
           </button>
-          <button
-            type="button"
-            onClick={onCreateOrg}
-            className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
-          >
+          <button type="button" onClick={onCreateOrg} className={iconBtnClass}>
             <Plus size={16} />
           </button>
         </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto p-1.5 flex flex-col gap-1">
+        {filtered.length === 0 && (
+          <p className="px-3 py-4 text-sm text-muted-foreground/60 text-center">
+            No organizations match "{query}"
+          </p>
+        )}
         {filtered.map((org) => (
           <button
             key={org.id}
@@ -254,6 +253,7 @@ function AccountPopoverContent({
   onCreateOrg,
   close,
   isMobile,
+  open,
 }: {
   user: { id?: string; name?: string; email?: string } | undefined;
   userImage?: string;
@@ -273,6 +273,7 @@ function AccountPopoverContent({
   onCreateOrg: () => void;
   close: () => void;
   isMobile: boolean;
+  open: boolean;
 }) {
   if (isMobile) {
     // Mobile: single-column scrollable layout
@@ -324,6 +325,7 @@ function AccountPopoverContent({
           {/* Org switcher */}
           <div className="border-b border-border pb-2">
             <OrganizationsPanel
+              key={String(open)}
               sortedOrgs={sortedOrgs}
               orgParam={orgParam}
               onSelectOrg={onSelectOrg}
@@ -507,6 +509,7 @@ function AccountPopoverContent({
       {/* Right panel - org selector */}
       <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
         <OrganizationsPanel
+          key={String(open)}
           sortedOrgs={sortedOrgs}
           orgParam={orgParam}
           onSelectOrg={onSelectOrg}
@@ -638,6 +641,7 @@ export function AccountPopover() {
     },
     close,
     isMobile,
+    open,
   };
 
   return (

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -203,7 +203,9 @@ function OrganizationsPanel({
       <div className="flex-1 min-h-0 overflow-y-auto p-1.5 flex flex-col gap-1">
         {filtered.length === 0 && (
           <p className="px-3 py-4 text-sm text-muted-foreground/60 text-center">
-            No organizations match "{query}"
+            {query
+              ? `No organizations match "${query}"`
+              : "No organizations available"}
           </p>
         )}
         {filtered.map((org) => (

--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -28,12 +28,14 @@ import {
   Monitor01,
   Moon01,
   Plus,
+  SearchMd,
   Settings02,
   Shield01,
   Sun,
   Users03,
   VolumeMax,
   VolumeX,
+  XClose,
 } from "@untitledui/icons";
 import { GitHubIcon } from "@daveyplate/better-auth-ui";
 import { SidebarMenuButton } from "@deco/ui/components/sidebar.tsx";
@@ -152,22 +154,60 @@ function OrganizationsPanel({
   onSelectOrg: (slug: string) => void;
   onCreateOrg: () => void;
 }) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const filtered = query
+    ? sortedOrgs.filter(
+        (o) =>
+          o.name.toLowerCase().includes(query.toLowerCase()) ||
+          o.slug.toLowerCase().includes(query.toLowerCase()),
+      )
+    : sortedOrgs;
+
+  function toggleSearch() {
+    setSearchOpen((prev) => {
+      if (prev) setQuery("");
+      return !prev;
+    });
+  }
+
   return (
     <>
       <div className="flex items-center justify-between px-4 py-3">
-        <span className="text-sm font-medium text-muted-foreground/60">
-          Your Organizations
-        </span>
-        <button
-          type="button"
-          onClick={onCreateOrg}
-          className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
-        >
-          <Plus size={16} />
-        </button>
+        {searchOpen ? (
+          <input
+            autoFocus
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search organizations..."
+            className="flex-1 min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
+          />
+        ) : (
+          <span className="text-sm font-medium text-muted-foreground/60">
+            Your Organizations
+          </span>
+        )}
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            onClick={toggleSearch}
+            className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+          >
+            {searchOpen ? <XClose size={16} /> : <SearchMd size={16} />}
+          </button>
+          <button
+            type="button"
+            onClick={onCreateOrg}
+            className="flex items-center justify-center size-7 rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+          >
+            <Plus size={16} />
+          </button>
+        </div>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto p-1.5 flex flex-col gap-1">
-        {sortedOrgs.map((org) => (
+        {filtered.map((org) => (
           <button
             key={org.id}
             type="button"


### PR DESCRIPTION
## What is this contribution about?

Adds a search icon button to the organization panel header in the account popover. Clicking it replaces the "Your Organizations" title with a bare inline input (no border or background). Typing filters the org list by name or slug in real time; clicking the X icon restores the title and clears the query.

## Screenshots/Demonstration

> Before: static "Your Organizations" header with only a + button.
> After: search icon (🔍) left of +; clicking swaps the label for a transparent inline input that filters the list live.

## How to Test

1. Open the account popover and navigate to the org list panel.
2. Click the search icon to the left of the + button.
3. Type part of an org name or slug — the list filters immediately.
4. Click the X icon to clear search and restore the header title.

## Migration Notes

N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add inline search to the Organizations panel in the account popover. Clicking the search icon swaps the title for a borderless input that live-filters by name or slug; press Escape or X to close, the query resets on popover close, and the panel shows correct empty states for no matches vs no organizations.

<sup>Written for commit 84a9d4a85422ff35e0d7a410941d023b56b905bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

