### PR TITLE
fix(shell): don't persist per-thread panel tabs across task switches

### DIFF
--- a/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { getWellKnownDecopilotVirtualMCP } from "@decocms/mesh-sdk";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useProjectContext } from "@decocms/mesh-sdk";
+import { isPerThreadTab } from "@/web/layouts/main-panel-tabs/tab-id";
 import { AUTOSEND_QUERY_VALUE } from "@/web/lib/autosend";
 
 export interface ChatNavigation {
@@ -36,7 +37,13 @@ export function useChatNavigation(): ChatNavigation {
         const next: Record<string, unknown> = {};
         const vmcp = opts?.virtualMcpId ?? prev.virtualmcpid;
         if (vmcp) next.virtualmcpid = vmcp;
-        if (prev.main) next.main = prev.main;
+        const prevMain = prev.main;
+        if (
+          prevMain &&
+          typeof prevMain === "string" &&
+          !isPerThreadTab(prevMain)
+        )
+          next.main = prevMain;
         if (prev.chat) next.chat = prev.chat;
         if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;
         return next;

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -92,6 +92,21 @@ export const FIXED_SYSTEM_TABS = [
 const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
 
 /**
+ * Returns true for tab ids that are scoped to a specific thread and must not
+ * be carried across task switches:
+ *   - "app:<connectionId>:<toolName>"  (expanded tool / pinned view)
+ *   - "web-page:<slug>"               (ephemeral web preview)
+ *   - "automation:<id>"               (ephemeral automation detail)
+ */
+export function isPerThreadTab(tabId: string): boolean {
+  return (
+    tabId.startsWith("app:") ||
+    tabId.startsWith("web-page:") ||
+    tabId.startsWith("automation:")
+  );
+}
+
+/**
  * Legacy tab ids that were merged into the unified "settings" tab. Kept
  * here so saved defaults / URL state migrate cleanly.
  */

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -26,6 +26,7 @@ import {
 import { KEYS } from "../lib/query-keys";
 import { readCachedTaskBranch } from "../lib/read-cached-task-branch";
 import { useThreadActions } from "@/web/components/chat/store/hooks";
+import { isPerThreadTab } from "@/web/layouts/main-panel-tabs/tab-id";
 import { useOrganizationSettingsSuspense } from "../hooks/use-organization-settings";
 import { useOrgSsoStatus } from "../hooks/use-org-sso";
 import { SsoRequiredScreen } from "../components/sso-required-screen";
@@ -117,14 +118,14 @@ export function usePanelActions() {
         if (virtualMcpId) next.virtualmcpid = virtualMcpId;
         else if (prev.virtualmcpid) next.virtualmcpid = prev.virtualmcpid;
         // Preserve system-level panel tabs (git, preview, settings, …) across
-        // thread switches, but drop per-thread tabs (expanded tool views and
-        // web-page previews) that are specific to the previous task.
+        // thread switches, but drop per-thread tabs (expanded tool views,
+        // web-page previews, automation details) that are specific to the
+        // previous task.
         const prevMain = prev.main;
         if (
           prevMain &&
           typeof prevMain === "string" &&
-          !prevMain.startsWith("app:") &&
-          !prevMain.startsWith("web-page:")
+          !isPerThreadTab(prevMain)
         ) {
           next.main = prevMain;
         }

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -116,9 +116,18 @@ export function usePanelActions() {
         const next: Record<string, unknown> = { chat: 1 };
         if (virtualMcpId) next.virtualmcpid = virtualMcpId;
         else if (prev.virtualmcpid) next.virtualmcpid = prev.virtualmcpid;
-        // Preserve the main panel tab (git / preview / env / …) so that
-        // switching tasks keeps the user's current view.
-        if (prev.main) next.main = prev.main;
+        // Preserve system-level panel tabs (git, preview, settings, …) across
+        // thread switches, but drop per-thread tabs (expanded tool views and
+        // web-page previews) that are specific to the previous task.
+        const prevMain = prev.main;
+        if (
+          prevMain &&
+          typeof prevMain === "string" &&
+          !prevMain.startsWith("app:") &&
+          !prevMain.startsWith("web-page:")
+        ) {
+          next.main = prevMain;
+        }
         if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;
         return next;
       },


### PR DESCRIPTION
## What is this contribution about?

When switching threads, `setTaskId` was unconditionally carrying the `?main` search param forward. This works fine for system-level tabs (git, preview, settings) but broke for per-thread tabs like expanded tool views (`app:<connectionId>:<toolName>`) and web-page preview tabs — which are stored in task metadata and are specific to a single thread.

The result: after switching threads, the tab chip disappeared from the header (the new thread has no matching `expandedTool`) but the main panel stayed open because `mainOpen` is still `true` when `?main` has any value.

Fix: only preserve `?main` when switching threads if the value doesn't start with `app:` or `web-page:`. System tabs and agent-declared tabs still carry over unchanged.

## Screenshots/Demonstration

> Steps to reproduce before fix:
> 1. Open an agent, let a tool call expand a panel tab (e.g. an MCP app view)
> 2. Switch to a different thread in the sidebar
> 3. The tab chip in the header disappears but the panel body remains open ← bug

## How to Test

1. Open any agent and trigger a tool that opens an `app:` panel tab (expand a tool call or open a pinned view)
2. While that tab is active, click a different thread in the sidebar
3. Expected: the main panel closes (no stale tab open, no orphaned panel)
4. Verify system tabs (git, preview, settings) still carry over when switching threads

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop persisting per-thread panel tabs when switching threads. System-level tabs still carry over so the main panel closes cleanly on thread change.

- **Bug Fixes**
  - Drop per-thread `?main` tabs (`app:`, `web-page:`, `automation:`) on thread switch in both shell and chat navigation to avoid orphaned panels.
  - Centralize the guard with `isPerThreadTab()`; keep system/agent tabs (git, preview, settings) when switching tasks.

<sup>Written for commit 22bc3b5f7d7a50e1de6df44de7429ca9f6ca4610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

