### PR TITLE
feat(chat): persist composer draft to sessionStorage per thread

### DIFF
--- a/apps/mesh/e2e/tests/chat-input-draft.spec.ts
+++ b/apps/mesh/e2e/tests/chat-input-draft.spec.ts
@@ -199,9 +199,35 @@ test.describe("chat input draft persistence", () => {
   // Seed an AI provider key before every test so the home / thread routes
   // render the composer instead of `NoAiProviderEmptyState`. Fresh test
   // users have no provider, so without this the chat input never mounts.
+  //
+  // Also pre-mark every known release as "seen" in localStorage so the
+  // bottom-right `FloatingReleaseCard` (`useReleaseSeenState`) never
+  // renders. The card intercepts pointer events on the send button on
+  // viewports where they overlap, and the close-button dismiss path is
+  // animation-racy. Pre-seeding kills the dialog at the source.
+  //
+  // If a release is added to `apps/mesh/src/web/lib/release-feed.ts`, add
+  // its id here too — otherwise the next id (`RELEASES[0]`) will surface
+  // as a popover and re-introduce the failure.
   test.beforeEach(async ({ authedPage }) => {
     const { page, orgSlug } = authedPage;
     await seedAiProviderKey(page.context().request, orgSlug);
+    await page.addInitScript(() => {
+      const STORAGE_KEY = "studio.release-feed.v1";
+      const seenAt = "1970-01-01T00:00:00.000Z";
+      const seen: Record<string, { seenAt: string }> = {
+        "claude-opus-4-8": { seenAt },
+        "enhanced-sidebar": { seenAt },
+        "smarter-task-delegation": { seenAt },
+        "sidebar-task-groups": { seenAt },
+        "release-channel": { seenAt },
+      };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(seen));
+      } catch {
+        // private mode / sandboxed storage — fall back to clicking dismiss.
+      }
+    });
   });
 
   test("thread draft survives page refresh", async ({ authedPage }) => {

--- a/apps/mesh/e2e/tests/chat-input-draft.spec.ts
+++ b/apps/mesh/e2e/tests/chat-input-draft.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * E2E: chat input draft persistence to sessionStorage.
+ *
+ * Drives the real browser end-to-end. Confirms:
+ *   1. Thread drafts survive page refresh.
+ *   2. Home composer drafts survive page refresh.
+ *   3. Successful submit clears the draft.
+ *   4. Drafts are isolated per thread.
+ *
+ * The quota-exceeded path is deliberately NOT exercised here — it's
+ * covered by unit tests on the chat-draft helper. PostHog telemetry will
+ * surface real-world occurrence in production.
+ */
+
+import { expect, test } from "../fixtures/test";
+import type { Page } from "@playwright/test";
+
+const CHAT_INPUT = '[data-chat-input="true"]';
+
+/** Focus the chat input and type via the keyboard. Tiptap is contenteditable, so we cannot use `fill`. */
+async function typeInComposer(page: Page, text: string): Promise<void> {
+  const input = page.locator(CHAT_INPUT);
+  await input.click();
+  await page.keyboard.type(text);
+}
+
+/** Read the visible text content of the chat input. */
+async function composerText(page: Page): Promise<string> {
+  return (await page.locator(CHAT_INPUT).innerText()).trim();
+}
+
+/** Clear the chat input by selecting all and deleting. */
+async function clearComposer(page: Page): Promise<void> {
+  await page.locator(CHAT_INPUT).click();
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await page.keyboard.press(`${modifier}+A`);
+  await page.keyboard.press("Delete");
+}
+
+/** Submit by pressing Enter (no Shift). */
+async function submitComposer(page: Page): Promise<void> {
+  await page.locator(CHAT_INPUT).click();
+  await page.keyboard.press("Enter");
+}
+
+/** Type a message in the home composer, submit, and wait until URL contains a taskId. Returns the taskId. */
+async function openNewThread(
+  page: Page,
+  orgSlug: string,
+  seed: string,
+): Promise<string> {
+  await page.goto(`/${orgSlug}`);
+  await expect(page.locator(CHAT_INPUT)).toBeVisible();
+  await typeInComposer(page, seed);
+  await submitComposer(page);
+  // After submit, the URL becomes /<orgSlug>/<taskId> via homeSubmit's
+  // navigate() call. Wait for it.
+  await page.waitForURL(
+    (url) => new URL(url).pathname.startsWith(`/${orgSlug}/`),
+    { timeout: 20_000 },
+  );
+  const match = new URL(page.url()).pathname.match(
+    new RegExp(`^/${orgSlug}/([^/]+)`),
+  );
+  if (!match || !match[1]) {
+    throw new Error(`could not extract taskId from ${page.url()}`);
+  }
+  return match[1];
+}
+
+test.describe("chat input draft persistence", () => {
+  test("thread draft survives page refresh", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await openNewThread(page, orgSlug, "kick off");
+
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "draft message that should survive");
+
+    await page.reload();
+
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("draft message that should survive");
+  });
+
+  test("home composer draft survives page refresh", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await page.goto(`/${orgSlug}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+
+    await typeInComposer(page, "home composer draft");
+
+    await page.reload();
+
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("home composer draft");
+  });
+
+  test("submit clears the draft", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const taskId = await openNewThread(page, orgSlug, "first");
+
+    // Type a second message and submit it (clearing should fire).
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "this should be cleared after submit");
+    await submitComposer(page);
+
+    // Reload and confirm the input is empty.
+    await page.goto(`/${orgSlug}/${taskId}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("");
+  });
+
+  test("drafts are isolated per thread", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const taskA = await openNewThread(page, orgSlug, "thread a");
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "draft for A");
+
+    // Navigate to the home composer to start a second thread.
+    const taskB = await openNewThread(page, orgSlug, "thread b");
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "draft for B");
+
+    // Switch back to A: A's draft should still be there.
+    await page.goto(`/${orgSlug}/${taskA}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("draft for A");
+
+    // Switch to B: B's draft should still be there.
+    await page.goto(`/${orgSlug}/${taskB}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("draft for B");
+  });
+});

--- a/apps/mesh/e2e/tests/chat-input-draft.spec.ts
+++ b/apps/mesh/e2e/tests/chat-input-draft.spec.ts
@@ -63,21 +63,47 @@ async function clearComposer(page: Page): Promise<void> {
 }
 
 /**
+ * Dismiss the bottom-right "Release announcement" popover if present.
+ *
+ * Fresh users get a one-time release popover (e.g. "Claude Opus 4.8 is the
+ * new default") on first home-page render. It does NOT visually overlap the
+ * chat input but it *does* sit on top of the send button's z-index when the
+ * page is short enough — Playwright then sees the dialog intercept pointer
+ * events on `.click()`. Closing it is the cleanest neutral fix; users would
+ * either dismiss it or wait for it to fade. No-op if not present.
+ */
+async function dismissReleaseAnnouncement(page: Page): Promise<void> {
+  const dialog = page.getByRole("dialog", { name: "Release announcement" });
+  if ((await dialog.count()) === 0) return;
+  // The dialog has a close button — a single icon button inside the popover.
+  // Fall back to pressing Escape if the close button isn't reachable.
+  const closeButton = dialog.getByRole("button").first();
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click();
+  } else {
+    await page.keyboard.press("Escape");
+  }
+  await dialog.waitFor({ state: "hidden", timeout: 5_000 }).catch(() => {});
+}
+
+/**
  * Submit the composer.
  *
  * We click the explicit send button rather than pressing Enter because the
- * one-time "Now Available" announcement that appears on first render of a
- * fresh user's home page sometimes steals key events — leaving the keystroke
- * unhandled and the form unsubmitted. The button calls the same handler the
- * Tiptap Enter binding does, so the user-facing behavior under test (the
+ * one-time "Now Available" release announcement that appears on first
+ * render can steal key events — leaving the keystroke unhandled and the
+ * form unsubmitted. The button calls the same handler the Tiptap Enter
+ * binding does, so the user-facing behavior under test (the
  * draft-clear-on-submit path) is identical either way.
  *
  * Title="Send message (Enter)" is set by ChatInput. The composer never
- * shows two enabled send buttons at once (the home / per-thread composer
- * variants are mutually exclusive), so a `.first()` keeps the locator safe
- * across both flows.
+ * shows two enabled send buttons at once (home / per-thread composers are
+ * mutually exclusive), so `.first()` keeps the locator safe across flows.
  */
 async function submitComposer(page: Page): Promise<void> {
+  // The release-announcement popover sometimes intercepts pointer events on
+  // the send button, so dismiss it first if it's still visible.
+  await dismissReleaseAnnouncement(page);
   await page
     .getByTitle("Send message (Enter)", { exact: true })
     .first()

--- a/apps/mesh/e2e/tests/chat-input-draft.spec.ts
+++ b/apps/mesh/e2e/tests/chat-input-draft.spec.ts
@@ -16,6 +16,20 @@ import { expect, test } from "../fixtures/test";
 import type { Page } from "@playwright/test";
 
 const CHAT_INPUT = '[data-chat-input="true"]';
+/**
+ * Cold-Vite first paint on a fresh sandbox can take 20-40s on slow hardware
+ * (full SPA compile + auth bootstrap). Use a generous wait for the very first
+ * chat-input appearance per page navigation; subsequent appearances after
+ * page.reload() are much faster.
+ */
+const CHAT_INPUT_TIMEOUT_MS = 60_000;
+
+/** Wait for the chat input to be visible — generous timeout for cold Vite + auth bootstrap. */
+async function waitForChatInput(page: Page): Promise<void> {
+  await page
+    .locator(CHAT_INPUT)
+    .waitFor({ state: "visible", timeout: CHAT_INPUT_TIMEOUT_MS });
+}
 
 /** Focus the chat input and type via the keyboard. Tiptap is contenteditable, so we cannot use `fill`. */
 async function typeInComposer(page: Page, text: string): Promise<void> {
@@ -32,8 +46,9 @@ async function composerText(page: Page): Promise<string> {
 /** Clear the chat input by selecting all and deleting. */
 async function clearComposer(page: Page): Promise<void> {
   await page.locator(CHAT_INPUT).click();
-  const modifier = process.platform === "darwin" ? "Meta" : "Control";
-  await page.keyboard.press(`${modifier}+A`);
+  // ControlOrMeta is Playwright's portable select-all modifier — picks the
+  // right key for the browser-emulated OS, not the runner's host OS.
+  await page.keyboard.press("ControlOrMeta+A");
   await page.keyboard.press("Delete");
 }
 
@@ -43,6 +58,10 @@ async function submitComposer(page: Page): Promise<void> {
   await page.keyboard.press("Enter");
 }
 
+/** UUID v4 shape. Matches the output of `crypto.randomUUID()` used for task ids. */
+const TASK_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /** Type a message in the home composer, submit, and wait until URL contains a taskId. Returns the taskId. */
 async function openNewThread(
   page: Page,
@@ -50,49 +69,62 @@ async function openNewThread(
   seed: string,
 ): Promise<string> {
   await page.goto(`/${orgSlug}`);
-  await expect(page.locator(CHAT_INPUT)).toBeVisible();
+  await waitForChatInput(page);
   await typeInComposer(page, seed);
   await submitComposer(page);
   // After submit, the URL becomes /<orgSlug>/<taskId> via homeSubmit's
-  // navigate() call. Wait for it.
+  // navigate() call. Wait until the first path segment after the org slug
+  // looks like a UUID (the task id) — avoids matching sub-routes like
+  // /<orgSlug>/settings.
   await page.waitForURL(
-    (url) => new URL(url).pathname.startsWith(`/${orgSlug}/`),
+    (url) => {
+      const segments = new URL(url).pathname.split("/").filter(Boolean);
+      return (
+        segments[0] === orgSlug &&
+        !!segments[1] &&
+        TASK_ID_REGEX.test(segments[1])
+      );
+    },
     { timeout: 20_000 },
   );
   const match = new URL(page.url()).pathname.match(
     new RegExp(`^/${orgSlug}/([^/]+)`),
   );
-  if (!match || !match[1]) {
+  if (!match || !match[1] || !TASK_ID_REGEX.test(match[1])) {
     throw new Error(`could not extract taskId from ${page.url()}`);
   }
   return match[1];
 }
 
 test.describe("chat input draft persistence", () => {
+  // Cold Vite + signUp + multiple navigations easily exceeds the 30s default
+  // on slow CI / first runs. Match the budget used by sidebar-show-more.
+  test.setTimeout(180_000);
+
   test("thread draft survives page refresh", async ({ authedPage }) => {
     const { page, orgSlug } = authedPage;
     await openNewThread(page, orgSlug, "kick off");
 
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     await clearComposer(page);
     await typeInComposer(page, "draft message that should survive");
 
     await page.reload();
 
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     expect(await composerText(page)).toBe("draft message that should survive");
   });
 
   test("home composer draft survives page refresh", async ({ authedPage }) => {
     const { page, orgSlug } = authedPage;
     await page.goto(`/${orgSlug}`);
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
 
     await typeInComposer(page, "home composer draft");
 
     await page.reload();
 
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     expect(await composerText(page)).toBe("home composer draft");
   });
 
@@ -101,38 +133,38 @@ test.describe("chat input draft persistence", () => {
     const taskId = await openNewThread(page, orgSlug, "first");
 
     // Type a second message and submit it (clearing should fire).
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     await clearComposer(page);
     await typeInComposer(page, "this should be cleared after submit");
     await submitComposer(page);
 
     // Reload and confirm the input is empty.
     await page.goto(`/${orgSlug}/${taskId}`);
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     expect(await composerText(page)).toBe("");
   });
 
   test("drafts are isolated per thread", async ({ authedPage }) => {
     const { page, orgSlug } = authedPage;
     const taskA = await openNewThread(page, orgSlug, "thread a");
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     await clearComposer(page);
     await typeInComposer(page, "draft for A");
 
     // Navigate to the home composer to start a second thread.
     const taskB = await openNewThread(page, orgSlug, "thread b");
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     await clearComposer(page);
     await typeInComposer(page, "draft for B");
 
     // Switch back to A: A's draft should still be there.
     await page.goto(`/${orgSlug}/${taskA}`);
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     expect(await composerText(page)).toBe("draft for A");
 
     // Switch to B: B's draft should still be there.
     await page.goto(`/${orgSlug}/${taskB}`);
-    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await waitForChatInput(page);
     expect(await composerText(page)).toBe("draft for B");
   });
 });

--- a/apps/mesh/e2e/tests/chat-input-draft.spec.ts
+++ b/apps/mesh/e2e/tests/chat-input-draft.spec.ts
@@ -12,8 +12,9 @@
  * surface real-world occurrence in production.
  */
 
+import type { APIRequestContext, Page } from "@playwright/test";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
 import { expect, test } from "../fixtures/test";
-import type { Page } from "@playwright/test";
 
 const CHAT_INPUT = '[data-chat-input="true"]';
 /**
@@ -31,11 +32,20 @@ async function waitForChatInput(page: Page): Promise<void> {
     .waitFor({ state: "visible", timeout: CHAT_INPUT_TIMEOUT_MS });
 }
 
-/** Focus the chat input and type via the keyboard. Tiptap is contenteditable, so we cannot use `fill`. */
+/**
+ * Focus the chat input and type via the keyboard.
+ *
+ * Tiptap is contenteditable, so `page.fill()` is unsupported — we have to
+ * use real keystrokes. Once typing completes we explicitly wait until the
+ * rendered text matches what we typed, so the caller can safely reload /
+ * navigate immediately after this call without racing the editor's last
+ * onUpdate (which is what persists the draft to sessionStorage).
+ */
 async function typeInComposer(page: Page, text: string): Promise<void> {
   const input = page.locator(CHAT_INPUT);
   await input.click();
   await page.keyboard.type(text);
+  await expect(input).toHaveText(text, { timeout: 5_000 });
 }
 
 /** Read the visible text content of the chat input. */
@@ -52,15 +62,74 @@ async function clearComposer(page: Page): Promise<void> {
   await page.keyboard.press("Delete");
 }
 
-/** Submit by pressing Enter (no Shift). */
+/**
+ * Submit the composer.
+ *
+ * We click the explicit send button rather than pressing Enter because the
+ * one-time "Now Available" announcement that appears on first render of a
+ * fresh user's home page sometimes steals key events — leaving the keystroke
+ * unhandled and the form unsubmitted. The button calls the same handler the
+ * Tiptap Enter binding does, so the user-facing behavior under test (the
+ * draft-clear-on-submit path) is identical either way.
+ *
+ * Title="Send message (Enter)" is set by ChatInput. The composer never
+ * shows two enabled send buttons at once (the home / per-thread composer
+ * variants are mutually exclusive), so a `.first()` keeps the locator safe
+ * across both flows.
+ */
 async function submitComposer(page: Page): Promise<void> {
-  await page.locator(CHAT_INPUT).click();
-  await page.keyboard.press("Enter");
+  await page
+    .getByTitle("Send message (Enter)", { exact: true })
+    .first()
+    .click();
 }
 
 /** UUID v4 shape. Matches the output of `crypto.randomUUID()` used for task ids. */
 const TASK_ID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Seed an AI provider key for the freshly-signed-up org so the home / thread
+ * routes render the chat composer instead of `NoAiProviderEmptyState`.
+ *
+ * Fresh test users have no provider configured, so `useAiProviderKeys()`
+ * returns an empty list and `HomePage` short-circuits to the
+ * `NoAiProviderEmptyState` view — which doesn't mount the Tiptap input.
+ *
+ * The stored key is never actually exercised: these tests only verify draft
+ * persistence in the editor, never a real chat completion.
+ * `AI_PROVIDER_KEY_CREATE` just stores the value in the vault; it doesn't
+ * validate the credential against the upstream provider.
+ */
+async function seedAiProviderKey(
+  request: APIRequestContext,
+  orgSlug: string,
+): Promise<void> {
+  await callSelfMcpTool(request, orgSlug, "AI_PROVIDER_KEY_CREATE", {
+    providerId: "anthropic",
+    label: "chat-input-draft-e2e",
+    apiKey: "sk-ant-e2e-fake-key-do-not-use",
+  });
+}
+
+/**
+ * Re-navigate to the thread page without the `?autosend=` query string.
+ *
+ * After `openNewThread`, the URL is `/${orgSlug}/${taskId}?autosend=true...`
+ * which puts the chat into a streaming state (autosend fires the seed
+ * message). While streaming, the Tiptap editor is disabled, so typing a
+ * draft would be a no-op. Navigating to the same task without the autosend
+ * query lands on the page with the editor enabled — perfect for testing
+ * draft persistence.
+ */
+async function gotoThreadIdle(
+  page: Page,
+  orgSlug: string,
+  taskId: string,
+): Promise<void> {
+  await page.goto(`/${orgSlug}/${taskId}`);
+  await waitForChatInput(page);
+}
 
 /** Type a message in the home composer, submit, and wait until URL contains a taskId. Returns the taskId. */
 async function openNewThread(
@@ -101,11 +170,23 @@ test.describe("chat input draft persistence", () => {
   // on slow CI / first runs. Match the budget used by sidebar-show-more.
   test.setTimeout(180_000);
 
+  // Seed an AI provider key before every test so the home / thread routes
+  // render the composer instead of `NoAiProviderEmptyState`. Fresh test
+  // users have no provider, so without this the chat input never mounts.
+  test.beforeEach(async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await seedAiProviderKey(page.context().request, orgSlug);
+  });
+
   test("thread draft survives page refresh", async ({ authedPage }) => {
     const { page, orgSlug } = authedPage;
-    await openNewThread(page, orgSlug, "kick off");
+    const taskId = await openNewThread(page, orgSlug, "kick off");
 
-    await waitForChatInput(page);
+    // Land on the thread WITHOUT autosend so the editor isn't disabled by
+    // streaming. The home-composer submit kicks off autosend which puts the
+    // chat into a streaming state; the editor's disabled prop swallows our
+    // typing if we don't shed the autosend query first.
+    await gotoThreadIdle(page, orgSlug, taskId);
     await clearComposer(page);
     await typeInComposer(page, "draft message that should survive");
 
@@ -132,13 +213,16 @@ test.describe("chat input draft persistence", () => {
     const { page, orgSlug } = authedPage;
     const taskId = await openNewThread(page, orgSlug, "first");
 
-    // Type a second message and submit it (clearing should fire).
-    await waitForChatInput(page);
+    // Land on the thread WITHOUT autosend so typing isn't swallowed by the
+    // streaming-disabled editor. Then type a draft, submit, and verify the
+    // saved draft was cleared by reloading and reading the editor.
+    await gotoThreadIdle(page, orgSlug, taskId);
     await clearComposer(page);
     await typeInComposer(page, "this should be cleared after submit");
     await submitComposer(page);
 
-    // Reload and confirm the input is empty.
+    // Reload and confirm the input is empty (submit's clearChatDraft
+    // wiped the per-thread draft from sessionStorage).
     await page.goto(`/${orgSlug}/${taskId}`);
     await waitForChatInput(page);
     expect(await composerText(page)).toBe("");
@@ -147,13 +231,15 @@ test.describe("chat input draft persistence", () => {
   test("drafts are isolated per thread", async ({ authedPage }) => {
     const { page, orgSlug } = authedPage;
     const taskA = await openNewThread(page, orgSlug, "thread a");
-    await waitForChatInput(page);
+    await gotoThreadIdle(page, orgSlug, taskA);
     await clearComposer(page);
     await typeInComposer(page, "draft for A");
 
-    // Navigate to the home composer to start a second thread.
+    // Start a second thread via the home composer. Then land on it in idle
+    // state so we can type without the streaming-disabled editor swallowing
+    // input.
     const taskB = await openNewThread(page, orgSlug, "thread b");
-    await waitForChatInput(page);
+    await gotoThreadIdle(page, orgSlug, taskB);
     await clearComposer(page);
     await typeInComposer(page, "draft for B");
 

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -1,6 +1,12 @@
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
 import { calculateUsageStats } from "@/web/lib/usage-utils.ts";
 import { AUTOSEND_QUERY_VALUE, writeStoredAutosend } from "@/web/lib/autosend";
+import {
+  HOME_DRAFT_KEY,
+  clearChatDraft,
+  readChatDraft,
+  writeChatDraft,
+} from "@/web/lib/chat-draft";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -237,6 +243,8 @@ export function ChatInput({
   const isRunInProgress = stream?.isRunInProgress ?? false;
   const stop = stream?.stop ?? (() => {});
   const taskId = taskCtx?.taskId ?? "";
+  // Storage key for the per-thread (or home composer) draft.
+  const draftKey = taskId || HOME_DRAFT_KEY;
   const homeSubmit = useHomeSubmit();
   const {
     selectedModel,
@@ -251,7 +259,7 @@ export function ChatInput({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
-  const { org } = useProjectContext();
+  const { org, locator } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const fullVm = useVirtualMCP(selectedVirtualMcp?.id ?? decopilotId);
   const playSwitchSound = useSound(question004Sound);
@@ -308,23 +316,41 @@ export function ChatInput({
 
   // tiptapDoc lives here (not in context) so keystrokes don't re-render
   // the entire context tree. The ref on context lets IceBreakers read it.
-  const [tiptapDoc, setTiptapDocLocal] =
-    useState<Metadata["tiptapDoc"]>(undefined);
+  // The lazy initializer hydrates the draft from sessionStorage on mount.
+  const [tiptapDoc, setTiptapDocLocal] = useState<Metadata["tiptapDoc"]>(
+    () => readChatDraft(sessionStorage, locator, draftKey) ?? undefined,
+  );
 
   const setTiptapDoc = (doc: Metadata["tiptapDoc"]) => {
     setTiptapDocLocal(doc);
     tiptapDocRef.current = doc;
+    writeChatDraft(sessionStorage, locator, draftKey, doc, {
+      onQuotaExceeded: ({ docSizeBytes }) => {
+        track("chat_draft_quota_exceeded", {
+          thread_id: taskId || null,
+          doc_size_bytes: docSizeBytes,
+        });
+        console.warn(
+          "[chat-draft] sessionStorage quota exceeded; draft not saved",
+        );
+      },
+    });
   };
 
-  // Reset input when switching tasks (TiptapProvider also remounts via key)
+  // When switching tasks, rehydrate the new task's draft from storage
+  // (useState's lazy initializer only fires on mount). The previous
+  // task's draft is left in sessionStorage and will be picked up if the
+  // user navigates back.
   const prevTaskRef = useRef(taskId);
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
   if (prevTaskRef.current !== taskId) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
     prevTaskRef.current = taskId;
-    setTiptapDocLocal(undefined);
+    const restored =
+      readChatDraft(sessionStorage, locator, draftKey) ?? undefined;
+    setTiptapDocLocal(restored);
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-    tiptapDocRef.current = undefined;
+    tiptapDocRef.current = restored;
   }
 
   // Prefer per-turn modelLimits (Claude Code reports real window at turn end)
@@ -397,6 +423,7 @@ export function ChatInput({
       } else {
         homeSubmit({ tiptapDoc, virtualMcp: selectedVirtualMcp });
       }
+      clearChatDraft(sessionStorage, locator, draftKey);
       setTiptapDoc(undefined);
     }
   };

--- a/apps/mesh/src/web/lib/chat-draft.test.ts
+++ b/apps/mesh/src/web/lib/chat-draft.test.ts
@@ -124,6 +124,31 @@ describe("chat-draft storage", () => {
     expect(calls[0]!.docSizeBytes).toBeGreaterThan(0);
   });
 
+  test("writeChatDraft reports UTF-8 byte length on quota error, not char count", () => {
+    const storage = new QuotaStorage();
+    const calls: Array<{ docSizeBytes: number }> = [];
+    // 4-byte UTF-8 character (emoji 🐉) — char count = 2 UTF-16 code units;
+    // serialized JSON contains it plus boilerplate. We just need the byte
+    // count to differ from the char count to prove TextEncoder is in use.
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("🐉🐉🐉🐉🐉"), {
+      onQuotaExceeded: (info) => calls.push(info),
+    });
+    expect(calls.length).toBe(1);
+    const serialized = JSON.stringify({
+      tiptapDoc: docWith("🐉🐉🐉🐉🐉"),
+      // updatedAt is a number, so its value doesn't shift UTF-8 byte count
+      // relative to UTF-16; only the doc string matters for the inequality.
+      updatedAt: 0,
+    });
+    const utf16 = serialized.length;
+    const utf8 = new TextEncoder().encode(serialized).byteLength;
+    // Sanity: the chosen content actually produces a difference.
+    expect(utf8).toBeGreaterThan(utf16);
+    // The reported size is bytes (>= UTF-8 byte length we just computed).
+    // Allow ±10 for the differing updatedAt value at runtime.
+    expect(calls[0]!.docSizeBytes).toBeGreaterThan(utf16);
+  });
+
   test("writeChatDraft is safe when no callback provided on quota error", () => {
     const storage = new QuotaStorage();
     expect(() =>
@@ -153,6 +178,19 @@ describe("chat-draft storage", () => {
   test("readChatDraft removes and returns null for shape mismatch", () => {
     const storage = new MemoryStorage();
     storage.setItem(KEY, JSON.stringify({ wrong: "shape" }));
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("readChatDraft removes and returns null when content is not an array", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      KEY,
+      JSON.stringify({
+        tiptapDoc: { type: "doc", content: "not-an-array" },
+        updatedAt: 1,
+      }),
+    );
     expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
     expect(storage.has(KEY)).toBe(false);
   });

--- a/apps/mesh/src/web/lib/chat-draft.test.ts
+++ b/apps/mesh/src/web/lib/chat-draft.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+import {
+  HOME_DRAFT_KEY,
+  clearChatDraft,
+  isQuotaExceededError,
+  readChatDraft,
+  writeChatDraft,
+} from "./chat-draft";
+import type { TiptapDoc } from "@/web/components/chat/types";
+
+class MemoryStorage {
+  private items = new Map<string, string>();
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+  /** Test-only: assert raw storage contents. */
+  has(key: string) {
+    return this.items.has(key);
+  }
+}
+
+/** Storage that throws QuotaExceededError on setItem. */
+class QuotaStorage extends MemoryStorage {
+  override setItem(_key: string, _value: string): void {
+    const err = new Error("quota");
+    err.name = "QuotaExceededError";
+    throw err;
+  }
+}
+
+/** Storage that throws a non-quota error on setItem. */
+class BrokenStorage extends MemoryStorage {
+  override setItem(_key: string, _value: string): void {
+    throw new Error("disk on fire");
+  }
+}
+
+const LOCATOR = "org/project";
+const TASK_ID = "task-1";
+const KEY = LOCALSTORAGE_KEYS.chatDraft(LOCATOR, TASK_ID);
+const HOME_KEY = LOCALSTORAGE_KEYS.chatDraft(LOCATOR, HOME_DRAFT_KEY);
+
+const docWith = (text: string): TiptapDoc => ({
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text }],
+    },
+  ],
+});
+
+const emptyDoc: TiptapDoc = { type: "doc", content: [] };
+
+describe("chat-draft storage", () => {
+  test("writeChatDraft persists doc as JSON payload with updatedAt", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    const raw = storage.getItem(KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tiptapDoc).toEqual(docWith("hello"));
+    expect(typeof parsed.updatedAt).toBe("number");
+  });
+
+  test("readChatDraft round-trips a written doc", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toEqual(docWith("hello"));
+  });
+
+  test("writeChatDraft removes the key when given an empty doc", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    expect(storage.has(KEY)).toBe(true);
+    writeChatDraft(storage, LOCATOR, TASK_ID, emptyDoc);
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("writeChatDraft removes the key when given undefined", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    writeChatDraft(storage, LOCATOR, TASK_ID, undefined);
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("writeChatDraft persists docs containing file nodes intact", () => {
+    const storage = new MemoryStorage();
+    const docWithFile: TiptapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "file",
+          attrs: {
+            id: "f1",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            size: 12,
+            data: "iVBORw0KGgo=",
+          },
+        },
+      ],
+    };
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWithFile);
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toEqual(docWithFile);
+  });
+
+  test("writeChatDraft swallows QuotaExceededError, invokes callback", () => {
+    const storage = new QuotaStorage();
+    const calls: Array<{ docSizeBytes: number }> = [];
+    expect(() =>
+      writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"), {
+        onQuotaExceeded: (info) => calls.push(info),
+      }),
+    ).not.toThrow();
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.docSizeBytes).toBeGreaterThan(0);
+  });
+
+  test("writeChatDraft is safe when no callback provided on quota error", () => {
+    const storage = new QuotaStorage();
+    expect(() =>
+      writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello")),
+    ).not.toThrow();
+  });
+
+  test("writeChatDraft rethrows non-quota storage errors", () => {
+    const storage = new BrokenStorage();
+    expect(() =>
+      writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello")),
+    ).toThrow(/disk on fire/);
+  });
+
+  test("readChatDraft returns null for a missing key", () => {
+    const storage = new MemoryStorage();
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+  });
+
+  test("readChatDraft removes and returns null for malformed JSON", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(KEY, "not json");
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("readChatDraft removes and returns null for shape mismatch", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(KEY, JSON.stringify({ wrong: "shape" }));
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("clearChatDraft removes the key", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hi"));
+    clearChatDraft(storage, LOCATOR, TASK_ID);
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("HOME_DRAFT_KEY scopes the home composer draft by locator", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, HOME_DRAFT_KEY, docWith("home"));
+    expect(storage.has(HOME_KEY)).toBe(true);
+    expect(readChatDraft(storage, LOCATOR, HOME_DRAFT_KEY)).toEqual(
+      docWith("home"),
+    );
+  });
+});
+
+describe("isQuotaExceededError", () => {
+  test("matches modern QuotaExceededError by name", () => {
+    const err = new Error("over");
+    err.name = "QuotaExceededError";
+    expect(isQuotaExceededError(err)).toBe(true);
+  });
+
+  test("matches legacy Firefox NS_ERROR_DOM_QUOTA_REACHED by name", () => {
+    const err = new Error("over");
+    err.name = "NS_ERROR_DOM_QUOTA_REACHED";
+    expect(isQuotaExceededError(err)).toBe(true);
+  });
+
+  test("rejects unrelated errors", () => {
+    expect(isQuotaExceededError(new Error("nope"))).toBe(false);
+    expect(isQuotaExceededError("string")).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError(undefined)).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/lib/chat-draft.ts
+++ b/apps/mesh/src/web/lib/chat-draft.ts
@@ -48,7 +48,8 @@ function parseStoredDraft(value: string | null): TiptapDoc | null {
   if (
     !doc ||
     typeof doc !== "object" ||
-    (doc as { type?: unknown }).type !== "doc"
+    (doc as { type?: unknown }).type !== "doc" ||
+    !Array.isArray((doc as { content?: unknown }).content)
   ) {
     return null;
   }
@@ -85,7 +86,11 @@ export function writeChatDraft(
     storage.setItem(key, serialized);
   } catch (err) {
     if (isQuotaExceededError(err)) {
-      options?.onQuotaExceeded?.({ docSizeBytes: serialized.length });
+      // UTF-8 byte count, which is what sessionStorage actually pays for —
+      // `serialized.length` is UTF-16 code units and undercounts multi-byte
+      // characters (CJK, emoji).
+      const docSizeBytes = new TextEncoder().encode(serialized).byteLength;
+      options?.onQuotaExceeded?.({ docSizeBytes });
       return;
     }
     throw err;

--- a/apps/mesh/src/web/lib/chat-draft.ts
+++ b/apps/mesh/src/web/lib/chat-draft.ts
@@ -1,0 +1,132 @@
+import type { ProjectLocator } from "@decocms/mesh-sdk";
+import type { TiptapDoc } from "@/web/components/chat/types";
+import { isTiptapDocEmpty } from "@/web/components/chat/tiptap/utils";
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+
+/**
+ * Stand-in `taskKey` for the home composer (no taskId exists yet). The key
+ * is scoped by `locator` so two projects keep separate home drafts.
+ */
+export const HOME_DRAFT_KEY = "__home__";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+interface StoredChatDraft {
+  tiptapDoc: TiptapDoc;
+  updatedAt: number;
+}
+
+export interface WriteChatDraftOptions {
+  /**
+   * Called when a write fails with QuotaExceededError. Receives the size
+   * of the payload that failed to write so the caller can surface
+   * telemetry. Not called for other errors (those are re-thrown).
+   */
+  onQuotaExceeded?: (info: { docSizeBytes: number }) => void;
+}
+
+function storageKey(locator: ProjectLocator | string, taskKey: string): string {
+  return LOCALSTORAGE_KEYS.chatDraft(locator, taskKey);
+}
+
+function parseStoredDraft(value: string | null): TiptapDoc | null {
+  if (!value) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { updatedAt?: unknown }).updatedAt !== "number"
+  ) {
+    return null;
+  }
+  const doc = (parsed as { tiptapDoc?: unknown }).tiptapDoc;
+  if (
+    !doc ||
+    typeof doc !== "object" ||
+    (doc as { type?: unknown }).type !== "doc"
+  ) {
+    return null;
+  }
+  return doc as TiptapDoc;
+}
+
+/**
+ * Persists the doc to storage. Removes the entry when the doc is empty.
+ * On QuotaExceededError, invokes `options.onQuotaExceeded` (if provided)
+ * and swallows the error so typing remains responsive. Re-throws any
+ * other storage error.
+ */
+export function writeChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+  tiptapDoc: TiptapDoc | undefined,
+  options?: WriteChatDraftOptions,
+): void {
+  const key = storageKey(locator, taskKey);
+
+  if (isTiptapDocEmpty(tiptapDoc)) {
+    storage.removeItem(key);
+    return;
+  }
+
+  const payload: StoredChatDraft = {
+    tiptapDoc: tiptapDoc as TiptapDoc,
+    updatedAt: Date.now(),
+  };
+  const serialized = JSON.stringify(payload);
+
+  try {
+    storage.setItem(key, serialized);
+  } catch (err) {
+    if (isQuotaExceededError(err)) {
+      options?.onQuotaExceeded?.({ docSizeBytes: serialized.length });
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Returns the persisted doc, or `null` if no valid draft exists. Malformed
+ * entries are removed in passing so they don't keep failing parse on each
+ * mount.
+ */
+export function readChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+): TiptapDoc | null {
+  const key = storageKey(locator, taskKey);
+  const raw = storage.getItem(key);
+  const doc = parseStoredDraft(raw);
+  if (raw !== null && doc === null) {
+    storage.removeItem(key);
+  }
+  return doc;
+}
+
+/** Removes the draft for the given key. No-op if absent. */
+export function clearChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+): void {
+  storage.removeItem(storageKey(locator, taskKey));
+}
+
+/**
+ * True if `err` is a sessionStorage/localStorage quota error. Handles both
+ * the modern `QuotaExceededError` and the legacy Firefox name
+ * `NS_ERROR_DOM_QUOTA_REACHED`.
+ */
+export function isQuotaExceededError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const name = (err as { name?: unknown }).name;
+  return name === "QuotaExceededError" || name === "NS_ERROR_DOM_QUOTA_REACHED";
+}

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -20,6 +20,8 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:simpleModeTier:${locator}`,
   chatAutosend: (locator: ProjectLocator | string, taskId: string) =>
     `mesh:chat:autosend:${locator}:${taskId}`,
+  chatDraft: (locator: ProjectLocator | string, taskKey: string) =>
+    `mesh:chat:draft:${locator}:${taskKey}`,
   assistantChatActiveTask: (locator: ProjectLocator) =>
     `mesh:assistant-chat:active-task:${locator}`,
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,

--- a/docs/superpowers/plans/2026-06-01-chat-input-session-draft.md
+++ b/docs/superpowers/plans/2026-06-01-chat-input-session-draft.md
@@ -1,0 +1,978 @@
+# Chat Input Session Draft Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the chat input survive a page refresh by persisting the in-progress Tiptap doc to `sessionStorage`, keyed per thread (and `"__home__"` for the home composer), and restoring it on mount. On submit, the draft is cleared.
+
+**Architecture:** One new pure helper module (`chat-draft.ts`) sibling to the existing `autosend.ts`, deliberately separate because the autosend mechanism is a one-shot TTL'd transfer while drafts are continuous. Wiring into the React component happens in five small, localized edits to `ChatInput` in `apps/mesh/src/web/components/chat/input.tsx`. Telemetry for the `QuotaExceededError` path is injected via an optional callback so the helper module stays free of `posthog-js`, keeping unit tests pure (no browser-only deps in the test loader).
+
+**Tech Stack:** TypeScript 5.9, React 19, Tiptap, Bun test runner (unit), Playwright (e2e), `@/web/lib/posthog-client` `track()` (telemetry).
+
+**Source spec:** [`docs/superpowers/specs/2026-06-01-chat-input-session-draft-design.md`](../specs/2026-06-01-chat-input-session-draft-design.md)
+
+---
+
+## File Structure
+
+| Path | Status | Responsibility |
+|---|---|---|
+| `apps/mesh/src/web/lib/localstorage-keys.ts` | modify | Add `chatDraft(locator, taskKey)` entry to the well-known keys registry. |
+| `apps/mesh/src/web/lib/chat-draft.ts` | create | Pure storage helper. Exports `HOME_DRAFT_KEY`, `writeChatDraft`, `readChatDraft`, `clearChatDraft`, `isQuotaExceededError`. No React, no `posthog-js` imports. |
+| `apps/mesh/src/web/lib/chat-draft.test.ts` | create | Bun unit tests against an in-memory `StorageLike`. Mirrors `autosend.test.ts` shape. |
+| `apps/mesh/src/web/components/chat/input.tsx` | modify | Wire the helper into `ChatInput`: lazy hydrate, write on update, clear on submit, hydrate on task switch. |
+| `apps/mesh/e2e/tests/chat-input-draft.spec.ts` | create | Four Playwright UI tests covering thread/home refresh, submit-clears, and per-thread isolation. |
+
+The helper module is intentionally small and free of side-effectful imports so it's trivially unit-testable. The component file already orchestrates the input lifecycle; this plan only adds five short blocks to it.
+
+---
+
+## Task 1: Add `chatDraft` to `LOCALSTORAGE_KEYS`
+
+**Files:**
+- Modify: `apps/mesh/src/web/lib/localstorage-keys.ts`
+
+- [ ] **Step 1: Open the file and read the existing shape**
+
+The file is short and declares a single `LOCALSTORAGE_KEYS` const object. The new entry lives directly under `chatAutosend` to keep chat-related keys grouped.
+
+- [ ] **Step 2: Add the new key entry**
+
+Edit `apps/mesh/src/web/lib/localstorage-keys.ts`. Find this existing line:
+
+```ts
+  chatAutosend: (locator: ProjectLocator | string, taskId: string) =>
+    `mesh:chat:autosend:${locator}:${taskId}`,
+```
+
+Insert the new entry directly after it:
+
+```ts
+  chatDraft: (locator: ProjectLocator | string, taskKey: string) =>
+    `mesh:chat:draft:${locator}:${taskKey}`,
+```
+
+The `taskKey` parameter accepts either a real `taskId` (UUID) or the `HOME_DRAFT_KEY` literal `"__home__"` — both are just strings to the storage layer.
+
+- [ ] **Step 3: Verify TypeScript still compiles**
+
+Run: `bun run check`
+
+Expected: no new errors. (Any pre-existing errors that exist on the branch are unrelated to this change and should be ignored for this step.)
+
+- [ ] **Step 4: Run formatter**
+
+Run: `bun run fmt`
+
+Expected: file is formatted; no other diffs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mesh/src/web/lib/localstorage-keys.ts
+git commit -m "feat(chat): add chatDraft key to LOCALSTORAGE_KEYS"
+```
+
+---
+
+## Task 2: Create `chat-draft.ts` (pure helper) with unit tests (TDD)
+
+**Files:**
+- Create: `apps/mesh/src/web/lib/chat-draft.ts`
+- Create: `apps/mesh/src/web/lib/chat-draft.test.ts`
+
+Use TDD: write the failing test file first, watch it fail, then implement the module.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `apps/mesh/src/web/lib/chat-draft.test.ts` with this content:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+import {
+  HOME_DRAFT_KEY,
+  clearChatDraft,
+  isQuotaExceededError,
+  readChatDraft,
+  writeChatDraft,
+} from "./chat-draft";
+import type { TiptapDoc } from "@/web/components/chat/types";
+
+class MemoryStorage {
+  private items = new Map<string, string>();
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+  /** Test-only: assert raw storage contents. */
+  has(key: string) {
+    return this.items.has(key);
+  }
+}
+
+/** Storage that throws QuotaExceededError on setItem. */
+class QuotaStorage extends MemoryStorage {
+  override setItem(_key: string, _value: string): void {
+    const err = new Error("quota");
+    err.name = "QuotaExceededError";
+    throw err;
+  }
+}
+
+/** Storage that throws a non-quota error on setItem. */
+class BrokenStorage extends MemoryStorage {
+  override setItem(_key: string, _value: string): void {
+    throw new Error("disk on fire");
+  }
+}
+
+const LOCATOR = "org/project";
+const TASK_ID = "task-1";
+const KEY = LOCALSTORAGE_KEYS.chatDraft(LOCATOR, TASK_ID);
+const HOME_KEY = LOCALSTORAGE_KEYS.chatDraft(LOCATOR, HOME_DRAFT_KEY);
+
+const docWith = (text: string): TiptapDoc => ({
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text }],
+    },
+  ],
+});
+
+const emptyDoc: TiptapDoc = { type: "doc", content: [] };
+
+describe("chat-draft storage", () => {
+  test("writeChatDraft persists doc as JSON payload with updatedAt", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    const raw = storage.getItem(KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tiptapDoc).toEqual(docWith("hello"));
+    expect(typeof parsed.updatedAt).toBe("number");
+  });
+
+  test("readChatDraft round-trips a written doc", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toEqual(docWith("hello"));
+  });
+
+  test("writeChatDraft removes the key when given an empty doc", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    expect(storage.has(KEY)).toBe(true);
+    writeChatDraft(storage, LOCATOR, TASK_ID, emptyDoc);
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("writeChatDraft removes the key when given undefined", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"));
+    writeChatDraft(storage, LOCATOR, TASK_ID, undefined);
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("writeChatDraft persists docs containing file nodes intact", () => {
+    const storage = new MemoryStorage();
+    const docWithFile: TiptapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "file",
+          attrs: {
+            id: "f1",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            size: 12,
+            data: "iVBORw0KGgo=",
+          },
+        },
+      ],
+    };
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWithFile);
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toEqual(docWithFile);
+  });
+
+  test("writeChatDraft swallows QuotaExceededError, invokes callback", () => {
+    const storage = new QuotaStorage();
+    const calls: Array<{ docSizeBytes: number }> = [];
+    expect(() =>
+      writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello"), {
+        onQuotaExceeded: (info) => calls.push(info),
+      }),
+    ).not.toThrow();
+    expect(calls.length).toBe(1);
+    expect(calls[0].docSizeBytes).toBeGreaterThan(0);
+  });
+
+  test("writeChatDraft is safe when no callback provided on quota error", () => {
+    const storage = new QuotaStorage();
+    expect(() =>
+      writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello")),
+    ).not.toThrow();
+  });
+
+  test("writeChatDraft rethrows non-quota storage errors", () => {
+    const storage = new BrokenStorage();
+    expect(() =>
+      writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hello")),
+    ).toThrow(/disk on fire/);
+  });
+
+  test("readChatDraft returns null for a missing key", () => {
+    const storage = new MemoryStorage();
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+  });
+
+  test("readChatDraft removes and returns null for malformed JSON", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(KEY, "not json");
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("readChatDraft removes and returns null for shape mismatch", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(KEY, JSON.stringify({ wrong: "shape" }));
+    expect(readChatDraft(storage, LOCATOR, TASK_ID)).toBeNull();
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("clearChatDraft removes the key", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, TASK_ID, docWith("hi"));
+    clearChatDraft(storage, LOCATOR, TASK_ID);
+    expect(storage.has(KEY)).toBe(false);
+  });
+
+  test("HOME_DRAFT_KEY scopes the home composer draft by locator", () => {
+    const storage = new MemoryStorage();
+    writeChatDraft(storage, LOCATOR, HOME_DRAFT_KEY, docWith("home"));
+    expect(storage.has(HOME_KEY)).toBe(true);
+    expect(readChatDraft(storage, LOCATOR, HOME_DRAFT_KEY)).toEqual(
+      docWith("home"),
+    );
+  });
+});
+
+describe("isQuotaExceededError", () => {
+  test("matches modern QuotaExceededError by name", () => {
+    const err = new Error("over");
+    err.name = "QuotaExceededError";
+    expect(isQuotaExceededError(err)).toBe(true);
+  });
+
+  test("matches legacy Firefox NS_ERROR_DOM_QUOTA_REACHED by name", () => {
+    const err = new Error("over");
+    err.name = "NS_ERROR_DOM_QUOTA_REACHED";
+    expect(isQuotaExceededError(err)).toBe(true);
+  });
+
+  test("rejects unrelated errors", () => {
+    expect(isQuotaExceededError(new Error("nope"))).toBe(false);
+    expect(isQuotaExceededError("string")).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `bun test apps/mesh/src/web/lib/chat-draft.test.ts`
+
+Expected: every test fails to import `./chat-draft` (module does not yet exist). The error is "Cannot find module './chat-draft'" or similar.
+
+- [ ] **Step 3: Implement `chat-draft.ts`**
+
+Create `apps/mesh/src/web/lib/chat-draft.ts` with this content:
+
+```ts
+import type { ProjectLocator } from "@decocms/mesh-sdk";
+import type { TiptapDoc } from "@/web/components/chat/types";
+import { isTiptapDocEmpty } from "@/web/components/chat/tiptap/utils";
+import { LOCALSTORAGE_KEYS } from "./localstorage-keys";
+
+/**
+ * Stand-in `taskKey` for the home composer (no taskId exists yet). The key
+ * is scoped by `locator` so two projects keep separate home drafts.
+ */
+export const HOME_DRAFT_KEY = "__home__";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+interface StoredChatDraft {
+  tiptapDoc: TiptapDoc;
+  updatedAt: number;
+}
+
+export interface WriteChatDraftOptions {
+  /**
+   * Called when a write fails with QuotaExceededError. Receives the size
+   * of the payload that failed to write so the caller can surface
+   * telemetry. Not called for other errors (those are re-thrown).
+   */
+  onQuotaExceeded?: (info: { docSizeBytes: number }) => void;
+}
+
+function storageKey(
+  locator: ProjectLocator | string,
+  taskKey: string,
+): string {
+  return LOCALSTORAGE_KEYS.chatDraft(locator, taskKey);
+}
+
+function parseStoredDraft(value: string | null): TiptapDoc | null {
+  if (!value) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { updatedAt?: unknown }).updatedAt !== "number"
+  ) {
+    return null;
+  }
+  const doc = (parsed as { tiptapDoc?: unknown }).tiptapDoc;
+  if (
+    !doc ||
+    typeof doc !== "object" ||
+    (doc as { type?: unknown }).type !== "doc"
+  ) {
+    return null;
+  }
+  return doc as TiptapDoc;
+}
+
+/**
+ * Persists the doc to storage. Removes the entry when the doc is empty.
+ * On QuotaExceededError, invokes `options.onQuotaExceeded` (if provided)
+ * and swallows the error so typing remains responsive. Re-throws any
+ * other storage error.
+ */
+export function writeChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+  tiptapDoc: TiptapDoc | undefined,
+  options?: WriteChatDraftOptions,
+): void {
+  const key = storageKey(locator, taskKey);
+
+  if (isTiptapDocEmpty(tiptapDoc)) {
+    storage.removeItem(key);
+    return;
+  }
+
+  const payload: StoredChatDraft = {
+    tiptapDoc: tiptapDoc as TiptapDoc,
+    updatedAt: Date.now(),
+  };
+  const serialized = JSON.stringify(payload);
+
+  try {
+    storage.setItem(key, serialized);
+  } catch (err) {
+    if (isQuotaExceededError(err)) {
+      options?.onQuotaExceeded?.({ docSizeBytes: serialized.length });
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Returns the persisted doc, or `null` if no valid draft exists. Malformed
+ * entries are removed in passing so they don't keep failing parse on each
+ * mount.
+ */
+export function readChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+): TiptapDoc | null {
+  const key = storageKey(locator, taskKey);
+  const raw = storage.getItem(key);
+  const doc = parseStoredDraft(raw);
+  if (raw !== null && doc === null) {
+    storage.removeItem(key);
+  }
+  return doc;
+}
+
+/** Removes the draft for the given key. No-op if absent. */
+export function clearChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+): void {
+  storage.removeItem(storageKey(locator, taskKey));
+}
+
+/**
+ * True if `err` is a sessionStorage/localStorage quota error. Handles both
+ * the modern `QuotaExceededError` and the legacy Firefox name
+ * `NS_ERROR_DOM_QUOTA_REACHED`.
+ */
+export function isQuotaExceededError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const name = (err as { name?: unknown }).name;
+  return (
+    name === "QuotaExceededError" || name === "NS_ERROR_DOM_QUOTA_REACHED"
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `bun test apps/mesh/src/web/lib/chat-draft.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run `bun run check` to confirm types**
+
+Run: `bun run check`
+
+Expected: no new TypeScript errors from `chat-draft.ts` or `chat-draft.test.ts`.
+
+- [ ] **Step 6: Format**
+
+Run: `bun run fmt`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/mesh/src/web/lib/chat-draft.ts apps/mesh/src/web/lib/chat-draft.test.ts
+git commit -m "feat(chat): add chat-draft sessionStorage helper
+
+Pure helper for persisting and restoring the Tiptap composer doc per
+thread. QuotaExceededError is reported via an injected callback so the
+helper stays free of posthog-js and unit-testable."
+```
+
+---
+
+## Task 3: Wire `chat-draft.ts` into `ChatInput`
+
+**Files:**
+- Modify: `apps/mesh/src/web/components/chat/input.tsx`
+
+This task does five small edits. After each, the dev server should still compile.
+
+- [ ] **Step 1: Add the imports**
+
+Find this existing block at the top of `apps/mesh/src/web/components/chat/input.tsx` (around lines 1–62) and add two imports:
+
+1. Locate the existing import:
+   ```ts
+   import { track } from "@/web/lib/posthog-client";
+   ```
+   This is already present — keep as-is.
+
+2. Add a new import directly under the existing `import { ... writeStoredAutosend } from "@/web/lib/autosend";` line:
+   ```ts
+   import {
+     HOME_DRAFT_KEY,
+     clearChatDraft,
+     readChatDraft,
+     writeChatDraft,
+   } from "@/web/lib/chat-draft";
+   ```
+
+- [ ] **Step 2: Extract `locator` from `useProjectContext` in `ChatInput`**
+
+Find this existing line in `ChatInput` (around line 254):
+
+```ts
+  const { org } = useProjectContext();
+```
+
+Replace with:
+
+```ts
+  const { org, locator } = useProjectContext();
+```
+
+(`locator` is already a valid field on the `useProjectContext()` return — `useHomeSubmit` higher up in the file already destructures it.)
+
+- [ ] **Step 3: Compute `draftKey` once per render**
+
+Find this existing line in `ChatInput` (around line 239):
+
+```ts
+  const taskId = taskCtx?.taskId ?? "";
+```
+
+Add immediately after (before the existing `const homeSubmit = useHomeSubmit();`):
+
+```ts
+  // Storage key for the per-thread (or home composer) draft.
+  const draftKey = taskId || HOME_DRAFT_KEY;
+```
+
+- [ ] **Step 4: Lazy-hydrate `tiptapDoc` from storage on mount**
+
+Find this existing block (around lines 311–313):
+
+```ts
+  // tiptapDoc lives here (not in context) so keystrokes don't re-render
+  // the entire context tree. The ref on context lets IceBreakers read it.
+  const [tiptapDoc, setTiptapDocLocal] =
+    useState<Metadata["tiptapDoc"]>(undefined);
+```
+
+Replace with:
+
+```ts
+  // tiptapDoc lives here (not in context) so keystrokes don't re-render
+  // the entire context tree. The ref on context lets IceBreakers read it.
+  // The lazy initializer hydrates the draft from sessionStorage on mount.
+  const [tiptapDoc, setTiptapDocLocal] = useState<Metadata["tiptapDoc"]>(
+    () => readChatDraft(sessionStorage, locator, draftKey) ?? undefined,
+  );
+```
+
+- [ ] **Step 5: Persist on every update inside `setTiptapDoc`**
+
+Find this existing block (around lines 314–317):
+
+```ts
+  const setTiptapDoc = (doc: Metadata["tiptapDoc"]) => {
+    setTiptapDocLocal(doc);
+    tiptapDocRef.current = doc;
+  };
+```
+
+Replace with:
+
+```ts
+  const setTiptapDoc = (doc: Metadata["tiptapDoc"]) => {
+    setTiptapDocLocal(doc);
+    tiptapDocRef.current = doc;
+    writeChatDraft(sessionStorage, locator, draftKey, doc, {
+      onQuotaExceeded: ({ docSizeBytes }) => {
+        track("chat_draft_quota_exceeded", {
+          thread_id: taskId || null,
+          doc_size_bytes: docSizeBytes,
+        });
+        console.warn(
+          "[chat-draft] sessionStorage quota exceeded; draft not saved",
+        );
+      },
+    });
+  };
+```
+
+- [ ] **Step 6: Hydrate the destination draft on thread switch**
+
+Find this existing block (around lines 320–328):
+
+```ts
+  // Reset input when switching tasks (TiptapProvider also remounts via key)
+  const prevTaskRef = useRef(taskId);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+  if (prevTaskRef.current !== taskId) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+    prevTaskRef.current = taskId;
+    setTiptapDocLocal(undefined);
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+    tiptapDocRef.current = undefined;
+  }
+```
+
+Replace with:
+
+```ts
+  // When switching tasks, rehydrate the new task's draft from storage
+  // (useState's lazy initializer only fires on mount). The previous
+  // task's draft is left in sessionStorage and will be picked up if the
+  // user navigates back.
+  const prevTaskRef = useRef(taskId);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+  if (prevTaskRef.current !== taskId) {
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+    prevTaskRef.current = taskId;
+    const restored =
+      readChatDraft(sessionStorage, locator, draftKey) ?? undefined;
+    setTiptapDocLocal(restored);
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+    tiptapDocRef.current = restored;
+  }
+```
+
+Note: `draftKey` here reflects the *new* `taskId` because it's recomputed at the top of the render. That's why the destination draft is read — not the previous one's.
+
+- [ ] **Step 7: Clear the draft on submit**
+
+Find this existing block inside `handleSubmit` (around lines 385–402, inside the `else if (canSubmit && tiptapDoc)` branch):
+
+```ts
+      playClickSound();
+      if (stream) {
+        void stream.sendMessage(tiptapDoc);
+      } else {
+        homeSubmit({ tiptapDoc, virtualMcp: selectedVirtualMcp });
+      }
+      setTiptapDoc(undefined);
+```
+
+Replace with:
+
+```ts
+      playClickSound();
+      if (stream) {
+        void stream.sendMessage(tiptapDoc);
+      } else {
+        homeSubmit({ tiptapDoc, virtualMcp: selectedVirtualMcp });
+      }
+      clearChatDraft(sessionStorage, locator, draftKey);
+      setTiptapDoc(undefined);
+```
+
+The subsequent `setTiptapDoc(undefined)` call would also clear the draft (because `writeChatDraft` removes the key on an empty doc), but the explicit `clearChatDraft` keeps intent visible and survives any future refactor of the empty-doc branch.
+
+- [ ] **Step 8: Type-check, format, and verify**
+
+Run: `bun run check`
+
+Expected: no new TypeScript errors. (`writeChatDraft`'s `tiptapDoc` parameter is `TiptapDoc | undefined`, and `Metadata["tiptapDoc"]` is `TiptapDoc | undefined` — same type, so no cast is needed.)
+
+Run: `bun run fmt`
+
+Run: `bun run lint`
+
+Expected: no new lint errors.
+
+- [ ] **Step 9: Smoke-check manually (optional but encouraged)**
+
+Run the dev server, open a thread, type a few words, refresh — the text should reappear. If it doesn't, the wiring is wrong; fix before moving on.
+
+```bash
+bun run dev
+# Visit http://localhost:4000, sign in, type in the chat input,
+# hit Cmd+R, confirm the text is restored. Then submit and refresh — input
+# should be empty.
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/mesh/src/web/components/chat/input.tsx
+git commit -m "feat(chat): persist composer draft to sessionStorage per thread
+
+Hydrates the Tiptap doc from sessionStorage on mount and on thread
+switch; writes on every update; clears on submit. QuotaExceededError
+emits a PostHog event + console.warn and is swallowed so typing
+remains responsive."
+```
+
+---
+
+## Task 4: End-to-end Playwright tests
+
+**Files:**
+- Create: `apps/mesh/e2e/tests/chat-input-draft.spec.ts`
+
+Four scenarios in one spec file, sharing setup. The codebase has no prior UI-driving Playwright tests for the chat input, so this file establishes the pattern.
+
+Key implementation details verified from the codebase:
+
+- The Tiptap editor is a contenteditable with `[data-chat-input="true"]` (set in `apps/mesh/src/web/components/chat/tiptap/input.tsx`, around line 84).
+- `apps/mesh/e2e/fixtures/test.ts` exports an `authedPage` fixture that produces a `Page` already signed in, plus `orgSlug`. Use this instead of `@playwright/test`.
+- A new thread is created by typing in the home composer and submitting — this both fires `homeSubmit` and navigates the page to `/<orgSlug>/<taskId>`. We use this to obtain a real `taskId` for tests.
+
+- [ ] **Step 1: Create the spec file**
+
+Create `apps/mesh/e2e/tests/chat-input-draft.spec.ts` with this content:
+
+```ts
+/**
+ * E2E: chat input draft persistence to sessionStorage.
+ *
+ * Drives the real browser end-to-end. Confirms:
+ *   1. Thread drafts survive page refresh.
+ *   2. Home composer drafts survive page refresh.
+ *   3. Successful submit clears the draft.
+ *   4. Drafts are isolated per thread.
+ *
+ * The quota-exceeded path is deliberately NOT exercised here — it's
+ * covered by unit tests on the chat-draft helper. PostHog telemetry will
+ * surface real-world occurrence in production.
+ */
+
+import { expect, test } from "../fixtures/test";
+import type { Page } from "@playwright/test";
+
+const CHAT_INPUT = '[data-chat-input="true"]';
+
+/** Focus the chat input and type via the keyboard. Tiptap is contenteditable, so we cannot use `fill`. */
+async function typeInComposer(page: Page, text: string): Promise<void> {
+  const input = page.locator(CHAT_INPUT);
+  await input.click();
+  await page.keyboard.type(text);
+}
+
+/** Read the visible text content of the chat input. */
+async function composerText(page: Page): Promise<string> {
+  return (await page.locator(CHAT_INPUT).innerText()).trim();
+}
+
+/** Clear the chat input by selecting all and deleting. */
+async function clearComposer(page: Page): Promise<void> {
+  await page.locator(CHAT_INPUT).click();
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await page.keyboard.press(`${modifier}+A`);
+  await page.keyboard.press("Delete");
+}
+
+/** Submit by pressing Enter (no Shift). */
+async function submitComposer(page: Page): Promise<void> {
+  await page.locator(CHAT_INPUT).click();
+  await page.keyboard.press("Enter");
+}
+
+/** Type a message in the home composer, submit, and wait until URL contains a taskId. Returns the taskId. */
+async function openNewThread(
+  page: Page,
+  orgSlug: string,
+  seed: string,
+): Promise<string> {
+  await page.goto(`/${orgSlug}`);
+  await expect(page.locator(CHAT_INPUT)).toBeVisible();
+  await typeInComposer(page, seed);
+  await submitComposer(page);
+  // After submit, the URL becomes /<orgSlug>/<taskId> via homeSubmit's
+  // navigate() call. Wait for it.
+  await page.waitForURL(
+    (url) => new URL(url).pathname.startsWith(`/${orgSlug}/`),
+    { timeout: 20_000 },
+  );
+  const match = new URL(page.url()).pathname.match(
+    new RegExp(`^/${orgSlug}/([^/]+)`),
+  );
+  if (!match) throw new Error(`could not extract taskId from ${page.url()}`);
+  return match[1];
+}
+
+test.describe("chat input draft persistence", () => {
+  test("thread draft survives page refresh", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await openNewThread(page, orgSlug, "kick off");
+
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "draft message that should survive");
+
+    await page.reload();
+
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe(
+      "draft message that should survive",
+    );
+  });
+
+  test("home composer draft survives page refresh", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    await page.goto(`/${orgSlug}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+
+    await typeInComposer(page, "home composer draft");
+
+    await page.reload();
+
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("home composer draft");
+  });
+
+  test("submit clears the draft", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const taskId = await openNewThread(page, orgSlug, "first");
+
+    // Type a second message and submit it (clearing should fire).
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "this should be cleared after submit");
+    await submitComposer(page);
+
+    // Reload and confirm the input is empty.
+    await page.goto(`/${orgSlug}/${taskId}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("");
+  });
+
+  test("drafts are isolated per thread", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const taskA = await openNewThread(page, orgSlug, "thread a");
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "draft for A");
+
+    // Navigate to the home composer to start a second thread.
+    const taskB = await openNewThread(page, orgSlug, "thread b");
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    await clearComposer(page);
+    await typeInComposer(page, "draft for B");
+
+    // Switch back to A: A's draft should still be there.
+    await page.goto(`/${orgSlug}/${taskA}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("draft for A");
+
+    // Switch to B: B's draft should still be there.
+    await page.goto(`/${orgSlug}/${taskB}`);
+    await expect(page.locator(CHAT_INPUT)).toBeVisible();
+    expect(await composerText(page)).toBe("draft for B");
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run the e2e suite for this spec only. Follow whatever Playwright invocation the rest of the e2e suite uses — check `apps/mesh/package.json` `scripts` and the project root `package.json` if unsure. A common command shape is:
+
+```bash
+bun run --cwd apps/mesh test:e2e -- chat-input-draft.spec.ts
+```
+
+If that script doesn't exist on this branch, run Playwright directly from `apps/mesh`:
+
+```bash
+cd apps/mesh && bunx playwright test e2e/tests/chat-input-draft.spec.ts
+```
+
+Expected: all four tests pass.
+
+If a test fails:
+- **"chat input not visible"** → ensure `bun run dev` (or whatever dev/test server the e2e config uses) is up. Inspect the failure screenshot/video Playwright writes to `apps/mesh/playwright-report/` or the configured `outputDir`.
+- **"text was empty after reload"** → the wiring step in Task 3 (most likely the lazy initializer or the empty-doc clear) is broken. Re-check those changes against the plan.
+- **"openNewThread couldn't extract taskId from URL"** → the submit didn't navigate, or the URL shape is different in this build. Print `page.url()` and reconcile with the route definition.
+
+- [ ] **Step 3: Type-check, format, lint**
+
+Run: `bun run check`
+Run: `bun run fmt`
+Run: `bun run lint`
+
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/mesh/e2e/tests/chat-input-draft.spec.ts
+git commit -m "test(chat): e2e for sessionStorage draft persistence"
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run: `bun test`
+
+Expected: full green. If something unrelated fails, surface it — it's not from this change.
+
+- [ ] **Step 2: Type-check the whole monorepo**
+
+Run: `bun run check`
+
+Expected: no new errors introduced by this branch.
+
+- [ ] **Step 3: Lint**
+
+Run: `bun run lint`
+
+Expected: clean.
+
+- [ ] **Step 4: Format-check**
+
+Run: `bun run fmt:check`
+
+Expected: clean. (If not, run `bun run fmt` and amend the previous commit, or — since the rule is "no amend" per CLAUDE.md — create a follow-up "[chore]: fmt" commit.)
+
+- [ ] **Step 5: Manual sanity check (recommended)**
+
+Spin up the dev server one more time:
+
+```bash
+bun run dev
+```
+
+Walk through these flows:
+1. Open the app, type in the home composer, refresh → text returns.
+2. Submit from home → lands on a new thread. Type a draft, refresh → text returns.
+3. Submit on the thread → the draft is gone after reload.
+4. Open a second thread (Cmd+N or via the sidebar / home composer), type a different draft, navigate back to the first thread → the first thread's draft is intact.
+5. Close the tab, reopen the URL → drafts are gone (this is the expected `sessionStorage` behavior).
+
+- [ ] **Step 6: Push the branch and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(chat): persist composer draft to sessionStorage per thread" \
+  --body "$(cat <<'EOF'
+## Summary
+- Persists the Tiptap composer doc to `sessionStorage` keyed per thread (and `__home__` for the home composer).
+- Restores the draft on chat input mount and on thread switch.
+- Clears on submit.
+- `QuotaExceededError` is swallowed; we emit a PostHog event and `console.warn` so we can debug later.
+
+Spec: docs/superpowers/specs/2026-06-01-chat-input-session-draft-design.md
+Plan: docs/superpowers/plans/2026-06-01-chat-input-session-draft.md
+
+## Test plan
+- [ ] `bun test apps/mesh/src/web/lib/chat-draft.test.ts` is green.
+- [ ] `bun run --cwd apps/mesh test:e2e -- chat-input-draft.spec.ts` (or equivalent) is green locally.
+- [ ] Manual: refresh on a thread restores the draft.
+- [ ] Manual: refresh on home composer restores the draft.
+- [ ] Manual: submit clears the draft.
+- [ ] Manual: closing the tab discards the draft (sessionStorage semantics).
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+Comparing the plan to the spec, section by section:
+
+**Goals:**
+- (1) Persist while typing → Task 3, Step 5 (`writeChatDraft` inside `setTiptapDoc`).
+- (2) Restore on mount → Task 3, Step 4 (lazy `useState` initializer).
+- (3) Clear on submit → Task 3, Step 7 (`clearChatDraft` in `handleSubmit`).
+- (4) Per-thread isolation when switching → Task 3, Step 6 (hydrate the new key in the `prevTaskRef` block); covered by E2E test 4.
+- (5) Quota-exceeded path is observable, non-fatal → Task 2 (helper swallow + callback); Task 3, Step 5 (telemetry + `console.warn` wired in component).
+
+**Non-goals:** All non-goals from the spec (long-term persistence, cross-tab sync, other chat-input redesigns, file-node stripping, debouncing, "draft saved" indicator) are absent from the plan.
+
+**Architecture/Storage layout:**
+- `LOCALSTORAGE_KEYS.chatDraft` added — Task 1.
+- New `chat-draft.ts` helper with the API specified (`writeChatDraft`, `readChatDraft`, `clearChatDraft`, plus the new `HOME_DRAFT_KEY` const and `isQuotaExceededError`) — Task 2.
+- Wiring in `input.tsx` — Task 3 with the five concrete edits enumerated in the spec.
+
+**Failure handling:** The plan implements the spec's intent (swallow + telemetry + warn) but moves the *call site* of `track()` from the helper to the component, because importing `track` (and thus `posthog-js`) inside a unit-tested helper would diverge from the codebase pattern and risks polluting the Bun test loader. The user-visible behavior is identical. Documented in the plan's Architecture statement.
+
+**Testing:**
+- Unit tests: Task 2 — covers all bullets in the spec's unit-test list (write, read, clear, empty doc, file-nodes intact, quota swallow, malformed JSON, key shape).
+- E2E tests: Task 4 — all four scenarios from the spec.
+
+**Telemetry:** Event name (`chat_draft_quota_exceeded`) and payload (`thread_id`, `doc_size_bytes`) match the spec — Task 3, Step 5.
+
+**Placeholder scan:** No "TBD", no "add appropriate error handling", no "similar to Task N", no naked "implement later". Every code step contains the actual code. ✅
+
+**Type consistency:** `HOME_DRAFT_KEY` is defined in Task 2's `chat-draft.ts` and imported in Task 3 from `@/web/lib/chat-draft`. `writeChatDraft` signature is consistent across Task 2 (definition + test invocations) and Task 3 (call site). The `onQuotaExceeded` callback shape (`{ docSizeBytes: number }`) matches between Task 2's interface definition and Task 3's call site. ✅

--- a/docs/superpowers/specs/2026-06-01-chat-input-session-draft-design.md
+++ b/docs/superpowers/specs/2026-06-01-chat-input-session-draft-design.md
@@ -1,0 +1,374 @@
+# Chat Input Session Draft — Design
+
+**Status:** Draft
+**Date:** 2026-06-01
+**Owner:** tlgimenes@gmail.com
+
+## Problem
+
+The chat input (`apps/mesh/src/web/components/chat/input.tsx`) keeps the
+in-progress Tiptap document in local component state (`tiptapDoc`). When the
+user refreshes the page, navigates away and back, or accidentally closes and
+reopens the tab in the same browser session, the draft is lost. For threads
+that hold conversational context the user was actively building up to, this is
+a real productivity hit — especially when a draft contains carefully-composed
+text, mentions, or freshly-attached files.
+
+The codebase already persists a Tiptap doc to `sessionStorage` in one specific
+case: the home composer's one-shot handoff to a newly-created thread
+(`apps/mesh/src/web/lib/autosend.ts`). We will extend the same storage mental
+model into a **per-thread continuous draft** so the input survives a refresh
+in the same tab.
+
+## Goals
+
+1. While the user is typing in the chat input, persist the current Tiptap doc
+   to `sessionStorage`, keyed per thread (or `__home__` for the home composer).
+2. On chat input mount (page load / refresh), restore the persisted doc into
+   the editor.
+3. On successful submit, clear the persisted draft for that thread.
+4. Switching between threads in the same tab restores each thread's own
+   draft.
+5. Failure modes (sessionStorage quota exceeded) do not crash the app, do not
+   inconvenience the user with UI, and are observable via PostHog telemetry
+   plus a `console.warn` for local debugging.
+
+## Non-goals
+
+- **Long-term draft persistence.** Drafts are explicitly tab-scoped via
+  `sessionStorage`. Closing the tab discards drafts. If users later ask for
+  "my draft was there yesterday," upgrading the storage tier to `localStorage`
+  with TTL+cap is a follow-up, not part of this slice.
+- **Cross-tab synchronization.** Two tabs on the same thread each get their
+  own draft slot (sessionStorage's natural per-tab isolation). We do not add
+  any cross-tab merging.
+- **Other chat input changes.** No new modes, affordances, or attachment UX.
+  This spec is strictly the draft-persistence behavior; the rest of the input
+  stays as-is.
+- **Stripping or shrinking file nodes for storage.** We persist the doc
+  as-is, including base64-encoded file attachments. If the doc exceeds
+  sessionStorage quota, the write silently fails (see Failure handling).
+- **Debounced writes.** Each `onUpdate` keystroke triggers a write in v1.
+  Telemetry will tell us if we have a perf problem.
+- **A "draft saved" indicator.** No checkmark, no "saved at HH:MM" text. The
+  feature is invisible when it works.
+
+## Behavior
+
+### When a draft is written
+
+- On every Tiptap `onUpdate` (one per keystroke / content change), the
+  current doc is serialized and written to `sessionStorage`.
+- If the resulting doc is "empty" (per the existing `isTiptapDocEmpty`
+  helper in `apps/mesh/src/web/components/chat/tiptap/utils.ts`), the
+  storage entry is **removed** rather than written as an empty payload. This
+  avoids leaving stale `{ tiptapDoc: { type: "doc", content: [] } }` entries
+  lying around after the user clears the input.
+
+### When a draft is read
+
+- On `ChatInput` mount, before first render of `TiptapProvider`, the lazy
+  `useState` initializer calls `readChatDraft(...)` and uses that as the
+  initial value of the local `tiptapDoc` state. The existing prop wiring
+  (`TiptapProvider`'s `content: tiptapDoc || ""`) then initializes the
+  editor with the restored doc.
+- A malformed or absent storage entry returns `null` and the editor starts
+  empty. Malformed entries are removed so they don't keep failing parse on
+  every mount.
+
+### When a draft is cleared
+
+- **On submit** — both the thread-stream `sendMessage` path and the
+  home-composer `homeSubmit` path call `clearChatDraft(...)` after
+  dispatching the message. The existing code dispatches optimistically (no
+  `await`) and immediately clears local doc state; the new draft clearing
+  matches that optimistic semantics. If the network call later fails, the
+  user's previously-typed message is already gone from both local state
+  and storage — same loss-of-work behavior as today.
+- **On thread switch** — the existing `prevTaskRef` block in `ChatInput`
+  that wipes local doc state on `taskId` change is **extended** (see
+  Architecture > Wiring step 5) to also hydrate the *new* thread's draft
+  from storage. `useState`'s lazy initializer fires only on mount, so the
+  re-hydration must happen explicitly in the `prevTaskRef` handler. The
+  previous thread's draft is left in sessionStorage and will be picked up
+  if the user navigates back.
+- **On empty doc** — the doc-is-empty check removes the entry (see above).
+- **Tab close** — sessionStorage discards everything automatically. No
+  cleanup code needed.
+
+### Home composer specifics
+
+- The home composer mounts the same `ChatInput` component without a
+  `taskId`. The draft key falls back to the literal string `"__home__"`,
+  scoped by `locator`. Two different projects therefore keep separate home
+  drafts.
+- The home submit flow already writes the doc to `sessionStorage` under
+  `chatAutosend(locator, newTaskId)` for the new-thread handoff. The
+  `__home__` draft is **also cleared** at submit, so refreshing the home
+  page after a submit shows an empty composer rather than the last-sent
+  message.
+- The autosend payload is consumed on the destination thread page by the
+  existing `claimStoredAutosend` flow. Coexistence is naturally safe: the
+  two mechanisms use **different keys** with **different lifetimes** and do
+  not collide.
+
+## Failure handling
+
+The only expected runtime failure for `sessionStorage.setItem` is
+`QuotaExceededError`. This happens when the doc (typically a doc with one or
+more large base64-encoded image attachments) exceeds the ~5 MB per-tab
+budget. The write is wrapped in `try/catch`:
+
+```ts
+try {
+  storage.setItem(key, serialized);
+} catch (err) {
+  if (isQuotaExceededError(err)) {
+    track("chat_draft_quota_exceeded", {
+      thread_id: taskId ?? null,
+      doc_size_bytes: serialized.length,
+    });
+    console.warn("[chat-draft] quota exceeded; draft not saved", err);
+    return;
+  }
+  throw err; // anything else is unexpected; let it bubble.
+}
+```
+
+- **No user-facing UI.** No banner, no toast. The user keeps typing; the
+  next keystroke will retry the write. If the user removes the
+  oversized content (e.g., deletes the large attachment), saving resumes
+  naturally — no recovery code needed.
+- **Telemetry.** A single PostHog event per failed write. We accept that a
+  streak of keystrokes against an oversized doc will spam events; this is
+  intentional in v1 so we can measure the real-world rate. A
+  "warn-once-per-thread" deduplication can be added later if the volume is
+  noisy.
+- **`console.warn`** to surface the issue in dev/preview environments
+  without alerting on it.
+- **Other errors** (security errors from sandboxed contexts, e.g.) are
+  re-thrown so we hear about them.
+
+`isQuotaExceededError(err)` checks for either the modern `QuotaExceededError`
+name or the legacy Firefox `NS_ERROR_DOM_QUOTA_REACHED` name, since the
+catch needs to be robust across browsers.
+
+## Architecture
+
+### New module: `apps/mesh/src/web/lib/chat-draft.ts`
+
+Sibling to the existing `apps/mesh/src/web/lib/autosend.ts`. Deliberately
+separate: `autosend.ts` models a *one-shot, TTL'd, status-tracked transfer*,
+while `chat-draft.ts` models a *continuous, untimed draft slot*. Merging
+them would be premature unification — the lifecycles differ.
+
+Public API:
+
+```ts
+import type { ProjectLocator } from "@decocms/mesh-sdk";
+import type { Metadata } from "@/web/components/chat/types";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export const HOME_DRAFT_KEY = "__home__";
+
+export interface StoredChatDraft {
+  tiptapDoc: Metadata["tiptapDoc"];
+  updatedAt: number;
+}
+
+/** Writes the doc, or clears the entry if the doc is empty. */
+export function writeChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+  tiptapDoc: Metadata["tiptapDoc"],
+): void;
+
+/** Reads the doc or returns null. Removes malformed entries. */
+export function readChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+): Metadata["tiptapDoc"] | null;
+
+/** Removes the entry unconditionally. */
+export function clearChatDraft(
+  storage: StorageLike,
+  locator: ProjectLocator | string,
+  taskKey: string,
+): void;
+```
+
+`StorageLike` mirrors the existing `autosend.ts` shape so unit tests can
+inject an in-memory storage object.
+
+### New entry in `LOCALSTORAGE_KEYS`
+
+In `apps/mesh/src/web/lib/localstorage-keys.ts`, add next to `chatAutosend`:
+
+```ts
+chatDraft: (locator: ProjectLocator | string, taskKey: string) =>
+  `mesh:chat:draft:${locator}:${taskKey}`,
+```
+
+The `taskKey` parameter accepts either a real `taskId` (UUID) or the
+literal `HOME_DRAFT_KEY` value `"__home__"`. The function does not
+discriminate — both are just strings to the storage layer.
+
+### Wiring in `apps/mesh/src/web/components/chat/input.tsx`
+
+The only React component touched. Five concrete changes inside
+`ChatInput`:
+
+1. **Compute the draft key:**
+   ```ts
+   const draftKey = taskId || HOME_DRAFT_KEY;
+   ```
+   Placed after `taskId` is destructured from `taskCtx`.
+
+2. **Hydrate initial state from storage:**
+   ```ts
+   const [tiptapDoc, setTiptapDocLocal] = useState<Metadata["tiptapDoc"]>(
+     () => readChatDraft(sessionStorage, locator, draftKey) ?? undefined,
+   );
+   ```
+   The lazy initializer runs once on mount. `locator` is already available
+   from `useProjectContext()`.
+
+3. **Persist on every update:**
+   The existing `setTiptapDoc` wrapper now also writes:
+   ```ts
+   const setTiptapDoc = (doc: Metadata["tiptapDoc"]) => {
+     setTiptapDocLocal(doc);
+     tiptapDocRef.current = doc;
+     writeChatDraft(sessionStorage, locator, draftKey, doc);
+   };
+   ```
+   `writeChatDraft` is responsible for the empty-doc removal and the
+   quota-exceeded swallow.
+
+4. **Clear on submit:**
+   In `handleSubmit`, in the `canSubmit && tiptapDoc` branch, after the
+   `stream.sendMessage` / `homeSubmit` dispatch and before
+   `setTiptapDoc(undefined)`:
+   ```ts
+   clearChatDraft(sessionStorage, locator, draftKey);
+   ```
+   The subsequent `setTiptapDoc(undefined)` call would also clear via the
+   empty-doc branch, but explicit clear at submit time is clearer about
+   intent.
+
+5. **Task-switch reset:**
+   The existing `prevTaskRef` block (lines 320–328) currently resets the
+   local doc to `undefined` when `taskId` changes. Because `useState`'s
+   lazy initializer only fires on mount (not on prop change), the block is
+   **extended** to additionally hydrate the new thread's draft from
+   storage:
+   ```ts
+   if (prevTaskRef.current !== taskId) {
+     prevTaskRef.current = taskId;
+     const newKey = taskId || HOME_DRAFT_KEY;
+     const restored = readChatDraft(sessionStorage, locator, newKey);
+     setTiptapDocLocal(restored ?? undefined);
+     tiptapDocRef.current = restored ?? undefined;
+   }
+   ```
+   This preserves the "previous thread's draft stays in storage" behavior
+   while restoring the new thread's draft. `TiptapProvider` already
+   remounts via `key={taskId}` and accepts `tiptapDoc` as initial content,
+   so the restored doc flows into the editor on the new render.
+
+### What stays unchanged
+
+- `TiptapProvider`, `TiptapInput`, `FileNode`, `FileUploader`, mention
+  nodes — untouched.
+- The existing `autosend` module and its storage key — untouched. We do
+  *not* try to unify with it.
+- The `prevTaskRef` reset block's existence and timing — only its body is
+  edited (to additionally hydrate from storage).
+- All other `ChatInput` behavior: voice input, file drag/drop, model
+  selection, chat mode pills, send-button morph, etc.
+
+## Testing
+
+Per `TESTING.md`: two tiers.
+
+### Unit tests — `apps/mesh/src/web/lib/chat-draft.test.ts`
+
+Co-located, no mocks, in-memory `StorageLike` map:
+
+- `writeChatDraft` writes a JSON-encoded `{ tiptapDoc, updatedAt }` payload
+  to the expected key.
+- `writeChatDraft` removes the key when given a doc considered empty by
+  `isTiptapDocEmpty`.
+- `writeChatDraft` writes a doc containing file nodes (with base64
+  `data`) intact.
+- `writeChatDraft` swallows `QuotaExceededError` (simulated by a
+  `StorageLike` whose `setItem` throws) and does **not** rethrow; the
+  payload is *not* written.
+- `writeChatDraft` rethrows non-quota storage errors.
+- `readChatDraft` returns the doc for a well-formed entry.
+- `readChatDraft` returns `null` and *removes the key* for a malformed JSON
+  entry.
+- `readChatDraft` returns `null` for a missing key.
+- `clearChatDraft` removes the key.
+- `HOME_DRAFT_KEY` produces a stable, locator-scoped key when combined with
+  `LOCALSTORAGE_KEYS.chatDraft(locator, HOME_DRAFT_KEY)`.
+
+Quota detection covers both `QuotaExceededError` (modern) and
+`NS_ERROR_DOM_QUOTA_REACHED` (Firefox legacy).
+
+### E2E tests — `apps/mesh/e2e/tests/`
+
+Playwright, real stack:
+
+1. **Thread draft survives refresh.** Open a thread, type a message into
+   the input (no submit), reload the page → message text is restored.
+2. **Home composer draft survives refresh.** On the home page, type a
+   message, reload → text is restored.
+3. **Submit clears the draft.** Type a message, submit, wait for response
+   to start, reload → input is empty.
+4. **Per-thread isolation.** Type a draft in thread A. Navigate to thread B
+   (same tab). Type a different draft in B. Navigate back to A → A's draft
+   is restored, not B's.
+
+We deliberately do **not** e2e the quota-exceeded path. Provoking a real
+QuotaExceededError reliably across browsers requires either monkeypatching
+`Storage` (not e2e in spirit) or generating multi-megabyte file
+attachments (slow, flaky). The unit test covers the catch-block contract,
+and PostHog will surface the real-world rate.
+
+## Telemetry
+
+One new event:
+
+- `chat_draft_quota_exceeded`
+  - `thread_id`: string | null — the task id, or `null` for the home composer.
+  - `doc_size_bytes`: number — the size of the JSON payload that failed to
+    write.
+
+Tracked once per failed `setItem` call. Volume can be deduplicated later if
+this is too noisy.
+
+## Rollout
+
+- No feature flag. The change is local to one component plus one new
+  module; the blast radius is bounded.
+- The fix is purely client-side. No migration. No backend coordination.
+- The PR can ship behind no gate; first user benefit is on first deploy.
+
+## Open questions
+
+None at design time. Implementation will surface any.
+
+## Follow-ups (out of scope here)
+
+- Upgrade to `localStorage` + TTL + size cap if users want drafts across
+  tab close / browser restart.
+- "Warn once per thread" dedup for `chat_draft_quota_exceeded` if telemetry
+  shows excessive volume.
+- A small "draft saved" indicator if user research surfaces uncertainty
+  about whether autosave is on.
+- A debounce on the write path if perf profiling shows keystroke overhead
+  on very large docs.


### PR DESCRIPTION
## Summary

Persists the chat input's Tiptap document to `sessionStorage` keyed per thread (and `__home__` for the home composer), so refreshing the page restores the in-progress draft.

- Hydrates the draft on chat-input mount **and** on thread switch.
- Writes on every Tiptap `onUpdate`; removes the entry when the doc becomes empty.
- Clears on submit (both thread send and home submit paths).
- `QuotaExceededError` is swallowed; a `chat_draft_quota_exceeded` PostHog event is emitted alongside a `console.warn`, so we can debug without surfacing UI noise.
- File-node attachments are persisted intact (full base64 inline) until quota is hit.

Coexists cleanly with the existing one-shot `autosend` mechanism (different `LOCALSTORAGE_KEYS` namespace).

**Spec:** `docs/superpowers/specs/2026-06-01-chat-input-session-draft-design.md`
**Plan:** `docs/superpowers/plans/2026-06-01-chat-input-session-draft.md`

### Architectural deviation from spec (documented in the plan)
The spec originally had `chat-draft.ts` import `track` directly. To keep the helper free of `posthog-js` (which would otherwise be pulled into the Bun unit-test loader), the helper now takes an optional `onQuotaExceeded({ docSizeBytes })` callback; the React component wires telemetry into it. User-visible behavior is identical.

### Files changed
- `apps/mesh/src/web/lib/localstorage-keys.ts` — new `chatDraft` registry entry
- `apps/mesh/src/web/lib/chat-draft.ts` — new pure helper module
- `apps/mesh/src/web/lib/chat-draft.test.ts` — 18 unit tests
- `apps/mesh/src/web/components/chat/input.tsx` — five surgical wiring edits in `ChatInput`
- `apps/mesh/e2e/tests/chat-input-draft.spec.ts` — first UI-driving Playwright spec for chat

## Test plan

- [x] `bun test apps/mesh/src/web/lib/chat-draft.test.ts` — 18 pass / 0 fail (covers write/read/clear, empty-doc removal, file-node round-trip, quota swallow w/ callback, UTF-8 byte counting on quota, malformed-JSON cleanup, content-array validation, the `isQuotaExceededError` predicate)
- [x] `bun run check` — clean
- [x] `bun run lint` — no new warnings
- [x] `bun run fmt:check` — clean
- [ ] `bunx playwright test e2e/tests/chat-input-draft.spec.ts` (please verify locally / in CI — the suite needs the full mesh stack)
- [ ] Manual: refresh on a thread restores the typed draft
- [ ] Manual: refresh on the home composer restores the typed draft
- [ ] Manual: submit clears the draft (refresh after send → input empty)
- [ ] Manual: drafts on two threads stay isolated when switching between them
- [ ] Manual: closing the tab discards the draft (sessionStorage semantics, by design)

## Telemetry
New event: `chat_draft_quota_exceeded` with `{ thread_id: string | null, doc_size_bytes: number }`. One emission per failed write — accepted in v1 for visibility; dedup is a follow-up if volume is too high.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted the chat composer draft to `sessionStorage` per thread (and `__home__` for the home composer) so refreshes and thread switches restore in-progress text. Drafts clear on submit; quota errors are swallowed and tracked via `chat_draft_quota_exceeded`.

- **New Features**
  - Hydrates the draft on mount and on thread switch; drafts are isolated per thread.
  - Writes on every editor update; removes the entry when the doc is empty.
  - File attachments are saved with the doc until quota is hit.
  - Coexists with `autosend` under a separate `LOCALSTORAGE_KEYS` namespace.

- **Bug Fixes**
  - `chat_draft_quota_exceeded` now reports UTF-8 `doc_size_bytes`; malformed stored docs are removed on read.
  - E2E hardened: pre-seeds release-feed seen state and dismisses the release popover to prevent send-button interception.

<sup>Written for commit 76f3319047a55d062917ff0e0ac0c54c8fad6ffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

