### PR TITLE
Branded access screens + HTML-aware org access redirects

### DIFF
--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -5,6 +5,16 @@ import { DevObjectStorage } from "../../object-storage/dev-object-storage";
 import { decorateStorageWithAssetHoisting } from "../../object-storage/asset-hoister";
 import { getObjectStorageS3Service } from "../../object-storage/factory";
 
+// A top-level browser navigation (clicking a link, pasting a URL) sends
+// `Accept: text/html`. API clients — `<img>` tags, `fetch`, and OAuth
+// discovery (Cursor/Claude) — do not. We use that to decide whether a denied
+// request should get a raw JSON error (machines) or be bounced into the SPA so
+// the existing OrgAccessGate can render a styled no-access / not-found screen
+// instead of dumping JSON into the address bar.
+export const isBrowserNavigation = (c: {
+  req: { header: (name: string) => string | undefined };
+}) => (c.req.header("accept") ?? "").includes("text/html");
+
 export const resolveOrgFromPath: MiddlewareHandler<{
   Variables: { meshContext: MeshContext };
 }> = async (c, next) => {
@@ -26,6 +36,11 @@ export const resolveOrgFromPath: MiddlewareHandler<{
     .executeTakeFirst();
 
   if (!org) {
+    // Bounce browser navigations into the SPA so OrgAccessGate shows the
+    // "Organization not found" screen instead of raw JSON.
+    if (isBrowserNavigation(c)) {
+      return c.redirect(`/${encodeURIComponent(slug)}`, 302);
+    }
     return c.json({ error: `organization "${slug}" not found` }, 404);
   }
 
@@ -52,6 +67,12 @@ export const resolveOrgFromPath: MiddlewareHandler<{
       .executeTakeFirst();
 
     if (!membership) {
+      // Bounce browser navigations into the SPA so OrgAccessGate shows the
+      // styled "No access" screen (with invite/auto-join handling) instead of
+      // raw JSON in the address bar.
+      if (isBrowserNavigation(c)) {
+        return c.redirect(`/${encodeURIComponent(org.slug)}`, 302);
+      }
       return c.json({ error: "forbidden: not a member of organization" }, 403);
     }
     pathRole = membership.role;

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -5,29 +5,7 @@ import { DevObjectStorage } from "../../object-storage/dev-object-storage";
 import { decorateStorageWithAssetHoisting } from "../../object-storage/asset-hoister";
 import { getObjectStorageS3Service } from "../../object-storage/factory";
 
-// Decides whether a denied request should get a raw JSON error (machines) or be
-// bounced into the SPA so the existing OrgAccessGate can render a styled
-// no-access / not-found screen instead of dumping JSON into the address bar.
-//
-// The authoritative signal for "a person navigated here in a browser" is the
-// Fetch Metadata header `Sec-Fetch-Dest: document`, set by browsers ONLY for
-// top-level navigations. It's a forbidden header — `fetch`/XHR cannot set or
-// override it — so a browser's own subresource requests are correctly excluded:
-// `<img>` sends `image`, `fetch`/XHR send `empty`, an iframe sends `iframe`.
-// When the header is present we trust it exclusively, which fixes the previous
-// `Accept`-only heuristic that could misclassify an API client carrying a broad
-// `Accept` (or a browser <img>/fetch) as a navigation.
-//
-// Clients that don't send Sec-Fetch-* (older browsers, some tools) fall back to
-// content negotiation: real API clients send `application/json` or `*/*` (no
-// `text/html` substring), so only an HTML-preferring navigation matches.
-export const isBrowserNavigation = (c: {
-  req: { header: (name: string) => string | undefined };
-}) => {
-  const dest = c.req.header("sec-fetch-dest");
-  if (dest !== undefined) return dest === "document";
-  return (c.req.header("accept") ?? "").includes("text/html");
-};
+import { isBrowserNavigation } from "../utils/browser-navigation";
 
 export const resolveOrgFromPath: MiddlewareHandler<{
   Variables: { meshContext: MeshContext };

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -5,15 +5,29 @@ import { DevObjectStorage } from "../../object-storage/dev-object-storage";
 import { decorateStorageWithAssetHoisting } from "../../object-storage/asset-hoister";
 import { getObjectStorageS3Service } from "../../object-storage/factory";
 
-// A top-level browser navigation (clicking a link, pasting a URL) sends
-// `Accept: text/html`. API clients — `<img>` tags, `fetch`, and OAuth
-// discovery (Cursor/Claude) — do not. We use that to decide whether a denied
-// request should get a raw JSON error (machines) or be bounced into the SPA so
-// the existing OrgAccessGate can render a styled no-access / not-found screen
-// instead of dumping JSON into the address bar.
+// Decides whether a denied request should get a raw JSON error (machines) or be
+// bounced into the SPA so the existing OrgAccessGate can render a styled
+// no-access / not-found screen instead of dumping JSON into the address bar.
+//
+// The authoritative signal for "a person navigated here in a browser" is the
+// Fetch Metadata header `Sec-Fetch-Dest: document`, set by browsers ONLY for
+// top-level navigations. It's a forbidden header — `fetch`/XHR cannot set or
+// override it — so a browser's own subresource requests are correctly excluded:
+// `<img>` sends `image`, `fetch`/XHR send `empty`, an iframe sends `iframe`.
+// When the header is present we trust it exclusively, which fixes the previous
+// `Accept`-only heuristic that could misclassify an API client carrying a broad
+// `Accept` (or a browser <img>/fetch) as a navigation.
+//
+// Clients that don't send Sec-Fetch-* (older browsers, some tools) fall back to
+// content negotiation: real API clients send `application/json` or `*/*` (no
+// `text/html` substring), so only an HTML-preferring navigation matches.
 export const isBrowserNavigation = (c: {
   req: { header: (name: string) => string | undefined };
-}) => (c.req.header("accept") ?? "").includes("text/html");
+}) => {
+  const dest = c.req.header("sec-fetch-dest");
+  if (dest !== undefined) return dest === "document";
+  return (c.req.header("accept") ?? "").includes("text/html");
+};
 
 export const resolveOrgFromPath: MiddlewareHandler<{
   Variables: { meshContext: MeshContext };

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -20,6 +20,7 @@ import { HTTPException } from "hono/http-exception";
 import type { MeshContext } from "@/core/mesh-context";
 import { generatePresignedGetUrl } from "./decopilot/file-materializer";
 import { usesLocalObjectStorage } from "@/tools/connection/dev-assets";
+import { isBrowserNavigation } from "../middleware/resolve-org-from-path";
 
 type Variables = { meshContext: MeshContext };
 
@@ -31,6 +32,13 @@ app.get("/:org/files/*", async (c) => {
   const orgId = ctx.organization?.id;
 
   if (!ctx.auth?.user?.id) {
+    // A logged-out person opening a file link in the browser should land on
+    // login (and return to this org afterward), not a raw JSON 401. API
+    // clients (no `Accept: text/html`) still get the 401.
+    if (isBrowserNavigation(c)) {
+      const slug = c.req.param("org");
+      return c.redirect(`/login?next=${encodeURIComponent(`/${slug}`)}`, 302);
+    }
     throw new HTTPException(401, { message: "Authentication required" });
   }
 

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -20,7 +20,7 @@ import { HTTPException } from "hono/http-exception";
 import type { MeshContext } from "@/core/mesh-context";
 import { generatePresignedGetUrl } from "./decopilot/file-materializer";
 import { usesLocalObjectStorage } from "@/tools/connection/dev-assets";
-import { isBrowserNavigation } from "../middleware/resolve-org-from-path";
+import { isBrowserNavigation } from "../utils/browser-navigation";
 
 type Variables = { meshContext: MeshContext };
 
@@ -36,8 +36,7 @@ app.get("/:org/files/*", async (c) => {
     // login (and return to this org afterward), not a raw JSON 401. API
     // clients (no `Accept: text/html`) still get the 401.
     if (isBrowserNavigation(c)) {
-      const slug = c.req.param("org");
-      return c.redirect(`/login?next=${encodeURIComponent(`/${slug}`)}`, 302);
+      return c.redirect(`/login?next=${encodeURIComponent(c.req.path)}`, 302);
     }
     throw new HTTPException(401, { message: "Authentication required" });
   }

--- a/apps/mesh/src/api/utils/browser-navigation.ts
+++ b/apps/mesh/src/api/utils/browser-navigation.ts
@@ -13,5 +13,10 @@ export const isBrowserNavigation = (c: {
 }) => {
   const dest = c.req.header("sec-fetch-dest");
   if (dest !== undefined) return dest === "document";
-  return (c.req.header("accept") ?? "").includes("text/html");
+  // A client explicitly opting out with q=0 (e.g. `text/html;q=0`) must not
+  // be treated as a browser navigation even though the substring matches.
+  const accept = c.req.header("accept") ?? "";
+  return (
+    accept.includes("text/html") && !/text\/html\s*;\s*q\s*=\s*0/.test(accept)
+  );
 };

--- a/apps/mesh/src/api/utils/browser-navigation.ts
+++ b/apps/mesh/src/api/utils/browser-navigation.ts
@@ -1,0 +1,17 @@
+// The authoritative signal for "a person navigated here in a browser" is the
+// Fetch Metadata header `Sec-Fetch-Dest: document`, set by browsers ONLY for
+// top-level navigations. It's a forbidden header — `fetch`/XHR cannot set or
+// override it — so a browser's own subresource requests are correctly excluded:
+// `<img>` sends `image`, `fetch`/XHR send `empty`, an iframe sends `iframe`.
+// When the header is present we trust it exclusively.
+//
+// Clients that don't send Sec-Fetch-* (older browsers, some tools) fall back to
+// content negotiation: real API clients send `application/json` or `*/*` (no
+// `text/html` substring), so only an HTML-preferring navigation matches.
+export const isBrowserNavigation = (c: {
+  req: { header: (name: string) => string | undefined };
+}) => {
+  const dest = c.req.header("sec-fetch-dest");
+  if (dest !== undefined) return dest === "document";
+  return (c.req.header("accept") ?? "").includes("text/html");
+};

--- a/apps/mesh/src/web/components/access-screen-layout.tsx
+++ b/apps/mesh/src/web/components/access-screen-layout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+// Subtle brand aurora bled in from the edges, using the three brand accent
+// colors from the design tokens (packages/ui global.css):
+//   --brand-purple-light #a595ff, --brand-green-light #d0ec1a,
+//   --brand-yellow-light #ffc116
+// Same radial-gradient overlay pattern as the Deco nudge card / credits banner,
+// kept low-opacity so it reads as branded but never competes with content.
+const BRAND_GRADIENT = [
+  "radial-gradient(ellipse 85% 85% at 0% 0%, rgba(165,149,255,0.6) 0%, transparent 72%)",
+  "radial-gradient(ellipse 85% 85% at 100% 100%, rgba(208,236,26,0.52) 0%, transparent 72%)",
+  "radial-gradient(ellipse 85% 85% at 0% 100%, rgba(255,193,22,0.48) 0%, transparent 72%)",
+].join(", ");
+
+/**
+ * Full-screen centered shell shared by every org access-gate screen
+ * (no-access, not-found, pending invite, auto domain join, archived org).
+ * Provides the branded gradient background so these pages feel like part of
+ * the product instead of a bare error page.
+ */
+export function AccessScreenLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative flex items-center justify-center min-h-screen bg-background overflow-hidden">
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{ backgroundImage: BRAND_GRADIENT }}
+      />
+      <div className="relative flex flex-col items-center text-center space-y-4 max-w-sm px-6">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/access-screen-layout.tsx
+++ b/apps/mesh/src/web/components/access-screen-layout.tsx
@@ -14,7 +14,7 @@ const BRAND_GRADIENT = [
 
 /**
  * Full-screen centered shell shared by every org access-gate screen
- * (no-access, not-found, pending invite, auto domain join, archived org).
+ * (no-access, not-found, pending invite, auto domain join, archived org, SSO required).
  * Provides the branded gradient background so these pages feel like part of
  * the product instead of a bare error page.
  */

--- a/apps/mesh/src/web/components/archived-org-screen.tsx
+++ b/apps/mesh/src/web/components/archived-org-screen.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import { Archive } from "@untitledui/icons";
+import { AccessScreenLayout } from "@/web/components/access-screen-layout";
 
 export interface ArchivedOrgScreenProps {
   orgName?: string;
@@ -11,26 +12,24 @@ export function ArchivedOrgScreen({ orgName }: ArchivedOrgScreenProps) {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background">
-      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
-        <div className="bg-muted p-3 rounded-full">
-          <Archive className="h-6 w-6 text-muted-foreground" />
-        </div>
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium">Organization unavailable</h3>
-          <p className="text-sm text-muted-foreground">
-            {orgName ? (
-              <>
-                <strong>{orgName}</strong> has been deleted or is no longer
-                available.
-              </>
-            ) : (
-              "This organization has been deleted or is no longer available."
-            )}
-          </p>
-        </div>
-        <Button onClick={handleGoHome}>Go to home</Button>
+    <AccessScreenLayout>
+      <div className="bg-muted p-3 rounded-full">
+        <Archive className="h-6 w-6 text-muted-foreground" />
       </div>
-    </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">Organization unavailable</h3>
+        <p className="text-sm text-muted-foreground">
+          {orgName ? (
+            <>
+              <strong>{orgName}</strong> has been deleted or is no longer
+              available.
+            </>
+          ) : (
+            "This organization has been deleted or is no longer available."
+          )}
+        </p>
+      </div>
+      <Button onClick={handleGoHome}>Go to home</Button>
+    </AccessScreenLayout>
   );
 }

--- a/apps/mesh/src/web/components/auto-domain-join-screen.tsx
+++ b/apps/mesh/src/web/components/auto-domain-join-screen.tsx
@@ -1,3 +1,4 @@
+import { AccessScreenLayout } from "@/web/components/access-screen-layout";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Building02 } from "@untitledui/icons";
@@ -50,44 +51,42 @@ export function AutoDomainJoinScreen({
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background">
-      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
-        {orgLogo ? (
-          <Avatar
-            url={orgLogo}
-            fallback={orgName.charAt(0).toUpperCase()}
-            shape="square"
-            size="base"
-            className="h-12 w-12"
-          />
-        ) : (
-          <div className="bg-primary/10 p-3 rounded-full">
-            <Building02 className="h-6 w-6 text-primary" />
-          </div>
-        )}
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium">Join {orgName}?</h3>
-          <p className="text-sm text-muted-foreground">
-            Anyone with an <strong>@{domain}</strong> email can join this
-            organization.
-          </p>
+    <AccessScreenLayout>
+      {orgLogo ? (
+        <Avatar
+          url={orgLogo}
+          fallback={orgName.charAt(0).toUpperCase()}
+          shape="square"
+          size="base"
+          className="h-12 w-12"
+        />
+      ) : (
+        <div className="bg-primary/10 p-3 rounded-full">
+          <Building02 className="h-6 w-6 text-primary" />
         </div>
-        <div className="flex flex-col gap-2 w-full">
-          <Button
-            onClick={() => joinMutation.mutate()}
-            disabled={joinMutation.isPending}
-          >
-            {joinMutation.isPending ? "Joining…" : `Enter ${orgName}`}
-          </Button>
-          <Button
-            variant="ghost"
-            onClick={handleGoHome}
-            disabled={joinMutation.isPending}
-          >
-            Go to home
-          </Button>
-        </div>
+      )}
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">Join {orgName}?</h3>
+        <p className="text-sm text-muted-foreground">
+          Anyone with an <strong>@{domain}</strong> email can join this
+          organization.
+        </p>
       </div>
-    </div>
+      <div className="flex flex-col gap-2 w-full">
+        <Button
+          onClick={() => joinMutation.mutate()}
+          disabled={joinMutation.isPending}
+        >
+          {joinMutation.isPending ? "Joining…" : `Enter ${orgName}`}
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={handleGoHome}
+          disabled={joinMutation.isPending}
+        >
+          Go to home
+        </Button>
+      </div>
+    </AccessScreenLayout>
   );
 }

--- a/apps/mesh/src/web/components/no-access-screen.tsx
+++ b/apps/mesh/src/web/components/no-access-screen.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import { Lock01, SearchLg } from "@untitledui/icons";
+import { AccessScreenLayout } from "@/web/components/access-screen-layout";
 
 export interface NoAccessScreenProps {
   orgSlug: string;
@@ -25,23 +26,22 @@ export function NoAccessScreen({
     </>
   ) : (
     <>
-      You don&apos;t have access to <strong>{orgName ?? orgSlug}</strong>. Ask
-      an admin to invite you.
+      You don&apos;t have access to <strong>{orgName ?? orgSlug}</strong>.
+      <br />
+      Ask an admin to invite you.
     </>
   );
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background">
-      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
-        <div className="bg-muted p-3 rounded-full">
-          <Icon className="h-6 w-6 text-muted-foreground" />
-        </div>
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium">{title}</h3>
-          <p className="text-sm text-muted-foreground">{body}</p>
-        </div>
-        <Button onClick={handleGoHome}>Go to home</Button>
+    <AccessScreenLayout>
+      <div className="bg-muted p-3 rounded-full">
+        <Icon className="h-6 w-6 text-muted-foreground" />
       </div>
-    </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">{title}</h3>
+        <p className="text-sm text-muted-foreground">{body}</p>
+      </div>
+      <Button onClick={handleGoHome}>Go to home</Button>
+    </AccessScreenLayout>
   );
 }

--- a/apps/mesh/src/web/components/pending-invite-screen.tsx
+++ b/apps/mesh/src/web/components/pending-invite-screen.tsx
@@ -2,6 +2,7 @@ import {
   authClient,
   invalidateOrganizationListCache,
 } from "@/web/lib/auth-client";
+import { AccessScreenLayout } from "@/web/components/access-screen-layout";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Mail01 } from "@untitledui/icons";
@@ -64,42 +65,40 @@ export function PendingInviteScreen({
   const isBusy = acceptMutation.isPending || rejectMutation.isPending;
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background">
-      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
-        {orgLogo ? (
-          <Avatar
-            url={orgLogo}
-            fallback={orgName.charAt(0).toUpperCase()}
-            shape="square"
-            size="base"
-            className="h-12 w-12"
-          />
-        ) : (
-          <div className="bg-primary/10 p-3 rounded-full">
-            <Mail01 className="h-6 w-6 text-primary" />
-          </div>
-        )}
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium">
-            You&apos;ve been invited to <strong>{orgName}</strong>
-          </h3>
-          <p className="text-sm text-muted-foreground">
-            Accept the invitation to join this organization.
-          </p>
+    <AccessScreenLayout>
+      {orgLogo ? (
+        <Avatar
+          url={orgLogo}
+          fallback={orgName.charAt(0).toUpperCase()}
+          shape="square"
+          size="base"
+          className="h-12 w-12"
+        />
+      ) : (
+        <div className="bg-primary/10 p-3 rounded-full">
+          <Mail01 className="h-6 w-6 text-primary" />
         </div>
-        <div className="flex flex-col gap-2 w-full">
-          <Button onClick={() => acceptMutation.mutate()} disabled={isBusy}>
-            {acceptMutation.isPending ? "Accepting…" : "Accept invitation"}
-          </Button>
-          <Button
-            variant="ghost"
-            onClick={() => rejectMutation.mutate()}
-            disabled={isBusy}
-          >
-            {rejectMutation.isPending ? "Declining…" : "Decline"}
-          </Button>
-        </div>
+      )}
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">
+          You&apos;ve been invited to <strong>{orgName}</strong>
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          Accept the invitation to join this organization.
+        </p>
       </div>
-    </div>
+      <div className="flex flex-col gap-2 w-full">
+        <Button onClick={() => acceptMutation.mutate()} disabled={isBusy}>
+          {acceptMutation.isPending ? "Accepting…" : "Accept invitation"}
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() => rejectMutation.mutate()}
+          disabled={isBusy}
+        >
+          {rejectMutation.isPending ? "Declining…" : "Decline"}
+        </Button>
+      </div>
+    </AccessScreenLayout>
   );
 }

--- a/apps/mesh/src/web/components/sso-required-screen.tsx
+++ b/apps/mesh/src/web/components/sso-required-screen.tsx
@@ -1,3 +1,4 @@
+import { AccessScreenLayout } from "@/web/components/access-screen-layout";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Lock01 } from "@untitledui/icons";
 
@@ -22,31 +23,29 @@ export function SsoRequiredScreen({
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background">
-      <div className="flex flex-col items-center text-center space-y-4 max-w-sm px-6">
-        <div className="bg-primary/10 p-3 rounded-full">
-          <Lock01 className="h-6 w-6 text-primary" />
-        </div>
-        <div className="space-y-2">
-          <h3 className="text-lg font-medium">SSO Authentication Required</h3>
-          <p className="text-sm text-muted-foreground">
-            {orgName ? (
-              <>
-                <strong>{orgName}</strong> requires SSO authentication
-                {domain ? ` via ${domain}` : ""}.
-              </>
-            ) : (
-              "This organization requires SSO authentication to access."
-            )}
-          </p>
-        </div>
-        <div className="flex flex-col gap-2 w-full">
-          <Button onClick={handleSsoLogin}>Sign in with SSO</Button>
-          <Button variant="ghost" onClick={handleGoBack}>
-            Go back
-          </Button>
-        </div>
+    <AccessScreenLayout>
+      <div className="bg-primary/10 p-3 rounded-full">
+        <Lock01 className="h-6 w-6 text-primary" />
       </div>
-    </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">SSO Authentication Required</h3>
+        <p className="text-sm text-muted-foreground">
+          {orgName ? (
+            <>
+              <strong>{orgName}</strong> requires SSO authentication
+              {domain ? ` via ${domain}` : ""}.
+            </>
+          ) : (
+            "This organization requires SSO authentication to access."
+          )}
+        </p>
+      </div>
+      <div className="flex flex-col gap-2 w-full">
+        <Button onClick={handleSsoLogin}>Sign in with SSO</Button>
+        <Button variant="ghost" onClick={handleGoBack}>
+          Go back
+        </Button>
+      </div>
+    </AccessScreenLayout>
   );
 }


### PR DESCRIPTION
## What is this contribution about?
Opening an org-scoped API URL (e.g. a file link) in the browser for an org you can't access used to dump raw JSON (`{"error":"forbidden: not a member of organization"}`) into the address bar. Now `resolveOrgFromPath` and the files route detect top-level browser navigations (`Accept: text/html`) and redirect into the SPA instead — no-access/not-found render through the existing `OrgAccessGate`, and logged-out file visits go to `/login?next=` and return afterward. The access-gate screens (no-access, not-found, pending invite, auto domain join, archived org) now share a new `AccessScreenLayout` with a branded green/yellow/purple gradient background so they feel like part of the product. Machine clients (`<img>`, `fetch`, OAuth discovery) are unchanged and still receive JSON/401.

## Screenshots/Demonstration
Branded "No access" / "Organization not found" screens with the brand gradient — see the access-gate states at `/<org-slug>`.

## How to Test
1. Run `bun run dev` and log in.
2. In the browser, open a file URL for an org you're **not** a member of: `/api/<other-org>/files/anything` → you're redirected to `/<other-org>` showing the branded **No access** screen (not raw JSON). A bogus slug shows **Organization not found**.
3. Log out and open the same file URL → you land on `/login?next=/<org>` and return to the org after signing in.
4. Confirm machines are unchanged: `curl -H "Accept: application/json" <url>` still returns the JSON 403/401.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Browser visits to org-scoped API URLs now redirect into the SPA with hardened browser-navigation detection, and all org access screens use a new branded layout. This removes raw JSON-in-address-bar and gives a consistent, on-brand experience.

- **New Features**
  - Browser-navigation detection: `Sec-Fetch-Dest: document` with `Accept: text/html` fallback that honors `q=0`. Top-level visits redirect to `/<org>`; logged-out file links go to `/login?next=<full path>`.
  - API clients (`<img>`, `fetch`, OAuth) still receive JSON 403/401.

- **Refactors**
  - Extracted `isBrowserNavigation` HTTP util for reuse across routes.
  - Added `AccessScreenLayout` with a brand gradient; applied to no-access, not-found, pending invite, auto domain join, archived org, and SSO required screens.
  - Tweaked no-access copy for clarity.

<sup>Written for commit 023a09b42e2a3772700226cca7b0a88b1c23f2ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/3608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

